### PR TITLE
✨ feat: add claude 3 to bedrock provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ant-design/icons": "^5",
     "@anthropic-ai/sdk": "^0.17.0",
     "@auth/core": "latest",
-    "@aws-sdk/client-bedrock-runtime": "^3.503.1",
+    "@aws-sdk/client-bedrock-runtime": "^3.525.0",
     "@azure/openai": "^1.0.0-beta.11",
     "@cfworker/json-schema": "^1",
     "@google/generative-ai": "^0.2.0",

--- a/src/config/modelProviders/anthropic.ts
+++ b/src/config/modelProviders/anthropic.ts
@@ -24,8 +24,7 @@ const Anthropic: ModelProviderCard = {
       description:
         'Fastest and most compact model for near-instant responsiveness. Quick and accurate targeted performance',
       displayName: 'Claude 3 Haiku',
-      hidden: true,
-      id: 'claude-3-haiku-20240229',
+      id: 'claude-3-haiku-20240307',
       maxOutput: 4096,
       tokens: 200_000,
       vision: true,

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -12,9 +12,17 @@ const Bedrock: ModelProviderCard = {
     },
     {
       description:
-        'Claude 3 Sonnet，上下文大小等于 200k。Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之间取得理想的平衡，尤其是在处理企业工作负载方面。该模型提供最大的效用，同时价格低于竞争产品，并且其经过精心设计，是大规模部署人工智能的可信赖、高耐久性骨干模型。',
+        'Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之间取得理想的平衡，尤其是在处理企业工作负载方面。该模型提供最大的效用，同时价格低于竞争产品，并且其经过精心设计，是大规模部署人工智能的可信赖、高耐久性骨干模型。 Claude 3 Sonnet 可以处理图像和返回文本输出，并且提供 200K 上下文窗口。',
       displayName: 'Claude 3 Sonnet',
       id: 'anthropic.claude-3-sonnet-20240229-v1:0',
+      tokens: 200_000,
+      vision: true,
+    },
+    {
+      description:
+        'Claude 3 Haiku 是 Anthropic 最快速、最紧凑的模型，具有近乎即时的响应能力。该模型可以快速回答简单的查询和请求。客户将能够构建模仿人类交互的无缝人工智能体验。 Claude 3 Haiku 可以处理图像和返回文本输出，并且提供 200K 上下文窗口。',
+      displayName: 'Claude 3 Haiku',
+      id: 'anthropic.claude-3-haiku-20240307-v1:0',
       tokens: 200_000,
       vision: true,
     },

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -12,17 +12,25 @@ const Bedrock: ModelProviderCard = {
     },
     {
       description:
-        'Claude Instant 1.2 v1.2，上下文大小等于 100k，一个更快更便宜但仍然非常能干的模型，可以处理包括随意对话在内的多种任务。',
-      displayName: 'Claude Instant 1.2',
-      id: 'anthropic.claude-instant-v1',
-      tokens: 100_000,
+        'Claude 3 Sonnet，上下文大小等于 200k。Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之间取得理想的平衡，尤其是在处理企业工作负载方面。该模型提供最大的效用，同时价格低于竞争产品，并且其经过精心设计，是大规模部署人工智能的可信赖、高耐久性骨干模型。',
+      displayName: 'Claude 3 Sonnet',
+      id: 'anthropic.claude-3-sonnet-20240229-v1:0',
+      tokens: 200_000,
+      vision: true,
     },
     {
       description:
-        'Claude 2.1 v2.1，上下文大小等于 200k，Claude 2 的更新版本，特性包括双倍的上下文窗口，以及在可靠性等方面的提升。',
+        'Claude 2.1 v2.1，上下文大小等于 200k。Claude 2 的更新版本，采用双倍的上下文窗口，并在长文档和 RAG 上下文中提高可靠性、幻觉率和循证准确性。',
       displayName: 'Claude 2.1',
       id: 'anthropic.claude-v2:1',
       tokens: 200_000,
+    },
+    {
+      description:
+        'Claude Instant 1.2 v1.2，上下文大小等于 100k。一种更快速、更实惠但仍然非常强大的模型，它可以处理一系列任务，包括随意对话、文本分析、摘要和文档问题回答。',
+      displayName: 'Claude Instant 1.2',
+      id: 'anthropic.claude-instant-v1',
+      tokens: 100_000,
     },
     {
       description: 'Llama 2 Chat 13B v1，上下文大小为 4k，Llama 2 模型的对话用例优化变体。',

--- a/src/libs/agent-runtime/anthropic/index.ts
+++ b/src/libs/agent-runtime/anthropic/index.ts
@@ -9,14 +9,12 @@ import { AgentRuntimeErrorType } from '../error';
 import {
   ChatCompetitionOptions,
   ChatStreamPayload,
-  ModelProvider,
-  OpenAIChatMessage,
-  UserMessageContentPart,
+  ModelProvider
 } from '../types';
 import { AgentRuntimeError } from '../utils/createError';
 import { debugStream } from '../utils/debugStream';
 import { desensitizeUrl } from '../utils/desensitizeUrl';
-import { parseDataUri } from '../utils/uriParser';
+import { buildAnthropicMessages } from '../utils/anthropicHelpers';
 
 const DEFAULT_BASE_URL = 'https://api.anthropic.com';
 
@@ -32,40 +30,22 @@ export class LobeAnthropicAI implements LobeRuntimeAI {
     this.baseURL = this.client.baseURL;
   }
 
-  private buildAnthropicMessages = (
-    messages: OpenAIChatMessage[],
-  ): Anthropic.Messages.MessageParam[] =>
-    messages.map((message) => this.convertToAnthropicMessage(message));
-
-  private convertToAnthropicMessage = (
-    message: OpenAIChatMessage,
-  ): Anthropic.Messages.MessageParam => {
-    const content = message.content as string | UserMessageContentPart[];
-
-    return {
-      content:
-        typeof content === 'string' ? content : content.map((c) => this.convertToAnthropicBlock(c)),
-      role: message.role === 'function' || message.role === 'system' ? 'assistant' : message.role,
-    };
-  };
-
   async chat(payload: ChatStreamPayload, options?: ChatCompetitionOptions) {
     const { messages, model, max_tokens, temperature, top_p } = payload;
     const system_message = messages.find((m) => m.role === 'system');
     const user_messages = messages.filter((m) => m.role !== 'system');
 
-    const requestParams: Anthropic.MessageCreateParams = {
-      max_tokens: max_tokens || 4096,
-      messages: this.buildAnthropicMessages(user_messages),
-      model: model,
-      stream: true,
-      system: system_message?.content as string,
-      temperature: temperature,
-      top_p: top_p,
-    };
-
     try {
-      const response = await this.client.messages.create(requestParams);
+      const response = await this.client.messages.create({
+        max_tokens: max_tokens || 4096,
+        messages: buildAnthropicMessages(user_messages),
+        model: model,
+        stream: true,
+        system: system_message?.content as string,
+        temperature: temperature,
+        top_p: top_p,
+      });
+
       const [prod, debug] = response.tee();
 
       if (process.env.DEBUG_ANTHROPIC_CHAT_COMPLETION === '1') {
@@ -103,29 +83,6 @@ export class LobeAnthropicAI implements LobeRuntimeAI {
         errorType: AgentRuntimeErrorType.AnthropicBizError,
         provider: ModelProvider.Anthropic,
       });
-    }
-  }
-
-  private convertToAnthropicBlock(
-    content: UserMessageContentPart,
-  ): Anthropic.ContentBlock | Anthropic.ImageBlockParam {
-    switch (content.type) {
-      case 'text': {
-        return content;
-      }
-
-      case 'image_url': {
-        const { mimeType, base64 } = parseDataUri(content.image_url.url);
-
-        return {
-          source: {
-            data: base64 as string,
-            media_type: mimeType as Anthropic.ImageBlockParam.Source['media_type'],
-            type: 'base64',
-          },
-          type: 'image',
-        };
-      }
     }
   }
 }

--- a/src/libs/agent-runtime/bedrock/index.test.ts
+++ b/src/libs/agent-runtime/bedrock/index.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  InvokeModelWithResponseStreamCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import * as debugStreamModule from '../utils/debugStream';
+import { LobeBedrockAI } from './index';
+
+const provider = 'bedrock';
+
+// Mock the console.error to avoid polluting test output
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", async (importOriginal) => {
+  const module = await importOriginal();
+  return {
+    ...(module as any),
+    InvokeModelWithResponseStreamCommand: vi.fn()
+  }
+})
+
+let instance: LobeBedrockAI;
+
+beforeEach(() => {
+  instance = new LobeBedrockAI({
+    region: 'us-west-2',
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+  });
+
+  vi.spyOn(instance['client'], 'send').mockReturnValue(new ReadableStream() as any);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('LobeBedrockAI', () => {
+  describe('init', () => {
+    it('should correctly initialize with AWS credentials', async () => {
+      const instance = new LobeBedrockAI({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key-id',
+        accessKeySecret: 'test-access-key-secret',
+      });
+      expect(instance).toBeInstanceOf(LobeBedrockAI);
+    });
+  });
+
+  describe('chat', () => {
+
+    describe('Claude model', () => {
+
+      it('should return a Response on successful API call', async () => {
+        const result = await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'anthropic.claude-v2:1',
+          temperature: 0,
+        });
+  
+        // Assert
+        expect(result).toBeInstanceOf(Response);
+      });
+
+      it('should handle text messages correctly', async () => {
+        // Arrange
+        const mockStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue('Hello, world!');
+            controller.close();
+          },
+        });
+        const mockResponse = Promise.resolve(mockStream);
+        (instance['client'].send as Mock).mockResolvedValue(mockResponse);
+  
+        // Act
+        const result = await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'anthropic.claude-v2:1',
+          temperature: 0,
+          top_p: 1,
+        });
+  
+        // Assert
+        expect(InvokeModelWithResponseStreamCommand).toHaveBeenCalledWith({
+          accept: 'application/json',
+          body: JSON.stringify({
+            anthropic_version: "bedrock-2023-05-31",
+            max_tokens: 4096,
+            messages: [{ content: 'Hello', role: 'user' }],
+            temperature: 0,
+            top_p: 1,
+          }),
+          contentType: 'application/json',
+          modelId: 'anthropic.claude-v2:1',
+        });
+        expect(result).toBeInstanceOf(Response);
+      });
+
+      it('should handle system prompt correctly', async () => {
+        // Arrange
+        const mockStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue('Hello, world!');
+            controller.close();
+          },
+        });
+        const mockResponse = Promise.resolve(mockStream);
+        (instance['client'].send as Mock).mockResolvedValue(mockResponse);
+  
+        // Act
+        const result = await instance.chat({
+          messages: [
+            { content: 'You are an awesome greeter', role: 'system' },
+            { content: 'Hello', role: 'user' },
+          ],
+          model: 'anthropic.claude-v2:1',
+          temperature: 0,
+          top_p: 1,
+        });
+  
+        // Assert
+        expect(InvokeModelWithResponseStreamCommand).toHaveBeenCalledWith({
+          accept: 'application/json',
+          body: JSON.stringify({
+            anthropic_version: "bedrock-2023-05-31",
+            max_tokens: 4096,
+            messages: [{ content: 'Hello', role: 'user' }],
+            system: 'You are an awesome greeter',
+            temperature: 0,
+            top_p: 1,
+          }),
+          contentType: 'application/json',
+          modelId: 'anthropic.claude-v2:1',
+        });
+        expect(result).toBeInstanceOf(Response);
+      });
+
+      it('should call Anthropic model with supported opions', async () => {
+        // Arrange
+        const mockStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue('Hello, world!');
+            controller.close();
+          },
+        });
+        const mockResponse = Promise.resolve(mockStream);
+        (instance['client'].send as Mock).mockResolvedValue(mockResponse);
+  
+        // Act
+        const result = await instance.chat({
+          max_tokens: 2048,
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'anthropic.claude-v2:1',
+          temperature: 0.5,
+          top_p: 1,
+        });
+  
+        // Assert
+        expect(InvokeModelWithResponseStreamCommand).toHaveBeenCalledWith({
+          accept: 'application/json',
+          body: JSON.stringify({
+            anthropic_version: "bedrock-2023-05-31",
+            max_tokens: 2048,
+            messages: [{ content: 'Hello', role: 'user' }],
+            temperature: 0.5,
+            top_p: 1,
+          }),
+          contentType: 'application/json',
+          modelId: 'anthropic.claude-v2:1',
+        });
+        expect(result).toBeInstanceOf(Response);
+      });
+  
+      it('should call Anthropic model without unsupported opions', async () => {
+        // Arrange
+        const mockStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue('Hello, world!');
+            controller.close();
+          },
+        });
+        const mockResponse = Promise.resolve(mockStream);
+        (instance['client'].send as Mock).mockResolvedValue(mockResponse);
+  
+        // Act
+        const result = await instance.chat({
+          frequency_penalty: 0.5, // Unsupported option
+          max_tokens: 2048,
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'anthropic.claude-v2:1',
+          presence_penalty: 0.5,
+          temperature: 0.5,
+          top_p: 1,
+        });
+  
+        // Assert
+        expect(InvokeModelWithResponseStreamCommand).toHaveBeenCalledWith({
+          accept: 'application/json',
+          body: JSON.stringify({
+            anthropic_version: "bedrock-2023-05-31",
+            max_tokens: 2048,
+            messages: [{ content: 'Hello', role: 'user' }],
+            temperature: 0.5,
+            top_p: 1,
+          }),
+          contentType: 'application/json',
+          modelId: 'anthropic.claude-v2:1',
+        });
+        expect(result).toBeInstanceOf(Response);
+      });
+
+    });
+
+  });
+});

--- a/src/libs/agent-runtime/bedrock/index.ts
+++ b/src/libs/agent-runtime/bedrock/index.ts
@@ -2,15 +2,23 @@ import {
   BedrockRuntimeClient,
   InvokeModelWithResponseStreamCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import { AWSBedrockAnthropicStream, AWSBedrockLlama2Stream, StreamingTextResponse } from 'ai';
-import { experimental_buildAnthropicPrompt, experimental_buildLlama2Prompt } from 'ai/prompts';
+import {
+  AWSBedrockLlama2Stream,
+  AWSBedrockStream,
+  StreamingTextResponse
+} from 'ai';
+import { experimental_buildLlama2Prompt } from 'ai/prompts';
 
 import { LobeRuntimeAI } from '../BaseAI';
 import { AgentRuntimeErrorType } from '../error';
-import { ChatStreamPayload, ModelProvider } from '../types';
+import {
+  ChatCompetitionOptions,
+  ChatStreamPayload,
+  ModelProvider,
+} from '../types';
 import { AgentRuntimeError } from '../utils/createError';
 import { debugStream } from '../utils/debugStream';
-import { DEBUG_CHAT_COMPLETION } from '../utils/env';
+import { buildAnthropicMessages } from '../utils/anthropicHelpers';
 
 export interface LobeBedrockAIParams {
   accessKeyId?: string;
@@ -38,23 +46,32 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     });
   }
 
-  async chat(payload: ChatStreamPayload) {
+  async chat(payload: ChatStreamPayload, options?: ChatCompetitionOptions) {
     if (payload.model.startsWith('meta')) return this.invokeLlamaModel(payload);
 
-    return this.invokeClaudeModel(payload);
+    return this.invokeClaudeModel(payload, options);
   }
 
   private invokeClaudeModel = async (
     payload: ChatStreamPayload,
+    options?: ChatCompetitionOptions
   ): Promise<StreamingTextResponse> => {
+    const { max_tokens, messages, model, temperature, top_p } = payload;
+    const system_message = messages.find((m) => m.role === 'system');
+    const user_messages = messages.filter((m) => m.role !== 'system');
+
     const command = new InvokeModelWithResponseStreamCommand({
       accept: 'application/json',
       body: JSON.stringify({
-        max_tokens_to_sample: payload.max_tokens || 400,
-        prompt: experimental_buildAnthropicPrompt(payload.messages as any),
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: max_tokens || 4096,
+        messages: buildAnthropicMessages(user_messages),
+        system: system_message?.content as string,
+        temperature: temperature,
+        top_p: top_p,
       }),
       contentType: 'application/json',
-      modelId: payload.model,
+      modelId: model,
     });
 
     try {
@@ -62,11 +79,15 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       const bedrockResponse = await this.client.send(command);
 
       // Convert the response into a friendly text-stream
-      const stream = AWSBedrockAnthropicStream(bedrockResponse);
+      const stream = AWSBedrockStream(bedrockResponse, options?.callback, (chunk) => {
+        if (chunk.type === 'content_block_delta') {
+          return chunk.delta?.text;
+        }
+      });
 
       const [debug, output] = stream.tee();
 
-      if (DEBUG_CHAT_COMPLETION) {
+      if (process.env.DEBUG_BEDROCK_CHAT_COMPLETION === '1') {
         debugStream(debug).catch(console.error);
       }
 
@@ -88,15 +109,18 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     }
   };
 
-  private invokeLlamaModel = async (payload: ChatStreamPayload) => {
+  private invokeLlamaModel = async (
+    payload: ChatStreamPayload
+  ): Promise<StreamingTextResponse> => {
+    const { max_tokens, messages, model } = payload;
     const command = new InvokeModelWithResponseStreamCommand({
       accept: 'application/json',
       body: JSON.stringify({
-        max_gen_len: payload.max_tokens || 400,
-        prompt: experimental_buildLlama2Prompt(payload.messages as any),
+        max_gen_len: max_tokens || 400,
+        prompt: experimental_buildLlama2Prompt(messages as any),
       }),
       contentType: 'application/json',
-      modelId: payload.model,
+      modelId: model,
     });
 
     try {
@@ -108,7 +132,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
 
       const [debug, output] = stream.tee();
 
-      if (DEBUG_CHAT_COMPLETION) {
+      if (process.env.DEBUG_BEDROCK_CHAT_COMPLETION === '1') {
         debugStream(debug).catch(console.error);
       }
       // Respond with the stream
@@ -129,6 +153,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       });
     }
   };
+
 }
 
 export default LobeBedrockAI;

--- a/src/libs/agent-runtime/bedrock/index.ts
+++ b/src/libs/agent-runtime/bedrock/index.ts
@@ -79,11 +79,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       const bedrockResponse = await this.client.send(command);
 
       // Convert the response into a friendly text-stream
-      const stream = AWSBedrockStream(bedrockResponse, options?.callback, (chunk) => {
-        if (chunk.type === 'content_block_delta') {
-          return chunk.delta?.text;
-        }
-      });
+      const stream = AWSBedrockStream(bedrockResponse, options?.callback, (chunk) => chunk.delta?.text);
 
       const [debug, output] = stream.tee();
 

--- a/src/libs/agent-runtime/utils/anthropicHelpers.test.ts
+++ b/src/libs/agent-runtime/utils/anthropicHelpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAnthropicMessage,
+  buildAnthropicBlock,
+} from './anthropicHelpers';
+
+import { parseDataUri } from './uriParser';
+import {
+  OpenAIChatMessage,
+  UserMessageContentPart,
+} from '../types/chat';
+
+describe('anthropicHelpers', () => {
+
+  // Mock the parseDataUri function since it's an implementation detail
+  vi.mock('./uriParser', () => ({
+    parseDataUri: vi.fn().mockReturnValue({
+      mimeType: 'image/jpeg',
+      base64: 'base64EncodedString',
+    }),
+  }));
+
+  describe('buildAnthropicBlock', () => {
+    it('should return the content as is for text type', () => {
+      const content: UserMessageContentPart =
+        { type: 'text', text: 'Hello!' };
+      const result = buildAnthropicBlock(content);
+      expect(result).toEqual(content);
+    });
+  
+    it('should transform an image URL into an Anthropic.ImageBlockParam', () => {
+      const content: UserMessageContentPart =
+        { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,base64EncodedString' } };
+      const result = buildAnthropicBlock(content);
+      expect(parseDataUri).toHaveBeenCalledWith(content.image_url.url);
+      expect(result).toEqual({
+        source: {
+          data: 'base64EncodedString',
+          media_type: 'image/jpeg',
+          type: 'base64',
+        },
+        type: 'image',
+      });
+    });
+  });
+
+  describe('buildAnthropicMessage', () => {
+    it('should correctly convert system message to assistant message', () => {
+      const message: OpenAIChatMessage = 
+        { content: [{ type: 'text', text: 'Hello!' }], role: 'system' };
+      const result = buildAnthropicMessage(message);
+      expect(result).toEqual(
+        { content: [{ type: 'text', text: 'Hello!' }], role: 'assistant' }
+      );
+    });
+  });
+
+});

--- a/src/libs/agent-runtime/utils/anthropicHelpers.ts
+++ b/src/libs/agent-runtime/utils/anthropicHelpers.ts
@@ -1,0 +1,47 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+import {
+  OpenAIChatMessage,
+  UserMessageContentPart,
+} from '../types';
+
+import { parseDataUri } from './uriParser';
+
+export const buildAnthropicBlock = (
+  content: UserMessageContentPart,
+): Anthropic.ContentBlock | Anthropic.ImageBlockParam => {
+  switch (content.type) {
+    case 'text': {
+      return content;
+    }
+
+    case 'image_url': {
+      const { mimeType, base64 } = parseDataUri(content.image_url.url);
+
+      return {
+        source: {
+          data: base64 as string,
+          media_type: mimeType as Anthropic.ImageBlockParam.Source['media_type'],
+          type: 'base64',
+        },
+        type: 'image',
+      };
+    }
+  }
+}
+
+export const buildAnthropicMessage = (
+  message: OpenAIChatMessage,
+): Anthropic.Messages.MessageParam => {
+  const content = message.content as string | UserMessageContentPart[];
+  return {
+    content:
+      typeof content === 'string' ? content : content.map((c) => buildAnthropicBlock(c)),
+    role: message.role === 'function' || message.role === 'system' ? 'assistant' : message.role,
+  };
+};
+
+export const buildAnthropicMessages = (
+  messages: OpenAIChatMessage[],
+): Anthropic.Messages.MessageParam[] =>
+  messages.map((message) => buildAnthropicMessage(message));


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Add Claude 3 support to AWS Bedrock provider

<img width="1453" alt="image" src="https://github.com/lobehub/lobe-chat/assets/1489309/26ea63aa-9254-4f19-9ddc-4e218cfee606">

fix #1511 

#### 📝 补充信息 | Additional Information

Anthropic has two APIs, the Messages API and the Text Completions API. They have different interfaces and different streaming formats. The Text Completions API is now marked as "Legacy" and Anthropic encourages to use of the Messages API instead.

<img width="1453" alt="image" src="https://github.com/lobehub/lobe-chat/assets/1489309/d9399792-35ef-4cf7-913c-576a0446d911">

Previous to the release of Claude 3, AWS Bedrock supported the Text Completions API for Claude 1.2, 2 & 2.1. Claude 3 was only released with the Messages API (due to the reason above), which was why simply adding a new model didn't work.

Therefore, this PR replaces the existing Text Completions API implementation with Messages API implementation. 

