### PR TITLE
🐛 fix: support Gemini 2.0 HarmBlockThreshold

### DIFF
--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -71,19 +71,19 @@ export class LobeGoogleAI implements LobeRuntimeAI {
             safetySettings: [
               {
                 category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? (HarmBlockThreshold.OFF as any) : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? (HarmBlockThreshold.OFF as any) : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? (HarmBlockThreshold.OFF as any) : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? (HarmBlockThreshold.OFF as any) : HarmBlockThreshold.BLOCK_NONE,
               },
             ],
           },

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -36,6 +36,7 @@ enum HarmCategory {
 
 enum HarmBlockThreshold {
   BLOCK_NONE = 'BLOCK_NONE',
+  OFF = 'OFF', // https://discuss.ai.google.dev/t/59352
 }
 
 export class LobeGoogleAI implements LobeRuntimeAI {
@@ -70,19 +71,19 @@ export class LobeGoogleAI implements LobeRuntimeAI {
             safetySettings: [
               {
                 category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-                threshold: HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-                threshold: HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_HARASSMENT,
-                threshold: HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
               },
               {
                 category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-                threshold: HarmBlockThreshold.BLOCK_NONE,
+                threshold: model.includes('2.0') ? HarmBlockThreshold.OFF : HarmBlockThreshold.BLOCK_NONE,
               },
             ],
           },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

根据[官方论坛](https://discuss.ai.google.dev/t/59352)，gemini-2.0-flash 已不再响应 `BLOCK_NONE` ，而是暂时替换为 `OFF` 。

由测试可见，遇到安全风险时，模型会直接截断输出。

![image](https://github.com/user-attachments/assets/8c8906c6-2555-4e74-915f-8566aa81d6be)

#### 📝 补充信息 | Additional Information

这是更改后的效果。

![image](https://github.com/user-attachments/assets/1de0e6d3-ee2d-4c2e-9d31-4ba580c291b9)

