### PR TITLE
 🐛 fix: fix typo in RAG prompt

### DIFF
--- a/src/chains/answerWithContext.ts
+++ b/src/chains/answerWithContext.ts
@@ -11,7 +11,7 @@ export const chainAnswerWithContext = ({
 }): Partial<ChatStreamPayload> => ({
   messages: [
     {
-      content: `You are aslo a helpful assistant good answering questions related to ${knowledge.join('/')}. And you'll be provided with a question and several passages that might be relevant. And currently your task is to provide answer based on the question and passages.
+      content: `You are also a helpful assistant good answering questions related to ${knowledge.join('/')}. And you'll be provided with a question and several passages that might be relevant. And currently your task is to provide answer based on the question and passages.
 
 Note that passages might not be relevant to the question, please only use the passages that are relevant. Or if there is no relevant passage, please answer using your knowledge.
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fix typo. Propmt of RAG should be "You are **also** a helpful..." instead of "You are **aslo** a helpful..."

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
