### PR TITLE
🐛 fix: Fix the issue of the input box losing focus after sending a message on the desktop version

### DIFF
--- a/src/features/ChatInput/useChatInput.ts
+++ b/src/features/ChatInput/useChatInput.ts
@@ -1,6 +1,7 @@
 import { TextAreaRef } from 'antd/es/input/TextArea';
 import { useCallback, useRef, useState } from 'react';
 
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import { useSessionStore } from '@/store/session';
@@ -23,12 +24,15 @@ export const useChatInput = () => {
     s.updateInputMessage,
     s.stopGenerateMessage,
   ]);
+  const mobile = useIsMobile();
 
   const handleSend = useCallback(() => {
     setExpand(false);
-    ref?.current?.blur();
+    if (mobile) {
+      ref?.current?.blur();
+    }
     onSend();
-  }, [onSend]);
+  }, [onSend, mobile]);
 
   return {
     canUpload,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Close #829

#### 📝 补充信息 | Additional Information

原本的逻辑应该是用于移动端的，发送消息后输入框失去焦点，所以加一个判断
