### PR TITLE
fix: missing languages it-IT, pl-PL, nl-NL

### DIFF
--- a/src/locales/resources.ts
+++ b/src/locales/resources.ts
@@ -18,6 +18,9 @@ export const locales = [
   'zh-TW',
   'vi-VN',
   'fa-IR',
+  'it-IT',
+  'pl-PL',
+  'nl-NL',
 ] as const;
 
 export type DefaultResources = typeof resources;

--- a/src/server/sitemap.test.ts
+++ b/src/server/sitemap.test.ts
@@ -80,7 +80,7 @@ describe('Sitemap', () => {
       ]);
 
       const assistantsSitemap = await sitemap.getAssistants();
-      expect(assistantsSitemap.length).toBe(15);
+      expect(assistantsSitemap.length).toBe(18);
       expect(assistantsSitemap).toContainEqual(
         expect.objectContaining({
           url: getCanonicalUrl('/discover/assistant/test-assistant'),
@@ -136,7 +136,7 @@ describe('Sitemap', () => {
       ]);
 
       const pluginsSitemap = await sitemap.getPlugins();
-      expect(pluginsSitemap.length).toBe(15);
+      expect(pluginsSitemap.length).toBe(18);
       expect(pluginsSitemap).toContainEqual(
         expect.objectContaining({
           url: getCanonicalUrl('/discover/plugin/test-plugin'),
@@ -180,7 +180,7 @@ describe('Sitemap', () => {
       ]);
 
       const modelsSitemap = await sitemap.getModels();
-      expect(modelsSitemap.length).toBe(15);
+      expect(modelsSitemap.length).toBe(18);
       expect(modelsSitemap).toContainEqual(
         expect.objectContaining({
           url: getCanonicalUrl('/discover/model/test:model'),
@@ -224,7 +224,7 @@ describe('Sitemap', () => {
       ]);
 
       const providersSitemap = await sitemap.getProviders();
-      expect(providersSitemap.length).toBe(15);
+      expect(providersSitemap.length).toBe(18);
       expect(providersSitemap).toContainEqual(
         expect.objectContaining({
           url: getCanonicalUrl('/discover/provider/test-provider'),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Three languages were inside `const localeOptions` but missing inside `const locales`, resulting in a fallback on `DEFAULT_LANG`.

#### 📝 补充信息 | Additional Information

- close: https://github.com/lobehub/lobe-chat/issues/7293
