### PR TITLE
:bug: fix: plugins with multiple settings cannot be correctly configured

### DIFF
--- a/src/features/PluginSettings/index.tsx
+++ b/src/features/PluginSettings/index.tsx
@@ -74,7 +74,7 @@ const PluginSettingsConfig = memo<PluginSettingsConfigProps>(({ schema, id }) =>
             maximum={item.maximum}
             minimum={item.minimum}
             onChange={(value) => {
-              updatePluginSettings(id, { [item.name]: value });
+              updatePluginSettings(id, { ...pluginSetting, [item.name]: value });
             }}
             type={item.type as any}
           />

--- a/src/features/PluginSettings/index.tsx
+++ b/src/features/PluginSettings/index.tsx
@@ -74,7 +74,7 @@ const PluginSettingsConfig = memo<PluginSettingsConfigProps>(({ schema, id }) =>
             maximum={item.maximum}
             minimum={item.minimum}
             onChange={(value) => {
-              updatePluginSettings(id, { ...pluginSetting, [item.name]: value });
+              updatePluginSettings(id, { [item.name]: value });
             }}
             type={item.type as any}
           />

--- a/src/store/tool/slices/plugin/action.test.ts
+++ b/src/store/tool/slices/plugin/action.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { pluginService } from '@/services/plugin';
 import { LobeTool } from '@/types/tool';
+import { merge } from '@/utils/merge';
 
 import { useToolStore } from '../../store';
 
@@ -90,6 +91,24 @@ describe('useToolStore:plugin', () => {
       });
 
       expect(pluginService.updatePluginSettings).toBeCalledWith(pluginId, newSettings);
+    });
+
+    it('should merge settings for a plugin with existing settings', async () => {
+      const pluginId = 'test-plugin';
+      const existingSettings = { setting1: 'old-value', setting2: 'old-value' };
+      const newSettings = { setting1: 'new-value' };
+      const mergedSettings = merge(existingSettings, newSettings);
+      useToolStore.setState({
+        installedPlugins: [{ identifier: pluginId, settings: existingSettings }] as LobeTool[],
+      });
+
+      const { result } = renderHook(() => useToolStore());
+
+      await act(async () => {
+        await result.current.updatePluginSettings(pluginId, newSettings);
+      });
+
+      expect(pluginService.updatePluginSettings).toBeCalledWith(pluginId, mergedSettings);
     });
   });
 

--- a/src/store/tool/slices/plugin/action.ts
+++ b/src/store/tool/slices/plugin/action.ts
@@ -3,6 +3,7 @@ import useSWR, { SWRResponse } from 'swr';
 import { StateCreator } from 'zustand/vanilla';
 
 import { pluginService } from '@/services/plugin';
+import { merge } from '@/utils/merge';
 
 import { ToolStore } from '../../store';
 import { pluginStoreSelectors } from '../store/selectors';
@@ -44,7 +45,11 @@ export const createPluginSlice: StateCreator<
     await get().refreshPlugins();
   },
   updatePluginSettings: async (id, settings) => {
-    await pluginService.updatePluginSettings(id, settings);
+    const previousSettings = pluginSelectors.getPluginSettingsById(id)(get());
+
+    const nextSettings = merge(previousSettings, settings);
+    await pluginService.updatePluginSettings(id, nextSettings);
+
     await get().refreshPlugins();
   },
   useCheckPluginsIsInstalled: (plugins) => useSWR(plugins, get().checkPluginsIsInstalled),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Currently, when a LobeChat plugin provides multiple fields in its settings, and the user edits one of the fields, the other fields will be cleared.

For example, the following screenshot demonstrates a plugin `Midjourney DEV` providing 2 fields in the settings `MIDJOURNEY_PROXY_URL` and `MIDJOURNEY_PROXY_API_SECRET`. By adding a logging statement in `PluginService.updatePluginSettings`, it can be seen that editing either of them will result in the other being cleared.

![image](https://github.com/lobehub/lobe-chat/assets/8692892/96ca0f28-bd94-463a-b225-d7cbbdf8d8b3)

This PR fixes this issue by merging the edited field into the existing settings object.


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
