### PR TITLE
♻️ refactor: change empty content stream behavior

### DIFF
--- a/src/libs/agent-runtime/utils/streams/openai.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.ts
@@ -56,6 +56,13 @@ export const transformOpenAIStream = (
 
     // 给定结束原因
     if (item.finish_reason) {
+      // one-api 的流式接口，会出现既有 finish_reason ，也有 content 的情况
+      //  {"id":"demo","model":"deepl-en","choices":[{"index":0,"delta":{"role":"assistant","content":"Introduce yourself."},"finish_reason":"stop"}]}
+
+      if (typeof item.delta?.content === 'string' && !!item.delta.content) {
+        return { data: item.delta.content, id: chunk.id, type: 'text' };
+      }
+
       return { data: item.finish_reason, id: chunk.id, type: 'stop' };
     }
 

--- a/src/libs/agent-runtime/utils/streams/openai.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.ts
@@ -27,10 +27,6 @@ export const transformOpenAIStream = (
       return { data: chunk, id: chunk.id, type: 'data' };
     }
 
-    if (typeof item.delta?.content === 'string' && !item.finish_reason && !item.delta?.tool_calls) {
-      return { data: item.delta.content, id: chunk.id, type: 'text' };
-    }
-
     if (item.delta?.tool_calls) {
       return {
         data: item.delta.tool_calls.map((value, index): StreamToolCallChunkData => {
@@ -61,6 +57,10 @@ export const transformOpenAIStream = (
     // 给定结束原因
     if (item.finish_reason) {
       return { data: item.finish_reason, id: chunk.id, type: 'stop' };
+    }
+
+    if (typeof item.delta?.content === 'string') {
+      return { data: item.delta.content, id: chunk.id, type: 'text' };
     }
 
     if (item.delta?.content === null) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

从 #3392 中拆分，Stream 流中 `content` 为空的处理行为

情况如下：
当 `tool_calls` 存在，但 `content` 为空字符串，引起 UI 对话界面显示空，但无报错
![image](https://github.com/user-attachments/assets/ee45ab61-f254-43be-9c44-120294eb1dec)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

```
{"choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"3NcHNntdRyaHu8zisKJAhQ","function":{"name":"realtime-weather____fetchCurrentWeather","arguments":"{\"city\": \"Singapore\"}"}}]},"stop_reason":"tool_calls"}]}
```

<!-- Add any other context about the Pull Request here. -->
