### PR TITLE
:construction: wip: Dify integration & Agnet code refactor

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -10,6 +10,7 @@ export const runtime = 'edge';
 
 export const POST = checkAuth(async (req: Request, { params, jwtPayload, createRuntime }) => {
   const { provider } = params;
+  console.log(jwtPayload);
 
   try {
     // ============  1. init chat model   ============ //

--- a/src/const/settings/agent.ts
+++ b/src/const/settings/agent.ts
@@ -22,6 +22,12 @@ export const DEFAULT_AGENT_CHAT_CONFIG: LobeAgentChatConfig = {
 
 export const DEFAULT_AGENT_CONFIG: LobeAgentConfig = {
   chatConfig: DEFAULT_AGENT_CHAT_CONFIG,
+  dify: {
+    baseUrl: 'https://api.dify.ai/v1',
+    enabled: false,
+    token: '',
+    userId: 'devTest',
+  },
   model: DEFAULT_MODEL,
   params: {
     frequency_penalty: 0,
@@ -32,7 +38,7 @@ export const DEFAULT_AGENT_CONFIG: LobeAgentConfig = {
   plugins: [],
   provider: ModelProvider.OpenAI,
   systemRole: '',
-  tts: DEFAUTT_AGENT_TTS_CONFIG,
+  tts: DEFAUTT_AGENT_TTS_CONFIG
 };
 
 export const DEFAULT_AGENT: UserDefaultAgent = {

--- a/src/features/AgentSetting/AgentSettings.tsx
+++ b/src/features/AgentSetting/AgentSettings.tsx
@@ -4,6 +4,7 @@ import AgentModal from './AgentModal';
 import AgentPlugin from './AgentPlugin';
 import AgentPrompt from './AgentPrompt';
 import AgentTTS from './AgentTTS';
+import Dify from './Dify'
 import StoreUpdater, { StoreUpdaterProps } from './StoreUpdater';
 import { Provider, createStore } from './store';
 
@@ -19,6 +20,7 @@ export const AgentSettings = (props: AgentSettingsProps) => {
       <AgentModal />
       <AgentTTS />
       <AgentPlugin />
+      <Dify />
     </Provider>
   );
 };

--- a/src/features/AgentSetting/Dify/index.tsx
+++ b/src/features/AgentSetting/Dify/index.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Form, type ItemGroup, Input } from '@lobehub/ui';
+import { Switch } from 'antd';
+import { memo, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { FORM_STYLE } from '@/const/layoutTokens';
+
+import { useStore } from '../store';
+import { useUserStore } from '@/store/user';
+
+const AgentMeta = memo(() => {
+  const { t } = useTranslation('setting');
+
+  const [setAgentConfig, agentConfig ] = useStore((s) => [
+    s.setAgentConfig,
+    s.config
+  ]);
+
+  const updateKeyVaultConfig = useUserStore((s)=>s.updateKeyVaultConfig)
+
+  const [difyBaseUrl, setDifyBaseUrl] = useState<string>('https://api.dify.ai/v1')
+  const [difyToken, setDifyToken] = useState<string>('app-1WHrUsnegCQqYgSjN952dHyt')
+  const [difyUserId, setDifyUserId] = useState<string>('dev')
+  const [difyEnabled, setDifyEnable] = useState<boolean>(true)
+
+  useEffect(() => {
+    setAgentConfig({
+      dify: {
+        baseUrl: difyBaseUrl,
+        token: difyToken,
+        userId: difyUserId,
+        enabled: difyEnabled,
+      },
+      provider: 'dify',
+      model: 'Dofy Workflow'
+    })
+    updateKeyVaultConfig('dify', {
+      baseUrl: difyBaseUrl,
+      token: difyToken,
+      userId: difyUserId,
+    })
+  }, [difyBaseUrl, difyToken, difyUserId, difyEnabled])
+
+  const metaData: ItemGroup = {
+    children: [
+      {
+        children: (
+          <Input 
+            onChange={(event) => setDifyBaseUrl(event.currentTarget.value)}
+            placeholder='https://api.dify.ai/v1' 
+            value={agentConfig.dify.baseUrl} />
+        ),
+        label: 'BaseUrl'
+      },
+      {
+        children: (
+          <Input 
+            onChange={(event) => setDifyToken(event.currentTarget.value)} 
+            value={agentConfig.dify.token}
+            />
+        ),
+        label: 'Token'
+      },
+      {
+        children: (
+          <Input 
+            onChange={(event) => setDifyUserId(event.currentTarget.value)} 
+            value={agentConfig.dify.userId}
+          />
+        ),
+        label: 'UserId'
+      },
+      {
+        children: (
+          <Switch 
+            onChange={setDifyEnable}
+            value={agentConfig.dify.enabled}
+          />
+        ),
+        label: 'BaseUrl'
+      }
+    ],
+    title: t('settingAgent.title'),
+  };
+
+  return <Form items={[metaData]} itemsType={'group'} variant={'pure'} {...FORM_STYLE} />;
+});
+
+export default AgentMeta;

--- a/src/features/AgentSetting/store/action.ts
+++ b/src/features/AgentSetting/store/action.ts
@@ -58,8 +58,8 @@ export interface Action extends PublicAction {
   resetAgentMeta: () => void;
   setAgentConfig: (config: DeepPartial<LobeAgentConfig>) => void;
   setAgentMeta: (meta: Partial<MetaData>) => void;
-
   setChatConfig: (config: Partial<LobeAgentChatConfig>) => void;
+
   streamUpdateMetaArray: (key: keyof MetaData) => any;
   streamUpdateMetaString: (key: keyof MetaData) => any;
   toggleAgentPlugin: (pluginId: string, state?: boolean) => void;
@@ -290,6 +290,7 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
       }
     };
   },
+
 
   toggleAgentPlugin: (id, state) => {
     get().dispatchConfig({ pluginId: id, state, type: 'togglePlugin' });

--- a/src/libs/agent-runtime/AgentRuntime.ts
+++ b/src/libs/agent-runtime/AgentRuntime.ts
@@ -42,6 +42,7 @@ import {
 import { LobeUpstageAI } from './upstage';
 import { LobeZeroOneAI } from './zeroone';
 import { LobeZhipuAI } from './zhipu';
+import LobeDify from './dify';
 
 export interface AgentChatOptions {
   enableTrace?: boolean;
@@ -154,6 +155,7 @@ class AgentRuntime {
       upstage: Partial<ClientOptions>;
       zeroone: Partial<ClientOptions>;
       zhipu: Partial<ClientOptions>;
+      dify: Partial<{ baseUrl: string; token: string; userId: string; conversation_id: string}>;
     }>,
   ) {
     let runtimeModel: LobeRuntimeAI;
@@ -313,6 +315,11 @@ class AgentRuntime {
       case ModelProvider.Hunyuan: {
         runtimeModel = new LobeHunyuanAI(params.hunyuan);
         break;
+      }
+
+      case ModelProvider.Dify: {
+        runtimeModel = new LobeDify(params.dify || {})
+        break
       }
     }
 

--- a/src/libs/agent-runtime/dify/index.ts
+++ b/src/libs/agent-runtime/dify/index.ts
@@ -1,0 +1,75 @@
+import { LobeRuntimeAI } from '../BaseAI';
+import { AgentRuntimeErrorType } from '../error';
+import { ChatCompetitionOptions, ChatStreamPayload, ModelProvider } from '../types';
+import { AgentRuntimeError } from '../utils/createError';
+import { StreamingResponse } from '../utils/response';
+import { DifyStream } from '../utils/streams/dify';
+import urlJoin from 'url-join';
+
+export interface DifyParams {
+  baseUrl: string
+  token?: string
+  userId: string
+  conversation_id?: string
+}
+
+export class LobeDify implements LobeRuntimeAI {
+  difyParams: DifyParams
+
+  constructor({ baseUrl, token, userId, conversation_id }: Partial<DifyParams>) {
+    if (!(userId && token))
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
+
+    this.difyParams = {
+      baseUrl: baseUrl ?? 'https://api.dify.ai/v1',
+      conversation_id,
+      userId,
+      token,
+    }
+  }
+
+  async chat(payload: ChatStreamPayload, options?: ChatCompetitionOptions) {
+    const { messages } = payload
+    // Get the last message as query
+    const query = messages.at(-1)
+    if (!query) {
+      throw new Error('[Dify]: No query')
+    }
+    let textQuery = ''
+    if (typeof query.content === 'string')
+      textQuery = query.content
+    else
+      throw new Error('[Dify]: Unsupport user message type')
+
+    const response = await fetch(urlJoin(this.difyParams.baseUrl, '/chat-messages'), {
+      method: 'POST',
+      // signal: options?.signal,
+      headers: {
+        Authorization: `Bearer ${this.difyParams.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        query: textQuery,
+        user: this.difyParams.userId,
+        conversation_id: this.difyParams?.conversation_id ?? '',
+        response_mode: 'streaming',
+        inputs: [],
+        files: [],
+      }),
+    })
+    if (!response.body || !response.ok) {
+      throw AgentRuntimeError.chat({
+        error: {
+          status: response.status,
+          statusText: response.statusText,
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        provider: ModelProvider.Dify,
+      });
+    }
+    const [prod, _] = response.body.tee();
+    return StreamingResponse(DifyStream(prod), { headers: options?.headers });
+  }
+}
+
+export default LobeDify;

--- a/src/libs/agent-runtime/index.ts
+++ b/src/libs/agent-runtime/index.ts
@@ -20,3 +20,4 @@ export * from './types';
 export { AgentRuntimeError } from './utils/createError';
 export { LobeZeroOneAI } from './zeroone';
 export { LobeZhipuAI } from './zhipu';
+export { LobeDify } from './dify'

--- a/src/libs/agent-runtime/types/type.ts
+++ b/src/libs/agent-runtime/types/type.ts
@@ -53,6 +53,7 @@ export enum ModelProvider {
   Wenxin = 'wenxin',
   ZeroOne = 'zeroone',
   ZhiPu = 'zhipu',
+  Dify = 'dify'
 }
 
 export type ModelProviderKey = Lowercase<keyof typeof ModelProvider>;

--- a/src/libs/agent-runtime/utils/streams/dify.ts
+++ b/src/libs/agent-runtime/utils/streams/dify.ts
@@ -1,0 +1,74 @@
+import { createCallbacksTransformer, createSSEProtocolTransformer, StreamProtocolChunk } from ".";
+import { ChatStreamCallbacks } from "../..";
+
+interface DifyChunk {
+    event: string;
+    task_id?: string;
+    answer?: string;
+    message?: string;
+    message_id?: string;
+    id?: string
+}
+
+const processDifyData = (buffer: string): DifyChunk | undefined => {
+    try {
+        // Remove the prefix `data:`
+        if (buffer.startsWith('data:'))
+            return JSON.parse(buffer.slice(5).trim()) as DifyChunk
+        return JSON.parse(buffer.trim())
+    } catch (error) {
+        // Try another way to parse the data
+        // Dify is wired, sometimes the stream data contains multiple lines of 
+        // stream event in a single chunk, so we need to split the data by `data:`
+        // and ONLY keep the last slice of the chunk
+        const slices = buffer.split('data: ');
+        try {
+            return JSON.parse(slices[slices.length - 1].trim()) as DifyChunk
+        } catch { }
+    }
+}
+
+export const transformDifyStream = (buffer: Uint8Array): StreamProtocolChunk => {
+    const decoder = new TextDecoder()
+    const chunk = processDifyData(decoder.decode(buffer, { stream: true }))
+    const id = chunk?.message_id ?? chunk?.task_id ?? chunk?.id;
+    // Return empty block if error
+    if (!chunk || !id) return {
+        data: '',
+        type: 'text',
+    }
+    let type: StreamProtocolChunk['type'] = 'text';
+    let data: DifyChunk | string = chunk;
+    switch (chunk.event) {
+        case 'message_end':
+            type = 'stop'
+            break;
+        case 'message':
+            type = 'text';
+            data = chunk.answer ?? '';
+            break;
+        case 'workflow_started':
+            type = 'tool_using';
+            break;
+        case 'node_started':
+            type = 'thoughts';
+            break;
+        case 'workflow_finished':
+            type = 'tool_using';
+            break;
+        case 'node_finished':
+            type = 'thoughts';
+            break;
+    }
+    return {
+        id,
+        data,
+        type,
+    }
+}
+
+export const DifyStream = (stream: ReadableStream, callbacks?: ChatStreamCallbacks) => {
+    return stream
+        .pipeThrough(createSSEProtocolTransformer(transformDifyStream))
+        .pipeThrough(createCallbacksTransformer(callbacks));
+};

--- a/src/libs/agent-runtime/utils/streams/protocol.ts
+++ b/src/libs/agent-runtime/utils/streams/protocol.ts
@@ -15,7 +15,11 @@ export interface StreamStack {
 export interface StreamProtocolChunk {
   data: any;
   id?: string;
-  type: 'text' | 'tool_calls' | 'data' | 'stop' | 'error';
+  /**
+    * - thoughts: the thoughts of the AI
+    * - tool_using: the tool is using
+    */
+  type: 'text' | 'tool_calls' | 'data' | 'stop' | 'error' | 'thoughts' | 'tool_using'
 }
 
 export interface StreamToolCallChunkData {

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -263,6 +263,9 @@ const getLlmOptionsFromPayload = (provider: string, payload: JWTPayload) => {
 
       return { apiKey };
     }
+    case ModelProvider.Dify: {
+      return payload
+    }
   }
 };
 

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -55,6 +55,15 @@ export const getProviderAuthPayload = (provider: string) => {
       return { endpoint: config?.baseURL };
     }
 
+    case ModelProvider.Dify: {
+      const { token, baseUrl, userId } = keyVaultsConfigSelectors.difyConfig(useUserStore.getState())
+      return {
+        token,
+        baseUrl,
+        userId,
+      }
+    }
+
     default: {
       const config = keyVaultsConfigSelectors.getVaultByProvider(provider as GlobalLLMProviderKey)(
         useUserStore.getState(),

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -165,6 +165,14 @@ export function initializeWithClientStore(provider: string, payload: any) {
     case ModelProvider.ZeroOne: {
       break;
     }
+    case ModelProvider.Dify: {
+      providerOptions = {
+        token: providerAuthPayload?.apiKey,
+        baseUrl: providerAuthPayload?.endpoint,
+        userId: providerAuthPayload?.userId,
+      }
+      break;
+    }
   }
 
   /**

--- a/src/store/chat/slices/aiChat/action.ts
+++ b/src/store/chat/slices/aiChat/action.ts
@@ -355,7 +355,7 @@ export const chatAiChat: StateCreator<
 
     const agentConfig = getAgentConfig();
     const chatConfig = agentConfig.chatConfig;
-
+    
     const compiler = template(chatConfig.inputTemplate, { interpolate: /{{([\S\s]+?)}}/g });
 
     // ================================== //
@@ -444,6 +444,7 @@ export const chatAiChat: StateCreator<
         await internal_updateMessageContent(assistantId, content, toolCalls);
       },
       onMessageHandle: async (chunk) => {
+        console.log('[onMessageHandle] :', chunk);
         switch (chunk.type) {
           case 'text': {
             output += chunk.text;

--- a/src/store/user/slices/modelList/selectors/keyVaults.ts
+++ b/src/store/user/slices/modelList/selectors/keyVaults.ts
@@ -17,6 +17,7 @@ const bedrockConfig = (s: UserStore) => keyVaultsSettings(s).bedrock || {};
 const wenxinConfig = (s: UserStore) => keyVaultsSettings(s).wenxin || {};
 const ollamaConfig = (s: UserStore) => keyVaultsSettings(s).ollama || {};
 const azureConfig = (s: UserStore) => keyVaultsSettings(s).azure || {};
+const difyConfig = (s: UserStore) => keyVaultsSettings(s).dify || {};
 const getVaultByProvider = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
   (keyVaultsSettings(s)[provider] || {}) as OpenAICompatibleKeyVault &
     AzureOpenAIKeyVault &
@@ -44,4 +45,5 @@ export const keyVaultsConfigSelectors = {
   openAIConfig,
   password,
   wenxinConfig,
+  difyConfig,
 };

--- a/src/types/agent/index.ts
+++ b/src/types/agent/index.ts
@@ -17,8 +17,29 @@ export interface LobeAgentTTSConfig {
   };
 }
 
+export interface DifyConfig {
+  /**
+   * API地址
+   */
+  baseUrl?: string;
+  /**
+   * 是否启用
+   */
+  enabled: boolean;
+  /**
+   * token
+   */
+  token?: string
+
+  /**
+   * 用户id
+   */
+  userId: string
+}
+
 export interface LobeAgentConfig {
   chatConfig: LobeAgentChatConfig;
+  dify: DifyConfig;
   fewShots?: FewShots;
   files?: FileItem[];
   id?: string;
@@ -43,6 +64,7 @@ export interface LobeAgentConfig {
    *  模型供应商
    */
   provider?: string;
+
   /**
    * 系统角色
    */

--- a/src/types/user/settings/keyVaults.ts
+++ b/src/types/user/settings/keyVaults.ts
@@ -21,6 +21,12 @@ export interface WenxinKeyVault {
   secretKey?: string;
 }
 
+export interface DifyKeyValut {
+  token?: string;
+  baseUrl?: string;
+  userId?: string;
+}
+
 export interface UserKeyVaults {
   ai21?: OpenAICompatibleKeyVault;
   ai360?: OpenAICompatibleKeyVault;
@@ -55,4 +61,5 @@ export interface UserKeyVaults {
   wenxin?: WenxinKeyVault;
   zeroone?: OpenAICompatibleKeyVault;
   zhipu?: OpenAICompatibleKeyVault;
+  dify?: DifyKeyValut;
 }

--- a/src/utils/fetch/fetchSSE.ts
+++ b/src/utils/fetch/fetchSSE.ts
@@ -351,6 +351,11 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
             options.onMessageHandle?.({ tool_calls: toolCalls, type: 'tool_calls' });
           }
         }
+
+        case 'thoughts':
+          // TODO: add process logit
+          console.log('[fetchSSE - dify]: ', data);
+          break;
       }
     },
     onopen: async (res) => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

对 Dify 的接入需要对以下方面进行重构

- [ ] 1. 助手层面
- 允许自定义 conversation list 获取，并且不存储
- 自定义 根据 conversation_id 的 chat message 获取，并且不存储

- [x] 2. Model Provider
- 增加一个处理Dify响应流的 model provider
- 对 convesation context 的追踪由前端传入的 conversation id追踪，而非先前的整个 messages 历史
- 目前方案 `src/libs/agent-runtime/dify/index.ts`

- [ ] 3. Dify 响应流的处理
read first [key concepts | dify](https://docs.dify.ai/guides/workflow/key-concepts)

- `message` 处理
- `node event` 处理
- `workflow` 处理 

- 目前方案 `src/libs/agent-runtime/utils/streams/dify.ts`
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

进度track

- 2024/10/18

完成 Model Provider 的实现，初步处理 Dify 响应流
![image](https://github.com/user-attachments/assets/000da6ad-ae1c-42c7-b76e-4029c9f21c2d)


<!-- Add any other context about the Pull Request here. -->
