### PR TITLE
fix: 助手和插件分享連結錯誤，fixes #7995

### DIFF
--- a/src/app/[variants]/(main)/discover/(detail)/assistant/[slug]/features/Actions.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/[slug]/features/Actions.tsx
@@ -16,6 +16,10 @@ interface AssistantActionProps extends FlexboxProps {
 }
 
 const AssistantAction = memo<AssistantActionProps>(({ identifier, data }) => {
+  const baseUrl = OFFICIAL_URL.includes(location.host)
+    ? OFFICIAL_URL
+    : `${location.protocol}//${location.host}`;
+
   return (
     <Flexbox align={'center'} gap={8} horizontal>
       <AddAgent data={data} />
@@ -25,7 +29,7 @@ const AssistantAction = memo<AssistantActionProps>(({ identifier, data }) => {
           desc: data.meta.description,
           hashtags: data.meta.tags,
           title: data.meta.title,
-          url: urlJoin(OFFICIAL_URL, '/discover/assistant', identifier),
+          url: urlJoin(baseUrl, '/discover/assistant', identifier),
         }}
       />
     </Flexbox>

--- a/src/app/[variants]/(main)/discover/(detail)/plugin/[slug]/features/Actions.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/plugin/[slug]/features/Actions.tsx
@@ -16,6 +16,10 @@ interface PluginActionsProps extends FlexboxProps {
 }
 
 const PluginActions = memo<PluginActionsProps>(({ identifier, data }) => {
+  const baseUrl = OFFICIAL_URL.includes(location.host)
+    ? OFFICIAL_URL
+    : `${location.protocol}//${location.host}`;
+
   return (
     <Flexbox align={'center'} gap={8} horizontal>
       <InstallTool identifier={identifier} />
@@ -25,7 +29,7 @@ const PluginActions = memo<PluginActionsProps>(({ identifier, data }) => {
           desc: data.meta.description,
           hashtags: data.meta.tags,
           title: data.meta.title,
-          url: urlJoin(OFFICIAL_URL, '/discover/plugin', identifier),
+          url: urlJoin(baseUrl, '/discover/plugin', identifier),
         }}
       />
     </Flexbox>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

兼容self-hosting 下，使用当前Domain

#### 📝 补充信息 | Additional Information

Supports self-hosting by using the current domain.

## Summary by Sourcery

Bug Fixes:
- Fix share URL generation to fallback to the running host instead of the constant official domain when self-hosted