### PR TITLE
Lock @azure/core-rest-pipeline to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.600.0",
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/s3-request-presigner": "^3.600.0",
+    "@azure/core-rest-pipeline": "1.16.0",
     "@azure/openai": "1.0.0-beta.12",
     "@cfworker/json-schema": "^1.12.8",
     "@clerk/localizations": "2.0.0",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Lock @azure/core-rest-pipeline to 1.16.0. Workaround for #3037, #3053

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
~~This is just a workaround. We should switch backend environment to Node~~

----

core reason: `@azure/openai` not make the ege runtime as the official supported runtime: https://github.com/Azure/azure-sdk-for-js/pull/30194#discussion_r1658253364

need to be fixed at azure side: https://github.com/Azure/azure-sdk-for-js/pull/30194