### PR TITLE
💄 style: improve hotkey for delete messages

### DIFF
--- a/src/const/hotkeys.ts
+++ b/src/const/hotkeys.ts
@@ -91,7 +91,7 @@ export const HOTKEYS_REGISTRATION: HotkeyRegistration = [
   {
     group: HotkeyGroupEnum.Conversation,
     id: HotkeyEnum.ClearCurrentMessages,
-    keys: combineKeys([KeyEnum.Alt, KeyEnum.Backspace]),
+    keys: combineKeys([KeyEnum.Alt, KeyEnum.Shift, KeyEnum.Backspace]),
     scopes: [HotkeyScopeEnum.Chat],
   },
 ];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

目前 "清空当前会话消息" 快捷键为 `windows: Alt + Backspace`，`mac:  Option + Delete`

<img width="1020" alt="Image" src="https://github.com/user-attachments/assets/46c41d59-a016-41d8-8506-0ba980e1f285" />

该快捷键属于文本编辑中的常用组合，同 `windows: Ctrl + Backspace `，`mac:  Cmd + Delete` 

无论 win 还是 mac 都会在正常文本编辑时冲突

[Mac 鍵盤快速鍵](https://support.apple.com/zh-tw/102650)
[Windows 的键盘快捷方式](https://support.microsoft.com/zh-cn/windows/windows-%E7%9A%84%E9%94%AE%E7%9B%98%E5%BF%AB%E6%8D%B7%E6%96%B9%E5%BC%8F-dcc61a57-8ff0-cffe-9796-cb9706c75eec)
<!-- Thank you for your Pull Request. Please provide a description above. -->

**将 KeyEnum.Alt, KeyEnum.Backspace 更改为 KeyEnum.Alt, KeyEnum.Shift, KeyEnum.Backspace**

> 问了下 AI 应该没有什么冲突和习惯上的问题

<img width="1034" alt="截屏2025-04-28 上午12 57 01" src="https://github.com/user-attachments/assets/22e6432a-f852-4965-878d-9e135d0fdf0b" />


#### 📝 补充信息 | Additional Information

> 主要该快捷方式可以在**文本输入时直接触发**，最近在文本编辑删除文字时，经常遇到，起初还以为是 创建 message 失败了。。。

<!-- Add any other context about the Pull Request here. -->
