### PR TITLE
👷 docs: Fix the issue that the communication with the casdoor server is not available due to the port change

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       postgresql:
         condition: service_healthy
     environment:
+      httpport: ${CASDOOR_PORT}
       RUNNING_IN_DOCKER: 'true'
       driverName: 'postgres'
       dataSourceName: 'user=postgres password=${POSTGRES_PASSWORD} host=postgresql port=5432 sslmode=disable dbname=casdoor'


### PR DESCRIPTION
Fix the issue that the communication with the casdoor server is not available due to the port change.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

When the user modifies the value of CASDOOR_PORT in the .env file, it will cause the application to fail to communicate with the casdoor network. The address that casdoor listens to should be informed through environment variables.

#### 📝 补充信息 | Additional Information

https://casdoor.org/docs/basic/server-installation#via-environment-variables
