### PR TITLE
🔨 chore: pin `lobe-chat-database@1.51.3` in docker-compose.yml to avoid one-click deploy error

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - .env
 
   lobe:
-    image: lobehub/lobe-chat-database
+    image: lobehub/lobe-chat-database:1.51.3
     container_name: lobe-chat
     network_mode: 'service:network-service'
     depends_on:


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `docker-compose/local/docker-compose.yml`:  将 lobe-chat-database 版本锁定为 `1.51.3`，避免 next-auth 无法登录的问题

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
