### PR TITLE
if enable login and not signed in, then auto pop up user panel

### DIFF
--- a/src/features/User/UserPanel/index.tsx
+++ b/src/features/User/UserPanel/index.tsx
@@ -2,7 +2,9 @@
 
 import { Popover } from 'antd';
 import { createStyles } from 'antd-style';
-import { PropsWithChildren, memo, useState } from 'react';
+import { PropsWithChildren, memo, useEffect, useState } from 'react';
+
+import { useUserStore } from '@/store/user';
 
 import PanelContent from './PanelContent';
 import UpgradeBadge from './UpgradeBadge';
@@ -19,6 +21,12 @@ const UserPanel = memo<PropsWithChildren>(({ children }) => {
   const hasNewVersion = useNewVersion();
   const [open, setOpen] = useState(false);
   const { styles } = useStyles();
+  const userStore = useUserStore();
+  useEffect(() => {
+    if (userStore.enableAuth() && !userStore.isSignedIn) {
+      setOpen(true);
+    }
+  }, [userStore.isSignedIn]);
 
   return (
     <UpgradeBadge showBadge={hasNewVersion}>

--- a/src/features/User/UserPanel/index.tsx
+++ b/src/features/User/UserPanel/index.tsx
@@ -23,11 +23,7 @@ const UserPanel = memo<PropsWithChildren>(({ children }) => {
   const { styles } = useStyles();
   const userStore = useUserStore();
   useEffect(() => {
-    if (userStore.enableAuth() && !userStore.isSignedIn) {
-      setOpen(true);
-    } else {
-      setOpen(false);
-    }
+    setOpen(userStore.enableAuth() && !userStore.isSignedIn);
   }, [userStore.isSignedIn]);
 
   return (

--- a/src/features/User/UserPanel/index.tsx
+++ b/src/features/User/UserPanel/index.tsx
@@ -25,6 +25,8 @@ const UserPanel = memo<PropsWithChildren>(({ children }) => {
   useEffect(() => {
     if (userStore.enableAuth() && !userStore.isSignedIn) {
       setOpen(true);
+    } else {
+      setOpen(false);
     }
   }, [userStore.isSignedIn]);
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
开启了登录，但用户未登录，则打开页面时，自动弹出用户面板，提示用户需要进行登录/注册。
![image](https://github.com/user-attachments/assets/e9053413-8ee6-4717-b427-5b4959c88a28)


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
