### PR TITLE
:bug: fix: allow use email as name in logto

### DIFF
--- a/src/libs/next-auth/sso-providers/logto.ts
+++ b/src/libs/next-auth/sso-providers/logto.ts
@@ -25,7 +25,7 @@ function LobeLogtoProvider(config: OIDCUserConfig<LogtoProfile>): OIDCConfig<Log
         email: profile.email,
         id: profile.sub,
         image: profile.picture,
-        name: profile.name ?? profile.username,
+        name: profile.name ?? profile.username ?? profile.email,
         providerAccountId: profile.sub,
       };
     },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/libs/next-auth/sso-providers/logto.ts`: 使用 `email` 作为用户标识。
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- fix #3749 
<!-- Add any other context about the Pull Request here. -->
