### PR TITLE
💄 style: resize the image size in chat message

### DIFF
--- a/src/components/GalleyGrid/index.tsx
+++ b/src/components/GalleyGrid/index.tsx
@@ -32,7 +32,7 @@ const GalleyGrid = memo<GalleyGridProps>(({ items, renderItem: Render }) => {
   const { gap, max } = useMemo(
     () => ({
       gap: mobile ? 4 : 6,
-      max: mobile ? MAX_SIZE_MOBILE : MAX_SIZE_DESKTOP,
+      max: (mobile ? MAX_SIZE_MOBILE : MAX_SIZE_DESKTOP) * firstRow.length,
     }),
     [mobile],
   );

--- a/src/components/GalleyGrid/style.ts
+++ b/src/components/GalleyGrid/style.ts
@@ -1,8 +1,8 @@
 import { createStyles } from 'antd-style';
 
 export const MIN_IMAGE_SIZE = 64;
-export const MAX_SIZE_DESKTOP = 640;
-export const MAX_SIZE_MOBILE = 280;
+export const MAX_SIZE_DESKTOP = 200;
+export const MAX_SIZE_MOBILE = 90;
 export const useStyles = createStyles(
   ({ css }, { col, gap, max, min }: { col: number; gap: number; max: number; min: number }) => ({
     container: css`


### PR DESCRIPTION
修改聊天界面图片展示大小，1张图片时默认200宽度，2张400，3张600，最多到600，避免图片占太大位置，看聊天信息很不方便。如果要看图片，直接查看大图就可以了。

修改前：
![image](https://github.com/user-attachments/assets/55d44efc-4d6f-4912-88c1-4b045c831b8d)

修改后：
![image](https://github.com/user-attachments/assets/b256e37e-e3ab-47ff-a001-ab5382dc42bf)


#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

- close #2132

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
