### PR TITLE
:bug: fix: fix url config import after user state init

### DIFF
--- a/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -13,7 +13,7 @@ import { useGlobalStore } from '@/store/global';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 import { useUserStore } from '@/store/user';
-import { authSelectors, preferenceSelectors } from '@/store/user/selectors';
+import { authSelectors } from '@/store/user/selectors';
 
 const StoreInitialization = memo(() => {
   // prefetch error ns to avoid don't show error content correctly
@@ -26,7 +26,7 @@ const StoreInitialization = memo(() => {
       s.isSignedIn,
       s.useInitUserState,
       s.importUrlShareSettings,
-      preferenceSelectors.isPreferenceInit(s),
+      s.isUserStateInit,
     ]);
 
   const { serverConfig } = useServerConfigStore();

--- a/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -13,19 +13,21 @@ import { useGlobalStore } from '@/store/global';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 import { useUserStore } from '@/store/user';
-import { authSelectors } from '@/store/user/selectors';
+import { authSelectors, preferenceSelectors } from '@/store/user/selectors';
 
 const StoreInitialization = memo(() => {
   // prefetch error ns to avoid don't show error content correctly
   useTranslation('error');
 
   const router = useRouter();
-  const [isLogin, isSignedIn, useInitUserState, importUrlShareSettings] = useUserStore((s) => [
-    authSelectors.isLogin(s),
-    s.isSignedIn,
-    s.useInitUserState,
-    s.importUrlShareSettings,
-  ]);
+  const [isLogin, isSignedIn, useInitUserState, importUrlShareSettings, isPreferenceInit] =
+    useUserStore((s) => [
+      authSelectors.isLogin(s),
+      s.isSignedIn,
+      s.useInitUserState,
+      s.importUrlShareSettings,
+      preferenceSelectors.isPreferenceInit(s),
+    ]);
 
   const { serverConfig } = useServerConfigStore();
 
@@ -74,8 +76,8 @@ const StoreInitialization = memo(() => {
   // Import settings from the url
   const searchParam = useSearchParams().get(LOBE_URL_IMPORT_NAME);
   useEffect(() => {
-    importUrlShareSettings(searchParam);
-  }, [searchParam]);
+    if (isPreferenceInit) importUrlShareSettings(searchParam);
+  }, [searchParam, isPreferenceInit]);
 
   useEffect(() => {
     if (mobile) {

--- a/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -20,7 +20,7 @@ const StoreInitialization = memo(() => {
   useTranslation('error');
 
   const router = useRouter();
-  const [isLogin, isSignedIn, useInitUserState, importUrlShareSettings, isPreferenceInit] =
+  const [isLogin, isSignedIn, useInitUserState, importUrlShareSettings, isUserStateInit] =
     useUserStore((s) => [
       authSelectors.isLogin(s),
       s.isSignedIn,
@@ -76,8 +76,10 @@ const StoreInitialization = memo(() => {
   // Import settings from the url
   const searchParam = useSearchParams().get(LOBE_URL_IMPORT_NAME);
   useEffect(() => {
-    if (isPreferenceInit) importUrlShareSettings(searchParam);
-  }, [searchParam, isPreferenceInit]);
+    // Why use `usUserStateInit`,
+    // see: https://github.com/lobehub/lobe-chat/pull/4072
+    if (searchParam && isUserStateInit) importUrlShareSettings(searchParam);
+  }, [searchParam, isUserStateInit]);
 
   useEffect(() => {
     if (mobile) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/layout/GlobalProvider/StoreInitialization.tsx`: 只在用户 Preference Init 完成后再使用 url 的设置覆盖
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

1. **问题复现步骤**
> 因为之前的Issue找不到了，此处补充下问题复现步骤：

- 访问llm页面并填写OpenAi设置信息，如打开“客户端请求模式”
```
http://localhost:3010/settings/llm
```
- 访问含有设置导入的url
```
http://localhost:3010/settings/llm?settings={"keyVaults":{"openai":{"apiKey":"user-key","baseURL":"https://your-proxy.com/v1"}}}
```

期望表现：“客户端请求”仍为“开启”。同时llm处有key和endpoint信息导入。
实际表现：“客户端请求”设置被清除

2. 问题成因

用户设置与URL导入的配置产生冲突。

- “导入设置”是指这段代码：
https://github.com/lobehub/lobe-chat/blob/b1e51e3d85954fd0d35a4bbdeea872ca2e61faef/src/layout/GlobalProvider/StoreInitialization.tsx#L58-L65

- 这段代码在导入成功后，会将 `isUserStateInit = ture` 
https://github.com/lobehub/lobe-chat/blob/f99c9ce90e6424de123eb9c355f0b9b5f28b4c8d/src/store/user/slices/common/action.ts#L108

初步解决办法为使用 `isUserSateInit` 作为是否执行导入动作的依据

3. 测试验证
本修复方案在三个配置下进行验证，结果如下：
-  `数据库版，已登录` ✅
- `非数据库版，已登录` ✅
> `非数据库版，未登录` 配置下不记录用户偏好，所以不存在该bug。

<!-- Add any other context about the Pull Request here. -->
