### PR TITLE
🐛 fix: support `PROXY_URL` in docker with proxychains-ng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,8 @@ CMD \
         host="${host_with_port%%:*}"; \
         port="${PROXY_URL##*:}"; \
         protocol="${PROXY_URL%%://*}"; \
-        nslookup=$(nslookup -q=A "$host" | tail -n +3 | grep 'Address:'); \
+        # Resolve the host to IP address, if it's a domain
+        nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
         if [ ! -z "$nslookup" ]; then \
             host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \
         fi; \
@@ -178,4 +179,4 @@ CMD \
         > "/etc/proxychains/proxychains.conf"; \
     fi; \
     # Run the server
-    ${PROXYCHAINS} node /app/server.js;
+    ${PROXYCHAINS} node "/app/server.js";

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,8 +162,8 @@ CMD \
         host="${host_with_port%%:*}"; \
         port="${PROXY_URL##*:}"; \
         protocol="${PROXY_URL%%://*}"; \
-        # Resolve the host to IP address, if it's a domain
-        if ! [[ "$host" =~ $IP_REGEX ]]; then \
+        # Resolve to IP address if the host is a domain
+        if ! [[ "$host" =~ "$IP_REGEX" ]]; then \
             nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
             if [ -n "$nslookup" ]; then \
                 host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,9 +161,12 @@ CMD \
         port="${PROXY_URL##*:}"; \
         protocol="${PROXY_URL%%://*}"; \
         # Resolve the host to IP address, if it's a domain
-        nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
-        if [ ! -z "$nslookup" ]; then \
-            host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \
+        IP_REGEX="^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$"; \
+        if ! [[ "$host" =~ $IP_REGEX ]]; then \
+            nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
+            if [ ! -z "$nslookup" ]; then \
+                host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \
+            fi; \
         fi; \
         # Generate proxychains configuration file
         printf "%s\n" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,9 @@ EXPOSE 3210/tcp
 
 CMD \
     if [ -n "$PROXY_URL" ]; then \
+        # Set proxychains command
+        PROXYCHAINS="proxychains -q"; \
+        # Parse the proxy URL
         host_with_port="${PROXY_URL#*//}"; \
         host="${host_with_port%%:*}"; \
         port="${PROXY_URL##*:}"; \
@@ -161,6 +164,7 @@ CMD \
         if [ ! -z "$nslookup" ]; then \
             host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \
         fi; \
+        # Generate proxychains configuration file
         printf "%s\n" \
             'localnet 127.0.0.0/255.0.0.0' \
             'localnet ::1/128' \
@@ -172,7 +176,6 @@ CMD \
             '[ProxyList]' \
             "$protocol $host $port" \
         > "/etc/proxychains/proxychains.conf"; \
-        proxychains -q node /app/server.js; \
-    else \
-        node /app/server.js; \
-    fi
+    fi; \
+    # Run the server
+    ${PROXYCHAINS} node /app/server.js;

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
     # Add user nextjs to run the app
     && addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs \
+    && chown -R nextjs:nodejs "/etc/proxychains" \
     && rm -rf /tmp/* /var/cache/apk/*
 
 ## Builder image, install all the dependencies and build the app

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,8 @@ ENV HOSTNAME="0.0.0.0" \
 # General Variables
 ENV ACCESS_CODE="" \
     API_KEY_SELECT_MODE="" \
+    DEFAULT_AGENT_CONFIG="" \
+    SYSTEM_AGENT="" \
     FEATURE_FLAGS="" \
     PROXY_URL=""
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,7 +165,7 @@ CMD \
         # Resolve the host to IP address, if it's a domain
         if ! [[ "$host" =~ $IP_REGEX ]]; then \
             nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
-            if [ ! -z "$nslookup" ]; then \
+            if [ -n "$nslookup" ]; then \
                 host=$(echo "$nslookup" | tail -n 1 | awk '{print $2}'); \
             fi; \
         fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ## Base image for all the stages
 FROM node:20-alpine AS base
 
+ARG USE_CN_MIRROR
+
 RUN \
     # If you want to build docker in China, build with --build-arg USE_CN_MIRROR=true
     if [ "${USE_CN_MIRROR:-false}" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN \
     # If you want to build docker in China, build with --build-arg USE_CN_MIRROR=true
     if [ "${USE_CN_MIRROR:-false}" = "true" ]; then \
         sed -i "s/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g" "/etc/apk/repositories"; \
-    fi; \
+    fi \
+    # Add proxychains-ng package & update base package
     && apk update \
     && apk add --no-cache proxychains-ng \
     && apk upgrade --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ CMD \
             '[ProxyList]' \
             "$protocol ${host%%:*} $port" \
         > "/etc/proxychains/proxychains.conf"; \
-        proxychains -q node /opt/lobechat/server.js; \
+        proxychains -q node /app/server.js; \
     else \
-        node /opt/lobechat/server.js; \
+        node /app/server.js; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN \
     # Add user nextjs to run the app
     addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs \
+    && apk update \
     && apk add --no-cache proxychains-ng \
     && apk upgrade --no-cache \
     && rm -rf /tmp/* /var/cache/apk/*
@@ -147,15 +148,16 @@ CMD \
         host="${PROXY_URL#*//}"; \
         port="${PROXY_URL##*:}"; \
         protocol="${PROXY_URL%%://*}"; \
-        printf "%s\n" 'localnet 127.0.0.0/255.0.0.0' \
-                      'localnet ::1/128' \
-                      'proxy_dns' \
-                      'remote_dns_subnet 224' \
-                      'strict_chain' \
-                      'tcp_connect_time_out 8000' \
-                      'tcp_read_time_out 15000' \
-                      '[ProxyList]' \
-                      "$protocol ${host%%:*} $port" \
+        printf "%s\n" \
+            'localnet 127.0.0.0/255.0.0.0' \
+            'localnet ::1/128' \
+            'proxy_dns' \
+            'remote_dns_subnet 224' \
+            'strict_chain' \
+            'tcp_connect_time_out 8000' \
+            'tcp_read_time_out 15000' \
+            '[ProxyList]' \
+            "$protocol ${host%%:*} $port" \
         > "/etc/proxychains/proxychains.conf"; \
         proxychains -q node /opt/lobechat/server.js; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,8 @@ EXPOSE 3210/tcp
 
 CMD \
     if [ -n "$PROXY_URL" ]; then \
+        # Set regex for IPv4
+        IP_REGEX="^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$"; \
         # Set proxychains command
         PROXYCHAINS="proxychains -q"; \
         # Parse the proxy URL
@@ -161,7 +163,6 @@ CMD \
         port="${PROXY_URL##*:}"; \
         protocol="${PROXY_URL%%://*}"; \
         # Resolve the host to IP address, if it's a domain
-        IP_REGEX="^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$"; \
         if ! [[ "$host" =~ $IP_REGEX ]]; then \
             nslookup=$(nslookup -q="A" "$host" | tail -n +3 | grep 'Address:'); \
             if [ ! -z "$nslookup" ]; then \

--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -80,6 +80,17 @@ Further reading:
 
 For specific content, please refer to the [Feature Flags](/docs/self-hosting/advanced/feature-flags) documentation.
 
+### `PROXY_URL`
+
+- Type: Optional
+- Description: Used to specify the proxy URL for connecting to external services. The value of this variable should be different in different deployment environments.
+- Default: -
+- Example: `http://127.0.0.1:7890` or `socks5://localhost:7891`
+
+<Callout type="info">
+If you're using Docker Desktop on Windows or macOS, it relies on a virtual machine. In this setup, `localhost` / `127.0.0.1` refers to the localhost of the container itself. In such cases, please try using `host.docker.internal` instead of `localhost`.
+</Callout>
+
 ## Plugin Service
 
 ### `PLUGINS_INDEX_URL`

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -76,6 +76,18 @@ LobeChat 在部署时提供了一些额外的配置项，你可以使用环境�
 
 具体的内容可以参见 [特性标志](/zh/docs/self-hosting/advanced/feature-flags) 中的说明。
 
+### `PROXY_URL`
+
+- 类型：可选
+- 描述：用于指定连接到外部服务的代理 URL。该变量的值在不同的部署环境中应该有所不同。
+- 默认值：-
+- 示例：`http://127.0.0.1:7890` 或 `socks5://localhost:7891`
+
+
+<Callout type="info">
+`Docker Desktop` 在 `Windows `和 `macOS `上走的是虚拟机方案，如果是 `localhost` / `127.0.0.1` 是走到自身容器的 `localhost`，此时请尝试用 `host.docker.internal` 替代 `localhost`
+</Callout>
+
 ## 插件服务
 
 ### `PLUGINS_INDEX_URL`

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pull": "git pull",
     "release": "semantic-release",
     "self-hosting:docker": "docker build -t lobe-chat:local .",
-    "self-hosting:docker-cn": "docker build -t lobe-chat:local --build-arg USE_NPM_CN_MIRROR=true .",
+    "self-hosting:docker-cn": "docker build -t lobe-chat:local --build-arg USE_CN_MIRROR=true .",
     "start": "next start -p 3210",
     "stylelint": "stylelint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "test": "npm run test-app && npm run test-server",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [x] 👷 build
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change
1. 以 Xray 的 Socks5 为例，配置 `PROXY_URL="socks5://127.0.0.1:7891"`
2. 增加 Alpine Package Mirror，加速构建 [TODO: 镜像源当前为 USTC，是否有必要改为其他？]
3. 重命名 `USE_NPM_CN_MIRROR` 为 `USE_CN_MIRROR`
<!-- Thank you for your Pull Request. Please provide a description above. -->

- close #2004 
- close #1936 
- close #1990 
- close #1613 
- close #1303 
- close #985 

#### 📝 补充信息 | Additional Information
![image](https://github.com/user-attachments/assets/14888394-5e82-46fc-9059-c0deb64855d5)
![image](https://github.com/user-attachments/assets/6649b66b-9d64-4a00-801c-2f77fe7b7c20)

replace: https://github.com/lobehub/lobe-chat/pull/2382
<!-- Add any other context about the Pull Request here. -->
