### PR TITLE
🐛 fix: fix DraggablePanel bar interfere with the operation of the scrollbar

### DIFF
--- a/src/app/chat/(desktop)/features/SideBar/index.tsx
+++ b/src/app/chat/(desktop)/features/SideBar/index.tsx
@@ -27,6 +27,8 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
+DraggablePanel.displayName = 'DraggablePanel';
+
 const Desktop = memo(() => {
   const { styles } = useStyles();
   const [showAgentSettings, toggleConfig] = useGlobalStore((s) => [
@@ -47,6 +49,7 @@ const Desktop = memo(() => {
       mode={'fixed'}
       onExpandChange={toggleConfig}
       placement={'right'}
+      showHandlerWideArea={false}
     >
       <DraggablePanelContainer
         style={{

--- a/src/app/chat/(desktop)/features/SideBar/index.tsx
+++ b/src/app/chat/(desktop)/features/SideBar/index.tsx
@@ -27,8 +27,6 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-DraggablePanel.displayName = 'DraggablePanel';
-
 const Desktop = memo(() => {
   const { styles } = useStyles();
   const [showAgentSettings, toggleConfig] = useGlobalStore((s) => [

--- a/src/app/market/_layout/Desktop/AgentDetail.tsx
+++ b/src/app/market/_layout/Desktop/AgentDetail.tsx
@@ -55,6 +55,7 @@ const SideBar = memo(() => {
       mode={'fixed'}
       onExpandChange={handleExpandChange}
       placement={'right'}
+      showHandlerWideArea={false}
     >
       <DraggablePanelContainer
         style={{


### PR DESCRIPTION
…peration of the scrollbar below.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

When the content on the `/chat` and `/market` pages is too large, the mouse cannot be used to scroll because the DraggablePanel's overlay covers the scrollbar. By enabling `showHandlerWideArea = true`, the overlay will have `pointer-event: none` to allow the mouse event to bypass it and solve this issue.


- fix https://github.com/lobehub/lobe-chat/issues/1827
