### PR TITLE
⚡️ perf: fix SSR hydration to improve first-visit first-page loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "remark": "^14.0.3",
     "remark-gfm": "^3.0.1",
     "remark-html": "^15.0.2",
+    "resolve-accept-language": "^3.1.4",
     "rtl-detect": "^1.1.2",
     "semver": "^7.6.2",
     "sharp": "^0.33.4",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

close #2572
close [#2516](https://github.com/lobehub/lobe-chat/issues/2516#issuecomment-2120845055)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

在 https://github.com/lobehub/lobe-chat/discussions/253 中，我们基于 Cookie 实现了用户浏览器自适应语种的 SSR 方案。

当时存在一个问题是：用户第一次打开时是没有 cookie 的，这就会导致 fallback 到 en-US，而中文用户的浏览器（client端）又是 zh-CN ，这就会出现 SSR 水合不匹配问题。

利用 `next@14.2.x` 的 dev 报错可以看得非常清楚：

![image](https://github.com/lobehub/lobe-chat/assets/28616219/678d0f77-531d-45ab-8019-d51c48927441)

当 React SSR 水合出错时，界面会一直维持在骨架屏上，必须要用户做一次鼠标点击的操作，才能触发 client fallback 渲染。 

在之前看来，在第二次及以后都不会出现这个问题，只有首次会遇到，而且是必须什么也不做才会碰到，这个场景感觉不算很多，因此暂时选择了搁置。

但也是因此，很多用户认为是加载资源多导致感觉加载慢的问题。（譬如 https://github.com/lobehub/lobe-chat/issues/2516#issuecomment-2120285833 的反馈）

本 PR 通过读取 header 中的 `accept-language` 字段，针对没有 cookie 的场景，补充 fallback 语种。这样一来，理论上就能解决大部分用户的首次访问的首屏水合问题。
<!-- Add any other context about the Pull Request here. -->
