### PR TITLE
Add missing "fast-xml-parser" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "dexie": "^3",
     "diff": "^5.2.0",
     "fast-deep-equal": "^3",
+    "fast-xml-parser": "^4.3.5",
     "gpt-tokenizer": "^2",
     "i18next": "^23",
     "i18next-browser-languagedetector": "^7",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

In my tests, deploying to Vercel failed with error `Module not found: Can't resolve 'fast-xml-parser'` (Issue: https://github.com/lobehub/lobe-chat/issues/1495). As suggested by [ysrdevs](https://github.com/ysrdevs), adding `fast-xml-parser` dependency seem to have resolved the issue.

#### 📝 补充信息 | Additional Information

Link to issue: https://github.com/lobehub/lobe-chat/issues/1495
