### PR TITLE
💄 style: Skip NextAuth login page if only one sso provider exists

### DIFF
--- a/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -40,6 +40,8 @@ const StoreInitialization = memo(() => {
   const useUserStoreUpdater = createStoreUpdater(useUserStore);
   const enableNextAuth = useServerConfigStore(serverConfigSelectors.enabledOAuthSSO);
   useUserStoreUpdater('enabledNextAuth', enableNextAuth);
+  const oAuthSSOProviders = useServerConfigStore(serverConfigSelectors.oAuthSSOProviders);
+  useUserStoreUpdater('oAuthSSOProviders', oAuthSSOProviders);
 
   /**
    * The store function of `isLogin` will both consider the values of `enableAuth` and `isSignedIn`.

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -1,4 +1,5 @@
 import { appEnv, getAppConfig } from '@/config/app';
+import { authEnv } from '@/config/auth';
 import { fileEnv } from '@/config/file';
 import { langfuseEnv } from '@/config/langfuse';
 import { getLLMConfig } from '@/config/llm';
@@ -126,6 +127,7 @@ export const getServerGlobalConfig = () => {
       zeroone: { enabled: ENABLED_ZEROONE },
       zhipu: { enabled: ENABLED_ZHIPU },
     },
+    oAuthSSOProviders: authEnv.NEXT_AUTH_SSO_PROVIDERS.trim().split(/[,，]/),
     systemAgent: parseSystemAgent(appEnv.SYSTEM_AGENT),
     telemetry: {
       langfuse: langfuseEnv.ENABLE_LANGFUSE,

--- a/src/store/serverConfig/selectors.ts
+++ b/src/store/serverConfig/selectors.ts
@@ -11,4 +11,5 @@ export const serverConfigSelectors = {
   enabledOAuthSSO: (s: ServerConfigStore) => s.serverConfig.enabledOAuthSSO,
   enabledTelemetryChat: (s: ServerConfigStore) => s.serverConfig.telemetry.langfuse || false,
   isMobile: (s: ServerConfigStore) => s.isMobile || false,
+  oAuthSSOProviders: (s: ServerConfigStore) => s.serverConfig.oAuthSSOProviders,
 };

--- a/src/store/user/slices/auth/action.ts
+++ b/src/store/user/slices/auth/action.ts
@@ -49,6 +49,12 @@ export const createAuthSlice: StateCreator<
     const enableNextAuth = get().enabledNextAuth;
     if (enableNextAuth) {
       const { signIn } = await import('next-auth/react');
+      // Check if only one provider is available
+      const providers = get()?.oAuthSSOProviders;
+      if (providers && providers.length === 1) {
+        signIn(providers[0]);
+        return;
+      }
       signIn();
     }
   },

--- a/src/store/user/slices/auth/initialState.ts
+++ b/src/store/user/slices/auth/initialState.ts
@@ -17,11 +17,12 @@ export interface UserAuthState {
   clerkSignOut?: SignOut;
   clerkUser?: UserResource;
   enabledNextAuth?: boolean;
-
   isLoaded?: boolean;
+
   isSignedIn?: boolean;
   nextSession?: Session;
   nextUser?: User;
+  oAuthSSOProviders?: string[];
   user?: LobeUser;
 }
 

--- a/src/types/serverConfig.ts
+++ b/src/types/serverConfig.ts
@@ -25,6 +25,7 @@ export interface GlobalServerConfig {
   enabledAccessCode?: boolean;
   enabledOAuthSSO?: boolean;
   languageModel?: ServerLanguageModel;
+  oAuthSSOProviders?: string[];
   systemAgent?: DeepPartial<UserSystemAgentConfig>;
   telemetry: {
     langfuse?: boolean;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- ✨ `src/types/serverConfig.tssrc/types/serverConfig.ts`: 增加变量类型定义：`oAuthSSOProviders?: string[]` ，表示当前nextauth启用的Providers；
- ✨ `src/server/globalConfig/index.ts`: 为上述变量定义初始值；
- ✨`src/store/serverConfig/selectors.ts`: 为上述变量增加selector；
- ✨ `src/store/user/slices/auth/initialState.ts`: 在客户端`UserStore`中增加对应类型定义；
- ✨ `src/layout/GlobalProvider/StoreInitialization.tsx`: 初始化store时将上述服务端变量赋值到客户端对应变量；
- ✨ `src/store/user/slices/auth/action.ts`: 使用NextAuth登录时，若只有一个 provider ，则跳过 sso 选择页面；

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

需求
fix #1913 
<!-- Add any other context about the Pull Request here. -->
