### PR TITLE
♻️ refactor: Remove proxy url settings for NextAuth

### DIFF
--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -16,6 +16,8 @@ declare global {
 
       NEXT_AUTH_SSO_PROVIDERS?: string;
 
+      NEXT_AUTH_DEBUG?: string;
+
       AUTH0_CLIENT_ID?: string;
       AUTH0_CLIENT_SECRET?: string;
       AUTH0_ISSUER?: string;
@@ -156,6 +158,7 @@ export const getAuthConfig = () => {
       // NEXT-AUTH
       NEXT_AUTH_SECRET: z.string().optional(),
       NEXT_AUTH_SSO_PROVIDERS: z.string().optional().default('auth0'),
+      NEXT_AUTH_DEBUG: z.boolean().optional().default(false),
 
       // Auth0
       AUTH0_CLIENT_ID: z.string().optional(),
@@ -217,6 +220,7 @@ export const getAuthConfig = () => {
       NEXT_PUBLIC_ENABLE_NEXT_AUTH: !!process.env.NEXT_AUTH_SECRET,
       NEXT_AUTH_SSO_PROVIDERS: process.env.NEXT_AUTH_SSO_PROVIDERS,
       NEXT_AUTH_SECRET: process.env.NEXT_AUTH_SECRET,
+      NEXT_AUTH_DEBUG: !!process.env.NEXT_AUTH_DEBUG,
 
       // Auth0
       AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,

--- a/src/libs/next-auth/auth.config.ts
+++ b/src/libs/next-auth/auth.config.ts
@@ -41,7 +41,6 @@ export default {
     },
   },
   providers: initSSOProviders(),
-  redirectProxyUrl: process.env.APP_URL ? urlJoin(process.env.APP_URL, '/api/auth') : undefined,
   secret: authEnv.NEXT_AUTH_SECRET,
   trustHost: process.env?.AUTH_TRUST_HOST ? process.env.AUTH_TRUST_HOST === 'true' : true,
 } satisfies NextAuthConfig;

--- a/src/libs/next-auth/auth.config.ts
+++ b/src/libs/next-auth/auth.config.ts
@@ -39,8 +39,8 @@ export default {
       return session;
     },
   },
+  debug: authEnv.NEXT_AUTH_DEBUG,
   providers: initSSOProviders(),
   secret: authEnv.NEXT_AUTH_SECRET,
   trustHost: process.env?.AUTH_TRUST_HOST ? process.env.AUTH_TRUST_HOST === 'true' : true,
-  debug: authEnv.NEXT_AUTH_DEBUG,
 } satisfies NextAuthConfig;

--- a/src/libs/next-auth/auth.config.ts
+++ b/src/libs/next-auth/auth.config.ts
@@ -42,4 +42,5 @@ export default {
   providers: initSSOProviders(),
   secret: authEnv.NEXT_AUTH_SECRET,
   trustHost: process.env?.AUTH_TRUST_HOST ? process.env.AUTH_TRUST_HOST === 'true' : true,
+  debug: authEnv.NEXT_AUTH_DEBUG,
 } satisfies NextAuthConfig;

--- a/src/libs/next-auth/auth.config.ts
+++ b/src/libs/next-auth/auth.config.ts
@@ -1,5 +1,4 @@
 import type { NextAuthConfig } from 'next-auth';
-import urlJoin from 'url-join';
 
 import { authEnv } from '@/config/auth';
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/libs/next-auth/auth.config.ts`: 
    - 移除通过 `APP_URL` 设定 `redirectProxyUrl`
    - 增加打印日志的选项,可通过环境变量 `NEXT_AUTH_DEBUG`

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- 去除的理由：
    - 该设置自 #3701 引入，目的是让其替代 `AUTH_URL` ，因为 `AUTH_URL` 影响前端 next-auth 组件请求 auth session, login, logout 等api接口，同时影响 redirect 时的 auth 服务地址。
    - 但该设置只影响了 redirect 时的 auth 服务地址，并不能完全代替 `AUTH_URL` 的功能，同时会触发 warning。
    - 该问题是本人对authjs文档的变量理解有误，现进行更正。
- 后来导致相关 warning 出现在： #4138 #3965 

<!-- Add any other context about the Pull Request here. -->
