### PR TITLE
👷 build: set `--dns-result-order=ipv4first` as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ FROM scratch
 COPY --from=app / /
 
 ENV NODE_ENV="production" \
-    NODE_OPTIONS="--use-openssl-ca" \
+    NODE_OPTIONS="--dns-result-order=ipv4first --use-openssl-ca" \
     NODE_EXTRA_CA_CERTS="" \
     NODE_TLS_REJECT_UNAUTHORIZED="" \
     SSL_CERT_DIR="/etc/ssl/certs/ca-certificates.crt"

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -126,7 +126,7 @@ FROM scratch
 COPY --from=app / /
 
 ENV NODE_ENV="production" \
-    NODE_OPTIONS="--use-openssl-ca" \
+    NODE_OPTIONS="--dns-result-order=ipv4first --use-openssl-ca" \
     NODE_EXTRA_CA_CERTS="" \
     NODE_TLS_REJECT_UNAUTHORIZED="" \
     SSL_CERT_DIR="/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [X] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

设置 IPv4 优先，对 DNS 结果排序，缓解部分场景下的 Corner Case
1. Docker Compose / Docker 使用不带 v6 的 Bridge Network
 
Note:
node v18 后使用 `verbatim` 做为默认值，受主机行为返回的顺序（随机），在使用双栈域名如 `localhost` 时会优先使用 `::1`；如主机环境为 v4 优先则会使用 `127.0.0.1` 

https://nodejs.org/api/cli.html#--dns-result-orderorder
![image](https://github.com/user-attachments/assets/1fb1e851-12bf-4f48-a654-82f0c19c43f9)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

```
测试脚本
const dns = require( 'dns' ).promises

const resolveHostIP = async ( host ) =>
{
    try
    {
        const result = await dns.lookup( host, { all: true } )

        console.log( result )
    } catch ( err )
    {
        console.error( err )
    }
}

resolveHostIP( 'localhost' )
```
结果
![image](https://github.com/user-attachments/assets/5b4a72ba-b8eb-4801-aeb7-aa567afce811)
<!-- Add any other context about the Pull Request here. -->
