### PR TITLE
💄 style: Support DeepSeek-R1 <think> tags 

### DIFF
--- a/src/libs/agent-runtime/utils/streams/openai.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.ts
@@ -106,13 +106,19 @@ export const transformOpenAIStream = (
       return { data: item.delta.content, id: chunk.id, type: isThinking ? 'reasoning' : 'text' };
     }
 
+    // DeepSeek reasoner 会将 thinking 放在 reasoning_content 字段中
+    // litellm 处理 reasoning content 时 不会设定 content = null
+    if (
+      item.delta &&
+      'reasoning_content' in item.delta &&
+      typeof item.delta.reasoning_content === 'string'
+    ) {
+      return { data: item.delta.reasoning_content, id: chunk.id, type: 'reasoning' };
+    }
+
+
     // 无内容情况
     if (item.delta && item.delta.content === null) {
-      // deepseek reasoner 会将 thinking 放在 reasoning_content 字段中
-      if ('reasoning_content' in item.delta && typeof item.delta.reasoning_content === 'string') {
-        return { data: item.delta.reasoning_content, id: chunk.id, type: 'reasoning' };
-      }
-
       return { data: item.delta, id: chunk.id, type: 'data' };
     }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

### 这个实现方式属于临时方案，不受 abilities.reasoning 控制，大概无法被合并，仅作演示。

目前仅适配开源 DeepSeek-R1 的 <think></think> 思考内容，且仅在流式输出时可用。

已通过 siliconflow 的 deepseek-r1 验证可用。

![image](https://github.com/user-attachments/assets/47f43bc1-04de-4126-8a53-6213cea61b77)

#### 📝 补充信息 | Additional Information

可以讨论下适配更多模型，比如智谱的 GLM-Zero-Preview 采用 ##think 的标志，最好能在这里加个 model 名称判断，以避免误伤。
