### PR TITLE
📝 docs: Add documentations for XAI and Wenxin server environment variables

### DIFF
--- a/docs/self-hosting/environment-variables/model-provider.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.mdx
@@ -183,6 +183,24 @@ If you need to use Azure OpenAI to provide model services, you can refer to the 
 - Default: -
 - Example: `sk-xxxxxx...xxxxxx`
 
+## XAI
+
+### `XAI_API_KEY`
+
+- Type: Required
+- Description: This is the API key you applied for in the XAI service
+- Default: -
+- Example: `xai-xxxxxx...xxxxxx`
+
+## Wenxin
+
+### `WENXIN_API_KEY`
+
+- Type: Required
+- Description: This is the API key you applied for in the Baidu Wenxin service
+- Default: -
+- Example: `xxxxxx...xxxxxx`
+
 ## OpenRouter AI
 
 ### `OPENROUTER_API_KEY`

--- a/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
@@ -181,6 +181,24 @@ LobeChat 在部署时提供了丰富的模型服务商相关的环境变量，�
 - 默认值：-
 - 示例：`sk-xxxxxx...xxxxxx`
 
+## XAI
+
+### `XAI_API_KEY`
+
+- 类型：必选
+- 描述：这是你在 XAI 服务中申请的 API 密钥
+- 默认值：-
+- 示例：`xai-xxxxxx...xxxxxx`
+
+## 文心一言
+
+### `WENXIN_API_KEY`
+
+- 类型：必选
+- 描述：这是你在百度智能云平台申请的文心一言 API 密钥
+- 默认值：-
+- 示例：`xxxxxx...xxxxxx`
+
 ## OpenRouter AI
 
 ### `OPENROUTER_API_KEY`


### PR DESCRIPTION
…nfig.

#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

添加了XAI和文心一言相关的服务端环境变量配置说明文档

#### 📝 补充信息 | Additional Information

`docs/self-hosting/environment-variables/model-provider.mdx`以及`docs/self-hosting/environment-variables/model-provider.zh-CN.mdx`文档中仍然缺少若干已经在`src/config/llm.ts`中定义并使用的环境变量的说明。本次仅补充了2个我使用过的provider相关的文档，仍然有其他缺失的文档待补全。
