### PR TITLE
移动端减少个人中心的菜单层级

### DIFF
--- a/src/app/[variants]/(main)/profile/_layout/Mobile/Header.tsx
+++ b/src/app/[variants]/(main)/profile/_layout/Mobile/Header.tsx
@@ -19,7 +19,7 @@ const Header = memo(() => {
   const isStats = activeSettingsKey === 'stats';
 
   const handleBackClick = () => {
-    router.push('/me/profile');
+    router.push('/me');
   };
 
   return (


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

把账户管理里的菜单移到我的这一层，包括退出登录，减少菜单层级。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
