### PR TITLE
♻️ refactor: refactor `keyVaults` and rename `endpoint` to `baseURL`

### DIFF
--- a/src/app/(main)/chat/settings/features/SubmitAgentButton/SubmitAgentModal.tsx
+++ b/src/app/(main)/chat/settings/features/SubmitAgentButton/SubmitAgentModal.tsx
@@ -17,7 +17,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionMetaSelectors } from '@/store/session/selectors';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const SubmitAgentModal = memo<ModalProps>(({ open, onCancel }) => {
   const { t } = useTranslation('setting');
@@ -25,7 +25,7 @@ const SubmitAgentModal = memo<ModalProps>(({ open, onCancel }) => {
   const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
   const theme = useTheme();
   const meta = useSessionStore(sessionMetaSelectors.currentAgentMeta, isEqual);
-  const language = useUserStore((s) => settingsSelectors.currentSettings(s).language);
+  const language = useUserStore((s) => userGeneralSettingsSelectors.currentLanguage(s));
 
   const isMetaPass = Boolean(
     meta && meta.title && meta.description && (meta.tags as string[])?.length > 0 && meta.avatar,
@@ -46,7 +46,7 @@ const SubmitAgentModal = memo<ModalProps>(({ open, onCancel }) => {
       '### tags',
       (meta.tags as string[]).join(', '),
       '### locale',
-      language === 'auto' ? navigator.language : language,
+      language,
     ].join('\n\n');
 
     const url = qs.stringifyUrl({

--- a/src/app/(main)/settings/common/features/Common.tsx
+++ b/src/app/(main)/settings/common/features/Common.tsx
@@ -110,7 +110,7 @@ const Common = memo(() => {
         desc: t('settingSystem.accessCode.desc'),
         hidden: !showAccessCodeConfig,
         label: t('settingSystem.accessCode.title'),
-        name: 'password',
+        name: ['keyVaults', 'password'],
       },
       {
         children: isSignedIn ? (

--- a/src/app/(main)/settings/common/features/Theme/ThemeSwatches/ThemeSwatchesNeutral.tsx
+++ b/src/app/(main)/settings/common/features/Theme/ThemeSwatches/ThemeSwatchesNeutral.tsx
@@ -8,17 +8,17 @@ import {
 import { memo } from 'react';
 
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const ThemeSwatchesNeutral = memo(() => {
-  const [neutralColor, setSettings] = useUserStore((s) => [
-    settingsSelectors.currentSettings(s).neutralColor,
-    s.setSettings,
+  const [neutralColor, updateGeneralConfig] = useUserStore((s) => [
+    userGeneralSettingsSelectors.neutralColor(s),
+    s.updateGeneralConfig,
   ]);
 
   const handleSelect = (v: any) => {
     const name = findCustomThemeName('neutral', v) as NeutralColors;
-    setSettings({ neutralColor: name || '' });
+    updateGeneralConfig({ neutralColor: name || '' });
   };
 
   return (

--- a/src/app/(main)/settings/common/features/Theme/ThemeSwatches/ThemeSwatchesPrimary.tsx
+++ b/src/app/(main)/settings/common/features/Theme/ThemeSwatches/ThemeSwatchesPrimary.tsx
@@ -8,17 +8,17 @@ import {
 import { memo } from 'react';
 
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const ThemeSwatchesPrimary = memo(() => {
-  const [primaryColor, setSettings] = useUserStore((s) => [
-    settingsSelectors.currentSettings(s).primaryColor,
-    s.setSettings,
+  const [primaryColor, updateGeneralConfig] = useUserStore((s) => [
+    userGeneralSettingsSelectors.primaryColor(s),
+    s.updateGeneralConfig,
   ]);
 
   const handleSelect = (v: any) => {
     const name = findCustomThemeName('primary', v) as PrimaryColors;
-    setSettings({ primaryColor: name || '' });
+    updateGeneralConfig({ primaryColor: name || '' });
   };
 
   return (

--- a/src/app/(main)/settings/common/features/Theme/index.tsx
+++ b/src/app/(main)/settings/common/features/Theme/index.tsx
@@ -14,7 +14,7 @@ import { imageUrl } from '@/const/url';
 import AvatarWithUpload from '@/features/AvatarWithUpload';
 import { localeOptions } from '@/locales/resources';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { switchLang } from '@/utils/client/switchLang';
 
 import { ThemeSwatchesNeutral, ThemeSwatchesPrimary } from './ThemeSwatches';
@@ -25,6 +25,7 @@ const Theme = memo(() => {
   const { t } = useTranslation('setting');
   const [form] = Form.useForm();
   const settings = useUserStore(settingsSelectors.currentSettings, isEqual);
+  const themeMode = useUserStore(userGeneralSettingsSelectors.currentThemeMode);
   const [setThemeMode, setSettings] = useUserStore((s) => [s.switchThemeMode, s.setSettings]);
 
   useSyncSettings(form);
@@ -40,7 +41,7 @@ const Theme = memo(() => {
       {
         children: (
           <SelectWithImg
-            defaultValue={settings.themeMode}
+            defaultValue={themeMode}
             height={60}
             onChange={setThemeMode}
             options={[
@@ -78,7 +79,7 @@ const Theme = memo(() => {
           />
         ),
         label: t('settingTheme.lang.title'),
-        name: 'language',
+        name: ['general', 'language'],
       },
       {
         children: (
@@ -113,7 +114,7 @@ const Theme = memo(() => {
         ),
         desc: t('settingTheme.fontSize.desc'),
         label: t('settingTheme.fontSize.title'),
-        name: 'fontSize',
+        name: ['general', 'fontSize'],
       },
       {
         children: <ThemeSwatchesPrimary />,

--- a/src/app/(main)/settings/llm/Azure/index.tsx
+++ b/src/app/(main)/settings/llm/Azure/index.tsx
@@ -13,7 +13,7 @@ import { useUserStore } from '@/store/user';
 import { modelProviderSelectors } from '@/store/user/selectors';
 
 import ProviderConfig from '../components/ProviderConfig';
-import { LLMProviderApiTokenKey, LLMProviderBaseUrlKey, LLMProviderConfigKey } from '../const';
+import { KeyVaultsConfigKey, LLMProviderApiTokenKey } from '../const';
 
 const useStyles = createStyles(({ css, token }) => ({
   markdown: css`
@@ -57,13 +57,13 @@ const AzureOpenAIProvider = memo(() => {
           ),
           desc: t('azure.token.desc'),
           label: t('azure.token.title'),
-          name: [LLMProviderConfigKey, providerKey, LLMProviderApiTokenKey],
+          name: [KeyVaultsConfigKey, providerKey, LLMProviderApiTokenKey],
         },
         {
           children: <Input allowClear placeholder={t('azure.endpoint.placeholder')} />,
           desc: t('azure.endpoint.desc'),
           label: t('azure.endpoint.title'),
-          name: [LLMProviderConfigKey, providerKey, LLMProviderBaseUrlKey],
+          name: [KeyVaultsConfigKey, providerKey, 'endpoint'],
         },
         {
           children: (
@@ -85,7 +85,7 @@ const AzureOpenAIProvider = memo(() => {
             </Markdown>
           ),
           label: t('azure.azureApiVersion.title'),
-          name: [LLMProviderConfigKey, providerKey, 'apiVersion'],
+          name: [KeyVaultsConfigKey, providerKey, 'apiVersion'],
         },
       ]}
       checkModel={checkModel}

--- a/src/app/(main)/settings/llm/Bedrock/index.tsx
+++ b/src/app/(main)/settings/llm/Bedrock/index.tsx
@@ -10,7 +10,7 @@ import { ModelProvider } from '@/libs/agent-runtime';
 import { GlobalLLMProviderKey } from '@/types/user/settings';
 
 import ProviderConfig from '../components/ProviderConfig';
-import { LLMProviderConfigKey } from '../const';
+import { KeyVaultsConfigKey } from '../const';
 
 const providerKey: GlobalLLMProviderKey = 'bedrock';
 
@@ -29,7 +29,7 @@ const BedrockProvider = memo(() => {
           ),
           desc: t(`${providerKey}.accessKeyId.desc`),
           label: t(`${providerKey}.accessKeyId.title`),
-          name: [LLMProviderConfigKey, providerKey, 'accessKeyId'],
+          name: [KeyVaultsConfigKey, providerKey, 'accessKeyId'],
         },
         {
           children: (
@@ -40,7 +40,7 @@ const BedrockProvider = memo(() => {
           ),
           desc: t(`${providerKey}.secretAccessKey.desc`),
           label: t(`${providerKey}.secretAccessKey.title`),
-          name: [LLMProviderConfigKey, providerKey, 'secretAccessKey'],
+          name: [KeyVaultsConfigKey, providerKey, 'secretAccessKey'],
         },
         {
           children: (
@@ -55,7 +55,7 @@ const BedrockProvider = memo(() => {
           ),
           desc: t(`${providerKey}.region.desc`),
           label: t(`${providerKey}.region.title`),
-          name: [LLMProviderConfigKey, providerKey, 'region'],
+          name: [KeyVaultsConfigKey, providerKey, 'region'],
         },
       ]}
       checkModel={'anthropic.claude-instant-v1'}

--- a/src/app/(main)/settings/llm/Ollama/Checker.tsx
+++ b/src/app/(main)/settings/llm/Ollama/Checker.tsx
@@ -27,7 +27,7 @@ const OllamaChecker = memo(() => {
   );
 
   const checkConnection = () => {
-    mutate();
+    mutate().catch();
   };
 
   const isMobile = useIsMobile();

--- a/src/app/(main)/settings/llm/components/ProviderConfig/index.tsx
+++ b/src/app/(main)/settings/llm/components/ProviderConfig/index.tsx
@@ -10,6 +10,7 @@ import { Flexbox } from 'react-layout-kit';
 
 import { useSyncSettings } from '@/app/(main)/settings/hooks/useSyncSettings';
 import {
+  KeyVaultsConfigKey,
   LLMProviderApiTokenKey,
   LLMProviderBaseUrlKey,
   LLMProviderConfigKey,
@@ -17,7 +18,7 @@ import {
 } from '@/app/(main)/settings/llm/const';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors } from '@/store/user/selectors';
+import { keyVaultsConfigSelectors, modelConfigSelectors } from '@/store/user/selectors';
 import { GlobalLLMProviderKey } from '@/types/user/settings';
 
 import Checker from '../Checker';
@@ -100,7 +101,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
       s.setSettings,
       modelConfigSelectors.isProviderEnabled(provider)(s),
       modelConfigSelectors.isProviderFetchOnClient(provider)(s),
-      modelConfigSelectors.isProviderEndpointNotEmpty(provider)(s),
+      keyVaultsConfigSelectors.isProviderEndpointNotEmpty(provider)(s),
     ]);
 
     useSyncSettings(form);
@@ -117,7 +118,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
             ),
             desc: modelT(`${provider}.token.desc` as any),
             label: modelT(`${provider}.token.title` as any),
-            name: [LLMProviderConfigKey, provider, LLMProviderApiTokenKey],
+            name: [KeyVaultsConfigKey, provider, LLMProviderApiTokenKey],
           },
         ];
 
@@ -128,7 +129,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
         children: <Input allowClear placeholder={proxyUrl?.placeholder} />,
         desc: proxyUrl?.desc || t('llm.proxyUrl.desc'),
         label: proxyUrl?.title || t('llm.proxyUrl.title'),
-        name: [LLMProviderConfigKey, provider, LLMProviderBaseUrlKey],
+        name: [KeyVaultsConfigKey, provider, LLMProviderBaseUrlKey],
       },
       (showBrowserRequest || (showEndpoint && isProviderEndpointNotEmpty)) && {
         children: (

--- a/src/app/(main)/settings/llm/const.ts
+++ b/src/app/(main)/settings/llm/const.ts
@@ -1,4 +1,5 @@
 export const LLMProviderConfigKey = 'languageModel';
+export const KeyVaultsConfigKey = 'keyVaults';
 
 /**
  * we use this key to define default api key
@@ -10,7 +11,7 @@ export const LLMProviderApiTokenKey = 'apiKey';
  * we use this key to define the baseURL
  * equal OPENAI_PROXY_URL
  */
-export const LLMProviderBaseUrlKey = 'endpoint';
+export const LLMProviderBaseUrlKey = 'baseURL';
 
 /**
  * we use this key to define the custom model name

--- a/src/const/settings/common.ts
+++ b/src/const/settings/common.ts
@@ -1,6 +1,6 @@
-import { UserGeneralSettings } from '@/types/user/settings';
+import { UserGeneralConfig } from '@/types/user/settings';
 
-export const DEFAULT_COMMON_SETTINGS: UserGeneralSettings = {
+export const DEFAULT_COMMON_SETTINGS: UserGeneralConfig = {
   fontSize: 14,
   language: 'auto',
   password: '',

--- a/src/const/settings/index.ts
+++ b/src/const/settings/index.ts
@@ -18,10 +18,11 @@ export * from './tts';
 
 export const DEFAULT_SETTINGS: UserSettings = {
   defaultAgent: DEFAULT_AGENT,
+  general: DEFAULT_COMMON_SETTINGS,
+  keyVaults: {},
   languageModel: DEFAULT_LLM_CONFIG,
   sync: DEFAULT_SYNC_CONFIG,
   systemAgent: DEFAULT_SYSTEM_AGENT_CONFIG,
   tool: DEFAULT_TOOL_CONFIG,
   tts: DEFAULT_TTS_CONFIG,
-  ...DEFAULT_COMMON_SETTINGS,
 };

--- a/src/const/settings/llm.ts
+++ b/src/const/settings/llm.ts
@@ -21,85 +21,66 @@ import { UserModelProviderConfig } from '@/types/user/settings';
 
 export const DEFAULT_LLM_CONFIG: UserModelProviderConfig = {
   anthropic: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(AnthropicProviderCard),
   },
   azure: {
-    apiKey: '',
     enabled: false,
-    endpoint: '',
   },
   bedrock: {
-    accessKeyId: '',
     enabled: false,
     enabledModels: filterEnabledModels(BedrockProviderCard),
-    region: 'us-east-1',
-    secretAccessKey: '',
   },
   deepseek: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(DeepSeekProviderCard),
   },
   google: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(GoogleProviderCard),
   },
   groq: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(GroqProviderCard),
   },
   minimax: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(MinimaxProviderCard),
   },
   mistral: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(MistralProviderCard),
   },
   moonshot: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(MoonshotProviderCard),
   },
   ollama: {
     enabled: true,
     enabledModels: filterEnabledModels(OllamaProviderCard),
-    endpoint: '',
     fetchOnClient: true,
   },
   openai: {
-    apiKey: '',
     enabled: true,
     enabledModels: filterEnabledModels(OpenAIProviderCard),
   },
   openrouter: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(OpenRouterProviderCard),
   },
   perplexity: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(PerplexityProviderCard),
   },
   togetherai: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(TogetherAIProviderCard),
   },
   zeroone: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(ZeroOneProviderCard),
   },
   zhipu: {
-    apiKey: '',
     enabled: false,
     enabledModels: filterEnabledModels(ZhiPuProviderCard),
   },

--- a/src/database/client/core/schemas.ts
+++ b/src/database/client/core/schemas.ts
@@ -76,10 +76,11 @@ export const dbSchemaV7 = {
   plugins:
     '&identifier, id, type, manifest.type, manifest.meta.title, manifest.meta.description, manifest.meta.author, createdAt, updatedAt',
 };
+
 // ************************************** //
-// ******* Version 9 - 2024-03-14 ******* //
+// ******* Version 9 - 2024-05-11 ******* //
 // ************************************** //
-// - Added id to `plugins` table
+// - Added tool_call_id to `messages` table
 export const dbSchemaV9 = {
   ...dbSchemaV7,
   messages:

--- a/src/database/client/models/__tests__/user.test.ts
+++ b/src/database/client/models/__tests__/user.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { UserSettings } from '@/types/user/settings';
-
 import { UserModel } from '../user';
 
 describe('UserModel', () => {
@@ -51,17 +49,19 @@ describe('UserModel', () => {
   it('should update user settings', async () => {
     await UserModel.create(userData);
 
-    await UserModel.updateSettings({ themeMode: 'dark' });
+    await UserModel.updateSettings({ general: { themeMode: 'dark' } });
 
     const userInDb = await UserModel.getUser();
 
-    expect(userInDb).toHaveProperty('settings', { themeMode: 'dark' });
+    expect(userInDb).toHaveProperty('settings', {
+      general: { themeMode: 'dark' },
+    });
   });
 
   it('should reset user settings', async () => {
     await UserModel.create(userData);
 
-    await UserModel.updateSettings({ themeMode: 'dark' });
+    await UserModel.updateSettings({ general: { themeMode: 'dark' } });
 
     await UserModel.resetSettings();
 

--- a/src/database/client/models/user.ts
+++ b/src/database/client/models/user.ts
@@ -2,10 +2,9 @@ import { DeepPartial } from 'utility-types';
 
 import { BaseModel } from '@/database/client/core';
 import { LobeAgentConfig } from '@/types/agent';
-import { UserSettings } from '@/types/user/settings';
 import { uuid } from '@/utils/uuid';
 
-import { DB_User, DB_UserSchema } from '../schemas/user';
+import { DB_Settings, DB_User, DB_UserSchema } from '../schemas/user';
 
 class _UserModel extends BaseModel {
   constructor() {
@@ -42,7 +41,7 @@ class _UserModel extends BaseModel {
 
   // **************** Update *************** //
 
-  async updateSettings(settings: DeepPartial<UserSettings>) {
+  async updateSettings(settings: DeepPartial<DB_Settings>) {
     const user = await this.getUser();
 
     return this.update(user.id, { settings: settings as any });

--- a/src/database/client/schemas/user.ts
+++ b/src/database/client/schemas/user.ts
@@ -3,16 +3,22 @@ import { z } from 'zod';
 import { AgentSchema } from '@/database/client/schemas/session';
 import { LobeMetaDataSchema } from '@/types/meta';
 
+const generalSechma = z.object({
+  fontSize: z.number().default(14),
+  language: z.string(),
+  neutralColor: z.string().optional(),
+  password: z.string(),
+  themeMode: z.string(),
+});
+
 const settingsSchema = z.object({
   defaultAgent: z.object({
     config: AgentSchema,
     meta: LobeMetaDataSchema,
   }),
-  fontSize: z.number().default(14),
-  language: z.string(),
+  general: generalSechma.partial().optional(),
+  keyVaults: z.any().optional(),
   languageModel: z.any().optional(),
-  password: z.string(),
-  themeMode: z.string(),
   tts: z.object({
     openAI: z.object({
       sttModel: z.string(),

--- a/src/features/AgentSetting/AgentMeta/index.tsx
+++ b/src/features/AgentSetting/AgentMeta/index.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import { FORM_STYLE } from '@/const/layoutTokens';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { useStore } from '../store';
 import { SessionLoadingState } from '../store/initialState';
@@ -30,7 +30,7 @@ const AgentMeta = memo(() => {
     s.autocompleteMeta,
     s.autocompleteAllMeta,
   ]);
-  const locale = useUserStore(settingsSelectors.currentLanguage);
+  const locale = useUserStore(userGeneralSettingsSelectors.currentLanguage);
   const loading = useStore((s) => s.autocompleteLoading);
   const meta = useStore((s) => s.meta, isEqual);
 

--- a/src/features/AgentSetting/AgentTTS/index.tsx
+++ b/src/features/AgentSetting/AgentTTS/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { FORM_STYLE } from '@/const/layoutTokens';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { useStore } from '../store';
 import { useAgentSyncSettings } from '../useSyncAgemtSettings';
@@ -24,7 +24,7 @@ const AgentTTS = memo(() => {
   const { t } = useTranslation('setting');
   const [form] = Form.useForm();
   const voiceList = useUserStore((s) => {
-    const locale = settingsSelectors.currentLanguage(s);
+    const locale = userGeneralSettingsSelectors.currentLanguage(s);
     return (all?: boolean) => new VoiceList(all ? undefined : locale);
   });
   const [showAllLocaleVoice, ttsService, updateConfig] = useStore((s) => [

--- a/src/features/ChatInput/STT/browser.tsx
+++ b/src/features/ChatInput/STT/browser.tsx
@@ -9,7 +9,7 @@ import { agentSelectors } from '@/store/agent/slices/chat';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { ChatMessageError } from '@/types/message';
 import { getMessageError } from '@/utils/fetch';
 
@@ -22,7 +22,7 @@ interface STTConfig extends SWRConfiguration {
 const useBrowserSTT = (config: STTConfig) => {
   const ttsSettings = useUserStore(settingsSelectors.currentTTS, isEqual);
   const ttsAgentSettings = useAgentStore(agentSelectors.currentAgentTTS, isEqual);
-  const locale = useUserStore(settingsSelectors.currentLanguage);
+  const locale = useUserStore(userGeneralSettingsSelectors.currentLanguage);
 
   const autoStop = ttsSettings.sttAutoStop;
   const sttLocale =

--- a/src/features/ChatInput/STT/openai.tsx
+++ b/src/features/ChatInput/STT/openai.tsx
@@ -12,7 +12,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/slices/message/selectors';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { ChatMessageError } from '@/types/message';
 import { getMessageError } from '@/utils/fetch';
 
@@ -25,7 +25,7 @@ interface STTConfig extends SWRConfiguration {
 const useOpenaiSTT = (config: STTConfig) => {
   const ttsSettings = useUserStore(settingsSelectors.currentTTS, isEqual);
   const ttsAgentSettings = useAgentStore(agentSelectors.currentAgentTTS, isEqual);
-  const locale = useUserStore(settingsSelectors.currentLanguage);
+  const locale = useUserStore(userGeneralSettingsSelectors.currentLanguage);
 
   const autoStop = ttsSettings.sttAutoStop;
   const sttLocale =

--- a/src/features/Conversation/Error/APIKeyForm/Bedrock.tsx
+++ b/src/features/Conversation/Error/APIKeyForm/Bedrock.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ModelProvider } from '@/libs/agent-runtime';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors } from '@/store/user/selectors';
+import { keyVaultsConfigSelectors } from '@/store/user/selectors';
 
 import { FormAction } from '../style';
 
@@ -17,10 +17,10 @@ const BedrockForm = memo(() => {
   const [showRegion, setShow] = useState(false);
 
   const [accessKeyId, secretAccessKey, region, setConfig] = useUserStore((s) => [
-    modelConfigSelectors.bedrockConfig(s).accessKeyId,
-    modelConfigSelectors.bedrockConfig(s).secretAccessKey,
-    modelConfigSelectors.bedrockConfig(s).region,
-    s.setModelProviderConfig,
+    keyVaultsConfigSelectors.bedrockConfig(s).accessKeyId,
+    keyVaultsConfigSelectors.bedrockConfig(s).secretAccessKey,
+    keyVaultsConfigSelectors.bedrockConfig(s).region,
+    s.updateKeyVaultConfig,
   ]);
 
   const theme = useTheme();

--- a/src/features/Conversation/Error/APIKeyForm/ProviderApiKeyForm.tsx
+++ b/src/features/Conversation/Error/APIKeyForm/ProviderApiKeyForm.tsx
@@ -5,7 +5,7 @@ import { ReactNode, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { keyVaultsConfigSelectors } from '@/store/user/selectors';
 import { GlobalLLMProviderKey } from '@/types/user/settings';
 
 import { FormAction } from '../style';
@@ -24,9 +24,9 @@ const ProviderApiKeyForm = memo<ProviderApiKeyFormProps>(
     const [showProxy, setShow] = useState(false);
 
     const [apiKey, proxyUrl, setConfig] = useUserStore((s) => [
-      settingsSelectors.providerConfig(provider)(s)?.apiKey,
-      settingsSelectors.providerConfig(provider)(s)?.endpoint,
-      s.setModelProviderConfig,
+      keyVaultsConfigSelectors.getVaultByProvider(provider)(s)?.apiKey,
+      keyVaultsConfigSelectors.getVaultByProvider(provider)(s)?.baseURL,
+      s.updateKeyVaultConfig,
     ]);
 
     return (

--- a/src/features/Conversation/Error/AccessCodeForm.tsx
+++ b/src/features/Conversation/Error/AccessCodeForm.tsx
@@ -15,9 +15,9 @@ interface AccessCodeFormProps {
 
 const AccessCodeForm = memo<AccessCodeFormProps>(({ id }) => {
   const { t } = useTranslation('error');
-  const [password, setSettings] = useUserStore((s) => [
-    settingsSelectors.currentSettings(s).password,
-    s.setSettings,
+  const [password, updateKeyVaults] = useUserStore((s) => [
+    settingsSelectors.password(s),
+    s.updateKeyVaults,
   ]);
   const [resend, deleteMessage] = useChatStore((s) => [s.regenerateMessage, s.deleteMessage]);
 
@@ -31,7 +31,7 @@ const AccessCodeForm = memo<AccessCodeFormProps>(({ id }) => {
         <Input.Password
           autoComplete={'new-password'}
           onChange={(e) => {
-            setSettings({ password: e.target.value });
+            updateKeyVaults({ password: e.target.value });
           }}
           placeholder={t('unlock.password.placeholder')}
           type={'block'}

--- a/src/features/Conversation/Extras/TTS/index.tsx
+++ b/src/features/Conversation/Extras/TTS/index.tsx
@@ -4,7 +4,7 @@ import { Md5 } from 'ts-md5';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/slices/chat';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import FilePlayer from './FilePlayer';
 import InitPlayer, { TTSProps } from './InitPlayer';
@@ -12,7 +12,7 @@ import InitPlayer, { TTSProps } from './InitPlayer';
 const TTS = memo<TTSProps>(
   (props) => {
     const { file, voice, content, contentMd5 } = props;
-    const lang = useUserStore(settingsSelectors.currentLanguage);
+    const lang = useUserStore(userGeneralSettingsSelectors.currentLanguage);
     const currentVoice = useAgentStore(agentSelectors.currentAgentTTSVoice(lang));
 
     const md5 = useMemo(() => Md5.hashStr(content).toString(), [content]);

--- a/src/features/Conversation/Plugins/Render/MarkdownType/index.tsx
+++ b/src/features/Conversation/Plugins/Render/MarkdownType/index.tsx
@@ -2,7 +2,7 @@ import { Markdown } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useUserStore } from '@/store/user';
-import {settingsSelectors, userGeneralSettingsSelectors} from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import Loading from '../Loading';
 

--- a/src/features/Conversation/Plugins/Render/MarkdownType/index.tsx
+++ b/src/features/Conversation/Plugins/Render/MarkdownType/index.tsx
@@ -2,7 +2,7 @@ import { Markdown } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import {settingsSelectors, userGeneralSettingsSelectors} from '@/store/user/selectors';
 
 import Loading from '../Loading';
 
@@ -12,7 +12,7 @@ export interface PluginMarkdownTypeProps {
 }
 
 const PluginMarkdownType = memo<PluginMarkdownTypeProps>(({ content, loading }) => {
-  const fontSize = useUserStore((s) => settingsSelectors.currentSettings(s).fontSize);
+  const fontSize = useUserStore(userGeneralSettingsSelectors.fontSize);
   if (loading) return <Loading />;
 
   return (

--- a/src/features/Conversation/components/ChatItem/index.tsx
+++ b/src/features/Conversation/components/ChatItem/index.tsx
@@ -11,7 +11,7 @@ import { chatSelectors } from '@/store/chat/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionMetaSelectors } from '@/store/session/selectors';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { ChatMessage } from '@/types/message';
 
 import ErrorMessageExtra, { getErrorAlertConfig } from '../../Error';
@@ -38,7 +38,7 @@ export interface ChatListItemProps {
 }
 
 const Item = memo<ChatListItemProps>(({ index, id }) => {
-  const fontSize = useUserStore((s) => settingsSelectors.currentSettings(s).fontSize);
+  const fontSize = useUserStore(userGeneralSettingsSelectors.fontSize);
   const { t } = useTranslation('common');
   const { styles, cx } = useStyles();
   const [type = 'chat'] = useAgentStore((s) => {

--- a/src/features/PluginDevModal/LocalForm.tsx
+++ b/src/features/PluginDevModal/LocalForm.tsx
@@ -7,13 +7,13 @@ import { useTranslation } from 'react-i18next';
 import { useToolStore } from '@/store/tool';
 import { pluginSelectors } from '@/store/tool/selectors';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const EmojiPicker = dynamic(() => import('@lobehub/ui/es/EmojiPicker'), { ssr: false });
 
 const LocalForm = memo<{ form: FormInstance; mode?: 'edit' | 'create' }>(({ form, mode }) => {
   const isEditMode = mode === 'edit';
-  const locale = useUserStore(settingsSelectors.currentLanguage);
+  const locale = useUserStore(userGeneralSettingsSelectors.currentLanguage);
   const { t } = useTranslation('plugin');
 
   const pluginIds = useToolStore(pluginSelectors.storeAndInstallPluginsIdList);

--- a/src/features/User/UserPanel/LangButton.tsx
+++ b/src/features/User/UserPanel/LangButton.tsx
@@ -8,12 +8,12 @@ import { useTranslation } from 'react-i18next';
 import Menu, { type MenuProps } from '@/components/Menu';
 import { localeOptions } from '@/locales/resources';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const LangButton = memo(() => {
   const theme = useTheme();
   const [language, switchLocale] = useUserStore((s) => [
-    settingsSelectors.currentSettings(s).language,
+    userGeneralSettingsSelectors.language(s),
     s.switchLocale,
   ]);
 

--- a/src/features/User/UserPanel/ThemeButton.tsx
+++ b/src/features/User/UserPanel/ThemeButton.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import Menu, { type MenuProps } from '@/components/Menu';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const themeIcons = {
   auto: Monitor,
@@ -18,7 +18,7 @@ const themeIcons = {
 const ThemeButton = memo(() => {
   const theme = useTheme();
   const [themeMode, switchThemeMode] = useUserStore((s) => [
-    settingsSelectors.currentSettings(s).themeMode,
+    userGeneralSettingsSelectors.currentThemeMode(s),
     s.switchThemeMode,
   ]);
 

--- a/src/hooks/_header.ts
+++ b/src/hooks/_header.ts
@@ -1,14 +1,17 @@
 import { LOBE_CHAT_ACCESS_CODE, OPENAI_API_KEY_HEADER_KEY, OPENAI_END_POINT } from '@/const/fetch';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors, settingsSelectors } from '@/store/user/selectors';
+import {
+  keyVaultsConfigSelectors,
+  settingsSelectors,
+} from '@/store/user/selectors';
 
 // TODO: Need to be removed after tts refactor
 // eslint-disable-next-line no-undef
 export const createHeaderWithOpenAI = (header?: HeadersInit): HeadersInit => {
-  const openai = modelConfigSelectors.openAIConfig(useUserStore.getState());
+  const openai = keyVaultsConfigSelectors.openAIConfig(useUserStore.getState());
 
   const apiKey = openai.apiKey || '';
-  const endpoint = openai.endpoint || '';
+  const endpoint = openai.baseURL || '';
 
   // eslint-disable-next-line no-undef
   return {

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -14,7 +14,7 @@ import { API_ENDPOINTS } from '@/services/_url';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/slices/chat';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { TTSServer } from '@/types/agent';
 
 interface TTSConfig extends TTSOptions {
@@ -26,7 +26,7 @@ interface TTSConfig extends TTSOptions {
 export const useTTS = (content: string, config?: TTSConfig) => {
   const ttsSettings = useUserStore(settingsSelectors.currentTTS, isEqual);
   const ttsAgentSettings = useAgentStore(agentSelectors.currentAgentTTS, isEqual);
-  const lang = useUserStore(settingsSelectors.currentLanguage);
+  const lang = useUserStore(userGeneralSettingsSelectors.currentLanguage);
   const voice = useAgentStore(agentSelectors.currentAgentTTSVoice(lang));
   let useSelectedTTS;
   let options: any = {};

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -14,7 +14,7 @@ import {
   LOBE_THEME_PRIMARY_COLOR,
 } from '@/const/theme';
 import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { GlobalStyle } from '@/styles';
 import { setCookie } from '@/utils/cookie';
 
@@ -86,11 +86,11 @@ const AppTheme = memo<AppThemeProps>(
     // console.debug('server:appearance', defaultAppearance);
     // console.debug('server:primaryColor', defaultPrimaryColor);
     // console.debug('server:neutralColor', defaultNeutralColor);
-    const themeMode = useUserStore(settingsSelectors.currentThemeMode);
+    const themeMode = useUserStore(userGeneralSettingsSelectors.currentThemeMode);
     const { styles, cx } = useStyles();
     const [primaryColor, neutralColor] = useUserStore((s) => [
-      settingsSelectors.currentSettings(s).primaryColor,
-      settingsSelectors.currentSettings(s).neutralColor,
+      userGeneralSettingsSelectors.primaryColor(s),
+      userGeneralSettingsSelectors.neutralColor(s),
     ]);
 
     useEffect(() => {

--- a/src/libs/agent-runtime/types/type.ts
+++ b/src/libs/agent-runtime/types/type.ts
@@ -25,7 +25,6 @@ export enum ModelProvider {
   Anthropic = 'anthropic',
   Azure = 'azure',
   Bedrock = 'bedrock',
-  ChatGLM = 'chatglm',
   DeepSeek = 'deepseek',
   Google = 'google',
   Groq = 'groq',
@@ -37,7 +36,9 @@ export enum ModelProvider {
   OpenRouter = 'openrouter',
   Perplexity = 'perplexity',
   TogetherAI = 'togetherai',
-  Tongyi = 'tongyi',
+  // Tongyi = 'tongyi',
   ZeroOne = 'zeroone',
   ZhiPu = 'zhipu',
 }
+
+export type ModelProviderKey = Lowercase<keyof typeof ModelProvider>;

--- a/src/migrations/FromV6ToV7/fixtures/output-v7-from-v1.json
+++ b/src/migrations/FromV6ToV7/fixtures/output-v7-from-v1.json
@@ -1,0 +1,203 @@
+{
+  "exportType": "sessions",
+  "state": {
+    "sessions": [
+      {
+        "config": {
+          "displayMode": "chat",
+          "historyCount": 1,
+          "model": "gpt-3.5-turbo",
+          "params": {
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "temperature": 0.6,
+            "top_p": 1,
+            "max_tokens": 2200
+          },
+          "plugins": [],
+          "systemRole": "你是一名 Postgresql 的数据库专家。用户是一名数据库小白，你需要使用简单直白的方式告诉用户如何使用 ostgresql 和它相应的 orm 工具 primsa",
+          "enableCompressThreshold": false,
+          "enableMaxTokens": false,
+          "inputTemplate": ""
+        },
+        "createdAt": 1698463356269,
+        "id": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "meta": {
+          "avatar": "🐘",
+          "backgroundColor": "rgba(0,0,0,0)",
+          "title": "Postgresql 指南",
+          "description": "PostgreSQL 数据库和 Prisma ORM 工具的简单使用指南",
+          "tags": ["数据库", "PostgreSQL", "教程", "ORM", "Prisma"]
+        },
+        "type": "agent",
+        "updatedAt": 1698463356269,
+        "group": "default",
+        "pinned": true
+      }
+    ],
+    "topics": [
+      {
+        "createdAt": 1698463911747,
+        "id": "CZg3IEdy",
+        "title": "Prisma中的cuid函数作用是什么",
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "updatedAt": 1698463915716
+      },
+      {
+        "createdAt": 1698754463117,
+        "id": "MNWhBEh5",
+        "title": "启动 PostgreSQL Docker 镜像方法",
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "updatedAt": 1698754464867
+      }
+    ],
+    "messages": [
+      {
+        "content": "是的，你可以使用 Prisma 来自定义生成 `id` 的逻辑，例如使用 `nanoid` 库来生成唯一标识符。\n\n首先，你需要在项目中安装 `nanoid` 库：\n\n```\nnpm install nanoid\n```\n\n然后，你可以在 Prisma 的模型定义中使用 `@default` 指令，并提供一个自定义的默认值函数来生成 `id`。\n\n```prisma\nmodel Message {\n  id String @id @default(dbgenerated(\"nanoid(10)\"))\n\n  createdAt DateTime @default(now())\n  updatedAt DateTime @updatedAt\n}\n```\n\n在上述模型定义中，我们使用 `dbgenerated` 指令来定义一个自定义的默认值函数。函数 `nanoid(10)` 会生成一个长度为 10 的唯一标识符。\n\n请注意，使用自定义的 `id` 生成逻辑可能会对数据库性能产生一些影响，因为每次创建新记录时都需要执行自定义函数。因此，请确保你的自定义逻辑是高效的，并在实际使用中进行测试和评估性能。",
+        "createdAt": 1698463981313,
+        "id": "n2Tsl3Dm",
+        "meta": {},
+        "parentId": "JSZaJOGj",
+        "role": "assistant",
+        "updatedAt": 1698464004494,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "CZg3IEdy",
+        "fromModel": "gpt-3.5-turbo"
+      },
+      {
+        "content": "如何指定 自定义函数的引入位置？",
+        "createdAt": 1698464173224,
+        "id": "xPft8Msa",
+        "meta": {},
+        "role": "user",
+        "updatedAt": 1698464173226,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "CZg3IEdy"
+      },
+      {
+        "content": "在 Prisma 中，你可以通过在 `schema.prisma` 文件的顶部使用 `generator` 块来指定自定义函数的引入位置。\n\n例如，假设你想使用 `nanoid` 库来生成自定义的 `id`，你可以按照以下方式配置：\n\n```prisma\ngenerator client {\n  provider = \"prisma-client-js\"\n  output   = \"./node_modules/@prisma/client\"\n}\n\ngenerator dbgenerated {\n  provider = \"prisma-dbgenerator\"\n  output   = \"./node_modules/@prisma/client\"\n  binaryTargets = [\"native\"]\n  previewFeatures = [\"nativeTypes\"]\n  config = {\n    \"generator\": {\n      \"dbgenerated\": {\n        \"output\": \"./src/db/generated\",\n        \"provider\": \"./src/db/generated/provider.js\"\n      }\n    }\n  }\n}\n```\n\n在上述配置中，我们定义了两个生成器。`client` 生成器用于生成 Prisma 客户端代码，而 `dbgenerated` 生成器用于生成数据库相关的代码。\n\n注意到 `dbgenerated` 生成器的 `config` 部分中有一个 `provider` 字段，它指定了自定义函数的引入位置。在这个示例中，我们将自定义函数放在 `./src/db/generated/provider.js` 文件中。\n\n你可以根据你的项目结构和需要来调整路径和文件名，确保指定的 `provider` 路径正确引入了自定义函数。",
+        "createdAt": 1698464173228,
+        "id": "jZc2KKRs",
+        "meta": {},
+        "parentId": "xPft8Msa",
+        "role": "assistant",
+        "updatedAt": 1698464181896,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "CZg3IEdy",
+        "fromModel": "gpt-3.5-turbo"
+      },
+      {
+        "content": "如何启动一个 postgres Docker 镜像？",
+        "createdAt": 1698754460196,
+        "id": "LjG9XSuq",
+        "meta": {},
+        "role": "user",
+        "updatedAt": 1698754463118,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5"
+      },
+      {
+        "content": "要启动一个 PostgreSQL Docker 镜像，你可以按照以下步骤操作：\n\n1. 首先，确保你已经安装了 Docker，可以在终端中运行 `docker --version` 来检查。\n\n2. 在终端中运行以下命令以下载并启动一个 PostgreSQL 镜像：\n\n   ```shell\n   docker run --name my-postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d postgres\n   ```\n\n   这将从 Docker Hub 下载 PostgreSQL 镜像",
+        "createdAt": 1698754479751,
+        "id": "CL7E1Mc5",
+        "meta": {},
+        "parentId": "LjG9XSuq",
+        "role": "assistant",
+        "updatedAt": 1698754507690,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5",
+        "fromModel": "gpt-3.5-turbo"
+      },
+      {
+        "content": "如何指定本地存储的目录到 /www/database/postgres",
+        "createdAt": 1698754591763,
+        "id": "UIvHZr7m",
+        "meta": {},
+        "role": "user",
+        "updatedAt": 1698754591764,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5"
+      },
+      {
+        "content": "要将本地存储的目录映射到容器内的 `/var/lib/postgresql/data` 目录，你可以使用 Docker 的 `-v` 参数。\n\n以下是示例命令：\n\n```shell\ndocker run --name my-postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -v /www/database/postgres:/var/lib/postgresql/data -d postgres\n```\n\n在这个命令中，我们使用了 `-v` 参数来指定本地目录 `/www/database/postgres` 映射到容器内的 `/var/lib/postgresql/data` 目录。这样，所有的 PostgreSQL 数据将会保存在本地指定的目录中。",
+        "createdAt": 1698754591765,
+        "id": "XLJOK44r",
+        "meta": {},
+        "parentId": "UIvHZr7m",
+        "role": "assistant",
+        "updatedAt": 1698754609275,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5",
+        "fromModel": "gpt-3.5-turbo"
+      },
+      {
+        "content": "docker run --name postgres -e POSTGRES_PASSWORD=DSLapHYdzNrai5j6 -p 33300:5432 -v /www/database/postgres:/var/lib/postgresql/data -d postgres",
+        "createdAt": 1698754700529,
+        "id": "W3J6jQjm",
+        "meta": {},
+        "role": "user",
+        "updatedAt": 1698754700530,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5"
+      },
+      {
+        "content": "如何启动 pgadmin",
+        "createdAt": 1698755749886,
+        "id": "L7mq0ehV",
+        "meta": {},
+        "role": "user",
+        "updatedAt": 1698755749888,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5"
+      },
+      {
+        "content": "要启动 pgAdmin，你可以按照以下步骤操作：\n\n1. 首先，确保你已经安装了 Docker，并且已经成功启动了 PostgreSQL Docker 容器。\n\n2. 在终端中运行以下命令以启动 pgAdmin Docker 容器：\n\n   ```shell\n   docker run --name my-pgadmin -p 5050:80 -e PGADMIN_DEFAULT_EMAIL=myemail@example.com -e PGADMIN_DEFAULT_PASSWORD=mypassword -d dpage/pgadmin4\n   ```\n\n   在这个命令中，我们使用了 `-p` 参数来将容器的端口 80 映射到本地的端口 5050。你可以根据需要修改这个端口映射。\n\n   我们还使用了 `-e` 参数来设置 pgAdmin 的默认登录邮箱和密码。你可以根据需要修改这些值。\n\n3. 在浏览器中访问 `http://localhost:5050`，你将看到 pgAdmin 的登录界面。\n\n4. 使用在上一步中设置的邮箱和密码进行登录。\n\n5. 在 pgAdmin 中，你可以添加一个新的服务器连接，以连接到运行在 Docker 容器中的 PostgreSQL 数据库。要添加一个新的服务器连接，你需要提供以下信息：\n\n   - 主机名/地址：使用 Docker 容器的 IP 地址或者 `localhost`。\n   - 端口：使用 Docker 容器中 PostgreSQL 的映射端口，例如 33300。\n   - 用户名和密码：使用在启动 PostgreSQL 容器时设置的用户名和密码。\n\n   完成上述信息的填写后，点击保存并连接到 PostgreSQL 服务器。\n\n现在，你已经成功启动了 pgAdmin 并连接到了你的 PostgreSQL 数据库。你可以使用 pgAdmin 来管理和操作你的数据库。",
+        "createdAt": 1698755749889,
+        "id": "d5XTX9EQ",
+        "meta": {},
+        "parentId": "L7mq0ehV",
+        "role": "assistant",
+        "updatedAt": 1698755786183,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "topicId": "MNWhBEh5",
+        "fromModel": "gpt-3.5-turbo"
+      },
+      {
+        "content": "abcabc",
+        "createdAt": 1690650544852,
+        "id": "KPPDiRyW",
+        "meta": {},
+        "parentId": "42k72jMi",
+        "role": "function",
+        "updatedAt": 1690650572399,
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+
+        "fromModel": "gpt-3.5-turbo-16k",
+        "plugin": {
+          "apiName": "websiteCrawler",
+          "arguments": "{\n  \"url\": \"https://mp.weixin.qq.com/s?__biz=MjM5MTA1MjAxMQ==&mid=2651264337&idx=1&sn=d7d9126578c74c912e1f0d42cb5629da&chksm=bd48ccd58a3f45c3f2cbc7d7b732c820b9e7cd6b547c06acc8170b233710b5fb5ed62f5fd94d&mpshare=1&scene=1&srcid=07294Mpw7C6JCLgtagL1cBDR&sharer_sharetime=1690622712877&sharer_shareid=0358058a42fc25387d28337fc3d22c3c#rd\"\n}",
+          "identifier": "websiteCrawler",
+          "type": "default"
+        }
+      },
+      {
+        "content": "bbbbb",
+        "createdAt": 1700065743405,
+        "id": "9cRjevRQ",
+        "meta": {},
+        "parentId": "3nDXtEKv",
+        "role": "function",
+        "sessionId": "06cc3e20-e870-4099-a619-c07a849d742d",
+        "updatedAt": 1700065751861,
+        "fromModel": "gpt-3.5-turbo-16k",
+        "plugin": {
+          "apiName": "getWebsiteContent",
+          "arguments": "{\n  \"url\": \"https://nodejs.org/api/packages.html#dual-package-hazard\"\n}",
+          "identifier": "website-crawler",
+          "type": "default"
+        }
+      }
+    ]
+  },
+  "version": 7
+}

--- a/src/migrations/FromV6ToV7/fixtures/provider-input-v6.json
+++ b/src/migrations/FromV6ToV7/fixtures/provider-input-v6.json
@@ -29,7 +29,7 @@
       },
       "password": "213455",
       "languageModel": {
-        "anthropic": { "apiKey": "anthropic", "enabled": false },
+        "anthropic": { "apiKey": "anthropic", "enabled": false, "endpoint": "anthropic-baseURL" },
         "azure": {
           "apiKey": "asbdasd",
           "apiVersion": "2024-02-15-preview",
@@ -42,8 +42,9 @@
           "region": "us-east-1",
           "secretAccessKey": "secretAccessKey"
         },
-        "google": { "apiKey": "google", "enabled": false },
-        "groq": { "apiKey": "groq", "enabled": false },
+        "google": { "apiKey": "google", "enabled": false, "endpoint": "google-baseURL" },
+        "deepseek": { "apiKey": "deepseek", "enabled": true },
+        "groq": { "apiKey": "groq", "enabled": false, "endpoint": "groq-baseURL" },
         "mistral": { "apiKey": "mistral", "enabled": false },
         "moonshot": { "apiKey": "moonshot", "enabled": false },
         "ollama": { "enabled": false, "endpoint": "http://1237.0.0.1:3245" },
@@ -63,7 +64,11 @@
             }
           ]
         },
-        "perplexity": { "apiKey": "perplexity", "enabled": false },
+        "perplexity": {
+          "apiKey": "perplexity",
+          "enabled": false,
+          "endpoint": "perplexity-baseURL"
+        },
         "togetherai": { "apiKey": "togetherai", "enabled": false },
         "zeroone": { "apiKey": "zeroone", "enabled": false },
         "zhipu": { "apiKey": "zhipu", "enabled": false },

--- a/src/migrations/FromV6ToV7/fixtures/provider-input-v6.json
+++ b/src/migrations/FromV6ToV7/fixtures/provider-input-v6.json
@@ -1,0 +1,98 @@
+{
+  "exportType": "settings",
+  "state": {
+    "settings": {
+      "defaultAgent": {
+        "config": {
+          "autoCreateTopicThreshold": 2,
+          "displayMode": "chat",
+          "enableAutoCreateTopic": true,
+          "historyCount": 1,
+          "model": "gpt-4-vision-preview",
+          "params": {
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "temperature": 0.6,
+            "top_p": 1
+          },
+          "plugins": ["realtime-weather", "steam"],
+          "provider": "openai",
+          "systemRole": "",
+          "tts": {
+            "showAllLocaleVoice": false,
+            "sttLocale": "auto",
+            "ttsService": "openai",
+            "voice": { "openai": "alloy" }
+          }
+        },
+        "meta": {}
+      },
+      "password": "213455",
+      "languageModel": {
+        "anthropic": { "apiKey": "anthropic", "enabled": false },
+        "azure": {
+          "apiKey": "asbdasd",
+          "apiVersion": "2024-02-15-preview",
+          "enabled": true,
+          "endpoint": "https://api.chatanywhere.com.cn"
+        },
+        "bedrock": {
+          "accessKeyId": "accessKeyId",
+          "enabled": false,
+          "region": "us-east-1",
+          "secretAccessKey": "secretAccessKey"
+        },
+        "google": { "apiKey": "google", "enabled": false },
+        "groq": { "apiKey": "groq", "enabled": false },
+        "mistral": { "apiKey": "mistral", "enabled": false },
+        "moonshot": { "apiKey": "moonshot", "enabled": false },
+        "ollama": { "enabled": false, "endpoint": "http://1237.0.0.1:3245" },
+        "openrouter": {
+          "apiKey": "openrouter-key",
+          "enabled": true,
+          "customModelCards": [
+            {
+              "displayName": "01-ai/yi-34b-chat",
+              "enabled": true,
+              "id": "01-ai/yi-34b-chat"
+            },
+            {
+              "displayName": "huggingfaceh4/zephyr-7b-beta",
+              "enabled": true,
+              "id": "huggingfaceh4/zephyr-7b-beta"
+            }
+          ]
+        },
+        "perplexity": { "apiKey": "perplexity", "enabled": false },
+        "togetherai": { "apiKey": "togetherai", "enabled": false },
+        "zeroone": { "apiKey": "zeroone", "enabled": false },
+        "zhipu": { "apiKey": "zhipu", "enabled": false },
+        "openai": {
+          "apiKey": "openai",
+          "endpoint": "endpoint",
+          "enabled": true,
+          "customModelCards": [
+            {
+              "displayName": "deerercsds",
+              "enabled": true,
+              "id": "deerercsds"
+            }
+          ]
+        }
+      },
+      "sync": { "webrtc": { "enabled": false } },
+      "tool": { "dalle": { "autoGenerate": false } },
+      "tts": {
+        "openAI": { "sttModel": "whisper-1", "ttsModel": "tts-1" },
+        "sttAutoStop": true,
+        "sttServer": "openai"
+      },
+      "fontSize": 14,
+      "language": "auto",
+      "themeMode": "auto",
+      "primaryColor": "",
+      "neutralColor": ""
+    }
+  },
+  "version": 6
+}

--- a/src/migrations/FromV6ToV7/fixtures/provider-output-v7.json
+++ b/src/migrations/FromV6ToV7/fixtures/provider-output-v7.json
@@ -32,6 +32,7 @@
         "azure": { "enabled": true },
         "bedrock": { "enabled": false },
         "google": { "enabled": false },
+        "deepseek": { "enabled": true },
         "groq": { "enabled": false },
         "mistral": { "enabled": false },
         "moonshot": { "enabled": false },
@@ -68,7 +69,7 @@
       },
       "keyVaults": {
         "password": "213455",
-        "anthropic": { "apiKey": "anthropic" },
+        "anthropic": { "apiKey": "anthropic", "baseURL": "anthropic-baseURL" },
         "azure": {
           "apiKey": "asbdasd",
           "apiVersion": "2024-02-15-preview",
@@ -79,21 +80,22 @@
           "region": "us-east-1",
           "secretAccessKey": "secretAccessKey"
         },
-        "google": { "apiKey": "google" },
-        "groq": { "apiKey": "groq" },
+        "google": { "apiKey": "google", "baseURL": "google-baseURL" },
+        "groq": { "apiKey": "groq", "baseURL": "groq-baseURL" },
         "mistral": { "apiKey": "mistral" },
         "moonshot": { "apiKey": "moonshot" },
-        "ollama": { "endpoint": "http://1237.0.0.1:3245" },
+        "ollama": { "baseURL": "http://1237.0.0.1:3245" },
         "openrouter": {
           "apiKey": "openrouter-key"
         },
-        "perplexity": { "apiKey": "perplexity" },
+        "perplexity": { "apiKey": "perplexity", "baseURL": "perplexity-baseURL" },
         "togetherai": { "apiKey": "togetherai" },
+        "deepseek": { "apiKey": "deepseek" },
         "zeroone": { "apiKey": "zeroone" },
         "zhipu": { "apiKey": "zhipu" },
         "openai": {
           "apiKey": "openai",
-          "endpoint": "endpoint"
+          "baseURL": "endpoint"
         }
       },
       "sync": { "webrtc": { "enabled": false } },

--- a/src/migrations/FromV6ToV7/fixtures/provider-output-v7.json
+++ b/src/migrations/FromV6ToV7/fixtures/provider-output-v7.json
@@ -1,0 +1,116 @@
+{
+  "exportType": "settings",
+  "state": {
+    "settings": {
+      "defaultAgent": {
+        "config": {
+          "autoCreateTopicThreshold": 2,
+          "displayMode": "chat",
+          "enableAutoCreateTopic": true,
+          "historyCount": 1,
+          "model": "gpt-4-vision-preview",
+          "params": {
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "temperature": 0.6,
+            "top_p": 1
+          },
+          "plugins": ["realtime-weather", "steam"],
+          "provider": "openai",
+          "systemRole": "",
+          "tts": {
+            "showAllLocaleVoice": false,
+            "sttLocale": "auto",
+            "ttsService": "openai",
+            "voice": { "openai": "alloy" }
+          }
+        },
+        "meta": {}
+      },
+      "languageModel": {
+        "anthropic": { "enabled": false },
+        "azure": { "enabled": true },
+        "bedrock": { "enabled": false },
+        "google": { "enabled": false },
+        "groq": { "enabled": false },
+        "mistral": { "enabled": false },
+        "moonshot": { "enabled": false },
+        "ollama": { "enabled": false },
+        "openrouter": {
+          "enabled": true,
+          "customModelCards": [
+            {
+              "displayName": "01-ai/yi-34b-chat",
+              "enabled": true,
+              "id": "01-ai/yi-34b-chat"
+            },
+            {
+              "displayName": "huggingfaceh4/zephyr-7b-beta",
+              "enabled": true,
+              "id": "huggingfaceh4/zephyr-7b-beta"
+            }
+          ]
+        },
+        "perplexity": { "enabled": false },
+        "togetherai": { "enabled": false },
+        "zeroone": { "enabled": false },
+        "zhipu": { "enabled": false },
+        "openai": {
+          "enabled": true,
+          "customModelCards": [
+            {
+              "displayName": "deerercsds",
+              "enabled": true,
+              "id": "deerercsds"
+            }
+          ]
+        }
+      },
+      "keyVaults": {
+        "password": "213455",
+        "anthropic": { "apiKey": "anthropic" },
+        "azure": {
+          "apiKey": "asbdasd",
+          "apiVersion": "2024-02-15-preview",
+          "endpoint": "https://api.chatanywhere.com.cn"
+        },
+        "bedrock": {
+          "accessKeyId": "accessKeyId",
+          "region": "us-east-1",
+          "secretAccessKey": "secretAccessKey"
+        },
+        "google": { "apiKey": "google" },
+        "groq": { "apiKey": "groq" },
+        "mistral": { "apiKey": "mistral" },
+        "moonshot": { "apiKey": "moonshot" },
+        "ollama": { "endpoint": "http://1237.0.0.1:3245" },
+        "openrouter": {
+          "apiKey": "openrouter-key"
+        },
+        "perplexity": { "apiKey": "perplexity" },
+        "togetherai": { "apiKey": "togetherai" },
+        "zeroone": { "apiKey": "zeroone" },
+        "zhipu": { "apiKey": "zhipu" },
+        "openai": {
+          "apiKey": "openai",
+          "endpoint": "endpoint"
+        }
+      },
+      "sync": { "webrtc": { "enabled": false } },
+      "tool": { "dalle": { "autoGenerate": false } },
+      "tts": {
+        "openAI": { "sttModel": "whisper-1", "ttsModel": "tts-1" },
+        "sttAutoStop": true,
+        "sttServer": "openai"
+      },
+      "general": {
+        "fontSize": 14,
+        "language": "auto",
+        "themeMode": "auto",
+        "primaryColor": "",
+        "neutralColor": ""
+      }
+    }
+  },
+  "version": 7
+}

--- a/src/migrations/FromV6ToV7/index.ts
+++ b/src/migrations/FromV6ToV7/index.ts
@@ -1,0 +1,53 @@
+import type { Migration, MigrationData } from '@/migrations/VersionController';
+
+import { V6ConfigState, V6Settings } from './types/v6';
+import { V7ConfigState, V7Settings } from './types/v7';
+
+export class MigrationV6ToV7 implements Migration {
+  // from this version to start migration
+  version = 6;
+
+  migrate(data: MigrationData<V6ConfigState>): MigrationData<V7ConfigState> {
+    const { settings } = data.state;
+
+    return {
+      ...data,
+      state: {
+        ...data.state,
+        settings: !settings ? undefined : MigrationV6ToV7.migrateSettings(settings),
+      },
+    };
+  }
+
+  static migrateSettings = (settings: V6Settings): V7Settings => {
+    const {
+      languageModel,
+      password,
+      neutralColor,
+      themeMode,
+      fontSize,
+      primaryColor,
+      language,
+      ...res
+    } = settings;
+    return {
+      ...res,
+      general: {
+        fontSize,
+        language,
+        neutralColor,
+        primaryColor,
+        themeMode,
+      },
+      // @ts-ignore
+      keyVaults: {
+        password,
+      },
+
+      // @ts-ignore
+      languageModel,
+    };
+  };
+}
+
+export const MigrationKeyValueSettings = MigrationV6ToV7;

--- a/src/migrations/FromV6ToV7/migrations.test.ts
+++ b/src/migrations/FromV6ToV7/migrations.test.ts
@@ -1,0 +1,64 @@
+import { describe } from 'vitest';
+
+import { MigrationV1ToV2 } from '@/migrations/FromV1ToV2';
+import { MigrationV2ToV3 } from '@/migrations/FromV2ToV3';
+import { MigrationV3ToV4 } from '@/migrations/FromV3ToV4';
+import { MigrationV4ToV5 } from '@/migrations/FromV4ToV5';
+import { MigrationV5ToV6 } from '@/migrations/FromV5ToV6';
+import { MigrationData, VersionController } from '@/migrations/VersionController';
+
+import inputV1Data from '../FromV1ToV2/fixtures/input-v1-session.json';
+import outputV7Data from './fixtures/output-v7-from-v1.json';
+import providerInputV6 from './fixtures/provider-input-v6.json';
+import providerOutputV7 from './fixtures/provider-output-v7.json';
+import { MigrationV6ToV7 } from './index';
+
+describe('MigrationV6ToV7', () => {
+  let migrations;
+  let versionController: VersionController<any>;
+
+  beforeEach(() => {
+    migrations = [MigrationV6ToV7];
+    versionController = new VersionController(migrations, 7);
+  });
+
+  describe('should migrate data correctly from previous versions', () => {
+    it('provider', () => {
+      const data: MigrationData = providerInputV6;
+
+      const migratedData = versionController.migrate(data);
+
+      expect(migratedData.version).toEqual(providerOutputV7.version);
+      expect(migratedData.state.settings.languageModel).toEqual(
+        providerOutputV7.state.settings.languageModel,
+      );
+      expect(migratedData.state.settings.keyVaults).toEqual(
+        providerOutputV7.state.settings.keyVaults,
+      );
+      expect(migratedData.state.settings.general).toEqual(providerOutputV7.state.settings.general);
+    });
+  });
+
+  it('should work correct from v1 to v7', () => {
+    const data: MigrationData = inputV1Data;
+
+    versionController = new VersionController(
+      [
+        MigrationV6ToV7,
+        MigrationV5ToV6,
+        MigrationV4ToV5,
+        MigrationV3ToV4,
+        MigrationV2ToV3,
+        MigrationV1ToV2,
+      ],
+      7,
+    );
+
+    const migratedData = versionController.migrate(data);
+
+    expect(migratedData.version).toEqual(outputV7Data.version);
+    // expect(migratedData.state.sessions).toEqual(outputV3DataFromV1.state.sessions);
+    // expect(migratedData.state.topics).toEqual(outputV3DataFromV1.state.topics);
+    // expect(migratedData.state.messages).toEqual(outputV3DataFromV1.state.messages);
+  });
+});

--- a/src/migrations/FromV6ToV7/types/v6.ts
+++ b/src/migrations/FromV6ToV7/types/v6.ts
@@ -40,6 +40,8 @@ interface V6ModelProviderConfig {
   zhipu: V6OpenAICompatibleConfig;
 }
 
+export type V6ProviderKey = keyof V6ModelProviderConfig;
+
 export interface V6Settings {
   defaultAgent: any;
   fontSize: number;

--- a/src/migrations/FromV6ToV7/types/v6.ts
+++ b/src/migrations/FromV6ToV7/types/v6.ts
@@ -1,0 +1,59 @@
+interface V6OpenAICompatibleConfig {
+  apiKey?: string;
+  autoFetchModelLists?: boolean;
+  customModelCards?: any[];
+  enabled: boolean;
+  enabledModels?: string[] | null;
+  endpoint?: string;
+  fetchOnClient?: boolean;
+  latestFetchTime?: number;
+  remoteModelCards?: any[];
+}
+
+interface AzureOpenAIConfig extends Omit<V6OpenAICompatibleConfig, 'endpoint'> {
+  apiVersion?: string;
+  endpoint?: string;
+}
+
+interface AWSBedrockConfig extends Omit<V6OpenAICompatibleConfig, 'apiKey' | 'endpoint'> {
+  accessKeyId?: string;
+  region?: string;
+  secretAccessKey?: string;
+}
+
+interface V6ModelProviderConfig {
+  anthropic: V6OpenAICompatibleConfig;
+  azure: AzureOpenAIConfig;
+  bedrock: AWSBedrockConfig;
+  deepseek: V6OpenAICompatibleConfig;
+  google: V6OpenAICompatibleConfig;
+  groq: V6OpenAICompatibleConfig;
+  minimax: V6OpenAICompatibleConfig;
+  mistral: V6OpenAICompatibleConfig;
+  moonshot: V6OpenAICompatibleConfig;
+  ollama: V6OpenAICompatibleConfig;
+  openai: V6OpenAICompatibleConfig;
+  openrouter: V6OpenAICompatibleConfig;
+  perplexity: V6OpenAICompatibleConfig;
+  togetherai: V6OpenAICompatibleConfig;
+  zeroone: V6OpenAICompatibleConfig;
+  zhipu: V6OpenAICompatibleConfig;
+}
+
+export interface V6Settings {
+  defaultAgent: any;
+  fontSize: number;
+  language: string;
+  languageModel?: V6ModelProviderConfig;
+  neutralColor?: string;
+  password: string;
+  primaryColor?: string;
+  sync: any;
+  themeMode: string;
+  tool: any;
+  tts: any;
+}
+
+export interface V6ConfigState {
+  settings?: V6Settings;
+}

--- a/src/migrations/FromV6ToV7/types/v7.ts
+++ b/src/migrations/FromV6ToV7/types/v7.ts
@@ -1,0 +1,71 @@
+
+
+interface OpenAICompatibleKeyVault {
+  apiKey?: string;
+  baseURL?: string;
+}
+interface AzureOpenAIKeyVault {
+  apiKey?: string;
+  apiVersion?: string;
+  endpoint?: string;
+}
+
+export interface AWSBedrockKeyVault {
+  accessKeyId?: string;
+  region?: string;
+  secretAccessKey?: string;
+}
+
+export interface V7KeyVaults {
+  anthropic: OpenAICompatibleKeyVault;
+  azure: AzureOpenAIKeyVault;
+  bedrock: AWSBedrockKeyVault;
+  deepseek: OpenAICompatibleKeyVault;
+  google: OpenAICompatibleKeyVault;
+  groq: OpenAICompatibleKeyVault;
+  minimax: OpenAICompatibleKeyVault;
+  mistral: OpenAICompatibleKeyVault;
+  moonshot: OpenAICompatibleKeyVault;
+  ollama: OpenAICompatibleKeyVault;
+  openai: OpenAICompatibleKeyVault;
+  openrouter: OpenAICompatibleKeyVault;
+  password: string;
+  perplexity: OpenAICompatibleKeyVault;
+  togetherai: OpenAICompatibleKeyVault;
+  zeroone: OpenAICompatibleKeyVault;
+  zhipu: OpenAICompatibleKeyVault;
+}
+
+interface V7ProviderConfig {
+  autoFetchModelLists?: boolean;
+  customModelCards?: any[];
+  enabled: boolean;
+  enabledModels?: string[] | null;
+  fetchOnClient?: boolean;
+  latestFetchTime?: number;
+  remoteModelCards?: any[];
+}
+
+export type V7ModelProviderConfig = Record<string, V7ProviderConfig>;
+
+export interface V7GeneralSettings {
+  fontSize: number;
+  language: string;
+  neutralColor?: string;
+  primaryColor?: string;
+  themeMode: string;
+}
+
+export interface V7Settings {
+  defaultAgent: any;
+  general: V7GeneralSettings;
+  keyVaults: V7KeyVaults;
+  languageModel?: V7ModelProviderConfig;
+  sync: any;
+  tool: any;
+  tts: any;
+}
+
+export interface V7ConfigState {
+  settings?: V7Settings;
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -7,18 +7,24 @@ import { MigrationV1ToV2 } from './FromV1ToV2';
 import { MigrationV3ToV4 } from './FromV3ToV4';
 import { MigrationV4ToV5 } from './FromV4ToV5';
 import { MigrationV5ToV6 } from './FromV5ToV6';
+import { MigrationV6ToV7 } from './FromV6ToV7';
 
 // Current latest version
-export const CURRENT_CONFIG_VERSION = 6;
+export const CURRENT_CONFIG_VERSION = 7;
 
 // Version migrations module
 const ConfigMigrations = [
   /**
+   * 2024.05.27
+   *
+   * apiKey in languageModel change to keyVaults
+   */
+  MigrationV6ToV7,
+  /**
    * 2024.05.24
    *
    * some config in agentConfig change to chatConfig
-   */
-  MigrationV5ToV6,
+   */ MigrationV5ToV6,
   /**
    * 2024.05.11
    *

--- a/src/services/__tests__/chat.test.ts
+++ b/src/services/__tests__/chat.test.ts
@@ -676,10 +676,10 @@ describe('AgentRuntimeOnClient', () => {
         // Mock the global store to return the user's OpenAI API key and endpoint
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               openai: {
                 apiKey: 'user-openai-key',
-                endpoint: 'user-openai-endpoint',
+                baseURL: 'user-openai-endpoint',
               },
             },
           },
@@ -693,7 +693,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Azure provider: with apiKey, apiVersion, endpoint', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               azure: {
                 apiKey: 'user-azure-key',
                 endpoint: 'user-azure-endpoint',
@@ -710,7 +710,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Google provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               google: {
                 apiKey: 'user-google-key',
               },
@@ -725,7 +725,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Moonshot AI provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               moonshot: {
                 apiKey: 'user-moonshot-key',
               },
@@ -740,7 +740,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Bedrock provider: with accessKeyId, region, secretAccessKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               bedrock: {
                 accessKeyId: 'user-bedrock-access-key',
                 region: 'user-bedrock-region',
@@ -757,9 +757,9 @@ describe('AgentRuntimeOnClient', () => {
       it('Ollama provider: with endpoint', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               ollama: {
-                endpoint: 'http://127.0.0.1:1234',
+                baseURL: 'http://127.0.0.1:1234',
               },
             },
           },
@@ -772,7 +772,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Perplexity provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               perplexity: {
                 apiKey: 'user-perplexity-key',
               },
@@ -787,7 +787,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Anthropic provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               anthropic: {
                 apiKey: 'user-anthropic-key',
               },
@@ -802,7 +802,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Mistral provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               mistral: {
                 apiKey: 'user-mistral-key',
               },
@@ -817,7 +817,7 @@ describe('AgentRuntimeOnClient', () => {
       it('OpenRouter provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               openrouter: {
                 apiKey: 'user-openrouter-key',
               },
@@ -832,7 +832,7 @@ describe('AgentRuntimeOnClient', () => {
       it('TogetherAI provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               togetherai: {
                 apiKey: 'user-togetherai-key',
               },
@@ -847,7 +847,7 @@ describe('AgentRuntimeOnClient', () => {
       it('ZeroOneAI provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               zeroone: {
                 apiKey: 'user-zeroone-key',
               },
@@ -862,7 +862,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Groq provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               groq: {
                 apiKey: 'user-groq-key',
               },
@@ -877,7 +877,7 @@ describe('AgentRuntimeOnClient', () => {
       it('DeepSeek provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               deepseek: {
                 apiKey: 'user-deepseek-key',
               },
@@ -888,7 +888,7 @@ describe('AgentRuntimeOnClient', () => {
         expect(runtime).toBeInstanceOf(AgentRuntime);
         expect(runtime['_runtime']).toBeInstanceOf(LobeDeepSeekAI);
       });
-      
+
       /**
        * Should not have a unknown provider in client, but has
        * similar cases in server side
@@ -896,7 +896,7 @@ describe('AgentRuntimeOnClient', () => {
       it('Unknown provider: with apiKey', async () => {
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               unknown: {
                 apiKey: 'user-unknown-key',
                 endpoint: 'user-unknown-endpoint',
@@ -924,7 +924,7 @@ describe('AgentRuntimeOnClient', () => {
         }));
         merge(initialSettingsState, {
           settings: {
-            languageModel: {
+            keyVaults: {
               zhipu: {
                 apiKey: 'zhipu.user-key',
               },

--- a/src/services/__tests__/share.test.ts
+++ b/src/services/__tests__/share.test.ts
@@ -100,7 +100,7 @@ describe('ShareViaUrl', () => {
       };
       const url = shareService.createShareSettingsUrl(settings);
       expect(url).toBe(
-        `/?${LOBE_URL_IMPORT_NAME}=%7B%22languageModel%22:%7B%22openai%22:%7B%22apiKey%22:%22user-key%22%7D%7D%7D`,
+        `/?${LOBE_URL_IMPORT_NAME}=%7B%22keyVaults%22:%7B%22openai%22:%7B%22apiKey%22:%22user-key%22%7D%7D%7D`,
       );
     });
   });

--- a/src/services/__tests__/share.test.ts
+++ b/src/services/__tests__/share.test.ts
@@ -92,7 +92,7 @@ describe('ShareViaUrl', () => {
   describe('createShareSettingsUrl', () => {
     it('should create a share settings URL with the provided settings', () => {
       const settings: DeepPartial<UserSettings> = {
-        languageModel: {
+        keyVaults: {
           openai: {
             apiKey: 'user-key',
           },

--- a/src/services/_auth.test.ts
+++ b/src/services/_auth.test.ts
@@ -152,6 +152,7 @@ describe('getProviderAuthPayload', () => {
     // 假设的 OpenAI 配置
     const mockOpenAIConfig = {
       apiKey: 'openai-api-key',
+      baseURL: 'openai-baseURL',
       endpoint: 'openai-endpoint',
       useAzure: true,
       azureApiVersion: 'openai-azure-api-version',
@@ -163,7 +164,7 @@ describe('getProviderAuthPayload', () => {
     const payload = getProviderAuthPayload(ModelProvider.OpenAI);
     expect(payload).toEqual({
       apiKey: mockOpenAIConfig.apiKey,
-      endpoint: mockOpenAIConfig.endpoint,
+      endpoint: mockOpenAIConfig.baseURL,
     });
   });
 

--- a/src/services/_auth.test.ts
+++ b/src/services/_auth.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ModelProvider } from '@/libs/agent-runtime';
 import { useUserStore } from '@/store/user';
-import { UserModelProviderConfig, GlobalLLMProviderKey } from '@/types/user/settings';
+import {
+  GlobalLLMProviderKey,
+  UserKeyVaults,
+  UserModelProviderConfig,
+} from '@/types/user/settings';
 
 import { getProviderAuthPayload } from './_auth';
 
@@ -21,10 +25,10 @@ vi.mock('zustand/traditional');
 
 const setModelProviderConfig = <T extends GlobalLLMProviderKey>(
   provider: T,
-  config: Partial<UserModelProviderConfig[T]>,
+  config: Partial<UserKeyVaults[T]>,
 ) => {
   useUserStore.setState({
-    settings: { languageModel: { [provider]: config } },
+    settings: { keyVaults: { [provider]: config } },
   });
 };
 
@@ -135,7 +139,7 @@ describe('getProviderAuthPayload', () => {
     // 假设的 Ollama 配置
     const mockOllamaProxyUrl = 'ollama-proxy-url';
     act(() => {
-      setModelProviderConfig('ollama', { endpoint: mockOllamaProxyUrl });
+      setModelProviderConfig('ollama', { baseURL: mockOllamaProxyUrl });
     });
 
     const payload = getProviderAuthPayload(ModelProvider.Ollama);

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -1,15 +1,17 @@
 import { JWTPayload, LOBE_CHAT_AUTH_HEADER } from '@/const/auth';
 import { ModelProvider } from '@/libs/agent-runtime';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors, settingsSelectors } from '@/store/user/selectors';
+import { keyVaultsConfigSelectors, settingsSelectors } from '@/store/user/selectors';
+import { GlobalLLMProviderKey } from '@/types/user/settings';
 import { createJWT } from '@/utils/jwt';
 
 export const getProviderAuthPayload = (provider: string) => {
   switch (provider) {
     case ModelProvider.Bedrock: {
-      const { accessKeyId, region, secretAccessKey } = modelConfigSelectors.bedrockConfig(
+      const { accessKeyId, region, secretAccessKey } = keyVaultsConfigSelectors.bedrockConfig(
         useUserStore.getState(),
       );
+
       const awsSecretAccessKey = secretAccessKey;
       const awsAccessKeyId = accessKeyId;
 
@@ -19,7 +21,7 @@ export const getProviderAuthPayload = (provider: string) => {
     }
 
     case ModelProvider.Azure: {
-      const azure = modelConfigSelectors.azureConfig(useUserStore.getState());
+      const azure = keyVaultsConfigSelectors.azureConfig(useUserStore.getState());
 
       return {
         apiKey: azure.apiKey,
@@ -29,15 +31,17 @@ export const getProviderAuthPayload = (provider: string) => {
     }
 
     case ModelProvider.Ollama: {
-      const config = modelConfigSelectors.ollamaConfig(useUserStore.getState());
+      const config = keyVaultsConfigSelectors.ollamaConfig(useUserStore.getState());
 
-      return { endpoint: config?.endpoint };
+      return { endpoint: config?.baseURL };
     }
 
     default: {
-      const config = settingsSelectors.providerConfig(provider)(useUserStore.getState());
+      const config = keyVaultsConfigSelectors.getVaultByProvider(provider as GlobalLLMProviderKey)(
+        useUserStore.getState(),
+      );
 
-      return { apiKey: config?.apiKey, endpoint: config?.endpoint };
+      return { apiKey: config?.apiKey, endpoint: config?.baseURL };
     }
   }
 };

--- a/src/services/_header.ts
+++ b/src/services/_header.ts
@@ -1,6 +1,9 @@
 import { LOBE_CHAT_ACCESS_CODE, OPENAI_API_KEY_HEADER_KEY, OPENAI_END_POINT } from '@/const/fetch';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors, settingsSelectors } from '@/store/user/selectors';
+import {
+  keyVaultsConfigSelectors,
+  settingsSelectors,
+} from '@/store/user/selectors';
 
 /**
  * TODO: Need to be removed after tts refactor
@@ -8,13 +11,13 @@ import { modelConfigSelectors, settingsSelectors } from '@/store/user/selectors'
  */
 // eslint-disable-next-line no-undef
 export const createHeaderWithOpenAI = (header?: HeadersInit): HeadersInit => {
-  const openAIConfig = modelConfigSelectors.openAIConfig(useUserStore.getState());
+  const openAIConfig = keyVaultsConfigSelectors.openAIConfig(useUserStore.getState());
 
   // eslint-disable-next-line no-undef
   return {
     ...header,
     [LOBE_CHAT_ACCESS_CODE]: settingsSelectors.password(useUserStore.getState()),
     [OPENAI_API_KEY_HEADER_KEY]: openAIConfig.apiKey || '',
-    [OPENAI_END_POINT]: openAIConfig.endpoint || '',
+    [OPENAI_END_POINT]: openAIConfig.baseURL || '',
   };
 };

--- a/src/services/ollama.ts
+++ b/src/services/ollama.ts
@@ -3,7 +3,7 @@ import { ListResponse, Ollama as OllamaBrowser, ProgressResponse } from 'ollama/
 import { createErrorResponse } from '@/app/api/errorResponse';
 import { ModelProvider } from '@/libs/agent-runtime';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors } from '@/store/user/selectors';
+import { keyVaultsConfigSelectors } from '@/store/user/selectors';
 import { ChatErrorType } from '@/types/fetch';
 import { getMessageError } from '@/utils/fetch';
 
@@ -25,9 +25,9 @@ export class OllamaService {
   }
 
   getHost = (): string => {
-    const config = modelConfigSelectors.ollamaConfig(useUserStore.getState());
+    const config = keyVaultsConfigSelectors.ollamaConfig(useUserStore.getState());
 
-    return config.endpoint || DEFAULT_BASE_URL;
+    return config.baseURL || DEFAULT_BASE_URL;
   };
 
   getOllamaClient = () => {

--- a/src/services/user/client.test.ts
+++ b/src/services/user/client.test.ts
@@ -58,7 +58,7 @@ describe('ClientService', () => {
   });
 
   it('should update user settings correctly', async () => {
-    const settingsPatch: DeepPartial<UserSettings> = { themeMode: 'dark' };
+    const settingsPatch: DeepPartial<UserSettings> = { general: { themeMode: 'dark' } };
     (UserModel.updateSettings as Mock).mockResolvedValue(undefined);
 
     await clientService.updateUserSettings(settingsPatch);

--- a/src/store/user/helpers.ts
+++ b/src/store/user/helpers.ts
@@ -1,7 +1,8 @@
-import { settingsSelectors } from './slices/settings/selectors';
+import { userGeneralSettingsSelectors } from './slices/settings/selectors';
 import { useUserStore } from './store';
 
-const getCurrentLanguage = () => settingsSelectors.currentLanguage(useUserStore.getState());
+const getCurrentLanguage = () =>
+  userGeneralSettingsSelectors.currentLanguage(useUserStore.getState());
 
 export const globalHelpers = {
   getCurrentLanguage,

--- a/src/store/user/selectors.ts
+++ b/src/store/user/selectors.ts
@@ -1,5 +1,13 @@
 export { authSelectors, userProfileSelectors } from './slices/auth/selectors';
-export { modelConfigSelectors, modelProviderSelectors } from './slices/modelList/selectors';
+export {
+  keyVaultsConfigSelectors,
+  modelConfigSelectors,
+  modelProviderSelectors,
+} from './slices/modelList/selectors';
 export { preferenceSelectors } from './slices/preference/selectors';
-export { settingsSelectors, systemAgentSelectors } from './slices/settings/selectors';
+export {
+  settingsSelectors,
+  systemAgentSelectors,
+  userGeneralSettingsSelectors,
+} from './slices/settings/selectors';
 export { syncSettingsSelectors } from './slices/sync/selectors';

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -84,7 +84,7 @@ describe('createCommonSlice', () => {
           telemetry: true,
         },
         settings: {
-          language: 'en-US',
+          general: { language: 'en-US' },
         },
       };
 
@@ -166,7 +166,7 @@ describe('createCommonSlice', () => {
         isOnboard: true,
         preference: savedPreference,
         settings: {
-          language: 'en-US',
+          general: { language: 'en-US' },
         },
       };
       vi.spyOn(userService, 'getUserState').mockResolvedValueOnce(mockUserState);
@@ -216,7 +216,7 @@ describe('createCommonSlice', () => {
         isOnboard: true,
         preference: {} as any,
         settings: {
-          language: 'en-US',
+          general: { language: 'en-US' },
         },
       };
 

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -14,7 +14,7 @@ import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { preferenceSelectors } from '../preference/selectors';
-import { settingsSelectors } from '../settings/selectors';
+import { userGeneralSettingsSelectors } from '../settings/selectors';
 
 const n = setNamespace('common');
 
@@ -115,7 +115,7 @@ export const createCommonSlice: StateCreator<
             get().refreshDefaultModelProviderList({ trigger: 'fetchUserState' });
 
             // auto switch language
-            const { language } = settingsSelectors.currentSettings(get());
+            const language = userGeneralSettingsSelectors.config(get()).language;
             if (language === 'auto') {
               switchLang('auto');
             }

--- a/src/store/user/slices/modelList/action.test.ts
+++ b/src/store/user/slices/modelList/action.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { modelsService } from '@/services/models';
 import { userService } from '@/services/user';
 import { useUserStore } from '@/store/user';
-import { OpenAICompatibleProviderConfig } from '@/types/user/settings';
+import { ProviderConfig } from '@/types/user/settings';
 
 import { settingsSelectors } from '../settings/selectors';
 import { CustomModelCardDispatch } from './reducers/customModelCard';
@@ -24,7 +24,7 @@ describe('LLMSettingsSliceAction', () => {
   describe('setModelProviderConfig', () => {
     it('should set OpenAI configuration', async () => {
       const { result } = renderHook(() => useUserStore());
-      const openAIConfig: Partial<OpenAICompatibleProviderConfig> = { apiKey: 'test-key' };
+      const openAIConfig: Partial<ProviderConfig> = { fetchOnClient: true };
 
       // Perform the action
       await act(async () => {

--- a/src/store/user/slices/modelList/action.ts
+++ b/src/store/user/slices/modelList/action.ts
@@ -6,7 +6,11 @@ import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import { ModelProvider } from '@/libs/agent-runtime';
 import { UserStore } from '@/store/user';
 import { ChatModelCard } from '@/types/llm';
-import { UserModelProviderConfig, GlobalLLMProviderKey } from '@/types/user/settings';
+import {
+  GlobalLLMProviderKey,
+  UserKeyVaults,
+  UserModelProviderConfig,
+} from '@/types/user/settings';
 
 import { settingsSelectors } from '../settings/selectors';
 import { CustomModelCardDispatch, customModelCardsReducer } from './reducers/customModelCard';
@@ -30,7 +34,6 @@ export interface ModelListAction {
     provider: T,
     config: Partial<UserModelProviderConfig[T]>,
   ) => Promise<void>;
-
   toggleEditingCustomModelCard: (params?: { id: string; provider: GlobalLLMProviderKey }) => void;
 
   toggleProviderEnabled: (provider: GlobalLLMProviderKey, enabled: boolean) => Promise<void>;
@@ -39,6 +42,11 @@ export interface ModelListAction {
     provider: GlobalLLMProviderKey,
     modelKeys: string[],
     options: { label?: string; value?: string }[],
+  ) => Promise<void>;
+
+  updateKeyVaultConfig: <T extends GlobalLLMProviderKey>(
+    provider: T,
+    config: Partial<UserKeyVaults[T]>,
   ) => Promise<void>;
 
   useFetchProviderModelList: (
@@ -137,10 +145,10 @@ export const createModelListSlice: StateCreator<
   toggleEditingCustomModelCard: (params) => {
     set({ editingCustomCardModel: params }, false, 'toggleEditingCustomModelCard');
   },
+
   toggleProviderEnabled: async (provider, enabled) => {
     await get().setSettings({ languageModel: { [provider]: { enabled } } });
   },
-
   updateEnabledModels: async (provider, value, options) => {
     const { dispatchCustomModelCards, setModelProviderConfig } = get();
     const enabledModels = modelProviderSelectors.getEnableModelsById(provider)(get());
@@ -169,6 +177,10 @@ export const createModelListSlice: StateCreator<
     await Promise.all(pools);
 
     await setModelProviderConfig(provider, { enabledModels: value.filter(Boolean) });
+  },
+
+  updateKeyVaultConfig: async (provider, config) => {
+    await get().setSettings({ keyVaults: { [provider]: config } });
   },
 
   useFetchProviderModelList: (provider, enabledAutoFetch) =>

--- a/src/store/user/slices/modelList/selectors/index.ts
+++ b/src/store/user/slices/modelList/selectors/index.ts
@@ -1,2 +1,3 @@
+export { keyVaultsConfigSelectors } from './keyVaults';
 export { modelConfigSelectors } from './modelConfig';
 export { modelProviderSelectors } from './modelProvider';

--- a/src/store/user/slices/modelList/selectors/keyVaults.ts
+++ b/src/store/user/slices/modelList/selectors/keyVaults.ts
@@ -1,0 +1,25 @@
+import { UserStore } from '@/store/user';
+import { GlobalLLMProviderKey, OpenAICompatibleKeyVault } from '@/types/user/settings';
+
+import { currentSettings } from '../../settings/selectors/settings';
+
+export const keyVaultsSettings = (s: UserStore) => currentSettings(s).keyVaults;
+
+const openAIConfig = (s: UserStore) => keyVaultsSettings(s).openai || {};
+const bedrockConfig = (s: UserStore) => keyVaultsSettings(s).bedrock || {};
+const ollamaConfig = (s: UserStore) => keyVaultsSettings(s).ollama || {};
+const azureConfig = (s: UserStore) => keyVaultsSettings(s).azure || {};
+const getVaultByProvider = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
+  (keyVaultsSettings(s)[provider] || {}) as OpenAICompatibleKeyVault;
+
+const isProviderEndpointNotEmpty = (provider: string) => (s: UserStore) =>
+  !!getVaultByProvider(provider as GlobalLLMProviderKey)(s)?.baseURL;
+
+export const keyVaultsConfigSelectors = {
+  azureConfig,
+  bedrockConfig,
+  getVaultByProvider,
+  isProviderEndpointNotEmpty,
+  ollamaConfig,
+  openAIConfig,
+};

--- a/src/store/user/slices/modelList/selectors/modelConfig.test.ts
+++ b/src/store/user/slices/modelList/selectors/modelConfig.test.ts
@@ -38,7 +38,7 @@ describe('modelConfigSelectors', () => {
     it('client fetch should disabled on default', () => {
       const s = merge(initialSettingsState, {
         settings: {
-          languageModel: {
+          keyVaults: {
             azure: {
               endpoint: 'endpoint',
               apiKey: 'apikey',

--- a/src/store/user/slices/modelList/selectors/modelConfig.ts
+++ b/src/store/user/slices/modelList/selectors/modelConfig.ts
@@ -6,9 +6,6 @@ import { currentLLMSettings, getProviderConfigById } from '../../settings/select
 const isProviderEnabled = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
   getProviderConfigById(provider)(s)?.enabled || false;
 
-const isProviderEndpointNotEmpty = (provider: GlobalLLMProviderKey | string) => (s: UserStore) =>
-  !!getProviderConfigById(provider)(s)?.endpoint;
-
 const isProviderFetchOnClient = (provider: GlobalLLMProviderKey | string) => (s: UserStore) => {
   const config = getProviderConfigById(provider)(s);
   if (typeof config?.fetchOnClient !== 'undefined') return config?.fetchOnClient;
@@ -56,10 +53,8 @@ export const modelConfigSelectors = {
   isAutoFetchModelsEnabled,
   isAzureEnabled,
   isProviderEnabled,
-  isProviderEndpointNotEmpty,
   isProviderFetchOnClient,
 
   ollamaConfig,
-
   openAIConfig,
 };

--- a/src/store/user/slices/settings/action.test.ts
+++ b/src/store/user/slices/settings/action.test.ts
@@ -21,10 +21,12 @@ describe('SettingsAction', () => {
   describe('importAppSettings', () => {
     it('should import app settings', async () => {
       const { result } = renderHook(() => useUserStore());
-      const newSettings: UserSettings = {
-        ...DEFAULT_SETTINGS,
-        themeMode: 'dark',
-      };
+      const newSettings = {
+        general: {
+          ...DEFAULT_SETTINGS,
+          themeMode: 'dark',
+        },
+      } as unknown as UserSettings;
 
       // Mock the internal setSettings function call
       const setSettingsSpy = vi.spyOn(result.current, 'setSettings');
@@ -69,7 +71,7 @@ describe('SettingsAction', () => {
   describe('setSettings', () => {
     it('should set partial settings', async () => {
       const { result } = renderHook(() => useUserStore());
-      const partialSettings: Partial<UserSettings> = { themeMode: 'dark' };
+      const partialSettings: DeepPartial<UserSettings> = { general: { themeMode: 'dark' } };
 
       // Perform the action
       await act(async () => {

--- a/src/store/user/slices/settings/action.test.ts
+++ b/src/store/user/slices/settings/action.test.ts
@@ -8,6 +8,9 @@ import { userService } from '@/services/user';
 import { useUserStore } from '@/store/user';
 import { LobeAgentSettings } from '@/types/session';
 import { UserSettings } from '@/types/user/settings';
+import { merge } from '@/utils/merge';
+
+vi.mock('zustand/traditional');
 
 // Mock userService
 vi.mock('@/services/user', () => ({
@@ -21,12 +24,9 @@ describe('SettingsAction', () => {
   describe('importAppSettings', () => {
     it('should import app settings', async () => {
       const { result } = renderHook(() => useUserStore());
-      const newSettings = {
-        general: {
-          ...DEFAULT_SETTINGS,
-          themeMode: 'dark',
-        },
-      } as unknown as UserSettings;
+      const newSettings: UserSettings = merge(DEFAULT_SETTINGS, {
+        general: { themeMode: 'dark' },
+      });
 
       // Mock the internal setSettings function call
       const setSettingsSpy = vi.spyOn(result.current, 'setSettings');
@@ -37,14 +37,12 @@ describe('SettingsAction', () => {
       });
 
       // Assert that setSettings was called with the correct settings
-      expect(setSettingsSpy).toHaveBeenCalledWith({
-        ...DEFAULT_SETTINGS,
-        password: undefined,
-        themeMode: 'dark',
-      });
+      expect(setSettingsSpy).toHaveBeenCalledWith(newSettings);
 
       // Assert that the state has been updated
-      expect(userService.updateUserSettings).toHaveBeenCalledWith({ themeMode: 'dark' });
+      expect(userService.updateUserSettings).toHaveBeenCalledWith({
+        general: { themeMode: 'dark' },
+      });
 
       // Restore the spy
       setSettingsSpy.mockRestore();
@@ -94,7 +92,9 @@ describe('SettingsAction', () => {
       });
 
       // Assert that updateUserSettings was called with the correct theme mode
-      expect(userService.updateUserSettings).toHaveBeenCalledWith({ themeMode });
+      expect(userService.updateUserSettings).toHaveBeenCalledWith({
+        general: { themeMode },
+      });
     });
   });
 

--- a/src/store/user/slices/settings/action.ts
+++ b/src/store/user/slices/settings/action.ts
@@ -7,7 +7,7 @@ import { userService } from '@/services/user';
 import type { UserStore } from '@/store/user';
 import { LocaleMode } from '@/types/locale';
 import { LobeAgentSettings } from '@/types/session';
-import { UserSettings } from '@/types/user/settings';
+import { UserGeneralConfig, UserSettings , UserKeyVaults } from '@/types/user/settings';
 import { switchLang } from '@/utils/client/switchLang';
 import { difference } from '@/utils/difference';
 import { merge } from '@/utils/merge';
@@ -20,6 +20,8 @@ export interface UserSettingsAction {
   switchLocale: (locale: LocaleMode) => Promise<void>;
   switchThemeMode: (themeMode: ThemeMode) => Promise<void>;
   updateDefaultAgent: (agent: DeepPartial<LobeAgentSettings>) => Promise<void>;
+  updateGeneralConfig: (settings: Partial<UserGeneralConfig>) => Promise<void>;
+  updateKeyVaults: (settings: Partial<UserKeyVaults>) => Promise<void>;
 }
 
 export const createSettingsSlice: StateCreator<
@@ -30,10 +32,8 @@ export const createSettingsSlice: StateCreator<
 > = (set, get) => ({
   importAppSettings: async (importAppSettings) => {
     const { setSettings } = get();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { password: _, ...settings } = importAppSettings;
 
-    await setSettings(settings);
+    await setSettings(importAppSettings);
   },
   resetSettings: async () => {
     await userService.resetUserSettings();
@@ -62,14 +62,20 @@ export const createSettingsSlice: StateCreator<
     });
   },
   switchLocale: async (locale) => {
-    await get().setSettings({ language: locale });
+    await get().updateGeneralConfig({ language: locale });
 
     switchLang(locale);
   },
   switchThemeMode: async (themeMode) => {
-    await get().setSettings({ themeMode });
+    await get().updateGeneralConfig({ themeMode });
   },
   updateDefaultAgent: async (defaultAgent) => {
     await get().setSettings({ defaultAgent });
+  },
+  updateGeneralConfig: async (general) => {
+    await get().setSettings({ general });
+  },
+  updateKeyVaults: async (keyVaults) => {
+    await get().setSettings({ keyVaults });
   },
 });

--- a/src/store/user/slices/settings/action.ts
+++ b/src/store/user/slices/settings/action.ts
@@ -7,7 +7,7 @@ import { userService } from '@/services/user';
 import type { UserStore } from '@/store/user';
 import { LocaleMode } from '@/types/locale';
 import { LobeAgentSettings } from '@/types/session';
-import { UserGeneralConfig, UserSettings , UserKeyVaults } from '@/types/user/settings';
+import { UserGeneralConfig, UserKeyVaults, UserSettings } from '@/types/user/settings';
 import { switchLang } from '@/utils/client/switchLang';
 import { difference } from '@/utils/difference';
 import { merge } from '@/utils/merge';

--- a/src/store/user/slices/settings/selectors/general.test.ts
+++ b/src/store/user/slices/settings/selectors/general.test.ts
@@ -1,0 +1,43 @@
+import { UserStore } from '../../../store';
+import { userGeneralSettingsSelectors } from './general';
+
+describe('settingsSelectors', () => {
+  describe('currentLanguage', () => {
+    it('should return the correct language setting', () => {
+      const s = {
+        settings: {
+          language: 'fr',
+        },
+      } as unknown as UserStore;
+
+      const result = userGeneralSettingsSelectors.currentLanguage(s);
+
+      expect(result).toBe('fr');
+    });
+  });
+
+  describe('currentThemeMode', () => {
+    it('should return the correct theme', () => {
+      const s = {
+        settings: {
+          themeMode: 'light',
+        },
+      } as unknown as UserStore;
+
+      const result = userGeneralSettingsSelectors.currentThemeMode(s);
+
+      expect(result).toBe('light');
+    });
+    it('should return the auto if not set the themeMode', () => {
+      const s = {
+        settings: {
+          themeMode: undefined,
+        },
+      } as unknown as UserStore;
+
+      const result = userGeneralSettingsSelectors.currentThemeMode(s);
+
+      expect(result).toBe('auto');
+    });
+  });
+});

--- a/src/store/user/slices/settings/selectors/general.test.ts
+++ b/src/store/user/slices/settings/selectors/general.test.ts
@@ -1,16 +1,19 @@
-import { UserStore } from '../../../store';
+import { UserStore } from '@/store/user';
+import { UserState, initialState } from '@/store/user/initialState';
+import { merge } from '@/utils/merge';
+
 import { userGeneralSettingsSelectors } from './general';
 
 describe('settingsSelectors', () => {
   describe('currentLanguage', () => {
     it('should return the correct language setting', () => {
-      const s = {
+      const s: UserState = merge(initialState, {
         settings: {
-          language: 'fr',
+          general: { language: 'fr' },
         },
-      } as unknown as UserStore;
+      });
 
-      const result = userGeneralSettingsSelectors.currentLanguage(s);
+      const result = userGeneralSettingsSelectors.currentLanguage(s as UserStore);
 
       expect(result).toBe('fr');
     });
@@ -18,24 +21,23 @@ describe('settingsSelectors', () => {
 
   describe('currentThemeMode', () => {
     it('should return the correct theme', () => {
-      const s = {
+      const s: UserState = merge(initialState, {
         settings: {
-          themeMode: 'light',
+          general: { themeMode: 'light' },
         },
-      } as unknown as UserStore;
+      });
 
-      const result = userGeneralSettingsSelectors.currentThemeMode(s);
+      const result = userGeneralSettingsSelectors.currentThemeMode(s as UserStore);
 
       expect(result).toBe('light');
     });
     it('should return the auto if not set the themeMode', () => {
-      const s = {
+      const s: UserState = merge(initialState, {
         settings: {
-          themeMode: undefined,
+          general: { themeMode: undefined },
         },
-      } as unknown as UserStore;
-
-      const result = userGeneralSettingsSelectors.currentThemeMode(s);
+      });
+      const result = userGeneralSettingsSelectors.currentThemeMode(s as UserStore);
 
       expect(result).toBe('auto');
     });

--- a/src/store/user/slices/settings/selectors/general.ts
+++ b/src/store/user/slices/settings/selectors/general.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_LANG } from '@/const/locale';
+import { Locales } from '@/locales/resources';
+import { isOnServerSide } from '@/utils/env';
+
+import { UserStore } from '../../../store';
+import { currentSettings } from './settings';
+
+const generalConfig = (s: UserStore) => currentSettings(s).general || {};
+
+const currentLanguage = (s: UserStore) => {
+  const locale = generalConfig(s).language;
+
+  if (locale === 'auto') {
+    if (isOnServerSide) return DEFAULT_LANG;
+
+    return navigator.language as Locales;
+  }
+
+  return locale;
+};
+
+const currentThemeMode = (s: UserStore) => {
+  const themeMode = generalConfig(s).themeMode;
+  return themeMode || 'auto';
+};
+
+const neutralColor = (s: UserStore) => generalConfig(s).neutralColor;
+const primaryColor = (s: UserStore) => generalConfig(s).primaryColor;
+const fontSize = (s: UserStore) => generalConfig(s).fontSize;
+const language = (s: UserStore) => generalConfig(s).language;
+
+export const userGeneralSettingsSelectors = {
+  config: generalConfig,
+  currentLanguage,
+  currentThemeMode,
+  fontSize,
+  language,
+  neutralColor,
+  primaryColor,
+};

--- a/src/store/user/slices/settings/selectors/index.ts
+++ b/src/store/user/slices/settings/selectors/index.ts
@@ -1,2 +1,3 @@
+export { userGeneralSettingsSelectors } from './general';
 export { settingsSelectors } from './settings';
 export { systemAgentSelectors } from './systemAgent';

--- a/src/store/user/slices/settings/selectors/settings.test.ts
+++ b/src/store/user/slices/settings/selectors/settings.test.ts
@@ -117,45 +117,6 @@ describe('settingsSelectors', () => {
     });
   });
 
-  describe('currentLanguage', () => {
-    it('should return the correct language setting', () => {
-      const s = {
-        settings: {
-          language: 'fr',
-        },
-      } as unknown as UserStore;
-
-      const result = settingsSelectors.currentLanguage(s);
-
-      expect(result).toBe('fr');
-    });
-  });
-
-  describe('currentThemeMode', () => {
-    it('should return the correct theme', () => {
-      const s = {
-        settings: {
-          themeMode: 'light',
-        },
-      } as unknown as UserStore;
-
-      const result = settingsSelectors.currentThemeMode(s);
-
-      expect(result).toBe('light');
-    });
-    it('should return the auto if not set the themeMode', () => {
-      const s = {
-        settings: {
-          themeMode: undefined,
-        },
-      } as unknown as UserStore;
-
-      const result = settingsSelectors.currentThemeMode(s);
-
-      expect(result).toBe('auto');
-    });
-  });
-
   describe('dalleConfig', () => {
     it('should return the dalle configuration', () => {
       const s = {

--- a/src/store/user/slices/settings/selectors/settings.ts
+++ b/src/store/user/slices/settings/selectors/settings.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_LANG } from '@/const/locale';
 import { DEFAULT_AGENT_META } from '@/const/meta';
 import {
   DEFAULT_AGENT,
@@ -6,13 +5,11 @@ import {
   DEFAULT_SYSTEM_AGENT_CONFIG,
   DEFAULT_TTS_CONFIG,
 } from '@/const/settings';
-import { Locales } from '@/locales/resources';
 import {
-  OpenAICompatibleProviderConfig,
   GlobalLLMProviderKey,
+  ProviderConfig,
   UserSettings,
 } from '@/types/user/settings';
-import { isOnServerSide } from '@/utils/env';
 import { merge } from '@/utils/merge';
 
 import { UserStore } from '../../../store';
@@ -22,9 +19,11 @@ export const currentSettings = (s: UserStore): UserSettings => merge(s.defaultSe
 export const currentLLMSettings = (s: UserStore) => currentSettings(s).languageModel;
 
 export const getProviderConfigById = (provider: string) => (s: UserStore) =>
-  currentLLMSettings(s)[provider as GlobalLLMProviderKey] as OpenAICompatibleProviderConfig | undefined;
+  currentLLMSettings(s)[provider as GlobalLLMProviderKey] as
+    | ProviderConfig
+    | undefined;
 
-const password = (s: UserStore) => currentSettings(s).password;
+const password = (s: UserStore) => currentSettings(s).keyVaults.password || '';
 
 const currentTTS = (s: UserStore) => merge(DEFAULT_TTS_CONFIG, currentSettings(s).tts);
 
@@ -33,30 +32,7 @@ const defaultAgentConfig = (s: UserStore) => merge(DEFAULT_AGENT_CONFIG, default
 
 const defaultAgentMeta = (s: UserStore) => merge(DEFAULT_AGENT_META, defaultAgent(s).meta);
 
-// TODO: Maybe we can also export settings difference
-const exportSettings = (s: UserStore) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { password: _, ...settings } = currentSettings(s);
-
-  return settings as UserSettings;
-};
-
-const currentLanguage = (s: UserStore) => {
-  const locale = currentSettings(s).language;
-
-  if (locale === 'auto') {
-    if (isOnServerSide) return DEFAULT_LANG;
-
-    return navigator.language as Locales;
-  }
-
-  return locale;
-};
-
-export const currentThemeMode = (s: UserStore) => {
-  const themeMode = currentSettings(s).themeMode;
-  return themeMode || 'auto';
-};
+const exportSettings = currentSettings;
 
 const dalleConfig = (s: UserStore) => currentSettings(s).tool?.dalle || {};
 const isDalleAutoGenerating = (s: UserStore) => currentSettings(s).tool?.dalle?.autoGenerate;
@@ -65,11 +41,9 @@ const currentSystemAgent = (s: UserStore) =>
   merge(DEFAULT_SYSTEM_AGENT_CONFIG, currentSettings(s).systemAgent);
 
 export const settingsSelectors = {
-  currentLanguage,
   currentSettings,
   currentSystemAgent,
   currentTTS,
-  currentThemeMode,
   dalleConfig,
   defaultAgent,
   defaultAgentConfig,

--- a/src/types/user/settings/general.ts
+++ b/src/types/user/settings/general.ts
@@ -3,7 +3,7 @@ import type { ThemeMode } from 'antd-style';
 
 import { LocaleMode } from '@/types/locale';
 
-export interface UserGeneralSettings {
+export interface UserGeneralConfig {
   fontSize: number;
   language: LocaleMode;
   neutralColor?: NeutralColors;

--- a/src/types/user/settings/index.ts
+++ b/src/types/user/settings/index.ts
@@ -1,18 +1,17 @@
-import type { NeutralColors, PrimaryColors } from '@lobehub/ui';
-import type { ThemeMode } from 'antd-style';
+import type { LobeAgentSettings } from '@/types/session';
 
-import { LocaleMode } from '@/types/locale';
-import type { LobeAgentSession } from '@/types/session';
-
+import { UserGeneralConfig } from './general';
+import { UserKeyVaults } from './keyVaults';
 import { UserModelProviderConfig } from './modelProvider';
 import { UserSyncSettings } from './sync';
 import { UserSystemAgentConfig } from './systemAgent';
 import { UserToolConfig } from './tool';
 import { UserTTSConfig } from './tts';
 
-export type UserDefaultAgent = Pick<LobeAgentSession, 'config' | 'meta'>;
+export type UserDefaultAgent = LobeAgentSettings;
 
 export * from './general';
+export * from './keyVaults';
 export * from './modelProvider';
 export * from './sync';
 export * from './systemAgent';
@@ -23,32 +22,11 @@ export * from './tts';
  */
 export interface UserSettings {
   defaultAgent: UserDefaultAgent;
-  /**
-   * @deprecated
-   */
-  fontSize: number;
-  /**
-   * @deprecated
-   */
-  language: LocaleMode;
+  general: UserGeneralConfig;
+  keyVaults: UserKeyVaults;
   languageModel: UserModelProviderConfig;
-  /**
-   * @deprecated
-   */
-  neutralColor?: NeutralColors;
-
-  password: string;
-
-  /**
-   * @deprecated
-   */
-  primaryColor?: PrimaryColors;
   sync: UserSyncSettings;
   systemAgent: UserSystemAgentConfig;
-  /**
-   * @deprecated
-   */
-  themeMode: ThemeMode;
   tool: UserToolConfig;
   tts: UserTTSConfig;
 }

--- a/src/types/user/settings/keyVaults.ts
+++ b/src/types/user/settings/keyVaults.ts
@@ -1,0 +1,36 @@
+export interface OpenAICompatibleKeyVault {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+interface AzureOpenAIKeyVault {
+  apiKey?: string;
+  apiVersion?: string;
+  endpoint?: string;
+}
+
+export interface AWSBedrockKeyVault {
+  accessKeyId?: string;
+  region?: string;
+  secretAccessKey?: string;
+}
+
+export interface UserKeyVaults {
+  anthropic?: OpenAICompatibleKeyVault;
+  azure?: AzureOpenAIKeyVault;
+  bedrock?: AWSBedrockKeyVault;
+  deepseek?: OpenAICompatibleKeyVault;
+  google?: OpenAICompatibleKeyVault;
+  groq?: OpenAICompatibleKeyVault;
+  minimax?: OpenAICompatibleKeyVault;
+  mistral?: OpenAICompatibleKeyVault;
+  moonshot?: OpenAICompatibleKeyVault;
+  ollama?: OpenAICompatibleKeyVault;
+  openai?: OpenAICompatibleKeyVault;
+  openrouter?: OpenAICompatibleKeyVault;
+  password?: string;
+  perplexity?: OpenAICompatibleKeyVault;
+  togetherai?: OpenAICompatibleKeyVault;
+  zeroone?: OpenAICompatibleKeyVault;
+  zhipu?: OpenAICompatibleKeyVault;
+}

--- a/src/types/user/settings/modelProvider.ts
+++ b/src/types/user/settings/modelProvider.ts
@@ -1,10 +1,7 @@
+import { ModelProviderKey } from '@/libs/agent-runtime';
 import { ChatModelCard } from '@/types/llm';
 
-export interface OpenAICompatibleProviderConfig {
-  /**
-   * @deprecated
-   */
-  apiKey?: string;
+export interface ProviderConfig {
   /**
    * whether to auto fetch model lists
    */
@@ -19,10 +16,6 @@ export interface OpenAICompatibleProviderConfig {
    */
   enabledModels?: string[] | null;
   /**
-   * @deprecated
-   */
-  endpoint?: string;
-  /**
    * whether fetch on client
    */
   fetchOnClient?: boolean;
@@ -36,35 +29,6 @@ export interface OpenAICompatibleProviderConfig {
   remoteModelCards?: ChatModelCard[];
 }
 
-export interface AzureOpenAIConfig extends Omit<OpenAICompatibleProviderConfig, 'endpoint'> {
-  apiVersion?: string;
-  endpoint?: string;
-}
+export type GlobalLLMProviderKey = ModelProviderKey;
 
-export interface AWSBedrockConfig
-  extends Omit<OpenAICompatibleProviderConfig, 'apiKey' | 'endpoint'> {
-  accessKeyId?: string;
-  region?: string;
-  secretAccessKey?: string;
-}
-
-export interface UserModelProviderConfig {
-  anthropic: OpenAICompatibleProviderConfig;
-  azure: AzureOpenAIConfig;
-  bedrock: AWSBedrockConfig;
-  deepseek: OpenAICompatibleProviderConfig;
-  google: OpenAICompatibleProviderConfig;
-  groq: OpenAICompatibleProviderConfig;
-  minimax: OpenAICompatibleProviderConfig;
-  mistral: OpenAICompatibleProviderConfig;
-  moonshot: OpenAICompatibleProviderConfig;
-  ollama: OpenAICompatibleProviderConfig;
-  openai: OpenAICompatibleProviderConfig;
-  openrouter: OpenAICompatibleProviderConfig;
-  perplexity: OpenAICompatibleProviderConfig;
-  togetherai: OpenAICompatibleProviderConfig;
-  zeroone: OpenAICompatibleProviderConfig;
-  zhipu: OpenAICompatibleProviderConfig;
-}
-
-export type GlobalLLMProviderKey = keyof UserModelProviderConfig;
+export type UserModelProviderConfig = Record<ModelProviderKey, ProviderConfig>;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

为增强用户输入的秘钥安全性，计划将 apikey 和 endpoint 作为关键私密数据从 languageModel 中抽取出来，后续将采用加密算法进行加密存储。借由此次变更，顺带可以实现 endpoint -> baseURL 的字段重构操作。

几个关键变更：

1. 所有 apiKey 的位置从 languageModel -> keyVaults ，涉及到 url 分享的兼容性问题， @cy948 看下是 Breaking ，还是兼容下；
2. `endpoint` 改名为 `baseURL`，与 agent-runtime 对齐，这样就可以直接透传 keyVaults 而不需要再解构了，后续 agent-runtime 的赋值初始化可以简化实现。 cc @cy948 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `themeMode` in settings, allowing users to toggle between different themes.
  - Added new configurations for key vaults, enhancing security and management of API keys.

- **Bug Fixes**
  - Improved language retrieval logic in user settings.

- **Refactor**
  - Renamed various selectors and updated import statements for better code clarity and maintainability.

- **Tests**
  - Added new test cases for user settings selectors, ensuring correct retrieval of language and theme mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->