### PR TITLE
🐛 fix: fix clerk auth error after long-time hang-up

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -53,7 +53,12 @@ export default authEnv.NEXT_PUBLIC_ENABLE_CLERK_AUTH
       (auth, req) => {
         if (isProtectedRoute(req)) auth().protect();
       },
-      { signInUrl: '/login', signUpUrl: '/signup' },
+      {
+        // https://clerk.com/docs/references/nextjs/clerk-middleware#clerk-middleware-options
+        clockSkewInMs: 60 * 60 * 1000,
+        signInUrl: '/login',
+        signUpUrl: '/signup',
+      },
     )
   : authEnv.NEXT_PUBLIC_ENABLE_NEXT_AUTH
     ? nextAuthMiddleware

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -54,7 +54,7 @@ export default authEnv.NEXT_PUBLIC_ENABLE_CLERK_AUTH
         if (isProtectedRoute(req)) auth().protect();
       },
       {
-        // https://clerk.com/docs/references/nextjs/clerk-middleware#clerk-middleware-options
+        // https://github.com/lobehub/lobe-chat/pull/3084
         clockSkewInMs: 60 * 60 * 1000,
         signInUrl: '/login',
         signUpUrl: '/signup',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修正在 Clerk 鉴权不通过的问题。

原因：clerk 默认的 token 有效时间是 5s ，因此在发送新的请求时，如果 token 有效期超过 5s 就会无法正常被解析到（token 有效期超过 5s 的场景比如息屏、手机上将 PWA 放到后台），进而抛错。

为什么 LobeChat 会有这个问题？

由于 LobeChat 采用的 SWR 会用户重新聚焦屏幕的时候重新请求数据，而此时请求携带的 token 大概率还是旧的，没有被正常刷新成功。因此经过服务端鉴权后就是失效的 user auth。
<!-- Thank you for your Pull Request. Please provide a description above. -->

解决方案：将 token 的有效时间拉长，目前暂定 1 小时。如果 1 小时抛错的频率还是很高，那么估计要再延长一些。

#### 📝 补充信息 | Additional Information

- 官方文档：https://clerk.com/docs/references/nextjs/clerk-middleware#clerk-middleware-options

> `clockSkewInMs` ? number
Specifies the allowed time difference (in milliseconds) between the Clerk server (which generates the token) and the clock of the user's application server when validating a token. Defaults to 5000 ms (5 seconds).

指定验证令牌时 Clerk 服务器（生成令牌）与用户应用程序服务器的时钟之间允许的时间差（以毫秒为单位）。默认为 5000 毫秒（5 秒）。


- 社区其他人也遇到了类似的问题：https://stackoverflow.com/questions/78072953/how-can-i-handle-uncaught-in-promise-error-clerkjs-token-refresh-failed-er

<img width="719" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/079ec14f-9e42-46c4-86b7-cd50ab569675">

