### PR TITLE
✨ feat: Do not display the access password form in the settings when there is no `ACCESS_CODE` set

### DIFF
--- a/src/app/settings/(desktop)/index.tsx
+++ b/src/app/settings/(desktop)/index.tsx
@@ -6,14 +6,15 @@ import { FC, memo } from 'react';
 import ResponsiveIndex from '@/components/ResponsiveIndex';
 
 import Common from '../common';
+import { SettingsCommonProps } from '../common/Common';
 import Layout from './layout.desktop';
 
 const Mobile: FC = dynamic(() => import('../(mobile)'), { ssr: false }) as FC;
 
-export default memo(() => (
+export default memo<SettingsCommonProps>((props) => (
   <ResponsiveIndex Mobile={Mobile}>
     <Layout>
-      <Common />
+      <Common {...props} />
     </Layout>
   </ResponsiveIndex>
 ));

--- a/src/app/settings/common/Common.tsx
+++ b/src/app/settings/common/Common.tsx
@@ -21,7 +21,11 @@ import { ThemeSwatchesNeutral, ThemeSwatchesPrimary } from '../features/ThemeSwa
 
 type SettingItemGroup = ItemGroup;
 
-const Common = memo(() => {
+export interface SettingsCommonProps {
+  showAccessCodeConfig: boolean;
+}
+
+const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig }) => {
   const { t } = useTranslation('setting');
   const [form] = AntForm.useForm();
 
@@ -154,6 +158,7 @@ const Common = memo(() => {
       {
         children: <Input.Password placeholder={t('settingSystem.accessCode.placeholder')} />,
         desc: t('settingSystem.accessCode.desc'),
+        hidden: !showAccessCodeConfig,
         label: t('settingSystem.accessCode.title'),
         name: 'password',
       },

--- a/src/app/settings/common/index.tsx
+++ b/src/app/settings/common/index.tsx
@@ -9,16 +9,16 @@ import { useSwitchSideBarOnInit } from '@/store/global/hooks/useSwitchSettingsOn
 import { SettingsTabs } from '@/store/global/initialState';
 
 import Footer from '../features/Footer';
-import Common from './Common';
+import Common, { SettingsCommonProps } from './Common';
 
-export default memo(() => {
+export default memo<SettingsCommonProps>((props) => {
   useSwitchSideBarOnInit(SettingsTabs.Common);
   const { t } = useTranslation('setting');
 
   return (
     <>
       <PageTitle title={t('tab.common')} />
-      <Common />
+      <Common {...props} />
       <Footer>LobeChat v{CURRENT_VERSION}</Footer>
     </>
   );

--- a/src/app/settings/common/page.tsx
+++ b/src/app/settings/common/page.tsx
@@ -1,3 +1,9 @@
+import { getServerConfig } from '@/config/server';
+
 import Index from './index';
 
-export default () => <Index />;
+export default () => {
+  const { SHOW_ACCESS_CODE_CONFIG } = getServerConfig();
+
+  return <Index showAccessCodeConfig={SHOW_ACCESS_CODE_CONFIG} />;
+};

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import { getServerConfig } from '@/config/server';
 import { isMobileDevice } from '@/utils/responsive';
 
 import DesktopPage from './(desktop)';
@@ -8,7 +9,9 @@ const Page = () => {
 
   const Page = mobile ? MobilePage : DesktopPage;
 
-  return <Page />;
+  const { SHOW_ACCESS_CODE_CONFIG } = getServerConfig();
+
+  return <Page showAccessCodeConfig={SHOW_ACCESS_CODE_CONFIG} />;
 };
 
 export default Page;

--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -33,8 +33,12 @@ export const getServerConfig = () => {
     regions = process.env.OPENAI_FUNCTION_REGIONS.split(',');
   }
 
+  const ACCESS_CODE = process.env.ACCESS_CODE;
+
   return {
-    ACCESS_CODE: process.env.ACCESS_CODE,
+    ACCESS_CODE,
+
+    SHOW_ACCESS_CODE_CONFIG: !!ACCESS_CODE,
 
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     OPENAI_PROXY_URL: process.env.OPENAI_PROXY_URL,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

close #547

#### 🔀 变更说明 | Description of Change

在服务端组件里获取服务端的环境变量，来判断是否有访问密码，再传给子组件，相关文档：https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-fetch

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
