### PR TITLE
🐛 fix: fix setting plugin i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@types/ua-parser-js": "^0.7",
     "@types/uuid": "^9",
     "@umijs/lint": "^4",
-    "@vitest/coverage-v8": "^1",
+    "@vitest/coverage-v8": "0.34.6",
     "commitlint": "^18",
     "consola": "^3",
     "dpdm": "^3",
@@ -162,7 +162,7 @@
     "stylelint": "^15",
     "ts-node": "^10",
     "typescript": "^5",
-    "vitest": "^1"
+    "vitest": "0.34.6"
   },
   "publishConfig": {
     "access": "public",

--- a/src/features/AgentSetting/AgentPlugin/index.tsx
+++ b/src/features/AgentSetting/AgentPlugin/index.tsx
@@ -27,7 +27,7 @@ const AgentPlugin = memo(() => {
     s.toggleAgentPlugin,
   ]);
 
-  const installedPlugins = useToolStore(pluginSelectors.installedPlugins, isEqual);
+  const installedPlugins = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
   const useFetchInstalledPlugins = useToolStore((s) => s.useFetchInstalledPlugins);
 
   const { isLoading } = useFetchInstalledPlugins();
@@ -36,7 +36,7 @@ const AgentPlugin = memo(() => {
 
   //  =========== Plugin List =========== //
 
-  const list = installedPlugins.map(({ identifier, type, manifest: { meta } = {} }) => {
+  const list = installedPlugins.map(({ identifier, type, meta }) => {
     const isCustomPlugin = type === 'customPlugin';
 
     return {

--- a/src/store/tool/slices/plugin/selectors.test.ts
+++ b/src/store/tool/slices/plugin/selectors.test.ts
@@ -7,7 +7,7 @@ import { pluginSelectors } from './selectors';
 
 const mockState = {
   ...initialState,
-  pluginManifestLoading: {
+  pluginInstallLoading: {
     'plugin-1': false,
     'plugin-2': true,
   },
@@ -137,6 +137,75 @@ describe('pluginSelectors', () => {
       } as ToolStoreState;
       const result = pluginSelectors.isPluginHasUI('ui-plugin')(stateWithUIPlugin);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('isPluginInstalled', () => {
+    it('should return true if the plugin is installed', () => {
+      const result = pluginSelectors.isPluginInstalled('plugin-1')(mockState);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the plugin is not installed', () => {
+      const result = pluginSelectors.isPluginInstalled('non-installed-plugin')(mockState);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getInstalledPluginById', () => {
+    it('should return the installed plugin by id', () => {
+      const result = pluginSelectors.getInstalledPluginById('plugin-1')(mockState);
+      expect(result).toEqual(mockState.installedPlugins[0]);
+    });
+
+    it('should return undefined if the plugin is not installed', () => {
+      const result = pluginSelectors.getInstalledPluginById('non-installed-plugin')(mockState);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getPluginManifestLoadingStatus', () => {
+    it('should return "loading" if the plugin manifest is being loaded', () => {
+      const result = pluginSelectors.getPluginManifestLoadingStatus('plugin-2')(mockState);
+      expect(result).toBe('loading');
+    });
+
+    it('should return "error" if the plugin manifest is not found', () => {
+      const result =
+        pluginSelectors.getPluginManifestLoadingStatus('non-existing-plugin')(mockState);
+      expect(result).toBe('error');
+    });
+
+    it('should return "success" if the plugin manifest is loaded', () => {
+      const result = pluginSelectors.getPluginManifestLoadingStatus('plugin-1')(mockState);
+      expect(result).toBe('success');
+    });
+  });
+
+  describe('storeAndInstallPluginsIdList', () => {
+    it('should return a list of unique plugin identifiers from both installed and store lists', () => {
+      const result = pluginSelectors.storeAndInstallPluginsIdList(mockState);
+      expect(result).toEqual(['plugin-1', 'plugin-2']);
+    });
+  });
+
+  describe('installedPluginManifestList', () => {
+    it('should return a list of manifests for installed plugins', () => {
+      const result = pluginSelectors.installedPluginManifestList(mockState);
+      const expectedManifests = mockState.installedPlugins.map((p) => p.manifest);
+      expect(result).toEqual(expectedManifests);
+    });
+  });
+
+  describe('installedPluginMetaList', () => {
+    it('should return a list of meta information for installed plugins', () => {
+      const result = pluginSelectors.installedPluginMetaList(mockState);
+      const expectedMetaList = mockState.installedPlugins.map((p) => ({
+        identifier: p.identifier,
+        meta: pluginSelectors.getPluginMetaById(p.identifier)(mockState),
+        type: p.type,
+      }));
+      expect(result).toEqual(expectedMetaList);
     });
   });
 });

--- a/src/store/tool/slices/plugin/selectors.ts
+++ b/src/store/tool/slices/plugin/selectors.ts
@@ -63,6 +63,7 @@ const installedPluginMetaList = (s: ToolStoreState) =>
   installedPlugins(s).map((p) => ({
     identifier: p.identifier,
     meta: getPluginMetaById(p.identifier)(s),
+    type: p.type,
   }));
 
 const isPluginHasUI = (id: string) => (s: ToolStoreState) => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

close #602 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

webstorm 的测试模块暂未兼容 vitest v1 ，因此临时先降级到 `0.34.6`。预计兼容能力将在 `2023.3.1` 中释出。届时再升级到 vitest v1。refs: https://youtrack.jetbrains.com/issue/WEB-64001/Prepare-update-to-Vitest-1.0.0

<!-- Add any other context about the Pull Request here. -->
