### PR TITLE
:memo: docs(self hosting): Add deployment link for Alibaba Cloud international site

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,15 +439,15 @@ Beside these features, LobeChat also have much better basic technique undergroun
 
 ## 🛳 Self Hosting
 
-LobeChat provides Self-Hosted Version with Vercel and [Docker Image][docker-release-link]. This allows you to deploy your own chatbot within a few minutes without any prior knowledge.
+LobeChat provides Self-Hosted Version with Vercel, Alibaba Cloud, and [Docker Image][docker-release-link]. This allows you to deploy your own chatbot within a few minutes without any prior knowledge.
 
 > \[!TIP]
 >
 > Learn more about [📘 Build your own LobeChat][docs-self-hosting] by checking it out.
 
-### `A` Deploying with Vercel, Zeabur or Sealos
+### `A` Deploying with Vercel, Zeabur , Sealos or Alibaba Cloud
 
-If you want to deploy this service yourself on either Vercel or Zeabur, you can follow these steps:
+"If you want to deploy this service yourself on Vercel, Zeabur or Alibaba Cloud, you can follow these steps:
 
 - Prepare your [OpenAI API Key](https://platform.openai.com/account/api-keys).
 - Click the button below to start deployment: Log in directly with your GitHub account, and remember to fill in the `OPENAI_API_KEY`(required) and `ACCESS_CODE` (recommended) on the environment variable section.
@@ -456,9 +456,9 @@ If you want to deploy this service yourself on either Vercel or Zeabur, you can 
 
 <div align="center">
 
-|           Deploy with Vercel            |                     Deploy with Zeabur                      |                     Deploy with Sealos                      |                       Deploy with RepoCloud                       |
-| :-------------------------------------: | :---------------------------------------------------------: | :---------------------------------------------------------: | :---------------------------------------------------------------: |
-| [![][deploy-button-image]][deploy-link] | [![][deploy-on-zeabur-button-image]][deploy-on-zeabur-link] | [![][deploy-on-sealos-button-image]][deploy-on-sealos-link] | [![][deploy-on-repocloud-button-image]][deploy-on-repocloud-link] |
+|           Deploy with Vercel            |                     Deploy with Zeabur                      |                     Deploy with Sealos                      |                       Deploy with RepoCloud                       |                         Deploy with Alibaba Cloud                         |
+|:---------------------------------------:|:-----------------------------------------------------------:|:-----------------------------------------------------------:|:-----------------------------------------------------------------:|:-------------------------------------------------------------------------:|
+| [![][deploy-button-image]][deploy-link] | [![][deploy-on-zeabur-button-image]][deploy-on-zeabur-link] | [![][deploy-on-sealos-button-image]][deploy-on-sealos-link] | [![][deploy-on-repocloud-button-image]][deploy-on-repocloud-link] | [![][deploy-on-alibaba-cloud-button-image]][deploy-on-alibaba-cloud-link] |
 
 </div>
 
@@ -711,6 +711,8 @@ This project is [Apache 2.0](./LICENSE) licensed.
 [deploy-on-sealos-link]: https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dlobe-chat
 [deploy-on-zeabur-button-image]: https://zeabur.com/button.svg
 [deploy-on-zeabur-link]: https://zeabur.com/templates/VZGGTI
+[deploy-on-alibaba-cloud-button-image]: https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest-en.svg
+[deploy-on-alibaba-cloud-link]: https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=LobeChat%E7%A4%BE%E5%8C%BA%E7%89%88
 [discord-link]: https://discord.gg/AYFPHvv2jT
 [discord-shield]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
 [discord-shield-badge]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge

--- a/docs/self-hosting/platform/alibaba-cloud.mdx
+++ b/docs/self-hosting/platform/alibaba-cloud.mdx
@@ -1,0 +1,33 @@
+---
+title: Deploy LobeChat on Alibaba Cloud
+description: Learn how to deploy the LobeChat application on Alibaba Cloud, including preparing the large model API Key, clicking the deploy button, and other operations.
+tags:
+  - Alibaba Cloud
+  - LobeChat
+  - Alibaba Cloud Compute Nest
+  - API Key
+---
+
+# Deploy LobeChat with Alibaba Cloud
+
+If you want to deploy LobeChat on Alibaba Cloud, you can follow the steps below:
+
+## Alibaba Cloud Deployment Process
+
+<Steps>
+
+### Prepare your API Key
+
+Go to [OpenAI API Key](https://platform.openai.com/account/api-keys) to get your OpenAI API Key.
+Or go to [Tongyi Qianwen API Key](https://bailian.console.aliyun.com/?apiKey=1#/api-key) to get your API Key.
+
+### One-click to deploy
+
+[![][deploy-button-image]][deploy-link]
+
+### Once deployed, you can start using it
+
+</Steps>
+
+[deploy-button-image]: https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest-en.svg
+[deploy-link]: https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=LobeChat%E7%A4%BE%E5%8C%BA%E7%89%88

--- a/docs/self-hosting/platform/alibaba-cloud.zh-CN.mdx
+++ b/docs/self-hosting/platform/alibaba-cloud.zh-CN.mdx
@@ -1,0 +1,33 @@
+---
+title: 在 阿里云 上部署 LobeChat
+description: 学习如何在阿里云上部署LobeChat应用，包括准备大模型 API Key、点击部署按钮等操作。
+tags:
+  - 阿里云
+  - LobeChat
+  - 部署流程
+  - 大模型 API Key
+---
+
+# 使用 阿里云计算巢 部署
+
+如果想在 阿里云 上部署 LobeChat，可以按照以下步骤进行操作：
+
+## 阿里云 部署流程
+
+<Steps>
+
+### 准备好你的 API Key
+
+前往 [OpenAI API Key](https://platform.openai.com/account/api-keys) 获取你的 OpenAI API Key
+或 前往 [通义千问 API Key](https://bailian.console.aliyun.com/?apiKey=1#/api-key) 获取你的通义千问 API Key
+
+### 点击下方按钮进行部署
+
+[![][deploy-button-image]][deploy-link]
+
+### 部署完毕后，即可开始使用
+
+</Steps>
+
+[deploy-button-image]: https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest-en.svg
+[deploy-link]: https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=LobeChat%E7%A4%BE%E5%8C%BA%E7%89%88

--- a/docs/self-hosting/start.mdx
+++ b/docs/self-hosting/start.mdx
@@ -9,6 +9,7 @@ tags:
   - Vercel
   - Docker
   - Docker Compose
+  - Alibaba Cloud
 ---
 # Build Your Own Lobe Chat
 

--- a/docs/self-hosting/start.zh-CN.mdx
+++ b/docs/self-hosting/start.zh-CN.mdx
@@ -9,12 +9,13 @@ tags:
   - Docker
   - Netlify
   - Vercel
+  - 阿里云计算巢
   - 个性化
 ---
 
 # 构建属于自己的 Lobe Chat
 
-LobeChat 支持多种部署平台，包括 Vercel、Docker 和 Docker Compose 等，你可以选择适合自己的部署平台进行部署，构建属于自己的 Lobe Chat。
+LobeChat 支持多种部署平台，包括 Vercel、Docker、 Docker Compose 和 阿里云计算巢 等，你可以选择适合自己的部署平台进行部署，构建属于自己的 Lobe Chat。
 
 ## 快速部署
 


### PR DESCRIPTION
:memo: docs(self hosting): Add deployment link for Alibaba Cloud international site
#### 💻 变更类型 | Change Type

#### 📝 补充信息 | Additional Information
"We discussed last time (https://github.com/lobehub/lobe-chat/pull/4309) how to identify domestic and international users in the English deployment links, and now I have the exact answer.

deployment link : https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=LobeChat%E7%A4%BE%E5%8C%BA%E7%89%88

Two prerequisites:

A browser can only log in to one account at a time, and the system will automatically switch between the domestic and international sites based on the account.
If the user is not logged in, the system will determine the appropriate login interface based on the user's last logged-in account.
This means that when a domestic user accesses our deployment link, the system automatically recognizes that the account is domestic, leading to the domestic login interface. 
![image](https://github.com/user-attachments/assets/59a586b9-0afd-4620-888e-bfb1a6145d1c)

Conversely, when an international user accesses our deployment link, the system automatically recognizes the account as international, directing them to the international deployment link."
![image](https://github.com/user-attachments/assets/78bbdd58-f8a5-4da9-b1df-fa87cd1a2a3b)

The two images above correspond to the domestic and international test accounts. You can identify from the callback URL in the images that I accessed it through a single deployment link, so there's no need to worry about the login issues for international users.