### PR TITLE
💄 style: fix  default plugins height unstabled when scrolling

### DIFF
--- a/src/features/Conversation/Plugins/Inspector/index.tsx
+++ b/src/features/Conversation/Plugins/Inspector/index.tsx
@@ -118,7 +118,7 @@ const Inspector = memo<InspectorProps>(
                 label: t('debug.response'),
               },
             ]}
-            style={{ maxWidth: 800 }}
+            style={{ display: 'grid', maxWidth: 800 }}
           />
         )}
       </Flexbox>

--- a/src/features/Conversation/Plugins/Render/DefaultType/SystemJsRender/index.tsx
+++ b/src/features/Conversation/Plugins/Render/DefaultType/SystemJsRender/index.tsx
@@ -8,18 +8,23 @@ interface SystemJsRenderProps extends PluginRenderProps {
   url: string;
 }
 
+const RenderCache: {
+  [url: string]: PluginRender;
+} = {};
+
 const SystemJsRender = memo<SystemJsRenderProps>(({ url, ...props }) => {
-  const [component, setComp] = useState<PluginRender | null>(null);
+  const [component, setComp] = useState<PluginRender | undefined>(RenderCache[url]);
 
   useEffect(() => {
     system
       .import(url)
       .then((module1) => {
         setComp(module1.default);
+        RenderCache[url] = module1.default;
         // 使用module1模块
       })
       .catch((error) => {
-        setComp(null);
+        setComp(undefined);
         console.error(error);
       });
   }, [url]);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [x] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Close: #1135

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

我看只有默认类型插件需要缓存，standalone 的高度是直接从 manifest 取的
