### PR TITLE
💄 style: add `kimi-thinking-preview` model from Moonshot

### DIFF
--- a/src/config/aiModels/moonshot.ts
+++ b/src/config/aiModels/moonshot.ts
@@ -28,6 +28,25 @@ const moonshotChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'kimi-thinking-preview 模型是月之暗面提供的具有多模态推理能力和通用推理能力的多模态思考模型，它擅长深度推理，帮助解决更多更难的事情',
+    displayName: 'Kimi Thinking Preview',
+    enabled: true,
+    id: 'kimi-thinking-preview',
+    pricing: {
+      currency: 'CNY',
+      input: 200,
+      output: 200,
+    },
+    releasedAt: '2025-05-06',
+    type: 'chat',
+  },
+  {
+    abilities: {
       functionCall: true,
       search: true,
     },

--- a/src/libs/model-runtime/moonshot/index.ts
+++ b/src/libs/model-runtime/moonshot/index.ts
@@ -40,7 +40,9 @@ export const LobeMoonshotAI = createOpenAICompatibleRuntime({
 
     const functionCallKeywords = ['moonshot-v1', 'kimi-latest'];
 
-    const visionKeywords = ['kimi-latest', 'vision'];
+    const visionKeywords = ['kimi-latest', 'kimi-thinking', 'vision'];
+
+    const reasoningKeywords = ['thinking'];
 
     const modelsPage = (await client.models.list()) as any;
     const modelList: MoonshotModelCard[] = modelsPage.data;
@@ -60,7 +62,10 @@ export const LobeMoonshotAI = createOpenAICompatibleRuntime({
             knownModel?.abilities?.functionCall ||
             false,
           id: model.id,
-          reasoning: knownModel?.abilities?.reasoning || false,
+          reasoning:
+            reasoningKeywords.some((keyword) => model.id.toLowerCase().includes(keyword)) ||
+            knownModel?.abilities?.reasoning ||
+            false,
           vision:
             visionKeywords.some((keyword) => model.id.toLowerCase().includes(keyword)) ||
             knownModel?.abilities?.vision ||


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 增加 `kimi-thinking-preview` 模型

---

|Screenshot|
|-|
|![image](https://github.com/user-attachments/assets/492da1ea-77b3-44a8-8fca-deff72b8923c)|
|![image](https://github.com/user-attachments/assets/4f4c25ff-ef97-4976-99fa-5ba624116a80)|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

ref: https://platform.moonshot.cn/docs/guide/use-kimi-thinking-preview-model

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

New Features:
- Include the kimi-thinking-preview multimodal reasoning model with vision support and a 131,072-token context window