### PR TITLE
👷 build: Node.js command line arguments use hyphens (-) as word separators

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "pnpm run build"
 publish = ".next"
 
 [build.environment]
-NODE_OPTIONS = "--max_old_space_size=4096"
+NODE_OPTIONS = "--max-old-space-size=4096"
 
 [template.environment]
 OPENAI_API_KEY = "set your OpenAI API Key"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Node.js 的命令行参数使用连字符（-）作为单词之间的分隔符，这是一个普遍的命令行参数命名约定，也是 Node.js 官方文档中采用的标准格式。

Node.js command line arguments use hyphens (-) as word separators, which is a common convention for command line parameters.

#### 📝 补充信息 | Additional Information

NODE_OPTIONS="--max-old-space-size=4096"，将原来的分隔符“_”换成了“-”。
