### PR TITLE
🐛 fix: fix remark gfm regex breaks in Safari versions < 16.4

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -167,7 +167,7 @@ const nextConfig: NextConfig = {
   ],
   serverExternalPackages: ['@electric-sql/pglite', 'sharp'],
 
-  transpilePackages: ['pdfjs-dist', 'mermaid', 'micromark-util-character'],
+  transpilePackages: ['pdfjs-dist', 'mermaid'],
 
   webpack(config) {
     config.experiments = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,7 @@ const nextConfig: NextConfig = {
       'gpt-tokenizer',
     ],
     webVitalsAttribution: ['CLS', 'LCP'],
+    webpackMemoryOptimizations: true,
   },
   async headers() {
     return [
@@ -166,7 +167,7 @@ const nextConfig: NextConfig = {
   ],
   serverExternalPackages: ['@electric-sql/pglite', 'sharp'],
 
-  transpilePackages: ['pdfjs-dist', 'mermaid'],
+  transpilePackages: ['pdfjs-dist', 'mermaid', 'micromark-util-character'],
 
   webpack(config) {
     config.experiments = {

--- a/package.json
+++ b/package.json
@@ -321,6 +321,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "pnpm": {
+    "overrides": {
+      "mdast-util-gfm-autolink-literal": "2.0.0"
+    },
     "packageExtensions": {
       "@inkjs/ui": {
         "dependencies": {
@@ -328,5 +331,8 @@
         }
       }
     }
+  },
+  "overrides": {
+    "mdast-util-gfm-autolink-literal": "2.0.0"
   }
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

锁定 `mdast-util-gfm-autolink-literal@2.0.0` 以修复在 Safari 内核版本 16.4 及以下的问题

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

refs: https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/issues/10
