### PR TITLE
💄 style: update model card for Gemini 2.5 Pro via OpenRouter

### DIFF
--- a/src/config/aiModels/openrouter.ts
+++ b/src/config/aiModels/openrouter.ts
@@ -177,25 +177,6 @@ const openrouterChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
-      reasoning: true,
-      vision: true,
-    },
-    contextWindowTokens: 1_048_576,
-    description:
-      'Gemini 2.5 Pro 是 Google 最先进的 AI 模型，专为高级推理、编码、数学和科学任务而设计。它采用“思考”能力，使其能够以更高的准确性和细致的上下文处理来推理响应。Gemini 2.5 Pro 在多个基准测试中取得了顶级性能，包括在 LMArena 排行榜上排名第一，反映了卓越的人类偏好对齐和复杂问题解决能力。',
-    displayName: 'Gemini 2.5 Pro Preview',
-    id: 'google/gemini-2.5-pro-preview-03-25',
-    maxOutput: 65_535,
-    pricing: {
-      cachedInput: 0.625,
-      input: 1.25,
-      output: 10,
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
       reasoning: true,
     },
     contextWindowTokens: 32_768,
@@ -243,6 +224,24 @@ const openrouterChatModels: AIChatModelCard[] = [
     pricing: {
       input: 0.24,
       output: 0.24,
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
+      'Gemini 2.5 Pro Preview 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
+    displayName: 'Gemini 2.5 Pro Preview',
+    id: 'google/gemini-2.5-pro-preview',
+    maxOutput: 65_536,
+    pricing: {
+      input: 1.25,
+      output: 10,
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Updates the AI model card for [_Gemini 2.5 Pro Preview_ for _OpenRouter_](https://openrouter.ai/google/gemini-2.5-pro-preview).

#### 📝 补充信息 | Additional Information

Unfortunately, when running a local server with `bun run dev` I found none of the AI model cards for _OpenRouter_ are considered. That means I was not able to test this change locally.