### PR TITLE
🔨 chore: upgrade antd version

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@vercel/speed-insights": "^1.1.0",
     "ahooks": "^3.8.4",
     "ai": "^3.4.33",
-    "antd": "^5.23.0",
+    "antd": "^5.24.4",
     "antd-style": "^3.7.1",
     "brotli-wasm": "^3.0.1",
     "chroma-js": "^3.1.2",


### PR DESCRIPTION
: src/features/InitClientDB/features/DatabaseRepair/Repair.tsx(123,9): error TS2322: Type '{ children: Element; className: string; extra: Element; title: string; variant: string; }' is not assignable to type 'IntrinsicAttributes & CardProps & RefAttributes<HTMLDivElement>'.

                                  Property 'variant' does not exist on type 'IntrinsicAttributes & CardProps & RefAttributes<HTMLDivElement>'.

#### 💻 变更类型 | Change Type

Card组件variant属性，需要antd 5.24版本才支持。

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
