### PR TITLE
🐛fix: Replace "it" with "general" in search categories to improve sea…

### DIFF
--- a/src/server/services/search/impls/searxng/index.test.ts
+++ b/src/server/services/search/impls/searxng/index.test.ts
@@ -22,5 +22,24 @@ describe('SearXNGImpl', () => {
       // Assert
       expect(results.results.length).toEqual(43);
     });
+
+    it('应该将搜索类别"it"替换为"general"', async () => {
+      const mockSearch = vi
+        .spyOn(SearXNGClient.prototype, 'search')
+        .mockResolvedValueOnce(hetongxue);
+
+      const searchImpl = new SearXNGImpl();
+      await searchImpl.query('test query', {
+        searchCategories: ['it', 'images', 'it'],
+      });
+
+      // Assert search was called with correct categories
+      expect(mockSearch).toHaveBeenCalledWith(
+        'test query',
+        expect.objectContaining({
+          categories: ['general', 'images'],
+        }),
+      );
+    });
   });
 });

--- a/src/server/services/search/impls/searxng/index.ts
+++ b/src/server/services/search/impls/searxng/index.ts
@@ -27,8 +27,12 @@ export class SearXNGImpl implements SearchServiceImpl {
     try {
       let costTime = 0;
       const startAt = Date.now();
+      // Replace "it" with "general" in search categories to improve search results
+      const categories = Array.from(
+        new Set(params?.searchCategories?.map((c) => (c === 'it' ? 'general' : c))),
+      );
       const data = await client.search(query, {
-        categories: params?.searchCategories,
+        categories: categories,
         engines: params?.searchEngines,
         time_range: params?.searchTimeRange,
       });


### PR DESCRIPTION
…rch results

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
在SearXNG中指定搜索参数`"searchCategories": ["it"]`会导致搜索结果中hub.docker.com和developer.mozilla.org比重过大，搜索结果变得非常糟糕。详细问题描述见https://github.com/lobehub/lobe-chat/issues/7548

