### PR TITLE
⚡️ perf: fix scrolling laggy in some chat list

### DIFF
--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -107,7 +107,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile }) => {
         computeItemKey={(_, item) => item}
         data={data}
         followOutput={getFollowOutput}
-        // increaseViewportBy={overscan}
+        increaseViewportBy={overscan}
         initialTopMostItemIndex={data?.length - 1}
         isScrolling={setIsScrolling}
         itemContent={itemContent}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

 Before 

 https://github.com/user-attachments/assets/2f010849-db26-4b7e-a439-fee474cb40d6

 After

 https://github.com/user-attachments/assets/82710127-9b94-4a5c-877a-afc6a27a5f59


<!-- Thank you for your Pull Request. Please provide a description above. -->

卡顿感由来：

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/2de8c5c5-88a9-4225-a505-521f2cc8c287">

顶上一个复杂消息块的渲染大致需要 300ms 左右，并且假设这样一个复杂消息块的渲染时间无法被消除。（理论上应该有一些优化方法可以优化复杂消息块的渲染）

卡顿感的来源就是在垂直滚动时由于消息块的渲染阻塞了界面，必须要等到渲染完毕后才能继续滚动，再未渲染完毕之前，此处的界面是完全卡死的。

对应的解决方案思路上比较简单，既然是因为本身消息块的渲染比较慢，那么将其提前渲染即可。

在 `Virtuoso` 中有一个 props 叫 `increaseViewportBy`，它扩展渲染的视窗，进而提升实际渲染的数据量。

默认情况下渲染的视窗是只有可见区域，这就会导致只要一个组件移出了视窗就会直接被卸载，那这其实就会带来额外的渲染负担。

#### 📝 补充信息 | Additional Information


补充： Claude 3.5-sonnet 针对 `increaseViewportBy` 和 `overscan` 两个参数的解释：

作为前端专家，我很高兴为你详细解析 increaseViewportBy 和 overscan 这两个参数的区别。虽然这两个参数看起来功能相似，但它们在实现和使用场景上有一些重要的区别。让我们深入比较：

1. 目的和功能

increaseViewportBy:
- 主要目的是扩大虚拟的"视口"大小。
- 适用于提前渲染视口外的内容，特别有助于处理加载较慢的内容。
- 可以改善用户体验，尤其是在滚动到新内容时减少白屏时间。

overscan:
- 主要目的是优化滚动性能。
- 通过"分块"渲染新项目来减少滚动时的重新渲染次数。
- 更侧重于提高滚动的流畅度和响应性。

2. 配置方式

increaseViewportBy:
- 可以设置为单一数值，均匀增加顶部和底部的视口大小。
- 也可以设置为对象 `{ top: number, bottom: number }`，分别控制顶部和底部。

overscan:
- 可以设置为单一数值，在主滚动方向增加渲染区域。
- 也可以设置为对象 `{ main: number, reverse: number }`，分别控制主滚动方向和反向。

3. 渲染行为

increaseViewportBy:
- 直接增加渲染区域的大小，无论是否正在滚动。
- 渲染的额外内容始终保持在指定的像素范围内。

overscan:
- 在滚动过程中动态调整渲染区域。
- 可能会根据滚动速度和方向动态调整渲染的内容量。

4. 性能影响

increaseViewportBy:
- 可能会导致更多的初始渲染，因为它始终保持额外的渲染区域。
- 对于变高度项目或复杂布局可能更有效。

overscan:
- 可能在快速滚动时提供更好的性能，因为它专注于优化滚动行为。
- 对于固定高度项目可能更有效。

5. 使用场景

increaseViewportBy:
- 适合需要预加载内容的场景，如图片加载或数据预取。
- 对于变高度项目列表或复杂布局更有优势。

overscan:
- 适合需要高性能滚动的场景，特别是在处理大量数据时。
- 对于固定高度项目或简单布局可能更有效。

6. 与其他虚拟滚动库的兼容性

increaseViewportBy:
- 在概念上类似于其他一些虚拟滚动库（如 react-window）中的 overscan 概念。

overscan:
- 在 Virtuoso 中的实现方式独特，专注于优化滚动性能。

总结：
虽然这两个参数都可以用来扩展渲染区域，但它们的设计初衷和优化重点是不同的。increaseViewportBy 更侧重于提前渲染和内容预加载，而 overscan 更专注于优化滚动性能。在实际应用中，你可能需要根据具体的需求场景来选择使用哪个参数，或者在某些情况下同时使用两者以获得最佳效果。

<!-- Add any other context about the Pull Request here. -->


cc @sxjeru ， 上次的一个疑问有了解答