### PR TITLE
🐛 fix: add `LLM_VISION_IMAGE_USE_BASE64` to support local s3 in vision model

### DIFF
--- a/src/config/modelProviders/stepfun.ts
+++ b/src/config/modelProviders/stepfun.ts
@@ -61,6 +61,10 @@ const Stepfun: ModelProviderCard = {
   id: 'stepfun',
   modelList: { showModelFetcher: true },
   name: '阶跃星辰',
+  smoothing: {
+    speed: 2,
+    text: true,
+  },
 };
 
 export default Stepfun;

--- a/src/libs/agent-runtime/google/index.test.ts
+++ b/src/libs/agent-runtime/google/index.test.ts
@@ -309,7 +309,10 @@ describe('LobeGoogleAI', () => {
         const mockBase64 = 'mockBase64Data';
 
         // Mock the imageUrlToBase64 function
-        vi.spyOn(imageToBase64Module, 'imageUrlToBase64').mockResolvedValueOnce(mockBase64);
+        vi.spyOn(imageToBase64Module, 'imageUrlToBase64').mockResolvedValueOnce({
+          base64: mockBase64,
+          mimeType: 'image/png',
+        });
 
         const result = await instance['convertContentToGooglePart']({
           type: 'image_url',

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -133,12 +133,12 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         }
 
         if (type === 'url') {
-          const base64Image = await imageUrlToBase64(content.image_url.url);
+          const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
 
           return {
             inlineData: {
-              data: base64Image,
-              mimeType: mimeType || 'image/png',
+              data: base64,
+              mimeType,
             },
           };
         }

--- a/src/libs/agent-runtime/utils/anthropicHelpers.test.ts
+++ b/src/libs/agent-runtime/utils/anthropicHelpers.test.ts
@@ -53,7 +53,10 @@ describe('anthropicHelpers', () => {
         base64: null,
         type: 'url',
       });
-      vi.mocked(imageUrlToBase64).mockResolvedValue('convertedBase64String');
+      vi.mocked(imageUrlToBase64).mockResolvedValue({
+        base64: 'convertedBase64String',
+        mimeType: 'image/jpg',
+      });
 
       const content = {
         type: 'image_url',
@@ -67,7 +70,7 @@ describe('anthropicHelpers', () => {
       expect(result).toEqual({
         source: {
           data: 'convertedBase64String',
-          media_type: 'image/png',
+          media_type: 'image/jpg',
           type: 'base64',
         },
         type: 'image',
@@ -80,7 +83,10 @@ describe('anthropicHelpers', () => {
         base64: null,
         type: 'url',
       });
-      vi.mocked(imageUrlToBase64).mockResolvedValue('convertedBase64String');
+      vi.mocked(imageUrlToBase64).mockResolvedValue({
+        base64: 'convertedBase64String',
+        mimeType: 'image/png',
+      });
 
       const content = {
         type: 'image_url',

--- a/src/libs/agent-runtime/utils/anthropicHelpers.ts
+++ b/src/libs/agent-runtime/utils/anthropicHelpers.ts
@@ -28,11 +28,11 @@ export const buildAnthropicBlock = async (
         };
 
       if (type === 'url') {
-        const base64 = await imageUrlToBase64(content.image_url.url);
+        const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
         return {
           source: {
             data: base64 as string,
-            media_type: (mimeType as Anthropic.ImageBlockParam.Source['media_type']) || 'image/png',
+            media_type: mimeType as Anthropic.ImageBlockParam.Source['media_type'],
             type: 'base64',
           },
           type: 'image',

--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.test.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.test.ts
@@ -524,22 +524,31 @@ describe('LobeOpenAICompatibleFactory', () => {
               }) as any,
           );
 
-        const chatPromise = instance
-          .chat(
-            {
-              messages: [{ content: 'Hello', role: 'user' }],
-              model: 'mistralai/mistral-7b-instruct:free',
-              temperature: 0,
-            },
-            { signal: controller.signal },
-          )
-          .catch();
+        const chatPromise = instance.chat(
+          {
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: 'mistralai/mistral-7b-instruct:free',
+            temperature: 0,
+          },
+          { signal: controller.signal },
+        );
 
         // 给一些时间让请求开始
         await sleep(50);
 
         controller.abort();
 
+        // 等待并断言 Promise 被拒绝
+        // 使用 try-catch 来捕获和验证错误
+        try {
+          await chatPromise;
+          // 如果 Promise 没有被拒绝，测试应该失败
+          expect.fail('Expected promise to be rejected');
+        } catch (error) {
+          expect((error as any).errorType).toBe('AgentRuntimeError');
+          expect((error as any).error.name).toBe('AbortError');
+          expect((error as any).error.message).toBe('The user aborted a request.');
+        }
         expect(mockCreateMethod).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({

--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.test.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.test.ts
@@ -524,14 +524,16 @@ describe('LobeOpenAICompatibleFactory', () => {
               }) as any,
           );
 
-        const chatPromise = instance.chat(
-          {
-            messages: [{ content: 'Hello', role: 'user' }],
-            model: 'mistralai/mistral-7b-instruct:free',
-            temperature: 0,
-          },
-          { signal: controller.signal },
-        );
+        const chatPromise = instance
+          .chat(
+            {
+              messages: [{ content: 'Hello', role: 'user' }],
+              model: 'mistralai/mistral-7b-instruct:free',
+              temperature: 0,
+            },
+            { signal: controller.signal },
+          )
+          .catch();
 
         // 给一些时间让请求开始
         await sleep(50);

--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
@@ -2,9 +2,6 @@ import OpenAI, { ClientOptions } from 'openai';
 
 import { LOBE_DEFAULT_MODEL_LIST } from '@/config/modelProviders';
 import { TextToImagePayload } from '@/libs/agent-runtime/types/textToImage';
-import {
-  convertOpenAIMessages,
-} from '@/libs/agent-runtime/utils/openaiHelpers';
 import { ChatModelCard } from '@/types/llm';
 
 import { LobeRuntimeAI } from '../../BaseAI';
@@ -23,6 +20,7 @@ import { desensitizeUrl } from '../desensitizeUrl';
 import { handleOpenAIError } from '../handleOpenAIError';
 import { StreamingResponse } from '../response';
 import { OpenAIStream } from '../streams';
+import { convertOpenAIMessages } from '../openaiHelpers';
 
 // the model contains the following keywords is not a chat model, so we should filter them out
 const CHAT_MODELS_BLOCK_LIST = [

--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
@@ -2,9 +2,10 @@ import OpenAI, { ClientOptions } from 'openai';
 
 import { LOBE_DEFAULT_MODEL_LIST } from '@/config/modelProviders';
 import { TextToImagePayload } from '@/libs/agent-runtime/types/textToImage';
-import { parseDataUri } from '@/libs/agent-runtime/utils/uriParser';
+import {
+  convertOpenAIMessages,
+} from '@/libs/agent-runtime/utils/openaiHelpers';
 import { ChatModelCard } from '@/types/llm';
-import { imageUrlToBase64 } from '@/utils/imageToBase64';
 
 import { LobeRuntimeAI } from '../../BaseAI';
 import { AgentRuntimeErrorType, ILobeAgentRuntimeErrorType } from '../../error';
@@ -151,25 +152,6 @@ export const LobeOpenAICompatibleFactory = <T extends Record<string, any> = any>
       this.baseURL = this.client.baseURL;
     }
 
-    private async convertMessageContent(
-      content: OpenAI.ChatCompletionContentPart,
-    ): Promise<OpenAI.ChatCompletionContentPart> {
-      if (content.type === 'image_url') {
-        const { type } = parseDataUri(content.image_url.url);
-
-        if (type === 'url' && process.env.LLM_VISION_IMAGE_TYPE === 'base64') {
-          const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
-
-          return {
-            ...content,
-            image_url: { ...content.image_url, url: `data:${mimeType};base64,${base64}` },
-          };
-        }
-      }
-
-      return content;
-    }
-
     async chat({ responseMode, ...payload }: ChatStreamPayload, options?: ChatCompetitionOptions) {
       try {
         const postPayload = chatCompletion?.handlePayload
@@ -179,19 +161,7 @@ export const LobeOpenAICompatibleFactory = <T extends Record<string, any> = any>
               stream: payload.stream ?? true,
             } as OpenAI.ChatCompletionCreateParamsStreaming);
 
-        const messages = (await Promise.all(
-          postPayload.messages.map(async (message) => ({
-            ...message,
-            content:
-              typeof message.content === 'string'
-                ? message.content
-                : await Promise.all(
-                    (message.content || []).map((c) =>
-                      this.convertMessageContent(c as OpenAI.ChatCompletionContentPart),
-                    ),
-                  ),
-          })),
-        )) as OpenAI.ChatCompletionMessageParam[];
+        const messages = await convertOpenAIMessages(postPayload.messages);
 
         const response = await this.client.chat.completions.create(
           {

--- a/src/libs/agent-runtime/utils/openaiHelpers.test.ts
+++ b/src/libs/agent-runtime/utils/openaiHelpers.test.ts
@@ -1,0 +1,146 @@
+import OpenAI from 'openai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { imageUrlToBase64 } from '@/utils/imageToBase64';
+
+import { convertMessageContent, convertOpenAIMessages } from './openaiHelpers';
+import { parseDataUri } from './uriParser';
+
+// 模拟依赖
+vi.mock('@/utils/imageToBase64');
+vi.mock('./uriParser');
+
+describe('convertMessageContent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return the same content if not image_url type', async () => {
+    const content = { type: 'text', text: 'Hello' } as OpenAI.ChatCompletionContentPart;
+    const result = await convertMessageContent(content);
+    expect(result).toEqual(content);
+  });
+
+  it('should convert image URL to base64 when necessary', async () => {
+    // 设置环境变量
+    process.env.LLM_VISION_IMAGE_TYPE = 'base64';
+
+    const content = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/image.jpg' },
+    } as OpenAI.ChatCompletionContentPart;
+
+    vi.mocked(parseDataUri).mockReturnValue({ type: 'url', base64: null, mimeType: null });
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'base64String',
+      mimeType: 'image/jpeg',
+    });
+
+    const result = await convertMessageContent(content);
+
+    expect(result).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/jpeg;base64,base64String' },
+    });
+
+    expect(parseDataUri).toHaveBeenCalledWith('https://example.com/image.jpg');
+    expect(imageUrlToBase64).toHaveBeenCalledWith('https://example.com/image.jpg');
+  });
+
+  it('should not convert image URL when not necessary', async () => {
+    process.env.LLM_VISION_IMAGE_TYPE = 'url';
+
+    const content = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/image.jpg' },
+    } as OpenAI.ChatCompletionContentPart;
+
+    vi.mocked(parseDataUri).mockReturnValue({ type: 'url', base64: null, mimeType: null });
+
+    const result = await convertMessageContent(content);
+
+    expect(result).toEqual(content);
+    expect(imageUrlToBase64).not.toHaveBeenCalled();
+  });
+});
+
+describe('convertOpenAIMessages', () => {
+  it('should convert string content messages', async () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ] as OpenAI.ChatCompletionMessageParam[];
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  it('should convert array content messages', async () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'image_url', image_url: { url: 'https://example.com/image.jpg' } },
+        ],
+      },
+    ] as OpenAI.ChatCompletionMessageParam[];
+
+    vi.spyOn(Promise, 'all');
+    vi.mocked(parseDataUri).mockReturnValue({ type: 'url', base64: null, mimeType: null });
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'base64String',
+      mimeType: 'image/jpeg',
+    });
+
+    process.env.LLM_VISION_IMAGE_TYPE = 'base64';
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/jpeg;base64,base64String' },
+          },
+        ],
+      },
+    ]);
+
+    expect(Promise.all).toHaveBeenCalledTimes(2); // 一次用于消息数组，一次用于内容数组
+
+    process.env.LLM_VISION_IMAGE_TYPE = 'url';
+  });
+  it('should convert array content messages', async () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'image_url', image_url: { url: 'https://example.com/image.jpg' } },
+        ],
+      },
+    ] as OpenAI.ChatCompletionMessageParam[];
+
+    vi.spyOn(Promise, 'all');
+    vi.mocked(parseDataUri).mockReturnValue({ type: 'url', base64: null, mimeType: null });
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'base64String',
+      mimeType: 'image/jpeg',
+    });
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual(messages);
+
+    expect(Promise.all).toHaveBeenCalledTimes(2); // 一次用于消息数组，一次用于内容数组
+  });
+});

--- a/src/libs/agent-runtime/utils/openaiHelpers.test.ts
+++ b/src/libs/agent-runtime/utils/openaiHelpers.test.ts
@@ -27,7 +27,7 @@ describe('convertMessageContent', () => {
 
   it('should convert image URL to base64 when necessary', async () => {
     // 设置环境变量
-    process.env.LLM_VISION_IMAGE_TYPE = 'base64';
+    process.env.LLM_VISION_IMAGE_USE_BASE64 = '1';
 
     const content = {
       type: 'image_url',
@@ -52,7 +52,7 @@ describe('convertMessageContent', () => {
   });
 
   it('should not convert image URL when not necessary', async () => {
-    process.env.LLM_VISION_IMAGE_TYPE = 'url';
+    process.env.LLM_VISION_IMAGE_USE_BASE64 = undefined;
 
     const content = {
       type: 'image_url',
@@ -98,7 +98,7 @@ describe('convertOpenAIMessages', () => {
       mimeType: 'image/jpeg',
     });
 
-    process.env.LLM_VISION_IMAGE_TYPE = 'base64';
+    process.env.LLM_VISION_IMAGE_USE_BASE64 = '1';
 
     const result = await convertOpenAIMessages(messages);
 
@@ -117,7 +117,7 @@ describe('convertOpenAIMessages', () => {
 
     expect(Promise.all).toHaveBeenCalledTimes(2); // 一次用于消息数组，一次用于内容数组
 
-    process.env.LLM_VISION_IMAGE_TYPE = 'url';
+    process.env.LLM_VISION_IMAGE_USE_BASE64 = undefined;
   });
   it('should convert array content messages', async () => {
     const messages = [

--- a/src/libs/agent-runtime/utils/openaiHelpers.ts
+++ b/src/libs/agent-runtime/utils/openaiHelpers.ts
@@ -1,0 +1,40 @@
+import OpenAI from 'openai';
+
+import { imageUrlToBase64 } from '@/utils/imageToBase64';
+
+import { parseDataUri } from './uriParser';
+
+export const convertMessageContent = async (
+  content: OpenAI.ChatCompletionContentPart,
+): Promise<OpenAI.ChatCompletionContentPart> => {
+  if (content.type === 'image_url') {
+    const { type } = parseDataUri(content.image_url.url);
+
+    if (type === 'url' && process.env.LLM_VISION_IMAGE_TYPE === 'base64') {
+      const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
+
+      return {
+        ...content,
+        image_url: { ...content.image_url, url: `data:${mimeType};base64,${base64}` },
+      };
+    }
+  }
+
+  return content;
+};
+
+export const convertOpenAIMessages = async (messages: OpenAI.ChatCompletionMessageParam[]) => {
+  return (await Promise.all(
+    messages.map(async (message) => ({
+      ...message,
+      content:
+        typeof message.content === 'string'
+          ? message.content
+          : await Promise.all(
+              (message.content || []).map((c) =>
+                convertMessageContent(c as OpenAI.ChatCompletionContentPart),
+              ),
+            ),
+    })),
+  )) as OpenAI.ChatCompletionMessageParam[];
+};

--- a/src/libs/agent-runtime/utils/openaiHelpers.ts
+++ b/src/libs/agent-runtime/utils/openaiHelpers.ts
@@ -10,7 +10,7 @@ export const convertMessageContent = async (
   if (content.type === 'image_url') {
     const { type } = parseDataUri(content.image_url.url);
 
-    if (type === 'url' && process.env.LLM_VISION_IMAGE_TYPE === 'base64') {
+    if (type === 'url' && process.env.LLM_VISION_IMAGE_USE_BASE64 === '1') {
       const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
 
       return {

--- a/src/utils/imageToBase64.test.ts
+++ b/src/utils/imageToBase64.test.ts
@@ -72,13 +72,17 @@ describe('imageUrlToBase64', () => {
   it('should convert image URL to base64 string', async () => {
     mockFetch.mockResolvedValue({
       arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+      blob: () => Promise.resolve(new Blob([mockArrayBuffer], { type: 'image/jpg' })),
     });
 
     const result = await imageUrlToBase64('https://example.com/image.jpg');
 
     expect(mockFetch).toHaveBeenCalledWith('https://example.com/image.jpg');
     expect(global.btoa).toHaveBeenCalled();
-    expect(result).toBe('mockBase64String');
+    expect(result).toBe({
+      base64: 'mockBase64String',
+      mimeType: 'image/jpg',
+    });
   });
 
   it('should throw an error when fetch fails', async () => {

--- a/src/utils/imageToBase64.test.ts
+++ b/src/utils/imageToBase64.test.ts
@@ -79,10 +79,7 @@ describe('imageUrlToBase64', () => {
 
     expect(mockFetch).toHaveBeenCalledWith('https://example.com/image.jpg');
     expect(global.btoa).toHaveBeenCalled();
-    expect(result).toBe({
-      base64: 'mockBase64String',
-      mimeType: 'image/jpg',
-    });
+    expect(result).toEqual({ base64: 'mockBase64String', mimeType: 'image/jpg' });
   });
 
   it('should throw an error when fetch fails', async () => {

--- a/src/utils/imageToBase64.ts
+++ b/src/utils/imageToBase64.ts
@@ -36,16 +36,25 @@ export const imageToBase64 = ({
   return canvas.toDataURL(type);
 };
 
-export const imageUrlToBase64 = async (imageUrl: string): Promise<string> => {
+export const imageUrlToBase64 = async (
+  imageUrl: string,
+): Promise<{ base64: string; mimeType: string }> => {
   try {
     const res = await fetch(imageUrl);
-    const arrayBuffer = await res.arrayBuffer();
+    const blob = await res.blob();
+    const arrayBuffer = await blob.arrayBuffer();
 
-    return typeof btoa === 'function'
-      ? btoa(
-          new Uint8Array(arrayBuffer).reduce((data, byte) => data + String.fromCharCode(byte), ''),
-        )
-      : Buffer.from(arrayBuffer).toString('base64');
+    const base64 =
+      typeof btoa === 'function'
+        ? btoa(
+            new Uint8Array(arrayBuffer).reduce(
+              (data, byte) => data + String.fromCharCode(byte),
+              '',
+            ),
+          )
+        : Buffer.from(arrayBuffer).toString('base64');
+
+    return { base64, mimeType: blob.type };
   } catch (error) {
     console.error('Error converting image to base64:', error);
     throw error;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

add an env `LLM_VISION_IMAGE_USE_BASE64=1` will make the OpenAI and other models send image with base64

- fix #3881 
- fix #3863 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs

- #3888 

<!-- Add any other context about the Pull Request here. -->
