### PR TITLE
:bug: fix: fix OAuth errors on Docker deployment

### DIFF
--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -71,6 +71,13 @@ Further reading:
 - Default: `-`
 - Example: `Tfhi2t2pelSMEA8eaV61KaqPNEndFFdMIxDaJnS1CUI=`
 
+#### `NEXTAUTH_URL`
+
+- Type: Optional
+- Description: This URL is used to specify the callback address for Auth.js during OAuth authentication. It does not need to be set when deploying on Vercel.
+- Default: `-`
+- Example: `https://example.com/api/auth`
+
 ### Auth0
 
 <Callout>

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -71,6 +71,13 @@ LobeChat 在部署时提供了一些额外的配置项，你可以使用环境�
 - 默认值: `-`
 - 示例: `Tfhi2t2pelSMEA8eaV61KaqPNEndFFdMIxDaJnS1CUI=`
 
+#### `NEXTAUTH_URL`
+
+- 类型：可选
+- 描述：该URL用于指定Auth.js在执行OAuth验证时的回调地址，在Vercel上部署时无需设置。
+- 默认值：`-`
+- 示例：`https://example.com/api/auth`
+
 ### Auth0
 
 <Callout>

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "modern-screenshot": "^4",
     "nanoid": "^5",
     "next": "^14.1",
-    "next-auth": "beta",
+    "next-auth": "5.0.0-beta.11",
     "numeral": "^2.0.6",
     "nuqs": "^1.15.4",
     "openai": "^4.22",

--- a/src/app/api/auth/next-auth.ts
+++ b/src/app/api/auth/next-auth.ts
@@ -17,6 +17,7 @@ const nextAuth = NextAuth({
       ]
     : [],
   secret: NEXTAUTH_SECRET,
+  trustHost: true,
 });
 
 export const {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,10 @@ const defaultMiddleware = () => NextResponse.next();
 const withAuthMiddleware = auth((req) => {
   // Just check if session exists
   const session = req.auth;
-  const isLoggedIn = !!session;
+
+  // Check if next-auth throws errors
+  // refs: https://github.com/lobehub/lobe-chat/pull/1323
+  const isLoggedIn = !!session?.expires;
 
   // Remove & amend OAuth authorized header
   const requestHeaders = new Headers(req.headers);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change
- fix: 修复了在 Docker 部署下 OAuth 验证无法使用的问题, fix #1315 
- fix: 修复了`src/middleware.ts`在 Auth.js 登陆失败抛出错误下仍然识别为已登陆的问题 #1315 
- docs: 根据`Auth.js`[文档](https://authjs.dev/getting-started/providers/oauth-tutorial#setting-up-nextauth_url)增加了 `NEXTAUTH_URL` 环境变量。并根据`Auth.js`[相关PR](https://github.com/nextauthjs/next-auth/pull/9955)提供了该变量的设置示例。
- chore: 临时锁定 next-auth 到 beta.11 ，修正安装构建问题, fix #1326 ,fix #1327
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
- Docker 部署下 OAuth 验证无法使用：在 Docker 部署下会遇到 trusthost 问题，且该问题不会出现在 Vercel 部署中，因为[ Auth.js 会在受信任的平台上自动关闭该选项](https://authjs.dev/reference/sveltekit#trusthost)，故在 next-auth 的 config 中关闭该选项
- `src/middleware`中登陆状态判断：先前对登陆状态的判断中是根据`session`是否存在进行判断，是符合类型定义的。 https://github.com/lobehub/lobe-chat/blob/3aaf325e64084359946265cf343c5aa8fca94d2a/src/middleware.ts#L16
但在实际使用时发现，当 Auth.js 抛出异常时，`session` 可能为`string`或其他类型，此时根据`session`是否存在进行登陆状态判断会造成误判。因此改为根据`session.expires`是否存在进行判断，该属性在`session`的定义中是仅在`session`存在且 Auth.js 没有错误时存在。 附：auth.js中的`Session`定义。
```ts
export interface Session extends DefaultSession {}
export interface DefaultSession {
  user?: User
  expires: ISODateString
}
```
> 本地通过设置错误的`NEXTAUTH_URL`即可使Auth.js抛出异常
<!-- Add any other context about the Pull Request here. -->
