### PR TITLE
🐛 fix: disable fc for ds-v3

### DIFF
--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -22,7 +22,8 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
+      // Not support tool use, ref: https://cloud.siliconflow.cn/models?target=deepseek-ai%2FDeepSeek-V3
+      functionCall: false,
     },
     contextWindowTokens: 65_536,
     description:

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -67,7 +67,8 @@ const doubaoChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
+      // FC not supported yet, ref: https://www.volcengine.com/docs/82379/1262342#8c325d45
+      functionCall: false,
     },
     config: {
       deploymentName: 'deepseek-v3-241226',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/config/aiModels/siliconcloud.ts`: 为硅基流动ds-v3关闭函数调用，因为其 model card 中不支持 FC 且使用 FC 时会报错 https://cloud.siliconflow.cn/models?target=Pro/deepseek-ai/DeepSeek-V3
- `src/config/aiModels/volcengine.ts`: 为火山引擎ds-v3关闭函数调用，因为其 FC 文档中声明非 doubao 系列模型均无 FC， 且使用 FC 时会报错 https://www.volcengine.com/docs/82379/1262342#8c325d45

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- #6452 当选择了智能联网后会为支持 FC 的模型自动启动联网，如果模型不支持FC但model card标记为支持，会报错
<!-- Add any other context about the Pull Request here. -->
