### PR TITLE
🐛 fix: fix mobile route

### DIFF
--- a/src/layout/AppMobileLayout.tsx
+++ b/src/layout/AppMobileLayout.tsx
@@ -6,7 +6,6 @@ import { Flexbox } from 'react-layout-kit';
 
 import SafeSpacing from '@/components/SafeSpacing';
 import MobileTabBar from '@/features/MobileTabBar';
-import { useOnFinishHydrationSession, useSessionStore } from '@/store/session';
 
 const useStyles = createStyles(({ css, cx, stylish }) => ({
   container: cx(
@@ -48,10 +47,6 @@ interface AppMobileLayoutProps extends PropsWithChildren {
 const AppMobileLayout = memo<AppMobileLayoutProps>(
   ({ children, showTabBar, navBar, style, className }) => {
     const { styles, cx } = useStyles();
-
-    useOnFinishHydrationSession(() => {
-      useSessionStore.setState({ isMobile: true });
-    }, []);
 
     return (
       <>

--- a/src/pages/chat/index.page.tsx
+++ b/src/pages/chat/index.page.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { useSessionStore } from '@/store/session';
+import { useEffectAfterSessionHydrated } from '@/store/session/hooks';
 import { agentSelectors } from '@/store/session/selectors';
 import { genSiteHeadTitle } from '@/utils/genSiteHeadTitle';
 
@@ -21,6 +22,13 @@ const Chat = memo(() => {
   ]);
   const pageTitle = genSiteHeadTitle([avatar, title].filter(Boolean).join(' '));
   const RenderLayout = mobile ? MobileLayout : DesktopLayout;
+
+  useEffectAfterSessionHydrated(
+    (store) => {
+      store.setState({ isMobile: mobile });
+    },
+    [mobile],
+  );
 
   return (
     <>

--- a/src/store/session/hooks/index.ts
+++ b/src/store/session/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useEffectAfterHydrated';
 export * from './useOnFinishHydrationSession';
 export * from './useSessionChatInit';
 export * from './useSessionHydrated';

--- a/src/store/session/hooks/useEffectAfterHydrated.ts
+++ b/src/store/session/hooks/useEffectAfterHydrated.ts
@@ -10,7 +10,13 @@ export const useEffectAfterSessionHydrated = (
     const hasRehydrated = useSessionStore.persist.hasHydrated();
 
     if (hasRehydrated) {
+      // 等价 useEffect 多次触发
       fn(useSessionStore);
+    } else {
+      // 等价于 useEffect 第一次触发
+      useSessionStore.persist.onFinishHydration(() => {
+        fn(useSessionStore);
+      });
     }
   }, deps);
 };

--- a/src/store/session/hooks/useEffectAfterHydrated.ts
+++ b/src/store/session/hooks/useEffectAfterHydrated.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+import { useSessionStore } from '@/store/session';
+
+export const useEffectAfterSessionHydrated = (
+  fn: (session: typeof useSessionStore) => void,
+  deps: any[] = [],
+) => {
+  useEffect(() => {
+    const hasRehydrated = useSessionStore.persist.hasHydrated();
+
+    if (hasRehydrated) {
+      fn(useSessionStore);
+    }
+  }, deps);
+};

--- a/src/store/session/hooks/useEffectAfterHydrated.ts
+++ b/src/store/session/hooks/useEffectAfterHydrated.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useSessionStore } from '@/store/session';
+import { useSessionStore } from '../store';
 
 export const useEffectAfterSessionHydrated = (
   fn: (session: typeof useSessionStore) => void,

--- a/src/store/session/hooks/useOnFinishHydrationSession.ts
+++ b/src/store/session/hooks/useOnFinishHydrationSession.ts
@@ -5,16 +5,12 @@ import { SessionStore, useSessionStore } from '../store';
 /**
  * 当 Session 水合完毕后才会执行的 useEffect
  * @param fn
- * @param deps
  */
-export const useOnFinishHydrationSession = (
-  fn: (state: SessionStore) => void,
-  deps: any[] = [],
-) => {
+export const useOnFinishHydrationSession = (fn: (state: SessionStore) => void) => {
   useEffect(() => {
     // 只有当水合完毕后再开始做操作
     useSessionStore.persist.onFinishHydration(() => {
       fn(useSessionStore.getState());
     });
-  }, deps);
+  }, []);
 };

--- a/src/store/session/hooks/useSessionHydrated.ts
+++ b/src/store/session/hooks/useSessionHydrated.ts
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 
-import { useOnFinishHydrationSession } from '@/store/session';
-
 import { useSessionStore } from '../store';
+import { useOnFinishHydrationSession } from './useOnFinishHydrationSession';
 
 export const useSessionHydrated = () => {
   // 根据 sessions 是否有值来判断是否已经初始化

--- a/src/store/session/hooks/useSessionHydrated.ts
+++ b/src/store/session/hooks/useSessionHydrated.ts
@@ -1,4 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+
+import { useOnFinishHydrationSession } from '@/store/session';
 
 import { useSessionStore } from '../store';
 
@@ -8,11 +10,9 @@ export const useSessionHydrated = () => {
 
   const [isInit, setInit] = useState(hasInited);
 
-  useEffect(() => {
-    useSessionStore.persist.onFinishHydration(() => {
-      if (!isInit) setInit(true);
-    });
-  }, []);
+  useOnFinishHydrationSession(() => {
+    if (!isInit) setInit(true);
+  });
 
   return isInit;
 };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修正移动端路由跳转相关问题，close #163 


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

PC 和移动端，使用了两个路由：
- PC 的 `/chat` 包含 SessionList + Conversation;
- 移动端的 `/chat`  只包含 SessionList，由 `/chat/mobile` 渲染 Conversation；

现在的问题就是由于 SessionList 的路由跳转在 PC 端要跳转 `/chat#session=xxx`，在移动端要跳转`/chat/mobile#session=xxx`。

逻辑上是两套，因此需要加 `isMobile` 状态进行区分。

之前的实现在 `src/layout/AppMobileLayout.tsx` 中做了个简单判断

```
 useOnFinishHydrationSession(() => {
      useSessionStore.setState({ isMobile: true });
    }, []);
```
思路上比较简单，当渲染到这个Layout，就将状态标记为 true。 但响应式缩放场景与异步水合场景没有考虑，所以会遇到 #163 中提到的问题。

这一版优化方案的思路也比较简单，直接 isMobile 受控于 `useResponse` 参数即可。