### PR TITLE
✨ feat: support Moonshot AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 #ZHIPU_API_KEY=xxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxx
 
 ########################################
+########## Moonshot AI Service #########
+########################################
+
+#MOONSHOT_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+########################################
 ########### Google AI Service ##########
 ########################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,4 +75,7 @@ ENV GOOGLE_API_KEY ""
 # Zhipu
 ENV ZHIPU_API_KEY ""
 
+# Moonshot
+ENV MOONSHOT_API_KEY ""
+
 CMD ["node", "server.js"]

--- a/docs/Deployment/Environment-Variable.md
+++ b/docs/Deployment/Environment-Variable.md
@@ -10,6 +10,7 @@ LobeChat provides additional configuration options during deployment, which can 
   - [OpenAI](#openai)
   - [Azure OpenAI](#azure-openai)
   - [Zhipu AI](#zhipu-ai)
+  - [Moonshot AI](#moonshot-ai)
   - [Google AI](#google-ai)
   - [AWS Bedrock](#aws-bedrock)
 - [Plugin Service](#plugin-service)
@@ -107,6 +108,15 @@ If you need to use Azure OpenAI to provide model services, you can refer to the 
 - Description: This is the API key you applied for in the Zhipu AI service
 - Default Value: -
 - Example: `4582d332441a313f5c2ed9824d1798ca.rC8EcTAhgbOuAuVT`
+
+### Moonshot AI
+
+#### `MOONSHOT_API_KEY`
+
+- Type: Required
+- Description: This is the API key you applied for in the Zhipu AI service
+- Default Value: -
+- Example: `Y2xpdGhpMzNhZXNoYjVtdnZjMWc6bXNrLWIxQlk3aDNPaXpBWnc0V1RaMDhSRmRFVlpZUWY=`
 
 ### Google AI
 

--- a/docs/Deployment/Environment-Variable.zh-CN.md
+++ b/docs/Deployment/Environment-Variable.zh-CN.md
@@ -10,6 +10,7 @@ LobeChat 在部署时提供了一些额外的配置项，使用环境变量进�
   - [OpenAI](#openai)
   - [Azure OpenAI](#azure-openai)
   - [智谱 AI](#智谱-ai)
+  - [Moonshot AI](#moonshot-ai)
   - [Google AI](#google-ai)
   - [AWS Bedrock](#aws-bedrock)
 - [插件服务](#插件服务)
@@ -105,6 +106,15 @@ LobeChat 在部署时提供了一些额外的配置项，使用环境变量进�
 - 描述：这是你在 智谱 AI 服务中申请的 API 密钥
 - 默认值：-
 - 示例：`4582d332441a313f5c2ed9824d1798ca.rC8EcTAhgbOuAuVT`
+
+### Moonshot AI
+
+#### `MOONSHOT_API_KEY`
+
+- 类型：必选
+- 描述：这是你在 Moonshot AI 服务中申请的 API 密钥
+- 默认值：-
+- 示例：`Y2xpdGhpMzNhZXNoYjVtdnZjMWc6bXNrLWIxQlk3aDNPaXpBWnc0V1RaMDhSRmRFVlpZUWY=`
 
 ### Google AI
 

--- a/src/app/api/chat/[provider]/agentRuntime.ts
+++ b/src/app/api/chat/[provider]/agentRuntime.ts
@@ -5,12 +5,12 @@ import {
   LobeAzureOpenAI,
   LobeBedrockAI,
   LobeGoogleAI,
+  LobeMoonshotAI,
   LobeOpenAI,
   LobeRuntimeAI,
   LobeZhipuAI,
   ModelProvider,
 } from '@/libs/agent-runtime';
-import LobeMoonshotAI from '@/libs/agent-runtime/moonshot';
 
 interface AzureOpenAIParams {
   apiVersion?: string;
@@ -59,13 +59,13 @@ class AgentRuntime {
         break;
       }
 
-      case ModelProvider.Bedrock: {
-        runtimeModel = this.initBedrock(payload);
+      case ModelProvider.Moonshot: {
+        runtimeModel = this.initMoonshot(payload);
         break;
       }
 
-      case ModelProvider.Moonshot: {
-        runtimeModel = this.initMoonshot(payload);
+      case ModelProvider.Bedrock: {
+        runtimeModel = this.initBedrock(payload);
       }
     }
 

--- a/src/app/api/chat/[provider]/agentRuntime.ts
+++ b/src/app/api/chat/[provider]/agentRuntime.ts
@@ -10,12 +10,14 @@ import {
   LobeZhipuAI,
   ModelProvider,
 } from '@/libs/agent-runtime';
+import LobeMoonshotAI from '@/libs/agent-runtime/moonshot';
 
 interface AzureOpenAIParams {
   apiVersion?: string;
   model: string;
   useAzure?: boolean;
 }
+
 class AgentRuntime {
   private _runtime: LobeRuntimeAI;
 
@@ -59,6 +61,11 @@ class AgentRuntime {
 
       case ModelProvider.Bedrock: {
         runtimeModel = this.initBedrock(payload);
+        break;
+      }
+
+      case ModelProvider.Moonshot: {
+        runtimeModel = this.initMoonshot(payload);
       }
     }
 
@@ -100,6 +107,13 @@ class AgentRuntime {
     const apiKey = payload?.apiKey || ZHIPU_API_KEY;
 
     return LobeZhipuAI.fromAPIKey(apiKey);
+  }
+
+  private static initMoonshot(payload: JWTPayload) {
+    const { MOONSHOT_API_KEY, MOONSHOT_PROXY_URL } = getServerConfig();
+    const apiKey = payload?.apiKey || MOONSHOT_API_KEY;
+
+    return new LobeMoonshotAI(apiKey, MOONSHOT_PROXY_URL);
   }
 
   private static initGoogle(payload: JWTPayload) {

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -7,13 +7,15 @@ export const runtime = 'edge';
  * get Server config to client
  */
 export const GET = async () => {
-  const { CUSTOM_MODELS, ENABLED_ZHIPU, ENABLED_AWS_BEDROCK, ENABLED_GOOGLE } = getServerConfig();
+  const { CUSTOM_MODELS, ENABLED_MOONSHOT, ENABLED_ZHIPU, ENABLED_AWS_BEDROCK, ENABLED_GOOGLE } =
+    getServerConfig();
 
   const config: GlobalServerConfig = {
     customModelName: CUSTOM_MODELS,
     languageModel: {
       bedrock: { enabled: ENABLED_AWS_BEDROCK },
       google: { enabled: ENABLED_GOOGLE },
+      moonshot: { enabled: ENABLED_MOONSHOT },
       zhipu: { enabled: ENABLED_ZHIPU },
     },
   };

--- a/src/app/api/errorResponse.ts
+++ b/src/app/api/errorResponse.ts
@@ -34,8 +34,10 @@ const getStatus = (errorType: ILobeAgentRuntimeErrorType | ErrorType) => {
     case AgentRuntimeErrorType.GoogleBizError: {
       return 475;
     }
+    case AgentRuntimeErrorType.MoonshotBizError: {
+      return 476;
+    }
   }
-
   return errorType as number;
 };
 

--- a/src/app/settings/llm/Moonshot/index.tsx
+++ b/src/app/settings/llm/Moonshot/index.tsx
@@ -1,0 +1,77 @@
+import { Moonshot } from '@lobehub/icons';
+import { Form, type ItemGroup } from '@lobehub/ui';
+import { Form as AntForm, Input, Switch } from 'antd';
+import { useTheme } from 'antd-style';
+import { debounce } from 'lodash-es';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { FORM_STYLE } from '@/const/layoutTokens';
+import { ModelProvider } from '@/libs/agent-runtime';
+import { useGlobalStore } from '@/store/global';
+import { modelProviderSelectors } from '@/store/global/selectors';
+
+import Checker from '../Checker';
+import { LLMProviderApiTokenKey, LLMProviderConfigKey } from '../const';
+import { useSyncSettings } from '../useSyncSettings';
+
+const providerKey = 'moonshot';
+
+const MoonshotProvider = memo(() => {
+  const { t } = useTranslation('setting');
+  const [form] = AntForm.useForm();
+  const theme = useTheme();
+  const [toggleProviderEnabled, setSettings] = useGlobalStore((s) => [
+    s.toggleProviderEnabled,
+    s.setSettings,
+  ]);
+  const enabled = useGlobalStore(modelProviderSelectors.enableMoonshot);
+
+  useSyncSettings(form);
+
+  const model: ItemGroup = {
+    children: [
+      {
+        children: (
+          <Input.Password
+            autoComplete={'new-password'}
+            placeholder={t('llm.Moonshot.token.placeholder')}
+          />
+        ),
+        desc: t('llm.Moonshot.token.desc'),
+        label: t('llm.Moonshot.token.title'),
+        name: [LLMProviderConfigKey, providerKey, LLMProviderApiTokenKey],
+      },
+      {
+        children: <Checker model={'moonshot-v1-8k'} provider={ModelProvider.Moonshot} />,
+        desc: t('llm.checker.desc'),
+        label: t('llm.checker.title'),
+        minWidth: undefined,
+      },
+    ],
+    defaultActive: enabled,
+    extra: (
+      <Switch
+        onChange={(enabled) => {
+          toggleProviderEnabled(providerKey, enabled);
+        }}
+        value={enabled}
+      />
+    ),
+    title: (
+      <Flexbox align={'center'} gap={8} horizontal>
+        <Moonshot.Combine
+          color={theme.isDarkMode ? theme.colorText : Moonshot.colorPrimary}
+          size={24}
+        />
+      </Flexbox>
+    ),
+  };
+
+  return (
+    <Form form={form} items={[model]} onValuesChange={debounce(setSettings, 100)} {...FORM_STYLE} />
+  );
+});
+
+export default MoonshotProvider;

--- a/src/app/settings/llm/page.tsx
+++ b/src/app/settings/llm/page.tsx
@@ -11,6 +11,7 @@ import { SettingsTabs } from '@/store/global/initialState';
 
 import Bedrock from './Bedrock';
 import Google from './Google';
+import Moonshot from './Moonshot';
 import OpenAI from './OpenAI';
 import Zhipu from './Zhipu';
 
@@ -23,6 +24,7 @@ export default memo(() => {
       <OpenAI />
       {/*<AzureOpenAI />*/}
       <Zhipu />
+      <Moonshot />
       <Google />
       <Bedrock />
       <Footer>

--- a/src/components/ModelIcon/index.tsx
+++ b/src/components/ModelIcon/index.tsx
@@ -7,6 +7,7 @@ import {
   Meta,
   Minimax,
   Mistral,
+  Moonshot,
   OpenAI,
   Tongyi,
 } from '@lobehub/icons';
@@ -29,6 +30,7 @@ const ModelIcon = memo<ModelProviderIconProps>(({ model, size = 12 }) => {
   if (model.includes('gemini')) return <Gemini.Avatar size={size} />;
   if (model.includes('qwen')) return <Tongyi.Avatar background={Tongyi.colorPrimary} size={size} />;
   if (model.includes('minmax')) return <Minimax.Avatar size={size} />;
+  if (model.includes('moonshot')) return <Moonshot.Avatar size={size} />;
   if (model.includes('baichuan'))
     return <Baichuan.Avatar background={Baichuan.colorPrimary} size={size} />;
   if (model.includes('mistral')) return <Mistral.Avatar size={size} />;

--- a/src/components/ModelProviderIcon/index.tsx
+++ b/src/components/ModelProviderIcon/index.tsx
@@ -1,4 +1,4 @@
-import { Azure, Bedrock, Google, OpenAI, Zhipu } from '@lobehub/icons';
+import { Azure, Bedrock, Google, Moonshot, OpenAI, Zhipu } from '@lobehub/icons';
 import { memo } from 'react';
 import { Center } from 'react-layout-kit';
 
@@ -32,6 +32,10 @@ const ModelProviderIcon = memo<ModelProviderIconProps>(({ provider }) => {
           <Azure size={14} />
         </Center>
       );
+    }
+
+    case ModelProvider.Moonshot: {
+      return <Moonshot size={20} />;
     }
 
     case ModelProvider.OpenAI: {

--- a/src/components/ModelTag/ModelIcon.tsx
+++ b/src/components/ModelTag/ModelIcon.tsx
@@ -7,6 +7,7 @@ import {
   Meta,
   Minimax,
   Mistral,
+  Moonshot,
   OpenAI,
   Tongyi,
 } from '@lobehub/icons';
@@ -26,6 +27,7 @@ const ModelIcon = memo<ModelIconProps>(({ model, size = 12 }) => {
   if (model.includes('titan')) return <Aws size={size} />;
   if (model.includes('llama')) return <Meta size={size} />;
   if (model.includes('gemini')) return <Gemini size={size} />;
+  if (model.includes('moonshot')) return <Moonshot size={size} />;
   if (model.includes('qwen')) return <Tongyi size={size} />;
   if (model.includes('minmax')) return <Minimax size={size} />;
   if (model.includes('baichuan')) return <Baichuan size={size} />;

--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -2,6 +2,7 @@ import { ChatModelCard } from '@/types/llm';
 
 import BedrockProvider from './bedrock';
 import GoogleProvider from './google';
+import MoonshotProvider from './moonshot';
 import OpenAIProvider from './openai';
 import ZhiPuProvider from './zhipu';
 
@@ -10,9 +11,11 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   ZhiPuProvider.chatModels,
   BedrockProvider.chatModels,
   GoogleProvider.chatModels,
+  MoonshotProvider.chatModels,
 ].flat();
 
 export { default as BedrockProvider } from './bedrock';
 export { default as GoogleProvider } from './google';
+export { default as MoonshotProvider } from './moonshot';
 export { default as OpenAIProvider } from './openai';
 export { default as ZhiPuProvider } from './zhipu';

--- a/src/config/modelProviders/moonshot.ts
+++ b/src/config/modelProviders/moonshot.ts
@@ -1,0 +1,24 @@
+import { ModelProviderCard } from '@/types/llm';
+
+const Moonshot: ModelProviderCard = {
+  chatModels: [
+    {
+      displayName: 'Moonshot V1 8K',
+      id: 'moonshot-v1-8k',
+      tokens: 8192,
+    },
+    {
+      displayName: 'Moonshot V1 32K',
+      id: 'moonshot-v1-32k',
+      tokens: 32_768,
+    },
+    {
+      displayName: 'Moonshot V1 128K',
+      id: 'moonshot-v1-128k',
+      tokens: 128_000,
+    },
+  ],
+  id: 'moonshot',
+};
+
+export default Moonshot;

--- a/src/config/server/provider.ts
+++ b/src/config/server/provider.ts
@@ -24,6 +24,10 @@ declare global {
       // Google Provider
       GOOGLE_API_KEY?: string;
 
+      // Moonshot Provider
+      MOONSHOT_API_KEY?: string;
+      MOONSHOT_PROXY_URL?: string;
+
       // AWS Credentials
       AWS_REGION?: string;
       AWS_ACCESS_KEY_ID?: string;
@@ -44,6 +48,8 @@ export const getProviderConfig = () => {
 
   const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY || '';
 
+  const MOONSHOT_API_KEY = process.env.MOONSHOT_API_KEY || '';
+
   // region format: iad1,sfo1
   let regions: string[] = [];
   if (process.env.OPENAI_FUNCTION_REGIONS) {
@@ -62,6 +68,10 @@ export const getProviderConfig = () => {
 
     ENABLED_GOOGLE: !!GOOGLE_API_KEY,
     GOOGLE_API_KEY,
+
+    ENABLED_MOONSHOT: !!MOONSHOT_API_KEY,
+    MOONSHOT_API_KEY,
+    MOONSHOT_PROXY_URL: process.env.MOONSHOT_PROXY_URL,
 
     ENABLED_AWS_BEDROCK: !!AWS_ACCESS_KEY_ID,
     AWS_REGION: process.env.AWS_REGION,

--- a/src/const/settings.ts
+++ b/src/const/settings.ts
@@ -62,6 +62,10 @@ export const DEFAULT_LLM_CONFIG: GlobalLLMConfig = {
     apiKey: '',
     enabled: false,
   },
+  moonshot: {
+    apiKey: '',
+    enabled: false,
+  },
   openAI: {
     OPENAI_API_KEY: '',
     models: [],

--- a/src/features/Conversation/Error/APIKeyForm/Moonshot.tsx
+++ b/src/features/Conversation/Error/APIKeyForm/Moonshot.tsx
@@ -1,0 +1,60 @@
+import { Moonshot } from '@lobehub/icons';
+import { Input } from 'antd';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ModelProvider } from '@/libs/agent-runtime';
+import { useGlobalStore } from '@/store/global';
+import { modelProviderSelectors } from '@/store/global/selectors';
+
+import { FormAction } from '../style';
+
+const MoonshotForm = memo(() => {
+  const { t } = useTranslation('error');
+  // const [showProxy, setShow] = useState(false);
+
+  const [apiKey, setConfig] = useGlobalStore((s) => [
+    modelProviderSelectors.moonshotAPIKey(s),
+    s.setModelProviderConfig,
+  ]);
+
+  return (
+    <FormAction
+      avatar={<Moonshot size={56} />}
+      description={t('unlock.apikey.Moonshot.description')}
+      title={t('unlock.apikey.Moonshot.title')}
+    >
+      <Input.Password
+        autoComplete={'new-password'}
+        onChange={(e) => {
+          setConfig(ModelProvider.Moonshot, { apiKey: e.target.value });
+        }}
+        placeholder={'*********************************'}
+        type={'block'}
+        value={apiKey}
+      />
+      {/*{showProxy ? (*/}
+      {/*  <Input*/}
+      {/*    onChange={(e) => {*/}
+      {/*      setConfig({ endpoint: e.target.value });*/}
+      {/*    }}*/}
+      {/*    placeholder={'https://api.openai.com/v1'}*/}
+      {/*    type={'block'}*/}
+      {/*    value={proxyUrl}*/}
+      {/*  />*/}
+      {/*) : (*/}
+      {/*  <Button*/}
+      {/*    icon={<Icon icon={Network} />}*/}
+      {/*    onClick={() => {*/}
+      {/*      setShow(true);*/}
+      {/*    }}*/}
+      {/*    type={'text'}*/}
+      {/*  >*/}
+      {/*    {t('unlock.apikey.addProxyUrl')}*/}
+      {/*  </Button>*/}
+      {/*)}*/}
+    </FormAction>
+  );
+});
+
+export default MoonshotForm;

--- a/src/features/Conversation/Error/APIKeyForm/index.tsx
+++ b/src/features/Conversation/Error/APIKeyForm/index.tsx
@@ -8,6 +8,7 @@ import { useChatStore } from '@/store/chat';
 
 import BedrockForm from './Bedrock';
 import GoogleForm from './Google';
+import MoonshotForm from './Moonshot';
 import OpenAIForm from './OpenAI';
 import ZhipuForm from './Zhipu';
 
@@ -33,6 +34,10 @@ const APIKeyForm = memo<APIKeyFormProps>(({ id, provider }) => {
 
       case ModelProvider.ZhiPu: {
         return <ZhipuForm />;
+      }
+
+      case ModelProvider.Moonshot: {
+        return <MoonshotForm />;
       }
 
       default:

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -31,7 +31,7 @@ export const getErrorAlertConfig = (
       };
     }
 
-    case ChatErrorType.InvalidAccessCode: {
+    case AgentRuntimeErrorType.NoOpenAIAPIKey: {
       return {
         extraDefaultExpand: true,
         extraIsolate: true,
@@ -64,6 +64,7 @@ const ErrorMessageExtra = memo<{ data: ChatMessage }>(({ data }) => {
 
     case AgentRuntimeErrorType.InvalidBedrockCredentials:
     case AgentRuntimeErrorType.InvalidZhipuAPIKey:
+    case AgentRuntimeErrorType.InvalidMoonshotAPIKey:
     case AgentRuntimeErrorType.InvalidGoogleAPIKey:
     case AgentRuntimeErrorType.NoOpenAIAPIKey: {
       return <InvalidAPIKey id={data.id} provider={data.error?.body?.provider} />;

--- a/src/libs/agent-runtime/error.ts
+++ b/src/libs/agent-runtime/error.ts
@@ -19,6 +19,9 @@ export const AgentRuntimeErrorType = {
 
   InvalidBedrockCredentials: 'InvalidBedrockCredentials',
   BedrockBizError: 'BedrockBizError',
+
+  InvalidMoonshotAPIKey: 'InvalidMoonshotAPIKey',
+  MoonshotBizError: 'MoonshotBizError',
 } as const;
 
 export type ILobeAgentRuntimeErrorType =

--- a/src/libs/agent-runtime/index.ts
+++ b/src/libs/agent-runtime/index.ts
@@ -3,6 +3,7 @@ export * from './BaseAI';
 export { LobeBedrockAI } from './bedrock';
 export * from './error';
 export { LobeGoogleAI } from './google';
+export { LobeMoonshotAI } from './moonshot';
 export { LobeOpenAI } from './openai';
 export * from './types';
 export { AgentRuntimeError } from './utils/createError';

--- a/src/libs/agent-runtime/moonshot/index.ts
+++ b/src/libs/agent-runtime/moonshot/index.ts
@@ -1,0 +1,82 @@
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import OpenAI from 'openai';
+
+import { LobeRuntimeAI } from '../BaseAI';
+import { AgentRuntimeErrorType } from '../error';
+import { ChatStreamPayload, ModelProvider } from '../types';
+import { AgentRuntimeError } from '../utils/createError';
+import { debugStream } from '../utils/debugStream';
+import { desensitizeUrl } from '../utils/desensitizeUrl';
+import { DEBUG_CHAT_COMPLETION } from '../utils/env';
+import { handleOpenAIError } from '../utils/handleOpenAIError';
+
+const DEFAULT_BASE_URL = 'https://api.moonshot.cn/v1';
+
+export class LobeMoonshotAI implements LobeRuntimeAI {
+  private _llm: OpenAI;
+
+  baseURL: string;
+
+  constructor(apiKey?: string, baseURL: string = DEFAULT_BASE_URL) {
+    if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidMoonshotAPIKey);
+
+    const header = { Authorization: `Bearer ${apiKey}` };
+
+    this._llm = new OpenAI({ apiKey, baseURL, defaultHeaders: header });
+    this.baseURL = this._llm.baseURL;
+  }
+
+  async chat(payload: ChatStreamPayload) {
+    try {
+      const response = await this._llm.chat.completions.create(
+        payload as unknown as OpenAI.ChatCompletionCreateParamsStreaming,
+      );
+
+      const stream = OpenAIStream(response);
+
+      const [debug, returnStream] = stream.tee();
+
+      if (DEBUG_CHAT_COMPLETION) {
+        debugStream(debug).catch(console.error);
+      }
+
+      return new StreamingTextResponse(returnStream);
+    } catch (error) {
+      let desensitizedEndpoint = this.baseURL;
+
+      if (this.baseURL !== DEFAULT_BASE_URL) {
+        desensitizedEndpoint = desensitizeUrl(this.baseURL);
+      }
+
+      if ('status' in (error as any)) {
+        switch ((error as Response).status) {
+          case 401: {
+            throw AgentRuntimeError.chat({
+              endpoint: desensitizedEndpoint,
+              error: error as any,
+              errorType: AgentRuntimeErrorType.InvalidMoonshotAPIKey,
+              provider: ModelProvider.Moonshot,
+            });
+          }
+
+          default: {
+            break;
+          }
+        }
+      }
+
+      const { errorResult, RuntimeError } = handleOpenAIError(error);
+
+      const errorType = RuntimeError || AgentRuntimeErrorType.MoonshotBizError;
+
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizedEndpoint,
+        error: errorResult,
+        errorType,
+        provider: ModelProvider.Moonshot,
+      });
+    }
+  }
+}
+
+export default LobeMoonshotAI;

--- a/src/libs/agent-runtime/types/type.ts
+++ b/src/libs/agent-runtime/types/type.ts
@@ -28,6 +28,7 @@ export enum ModelProvider {
   ChatGLM = 'chatglm',
   Google = 'google',
   Mistral = 'mistral',
+  Moonshot = 'moonshot',
   OpenAI = 'openai',
   Tongyi = 'tongyi',
   ZhiPu = 'zhipu',

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -102,6 +102,7 @@ export default {
     azure: 'Azure',
     bedrock: 'AWS Bedrock',
     google: 'Google',
+    moonshot: 'Moonshot AI',
     oneapi: 'One API',
     openai: 'OpenAI',
     zhipu: '智谱AI',

--- a/src/locales/default/error.ts
+++ b/src/locales/default/error.ts
@@ -61,6 +61,9 @@ export default {
     ZhipuBizError: '请求智谱服务出错，请根据以下信息排查或重试',
     InvalidZhipuAPIKey: 'Zhipu API Key 不正确或为空，请检查 Zhipu API Key 后重试',
 
+    MoonshotBizError: '请求月之暗面服务出错，请根据以下信息排查或重试',
+    InvalidMoonshotAPIKey: 'Moonshot AI API Key 不正确或为空，请检查 Moonshot API Key 后重试',
+
     GoogleBizError: '请求 Google 服务出错，请根据以下信息排查或重试',
     InvalidGoogleAPIKey: 'Google API Key 不正确或为空，请检查 Google API Key 后重试',
 
@@ -90,6 +93,10 @@ export default {
       Google: {
         description: '输入你的 Google API Key 即可开始会话。应用不会记录你的 API Key',
         title: '使用自定义 Google API Key',
+      },
+      Moonshot: {
+        description: '输入你的 Moonshot AI API Key 即可开始会话。应用不会记录你的 API Key',
+        title: '使用自定义 Moonshot AI API Key',
       },
       OpenAI: {
         addProxyUrl: '添加 OpenAI 代理地址（可选）',

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -77,6 +77,14 @@ export default {
         title: 'API Key',
       },
     },
+    Moonshot: {
+      title: '月之暗面',
+      token: {
+        desc: '填入来自 Moonshot AI 的 API Key',
+        placeholder: 'Moonshot AI API Key',
+        title: 'API Key',
+      },
+    },
     OpenAI: {
       azureApiVersion: {
         desc: 'Azure 的 API 版本，遵循 YYYY-MM-DD 格式，查阅[最新版本](https://learn.microsoft.com/zh-cn/azure/ai-services/openai/reference#chat-completions)',

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -10,6 +10,10 @@ const getProviderAuthPayload = (provider: string) => {
       return { apiKey: modelProviderSelectors.zhipuAPIKey(useGlobalStore.getState()) };
     }
 
+    case ModelProvider.Moonshot: {
+      return { apiKey: modelProviderSelectors.moonshotAPIKey(useGlobalStore.getState()) };
+    }
+
     case ModelProvider.Google: {
       return { apiKey: modelProviderSelectors.googleAPIKey(useGlobalStore.getState()) };
     }

--- a/src/store/global/slices/settings/selectors/modelProvider.ts
+++ b/src/store/global/slices/settings/selectors/modelProvider.ts
@@ -4,6 +4,7 @@ import {
   BedrockProvider,
   GoogleProvider,
   LOBE_DEFAULT_MODEL_LIST,
+  MoonshotProvider,
   OpenAIProvider,
   ZhiPuProvider,
 } from '@/config/modelProviders';
@@ -32,6 +33,9 @@ const googleProxyUrl = (s: GlobalStore) => modelProvider(s).google.endpoint;
 
 const enableAzure = (s: GlobalStore) => modelProvider(s).openAI.useAzure;
 const azureConfig = (s: GlobalStore) => modelProvider(s).azure;
+
+const enableMoonshot = (s: GlobalStore) => modelProvider(s).moonshot.enabled;
+const moonshotAPIKey = (s: GlobalStore) => modelProvider(s).moonshot.apiKey;
 
 // const azureModelList = (s: GlobalStore): ModelProviderCard => {
 //   const azure = azureConfig(s);
@@ -105,6 +109,7 @@ const modelSelectList = (s: GlobalStore): ModelProviderCard[] => {
     },
     // { ...azureModelList(s), enabled: enableAzure(s) },
     { ...ZhiPuProvider, enabled: enableZhipu(s) },
+    { ...MoonshotProvider, enabled: enableMoonshot(s) },
     { ...GoogleProvider, enabled: enableGoogle(s) },
     { ...BedrockProvider, enabled: enableBedrock(s) },
   ];
@@ -165,4 +170,8 @@ export const modelProviderSelectors = {
   // Bedrock
   enableBedrock,
   bedrockConfig,
+
+  // Moonshot
+  enableMoonshot,
+  moonshotAPIKey,
 };

--- a/src/types/settings/modelProvider.ts
+++ b/src/types/settings/modelProvider.ts
@@ -29,6 +29,11 @@ export interface ZhiPuConfig {
   endpoint?: string;
 }
 
+export interface MoonshotConfig {
+  apiKey?: string;
+  enabled: boolean;
+}
+
 export interface GoogleConfig {
   apiKey?: string;
   enabled: boolean;
@@ -46,6 +51,7 @@ export interface GlobalLLMConfig {
   azure: AzureOpenAIConfig;
   bedrock: AWSBedrockConfig;
   google: GoogleConfig;
+  moonshot: MoonshotConfig;
   openAI: OpenAIConfig;
   zhipu: ZhiPuConfig;
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

Moonshot 今天发布 API 开放平台，尝试了下 1 小时完成接入：

<img width="1193" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/0151c3df-1096-4bf9-8698-7126c3d7b43d">

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

以此为示例，验证一下现有的链路，接入一个新 Provider 大致的流程和步骤。


服务端：
1. 服务端环境变量 ：`config/server/provider.ts` 新增 MOONSHOT_API_KEY 等环境变量；
2. Moonshot 运行时 `libs/agent-runtime` 新增 LobeMoonshotAI ，
  - 实现 `init` 和 `chat` 两个方法；
  - 完善相应的  `InvalidMoonshotAPIKey` 和 `MoonshotBizError` 两个错误状态
3. 路由定义： `api/chat/[provider]/agentRuntime.ts` 新增 moonshotRuntime 初始化逻辑（客户端key 与 环境变量）
4. 服务端配置: `api/config/route.ts` 定义 Provider 默认开启逻辑
5. 错误响应状态码处理： `api/errorResponse.ts` 定义 `MoonshotBizError` 状态码

客户端：
1. 模型元数据定义（`config/modelProviders`），补充完善相应的模型元信息
2. 模型设置： `types/settings/modelProvider` 定义 `MoonshotConfig`，在 `const/settings` 设定默认值；
3. 取数 seletors： `store/global/slices/settings/selector/modelProvider.ts` 补充取数 selector （enableMoonshot、 moonshotAPIKey）
4. 前端鉴权 token： `services/_auth` 补充获取 apiKey 相关逻辑；
5. 模型UI （模型选择器、模型 Tag ）：
   - Provider Logo: `components/ModelProviderIcon` 更新
   - Model Logo: `components/ModelIcon` 更新
   - Model Tag: `components/ModelTag` 更新
6. 错误处理 `features/Conversation/Error` 新增一种对应的 APIKeyForm 
7. 全局模型设置 `app/settings/llm` 新增一个配置组件（可以拷贝复用 Zhipu ）
<!-- Add any other context about the Pull Request here. -->
