### PR TITLE
🐛fix: wrong judgement on client fetch 

### DIFF
--- a/src/app/(main)/settings/llm/Azure/index.tsx
+++ b/src/app/(main)/settings/llm/Azure/index.tsx
@@ -95,6 +95,7 @@ const AzureOpenAIProvider = memo(() => {
         placeholder: t('azure.modelListPlaceholder'),
       }}
       provider={providerKey}
+      showBrowserRequest
       title={
         <Flexbox align={'center'} gap={8} horizontal>
           <Azure.Combine size={22} type={'color'}></Azure.Combine>

--- a/src/const/settings/index.ts
+++ b/src/const/settings/index.ts
@@ -74,6 +74,9 @@ export const DEFAULT_LLM_CONFIG: GlobalLLMConfig = {
     apiKey: '',
     enabled: false,
     endpoint: '',
+    // Fetch on client cause the CORS error like:
+    // https://github.com/lobehub/lobe-chat/issues/2487
+    fetchOnClient: false,
   },
   bedrock: {
     accessKeyId: '',

--- a/src/const/settings/index.ts
+++ b/src/const/settings/index.ts
@@ -74,9 +74,6 @@ export const DEFAULT_LLM_CONFIG: GlobalLLMConfig = {
     apiKey: '',
     enabled: false,
     endpoint: '',
-    // Fetch on client cause the CORS error like:
-    // https://github.com/lobehub/lobe-chat/issues/2487
-    fetchOnClient: false,
   },
   bedrock: {
     accessKeyId: '',

--- a/src/store/user/slices/settings/selectors/modelConfig.test.ts
+++ b/src/store/user/slices/settings/selectors/modelConfig.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { UserStore } from '@/store/user';
 import { merge } from '@/utils/merge';
 
-import { UserStore, useUserStore } from '../../../store';
 import { UserSettingsState, initialSettingsState } from '../initialState';
 import { modelConfigSelectors } from './modelConfig';
 
@@ -30,6 +30,34 @@ describe('modelConfigSelectors', () => {
       } as UserSettingsState) as unknown as UserStore;
 
       expect(modelConfigSelectors.isProviderEnabled('perplexity')(s)).toBe(false);
+    });
+  });
+
+  describe('isProviderFetchOnClient', () => {
+    it('client fetch should disabled on default', () => {
+      const s = merge(initialSettingsState, {
+        settings: {
+          languageModel: {
+            azure: {
+              endpoint: 'endpoint',
+              apiKey: 'apikey',
+            },
+          },
+        },
+      } as UserSettingsState) as unknown as UserStore;
+
+      expect(modelConfigSelectors.isProviderFetchOnClient('azure')(s)).toBe(false);
+    });
+
+    it('client fetch should enabled if user set it enabled', () => {
+      const s = merge(initialSettingsState, {
+        settings: {
+          languageModel: {
+            azure: { fetchOnClient: true },
+          },
+        },
+      } as UserSettingsState) as unknown as UserStore;
+      expect(modelConfigSelectors.isProviderFetchOnClient('azure')(s)).toBe(true);
     });
   });
 

--- a/src/store/user/slices/settings/selectors/modelConfig.ts
+++ b/src/store/user/slices/settings/selectors/modelConfig.ts
@@ -13,7 +13,7 @@ const isProviderFetchOnClient = (provider: GlobalLLMProviderKey | string) => (s:
   const config = getProviderConfigById(provider)(s);
   if (typeof config?.fetchOnClient !== 'undefined') return config?.fetchOnClient;
 
-  return isProviderEndpointNotEmpty(provider)(s);
+  return false;
 };
 
 const getCustomModelCard =


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- 🐛 `src/store/user/slices/settings/selectors/modelConfig.ts`： 不再根据用户填写的 endpoint 自动开启客户端请求；

== 05/16/2024 更新 ==
- 🧪 `src/store/user/slices/settings/selectors/modelConfig.test.ts`： 增加两条测试：
  - 在用户不主动开启的情况下，功能是关闭的，
  - 在用户主动打开时，功能是启用的；

== 05/17/2024 更新 ==
- 🔧 `src/app/(main)/settings/llm/Azure/index.tsx`：展示 Azure Provider 的”客户端请求“功能；  fix #2487 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- 🤔 目前尚不清楚是否需要强制展示“客户端请求”的功能开关，或是当“客户端请求”功能启用后，强制显示能关闭该功能的 Switch；
- 该 fix 合并后，除了初始化 Store 时读取的设置外，将无隐式启用“客户端请求”功能的代码部分；
- [Preview](https://lobe-chat-git-fix-fetch-on-client-cy948s-projects.vercel.app/settings/llm)
<!-- Add any other context about the Pull Request here. -->
