### PR TITLE
👷 build: pin`@smithy/util-stream@3.1.9` to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@react-spring/web": "^9.7.5",
     "@sentry/nextjs": "^7.119.2",
     "@serwist/next": "^9.0.9",
+    "@smithy/util-stream": "3.1.9",
     "@t3-oss/env-nextjs": "^0.11.1",
     "@tanstack/react-query": "^5.59.15",
     "@trpc/client": "next",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@react-spring/web": "^9.7.5",
     "@sentry/nextjs": "^7.119.2",
     "@serwist/next": "^9.0.9",
-    "@smithy/core": "3.1.9",
+    "@smithy/core": "2.4.8",
     "@smithy/util-stream": "3.1.9",
     "@t3-oss/env-nextjs": "^0.11.1",
     "@tanstack/react-query": "^5.59.15",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@react-spring/web": "^9.7.5",
     "@sentry/nextjs": "^7.119.2",
     "@serwist/next": "^9.0.9",
+    "@smithy/core": "3.1.9",
     "@smithy/util-stream": "3.1.9",
     "@t3-oss/env-nextjs": "^0.11.1",
     "@tanstack/react-query": "^5.59.15",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

`@smithy/util-stream@3.2.0` 直接依赖了 node stream ，导致 edge runtime 下挂了，先锁定 3.1.9

---
补充：锁了一个依赖还不够，还得锁 `@smithy/core` 。无语

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information


refs: https://github.com/smithy-lang/smithy-typescript/issues/1435

<!-- Add any other context about the Pull Request here. -->
