### PR TITLE
🔨chore: Optimize the addresses generated by `SITEMAPS` and `SITEMAP INDICES`

### DIFF
--- a/next-sitemap.config.mjs
+++ b/next-sitemap.config.mjs
@@ -1,10 +1,14 @@
 import { glob } from 'glob';
 
+const inVercelProduction = process.env.VERCEL === '1' && process.env.VERCEL_ENV === 'production';
+
 const isVercelPreview = process.env.VERCEL === '1' && process.env.VERCEL_ENV !== 'production';
+
+const vercelProductionUrl = `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
 
 const vercelPreviewUrl = `https://${process.env.VERCEL_URL}`;
 
-const siteUrl = isVercelPreview ? vercelPreviewUrl : 'https://chat-preview.lobehub.com';
+const siteUrl = inVercelProduction ? vercelProductionUrl : isVercelPreview ? vercelPreviewUrl : 'https://chat-preview.lobehub.com';
 
 /** @type {import('next-sitemap').IConfig} */
 const config = {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
优化vercel平台的生成环境下，自动生成的`SITEMAPS`及`SITEMAP INDICES`的域名

Optimize the generation environment of the vercel platform to automatically generate the domain names of `SITEMAPS` and `SITEMAP INDICES`
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
在vercel平台的生产环境下部署时，生成的`SITEMAPS`和`SITEMAP INDICES`将在该实例域名下，而非原有的`https://chat-preview.lobehub.com/`

When deployed in the production environment of the vercel platform, the generated `SITEMAPS` and `SITEMAP INDICES` will be under the instance domain name instead of the original `https://chat-preview.lobehub.com/`
<!-- Add any other context about the Pull Request here. -->
