### PR TITLE
📝 docs: Add warnings to disable signup for casdoor

### DIFF
--- a/docs/self-hosting/advanced/auth/next-auth/casdoor.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/casdoor.mdx
@@ -95,6 +95,14 @@ If you are deploying using a public network, the following assumptions apply:
 
   Then, copy the `Client ID` and `Client Secret` and save them.
 
+  ### Disable User Registration
+
+  Go to `Identity` -> `Applications`, select the `LobeChat` application, and set `Allow Register` to `false`.
+
+  <Callout type={'warning'}>
+    Disabling user registration is necessary to prevent users from registering through the Casdoor login page.
+  </Callout>
+
   ### Configure Webhook (Optional)
 
   Configure the Casdoor webhook so that LobeChat can receive notifications when user information is updated.

--- a/docs/self-hosting/advanced/auth/next-auth/casdoor.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/casdoor.zh-CN.mdx
@@ -109,6 +109,16 @@ tags:
 
   保存，并退出。 将该密钥填写到环境变量中的 `CASDOOR_WEBHOOK_SECRET`。
 
+  ### 关闭注册
+
+  为了保证你的应用安全，建议关闭 Casdoor 的注册功能，改为由管理员手动添加用户。
+  
+  前往 `身份认证` -> `应用`，将 `启用注册` 设置为 `否`。
+
+  <Callout type={'warning'}>
+    Casdoor 的注册功能默认是开启的，若你不关闭注册功能，任何人都可以注册并登录你的应用。
+  </Callout>
+
   ### 配置环境变量
 
   将获取到的 `客户端 ID` 和 `客户端`，设为 LobeChat 环境变量中的 `AUTH_CASDOOR_ID` 和 `AUTH_CASDOOR_SECRET`。

--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -189,6 +189,13 @@ The script supports the following deployment modes; please choose the appropriat
   ### Access Application
 
   You can access your LobeChat service at `http://your_server_ip:3210`. The account credentials for the application can be found in the report from step `2`.
+
+  <Callout type="warning">
+    If your service can accessed via the public network, 
+    we strongly recommend disabling the registration, 
+    refer to the [documentation](https://lobehub.com/docs/self-hosting/advanced/auth/next-auth/casdoor)
+    for more information.
+  </Callout>
 </Steps>
 
 ### Domain Mode
@@ -206,9 +213,9 @@ The script supports the following deployment modes; please choose the appropriat
   | `minio-ui.example.com` | `9001`     |          |
 
   <Callout type="important">
-    If you are using panel software like [APanel](https://www.bt.cn/) for reverse proxy configuration,
+    If you are using panel software like [aaPanel](https://www.bt.cn/) for reverse proxy configuration,
     ensure it does not intercept requests to the `.well-known` path to facilitate the proper functioning of Casdoor's OAuth2 configuration.
-    Below is a whitelist configuration for the Nginx server block concerning paths:
+    Below is a whitelist configuration for the Nginx server block concerning paths for Casdoor reverse proxy:
 
     ```nginx
     location /.well-known/openid-configuration {
@@ -293,6 +300,13 @@ The script supports the following deployment modes; please choose the appropriat
   ### Access Application
 
   You can access your LobeChat service via `https://lobe.example.com`. The account credentials for the application can be found in the report from step `3`.
+  
+  <Callout type="warning">
+    If your service can accessed via the public network, 
+    we strongly recommend disabling the registration, 
+    refer to the [documentation](https://lobehub.com/docs/self-hosting/advanced/auth/next-auth/casdoor)
+    for more information.
+  </Callout>
 </Steps>
 
 ## Custom Deployment

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -190,6 +190,10 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   你可以通过 `http://your_server_ip:3210` 访问你的 LobeChat 服务。
   应用的账号密码在步骤`2`的报告中。
+
+  <Callout type="warning">
+    请注意，如果你的服务能够被公网访问，我们强烈建议你参考 [文档](https://lobehub.com/docs/self-hosting/advanced/auth/next-auth/casdoor) 关闭注册功能。
+  </Callout>
 </Steps>
 
 ### 域名模式
@@ -209,7 +213,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   <Callout type="important">
     如果你使用如 [宝塔面板](https://www.bt.cn/) 等面板软件进行反向代理配置，
     你需要确保其对 `.well-known` 路径的请求不进行拦截，以确保 Casdoor 的 OAuth2 配置能够正常工作。
-    这里提供一份针对 Nginx server 块的路径白名单配置：
+    这里提供一份针对 Casdoor 服务的 Nginx server 块的路径白名单配置：
 
     ```nginx
     location /.well-known/openid-configuration {
@@ -294,6 +298,10 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   ### 访问应用
 
   你可以通过 `https://lobe.example.com` 访问你的 LobeChat 服务。应用的账号密码在步骤`3`的报告中。
+
+  <Callout type="warning">
+    请注意，如果你的服务能够被公网访问，我们强烈建议你参考 [文档](https://lobehub.com/docs/self-hosting/advanced/auth/next-auth/casdoor) 关闭注册功能。
+  </Callout>
 </Steps>
 
 ## 自定义部署


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `docs/self-hosting/advanced/auth/next-auth/casdoor*.mdx`: 提供关闭注册的方法描述。
- `docs/self-hosting/server-database/docker-compose.mdx`
  - 提醒用户在一键部署完成后关闭注册
  - 在反向代理的额外规则部分强调是 `casdoor` 的反代配置，避免歧义
 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
