### PR TITLE
✨ feat: simple example of customizing endpoint of dashscope

### DIFF
--- a/src/app/api/chat/agentRuntime.ts
+++ b/src/app/api/chat/agentRuntime.ts
@@ -159,11 +159,12 @@ const getLlmOptionsFromPayload = (provider: string, payload: JWTPayload) => {
       return { apiKey };
     }
     case ModelProvider.Qwen: {
-      const { QWEN_API_KEY } = getLLMConfig();
+      const { QWEN_API_KEY, QWEN_ENDPOINT } = getLLMConfig();
 
       const apiKey = apiKeyManager.pick(payload?.apiKey || QWEN_API_KEY);
+      const baseURL = payload?.endpoint || QWEN_ENDPOINT;
 
-      return { apiKey };
+      return { apiKey, baseURL };
     }
     case ModelProvider.Stepfun: {
       const { STEPFUN_API_KEY } = getLLMConfig();

--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -72,6 +72,7 @@ export const getLLMConfig = () => {
 
       ENABLED_QWEN: z.boolean(),
       QWEN_API_KEY: z.string().optional(),
+      QWEN_ENDPOINT: z.string().optional(),
 
       ENABLED_STEPFUN: z.boolean(),
       STEPFUN_API_KEY: z.string().optional(),
@@ -153,6 +154,7 @@ export const getLLMConfig = () => {
 
       ENABLED_QWEN: !!process.env.QWEN_API_KEY,
       QWEN_API_KEY: process.env.QWEN_API_KEY,
+      QWEN_ENDPOINT: process.env.QWEN_ENDPOINT,
 
       ENABLED_STEPFUN: !!process.env.STEPFUN_API_KEY,
       STEPFUN_API_KEY: process.env.STEPFUN_API_KEY,

--- a/src/config/modelProviders/qwen.ts
+++ b/src/config/modelProviders/qwen.ts
@@ -78,6 +78,11 @@ const Qwen: ModelProviderCard = {
   id: 'qwen',
   modelList: { showModelFetcher: true },
   name: 'Qwen',
+  proxyUrl: {
+    desc: '如果您所在的区域无法使用大陆的endpoint，请尝试切换至https://dashscope-intl.aliyuncs.com/compatible-mode/v1，但请注意，两者的API-KEY不通用，您可能需要获取国际版的API-KEY',
+    placeholder: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    title: 'Endpoint',
+  },
 };
 
 export default Qwen;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

增加`dashscope-intl.aliyuncs.com`作为qwen系列模型国际endpoint的demo。

本PR暂不计划merge，仅做说明使用。

#### 📝 补充信息 | Additional Information

* 国际站和国内站的API-KEY并不通用，需要登录aliyun国际站账号并开通Model Studio后再重新创建API-KEY；
* 国际站目前仅支持qwen-turbo/plus/max和qwen-1.5开源系列，暂时不支持VL模型；
* 理论上国内的endpoint是公网可访问的，并不要求国际用户必须通过intl访问。

如果确认在你部署的环境(注意不是lobe-chat这个应用）无法通过`https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completion`调用到模型，请贴下更详细的调用/报错信息。
