### PR TITLE
🐛 fix: pwa-install cause mobile infinity scroll

### DIFF
--- a/src/features/PWAInstall/index.tsx
+++ b/src/features/PWAInstall/index.tsx
@@ -5,6 +5,8 @@ import { pwaInstallHandler } from 'pwa-install-handler';
 import { memo, useEffect, useState } from 'react';
 
 import { usePlatform } from '@/hooks/usePlatform';
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 
 const Install: any = dynamic(() => import('./Install'), {
@@ -14,6 +16,7 @@ const Install: any = dynamic(() => import('./Install'), {
 const PWAInstall = memo(() => {
   const { isPWA, isSupportInstallPWA } = usePlatform();
   const isShowPWAGuide = useUserStore((s) => s.isShowPWAGuide);
+  const hidePWAInstaller = useGlobalStore((s) => systemStatusSelectors.hidePWAInstaller(s));
   const [canInstallFromPWAInstallHandler, setCanInstallFromPWAInstallHandler] = useState<
     boolean | undefined
   >();
@@ -27,7 +30,13 @@ const PWAInstall = memo(() => {
     };
   }, []);
 
-  if (isPWA || !isShowPWAGuide || !isSupportInstallPWA || canInstallFromPWAInstallHandler === false)
+  if (
+    isPWA ||
+    !isShowPWAGuide ||
+    !isSupportInstallPWA ||
+    hidePWAInstaller ||
+    canInstallFromPWAInstallHandler === false
+  )
     return null;
 
   // only when the user is suitable for the pwa install and not install the pwa

--- a/src/features/PWAInstall/index.tsx
+++ b/src/features/PWAInstall/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { memo } from 'react';
+import { pwaInstallHandler } from 'pwa-install-handler';
+import { memo, useEffect, useState } from 'react';
 
 import { usePlatform } from '@/hooks/usePlatform';
 import { useUserStore } from '@/store/user';
@@ -13,8 +14,21 @@ const Install: any = dynamic(() => import('./Install'), {
 const PWAInstall = memo(() => {
   const { isPWA, isSupportInstallPWA } = usePlatform();
   const isShowPWAGuide = useUserStore((s) => s.isShowPWAGuide);
+  const [canInstallFromPWAInstallHandler, setCanInstallFromPWAInstallHandler] = useState<
+    boolean | undefined
+  >();
 
-  if (isPWA || !isShowPWAGuide || !isSupportInstallPWA) return null;
+  useEffect(() => {
+    pwaInstallHandler.addListener((canInstall) => {
+      setCanInstallFromPWAInstallHandler(canInstall);
+    });
+    return () => {
+      pwaInstallHandler.removeListener(setCanInstallFromPWAInstallHandler);
+    };
+  }, []);
+
+  if (isPWA || !isShowPWAGuide || !isSupportInstallPWA || canInstallFromPWAInstallHandler === false)
+    return null;
 
   // only when the user is suitable for the pwa install and not install the pwa
   // then show the installation guide


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

首先那个滚动区域其实是没 install 的 pwa-install 区域。

目前 pwa-install 的 install 依赖 pwa-install 自定义元素挂载到 DOM 上，但是有可能后序判断导致不 install，而被挂载的 pwa-install 元素导致移动端滚动问题。

可能最理想的方法还是实现没有 install pwa-install 的情况下不应该影响当前布局，但是 shadowDOM 设计上就改不了内部的样式。

当前的解决办法：不需要渲染 pwa-install 的时候不渲染 pws-install。

能修复以下场景：

- 判断需要安装，并且不支持安装 pwa 的场景（例如已安装或者环境不允许）
- 用户选择 dismiss 安装 pwa

close #7408

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7c1f4f22-6aae-4af4-a432-c008183e2399" />
