### PR TITLE
📝 docs: support use custom `host` in docker-compose setup script & regenerate secrets

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - 'MINIO_ROOT_USER=${MINIO_ROOT_USER}'
       - 'MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}'
       - 'MINIO_API_CORS_ALLOW_ORIGIN=http://localhost:${LOBE_PORT}'
+      - 'MINIO_ACCESS_KEY=${S3_ACCESS_KEY_ID}'
+      - 'MINIO_SECRET_KEY=${S3_SECRET_ACCESS_KEY}'
     restart: always
     command: >
       server /etc/minio/data --address ":${MINIO_PORT}" --console-address ":9001"

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       - 'MINIO_ROOT_USER=${MINIO_ROOT_USER}'
       - 'MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}'
       - 'MINIO_API_CORS_ALLOW_ORIGIN=http://localhost:${LOBE_PORT}'
-      - 'MINIO_ACCESS_KEY=${S3_ACCESS_KEY_ID}'
-      - 'MINIO_SECRET_KEY=${S3_SECRET_ACCESS_KEY}'
     restart: always
     command: >
       server /etc/minio/data --address ":${MINIO_PORT}" --console-address ":9001"

--- a/docker-compose/local/init_data.json
+++ b/docker-compose/local/init_data.json
@@ -152,7 +152,7 @@
           "name": "Logo",
           "visible": true,
           "label": "",
-          "customCss": ".login-logo-box {}",
+          "customCss": ".login-logo-box {} \n.panel-logo {\n    width: 80px;\n}",
           "placeholder": "",
           "rule": "None",
           "isCustom": false

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -277,56 +277,88 @@ rm s3_data.tar.gz
 # === Regenerate Secrets ===
 # ==========================
 
+generate_key() {
+  if [[ -z "$1" ]]; then
+    echo "Usage: generate_key <length>"
+    return 1
+  fi
+  echo $(openssl rand -hex $1 | tr -d '\n' | fold -w $1 | head -n 1)
+}
+
 echo $(show_message "security_secrect_regenerate")
 
 # Generate CASDOOR_SECRET
-CASDOOR_SECRET=$(openssl rand -base64 32)
+CASDOOR_SECRET=$(generate_key 32)
 if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_SECRET"
 else
   # Search and replace the value of CASDOOR_SECRET in .env
-  sed -i "s|^AUTH_CASDOOR_SECRET=.*|AUTH_CASDOOR_SECRET=${CASDOOR_SECRET}|" .env
+  sed -i "s#^AUTH_CASDOOR_SECRET=.*#AUTH_CASDOOR_SECRET=${CASDOOR_SECRET}#" .env
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "AUTH_CASDOOR_SECRET in \`.env\`"
+  fi
   # replace `clientSecrect` in init_data.json
-  sed -i "s/"dbf205949d704de81b0b5b3603174e23fbecc354"/${CASDOOR_SECRET}/" init_data.json
+  sed -i "s#dbf205949d704de81b0b5b3603174e23fbecc354#${CASDOOR_SECRET}#" init_data.json
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "AUTH_CASDOOR_SECRET in \`init_data.json\`"
+  fi
 fi
 
 # Generate Casdoor User
 CASDOOR_USER="admin"
-CASDOOR_PASSWORD=$(openssl rand -base64 6)
+CASDOOR_PASSWORD=$(generate_key 6)
 if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_PASSWORD"
 else
   # replace `password` in init_data.json
   sed -i "s/"123"/${CASDOOR_PASSWORD}/" init_data.json
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_PASSWORD in \`init_data.json\`"
+  fi
 fi
 
 # Generate Minio S3 access key
-S3_SECRET_ACCESS_KEY=$(openssl rand -base64 32)
+S3_SECRET_ACCESS_KEY=$(generate_key 32)
 if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY"
 else
   # Search and replace the value of S3_SECRET_ACCESS_KEY in .env
   sed -i "s|^S3_SECRET_ACCESS_KEY=.*|S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}|" .env
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY in \`.env\`"
+  fi
 fi
 
 # Generate Minio S3 user
 MINIO_ROOT_USER="admin"
-MINIO_ROOT_PASSWORD=$(openssl rand -base64 6)
+MINIO_ROOT_PASSWORD=$(generate_key 6)
 if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD"
 else
   # Search and replace the value of MINIO_ROOT_PASSWORD in .env
   sed -i "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" .env
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD in \`.env\`"
+  fi
   # Modify user
   sed -i "s/^MINIO_ROOT_USER=.*/MINIO_ROOT_USER=${MINIO_ROOT_USER}/" .env
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_USER in \`.env\`"
+  fi
 fi
 
 # Modify the .env file if the host is specified
 if [ -n "$HOST" ]; then
   # Modify env
   sed -i "s/localhost/$HOST/g" .env
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "HOST in \`.env\`"
+  fi
   # Modify casdoor init data
   sed -i "s/localhost/$HOST/g" init_data.json
+  if [ $? -ne 0 ]; then
+    echo $(show_message "security_secrect_regenerate_failed") "HOST in \`init_data.json\`"
+  fi
 fi
 
 # Display configuration reports

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -323,7 +323,7 @@ if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY"
 else
   # Search and replace the value of S3_SECRET_ACCESS_KEY in .env
-  sed -i "s|^S3_SECRET_ACCESS_KEY=.*|S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}|" .env
+  sed -i "s#^S3_SECRET_ACCESS_KEY=.*#S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}#" .env
   if [ $? -ne 0 ]; then
     echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY in \`.env\`"
   fi
@@ -336,7 +336,7 @@ if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD"
 else
   # Search and replace the value of MINIO_ROOT_PASSWORD in .env
-  sed -i "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" .env
+  sed -i "s#^MINIO_ROOT_PASSWORD=.*#MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}#" .env
   if [ $? -ne 0 ]; then
     echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD in \`.env\`"
   fi

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -371,7 +371,7 @@ if [ -n "$HOST" ]; then
   echo -e "Server Host: $HOST"
 fi
 echo -e "Casdoor: \n - Username: admin\n  - Password: ${CASDOOR_PASSWORD}\n  - Client Secret: ${CASDOOR_SECRET}"
-echo -e "Minio S3: \n - MinIO User: ${MINIO_ROOT_USER}\n  - MinIO PassWord: ${MINIO_ROOT_PASSWORD}\n  - MinIO Access Key: ${S3_SECRET_ACCESS_KEY}\n"
+echo -e "Minio S3: \n - MinIO User: ${MINIO_ROOT_USER}\n  - MinIO PassWord: ${MINIO_ROOT_PASSWORD}\n"
 
 # ===========================
 # == Display final message ==

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -331,24 +331,6 @@ fi
 #  fi
 #fi
 
-# Generate Minio S3 user
-MINIO_ROOT_USER="admin"
-MINIO_ROOT_PASSWORD=$(generate_key 8)
-if [ $? -ne 0 ]; then
-  echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD"
-else
-  # Search and replace the value of MINIO_ROOT_PASSWORD in .env
-  sed -i "s#^MINIO_ROOT_PASSWORD=.*#MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}#" .env
-  if [ $? -ne 0 ]; then
-    echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD in \`.env\`"
-  fi
-  # Modify user
-  sed -i "s/^MINIO_ROOT_USER=.*/MINIO_ROOT_USER=${MINIO_ROOT_USER}/" .env
-  if [ $? -ne 0 ]; then
-    echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_USER in \`.env\`"
-  fi
-fi
-
 # Modify the .env file if the host is specified
 if [ -n "$HOST" ]; then
   # Modify env
@@ -371,7 +353,6 @@ if [ -n "$HOST" ]; then
   echo -e "Server Host: $HOST"
 fi
 echo -e "Casdoor: \n - Username: admin\n  - Password: ${CASDOOR_PASSWORD}\n  - Client Secret: ${CASDOOR_SECRET}"
-echo -e "Minio S3: \n - MinIO User: ${MINIO_ROOT_USER}\n  - MinIO PassWord: ${MINIO_ROOT_PASSWORD}\n"
 
 # ===========================
 # == Display final message ==

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -331,7 +331,7 @@ fi
 
 # Generate Minio S3 user
 MINIO_ROOT_USER="admin"
-MINIO_ROOT_PASSWORD=$(generate_key 6)
+MINIO_ROOT_PASSWORD=$(generate_key 8)
 if [ $? -ne 0 ]; then
   echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD"
 else

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -318,16 +318,18 @@ else
 fi
 
 # Generate Minio S3 access key
-S3_SECRET_ACCESS_KEY=$(generate_key 32)
-if [ $? -ne 0 ]; then
-  echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY"
-else
-  # Search and replace the value of S3_SECRET_ACCESS_KEY in .env
-  sed -i "s#^S3_SECRET_ACCESS_KEY=.*#S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}#" .env
-  if [ $? -ne 0 ]; then
-    echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY in \`.env\`"
-  fi
-fi
+# Temporarily disable key gen for minio because 
+# minio can not start with a access key in envs
+#S3_SECRET_ACCESS_KEY=$(generate_key 32)
+#if [ $? -ne 0 ]; then
+#  echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY"
+#else
+#  # Search and replace the value of S3_SECRET_ACCESS_KEY in .env
+#  sed -i "s#^S3_SECRET_ACCESS_KEY=.*#S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}#" .env
+#  if [ $? -ne 0 ]; then
+#    echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY in \`.env\`"
+#  fi
+#fi
 
 # Generate Minio S3 user
 MINIO_ROOT_USER="admin"

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -130,13 +130,43 @@ show_message() {
           ;;
       esac
       ;;
+    security_secrect_regenerate)
+      case $LANGUAGE in
+        zh_CN)
+          echo "重新生成安全密钥..."
+          ;;
+        *)
+          echo "Regenerate security secrets..."
+          ;;
+      esac
+      ;;
+    security_secrect_regenerate_failed)
+      case $LANGUAGE in
+        zh_CN)
+          echo "无法重新生成安全密钥："
+          ;;
+        *)
+          echo "Failed to regenerate security secrets: "
+          ;;
+      esac
+      ;;
+    security_secrect_regenerate_report)
+      case $LANGUAGE in
+        zh_CN)
+          echo "安全密钥生成结果如下："
+          ;;
+        *)
+          echo "Security secret generation results are as follows:"
+          ;;
+      esac
+      ;;
     tips_run_command)
       case $LANGUAGE in
         zh_CN)
-          echo "您已经完成了所有配置文件的下载。请运行以下命令启动LobeChat："
+          echo "您已经完成了所有配置。请运行以下命令启动LobeChat："
           ;;
         *)
-          echo "You have completed downloading all configuration files. Please run this command to start LobeChat:"
+          echo "You have completed all configurations. Please run this command to start LobeChat:"
           ;;
       esac
       ;;
@@ -247,11 +277,12 @@ rm s3_data.tar.gz
 # === Regenerate Secrets ===
 # ==========================
 
+echo $(show_message "security_secrect_regenerate")
+
 # Generate CASDOOR_SECRET
 CASDOOR_SECRET=$(openssl rand -base64 32)
 if [ $? -ne 0 ]; then
-  echo "[Warning] Failed to generate CASDOOR_SECRET with openssl, keep default"
-  exit 1
+  echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_SECRET"
 else
   # Search and replace the value of CASDOOR_SECRET in .env
   sed -i "s|^AUTH_CASDOOR_SECRET=.*|AUTH_CASDOOR_SECRET=${CASDOOR_SECRET}|" .env
@@ -259,11 +290,20 @@ else
   sed -i "s/"dbf205949d704de81b0b5b3603174e23fbecc354"/${CASDOOR_SECRET}/" init_data.json
 fi
 
+# Generate Casdoor User
+CASDOOR_USER="admin"
+CASDOOR_PASSWORD=$(openssl rand -base64 6)
+if [ $? -ne 0 ]; then
+  echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_PASSWORD"
+else
+  # replace `password` in init_data.json
+  sed -i "s/"123"/${CASDOOR_PASSWORD}/" init_data.json
+fi
+
 # Generate Minio S3 access key
 S3_SECRET_ACCESS_KEY=$(openssl rand -base64 32)
 if [ $? -ne 0 ]; then
-  echo "[Warning] Failed to generate S3_SECRET_ACCESS_KEY with openssl, keep default"
-  exit 1
+  echo $(show_message "security_secrect_regenerate_failed") "S3_SECRET_ACCESS_KEY"
 else
   # Search and replace the value of S3_SECRET_ACCESS_KEY in .env
   sed -i "s|^S3_SECRET_ACCESS_KEY=.*|S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}|" .env
@@ -271,10 +311,9 @@ fi
 
 # Generate Minio S3 user
 MINIO_ROOT_USER="admin"
-MINIO_ROOT_PASSWORD=$(openssl rand -base64 16)
+MINIO_ROOT_PASSWORD=$(openssl rand -base64 6)
 if [ $? -ne 0 ]; then
-  echo "[Warning] Failed to generate MINIO_ROOT_PASSWORD with openssl, keep default"
-  exit 1
+  echo $(show_message "security_secrect_regenerate_failed") "MINIO_ROOT_PASSWORD"
 else
   # Search and replace the value of MINIO_ROOT_PASSWORD in .env
   sed -i "s|^MINIO_ROOT_PASSWORD=.*|MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}|" .env
@@ -291,14 +330,19 @@ if [ -n "$HOST" ]; then
 fi
 
 # Display configuration reports
-echo -e "\nConfiguration details:\n"
+
+echo $(show_message "security_secrect_regenerate_report")
+
 if [ -n "$HOST" ]; then
   echo -e "Server Host: $HOST"
 fi
-echo -e "Casdoor: \n - Username: admin\n  - Password: 123\n  - Client Secret: ${CASDOOR_SECRET}"
+echo -e "Casdoor: \n - Username: admin\n  - Password: ${CASDOOR_PASSWORD}\n  - Client Secret: ${CASDOOR_SECRET}"
 echo -e "Minio S3: \n - MinIO User: ${MINIO_ROOT_USER}\n  - MinIO PassWord: ${MINIO_ROOT_PASSWORD}\n  - MinIO Access Key: ${S3_SECRET_ACCESS_KEY}\n"
 
-# Display final message
+# ===========================
+# == Display final message ==
+# ===========================
+
 printf "\n%s\n\n" "$(show_message "tips_run_command")"
 print_centered "docker compose up -d" "green"
 printf "\n%s" "$(show_message "tips_show_documentation")"

--- a/docker-compose/local/setup.sh
+++ b/docker-compose/local/setup.sh
@@ -193,10 +193,10 @@ show_message() {
     tips_warning)
       case $LANGUAGE in
         zh_CN)
-          echo "警告：不要在生产环境中使用此演示应用程序！！！"
+          echo "警告：如果你正在生产环境中使用，请在日志中检查密钥是否已经生成！！！"
           ;;
         *)
-          echo "Warning: do not use this demo application in production!!!"
+          echo "Warning: If you are using it in a production environment, please check if the keys have been generated in the logs!!!"
           ;;
       esac
       ;;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 👷 `docker-compose/local/setup.sh`
    - 支持自动修改 Casdoor 的初始化配置，密钥重新生成
    - 支持通过 `--host` 选项修改默认`host`

使用示例：
```sh
bash <(curl -fsSL https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/setup.sh) -f -l zh_CN --host my.site
```

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- pr未合并时请使用以下命令测试：
```sh
bash <(curl -fsSL https://raw.githubusercontent.com/cy948/lobe-chat/style/setup-host/docker-compose/local/setup.sh) -f -l zh_CN --host my.site
```

- MINIO 仍需手动修改，尚未找到能配置 MINIO 初始化设置的方法。文档中仍需保留 MinIO 配置的章节。

<!-- Add any other context about the Pull Request here. -->
