### PR TITLE
🐛 fix: Multiple deepseek-reasoner errors

### DIFF
--- a/src/libs/agent-runtime/deepseek/index.ts
+++ b/src/libs/agent-runtime/deepseek/index.ts
@@ -12,7 +12,7 @@ export interface DeepSeekModelCard {
 export const LobeDeepSeekAI = LobeOpenAICompatibleFactory({
   baseURL: 'https://api.deepseek.com/v1',
   chatCompletion: {
-    handlePayload: ({ messages, frequency_penalty, model, presence_penalty, temperature, top_p, ...payload }: ChatStreamPayload) => {
+    handlePayload: ({ frequency_penalty, messages, model, presence_penalty, temperature, top_p, ...payload }: ChatStreamPayload) => {
       // github.com/lobehub/lobe-chat/pull/5548
       let filteredMessages = messages.filter(message => message.role !== 'system');
 

--- a/src/libs/agent-runtime/deepseek/index.ts
+++ b/src/libs/agent-runtime/deepseek/index.ts
@@ -15,9 +15,19 @@ export const LobeDeepSeekAI = LobeOpenAICompatibleFactory({
     handlePayload: ({ messages, frequency_penalty, model, presence_penalty, temperature, top_p, ...payload }: ChatStreamPayload) => {
       // github.com/lobehub/lobe-chat/pull/5548
       let filteredMessages = messages.filter(message => message.role !== 'system');
+
       while (filteredMessages.length > 0 && filteredMessages[0].role === 'assistant') {
         filteredMessages.shift();
       }
+
+      let lastRole = '';
+      filteredMessages = filteredMessages.filter(message => {
+        if (message.role === lastRole) {
+          return false;
+        }
+        lastRole = message.role;
+        return true;
+      });
 
       return {
         ...payload,

--- a/src/libs/agent-runtime/deepseek/index.ts
+++ b/src/libs/agent-runtime/deepseek/index.ts
@@ -34,15 +34,15 @@ export const LobeDeepSeekAI = LobeOpenAICompatibleFactory({
         model,
         ...(model === 'deepseek-reasoner'
           ? {
-              messages: filteredMessages,
               frequency_penalty: undefined,
+              messages: filteredMessages,
               presence_penalty: undefined,
               temperature: undefined,
               top_p: undefined,
             }
           : {
-              messages,
               frequency_penalty,
+              messages,
               presence_penalty,
               temperature,
               top_p,

--- a/src/libs/agent-runtime/deepseek/index.ts
+++ b/src/libs/agent-runtime/deepseek/index.ts
@@ -13,7 +13,7 @@ export const LobeDeepSeekAI = LobeOpenAICompatibleFactory({
   baseURL: 'https://api.deepseek.com/v1',
   chatCompletion: {
     handlePayload: ({ messages, frequency_penalty, model, presence_penalty, temperature, top_p, ...payload }: ChatStreamPayload) => {
-      // Filter out system messages and remove assistant messages from the beginning until the first user message
+      // github.com/lobehub/lobe-chat/pull/5548
       let filteredMessages = messages.filter(message => message.role !== 'system');
       while (filteredMessages.length > 0 && filteredMessages[0].role === 'assistant') {
         filteredMessages.shift();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

修复 deepseek-r1 的下述报错。当前采用直接剔除不合规消息的方案，应当有更合适的方案，比如通过添加一条空消息使其合规。

```
The first message (except the system message) of deepseek-reasoner must be a user message, 
but an assistant message detected.
```

```
deepseek-reasoner does not support successive user or assistant messages (messages[x] and messages[x] in your input). 
You should interleave the user/assistant messages in the message sequence.
```

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
