### PR TITLE
🐛 fix: match o1 series models more robust in Azure OpenAI provider

### DIFF
--- a/src/libs/agent-runtime/azureOpenai/index.ts
+++ b/src/libs/agent-runtime/azureOpenai/index.ts
@@ -32,7 +32,7 @@ export class LobeAzureOpenAI implements LobeRuntimeAI {
   async chat(payload: ChatStreamPayload, options?: ChatCompetitionOptions) {
     const { messages, model, ...params } = payload;
     // o1 series models on Azure OpenAI does not support streaming currently
-    const enableStreaming = model.startsWith('o1') ? false : (params.stream ?? true);
+    const enableStreaming = model.includes('o1') ? false : (params.stream ?? true);
     try {
       const response = await this.client.chat.completions.create({
         messages: messages as OpenAI.ChatCompletionMessageParam[],


### PR DESCRIPTION
…startsWith

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

fix:Using ncludes is more in line with naming conventions than using startsWith

#### 📝 补充信息 | Additional Information

Not all developers start model names with 'o1', which helps reduce issues
