### PR TITLE
🔨 chore: fix vercel build error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "/bun1/bun install"
+  "installCommand": "npx bun@1.0.15 install"
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Vercel bump the bun version to 1.0.21 and cause the `Cannot find module '/vercel/path0/install.js'` error.

downgrade the bun version to 1.0.15 and fixed.

fix #953 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

relate issue: https://github.com/oven-sh/bun/issues/8010

<!-- Add any other context about the Pull Request here. -->
