### PR TITLE
💄 style: add preview for image file

### DIFF
--- a/src/features/FileViewer/Renderer/Image/index.tsx
+++ b/src/features/FileViewer/Renderer/Image/index.tsx
@@ -1,0 +1,36 @@
+import { DocRenderer } from '@cyntler/react-doc-viewer';
+import { Center } from 'react-layout-kit';
+
+const ImageRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
+  const { uri, fileName } = currentDocument || {};
+
+  return (
+    <Center height={'100%'} width={'100%'}>
+      <img
+        alt={fileName}
+        height={'100%'}
+        src={uri}
+        style={{ objectFit: 'contain', overflow: 'hidden' }}
+        width={'100%'}
+      />
+    </Center>
+  );
+};
+
+export default ImageRenderer;
+
+ImageRenderer.fileTypes = [
+  'jpg',
+  'jpeg',
+  'image/jpg',
+  'image/jpeg',
+  'png',
+  'image/png',
+  'webp',
+  'image/webp',
+  'gif',
+  'image/gif',
+  'bmp',
+  'image/bmp',
+];
+ImageRenderer.weight = 0;

--- a/src/features/FileViewer/Renderer/index.ts
+++ b/src/features/FileViewer/Renderer/index.ts
@@ -1,4 +1,5 @@
+import ImageRenderer from './Image';
 import MSDocRenderer from './MSDoc';
 import TXTRenderer from './TXT';
 
-export const FileViewRenderers = [TXTRenderer, MSDocRenderer];
+export const FileViewRenderers = [TXTRenderer, ImageRenderer, MSDocRenderer];


### PR DESCRIPTION
add image file preview for File Preview

<img width="1397" alt="image" src="https://github.com/user-attachments/assets/2f533d76-b444-445b-b364-95c8d7b66689">


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs: https://github.com/cyntler/react-doc-viewer/blob/main/src/renderers/png/index.tsx

Implement Steps:

1. add a folder in `src/features/FileViewer/Renderer` named `Image`
2. create a React Compoent with `DocRenderer` type and then implement the renderer
3. set the renderer with `fileTypes` and `weight` (weight can be 0 by default)

-----

实现步骤:

1. 在 `src/features/FileViewer/Renderer` 目录下新建一个名为 `Image` 的文件夹
2. 创建一个 React 组件,类型为 `DocRenderer`,然后实现该渲染器
3. 为该渲染器设置 `fileTypes` 和 `weight` 属性(weight 默认可以设为 0)