### PR TITLE
:pushpin: ci: pin ai package version to solve deploy error

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@lobehub/ui": "latest",
     "@vercel/analytics": "^1",
     "ahooks": "^3",
-    "ai": "^2",
+    "ai": "2.2.20",
     "antd": "^5",
     "antd-style": "^3",
     "brotli-wasm": "^1",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

close #425 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

`ai` package update types to match `openai` , but we have pin openai to `~4.15.0` to solve type error. So we need pin `ai`  version to match `openai`.

After we release the image upload. We will turn back to `^4` of `openai` .
<!-- Add any other context about the Pull Request here. -->
