### PR TITLE
🐛 fix: Revert "Enable googleSearch Tool for gemini-2.0-flash-exp"

### DIFF
--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -91,12 +91,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         .generateContentStream({
           contents,
           systemInstruction: payload.system as string,
-          tools: (() => {
-            if (!payload.tools && model.startsWith('gemini-2.0')) {
-              return [{ googleSearch: {} } as GoogleFunctionCallTool];
-            }
-            return this.buildGoogleTools(payload.tools);
-          })(),
+          tools: this.buildGoogleTools(payload.tools),
         });
 
       const googleStream = convertIterableToStream(geminiStreamResult.stream);


### PR DESCRIPTION
Reverts lobehub/lobe-chat#4997

https://github.com/lobehub/lobe-chat/pull/4997#issuecomment-2540482107

![image](https://github.com/user-attachments/assets/8fa13cbf-cb86-4618-bc34-4ef34c072df4)
