### PR TITLE
💄 style: Support shortcut keys to open session settings

### DIFF
--- a/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
+++ b/src/app/(main)/chat/(workspace)/_layout/Desktop/HotKeys.tsx
@@ -4,6 +4,7 @@ import isEqual from 'fast-deep-equal';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { HOTKEYS } from '@/const/hotkeys';
+import { useOpenChatSettings } from '@/hooks/useInterceptingRoutes';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -13,8 +14,14 @@ const HotKeys = () => {
   const lastMessage = useChatStore(chatSelectors.latestMessage, isEqual);
 
   const toggleZenMode = useGlobalStore((s) => s.toggleZenMode);
+  const openChatSettings = useOpenChatSettings();
 
   useHotkeys(HOTKEYS.zenMode, toggleZenMode, {
+    enableOnFormTags: true,
+    preventDefault: true,
+  });
+
+  useHotkeys(HOTKEYS.chatSettings, () => openChatSettings(), {
     enableOnFormTags: true,
     preventDefault: true,
   });

--- a/src/const/hotkeys.ts
+++ b/src/const/hotkeys.ts
@@ -4,6 +4,7 @@ export const SAVE_TOPIC_KEY = 'n';
 export const CLEAN_MESSAGE_KEY = 'backspace';
 
 export const HOTKEYS = {
+  chatSettings: 'mod+comma',
   regenerate: 'alt+r',
   saveTopic: 'alt+n',
   zenMode: 'mod+\\',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

看代码支持了禅模式，加了一个心心念念的快捷键设置页面，之前[提过一嘴](https://github.com/lobehub/lobe-chat/issues/1451#issuecomment-1977069296)。

一开始想的是支持 打开全局设置 和 会话设置，但是感觉会有冲突，先支持会话设置吧。

评估一下看看是否需要吧。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
