### PR TITLE
♻️  refactor: Support Provider Output Performance Statistics for OpenAI Compatible Providers with Custom Stream

### DIFF
--- a/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts
@@ -68,7 +68,7 @@ interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = any> {
     ) => OpenAI.ChatCompletionCreateParamsStreaming;
     handleStream?: (
       stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-      callbacks?: ChatStreamCallbacks,
+      { callbacks, inputStartAt }: { callbacks?: ChatStreamCallbacks; inputStartAt?: number },
     ) => ReadableStream;
     handleStreamBizErrorType?: (error: {
       message: string;
@@ -256,7 +256,10 @@ export const LobeOpenAICompatibleFactory = <T extends Record<string, any> = any>
 
           return StreamingResponse(
             chatCompletion?.handleStream
-              ? chatCompletion.handleStream(prod, streamOptions.callbacks)
+              ? chatCompletion.handleStream(prod, {
+                  callbacks: streamOptions.callbacks,
+                  inputStartAt,
+                })
               : OpenAIStream(prod, { ...streamOptions, inputStartAt }),
             {
               headers: options?.headers,
@@ -276,7 +279,10 @@ export const LobeOpenAICompatibleFactory = <T extends Record<string, any> = any>
 
         return StreamingResponse(
           chatCompletion?.handleStream
-            ? chatCompletion.handleStream(stream, streamOptions.callbacks)
+            ? chatCompletion.handleStream(stream, {
+                callbacks: streamOptions.callbacks,
+                inputStartAt,
+              })
             : OpenAIStream(stream, { ...streamOptions, inputStartAt }),
           {
             headers: options?.headers,

--- a/src/libs/agent-runtime/utils/streams/qwen.test.ts
+++ b/src/libs/agent-runtime/utils/streams/qwen.test.ts
@@ -46,9 +46,11 @@ describe('QwenAIStream', () => {
     const onCompletionMock = vi.fn();
 
     const protocolStream = QwenAIStream(mockOpenAIStream, {
-      onStart: onStartMock,
-      onText: onTextMock,
-      onCompletion: onCompletionMock,
+      callbacks: {
+        onStart: onStartMock,
+        onText: onTextMock,
+        onCompletion: onCompletionMock,
+      },
     });
 
     const decoder = new TextDecoder();
@@ -111,7 +113,9 @@ describe('QwenAIStream', () => {
     const onToolCallMock = vi.fn();
 
     const protocolStream = QwenAIStream(mockOpenAIStream, {
-      onToolsCalling: onToolCallMock,
+      callbacks: {
+        onToolsCalling: onToolCallMock,
+      },
     });
 
     const decoder = new TextDecoder();

--- a/src/libs/agent-runtime/utils/streams/qwen.ts
+++ b/src/libs/agent-runtime/utils/streams/qwen.ts
@@ -92,7 +92,9 @@ export const transformQwenStream = (chunk: OpenAI.ChatCompletionChunk): StreamPr
 
 export const QwenAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-  callbacks?: ChatStreamCallbacks,
+  // TODO: preserve for RFC 097
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+  { callbacks, inputStartAt }: { callbacks?: ChatStreamCallbacks; inputStartAt?: number } = {},
 ) => {
   const readableStream =
     stream instanceof ReadableStream ? stream : convertIterableToStream(stream);

--- a/src/libs/agent-runtime/utils/streams/spark.test.ts
+++ b/src/libs/agent-runtime/utils/streams/spark.test.ts
@@ -96,7 +96,9 @@ describe('SparkAIStream', () => {
     const onToolCallMock = vi.fn();
 
     const protocolStream = SparkAIStream(mockStream, {
-      onToolsCalling: onToolCallMock,
+      callbacks: {
+        onToolsCalling: onToolCallMock,
+      },
     });
 
     const decoder = new TextDecoder();
@@ -156,7 +158,9 @@ describe('SparkAIStream', () => {
     const onTextMock = vi.fn();
 
     const protocolStream = SparkAIStream(mockStream, {
-      onText: onTextMock,
+      callbacks: {
+        onText: onTextMock,
+      },
     });
 
     const decoder = new TextDecoder();

--- a/src/libs/agent-runtime/utils/streams/spark.ts
+++ b/src/libs/agent-runtime/utils/streams/spark.ts
@@ -123,7 +123,9 @@ export const transformSparkStream = (chunk: OpenAI.ChatCompletionChunk): StreamP
 
 export const SparkAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-  callbacks?: ChatStreamCallbacks,
+  // TODO: preserve for RFC 097
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+  { callbacks, inputStartAt }: { callbacks?: ChatStreamCallbacks; inputStartAt?: number } = {},
 ) => {
   const readableStream =
     stream instanceof ReadableStream ? stream : convertIterableToStream(stream);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- `src/libs/agent-runtime/utils/openaiCompatibleFactory/index.ts`: 在 `handleStream` 入参中传入发送请求前的时间，方便在自定义流中进行性能统计。
- `src/libs/agent-runtime/utils/streams/qwen.ts`: 为性能统计预留参数
- `src/libs/agent-runtime/utils/streams/qwen.test.ts`: `handleStream` 相关变更
- `src/libs/agent-runtime/utils/streams/spark.ts`: 为性能统计预留参数
- `src/libs/agent-runtime/utils/streams/spark.test.ts`: `handleStream` 相关变更

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- #6922 
<!-- Add any other context about the Pull Request here. -->
