### PR TITLE
🐛 fix: session not found error on mobile

### DIFF
--- a/src/app/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/index.tsx
+++ b/src/app/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/index.tsx
@@ -4,6 +4,7 @@ import { MobileNavBar } from '@lobehub/ui';
 import { memo, useState } from 'react';
 
 import { useInitAgentConfig } from '@/app/(main)/chat/(workspace)/_layout/useInitAgentConfig';
+import { INBOX_SESSION_ID } from '@/const/session';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
@@ -21,7 +22,9 @@ const MobileHeader = memo(() => {
   return (
     <MobileNavBar
       center={<ChatHeaderTitle />}
-      onBackClick={() => router.push('/chat', { query: { session: '' }, replace: true })}
+      onBackClick={() =>
+        router.push('/chat', { query: { session: INBOX_SESSION_ID }, replace: true })
+      }
       right={
         <>
           <ShareButton mobile open={open} setOpen={setOpen} />


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

This PR sets the default session value to `@/const/session/INBOX_SESSION_ID ` on `MobileNavBar` back click handler to prevent empty session value being added to query string as empty value will invoke `server/routers/lambda/session/getSessionConfig` with empty string leading to `Error: Session not found` from database.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

Closes: #3427 

<!-- Add any other context about the Pull Request here. -->
