### PR TITLE
🐛 fix: can't switch session correctly after searching and clicking a topic item

### DIFF
--- a/src/app/chat/features/TopicListContent/Topic/TopicItem.tsx
+++ b/src/app/chat/features/TopicListContent/Topic/TopicItem.tsx
@@ -4,6 +4,7 @@ import { Flexbox } from 'react-layout-kit';
 
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
+import { useSessionStore } from '@/store/session';
 
 import DefaultContent from './DefaultContent';
 import TopicContent from './TopicContent';
@@ -35,13 +36,15 @@ export interface ConfigCellProps {
   active?: boolean;
   fav?: boolean;
   id?: string;
+  sessionId?: string;
   title: string;
 }
 
-const TopicItem = memo<ConfigCellProps>(({ title, active, id, fav }) => {
+const TopicItem = memo<ConfigCellProps>(({ title, active, id, sessionId, fav }) => {
   const { styles, cx } = useStyles();
   const toggleConfig = useGlobalStore((s) => s.toggleMobileTopic);
   const [toggleTopic] = useChatStore((s) => [s.switchTopic]);
+  const switchSession = useSessionStore((s) => s.switchSession);
   const [isHover, setHovering] = useState(false);
 
   return (
@@ -51,6 +54,7 @@ const TopicItem = memo<ConfigCellProps>(({ title, active, id, fav }) => {
       distribution={'space-between'}
       horizontal
       onClick={() => {
+        switchSession(sessionId);
         toggleTopic(id);
         toggleConfig(false);
       }}

--- a/src/app/chat/features/TopicListContent/Topic/index.tsx
+++ b/src/app/chat/features/TopicListContent/Topic/index.tsx
@@ -19,9 +19,10 @@ export const Topic = memo(() => {
   const { t } = useTranslation('chat');
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const { isDarkMode } = useThemeMode();
-  const [topicsInit, activeTopicId, topicLength] = useChatStore((s) => [
+  const [topicsInit, activeTopicId, activeSessionId, topicLength] = useChatStore((s) => [
     s.topicsInit,
     s.activeTopicId,
+    s.activeId,
     topicSelectors.currentTopicLength(s),
   ]);
   const [visible, updateGuideState] = useGlobalStore((s) => [
@@ -34,6 +35,7 @@ export const Topic = memo(() => {
       {
         favorite: false,
         id: 'default',
+        sessionId: activeSessionId,
         title: t('topic.defaultTitle'),
       } as ChatTopic,
       ...topicSelectors.displayTopics(s),
@@ -42,11 +44,18 @@ export const Topic = memo(() => {
   );
 
   const itemContent = useCallback(
-    (index: number, { id, favorite, title }: ChatTopic) =>
+    (index: number, { id, favorite, sessionId, title }: ChatTopic) =>
       index === 0 ? (
-        <TopicItem active={!activeTopicId} fav={favorite} title={title} />
+        <TopicItem active={!activeTopicId} fav={favorite} sessionId={sessionId} title={title} />
       ) : (
-        <TopicItem active={activeTopicId === id} fav={favorite} id={id} key={id} title={title} />
+        <TopicItem
+          active={activeTopicId === id}
+          fav={favorite}
+          id={id}
+          key={id}
+          sessionId={sessionId}
+          title={title}
+        />
       ),
     [activeTopicId],
   );


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
搜索话题是全局搜索，在session A搜索到session B的话题点击之后无法正确的跳转到session B
1. 点击topic-item 通过switchSession更新activeId.
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
