### PR TITLE
📝 docs: fix incorrect casdoor password information in self-hosting guide

### DIFF
--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -81,7 +81,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docke
 docker compose up -d
 ```
 
-The default login account is the default account of Casdoor, with the username `admin` and password `123`.
+The default login account is the default account of Casdoor, with the username `admin`. You can find the password in the `init_data.json` file that is downloaded during setup. Note that the secret might fail to generate, please check the shell output.
 
 ### Check Logs
 
@@ -129,7 +129,7 @@ docker compose up -d
 
 ### Configuring Casdoor
 
-1. After starting with the `setup.sh` script, the default port for Casdoor WebUI is `8000`. You can access it via `http://your_server_ip:8000`, with the default username `admin` and password `123`.
+1. After starting with the `setup.sh` script, the default port for Casdoor WebUI is `8000`. You can access it via `http://your_server_ip:8000`, with the default username `admin`. The password can be found in the `init_data.json` file that is downloaded during setup. Note that the secret might fail to generate, please check the shell output.
 
 2. In `Identity -> Applications`, add a new line:
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
Update the default password information in the self-hosting documentation to accurately reflect that the password is dynamically generated during setup. The current documentation incorrectly states a static password "123", which has been removed and replaced with instructions to check the init_data.json file for the actual password.

#### 📝 补充信息 | Additional Information
This change helps prevent user confusion by directing them to the correct location for finding their default password. The password is dynamically generated during the setup process and stored in init_data.json, rather than being a static value as previously documented.

Note: Some Docker shields were unintentionally removed due to a possible Holocron editor issue. I've attempted to add them back but they don't persist when saving.

https://github.com/lobehub/lobe-chat/pull/5258
