### PR TITLE
:bug: fix: upgrade viewport for nextjs 14

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Viewport } from 'next';
 import { cookies } from 'next/headers';
 import { PropsWithChildren } from 'react';
 
@@ -42,3 +43,16 @@ const RootLayout = ({ children }: PropsWithChildren) => {
 export default RootLayout;
 
 export { default as metadata } from './metadata';
+
+export const viewport: Viewport = {
+  initialScale: 1,
+  maximumScale: 1,
+  minimumScale: 1,
+  themeColor: [
+    { color: '#f8f8f8', media: '(prefers-color-scheme: light)' },
+    { color: '#000', media: '(prefers-color-scheme: dark)' },
+  ],
+  userScalable: false,
+  viewportFit: 'cover',
+  width: 'device-width',
+};

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -40,10 +40,7 @@ const metadata: Metadata = {
     type: 'website',
     url: homepage,
   },
-  themeColor: [
-    { color: '#f8f8f8', media: '(prefers-color-scheme: light)' },
-    { color: '#000', media: '(prefers-color-scheme: dark)' },
-  ],
+
   title: {
     default: title,
     template: '%s · LobeChat',
@@ -56,14 +53,6 @@ const metadata: Metadata = {
       'https://registry.npmmirror.com/@lobehub/assets-favicons/latest/files/assets/og-960x540.png',
     ],
     title,
-  },
-  viewport: {
-    initialScale: 1,
-    maximumScale: 1,
-    minimumScale: 1,
-    userScalable: false,
-    viewportFit: 'cover',
-    width: 'device-width',
   },
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

We have upgrade to nextjs 14 in #434 (thanks to @Asuka109 ).

But due to `viewport` and `themeColor` has move to `viewport` export in nextjs 14, we need to move them to `viewport`.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs: https://nextjs.org/blog/next-14#metadata-improvements


<!-- Add any other context about the Pull Request here. -->
