### PR TITLE
🐛 fix: fix duplicate error when creating new user

### DIFF
--- a/src/database/server/models/user.ts
+++ b/src/database/server/models/user.ts
@@ -19,6 +19,12 @@ export class UserNotFoundError extends TRPCError {
 
 export class UserModel {
   static createUser = async (params: NewUser) => {
+    // if user already exists, skip creation
+    if (params.id) {
+      const user = await serverDB.query.users.findFirst({ where: eq(users.id, params.id) });
+      if (!!user) return;
+    }
+
     const [user] = await serverDB
       .insert(users)
       .values({ ...params })

--- a/src/libs/langchain/loaders/index.ts
+++ b/src/libs/langchain/loaders/index.ts
@@ -61,7 +61,7 @@ export class ChunkingLoader {
 
         default: {
           throw new Error(
-            'Unsupported file type, please check your file is a supported type, or just create an issue.',
+            `Unsupported file type [${type}], please check your file is supported, or create report issue here: https://github.com/lobehub/lobe-chat/discussions/3550`,
           );
         }
       }


### PR DESCRIPTION
(cherry picked from commit 76eb9b428c480ae75592e9ba0d59402b2ae5fbda)

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

fix error 

```log
error: duplicate key value violates unique constraint "users_pkey"
    at /var/task/.next/server/chunks/1148.js:9:29015
    ... 8 lines matching cause stack trace ...
    at async c (/var/task/.next/server/chunks/88674.js:4:68) {
  code: 'INTERNAL_SERVER_ERROR',
  name: 'TRPCError',
  [cause]: error: duplicate key value violates unique constraint "users_pkey"
      at /var/task/.next/server/chunks/1148.js:9:29015
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async f.execute (/var/task/.next/server/chunks/1148.js:18:9079)
      at async o.createUser (/var/task/.next/server/chunks/13899.js:5:9975)
      at async o.createUser (/var/task/.next/server/chunks/65261.js:6:17554)
      at async /var/task/.next/server/chunks/65261.js:6:15459
      at async u.middlewares (/var/task/.next/server/chunks/88674.js:1:5426)
      at async c (/var/task/.next/server/chunks/88674.js:4:68)
      at async c (/var/task/.next/server/chunks/88674.js:4:68)
      at async c (/var/task/.next/server/chunks/88674.js:4:68) {
    length: 211,
    severity: 'ERROR',
    code: '23505',
    detail: 'Key (id)=(user_xxxxx) already exists.',
    hint: undefined,
    position: undefined,
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: 'public',
    table: 'users',
    column: undefined,
    dataType: undefined,
    constraint: 'users_pkey',
    file: 'nbtinsert.c',
    line: '666',
    routine: '_bt_check_unique'
  }
}
```
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
