### PR TITLE
 🔨 chore: add missing `restart: always` on network-service

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   network-service:
     image: alpine
     container_name: lobe-network
+    restart: always
     ports:
       - '${MINIO_PORT}:${MINIO_PORT}' # MinIO API
       - '9001:9001' # MinIO Console


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

修复 host 重启后 docker compose 服务自启失败的问题。

#### 📝 补充信息 | Additional Information

network-service 缺少 `restart: always` 所以在宿主机重启后不会自动启动，而其他 service 依赖这个服务，这导致 docker-compose 中的其他 service 自动启动失败。
