### PR TITLE
🐛 fix: sharp missing in docker production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM node:20-slim AS base
 
+## Sharp dependencies, copy all the files for production
+FROM base AS sharp
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+RUN pnpm add sharp
+
 ## Install dependencies only when needed
 FROM base AS builder
 ENV PNPM_HOME="/pnpm"
@@ -13,9 +23,6 @@ COPY package.json ./
 # If you want to build docker in China
 # RUN npm config set registry https://registry.npmmirror.com/
 RUN pnpm i
-
-# https://nextjs.org/docs/messages/sharp-missing-in-production
-ENV NEXT_SHARP_PATH /app/node_modules/sharp
 
 COPY . .
 RUN pnpm run build:docker # run build standalone for docker version
@@ -39,6 +46,7 @@ RUN chown nextjs:nodejs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=sharp --chown=nextjs:nodejs /app/node_modules/.pnpm ./node_modules/.pnpm
 
 USER nextjs
 

--- a/docs/Docker-Deployment.md
+++ b/docs/Docker-Deployment.md
@@ -42,6 +42,10 @@ $ docker run -d -p 3210:3210 \
 > - The password set in the official Docker image is `lobe66` by default. Replace it with your own password to improve security.
 > - For a complete list of environment variables supported by LobeChat, please refer to the [Environment Variables](https://github.com/lobehub/lobe-chat/wiki/Environment-Variable.zh-CN) section.
 
+> \[!WARNING]
+>
+> If the architecture of your **deployed server differs from the container architecture**, you may need to perform cross-compilation for **Sharp**. For further details, please refer to the documentation on [Sharp Cross-platform](https://sharp.pixelplumbing.com/install#cross-platform).
+
 #### Use a proxy address
 
 If you need to use OpenAI service through a proxy, you can use the `OPENAI_PROXY_URL` environment variable to configure the proxy address:

--- a/docs/Docker-Deployment.zh-CN.md
+++ b/docs/Docker-Deployment.zh-CN.md
@@ -42,6 +42,10 @@ $ docker run -d -p 3210:3210 \
 > - 官方 Docker 镜像中设定的密码默认为 `lobe66`，请将其替换为自己的密码以提升安全性
 > - LobeChat 支持的完整环境变量列表请参考 [环境变量](https://github.com/lobehub/lobe-chat/wiki/Environment-Variable.zh-CN) 部分
 
+> \[!WARNING]
+>
+> 注意，当**部署架构与镜像的不一致时**，需要对 **Sharp** 进行交叉编译，详见 [Sharp 交叉编译](https://sharp.pixelplumbing.com/install#cross-platform)
+
 #### 使用代理地址
 
 如果你需要通过代理使用 OpenAI 服务，你可以使用 `OPENAI_PROXY_URL` 环境变量来配置代理地址：


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

#598 was committed to fix the issue of missing "sharp" in the production environment. I apologize for the oversight in my previous PR(#598), as I did not encounter any errors when testing with `NEXT_SHARP_PATH` in my local environment. However, upon deploying on other devices, the error resurfaced. Therefore, after further investigation, I concluded that the **previous PR(#598) did not effectively resolve the issue**, and using `NEXT_SHARP_PATH` proved to be an invalid solution in this case.

I reviewed the regarding the error from the following sources: [Stack Overflow](https://stackoverflow.com/a/77393576) and [NextJS GitHub Discussions](https://github.com/vercel/next.js/discussions/40125#discussioncomment-7431315).

I attempted to run the `node -e "require('/app/node_modules/sharp')"` command to check if the sharp dependency is correctly imported. In the container of the previous release version (v0.110.0), the sharp package failed to load properly. Subsequently, I validated the solution mentioned in the post and confirmed that the sharp dependency could be imported successfully. and the error `⨯ Error: 'sharp' is required to be installed in standalone mode for the image optimization to function correctly.` did not occur when rendering the image component.

<img width="1398" alt="Screenshot 2023-12-09 035907" src="https://github.com/lobehub/lobe-chat/assets/18101258/99fe422b-5188-4c43-bcee-ee8ced9e247e">

Lastly, to minimize the size of the image as much as possible, I created a stage for sharp, which solely copies the sharp-related dependency files into the production environment.

#### 📝 补充信息 | Additional Information

When the architecture of the image is different from the deployment, cross-compilation is required for sharp. I made a warning in the documentation regarding this, which can be found at this link: https://sharp.pixelplumbing.com/install#cross-platform.
