### PR TITLE
🐛 fix: fix `UNAUTHORIZED` issue with clerk auth provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@azure/openai": "1.0.0-beta.12",
     "@cfworker/json-schema": "^1.12.8",
     "@clerk/localizations": "2.0.0",
-    "@clerk/nextjs": "^5.2.2",
+    "@clerk/nextjs": "^5.2.6",
     "@clerk/themes": "^2.1.10",
     "@google/generative-ai": "^0.14.1",
     "@icons-pack/react-simple-icons": "^9.6.0",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`@clerk/nextjs@5.2.5` 's have an issue with auth in production

After I downgrade to 5.2.4, it works as expect.

But this issue only occurs in the prod. I try with the local dev it still work correctly.

Now it turns out to be the issue of `@clerk/nextjs@5.2.5`. here is the PR that fixed it: https://github.com/clerk/javascript/pull/3789

so we need to bump the version to `5.2.6` to avoid it.
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

I have reported it to the Clerk discord: https://discord.com/channels/856971667393609759/1265363958013890593
<!-- Add any other context about the Pull Request here. -->
