### PR TITLE
🐛 fix: fix agent market detail scroll error

### DIFF
--- a/src/app/market/(desktop)/features/AgentDetail.tsx
+++ b/src/app/market/(desktop)/features/AgentDetail.tsx
@@ -12,6 +12,7 @@ const useStyles = createStyles(({ css, token, stylish }) => ({
   content: css`
     display: flex;
     flex-direction: column;
+    height: 100% !important;
   `,
   drawer: css`
     background: ${token.colorBgLayout};

--- a/src/layout/GlobalLayout/index.tsx
+++ b/src/layout/GlobalLayout/index.tsx
@@ -11,7 +11,7 @@ import StoreHydration from './StoreHydration';
 
 const useStyles = createStyles(({ css, token }) => ({
   bg: css`
-    overflow-y: scroll;
+    overflow-y: hidden;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
BUG复现步骤：从chat路由切换到market路由页面->点击详情超过一屏的代理（如文档问答专家）->在代理详情部分滚动
画面显示异常，整个页面产生滚动：
<img width="1180" alt="image" src="https://github.com/lobehub/lobe-chat/assets/2390305/aa34eb8a-edc0-47b9-b0a6-6b3b581e5980">
修复思路：
1.修改globalLayout的节点样式，模块内容局部滚动，这层容器应该没有内容滚动的需求了，改成overflow-y:hidden，确保外层容器不受内部组件影响产生内容溢出。
<img width="1508" alt="image" src="https://github.com/lobehub/lobe-chat/assets/2390305/995c7a2e-69e7-4fa0-9fd7-9125865f101f">
2.修改AgentDetail的DraggablePanel组件样式，该组件在当前页面刷新时高度正确设置为“100%”：
<img width="728" alt="image" src="https://github.com/lobehub/lobe-chat/assets/2390305/7ea1e2e5-bc0c-4545-b98c-e4fea362d7b6">
而在路由切换时height被错误设置为"auto"（具体原因尚未查清），导致子滚动容器DraggablePanelBody没有正确设置高度，产生内容内部滚动，导致整体内容溢出：
<img width="765" alt="image" src="https://github.com/lobehub/lobe-chat/assets/2390305/2251a4fe-dcec-4630-a695-860b17487eb8">
考虑到这个节点并没有height:auto的需求，故而在样式层面强制设置成height:100%!important来容错。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
