### PR TITLE
 📝 docs: Add `NEXT_PUBLIC_ENABLE_NEXT_AUTH` to clerk example

### DIFF
--- a/docs/self-hosting/advanced/auth/clerk.mdx
+++ b/docs/self-hosting/advanced/auth/clerk.mdx
@@ -27,6 +27,7 @@ Go to [Clerk](https://clerk.com?utm_source=lobehub\&utm_medium=docs) to register
   ```shell
   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_xxxxxxxxxxx
   CLERK_SECRET_KEY=sk_live_xxxxxxxxxxxxxxxxxxxxxx
+  NEXT_PUBLIC_ENABLE_NEXT_AUTH=0
   ```
 
   ### Create and Configure Webhook in Clerk


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

As written in the release notes, it's necessary to add NEXT_PUBLIC_ENABLE_NEXT_AUTH if self hosting with docker.

From the release notes:

> For users using clerk in self-built images, it is necessary to additionally configure NEXT_PUBLIC_ENABLE_NEXT_AUTH=0 to disable Next Auth

https://github.com/lobehub/lobe-chat/releases/tag/v1.52.0

#### 📝 补充信息 | Additional Information


