### PR TITLE
🐛 fix: fix local for modal triggered by static method

### DIFF
--- a/src/app/chat/features/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/app/chat/features/SessionListContent/CollapseGroup/Actions.tsx
@@ -81,8 +81,10 @@ const Actions = memo<ActionsProps>(
           onClick: ({ domEvent }) => {
             domEvent.stopPropagation();
             modal.confirm({
+              cancelText: t('cancel', { ns: 'common' }),
               centered: true,
               okButtonProps: { danger: true },
+              okText: t('ok', { ns: 'common' }),
               onOk: () => {
                 if (!id) return;
                 removeSessionGroup(id);

--- a/src/app/chat/features/SessionListContent/List/Item/Actions.tsx
+++ b/src/app/chat/features/SessionListContent/List/Item/Actions.tsx
@@ -148,8 +148,10 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, setOpen })
         onClick: ({ domEvent }) => {
           domEvent.stopPropagation();
           modal.confirm({
+            cancelText: t('cancel', { ns: 'common' }),
             centered: true,
             okButtonProps: { danger: true },
+            okText: t('ok', { ns: 'common' }),
             onOk: () => {
               removeSession(id);
             },

--- a/src/app/chat/features/TopicListContent/Header.tsx
+++ b/src/app/chat/features/TopicListContent/Header.tsx
@@ -30,8 +30,10 @@ const Header = memo(() => {
         label: t('topic.removeUnstarred'),
         onClick: () => {
           modal.confirm({
+            cancelText: t('cancel', { ns: 'common' }),
             centered: true,
             okButtonProps: { danger: true },
+            okText: t('ok', { ns: 'common' }),
             onOk: removeUnstarredTopic,
             title: t('topic.confirmRemoveUnstarred', { ns: 'chat' }),
           });
@@ -44,8 +46,10 @@ const Header = memo(() => {
         label: t('topic.removeAll'),
         onClick: () => {
           modal.confirm({
+            cancelText: t('cancel', { ns: 'common' }),
             centered: true,
             okButtonProps: { danger: true },
+            okText: t('ok', { ns: 'common' }),
             onOk: removeAllTopic,
             title: t('topic.confirmRemoveAll', { ns: 'chat' }),
           });

--- a/src/app/chat/features/TopicListContent/Topic/TopicContent.tsx
+++ b/src/app/chat/features/TopicListContent/Topic/TopicContent.tsx
@@ -112,8 +112,10 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
           if (!id) return;
 
           modal.confirm({
+            cancelText: t('cancel', { ns: 'common' }),
             centered: true,
             okButtonProps: { danger: true },
+            okText: t('ok', { ns: 'common' }),
             onOk: () => {
               removeTopic(id);
             },

--- a/src/app/settings/common/Common.tsx
+++ b/src/app/settings/common/Common.tsx
@@ -47,8 +47,10 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig, showOAuthLogin
 
   const handleSignOut = useCallback(() => {
     modal.confirm({
+      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: { danger: true },
+      okText: t('ok', { ns: 'common' }),
       onOk: () => {
         signOut();
         message.success(t('settingSystem.oauth.signout.success'));
@@ -63,8 +65,10 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig, showOAuthLogin
 
   const handleReset = useCallback(() => {
     modal.confirm({
+      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: { danger: true },
+      okText: t('ok', { ns: 'common' }),
       onOk: () => {
         resetSettings();
         form.setFieldsValue(DEFAULT_SETTINGS);
@@ -75,10 +79,12 @@ const Common = memo<SettingsCommonProps>(({ showAccessCodeConfig, showOAuthLogin
 
   const handleClear = useCallback(() => {
     modal.confirm({
+      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: {
         danger: true,
       },
+      okText: t('ok', { ns: 'common' }),
       onOk: async () => {
         await clearSessions();
         await removeAllPlugins();

--- a/src/features/Conversation/Error/OAuthForm.tsx
+++ b/src/features/Conversation/Error/OAuthForm.tsx
@@ -22,8 +22,10 @@ const OAuthForm = memo<{ id: string }>(({ id }) => {
 
   const handleSignOut = useCallback(() => {
     modal.confirm({
+      cancelText: t('cancel', { ns: 'common' }),
       centered: true,
       okButtonProps: { danger: true },
+      okText: t('ok', { ns: 'common' }),
       onOk: () => {
         signOut();
         message.success(t('settingSystem.oauth.signout.success', { ns: 'setting' }));


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
应该是静态方法丢失上下文导致的。modal.confirm 方法封装后手动指定 okText cancelText 或许可以。

#### 📝 补充信息 | Additional Information
https://ant.design/docs/blog/why-not-static-cn
