### PR TITLE
🐛 fix: Fix qwen, chatglm request failed

### DIFF
--- a/src/app/api/openai/createChatCompletion.ts
+++ b/src/app/api/openai/createChatCompletion.ts
@@ -23,11 +23,14 @@ export const createChatCompletion = async ({ payload, openai }: CreateChatComple
   // ============  2. send api   ============ //
 
   try {
-    const response = await openai.chat.completions.create({
-      messages: formatMessages,
-      ...params,
-      stream: true,
-    });
+    const response = await openai.chat.completions.create(
+      {
+        messages: formatMessages,
+        ...params,
+        stream: true,
+      },
+      { headers: { Accept: '*/*' } },
+    );
     const stream = OpenAIStream(response);
     return new StreamingTextResponse(stream);
   } catch (error) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修复使用第三方平台(如 one api)转openai API 时，使用qwen、chatglm 模型请求失败的问题。

这个问题是因为 openai-node 使用的错误的 `Accept`请求头部， qwen、chatglm API 验证失败而导致的。

已经向openai-node 提了issues： openai/openai-node#375，等待上游修复前，可以通过更改`Accept`解决错误请求的问题。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
