### PR TITLE
✅ test: `deps.inline` uses `server.deps.inline` instead

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,9 +24,6 @@ export default defineConfig({
       reporter: ['text', 'json', 'lcov', 'text-summary'],
       reportsDirectory: './coverage/app',
     },
-    deps: {
-      inline: ['vitest-canvas-mock'],
-    },
     environment: 'happy-dom',
     exclude: [
       '**/node_modules/**',
@@ -36,6 +33,11 @@ export default defineConfig({
       'src/server/modules/**/**',
     ],
     globals: true,
+    server: {
+      deps: {
+        inline: ['vitest-canvas-mock'],
+      },
+    },
     setupFiles: './tests/setup.ts',
   },
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
Vitest `deps.inline`已被弃用

Vitest  `deps.inline` is deprecated
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
