### PR TITLE
📦 fix patch: glm-4 module content empty response and base64 img response fix

### DIFF
--- a/src/libs/agent-runtime/zhipu/index.ts
+++ b/src/libs/agent-runtime/zhipu/index.ts
@@ -53,9 +53,11 @@ export class LobeZhipuAI implements LobeRuntimeAI {
     try {
       const params = this.buildCompletionsParams(payload);
 
-      const response = await this.client.chat.completions.create(
+      let response = await this.client.chat.completions.create(
         params as unknown as OpenAI.ChatCompletionCreateParamsStreaming,
       );
+
+      response = this.handleZhipuResponse(response);
 
       const [prod, debug] = response.tee();
 
@@ -124,6 +126,13 @@ export class LobeZhipuAI implements LobeRuntimeAI {
             }),
     };
   };
+  // TODO: fix delta问题以及消息回复有base64图片时问题，临时处理，后续需要移除
+  private handleZhipuResponse(response: any) {
+    if (response.delta.role === 'assistant' && response.delta.content === '') {
+      return;
+    }
+    return this.transformMessage(response);
+  }
 }
 
 export default LobeZhipuAI;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

由于 https://github.com/lobehub/lobe-chat/discussions/737#discussioncomment-8315815
在接收 response 后尝试处理 response 结构，如果其中的 delta 内容为空字符串，则直接返回 undefined, 会在通用处理 tool_calls 里面被忽略

与此同时，发现 GLM-4 在生成回答时，可能会夹杂图片，同样因为没有携带头部描述而导致图片无法显示的问题，所以对 response 也进行了转换处理。

#### 📝 补充信息 | Additional Information

N/A
