### PR TITLE
🐛 fix: Could not get user_id from session

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5",
-    "@auth/core": "^0.26.3",
+    "@auth/core": "^0.27.0",
     "@aws-sdk/client-bedrock-runtime": "^3.503.1",
     "@azure/openai": "^1.0.0-beta.11",
     "@cfworker/json-schema": "^1",
@@ -107,7 +107,7 @@
     "modern-screenshot": "^4",
     "nanoid": "^5",
     "next": "^14.1",
-    "next-auth": "5.0.0-beta.11",
+    "next-auth": "5.0.0-beta.13",
     "next-sitemap": "^4.2.3",
     "numeral": "^2.0.6",
     "nuqs": "^1.15.4",

--- a/src/app/api/auth/next-auth.ts
+++ b/src/app/api/auth/next-auth.ts
@@ -7,9 +7,30 @@ const { AUTH0_CLIENT_ID, ENABLE_OAUTH_SSO, AUTH0_CLIENT_SECRET, AUTH0_ISSUER, NE
   getServerConfig();
 
 const nextAuth = NextAuth({
+  callbacks: {
+    async jwt({ token, profile }) {
+      // Override with the attributes from the Auth0 Profile.
+      // Default values for profile.sub: 'auth0|USER-ID'.
+      // ref: https://auth0.com/docs/get-started/apis/scopes/sample-use-cases-scopes-and-claims#authenticate-a-user-and-request-standard-claims
+      if (profile) {
+        token.sub = profile.sub ?? token.sub;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      // Pick userid from token
+      if (session.user) {
+        session.user.id = token.sub ?? session.user.id;
+      }
+      return session;
+    },
+  },
   providers: ENABLE_OAUTH_SSO
     ? [
         Auth0({
+          // Specify auth scope, at least include 'openid email'
+          // all scopes in Auth0 ref: https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims
+          authorization: { params: { scope: 'openid email profile' } },
           clientId: AUTH0_CLIENT_ID,
           clientSecret: AUTH0_CLIENT_SECRET,
           issuer: AUTH0_ISSUER,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
- fix: `@/hooks/useOAuthSession`获取的`Session`中没有`user_id`的问题。也许可用作[RFC 009 跨端同步](https://github.com/lobehub/lobe-chat/discussions/368)的用户标识？
下图为更改后的效果：
```ts
import { useOAuthSession } from '@/hooks/useOAuthSession';
const { user, isOAuthLoggedIn } = useOAuthSession();
console.log(user);
```
![image](https://github.com/lobehub/lobe-chat/assets/67412196/9bf18a2e-5519-418a-9eed-86610dcf931a)

- chore: next-auth修复了依赖版本问题，同时删除了多余的日志控制台输出，同步更新到`5.0.0-beta.13`
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
- 继承了Auth0的设计，在对 `src/app/api/auth/next-auth.ts` 中的commit中把返回给客户端 token 的`sub` 属性更换成了用户 id
<!-- Add any other context about the Pull Request here. -->
