### PR TITLE
🐛 fix: antd i18n miss error

### DIFF
--- a/src/app/chat/features/SessionListContent/List/Item/Actions.tsx
+++ b/src/app/chat/features/SessionListContent/List/Item/Actions.tsx
@@ -94,10 +94,8 @@ const Actions = memo<ActionProps>(({ id, setOpen }) => {
           domEvent.stopPropagation();
 
           modal.confirm({
-            cancelText: t('cancel'),
             centered: true,
             okButtonProps: { danger: true },
-            okText: t('ok'),
             onOk: () => {
               removeSession(id);
             },

--- a/src/app/settings/common/Common.tsx
+++ b/src/app/settings/common/Common.tsx
@@ -49,10 +49,8 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig }) => {
 
   const handleReset = useCallback(() => {
     modal.confirm({
-      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: { danger: true },
-      okText: t('ok', { ns: 'common' }),
       onOk: () => {
         resetSettings();
         form.setFieldsValue(DEFAULT_SETTINGS);
@@ -63,12 +61,10 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig }) => {
 
   const handleClear = useCallback(() => {
     modal.confirm({
-      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: {
         danger: true,
       },
-      okText: t('ok', { ns: 'common' }),
       onOk: async () => {
         await clearSessions();
         await removeAllPlugins();

--- a/src/const/locale.ts
+++ b/src/const/locale.ts
@@ -1,4 +1,4 @@
-import { Locales, normalizeLocale, supportLocales } from '@/locales/resources';
+import { normalizeLocale, supportLocales } from '@/locales/resources';
 
 export const DEFAULT_LANG = 'en-US';
 export const LOBE_LOCALE_COOKIE = 'LOBE_LOCALE';
@@ -7,6 +7,6 @@ export const LOBE_LOCALE_COOKIE = 'LOBE_LOCALE';
  * Check if the language is supported
  * @param locale
  */
-export const isLocaleNotSupport = (locale: Locales) => {
+export const isLocaleNotSupport = (locale: string) => {
   return normalizeLocale(locale) === DEFAULT_LANG || !supportLocales.includes(locale);
 };

--- a/src/features/ChatInput/ActionBar/Clear.tsx
+++ b/src/features/ChatInput/ActionBar/Clear.tsx
@@ -22,9 +22,7 @@ const Clear = memo(() => {
 
   return (
     <Popconfirm
-      cancelText={t('cancel', { ns: 'common' })}
       okButtonProps={{ danger: true }}
-      okText={t('ok', { ns: 'common' })}
       onConfirm={() => {
         resetConversation();
       }}

--- a/src/features/PluginDetailModal/index.tsx
+++ b/src/features/PluginDetailModal/index.tsx
@@ -33,8 +33,6 @@ const PluginDetailModal = memo<PluginDetailModalProps>(
     return (
       <Modal
         allowFullscreen
-        cancelText={t('cancel', { ns: 'common' })}
-        okText={t('ok', { ns: 'common' })}
         onCancel={onClose}
         onOk={() => {
           onClose();

--- a/src/features/PluginDevModal/index.tsx
+++ b/src/features/PluginDevModal/index.tsx
@@ -96,7 +96,6 @@ const DevModal = memo<DevModalProps>(
       >
         <Modal
           allowFullscreen
-          cancelText={t('cancel', { ns: 'common' })}
           footer={footer}
           okText={t('dev.save')}
           onCancel={(e) => {

--- a/src/layout/GlobalLayout/Locale.tsx
+++ b/src/layout/GlobalLayout/Locale.tsx
@@ -1,40 +1,61 @@
 import { ConfigProvider } from 'antd';
-import { PropsWithChildren, memo, useState } from 'react';
+import { PropsWithChildren, memo, useEffect, useRef, useState } from 'react';
 import useSWR from 'swr';
 
+import { DEFAULT_LANG } from '@/const/locale';
 import { createI18nNext } from '@/locales/create';
 import { useOnFinishHydrationGlobal } from '@/store/global';
 import { isOnServerSide } from '@/utils/env';
 import { switchLang } from '@/utils/switchLang';
 
 interface LocaleLayoutProps extends PropsWithChildren {
-  lang?: string;
+  defaultLang?: string;
 }
 
-const Locale = memo<LocaleLayoutProps>(({ children, lang }) => {
+const FETCH_ANTD_LOCALE = 'fetch-antd-locale';
+
+const Locale = memo<LocaleLayoutProps>(({ children, defaultLang }) => {
+  const [lang, setLang] = useState(defaultLang ?? DEFAULT_LANG);
+  const [i18n] = useState(createI18nNext(defaultLang));
+
   const { data: locale } = useSWR(
-    lang,
-    async () =>
-      await import(`antd/locale/${lang?.includes('-') ? lang?.replace('-', '_') : 'en_US'}.js`),
+    [FETCH_ANTD_LOCALE, lang],
+    async ([, l]) => {
+      const localeName = l?.includes('-') ? l?.replace('-', '_') : 'en_US';
+      const antdLocale = await import(`antd/locale/${localeName}.js`);
+
+      return antdLocale.default ?? antdLocale;
+    },
     { revalidateOnFocus: false },
   );
-  const [i18n] = useState(createI18nNext(lang));
 
   // if run on server side, init i18n instance everytime
   if (isOnServerSide) {
     i18n.init();
   } else {
     // if on browser side, init i18n instance only once
-    if (!i18n.instance.isInitialized)
-      // console.debug('locale', lang);
-      i18n.init().then(() => {
-        // console.debug('inited.');
-      });
+    if (!i18n.instance.isInitialized) {
+      i18n.init();
+    }
   }
 
+  // 判断注水后，用户本地持久化偏好语言是否被切换
+  const isHydrated = useRef(false);
+  useEffect(() => {
+    const putLang = (lng: string) => {
+      if (isHydrated.current) {
+        return (isHydrated.current = false);
+      }
+      setLang(lng);
+    };
+    i18n.instance.on('languageChanged', putLang);
+    return () => i18n.instance.off('languageChanged', putLang);
+  }, []);
+
   useOnFinishHydrationGlobal((s) => {
-    if (s.settings.language === 'auto') {
-      switchLang('auto');
+    if (s.settings.language !== defaultLang) {
+      isHydrated.current = true;
+      switchLang(s.settings.language);
     }
   }, []);
 

--- a/src/layout/GlobalLayout/Locale.tsx
+++ b/src/layout/GlobalLayout/Locale.tsx
@@ -1,7 +1,6 @@
 import { ConfigProvider } from 'antd';
 import { PropsWithChildren, memo, useEffect, useState } from 'react';
 import useSWR from 'swr';
-import useMergeState from 'use-merge-value';
 
 import { createI18nNext } from '@/locales/create';
 import { normalizeLocale } from '@/locales/resources';
@@ -29,13 +28,12 @@ interface LocaleLayoutProps extends PropsWithChildren {
 }
 
 const Locale = memo<LocaleLayoutProps>(({ children, defaultLang }) => {
-  const [lang, setLang] = useMergeState(defaultLang);
+  const [i18n] = useState(createI18nNext(defaultLang));
+  const [lang, setLang] = useState(defaultLang);
 
   const { data: locale } = useSWR(['antd-locale', lang], ([, key]) => getAntdLocale(key), {
     revalidateOnFocus: false,
   });
-
-  const [i18n] = useState(createI18nNext(defaultLang));
 
   // if run on server side, init i18n instance everytime
   if (isOnServerSide) {

--- a/src/layout/GlobalLayout/Locale.tsx
+++ b/src/layout/GlobalLayout/Locale.tsx
@@ -1,63 +1,68 @@
 import { ConfigProvider } from 'antd';
-import { PropsWithChildren, memo, useEffect, useRef, useState } from 'react';
+import { PropsWithChildren, memo, useEffect, useState } from 'react';
 import useSWR from 'swr';
+import useMergeState from 'use-merge-value';
 
-import { DEFAULT_LANG } from '@/const/locale';
 import { createI18nNext } from '@/locales/create';
+import { normalizeLocale } from '@/locales/resources';
 import { useOnFinishHydrationGlobal } from '@/store/global';
 import { isOnServerSide } from '@/utils/env';
 import { switchLang } from '@/utils/switchLang';
+
+const getAntdLocale = async (lang: string) => {
+  let normalLang = normalizeLocale(lang);
+
+  // due to antd only have ar-EG locale, we need to convert ar to ar-EG
+  // refs: https://ant.design/docs/react/i18n
+  // And we don't want to handle it in `normalizeLocale` function
+  // because of other locale files are all `ar` not `ar-EG`
+  if (normalLang === 'ar') normalLang = 'ar-EG';
+
+  const locale = await import(`antd/locale/${normalLang.replace('-', '_')}.js`);
+
+  return locale.default ?? locale;
+};
 
 interface LocaleLayoutProps extends PropsWithChildren {
   defaultLang?: string;
 }
 
-const FETCH_ANTD_LOCALE = 'fetch-antd-locale';
-
 const Locale = memo<LocaleLayoutProps>(({ children, defaultLang }) => {
-  const [lang, setLang] = useState(defaultLang ?? DEFAULT_LANG);
+  const [lang, setLang] = useMergeState(defaultLang);
+
+  const { data: locale } = useSWR(lang, getAntdLocale, { revalidateOnFocus: false });
+
   const [i18n] = useState(createI18nNext(defaultLang));
-
-  const { data: locale } = useSWR(
-    [FETCH_ANTD_LOCALE, lang],
-    async ([, l]) => {
-      const localeName = l?.includes('-') ? l?.replace('-', '_') : 'en_US';
-      const antdLocale = await import(`antd/locale/${localeName}.js`);
-
-      return antdLocale.default ?? antdLocale;
-    },
-    { revalidateOnFocus: false },
-  );
 
   // if run on server side, init i18n instance everytime
   if (isOnServerSide) {
     i18n.init();
   } else {
     // if on browser side, init i18n instance only once
-    if (!i18n.instance.isInitialized) {
-      i18n.init();
-    }
+    if (!i18n.instance.isInitialized)
+      // console.debug('locale', lang);
+      i18n.init().then(() => {
+        // console.debug('inited.');
+      });
   }
 
-  // 判断注水后，用户本地持久化偏好语言是否被切换
-  const isHydrated = useRef(false);
-  useEffect(() => {
-    const putLang = (lng: string) => {
-      if (isHydrated.current) {
-        return (isHydrated.current = false);
-      }
-      setLang(lng);
-    };
-    i18n.instance.on('languageChanged', putLang);
-    return () => i18n.instance.off('languageChanged', putLang);
-  }, []);
-
   useOnFinishHydrationGlobal((s) => {
-    if (s.settings.language !== defaultLang) {
-      isHydrated.current = true;
-      switchLang(s.settings.language);
+    if (s.settings.language === 'auto') {
+      switchLang('auto');
     }
   }, []);
+
+  // handle i18n instance language change
+  useEffect(() => {
+    const handleLang = (e: string) => {
+      setLang(e);
+    };
+
+    i18n.instance.on('languageChanged', handleLang);
+    return () => {
+      i18n.instance.off('languageChanged', handleLang);
+    };
+  }, [i18n]);
 
   return <ConfigProvider locale={locale}>{children}</ConfigProvider>;
 });

--- a/src/layout/GlobalLayout/index.tsx
+++ b/src/layout/GlobalLayout/index.tsx
@@ -48,7 +48,7 @@ interface GlobalLayoutProps extends AppThemeProps {
 
 const GlobalLayout = ({ children, defaultLang, ...theme }: GlobalLayoutProps) => (
   <AppTheme {...theme}>
-    <Locale lang={defaultLang}>
+    <Locale defaultLang={defaultLang}>
       <StoreHydration />
       <Container>{children}</Container>
       <DebugUI />

--- a/src/locales/create.ts
+++ b/src/locales/create.ts
@@ -5,7 +5,7 @@ import { initReactI18next } from 'react-i18next';
 import { isRtlLang } from 'rtl-detect';
 
 import { getClientConfig } from '@/config/client';
-import { DEFAULT_LANG, LOBE_LOCALE_COOKIE, isLocaleNotSupport } from '@/const/locale';
+import { DEFAULT_LANG, LOBE_LOCALE_COOKIE } from '@/const/locale';
 import { COOKIE_CACHE_DAYS } from '@/const/settings';
 import { normalizeLocale } from '@/locales/resources';
 import { isDev, isOnServerSide } from '@/utils/env';
@@ -19,11 +19,9 @@ export const createI18nNext = (lang?: string) => {
     .use(LanguageDetector)
     .use(
       resourcesToBackend(async (lng: string, ns: string) => {
-        let normalizedLng = lng;
-        if (isLocaleNotSupport(lng)) normalizedLng = DEFAULT_LANG;
+        if (isDev && lng === 'zh-CN') return import(`./default/${ns}`);
 
-        if (isDev && normalizedLng === 'zh-CN') return import(`./default/${ns}`);
-        return import(`@/../locales/${normalizedLng}/${ns}.json`);
+        return import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);
       }),
     );
   // Dynamically set HTML direction on language change
@@ -40,7 +38,6 @@ export const createI18nNext = (lang?: string) => {
         defaultNS: ['error', 'common', 'chat'],
         detection: {
           caches: ['cookie'],
-          convertDetectedLanguage: normalizeLocale,
           cookieMinutes: 60 * 24 * COOKIE_CACHE_DAYS,
           lookupCookie: LOBE_LOCALE_COOKIE,
         },

--- a/src/locales/create.ts
+++ b/src/locales/create.ts
@@ -5,7 +5,7 @@ import { initReactI18next } from 'react-i18next';
 import { isRtlLang } from 'rtl-detect';
 
 import { getClientConfig } from '@/config/client';
-import { DEFAULT_LANG, LOBE_LOCALE_COOKIE } from '@/const/locale';
+import { DEFAULT_LANG, LOBE_LOCALE_COOKIE, isLocaleNotSupport } from '@/const/locale';
 import { COOKIE_CACHE_DAYS } from '@/const/settings';
 import { normalizeLocale } from '@/locales/resources';
 import { isDev, isOnServerSide } from '@/utils/env';
@@ -19,9 +19,11 @@ export const createI18nNext = (lang?: string) => {
     .use(LanguageDetector)
     .use(
       resourcesToBackend(async (lng: string, ns: string) => {
-        if (isDev && lng === 'zh-CN') return import(`./default/${ns}`);
+        let normalizedLng = lng;
+        if (isLocaleNotSupport(lng)) normalizedLng = DEFAULT_LANG;
 
-        return import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);
+        if (isDev && normalizedLng === 'zh-CN') return import(`./default/${ns}`);
+        return import(`@/../locales/${normalizedLng}/${ns}.json`);
       }),
     );
   // Dynamically set HTML direction on language change
@@ -38,6 +40,7 @@ export const createI18nNext = (lang?: string) => {
         defaultNS: ['error', 'common', 'chat'],
         detection: {
           caches: ['cookie'],
+          convertDetectedLanguage: normalizeLocale,
           cookieMinutes: 60 * 24 * COOKIE_CACHE_DAYS,
           lookupCookie: LOBE_LOCALE_COOKIE,
         },

--- a/src/locales/resources.ts
+++ b/src/locales/resources.ts
@@ -45,8 +45,8 @@ type LocaleOptions = {
 
 export const localeOptions: LocaleOptions = [
   {
-    label: 'العربية',
-    value: 'ar',
+    label: 'English',
+    value: 'en-US',
   },
   {
     label: '简体中文',
@@ -55,10 +55,6 @@ export const localeOptions: LocaleOptions = [
   {
     label: '繁體中文',
     value: 'zh-TW',
-  },
-  {
-    label: 'English',
-    value: 'en-US',
   },
   {
     label: '日本語',
@@ -75,6 +71,10 @@ export const localeOptions: LocaleOptions = [
   {
     label: 'Español',
     value: 'es-ES',
+  },
+  {
+    label: 'العربية',
+    value: 'ar',
   },
   {
     label: 'Français',

--- a/src/locales/resources.ts
+++ b/src/locales/resources.ts
@@ -19,7 +19,9 @@ export const locales = [
 export type DefaultResources = typeof resources;
 export type Locales = (typeof locales)[number];
 
-export const normalizeLocale = (locale: string) => {
+export const normalizeLocale = (locale?: string) => {
+  if (!locale) return 'en-US';
+
   switch (locale) {
     case 'zh-CN':
     case 'zh': {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

1. `import "antd/locale/xxx"` 确定需要取 default 。因为 import 导入的是 es 模块，默认值在 default 里。  cc @canisminor1990 ；
2. 使用 i18n instace 的 `languageChanged` 来更改 lang，lang 作为 swr key 变更时，触发 swr 变更 locale 的获取。 cc @Wxh16144 ；

<!-- Thank you for your Pull Request. Please provide a description above. -->
注意事项：
1. 需要补充 swr  key 前缀 ，避免重复其他地方使用 locale 作为 key 时导致内容被冲掉；
2.  `ar` 需要替换为`ar-EG`；
3. 后续就需要不给 antd 组件额外加 locale 了

#### 📝 补充信息 | Additional Information

refs: #1083


<!-- Add any other context about the Pull Request here. -->
