### PR TITLE
🐛 fix: Enable thinking output only for supported Gemini thinking models

### DIFF
--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -142,7 +142,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
               response_modalities: modelsWithModalities.has(model) ? ['Text', 'Image'] : undefined,
               temperature: payload.temperature,
               topP: payload.top_p,
-              ...(modelsDisableInstuction.has(model) ? {} : { thinkingConfig }),
+              ...(modelsDisableInstuction.has(model) || model.toLowerCase().includes('learnlm') ? {} : { thinkingConfig }),
             },
             model,
             // avoid wide sensitive words

--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -122,7 +122,12 @@ export class LobeGoogleAI implements LobeRuntimeAI {
           (!thinking && model && (model.includes('-2.5-') || model.includes('thinking'))) 
             ? true
             : undefined,
-        thinkingBudget: thinking?.type === 'enabled' ? Math.min(thinking.budget_tokens, 24_576) : 0,
+        thinkingBudget:
+          thinking?.type === 'enabled'
+            ? Math.min(thinking.budget_tokens, 24_576)
+            : thinking?.type === 'disabled'
+              ? 0
+              : undefined,
       };
 
       const contents = await this.buildGoogleMessages(payload.messages);
@@ -136,8 +141,8 @@ export class LobeGoogleAI implements LobeRuntimeAI {
               // @ts-expect-error - Google SDK 0.24.0 doesn't have this property for now with
               response_modalities: modelsWithModalities.has(model) ? ['Text', 'Image'] : undefined,
               temperature: payload.temperature,
-              thinkingConfig,
               topP: payload.top_p,
+              ...(modelsDisableInstuction.has(model) ? {} : { thinkingConfig }),
             },
             model,
             // avoid wide sensitive words

--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -117,7 +117,11 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const { model, thinking } = payload;
 
       const thinkingConfig: GoogleAIThinkingConfig = {
-        includeThoughts: thinking?.type === 'enabled' ? true : undefined,
+        includeThoughts:
+          (thinking?.type === 'enabled') || 
+          (!thinking && model && (model.includes('-2.5-') || model.includes('thinking'))) 
+            ? true
+            : undefined,
         thinkingBudget: thinking?.type === 'enabled' ? Math.min(thinking.budget_tokens, 24_576) : 0,
       };
 

--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -117,7 +117,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const { model, thinking } = payload;
 
       const thinkingConfig: GoogleAIThinkingConfig = {
-        includeThoughts: true,
+        includeThoughts: thinking?.type === 'enabled' ? true : undefined,
         thinkingBudget: thinking?.type === 'enabled' ? Math.min(thinking.budget_tokens, 24_576) : 0,
       };
 

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -225,12 +225,20 @@ class ChatService {
       )(getAiInfraStoreState());
       // if model has extended params, then we need to check if the model can use reasoning
 
-      if (modelExtendParams!.includes('enableReasoning') && chatConfig.enableReasoning) {
-        extendParams.thinking = {
-          budget_tokens: chatConfig.reasoningBudgetToken || 1024,
-          type: 'enabled',
-        };
+      if (modelExtendParams!.includes('enableReasoning')) {
+        if (chatConfig.enableReasoning) {
+          extendParams.thinking = {
+            budget_tokens: chatConfig.reasoningBudgetToken || 1024,
+            type: 'enabled',
+          };
+        } else {
+          extendParams.thinking = {
+            budget_tokens: 0,
+            type: 'disabled',
+          };
+        }
       }
+      
       if (
         modelExtendParams!.includes('disableContextCaching') &&
         chatConfig.disableContextCaching


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

优化关闭推理开关的行为，定义 thinking.type 为 disabled，不再和无开关时类似。（不定义 thinking）

### 已测试多数推理模型，包括 Gemini、Claude3、Qwen3，一切正常。

- fix #7985

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
