### PR TITLE
🐛 fix: lock zustand version to avoid type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "yaml": "^2.8.0",
     "yjs": "^13.6.27",
     "zod": "^3.25.7",
-    "zustand": "^5.0.4",
+    "zustand": "5.0.4",
     "zustand-utils": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

zustand 更新 5.0.5 后，更新了 shallow 的对比逻辑，导致类型错误 https://github.com/pmndrs/zustand/pull/3108
https://github.com/pmndrs/zustand/releases


src/features/AgentSetting/store/index.ts

Argument of type 'StateCreator<Store, [["zustand/devtools", never]]>' is not assignable to parameter of type 'StateCreator<Store, [["zustand/subscribeWithSelector", never]], []>'.
  Type 'StateCreator<Store, [["zustand/devtools", never]]>' is not assignable to type '(setState: { (partial: Store | Partial<Store> | ((state: Store) => Store | Partial<Store>), replace?: false | undefined): void; (state: Store | ((state: Store) => Store), replace: true): void; }, getState: () => Store, store: Write<...>) => Store'.
    Types of parameters 'store' and 'store' are incompatible.
      Type 'Write<StoreApi<Store>, StoreSubscribeWithSelector<Store>>' is not assignable to type 'WithDevtools<StoreApi<Store>>'.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- close #7935 
- close #7934

<!-- Add any other context about the Pull Request here. -->
