### PR TITLE
 🐛 fix: fix Qwen baseUrl calling

### DIFF
--- a/src/libs/agent-runtime/qwen/index.ts
+++ b/src/libs/agent-runtime/qwen/index.ts
@@ -29,14 +29,11 @@ export class LobeQwenAI implements LobeRuntimeAI {
 
   constructor({
     apiKey,
-    baseURL,
+    baseURL = DEFAULT_BASE_URL,
     ...res
   }: ClientOptions & Record<string, any> = {}) {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
-
-    const finalBaseURL = baseURL ? baseURL : DEFAULT_BASE_URL;
-
-    this.client = new OpenAI({ apiKey, baseURL: finalBaseURL, ...res });
+    this.client = new OpenAI({ apiKey, baseURL, ...res });
     this.baseURL = this.client.baseURL;
   }
 

--- a/src/libs/agent-runtime/qwen/index.ts
+++ b/src/libs/agent-runtime/qwen/index.ts
@@ -29,11 +29,14 @@ export class LobeQwenAI implements LobeRuntimeAI {
 
   constructor({
     apiKey,
-    baseURL = DEFAULT_BASE_URL,
+    baseURL,
     ...res
   }: ClientOptions & Record<string, any> = {}) {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
-    this.client = new OpenAI({ apiKey, baseURL, ...res });
+
+    const finalBaseURL = baseURL ? baseURL : DEFAULT_BASE_URL;
+
+    this.client = new OpenAI({ apiKey, baseURL: finalBaseURL, ...res });
     this.baseURL = this.client.baseURL;
   }
 

--- a/src/server/modules/AgentRuntime/index.test.ts
+++ b/src/server/modules/AgentRuntime/index.test.ts
@@ -273,6 +273,16 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       expect(runtime['_runtime']).toBeInstanceOf(LobeQwenAI);
     });
 
+    it('Qwen AI provider: without endpoint', async () => {
+      const jwtPayload: JWTPayload = { apiKey: 'user-qwen-key' };
+      const runtime = await initAgentRuntimeWithUserPayload(ModelProvider.Qwen, jwtPayload);
+
+      // 假设 LobeQwenAI 是 Qwen 提供者的实现类
+      expect(runtime['_runtime']).toBeInstanceOf(LobeQwenAI);
+      // endpoint 不存在，应返回 DEFAULT_BASE_URL
+      expect(runtime['_runtime'].baseURL).toBe('https://dashscope.aliyuncs.com/compatible-mode/v1');
+    });
+
     it('Bedrock AI provider: without apikey', async () => {
       const jwtPayload = {};
       const runtime = await initAgentRuntimeWithUserPayload(ModelProvider.Bedrock, jwtPayload);

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -40,7 +40,7 @@ const getLlmOptionsFromPayload = (provider: string, payload: JWTPayload) => {
       const apiKey = apiKeyManager.pick(payload?.apiKey || llmConfig[`${upperProvider}_API_KEY`]);
       const baseURL = payload?.endpoint || process.env[`${upperProvider}_PROXY_URL`];
 
-      return { apiKey, baseURL };
+      return baseURL ? { apiKey, baseURL } : { apiKey };
     }
 
     case ModelProvider.Azure: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

触发原因：
`src/server/modules/AgentRuntime/index.ts` 中 `getLlmOptionsFromPayload` 默认处理返回了 `baseUrl` ，使得 `LobeQwenAI` 中引入的 baseUrl 为空，fallback 使用 OpenAI Client 内建地址

改造方法：
~~1. `src/libs/agent-runtime/qwen/index.ts` 对 baseUrl 进行校验，为空或不存在时使用 `DEFAULT_BASE_URL`~~ 存在更优解
2. `getLlmOptionsFromPayload` 中，如果 `baseUrl` 不存在则不引入

close #4796

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/e411c00f-9835-40a5-9567-57a3afeb8080)|![image](https://github.com/user-attachments/assets/dcd4d15a-2cf8-49e5-95ec-dd45bfd2b588)|
<!-- Add any other context about the Pull Request here. -->
