### PR TITLE
🐛 fix: fix Huggingface API interrupting when the output exceeds 140 tokens

### DIFF
--- a/src/libs/agent-runtime/huggingface/index.ts
+++ b/src/libs/agent-runtime/huggingface/index.ts
@@ -21,8 +21,10 @@ export const LobeHuggingFaceAI = LobeOpenAICompatibleFactory({
   },
   customClient: {
     createChatCompletionStream: (client: HfInference, payload, instance) => {
+      const { max_tokens = 4096} = payload;
       const hfRes = client.chatCompletionStream({
         endpointUrl: instance.baseURL,
+        max_tokens: max_tokens,
         messages: payload.messages,
         model: payload.model,
         stream: true,


### PR DESCRIPTION


#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

解决Huggingface API在输出超过140多个token时中断的问题

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
