### PR TITLE
:sparkles: feat(llm): support Ollama AI Provider (local llm)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 #AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ########################################
+######### Ollama AI Service ##########
+########################################
+
+# You can use ollama to get and run LLM locally, learn more about it via https://github.com/ollama/ollama
+# The local/remote ollama service url
+# OLLAMA_PROXY_URL=http://127.0.0.1:11434/v1
+
+########################################
 ############ Market Service ############
 ########################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,7 @@ ENV ZHIPU_API_KEY ""
 # Moonshot
 ENV MOONSHOT_API_KEY ""
 
+# Ollama
+ENV OLLAMA_PROXY_URL ""
+
 CMD ["node", "server.js"]

--- a/docs/Deployment/Environment-Variable.md
+++ b/docs/Deployment/Environment-Variable.md
@@ -18,6 +18,7 @@ LobeChat provides additional configuration options during deployment, which can 
   - [Moonshot AI](#moonshot-ai)
   - [Google AI](#google-ai)
   - [AWS Bedrock](#aws-bedrock)
+  - [Ollama](#ollama)
 - [Plugin Service](#plugin-service)
   - [`PLUGINS_INDEX_URL`](#plugins_index_url)
   - [`PLUGIN_SETTINGS`](#plugin_settings)
@@ -207,6 +208,15 @@ If you need to use Azure OpenAI to provide model services, you can refer to the 
 - Description: The region setting for AWS services
 - Default Value: `us-east-1`
 - Example: `us-east-1`
+
+### Ollama
+
+#### `OLLAMA_PROXY_URL`
+
+- Type: Optional
+- Description: To enable the Ollama service provider, if set up which will appear as selectable model card in the language model setting page, you can also specify a custom language model.
+- Default: -
+- Example: `http://127.0.0.1:11434/v1`
 
 ## Plugin Service
 

--- a/docs/Deployment/Environment-Variable.zh-CN.md
+++ b/docs/Deployment/Environment-Variable.zh-CN.md
@@ -18,6 +18,7 @@ LobeChat 在部署时提供了一些额外的配置项，使用环境变量进�
   - [Moonshot AI](#moonshot-ai)
   - [Google AI](#google-ai)
   - [AWS Bedrock](#aws-bedrock)
+  - [Ollama](#ollama)
 - [插件服务](#插件服务)
   - [`PLUGINS_INDEX_URL`](#plugins_index_url)
   - [`PLUGIN_SETTINGS`](#plugin_settings)
@@ -205,6 +206,15 @@ LobeChat 在部署时提供了一些额外的配置项，使用环境变量进�
 - 描述：AWS 服务的区域设置
 - 默认值：`us-east-1`
 - 示例：`us-east-1`
+
+### Ollama
+
+#### `OLLAMA_PROXY_URL`
+
+- 类型：可选
+- 描述：用于启用 Ollama 服务，设置后可在语言模型列表内展示可选开源语言模型，也可以指定自定义语言模型
+- 默认值：-
+- 示例：`http://127.0.0.1:11434/v1`
 
 ## 插件服务
 

--- a/src/app/api/chat/[provider]/agentRuntime.ts
+++ b/src/app/api/chat/[provider]/agentRuntime.ts
@@ -6,6 +6,7 @@ import {
   LobeBedrockAI,
   LobeGoogleAI,
   LobeMoonshotAI,
+  LobeOllamaAI,
   LobeOpenAI,
   LobeRuntimeAI,
   LobeZhipuAI,
@@ -66,6 +67,12 @@ class AgentRuntime {
 
       case ModelProvider.Bedrock: {
         runtimeModel = this.initBedrock(payload);
+        break;
+      }
+
+      case ModelProvider.Ollama: {
+        runtimeModel = this.initOllama(payload);
+        break;
       }
     }
 
@@ -137,6 +144,13 @@ class AgentRuntime {
     }
 
     return new LobeBedrockAI({ accessKeyId, accessKeySecret, region });
+  }
+
+  private static initOllama(payload: JWTPayload) {
+    const { OLLAMA_PROXY_URL } = getServerConfig();
+    const baseUrl = payload?.endpoint || OLLAMA_PROXY_URL;
+
+    return new LobeOllamaAI(baseUrl);
   }
 }
 

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -14,6 +14,7 @@ export const GET = async () => {
     ENABLED_AWS_BEDROCK,
     ENABLED_GOOGLE,
     ENABLE_OAUTH_SSO,
+    ENABLE_OLLAMA,
   } = getServerConfig();
 
   const config: GlobalServerConfig = {
@@ -23,6 +24,7 @@ export const GET = async () => {
       bedrock: { enabled: ENABLED_AWS_BEDROCK },
       google: { enabled: ENABLED_GOOGLE },
       moonshot: { enabled: ENABLED_MOONSHOT },
+      ollama: { enabled: ENABLE_OLLAMA },
       zhipu: { enabled: ENABLED_ZHIPU },
     },
   };

--- a/src/app/api/errorResponse.ts
+++ b/src/app/api/errorResponse.ts
@@ -37,6 +37,9 @@ const getStatus = (errorType: ILobeAgentRuntimeErrorType | ErrorType) => {
     case AgentRuntimeErrorType.MoonshotBizError: {
       return 476;
     }
+    case AgentRuntimeErrorType.OllamaBizError: {
+      return 478;
+    }
   }
   return errorType as number;
 };

--- a/src/app/settings/llm/Ollama/index.tsx
+++ b/src/app/settings/llm/Ollama/index.tsx
@@ -1,0 +1,75 @@
+import { Ollama } from '@lobehub/icons';
+import { Form, type ItemGroup } from '@lobehub/ui';
+import { Form as AntForm, Input, Switch } from 'antd';
+import { useTheme } from 'antd-style';
+import { debounce } from 'lodash-es';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { FORM_STYLE } from '@/const/layoutTokens';
+import { ModelProvider } from '@/libs/agent-runtime';
+import { useGlobalStore } from '@/store/global';
+import { modelProviderSelectors } from '@/store/global/selectors';
+
+import Checker from '../Checker';
+import { LLMProviderBaseUrlKey, LLMProviderConfigKey } from '../const';
+import { useSyncSettings } from '../useSyncSettings';
+
+const providerKey = 'ollama';
+
+const OllamaProvider = memo(() => {
+  const { t } = useTranslation('setting');
+  const [form] = AntForm.useForm();
+  const theme = useTheme();
+  const [toggleProviderEnabled, setSettings] = useGlobalStore((s) => [
+    s.toggleProviderEnabled,
+    s.setSettings,
+  ]);
+  const enabled = useGlobalStore(modelProviderSelectors.enableOllama);
+
+  useSyncSettings(form);
+
+  const model: ItemGroup = {
+    children: [
+      {
+        children: <Input allowClear placeholder={t('llm.Ollama.endpoint.placeholder')} />,
+        desc: t('llm.Ollama.endpoint.desc'),
+        label: t('llm.Ollama.endpoint.title'),
+        name: [LLMProviderConfigKey, providerKey, LLMProviderBaseUrlKey],
+      },
+      {
+        children: <Input allowClear placeholder={t('llm.Ollama.customModelName.placeholder')} />,
+        desc: t('llm.Ollama.customModelName.desc'),
+        label: t('llm.Ollama.customModelName.title'),
+        name: [LLMProviderConfigKey, providerKey, 'customModelName'],
+      },
+      {
+        children: <Checker model={'llama2'} provider={ModelProvider.Ollama} />,
+        desc: t('llm.Ollama.checker.desc'),
+        label: t('llm.checker.title'),
+        minWidth: undefined,
+      },
+    ],
+    defaultActive: enabled,
+    extra: (
+      <Switch
+        onChange={(enabled: boolean) => {
+          toggleProviderEnabled(providerKey, enabled);
+        }}
+        value={enabled}
+      />
+    ),
+    title: (
+      <Flexbox align={'center'} gap={8} horizontal>
+        <Ollama.Combine color={theme.isDarkMode ? theme.colorText : theme.colorPrimary} size={24} />
+      </Flexbox>
+    ),
+  };
+
+  return (
+    <Form form={form} items={[model]} onValuesChange={debounce(setSettings, 100)} {...FORM_STYLE} />
+  );
+});
+
+export default OllamaProvider;

--- a/src/app/settings/llm/page.tsx
+++ b/src/app/settings/llm/page.tsx
@@ -7,17 +7,23 @@ import { Trans, useTranslation } from 'react-i18next';
 import Footer from '@/app/settings/features/Footer';
 import PageTitle from '@/components/PageTitle';
 import { MORE_MODEL_PROVIDER_REQUEST_URL } from '@/const/url';
+import { useGlobalStore } from '@/store/global';
 import { useSwitchSideBarOnInit } from '@/store/global/hooks/useSwitchSettingsOnInit';
 import { SettingsTabs } from '@/store/global/initialState';
+import { modelProviderSelectors } from '@/store/global/selectors';
 
 import Bedrock from './Bedrock';
 import Google from './Google';
 import Moonshot from './Moonshot';
+import Ollama from './Ollama';
 import OpenAI from './OpenAI';
 import Zhipu from './Zhipu';
 
 export default memo(() => {
   useSwitchSideBarOnInit(SettingsTabs.LLM);
+  const enableOllamaFormServerConfig = useGlobalStore(
+    modelProviderSelectors.enableOllamaFromServerConfig,
+  );
   const { t } = useTranslation('setting');
   return (
     <>
@@ -28,6 +34,7 @@ export default memo(() => {
       <Moonshot />
       <Google />
       <Bedrock />
+      {enableOllamaFormServerConfig ? <Ollama /> : null}
       <Footer>
         <Trans i18nKey="llm.waitingForMore" ns={'setting'}>
           更多模型正在

--- a/src/components/ModelProviderIcon/index.tsx
+++ b/src/components/ModelProviderIcon/index.tsx
@@ -1,4 +1,4 @@
-import { Azure, Bedrock, Google, Moonshot, OpenAI, Zhipu } from '@lobehub/icons';
+import { Azure, Bedrock, Google, Moonshot, Ollama, OpenAI, Zhipu } from '@lobehub/icons';
 import { memo } from 'react';
 import { Center } from 'react-layout-kit';
 
@@ -40,6 +40,10 @@ const ModelProviderIcon = memo<ModelProviderIconProps>(({ provider }) => {
 
     case ModelProvider.OpenAI: {
       return <OpenAI size={20} />;
+    }
+
+    case ModelProvider.Ollama: {
+      return <Ollama size={20} />;
     }
 
     default: {

--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -3,6 +3,7 @@ import { ChatModelCard } from '@/types/llm';
 import BedrockProvider from './bedrock';
 import GoogleProvider from './google';
 import MoonshotProvider from './moonshot';
+import OllamaProvider from './ollama';
 import OpenAIProvider from './openai';
 import ZhiPuProvider from './zhipu';
 
@@ -12,10 +13,12 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   BedrockProvider.chatModels,
   GoogleProvider.chatModels,
   MoonshotProvider.chatModels,
+  OllamaProvider.chatModels,
 ].flat();
 
 export { default as BedrockProvider } from './bedrock';
 export { default as GoogleProvider } from './google';
 export { default as MoonshotProvider } from './moonshot';
+export { default as OllamaProvider } from './ollama';
 export { default as OpenAIProvider } from './openai';
 export { default as ZhiPuProvider } from './zhipu';

--- a/src/config/modelProviders/ollama.ts
+++ b/src/config/modelProviders/ollama.ts
@@ -1,0 +1,27 @@
+import { ModelProviderCard } from '@/types/llm';
+
+const Ollama: ModelProviderCard = {
+  chatModels: [
+    {
+      displayName: 'Llama2 7B',
+      functionCall: false,
+      id: 'llama2',
+      vision: false,
+    },
+    {
+      displayName: 'Mistral',
+      functionCall: false,
+      id: 'mistral',
+      vision: false,
+    },
+    {
+      displayName: 'Qwen 7B Chat',
+      functionCall: false,
+      id: 'qwen:7b-chat',
+      vision: false,
+    },
+  ],
+  id: 'ollama',
+};
+
+export default Ollama;

--- a/src/config/server/provider.ts
+++ b/src/config/server/provider.ts
@@ -33,6 +33,9 @@ declare global {
       AWS_ACCESS_KEY_ID?: string;
       AWS_SECRET_ACCESS_KEY?: string;
 
+      // Ollama Provider;
+      OLLAMA_PROXY_URL?: string;
+
       DEBUG_CHAT_COMPLETION?: string;
     }
   }
@@ -82,6 +85,9 @@ export const getProviderConfig = () => {
     AZURE_API_VERSION: process.env.AZURE_API_VERSION,
     AZURE_ENDPOINT: process.env.AZURE_ENDPOINT,
     USE_AZURE_OPENAI: process.env.USE_AZURE_OPENAI === '1',
+
+    ENABLE_OLLAMA: !!process.env.OLLAMA_PROXY_URL,
+    OLLAMA_PROXY_URL: process.env.OLLAMA_PROXY_URL || '',
 
     DEBUG_CHAT_COMPLETION: process.env.DEBUG_CHAT_COMPLETION === '1',
   };

--- a/src/const/settings.ts
+++ b/src/const/settings.ts
@@ -66,6 +66,10 @@ export const DEFAULT_LLM_CONFIG: GlobalLLMConfig = {
     apiKey: '',
     enabled: false,
   },
+  ollama: {
+    enabled: false,
+    endpoint: '',
+  },
   openAI: {
     OPENAI_API_KEY: '',
     models: [],

--- a/src/libs/agent-runtime/error.ts
+++ b/src/libs/agent-runtime/error.ts
@@ -22,6 +22,9 @@ export const AgentRuntimeErrorType = {
 
   InvalidMoonshotAPIKey: 'InvalidMoonshotAPIKey',
   MoonshotBizError: 'MoonshotBizError',
+
+  InvalidOllamaArgs: 'InvalidOllamaArgs',
+  OllamaBizError: 'OllamaBizError',
 } as const;
 
 export type ILobeAgentRuntimeErrorType =

--- a/src/libs/agent-runtime/index.ts
+++ b/src/libs/agent-runtime/index.ts
@@ -4,6 +4,7 @@ export { LobeBedrockAI } from './bedrock';
 export * from './error';
 export { LobeGoogleAI } from './google';
 export { LobeMoonshotAI } from './moonshot';
+export { LobeOllamaAI } from './ollama';
 export { LobeOpenAI } from './openai';
 export * from './types';
 export { AgentRuntimeError } from './utils/createError';

--- a/src/libs/agent-runtime/ollama/index.ts
+++ b/src/libs/agent-runtime/ollama/index.ts
@@ -1,0 +1,80 @@
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import OpenAI from 'openai';
+
+import { LobeRuntimeAI } from '../BaseAI';
+import { AgentRuntimeErrorType } from '../error';
+import { ChatStreamPayload, ModelProvider } from '../types';
+import { AgentRuntimeError } from '../utils/createError';
+import { debugStream } from '../utils/debugStream';
+import { desensitizeUrl } from '../utils/desensitizeUrl';
+import { DEBUG_CHAT_COMPLETION } from '../utils/env';
+import { handleOpenAIError } from '../utils/handleOpenAIError';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:11434/v1';
+
+export class LobeOllamaAI implements LobeRuntimeAI {
+  private _llm: OpenAI;
+
+  baseURL: string;
+
+  constructor(baseURL: string = DEFAULT_BASE_URL) {
+    if (!baseURL) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidOllamaArgs);
+
+    this._llm = new OpenAI({ apiKey: 'ollama', baseURL });
+    this.baseURL = baseURL;
+  }
+
+  async chat(payload: ChatStreamPayload) {
+    try {
+      const response = await this._llm.chat.completions.create(
+        payload as unknown as OpenAI.ChatCompletionCreateParamsStreaming,
+      );
+
+      const stream = OpenAIStream(response);
+
+      const [debug, returnStream] = stream.tee();
+
+      if (DEBUG_CHAT_COMPLETION) {
+        debugStream(debug).catch(console.error);
+      }
+
+      return new StreamingTextResponse(returnStream);
+    } catch (error) {
+      let desensitizedEndpoint = this.baseURL;
+
+      if (this.baseURL !== DEFAULT_BASE_URL) {
+        desensitizedEndpoint = desensitizeUrl(this.baseURL);
+      }
+
+      if ('status' in (error as any)) {
+        switch ((error as Response).status) {
+          case 401: {
+            throw AgentRuntimeError.chat({
+              endpoint: desensitizedEndpoint,
+              error: error as any,
+              errorType: AgentRuntimeErrorType.InvalidOllamaArgs,
+              provider: ModelProvider.Ollama,
+            });
+          }
+
+          default: {
+            break;
+          }
+        }
+      }
+
+      const { errorResult, RuntimeError } = handleOpenAIError(error);
+
+      const errorType = RuntimeError || AgentRuntimeErrorType.OllamaBizError;
+
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizedEndpoint,
+        error: errorResult,
+        errorType,
+        provider: ModelProvider.Ollama,
+      });
+    }
+  }
+}
+
+export default LobeOllamaAI;

--- a/src/libs/agent-runtime/types/type.ts
+++ b/src/libs/agent-runtime/types/type.ts
@@ -29,6 +29,7 @@ export enum ModelProvider {
   Google = 'google',
   Mistral = 'mistral',
   Moonshot = 'moonshot',
+  Ollama = 'ollama',
   OpenAI = 'openai',
   Tongyi = 'tongyi',
   ZhiPu = 'zhipu',

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -103,6 +103,7 @@ export default {
     bedrock: 'AWS Bedrock',
     google: 'Google',
     moonshot: 'Moonshot AI',
+    ollama: 'Ollama',
     oneapi: 'One API',
     openai: 'OpenAI',
     zhipu: '智谱AI',

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -85,6 +85,22 @@ export default {
         title: 'API Key',
       },
     },
+    Ollama: {
+      checker: {
+        desc: '测试代理地址是否正确填写',
+      },
+      customModelName: {
+        desc: '增加自定义模型，多个模型使用逗号（,）隔开',
+        placeholder: 'model1,model2,model3',
+        title: '自定义模型名称',
+      },
+      endpoint: {
+        desc: '填入 Ollama 接口代理地址，本地未额外指定可留空',
+        placeholder: 'http://127.0.0.1:11434/v1',
+        title: '接口代理地址',
+      },
+      title: 'Ollama',
+    },
     OpenAI: {
       azureApiVersion: {
         desc: 'Azure 的 API 版本，遵循 YYYY-MM-DD 格式，查阅[最新版本](https://learn.microsoft.com/zh-cn/azure/ai-services/openai/reference#chat-completions)',

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -40,6 +40,14 @@ const getProviderAuthPayload = (provider: string) => {
       };
     }
 
+    case ModelProvider.Ollama: {
+      const endpoint = modelProviderSelectors.ollamaProxyUrl(useGlobalStore.getState());
+
+      return {
+        endpoint,
+      };
+    }
+
     default:
     case ModelProvider.OpenAI: {
       const openai = modelProviderSelectors.openAIConfig(useGlobalStore.getState());

--- a/src/store/global/slices/settings/selectors/modelProvider.ts
+++ b/src/store/global/slices/settings/selectors/modelProvider.ts
@@ -5,6 +5,7 @@ import {
   GoogleProvider,
   LOBE_DEFAULT_MODEL_LIST,
   MoonshotProvider,
+  OllamaProvider,
   OpenAIProvider,
   ZhiPuProvider,
 } from '@/config/modelProviders';
@@ -37,6 +38,11 @@ const azureConfig = (s: GlobalStore) => modelProvider(s).azure;
 const enableMoonshot = (s: GlobalStore) => modelProvider(s).moonshot.enabled;
 const moonshotAPIKey = (s: GlobalStore) => modelProvider(s).moonshot.apiKey;
 
+const enableOllamaFromServerConfig = (s: GlobalStore) =>
+  s.serverConfig.languageModel?.ollama?.enabled;
+const enableOllama = (s: GlobalStore) => modelProvider(s).ollama.enabled;
+const ollamaProxyUrl = (s: GlobalStore) => modelProvider(s).ollama.endpoint;
+
 // const azureModelList = (s: GlobalStore): ModelProviderCard => {
 //   const azure = azureConfig(s);
 //   return {
@@ -46,8 +52,11 @@ const moonshotAPIKey = (s: GlobalStore) => modelProvider(s).moonshot.apiKey;
 // };
 
 // 提取处理 chatModels 的专门方法
-const processChatModels = (modelConfig: ReturnType<typeof parseModelString>): ChatModelCard[] => {
-  let chatModels = modelConfig.removeAll ? [] : OpenAIProvider.chatModels;
+const processChatModels = (
+  modelConfig: ReturnType<typeof parseModelString>,
+  defaultChartModels = OpenAIProvider.chatModels,
+): ChatModelCard[] => {
+  let chatModels = modelConfig.removeAll ? [] : defaultChartModels;
 
   // 处理移除逻辑
   if (!modelConfig.removeAll) {
@@ -102,6 +111,12 @@ const modelSelectList = (s: GlobalStore): ModelProviderCard[] => {
 
   const chatModels = processChatModels(modelConfig);
 
+  const ollamaModelConfig = parseModelString(
+    currentSettings(s).languageModel.ollama.customModelName,
+  );
+
+  const ollamaChatModels = processChatModels(ollamaModelConfig, OllamaProvider.chatModels);
+
   return [
     {
       ...OpenAIProvider,
@@ -112,6 +127,7 @@ const modelSelectList = (s: GlobalStore): ModelProviderCard[] => {
     { ...MoonshotProvider, enabled: enableMoonshot(s) },
     { ...GoogleProvider, enabled: enableGoogle(s) },
     { ...BedrockProvider, enabled: enableBedrock(s) },
+    { ...OllamaProvider, chatModels: ollamaChatModels, enabled: enableOllama(s) },
   ];
 };
 
@@ -174,4 +190,9 @@ export const modelProviderSelectors = {
   // Moonshot
   enableMoonshot,
   moonshotAPIKey,
+
+  // Ollama
+  enableOllamaFromServerConfig,
+  enableOllama,
+  ollamaProxyUrl,
 };

--- a/src/types/settings/modelProvider.ts
+++ b/src/types/settings/modelProvider.ts
@@ -47,11 +47,18 @@ export interface AWSBedrockConfig {
   secretAccessKey?: string;
 }
 
+export interface OllamaConfig {
+  customModelName?: string;
+  enabled?: boolean;
+  endpoint?: string;
+}
+
 export interface GlobalLLMConfig {
   azure: AzureOpenAIConfig;
   bedrock: AWSBedrockConfig;
   google: GoogleConfig;
   moonshot: MoonshotConfig;
+  ollama: OllamaConfig;
   openAI: OpenAIConfig;
   zhipu: ZhiPuConfig;
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat support local llm via ollama (openai compatible) 

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

Refs #1283

<!-- Add any other context about the Pull Request here. -->

- [x] Need to wait for the ollma PR merged this https://github.com/ollama/ollama/pull/2376/files
- [x] Which open source models are listed under Ollama by default ( currently is Mistral and Llama2 and Qwen)
- [x] Add visible control via server config (env var control)
- [x] Add form field so that user can select customized model  (leverage the capability of Ollama)
<img width="344" alt="image" src="https://github.com/lobehub/lobe-chat/assets/1523060/205800ba-fcd9-46b3-a4de-8a37abdd67e2">
<img width="582" alt="image" src="https://github.com/lobehub/lobe-chat/assets/1523060/c7707746-ebbd-4f40-823c-cb8f021e7af3">


