### PR TITLE
🔨 chore: fix vercel deployment error 

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "bun install"
+  "installCommand": "npx bun@1.0.31 install"
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

due to https://github.com/oven-sh/bun/issues/9503 and https://github.com/oven-sh/bun/issues/9489#issuecomment-2003903312 , there is an install failure with bun@v1.0.32 and 1.0.33.

Vercel bump bun version to 1.0.32 then casue the deployment failed.

just temporarily lock bun version to 1.0.31 to avoid failure. fix #1651 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

bun install failure again after several months (https://github.com/lobehub/lobe-chat/pull/960).

Hello bun team, @Jarred-Sumner @dylan-conway @Electroid, can we have some methods to avoid this problem ever? Because the install failure will block lots of LobeChat self-hosting users to start their deployment.

If not, maybe we have to consider to switch back to pnpm 😰

<!-- Add any other context about the Pull Request here. -->
