### PR TITLE
👷 build: support to ignore `\n` with `XXX_MODEL_LIST` env

### DIFF
--- a/src/utils/__snapshots__/parseModels.test.ts.snap
+++ b/src/utils/__snapshots__/parseModels.test.ts.snap
@@ -37,6 +37,23 @@ exports[`parseModelString > duplicate naming model 1`] = `
 }
 `;
 
+exports[`parseModelString > empty string model 1`] = `
+{
+  "add": [
+    {
+      "displayName": "gpt-4-turbo",
+      "id": "gpt-4-1106-preview",
+    },
+    {
+      "displayName": undefined,
+      "id": "claude-2",
+    },
+  ],
+  "removeAll": false,
+  "removed": [],
+}
+`;
+
 exports[`parseModelString > only add the model 1`] = `
 {
   "add": [

--- a/src/utils/parseModels.test.ts
+++ b/src/utils/parseModels.test.ts
@@ -25,6 +25,11 @@ describe('parseModelString', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('empty string model', () => {
+    const result = parseModelString('gpt-4-1106-preview=gpt-4-turbo,,  ,\n  ，+claude-2');
+    expect(result).toMatchSnapshot();
+  });
+
   describe('extension capabilities', () => {
     it('with token', () => {
       const result = parseModelString('chatglm-6b=ChatGLM 6B<4096>');

--- a/src/utils/parseModels.ts
+++ b/src/utils/parseModels.ts
@@ -34,6 +34,11 @@ export const parseModelString = (modelString: string = '', withDeploymentName = 
       continue;
     }
 
+    // remove empty model name
+    if (!item.trim().length) {
+      continue;
+    }
+
     // Remove duplicate model entries.
     const existingIndex = models.findIndex(({ id: n }) => n === id);
     if (existingIndex !== -1) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
在docker compose文件里自定义模型时，如果模型比较多写在一行里不方便阅读，为了方便阅读只能换行写类似这样
![image](https://github.com/user-attachments/assets/98f0be12-25c3-4d9b-bc56-e3d2d6923974)
但是这样写会出现模型为空字符串的情况
![image](https://github.com/user-attachments/assets/d3f779f5-69f6-44ac-a9d9-61d6188f5603)
所以兼容一下名称名称里只包含空字符串和换行的情况

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
