### PR TITLE
🐛 fix: hotkey disabled in form tags

### DIFF
--- a/src/app/chat/features/ChatInputContent/Topic/index.tsx
+++ b/src/app/chat/features/ChatInputContent/Topic/index.tsx
@@ -25,6 +25,7 @@ const SaveTopic = memo(() => {
 
   const hotkeys = [PREFIX_KEY, SAVE_TOPIC_KEY].join('+');
   useHotkeys(hotkeys, openNewTopicOrSaveTopic, {
+    enableOnFormTags: true,
     preventDefault: true,
   });
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

It is not a dead key issue, just turn the `enableOnFormTags` option on.

Refer to:
- https://github.com/JohannesKlauss/react-hotkeys-hook#:~:text=events%20are%20prevented.-,enableOnFormTags,-boolean%20or%20FormTags
- https://github.com/JohannesKlauss/react-hotkeys-hook/issues/678

May close https://github.com/lobehub/lobe-chat/issues/349

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
