### PR TITLE
🐛 fix: fix antd locale

### DIFF
--- a/src/layout/GlobalProvider/index.tsx
+++ b/src/layout/GlobalProvider/index.tsx
@@ -44,17 +44,17 @@ const GlobalLayout = async ({ children }: GlobalLayoutProps) => {
 
   return (
     <StyleRegistry>
-      <AppTheme
-        defaultAppearance={appearance?.value}
-        defaultNeutralColor={neutralColor?.value as any}
-        defaultPrimaryColor={primaryColor?.value as any}
-      >
-        <Locale antdLocale={antdLocale} defaultLang={defaultLang?.value}>
+      <Locale antdLocale={antdLocale} defaultLang={defaultLang?.value}>
+        <AppTheme
+          defaultAppearance={appearance?.value}
+          defaultNeutralColor={neutralColor?.value as any}
+          defaultPrimaryColor={primaryColor?.value as any}
+        >
           <StoreHydration />
           {children}
           <DebugUI />
-        </Locale>
-      </AppTheme>
+        </AppTheme>
+      </Locale>
     </StyleRegistry>
   );
 };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

fix #1772 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

原因是 Provider 顺序反了。 Locale 的 ConfigProvider 写到 App 里面了，那么 `App.useApp` 拿到的 modal 吃不到 locale 的 context 。
<!-- Add any other context about the Pull Request here. -->
