### PR TITLE
🐛 fix: Baichuan should not introduce freequency_penality parameters

### DIFF
--- a/src/libs/agent-runtime/baichuan/index.ts
+++ b/src/libs/agent-runtime/baichuan/index.ts
@@ -7,7 +7,7 @@ export const LobeBaichuanAI = LobeOpenAICompatibleFactory({
   baseURL: 'https://api.baichuan-ai.com/v1',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload) => {
-      const { frequency_penalty, temperature, ...rest } = payload;
+      const { temperature, ...rest } = payload;
 
       return { 
         ...rest, 

--- a/src/libs/agent-runtime/baichuan/index.ts
+++ b/src/libs/agent-runtime/baichuan/index.ts
@@ -7,10 +7,12 @@ export const LobeBaichuanAI = LobeOpenAICompatibleFactory({
   baseURL: 'https://api.baichuan-ai.com/v1',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload) => {
-      const { temperature, ...rest } = payload;
+      const { frequency_penalty, temperature, ...rest } = payload;
 
       return { 
         ...rest, 
+        // [baichuan] frequency_penalty must be between 1 and 2.
+        frequency_penalty: undefined,
         temperature: 
           temperature !== undefined 
           ? temperature / 2


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

`# [baichuan] frequency_penalty must be between 1 and 2.`

先尝试去掉 freequency_penality 的默认值（lobechat 默认为 0），看能否修复。
根据文档，不应该在此接口使用该参数。

fix #3356 

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
