### PR TITLE
:bug: fix: ollama not enabled on default & not support baseUrl on remote

### DIFF
--- a/src/store/user/slices/modelList/selectors/modelConfig.test.ts
+++ b/src/store/user/slices/modelList/selectors/modelConfig.test.ts
@@ -32,6 +32,27 @@ describe('modelConfigSelectors', () => {
 
       expect(modelConfigSelectors.isProviderEnabled('perplexity')(s)).toBe(false);
     });
+
+    it('should follow the user settings if provider is in the whitelist', () => {
+      const s = merge(initialSettingsState, {
+        settings: {
+          languageModel: {
+            ollama: { enabled: false },
+          },
+        },
+      } as UserSettingsState) as unknown as UserStore;
+
+      expect(modelConfigSelectors.isProviderEnabled('ollama')(s)).toBe(false);
+    });
+
+    it('ollama should be enabled by default', () => {
+      const s = merge(initialSettingsState, {
+        settings: {
+          languageModel: {},
+        },
+      } as UserSettingsState) as unknown as UserStore;
+      expect(modelConfigSelectors.isProviderEnabled('ollama')(s)).toBe(true);
+    });
   });
 
   describe('isProviderFetchOnClient', () => {

--- a/src/store/user/slices/modelList/selectors/modelConfig.ts
+++ b/src/store/user/slices/modelList/selectors/modelConfig.ts
@@ -7,6 +7,7 @@ import { keyVaultsConfigSelectors } from './keyVaults';
 const isProviderEnabled = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
   getProviderConfigById(provider)(s)?.enabled || false;
 
+const providerWhitelist = new Set(['ollama']);
 /**
  * @description The conditions to enable client fetch
  * 1. If no baseUrl and apikey input, force on Server.
@@ -16,6 +17,10 @@ const isProviderEnabled = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
  */
 const isProviderFetchOnClient = (provider: GlobalLLMProviderKey | string) => (s: UserStore) => {
   const config = getProviderConfigById(provider)(s);
+
+  // If the provider in the whitelist, follow the user settings
+  if (providerWhitelist.has(provider) && typeof config?.fetchOnClient !== 'undefined')
+    return config?.fetchOnClient;
 
   // 1. If no baseUrl and apikey input, force on Server.
   const isProviderEndpointNotEmpty =


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

- 🐛 `src/store/user/slices/modelList/selectors/modelConfig.ts`: 对在白名单中的 provider 免去 endpoint 及 apikey 的检查，跟随用户设置。
- ✅ `src/store/user/slices/modelList/selectors/modelConfig.test.ts`: 补充了测试：
  - 在白名单中的Provider须跟随用户设置
  - `ollama`应该默认开启 client fetch

#### 📝 补充信息 | Additional Information

- fix #2934 

<!-- Add any other context about the Pull Request here. -->
