### PR TITLE
💄 style: fix footer being cut on wide screen

### DIFF
--- a/src/app/(main)/welcome/_layout/Desktop.tsx
+++ b/src/app/(main)/welcome/_layout/Desktop.tsx
@@ -18,7 +18,11 @@ const DesktopLayout = ({ children }: PropsWithChildren) => {
         width={'100%'}
       >
         <Logo size={36} style={{ alignSelf: 'flex-start' }} type={'text'} />
-        <GridShowcase innerProps={{ gap: 24 }} style={{ maxWidth: 1024 }} width={'100%'}>
+        <GridShowcase
+          innerProps={{ gap: 24 }}
+          style={{ maxHeight: 'calc(100% - 104px)', maxWidth: 1024 }}
+          width={'100%'}
+        >
           {children}
         </GridShowcase>
         <Flexbox align={'center'} horizontal justify={'space-between'}>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

On wide screen, footer in welcome page being cut because the content overflows the screen height. This makes sure the content doesn't overflow to the footer space.
