### PR TITLE
📌 chore: pin `@clerk/nextjs` to `5.1.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@azure/openai": "1.0.0-beta.12",
     "@cfworker/json-schema": "^1.12.8",
     "@clerk/localizations": "2.0.0",
-    "@clerk/nextjs": "^5.1.6",
+    "@clerk/nextjs": "5.1.6",
     "@clerk/themes": "^2.1.10",
     "@google/generative-ai": "^0.13.0",
     "@icons-pack/react-simple-icons": "^9.5.0",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

pin `@clerk/nextjs` to `5.1.6` to avoid nextjs build warning
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs: https://github.com/clerk/javascript/issues/3660

<!-- Add any other context about the Pull Request here. -->
