### PR TITLE
🔨 chore: Correcting the env example url

### DIFF
--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -319,8 +319,8 @@ This section mainly introduces the configurations that need to be modified to cu
 
 ```sh
 curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/docker-compose.yml
-curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/.env.en_US.example
-mv .env.en_US.example .env
+curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/.env.example
+mv .env.example .env
 ```
 
 <Callout type="info">


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `docs/self-hosting/server-database/docker-compose.mdx`: 修正 url 错误: `.env.en_US.example` -> `.env.example`

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
- close #7290 
- 应该是上次做 setup.sh 变更时使用 i18n 转译后的检查出现疏忽, 忽略了这一细节..
<!-- Add any other context about the Pull Request here. -->
