### PR TITLE
💄 style(ui): Modify and repair UI layout

### DIFF
--- a/src/app/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/ChatHeaderTitle.tsx
+++ b/src/app/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/ChatHeaderTitle.tsx
@@ -43,7 +43,16 @@ const ChatHeaderTitle = memo(() => {
         </Flexbox>
       }
       title={
-        <div onClick={() => toggleConfig()}>
+        <div
+          onClick={() => toggleConfig()}
+          style={{
+            marginRight: '8px',
+            maxWidth: '64vw',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
           {displayTitle}
           {topicLength > 1 ? `(${topicLength + 1})` : ''}
         </div>

--- a/src/app/(main)/chat/@session/features/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/app/(main)/chat/@session/features/SessionListContent/CollapseGroup/Actions.tsx
@@ -5,6 +5,7 @@ import { MoreVertical, PencilLine, Plus, Settings2, Trash } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useSessionStore } from '@/store/session';
 
@@ -29,6 +30,8 @@ const Actions = memo<ActionsProps>(
     const { t } = useTranslation('chat');
     const { styles } = useStyles();
     const { modal, message } = App.useApp();
+
+    const isMobile = useIsMobile();
 
     const [createSession, removeSessionGroup] = useSessionStore((s) => [
       s.createSession,
@@ -123,12 +126,13 @@ const Actions = memo<ActionsProps>(
         trigger={['click']}
       >
         <ActionIcon
+          active={isMobile ? true : false}
           icon={MoreVertical}
           onClick={(e) => {
             e.stopPropagation();
           }}
           size={{ blockSize: 22, fontSize: 16 }}
-          style={{ marginRight: -8 }}
+          style={{ background: isMobile ? 'transparent' : '', marginRight: -8 }}
         />
       </Dropdown>
     );

--- a/src/app/(main)/settings/llm/components/ProviderModelList/CustomModelOption.tsx
+++ b/src/app/(main)/settings/llm/components/ProviderModelList/CustomModelOption.tsx
@@ -9,7 +9,7 @@ import { Flexbox } from 'react-layout-kit';
 import ModelIcon from '@/components/ModelIcon';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import { useUserStore } from '@/store/user';
-import { modelConfigSelectors } from '@/store/user/selectors';
+import { modelConfigSelectors, modelProviderSelectors } from '@/store/user/selectors';
 import { GlobalLLMProviderKey } from '@/types/user/settings';
 
 interface CustomModelOptionProps {
@@ -28,30 +28,34 @@ const CustomModelOption = memo<CustomModelOptionProps>(({ id, provider }) => {
       s.toggleEditingCustomModelCard,
       s.removeEnabledModels,
     ]);
+
   const modelCard = useUserStore(
     modelConfigSelectors.getCustomModelCard({ id, provider }),
     isEqual,
   );
 
+  const isEnabled = useUserStore(
+    (s) => modelProviderSelectors.getEnableModelsById(provider)(s)?.includes(id),
+    isEqual,
+  );
+
   return (
     <Flexbox align={'center'} distribution={'space-between'} gap={8} horizontal>
-      <Flexbox align={'center'} gap={8} horizontal>
+      <Flexbox align={'center'} gap={8} horizontal style={{ flex: 1, width: '70%' }}>
         <ModelIcon model={id} size={32} />
-        <Flexbox>
+        <Flexbox direction={'vertical'} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox align={'center'} gap={8} horizontal>
-            {modelCard?.displayName || id}
+            <Typography.Text ellipsis>{modelCard?.displayName || id}</Typography.Text>
             <ModelInfoTags id={id} {...modelCard} isCustom />
           </Flexbox>
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
-            <Flexbox gap={2} horizontal>
-              {id}
-              {!!modelCard?.deploymentName && (
-                <>
-                  <Icon icon={LucideArrowRight} />
-                  {modelCard?.deploymentName}
-                </>
-              )}
-            </Flexbox>
+          <Typography.Text ellipsis style={{ fontSize: 12, marginTop: '4px' }} type={'secondary'}>
+            {id}
+            {!!modelCard?.deploymentName && (
+              <>
+                <Icon icon={LucideArrowRight} />
+                {modelCard?.deploymentName}
+              </>
+            )}
           </Typography.Text>
         </Flexbox>
       </Flexbox>
@@ -83,6 +87,7 @@ const CustomModelOption = memo<CustomModelOptionProps>(({ id, provider }) => {
               type: 'warning',
             });
           }}
+          style={isEnabled ? { marginRight: '10px' } : {}}
           title={t('delete')}
         />
       </Flexbox>

--- a/src/app/(main)/settings/llm/components/ProviderModelList/ModelConfigModal/Form.tsx
+++ b/src/app/(main)/settings/llm/components/ProviderModelList/ModelConfigModal/Form.tsx
@@ -2,6 +2,7 @@ import { Checkbox, Form, FormInstance, Input } from 'antd';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { ChatModelCard } from '@/types/llm';
 
 import MaxTokenSlider from './MaxTokenSlider';
@@ -17,6 +18,8 @@ const ModelConfigForm = memo<ModelConfigFormProps>(
     const { t } = useTranslation('setting');
 
     const [formInstance] = Form.useForm();
+
+    const isMobile = useIsMobile();
 
     useEffect(() => {
       onFormInstanceReady(formInstance);
@@ -37,7 +40,7 @@ const ModelConfigForm = memo<ModelConfigFormProps>(
           initialValues={initialValues}
           labelCol={{ span: 4 }}
           style={{ marginTop: 16 }}
-          wrapperCol={{ offset: 1, span: 18 }}
+          wrapperCol={isMobile ? { span: 18 } : { offset: 1, span: 18 }}
         >
           <Form.Item
             extra={t('llm.customModelCards.modelConfig.id.extra')}

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -143,10 +143,7 @@ export const ModelItemRender = memo<ModelItemRenderProps>(({ showInfoTag = true,
     <Flexbox align={'center'} gap={32} horizontal justify={'space-between'}>
       <Flexbox align={'center'} gap={8} horizontal>
         <ModelIcon model={model.id} size={20} />
-        <Typography.Paragraph
-          ellipsis={{ expandable: 'collapsible', rows: 1 }}
-          style={{ marginBottom: 0 }}
-        >
+        <Typography.Paragraph ellipsis={false} style={{ marginBottom: 0 }}>
           {model.displayName || model.id}
         </Typography.Paragraph>
       </Flexbox>

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -1,4 +1,5 @@
 import { Icon, Tooltip } from '@lobehub/ui';
+import { Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import { Infinity, LucideEye, LucidePaperclip, ToyBrick } from 'lucide-react';
 import numeral from 'numeral';
@@ -142,7 +143,12 @@ export const ModelItemRender = memo<ModelItemRenderProps>(({ showInfoTag = true,
     <Flexbox align={'center'} gap={32} horizontal justify={'space-between'}>
       <Flexbox align={'center'} gap={8} horizontal>
         <ModelIcon model={model.id} size={20} />
-        {model.displayName || model.id}
+        <Typography.Paragraph
+          ellipsis={{ expandable: true, rows: 1, symbol: 'more' }}
+          style={{ marginBottom: 0 }}
+        >
+          {model.displayName || model.id}
+        </Typography.Paragraph>
       </Flexbox>
 
       {showInfoTag && <ModelInfoTags {...model} />}

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -144,7 +144,7 @@ export const ModelItemRender = memo<ModelItemRenderProps>(({ showInfoTag = true,
       <Flexbox align={'center'} gap={8} horizontal>
         <ModelIcon model={model.id} size={20} />
         <Typography.Paragraph
-          ellipsis={{ expandable: true, rows: 1, symbol: 'more' }}
+          ellipsis={{ expandable: 'collapsible', rows: 1 }}
           style={{ marginBottom: 0 }}
         >
           {model.displayName || model.id}

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { ModelItemRender, ProviderItemRender } from '@/components/ModelSelect';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/slices/chat';
 import { useUserStore } from '@/store/user';
@@ -49,7 +50,10 @@ const ModelSwitchPanel = memo<PropsWithChildren>(({ children }) => {
     s.updateAgentConfig,
   ]);
 
+  const isMobile = useIsMobile();
+
   const router = useRouter();
+
   const enabledList = useUserStore(modelProviderSelectors.modelProviderListForModelSelect, isEqual);
 
   const items = useMemo<ItemType[]>(() => {
@@ -102,7 +106,7 @@ const ModelSwitchPanel = memo<PropsWithChildren>(({ children }) => {
           overflowY: 'scroll',
         },
       }}
-      placement={'topLeft'}
+      placement={isMobile ? 'top' : 'topLeft'}
       trigger={['click']}
     >
       <div className={styles.tag}>{children}</div>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- 修复`助手名称`过长而导致的显示问题
- 修复模型选择中，由于`模型名称`过长导致的显示不完全
- 修复`模型ID`或`模型名称`过长，导致`设置`与`删除`按钮消失的问题
- 调整移动端的列表设置按钮显示样式
- 修改移动端的`自定义模型配置`页面
---
- Fix the display problem caused by the `Assistant Name` being too long.
- Fix the problem that the display of the `Model Name` was incomplete due to it being too long in `Model Selection`.
- Fix the problem where the `Set` and `Delete` buttons disappear when the `Model ID` or `Model Name` is too long.
- Adjust the display style of list setting button.
- Modify `custom model configuration` page on `mobile`

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information


| Before | After |
|--- | ---|
| ![BF1](https://github.com/user-attachments/assets/f5b49756-adab-43d1-be99-12f3ff8b9da5) | ![AF1](https://github.com/user-attachments/assets/a30dc4b1-8b05-40a0-9507-7b7ef666d82f) |

---

| Before | After | 
| --- | --- |
| ![BF2](https://github.com/user-attachments/assets/a801e3f6-6260-44e1-971a-638d6bf63bac) |  ![AF2](https://github.com/user-attachments/assets/2ffb7894-8b10-412c-a23f-f4f3f3efc05f) | 

---

| Before |  After |
| --- | --- |
| ![BF3](https://github.com/user-attachments/assets/a39b54ed-0cd0-446d-bee2-16888922192c) | ![AF3](https://github.com/user-attachments/assets/888069fc-0478-42ac-b1aa-7a7cd8b747dc) | 

---

| Before | After |
| --- | --- |
| ![BF4](https://github.com/user-attachments/assets/cd020fce-0ea4-445e-9f53-02f573ed35b3) |![AF4](https://github.com/user-attachments/assets/86b5e7ba-4e15-44d8-a1f7-c41d8349ac75)| 

---

| Before | After |
| --- | --- |
|![BF5](https://github.com/user-attachments/assets/6c04aecd-bd2a-476e-b0c0-9979091ac2ff)|![AF5](https://github.com/user-attachments/assets/0ad7c04d-11be-474a-91e8-e2dbb3b256ef)|
<!-- Add any other context about the Pull Request here. -->
