### PR TITLE
🐛 fix: improve delete orphan chunks when delete files

### DIFF
--- a/src/database/server/models/chunk.ts
+++ b/src/database/server/models/chunk.ts
@@ -1,5 +1,6 @@
 import { asc, cosineDistance, count, eq, inArray, sql } from 'drizzle-orm';
 import { and, desc, isNull } from 'drizzle-orm/expressions';
+import { chunk } from 'lodash-es';
 
 import { serverDB } from '@/database/server';
 import { ChunkMetadata, FileChunk, SemanticSearchChunk } from '@/types/chunk';
@@ -53,7 +54,15 @@ export class ChunkModel {
     const ids = orphanedChunks.map((chunk) => chunk.chunkId);
     if (ids.length === 0) return;
 
-    await serverDB.delete(chunks).where(inArray(chunks.id, ids));
+    const list = chunk(ids, 3000);
+
+    await serverDB.transaction(async (trx) => {
+      await Promise.all(
+        list.map(async (chunkIds) => {
+          await trx.delete(chunks).where(inArray(chunks.id, chunkIds));
+        }),
+      );
+    });
   };
 
   findById = async (id: string) => {

--- a/src/database/server/models/chunk.ts
+++ b/src/database/server/models/chunk.ts
@@ -54,7 +54,7 @@ export class ChunkModel {
     const ids = orphanedChunks.map((chunk) => chunk.chunkId);
     if (ids.length === 0) return;
 
-    const list = chunk(ids, 3000);
+    const list = chunk(ids, 500);
 
     await serverDB.transaction(async (trx) => {
       await Promise.all(


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change



<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

在 LobeChat Cloud 实际生产中遇到一个奇怪的 bug，然后有两个用户提来反馈：

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/eb9cdcc6-a4b4-4843-8582-748a7dc15150">


具体抛错如下：

```ts
RangeError: Maximum call stack size exceeded
    at /var/task/.next/server/chunks/59261.js:22:22558
    ... 8 lines matching cause stack trace ...
    at Object.startActiveSpan (/var/task/.next/server/chunks/59261.js:22:28365) {
  code: 'INTERNAL_SERVER_ERROR',
  name: 'TRPCError',
  [cause]: RangeError: Maximum call stack size exceeded
      at /var/task/.next/server/chunks/59261.js:22:22558
      at m.buildQueryFromSourceParams (/var/task/.next/server/chunks/59261.js:22:22661)
      at /var/task/.next/server/chunks/59261.js:22:23020
      at Array.map (<anonymous>)
      at m.buildQueryFromSourceParams (/var/task/.next/server/chunks/59261.js:22:22664)
      at /var/task/.next/server/chunks/59261.js:22:23020
      at Array.map (<anonymous>)
      at m.buildQueryFromSourceParams (/var/task/.next/server/chunks/59261.js:22:22664)
      at /var/task/.next/server/chunks/59261.js:22:22086
      at Object.startActiveSpan (/var/task/.next/server/chunks/59261.js:22:28365)
}
```

首先在 src 下搜了下不存在 `buildQueryFromSourceParams` 这个调用，因此抛错处不是源码部分。然后拿这个搜了下发现是 Drizzle 的调用实现，也有一个一模一样的 issue: 
- https://github.com/drizzle-team/drizzle-orm/issues/1702
- https://github.com/drizzle-team/drizzle-orm/issues/2628

找抛错的位置找到了这一部分：

```ts
deleteOrphanChunks = async () => {
    const orphanedChunks = await serverDB
      .select({ chunkId: chunks.id })
      .from(chunks)
      .leftJoin(fileChunks, eq(chunks.id, fileChunks.chunkId))
      .where(isNull(fileChunks.fileId));
    const ids = orphanedChunks.map((chunk) => chunk.chunkId);
    if (ids.length === 0) return;

    await serverDB.delete(chunks).where(inArray(chunks.id, ids));
  };
```

它的问题就出在如果 chunkIds 的总数过多，那么 `inArray(chunks.id, chunkIds)` 这样的写法就会出现堆栈溢出的情况。

而在 Neon 控制台写了段 SQL 查询，发现 orphanedChunks 居然有 161k 之多… 这才导致线上删文件时无法正常删除。

因此尝试将 inArrary 的实现优化为平行分批删除，期望优化该效果能解决过多的问题