### PR TITLE
🐛 fix: Automatically fill in the wrong password

### DIFF
--- a/src/app/settings/common/Common.tsx
+++ b/src/app/settings/common/Common.tsx
@@ -186,7 +186,12 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig }) => {
   const system: SettingItemGroup = {
     children: [
       {
-        children: <Input.Password placeholder={t('settingSystem.accessCode.placeholder')} />,
+        children: (
+          <Input.Password
+            autoComplete={'new-password'}
+            placeholder={t('settingSystem.accessCode.placeholder')}
+          />
+        ),
         desc: t('settingSystem.accessCode.desc'),
         hidden: !showAccessCodeConfig,
         label: t('settingSystem.accessCode.title'),

--- a/src/app/settings/llm/LLM/index.tsx
+++ b/src/app/settings/llm/LLM/index.tsx
@@ -50,6 +50,7 @@ const LLM = memo(() => {
       {
         children: (
           <Input.Password
+            autoComplete={'new-password'}
             placeholder={
               useAzure ? t('llm.AzureOpenAI.token.placeholder') : t('llm.OpenAI.token.placeholder')
             }

--- a/src/features/Conversation/Error/ApiKeyForm.tsx
+++ b/src/features/Conversation/Error/ApiKeyForm.tsx
@@ -31,6 +31,7 @@ const APIKeyForm = memo<{ id: string }>(({ id }) => {
         title={t('unlock.apikey.title')}
       >
         <Input.Password
+          autoComplete={'new-password'}
           onChange={(e) => {
             setConfig({ OPENAI_API_KEY: e.target.value });
           }}

--- a/src/features/Conversation/Error/InvalidAccess.tsx
+++ b/src/features/Conversation/Error/InvalidAccess.tsx
@@ -48,6 +48,7 @@ const InvalidAccess: RenderErrorMessage['Render'] = memo(({ id }) => {
               title={t('unlock.password.title')}
             >
               <Input.Password
+                autoComplete={'new-password'}
                 onChange={(e) => {
                   setSettings({ password: e.target.value });
                 }}

--- a/src/features/PluginSettings/PluginSettingRender.tsx
+++ b/src/features/PluginSettings/PluginSettingRender.tsx
@@ -22,6 +22,7 @@ const PluginSettingRender = memo<PluginSettingsProps>(
             return (
               <Input.Password
                 {...props}
+                autoComplete={'new-password'}
                 defaultValue={defaultValue}
                 onChange={(v) => {
                   onChange(v.target.value);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Close: #1075

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

给所有密码类型的输入框都加了禁止填充，因为表单都没有确认按钮，不然自动就将密码改了

