### PR TITLE
💄 style: autoScroll to the fully end

### DIFF
--- a/src/features/Conversation/components/ChatItem/HistoryDivider.tsx
+++ b/src/features/Conversation/components/ChatItem/HistoryDivider.tsx
@@ -14,7 +14,7 @@ const HistoryDivider = memo<HistoryDividerProps>(({ enable }) => {
 
   return (
     <div style={{ padding: '0 20px' }}>
-      <Divider>
+      <Divider style={{ margin: '0 0', padding: '20px 0' }}>
         <Tag icon={<Icon icon={Timer} />}>
           {t('historyRange', { defaultValue: 'History Message' })}
         </Tag>

--- a/src/features/Conversation/components/ChatItem/HistoryDivider.tsx
+++ b/src/features/Conversation/components/ChatItem/HistoryDivider.tsx
@@ -14,7 +14,7 @@ const HistoryDivider = memo<HistoryDividerProps>(({ enable }) => {
 
   return (
     <div style={{ padding: '0 20px' }}>
-      <Divider style={{ margin: '0 0', padding: '20px 0' }}>
+      <Divider style={{ margin: 0, padding: '20px 0' }}>
         <Tag icon={<Icon icon={Timer} />}>
           {t('historyRange', { defaultValue: 'History Message' })}
         </Tag>

--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -50,7 +50,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile }) => {
 
   useEffect(() => {
     if (virtuosoRef.current) {
-      virtuosoRef.current.scrollToIndex({ align: 'end', behavior: 'auto', index: 'LAST' });
+      virtuosoRef.current.scrollToIndex({ align: 'center', behavior: 'auto', index: 'LAST' });
     }
   }, [id]);
 
@@ -89,11 +89,11 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile }) => {
           const virtuoso = virtuosoRef.current;
           switch (type) {
             case 'auto': {
-              virtuoso?.scrollToIndex({ align: 'end', behavior: 'auto', index: 'LAST' });
+              virtuoso?.scrollToIndex({ align: 'center', behavior: 'auto', index: 'LAST' });
               break;
             }
             case 'click': {
-              virtuoso?.scrollToIndex({ align: 'end', behavior: 'smooth', index: 'LAST' });
+              virtuoso?.scrollToIndex({ align: 'center', behavior: 'smooth', index: 'LAST' });
               break;
             }
           }

--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -50,7 +50,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile }) => {
 
   useEffect(() => {
     if (virtuosoRef.current) {
-      virtuosoRef.current.scrollToIndex({ align: 'center', behavior: 'auto', index: 'LAST' });
+      virtuosoRef.current.scrollToIndex({ align: 'end', behavior: 'auto', index: 'LAST' });
     }
   }, [id]);
 
@@ -89,11 +89,11 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile }) => {
           const virtuoso = virtuosoRef.current;
           switch (type) {
             case 'auto': {
-              virtuoso?.scrollToIndex({ align: 'center', behavior: 'auto', index: 'LAST' });
+              virtuoso?.scrollToIndex({ align: 'end', behavior: 'auto', index: 'LAST' });
               break;
             }
             case 'click': {
-              virtuoso?.scrollToIndex({ align: 'center', behavior: 'smooth', index: 'LAST' });
+              virtuoso?.scrollToIndex({ align: 'end', behavior: 'smooth', index: 'LAST' });
               break;
             }
           }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

当开启历史消息限制时，且“历史范围”分割线离底部较近时，（仅桌面端）无法自动**完全**滚动到消息框底部。
移动端无影响。

#### 📝 补充信息 | Additional Information

![image](https://github.com/lobehub/lobe-chat/assets/20513115/81700d48-18dd-4230-b40f-9d527c4fea83)

![image](https://github.com/lobehub/lobe-chat/assets/20513115/c27c1d92-1990-4e6d-a529-ea826912b4a8)

