### PR TITLE
fix: fix the disabled status of service provider configuration

### DIFF
--- a/src/app/(main)/discover/(detail)/provider/[slug]/features/ProviderConfig.tsx
+++ b/src/app/(main)/discover/(detail)/provider/[slug]/features/ProviderConfig.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { Button, Dropdown } from 'antd';
+import { Button, ButtonProps, Dropdown } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronDownIcon, SquareArrowOutUpRight } from 'lucide-react';
 import Link from 'next/link';
-import { memo } from 'react';
+import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FlexboxProps } from 'react-layout-kit';
 
 import { useOpenSettings } from '@/hooks/useInterceptingRoutes';
 import { SettingsTabs } from '@/store/global/initialState';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { DiscoverProviderItem } from '@/types/discover';
 
 const useStyles = createStyles(({ css }) => ({
@@ -30,6 +31,7 @@ const ProviderConfig = memo<ProviderConfigProps>(({ data }) => {
   const { styles } = useStyles();
   const { t } = useTranslation('discover');
   const openSettings = useOpenSettings(SettingsTabs.LLM);
+  const { showLLM } = useServerConfigStore(featureFlagsSelectors);
 
   const icon = <Icon icon={SquareArrowOutUpRight} size={{ fontSize: 16 }} />;
 
@@ -56,13 +58,23 @@ const ProviderConfig = memo<ProviderConfigProps>(({ data }) => {
 
   if (!items || items?.length === 0)
     return (
-      <Button onClick={openSettings} size={'large'} style={{ flex: 1 }} type={'primary'}>
+      <Button
+        disabled={!showLLM}
+        onClick={openSettings}
+        size={'large'}
+        style={{ flex: 1 }}
+        type={'primary'}
+      >
         {t('providers.config')}
       </Button>
     );
 
   return (
     <Dropdown.Button
+      buttonsRender={(buttons) => {
+        const [leftButton, rightButton] = buttons as React.ReactElement<ButtonProps>[];
+        return [{ ...leftButton, props: { ...leftButton.props, disabled: !showLLM } }, rightButton];
+      }}
       className={styles.button}
       icon={<Icon icon={ChevronDownIcon} />}
       menu={{ items }}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

fix #5170 
当 language_model_settings 关闭时，模型服务商页面的配置服务商按钮为禁用状态。

![image](https://github.com/user-attachments/assets/250e500d-87c8-446c-857b-512d8578a4ca)


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
