### PR TITLE
🐛 fix: Avoid baseURL being an empty string, resulting in incorrect cl…

### DIFF
--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
@@ -128,8 +128,10 @@ export const LobeOpenAICompatibleFactory = <T extends Record<string, any> = any>
     private _options: ConstructorOptions<T>;
 
     constructor(options: ClientOptions & Record<string, any> = {}) {
-      const { apiKey, baseURL = DEFAULT_BASE_URL, ...res } = options;
-      this._options = options as ConstructorOptions<T>;
+      const _options = { ...options, baseURL: options.baseURL?.trim() || DEFAULT_BASE_URL };
+      const { apiKey, baseURL = DEFAULT_BASE_URL, ...res } = _options;
+      this._options = _options as ConstructorOptions<T>;
+
       if (!apiKey) throw AgentRuntimeError.createError(ErrorType?.invalidAPIKey);
 
       this.client = new OpenAI({ apiKey, baseURL, ...constructorOptions, ...res });

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -125,6 +125,10 @@ export function initializeWithClientStore(provider: string, payload: any) {
       break;
     }
     case ModelProvider.Perplexity: {
+      providerOptions = {
+        apikey: providerAuthPayload?.apiKey,
+        baseURL: providerAuthPayload?.endpoint,
+      };
       break;
     }
     case ModelProvider.Qwen: {


### PR DESCRIPTION
When baseURL="", baseURL should be set to DEFAULT_BASE_URL in client fetch
close #3307, close #3316
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
