### PR TITLE
🐛 fix: image optimization in docker standalone build

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "remark-gfm": "^3",
     "remark-html": "^15",
     "semver": "^7",
+    "sharp": "^0.32.6",
     "swr": "^2",
     "systemjs": "^6",
     "ts-md5": "^1",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Add `sharp` as dependency so image optimization can work in next standalone builds.
This is explained in Next.js [docs](https://nextjs.org/docs/messages/sharp-missing-in-production).

close #495 

#### 📝 补充信息 | Additional Information

We can install sharp as dependency in `Dockerfile` only if required.