### PR TITLE
♻️ refactor: refactor the service with browser db invoke

### DIFF
--- a/src/features/PluginDevModal/UrlManifestForm.tsx
+++ b/src/features/PluginDevModal/UrlManifestForm.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import ManifestPreviewer from '@/components/ManifestPreviewer';
-import { pluginService } from '@/services/plugin';
+import { toolService } from '@/services/tool';
 import { useToolStore } from '@/store/tool';
 import { pluginSelectors } from '@/store/tool/selectors';
 import { PluginInstallError } from '@/types/tool/plugin';
@@ -77,7 +77,7 @@ const UrlManifestForm = memo<{ form: FormInstance; isEditMode: boolean }>(
 
                 try {
                   const useProxy = form.getFieldValue(proxyKey);
-                  const data = await pluginService.getPluginManifest(value, useProxy);
+                  const data = await toolService.getPluginManifest(value, useProxy);
                   setManifest(data);
 
                   form.setFieldsValue({ identifier: data.identifier, manifest: data });

--- a/src/services/__tests__/__snapshots__/tool.test.ts.snap
+++ b/src/services/__tests__/__snapshots__/tool.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PluginService > can parse the OpenAI plugin 1`] = `
+exports[`ToolService > can parse the OpenAI plugin 1`] = `
 {
   "api": [],
   "homepage": "https://products.wolframalpha.com/api/commercial-termsofuse",
@@ -78,7 +78,7 @@ getWolframCloudResults guidelines:
 }
 `;
 
-exports[`PluginService > getPluginManifest > support OpenAPI manifest > should get plugin manifest 1`] = `
+exports[`ToolService > getPluginManifest > support OpenAPI manifest > should get plugin manifest 1`] = `
 {
   "$schema": "../node_modules/@lobehub/chat-plugin-sdk/schema.json",
   "api": [

--- a/src/services/__tests__/chat.test.ts
+++ b/src/services/__tests__/chat.test.ts
@@ -9,7 +9,6 @@ import { DalleManifest } from '@/tools/dalle';
 import { ChatMessage } from '@/types/message';
 import { ChatStreamPayload } from '@/types/openai/chat';
 import { LobeTool } from '@/types/tool';
-import { FetchSSEOptions, fetchSSE } from '@/utils/fetch';
 
 import { chatService } from '../chat';
 

--- a/src/services/__tests__/tool.test.ts
+++ b/src/services/__tests__/tool.test.ts
@@ -1,13 +1,8 @@
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { PluginModel } from '@/database/client/models/plugin';
-import { DB_Plugin } from '@/database/client/schemas/plugin';
 import { globalHelpers } from '@/store/global/helpers';
-import { LobeTool } from '@/types/tool';
-import { LobeToolCustomPlugin } from '@/types/tool/plugin';
 
-import { InstallPluginParams, pluginService } from '../plugin';
+import { toolService } from '../tool';
 import openAPIV3 from './openai/OpenAPI_V3.json';
 import OpenAIPlugin from './openai/plugin.json';
 
@@ -18,21 +13,12 @@ vi.mock('@/store/global/helpers', () => ({
     getCurrentLanguage: vi.fn(),
   },
 }));
-vi.mock('@/database/client/models/plugin', () => ({
-  PluginModel: {
-    getList: vi.fn(),
-    create: vi.fn(),
-    delete: vi.fn(),
-    update: vi.fn(),
-    clear: vi.fn(),
-  },
-}));
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-describe('PluginService', () => {
+describe('ToolService', () => {
   describe('getPluginList', () => {
     it('should fetch and return the plugin list', async () => {
       // Arrange
@@ -45,7 +31,7 @@ describe('PluginService', () => {
       ) as any;
 
       // Act
-      const pluginList = await pluginService.getPluginList();
+      const pluginList = await toolService.getPluginList();
 
       // Assert
       expect(globalHelpers.getCurrentLanguage).toHaveBeenCalled();
@@ -60,7 +46,7 @@ describe('PluginService', () => {
       global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
 
       // Act & Assert
-      await expect(pluginService.getPluginList()).rejects.toThrow('Network error');
+      await expect(toolService.getPluginList()).rejects.toThrow('Network error');
     });
   });
 
@@ -112,7 +98,7 @@ describe('PluginService', () => {
         }),
       ) as any;
 
-      const manifest = await pluginService.getPluginManifest(manifestUrl);
+      const manifest = await toolService.getPluginManifest(manifestUrl);
 
       expect(fetch).toHaveBeenCalledWith(manifestUrl);
       expect(manifest).toEqual(fakeManifest);
@@ -120,7 +106,7 @@ describe('PluginService', () => {
 
     it('should return error on noManifest', async () => {
       try {
-        await pluginService.getPluginManifest();
+        await toolService.getPluginManifest();
       } catch (e) {
         expect(e).toEqual(new TypeError('noManifest'));
       }
@@ -138,7 +124,7 @@ describe('PluginService', () => {
       ) as any;
 
       try {
-        await pluginService.getPluginManifest(manifestUrl);
+        await toolService.getPluginManifest(manifestUrl);
       } catch (e) {
         expect(e).toEqual(new TypeError('manifestInvalid'));
       }
@@ -149,7 +135,7 @@ describe('PluginService', () => {
       global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
 
       try {
-        await pluginService.getPluginManifest(manifestUrl);
+        await toolService.getPluginManifest(manifestUrl);
       } catch (e) {
         expect(e).toEqual(new TypeError('fetchError'));
       }
@@ -170,7 +156,7 @@ describe('PluginService', () => {
       ) as any;
 
       try {
-        await pluginService.getPluginManifest(manifestUrl);
+        await toolService.getPluginManifest(manifestUrl);
       } catch (e) {
         expect(e).toEqual(new TypeError('urlError'));
       }
@@ -188,7 +174,7 @@ describe('PluginService', () => {
       ) as any;
 
       try {
-        await pluginService.getPluginManifest(manifestUrl);
+        await toolService.getPluginManifest(manifestUrl);
       } catch (e) {
         expect(e).toEqual(new TypeError('fetchError'));
       }
@@ -228,7 +214,7 @@ describe('PluginService', () => {
           }),
         ) as any;
 
-        const manifest = await pluginService.getPluginManifest(manifestUrl);
+        const manifest = await toolService.getPluginManifest(manifestUrl);
 
         expect(manifest).toMatchSnapshot();
       });
@@ -266,7 +252,7 @@ describe('PluginService', () => {
         ) as any;
 
         try {
-          await pluginService.getPluginManifest(manifestUrl);
+          await toolService.getPluginManifest(manifestUrl);
         } catch (e) {
           expect(e).toEqual(new TypeError('openAPIInvalid'));
         }
@@ -274,141 +260,8 @@ describe('PluginService', () => {
     });
   });
 
-  describe('installPlugin', () => {
-    it('should install a plugin', async () => {
-      // Arrange
-      const fakePlugin = {
-        identifier: 'test-plugin',
-        manifest: { name: 'TestPlugin', version: '1.0.0' } as unknown as LobeChatPluginManifest,
-        type: 'plugin',
-      } as InstallPluginParams;
-      vi.mocked(PluginModel.create).mockResolvedValue(fakePlugin);
-
-      // Act
-      const installedPlugin = await pluginService.installPlugin(fakePlugin);
-
-      // Assert
-      expect(PluginModel.create).toHaveBeenCalledWith(fakePlugin);
-      expect(installedPlugin).toEqual(fakePlugin);
-    });
-  });
-
-  describe('getInstalledPlugins', () => {
-    it('should return a list of installed plugins', async () => {
-      // Arrange
-      const fakePlugins = [{ identifier: 'test-plugin', type: 'plugin' }] as LobeTool[];
-      vi.mocked(PluginModel.getList).mockResolvedValue(fakePlugins as DB_Plugin[]);
-
-      // Act
-      const installedPlugins = await pluginService.getInstalledPlugins();
-
-      // Assert
-      expect(PluginModel.getList).toHaveBeenCalled();
-      expect(installedPlugins).toEqual(fakePlugins);
-    });
-  });
-
-  describe('uninstallPlugin', () => {
-    it('should uninstall a plugin', async () => {
-      // Arrange
-      const identifier = 'test-plugin';
-      vi.mocked(PluginModel.delete).mockResolvedValue();
-
-      // Act
-      const result = await pluginService.uninstallPlugin(identifier);
-
-      // Assert
-      expect(PluginModel.delete).toHaveBeenCalledWith(identifier);
-      expect(result).toBe(undefined);
-    });
-  });
-
-  describe('createCustomPlugin', () => {
-    it('should create a custom plugin', async () => {
-      // Arrange
-      const customPlugin = {
-        identifier: 'custom-plugin',
-        manifest: {},
-        type: 'customPlugin',
-      } as LobeToolCustomPlugin;
-      vi.mocked(PluginModel.create).mockResolvedValue(customPlugin);
-
-      // Act
-      const result = await pluginService.createCustomPlugin(customPlugin);
-
-      // Assert
-      expect(PluginModel.create).toHaveBeenCalledWith({
-        ...customPlugin,
-        type: 'customPlugin',
-      });
-      expect(result).toEqual(customPlugin);
-    });
-  });
-
-  describe('updatePlugin', () => {
-    it('should update a plugin', async () => {
-      // Arrange
-      const id = 'plugin-id';
-      const value = { settings: { ab: '1' } } as unknown as LobeToolCustomPlugin;
-      vi.mocked(PluginModel.update).mockResolvedValue(1);
-
-      // Act
-      const result = await pluginService.updatePlugin(id, value);
-
-      // Assert
-      expect(PluginModel.update).toHaveBeenCalledWith(id, value);
-      expect(result).toEqual(1);
-    });
-  });
-
-  describe('updatePluginManifest', () => {
-    it('should update a plugin manifest', async () => {
-      // Arrange
-      const id = 'plugin-id';
-      const manifest = { name: 'NewPluginManifest' } as unknown as LobeChatPluginManifest;
-      vi.mocked(PluginModel.update).mockResolvedValue(1);
-
-      // Act
-      const result = await pluginService.updatePluginManifest(id, manifest);
-
-      // Assert
-      expect(PluginModel.update).toHaveBeenCalledWith(id, { manifest });
-      expect(result).toEqual(1);
-    });
-  });
-
-  describe('removeAllPlugins', () => {
-    it('should remove all plugins', async () => {
-      // Arrange
-      vi.mocked(PluginModel.clear).mockResolvedValue(undefined);
-
-      // Act
-      const result = await pluginService.removeAllPlugins();
-
-      // Assert
-      expect(PluginModel.clear).toHaveBeenCalled();
-      expect(result).toBe(undefined);
-    });
-  });
-
-  describe('updatePluginSettings', () => {
-    it('should update plugin settings', async () => {
-      // Arrange
-      const id = 'plugin-id';
-      const settings = { color: 'blue' };
-      vi.mocked(PluginModel.update).mockResolvedValue(1);
-
-      // Act
-      const result = await pluginService.updatePluginSettings(id, settings);
-
-      // Assert
-      expect(PluginModel.update).toHaveBeenCalledWith(id, { settings });
-      expect(result).toEqual(1);
-    });
-  });
-
   it('can parse the OpenAI plugin', async () => {
-    const manifest = pluginService['convertOpenAIManifestToLobeManifest'](OpenAIPlugin as any);
+    const manifest = toolService['convertOpenAIManifestToLobeManifest'](OpenAIPlugin as any);
 
     expect(manifest).toMatchSnapshot();
   });

--- a/src/services/file/client.ts
+++ b/src/services/file/client.ts
@@ -3,9 +3,9 @@ import { DB_File } from '@/database/client/schemas/files';
 import { FilePreview } from '@/types/files';
 import compressImage from '@/utils/compressImage';
 
-import { API_ENDPOINTS } from './_url';
+import { API_ENDPOINTS } from '../_url';
 
-class FileService {
+export class FileService {
   private isImage(fileType: string) {
     const imageRegex = /^image\//;
     return imageRegex.test(fileType);
@@ -84,5 +84,3 @@ class FileService {
     };
   }
 }
-
-export const fileService = new FileService();

--- a/src/services/file/file.test.ts
+++ b/src/services/file/file.test.ts
@@ -3,7 +3,9 @@ import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileModel } from '@/database/client/models/file';
 import { DB_File } from '@/database/client/schemas/files';
 
-import { fileService } from '../file';
+import { FileService } from './client';
+
+const fileService = new FileService();
 
 // Mocks for the FileModel
 vi.mock('@/database/client/models/file', () => ({

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -1,0 +1,3 @@
+import { FileService } from './client';
+
+export const fileService = new FileService();

--- a/src/services/message/client.test.ts
+++ b/src/services/message/client.test.ts
@@ -1,15 +1,11 @@
 import { Mock, describe, expect, it, vi } from 'vitest';
 
 import { CreateMessageParams, MessageModel } from '@/database/client/models/message';
-import {
-  ChatMessage,
-  ChatMessageError,
-  ChatPluginPayload,
-  ChatTTS,
-  ChatTranslate,
-} from '@/types/message';
+import { ChatMessage, ChatMessageError, ChatPluginPayload } from '@/types/message';
 
-import { messageService } from '../message';
+import { MessageService } from './client';
+
+const messageService = new MessageService();
 
 // Mock the MessageModel
 vi.mock('@/database/client/models/message', () => {

--- a/src/services/message/client.ts
+++ b/src/services/message/client.ts
@@ -76,5 +76,3 @@ export class MessageService {
     return MessageModel.queryAll();
   }
 }
-
-export const messageService = new MessageService();

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -1,0 +1,4 @@
+import { MessageService } from './client';
+
+export const messageService = new MessageService();
+export type { CreateMessageParams } from './client';

--- a/src/services/plugin/client.ts
+++ b/src/services/plugin/client.ts
@@ -1,0 +1,44 @@
+import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+
+import { PluginModel } from '@/database/client/models/plugin';
+import { LobeTool } from '@/types/tool';
+import { LobeToolCustomPlugin } from '@/types/tool/plugin';
+
+export interface InstallPluginParams {
+  identifier: string;
+  manifest: LobeChatPluginManifest;
+  type: 'plugin' | 'customPlugin';
+}
+
+export class PluginService {
+  installPlugin = async (plugin: InstallPluginParams) => {
+    return PluginModel.create(plugin);
+  };
+
+  getInstalledPlugins = () => {
+    return PluginModel.getList() as Promise<LobeTool[]>;
+  };
+
+  uninstallPlugin(identifier: string) {
+    return PluginModel.delete(identifier);
+  }
+
+  async createCustomPlugin(customPlugin: LobeToolCustomPlugin) {
+    return PluginModel.create({ ...customPlugin, type: 'customPlugin' });
+  }
+
+  async updatePlugin(id: string, value: LobeToolCustomPlugin) {
+    return PluginModel.update(id, value);
+  }
+  async updatePluginManifest(id: string, manifest: LobeChatPluginManifest) {
+    return PluginModel.update(id, { manifest });
+  }
+
+  async removeAllPlugins() {
+    return PluginModel.clear();
+  }
+
+  async updatePluginSettings(id: string, settings: any) {
+    return PluginModel.update(id, { settings });
+  }
+}

--- a/src/services/plugin/index.ts
+++ b/src/services/plugin/index.ts
@@ -1,0 +1,5 @@
+import { PluginService } from './client';
+
+export type { InstallPluginParams } from './client';
+
+export const pluginService = new PluginService();

--- a/src/services/plugin/plugin.test.ts
+++ b/src/services/plugin/plugin.test.ts
@@ -1,0 +1,162 @@
+import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PluginModel } from '@/database/client/models/plugin';
+import { DB_Plugin } from '@/database/client/schemas/plugin';
+import { LobeTool } from '@/types/tool';
+import { LobeToolCustomPlugin } from '@/types/tool/plugin';
+
+import { InstallPluginParams, PluginService } from './client';
+
+const pluginService = new PluginService();
+
+// Mocking modules and functions
+
+vi.mock('@/database/client/models/plugin', () => ({
+  PluginModel: {
+    getList: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+    clear: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('PluginService', () => {
+  describe('installPlugin', () => {
+    it('should install a plugin', async () => {
+      // Arrange
+      const fakePlugin = {
+        identifier: 'test-plugin',
+        manifest: { name: 'TestPlugin', version: '1.0.0' } as unknown as LobeChatPluginManifest,
+        type: 'plugin',
+      } as InstallPluginParams;
+      vi.mocked(PluginModel.create).mockResolvedValue(fakePlugin);
+
+      // Act
+      const installedPlugin = await pluginService.installPlugin(fakePlugin);
+
+      // Assert
+      expect(PluginModel.create).toHaveBeenCalledWith(fakePlugin);
+      expect(installedPlugin).toEqual(fakePlugin);
+    });
+  });
+
+  describe('getInstalledPlugins', () => {
+    it('should return a list of installed plugins', async () => {
+      // Arrange
+      const fakePlugins = [{ identifier: 'test-plugin', type: 'plugin' }] as LobeTool[];
+      vi.mocked(PluginModel.getList).mockResolvedValue(fakePlugins as DB_Plugin[]);
+
+      // Act
+      const installedPlugins = await pluginService.getInstalledPlugins();
+
+      // Assert
+      expect(PluginModel.getList).toHaveBeenCalled();
+      expect(installedPlugins).toEqual(fakePlugins);
+    });
+  });
+
+  describe('uninstallPlugin', () => {
+    it('should uninstall a plugin', async () => {
+      // Arrange
+      const identifier = 'test-plugin';
+      vi.mocked(PluginModel.delete).mockResolvedValue();
+
+      // Act
+      const result = await pluginService.uninstallPlugin(identifier);
+
+      // Assert
+      expect(PluginModel.delete).toHaveBeenCalledWith(identifier);
+      expect(result).toBe(undefined);
+    });
+  });
+
+  describe('createCustomPlugin', () => {
+    it('should create a custom plugin', async () => {
+      // Arrange
+      const customPlugin = {
+        identifier: 'custom-plugin',
+        manifest: {},
+        type: 'customPlugin',
+      } as LobeToolCustomPlugin;
+      vi.mocked(PluginModel.create).mockResolvedValue(customPlugin);
+
+      // Act
+      const result = await pluginService.createCustomPlugin(customPlugin);
+
+      // Assert
+      expect(PluginModel.create).toHaveBeenCalledWith({
+        ...customPlugin,
+        type: 'customPlugin',
+      });
+      expect(result).toEqual(customPlugin);
+    });
+  });
+
+  describe('updatePlugin', () => {
+    it('should update a plugin', async () => {
+      // Arrange
+      const id = 'plugin-id';
+      const value = { settings: { ab: '1' } } as unknown as LobeToolCustomPlugin;
+      vi.mocked(PluginModel.update).mockResolvedValue(1);
+
+      // Act
+      const result = await pluginService.updatePlugin(id, value);
+
+      // Assert
+      expect(PluginModel.update).toHaveBeenCalledWith(id, value);
+      expect(result).toEqual(1);
+    });
+  });
+
+  describe('updatePluginManifest', () => {
+    it('should update a plugin manifest', async () => {
+      // Arrange
+      const id = 'plugin-id';
+      const manifest = { name: 'NewPluginManifest' } as unknown as LobeChatPluginManifest;
+      vi.mocked(PluginModel.update).mockResolvedValue(1);
+
+      // Act
+      const result = await pluginService.updatePluginManifest(id, manifest);
+
+      // Assert
+      expect(PluginModel.update).toHaveBeenCalledWith(id, { manifest });
+      expect(result).toEqual(1);
+    });
+  });
+
+  describe('removeAllPlugins', () => {
+    it('should remove all plugins', async () => {
+      // Arrange
+      vi.mocked(PluginModel.clear).mockResolvedValue(undefined);
+
+      // Act
+      const result = await pluginService.removeAllPlugins();
+
+      // Assert
+      expect(PluginModel.clear).toHaveBeenCalled();
+      expect(result).toBe(undefined);
+    });
+  });
+
+  describe('updatePluginSettings', () => {
+    it('should update plugin settings', async () => {
+      // Arrange
+      const id = 'plugin-id';
+      const settings = { color: 'blue' };
+      vi.mocked(PluginModel.update).mockResolvedValue(1);
+
+      // Act
+      const result = await pluginService.updatePluginSettings(id, settings);
+
+      // Assert
+      expect(PluginModel.update).toHaveBeenCalledWith(id, { settings });
+      expect(result).toEqual(1);
+    });
+  });
+});

--- a/src/services/session/client.ts
+++ b/src/services/session/client.ts
@@ -14,7 +14,7 @@ import {
   SessionGroups,
 } from '@/types/session';
 
-class SessionService {
+export class SessionService {
   async createNewSession(
     type: LobeSessionType,
     defaultValue: Partial<LobeAgentSession>,
@@ -118,5 +118,3 @@ class SessionService {
     return SessionGroupModel.clear();
   }
 }
-
-export const sessionService = new SessionService();

--- a/src/services/session/index.ts
+++ b/src/services/session/index.ts
@@ -1,0 +1,3 @@
+import { SessionService } from './client';
+
+export const sessionService = new SessionService();

--- a/src/services/session/session.test.ts
+++ b/src/services/session/session.test.ts
@@ -5,7 +5,9 @@ import { SessionGroupModel } from '@/database/client/models/sessionGroup';
 import { LobeAgentConfig } from '@/types/agent';
 import { LobeAgentSession, LobeSessionType, SessionGroups } from '@/types/session';
 
-import { sessionService } from '../session';
+import { SessionService } from './client';
+
+const sessionService = new SessionService();
 
 // Mock the SessionModel
 vi.mock('@/database/client/models/session', () => {

--- a/src/services/tool.ts
+++ b/src/services/tool.ts
@@ -4,20 +4,12 @@ import {
   pluginManifestSchema,
 } from '@lobehub/chat-plugin-sdk';
 
-import { PluginModel } from '@/database/client/models/plugin';
 import { globalHelpers } from '@/store/global/helpers';
 import { OpenAIPluginManifest } from '@/types/openai/plugin';
-import { LobeTool } from '@/types/tool';
-import { LobeToolCustomPlugin } from '@/types/tool/plugin';
 
 import { API_ENDPOINTS } from './_url';
 
-export interface InstallPluginParams {
-  identifier: string;
-  manifest: LobeChatPluginManifest;
-  type: 'plugin' | 'customPlugin';
-}
-class PluginService {
+class ToolService {
   private _fetchJSON = async <T = any>(url: string, proxy = false): Promise<T> => {
     // 2. 发送请求
     let res: Response;
@@ -107,37 +99,6 @@ class PluginService {
     return data;
   };
 
-  installPlugin = async (plugin: InstallPluginParams) => {
-    return PluginModel.create(plugin);
-  };
-
-  getInstalledPlugins = () => {
-    return PluginModel.getList() as Promise<LobeTool[]>;
-  };
-
-  uninstallPlugin(identifier: string) {
-    return PluginModel.delete(identifier);
-  }
-
-  async createCustomPlugin(customPlugin: LobeToolCustomPlugin) {
-    return PluginModel.create({ ...customPlugin, type: 'customPlugin' });
-  }
-
-  async updatePlugin(id: string, value: LobeToolCustomPlugin) {
-    return PluginModel.update(id, value);
-  }
-  async updatePluginManifest(id: string, manifest: LobeChatPluginManifest) {
-    return PluginModel.update(id, { manifest });
-  }
-
-  async removeAllPlugins() {
-    return PluginModel.clear();
-  }
-
-  async updatePluginSettings(id: string, settings: any) {
-    return PluginModel.update(id, { settings });
-  }
-
   private convertOpenAIManifestToLobeManifest = (
     data: OpenAIPluginManifest,
   ): LobeChatPluginManifest => {
@@ -180,4 +141,4 @@ class PluginService {
   };
 }
 
-export const pluginService = new PluginService();
+export const toolService = new ToolService();

--- a/src/services/topic/client.ts
+++ b/src/services/topic/client.ts
@@ -1,7 +1,7 @@
 import { CreateTopicParams, QueryTopicParams, TopicModel } from '@/database/client/models/topic';
 import { ChatTopic } from '@/types/topic';
 
-class TopicService {
+export class TopicService {
   async createTopic(params: CreateTopicParams): Promise<string> {
     const item = await TopicModel.create(params);
 
@@ -56,5 +56,3 @@ class TopicService {
     return TopicModel.duplicateTopic(id, newTitle);
   }
 }
-
-export const topicService = new TopicService();

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -1,0 +1,3 @@
+import { TopicService } from './client';
+
+export const topicService = new TopicService();

--- a/src/services/topic/topic.test.ts
+++ b/src/services/topic/topic.test.ts
@@ -3,8 +3,9 @@ import { Mock, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateTopicParams, TopicModel } from '@/database/client/models/topic';
 import { ChatTopic } from '@/types/topic';
 
-import { topicService } from '../topic';
+import { TopicService } from './client';
 
+const topicService = new TopicService();
 // Mock the TopicModel
 vi.mock('@/database/client/models/topic', () => {
   return {

--- a/src/services/user/client.ts
+++ b/src/services/user/client.ts
@@ -9,7 +9,7 @@ export interface UserConfig {
   uuid: string;
 }
 
-class UserService {
+export class UserService {
   getUserConfig = async () => {
     const user = await UserModel.getUser();
     return user as unknown as UserConfig;
@@ -27,5 +27,3 @@ class UserService {
     return UserModel.updateAvatar(avatar);
   }
 }
-
-export const userService = new UserService();

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,0 +1,5 @@
+import { UserService } from './client';
+
+export type { UserConfig } from './client';
+
+export const userService = new UserService();

--- a/src/store/tool/slices/customPlugin/action.test.ts
+++ b/src/store/tool/slices/customPlugin/action.test.ts
@@ -12,13 +12,19 @@ beforeEach(() => {
 });
 vi.mock('@/services/plugin', () => ({
   pluginService: {
-    getPluginManifest: vi.fn(),
     updatePlugin: vi.fn(),
     createCustomPlugin: vi.fn(),
     uninstallPlugin: vi.fn(),
     updatePluginManifest: vi.fn(),
   },
 }));
+
+vi.mock('@/services/tool', () => ({
+  toolService: {
+    getPluginManifest: vi.fn(),
+  },
+}));
+
 describe('useToolStore:customPlugin', () => {
   describe('deleteCustomPlugin', () => {
     it('should delete custom plugin and related settings', async () => {

--- a/src/store/tool/slices/customPlugin/action.ts
+++ b/src/store/tool/slices/customPlugin/action.ts
@@ -4,6 +4,7 @@ import { StateCreator } from 'zustand/vanilla';
 
 import { notification } from '@/components/AntdStaticMethods';
 import { pluginService } from '@/services/plugin';
+import { toolService } from '@/services/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { LobeToolCustomPlugin, PluginInstallError } from '@/types/tool/plugin';
 import { setNamespace } from '@/utils/storeDebug';
@@ -41,7 +42,7 @@ export const createCustomPluginSlice: StateCreator<
     const { refreshPlugins, updateInstallLoadingState } = get();
     try {
       updateInstallLoadingState(id, true);
-      const manifest = await pluginService.getPluginManifest(
+      const manifest = await toolService.getPluginManifest(
         plugin.customParams?.manifestUrl,
         plugin.customParams?.useProxy,
       );

--- a/src/store/tool/slices/store/action.test.ts
+++ b/src/store/tool/slices/store/action.test.ts
@@ -5,6 +5,7 @@ import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { notification } from '@/components/AntdStaticMethods';
 import { pluginService } from '@/services/plugin';
+import { toolService } from '@/services/tool';
 
 import { useToolStore } from '../../store';
 
@@ -17,10 +18,15 @@ vi.mock('@/components/AntdStaticMethods', () => ({
 // Mock the pluginService.getPluginList method
 vi.mock('@/services/plugin', () => ({
   pluginService: {
-    getPluginManifest: vi.fn(),
-    getPluginList: vi.fn(),
     uninstallPlugin: vi.fn(),
     installPlugin: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/tool', () => ({
+  toolService: {
+    getPluginManifest: vi.fn(),
+    getPluginList: vi.fn(),
   },
 }));
 
@@ -97,7 +103,7 @@ describe('useToolStore:pluginStore', () => {
     it('should load plugin list and update state', async () => {
       // Given
       const pluginListMock = { plugins: [{ identifier: 'plugin1' }, { identifier: 'plugin2' }] };
-      (pluginService.getPluginList as Mock).mockResolvedValue(pluginListMock);
+      (toolService.getPluginList as Mock).mockResolvedValue(pluginListMock);
 
       // When
       let pluginList;
@@ -106,7 +112,7 @@ describe('useToolStore:pluginStore', () => {
       });
 
       // Then
-      expect(pluginService.getPluginList).toHaveBeenCalled();
+      expect(toolService.getPluginList).toHaveBeenCalled();
       expect(pluginList).toEqual(pluginListMock);
       expect(useToolStore.getState().pluginStoreList).toEqual(pluginListMock.plugins);
     });
@@ -114,7 +120,7 @@ describe('useToolStore:pluginStore', () => {
     it('should handle errors when loading plugin list', async () => {
       // Given
       const error = new Error('Failed to load plugin list');
-      (pluginService.getPluginList as Mock).mockRejectedValue(error);
+      (toolService.getPluginList as Mock).mockRejectedValue(error);
 
       // When
       let pluginList;
@@ -128,7 +134,7 @@ describe('useToolStore:pluginStore', () => {
       }
 
       // Then
-      expect(pluginService.getPluginList).toHaveBeenCalled();
+      expect(toolService.getPluginList).toHaveBeenCalled();
       expect(errorOccurred).toBe(true);
       expect(pluginList).toBeUndefined();
       // Ensure the state is not updated with an undefined value
@@ -224,14 +230,14 @@ describe('useToolStore:pluginStore', () => {
         },
         version: '1',
       };
-      (pluginService.getPluginManifest as Mock).mockResolvedValue(pluginManifestMock);
+      (toolService.getPluginManifest as Mock).mockResolvedValue(pluginManifestMock);
 
       await act(async () => {
         await useToolStore.getState().installPlugin(pluginIdentifier);
       });
 
       // Then
-      expect(pluginService.getPluginManifest).toHaveBeenCalled();
+      expect(toolService.getPluginManifest).toHaveBeenCalled();
       expect(notification.error).not.toHaveBeenCalled();
       expect(updateInstallLoadingStateMock).toHaveBeenCalledTimes(2);
       expect(pluginService.installPlugin).toHaveBeenCalledWith({
@@ -253,7 +259,7 @@ describe('useToolStore:pluginStore', () => {
       const error = new TypeError('noManifest');
 
       // Mock necessary modules and functions
-      (pluginService.getPluginManifest as Mock).mockRejectedValue(error);
+      (toolService.getPluginManifest as Mock).mockRejectedValue(error);
 
       useToolStore.setState({
         pluginStoreList: [
@@ -297,7 +303,7 @@ describe('useToolStore:pluginStore', () => {
 
       const plugins = ['plugin1', 'plugin2'];
 
-      (pluginService.getPluginManifest as Mock).mockResolvedValue(pluginManifestMock);
+      (toolService.getPluginManifest as Mock).mockResolvedValue(pluginManifestMock);
 
       // When
       await act(async () => {

--- a/src/store/tool/slices/store/action.ts
+++ b/src/store/tool/slices/store/action.ts
@@ -6,6 +6,7 @@ import { StateCreator } from 'zustand/vanilla';
 
 import { notification } from '@/components/AntdStaticMethods';
 import { pluginService } from '@/services/plugin';
+import { toolService } from '@/services/tool';
 import { pluginStoreSelectors } from '@/store/tool/selectors';
 import { LobeTool } from '@/types/tool';
 import { PluginInstallError } from '@/types/tool/plugin';
@@ -43,7 +44,7 @@ export const createPluginStoreSlice: StateCreator<
     const { updateInstallLoadingState, refreshPlugins } = get();
     try {
       updateInstallLoadingState(name, true);
-      const data = await pluginService.getPluginManifest(plugin.manifest);
+      const data = await toolService.getPluginManifest(plugin.manifest);
       updateInstallLoadingState(name, undefined);
 
       // 4. 存储 manifest 信息
@@ -66,7 +67,7 @@ export const createPluginStoreSlice: StateCreator<
     await Promise.all(plugins.map((identifier) => installPlugin(identifier)));
   },
   loadPluginStore: async () => {
-    const pluginMarketIndex = await pluginService.getPluginList();
+    const pluginMarketIndex = await toolService.getPluginList();
 
     set({ pluginStoreList: pluginMarketIndex.plugins }, false, n('loadPluginList'));
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

将需要请求数据库部分的 service 先抽成文件夹，并区分 `client` 和 `server`，这样后续的 server 实现，只需要做 client 和 server 的 service 替换即可

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

重构过一波以后，发现之前写的 plugin 部分有耦合，既包含了请求，也包含了数据库读取，感觉需要拆分成两个 service。这样一来只有 DB 请求的部分就可以直接复用。

在 https://github.com/lobehub/lobe-chat/pull/2038/commits/9fce23e4f1da1a0f5269b6e62f400aab312585f7 完成了重构，请求调用走 toolService ，数据库服务走 pluginService 。 未来可能会考虑把 pluginService 里的内容直接合并到 user 里，有 user table 以后感觉可能没必要有独立的 `pluginService` 了。之前是没有 user table。

<!-- Add any other context about the Pull Request here. -->
