### PR TITLE
:lipstick: style: show topic tooltip on left side

### DIFF
--- a/src/pages/chat/features/Sidebar/Topic/TopicContent.tsx
+++ b/src/pages/chat/features/Sidebar/Topic/TopicContent.tsx
@@ -97,7 +97,7 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav }) => {
       {!editing ? (
         <Paragraph
           className={styles.title}
-          ellipsis={{ rows: 1, tooltip: title }}
+          ellipsis={{ rows: 1, tooltip: { placement: 'left', title } }}
           style={{ margin: 0 }}
         >
           {title}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
The current topic tooltip is displayed above, which obstructs the previous one. It can be moved to the left for better visibility.

#### 📝 补充信息 | Additional Information

##### Before:
![image](https://github.com/lobehub/lobe-chat/assets/3394863/775791d7-42b8-49b2-b6a0-f651b830d29f)
##### After:
![image](https://github.com/lobehub/lobe-chat/assets/3394863/0545bb1e-ae76-4f7d-afc0-4aaa27bcf7ff)

<!-- Add any other context about the Pull Request here. -->
