### PR TITLE
:memo: docs: add docs for the settings url share feature

### DIFF
--- a/docs/self-hosting/advanced/settings-url-share.mdx
+++ b/docs/self-hosting/advanced/settings-url-share.mdx
@@ -1,0 +1,100 @@
+# Share settings via URL 
+
+LobeChat support import settings from external URL to quickly set up LobeChat configuration.
+
+The currently supported settings are:
+
+- `languageModel`: Language model settings
+
+## Import from URL
+
+Use the following URL format to import settings parameters from an external URL:
+
+```plaintext
+https://lobehub.com/?settings=<settings object in JSON format>
+https://lobehub.com/?settings={"languageModel":{"openai":{"apiKey":"user-key","endpoint":"https://lobehub.com/v1"}}}
+```
+
+Example of settings in JSON format:
+
+```json
+{
+    "languageModel": {
+        "openai": {
+            "apiKey": "user-key"
+        }
+    }
+}
+```
+
+## Export settings to URL
+
+```ts
+// Generate settings to export to URL
+const settings = {
+    languageModel: {
+    openai: {
+        apiKey: 'user-key',
+        endpoint: 'https://lobehub.com/v1'
+    },
+}};
+// Convert settings to a JSON formatted string
+const url = `/?settings=${JSON.stringify(settings)}`;
+console.log(url); 
+// /?settings={"languageModel":{"openai":{"apiKey":"user-key","endpoint":"https://lobehub.com/v1"}}}
+```
+
+<Callout type={'warning'}>
+    LobeChat does not verify the correctness of the settings parameters in the URL, nor provide encryption or decryption methods. Please use with caution.
+</Callout>
+
+## Parameter schema
+
+### languageModel
+
+- Property name and type
+
+| Property name | Type                           |
+|---------------|--------------------------------|
+| anthropic     | GeneralModelProviderConfig      |
+| azure         | AzureOpenAIConfig               |
+| bedrock       | AWSBedrockConfig                |
+| google        | GeneralModelProviderConfig      |
+| groq          | GeneralModelProviderConfig      |
+| minimax       | GeneralModelProviderConfig      |
+| mistral       | GeneralModelProviderConfig      |
+| moonshot      | GeneralModelProviderConfig      |
+| ollama        | GeneralModelProviderConfig      |
+| openai        | GeneralModelProviderConfig      |
+| openrouter    | GeneralModelProviderConfig      |
+| perplexity    | GeneralModelProviderConfig      |
+| togetherai    | GeneralModelProviderConfig      |
+| zeroone       | GeneralModelProviderConfig      |
+| zhipu         | GeneralModelProviderConfig      |
+
+- Type `GeneralModelProviderConfig`
+
+| Property name | Type                           | Description                                                                 |
+|-----------------------|--------------------------|-----------------------------------------------------------------------------|
+| apiKey                | string                   | The API key for the model provider.                                          |
+| autoFetchModelLists   | boolean                  | Whether to automatically fetch model lists.                                  |
+| enabled               | boolean                  | Whether the model provider is enabled.                                       |
+| enabledModels         | string[] | null         | The IDs of the enabled models.                                               |
+| endpoint              | string                   | The endpoint for the model provider.                                         |
+| fetchOnClient         | boolean                  | Whether to fetch on the client.                                              |
+
+- Type `AzureOpenAIConfig`
+> Inherits the fields from `GeneralModelProviderConfig`
+
+| Property name | Type                           | Description                                                                 |
+|-----------------------|--------------------------|-----------------------------------------------------------------------------|
+| apiVersion                | string                   | The API version for Azure OpenAI.                                          |
+
+- Type `AWSBedrockConfig`
+> Inherits all fields from `GeneralModelProviderConfig` except `apiKey, endpoint`
+
+| Property name | Type                           | Description                                                                 |
+| accessKeyId           | string                   | The access key ID for AWS Bedrock.                                           |
+| region                | string                   | The region for AWS Bedrock.                                                  |
+| secretAccessKey       | string                   | The secret access key for AWS Bedrock.                                       |
+

--- a/docs/self-hosting/advanced/settings-url-share.zh-CN.mdx
+++ b/docs/self-hosting/advanced/settings-url-share.zh-CN.mdx
@@ -1,0 +1,100 @@
+# URL 分享设置参数
+
+LobeChat 支持从外部 URL 导入设置参数，以便于快速设置 LobeChat 的配置。
+
+目前支持的设置项有：
+
+- `languageModel`：语言模型设置 
+
+## 从 URL 中导入
+
+使用以下 URL 格式，可以从外部 URL 导入设置参数：
+
+```plaintext
+https://lobehub.com/?settings=<JSON格式的设置对象>
+https://lobehub.com/?settings={"languageModel":{"openai":{"apiKey":"user-key","endpoint":"https://lobehub.com/v1"}}}
+```
+
+JSON格式的设置示例：
+
+```json
+{
+    "languageModel": {
+        "openai": {
+            "apiKey": "user-key"
+        }
+    }
+}
+```
+
+## 将设置导出到 URL
+
+```ts
+// 生成要导出到 URL 的设置
+const settings = {
+    languageModel: {
+    openai: {
+        apiKey: 'user-key',
+        endpoint: 'https://lobehub.com/v1'
+    },
+}};
+// 将设置转为 JSON 格式的字符串
+const url = `/?settings=${JSON.stringify(settings)}`;
+console.log(url); 
+// /?settings={"languageModel":{"openai":{"apiKey":"user-key","endpoint":"https://lobehub.com/v1"}}}
+```
+
+<Callout type={'warning'}>
+    LobeChat 不对 URL 中的设置参数进行正确性校验，也不提供加密、解密方法，请谨慎使用。
+</Callout>
+
+## 参数格式
+
+### languageModel
+
+- 参数及其类型
+
+| 参数名称 | 类型                           |
+|---------------|--------------------------------|
+| anthropic     | GeneralModelProviderConfig      |
+| azure         | AzureOpenAIConfig               |
+| bedrock       | AWSBedrockConfig                |
+| google        | GeneralModelProviderConfig      |
+| groq          | GeneralModelProviderConfig      |
+| minimax       | GeneralModelProviderConfig      |
+| mistral       | GeneralModelProviderConfig      |
+| moonshot      | GeneralModelProviderConfig      |
+| ollama        | GeneralModelProviderConfig      |
+| openai        | GeneralModelProviderConfig      |
+| openrouter    | GeneralModelProviderConfig      |
+| perplexity    | GeneralModelProviderConfig      |
+| togetherai    | GeneralModelProviderConfig      |
+| zeroone       | GeneralModelProviderConfig      |
+| zhipu         | GeneralModelProviderConfig      |
+
+- 类型 `GeneralModelProviderConfig`
+
+| 参数               | TS 类型                       | 描述                                                                 |
+|-----------------------|--------------------------|-----------------------------------------------------------------------------|
+| apiKey | string | 模型的 API 密钥。 |
+| autoFetchModelLists | boolean | 是否自动获取模型列表。 |
+| enabled | boolean | 是否启用该模型。 |
+| enabledModels | string[] | 启用的模型的 ID。 |
+| endpoint | string | 模型API端点。 |
+| fetchOnClient | boolean | 是否在客户端发起请求，默认在服务端发起请求。 |
+
+- 类型 `AzureOpenAIConfig`
+> 继承 `GeneralModelProviderConfig` 中的字段
+
+| 参数               | TS 类型                       | 描述                                                                 |
+|-----------------------|--------------------------|-----------------------------------------------------------------------------|
+| apiVersion | string | Azure OpenAI 的 API 版本。 |
+
+- 类型 `AWSBedrockConfig`
+> 继承 `GeneralModelProviderConfig` 中除 `apiKey, endpoint` 外的所有字段
+
+| 参数               | TS 类型                       | 描述                                                                 |
+|-----------------------|--------------------------|-----------------------------------------------------------------------------|
+| accessKeyId | string | AWS Bedrock 的访问密钥 ID。 |
+| region | string | AWS Bedrock 的区域。 |
+| secretAccessKey | string | AWS Bedrock 的访问密钥。 |


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

- 📝 `docs/self-hosting/advanced/settings-url-share.mdx` ：功能描述文档，英文
- 📝 `docs/self-hosting/advanced/settings-url-share.zh-CN.mdx`：功能描述文档，中文

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- 功能 https://github.com/lobehub/lobe-chat/pull/2226/ 的文档补充
- 文档的“参数格式”中的格式是 `GlobalSettings` 类型中的定义。
- 目前仅提供了 `GlobalSettings.languageModel` 中的描述，因为不清楚其他设置属性的导入是否会影响APP功能正常运行。
- `GlobalSettings.languageModel` 的“参数格式”介绍中去除了部分不适宜被外部设置的属性，如：`latestFetchTime`，最后一次获取模型列表的时间，该属性应不能从外部导入。被去除的属性有：`customModelCards`，`remoteModelCards`，`latestFetchTime`

<!-- Add any other context about the Pull Request here. -->
