### PR TITLE
🐛 fix: remove the 'resetConversation' hot key

### DIFF
--- a/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
+++ b/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
@@ -1,19 +1,15 @@
 'use client';
 
 import isEqual from 'fast-deep-equal';
-import { useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { HOTKEYS } from '@/const/hotkeys';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
-import { useFileStore } from '@/store/file';
 import { useGlobalStore } from '@/store/global';
 
 const HotKeys = () => {
-  const [regenerateMessage] = useChatStore((s) => [
-    s.regenerateMessage,
-  ]);
+  const [regenerateMessage] = useChatStore((s) => [s.regenerateMessage]);
   const lastMessage = useChatStore(chatSelectors.latestMessage, isEqual);
 
   const toggleZenMode = useGlobalStore((s) => s.toggleZenMode);

--- a/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
+++ b/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
@@ -11,24 +11,12 @@ import { useFileStore } from '@/store/file';
 import { useGlobalStore } from '@/store/global';
 
 const HotKeys = () => {
-  const [regenerateMessage, clearMessage] = useChatStore((s) => [
+  const [regenerateMessage] = useChatStore((s) => [
     s.regenerateMessage,
-    s.clearMessage,
   ]);
   const lastMessage = useChatStore(chatSelectors.latestMessage, isEqual);
 
-  const [clearImageList] = useFileStore((s) => [s.clearChatUploadFileList]);
   const toggleZenMode = useGlobalStore((s) => s.toggleZenMode);
-
-  const resetConversation = useCallback(() => {
-    clearMessage();
-    clearImageList();
-  }, []);
-
-  useHotkeys(HOTKEYS.clear, resetConversation, {
-    enableOnFormTags: true,
-    preventDefault: true,
-  });
 
   useHotkeys(HOTKEYS.zenMode, toggleZenMode, {
     enableOnFormTags: true,

--- a/src/const/hotkeys.ts
+++ b/src/const/hotkeys.ts
@@ -4,7 +4,6 @@ export const SAVE_TOPIC_KEY = 'n';
 export const CLEAN_MESSAGE_KEY = 'backspace';
 
 export const HOTKEYS = {
-  clear: 'mod+alt+backspace',
   regenerate: 'alt+r',
   saveTopic: 'alt+n',
   zenMode: 'mod+\\',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

close: #4517

Because this hot key is used infrequently and can be misoperated, it has been decided to remove it after discussion.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
