### PR TITLE
📝 docs: Prevent '#' and its subsequent comments from affecting the URL of S3 configuration

### DIFF
--- a/docs/self-hosting/server-database/docker.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker.zh-CN.mdx
@@ -22,7 +22,8 @@ tags:
 <Callout type="info">
   本文已经假定你了解了 LobeChat 服务端数据库版本（下简称 DB
   版）的部署基本原理和流程，因此只包含核心环境变量配置的内容。如果你还不了解 LobeChat DB
-  版的部署原理，请先查阅 [使用服务端数据库部署](/zh/docs/self-hosting/server-database) 。
+  版的部署原理，请先查阅 [使用服务端数据库部署](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud) 。
+  此外，针对国内的腾讯云储存桶用户，可查询[配置腾讯云 COS 存储服务](/zh/docs/self-hosting/advanced/s3/tencent-cloud)
 </Callout>
 
 <Callout type="warning">
@@ -56,7 +57,7 @@ docker run --name my-postgres --network pg -e POSTGRES_PASSWORD=mysecretpassword
 
 <Callout type="warning">
   以上指令得到的 pg
-  实例并没有指定持久化存储位置，因此仅用于测试/演示，生产环境请自行配置持久化存储。此外，腾讯云储存桶的使用方法见[配置腾讯云 COS 存储服务](/zh/docs/self-hosting/advanced/s3/tencent-cloud)。
+  实例并没有指定持久化存储位置，因此仅用于测试/演示，生产环境请自行配置持久化存储。
 </Callout>
 
 ### 创建名为 `lobe-chat.env` 文件用于存放环境变量：

--- a/docs/self-hosting/server-database/docker.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker.zh-CN.mdx
@@ -23,7 +23,7 @@ tags:
   本文已经假定你了解了 LobeChat 服务端数据库版本（下简称 DB
   版）的部署基本原理和流程，因此只包含核心环境变量配置的内容。如果你还不了解 LobeChat DB
   版的部署原理，请先查阅 [使用服务端数据库部署](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud) 。
-  此外，针对国内的腾讯云储存桶用户，可查询[配置腾讯云 COS 存储服务](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud)
+  此外，针对国内的腾讯云储存桶用户，可查询[配置腾讯云 COS 存储服务](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud)。
 </Callout>
 
 <Callout type="warning">

--- a/docs/self-hosting/server-database/docker.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker.zh-CN.mdx
@@ -56,7 +56,7 @@ docker run --name my-postgres --network pg -e POSTGRES_PASSWORD=mysecretpassword
 
 <Callout type="warning">
   以上指令得到的 pg
-  实例并没有指定持久化存储位置，因此仅用于测试/演示，生产环境请自行配置持久化存储。
+  实例并没有指定持久化存储位置，因此仅用于测试/演示，生产环境请自行配置持久化存储。此外，腾讯云储存桶的使用方法见[配置腾讯云 COS 存储服务](/zh/docs/self-hosting/advanced/s3/tencent-cloud)。
 </Callout>
 
 ### 创建名为 `lobe-chat.env` 文件用于存放环境变量：
@@ -83,9 +83,11 @@ AUTH0_ISSUER=https://lobe-chat-demo.us.auth0.com
 # S3 相关
 S3_ACCESS_KEY_ID=xxxxxxxxxx
 S3_SECRET_ACCESS_KEY=xxxxxxxxxx
-S3_ENDPOINT=https://xxxxxxxxxx.r2.cloudflarestorage.com # 用于 S3 API 访问的域名
+# 用于 S3 API 访问的域名
+S3_ENDPOINT=https://xxxxxxxxxx.r2.cloudflarestorage.com 
 S3_BUCKET=lobechat
-S3_PUBLIC_DOMAIN=https://s3-for-lobechat.your-domain.com # 用于外网访问 S3 的公共域名，需配置 CORS
+# 用于外网访问 S3 的公共域名，需配置 CORS
+S3_PUBLIC_DOMAIN=https://s3-for-lobechat.your-domain.com 
 # S3_REGION=ap-chengdu # 如果需要指定地域
 
 # 其他环境变量，视需求而定

--- a/docs/self-hosting/server-database/docker.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker.zh-CN.mdx
@@ -23,7 +23,7 @@ tags:
   本文已经假定你了解了 LobeChat 服务端数据库版本（下简称 DB
   版）的部署基本原理和流程，因此只包含核心环境变量配置的内容。如果你还不了解 LobeChat DB
   版的部署原理，请先查阅 [使用服务端数据库部署](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud) 。
-  此外，针对国内的腾讯云储存桶用户，可查询[配置腾讯云 COS 存储服务](/zh/docs/self-hosting/advanced/s3/tencent-cloud)
+  此外，针对国内的腾讯云储存桶用户，可查询[配置腾讯云 COS 存储服务](https://lobehub.com/zh/docs/self-hosting/advanced/s3/tencent-cloud)
 </Callout>
 
 <Callout type="warning">


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
- 根据社区反映#4040 和我个人使用发现，该env文件中有关配置储存桶的URL部分存在注释影响运行的情况，将两个URL相关的注释进行换行处理以便代码正常运行。
- Based on community feedback and personal usage, I have found that there are comments in the URL section of the env file related to configuring the storage bucket that affect its operation. Therefore, the comments related to the two URLs were wrapped to ensure the normal operation of the code.
<!-- Thank you for your Pull Request. Please provide a description above. -->

close #4040
#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
