### PR TITLE
给随便聊聊增加右向箭头，为了增强点击可以进入的提示

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
@@ -28,7 +28,7 @@ const Inbox = memo(() => {
       }}
     >
       <ListItem
-        actions={<ChevronRight />}
+        actions={<ChevronRight onClick={() => switchSession(INBOX_SESSION_ID)}/>}
         active={activeId === INBOX_SESSION_ID}
         avatar={DEFAULT_INBOX_AVATAR}
         title={t('inbox.title')}

--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
@@ -8,6 +8,7 @@ import { SESSION_CHAT_URL } from '@/const/url';
 import { useSwitchSession } from '@/hooks/useSwitchSession';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useSessionStore } from '@/store/session';
+import { ChevronRight} from "lucide-react";
 
 import ListItem from '../ListItem';
 
@@ -27,6 +28,7 @@ const Inbox = memo(() => {
       }}
     >
       <ListItem
+        actions={<ChevronRight />}
         active={activeId === INBOX_SESSION_ID}
         avatar={DEFAULT_INBOX_AVATAR}
         title={t('inbox.title')}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
![image](https://github.com/user-attachments/assets/64e96ec7-069e-405f-aed2-bcb5c0bf4ea8)
给随便聊聊增加右向箭头，为了增强点击可以进入的提示，特别是移动端环境，不熟悉的人，不会注意到随便聊聊可以点进去，容易被右上角的新建助手吸引。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
