### PR TITLE
💄 style: fix the scrolling of the return result area of function calling

### DIFF
--- a/src/features/Conversation/Messages/Tool/Inspector/PluginResultJSON.tsx
+++ b/src/features/Conversation/Messages/Tool/Inspector/PluginResultJSON.tsx
@@ -15,7 +15,7 @@ const PluginResult = memo<FunctionMessageProps>(({ content }) => {
   }
 
   return (
-    <Highlighter language={'json'} style={{ maxHeight: 200, maxWidth: 800 }}>
+    <Highlighter language={'json'} style={{ maxHeight: 200, maxWidth: 800, overflow: 'scroll' }}>
       {data}
     </Highlighter>
   );


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<img width="864" alt="截屏2024-07-23 18 51 50" src="https://github.com/user-attachments/assets/e4f71f62-df25-4584-be87-11ce538e8870">

v1.6.8版本 Function Calling的”返回结果“区域不能上下滚动 截图是修复后的效果

#### 📝 补充信息 | Additional Information

无