### PR TITLE
♻️ refactor: Remove redundant payload remapping in client-fetch

### DIFF
--- a/src/services/__tests__/_auth.test.ts
+++ b/src/services/__tests__/_auth.test.ts
@@ -8,6 +8,7 @@ import {
   UserKeyVaults,
   UserModelProviderConfig,
 } from '@/types/user/settings';
+import { merge } from '@/utils/merge';
 
 import { getProviderAuthPayload } from '../_auth';
 
@@ -92,7 +93,15 @@ describe('getProviderAuthPayload', () => {
       awsAccessKeyId: mockBedrockConfig.accessKeyId,
       awsRegion: mockBedrockConfig.region,
       awsSecretAccessKey: mockBedrockConfig.secretAccessKey,
-    });
+    };
+    // For client
+    const clientPayload = {
+      apiKey: mockBedrockConfig.secretAccessKey + mockBedrockConfig.accessKeyId,
+      accessKeyId: mockBedrockConfig.accessKeyId,
+      region: mockBedrockConfig.region,
+      accessKeySecret: mockBedrockConfig.secretAccessKey,
+    };
+    expect(payload).toEqual(merge(serverPayload, clientPayload));
   });
 
   it('should return correct payload for Azure provider', () => {
@@ -108,7 +117,14 @@ describe('getProviderAuthPayload', () => {
       apiKey: mockAzureConfig.apiKey,
       azureApiVersion: mockAzureConfig.apiVersion,
       baseURL: mockAzureConfig.endpoint,
-    });
+    };
+    // For client
+    const clientPayload = {
+      apiKey: mockAzureConfig.apiKey,
+      apiVersion: mockAzureConfig.apiVersion,
+      baseURL: mockAzureConfig.endpoint,
+    };
+    expect(payload).toEqual(merge(serverPayload, clientPayload));
   });
 
   it('should return correct payload for Ollama provider', () => {
@@ -149,6 +165,30 @@ describe('getProviderAuthPayload', () => {
       apiKey: mockOpenAIConfig.apiKey,
       baseURL: mockOpenAIConfig.baseURL,
     });
+  });
+
+  it('should return correct payload for Cloudflare provider', () => {
+    // 假设的 Cloudflare 配置
+    const mockCloudflareConfig = {
+      apiKey: 'cloudflare-api-key',
+      baseURLOrAccountID: 'cloudflare-base-url-or-account-id',
+    };
+    act(() => {
+      setModelProviderConfig('cloudflare', mockCloudflareConfig);
+    });
+
+    const payload = getProviderAuthPayload(ModelProvider.Cloudflare);
+    // For server
+    const serverPayload = {
+      apiKey: mockCloudflareConfig.apiKey,
+      cloudflareBaseURLOrAccountID: mockCloudflareConfig.baseURLOrAccountID,
+    };
+    // For client
+    const clientPayload = {
+      apiKey: mockCloudflareConfig.apiKey,
+      baseURLOrAccountID: mockCloudflareConfig.baseURLOrAccountID,
+    };
+    expect(payload).toEqual(merge(serverPayload, clientPayload));
   });
 
   it('should return an empty object or throw an error for an unknown provider', () => {

--- a/src/services/__tests__/_auth.test.ts
+++ b/src/services/__tests__/_auth.test.ts
@@ -93,15 +93,12 @@ describe('getProviderAuthPayload', () => {
       awsAccessKeyId: mockBedrockConfig.accessKeyId,
       awsRegion: mockBedrockConfig.region,
       awsSecretAccessKey: mockBedrockConfig.secretAccessKey,
-    };
-    // For client
-    const clientPayload = {
-      apiKey: mockBedrockConfig.secretAccessKey + mockBedrockConfig.accessKeyId,
       accessKeyId: mockBedrockConfig.accessKeyId,
-      region: mockBedrockConfig.region,
       accessKeySecret: mockBedrockConfig.secretAccessKey,
-    };
-    expect(payload).toEqual(merge(serverPayload, clientPayload));
+      awsSessionToken: undefined,
+      region: mockBedrockConfig.region,
+      sessionToken: undefined,
+    });
   });
 
   it('should return correct payload for Azure provider', () => {
@@ -116,15 +113,9 @@ describe('getProviderAuthPayload', () => {
     expect(payload).toEqual({
       apiKey: mockAzureConfig.apiKey,
       azureApiVersion: mockAzureConfig.apiVersion,
-      baseURL: mockAzureConfig.endpoint,
-    };
-    // For client
-    const clientPayload = {
-      apiKey: mockAzureConfig.apiKey,
       apiVersion: mockAzureConfig.apiVersion,
       baseURL: mockAzureConfig.endpoint,
-    };
-    expect(payload).toEqual(merge(serverPayload, clientPayload));
+    });
   });
 
   it('should return correct payload for Ollama provider', () => {
@@ -177,18 +168,12 @@ describe('getProviderAuthPayload', () => {
       setModelProviderConfig('cloudflare', mockCloudflareConfig);
     });
 
-    const payload = getProviderAuthPayload(ModelProvider.Cloudflare);
-    // For server
-    const serverPayload = {
-      apiKey: mockCloudflareConfig.apiKey,
-      cloudflareBaseURLOrAccountID: mockCloudflareConfig.baseURLOrAccountID,
-    };
-    // For client
-    const clientPayload = {
+    const payload = getProviderAuthPayload(ModelProvider.Cloudflare, mockCloudflareConfig);
+    expect(payload).toEqual({
       apiKey: mockCloudflareConfig.apiKey,
       baseURLOrAccountID: mockCloudflareConfig.baseURLOrAccountID,
-    };
-    expect(payload).toEqual(merge(serverPayload, clientPayload));
+      cloudflareBaseURLOrAccountID: mockCloudflareConfig.baseURLOrAccountID,
+    });
   });
 
   it('should return an empty object or throw an error for an unknown provider', () => {

--- a/src/services/__tests__/_auth.test.ts
+++ b/src/services/__tests__/_auth.test.ts
@@ -8,7 +8,6 @@ import {
   UserKeyVaults,
   UserModelProviderConfig,
 } from '@/types/user/settings';
-import { merge } from '@/utils/merge';
 
 import { getProviderAuthPayload } from '../_auth';
 

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -31,17 +31,11 @@ export const getProviderAuthPayload = (
       const apiKey = (awsSecretAccessKey || '') + (awsAccessKeyId || '');
 
       return {
-        // Parameters for client fetch
-accessKeyId,
-        
-accessKeySecret: awsSecretAccessKey,
-        
-apiKey,
-        
-awsAccessKeyId,
-        
-awsRegion: region,
-        
+        accessKeyId,
+        accessKeySecret: awsSecretAccessKey,
+        apiKey,
+        awsAccessKeyId,
+        awsRegion: region,
         awsSecretAccessKey,
         awsSessionToken: sessionToken,
         region,

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -31,11 +31,21 @@ export const getProviderAuthPayload = (
       const apiKey = (awsSecretAccessKey || '') + (awsAccessKeyId || '');
 
       return {
-        apiKey,
-        awsAccessKeyId,
-        awsRegion: region,
+        // Parameters for client fetch
+accessKeyId,
+        
+accessKeySecret: awsSecretAccessKey,
+        
+apiKey,
+        
+awsAccessKeyId,
+        
+awsRegion: region,
+        
         awsSecretAccessKey,
         awsSessionToken: sessionToken,
+        region,
+        sessionToken,
       };
     }
 

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -60,6 +60,7 @@ export const getProviderAuthPayload = (
         apiKey: keyVaults.apiKey,
         azureApiVersion: keyVaults.apiVersion,
         baseURL: keyVaults.baseURL || keyVaults.endpoint,
+        apiVersion: keyVaults.apiVersion,
       };
     }
 
@@ -71,6 +72,7 @@ export const getProviderAuthPayload = (
       return {
         apiKey: keyVaults?.apiKey,
         cloudflareBaseURLOrAccountID: keyVaults?.baseURLOrAccountID,
+        baseURLOrAccountID: keyVaults?.baseURLOrAccountID,
       };
     }
 

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -34,9 +34,13 @@ export const getProviderAuthPayload = (
         accessKeyId,
         accessKeySecret: awsSecretAccessKey,
         apiKey,
+        /** @deprecated */
         awsAccessKeyId,
+        /** @deprecated */
         awsRegion: region,
+        /** @deprecated */
         awsSecretAccessKey,
+        /** @deprecated */
         awsSessionToken: sessionToken,
         region,
         sessionToken,
@@ -58,9 +62,11 @@ export const getProviderAuthPayload = (
     case ModelProvider.Azure: {
       return {
         apiKey: keyVaults.apiKey,
-        azureApiVersion: keyVaults.apiVersion,
-        baseURL: keyVaults.baseURL || keyVaults.endpoint,
+        
         apiVersion: keyVaults.apiVersion,
+        /** @deprecated */
+azureApiVersion: keyVaults.apiVersion,
+        baseURL: keyVaults.baseURL || keyVaults.endpoint,
       };
     }
 
@@ -71,8 +77,10 @@ export const getProviderAuthPayload = (
     case ModelProvider.Cloudflare: {
       return {
         apiKey: keyVaults?.apiKey,
-        cloudflareBaseURLOrAccountID: keyVaults?.baseURLOrAccountID,
+        
         baseURLOrAccountID: keyVaults?.baseURLOrAccountID,
+        /** @deprecated */
+cloudflareBaseURLOrAccountID: keyVaults?.baseURLOrAccountID,
       };
     }
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -127,87 +127,17 @@ export function initializeWithClientStore(provider: string, payload: any) {
   // add auth payload
   const providerAuthPayload = { ...payload, ...createPayloadWithKeyVaults(provider) };
   const commonOptions = {
-    // Some provider base openai sdk, so enable it run on browser
+    // Allow OpenAI SDK and Anthropic SDK run on browser
     dangerouslyAllowBrowser: true,
   };
-  let providerOptions = {};
-
-  switch (provider) {
-    default:
-    case ModelProvider.OpenAI: {
-      providerOptions = {
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Azure: {
-      providerOptions = {
-        apiKey: providerAuthPayload?.apiKey,
-        apiVersion: providerAuthPayload?.azureApiVersion,
-      };
-      break;
-    }
-    case ModelProvider.Google: {
-      providerOptions = {
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Bedrock: {
-      if (providerAuthPayload?.apiKey) {
-        providerOptions = {
-          accessKeyId: providerAuthPayload?.awsAccessKeyId,
-          accessKeySecret: providerAuthPayload?.awsSecretAccessKey,
-          region: providerAuthPayload?.awsRegion,
-          sessionToken: providerAuthPayload?.awsSessionToken,
-        };
-      }
-      break;
-    }
-    case ModelProvider.Ollama: {
-      providerOptions = {
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Perplexity: {
-      providerOptions = {
-        apikey: providerAuthPayload?.apiKey,
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Anthropic: {
-      providerOptions = {
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Groq: {
-      providerOptions = {
-        apikey: providerAuthPayload?.apiKey,
-        baseURL: providerAuthPayload?.baseURL,
-      };
-      break;
-    }
-    case ModelProvider.Cloudflare: {
-      providerOptions = {
-        apikey: providerAuthPayload?.apiKey,
-        baseURLOrAccountID: providerAuthPayload?.cloudflareBaseURLOrAccountID,
-      };
-      break;
-    }
-  }
-
   /**
    * Configuration override order:
-   * payload -> providerOptions -> providerAuthPayload -> commonOptions
+   * payload -> providerAuthPayload -> commonOptions
    */
   return AgentRuntime.initializeWithProviderOptions(provider, {
     [provider]: {
       ...commonOptions,
       ...providerAuthPayload,
-      ...providerOptions,
       ...payload,
     },
   });

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -124,7 +124,12 @@ interface CreateAssistantMessageStream extends FetchSSEOptions {
  * **Note**: if you try to fetch directly, use `fetchOnClient` instead.
  */
 export function initializeWithClientStore(provider: string, payload: any) {
-  // add auth payload
+  /**
+   * Since #5267, we map parameters for client-fetch in function `getProviderAuthPayload`
+   * which called by `createPayloadWithKeyVaults` below.
+   * @see https://github.com/lobehub/lobe-chat/pull/5267
+   * @file src/services/_auth.ts
+   */
   const providerAuthPayload = { ...payload, ...createPayloadWithKeyVaults(provider) };
   const commonOptions = {
     // Allow OpenAI SDK and Anthropic SDK run on browser


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
- 🧪 `src/services/__tests__/_auth.test.ts`: 补充针对客户端请求的`Auth payload`检查。
- ♻️ `src/services/_auth.ts`: 针对客户端请求的`Auth payload`映射。
- ♻️ `src/services/chat.ts`: 移除冗余的客户端请求`Auth payload`重映射。

#### 📝 补充信息 | Additional Information

- #5250 
- 运行测试
```bash
pnpm vitest --run src/services/__tests__/chat.test.ts src/services/__tests__/_auth.test.ts
```
- [ ] 重构相关测试用例，使其能测试传入参数。
<!-- Add any other context about the Pull Request here. -->
