### PR TITLE
:bug: fix: fix hydration error while OAuth callback

### DIFF
--- a/src/locales/create.ts
+++ b/src/locales/create.ts
@@ -39,6 +39,14 @@ export const createI18nNext = (lang?: string) => {
         detection: {
           caches: ['cookie'],
           cookieMinutes: 60 * 24 * COOKIE_CACHE_DAYS,
+          /**
+             Set `sameSite` to `lax` so that the i18n cookie can be passed to the
+             server side when returning from the OAuth authorization website.
+             ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
+          */
+          cookieOptions: {
+            sameSite: 'lax',
+          },
           lookupCookie: LOBE_LOCALE_COOKIE,
         },
         fallbackLng: DEFAULT_LANG,

--- a/src/locales/create.ts
+++ b/src/locales/create.ts
@@ -43,6 +43,7 @@ export const createI18nNext = (lang?: string) => {
              Set `sameSite` to `lax` so that the i18n cookie can be passed to the
              server side when returning from the OAuth authorization website.
              ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
+             discussion: https://github.com/lobehub/lobe-chat/pull/1474
           */
           cookieOptions: {
             sameSite: 'lax',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- fix: 当系统语言不为 `en-US` 时，单点登录回调时会产生 SSR 水合问题。即单点登录回调后 UI 一直处于 loading，直至用户点击才会重新渲染。
- 问题定位： `src\app\layout.tsx` 使用 cookie `LOBE_LOCALS` 判断语言，但 OAuth 回调时 `LOBE_LOCALS` cookie 无法传递到服务端，从而导致出现与 i18n 相关的水合的问题。
- 解决方案：变更 i18n 的cookie配置，放松对 cookie `LOBE_LOCALS` 的限制，将其设为允许跨站。即在 `i18next-browser-languageDetector` 插件的配置中将 `cookie` 的 [`sameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) 设置从默认的 `undefined` 改为 `lax`。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- `i18next-browser-languageDetector`的[默认配置](https://github.com/i18next/i18next-browser-languageDetector/blob/9efebe6ca0271c3797bc09b84babf1ba2d9b4dbb/src/index.js#L11)。
- `i18next-browser-languageDetector`默认不对 cookie 的 `sameSite` 进行设置。在默认情况下，chrome 和 edge 浏览器都会将该 cookie 的 `sameSite` 设为 `strict` 从而防止跨站攻击。个人认为该 cookie 仅用于标识语言，不涉及访问控制，可以放开对其限制。
> authjs 也将其需要跨站共享的 cookie，如 `callback url` 等的 `sameSite` 属性设为 `lax` 以便在 OAuth 回调重定向时能传递到服务端。
 ![image](https://github.com/lobehub/lobe-chat/assets/67412196/54c1cfcd-5200-4d1c-b92c-83d26277f7b2)


<!-- Add any other context about the Pull Request here. -->
