### PR TITLE
 🔨 chore: disable signups for the default lobechat org in Casdoor

### DIFF
--- a/docker-compose/local/init_data.json
+++ b/docker-compose/local/init_data.json
@@ -42,7 +42,7 @@
       "cert": "cert-built-in",
       "headerHtml": "",
       "enablePassword": true,
-      "enableSignUp": true,
+      "enableSignUp": false,
       "enableSigninSession": false,
       "enableAutoSignin": false,
       "enableCodeSignin": false,


### PR DESCRIPTION
Otherwise, anyone can signup with the lobechat organization and it is very likely that's not wanted. We should be closed and secure by default.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
