### PR TITLE
💄 style: add qwen vision model & update qwen2.5 72b to 128k for siliconcloud

### DIFF
--- a/src/config/modelProviders/huggingface.ts
+++ b/src/config/modelProviders/huggingface.ts
@@ -10,26 +10,6 @@ const HuggingFace: ModelProviderCard = {
       tokens: 8192,
     },
     {
-      description: '高质量多语言聊天模型,具有较大上下文长度',
-      displayName: 'Llama 3.1 8B Instruct',
-      enabled: true,
-      id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
-      tokens: 8192,
-    },
-    {
-      description: '高质量多语言聊天模型,具有大型上下文长度',
-      displayName: 'Llama 3.1 70B Instruct',
-      enabled: true,
-      id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
-      tokens: 32_768,
-    },
-    {
-      description: '最佳对话模型之一',
-      displayName: 'Llama 2 7B Chat',
-      id: 'meta-llama/Llama-2-7b-chat-hf',
-      tokens: 4096,
-    },
-    {
       description: 'Google的轻量级指令调优模型',
       displayName: 'Gemma 2 2B Instruct',
       id: 'google/gemma-2-2b-it',

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -32,6 +32,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Qwen2.5 是全新的大型语言模型系列，旨在优化指令式任务的处理。',
       displayName: 'Qwen2.5 14B',
+      enabled: true,
       functionCall: true,
       id: 'Qwen/Qwen2.5-14B-Instruct',
       pricing: {
@@ -44,6 +45,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Qwen2.5 是全新的大型语言模型系列，旨在优化指令式任务的处理。',
       displayName: 'Qwen2.5 32B',
+      enabled: true,
       functionCall: true,
       id: 'Qwen/Qwen2.5-32B-Instruct',
       pricing: {
@@ -164,7 +166,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Gemma 2 是Google轻量化的开源文本模型系列。',
       displayName: 'Gemma 2 9B',
-      enabled: true,
       id: 'google/gemma-2-9b-it',
       pricing: {
         currency: 'CNY',
@@ -176,7 +177,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Gemma 2 延续了轻量化与高效的设计理念。',
       displayName: 'Gemma 2 27B',
-      enabled: true,
       id: 'google/gemma-2-27b-it',
       pricing: {
         currency: 'CNY',
@@ -188,7 +188,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 提供多语言支持，是业界领先的生成模型之一。',
       displayName: 'Llama 3.1 8B',
-      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       pricing: {
@@ -201,7 +200,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 70B 提供多语言的高效对话支持。',
       displayName: 'Llama 3.1 70B',
-      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
       pricing: {
@@ -214,7 +212,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 405B 指令微调模型针对多语言对话场景进行了优化。',
       displayName: 'Llama 3.1 405B',
-      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-405B-Instruct',
       pricing: {

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -58,13 +58,26 @@ const SiliconCloud: ModelProviderCard = {
       displayName: 'Qwen2.5 72B',
       enabled: true,
       functionCall: true,
-      id: 'Qwen/Qwen2.5-72B-Instruct',
+      id: 'Qwen/Qwen2.5-72B-Instruct-128K',
+      pricing: {
+        currency: 'CNY',
+        input: 4.13,
+        output: 4.13,
+      },
+      tokens: 131_072,
+    },
+    {
+      description: 'Qwen2-VL 是 Qwen-VL 模型的最新迭代版本，在视觉理解基准测试中达到了最先进的性能。',
+      displayName: 'Qwen2 VL 72B',
+      enabled: true,
+      id: 'Qwen/Qwen2-VL-72B-Instruct',
       pricing: {
         currency: 'CNY',
         input: 4.13,
         output: 4.13,
       },
       tokens: 32_768,
+      vision: true,
     },
     {
       description: 'Qwen2.5-Math 专注于数学领域的问题求解，为高难度题提供专业解答。',
@@ -175,6 +188,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 提供多语言支持，是业界领先的生成模型之一。',
       displayName: 'Llama 3.1 8B',
+      functionCall: true,
       enabled: true,
       id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       pricing: {
@@ -187,6 +201,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 70B 提供多语言的高效对话支持。',
       displayName: 'Llama 3.1 70B',
+      functionCall: true,
       enabled: true,
       id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
       pricing: {
@@ -199,6 +214,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 405B 指令微调模型针对多语言对话场景进行了优化。',
       displayName: 'Llama 3.1 405B',
+      functionCall: true,
       enabled: true,
       id: 'meta-llama/Meta-Llama-3.1-405B-Instruct',
       pricing: {

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -32,7 +32,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Qwen2.5 是全新的大型语言模型系列，旨在优化指令式任务的处理。',
       displayName: 'Qwen2.5 14B',
-      enabled: true,
       functionCall: true,
       id: 'Qwen/Qwen2.5-14B-Instruct',
       pricing: {
@@ -45,7 +44,6 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Qwen2.5 是全新的大型语言模型系列，旨在优化指令式任务的处理。',
       displayName: 'Qwen2.5 32B',
-      enabled: true,
       functionCall: true,
       id: 'Qwen/Qwen2.5-32B-Instruct',
       pricing: {
@@ -166,6 +164,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Gemma 2 是Google轻量化的开源文本模型系列。',
       displayName: 'Gemma 2 9B',
+      enabled: true,
       id: 'google/gemma-2-9b-it',
       pricing: {
         currency: 'CNY',
@@ -177,6 +176,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'Gemma 2 延续了轻量化与高效的设计理念。',
       displayName: 'Gemma 2 27B',
+      enabled: true,
       id: 'google/gemma-2-27b-it',
       pricing: {
         currency: 'CNY',
@@ -188,6 +188,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 提供多语言支持，是业界领先的生成模型之一。',
       displayName: 'Llama 3.1 8B',
+      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       pricing: {
@@ -200,6 +201,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 70B 提供多语言的高效对话支持。',
       displayName: 'Llama 3.1 70B',
+      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
       pricing: {
@@ -212,6 +214,7 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 405B 指令微调模型针对多语言对话场景进行了优化。',
       displayName: 'Llama 3.1 405B',
+      enabled: true,
       functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-405B-Instruct',
       pricing: {

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -68,6 +68,19 @@ const SiliconCloud: ModelProviderCard = {
     },
     {
       description: 'Qwen2-VL 是 Qwen-VL 模型的最新迭代版本，在视觉理解基准测试中达到了最先进的性能。',
+      displayName: 'Qwen2 VL 7B',
+      enabled: true,
+      id: 'Pro/Qwen/Qwen2-VL-7B-Instruct',
+      pricing: {
+        currency: 'CNY',
+        input: 0.35,
+        output: 0.35,
+      },
+      tokens: 32_768,
+      vision: true,
+    },
+    {
+      description: 'Qwen2-VL 是 Qwen-VL 模型的最新迭代版本，在视觉理解基准测试中达到了最先进的性能。',
       displayName: 'Qwen2 VL 72B',
       enabled: true,
       id: 'Qwen/Qwen2-VL-72B-Instruct',
@@ -136,7 +149,7 @@ const SiliconCloud: ModelProviderCard = {
         input: 0.35,
         output: 0.35,
       },
-      tokens: 8192,
+      tokens: 32_768,
       vision: true,
     },
     {
@@ -148,7 +161,7 @@ const SiliconCloud: ModelProviderCard = {
         input: 1,
         output: 1,
       },
-      tokens: 8192,
+      tokens: 32_768,
       vision: true,
     },
     {

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -128,6 +128,39 @@ const SiliconCloud: ModelProviderCard = {
       tokens: 32_768,
     },
     {
+      description: 'InternVL2在各种视觉语言任务上展现出了卓越的性能，包括文档和图表理解、场景文本理解、OCR、科学和数学问题解决等。',
+      displayName: 'InternVL2 8B',
+      id: 'Pro/OpenGVLab/InternVL2-8B',
+      pricing: {
+        currency: 'CNY',
+        input: 0.35,
+        output: 0.35,
+      },
+      tokens: 8192,
+    },
+    {
+      description: 'InternVL2在各种视觉语言任务上展现出了卓越的性能，包括文档和图表理解、场景文本理解、OCR、科学和数学问题解决等。',
+      displayName: 'InternVL2 26B',
+      id: 'OpenGVLab/InternVL2-26B',
+      pricing: {
+        currency: 'CNY',
+        input: 1,
+        output: 1,
+      },
+      tokens: 8192,
+    },
+    {
+      description: 'InternVL2在各种视觉语言任务上展现出了卓越的性能，包括文档和图表理解、场景文本理解、OCR、科学和数学问题解决等。',
+      displayName: 'InternVL2 Llama3 76B',
+      id: 'OpenGVLab/InternVL2-Llama3-76B',
+      pricing: {
+        currency: 'CNY',
+        input: 4.13,
+        output: 4.13,
+      },
+      tokens: 8192,
+    },
+    {
       description: 'GLM-4 9B 开放源码版本，为会话应用提供优化后的对话体验。',
       displayName: 'GLM-4 9B',
       functionCall: true,
@@ -189,7 +222,6 @@ const SiliconCloud: ModelProviderCard = {
       description: 'LLaMA 3.1 提供多语言支持，是业界领先的生成模型之一。',
       displayName: 'Llama 3.1 8B',
       enabled: true,
-      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       pricing: {
         currency: 'CNY',
@@ -202,7 +234,6 @@ const SiliconCloud: ModelProviderCard = {
       description: 'LLaMA 3.1 70B 提供多语言的高效对话支持。',
       displayName: 'Llama 3.1 70B',
       enabled: true,
-      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
       pricing: {
         currency: 'CNY',
@@ -215,7 +246,6 @@ const SiliconCloud: ModelProviderCard = {
       description: 'LLaMA 3.1 405B 指令微调模型针对多语言对话场景进行了优化。',
       displayName: 'Llama 3.1 405B',
       enabled: true,
-      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-405B-Instruct',
       pricing: {
         currency: 'CNY',

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -188,8 +188,8 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 提供多语言支持，是业界领先的生成模型之一。',
       displayName: 'Llama 3.1 8B',
-      functionCall: true,
       enabled: true,
+      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       pricing: {
         currency: 'CNY',
@@ -201,8 +201,8 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 70B 提供多语言的高效对话支持。',
       displayName: 'Llama 3.1 70B',
-      functionCall: true,
       enabled: true,
+      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
       pricing: {
         currency: 'CNY',
@@ -214,8 +214,8 @@ const SiliconCloud: ModelProviderCard = {
     {
       description: 'LLaMA 3.1 405B 指令微调模型针对多语言对话场景进行了优化。',
       displayName: 'Llama 3.1 405B',
-      functionCall: true,
       enabled: true,
+      functionCall: true,
       id: 'meta-llama/Meta-Llama-3.1-405B-Instruct',
       pricing: {
         currency: 'CNY',

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -137,6 +137,7 @@ const SiliconCloud: ModelProviderCard = {
         output: 0.35,
       },
       tokens: 8192,
+      vision: true,
     },
     {
       description: 'InternVL2在各种视觉语言任务上展现出了卓越的性能，包括文档和图表理解、场景文本理解、OCR、科学和数学问题解决等。',
@@ -148,6 +149,7 @@ const SiliconCloud: ModelProviderCard = {
         output: 1,
       },
       tokens: 8192,
+      vision: true,
     },
     {
       description: 'InternVL2在各种视觉语言任务上展现出了卓越的性能，包括文档和图表理解、场景文本理解、OCR、科学和数学问题解决等。',
@@ -159,6 +161,7 @@ const SiliconCloud: ModelProviderCard = {
         output: 4.13,
       },
       tokens: 8192,
+      vision: true,
     },
     {
       description: 'GLM-4 9B 开放源码版本，为会话应用提供优化后的对话体验。',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
增加Qwen2 VL 72B视觉模型
增加书生系列视觉模型
更新Qwen2.5 72B上下文至128K
为Llama3.1支持函数调用(暂时还未支持，以后再加)

留言给Arvin：
由于HF的Llama3.1模型ID与硅基的Llama3.1模型ID相同，并且HF优先级高于硅基
导致硅基的Llama3.1即使添加了functioncall，也视为不支持函数调用模型
由于模型ID冲突且HF平台拥有大量的模型，让用户自己添加模型是为一种更好的选择
故删除HF中的Llama模型
![image](https://github.com/user-attachments/assets/1fad9ce9-cce4-4c1e-9ea6-e5f8452905e6)
![image](https://github.com/user-attachments/assets/c0ff11e5-c975-4477-8480-e59517d90a9e)


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
