### PR TITLE
:pushpin: chore: lock nextauth to beta.25 to prevent build failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "modern-screenshot": "^4.6.0",
     "nanoid": "^5.1.5",
     "next": "^15.3.0",
-    "next-auth": "beta",
+    "next-auth": "5.0.0-beta.25",
     "next-mdx-remote": "^5.0.0",
     "nextjs-toploader": "^3.8.16",
     "numeral": "^2.0.6",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 📌  `package.json`: 将 next-auth 锁到 `beta.25` 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- #6434 中引入的 error 处理方法在 next-auth 新版中存在类型问题~~，待适配~~
- https://www.npmjs.com/package/next-auth/v/5.0.0-beta.25
- https://authjs.dev/guides/pages/signin
- https://github.com/nextauthjs/next-auth/issues/12912 next-auth 将错误类型`error.type`标记为内部类型导致无法访问，待其修复后再解锁
<!-- Add any other context about the Pull Request here. -->
