### PR TITLE
🐛 fix: 角色设定弹窗不应该在整个屏幕滚动

### DIFF
--- a/src/app/chat/features/SystemRole/index.tsx
+++ b/src/app/chat/features/SystemRole/index.tsx
@@ -78,6 +78,7 @@ const SystemRole = memo(() => {
             <EditableMessage
               classNames={{ markdown: styles.prompt }}
               editing={editing}
+              height={editing ? 'calc(70vh - 108px)' : 'calc(70vh - 357.43px)'}
               model={{
                 extra: (
                   <AgentInfo


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

角色设定的弹窗，当编辑信息过多时，滚动区域是整个屏幕，我理解优秀的做法应该是仅在内容区域进行滚动，这样还可以将重要的按钮如[编辑]/[取消]总是显示。

#### 📝 补充信息 | Additional Information

修改前：

![PixPin_2023-12-19_15-27-06](https://github.com/lobehub/lobe-chat/assets/63507251/e8d8ba5b-f2ec-4668-8b00-c16979fdb9c5)

修改后：

![PixPin_2023-12-19_15-14-22](https://github.com/lobehub/lobe-chat/assets/63507251/f253d923-744d-45c5-9b2c-3dd6acd7e56c)

