### PR TITLE
♻️ refactor: refactor zustand usage with v4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "swr": "^2",
     "ts-md5": "^1",
     "uuid": "^9",
-    "zustand": "^4",
+    "zustand": "^4.4",
     "zustand-utils": "^1"
   },
   "devDependencies": {

--- a/src/store/session/index.ts
+++ b/src/store/session/index.ts
@@ -1,5 +1,6 @@
-import { create } from 'zustand';
+import equal from 'fast-deep-equal';
 import { PersistOptions, devtools, persist } from 'zustand/middleware';
+import { createWithEqualityFn } from 'zustand/traditional';
 
 import { isDev } from '@/utils/env';
 
@@ -22,13 +23,14 @@ const persistOptions: PersistOptions<SessionStore, SessionPersist> = {
   // version: Migration.targetVersion,
 };
 
-export const useSessionStore = create<SessionStore>()(
+export const useSessionStore = createWithEqualityFn<SessionStore>()(
   persist(
     devtools(createStore, {
       name: LOBE_CHAT + (isDev ? '_DEV' : ''),
     }),
     persistOptions,
   ),
+  equal,
 );
 
 export * from './selectors';

--- a/src/store/settings/index.ts
+++ b/src/store/settings/index.ts
@@ -1,5 +1,6 @@
-import { create } from 'zustand';
+import equal from 'fast-deep-equal';
 import { type PersistOptions, devtools, persist } from 'zustand/middleware';
+import { createWithEqualityFn } from 'zustand/traditional';
 
 import { isDev } from '@/utils/env';
 
@@ -12,13 +13,14 @@ const persistOptions: PersistOptions<SettingsStore> = {
   skipHydration: true,
 };
 
-export const useSettings = create<SettingsStore>()(
+export const useSettings = createWithEqualityFn<SettingsStore>()(
   persist(
     devtools(createStore, {
       name: LOBE_SETTINGS + (isDev ? '_DEV' : ''),
     }),
     persistOptions,
   ),
+  equal,
 );
 
 export * from './selectors';


### PR DESCRIPTION
refs: https://github.com/pmndrs/zustand/discussions/1937

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

兼容 zustand v4.4 版本代码。下一版默认的 create 不再支持 自定义 equal 方法。但通过 `createWithEqualityFn ` 方法能直接定义默认的对比方法。

目前使用最低成本的迁移方案，默认还是深比较，这样各个模块的写法就都不用变。且不会影响现有的应用性能。（甚至替换成 fast-deep-equal 后性能还能提升。


未来可以做的事情：
- 由于我们主要用的是 shallow 比较。只在部分返回 list 或者对象的时候才用深比较。后面可以改成默认浅比较，选择部分再做深比较。这样可以少些一些 selector部分的代码。

但上述方案的问题：**需要去改各个引用地方的比较逻辑，尤其是之前用的是深比较的地方。**

因为之前用深比较的地方基本上都是重新计算后的对象或者 list，在浅比较方法看起来就是不同的对象，会导致重渲染。整个改动起来就是回归成本有点高。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

Refs:
- https://github.com/pmndrs/zustand/discussions/1937
- https://github.com/pmndrs/zustand/pull/1945

<!-- Add any other context about the Pull Request here. -->
