### PR TITLE
⬆️ chore: upgrade vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@types/ua-parser-js": "^0.7",
     "@types/uuid": "^9",
     "@umijs/lint": "^4",
-    "@vitest/coverage-v8": "1.1.1",
+    "@vitest/coverage-v8": "^1.1.3",
     "commitlint": "^18",
     "consola": "^3",
     "dpdm": "^3",
@@ -177,7 +177,7 @@
     "typescript": "^5",
     "unified": "^11",
     "unist-util-visit": "^5",
-    "vitest": "1.1.1",
+    "vitest": "^1.1.3",
     "vitest-canvas-mock": "^0.3.3"
   },
   "publishConfig": {

--- a/src/store/tool/slices/store/action.test.ts
+++ b/src/store/tool/slices/store/action.test.ts
@@ -19,12 +19,6 @@ vi.mock('@/services/plugin', () => ({
   },
 }));
 
-// Mock necessary modules and functions
-vi.mock('antd', () => ({
-  notification: {
-    error: vi.fn(),
-  },
-}));
 // Mock i18next
 vi.mock('i18next', () => ({
   t: vi.fn((key) => key),
@@ -179,6 +173,8 @@ describe('useToolStore:pluginStore', () => {
 
   describe('installPlugin', () => {
     it('should install a plugin with valid manifest', async () => {
+      vi.spyOn(notification, 'error');
+
       const pluginIdentifier = 'plugin1';
 
       const originalUpdateInstallLoadingState = useToolStore.getState().updateInstallLoadingState;
@@ -253,6 +249,8 @@ describe('useToolStore:pluginStore', () => {
 
       const error = new TypeError('noManifest');
 
+      // Mock necessary modules and functions
+      vi.spyOn(notification, 'error');
       (pluginService.getPluginManifest as Mock).mockRejectedValue(error);
 
       useToolStore.setState({


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

升级 vitest 到 最新，针对 notification 的 mock 改造成 `spyOn`
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

vitest 1.1.2 起改动了 mock 的逻辑，之前可以正常跑的：
```
// Mock necessary modules and functions
vi.mock('antd', () => ({
  notification: {
    error: vi.fn(),
  },
}));
```

会报错：
```
⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: [vitest] Cannot mock "antd" because it is already loaded. Did you import it in a setup file?

Please, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again. See: https://vitest.dev/guide/common-errors.html#cannot-mock-mocked-file.js-because-it-is-already-loaded
```

https://github.com/lobehub/lobe-chat/actions/runs/7434828902/job/20229454903?pr=964


