### PR TITLE
📝 docs: Fix mentions of `SSO_PROVIDERS` and `NEXTAUTH_SECRET`

### DIFF
--- a/docs/self-hosting/advanced/sso-providers/auth0.mdx
+++ b/docs/self-hosting/advanced/sso-providers/auth0.mdx
@@ -76,7 +76,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 
 | Environment Variable | Type | Description |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
 | `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `auth0` for Auth0. |
 | `AUTH0_CLIENT_ID` | Required | Client ID of the Auth0 application |

--- a/docs/self-hosting/advanced/sso-providers/auth0.mdx
+++ b/docs/self-hosting/advanced/sso-providers/auth0.mdx
@@ -77,8 +77,8 @@ When deploying LobeChat, you need to configure the following environment variabl
 | Environment Variable | Type | Description |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
-| `NEXTAUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `auth0` for Auth0. |
+| `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `auth0` for Auth0. |
 | `AUTH0_CLIENT_ID` | Required | Client ID of the Auth0 application |
 | `AUTH0_CLIENT_SECRET` | Required | Client Secret of the Auth0 application |
 | `AUTH0_ISSUER` | Required | Domain of the Auth0 application, `https://example.auth0.com` |

--- a/docs/self-hosting/advanced/sso-providers/auth0.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/auth0.zh-CN.mdx
@@ -71,7 +71,6 @@ http(s)://your-domain/api/auth/callback/auth0
 
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
 | `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Auth0 请填写 `auth0`。 |
 | `AUTH0_CLIENT_ID` | 必选 | Auth0 应用程序的 Client ID |

--- a/docs/self-hosting/advanced/sso-providers/auth0.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/auth0.zh-CN.mdx
@@ -72,8 +72,8 @@ http(s)://your-domain/api/auth/callback/auth0
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
-| `NEXTAUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Auth0 请填写 `auth0`。 |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Auth0 请填写 `auth0`。 |
 | `AUTH0_CLIENT_ID` | 必选 | Auth0 应用程序的 Client ID |
 | `AUTH0_CLIENT_SECRET` | 必选 | Auth0 应用程序的 Client Secret |
 | `AUTH0_ISSUER` | 必选 | Auth0 应用程序的 Domain，`https://example.auth0.com` |

--- a/docs/self-hosting/advanced/sso-providers/authentik.mdx
+++ b/docs/self-hosting/advanced/sso-providers/authentik.mdx
@@ -54,7 +54,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 
 | Environment Variable | Type | Description |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | Required | Enable Single Sign-On (SSO) for LobeChat. Set to `1` to enable SSO. |
 | `NEXT_AUTH_SECRET` | Required | The secret used to encrypt Auth.js session tokens. You can generate a secret using the following command: `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the SSO provider for LoboChat. Use `authentik` for Authentik. |
 | `AUTHENTIK_CLIENT_ID` | Required | The Client ID from the Authentik application provider details page |

--- a/docs/self-hosting/advanced/sso-providers/authentik.mdx
+++ b/docs/self-hosting/advanced/sso-providers/authentik.mdx
@@ -55,8 +55,8 @@ When deploying LobeChat, you need to configure the following environment variabl
 | Environment Variable | Type | Description |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | Required | Enable Single Sign-On (SSO) for LobeChat. Set to `1` to enable SSO. |
-| `NEXTAUTH_SECRET` | Required | The secret used to encrypt Auth.js session tokens. You can generate a secret using the following command: `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | Required | Select the SSO provider for LoboChat. Use `authentik` for Authentik. |
+| `NEXT_AUTH_SECRET` | Required | The secret used to encrypt Auth.js session tokens. You can generate a secret using the following command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the SSO provider for LoboChat. Use `authentik` for Authentik. |
 | `AUTHENTIK_CLIENT_ID` | Required | The Client ID from the Authentik application provider details page |
 | `AUTHENTIK_CLIENT_SECRET` | Required | The Client Secret from the Authentik application provider details page |
 | `AUTHENTIK_ISSUER` | Required | The OpenID Configuration Issuer from the Authentik application provider details page |

--- a/docs/self-hosting/advanced/sso-providers/authentik.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/authentik.zh-CN.mdx
@@ -49,7 +49,6 @@ https://your-domain/api/auth/callback/authentik
 
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
 | `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Authentik 请填写 `authentik`。 |
 | `AUTHENTIK_CLIENT_ID` | 必选 | Authentik 提供程序详情页的 客户端 ID |

--- a/docs/self-hosting/advanced/sso-providers/authentik.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/authentik.zh-CN.mdx
@@ -50,8 +50,8 @@ https://your-domain/api/auth/callback/authentik
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
-| `NEXTAUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Authentik 请填写 `authentik`。 |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Authentik 请填写 `authentik`。 |
 | `AUTHENTIK_CLIENT_ID` | 必选 | Authentik 提供程序详情页的 客户端 ID |
 | `AUTHENTIK_CLIENT_SECRET` | 必选 | Authentik 提供程序详情页的 客户端 Secret |
 | `AUTHENTIK_ISSUER` | 必选 | Authentik 提供程序详情页的 OpenID 配置颁发者 |

--- a/docs/self-hosting/advanced/sso-providers/github.mdx
+++ b/docs/self-hosting/advanced/sso-providers/github.mdx
@@ -82,7 +82,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 
 | Environment Variable | Type | Description |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | Required | Enable Single Sign-On (SSO) for LobeChat. Set to `1` to enable SSO. |
 | `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the command: `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the Single Sign-On provider for LobeChat. Use `github` for Github. |
 | `GITHUB_CLIENT_ID` | Required | Client ID in the Github App details page. |

--- a/docs/self-hosting/advanced/sso-providers/github.mdx
+++ b/docs/self-hosting/advanced/sso-providers/github.mdx
@@ -83,8 +83,8 @@ When deploying LobeChat, you need to configure the following environment variabl
 | Environment Variable | Type | Description |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | Required | Enable Single Sign-On (SSO) for LobeChat. Set to `1` to enable SSO. |
-| `NEXTAUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the command: `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | Required | Select the Single Sign-On provider for LobeChat. Use `github` for Github. |
+| `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the Single Sign-On provider for LobeChat. Use `github` for Github. |
 | `GITHUB_CLIENT_ID` | Required | Client ID in the Github App details page. |
 | `GITHUB_CLIENT_SECRET` | Required | Client Secret in the Github App details page. |
 | `ACCESS_CODE` | Required | Add a password for accessing this service. You can set a long random password to "disable" access code authorization. |

--- a/docs/self-hosting/advanced/sso-providers/github.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/github.zh-CN.mdx
@@ -79,8 +79,8 @@ tags:
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
-| `NEXTAUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Github 请填写 `github`。 |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Github 请填写 `github`。 |
 | `GITHUB_CLIENT_ID` | 必选 | Github App详情页的 客户端 ID |
 | `GITHUB_CLIENT_SECRET` | 必选 | Github App详情页的 客户端 Secret |
 | `ACCESS_CODE` | 必选 | 添加访问此服务的密码，你可以设置一个足够长的随机密码以 “禁用” 访问码授权 |

--- a/docs/self-hosting/advanced/sso-providers/github.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/github.zh-CN.mdx
@@ -78,7 +78,6 @@ tags:
 
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
 | `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Github 请填写 `github`。 |
 | `GITHUB_CLIENT_ID` | 必选 | Github App详情页的 客户端 ID |

--- a/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.mdx
+++ b/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.mdx
@@ -71,7 +71,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 
 | Environment Variable | Type | Description |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
 | `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the following command: `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the single sign-on provider for LoboChat. Use `azure-ad` for Microsoft Entra ID. |
 | `AZURE_AD_CLIENT_ID` | Required | Client ID of the Microsoft Entra ID application. |

--- a/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.mdx
+++ b/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.mdx
@@ -72,8 +72,8 @@ When deploying LobeChat, you need to configure the following environment variabl
 | Environment Variable | Type | Description |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
-| `NEXTAUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the following command: `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | Required | Select the single sign-on provider for LoboChat. Use `azure-ad` for Microsoft Entra ID. |
+| `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate the key using the following command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the single sign-on provider for LoboChat. Use `azure-ad` for Microsoft Entra ID. |
 | `AZURE_AD_CLIENT_ID` | Required | Client ID of the Microsoft Entra ID application. |
 | `AZURE_AD_CLIENT_SECRET` | Required | Client Secret of the Microsoft Entra ID application. |
 | `AZURE_AD_TENANT_ID` | Required | Tenant ID of the Microsoft Entra ID application. |

--- a/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.zh-CN.mdx
@@ -69,8 +69,8 @@ https://your-domain/api/auth/callback/azure-ad
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
-| `NEXTAUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Microsoft Entra ID 请填写 `azure-ad`。 |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Microsoft Entra ID 请填写 `azure-ad`。 |
 | `AZURE_AD_CLIENT_ID` | 必选 | Microsoft Entra ID 应用程序的 Client ID |
 | `AZURE_AD_CLIENT_SECRET` | 必选 | Microsoft Entra ID 应用程序的 Client Secret |
 | `AZURE_AD_TENANT_ID` | 必选 | Microsoft Entra ID 应用程序的 Tenant ID |

--- a/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/microsoft-entra-id.zh-CN.mdx
@@ -68,7 +68,6 @@ https://your-domain/api/auth/callback/azure-ad
 
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录 (SSO)。设置为 `1` 以启用单点登录。 |
 | `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Microsoft Entra ID 请填写 `azure-ad`。 |
 | `AZURE_AD_CLIENT_ID` | 必选 | Microsoft Entra ID 应用程序的 Client ID |

--- a/docs/self-hosting/advanced/sso-providers/zitadel.mdx
+++ b/docs/self-hosting/advanced/sso-providers/zitadel.mdx
@@ -58,7 +58,7 @@ http(s)://your-domain/api/auth/callback/zitadel
   URL is consistent with the deployed URL.
 
 - Replace `http(s)://your-domain` with the actual URL that LobeChat is deployed to.
- 
+
 </Callout>
 
 Confirm the configuration and click **Create**.
@@ -100,8 +100,8 @@ When deploying LobeChat, you need to configure the following environment variabl
 | Environment Variable | Type | Description |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
-| `NEXTAUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
-| `SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `zitadel` for ZITADEL. |
+| `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `zitadel` for ZITADEL. |
 | `ZITADEL_CLIENT_ID` | Required | Client ID (`ClientId` as shown in ZITADEL) of the ZITADEL application |
 | `ZITADEL_CLIENT_SECRET` | Required | Client Secret (`ClientSecret` as shown in ZITADEL) of the ZITADEL application |
 | `ZITADEL_ISSUER` | Required | Issuer URL of the ZITADEL application |

--- a/docs/self-hosting/advanced/sso-providers/zitadel.mdx
+++ b/docs/self-hosting/advanced/sso-providers/zitadel.mdx
@@ -99,7 +99,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 
 | Environment Variable | Type | Description |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | Required | Enable single sign-on (SSO) for LobeChat. Set to `1` to enable single sign-on. |
 | `NEXT_AUTH_SECRET` | Required | Key used to encrypt Auth.js session tokens. You can generate a key using the following command: `openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | Optional | Select the single sign-on provider for LoboChat. Use `zitadel` for ZITADEL. |
 | `ZITADEL_CLIENT_ID` | Required | Client ID (`ClientId` as shown in ZITADEL) of the ZITADEL application |

--- a/docs/self-hosting/advanced/sso-providers/zitadel.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/zitadel.zh-CN.mdx
@@ -95,7 +95,6 @@ http(s)://your-domain/api/auth/callback/zitadel
 
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
-| `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录（SSO）。设置为 `1` 以启用单点登录。 |
 | `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成密钥：`openssl rand -base64 32` |
 | `NEXT_AUTH_SSO_PROVIDERS` | 可选 | 为 LobeChat 选择单点登录提供程序。对于 ZITADEL，请填写 `zitadel`。 |
 | `ZITADEL_CLIENT_ID` | 必选 | ZITADEL 应用的 Client ID（`ClientId`）。 |

--- a/docs/self-hosting/advanced/sso-providers/zitadel.zh-CN.mdx
+++ b/docs/self-hosting/advanced/sso-providers/zitadel.zh-CN.mdx
@@ -54,7 +54,7 @@ http(s)://your-domain/api/auth/callback/zitadel
   - 可以创建应用后再填写或修改重定向 URL，但请确保填写的 URL 与部署的 URL 一致。
 
 - 请将 `http(s)://your-domain` 替换为 LobeChat 部署的实际 URL。
- 
+
 </Callout>
 
 确认配置并点击「创建」。
@@ -96,8 +96,8 @@ http(s)://your-domain/api/auth/callback/zitadel
 | 环境变量 | 类型 | 描述 |
 | --- | --- | --- |
 | `ENABLE_OAUTH_SSO` | 必选 | 为 LobeChat 启用单点登录（SSO）。设置为 `1` 以启用单点登录。 |
-| `NEXTAUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成密钥：`openssl rand -base64 32` |
-| `SSO_PROVIDERS` | 可选 | 为 LobeChat 选择单点登录提供程序。对于 ZITADEL，请填写 `zitadel`。 |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成密钥：`openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 可选 | 为 LobeChat 选择单点登录提供程序。对于 ZITADEL，请填写 `zitadel`。 |
 | `ZITADEL_CLIENT_ID` | 必选 | ZITADEL 应用的 Client ID（`ClientId`）。 |
 | `ZITADEL_CLIENT_SECRET` | 必选 | ZITADEL 应用的 Client Secret（`ClientSecret`）。 |
 | `ZITADEL_ISSUER` | 必选 | ZITADEL 应用的 OpenID Connect 颁发者（issuer）URL。 |


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

I have a problem where my SSO login option disappeared from my Vercel deploy after I deployed the ~100 commits that I had lagged behind.

Given what changed in https://github.com/lobehub/lobe-chat/pull/2983, I think mentions of `SSO_PROVIDERS` and `NEXTAUTH_SECRET` in the docs are wrong? I think they should be `NEXT_AUTH_SSO_PROVIDERS` and `NEXT_AUTH_SECRET` respectively?

Not sure, still trying to figure this out.

EDIT: In my vercel deploy of lobe-chat, I tested out switching to these environment variables, and this fixed my problem. My SSO login is back 👍 