### PR TITLE
Revert "🔨 chore: fix build for the vercel (#1576)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@types/lodash-es": "^4",
     "@types/node": "^20",
     "@types/numeral": "^2",
-    "@types/react": "18.2.65",
+    "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/rtl-detect": "^1",
     "@types/semver": "^7",


### PR DESCRIPTION
This reverts commit 7bdfa70ad32271630458bca652fdd6136bb9d0b0.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Uses latest `@types/react` since type errors can no longer be reproduced.

#### 📝 补充信息 | Additional Information

Run `bun run type-check` and `bun run build` locally without failures.