### PR TITLE
👷 build: netlify build 137 error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "pnpm run build"
+command = "rm -rf .next node_modules/.cache && pnpm run build"
 publish = ".next"
 
 [build.environment]


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fix Netlify build 137 error by clearing the cache
通过清理cache修复netlify构建总是报137错误

#### 📝 补充信息 | Additional Information

在netlify上持续部署总是失败，报137错，在netlify UI中通过强制清理缓存后部署即可成功。因此在netlify.toml的build command中直接清理cache，实测持续部署可以成功！
