### PR TITLE
🐛 fix: fix Aliyun deepseek-r1 reasoning parsing with oneapi

### DIFF
--- a/src/libs/agent-runtime/utils/streams/openai.test.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.test.ts
@@ -755,6 +755,225 @@ describe('OpenAIStream', () => {
       );
     });
 
+    it('should handle reasoning event in aliyun bailian api', async () => {
+      const data = [
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { role: 'assistant', content: '', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '', reasoning_content: '您好' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '', reasoning_content: '！' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '你好', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '很高兴', reasoning_cont: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '为您', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '提供', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '帮助。', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: '1',
+          object: 'chat.completion.chunk',
+          created: 1737563070,
+          model: 'deepseek-reasoner',
+          system_fingerprint: 'fp_1c5d8833bc',
+          choices: [
+            {
+              index: 0,
+              delta: { content: '', reasoning_content: '' },
+              logprobs: null,
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 6,
+            completion_tokens: 104,
+            total_tokens: 110,
+            prompt_tokens_details: { cached_tokens: 0 },
+            completion_tokens_details: { reasoning_tokens: 70 },
+            prompt_cache_hit_tokens: 0,
+            prompt_cache_miss_tokens: 6,
+          },
+        },
+      ];
+
+      const mockOpenAIStream = new ReadableStream({
+        start(controller) {
+          data.forEach((chunk) => {
+            controller.enqueue(chunk);
+          });
+
+          controller.close();
+        },
+      });
+
+      const protocolStream = OpenAIStream(mockOpenAIStream);
+
+      const decoder = new TextDecoder();
+      const chunks = [];
+
+      // @ts-ignore
+      for await (const chunk of protocolStream) {
+        chunks.push(decoder.decode(chunk, { stream: true }));
+      }
+
+      expect(chunks).toEqual(
+        [
+          'id: 1',
+          'event: reasoning',
+          `data: ""\n`,
+          'id: 1',
+          'event: reasoning',
+          `data: "您好"\n`,
+          'id: 1',
+          'event: reasoning',
+          `data: "！"\n`,
+          'id: 1',
+          'event: reasoning',
+          `data: ""\n`,
+          'id: 1',
+          'event: text',
+          `data: "你好"\n`,
+          'id: 1',
+          'event: text',
+          `data: "很高兴"\n`,
+          'id: 1',
+          'event: text',
+          `data: "为您"\n`,
+          'id: 1',
+          'event: text',
+          `data: "提供"\n`,
+          'id: 1',
+          'event: text',
+          `data: "帮助。"\n`,
+          'id: 1',
+          'event: stop',
+          `data: "stop"\n`,
+        ].map((i) => `${i}\n`),
+      );
+    });
+
     it('should handle reasoning in litellm', async () => {
       const data = [
         {

--- a/src/libs/agent-runtime/utils/streams/openai.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.ts
@@ -87,21 +87,31 @@ export const transformOpenAIStream = (
       return { data: item.finish_reason, id: chunk.id, type: 'stop' };
     }
 
-    // DeepSeek reasoner will put thinking in the reasoning_content field
-    // litellm will not set content = null when processing reasoning content
-    // en: siliconflow has encountered a situation where both content and reasoning_content are present, so the parsing order go ahead
-    // refs: https://github.com/lobehub/lobe-chat/issues/5681
-    if (
-      item.delta &&
-      'reasoning_content' in item.delta &&
-      typeof item.delta.reasoning_content === 'string' &&
-      item.delta.reasoning_content.length > 0
-    ) {
-      return { data: item.delta.reasoning_content, id: chunk.id, type: 'reasoning' };
-    }
+    if (item.delta) {
+      let reasoning_content =
+        'reasoning_content' in item.delta ? item.delta.reasoning_content : null;
+      let content = 'content' in item.delta ? item.delta.content : null;
 
-    if (typeof item.delta?.content === 'string') {
-      return { data: item.delta.content, id: chunk.id, type: 'text' };
+      // DeepSeek reasoner will put thinking in the reasoning_content field
+      // litellm and not set content = null when processing reasoning content
+      // en: siliconflow and aliyun bailian has encountered a situation where both content and reasoning_content are present, so need to handle it
+      // refs: https://github.com/lobehub/lobe-chat/issues/5681 (siliconflow)
+      // refs: https://github.com/lobehub/lobe-chat/issues/5956 (aliyun bailian)
+      if (typeof content === 'string' && typeof reasoning_content === 'string') {
+        if (content === '' && reasoning_content === '') {
+          content = null;
+        } else if (reasoning_content === '') {
+          reasoning_content = null;
+        }
+      }
+
+      if (typeof reasoning_content === 'string') {
+        return { data: reasoning_content, id: chunk.id, type: 'reasoning' };
+      }
+
+      if (typeof content === 'string') {
+        return { data: content, id: chunk.id, type: 'text' };
+      }
     }
 
     // 无内容情况

--- a/src/libs/agent-runtime/utils/streams/openai.ts
+++ b/src/libs/agent-runtime/utils/streams/openai.ts
@@ -94,7 +94,8 @@ export const transformOpenAIStream = (
     if (
       item.delta &&
       'reasoning_content' in item.delta &&
-      typeof item.delta.reasoning_content === 'string'
+      typeof item.delta.reasoning_content === 'string' &&
+      item.delta.reasoning_content.length > 0
     ) {
       return { data: item.delta.reasoning_content, id: chunk.id, type: 'reasoning' };
     }


### PR DESCRIPTION
… with Aliyun Bailian

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change



- close #5951
- close #5956
- close #5979

当使用oneapi 代理百练，或者直接使用阿里云百练接口的时候，当需要输出content的时候，reasoning_content为空字符串而不是null

因此这里，完善openai流式请求的逻辑，当reasoning_content为空字符串时不作为reason而是继续后边的判断逻辑

#### 📝 补充信息 | Additional Information

https://bailian.console.aliyun.com/?spm=5176.28197581.0.0.ed4b29a48fl6kA#/model-market/detail/deepseek-r1?tabKey=sdk

![image](https://github.com/user-attachments/assets/2681662f-754b-4d21-b16d-fba63e301f5b)
