### PR TITLE
🐛 fix: correct the model list on the model provider's page

### DIFF
--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -328,7 +328,10 @@ export class DiscoverService {
 
   getModelById = async (locale: Locales, id: string): Promise<DiscoverModelItem | undefined> => {
     const list = await this.getModelList(locale);
-    let model = list.find((item) => item.identifier === id);
+    let model = list.find((item) => {
+      const ids = item.identifier.split('/');
+      return ids[1] === id || item.identifier === id;
+    });
 
     if (!model) return;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

模型列表去重时是以 `/` 后的名称作为唯一键的：
When deduplicating model lists, the name after the `/` is used as the unique key:

![image](https://github.com/user-attachments/assets/373495ca-bf74-4670-97d4-2a3f81064f35)

以 Qwen/Qwen2-7B-Instruct 为例，Gitee AI 中记录的模型 id 是 `Qwen2-7B-Instruct`，其它提供商的模型 id 是 `Qwen/Qwen2-7B-Instruct`，这种情况下，靠判断 `item.identifier === id` 是找不到 Gitee AI 的 `Qwen2-7B-Instruct` 模型详细的。

Using Qwen/Qwen2-7B-Instruct as an example, the model ID recorded in Gitee AI is `Qwen2-7B-Instruct`, while the model ID for other providers is `Qwen/Qwen2-7B-Instruct`. In this case, it is not possible to find detailed information about the Gitee AI's `Qwen2-7B-Instruct` model by determining that `item.identifier === id`.

因此，改成与 `getModelList()` 中相同的方式获取 id 再进行判断。
Therefore, it is changed to obtain the id in the same way as in `getModelList()` and then make a judgment.

#### 📝 补充信息 | Additional Information

**Before:**

The total number of models is 4 **+2**

![model-list-before](https://github.com/user-attachments/assets/c3021d9a-964d-49f2-880f-e54682fd0d0a)

**After:**

The total number of models is 4 **+10**

![model-list-after](https://github.com/user-attachments/assets/f725446e-e787-4d62-8c93-9d616fbac881)