### PR TITLE
✨ feat: implement custom session grouping

### DIFF
--- a/src/app/chat/features/SessionListContent/DefaultMode.tsx
+++ b/src/app/chat/features/SessionListContent/DefaultMode.tsx
@@ -17,6 +17,7 @@ const SessionListContent = memo(() => {
   const unpinnedSessionList = useSessionStore(sessionSelectors.unpinnedSessionList, isEqual);
   const pinnedList = useSessionStore(sessionSelectors.pinnedSessionList, isEqual);
   const hasPinnedSessionList = useSessionStore(sessionSelectors.hasPinnedSessionList);
+  const customSessionGroup = useSessionStore(sessionSelectors.customSessionGroup, isEqual);
 
   const [sessionGroupKeys, updatePreference] = useGlobalStore((s) => [
     preferenceSelectors.sessionGroupKeys(s),
@@ -29,10 +30,15 @@ const SessionListContent = memo(() => {
       key: 'pinned',
       label: t('pin'),
     },
+    ...Object.keys(customSessionGroup).map((key) => ({
+      children: <SessionList dataSource={customSessionGroup[key]} />,
+      key,
+      label: key,
+    })),
     {
       children: <SessionList dataSource={unpinnedSessionList} />,
-      key: 'sessionList',
-      label: t('sessionList'),
+      key: 'defaultList',
+      label: t('defaultList'),
     },
   ].filter(Boolean) as CollapseProps['items'];
 

--- a/src/app/chat/features/SessionListContent/List/Item/CreateGroupModal.tsx
+++ b/src/app/chat/features/SessionListContent/List/Item/CreateGroupModal.tsx
@@ -1,0 +1,45 @@
+import { Input, Modal, type ModalProps } from '@lobehub/ui';
+import { message } from 'antd';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type CreateGroupModalProps = ModalProps & {
+  onInputOk: (input: string) => void;
+};
+
+const CreateGroupModal = ({ open, onCancel, onInputOk }: CreateGroupModalProps) => {
+  const { t } = useTranslation('common');
+
+  const [input, setInput] = useState('');
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const handleClickOk = (input: string) => {
+    if (input.length === 0 || input.length > 10) {
+      messageApi.warning(t('group.inputMsg'));
+      return;
+    }
+    onInputOk(input);
+  };
+
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      <Modal
+        allowFullscreen
+        onCancel={onCancel}
+        onOk={() => handleClickOk(input)}
+        open={open}
+        title={t('group.newGroup')}
+        width={400}
+      >
+        <Input
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={t('group.inputPlaceholder')}
+          value={input}
+        />
+      </Modal>
+      {contextHolder}
+    </div>
+  );
+};
+
+export default CreateGroupModal;

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -7,6 +7,7 @@ export default {
   confirmClearCurrentMessages: '即将清空当前会话消息，清空后将无法找回，请确认你的操作',
   confirmRemoveSessionItemAlert: '即将删除该助手，删除后该将无法找回，请确认你的操作',
   defaultAgent: '自定义助手',
+  defaultList: '默认列表',
   defaultSession: '自定义助手',
   duplicateTitle: '{{title}} 副本',
   historyRange: '历史范围',

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -15,6 +15,7 @@ export default {
   copy: '复制',
   copySuccess: '复制成功',
   defaultAgent: '自定义助手',
+  defaultList: '默认列表',
   defaultSession: '自定义助手',
   delete: '删除',
   duplicate: '创建副本',
@@ -29,6 +30,12 @@ export default {
     globalSetting: '导出全局设置',
   },
   feedback: '反馈与建议',
+  group: {
+    inputMsg: '组名长度需在1-10之内',
+    inputPlaceholder: '新建分组/移入指定分组',
+    moveGroup: '移入分组',
+    newGroup: '新建分组',
+  },
   historyRange: '历史范围',
   import: '导入配置',
   importModal: {

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -66,6 +66,7 @@ export interface SessionAction {
    * switch session url
    */
   switchSession: (sessionId?: string) => void;
+  updateSessionGroup: (sessionId: string, group: string) => Promise<void>;
   /**
    * A custom hook that uses SWR to fetch sessions data.
    */
@@ -157,12 +158,19 @@ export const createSessionSlice: StateCreator<
 
     router?.push(SESSION_CHAT_URL(id, get().isMobile));
   },
+
   switchSession: (sessionId = INBOX_SESSION_ID) => {
     const { isMobile, router } = get();
 
     get().activeSession(sessionId);
 
     router?.push(SESSION_CHAT_URL(sessionId, isMobile));
+  },
+
+  updateSessionGroup: async (sessionId, group) => {
+    await sessionService.updateSessionGroup(sessionId, group);
+
+    await get().refreshSessions();
   },
 
   useFetchSessions: () =>

--- a/src/store/session/slices/session/selectors/list.ts
+++ b/src/store/session/slices/session/selectors/list.ts
@@ -16,6 +16,22 @@ const pinnedSessionList = (s: SessionStore) =>
 const unpinnedSessionList = (s: SessionStore) =>
   defaultSessions(s).filter((s) => s.group === SessionGroupDefaultKeys.Default);
 
+const customSessionGroup = (s: SessionStore) => {
+  const group2SessionList: Record<string, LobeAgentSession[]> = {};
+  // 1. 筛选用户自定义的session
+  const customList = defaultSessions(s).filter(
+    (s) =>
+      s.group !== SessionGroupDefaultKeys.Pinned && s.group !== SessionGroupDefaultKeys.Default,
+  );
+  // 2. 进行分组
+  for (const s of customList) {
+    if (!s.group) continue;
+    group2SessionList[s.group] = group2SessionList[s.group] || [];
+    group2SessionList[s.group].push(s);
+  }
+  return group2SessionList;
+};
+
 const getSessionById =
   (id: string) =>
   (s: SessionStore): LobeAgentSession =>
@@ -52,6 +68,7 @@ const isInboxSession = (s: SessionStore) => s.activeId === INBOX_SESSION_ID;
 export const sessionSelectors = {
   currentSession,
   currentSessionSafe,
+  customSessionGroup,
   getSessionById,
   getSessionMetaById,
   hasCustomAgents,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

新增的助手列表分组管理功能，视频演示：


https://github.com/lobehub/lobe-chat/assets/63507251/1973fc28-b109-456b-b059-7c2cff1a965b



#### 📝 补充信息 | Additional Information

1. 我是以尽量少的代码改动实现了一个相对简单的分组管理功能
2. 我理解分组管理功能对于大多数用户来说并不是一个常用的功能，甚至不会使用，即使使用，使用频率也是非常少的，所以入口比较深，在Dropdown里
3. 拖拽排序当前PR未实现，如果可以后续再来做，一步步来，当前PR已经能满足大部分分组场景

