### PR TITLE
🐛 fix: fix normalize russian locale

### DIFF
--- a/src/locales/resources.ts
+++ b/src/locales/resources.ts
@@ -33,6 +33,10 @@ export const normalizeLocale = (locale?: string) => {
       return 'de-DE';
     }
 
+    case 'ru': {
+      return 'ru-RU';
+    }
+
     case 'en': {
       return 'en-US';
     }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Normalize the locale handling to always return the expected ru-RU name.

#### 📝 补充信息 | Additional Information

In some browsers, the locale is returned as ru instead of ru-RU, resulting in an error: Error: Cannot find module './ru.js'.
The function should ensure that it always returns ru-RU, regardless of these discrepancies.
