### PR TITLE
🔨 build: pin `ajv@8.14.0` to fix vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "@types/uuid": "^9.0.8",
     "@umijs/lint": "^4.2.5",
     "@vitest/coverage-v8": "~1.2.2",
+    "ajv": "8.14.0",
     "ajv-keywords": "^5.1.0",
     "commitlint": "^19.3.0",
     "consola": "^3.2.3",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

ajv@8.15.0 make a change of deps, which use `node:url`, so make vercel build failed. we need to pin `ajv@8.14.0` to fix this issue.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs:  https://github.com/ajv-validator/ajv/issues/2446
<!-- Add any other context about the Pull Request here. -->
