### PR TITLE
⚡️ perf: improve performance

### DIFF
--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -1,6 +1,7 @@
 import { ChatModelCard, ModelProviderCard } from '@/types/llm';
 
 import AnthropicProvider from './anthropic';
+import AzureProvider from './azure';
 import BedrockProvider from './bedrock';
 import GoogleProvider from './google';
 import GroqProvider from './groq';
@@ -29,6 +30,23 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   AnthropicProvider.chatModels,
   ZeroOneProvider.chatModels,
 ].flat();
+
+export const DEFAULT_MODEL_PROVIDER_LIST = [
+  OpenAIProvider,
+  { ...AzureProvider, chatModels: [] },
+  OllamaProvider,
+  AnthropicProvider,
+  GoogleProvider,
+  OpenRouterProvider,
+  TogetherAIProvider,
+  BedrockProvider,
+  PerplexityProvider,
+  MistralProvider,
+  GroqProvider,
+  MoonshotProvider,
+  ZeroOneProvider,
+  ZhiPuProvider,
+];
 
 export const filterEnabledModels = (provider: ModelProviderCard) => {
   return provider.chatModels.filter((v) => v.enabled).map((m) => m.id);

--- a/src/features/AgentSetting/AgentConfig/ModelSelect.tsx
+++ b/src/features/AgentSetting/AgentConfig/ModelSelect.tsx
@@ -29,6 +29,7 @@ const ModelSelect = memo(() => {
     modelProviderSelectors.modelProviderListForModelSelect,
     isEqual,
   );
+
   const { styles } = useStyles();
 
   const options = useMemo<SelectProps['options']>(() => {

--- a/src/store/global/slices/common/action.ts
+++ b/src/store/global/slices/common/action.ts
@@ -62,6 +62,9 @@ export const createCommonSlice: StateCreator<
 
   refreshUserConfig: async () => {
     await mutate([USER_CONFIG_FETCH_KEY, true]);
+
+    // when get the user config ,refresh the model provider list to the latest
+    get().refreshModelProviderList();
   },
 
   switchBackToChat: (sessionId) => {
@@ -159,7 +162,10 @@ export const createCommonSlice: StateCreator<
           };
 
           const defaultSettings = merge(get().defaultSettings, serverSettings);
+
           set({ defaultSettings, serverConfig: data }, false, n('initGlobalConfig'));
+
+          get().refreshDefaultModelProviderList();
         }
       },
       revalidateOnFocus: false,
@@ -180,6 +186,9 @@ export const createCommonSlice: StateCreator<
             false,
             n('fetchUserConfig', data),
           );
+
+          // when get the user config ,refresh the model provider list to the latest
+          get().refreshModelProviderList();
 
           const { language } = settingsSelectors.currentSettings(get());
           if (language === 'auto') {

--- a/src/store/global/slices/settings/actions/llm.ts
+++ b/src/store/global/slices/settings/actions/llm.ts
@@ -18,11 +18,11 @@ import {
   ZhiPuProviderCard,
 } from '@/config/modelProviders';
 import { GlobalStore } from '@/store/global';
-import { modelProviderSelectors } from '@/store/global/slices/settings/selectors';
 import { ChatModelCard } from '@/types/llm';
 import { GlobalLLMConfig, GlobalLLMProviderKey } from '@/types/settings';
 
 import { CustomModelCardDispatch, customModelCardsReducer } from '../reducers/customModelCard';
+import { modelProviderSelectors } from '../selectors/modelProvider';
 import { settingsSelectors } from '../selectors/settings';
 
 /**

--- a/src/store/global/slices/settings/actions/llm.ts
+++ b/src/store/global/slices/settings/actions/llm.ts
@@ -1,7 +1,24 @@
 import useSWR, { SWRResponse } from 'swr';
 import type { StateCreator } from 'zustand/vanilla';
 
+import {
+  AnthropicProviderCard,
+  AzureProviderCard,
+  BedrockProviderCard,
+  GoogleProviderCard,
+  GroqProviderCard,
+  MistralProviderCard,
+  MoonshotProviderCard,
+  OllamaProviderCard,
+  OpenAIProviderCard,
+  OpenRouterProviderCard,
+  PerplexityProviderCard,
+  TogetherAIProviderCard,
+  ZeroOneProviderCard,
+  ZhiPuProviderCard,
+} from '@/config/modelProviders';
 import { GlobalStore } from '@/store/global';
+import { modelProviderSelectors } from '@/store/global/slices/settings/selectors';
 import { ChatModelCard } from '@/types/llm';
 import { GlobalLLMConfig, GlobalLLMProviderKey } from '@/types/settings';
 
@@ -16,12 +33,18 @@ export interface LLMSettingsAction {
     provider: GlobalLLMProviderKey,
     payload: CustomModelCardDispatch,
   ) => Promise<void>;
+  /**
+   * make sure the default model provider list is sync to latest state
+   */
+  refreshDefaultModelProviderList: () => void;
+  refreshModelProviderList: () => void;
   removeEnabledModels: (provider: GlobalLLMProviderKey, model: string) => Promise<void>;
   setModelProviderConfig: <T extends GlobalLLMProviderKey>(
     provider: T,
     config: Partial<GlobalLLMConfig[T]>,
   ) => Promise<void>;
   toggleEditingCustomModelCard: (params?: { id: string; provider: GlobalLLMProviderKey }) => void;
+
   toggleProviderEnabled: (provider: GlobalLLMProviderKey, enabled: boolean) => Promise<void>;
 
   useFetchProviderModelList: (
@@ -46,6 +69,74 @@ export const llmSettingsSlice: StateCreator<
     await get().setModelProviderConfig(provider, { customModelCards: nextState });
   },
 
+  refreshDefaultModelProviderList: () => {
+    /**
+     * Because we have several model cards sources, we need to merge the model cards
+     * the priority is below:
+     * 1 - server side model cards
+     * 2 - remote model cards
+     * 3 - default model cards
+     */
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const mergeModels = (provider: GlobalLLMProviderKey, defaultChatModels: ChatModelCard[]) => {
+      // if the chat model is config in the server side, use the server side model cards
+      const serverChatModels = modelProviderSelectors.serverProviderModelCards(provider)(get());
+      const remoteChatModels = modelProviderSelectors.remoteProviderModelCards(provider)(get());
+
+      return serverChatModels ?? remoteChatModels ?? defaultChatModels;
+    };
+
+    const defaultModelProviderList = [
+      {
+        ...OpenAIProviderCard,
+        chatModels: mergeModels('openai', OpenAIProviderCard.chatModels),
+      },
+      { ...AzureProviderCard, chatModels: mergeModels('azure', []) },
+      { ...OllamaProviderCard, chatModels: mergeModels('ollama', OllamaProviderCard.chatModels) },
+      AnthropicProviderCard,
+      GoogleProviderCard,
+      {
+        ...OpenRouterProviderCard,
+        chatModels: mergeModels('openrouter', OpenRouterProviderCard.chatModels),
+      },
+      {
+        ...TogetherAIProviderCard,
+        chatModels: mergeModels('togetherai', TogetherAIProviderCard.chatModels),
+      },
+      BedrockProviderCard,
+      PerplexityProviderCard,
+      MistralProviderCard,
+      GroqProviderCard,
+      MoonshotProviderCard,
+      ZeroOneProviderCard,
+      ZhiPuProviderCard,
+    ];
+
+    set({ defaultModelProviderList }, false, 'refreshDefaultModelProviderList');
+  },
+
+  refreshModelProviderList: () => {
+    const modelProviderList = get().defaultModelProviderList.map((list) => ({
+      ...list,
+      chatModels: modelProviderSelectors
+        .getModelCardsById(list.id)(get())
+        ?.map((model) => {
+          const models = modelProviderSelectors.getEnableModelsById(list.id)(get());
+
+          if (!models) return model;
+
+          return {
+            ...model,
+            enabled: models?.some((m) => m === model.id),
+          };
+        }),
+      enabled: modelProviderSelectors.isProviderEnabled(list.id as any)(get()),
+    }));
+
+    set({ modelProviderList }, false, 'refreshModelProviderList');
+  },
+
   removeEnabledModels: async (provider, model) => {
     const config = settingsSelectors.providerConfig(provider)(get());
 
@@ -60,6 +151,7 @@ export const llmSettingsSlice: StateCreator<
   toggleEditingCustomModelCard: (params) => {
     set({ editingCustomCardModel: params }, false, 'toggleEditingCustomModelCard');
   },
+
   toggleProviderEnabled: async (provider, enabled) => {
     await get().setSettings({ languageModel: { [provider]: { enabled } } });
   },

--- a/src/store/global/slices/settings/actions/llm.ts
+++ b/src/store/global/slices/settings/actions/llm.ts
@@ -114,6 +114,8 @@ export const llmSettingsSlice: StateCreator<
     ];
 
     set({ defaultModelProviderList }, false, 'refreshDefaultModelProviderList');
+
+    get().refreshModelProviderList();
   },
 
   refreshModelProviderList: () => {
@@ -171,6 +173,8 @@ export const llmSettingsSlice: StateCreator<
               latestFetchTime: Date.now(),
               remoteModelCards: data,
             });
+
+            get().refreshDefaultModelProviderList();
           }
         },
         revalidateOnFocus: false,

--- a/src/store/global/slices/settings/initialState.ts
+++ b/src/store/global/slices/settings/initialState.ts
@@ -1,20 +1,26 @@
 import { DeepPartial } from 'utility-types';
 
+import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import { DEFAULT_SETTINGS } from '@/const/settings';
+import { ModelProviderCard } from '@/types/llm';
 import { GlobalServerConfig } from '@/types/serverConfig';
 import { GlobalSettings } from '@/types/settings';
 
 export interface GlobalSettingsState {
   avatar?: string;
+  defaultModelProviderList: ModelProviderCard[];
   defaultSettings: GlobalSettings;
   editingCustomCardModel?: { id: string; provider: string } | undefined;
+  modelProviderList: ModelProviderCard[];
   serverConfig: GlobalServerConfig;
   settings: DeepPartial<GlobalSettings>;
   userId?: string;
 }
 
 export const initialSettingsState: GlobalSettingsState = {
+  defaultModelProviderList: DEFAULT_MODEL_PROVIDER_LIST,
   defaultSettings: DEFAULT_SETTINGS,
+  modelProviderList: DEFAULT_MODEL_PROVIDER_LIST,
   serverConfig: {
     telemetry: {},
   },

--- a/src/store/global/slices/settings/selectors/modelProvider.test.ts
+++ b/src/store/global/slices/settings/selectors/modelProvider.test.ts
@@ -7,71 +7,7 @@ import { GlobalSettingsState, initialSettingsState } from '../initialState';
 import { getDefaultModeProviderById, modelProviderSelectors } from './modelProvider';
 
 describe('modelProviderSelectors', () => {
-  describe('providerListWithConfig', () => {
-    it('visible', () => {
-      const s = merge(initialSettingsState, {
-        settings: {
-          languageModel: {
-            ollama: {
-              enabledModels: ['llava'],
-            },
-          },
-        },
-      } as GlobalSettingsState) as unknown as GlobalStore;
-
-      const ollamaList = modelProviderSelectors.modelProviderList(s).find((r) => r.id === 'ollama');
-
-      expect(ollamaList?.chatModels.find((c) => c.id === 'llava')).toEqual({
-        displayName: 'LLaVA 7B',
-        functionCall: false,
-        enabled: true,
-        id: 'llava',
-        tokens: 4000,
-        vision: true,
-      });
-    });
-    it('with user custom models', () => {
-      const s = merge(initialSettingsState, {
-        settings: {
-          languageModel: {
-            perplexity: {
-              customModelCards: [{ id: 'sonar-online', displayName: 'Sonar Online' }],
-            },
-          },
-        },
-      } as GlobalSettingsState) as unknown as GlobalStore;
-
-      const providerList = modelProviderSelectors
-        .modelProviderList(s)
-        .find((r) => r.id === 'perplexity');
-
-      expect(providerList?.chatModels.find((c) => c.id === 'sonar-online')).toEqual({
-        id: 'sonar-online',
-        displayName: 'Sonar Online',
-        enabled: false,
-        isCustom: true,
-      });
-    });
-  });
-
-  describe('providerListForModelSelect', () => {
-    it('should return only enabled providers', () => {
-      const s = merge(initialSettingsState, {
-        settings: {
-          languageModel: {
-            perplexity: { enabled: true },
-            azure: { enabled: false },
-          },
-        },
-      } as GlobalSettingsState) as unknown as GlobalStore;
-
-      const enabledProviders = modelProviderSelectors.modelProviderListForModelSelect(s);
-      expect(enabledProviders).toHaveLength(2);
-      expect(enabledProviders[1].id).toBe('perplexity');
-    });
-  });
-
-  describe('providerCard', () => {
+  describe('getDefaultModeProviderById', () => {
     it('should return the correct ModelProviderCard when provider ID matches', () => {
       const s = merge(initialSettingsState, {}) as unknown as GlobalStore;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change


修正 model list 化后出现的性能问题。

- fix #2014 
- fix #2013 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

原因：

LobeChat 中我们默认采用 selectors 的模式实现数据聚合。这对于小样本的数据量来说没啥问题，而且不用考虑数据重复的问题，研发心智是简单的。

但是以下比较复杂的数组：

```ts
const defaultModelProviderList = (s) => [
      {
        ...OpenAIProviderCard,
        chatModels: mergeModels('openai', OpenAIProviderCard.chatModels),
      },
      { ...AzureProviderCard, chatModels: mergeModels('azure', []) },
      { ...OllamaProviderCard, chatModels: mergeModels('ollama', OllamaProviderCard.chatModels) },
      AnthropicProviderCard,
      GoogleProviderCard,
      {
        ...OpenRouterProviderCard,
        chatModels: mergeModels('openrouter', OpenRouterProviderCard.chatModels),
      },
      {
        ...TogetherAIProviderCard,
        chatModels: mergeModels('togetherai', TogetherAIProviderCard.chatModels),
      },
      BedrockProviderCard,
      PerplexityProviderCard,
      MistralProviderCard,
      GroqProviderCard,
      MoonshotProviderCard,
      ZeroOneProviderCard,
      ZhiPuProviderCard,
    ];
```

在单次执行时大约会耗时 30ms ，而 selectors 的计算取值是非常频繁的，一次更新周期中可能会有3~5次，多达10次的selectors 计算，累加后就会造成不可忽略的，会造成明显的输入卡顿现象。

解决方案

这部分计算较为耗时，但其实它的变更频率是很低的，因此优化手段就很简单：将其缓存下来，在需要刷新时再进行触发。

目前 `modelProviderSelectors` 中存在两个耗时大户：

- `defaultModelProviderList`: 用于合并 `serverList` 、`remoteList` 和 `defaultList`； 
- `modelProviderList`: 用于结合用户的配置（`<provider>.enabled` 和 `enabledModels`）获得运行时的 list

每个 list 的一次计算大致都会耗时 30ms 左右。

`defaultModelProviderList` 的触发时机，是 `serverList` 、`remoteList`  变更时，前者在 `fetchServerConfig` 时做个触发，后者在点击拉取模型列表的时候做触发。

`modelProviderList` 的触发时机，一个是在 `defaultModelProviderList` 发生变更后，一个是在 `userConfig` 发生变更后。
