### PR TITLE
✨ feat: 助手列表增加拖拽排序功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5",
+    "@hello-pangea/dnd": "^16.5.0",
     "@icons-pack/react-simple-icons": "^9",
     "@lobehub/chat-plugin-sdk": "latest",
     "@lobehub/chat-plugins-gateway": "latest",

--- a/src/app/chat/features/SessionListContent/List/index.tsx
+++ b/src/app/chat/features/SessionListContent/List/index.tsx
@@ -1,3 +1,4 @@
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import { createStyles, useResponsive } from 'antd-style';
 import Link from 'next/link';
 import { memo } from 'react';
@@ -5,6 +6,7 @@ import LazyLoad from 'react-lazy-load';
 
 import { SESSION_CHAT_URL } from '@/const/url';
 import { useSessionHydrated, useSessionStore } from '@/store/session';
+import { SessionAction } from '@/store/session/slices/session/action';
 import { LobeAgentSession } from '@/types/session';
 
 import AddButton from './AddButton';
@@ -17,11 +19,47 @@ const useStyles = createStyles(
   `,
 );
 
+const getListStyle = (isDraggingOver: boolean) => ({
+  paddingBottom: isDraggingOver ? 70 : 0,
+  width: '100%',
+});
+
+interface Result {
+  destination: {
+    index: number;
+  } | null;
+  source: {
+    index: number;
+  };
+}
+
+const onDragEnd = (
+  result: Result,
+  dataSource: LobeAgentSession[],
+  batchUpdateSessionsFn: SessionAction['batchUpdateSessions'],
+) => {
+  const sourceIndex = result.source.index;
+  const destinationIndex = result.destination ? result.destination.index : null;
+  if (destinationIndex === null) return;
+  const step = destinationIndex - sourceIndex > 0 ? 1 : -1;
+  dataSource[sourceIndex].sortId = destinationIndex;
+  dataSource[destinationIndex].sortId = destinationIndex - step;
+  for (let i = sourceIndex + step; i !== destinationIndex; i += step) {
+    dataSource[i].sortId = i - step;
+  }
+  batchUpdateSessionsFn(dataSource.map((item) => ({ data: item, id: item.id })));
+};
+
 interface SessionListProps {
   dataSource: LobeAgentSession[];
 }
 const SessionList = memo<SessionListProps>(({ dataSource }) => {
-  const [activeSession, switchSession] = useSessionStore((s) => [s.activeSession, s.switchSession]);
+  dataSource.sort((a, b) => (a.sortId ?? -1) - (b.sortId ?? -1));
+  const [activeSession, switchSession, batchUpdateSessions] = useSessionStore((s) => [
+    s.activeSession,
+    s.switchSession,
+    s.batchUpdateSessions,
+  ]);
   const { styles } = useStyles();
   const isInit = useSessionHydrated();
 
@@ -30,21 +68,45 @@ const SessionList = memo<SessionListProps>(({ dataSource }) => {
   return !isInit ? (
     <SkeletonList />
   ) : dataSource.length > 0 ? (
-    dataSource.map(({ id }) => (
-      <LazyLoad className={styles} key={id}>
-        <Link
-          aria-label={id}
-          href={SESSION_CHAT_URL(id, mobile)}
-          onClick={(e) => {
-            e.preventDefault();
-            if (mobile) switchSession(id);
-            else activeSession(id);
-          }}
-        >
-          <SessionItem id={id} />
-        </Link>
-      </LazyLoad>
-    ))
+    <DragDropContext
+      onDragEnd={async (result) => await onDragEnd(result, dataSource, batchUpdateSessions)}
+    >
+      <Droppable droppableId="droppable">
+        {(provided, snapshot) => (
+          <div
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            style={getListStyle(snapshot.isDraggingOver)}
+          >
+            {dataSource.map(({ id }, index) => (
+              <Draggable draggableId={id} index={index} key={id}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.draggableProps}
+                    {...provided.dragHandleProps}
+                  >
+                    <LazyLoad className={styles} key={id}>
+                      <Link
+                        aria-label={id}
+                        href={SESSION_CHAT_URL(id, mobile)}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          if (mobile) switchSession(id);
+                          else activeSession(id);
+                        }}
+                      >
+                        <SessionItem id={id} />
+                      </Link>
+                    </LazyLoad>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
   ) : (
     <AddButton />
   );

--- a/src/database/models/session.ts
+++ b/src/database/models/session.ts
@@ -22,6 +22,10 @@ class _SessionModel extends BaseModel {
     return this._batchAdd(sessions, { idGenerator: uuid });
   }
 
+  async batchUpdate(sessions: Array<{ data: LobeAgentSession; id: string }>) {
+    return this._batchUpdate(sessions);
+  }
+
   async query({
     pageSize = 9999,
     current = 0,

--- a/src/database/schemas/session.ts
+++ b/src/database/schemas/session.ts
@@ -50,6 +50,7 @@ export const DB_SessionSchema = z.object({
   config: AgentSchema,
   group: z.string().default('default'),
   meta: LobeMetaDataSchema,
+  sortId: z.number().default(-1).optional(),
   type: z.enum(['agent', 'group']).default('agent'),
 });
 

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -21,6 +21,10 @@ class SessionService {
     return SessionModel.batchCreate(importSessions);
   }
 
+  async batchUpdateSessions(importSessions: Array<{ data: LobeAgentSession; id: string }>) {
+    return SessionModel.batchUpdate(importSessions);
+  }
+
   async getSessions(): Promise<LobeSessions> {
     return SessionModel.query();
   }

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -28,6 +28,7 @@ export interface SessionAction {
    * @param sessionId
    */
   activeSession: (sessionId: string) => void;
+  batchUpdateSessions: (agents: Array<{ data: LobeAgentSession; id: string }>) => Promise<void>;
   /**
    * reset sessions to default
    */
@@ -81,6 +82,12 @@ export const createSessionSlice: StateCreator<
 > = (set, get) => ({
   activeSession: (sessionId) => {
     set({ activeId: sessionId }, false, n('activeSession'));
+  },
+
+  batchUpdateSessions: async (agents) => {
+    await sessionService.batchUpdateSessions(agents);
+
+    await get().refreshSessions();
   },
 
   clearSessions: async () => {

--- a/src/store/session/slices/session/initialState.ts
+++ b/src/store/session/slices/session/initialState.ts
@@ -24,6 +24,7 @@ export const initLobeSession: LobeAgentSession = {
   createdAt: Date.now(),
   id: '',
   meta: DEFAULT_AGENT_META,
+  sortId: -1,
   type: LobeSessionType.Agent,
   updatedAt: Date.now(),
 };

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -20,6 +20,7 @@ export enum SessionGroupDefaultKeys {
 export interface LobeAgentSession extends BaseDataModel {
   config: LobeAgentConfig;
   group?: SessionGroupKey;
+  sortId?: number;
   type: LobeSessionType.Agent;
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

交互优化相关功能：为助手列表增加拖拽排序功能

主要变更如下

- 新增库`@hello-pangea/dnd`
- 本地数据操作层增加批量更新函数
- 助手列表中每个助手JSON新增`sortId`字段

> 为什么新增sortId字段，而不是直接调整数组的顺序？
>
> 因为该助手数组区分了是否pinned，即包含了两个数组列表

#### 📝 补充信息 | Additional Information

效果演示desktop：

![PixPin_2023-12-21_16-15-13](https://github.com/lobehub/lobe-chat/assets/63507251/ddcbdab1-9e9c-471d-ae60-563da2556f36)

效果演示mobile：

![PixPin_2023-12-21_16-17-05](https://github.com/lobehub/lobe-chat/assets/63507251/443c4620-f254-46ae-8bfa-4318599f0d47)

TODO：由于操作本地数据属于异步操作，所以产生了抖动，可以增加一个数组内存缓存来优化拖拽抖动
