### PR TITLE
🐛 fix: fix wrong email linking in next-auth db adapter

### DIFF
--- a/src/database/server/models/__tests__/nextauth.test.ts
+++ b/src/database/server/models/__tests__/nextauth.test.ts
@@ -115,6 +115,37 @@ describe('LobeNextAuthDbAdapter', () => {
           await serverDB.query.users.findMany({ where: eq(users.email, user.email) }),
         ).toHaveLength(1);
       });
+
+      it('should create a user if id not exist and email is null', async () => {
+        // In previous version, it will link the account to the existing user if the email is null
+        // issue: https://github.com/lobehub/lobe-chat/issues/4918
+        expect(nextAuthAdapter).toBeDefined();
+        expect(nextAuthAdapter.createUser).toBeDefined();
+
+        const existUserId = 'user-db-1';
+        const existUserName = 'John Doe 1';
+        // @ts-expect-error: createUser is defined
+        await nextAuthAdapter.createUser({
+          ...user,
+          id: existUserId,
+          name: existUserName,
+          email: '',
+        });
+
+        const anotherUserId = 'user-db-2';
+        const anotherUserName = 'John Doe 2';
+        // @ts-expect-error: createUser is defined
+        await nextAuthAdapter.createUser({
+          ...user,
+          id: anotherUserId,
+          name: anotherUserName,
+          email: '',
+        });
+        // Should create a new user if id not exists and email is null
+        expect(
+          await serverDB.query.users.findMany({ where: eq(users.id, anotherUserId) }),
+        ).toHaveLength(1);
+      });
     });
 
     describe('deleteUser', () => {

--- a/src/libs/next-auth/adapter/index.ts
+++ b/src/libs/next-auth/adapter/index.ts
@@ -8,8 +8,8 @@ import { and, eq } from 'drizzle-orm';
 import type { NeonDatabase } from 'drizzle-orm/neon-serverless';
 import { Adapter, AdapterAccount } from 'next-auth/adapters';
 
-import { UserModel } from '@/database/server/models/user';
 import * as schema from '@/database/schemas';
+import { UserModel } from '@/database/server/models/user';
 import { merge } from '@/utils/merge';
 
 import {
@@ -53,7 +53,7 @@ export function LobeNextAuthDbAdapter(serverDB: NeonDatabase<typeof schema>): Ad
     async createUser(user): Promise<AdapterUser> {
       const { id, name, email, emailVerified, image, providerAccountId } = user;
       // return the user if it already exists
-      let existingUser = await UserModel.findByEmail(serverDB, email);
+      let existingUser = email.trim() ? await UserModel.findByEmail(serverDB, email) : undefined;
       // If the user is not found by email, try to find by providerAccountId
       if (!existingUser && providerAccountId) {
         existingUser = await UserModel.findById(serverDB, providerAccountId);
@@ -169,7 +169,7 @@ export function LobeNextAuthDbAdapter(serverDB: NeonDatabase<typeof schema>): Ad
     },
 
     async getUserByEmail(email): Promise<AdapterUser | null> {
-      const lobeUser = await UserModel.findByEmail(serverDB, email);
+      const lobeUser = email.trim() ? await UserModel.findByEmail(serverDB, email) : undefined;
       return lobeUser ? mapLobeUserToAdapterUser(lobeUser) : null;
     },
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 🐛  `src/libs/next-auth/adapter/index.ts`: 修复当用户没有邮箱时，会根据邮箱用户链接到其他用户。
- 🧪 `src/database/server/models/__tests__/nextauth.test.ts`: 当存在一个没有邮箱的用户A时，再创建一个没有邮箱的用户不会自动链接到用户B。
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- fix #4918 
- 该PR合并后，将完全信任SSO Provider的身份验证，允许SSO Provider不向lobe提供email的情况下注册用户，可能存在风险。同时也使一键部署后默认能够匿名登录。 #4844 
<!-- Add any other context about the Pull Request here. -->
