### PR TITLE
📝docs: correct typo in 'openai api key' in .env example and documentation

### DIFF
--- a/docker-compose/local/.env.example
+++ b/docker-compose/local/.env.example
@@ -17,7 +17,7 @@ S3_SECRET_ACCESS_KEY=
 
 
 # Other environment variables, as needed. You can refer to the environment variables configuration for the client version, making sure not to have ACCESS_CODE.
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 

--- a/docker-compose/local/.env.zh-CN.example
+++ b/docker-compose/local/.env.zh-CN.example
@@ -17,7 +17,7 @@ S3_SECRET_ACCESS_KEY=
 # HTTPS_PROXY=http://localhost:7890
 
 # 其他环境变量，视需求而定，可以参照客户端版本的环境变量配置，注意不要有 ACCESS_CODE
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 

--- a/docker-compose/production/.env.example
+++ b/docker-compose/production/.env.example
@@ -51,6 +51,6 @@ S3_ENABLE_PATH_STYLE=1
 # See: https://lobehub.com/docs/self-hosting/environment-variables/basic
 # Note: For server versions, the API must support embedding models (OpenAI text-embedding-3-small) for file processing
 # You don't need to specify this model in OPENAI_MODEL_LIST
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...

--- a/docker-compose/production/.env.zh-CN.example
+++ b/docker-compose/production/.env.zh-CN.example
@@ -50,6 +50,6 @@ S3_ENABLE_PATH_STYLE=1
 # 其他基础环境变量，视需求而定。注意不要有 ACCESS_CODE
 # 请参考：https://lobehub.com/zh/docs/self-hosting/environment-variables/basic
 # 请注意，对于服务端版本，其 API 必须支持嵌入（即 OpenAI text-embedding-3-small）模型，否则无法对上传文件进行处理，但你无需在 OPENAI_MODEL_LIST 中指定此模型
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...

--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -365,7 +365,7 @@ S3_SECRET_ACCESS_KEY=
 # HTTPS_PROXY=http://localhost:7890
 
 # Other environment variables, as needed. You can refer to the environment variables configuration for the client version, making sure not to have ACCESS_CODE.
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 
@@ -546,7 +546,7 @@ S3_ENABLE_PATH_STYLE=1
 # See: https://lobehub.com/docs/self-hosting/environment-variables/basic
 # Note: For server versions, the API must support embedding models (OpenAI text-embedding-3-small) for file processing
 # You don't need to specify this model in OPENAI_MODEL_LIST
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -362,7 +362,7 @@ S3_SECRET_ACCESS_KEY=
 # HTTPS_PROXY=http://localhost:7890
 
 # 其他环境变量，视需求而定，可以参照客户端版本的环境变量配置，注意不要有 ACCESS_CODE
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 
@@ -542,7 +542,7 @@ S3_ENABLE_PATH_STYLE=1
 # 其他基础环境变量，视需求而定。注意不要有 ACCESS_CODE
 # 请参考：https://lobehub.com/zh/docs/self-hosting/environment-variables/basic
 # 请注意，对于服务端版本，其 API 必须支持嵌入（OpenAI text-embedding-3-small）模型，否则无法对上传文件进行处理，但你无需在 OPENAI_MODEL_LIST 中指定此模型
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 

--- a/docs/self-hosting/server-database/docker.mdx
+++ b/docs/self-hosting/server-database/docker.mdx
@@ -85,7 +85,7 @@ S3_BUCKET=lobechat
 S3_PUBLIC_DOMAIN=https://s3-for-lobechat.your-domain.com
 
 # Other environment variables, as needed. You can refer to the environment variables configuration for the client version, making sure not to have ACCESS_CODE.
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 ```

--- a/docs/self-hosting/server-database/docker.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker.zh-CN.mdx
@@ -89,7 +89,7 @@ S3_PUBLIC_DOMAIN=https://s3-for-lobechat.your-domain.com # 用于外网访问 S3
 # S3_REGION=ap-chengdu # 如果需要指定地域
 
 # 其他环境变量，视需求而定
-# OPEANAI_API_KEY=sk-xxxx
+# OPENAI_API_KEY=sk-xxxx
 # OPENAI_PROXY_URL=https://api.openai.com/v1
 # OPENAI_MODEL_LIST=...
 # ...


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
-将包含.env示例的文件和文档中OpenAI API key的拼写由“OPEAN_API_KEY”更改为“OPENAI_API_KEY”
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
