### PR TITLE
🐛 fix(DragUpload): resolve issue with pasting clipboard images in Safari

### DIFF
--- a/src/components/DragUpload/useDragUpload.tsx
+++ b/src/components/DragUpload/useDragUpload.tsx
@@ -37,18 +37,22 @@ const getFileListFromDataTransferItems = async (items: DataTransferItem[]) => {
   const filePromises: Promise<File[]>[] = [];
   for (const item of items) {
     if (item.kind === 'file') {
-      const entry = item.webkitGetAsEntry();
-      if (entry) {
-        filePromises.push(processEntry(entry));
-      } else {
-        const file = item.getAsFile();
+      // Safari browser may throw error when using FileSystemFileEntry.file()
+      // So we prioritize using getAsFile() method first for better browser compatibility
+      const file = item.getAsFile();
 
-        if (file)
-          filePromises.push(
-            new Promise((resolve) => {
-              resolve([file]);
-            }),
-          );
+      if (file) {
+        filePromises.push(
+          new Promise((resolve) => {
+            resolve([file]);
+          }),
+        );
+      } else {
+        const entry = item.webkitGetAsEntry();
+
+        if (entry) {
+          filePromises.push(processEntry(entry));
+        }
       }
     }
   }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
Safari browser may throw error when using FileSystemFileEntry.file(), so we prioritize using getAsFile() method first for better browser compatibility.

![image](https://github.com/user-attachments/assets/bfb0e9da-6832-4f4b-8d75-faefe2ec82bd)

closes: #7381

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
