### PR TITLE
🐛 fix: The back button on the chat setting page is consistent with the browser back button

### DIFF
--- a/src/app/chat/settings/(desktop)/features/Header.tsx
+++ b/src/app/chat/settings/(desktop)/features/Header.tsx
@@ -13,7 +13,7 @@ const Header = memo(() => {
   return (
     <ChatHeader
       left={<ChatHeaderTitle title={t('header.session')} />}
-      onBackClick={() => router.push(pathString('/chat', { hash: location.hash }))}
+      onBackClick={() => router.push(pathString('/chat', { hash: location.search }))}
       right={<HeaderContent />}
       showBackButton
     />


### PR DESCRIPTION
🐛 fix: The back button on the chat setting page is consistent with the browser back button

#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

原逻辑：无论在任何 Agent 的聊天界面中，当点击 chat setting 页面的“回退”按钮时，页面会直接跳转至“chat?session=inbox”页面

修改为使“chat setting”页面的回退行为与浏览器的回退功能保持一致。

![image](https://github.com/lobehub/lobe-chat/assets/18510448/086c465f-1f1b-46a5-842f-e84c6bcc9f32)


#### 📝 补充信息 | Additional Information

