### PR TITLE
feat: add token usage for google ai and vertex ai

### DIFF
--- a/src/config/aiModels/vertexai.ts
+++ b/src/config/aiModels/vertexai.ts
@@ -5,6 +5,46 @@ const vertexaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description: 'Gemini 2.5 Flash Preview 是 Google 性价比最高的模型，提供全面的功能。',
+    displayName: 'Gemini 2.5 Flash Preview 04-17',
+    enabled: true,
+    id: 'gemini-2.5-flash-preview-04-17',
+    maxOutput: 65_536,
+    pricing: {
+      input: 0.15,
+      output: 3.5, // Thinking
+    },
+    releasedAt: '2025-04-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      'Gemini 2.5 Pro Preview 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
+    displayName: 'Gemini 2.5 Pro Preview 03-25 (Paid)',
+    id: 'gemini-2.5-pro-preview-03-25',
+    maxOutput: 65_536,
+    pricing: {
+      input: 1.25, // prompts <= 200k tokens
+      output: 10, // prompts <= 200k tokens
+    },
+    releasedAt: '2025-04-09',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       vision: true,
     },
     contextWindowTokens: 2_097_152 + 8192,

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -161,9 +161,8 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       }
 
       // Convert the response into a friendly text-stream
-      const stream = this.isVertexAi
-        ? VertexAIStream(prod, options?.callback)
-        : GoogleGenerativeAIStream(prod, { callbacks: options?.callback, inputStartAt });
+      const Stream = this.isVertexAi ? VertexAIStream : GoogleGenerativeAIStream;
+      const stream = Stream(prod, { callbacks: options?.callback, inputStartAt });
 
       // Respond with the stream
       return StreamingResponse(stream, { headers: options?.headers });

--- a/src/libs/agent-runtime/google/index.ts
+++ b/src/libs/agent-runtime/google/index.ts
@@ -106,6 +106,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
 
       const contents = await this.buildGoogleMessages(payload.messages);
 
+      const inputStartAt = Date.now();
       const geminiStreamResult = await this.client
         .getGenerativeModel(
           {
@@ -160,8 +161,9 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       }
 
       // Convert the response into a friendly text-stream
-      const Stream = this.isVertexAi ? VertexAIStream : GoogleGenerativeAIStream;
-      const stream = Stream(prod, options?.callback);
+      const stream = this.isVertexAi
+        ? VertexAIStream(prod, options?.callback)
+        : GoogleGenerativeAIStream(prod, { callbacks: options?.callback, inputStartAt });
 
       // Respond with the stream
       return StreamingResponse(stream, { headers: options?.headers });

--- a/src/libs/agent-runtime/utils/streams/google-ai.test.ts
+++ b/src/libs/agent-runtime/utils/streams/google-ai.test.ts
@@ -34,10 +34,12 @@ describe('GoogleGenerativeAIStream', () => {
     const onCompletionMock = vi.fn();
 
     const protocolStream = GoogleGenerativeAIStream(mockGoogleStream, {
-      onStart: onStartMock,
-      onText: onTextMock,
-      onToolsCalling: onToolCallMock,
-      onCompletion: onCompletionMock,
+      callbacks: {
+        onStart: onStartMock,
+        onText: onTextMock,
+        onToolsCalling: onToolCallMock,
+        onCompletion: onCompletionMock,
+      },
     });
 
     const decoder = new TextDecoder();

--- a/src/libs/agent-runtime/utils/streams/google-ai.ts
+++ b/src/libs/agent-runtime/utils/streams/google-ai.ts
@@ -20,31 +20,57 @@ const transformGoogleGenerativeAIStream = (
   context: StreamContext,
 ): StreamProtocolChunk | StreamProtocolChunk[] => {
   // maybe need another structure to add support for multiple choices
+  const candidate = chunk.candidates?.[0];
+  const usage = chunk.usageMetadata;
+  const usageChunks: StreamProtocolChunk[] = [];
+  if (candidate?.finishReason && usage) {
+    usageChunks.push(
+      { data: candidate.finishReason, id: context?.id, type: 'stop' },
+      {
+        data: {
+          // TODO: Google SDK 0.24.0 don't have promptTokensDetails types
+          inputImageTokens: (usage as any).promptTokensDetails?.find(
+            (i: any) => i.modality === 'IMAGE',
+          )?.tokenCount,
+          inputTextTokens: (usage as any).promptTokensDetails?.find(
+            (i: any) => i.modality === 'TEXT',
+          )?.tokenCount,
+          totalInputTokens: usage.promptTokenCount,
+          totalOutputTokens: usage.candidatesTokenCount,
+          totalTokens: usage.totalTokenCount,
+        } as ModelTokensUsage,
+        id: context?.id,
+        type: 'usage',
+      },
+    );
+  }
+
   const functionCalls = chunk.functionCalls?.();
 
   if (functionCalls) {
-    return {
-      data: functionCalls.map(
-        (value, index): StreamToolCallChunkData => ({
-          function: {
-            arguments: JSON.stringify(value.args),
-            name: value.name,
-          },
-          id: generateToolCallId(index, value.name),
-          index: index,
-          type: 'function',
-        }),
-      ),
-      id: context.id,
-      type: 'tool_calls',
-    };
+    return [
+      {
+        data: functionCalls.map(
+          (value, index): StreamToolCallChunkData => ({
+            function: {
+              arguments: JSON.stringify(value.args),
+              name: value.name,
+            },
+            id: generateToolCallId(index, value.name),
+            index: index,
+            type: 'function',
+          }),
+        ),
+        id: context.id,
+        type: 'tool_calls',
+      },
+      ...usageChunks,
+    ];
   }
 
   const text = chunk.text?.();
 
-  if (chunk.candidates) {
-    const candidate = chunk.candidates[0];
-
+  if (candidate) {
     // return the grounding
     if (candidate.groundingMetadata) {
       const { webSearchQueries, groundingChunks } = candidate.groundingMetadata;
@@ -70,26 +96,9 @@ const transformGoogleGenerativeAIStream = (
 
     if (candidate.finishReason) {
       if (chunk.usageMetadata) {
-        const usage = chunk.usageMetadata;
         return [
           !!text ? { data: text, id: context?.id, type: 'text' } : undefined,
-          { data: candidate.finishReason, id: context?.id, type: 'stop' },
-          {
-            data: {
-              // TODO: Google SDK 0.24.0 don't have promptTokensDetails types
-              inputImageTokens: (usage as any).promptTokensDetails?.find(
-                (i: any) => i.modality === 'IMAGE',
-              )?.tokenCount,
-              inputTextTokens: (usage as any).promptTokensDetails?.find(
-                (i: any) => i.modality === 'TEXT',
-              )?.tokenCount,
-              totalInputTokens: usage.promptTokenCount,
-              totalOutputTokens: usage.candidatesTokenCount,
-              totalTokens: usage.totalTokenCount,
-            } as ModelTokensUsage,
-            id: context?.id,
-            type: 'usage',
-          },
+          ...usageChunks,
         ].filter(Boolean) as StreamProtocolChunk[];
       }
       return { data: candidate.finishReason, id: context?.id, type: 'stop' };

--- a/src/libs/agent-runtime/utils/streams/protocol.ts
+++ b/src/libs/agent-runtime/utils/streams/protocol.ts
@@ -298,7 +298,11 @@ export const TOKEN_SPEED_CHUNK_ID = 'output_speed';
  */
 export const createTokenSpeedCalculator = (
   transformer: (chunk: any, stack: StreamContext) => StreamProtocolChunk | StreamProtocolChunk[],
-  { streamStack, inputStartAt }: { inputStartAt?: number; streamStack?: StreamContext } = {},
+  {
+    inputStartAt,
+    outputThinking = true,
+    streamStack,
+  }: { inputStartAt?: number; outputThinking?: boolean; streamStack?: StreamContext } = {},
 ) => {
   let outputStartAt: number | undefined;
 
@@ -308,7 +312,9 @@ export const createTokenSpeedCalculator = (
     if (!outputStartAt && chunk.type === 'text') outputStartAt = Date.now();
     // if the chunk is the stop chunk, set as output finish
     if (inputStartAt && outputStartAt && chunk.type === 'usage') {
-      const outputTokens = chunk.data?.totalOutputTokens || chunk.data?.outputTextTokens;
+      const totalOutputTokens = chunk.data?.totalOutputTokens || chunk.data?.outputTextTokens;
+      const reasoningTokens = chunk.data?.outputReasoningTokens || 0;
+      const outputTokens = outputThinking ? totalOutputTokens : totalOutputTokens - reasoningTokens;
       result.push({
         data: {
           tps: (outputTokens / (Date.now() - outputStartAt)) * 1000,

--- a/src/libs/agent-runtime/utils/streams/vertex-ai.test.ts
+++ b/src/libs/agent-runtime/utils/streams/vertex-ai.test.ts
@@ -1,3 +1,4 @@
+import { EnhancedGenerateContentResponse } from '@google/generative-ai';
 import { describe, expect, it, vi } from 'vitest';
 
 import * as uuidModule from '@/utils/uuid';
@@ -103,10 +104,12 @@ describe('VertexAIStream', () => {
     const onCompletionMock = vi.fn();
 
     const protocolStream = VertexAIStream(mockGoogleStream, {
-      onStart: onStartMock,
-      onText: onTextMock,
-      onToolsCalling: onToolCallMock,
-      onCompletion: onCompletionMock,
+      callbacks: {
+        onStart: onStartMock,
+        onText: onTextMock,
+        onToolsCalling: onToolCallMock,
+        onCompletion: onCompletionMock,
+      },
     });
 
     const decoder = new TextDecoder();
@@ -136,63 +139,21 @@ describe('VertexAIStream', () => {
 
   it('tool_calls', async () => {
     vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1');
-    const rawChunks = [
-      {
-        candidates: [
-          {
-            content: {
-              role: 'model',
-              parts: [
-                {
-                  functionCall: {
-                    name: 'realtime-weather____fetchCurrentWeather',
-                    args: { city: '杭州' },
-                  },
-                },
-              ],
-            },
-            finishReason: 'STOP',
-            safetyRatings: [
-              {
-                category: 'HARM_CATERY_HATE_SPEECH',
-                probability: 'NEGLIGIBLE',
-                probabilityScore: 0.09814453,
-                severity: 'HARM_SEVERITY_NEGLIGIBLE',
-                severityScore: 0.07470703,
-              },
-              {
-                category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-                probability: 'NEGLIGIBLE',
-                probabilityScore: 0.1484375,
-                severity: 'HARM_SEVERITY_NEGLIGIBLE',
-                severityScore: 0.15136719,
-              },
-              {
-                category: 'HARM_CATEGORY_HARASSMENT',
-                probability: 'NEGLIGIBLE',
-                probabilityScore: 0.11279297,
-                severity: 'HARM_SEVERITY_NEGLIGIBLE',
-                severityScore: 0.10107422,
-              },
-              {
-                category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-                probability: 'NEGLIGIBLE',
-                probabilityScore: 0.048828125,
-                severity: 'HARM_SEVERITY_NEGLIGIBLE',
-                severityScore: 0.05493164,
-              },
-            ],
-            index: 0,
-          },
-        ],
-        usageMetadata: { promptTokenCount: 95, candidatesTokenCount: 9, totalTokenCount: 104 },
-        modelVersion: 'gemini-1.5-flash-001',
-      },
-    ];
+
+    const mockGenerateContentResponse = (text: string, functionCalls?: any[]) =>
+      ({
+        text: () => text,
+        functionCall: () => functionCalls?.[0],
+        functionCalls: () => functionCalls,
+      }) as EnhancedGenerateContentResponse;
 
     const mockGoogleStream = new ReadableStream({
       start(controller) {
-        rawChunks.forEach((chunk) => controller.enqueue(chunk));
+        controller.enqueue(
+          mockGenerateContentResponse('', [
+            { name: 'realtime-weather____fetchCurrentWeather', args: { city: '杭州' } },
+          ]),
+        );
 
         controller.close();
       },
@@ -204,10 +165,12 @@ describe('VertexAIStream', () => {
     const onCompletionMock = vi.fn();
 
     const protocolStream = VertexAIStream(mockGoogleStream, {
-      onStart: onStartMock,
-      onText: onTextMock,
-      onToolsCalling: onToolCallMock,
-      onCompletion: onCompletionMock,
+      callbacks: {
+        onStart: onStartMock,
+        onText: onTextMock,
+        onToolsCalling: onToolCallMock,
+        onCompletion: onCompletionMock,
+      },
     });
 
     const decoder = new TextDecoder();
@@ -228,5 +191,95 @@ describe('VertexAIStream', () => {
     expect(onStartMock).toHaveBeenCalledTimes(1);
     expect(onToolCallMock).toHaveBeenCalledTimes(1);
     expect(onCompletionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle stop with content', async () => {
+    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1');
+
+    const data = [
+      {
+        candidates: [
+          {
+            content: { parts: [{ text: '234' }], role: 'model' },
+            safetyRatings: [
+              { category: 'HARM_CATEGORY_HATE_SPEECH', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_HARASSMENT', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', probability: 'NEGLIGIBLE' },
+            ],
+          },
+        ],
+        text: () => '234',
+        usageMetadata: {
+          promptTokenCount: 20,
+          totalTokenCount: 20,
+          promptTokensDetails: [{ modality: 'TEXT', tokenCount: 20 }],
+        },
+        modelVersion: 'gemini-2.0-flash-exp-image-generation',
+      },
+      {
+        text: () => '567890\n',
+        candidates: [
+          {
+            content: { parts: [{ text: '567890\n' }], role: 'model' },
+            finishReason: 'STOP',
+            safetyRatings: [
+              { category: 'HARM_CATEGORY_HATE_SPEECH', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_HARASSMENT', probability: 'NEGLIGIBLE' },
+              { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', probability: 'NEGLIGIBLE' },
+            ],
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 19,
+          candidatesTokenCount: 11,
+          totalTokenCount: 30,
+          promptTokensDetails: [{ modality: 'TEXT', tokenCount: 19 }],
+          candidatesTokensDetails: [{ modality: 'TEXT', tokenCount: 11 }],
+        },
+        modelVersion: 'gemini-2.0-flash-exp-image-generation',
+      },
+    ];
+
+    const mockGoogleStream = new ReadableStream({
+      start(controller) {
+        data.forEach((item) => {
+          controller.enqueue(item);
+        });
+
+        controller.close();
+      },
+    });
+
+    const protocolStream = VertexAIStream(mockGoogleStream);
+
+    const decoder = new TextDecoder();
+    const chunks = [];
+
+    // @ts-ignore
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    expect(chunks).toEqual(
+      [
+        'id: chat_1',
+        'event: text',
+        'data: "234"\n',
+
+        'id: chat_1',
+        'event: text',
+        `data: "567890\\n"\n`,
+        // stop
+        'id: chat_1',
+        'event: stop',
+        `data: "STOP"\n`,
+        // usage
+        'id: chat_1',
+        'event: usage',
+        `data: {"inputTextTokens":19,"totalInputTokens":19,"totalOutputTokens":11,"totalTokens":30}\n`,
+      ].map((i) => i + '\n'),
+    );
   });
 });

--- a/src/libs/agent-runtime/utils/streams/vertex-ai.ts
+++ b/src/libs/agent-runtime/utils/streams/vertex-ai.ts
@@ -1,27 +1,51 @@
-import { EnhancedGenerateContentResponse, GenerateContentResponse } from '@google/generative-ai';
+import { EnhancedGenerateContentResponse } from '@google/generative-ai';
 
+import { ModelTokensUsage } from '@/types/message';
 import { nanoid } from '@/utils/uuid';
 
-import { ChatStreamCallbacks } from '../../types';
+import { GoogleAIStreamOptions } from './google-ai';
 import {
   StreamContext,
   StreamProtocolChunk,
+  StreamToolCallChunkData,
   createCallbacksTransformer,
   createSSEProtocolTransformer,
+  createTokenSpeedCalculator,
   generateToolCallId,
 } from './protocol';
 
 const transformVertexAIStream = (
-  chunk: GenerateContentResponse,
-  stack: StreamContext,
-): StreamProtocolChunk => {
+  chunk: EnhancedGenerateContentResponse,
+  context: StreamContext,
+): StreamProtocolChunk | StreamProtocolChunk[] => {
   // maybe need another structure to add support for multiple choices
+  const functionCalls = chunk.functionCalls?.();
+
+  if (functionCalls) {
+    return {
+      data: functionCalls.map(
+        (value, index): StreamToolCallChunkData => ({
+          function: {
+            arguments: JSON.stringify(value.args),
+            name: value.name,
+          },
+          id: generateToolCallId(index, value.name),
+          index: index,
+          type: 'function',
+        }),
+      ),
+      id: context.id,
+      type: 'tool_calls',
+    };
+  }
   const candidates = chunk.candidates;
+
+  const text = chunk.text?.();
 
   if (!candidates)
     return {
       data: '',
-      id: stack?.id,
+      id: context?.id,
       type: 'text',
     };
 
@@ -29,47 +53,61 @@ const transformVertexAIStream = (
   if (item.content) {
     const part = item.content.parts[0];
 
-    if (part.functionCall) {
-      const functionCall = part.functionCall;
-
-      return {
-        data: [
+    if (item.finishReason) {
+      if (chunk.usageMetadata) {
+        const usage = chunk.usageMetadata;
+        return [
+          !!text ? { data: text, id: context?.id, type: 'text' } : undefined,
+          { data: item.finishReason, id: context?.id, type: 'stop' },
           {
-            function: {
-              arguments: JSON.stringify(functionCall.args),
-              name: functionCall.name,
-            },
-            id: generateToolCallId(0, functionCall.name),
-            index: 0,
-            type: 'function',
+            data: {
+              // TODO: Google SDK 0.24.0 don't have promptTokensDetails types
+              inputImageTokens: (usage as any).promptTokensDetails?.find(
+                (i: any) => i.modality === 'IMAGE',
+              )?.tokenCount,
+              inputTextTokens: (usage as any).promptTokensDetails?.find(
+                (i: any) => i.modality === 'TEXT',
+              )?.tokenCount,
+              totalInputTokens: usage.promptTokenCount,
+              totalOutputTokens: usage.candidatesTokenCount,
+              totalTokens: usage.totalTokenCount,
+            } as ModelTokensUsage,
+            id: context?.id,
+            type: 'usage',
           },
-        ],
-        id: stack?.id,
-        type: 'tool_calls',
-      };
+        ].filter(Boolean) as StreamProtocolChunk[];
+      }
+      return { data: item.finishReason, id: context?.id, type: 'stop' };
     }
 
     return {
       data: part.text,
-      id: stack?.id,
+      id: context?.id,
       type: 'text',
     };
   }
 
   return {
     data: '',
-    id: stack?.id,
+    id: context?.id,
     type: 'stop',
   };
 };
 
 export const VertexAIStream = (
   rawStream: ReadableStream<EnhancedGenerateContentResponse>,
-  callbacks?: ChatStreamCallbacks,
+  { callbacks, inputStartAt }: GoogleAIStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: 'chat_' + nanoid() };
 
   return rawStream
-    .pipeThrough(createSSEProtocolTransformer(transformVertexAIStream, streamStack))
+    .pipeThrough(
+      createTokenSpeedCalculator(transformVertexAIStream, {
+        inputStartAt,
+        outputThinking: false,
+        streamStack,
+      }),
+    )
+    .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
     .pipeThrough(createCallbacksTransformer(callbacks));
 };

--- a/src/libs/agent-runtime/utils/streams/vertex-ai.ts
+++ b/src/libs/agent-runtime/utils/streams/vertex-ai.ts
@@ -44,9 +44,6 @@ const transformVertexAIStream = (
   }
 
   const candidates = chunk.candidates;
-
-  const text = chunk.text?.();
-
   if (!candidates)
     return {
       data: '',
@@ -84,7 +81,7 @@ const transformVertexAIStream = (
     if (item.finishReason) {
       if (chunk.usageMetadata) {
         return [
-          !!text ? { data: text, id: context?.id, type: 'text' } : undefined,
+          !!part.text ? { data: part.text, id: context?.id, type: 'text' } : undefined,
           ...usageChunks,
         ].filter(Boolean) as StreamProtocolChunk[];
       }

--- a/src/libs/agent-runtime/utils/streams/vertex-ai.ts
+++ b/src/libs/agent-runtime/utils/streams/vertex-ai.ts
@@ -1,4 +1,4 @@
-import { EnhancedGenerateContentResponse } from '@google/generative-ai';
+import { EnhancedGenerateContentResponse, GenerateContentResponse } from '@google/generative-ai';
 
 import { ModelTokensUsage } from '@/types/message';
 import { nanoid } from '@/utils/uuid';
@@ -14,7 +14,7 @@ import {
 } from './protocol';
 
 const transformVertexAIStream = (
-  chunk: EnhancedGenerateContentResponse,
+  chunk: GenerateContentResponse,
   context: StreamContext,
 ): StreamProtocolChunk | StreamProtocolChunk[] => {
   // maybe need another structure to add support for multiple choices


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- Add token usage statistics for Google Gemini API
- Add token usage statistics for Vertex AI
- Adjust `createTokenSpeedCalculator`'s TPS calculation to handle cases where reasoning steps are not output, but the total token count includes `reasoningTokens`.
- Return `token usage` during `function_call`.
- Add Vertex AI model configurations: `gemini-2.5-flash-preview-04-17`, `gemini-2.5-pro-preview-03-25`

#### 📝 补充信息 | Additional Information

![2025-04-27 15 33 19](https://github.com/user-attachments/assets/71f9f489-2e0f-4fcd-81bd-38859575e3ed)
![2025-04-27 15 54 42](https://github.com/user-attachments/assets/b1c0a203-f5e5-45ea-865d-743a094d412e)

