### PR TITLE
🐛 fix: Siliconflow requests with tools no longer force non-streaming

### DIFF
--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -132,6 +132,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 32_768,
@@ -148,6 +149,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 32_768,
@@ -164,6 +166,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      functionCall: true,
+    },
     contextWindowTokens: 32_768,
     description:
       'GLM-4-32B-0414 是 GLM 系列的新一代开源模型，拥有 320 亿参数。该模型性能可与 OpenAI 的 GPT 系列和 DeepSeek 的 V3/R1 系列相媲美。',
@@ -177,6 +182,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      functionCall: true,
+    },
     contextWindowTokens: 32_768,
     description:
       'GLM-4-9B-0414 是 GLM 系列的小型模型，拥有 90 亿参数。该模型继承了 GLM-4-32B 系列的技术特点，但提供了更轻量级的部署选择。尽管规模较小，GLM-4-9B-0414 仍在代码生成、网页设计、SVG 图形生成和基于搜索的写作等任务上展现出色能力。',

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -11,6 +11,28 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description:
       'Qwen3是一款能力大幅提升的新一代通义千问大模型，在推理、通用、Agent和多语言等多个核心能力上均达到业界领先水平，并支持思考模式切换。',
+    displayName: 'Qwen3 235B A22B',
+    id: 'Qwen/Qwen3-235B-A22B',
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      input: 1.25,
+      output: 5,
+    },
+    releasedAt: '2025-04-28',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'Qwen3是一款能力大幅提升的新一代通义千问大模型，在推理、通用、Agent和多语言等多个核心能力上均达到业界领先水平，并支持思考模式切换。',
     displayName: 'Qwen3 32B',
     id: 'Qwen/Qwen3-32B',
     organization: 'Qwen',

--- a/src/libs/agent-runtime/siliconcloud/index.ts
+++ b/src/libs/agent-runtime/siliconcloud/index.ts
@@ -58,7 +58,7 @@ export const LobeSiliconCloudAI = LobeOpenAICompatibleFactory({
         max_tokens:
           max_tokens === undefined ? undefined : Math.min(Math.max(max_tokens, 1), 16_384),
         model,
-        stream: !payload.tools,
+        // stream: !payload.tools,
       } as any;
     },
   },
@@ -73,6 +73,7 @@ export const LobeSiliconCloudAI = LobeOpenAICompatibleFactory({
     const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
 
     const functionCallKeywords = [
+      'qwen/qwen3',
       'qwen/qwen2.5',
       'thudm/glm-4',
       'deepseek-ai/deepseek',
@@ -89,7 +90,12 @@ export const LobeSiliconCloudAI = LobeOpenAICompatibleFactory({
       'deepseek-ai/deepseek-vl',
     ];
 
-    const reasoningKeywords = ['deepseek-ai/deepseek-r1', 'qwen/qvq', 'qwen/qwq'];
+    const reasoningKeywords = [
+      'deepseek-ai/deepseek-r1', 
+      'qwen/qvq', 
+      'qwen/qwq',
+      'qwen/qwen3',
+    ];
 
     const modelsPage = (await client.models.list()) as any;
     const modelList: SiliconCloudModelCard[] = modelsPage.data;

--- a/src/libs/agent-runtime/siliconcloud/index.ts
+++ b/src/libs/agent-runtime/siliconcloud/index.ts
@@ -58,7 +58,6 @@ export const LobeSiliconCloudAI = LobeOpenAICompatibleFactory({
         max_tokens:
           max_tokens === undefined ? undefined : Math.min(Math.max(max_tokens, 1), 16_384),
         model,
-        // stream: !payload.tools,
       } as any;
     },
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

lobechat 对非流式内容仍然没有适配，并且硅基流动貌似已经支持流式输出调用工具。（测试 Qwen/Qwen3-8B）

5.1 检查发现修好了，这个 pr 可以合了。

~~此外硅基流动的 api 貌似有问题，当 `enable_thinking` 是 false 时，内容会输出在 reasoning_content，而 content 保持 null~~

~~不知道如何联系他们，如果他们不修，迟早要在这里改动，目前关闭思考的话是无法正常显示的。~~

![image](https://github.com/user-attachments/assets/9c9f8e73-0c04-4e9d-98e9-2724b47dd785)

![image](https://github.com/user-attachments/assets/2586ed32-5e46-41c9-bebd-d084d46f22fa)


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
