### PR TITLE
 ✨ feat: Supports Authelia login

### DIFF
--- a/docs/self-hosting/advanced/auth/next-auth/authelia.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/authelia.mdx
@@ -1,0 +1,76 @@
+---
+title: Configuring Authelia Authentication Service for LobeChat
+description: >-
+  Learn how to configure Authelia authentication service in LobeChat, including
+  creating a provider, configuring environment variables, and deploying
+  LobeChat. Detailed steps and necessary environment variable settings.
+tags:
+  - Authelia Configuration
+  - Single Sign-On (SSO)
+  - LobeChat Authentication
+  - Environment Variables
+  - Deployment Instructions
+---
+
+## Configuring Authelia Authentication Service
+
+## Authelia Configuration Flow
+
+<Steps>
+### Create an Authelia Identity Provider
+
+We assume you are already familiar with using Authelia. Let's say your LobeChat instance is deployed at https://lobe.example.com/.
+Note that currently only localhost supports HTTP access; other domains need to enable TLS, otherwise Authelia will actively interrupt authentication by default.
+
+Now, let's open and edit the configuration file of your Authelia instance:
+
+Add a new lobe-chat item under identity_providers -> oidc:
+
+```yaml
+identity_providers:
+  oidc:
+    ...
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    - id: lobe-chat
+      description: LobeChat
+      secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+      public: false
+      authorization_policy: two_factor
+      redirect_uris:
+        - https://chat.example.com/api/auth/callback/authelia
+      scopes:
+        - openid
+        - profile
+        - email
+      userinfo_signing_algorithm: none
+```
+
+Make sure to replace secret and redirect_urls with your own values.
+Note! The secret configured in Authelia is ciphertext, i.e., a salted hash value. Its corresponding plaintext needs to be filled in LobeChat later.
+
+Save the configuration file and restart the Authelia service. Now we have completed the Authelia configuration.
+
+### Configure Environment Variables
+
+When deploying LobeChat, you need to configure the following environment variables:
+
+| Environment Variable | Type | Description |
+| --- | --- | --- |
+| `NEXT_AUTH_SECRET` | Required | The secret used to encrypt Auth.js session tokens. You can generate a secret using the following command: `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | Required | Select the SSO provider for LoboChat. Use `authentik` for Authentik. |
+| `AUTHELIA_CLIENT_ID` | Required | The id just configured in Authelia, example value is lobe-chat |
+| `AUTHELIA_CLIENT_SECRET` | The plaintext corresponding to the secret just configured in Authelia, example value is insecure_secret |
+| `AUTHELIA_ISSUER` | Required | Your Authelia URL, for example https://sso.example.com |
+| `ACCESS_CODE` | Required | Add a password to access this service. You can set a sufficiently long random password to "disable" access code authorization |
+| `NEXTAUTH_URL` | Optional | This URL is used to specify the callback address for Auth.js when performing OAuth verification. It only needs to be set when the default generated redirect address is incorrect. https://chat.example.com/api/auth |
+
+<Callout type={'tip'}>
+  Go to  [📘 Environment Variables](/docs/self-hosting/environment-variable#Authelia) for details about the variables.
+</Callout>
+</Steps>
+
+<Callout type={'info'}>
+  After a successful deployment, users will be able to use LobeChat by authenticating with the users
+  configured in Authelia.
+</Callout>

--- a/docs/self-hosting/advanced/auth/next-auth/authelia.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/authelia.mdx
@@ -62,7 +62,6 @@ When deploying LobeChat, you need to configure the following environment variabl
 | `AUTHELIA_CLIENT_ID` | Required | The id just configured in Authelia, example value is lobe-chat |
 | `AUTHELIA_CLIENT_SECRET` | The plaintext corresponding to the secret just configured in Authelia, example value is insecure_secret |
 | `AUTHELIA_ISSUER` | Required | Your Authelia URL, for example https://sso.example.com |
-| `ACCESS_CODE` | Required | Add a password to access this service. You can set a sufficiently long random password to "disable" access code authorization |
 | `NEXTAUTH_URL` | Optional | This URL is used to specify the callback address for Auth.js when performing OAuth verification. It only needs to be set when the default generated redirect address is incorrect. https://chat.example.com/api/auth |
 
 <Callout type={'tip'}>

--- a/docs/self-hosting/advanced/auth/next-auth/authelia.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/authelia.zh-CN.mdx
@@ -60,8 +60,7 @@ identity_providers:
 | `AUTHELIA_CLIENT_ID` | 必选 | 刚刚在 Authelia 配置的 `id`，示例值是 `lobe-chat` |
 | `AUTHELIA_CLIENT_SECRET` | 必选 | 刚刚在 Authelia 配置的 `secret` 对应的明文，示例值是 `insecure_secret` |
 | `AUTHELIA_ISSUER` | 必选 |您的 Authelia 的网址，例如 `https://sso.example.com` |
-| `ACCESS_CODE` | 必选 | 添加访问此服务的密码，你可以设置一个足够长的随机密码以 “禁用” 访问码授权 |
-| `AUTH_URL` | 可选 | 该 URL 用于指定 Auth.js 在执行 OAuth 验证时的回调地址，当默认生成的重定向地址发生不正确时才需要设置。`https://chat.example.com/api/auth` |
+| `NEXTAUTH_URL` | 可选 | 该 URL 用于指定 Auth.js 在执行 OAuth 验证时的回调地址，当默认生成的重定向地址发生不正确时才需要设置。`https://chat.example.com/api/auth` |
 
   <Callout type={'tip'}>
     前往 [📘 环境变量](/docs/self-hosting/environment-variable#Authelia) 可查阅相关变量详情。

--- a/docs/self-hosting/advanced/auth/next-auth/authelia.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/authelia.zh-CN.mdx
@@ -1,0 +1,74 @@
+---
+title: 在 LobeChat 中配置 Authelia 身份验证服务
+description: 学习如何在 LobeChat 中配置 Authelia 身份验证服务，包括创建提供程序、配置环境变量和部署 LobeChat。详细步骤和必要环境变量设置。
+tags:
+  - Authelia
+  - 身份验证
+  - 单点登录
+  - 环境变量
+  - LobeChat
+---
+
+# 配置 Authelia 身份验证服务
+
+## Authelia 配置流程
+
+<Steps>
+### 创建 Authelia 提供应用
+
+我们现在默认您已经了解了如何使用 Authelia。假设您的 LobeChat 实例部署在 `https://lobe.example.com/` 中。
+注意，目前只有 `localhost` 支持 HTTP 访问，其他域名需要启用 TLS，否则 Authelia 默认将主动中断身份认证。
+
+现在，我们打开 Authelia 实例的配置文件进行编辑：
+
+在 `identity_providers`-> `oidc` 下新增一个 `lobe-chat` 的项目：
+
+```yaml
+...
+identity_providers:
+  oidc:
+    ...
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    - id: lobe-chat
+      description: LobeChat
+      secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+      public: false
+      authorization_policy: two_factor
+      redirect_uris:
+        - https://chat.example.com/api/auth/callback/authelia
+      scopes:
+        - openid
+        - profile
+        - email
+      userinfo_signing_algorithm: none
+```
+
+请您确保 `secret` 和 `redirect_urls` 替换成您自己的值。
+注意！Authelia 中配置 `secret` 是密文，即加盐哈希值。其对应的明文稍后需要填写在 lobeChat 中。
+
+保存配置文件，然后重启 Authelia 服务。现在我们完成了 Authelia 的配置工作。
+
+### 配置环境变量
+
+在部署 LobeChat 时，你需要配置以下环境变量：
+
+| 环境变量 | 类型 | 描述 |
+| --- | --- | --- |
+| `NEXT_AUTH_SECRET` | 必选 | 用于加密 Auth.js 会话令牌的密钥。您可以使用以下命令生成秘钥： `openssl rand -base64 32` |
+| `NEXT_AUTH_SSO_PROVIDERS` | 必选 | 选择 LoboChat 的单点登录提供商。使用 Authelia 请填写 `authelia`。 |
+| `AUTHELIA_CLIENT_ID` | 必选 | 刚刚在 Authelia 配置的 `id`，示例值是 `lobe-chat` |
+| `AUTHELIA_CLIENT_SECRET` | 必选 | 刚刚在 Authelia 配置的 `secret` 对应的明文，示例值是 `insecure_secret` |
+| `AUTHELIA_ISSUER` | 必选 |您的 Authelia 的网址，例如 `https://sso.example.com` |
+| `ACCESS_CODE` | 必选 | 添加访问此服务的密码，你可以设置一个足够长的随机密码以 “禁用” 访问码授权 |
+| `AUTH_URL` | 可选 | 该 URL 用于指定 Auth.js 在执行 OAuth 验证时的回调地址，当默认生成的重定向地址发生不正确时才需要设置。`https://chat.example.com/api/auth` |
+
+  <Callout type={'tip'}>
+    前往 [📘 环境变量](/docs/self-hosting/environment-variable#Authelia) 可查阅相关变量详情。
+
+</Callout>
+</Steps>
+
+<Callout type={'info'}>
+  部署成功后，用户将可以使用 Authelia 中配置的用户通过身份认证并使用 LobeChat。
+</Callout>

--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -109,6 +109,29 @@ LobeChat provides a complete authentication service capability when deployed. Th
 - Default: `-`
 - Example: `https://your-authentik-domain.com/application/o/slug/`
 
+### Authelia
+
+#### `AUTHELIA_CLIENT_ID`
+
+- Type: Required
+- Description: Client ID of the Authelia provider application. You can access it [here][auth0-client-page] and navigate to the application settings to view.
+- Default: `-`
+- Example: `lobe-chat`
+
+#### `AUTHELIA_CLIENT_SECRET`
+
+- Type: Required
+- Description: The plaintext of the Client Secret for the Authelia provider
+- Default: `-`
+- Example: `insecure_secret`
+
+#### `AUTHELIA_ISSUER`
+
+- Type: Required
+- Description: Issuer of the Authelia provider application.
+- Default: `-`
+- Example: `https://sso.example.com`
+
 ### Github
 
 #### `GITHUB_CLIENT_ID`

--- a/docs/self-hosting/environment-variables/auth.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/auth.zh-CN.mdx
@@ -107,6 +107,29 @@ LobeChat 在部署时提供了完善的身份验证服务能力，以下是相�
 - 默认值: `-`
 - 示例: `https://your-authentik-domain.com/application/o/slug/`
 
+### Authelia
+
+#### `AUTHELIA_CLIENT_ID`
+
+- 类型：必选
+- 描述: Authelia 提供程序的 Client ID
+- 默认值: `-`
+- 示例: `lobe-chat`
+
+#### `AUTHELIA_CLIENT_SECRET`
+
+- 类型：必选
+- 描述: Authelia 提供程序的 Client Secret 的明文
+- 默认值: `-`
+- 示例: `insecure_secret`
+
+#### `AUTHELIA_ISSUER`
+
+- 类型：必选
+- 描述: Authentik 提供程序的 OpenID Connect 颁发者
+- 默认值: `-`
+- 示例: `https://sso.example.com`
+
 ### Github
 
 #### `GITHUB_CLIENT_ID`

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -81,6 +81,11 @@ export const getAuthConfig = () => {
       AUTHENTIK_CLIENT_SECRET: z.string().optional(),
       AUTHENTIK_ISSUER: z.string().optional(),
 
+      // AUTHELIA
+      AUTHELIA_CLIENT_ID: z.string().optional(),
+      AUTHELIA_CLIENT_SECRET: z.string().optional(),
+      AUTHELIA_ISSUER: z.string().optional(),
+
       // ZITADEL
       ZITADEL_CLIENT_ID: z.string().optional(),
       ZITADEL_CLIENT_SECRET: z.string().optional(),
@@ -117,6 +122,11 @@ export const getAuthConfig = () => {
       AUTHENTIK_CLIENT_ID: process.env.AUTHENTIK_CLIENT_ID,
       AUTHENTIK_CLIENT_SECRET: process.env.AUTHENTIK_CLIENT_SECRET,
       AUTHENTIK_ISSUER: process.env.AUTHENTIK_ISSUER,
+
+      // AUTHELIA
+      AUTHELIA_CLIENT_ID: process.env.AUTHELIA_CLIENT_ID,
+      AUTHELIA_CLIENT_SECRET: process.env.AUTHELIA_CLIENT_SECRET,
+      AUTHELIA_ISSUER: process.env.AUTHELIA_ISSUER,
 
       // ZITADEL
       ZITADEL_CLIENT_ID: process.env.ZITADEL_CLIENT_ID,

--- a/src/libs/next-auth/sso-providers/authelia.ts
+++ b/src/libs/next-auth/sso-providers/authelia.ts
@@ -4,6 +4,17 @@ import { authEnv } from '@/config/auth';
 
 import { CommonProviderConfig } from './sso.config';
 
+export type AutheliaProfile = {
+  // The users display name
+  email: string; 
+  // The users email
+  groups: string[]; 
+  // The username the user used to login with
+  name: string; 
+  preferred_username: string; // The users groups
+  sub: string; // The users id
+};
+
 const provider = {
   id: 'authelia',
   provider: {
@@ -15,8 +26,15 @@ const provider = {
     id: 'authelia',
     issuer: authEnv.AUTHELIA_ISSUER,
     name: 'Authelia',
+    profile(profile) {
+      return {
+        email: profile.email,
+        name: profile.name,
+        providerAccountId: profile.sub,
+      };
+    },
     type: 'oidc',
-  } satisfies OIDCConfig<unknown>,
+  } satisfies OIDCConfig<AutheliaProfile>,
 };
 
 export default provider;

--- a/src/libs/next-auth/sso-providers/authelia.ts
+++ b/src/libs/next-auth/sso-providers/authelia.ts
@@ -14,7 +14,7 @@ const provider = {
     clientSecret: authEnv.AUTHELIA_CLIENT_SECRET,
     id: 'authelia',
     issuer: authEnv.AUTHELIA_ISSUER,
-    name: 'Authentik',
+    name: 'Authelia',
     type: 'oidc',
   } satisfies OIDCConfig<unknown>,
 };

--- a/src/libs/next-auth/sso-providers/authelia.ts
+++ b/src/libs/next-auth/sso-providers/authelia.ts
@@ -1,0 +1,22 @@
+import type { OIDCConfig } from '@auth/core/providers';
+
+import { authEnv } from '@/config/auth';
+
+import { CommonProviderConfig } from './sso.config';
+
+const provider = {
+  id: 'authelia',
+  provider: {
+    ...CommonProviderConfig,
+    authorization: { params: { scope: 'openid email profile' } },
+    checks: ['state', 'pkce'],
+    clientId: authEnv.AUTHELIA_CLIENT_ID,
+    clientSecret: authEnv.AUTHELIA_CLIENT_SECRET,
+    id: 'authelia',
+    issuer: authEnv.AUTHELIA_ISSUER,
+    name: 'Authentik',
+    type: 'oidc',
+  } satisfies OIDCConfig<unknown>,
+};
+
+export default provider;

--- a/src/libs/next-auth/sso-providers/index.ts
+++ b/src/libs/next-auth/sso-providers/index.ts
@@ -1,7 +1,8 @@
 import Auth0 from './auth0';
+import Authelia from './authelia';
 import Authentik from './authentik';
 import AzureAD from './azure-ad';
 import Github from './github';
 import Zitadel from './zitadel';
 
-export const ssoProviders = [Auth0, Authentik, AzureAD, Github, Zitadel];
+export const ssoProviders = [Auth0, Authentik, AzureAD, Github, Zitadel, Authelia];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

通过增加 next-auth 的 provider 实现了对 Authelia 的支持。

Make lobeChat support Authelia login by adding a next-auth provider.


#### 📝 补充信息 | Additional Information

Authelia 是 Authentik 的一种替代品，包括我在内，很多喜欢 self-hosted 的朋友会选择使用 Authelia 作为身份验证和授权的方案。

希望 LobeChat 能够合入这一特性。
