### PR TITLE
🐛 fix: temporarily disable S3 client integrity check for Cloudflare R2

### DIFF
--- a/src/server/modules/S3/index.ts
+++ b/src/server/modules/S3/index.ts
@@ -44,6 +44,7 @@ export class S3 {
       endpoint: fileEnv.S3_ENDPOINT,
       forcePathStyle: fileEnv.S3_ENABLE_PATH_STYLE,
       region: fileEnv.S3_REGION || DEFAULT_S3_REGION,
+      // refs: https://github.com/lobehub/lobe-chat/pull/5479
       requestChecksumCalculation: 'WHEN_REQUIRED',
       responseChecksumValidation: 'WHEN_REQUIRED',
     });

--- a/src/server/modules/S3/index.ts
+++ b/src/server/modules/S3/index.ts
@@ -44,6 +44,8 @@ export class S3 {
       endpoint: fileEnv.S3_ENDPOINT,
       forcePathStyle: fileEnv.S3_ENABLE_PATH_STYLE,
       region: fileEnv.S3_REGION || DEFAULT_S3_REGION,
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     });
   }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

The latest version of `@aws-sdk/client-s3` introduced a default integrity check for all requests, which is incompatible with Cloudflare R2. This workaround is to temporarily disable the checksum.

#### 📝 补充信息 | Additional Information

Related topics:
- https://github.com/cloudflare/cloudflare-docs/pull/19236
- https://github.com/aws/aws-sdk-js-v3/issues/6810
