### PR TITLE
🐛 fix: fix mcp server stdio spawn ENOENT in electron bundle

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -68,10 +68,14 @@ const config = {
     gatekeeperAssess: false,
     hardenedRuntime: true,
     notarize: true,
-    target: [
-      { arch: ['x64', 'arm64'], target: 'dmg' },
-      { arch: ['x64', 'arm64'], target: 'zip' },
-    ],
+    target:
+      // 降低构建时间，nightly 只打 arm64
+      isNightly
+        ? [{ arch: ['arm64'], target: 'dmg' }]
+        : [
+            { arch: ['x64', 'arm64'], target: 'dmg' },
+            { arch: ['x64', 'arm64'], target: 'zip' },
+          ],
   },
   npmRebuild: true,
   nsis: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,6 +54,7 @@
     "electron-store": "^8.2.0",
     "electron-vite": "^3.0.0",
     "execa": "^9.5.2",
+    "fix-path": "^4.0.0",
     "just-diff": "^6.0.2",
     "lodash": "^4.17.21",
     "pglite-server": "^0.1.4",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,8 @@
+import fixPath from 'fix-path';
+
 import { App } from './core/App';
 
 const app = new App();
 
+fixPath();
 app.bootstrap();

--- a/src/app/[variants]/(main)/chat/_layout/Desktop/RegisterHotkeys.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/RegisterHotkeys.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { memo } from 'react';
+
 import { useRegisterChatHotkeys } from '@/hooks/useHotkeys';
 
-const RegisterHotkeys = () => {
+const RegisterHotkeys = memo(() => {
   useRegisterChatHotkeys();
-  return null;
-};
+
+  return '';
+});
 
 export default RegisterHotkeys;

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -1,5 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  StdioClientTransport,
+  getDefaultEnvironment,
+} from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.d.ts';
 import debug from 'debug';
@@ -24,9 +27,15 @@ export class MCPClient {
       }
       case 'stdio': {
         log('Using Stdio transport with command: %s and args: %O', params.command, params.args);
+        log('Stdio PATH env:', process.env.PATH);
+
         this.transport = new StdioClientTransport({
           args: params.args,
           command: params.command,
+          env: {
+            ...getDefaultEnvironment(),
+            ...params.env,
+          },
         });
         break;
       }

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -27,7 +27,6 @@ export class MCPClient {
       }
       case 'stdio': {
         log('Using Stdio transport with command: %s and args: %O', params.command, params.args);
-        log('Stdio PATH env:', process.env.PATH);
 
         this.transport = new StdioClientTransport({
           args: params.args,

--- a/src/libs/mcp/types.ts
+++ b/src/libs/mcp/types.ts
@@ -20,6 +20,7 @@ interface HttpMCPClientParams {
 interface StdioMCPParams {
   args: string[];
   command: string;
+  env?: Record<string, string>;
   name: string;
   type: 'stdio';
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

在 electron 打包后，会因为 path 路径的问题出现 `spawn npx ENOENT` 的报错。
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

Gemini：

好的，这个问题非常典型，直接指向了 Electron 应用在不同启动方式下 **环境变量** 差异的核心问题。

让我来帮你分析：

**核心原因：环境变量 `PATH` 的差异**

1.  **从终端启动 (`/Applications/.../LobeHub-Nightly`)：**
    *   当你从终端（Terminal）直接执行应用程序的可执行文件时，该应用程序进程会**继承**你当前终端会话的环境变量。
    *   你的终端通常已经通过 `.bash_profile`, `.zshrc`, `.bashrc` 或其他 shell 配置文件正确设置了 `PATH` 环境变量，使其包含了 Node.js 和 npm/npx 的安装路径（例如，通过 `nvm`, `brew` 或直接安装 Node.js 时设置的）。
    *   因此，当你的 Electron 应用内部使用 `spawn('npx', ...)` 时，它能在继承来的 `PATH` 中找到 `npx` 命令，执行成功。

2.  **双击启动 (通过 Finder 或 Dock)：**
    *   当你通过 macOS 的图形用户界面（GUI），如双击 `.app` 文件、从 Launchpad 或 Dock 启动时，应用程序是由系统的 GUI shell (launchd 进程等) 启动的。
    *   GUI 环境通常**不会**加载你在终端配置文件 (`.zshrc` 等) 中定义的 `PATH` 或其他环境变量。它会使用一个非常基础、默认的系统 `PATH`。
    *   这个默认的 `PATH` 通常**不包含** Node.js 或 npx 的安装路径，特别是如果你使用了像 `nvm` 这样的版本管理工具，或者 Node.js 安装在了非标准位置。
    *   因此，当你的 Electron 应用在这种环境下尝试 `spawn('npx', ...)` 时，操作系统在默认的 `PATH` 环境变量指定的目录中找不到 `npx` 这个可执行文件，从而抛出 `ENOENT` (Error NO ENTry / No Entity) 错误。

**总结：**

问题的关键在于，**双击启动的应用无法访问你在终端中配置好的 `PATH` 环境变量**，导致它不知道去哪里寻找 `npx` 命令。而从终端启动时，应用继承了终端的 `PATH`，所以能找到 `npx`。

**解决方案建议：**

既然我们知道了原因，解决思路就很清晰了，目标是让双击启动的应用也能找到 `npx`：

1.  **【推荐】使用 `npx` 的绝对路径：**
    *   在你的代码中，不要直接写 `'npx'`，而是使用 `npx` 的完整绝对路径。
    *   你可以在终端运行 `which npx` 来找到它的路径。
    *   **注意：** 这个路径可能在不同用户的机器上不同，特别是使用 `nvm` 的情况。你需要一种更健壮的方式来找到它，或者考虑下面的方案。

2.  **【推荐】使用 `fix-path` 模块：**
    *   有一个流行的 npm 模块叫 `fix-path`，专门用于解决 Electron 应用中 `PATH` 环境变量的问题。
    *   在你的主进程代码的早期（例如 `app.whenReady()` 之前或之后立即），调用 `fixPath()`。
    *   ```javascript
        const fixPath = require('fix-path');
        const { app } = require('electron');

        // Fix the PATH environment variable
        fixPath();

        // ... rest of your main process code
        app.whenReady().then(() => {
          // ... createWindow etc.
        });
        ```
    *   这个模块会尝试模拟登录 shell 的环境，并将正确的 `PATH` 设置到 `process.env.PATH` 中，使得后续的 `spawn` 调用能够找到像 `npx` 这样的命令。

3.  **【次推荐】使用 `shell: true` 选项 (需谨慎)：**
    *   在 `spawn` 的选项中设置 `shell: true`。
    *   ```javascript
        const childProcess = spawn('npx your-command', [], { // 注意命令格式变化
          shell: true,
          // ... 其他选项
        });
        ```
    *   这会让命令在系统的默认 shell 中执行，该 shell *可能* 会加载更完整的环境变量。但这并不总是保证有效，且可能有安全风险（如果命令或参数来自用户输入）。

4.  **避免依赖外部 `npx`：**
    *   思考一下你使用 `npx` 的目的是什么？是否可以将需要的功能直接集成到你的 Electron 应用中，或者将需要 `npx` 运行的脚本/包作为依赖项包含进来，然后用 `node` 直接执行脚本？
    *   例如，如果 `npx some-cli-tool`，你可以尝试 `npm install some-cli-tool`，然后在代码中 `require` 或使用 `node ./node_modules/.bin/some-cli-tool` 来执行。

对于打包后的 Electron 应用，**`fix-path` 模块通常是解决此类 `PATH` 问题的最佳实践**。如果 `fix-path` 不起作用，或者你想更精确地控制，使用绝对路径（可能需要动态查找）是另一个可靠的选择。
<!-- Add any other context about the Pull Request here. -->
