### PR TITLE
🐛 fix: Gemini error `Tool use with function calling is unsupported`

### DIFF
--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -368,7 +368,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     payload?: ChatStreamPayload,
   ): GoogleFunctionCallTool[] | undefined {
     // 目前 Tools (例如 googleSearch) 无法与其他 FunctionCall 同时使用
-    if (payload?.messages?.some(m => m.tool_calls?.length))) {
+    if (payload?.messages?.some(m => m.tool_calls?.length)) {
       return; // 若历史消息中已有 function calling，则不再注入任何 Tools
     }
     if (payload?.enabledSearch) {

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -368,6 +368,9 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     payload?: ChatStreamPayload,
   ): GoogleFunctionCallTool[] | undefined {
     // 目前 Tools (例如 googleSearch) 无法与其他 FunctionCall 同时使用
+    if (tools?.length && payload?.messages?.some(m => m.tool_calls?.length)) {
+      return; // 若历史消息中已有 function calling，则不再注入任何 Tools
+    }
     if (payload?.enabledSearch) {
       return [{ googleSearch: {} } as GoogleSearchRetrievalTool];
     }

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -368,7 +368,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     payload?: ChatStreamPayload,
   ): GoogleFunctionCallTool[] | undefined {
     // 目前 Tools (例如 googleSearch) 无法与其他 FunctionCall 同时使用
-    if (tools?.length && payload?.messages?.some(m => m.tool_calls?.length)) {
+    if (payload?.messages?.some(m => m.tool_calls?.length))) {
       return; // 若历史消息中已有 function calling，则不再注入任何 Tools
     }
     if (payload?.enabledSearch) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

避免历史消息中的 function calling 与 gemini 的 Tools 发生冲突。

解决方法是当历史消息中存在 tool_calls 时，自动关闭 Tools（目前特指 googleSearch）。

![image](https://github.com/user-attachments/assets/4b32229d-a557-4cad-9082-09835428f27e)


#### 📝 补充信息 | Additional Information

~~待测试~~

已验证可用。
