### PR TITLE
👷 build: remove unnecessary SSL judgments

### DIFF
--- a/scripts/serverLauncher/startServer.js
+++ b/scripts/serverLauncher/startServer.js
@@ -41,12 +41,12 @@ const isValidTLS = (url = '') => {
   const options = { host, port, servername: host };
   return new Promise((resolve, reject) => {
     const socket = tls.connect(options, () => {
-      if (socket.authorized) {
-        console.log(`✅ TLS Check: Valid certificate for ${host}:${port}.`);
-        console.log('-------------------------------------');
-        resolve();
-      }
+      console.log(`✅ TLS Check: Valid certificate for ${host}:${port}.`);
+      console.log('-------------------------------------');
+
       socket.end();
+
+      resolve();
     });
 
     socket.on('error', (err) => {

--- a/scripts/serverLauncher/startServer.js
+++ b/scripts/serverLauncher/startServer.js
@@ -54,6 +54,7 @@ const isValidTLS = (url = '') => {
       switch (err.code) {
         case 'CERT_HAS_EXPIRED':
         case 'DEPTH_ZERO_SELF_SIGNED_CERT':
+        case 'ERR_TLS_CERT_ALTNAME_INVALID':
           console.error(`${errMsg} Certificate is not valid. Consider setting NODE_TLS_REJECT_UNAUTHORIZED="0" or mapping /etc/ssl/certs/ca-certificates.crt.`);
           break;
         case 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY':


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [X] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
1. 移除多余的 `socket.authorized` 二次验证（IP 的证书即使信任也会被 Node 判定成 false）
2. Handle `ERR_TLS_CERT_ALTNAME_INVALID` 错误


close #4217 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
![image](https://github.com/user-attachments/assets/70f3f0d6-8d66-47ce-b7bb-e2c5ae7e95ee)
![image](https://github.com/user-attachments/assets/aa7d0acc-7f3a-4326-a696-e038e0215aa7)

<!-- Add any other context about the Pull Request here. -->

