### PR TITLE
✨ feat: add Brave & Google PSE & Kagi as build-in Search Provider

### DIFF
--- a/docs/self-hosting/advanced/online-search.mdx
+++ b/docs/self-hosting/advanced/online-search.mdx
@@ -14,15 +14,133 @@ tags:
 
 # Configuring Online Search Functionality
 
-LobeChat supports configuring online search functionality for AI, allowing it to access the latest web information and provide more accurate and timely responses. The online search feature is based on the [SearXNG](https://github.com/searxng/searxng) search engine, which is a privacy-respecting metasearch engine that aggregates results from multiple search engines.
+LobeChat supports configuring **web search functionality** for AI, enabling it to retrieve real-time information from the internet to provide more accurate and up-to-date responses. Web search supports multiple search engine providers, including [SearXNG](https://github.com/searxng/searxng), [Search1API](https://www.search1api.com), [Google](https://programmablesearchengine.google.com), and [Brave](https://brave.com/search/api), among others.
 
-<Callout type={'info'}>
-  SearXNG is an open-source metasearch engine that can be self-hosted or accessed via public
-  instances. By configuring SearXNG, LobeChat enables AI to retrieve the latest internet
-  information, allowing it to answer time-sensitive questions and provide up-to-date news.
+<Callout type="info">
+  Web search allows AI to access time-sensitive content, such as the latest news, technology trends, or product information. You can deploy the open-source SearXNG yourself, or choose to integrate mainstream search services like Search1API, Google, Brave, etc., combining them freely based on your use case.
 </Callout>
 
+By setting the search service environment variable `SEARCH_PROVIDERS` and the corresponding API Keys, LobeChat will query multiple sources and return the results. You can also configure crawler service environment variables such as `CRAWLER_IMPLS` (e.g., `browserless`, `firecrawl`, `tavily`, etc.) to extract webpage content, enhancing the capability of search + reading.
+
 # Core Environment Variables
+
+## `CRAWLER_IMPLS`
+
+Configure available web crawlers for structured extraction of webpage content.
+
+```env
+CRAWLER_IMPLS="native,search1api"
+```
+
+Supported crawler types are listed below:
+
+| Value         | Description                                                                                                         | Environment Variable       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `browserless` | Headless browser crawler based on [Browserless](https://www.browserless.io/), suitable for rendering complex pages. | `BROWSERLESS_TOKEN`        |
+| `exa`         | Crawler capabilities provided by [Exa](https://exa.ai/), API required.                                              | `EXA_API_KEY`              |
+| `firecrawl`   | [Firecrawl](https://firecrawl.dev/) headless browser API, ideal for modern websites.                                | `FIRECRAWL_API_KEY`        |
+| `jina`        | Crawler service from [Jina AI](https://jina.ai/), supports fast content summarization.                              | `JINA_READER_API_KEY`      |
+| `native`      | Built-in general-purpose crawler for standard web structures.                                                       |                            |
+| `search1api`  | Page crawling capabilities from [Search1API](https://www.search1api.com), great for structured content extraction.  | `SEARCH1API_CRAWL_API_KEY` |
+| `tavily`      | Web scraping and summarization API from [Tavily](https://www.tavily.com/).                                          | `TAVILY_API_KEY`           |
+
+> 💡 Setting multiple crawlers increases success rate; the system will try different ones based on priority.
+
+---
+
+## `SEARCH_PROVIDERS`
+
+Configure which search engine providers to use for web search.
+
+```env
+SEARCH_PROVIDERS="searxng"
+```
+
+Supported search engines include:
+
+| Value        | Description                                                                              | Environment Variable                        |
+| ------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `anspire`    | Search service provided by [Anspire](https://anspire.ai/).                               | `ANSPIRE_API_KEY`                           |
+| `bocha`      | Search service from [Bocha](https://open.bochaai.com/).                                  | `BOCHA_API_KEY`                             |
+| `brave`      | [Brave](https://search.brave.com/help/api), a privacy-friendly search source.            | `BRAVE_API_KEY`                             |
+| `exa`        | [Exa](https://exa.ai/), a search API designed for AI.                                    | `EXA_API_KEY`                               |
+| `firecrawl`  | Search capabilities via [Firecrawl](https://firecrawl.dev/).                             | `FIRECRAWL_API_KEY`                         |
+| `google`     | Uses [Google Programmable Search Engine](https://programmablesearchengine.google.com/).  | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID` |
+| `jina`       | Semantic search provided by [Jina AI](https://jina.ai/).                                 | `JINA_READER_API_KEY`                       |
+| `kagi`       | Premium search API by [Kagi](https://kagi.com/), requires a subscription key.            | `KAGI_API_KEY`                              |
+| `search1api` | Aggregated search capabilities from [Search1API](https://www.search1api.com).            | `SEARCH1API_CRAWL_API_KEY`                  |
+| `searxng`    | Use a self-hosted or public [SearXNG](https://searx.space/) instance.                    | `SEARXNG_URL`                               |
+| `tavily`     | [Tavily](https://www.tavily.com/), offers fast web summaries and answers.                | `TAVILY_API_KEY`                            |
+
+> ⚠️ Some search providers require you to apply for an API Key and configure it in your `.env` file.
+
+---
+
+## `BROWSERLESS_URL`
+
+Specifies the API endpoint for [Browserless](https://www.browserless.io/), used for web crawling tasks. Browserless is a browser automation platform based on Headless Chrome, ideal for rendering dynamic pages.
+
+```env
+BROWSERLESS_URL=https://chrome.browserless.io
+```
+
+> 📌 Usually used together with `CRAWLER_IMPLS=browserless`.
+
+---
+
+## `GOOGLE_PSE_ENGINE_ID`
+
+Configure the Search Engine ID for Google Programmable Search Engine (Google PSE), used to restrict the search scope. Must be used alongside `GOOGLE_PSE_API_KEY`.
+
+```env
+GOOGLE_PSE_ENGINE_ID=your-google-cx-id
+```
+
+> 🔑 How to get it: Visit [programmablesearchengine.google.com](https://programmablesearchengine.google.com/), create a search engine, and obtain the `cx` parameter.
+
+---
+
+## `FIRECRAWL_URL`
+
+Sets the access URL for the [Firecrawl](https://firecrawl.dev/) API, used for web content scraping. Default value:
+
+```env
+FIRECRAWL_URL=https://api.firecrawl.dev/v1
+```
+
+> ⚙️ Usually does not need to be changed unless you’re using a self-hosted version or a proxy service.
+
+---
+
+## `TAVILY_SEARCH_DEPTH`
+
+Configure the result depth for [Tavily](https://www.tavily.com/) searches.
+
+```env
+TAVILY_SEARCH_DEPTH=basic
+```
+
+Supported values:
+
+* `basic`: Fast search, returns brief results;
+* `advanced`: Deep search, returns more context and web page details.
+
+---
+
+## `TAVILY_EXTRACT_DEPTH`
+
+Configure how deeply Tavily extracts content from web pages.
+
+```env
+TAVILY_EXTRACT_DEPTH=basic
+```
+
+Supported values:
+
+* `basic`: Extracts basic info like title and content summary;
+* `advanced`: Extracts structured data, lists, charts, and more from web pages.
+
+---
 
 ## `SEARXNG_URL`
 

--- a/docs/self-hosting/advanced/online-search.zh-CN.mdx
+++ b/docs/self-hosting/advanced/online-search.zh-CN.mdx
@@ -10,14 +10,133 @@ tags:
 
 # 配置联网搜索功能
 
-LobeChat 支持为 AI 配置联网搜索功能，这使得 AI 能够获取最新的网络信息，从而提供更准确、更及时的回答。联网搜索功能基于 [SearXNG](https://github.com/searxng/searxng) 搜索引擎，它是一个尊重隐私的元搜索引擎，可以聚合多个搜索引擎的结果。
+LobeChat 支持为 AI 配置**联网搜索功能**，使其能够实时获取互联网信息，从而提供更准确、最新的回答。联网搜索支持多个搜索引擎提供商，包括 [SearXNG](https://github.com/searxng/searxng)、[Search1API](https://www.search1api.com)、[Google](https://programmablesearchengine.google.com)、[Brave](https://brave.com/search/api) 等。
 
-<Callout type={'info'}>
-  SearXNG 是一个开源的元搜索引擎，可以自行部署，也可以使用公共实例。通过配置 SearXNG，LobeChat
-  可以让 AI 获取最新的互联网信息，从而回答时效性问题、提供最新资讯。
+<Callout type="info">
+  联网搜索可以让 AI 获取时效性内容，如最新新闻、技术动态或产品信息。你可以使用开源的 SearXNG 自行部署，也可以选择集成主流搜索引擎服务，如 Search1API、Google、Brave 等，根据你的使用场景自由组合。
 </Callout>
 
+通过设置搜索服务环境变量 `SEARCH_PROVIDERS` 和对应的 API Key，LobeChat 将在多个搜索源中查询并返回结果。你还可以搭配配置爬虫服务环境变量 `CRAWLER_IMPLS`（如 `browserless`、`firecrawl`、`tavily` 等）以提取网页内容，实现搜索+阅读的增强能力。
+
 # 核心环境变量
+
+## `CRAWLER_IMPLS`
+
+配置可用的网页爬虫，用于对网页进行结构化内容提取。
+
+```env
+CRAWLER_IMPLS="native,search1api"
+```
+
+支持的爬虫类型如下：
+
+| 值            | 说明                                                                                   | 环境变量                   |
+| ------------- | -------------------------------------------------------------------------------------- | -------------------------- |
+| `browserless` | 基于 [Browserless](https://www.browserless.io/) 的无头浏览器爬虫，适合渲染复杂页面。   | `BROWSERLESS_TOKEN`        |
+| `exa`         | 使用 [Exa](https://exa.ai/) 提供的爬虫能力，需申请 API。                               | `EXA_API_KEY`              |
+| `firecrawl`   | [Firecrawl](https://firecrawl.dev/) 无头浏览器 API，适合现代网站抓取。                 | `FIRECRAWL_API_KEY`        |
+| `jina`        | 使用 [Jina AI](https://jina.ai/) 的爬虫服务，支持快速提取摘要信息。                    | `JINA_READER_API_KEY`      |
+| `native`      | 内置通用爬虫，适用于标准网页结构。                                                     |                            |
+| `search1api`  | 利用 [Search1API](https://www.search1api.com) 提供的页面抓取能力，适合结构化内容提取。 | `SEARCH1API_CRAWL_API_KEY` |
+| `tavily`      | 使用 [Tavily](https://www.tavily.com/) 的网页抓取与摘要 API。                          | `TAVILY_API_KEY`           |
+
+> 💡 设置多个爬虫可提升成功率，系统将根据优先级尝试不同爬虫。
+
+---
+
+## `SEARCH_PROVIDERS`
+
+配置联网搜索使用的搜索引擎提供商。
+
+```env
+SEARCH_PROVIDERS="searxng"
+```
+
+支持的搜索引擎如下：
+
+| 值           | 说明                                                                                     | 环境变量                                    |
+| ------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `anspire`    | 基于 [Anspire（安思派）](https://anspire.ai/) 提供的搜索服务。                           | `ANSPIRE_API_KEY`                           |
+| `bocha`      | 基于 [Bocha（博查）](https://open.bochaai.com/) 提供的搜索服务。                         | `BOCHA_API_KEY`                             |
+| `brave`      | [Brave](https://search.brave.com/help/api)，隐私友好的搜索源。                           | `BRAVE_API_KEY`                             |
+| `exa`        | [Exa](https://exa.ai/)，面向 AI 的搜索 API。                                             | `EXA_API_KEY`                               |
+| `firecrawl`  | 支持 [Firecrawl](https://firecrawl.dev/) 提供的搜索服务。                                | `FIRECRAWL_API_KEY`                         |
+| `google`     | 使用 [Google Programmable Search Engine](https://programmablesearchengine.google.com/)。 | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID` |
+| `jina`       | 使用 [Jina AI](https://jina.ai/) 提供的语义搜索服务。                                    | `JINA_READER_API_KEY`                       |
+| `kagi`       | [Kagi](https://kagi.com/) 提供的高级搜索 API，需订阅 Key。                               | `KAGI_API_KEY`                              |
+| `search1api` | 使用 [Search1API](https://www.search1api.com) 聚合搜索能力。                             | `SEARCH1API_CRAWL_API_KEY`                  |
+| `searxng`    | 使用自托管或公共 [SearXNG](https://searx.space/) 实例。                                  | `SEARXNG_URL`                               |
+| `tavily`     | [Tavily](https://www.tavily.com/)，快速网页摘要与答案返回。                              | `TAVILY_API_KEY`                            |
+
+> ⚠️ 某些搜索提供商需要单独申请 API Key，并在 `.env` 中配置相关凭证。
+
+---
+
+## `BROWSERLESS_URL`
+
+指定 [Browserless](https://www.browserless.io/) 服务的 API 地址，用于执行网页爬取任务。Browserless 是一个基于无头浏览器（Headless Chrome）的浏览器自动化平台，适合处理需要渲染的动态页面。
+
+```env
+BROWSERLESS_URL=https://chrome.browserless.io
+```
+
+> 📌 通常需要搭配 `CRAWLER_IMPLS=browserless` 启用。
+
+---
+
+## `GOOGLE_PSE_ENGINE_ID`
+
+配置 Google Programmable Search Engine（Google PSE）的搜索引擎 ID，用于限定搜索范围。需配合 `GOOGLE_PSE_API_KEY` 一起使用。
+
+```env
+GOOGLE_PSE_ENGINE_ID=your-google-cx-id
+```
+
+> 🔑 获取方式：访问 [programmablesearchengine.google.com](https://programmablesearchengine.google.com/)，创建搜索引擎后获取 `cx` 参数值。
+
+---
+
+## `FIRECRAWL_URL`
+
+设置 [Firecrawl](https://firecrawl.dev/) API 的访问地址。用于网页内容抓取，默认值如下：
+
+```env
+FIRECRAWL_URL=https://api.firecrawl.dev/v1
+```
+
+> ⚙️ 一般无需修改，除非你使用的是自托管版本或代理服务。
+
+---
+
+## `TAVILY_SEARCH_DEPTH`
+
+配置 [Tavily](https://www.tavily.com/) 搜索的结果深度。
+
+```env
+TAVILY_SEARCH_DEPTH=basic
+```
+
+支持的值：
+
+* `basic`: 快速搜索，返回简要结果；
+* `advanced`: 深度搜索，返回更多上下文和网页信息。
+
+---
+
+## `TAVILY_EXTRACT_DEPTH`
+
+配置 Tavily 在抓取网页内容时的提取深度。
+
+```env
+TAVILY_EXTRACT_DEPTH=basic
+```
+
+支持的值：
+
+* `basic`: 提取标题、正文摘要等基础信息；
+* `advanced`: 提取网页的结构化信息、列表、图表等更多内容。
+
+---
 
 ## `SEARXNG_URL`
 

--- a/src/server/services/search/impls/anspire/index.ts
+++ b/src/server/services/search/impls/anspire/index.ts
@@ -1,0 +1,132 @@
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { SearchParams, UniformSearchResponse, UniformSearchResult } from '@/types/tool/search';
+
+import { SearchServiceImpl } from '../type';
+import { AnspireSearchParameters, AnspireResponse } from './type';
+
+const log = debug('lobe-search:Anspire');
+
+/**
+ * Anspire implementation of the search service
+ * Primarily used for web crawling
+ */
+export class AnspireImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.ANSPIRE_API_KEY;
+  }
+
+  private get baseUrl(): string {
+    // Assuming the base URL is consistent with the crawl endpoint
+    return 'https://plugin.anspire.cn/api';
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting Anspire query with query: "%s", params: %o', query, params);
+    const endpoint = urlJoin(this.baseUrl, '/ntsearch/search');
+
+    const defaultQueryParams: AnspireSearchParameters = {
+      mode: 0,
+      query,
+      top_k: 20,
+    };
+
+    let body: AnspireSearchParameters = {
+      ...defaultQueryParams,
+      ...(params?.searchTimeRange && params.searchTimeRange !== 'anytime'
+        ? (() => {
+            const now = Date.now();
+            const days = { day: 1, month: 30, week: 7, year: 365 }[params.searchTimeRange!];
+
+            if (days === undefined) return {};
+
+            return {
+              FromTime: new Date(now - days * 86_400 * 1000).toISOString().slice(0, 19).replace('T', ' '),
+              ToTime: new Date(now).toISOString().slice(0, 19).replace('T', ' '),
+            };
+          })()
+        : {}),
+    };
+
+    log('Constructed request body: %o', body);
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      searchParams.append(key, String(value));
+    }
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime = 0;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+        headers: {
+          'Accept': '*/*',
+          'Authorization': this.apiKey ? `Bearer ${this.apiKey}` : '',
+          'Connection': 'keep-alive ',
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('Anspire fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Anspire.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `Anspire request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `Anspire request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const anspireResponse = (await response.json()) as AnspireResponse;
+
+      log('Parsed Anspire response: %o', anspireResponse);
+
+      const mappedResults = (anspireResponse.results || []).map(
+        (result): UniformSearchResult => ({
+          category: 'general', // Default category
+          content: result.content || '', // Prioritize content
+          engines: ['anspire'], // Use 'anspire' as the engine name
+          parsedUrl: result.url ? new URL(result.url).hostname : '', // Basic URL parsing
+          score: result.score || 0, // Default score to 0 if undefined
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      log('Mapped %d results to SearchResult format', mappedResults.length);
+
+      return {
+        costTime,
+        query: query,
+        resultNumbers: mappedResults.length,
+        results: mappedResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing Anspire response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Anspire response.',
+      });
+    }
+  }
+}

--- a/src/server/services/search/impls/anspire/type.ts
+++ b/src/server/services/search/impls/anspire/type.ts
@@ -1,0 +1,21 @@
+export interface AnspireSearchParameters {
+  FromTime?: string;
+  Insite?: string;
+  mode?: number;
+  query: string;
+  top_k?: number;
+  ToTime?: string;
+}
+
+interface AnspireResults {
+  content?: string;
+  score?: number;
+  title: string;
+  url: string;
+}
+
+export interface AnspireResponse {
+  query?: string;
+  results?: AnspireResults[];
+  Uuid?: string;
+}

--- a/src/server/services/search/impls/anspire/type.ts
+++ b/src/server/services/search/impls/anspire/type.ts
@@ -1,10 +1,10 @@
 export interface AnspireSearchParameters {
   FromTime?: string;
   Insite?: string;
+  ToTime?: string;
   mode?: number;
   query: string;
   top_k?: number;
-  ToTime?: string;
 }
 
 interface AnspireResults {
@@ -15,7 +15,7 @@ interface AnspireResults {
 }
 
 export interface AnspireResponse {
+  Uuid?: string;
   query?: string;
   results?: AnspireResults[];
-  Uuid?: string;
 }

--- a/src/server/services/search/impls/brave/index.ts
+++ b/src/server/services/search/impls/brave/index.ts
@@ -1,0 +1,129 @@
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { SearchParams, UniformSearchResponse, UniformSearchResult } from '@/types/tool/search';
+
+import { SearchServiceImpl } from '../type';
+import { BraveSearchParameters, BraveResponse } from './type';
+
+const log = debug('lobe-search:Brave');
+
+const timeRangeMapping = {
+  day: 'pd',
+  month: 'pm',
+  week: 'pw',
+  year: 'py',
+};
+
+/**
+ * Brave implementation of the search service
+ * Primarily used for web crawling
+ */
+export class BraveImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.BRAVE_API_KEY;
+  }
+
+  private get baseUrl(): string {
+    // Assuming the base URL is consistent with the crawl endpoint
+    return 'https://api.search.brave.com/res/v1';
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting Brave query with query: "%s", params: %o', query, params);
+    const endpoint = urlJoin(this.baseUrl, '/web/search');
+
+    const defaultQueryParams: BraveSearchParameters = {
+      count: 15,
+      q: query,
+      result_filter: 'web',
+    };
+
+    let body: BraveSearchParameters = {
+      ...defaultQueryParams,
+      freshness:
+        params?.searchTimeRange && params.searchTimeRange !== 'anytime'
+          ? timeRangeMapping[params.searchTimeRange as keyof typeof timeRangeMapping] ?? undefined
+          : undefined,
+    };
+
+    log('Constructed request body: %o', body);
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      searchParams.append(key, String(value));
+    }
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime = 0;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+        headers: {
+          'Accept': 'application/json',
+          'Accept-Encoding': 'gzip',
+          'X-Subscription-Token': this.apiKey ? this.apiKey : '',
+        },
+        method: 'GET',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('Brave fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Brave.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `Brave request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `Brave request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const braveResponse = (await response.json()) as BraveResponse;
+
+      log('Parsed Brave response: %o', braveResponse);
+
+      const mappedResults = (braveResponse.web.results || []).map(
+        (result): UniformSearchResult => ({
+          category: 'general', // Default category
+          content: result.description || '', // Prioritize content
+          engines: ['brave'], // Use 'brave' as the engine name
+          parsedUrl: result.url ? new URL(result.url).hostname : '', // Basic URL parsing
+          score: 1, // Default score to 1
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      log('Mapped %d results to SearchResult format', mappedResults.length);
+
+      return {
+        costTime,
+        query: query,
+        resultNumbers: mappedResults.length,
+        results: mappedResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing Brave response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Brave response.',
+      });
+    }
+  }
+}

--- a/src/server/services/search/impls/brave/type.ts
+++ b/src/server/services/search/impls/brave/type.ts
@@ -4,8 +4,8 @@ export interface BraveSearchParameters {
   enable_rich_callback?: boolean;
   extra_snippets?: boolean;
   freshness?: string;
-  goggles_id?: string;
   goggles?: string[];
+  goggles_id?: string;
   offset?: number;
   q: string;
   result_filter?: string;

--- a/src/server/services/search/impls/brave/type.ts
+++ b/src/server/services/search/impls/brave/type.ts
@@ -1,0 +1,58 @@
+export interface BraveSearchParameters {
+  count?: number;
+  country?: string;
+  enable_rich_callback?: boolean;
+  extra_snippets?: boolean;
+  freshness?: string;
+  goggles_id?: string;
+  goggles?: string[];
+  offset?: number;
+  q: string;
+  result_filter?: string;
+  safesearch?: string;
+  search_lang?: string;
+  spellcheck?: boolean;
+  summary?: boolean;
+  text_decorations?: boolean;
+  ui_lang?: string;
+  units?: string;
+}
+
+interface BraveResults {
+  age?: string;
+  description: string;
+  family_friendly?: boolean;
+  is_live?: boolean;
+  is_source_both?: boolean;
+  is_source_local?: boolean;
+  language?: string;
+  meta_url?: any;
+  page_age?: string;
+  profile?: any;
+  subtype?: string;
+  thumbnail?: any;
+  title: string;
+  type: string;
+  url: string;
+  video?: any;
+}
+
+interface BraveVideos {
+  mutated_by_goggles?: boolean;
+  results: BraveResults[];
+  type: string;
+}
+
+interface BraveWeb {
+  family_friendly?: boolean;
+  results: BraveResults[];
+  type: string;
+}
+
+export interface BraveResponse {
+  mixed: any;
+  query?: any;
+  type: string;
+  videos?: BraveVideos;
+  web: BraveWeb;
+}

--- a/src/server/services/search/impls/google/index.ts
+++ b/src/server/services/search/impls/google/index.ts
@@ -1,0 +1,129 @@
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { SearchParams, UniformSearchResponse, UniformSearchResult } from '@/types/tool/search';
+
+import { SearchServiceImpl } from '../type';
+import { GoogleSearchParameters, GoogleResponse } from './type';
+
+const log = debug('lobe-search:Google');
+
+const timeRangeMapping = {
+  day: 'd1',
+  month: 'm1',
+  week: 'w1',
+  year: 'y1',
+};
+
+/**
+ * Google implementation of the search service
+ * Primarily used for web crawling
+ */
+export class GoogleImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.GOOGLE_PSE_API_KEY;
+  }
+
+  private get engineId(): string | undefined {
+    return process.env.GOOGLE_PSE_ENGINE_ID;
+  }
+
+  private get baseUrl(): string {
+    // Assuming the base URL is consistent with the crawl endpoint
+    return 'https://www.googleapis.com';
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting Google query with query: "%s", params: %o', query, params);
+    const endpoint = urlJoin(this.baseUrl, '/customsearch/v1');
+
+    const defaultQueryParams: GoogleSearchParameters = {
+      cx: this.engineId || '',
+      key: this.apiKey || '',
+      num: 10,
+      q: query,
+    };
+
+    let body: GoogleSearchParameters = {
+      ...defaultQueryParams,
+      dateRestrict:
+        params?.searchTimeRange && params.searchTimeRange !== 'anytime'
+          ? timeRangeMapping[params.searchTimeRange as keyof typeof timeRangeMapping] ?? undefined
+          : undefined,
+    };
+
+    log('Constructed request body: %o', body);
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      searchParams.append(key, String(value));
+    }
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime = 0;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+        method: 'GET',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('Google fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Google.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `Google request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `Google request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const googleResponse = (await response.json()) as GoogleResponse;
+
+      log('Parsed Google response: %o', googleResponse);
+
+      const mappedResults = (googleResponse.items || []).map(
+        (result): UniformSearchResult => ({
+          category: 'general', // Default category
+          content: result.snippet || '', // Prioritize content
+          engines: ['google'], // Use 'google' as the engine name
+          parsedUrl: result.link ? new URL(result.link).hostname : '', // Basic URL parsing
+          score: 1, // Default score to 1
+          title: result.title || '',
+          url: result.link,
+        }),
+      );
+
+      log('Mapped %d results to SearchResult format', mappedResults.length);
+
+      return {
+        costTime,
+        query: query,
+        resultNumbers: mappedResults.length,
+        results: mappedResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing Google response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Google response.',
+      });
+    }
+  }
+}

--- a/src/server/services/search/impls/google/type.ts
+++ b/src/server/services/search/impls/google/type.ts
@@ -1,0 +1,53 @@
+export interface GoogleSearchParameters {
+  c2coff?: number;
+  cx: string;
+  dateRestrict?: string;
+  exactTerms?: string;
+  excludeTerms?: string;
+  fileType?: string;
+  filter?: string;
+  gl?: string;
+  highRange?: string;
+  hl?: string;
+  hq?: string;
+  imgColorType?: string;
+  imgDominantColor?: string;
+  imgSize?: string;
+  imgType?: string;
+  key: string;
+  linkSite?: string;
+  lowRange?: string;
+  lr?: string;
+  num?: number;
+  orTerms?: string;
+  q: string;
+  rights?: string;
+  safe?: string;
+  searchType?: string;
+  siteSearch?: string;
+  siteSearchFilter?: string;
+  sort?: string;
+  start?: string;
+}
+
+interface GoogleItems {
+  displayLink?: string;
+  formattedUrl?: string;
+  htmlFormattedUrl?: string;
+  htmlSnippet?: string;
+  htmlTitle?: string;
+  kind?: string;
+  link: string;
+  pagemap?: any;
+  snippet: string;
+  title: string;
+}
+
+export interface GoogleResponse {
+  context?: any;
+  items: GoogleItems[];
+  kind?: string;
+  queries?: any;
+  searchInformation?: any;
+  url?: any;
+}

--- a/src/server/services/search/impls/index.ts
+++ b/src/server/services/search/impls/index.ts
@@ -1,4 +1,5 @@
 import { BochaImpl } from './bocha';
+import { BraveImpl } from './brave';
 import { ExaImpl } from './exa';
 import { FirecrawlImpl } from './firecrawl';
 import { JinaImpl } from './jina';
@@ -13,6 +14,7 @@ import { SearchServiceImpl } from './type';
  */
 export enum SearchImplType {
   Bocha = 'bocha',
+  Brave = 'brave',
   Exa = 'exa',
   Firecrawl = 'firecrawl',
   Jina = 'jina',
@@ -30,6 +32,10 @@ export const createSearchServiceImpl = (
   switch (type) {
     case SearchImplType.Bocha: {
       return new BochaImpl();
+    }
+
+    case SearchImplType.Brave: {
+      return new BraveImpl();
     }
 
     case SearchImplType.Exa: {

--- a/src/server/services/search/impls/index.ts
+++ b/src/server/services/search/impls/index.ts
@@ -1,3 +1,4 @@
+import { AnspireImpl } from './anspire';
 import { BochaImpl } from './bocha';
 import { BraveImpl } from './brave';
 import { ExaImpl } from './exa';
@@ -15,6 +16,7 @@ import { SearchServiceImpl } from './type';
  * Available search service implementations
  */
 export enum SearchImplType {
+  Anspire = 'anspire',
   Bocha = 'bocha',
   Brave = 'brave',
   Exa = 'exa',
@@ -34,6 +36,10 @@ export const createSearchServiceImpl = (
   type: SearchImplType = SearchImplType.SearXNG,
 ): SearchServiceImpl => {
   switch (type) {
+    case SearchImplType.Anspire: {
+      return new AnspireImpl();
+    }
+
     case SearchImplType.Bocha: {
       return new BochaImpl();
     }

--- a/src/server/services/search/impls/index.ts
+++ b/src/server/services/search/impls/index.ts
@@ -3,6 +3,7 @@ import { BraveImpl } from './brave';
 import { ExaImpl } from './exa';
 import { FirecrawlImpl } from './firecrawl';
 import { JinaImpl } from './jina';
+import { KagiImpl } from './kagi';
 import { Search1APIImpl } from './search1api';
 import { SearXNGImpl } from './searxng';
 import { TavilyImpl } from './tavily';
@@ -18,6 +19,7 @@ export enum SearchImplType {
   Exa = 'exa',
   Firecrawl = 'firecrawl',
   Jina = 'jina',
+  Kagi = 'kagi',
   SearXNG = 'searxng',
   Search1API = 'search1api',
   Tavily = 'tavily',
@@ -48,6 +50,10 @@ export const createSearchServiceImpl = (
 
     case SearchImplType.Jina: {
       return new JinaImpl();
+    }
+
+    case SearchImplType.Kagi: {
+      return new KagiImpl();
     }
 
     case SearchImplType.SearXNG: {

--- a/src/server/services/search/impls/index.ts
+++ b/src/server/services/search/impls/index.ts
@@ -2,6 +2,7 @@ import { BochaImpl } from './bocha';
 import { BraveImpl } from './brave';
 import { ExaImpl } from './exa';
 import { FirecrawlImpl } from './firecrawl';
+import { GoogleImpl } from './google';
 import { JinaImpl } from './jina';
 import { KagiImpl } from './kagi';
 import { Search1APIImpl } from './search1api';
@@ -18,6 +19,7 @@ export enum SearchImplType {
   Brave = 'brave',
   Exa = 'exa',
   Firecrawl = 'firecrawl',
+  Google = 'google',
   Jina = 'jina',
   Kagi = 'kagi',
   SearXNG = 'searxng',
@@ -46,6 +48,10 @@ export const createSearchServiceImpl = (
 
     case SearchImplType.Firecrawl: {
       return new FirecrawlImpl();
+    }
+
+    case SearchImplType.Google: {
+      return new GoogleImpl();
     }
 
     case SearchImplType.Jina: {

--- a/src/server/services/search/impls/kagi/index.ts
+++ b/src/server/services/search/impls/kagi/index.ts
@@ -1,0 +1,111 @@
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { SearchParams, UniformSearchResponse, UniformSearchResult } from '@/types/tool/search';
+
+import { SearchServiceImpl } from '../type';
+import { KagiSearchParameters, KagiResponse } from './type';
+
+const log = debug('lobe-search:Kagi');
+
+/**
+ * Kagi implementation of the search service
+ * Primarily used for web crawling
+ */
+export class KagiImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.KAGI_API_KEY;
+  }
+
+  private get baseUrl(): string {
+    // Assuming the base URL is consistent with the crawl endpoint
+    return 'https://kagi.com/api/v0';
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting Kagi query with query: "%s", params: %o', query, params);
+    const endpoint = urlJoin(this.baseUrl, '/search');
+
+    const body: KagiSearchParameters = {
+      limit: 15,
+      q: query,
+    };
+
+    log('Constructed request body: %o', body);
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      searchParams.append(key, String(value));
+    }
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime = 0;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+        headers: {
+          'Authorization': this.apiKey ? `Bot ${this.apiKey}` : '',
+        },
+        method: 'GET',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('Kagi fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Kagi.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `Kagi request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `Kagi request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const kagiResponse = (await response.json()) as KagiResponse;
+
+      log('Parsed Kagi response: %o', kagiResponse);
+
+      const mappedResults = (kagiResponse.data || []).map(
+        (result): UniformSearchResult => ({
+          category: 'general', // Default category
+          content: result.snippet || '', // Prioritize content
+          engines: ['kagi'], // Use 'kagi' as the engine name
+          parsedUrl: result.url ? new URL(result.url).hostname : '', // Basic URL parsing
+          score: 1, // Default score to 1
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      log('Mapped %d results to SearchResult format', mappedResults.length);
+
+      return {
+        costTime,
+        query: query,
+        resultNumbers: mappedResults.length,
+        results: mappedResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing Kagi response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Kagi response.',
+      });
+    }
+  }
+}

--- a/src/server/services/search/impls/kagi/type.ts
+++ b/src/server/services/search/impls/kagi/type.ts
@@ -19,6 +19,6 @@ interface KagiData {
 }
 
 export interface KagiResponse {
-  meta?: any;
   data: KagiData[];
+  meta?: any;
 }

--- a/src/server/services/search/impls/kagi/type.ts
+++ b/src/server/services/search/impls/kagi/type.ts
@@ -1,0 +1,24 @@
+export interface KagiSearchParameters {
+  limit?: number;
+  q: string;
+}
+
+interface KagiThumbnail {
+  height?: number | null;
+  url: string;
+  width?: number | null;
+}
+
+interface KagiData {
+  published?: number;
+  snippet?: string;
+  t: number;
+  thumbnail?: KagiThumbnail;
+  title: string;
+  url: string;
+}
+
+export interface KagiResponse {
+  meta?: any;
+  data: KagiData[];
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [X] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [X] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 增加 `Brave Search` 为内建搜索供应商，支持时间范围搜索 `BRAVE_API_KEY`
2. 增加 `Google PSE` 为内建搜索供应商，支持时间范围搜索 `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID`
3. 增加 `Kagi` 为内建搜索供应商 `KAGI_API_KEY`
4. 增加 `Anspire (安思派)` 为内建搜索供应商，支持时间范围搜索 `ANSPIRE_API_KEY`
5. 更新完整搜索及爬虫提供商环境变量文档

---
Note:
1. 设置 `SEARCH_PROVIDERS` 以启用功能 `anspire` `brave` `google` `kagi`
2. Anspire 同 Bocha 中文检索优化，企业解决方案
3. Brave 提供每月 2000 次免费搜索
4. Google PSE 提供每天 100 次免费搜索
6. Kagi 搜索 API 还在测试中，需按照 ref 发邮件启用功能

---

|Provider|Screenshot|
|-|-|
|Anspire|![image](https://github.com/user-attachments/assets/6885b691-484d-48a6-a5dc-f33dfc527434)|
|Brave|![image](https://github.com/user-attachments/assets/dc4a9790-b216-4f44-9f6d-d13fe679f18d)|
|Google|![image](https://github.com/user-attachments/assets/096f1db1-6d5c-4357-b524-93fca67b8ab9)|
|Kagi|![image](https://github.com/user-attachments/assets/a4465b04-25d7-44cb-abbb-b3f8464cadb7)|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

ref: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
ref: https://programmablesearchengine.google.com/controlpanel/all
ref: https://help.kagi.com/kagi/api/search.html
ref: https://anchnet.feishu.cn/wiki/DwYgwWunOitu6XkfFvycF3FinWb?fromScene=spaceOverview

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add Brave as a built-in search provider and enable time-range filtering for search queries

New Features:
- Integrate Brave Search into the search service implementation
- Support specifying a time range parameter when querying search providers