### PR TITLE
📝 docs: fix casdoor webhooks & add Chinese warnings in local docker compose template

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -112,18 +112,34 @@ services:
           echo '⚠️Warining: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+          echo ''
+          echo '⚠️注意：无法从 Casdoor 获取 OIDC 配置'
+          echo '请求 URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
+          echo '了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+          echo ''
         else
           if ! wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep 'issuer' | grep ${AUTH_CASDOOR_ISSUER}; then
             printf '❌Error: The Auth issuer is conflict, Issuer in OIDC configuration is: %s' \$(wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E 'issuer.*' | awk -F '\"' '{print \$4}')
             echo ' , but the issuer in .env file is: ${AUTH_CASDOOR_ISSUER} '
             echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
             echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+            echo ''
+            printf '❌错误：Auth 的 issuer 冲突，OIDC 配置中的 issuer 是：%s' \$(wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E 'issuer.*' | awk -F '\"' '{print \$4}')
+            echo ' , 但 .env 文件中的 issuer 是：${AUTH_CASDOOR_ISSUER} '
+            echo '请求 URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
+            echo '了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+            echo ''
           fi
         fi
         if [ $(wget --timeout=5 --spider --server-response ${S3_ENDPOINT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warining: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+          echo ''
+          echo '⚠️注意：无法获取 MinIO 健康状态'
+          echo '请求 URL: ${S3_ENDPOINT}/minio/health/live'
+          echo '了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration'
+          echo ''
         fi
         wait \$LOBE_PID
       "

--- a/docs/self-hosting/advanced/auth/next-auth/casdoor.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/casdoor.mdx
@@ -109,7 +109,7 @@ If you are deploying using a public network, the following assumptions apply:
 
   Go to `Admin` -> `Webhooks`, add a webhook, and fill in the following fields:
 
-  - URL: `https://lobe.example.com/api/auth/webhooks/casdoor`
+  - URL: `https://lobe.example.com/api/webhooks/casdoor`
   - Method: `POST`
   - Content Type: `application/json`
   - Headers: `casdoor-secret`: `Your Webhook Secret`

--- a/docs/self-hosting/advanced/auth/next-auth/casdoor.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/casdoor.zh-CN.mdx
@@ -98,7 +98,7 @@ tags:
 
   前往 `管理工具` -> `Webhooks`，创建一个 Webhook，添加一个 Webhook，填写以下字段：
 
-  - 链接：`http://lobe.example.com/api/auth/webhooks/casdoor`
+  - 链接：`http://lobe.example.com/api/webhooks/casdoor`
   - 方法：`POST`
   - 内容类型：`application/json`
   - 协议头：`casdoor-secret`: `你的Webhook密钥`

--- a/docs/self-hosting/advanced/auth/next-auth/logto.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/logto.mdx
@@ -49,7 +49,7 @@ If you are using Logto Cloud, assume its endpoint domain is `https://example.log
 
   Go to `Webhooks`, create a Webhook, and fill in the following fields:
 
-  - Endpoint URL: `https://lobe.example.com/api/auth/webhooks/logto`
+  - Endpoint URL: `https://lobe.example.com/api/webhooks/logto`
   - Events: `User.Data.Updated`
 
   After successful creation, copy the Webhook's `Signing Key` and fill it in the `LOGTO_WEBHOOK_SIGNING_KEY` environment variable.

--- a/docs/self-hosting/advanced/auth/next-auth/logto.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/next-auth/logto.zh-CN.mdx
@@ -46,7 +46,7 @@ tags:
 
   前往 `Webhooks` ，创建一个 Webhook，填写以下字段：
 
-  - 端点 URL： `https://lobe.example.com/api/auth/webhooks/logto`
+  - 端点 URL： `https://lobe.example.com/api/webhooks/logto`
   - 事件： `User.Data.Updated`
 
   创建成功后，复制 Webhook 的 `签名密钥`。填写到环境变量中的 `LOGTO_WEBHOOK_SIGNING_KEY`。


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `docs/self-hosting/advanced/auth/next-auth/casdoor.mdx`, `docs/self-hosting/advanced/auth/next-auth/logto.mdx`: 更改 webhook url
- `docker-compose/local/docker-compose.yml`: 增加中文提醒

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- fix #6130  
- fix #6137

```
lobe-chat      | ⚠️Warining: Unable to fetch OIDC configuration from Casdoor
lobe-chat      | Request URL: http://localhost:8001/.well-known/openid-configuration
lobe-chat      | Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration
lobe-chat      |
lobe-chat      | ⚠️注意：无法从 Casdoor 获取 OIDC 配置
lobe-chat      | 请求 URL: http://localhost:8001/.well-known/openid-configuration
lobe-chat      | 了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration
lobe-chat      | 
lobe-chat      | ⚠️Warining: Unable to fetch MinIO health status
lobe-chat      | Request URL: http://localhost:9002/minio/health/live
lobe-chat      | Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration
lobe-chat      |
lobe-chat      | ⚠️注意：无法获取 MinIO 健康状态
lobe-chat      | 请求 URL: http://localhost:9002/minio/health/live
lobe-chat      | 了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration
lobe-chat      |
lobe-chat      | ❌Error: The Auth issuer is conflict, Issuer in OIDC configuration is: http://localhost:8001 , but the issuer in .env file is: http://localhost:8000
lobe-chat      | Request URL: http://localhost:8000/.well-known/openid-configuration
lobe-chat      | Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration
lobe-chat      |
lobe-chat      | ❌错误：Auth 的 issuer 冲突，OIDC 配置中的 issuer 是：http://localhost:8001 , 但 .env 文件中的 issuer  是：http://localhost:8000
lobe-chat      | 请求 URL: http://localhost:8000/.well-known/openid-configuration
lobe-chat      | 了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration
```
<!-- Add any other context about the Pull Request here. -->
