### PR TITLE
🐛 fix: fix fallback behavior of default mode in AgentRuntime

### DIFF
--- a/src/server/modules/AgentRuntime/index.test.ts
+++ b/src/server/modules/AgentRuntime/index.test.ts
@@ -370,6 +370,28 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       expect(runtime['_runtime']).toBeInstanceOf(LobeWenxinAI);
     });
 
+    it('OpenAI provider: without apikey with OPENAI_PROXY_URL', async () => {
+      process.env.OPENAI_PROXY_URL = 'https://proxy.example.com/v1';
+
+      const jwtPayload: JWTPayload = {};
+      const runtime = await initAgentRuntimeWithUserPayload(ModelProvider.OpenAI, jwtPayload);
+      expect(runtime['_runtime']).toBeInstanceOf(LobeOpenAI);
+      // 应返回 OPENAI_PROXY_URL
+      expect(runtime['_runtime'].baseURL).toBe('https://proxy.example.com/v1');
+    });
+
+    it('Qwen AI provider: without apiKey and endpoint with OPENAI_PROXY_URL', async () => {
+      process.env.OPENAI_PROXY_URL = 'https://proxy.example.com/v1';
+
+      const jwtPayload: JWTPayload = {};
+      const runtime = await initAgentRuntimeWithUserPayload(ModelProvider.Qwen, jwtPayload);
+
+      // 假设 LobeQwenAI 是 Qwen 提供者的实现类
+      expect(runtime['_runtime']).toBeInstanceOf(LobeQwenAI);
+      // endpoint 不存在，应返回 DEFAULT_BASE_URL
+      expect(runtime['_runtime'].baseURL).toBe('https://dashscope.aliyuncs.com/compatible-mode/v1');
+    });
+    
     it('Unknown Provider', async () => {
       const jwtPayload = {};
       const runtime = await initAgentRuntimeWithUserPayload('unknown', jwtPayload);

--- a/src/server/modules/AgentRuntime/index.test.ts
+++ b/src/server/modules/AgentRuntime/index.test.ts
@@ -370,7 +370,6 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       expect(runtime['_runtime']).toBeInstanceOf(LobeWenxinAI);
     });
 
-    /*
     it('Unknown Provider', async () => {
       const jwtPayload = {};
       const runtime = await initAgentRuntimeWithUserPayload('unknown', jwtPayload);
@@ -379,6 +378,5 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       // 例如，如果默认使用 OpenAI:
       expect(runtime['_runtime']).toBeInstanceOf(LobeOpenAI);
     });
-    */
   });
 });

--- a/src/server/modules/AgentRuntime/index.test.ts
+++ b/src/server/modules/AgentRuntime/index.test.ts
@@ -370,6 +370,7 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       expect(runtime['_runtime']).toBeInstanceOf(LobeWenxinAI);
     });
 
+    /*
     it('Unknown Provider', async () => {
       const jwtPayload = {};
       const runtime = await initAgentRuntimeWithUserPayload('unknown', jwtPayload);
@@ -378,5 +379,6 @@ describe('initAgentRuntimeWithUserPayload method', () => {
       // 例如，如果默认使用 OpenAI:
       expect(runtime['_runtime']).toBeInstanceOf(LobeOpenAI);
     });
+    */
   });
 });

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -33,11 +33,9 @@ const getLlmOptionsFromPayload = (provider: string, payload: JWTPayload) => {
     default: {
       let upperProvider = provider.toUpperCase();
 
-      /*
-      if (!llmConfig[`${upperProvider}_API_KEY`]) {
+      if (!( `${upperProvider}_API_KEY` in llmConfig)) {
         upperProvider = ModelProvider.OpenAI.toUpperCase(); // Use OpenAI options as default
       }
-      */
 
       const apiKey = apiKeyManager.pick(payload?.apiKey || llmConfig[`${upperProvider}_API_KEY`]);
       const baseURL = payload?.endpoint || process.env[`${upperProvider}_PROXY_URL`];

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -33,9 +33,11 @@ const getLlmOptionsFromPayload = (provider: string, payload: JWTPayload) => {
     default: {
       let upperProvider = provider.toUpperCase();
 
+      /*
       if (!llmConfig[`${upperProvider}_API_KEY`]) {
         upperProvider = ModelProvider.OpenAI.toUpperCase(); // Use OpenAI options as default
       }
+      */
 
       const apiKey = apiKeyManager.pick(payload?.apiKey || llmConfig[`${upperProvider}_API_KEY`]);
       const baseURL = payload?.endpoint || process.env[`${upperProvider}_PROXY_URL`];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

触发原因：
当时 Fallback 判定写的有问题，不应该用 APIKey 值是否存在作为判定依据，导致只要模型的 APIKey 环境变量为空，就走 OpenAI。也反向印证了昨天 Qwen 行为在设置 `QWEN_API_KEY` 后就正常

改进方法：
改为判定 `*_API_KEY` 是否在 llmConfig 中声明

close #4809

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

测试场景：
|环境变量|设置值|
|-|-|
|`OPENAI_PROXY_URL`|`https://proxy.example.org/v1`|
|`ANTHROPIC_API_KEY`|空|

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/9d39c654-9d21-4407-8e33-7fba5e6a7095)|![image](https://github.com/user-attachments/assets/46d7c57c-768d-427a-81af-23d1202d8688)|

<!-- Add any other context about the Pull Request here. -->
