### PR TITLE
🐛 fix: hydration mismatch on Mac

### DIFF
--- a/src/app/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/Footer/SendMore.tsx
+++ b/src/app/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/Footer/SendMore.tsx
@@ -13,7 +13,6 @@ import { useSendMessage } from '@/features/ChatInput/useSend';
 import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
-import { isMacOS } from '@/utils/platform';
 
 const useStyles = createStyles(({ css, prefixCls }) => {
   return {
@@ -25,13 +24,12 @@ const useStyles = createStyles(({ css, prefixCls }) => {
   };
 });
 
-const isMac = isMacOS();
-
 interface SendMoreProps {
   disabled?: boolean;
+  isMac?: boolean;
 }
 
-const SendMore = memo<SendMoreProps>(({ disabled }) => {
+const SendMore = memo<SendMoreProps>(({ disabled, isMac }) => {
   const { t } = useTranslation('chat');
 
   const { styles } = useStyles();
@@ -74,7 +72,7 @@ const SendMore = memo<SendMoreProps>(({ disabled }) => {
             icon: useCmdEnterToSend ? <Icon icon={LucideCheck} /> : <div />,
             key: 'sendWithCmdEnter',
             label: t('input.sendWithCmdEnter', {
-              meta: isMac ? 'Cmd' : 'Ctrl',
+              meta: typeof isMac === 'boolean' ? (isMac ? '⌘' : 'Ctrl') : '…',
             }),
             onClick: () => {
               updatePreference({ useCmdEnterToSend: true });

--- a/src/app/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/Footer/index.tsx
+++ b/src/app/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/Footer/index.tsx
@@ -1,9 +1,9 @@
 import { Icon } from '@lobehub/ui';
-import { Button, Space } from 'antd';
+import { Button, Skeleton, Space } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronUp, CornerDownLeft, LucideCommand } from 'lucide-react';
 import { rgba } from 'polished';
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
 
@@ -50,8 +50,6 @@ const useStyles = createStyles(({ css, prefixCls, token }) => {
   };
 });
 
-const isMac = isMacOS();
-
 interface FooterProps {
   setExpand?: (expand: boolean) => void;
 }
@@ -86,9 +84,20 @@ const Footer = memo<FooterProps>(({ setExpand }) => {
 
   const sendMessage = useSendMessage();
 
+  const [isMac, setIsMac] = useState<boolean>();
+  useEffect(() => {
+    setIsMac(isMacOS());
+  }, [setIsMac]);
+
   const cmdEnter = (
     <Flexbox gap={2} horizontal>
-      <Icon icon={isMac ? LucideCommand : ChevronUp} />
+      {typeof isMac === 'boolean' ? (
+        <Icon icon={isMac ? LucideCommand : ChevronUp} />
+      ) : (
+        <Skeleton.Node active style={{ height: '100%', width: 12 }}>
+          {' '}
+        </Skeleton.Node>
+      )}
       <Icon icon={CornerDownLeft} />
     </Flexbox>
   );
@@ -159,7 +168,7 @@ const Footer = memo<FooterProps>(({ setExpand }) => {
               >
                 {t('input.send')}
               </Button>
-              <SendMore disabled={buttonDisabled} />
+              <SendMore disabled={buttonDisabled} isMac={isMac} />
             </Space.Compact>
           )}
         </Flexbox>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

On MacOS, there will be a hydration issue on the hotkey indicators because isMacOS() function returns different value on server & client. This delays rendering them after hydration with proper loading during SSR.
