### PR TITLE
🐛 fix: keyword search for chat history & sessions

### DIFF
--- a/src/database/server/models/__tests__/session.test.ts
+++ b/src/database/server/models/__tests__/session.test.ts
@@ -231,8 +231,18 @@ describe('SessionModel', () => {
 
     it('should return sessions with matching title', async () => {
       await serverDB.insert(sessions).values([
-        { id: '1', userId, title: 'Hello World', description: 'Some description' },
-        { id: '2', userId, title: 'Another Session', description: 'Another description' },
+        { id: '1', userId },
+        { id: '2', userId },
+      ]);
+
+      await serverDB.insert(agents).values([
+        { id: 'agent-1', userId, model: 'gpt-3.5-turbo', title: 'Hello, Agent 1' },
+        { id: 'agent-2', userId, model: 'gpt-4', title: 'Agent 2' },
+      ]);
+
+      await serverDB.insert(agentsToSessions).values([
+        { agentId: 'agent-1', sessionId: '1' },
+        { agentId: 'agent-2', sessionId: '2' },
       ]);
 
       const result = await sessionModel.queryByKeyword('hello');
@@ -241,9 +251,21 @@ describe('SessionModel', () => {
     });
 
     it('should return sessions with matching description', async () => {
+      // The sessions has no title and desc,
+      // see: https://github.com/lobehub/lobe-chat/pull/4725
       await serverDB.insert(sessions).values([
-        { id: '1', userId, title: 'Session 1', description: 'Description with keyword' },
-        { id: '2', userId, title: 'Session 2', description: 'Another description' },
+        { id: '1', userId },
+        { id: '2', userId },
+      ]);
+
+      await serverDB.insert(agents).values([
+        { id: 'agent-1', userId, model: 'gpt-3.5-turbo', title: 'Agent 1', description: 'Description with Keyword' },
+        { id: 'agent-2', userId, model: 'gpt-4', title: 'Agent 2' },
+      ]);
+
+      await serverDB.insert(agentsToSessions).values([
+        { agentId: 'agent-1', sessionId: '1' },
+        { agentId: 'agent-2', sessionId: '2' },
       ]);
 
       const result = await sessionModel.queryByKeyword('keyword');
@@ -253,9 +275,21 @@ describe('SessionModel', () => {
 
     it('should return sessions with matching title or description', async () => {
       await serverDB.insert(sessions).values([
+        { id: '1', userId },
+        { id: '2', userId },
+        { id: '3', userId },
+      ]);
+
+      await serverDB.insert(agents).values([
         { id: '1', userId, title: 'Title with keyword', description: 'Some description' },
         { id: '2', userId, title: 'Another Session', description: 'Description with keyword' },
         { id: '3', userId, title: 'Third Session', description: 'Third description' },
+      ]);
+
+      await serverDB.insert(agentsToSessions).values([
+        { agentId: '1', sessionId: '1' },
+        { agentId: '2', sessionId: '2' },
+        { agentId: '3', sessionId: '3' },
       ]);
 
       const result = await sessionModel.queryByKeyword('keyword');

--- a/src/database/server/models/session.ts
+++ b/src/database/server/models/session.ts
@@ -61,7 +61,7 @@ export class SessionModel {
 
     const keywordLowerCase = keyword.toLowerCase();
 
-    const data = await this.findSessions({ keyword: keywordLowerCase });
+    const data = await this.findSessionsByKeywords({ keyword: keywordLowerCase });
 
     return data.map((item) => this.mapSessionItem(item as any));
   }
@@ -281,20 +281,53 @@ export class SessionModel {
         pinned !== undefined ? eq(sessions.pinned, pinned) : eq(sessions.userId, this.userId),
         keyword
           ? or(
-              like(
-                sql`lower(${sessions.title})` as unknown as Column,
-                `%${keyword.toLowerCase()}%`,
-              ),
-              like(
-                sql`lower(${sessions.description})` as unknown as Column,
-                `%${keyword.toLowerCase()}%`,
-              ),
-            )
+            like(
+              sql`lower(${sessions.title})` as unknown as Column,
+              `%${keyword.toLowerCase()}%`,
+            ),
+            like(
+              sql`lower(${sessions.description})` as unknown as Column,
+              `%${keyword.toLowerCase()}%`,
+            ),
+          )
           : eq(sessions.userId, this.userId),
         group ? eq(sessions.groupId, group) : isNull(sessions.groupId),
       ),
 
       with: { agentsToSessions: { columns: {}, with: { agent: true } }, group: true },
     });
+  }
+
+  async findSessionsByKeywords(params: {
+    current?: number;
+    keyword: string;
+    pageSize?: number;
+  }) {
+    const { keyword, pageSize = 9999, current = 0 } = params;
+    const offset = current * pageSize;
+    const results = await serverDB.query.agents.findMany({
+      limit: pageSize,
+      offset,
+      orderBy: [desc(agents.updatedAt)],
+      where: and(
+        eq(agents.userId, this.userId),
+        or(
+          like(
+            sql`lower(${agents.title})` as unknown as Column,
+            `%${keyword.toLowerCase()}%`,
+          ),
+          like(
+            sql`lower(${agents.description})` as unknown as Column,
+            `%${keyword.toLowerCase()}%`,
+          ),
+        )
+      ),
+      with: { agentsToSessions: { columns: {}, with: { session: true } } },
+    });
+    try {
+      // @ts-expect-error
+      return results.map((item) => item.agentsToSessions[0].session);
+    } catch {}
+    return []
   }
 }

--- a/src/database/server/models/topic.ts
+++ b/src/database/server/models/topic.ts
@@ -85,7 +85,12 @@ export class TopicModel {
             serverDB
               .select()
               .from(messages)
-              .where(and(eq(messages.topicId, topics.id), or(matchKeyword(messages.content)))),
+              .where(
+                and(
+                  eq(messages.topicId, topics.id),
+                  matchKeyword(messages.content)
+                )
+              ),
           ),
         ),
       ),

--- a/src/store/chat/slices/topic/selectors.ts
+++ b/src/store/chat/slices/topic/selectors.ts
@@ -42,7 +42,7 @@ const currentActiveTopicSummary = (s: ChatStoreState): ChatTopicSummary | undefi
 const isCreatingTopic = (s: ChatStoreState) => s.creatingTopic;
 
 const groupedTopicsSelector = (s: ChatStoreState): GroupedTopic[] => {
-  const topics = currentTopics(s);
+  const topics = displayTopics(s);
 
   if (!topics) return [];
   const favTopics = currentFavTopics(s);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- ♻️ `src/database/server/models/session.ts`: 增加 `findSessionsByKeywords` 方法进行模糊搜索。该方法从原来的模糊匹配 `sessions.title` 改为匹配 `agents.title`;
- 🐛  `src/database/server/models/topic.ts`: 去掉多余的 `or` 
- 🧪  `src/database/server/models/__tests__/session.test.ts`: 为上述改动补充测试

<!-- Thank you for your Pull Request. Please provide a description above. -->

- fix #4691 
- fix #3124

#### 📝 补充信息 | Additional Information

- 应该算是从 client db migrate 到 server db 的修复，日后有可能还是希望在数据库里面实现 full-text search 😋；
- 因为模糊搜索逻辑改动，部分测试用例需要相应变动；

run tests 
```sh
pnpm vitest --run --testNamePattern='^ ?SessionModel' ./src/database/server/models/__tests__/session.test.ts --config vitest.server.config.ts
```
<!-- Add any other context about the Pull Request here. -->
