### PR TITLE
🔨 chore: Add packageManager pnpm@9 to fix netlify deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "author": "LobeHub <i@lobehub.com>",
   "sideEffects": false,
+  "packageManager": "pnpm@9",
   "scripts": {
     "build": "next build",
     "postbuild": "npm run build-sitemap && npm run build-migrate-db",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "author": "LobeHub <i@lobehub.com>",
   "sideEffects": false,
-  "packageManager": "pnpm@^9.0.0",
+  "packageManager": "pnpm@9.5.0",
   "scripts": {
     "build": "next build",
     "postbuild": "npm run build-sitemap && npm run build-migrate-db",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "author": "LobeHub <i@lobehub.com>",
   "sideEffects": false,
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@^9.0.0",
   "scripts": {
     "build": "next build",
     "postbuild": "npm run build-sitemap && npm run build-migrate-db",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Based on 
- https://docs.netlify.com/configure-builds/manage-dependencies/#pnpm
- https://docs.netlify.com/frameworks/next-js/runtime-v4/overview/#pnpm-support
- https://docs.netlify.com/configure-builds/available-software-at-build-time/#tools

netlify needs to know that we want to use pnpm instead of npm which gives tons of errors and fail build.

#### 📝 补充信息 | Additional Information

