### PR TITLE
✨ feat: Add image download functionality to DallE render component

### DIFF
--- a/src/tools/dalle/Render/index.tsx
+++ b/src/tools/dalle/Render/index.tsx
@@ -1,21 +1,53 @@
-import { ImageGallery } from '@lobehub/ui';
-import { memo } from 'react';
+import { ActionIcon, ImageGallery } from '@lobehub/ui';
+import { Download } from 'lucide-react';
+import { memo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import GalleyGrid from '@/components/GalleyGrid';
+import { fileService } from '@/services/file';
 import { BuiltinRenderProps } from '@/types/tool';
 import { DallEImageItem } from '@/types/tool/dalle';
 
 import ImageItem from './Item';
 
-const DallE = memo<BuiltinRenderProps<DallEImageItem[]>>(({ content, messageId }) => (
-  <Flexbox gap={16}>
-    {/* 没想好工具条的作用 */}
-    {/*<ToolBar content={content} messageId={messageId} />*/}
-    <ImageGallery>
-      <GalleyGrid items={content.map((c) => ({ ...c, messageId }))} renderItem={ImageItem} />
-    </ImageGallery>
-  </Flexbox>
-));
+const DallE = memo<BuiltinRenderProps<DallEImageItem[]>>(({ content, messageId }) => {
+  const [current, setCurrent] = useState<number>(0);
+
+  const handleDownload = async () => {
+    // 1. Retrieve the blob URL of an image by its imageId
+    const id = content[current]?.imageId;
+    if (!id) return;
+    const { url } = await fileService.getFile(id);
+    // 2. Download the image
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'image.png'; // 设置下载的文件名
+    link.click();
+  };
+
+  return (
+    <Flexbox gap={16}>
+      {/* 没想好工具条的作用 */}
+      {/*<ToolBar content={content} messageId={messageId} />*/}
+      <ImageGallery
+        preview={{
+          // 切换图片时设置
+          onChange: (current: number) => {
+            setCurrent(current);
+          },
+          // 点击预览显示时设置
+          onVisibleChange: (visible: boolean, _prevVisible: boolean, current: number) => {
+            if (visible) {
+              setCurrent(current);
+            }
+          },
+          toolbarAddon: <ActionIcon color={'#fff'} icon={Download} onClick={handleDownload} />,
+        }}
+      >
+        <GalleyGrid items={content.map((c) => ({ ...c, messageId }))} renderItem={ImageItem} />
+      </ImageGallery>
+    </Flexbox>
+  );
+});
 
 export default DallE;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

在DallE中的图片预览中增加下载功能，页面预览如下：

![image](https://github.com/lobehub/lobe-chat/assets/63507251/453e49d4-69e1-4a27-8708-052d6555a03d)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

当前并未实现下载功能，因为lobe-ui中的preview组件的当前实现不能获取当前图片数组的下标，所以需要等lobe-ui发版之后，这里再更新一下组件库版号应该就可以了

```tsx
  onVisibleChange: (visible: boolean, _prevVisible: boolean, current: number) => {
    if (visible) {
      setCurrent(current);
    }
  },
```
` _prevVisible: boolean, current: numbe`这两个参数传不进去


[lobe-ui的PR链接](https://github.com/lobehub/lobe-ui/pull/98)

<!-- Add any other context about the Pull Request here. -->
