### PR TITLE
💄 style: Enable googleSearch Tool for gemini-2.0-flash-exp

### DIFF
--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -91,7 +91,12 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         .generateContentStream({
           contents,
           systemInstruction: payload.system as string,
-          tools: this.buildGoogleTools(payload.tools),
+          tools: (() => {
+            if (!payload.tools && model.startsWith('gemini-2.0')) {
+              return [{ googleSearch: {} }];
+            }
+            return this.buildGoogleTools(payload.tools);
+          })(),
         });
 
       const googleStream = convertIterableToStream(geminiStreamResult.stream);

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -93,7 +93,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
           systemInstruction: payload.system as string,
           tools: (() => {
             if (!payload.tools && model.startsWith('gemini-2.0')) {
-              return [{ googleSearch: {} }];
+              return [{ googleSearch: {} } as GoogleFunctionCallTool];
             }
             return this.buildGoogleTools(payload.tools);
           })(),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

参考文档：https://ai.google.dev/gemini-api/docs/models/gemini-v2#search-tool

原本 Gemini 的搜索服务（Grounding）是收费的，目前在 gemini-2.0-flash-exp 新模型上没有收费，故把此特性先引入了。

仅当模型为 gemini-2.0 系且未启用其他插件 tools 的情况下，默认启用。

#### 📝 补充信息 | Additional Information

close #4991 

效果（其中的事件已经手动搜索证实）：

![image](https://github.com/user-attachments/assets/e021f4da-bb5d-4cc5-a794-cb1b8c9ccfa4)
