### PR TITLE
Feat: support bedrock endpoint configuration with env variable

### DIFF
--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -66,6 +66,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: z.string().optional(),
       AWS_SECRET_ACCESS_KEY: z.string().optional(),
       AWS_SESSION_TOKEN: z.string().optional(),
+      AWS_ENDPOINT_URL_BEDROCK_RUNTIME: z.string().optional(),
 
       ENABLED_WENXIN: z.boolean(),
       WENXIN_API_KEY: z.string().optional(),
@@ -234,6 +235,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
       AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
       AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+      AWS_ENDPOINT_URL_BEDROCK_RUNTIME: process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME,
 
       ENABLED_WENXIN: !!process.env.WENXIN_API_KEY,
       WENXIN_API_KEY: process.env.WENXIN_API_KEY,

--- a/src/libs/model-runtime/bedrock/index.ts
+++ b/src/libs/model-runtime/bedrock/index.ts
@@ -59,7 +59,6 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     };
 
     if (endpoint) {
-      console.log('endpoint', endpoint);
       clientOptions.endpoint = endpoint;
     }
 

--- a/src/libs/model-runtime/bedrock/index.ts
+++ b/src/libs/model-runtime/bedrock/index.ts
@@ -28,6 +28,7 @@ import {
 export interface LobeBedrockAIParams {
   accessKeyId?: string;
   accessKeySecret?: string;
+  endpoint?: string;
   region?: string;
   sessionToken?: string;
 }
@@ -37,18 +38,32 @@ export class LobeBedrockAI implements LobeRuntimeAI {
 
   region: string;
 
-  constructor({ region, accessKeyId, accessKeySecret, sessionToken }: LobeBedrockAIParams = {}) {
+  constructor({
+    region,
+    accessKeyId,
+    accessKeySecret,
+    sessionToken,
+    endpoint,
+  }: LobeBedrockAIParams = {}) {
     if (!(accessKeyId && accessKeySecret))
       throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidBedrockCredentials);
     this.region = region ?? 'us-east-1';
-    this.client = new BedrockRuntimeClient({
+
+    const clientOptions: any = {
       credentials: {
         accessKeyId: accessKeyId,
         secretAccessKey: accessKeySecret,
         sessionToken: sessionToken,
       },
       region: this.region,
-    });
+    };
+
+    if (endpoint) {
+      console.log('endpoint', endpoint);
+      clientOptions.endpoint = endpoint;
+    }
+
+    this.client = new BedrockRuntimeClient(clientOptions);
   }
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -53,11 +53,19 @@ const getParamsFromPayload = (provider: string, payload: JWTPayload) => {
     }
 
     case ModelProvider.Bedrock: {
-      const { AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_REGION, AWS_SESSION_TOKEN } = llmConfig;
+      const {
+        AWS_SECRET_ACCESS_KEY,
+        AWS_ACCESS_KEY_ID,
+        AWS_REGION,
+        AWS_SESSION_TOKEN,
+        AWS_ENDPOINT_URL_BEDROCK_RUNTIME,
+      } = llmConfig;
       let accessKeyId: string | undefined = AWS_ACCESS_KEY_ID;
       let accessKeySecret: string | undefined = AWS_SECRET_ACCESS_KEY;
       let region = AWS_REGION;
       let sessionToken: string | undefined = AWS_SESSION_TOKEN;
+      let endpoint: string | undefined = AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+
       // if the payload has the api key, use user
       if (payload.apiKey) {
         accessKeyId = payload?.awsAccessKeyId;
@@ -65,7 +73,7 @@ const getParamsFromPayload = (provider: string, payload: JWTPayload) => {
         sessionToken = payload?.awsSessionToken;
         region = payload?.awsRegion;
       }
-      return { accessKeyId, accessKeySecret, region, sessionToken };
+      return { accessKeyId, accessKeySecret, endpoint, region, sessionToken };
     }
 
     case ModelProvider.Cloudflare: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
1. Add support for Bedrock endpoint setup by using environment variables 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

add environment variable: AWS_ENDPOINT_URL_BEDROCK_RUNTIME to support bedrock proxy 

it resolves the issue(feat request):https://github.com/lobehub/lobe-chat/issues/4815
user can set environment variable after following the project: https://github.com/jief123/bedrockproxy/blob/main/howto.md

AWS_ENDPOINT_URL_BEDROCK_RUNTIME="https://xxx.cloudfront.net"

<!-- Add any other context about the Pull Request here. -->
