### PR TITLE
🐛 fix: allow builtin tools to trigger AI message

### DIFF
--- a/src/store/chat/slices/plugin/action.ts
+++ b/src/store/chat/slices/plugin/action.ts
@@ -110,7 +110,7 @@ export const chatPlugin: StateCreator<
 
     if (!content) return;
 
-    await action(id, content);
+    return await action(id, content);
   },
 
   invokeDefaultTypePlugin: async (id, payload) => {
@@ -213,7 +213,7 @@ export const chatPlugin: StateCreator<
       // trigger the plugin call
       const data = await get().internal_invokeDifferentTypePlugin(id, payload);
 
-      if (payload.type === 'default' && data) {
+      if ((payload.type === 'default' || payload.type === 'builtin') && data) {
         shouldCreateMessage = true;
         latestToolId = id;
       }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

This enables built in plugin to return truthy data in its execution to signal that an AI message should be triggered. It's a non-breaking change, all current plugins & tools work the same. In the future, if a built in tool wants to trigger an AI message, it can just return a truthy value.

#### 📝 补充信息 | Additional Information

Feel free to change this to a fix if you think that's better.
