### PR TITLE
🐛 fix: The back button on the chat setting page can correctly return to the configured Agent chat page with search parameter 

### DIFF
--- a/src/app/chat/settings/(desktop)/features/Header.tsx
+++ b/src/app/chat/settings/(desktop)/features/Header.tsx
@@ -13,7 +13,7 @@ const Header = memo(() => {
   return (
     <ChatHeader
       left={<ChatHeaderTitle title={t('header.session')} />}
-      onBackClick={() => router.push(pathString('/chat', { hash: location.hash }))}
+      onBackClick={() => router.push(pathString('/chat', { search: location.search }))}
       right={<HeaderContent />}
       showBackButton
     />


### PR DESCRIPTION
🐛 fix: The back button on the chat setting page can correctly return to the configured Agent chat page

#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

原逻辑：无论在任何 Agent 的聊天界面中，当点击 chat setting 页面的“回退”按钮时，页面会直接跳转至“chat?session=inbox”页面。

现修复回退按钮逻辑，参数使用 location.search 

![image](https://github.com/lobehub/lobe-chat/assets/18510448/710cd669-fe51-471a-8f05-6570ba2537bc)


#### 📝 补充信息 | Additional Information

