### PR TITLE
💄 style: fix provider disabled title style

### DIFF
--- a/src/app/(main)/settings/llm/components/ProviderConfig/index.tsx
+++ b/src/app/(main)/settings/llm/components/ProviderConfig/index.tsx
@@ -266,7 +266,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
           ) : undefined}
         </Flexbox>
       ),
-      title: title ?? (
+      title: (
         <Flexbox
           align={'center'}
           className={styles.safariIconWidthFix}
@@ -277,7 +277,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
             ...(enabled ? {} : { filter: 'grayscale(100%)', maxHeight: 24, opacity: 0.66 }),
           }}
         >
-          <ProviderCombine provider={id} size={24} />
+          {title ?? <ProviderCombine provider={id} size={24} />}
         </Flexbox>
       ),
     };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

目前有个情况是，如果是自己新增的语言模型，卡片列表那边不不管模型是否启用禁用，都是一个色，把title放到Flexbox内部，当禁用时，会跟预置模型一样是灰色的，统一风格。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
