### PR TITLE
🐛 fix: create first-time user

### DIFF
--- a/src/database/server/models/user.ts
+++ b/src/database/server/models/user.ts
@@ -11,6 +11,12 @@ import { merge } from '@/utils/merge';
 import { NewUser, UserItem, userSettings, users } from '../schemas/lobechat';
 import { SessionModel } from './session';
 
+export class UserNotFoundError extends TRPCError {
+  constructor() {
+    super({ code: 'UNAUTHORIZED', message: 'user not found' });
+  }
+}
+
 export class UserModel {
   createUser = async (params: NewUser) => {
     const [user] = await serverDB
@@ -51,7 +57,7 @@ export class UserModel {
       .leftJoin(userSettings, eq(users.id, userSettings.id));
 
     if (!result || !result[0]) {
-      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      throw new UserNotFoundError();
     }
 
     const state = result[0];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

For first-time user, automatically create a user in database. This handles issue where if Clerk webhook unexpected failed, the user won't be able to use the app at all.

#### 📝 补充信息 | Additional Information

The code is optimized so that creating user only ever runs once per user and only if Clerk webhook failed and the code path is the same for all existing users.
