### PR TITLE
🐛 fix: typo in reset settings

### DIFF
--- a/src/app/(main)/settings/common/features/Common.tsx
+++ b/src/app/(main)/settings/common/features/Common.tsx
@@ -135,8 +135,8 @@ const Common = memo(() => {
             {t('danger.reset.action')}
           </Button>
         ),
-        desc: t('danger.reset.title'),
-        label: t('danger.reset.desc'),
+        desc: t('danger.reset.desc'),
+        label: t('danger.reset.title'),
         minWidth: undefined,
       },
       {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Title and Description of `Reset All Settings` are being misplaced to each other. This puts them in correct places.