### PR TITLE
🐛 fix: fix xAI API calling, not support `stream_options`

### DIFF
--- a/src/libs/agent-runtime/xai/index.test.ts
+++ b/src/libs/agent-runtime/xai/index.test.ts
@@ -10,4 +10,8 @@ testProvider({
   defaultBaseURL: 'https://api.x.ai/v1',
   chatDebugEnv: 'DEBUG_XAI_CHAT_COMPLETION',
   chatModel: 'grok',
+
+  test: {
+    skipAPICall: true,
+  },
 });

--- a/src/libs/agent-runtime/xai/index.ts
+++ b/src/libs/agent-runtime/xai/index.ts
@@ -9,6 +9,10 @@ export interface XAIModelCard {
 
 export const LobeXAI = LobeOpenAICompatibleFactory({
   baseURL: 'https://api.x.ai/v1',
+  chatCompletion: {
+    // xAI API does not support stream_options: { include_usage: true }
+    excludeUsage: true,
+  },
   debug: {
     chatCompletion: () => process.env.DEBUG_XAI_CHAT_COMPLETION === '1',
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 增加 `excludeUsage` 参数，xAI 不支持 `stream_options`

close #7336
close #7333

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

ref: https://docs.x.ai/docs/api-reference#chat-completions
![image](https://github.com/user-attachments/assets/95a16c5b-9e03-4ce5-adc5-dc1973c4a667)

<!-- Add any other context about the Pull Request here. -->
