### PR TITLE
🔧 chore(config): adjusting `stylelint` rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,11 @@
     "*.json": [
       "prettier --write --no-error-on-unmatched-pattern"
     ],
-    "*.{js,jsx,mjs,cjs}": [
+    "*.{mjs,cjs}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{js,jsx}": [
       "prettier --write",
       "stylelint --fix",
       "eslint --fix"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
取消对`mjs`和`cjs`文件的`stylelint --fix`检查

Disable `stylelint --fix` checks for `mjs` and `cjs` files
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
解决`next-sitemap.config.mjs`经过`stylelint --fix`检查出现的`Unknown word CssSyntaxError`错误

Fix the `Unknown word CssSyntaxError` error in `next-sitemap.config.mjs` after `stylelint --fix` check
<!-- Add any other context about the Pull Request here. -->
