### PR TITLE
♻️ refactor: refactor hotkey import to avoid db generate error

### DIFF
--- a/src/const/hotkeys.ts
+++ b/src/const/hotkeys.ts
@@ -1,5 +1,3 @@
-import { combineKeys } from '@lobehub/ui/es/Hotkey';
-
 import {
   HotkeyEnum,
   HotkeyGroupEnum,
@@ -7,6 +5,8 @@ import {
   HotkeyScopeEnum,
   KeyEnum,
 } from '@/types/hotkey';
+
+const combineKeys = (keys: string[]) => keys.join('+');
 
 // mod 在 Mac 上是 command 键，alt 在 Win 上是 ctrl 键
 export const HOTKEYS_REGISTRATION: HotkeyRegistration = [

--- a/src/types/hotkey.ts
+++ b/src/types/hotkey.ts
@@ -1,8 +1,59 @@
-import { KeyMapEnum } from '@lobehub/ui/es/Hotkey';
-
 export const KeyEnum = {
-  ...KeyMapEnum,
+  Alt: 'alt',
+  Backquote: 'backquote',
+  // `
+  Backslash: 'backslash',
+  // \
+  Backspace: 'backspace',
+  BracketLeft: 'bracketleft',
+  // [
+  BracketRight: 'bracketright',
+  // ]
+  Comma: 'comma',
+  // ,
+  Ctrl: 'ctrl',
+  Down: 'down',
+  Enter: 'enter',
+  Equal: 'equal',
+  // =
+  Esc: 'esc',
+  Left: 'left',
+  LeftClick: 'left-click',
+  LeftDoubleClick: 'left-double-click',
+  Meta: 'meta',
+  // Command on Mac, Win on Win
+  MiddleClick: 'middle-click',
+  Minus: 'minus',
+  // -
+  Mod: 'mod',
+
   Number: '1-9',
+
+  // Command on Mac, Ctrl on Win
+  Period: 'period',
+
+  // .
+  Plus: 'equal',
+
+  // +
+  QuestionMark: 'slash',
+
+  // ?
+  Quote: 'quote',
+  // '
+  Right: 'right',
+  RightClick: 'right-click',
+  RightDoubleClick: 'right-double-click',
+
+  Semicolon: 'semicolon',
+  // ;
+  Shift: 'shift',
+
+  Slash: 'slash',
+  // /
+  Space: 'space',
+  Tab: 'tab',
+  Up: 'up',
 } as const;
 
 export const HotkeyEnum = {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

hotkey 的 type 和 const 都导入了真实变量，然后 node 就按 esm 的标准模块来解析了，但现在 ui 里生成的导入都不带后缀的，所以导入真实变量就有问题。

根本原因是 ESM 的导入格式要求是 `xxx.js`  必须要带上后缀。但是目前 father 打包的东西没完全符合 esm 的格式规范，虽然用了 import 语法，但是import 也只是 import '.../file' ，没有加上后缀。所以在 node 端走 esm 解析的时候就会报错找不到模块的错误 `ERR_MODULE_NOT_FOUND` 

临时解法是真实变量不从 UI 导入，直接实现加进来。

长期最终的解法应该要等 father 把标准 esm 导出给支持上。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
