### PR TITLE
💄 style: add GPT-4-turbo and 2024-04-09 Turbo Vision model and mistral new model name

### DIFF
--- a/src/config/modelProviders/mistral.ts
+++ b/src/config/modelProviders/mistral.ts
@@ -35,7 +35,6 @@ const Mistral: ModelProviderCard = {
     },
     {
       displayName: 'Mixtral 8x22B',
-      enabled: true,
       id: 'mixtral-8x22b',
       tokens: 32_768,
     },

--- a/src/config/modelProviders/mistral.ts
+++ b/src/config/modelProviders/mistral.ts
@@ -1,5 +1,6 @@
 import { ModelProviderCard } from '@/types/llm';
 
+// ref https://docs.mistral.ai/platform/pricing/#chat-completions-api
 const Mistral: ModelProviderCard = {
   chatModels: [
     {
@@ -15,21 +16,27 @@ const Mistral: ModelProviderCard = {
       tokens: 32_768,
     },
     {
-      displayName: 'Mistral Small (2402)',
+      displayName: 'Mistral Small',
       enabled: true,
-      id: 'mistral-small-2402',
+      id: 'mistral-small-latest',
       tokens: 32_768,
     },
     {
-      displayName: 'Mistral Medium (2312)',
+      displayName: 'Mistral Medium',
       enabled: true,
-      id: 'mistral-medium-2312',
+      id: 'mistral-medium-latest',
       tokens: 32_768,
     },
     {
-      displayName: 'Mistral Large (2402)',
+      displayName: 'Mistral Large',
       enabled: true,
-      id: 'mistral-large-2402',
+      id: 'mistral-large-latest',
+      tokens: 32_768,
+    },
+    {
+      displayName: 'Mixtral 8x22B',
+      enabled: true,
+      id: 'mixtral-8x22b',
       tokens: 32_768,
     },
   ],

--- a/src/config/modelProviders/openai.ts
+++ b/src/config/modelProviders/openai.ts
@@ -1,6 +1,6 @@
 import { ModelProviderCard } from '@/types/llm';
 
-// refs to: https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
+// refs to: https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
 const OpenAI: ModelProviderCard = {
   chatModels: [
     {
@@ -101,6 +101,23 @@ const OpenAI: ModelProviderCard = {
       functionCall: true,
       id: 'gpt-4-32k-0613',
       tokens: 32_768,
+    },
+    {
+      description: 'GPT-4 Turbo 视觉版',
+      displayName: 'GPT-4 Turbo with Preview',
+      enabled: true,
+      functionCall: true,
+      id: 'gpt-4-turbo',
+      tokens: 128_000,
+      vision: true,
+    },
+    {
+      description: 'GPT-4 Turbo 视觉版 (240409)',
+      displayName: 'GPT-4 Turbo Vision (240409)',
+      functionCall: true,
+      id: 'gpt-4-turbo-2024-04-09',
+      tokens: 128_000,
+      vision: true,
     },
     {
       displayName: 'GPT-4 ALL',

--- a/src/config/modelProviders/openai.ts
+++ b/src/config/modelProviders/openai.ts
@@ -47,7 +47,6 @@ const OpenAI: ModelProviderCard = {
     },
     {
       displayName: 'GPT-4 Turbo Preview',
-      enabled: true,
       functionCall: true,
       id: 'gpt-4-turbo-preview',
       tokens: 128_000,
@@ -61,7 +60,6 @@ const OpenAI: ModelProviderCard = {
     {
       description: 'GPT-4 视觉预览版，支持视觉任务',
       displayName: 'GPT-4 Turbo Vision Preview',
-      enabled: true,
       id: 'gpt-4-vision-preview',
       tokens: 128_000,
       vision: true,

--- a/src/config/modelProviders/openai.ts
+++ b/src/config/modelProviders/openai.ts
@@ -104,7 +104,7 @@ const OpenAI: ModelProviderCard = {
     },
     {
       description: 'GPT-4 Turbo 视觉版',
-      displayName: 'GPT-4 Turbo with Preview',
+      displayName: 'GPT-4 Turbo Vision',
       enabled: true,
       functionCall: true,
       id: 'gpt-4-turbo',

--- a/src/libs/agent-runtime/openai/__snapshots__/index.test.ts.snap
+++ b/src/libs/agent-runtime/openai/__snapshots__/index.test.ts.snap
@@ -38,7 +38,6 @@ exports[`LobeOpenAI > models > should get models 1`] = `
   },
   {
     "displayName": "GPT-4 Turbo Preview",
-    "enabled": true,
     "functionCall": true,
     "id": "gpt-4-turbo-preview",
     "tokens": 128000,
@@ -72,7 +71,6 @@ exports[`LobeOpenAI > models > should get models 1`] = `
   {
     "description": "GPT-4 视觉预览版，支持视觉任务",
     "displayName": "GPT-4 Turbo Vision Preview",
-    "enabled": true,
     "id": "gpt-4-vision-preview",
     "tokens": 128000,
     "vision": true,

--- a/src/libs/agent-runtime/openrouter/__snapshots__/index.test.ts.snap
+++ b/src/libs/agent-runtime/openrouter/__snapshots__/index.test.ts.snap
@@ -47,7 +47,7 @@ Updated by OpenAI to point to the [latest version of GPT-3.5](/models?q=openai/g
 
 #multimodal",
     "displayName": "OpenAI: GPT-4 Vision",
-    "enabled": true,
+    "enabled": false,
     "functionCall": false,
     "id": "openai/gpt-4-vision-preview",
     "maxTokens": 4096,

--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
@@ -16,7 +16,7 @@ import { handleOpenAIError } from '../handleOpenAIError';
 const CHAT_MODELS_BLOCK_LIST = [
   'embedding',
   'davinci',
-  'cuire',
+  'curie',
   'moderation',
   'ada',
   'babbage',

--- a/src/store/global/slices/settings/selectors/modelProvider.test.ts
+++ b/src/store/global/slices/settings/selectors/modelProvider.test.ts
@@ -29,7 +29,7 @@ describe('modelProviderSelectors', () => {
       const s = merge(initialSettingsState, {}) as unknown as GlobalStore;
 
       const result = modelProviderSelectors.defaultEnabledProviderModels('openai')(s);
-      expect(result).toEqual(['gpt-3.5-turbo', 'gpt-4-turbo-preview', 'gpt-4-vision-preview']);
+      expect(result).toEqual(['gpt-3.5-turbo', 'gpt-4-turbo']);
     });
 
     it('should return undefined for a non-existing provider', () => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
1. 加入 OpenAI 最新发布的2个 GPT4 模型
2. 其中 gpt-4-turbo 设置 enabled
3. 禁用 GPT4的Preview类模型
4. 新增 8x33B 的 Mistral

fix:
- fix https://github.com/lobehub/lobe-chat/issues/1963
- fix #1953
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
无
<!-- Add any other context about the Pull Request here. -->
