### PR TITLE
:bug: fix: `providerAccountId` not exist in provider

### DIFF
--- a/src/libs/next-auth/sso-providers/auth0.ts
+++ b/src/libs/next-auth/sso-providers/auth0.ts
@@ -19,6 +19,7 @@ const provider = {
     profile(profile) {
       return {
         email: profile.email,
+        id: profile.sub,
         image: profile.picture,
         name: profile.name,
         providerAccountId: profile.sub,

--- a/src/libs/next-auth/sso-providers/authelia.ts
+++ b/src/libs/next-auth/sso-providers/authelia.ts
@@ -29,6 +29,7 @@ const provider = {
     profile(profile) {
       return {
         email: profile.email,
+        id: profile.sub,
         name: profile.name,
         providerAccountId: profile.sub,
       };

--- a/src/libs/next-auth/sso-providers/authentik.ts
+++ b/src/libs/next-auth/sso-providers/authentik.ts
@@ -23,6 +23,7 @@ const provider = {
     //     image: profile.picture,
     //     name: profile.name,
     //     providerAccountId: profile.user_id,
+    //     id: profile.user_id,
     //   };
     // },
   }),

--- a/src/libs/next-auth/sso-providers/azure-ad.ts
+++ b/src/libs/next-auth/sso-providers/azure-ad.ts
@@ -23,6 +23,7 @@ const provider = {
     //     image: profile.picture,
     //     name: profile.name,
     //     providerAccountId: profile.user_id,
+    //     id: profile.user_id,
     //   };
     // },
   }),

--- a/src/libs/next-auth/sso-providers/casdoor.ts
+++ b/src/libs/next-auth/sso-providers/casdoor.ts
@@ -25,6 +25,7 @@ function LobeCasdoorProvider(config: OIDCUserConfig<CasdoorProfile>): OIDCConfig
       return {
         email: profile.email,
         emailVerified: profile.emailVerified ? new Date() : null,
+        id: profile.id,
         image: profile.avatar,
         name: profile.displayName ?? profile.firstName ?? profile.lastName,
         providerAccountId: profile.id,

--- a/src/libs/next-auth/sso-providers/cloudflare-zero-trust.ts
+++ b/src/libs/next-auth/sso-providers/cloudflare-zero-trust.ts
@@ -25,6 +25,7 @@ const provider = {
     profile(profile) {
       return {
         email: profile.email,
+        id: profile.sub,
         name: profile.name ?? profile.email,
         providerAccountId: profile.sub,
       };

--- a/src/libs/next-auth/sso-providers/github.ts
+++ b/src/libs/next-auth/sso-providers/github.ts
@@ -17,6 +17,7 @@ const provider = {
     profile: (profile) => {
       return {
         email: profile.email,
+        id: profile.id.toString(),
         image: profile.avatar_url,
         name: profile.name,
         providerAccountId: profile.id.toString(),

--- a/src/libs/next-auth/sso-providers/zitadel.ts
+++ b/src/libs/next-auth/sso-providers/zitadel.ts
@@ -19,6 +19,7 @@ const provider = {
     //     image: profile.picture,
     //     name: profile.name,
     //     providerAccountId: profile.user_id,
+    //     id: profile.user_id,
     //   };
     // },
   }),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
- `src/libs/next-auth/sso-providers/*.ts`: 为 profile 重映射 id
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- 在创建 nexauth_account 时， `profile` 方法返回的字段的 id 会作为 `providerAccountId` 出现。
<!-- Add any other context about the Pull Request here. -->
