### PR TITLE
🐛 fix: clean gpt-3.5-turbo model

### DIFF
--- a/src/chains/__tests__/summaryTitle.test.ts
+++ b/src/chains/__tests__/summaryTitle.test.ts
@@ -51,7 +51,7 @@ describe('chainSummaryTitle', () => {
           role: 'user',
         },
       ],
-      model: LanguageModel.GPT3_5_16K,
+      model: LanguageModel.GPT4_PREVIEW,
     });
 
     // Verify that getMessagesTokenCount was called with the correct messages
@@ -97,7 +97,7 @@ describe('chainSummaryTitle', () => {
           role: 'user',
         },
       ],
-      model: 'gpt-3.5-turbo-16k',
+      // No model specified since the token count is below the limit
     });
 
     // Verify that getMessagesTokenCount was called with the correct messages

--- a/src/chains/summaryTitle.ts
+++ b/src/chains/summaryTitle.ts
@@ -1,3 +1,4 @@
+import { ModelTokens } from '@/const/modelTokens';
 import { chatHelpers } from '@/store/chat/helpers';
 import { globalHelpers } from '@/store/global/helpers';
 import { LanguageModel } from '@/types/llm';
@@ -20,11 +21,11 @@ export const chainSummaryTitle = async (
       role: 'user',
     },
   ];
-  // 如果超过 4k，则使用 GPT3.5 16K 模型
+  // 如果超过 16k，则使用 GPT-4-turbo 模型
   const tokens = await chatHelpers.getMessagesTokenCount(finalMessages);
   let model: LanguageModel | undefined = undefined;
-  if (tokens > 4000) {
-    model = LanguageModel.GPT3_5_16K;
+  if (tokens > ModelTokens[LanguageModel.GPT3_5]) {
+    model = LanguageModel.GPT4_PREVIEW;
   }
 
   return {

--- a/src/const/modelTokens.ts
+++ b/src/const/modelTokens.ts
@@ -2,9 +2,7 @@ import { LanguageModel } from '@/types/llm';
 
 // refs to: https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
 export const ModelTokens: Record<LanguageModel, number> = {
-  [LanguageModel.GPT3_5]: 4096,
-  [LanguageModel.GPT3_5_1106]: 16_385,
-  [LanguageModel.GPT3_5_16K]: 16_385,
+  [LanguageModel.GPT3_5]: 16_385,
   [LanguageModel.GPT4]: 8196,
   [LanguageModel.GPT4_PREVIEW]: 128_000,
   [LanguageModel.GPT4_VISION_PREVIEW]: 128_000,

--- a/src/store/global/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/global/selectors/__snapshots__/settings.test.ts.snap
@@ -24,14 +24,6 @@ exports[`settingsSelectors > CUSTOM_MODELS > duplicate naming model 1`] = `
     "name": "gpt-3.5-turbo",
   },
   {
-    "displayName": "gpt-3.5-turbo-1106",
-    "name": "gpt-3.5-turbo-1106",
-  },
-  {
-    "displayName": "gpt-3.5-turbo-16k",
-    "name": "gpt-3.5-turbo-16k",
-  },
-  {
     "displayName": "gpt-4",
     "name": "gpt-4",
   },
@@ -55,14 +47,6 @@ exports[`settingsSelectors > CUSTOM_MODELS > only add the model 1`] = `
   {
     "displayName": "gpt-3.5-turbo",
     "name": "gpt-3.5-turbo",
-  },
-  {
-    "displayName": "gpt-3.5-turbo-1106",
-    "name": "gpt-3.5-turbo-1106",
-  },
-  {
-    "displayName": "gpt-3.5-turbo-16k",
-    "name": "gpt-3.5-turbo-16k",
   },
   {
     "displayName": "gpt-4",

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -6,8 +6,6 @@ export enum LanguageModel {
    * GPT 3.5 Turbo
    */
   GPT3_5 = 'gpt-3.5-turbo',
-  GPT3_5_1106 = 'gpt-3.5-turbo-1106',
-  GPT3_5_16K = 'gpt-3.5-turbo-16k',
   /**
    * GPT 4
    */


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

GPT 3.5-turbo 模型在 12月 11号 之后，将默认使用最新的 3.5-turbo-1106。同时 3.5-turbo-16k 也会指向 1106，因此不再需要展示这两个模型。

**等到 12月 12 日合并**

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information


<img width="944" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/1e29d153-8a89-4012-9cb3-0defb0d0da70">

refs: https://platform.openai.com/docs/models/gpt-3-5

<!-- Add any other context about the Pull Request here. -->
