### PR TITLE
📦 build(config): Modify memory limit of vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "NODE_OPTIONS=--max-old-space-size=6144 next build", 
+  "buildCommand": "NODE_OPTIONS=--max-old-space-size=8192 next build",
   "installCommand": "bun install"
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change
修改`Vercel`平台build时的内存限制，加快构建速度

Modify memory limit on `Vercel` builds to speed up build.
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
`Vercel`默认设置可能会限制`Build`时可用的内存量    [来源](https://vercel.com/guides/troubleshooting-sigkill-out-of-memory-errors#4.-increase-memory-allocation-for-node)
每次`Build`时，`Vercel`向非付费用户最多提供8192MB的内存    [来源](https://vercel.com/docs/limits/overview#build-container-resources)

The default max heap size for Node.js is conservative and can limit the memory available to your `Build`.    [Source](https://vercel.com/guides/troubleshooting-sigkill-out-of-memory-errors#4.-increase-memory-allocation-for-node)
`Vercel` provides a maximum of 8192MB of memory to non-paying users for each `Build`.    [Source](https://vercel.com/docs/limits/overview#build-container-resources)
<!-- Add any other context about the Pull Request here. -->
