### PR TITLE
 👷 build: fix pnpm cannot be installed via corepack due to key id mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN \
     fi \
     # Set the registry for corepack
     && export COREPACK_NPM_REGISTRY=$(npm config get registry | sed 's/\/$//') \
+    # Update corepack to latest (nodejs/corepack#612)
+    && npm i -g corepack@latest \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     fi \
     # Add required package
     && apt update \
-    && apt install ca-certificates jq proxychains-ng -qy \
+    && apt install ca-certificates proxychains-ng -qy \
     # Prepare required package to distroless
     && mkdir -p /distroless/bin /distroless/etc /distroless/etc/ssl/certs /distroless/lib \
     # Copy proxychains to distroless
@@ -84,7 +84,7 @@ RUN \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack
-    && corepack use $(jq -r .packageManager package.json) \
+    && corepack use $(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) \
     # Install the dependencies
     && pnpm i \
     # Add sharp dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     fi \
     # Add required package
     && apt update \
-    && apt install ca-certificates proxychains-ng -qy \
+    && apt install ca-certificates jq proxychains-ng -qy \
     # Prepare required package to distroless
     && mkdir -p /distroless/bin /distroless/etc /distroless/etc/ssl/certs /distroless/lib \
     # Copy proxychains to distroless
@@ -82,7 +82,7 @@ RUN \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack
-    && corepack use pnpm@9 \
+    && corepack use $(jq -r .packageManager package.json) \
     # Install the dependencies
     && pnpm i \
     # Add sharp dependencies

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -15,7 +15,7 @@ RUN \
     fi \
     # Add required package
     && apt update \
-    && apt install ca-certificates jq proxychains-ng -qy \
+    && apt install ca-certificates proxychains-ng -qy \
     # Prepare required package to distroless
     && mkdir -p /distroless/bin /distroless/etc /distroless/etc/ssl/certs /distroless/lib \
     # Copy proxychains to distroless
@@ -91,7 +91,7 @@ RUN \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack
-    && corepack use $(jq -r .packageManager package.json) \
+    && corepack use $(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) \
     # Install the dependencies
     && pnpm i \
     # Add sharp and db migration dependencies

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -86,6 +86,8 @@ RUN \
     fi \
     # Set the registry for corepack
     && export COREPACK_NPM_REGISTRY=$(npm config get registry | sed 's/\/$//') \
+    # Update corepack to latest (nodejs/corepack#612)
+    && npm i -g corepack@latest \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -15,7 +15,7 @@ RUN \
     fi \
     # Add required package
     && apt update \
-    && apt install ca-certificates proxychains-ng -qy \
+    && apt install ca-certificates jq proxychains-ng -qy \
     # Prepare required package to distroless
     && mkdir -p /distroless/bin /distroless/etc /distroless/etc/ssl/certs /distroless/lib \
     # Copy proxychains to distroless
@@ -89,7 +89,7 @@ RUN \
     # Enable corepack
     && corepack enable \
     # Use pnpm for corepack
-    && corepack use pnpm@9 \
+    && corepack use $(jq -r .packageManager package.json) \
     # Install the dependencies
     && pnpm i \
     # Add sharp and db migration dependencies


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

从 `package.json` 中获取 pnpm 的固定版本后进行安装，行为与 Vercel 一致

```
$ jq -r .packageManager package.json                                         
pnpm@9.15.4
```

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

ref: https://vercel.com/docs/deployments/builds/package-managers
![image](https://github.com/user-attachments/assets/50b753e3-3026-49ae-844e-5b8a1d46aa53)

---

ref: https://github.com/nodejs/corepack/issues/612#issuecomment-2629496091

```
0.669 Installing pnpm@9.15.5 in the project...
1.263 Internal Error: Cannot find matching keyid: {"signatures":[{"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","sig":"MEQCIHGqHbvc2zImUPEPFpT4grh6rMYslel+lAjFArx8+RUdAiBfnJA+bgmUvO5Lctfkq+46KKDQdx/8RhLPge3pA+EdHA=="}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}
1.263     at verifySignature (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535:47)
1.263     at installVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21882:7)
1.263     at async Engine.ensurePackageManager (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22316:32)
1.263     at async UseCommand.execute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22920:32)
1.263     at async UseCommand.validateAndExecute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:19835:22)
1.263     at async _Cli.run (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:20772:18)
1.263     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23097:19)
```

<!-- Add any other context about the Pull Request here. -->
