### PR TITLE
📝 docs: update docs of next-auth in vercel deployment

### DIFF
--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -19,6 +19,16 @@ LobeChat provides a complete authentication service capability when deployed. Th
 
 ### General Settings
 
+#### `NEXT_PUBLIC_ENABLE_NEXT_AUTH`
+
+- Changes after v1.52.0.
+
+- For users who deploy with Vercel using Next Auth, it is necessary to add the environment variable NEXT_PUBLIC_ENABLE_NEXT_AUTH=1 to ensure that Next Auth is enabled.
+- For users who use Clerk in their self-built image, it is necessary to configure the environment variable NEXT_PUBLIC_ENABLE_NEXT_AUTH=0 to disable Next Auth.\n
+- Other standard deployment scenarios (using Clerk on Vercel and next-auth in Docker) are not affected
+
+
+
 #### `NEXT_AUTH_SECRET`
 
 - Type: Required

--- a/docs/self-hosting/environment-variables/auth.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/auth.zh-CN.mdx
@@ -17,6 +17,12 @@ LobeChat 在部署时提供了完善的身份验证服务能力，以下是相�
 
 ### 通用设置
 
+#### `NEXT_PUBLIC_ENABLE_NEXT_AUTH`
+- v1.52.0 之后有变更
+- 针对使用 Vercel 部署中使用 next-auth 的用户，需要额外添加 NEXT_PUBLIC_ENABLE_NEXT_AUTH=1 环境变量来确保开启 Next Auth
+- 针对使用自构建镜像中使用 clerk 的用户，需要额外配置 NEXT_PUBLIC_ENABLE_NEXT_AUTH=0 环境变量来关闭 Next Auth
+- 其他标准部署场景（Vercel 中使用 Clerk 与 Docker 中使用 next-auth ）不受影响
+
 #### `NEXT_AUTH_SECRET`
 
 - 类型：必选


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

自从v1.52之后的vercel部署启用nextauth需要设置环境变量，但是未在文档中体现，已添加至文档中

#### 📝 补充信息 | Additional Information

如题：https://github.com/lobehub/lobe-chat/releases/tag/v1.52.0