### PR TITLE
🐛 fix: Azure modelTag icon display（`Phi-3` & `wizardlm`）

### DIFF
--- a/src/components/ModelTag/ModelIcon.tsx
+++ b/src/components/ModelTag/ModelIcon.tsx
@@ -97,7 +97,7 @@ const ModelIcon = memo<ModelIconProps>(({ model: originModel, size = 12 }) => {
   )
     return <Stability size={size} />;
 
-  if (model.includes('phi3') || model.includes('phi-3') || model.includes('wizardlm')) return <Azure.Avatar size={size} />;
+  if (model.includes('phi3') || model.includes('phi-3') || model.includes('wizardlm')) return <Azure size={size} />;
   if (model.includes('firefly')) return <AdobeFirefly size={size} />;
   if (model.includes('jamba') || model.includes('j2-')) return <Ai21 size={size} />;
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
从 #3382 引入了这个 BUG，当时改的时候没注意...

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
Before
![image](https://github.com/user-attachments/assets/a193217b-1d12-4b90-b70b-d351d91c0b49)

After
![image](https://github.com/user-attachments/assets/491c8aef-e80d-4542-974d-a837eec4cf47)

<!-- Add any other context about the Pull Request here. -->
