### PR TITLE
🐛 fix: user feedback for empty/long group names in create/edit group modals

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/CreateGroupModal.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/CreateGroupModal.tsx
@@ -35,8 +35,6 @@ const CreateGroupModal = memo<CreateGroupModalProps>(
             onCancel?.(e);
           }}
           onOk={async (e: MouseEvent<HTMLButtonElement>) => {
-            if (!input) return;
-
             if (input.length === 0 || input.length > 20)
               return message.warning(t('sessionGroup.tooLong'));
 

--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/RenameGroupModal.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/RenameGroupModal.tsx
@@ -17,13 +17,13 @@ const RenameGroupModal = memo<RenameGroupModalProps>(({ id, open, onCancel }) =>
   const updateSessionGroupName = useSessionStore((s) => s.updateSessionGroupName);
   const group = useSessionStore((s) => sessionGroupSelectors.getGroupById(id)(s), isEqual);
 
-  const [input, setInput] = useState<string>();
+  const [input, setInput] = useState<string>('');
   const [loading, setLoading] = useState(false);
 
   const { message } = App.useApp();
 
   useEffect(() => {
-    setInput(group?.name);
+    setInput(group?.name ?? '');
   }, [group]);
 
   return (
@@ -32,11 +32,10 @@ const RenameGroupModal = memo<RenameGroupModalProps>(({ id, open, onCancel }) =>
       destroyOnClose
       okButtonProps={{ loading }}
       onCancel={(e) => {
-        setInput(group?.name);
+        setInput(group?.name ?? '');
         onCancel?.(e);
       }}
       onOk={async (e) => {
-        if (!input) return;
         if (input.length === 0 || input.length > 20)
           return message.warning(t('sessionGroup.tooLong'));
         setLoading(true);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

To show an alert when the user submits an empty or long group name in Create Group and Rename Group Modals.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

1. Removed the below `if` block in CreateModal

```
 onOk={async (e: MouseEvent<HTMLButtonElement>) => {
            if (!input) return;
```

To allow the input length check that shows an alert if the title does not meet the criteria.

2. Removed the below `if` block in RenameGroupModal

```
 onOk={async (e: MouseEvent<HTMLButtonElement>) => {
            if (!input) return;
```

To allow the input length check that shows an alert if the title does not meet the criteria.

2.1 And this forced to ensure types are valid for `input` state variable, as a result `input` state is initialized to '' (empty string - following the same convention in CreateGroupModal)

```
const [input, setInput] = useState<string>('');
```

2.2 Added fallback to empty string in the `onCancel`, in case the group.name is empty.

```
onCancel={(e) => {
        setInput(group?.name ?? '');
        onCancel?.(e);
      }}
```

<!-- Add any other context about the Pull Request here. -->
