### PR TITLE
💄 style: Support webhooks for casdoor

### DIFF
--- a/src/app/api/webhooks/casdoor/__tests__/route.test.ts
+++ b/src/app/api/webhooks/casdoor/__tests__/route.test.ts
@@ -42,8 +42,8 @@ const AUTH_CASDOOR_WEBHOOK_SECRET = 'casdoor-secret';
 // - Run this test with command:
 // pnpm vitest --run --testNamePattern='^ ?Test Casdoor Webhooks in Local dev'  src/app/api/webhooks/casdoor/__tests__/route.test.ts
 
-// describe.skip('Test Casdoor Webhooks in Local dev', () => {
-describe('Test Casdoor Webhooks in Local dev', () => {
+describe.skip('Test Casdoor Webhooks in Local dev', () => {
+  // describe('Test Casdoor Webhooks in Local dev', () => {
   it('should send a POST request with casdoor headers', async () => {
     const url = 'http://localhost:3010/api/webhooks/casdoor'; // 替换为目标URL
     const data = userDataUpdatedEvent;

--- a/src/app/api/webhooks/casdoor/__tests__/route.test.ts
+++ b/src/app/api/webhooks/casdoor/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+interface User {
+  name: string;
+  id: string;
+  type: 'normal-user' | 'admin' | 'super-admin';
+  displayName: string;
+  firstName: string;
+  lastName: string;
+  avatar: string;
+  email: string;
+  emailVerified: boolean;
+}
+
+interface UserDataUpdatedEvent {
+  user: string; // 用户名
+  action: 'update-user';
+  extendedUser: User; // 扩展用户信息
+}
+
+const userDataUpdatedEvent: UserDataUpdatedEvent = {
+  user: 'admin',
+  action: 'update-user',
+  extendedUser: {
+    name: 'admin',
+    id: '35edace3-00c6-41e1-895e-97c519b1d8cc',
+    type: 'normal-user',
+    displayName: 'Admin',
+    firstName: '',
+    lastName: '',
+    avatar: 'https://cdn.casbin.org/img/casbin.svg',
+    email: 'admin@example.cn',
+    emailVerified: false,
+  },
+};
+
+const AUTH_CASDOOR_WEBHOOK_SECRET = 'casdoor-secret';
+
+// Test Casdoor Webhooks in Local dev, here is some tips:
+// - Replace the var `AUTH_CASDOOR_WETHOOK_SECRET` with the actual value in your `.env` file
+// - Start web request: If you want to run the test, replace `describe.skip` with `describe` below
+// - Run this test with command:
+// pnpm vitest --run --testNamePattern='^ ?Test Casdoor Webhooks in Local dev'  src/app/api/webhooks/casdoor/__tests__/route.test.ts
+
+// describe.skip('Test Casdoor Webhooks in Local dev', () => {
+describe('Test Casdoor Webhooks in Local dev', () => {
+  it('should send a POST request with casdoor headers', async () => {
+    const url = 'http://localhost:3010/api/webhooks/casdoor'; // 替换为目标URL
+    const data = userDataUpdatedEvent;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'casdoor-secret': AUTH_CASDOOR_WEBHOOK_SECRET,
+      },
+      body: JSON.stringify(data),
+    });
+    expect(response.status).toBe(200); // 检查响应状态
+  });
+});

--- a/src/app/api/webhooks/casdoor/route.ts
+++ b/src/app/api/webhooks/casdoor/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+
+import { authEnv } from '@/config/auth';
+import { pino } from '@/libs/logger';
+import { NextAuthUserService } from '@/server/services/nextAuthUser';
+
+import { validateRequest } from './validateRequest';
+
+export const POST = async (req: Request): Promise<NextResponse> => {
+  const payload = await validateRequest(req, authEnv.CASDOOR_WEBHOOK_SECRET);
+
+  if (!payload) {
+    return NextResponse.json(
+      { error: 'webhook verification failed or payload was malformed' },
+      { status: 400 },
+    );
+  }
+
+  const { action, extendedUser } = payload;
+
+  pino.trace(`casdoor webhook payload: ${{ action, extendedUser }}`);
+
+  const nextAuthUserService = new NextAuthUserService();
+  switch (action) {
+    case 'update-user': {
+      return nextAuthUserService.safeUpdateUser(extendedUser.id, {
+        avatar: extendedUser?.avatar,
+        email: extendedUser?.email,
+        fullName: extendedUser.displayName,
+      });
+    }
+
+    default: {
+      pino.warn(
+        `${req.url} received event type "${action}", but no handler is defined for this type`,
+      );
+      return NextResponse.json({ error: `unrecognised payload type: ${action}` }, { status: 400 });
+    }
+  }
+};

--- a/src/app/api/webhooks/casdoor/validateRequest.ts
+++ b/src/app/api/webhooks/casdoor/validateRequest.ts
@@ -1,0 +1,38 @@
+import { headers } from 'next/headers';
+
+import { authEnv } from '@/config/auth';
+
+export type CasdoorUserEntity = {
+  avatar?: string;
+  displayName: string;
+  email?: string;
+  id: string;
+};
+
+interface CasdoorWebhookPayload {
+  action: string;
+  // Only support user event currently
+  extendedUser: CasdoorUserEntity;
+}
+
+export const validateRequest = async (request: Request, secret?: string) => {
+  const payloadString = await request.text();
+  const headerPayload = headers();
+  const casdoorSecret = headerPayload.get('casdoor-secret')!;
+  try {
+    if (casdoorSecret === secret) {
+      return JSON.parse(payloadString) as CasdoorWebhookPayload;
+    } else {
+      console.warn(
+        '[Casdoor]: secret verify failed, please check your secret in `CASDOOR_WEBHOOK_SECRET`',
+      );
+      return;
+    }
+  } catch (e) {
+    if (!authEnv.CASDOOR_WEBHOOK_SECRET) {
+      throw new Error('`CASDOOR_WEBHOOK_SECRET` environment variable is missing.');
+    }
+    console.error('[Casdoor]: incoming webhook failed in verification.\n', e);
+    return;
+  }
+};

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -201,6 +201,9 @@ export const getAuthConfig = () => {
       LOGTO_CLIENT_SECRET: z.string().optional(),
       LOGTO_ISSUER: z.string().optional(),
       LOGTO_WEBHOOK_SIGNING_KEY: z.string().optional(),
+
+      // Casdoor
+      CASDOOR_WEBHOOK_SECRET: z.string().optional(),
     },
 
     runtimeEnv: {
@@ -259,6 +262,9 @@ export const getAuthConfig = () => {
       LOGTO_CLIENT_SECRET: process.env.LOGTO_CLIENT_SECRET,
       LOGTO_ISSUER: process.env.LOGTO_ISSUER,
       LOGTO_WEBHOOK_SIGNING_KEY: process.env.LOGTO_WEBHOOK_SIGNING_KEY,
+
+      // Casdoor
+      CASDOOR_WEBHOOK_SECRET: process.env.CASDOOR_WEBHOOK_SECRET,
     },
   });
 };

--- a/src/libs/next-auth/sso-providers/casdoor.ts
+++ b/src/libs/next-auth/sso-providers/casdoor.ts
@@ -1,0 +1,49 @@
+import { OIDCConfig, OIDCUserConfig } from '@auth/core/providers';
+
+import { CommonProviderConfig } from './sso.config';
+
+interface CasdoorProfile extends Record<string, any> {
+  avatar: string;
+  displayName: string;
+  email: string;
+  emailVerified: boolean;
+  firstName: string;
+  id: string;
+  lastName: string;
+  name: string;
+  owner: string;
+  permanentAvatar: string;
+}
+
+function LobeCasdoorProvider(config: OIDCUserConfig<CasdoorProfile>): OIDCConfig<CasdoorProfile> {
+  return {
+    ...CommonProviderConfig,
+    ...config,
+    id: 'casdoor',
+    name: 'Casdoor',
+    profile(profile) {
+      return {
+        email: profile.email,
+        emailVerified: profile.emailVerified ? new Date() : null,
+        image: profile.avatar,
+        name: profile.displayName ?? profile.firstName ?? profile.lastName,
+        providerAccountId: profile.id,
+      };
+    },
+    type: 'oidc',
+  };
+}
+
+const provider = {
+  id: 'casdoor',
+  provider: LobeCasdoorProvider({
+    authorization: {
+      params: { scope: 'openid profile email' },
+    },
+    clientId: process.env.AUTH_CASDOOR_ID,
+    clientSecret: process.env.AUTH_CASDOOR_SECRET,
+    issuer: process.env.AUTH_CASDOOR_ISSUER,
+  }),
+};
+
+export default provider;

--- a/src/libs/next-auth/sso-providers/index.ts
+++ b/src/libs/next-auth/sso-providers/index.ts
@@ -2,10 +2,22 @@ import Auth0 from './auth0';
 import Authelia from './authelia';
 import Authentik from './authentik';
 import AzureAD from './azure-ad';
+import Casdoor from './casdoor';
 import CloudflareZeroTrust from './cloudflare-zero-trust';
 import GenericOIDC from './generic-oidc';
 import Github from './github';
 import Logto from './logto';
 import Zitadel from './zitadel';
 
-export const ssoProviders = [Auth0, Authentik, AzureAD, GenericOIDC, Github, Zitadel, Authelia, Logto, CloudflareZeroTrust];
+export const ssoProviders = [
+  Auth0,
+  Authentik,
+  AzureAD,
+  GenericOIDC,
+  Github,
+  Zitadel,
+  Authelia,
+  Logto,
+  CloudflareZeroTrust,
+  Casdoor,
+];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/app/api/webhooks/casdoor/__tests__/route.test.ts`: Local dev 测试 case;
- `src/app/api/webhooks/casdoor/route.ts`: 处理 Casdoor Event;
- `src/app/api/webhooks/casdoor/validateRequest.ts`: 检查 request 合法性，目前使用固定 secret;
- `src/libs/next-auth/sso-providers/casdoor.ts`: 添加 Casdoor SSO Provider;

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

1. Casdoor SSO Provider:
- pr #3701 后，所有 NextAuth 相关变量全部对齐为 `AUTH_[Provider]_[Param]` 形式，因此，Casdoor的三个环境变量分别为: `AUTH_CASDOOR_ID`, `AUTH_CASDOOR_SECRET`, `AUTH_CASDOOR_ISSUER`；
- 除此，应用的 callback_url 为： `<protocol>://<host>:<port>/api/auth/callback/casdoor`

2. Webhook 使用指南：
- 前往Casdoor控制台 `/webhooks` 创建一个 webhook
- 选择 hook 事件为： `update-user`
- 配置 Webhooks 地址为 `<protocol>://<host>:<port>/api/webhooks/casdoor`
- 勾选“拓展字段”选项
- 协议头添加：`casdoor-secret`，值为任意 secret，要与LobeChat环境变量 `CASDOOR_WEBHOOK_SECRET` 一致。

Link issues: 
- close #3875 
- close #3645 
<!-- Add any other context about the Pull Request here. -->
