### PR TITLE
🐛 fix: fix auth error in console and some other bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5",
+    "@auth/core": "^0.26.3",
     "@aws-sdk/client-bedrock-runtime": "^3.503.1",
     "@azure/openai": "^1.0.0-beta.11",
     "@cfworker/json-schema": "^1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { isRtlLang } from 'rtl-detect';
 
 import Analytics from '@/components/Analytics';
+import { getServerConfig } from '@/config/server';
 import { DEFAULT_LANG, LOBE_LOCALE_COOKIE } from '@/const/locale';
 import {
   LOBE_THEME_APPEARANCE,
@@ -13,6 +14,8 @@ import {
 import Layout from '@/layout/GlobalLayout';
 
 import StyleRegistry from './StyleRegistry';
+
+const { ENABLE_OAUTH_SSO } = getServerConfig();
 
 const RootLayout = ({ children }: PropsWithChildren) => {
   // get default theme config to use with ssr
@@ -32,6 +35,7 @@ const RootLayout = ({ children }: PropsWithChildren) => {
             defaultLang={lang?.value}
             defaultNeutralColor={neutralColor?.value as any}
             defaultPrimaryColor={primaryColor?.value as any}
+            enableOAuthSSO={ENABLE_OAUTH_SSO}
           >
             {children}
           </Layout>

--- a/src/app/settings/common/Common.tsx
+++ b/src/app/settings/common/Common.tsx
@@ -2,7 +2,7 @@ import { Form, type ItemGroup, SelectWithImg, SliderWithInput } from '@lobehub/u
 import { Form as AntForm, App, Button, Input, Select } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { AppWindow, Monitor, Moon, Palette, Sun } from 'lucide-react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, signOut } from 'next-auth/react';
 import { memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -10,6 +10,7 @@ import { FORM_STYLE } from '@/const/layoutTokens';
 import { DEFAULT_SETTINGS } from '@/const/settings';
 import { imageUrl } from '@/const/url';
 import AvatarWithUpload from '@/features/AvatarWithUpload';
+import { useOAuthSession } from '@/hooks/useOAuthSession';
 import { localeOptions } from '@/locales/resources';
 import { useChatStore } from '@/store/chat';
 import { useFileStore } from '@/store/file';
@@ -32,8 +33,7 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig, showOAuthLogin
   const { t } = useTranslation('setting');
   const [form] = AntForm.useForm();
 
-  const { data: session, status } = useSession();
-  const isOAuthLoggedIn = status === 'authenticated' && session && session.user;
+  const { user, isOAuthLoggedIn } = useOAuthSession();
 
   const [clearSessions, clearSessionGroups] = useSessionStore((s) => [
     s.clearSessions,
@@ -227,7 +227,7 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig, showOAuthLogin
           </Button>
         ),
         desc: isOAuthLoggedIn
-          ? `${session.user?.email} ${t('settingSystem.oauth.info.desc')}`
+          ? `${user?.email} ${t('settingSystem.oauth.info.desc')}`
           : t('settingSystem.oauth.signin.desc'),
         hidden: !showOAuthLogin,
         label: isOAuthLoggedIn

--- a/src/app/settings/llm/page.tsx
+++ b/src/app/settings/llm/page.tsx
@@ -6,6 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import Footer from '@/app/settings/features/Footer';
 import PageTitle from '@/components/PageTitle';
+import { MORE_MODEL_PROVIDER_REQUEST_URL } from '@/const/url';
 import { useSwitchSideBarOnInit } from '@/store/global/hooks/useSwitchSettingsOnInit';
 import { SettingsTabs } from '@/store/global/initialState';
 
@@ -30,11 +31,7 @@ export default memo(() => {
       <Footer>
         <Trans i18nKey="llm.waitingForMore" ns={'setting'}>
           更多模型正在
-          <Link
-            aria-label={'todo'}
-            href="https://github.com/lobehub/lobe-chat/issues/151"
-            target="_blank"
-          >
+          <Link aria-label={'todo'} href={MORE_MODEL_PROVIDER_REQUEST_URL} target="_blank">
             计划接入
           </Link>
           中 ，敬请期待 ✨

--- a/src/const/url.ts
+++ b/src/const/url.ts
@@ -15,6 +15,9 @@ export const DISCORD = 'https://discord.gg/AYFPHvv2jT';
 
 export const PLUGINS_INDEX_URL = 'https://chat-plugins.lobehub.com';
 
+export const MORE_MODEL_PROVIDER_REQUEST_URL =
+  'https://github.com/lobehub/lobe-chat/discussions/1284';
+
 export const AGENTS_INDEX_GITHUB = 'https://github.com/lobehub/lobe-chat-agents';
 export const AGENTS_INDEX_GITHUB_ISSUE = urlJoin(AGENTS_INDEX_GITHUB, 'issues/new');
 

--- a/src/features/Conversation/Error/OAuthForm.tsx
+++ b/src/features/Conversation/Error/OAuthForm.tsx
@@ -1,11 +1,12 @@
 import { Icon } from '@lobehub/ui';
 import { App, Button } from 'antd';
 import { ScanFace } from 'lucide-react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, signOut } from 'next-auth/react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
 
+import { useOAuthSession } from '@/hooks/useOAuthSession';
 import { useChatStore } from '@/store/chat';
 
 import { FormAction } from './style';
@@ -13,8 +14,7 @@ import { FormAction } from './style';
 const OAuthForm = memo<{ id: string }>(({ id }) => {
   const { t } = useTranslation('error');
 
-  const { data: session, status } = useSession();
-  const isOAuthLoggedIn = status === 'authenticated' && session && session.user;
+  const { user, isOAuthLoggedIn } = useOAuthSession();
 
   const [resend, deleteMessage] = useChatStore((s) => [s.resendMessage, s.deleteMessage]);
 
@@ -38,7 +38,7 @@ const OAuthForm = memo<{ id: string }>(({ id }) => {
         avatar={isOAuthLoggedIn ? '✅' : '🕵️‍♂️'}
         description={
           isOAuthLoggedIn
-            ? `${t('unlock.oauth.welcome')} ${session?.user?.name}`
+            ? `${t('unlock.oauth.welcome')} ${user?.name}`
             : t('unlock.oauth.description')
         }
         title={isOAuthLoggedIn ? t('unlock.oauth.success') : t('unlock.oauth.title')}

--- a/src/hooks/useOAuthSession.ts
+++ b/src/hooks/useOAuthSession.ts
@@ -1,0 +1,24 @@
+import { User } from '@auth/core/types';
+import { SessionContextValue, useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+
+interface OAuthSession {
+  isOAuthLoggedIn: boolean;
+  user?: User | null;
+}
+
+export const useOAuthSession = () => {
+  let authSession: SessionContextValue | null;
+  try {
+    // refs: https://github.com/lobehub/lobe-chat/pull/1286
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    authSession = useSession();
+  } catch {
+    authSession = null;
+  }
+
+  const { data: session, status } = authSession || {};
+  const isOAuthLoggedIn = (status === 'authenticated' && session && !!session.user) || false;
+
+  return useMemo<OAuthSession>(() => ({ isOAuthLoggedIn, user: session?.user }), [session, status]);
+};

--- a/src/layout/GlobalLayout/index.tsx
+++ b/src/layout/GlobalLayout/index.tsx
@@ -46,19 +46,29 @@ const Container = memo<PropsWithChildren>(({ children }) => {
 
 interface GlobalLayoutProps extends AppThemeProps {
   defaultLang?: string;
+  enableOAuthSSO?: boolean;
 }
 
-const GlobalLayout = ({ children, defaultLang, ...theme }: GlobalLayoutProps) => {
-  return (
-    <SessionProvider basePath={API_ENDPOINTS.oauth}>
-      <AppTheme {...theme}>
-        <Locale defaultLang={defaultLang}>
-          <StoreHydration />
-          <Container>{children}</Container>
-          <DebugUI />
-        </Locale>
-      </AppTheme>
-    </SessionProvider>
+const GlobalLayout = ({
+  children,
+  defaultLang,
+  enableOAuthSSO = false,
+  ...theme
+}: GlobalLayoutProps) => {
+  const content = (
+    <AppTheme {...theme}>
+      <Locale defaultLang={defaultLang}>
+        <StoreHydration />
+        <Container>{children}</Container>
+        <DebugUI />
+      </Locale>
+    </AppTheme>
+  );
+
+  return enableOAuthSSO ? (
+    <SessionProvider basePath={API_ENDPOINTS.oauth}>{content}</SessionProvider>
+  ) : (
+    content
   );
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- 修正终端输出报错的问题,close #1280
- 修正在使用插件时 Token 指示器展示不正确的问题,close #1285 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

SessionProvider 会自动触发 auth 请求，这对于不开启 OAuth 的私有化部署用户来说是一个很大的干扰项，因此 SessionProvider 应该只在开启 OAuth 后才被包裹。

<img width="1557" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/73d091fe-387d-49ae-8450-45d288404a95">


但 `next-auth` 的 `useSession` 必须要包裹 `SessionProvider` 才可使用，否则会抛出错误。于是重构了一个 useOAuthSession 的方法：

```ts
import { User } from '@auth/core/types';
import { SessionContextValue, useSession } from 'next-auth/react';
import { useMemo } from 'react';

interface OAuthSession {
  isOAuthLoggedIn: boolean;
  user?: User | null;
}

export const useOAuthSession = () => {
  let authSession: SessionContextValue | null;
  try {
    // eslint-disable-next-line react-hooks/rules-of-hooks
    authSession = useSession();
  } catch {
    authSession = null;
  }

  const { data: session, status } = authSession || {};
  const isOAuthLoggedIn = (status === 'authenticated' && session && !!session.user) || false;

  return useMemo<OAuthSession>(() => ({ isOAuthLoggedIn, user: session?.user }), [session, status]);
};
```

@CloudPassenger 看看这个实现有没有更好的方案？ https://github.com/lobehub/lobe-chat/pull/1286/commits/8e7ee8227cfccee2271f4ed26a066522b540674d