### PR TITLE
🐛 fix: Remove Azure AI o3-mini unsupported parameters

### DIFF
--- a/src/libs/agent-runtime/azureai/index.ts
+++ b/src/libs/agent-runtime/azureai/index.ts
@@ -34,7 +34,7 @@ export class LobeAzureAI implements LobeRuntimeAI {
   baseURL: string;
 
   async chat(payload: ChatStreamPayload, options?: ChatCompetitionOptions) {
-    const { messages, model, ...params } = payload;
+    const { messages, model, temperature, top_p, ...params } = payload;
     // o1 series models on Azure OpenAI does not support streaming currently
     const enableStreaming = model.includes('o1') ? false : (params.stream ?? true);
 
@@ -56,7 +56,9 @@ export class LobeAzureAI implements LobeRuntimeAI {
           model,
           ...params,
           stream: enableStreaming,
+          temperature: model.includes('o3') ? undefined : temperature,
           tool_choice: params.tools ? 'auto' : undefined,
+          top_p: model.includes('o3') ? undefined : top_p,
         },
       });
 

--- a/src/libs/agent-runtime/azureai/index.ts
+++ b/src/libs/agent-runtime/azureai/index.ts
@@ -58,7 +58,7 @@ export class LobeAzureAI implements LobeRuntimeAI {
           stream: enableStreaming,
           temperature: model.includes('o3') ? undefined : temperature,
           tool_choice: params.tools ? 'auto' : undefined,
-          top_p: (model.includes('o3') || model.includes('4o')) ? undefined : top_p,
+          top_p: model.includes('o3') ? undefined : top_p,
         },
       });
 

--- a/src/libs/agent-runtime/azureai/index.ts
+++ b/src/libs/agent-runtime/azureai/index.ts
@@ -58,7 +58,7 @@ export class LobeAzureAI implements LobeRuntimeAI {
           stream: enableStreaming,
           temperature: model.includes('o3') ? undefined : temperature,
           tool_choice: params.tools ? 'auto' : undefined,
-          top_p: model.includes('o3') ? undefined : top_p,
+          top_p: (model.includes('o3') || model.includes('4o')) ? undefined : top_p,
         },
       });
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

经测试 Azure AI 的 o3-mini 模型不支持 temperature 和 top_p 参数，会报错，且错误不在前台显示。


报错不显示的问题可以关注 #7326

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
