### PR TITLE
🔨 build: pin `antd@5.16.5` to fix vercel build too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@next/bundle-analyzer": "^14.2.3",
     "@next/eslint-plugin-next": "^14.2.3",
     "@peculiar/webcrypto": "^1.4.6",
-    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "^15.0.5",
     "@types/chroma-js": "^2.4.4",
     "@types/debug": "^4.1.12",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@vercel/speed-insights": "^1.0.10",
     "ahooks": "^3.7.11",
     "ai": "3.0.19",
-    "antd": "^5.16.5",
+    "antd": "5.16.5",
     "antd-style": "^3.6.2",
     "brotli-wasm": "^3.0.0",
     "chroma-js": "^2.4.2",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

fix #2354 

it seems the issue with `antd@5.17.0` due to the docker release is run too long. So it's not the issue of vercel.

<img width="1327" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/12fa10e9-872d-4dba-87b6-cbaaa2d6139c">

Let me pin the antd version to see whether it pass the build.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs: https://github.com/ant-design/ant-design/issues/48758
<!-- Add any other context about the Pull Request here. -->
