### PR TITLE
🐛 fix: Bind the selected group name in the rename modal.

### DIFF
--- a/src/app/(main)/chat/@session/features/SessionListContent/Modals/RenameGroupModal.tsx
+++ b/src/app/(main)/chat/@session/features/SessionListContent/Modals/RenameGroupModal.tsx
@@ -1,7 +1,7 @@
 import { Input, Modal, type ModalProps } from '@lobehub/ui';
 import { App } from 'antd';
 import isEqual from 'fast-deep-equal';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSessionStore } from '@/store/session';
@@ -21,6 +21,11 @@ const RenameGroupModal = memo<RenameGroupModalProps>(({ id, open, onCancel }) =>
   const [loading, setLoading] = useState(false);
 
   const { message } = App.useApp();
+
+  useEffect(() => {
+    setInput(group?.name);
+  }, [group]);
+
   return (
     <Modal
       allowFullscreen


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Bind the selected group name in the rename group modal. The issue was that when there is multiple groups with sessions and you choose to rename a group, previously selected group name appears. Attached video.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

1. Added useEffect dependent on group and then updated the setInput so that group.name fetched from the store is set in input.

```js
 useEffect(() => {
    setInput(group?.name);
  }, [group]);
```

##### Before fix:

https://github.com/user-attachments/assets/402b3d08-62f6-485b-b2b7-e65b2dedfa67


##### After fix:

https://github.com/user-attachments/assets/a6ee0de4-d91f-4510-9395-2b7a8f88de48

<!-- Add any other context about the Pull Request here. -->
