### PR TITLE
🐛 fix: Improve stability of Cloudflare Workers AI

### DIFF
--- a/src/libs/agent-runtime/utils/cloudflareHelpers.ts
+++ b/src/libs/agent-runtime/utils/cloudflareHelpers.ts
@@ -8,6 +8,8 @@ class CloudflareStreamTransformer {
     const dataPrefix = /^data: /;
     const json = chunk.replace(dataPrefix, '');
     const parsedChunk = JSON.parse(json);
+    const res = parsedChunk?.response;
+    if (!res) return; // TODO: Add test; Handle tool_call parameter.
     controller.enqueue(`event: text\n`);
     controller.enqueue(`data: ${JSON.stringify(parsedChunk.response)}\n\n`);
   }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
Skip data chunk when `response` is missing

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

This does not fix error in Cloudflare Workers AI. The primary reason of truncation is `max_tokens` limit, which defaults to `256`.
I'm not sure whether it is good to arbitratrily set a larger limit, say `2048`, because it may still be short, and it may overflow to the context window.
I believe the best solution is to give an option in frontend, enabling users to set the `max_tokens` by themselves. @arvinxx 

There's another issue with reasoning models in Cloudflare: missing of opening `<think>` tag. This is an expected behaviour by design, see https://discord.com/channels/595317990191398933/1105477009964027914/1354837625554604143. However, this behaviour may change, so I'm not going to prefix `<think>` for now