### PR TITLE
🐛 fix: fix tool message order

### DIFF
--- a/src/services/__tests__/chat.test.ts
+++ b/src/services/__tests__/chat.test.ts
@@ -32,7 +32,7 @@ import { UserStore } from '@/store/user';
 import { UserSettingsState, initialSettingsState } from '@/store/user/slices/settings/initialState';
 import { DalleManifest } from '@/tools/dalle';
 import { ChatMessage } from '@/types/message';
-import { ChatStreamPayload } from '@/types/openai/chat';
+import { ChatStreamPayload, type OpenAIChatMessage } from '@/types/openai/chat';
 import { LobeTool } from '@/types/tool';
 
 import { chatService, initializeWithClientStore } from '../chat';
@@ -664,6 +664,141 @@ Get data from users`,
         type: 404,
       });
       expect(onLoadingChange).toHaveBeenCalledWith(false); // 确认加载状态已经被设置为 false
+    });
+  });
+
+  describe('processMessage', () => {
+    it('should reorderToolMessages', () => {
+      const input: OpenAIChatMessage[] = [
+        {
+          content: '## Tools\n\nYou can use these tools',
+          role: 'system',
+        },
+        {
+          content: '',
+          role: 'assistant',
+          tool_calls: [
+            {
+              function: {
+                arguments:
+                  '{"query":"LobeChat","searchEngines":["brave","google","duckduckgo","qwant"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'call_6xCmrOtFOyBAcqpqO1TGfw2B',
+              type: 'function',
+            },
+            {
+              function: {
+                arguments:
+                  '{"query":"LobeChat","searchEngines":["brave","google","duckduckgo","qwant"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'tool_call_nXxXHW8Z',
+              type: 'function',
+            },
+            {
+              function: {
+                arguments: '{"query":"LobeHub","searchEngines":["bilibili"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'tool_call_2f3CEKz9',
+              type: 'function',
+            },
+          ],
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'call_6xCmrOtFOyBAcqpqO1TGfw2B',
+        },
+        {
+          content: 'LobeHub 是一个专注于设计和开发现代人工智能生成内容（AIGC）工具和组件的团队。',
+          role: 'assistant',
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'tool_call_nXxXHW8Z',
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'tool_call_2f3CEKz9',
+        },
+        {
+          content: '### LobeHub 智能AI聚合神器\n\nLobeHub 是一个强大的AI聚合平台',
+          role: 'assistant',
+        },
+      ];
+      const output = chatService['reorderToolMessages'](input);
+
+      expect(output).toEqual([
+        {
+          content: '## Tools\n\nYou can use these tools',
+          role: 'system',
+        },
+        {
+          content: '',
+          role: 'assistant',
+          tool_calls: [
+            {
+              function: {
+                arguments:
+                  '{"query":"LobeChat","searchEngines":["brave","google","duckduckgo","qwant"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'call_6xCmrOtFOyBAcqpqO1TGfw2B',
+              type: 'function',
+            },
+            {
+              function: {
+                arguments:
+                  '{"query":"LobeChat","searchEngines":["brave","google","duckduckgo","qwant"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'tool_call_nXxXHW8Z',
+              type: 'function',
+            },
+            {
+              function: {
+                arguments: '{"query":"LobeHub","searchEngines":["bilibili"]}',
+                name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+              },
+              id: 'tool_call_2f3CEKz9',
+              type: 'function',
+            },
+          ],
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'call_6xCmrOtFOyBAcqpqO1TGfw2B',
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'tool_call_nXxXHW8Z',
+        },
+        {
+          content: '[]',
+          name: 'lobe-web-browsing____searchWithSearXNG____builtin',
+          role: 'tool',
+          tool_call_id: 'tool_call_2f3CEKz9',
+        },
+        {
+          content: 'LobeHub 是一个专注于设计和开发现代人工智能生成内容（AIGC）工具和组件的团队。',
+          role: 'assistant',
+        },
+        {
+          content: '### LobeHub 智能AI聚合神器\n\nLobeHub 是一个强大的AI聚合平台',
+          role: 'assistant',
+        },
+      ]);
     });
   });
 });

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -420,7 +420,7 @@ class ChatService {
       ] as UserMessageContentPart[];
     };
 
-    const postMessages = messages.map((m): OpenAIChatMessage => {
+    let postMessages = messages.map((m): OpenAIChatMessage => {
       switch (m.role) {
         case 'user': {
           return { content: getContent(m), role: m.role };
@@ -458,7 +458,7 @@ class ChatService {
       }
     });
 
-    return produce(postMessages, (draft) => {
+    postMessages = produce(postMessages, (draft) => {
       // if it's a welcome question, inject InboxGuide SystemRole
       const inboxGuideSystemRole =
         options?.isWelcomeQuestion &&
@@ -492,6 +492,8 @@ class ChatService {
         });
       }
     });
+
+    return this.reorderToolMessages(postMessages);
   };
 
   private mapTrace(trace?: TracePayload, tag?: TraceTagMap): TracePayload {
@@ -522,6 +524,50 @@ class ChatService {
     const data = params.payload as ChatStreamPayload;
 
     return agentRuntime.chat(data, { signal: params.signal });
+  };
+
+  /**
+   * Reorder tool messages to ensure that tool messages are displayed in the correct order.
+   */
+  private reorderToolMessages = (messages: OpenAIChatMessage[]): OpenAIChatMessage[] => {
+    const reorderedMessages: OpenAIChatMessage[] = [];
+    const toolMessages: Record<string, OpenAIChatMessage> = {};
+
+    // 1. collect all tool messages
+    messages.forEach((message) => {
+      if (message.role === 'tool' && message.tool_call_id) {
+        toolMessages[message.tool_call_id] = message;
+      }
+    });
+
+    // 2. reorder messages
+    messages.forEach((message) => {
+      const hasPushed = reorderedMessages.some(
+        (m) => !!message.tool_call_id && m.tool_call_id === message.tool_call_id,
+      );
+
+      if (hasPushed) return;
+
+      reorderedMessages.push(message);
+
+      if (message.role === 'assistant' && message.tool_calls) {
+        message.tool_calls.forEach((toolCall) => {
+          const correspondingToolMessage = toolMessages[toolCall.id];
+          if (correspondingToolMessage) {
+            reorderedMessages.push(correspondingToolMessage);
+            // 从 toolMessages 中删除已处理的消息，避免重复
+            delete toolMessages[toolCall.id];
+          }
+        });
+      }
+    });
+
+    // 添加任何剩余的 tool 消息（以防有孤立的 tool 消息）
+    Object.values(toolMessages).forEach((message) => {
+      reorderedMessages.push(message);
+    });
+
+    return reorderedMessages;
   };
 }
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -528,6 +528,7 @@ class ChatService {
 
   /**
    * Reorder tool messages to ensure that tool messages are displayed in the correct order.
+   * see https://github.com/lobehub/lobe-chat/pull/3155
    */
   private reorderToolMessages = (messages: OpenAIChatMessage[]): OpenAIChatMessage[] => {
     const reorderedMessages: OpenAIChatMessage[] = [];
@@ -560,11 +561,6 @@ class ChatService {
           }
         });
       }
-    });
-
-    // 添加任何剩余的 tool 消息（以防有孤立的 tool 消息）
-    Object.values(toolMessages).forEach((message) => {
-      reorderedMessages.push(message);
     });
 
     return reorderedMessages;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<img width="1826" alt="image" src="https://github.com/lobehub/lobe-chat/assets/28616219/d14980f3-c5ec-4aa6-b2c4-96333df8923b">

```js
{
  code: 'None',
  message:
    "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: tool_call_CkwTEBjN, tool_call_LZeipxzM (request id: 2024070704082467692220007288555)",
  param: 'messages.[4].role',
  type: 'invalid_request_error',
};
```

由于 openai 接口规范限定， message 有几个 tools ，就要直接在它下面对应挂几个 message ，tool 中间不能留有其他类型的消息。因此先做一个临时解，在发送消息时，自动做一个 tool message 的重排，确保 assistant message 的tools 下面跟随对应的 tool message
<!-- Thank you for your Pull Request. Please provide a description above. -->


#### 📝 补充信息 | Additional Information

如果根据这个约束来看，感觉目前这个数据结构的设计可能并不合理。role=tool 的 message 可能并不应该作为独立的消息出现。考虑新增一个 tools 表，专门用于存放所有的 tool 相关字段。id 应该使用 tool_call_id ，然后 message 有一个 message_tool 的1对多关联表。

在聚合消息时直接挂载到 role= assistant 的 message 中的 tools 字段中。然后发送消息时再做一次重构，变成 role=assistant 和 role=tool 的多条消息。

这样一来可以直接解决现在调用插件时存在多条冗余消息的问题。同时应该还能简化数据库的查询数据结构。


claude 的 Tool Use: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#example-of-successful-tool-result
<!-- Add any other context about the Pull Request here. -->
