### PR TITLE
⬆️ chore: upgrade nextjs to 14.0.2

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,7 +69,7 @@ const nextConfig = {
 
   reactStrictMode: true,
 
-  transpilePackages: ['@lobehub/ui', 'antd-style', 'lodash-es'],
+  transpilePackages: ['antd-style'],
 
   webpack(config) {
     config.experiments = {
@@ -77,7 +77,15 @@ const nextConfig = {
       layers: true,
     };
 
-    config.resolve.alias['@ant-design/cssinjs'] = '@ant-design/cssinjs/lib';
+    // to fix shikiji compile error
+    // refs: https://github.com/antfu/shikiji/issues/23
+    config.module.rules.push({
+      test: /\.m?js$/,
+      type: 'javascript/auto',
+      resolve: {
+        fullySpecified: false,
+      },
+    });
 
     return config;
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,7 +69,7 @@ const nextConfig = {
 
   reactStrictMode: true,
 
-  transpilePackages: ['antd-style'],
+  transpilePackages: ['antd-style', '@lobehub/ui'],
 
   webpack(config) {
     config.experiments = {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lucide-react": "latest",
     "modern-screenshot": "^4",
     "nanoid": "^5",
-    "next": "14.0.1",
+    "next": "^14.0.2",
     "openai": "^4.17.3",
     "polished": "^4",
     "posthog-js": "^1",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

升级 Nextjs 到 14.0.2，核心做了两部分变更：
- 补充 mjs 的编译脚本，原因见下 1
- 移除 cssinjs lib  alias，原因见 2
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

相关问题记录：

1. 修正 shikiji 报错
直接升级到 14.0.2 ，会报错：`export 'getHighlighterCore' (reexported as 'getHighlighterCore') was not found in './core.mjs' (module has no exports)`。之前没详细排查，临时锁到了14.0.1：https://github.com/lobehub/lobe-chat/pull/439

<img width="1652" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/8c1db421-7309-4421-b96b-a87e89454074">

经过排查后发现是 nextjs 不支持 mjs 的编译，refs: https://github.com/antfu/shikiji/issues/23 。通过添加 webpack 构建脚本解决：

```js
  config.module.rules.push({
      test: /\.m?js$/,
      type: 'javascript/auto',
      resolve: {
        fullySpecified: false,
      },
    });
```

2. 修正 antd 的引入实例问题。背景：https://github.com/lobehub/lobe-chat/pull/434

antd 本身存在 es 和 lib 两个文件夹，对应两份组件实例。14.0.0 ~ 14.0.1 会将 antd 引入实例错误地锁定为 `lib`。（正常情况下应该是浏览器走 es，server 走 lib）。这个会导致 ssr 时cssinjs 库无法正确收集到样式缓存，进而造成 FOUC 问题（在 antd 社区中也被广泛讨论： https://github.com/ant-design/ant-design/issues/45567 ）
antd 官方给出的解决方案是将 cssinjs 的引入改为 lib，即 从 `import  { ... } from "@ant-design/cssinjs"`  改为 `import { ...} from '@ant-design/cssinjs/lib'`。而 LobeChat 中引入了 antd-style ，cssinjs 是被藏起来的。所以 @Asuka109 提供了 alias 的解决方案。

```js
    config.resolve.alias['@ant-design/cssinjs'] = '@ant-design/cssinjs/lib';
```

而 14.0.2 版本的 nextjs 应该解决了上述问题，因此将该补丁移除。

3. 虽然上面样式 FOUC 的问题通过 alias 解决了，但是 14.0.1 里仍然潜伏了一个很隐蔽的 bug：

我们在做 tts 时， 从 `@lobehub/tts/react` 引入 antd 组件会触发报错：
![76c28361803e8103cf35dbe4c75f74d6](https://github.com/lobehub/lobe-chat/assets/28616219/41df6261-7c48-4b57-839f-60a3485dd444)

此时如果打印一下这两个组件，会发现引入的不是标准的组件，而是一个 从 lib 转换为 es 模块的 object。
<img width="1780" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/653cba02-a7d4-46bf-aef7-247dfa9135ff">

升级到 14.0.2 该问题就被解决了……

<!-- Add any other context about the Pull Request here. -->
