### PR TITLE
✨ fix: fix hotkey for opening settings page

### DIFF
--- a/src/const/hotkeys.ts
+++ b/src/const/hotkeys.ts
@@ -58,7 +58,6 @@ export const HOTKEYS_REGISTRATION: HotkeyRegistration = [
   {
     group: HotkeyGroupEnum.Essential,
     id: HotkeyEnum.OpenSettings,
-    isDesktop: true,
     keys: combineKeys([KeyEnum.Mod, KeyEnum.Comma]),
     nonEditable: true,
     scopes: [HotkeyScopeEnum.Global],

--- a/src/features/HotkeyHelperPanel/HotkeyContent.tsx
+++ b/src/features/HotkeyHelperPanel/HotkeyContent.tsx
@@ -1,15 +1,23 @@
 import { Hotkey } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { HOTKEYS_REGISTRATION } from '@/const/hotkeys';
+import { isDesktop } from '@/const/version';
 import hotkeyMeta from '@/locales/default/hotkey';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/slices/settings/selectors';
-import { HotkeyGroupId } from '@/types/hotkey';
+import { HotkeyGroupId, HotkeyItem } from '@/types/hotkey';
+
+const filterByDesktop = (item: HotkeyItem) => {
+  if (isDesktop) return true;
+
+  // is not desktop, filter out desktop only items
+  if (!isDesktop) return !item.isDesktop;
+};
 
 const useStyle = createStyles(({ css, token }) => ({
   desc: css`
@@ -36,9 +44,15 @@ const HotkeyContent = memo<HotkeyContentProps>(({ groupId }) => {
   const settings = useUserStore(settingsSelectors.currentSettings, isEqual);
   const { t } = useTranslation('hotkey');
   const { styles } = useStyle();
+
+  const hotkeys = useMemo(
+    () => HOTKEYS_REGISTRATION.filter((item) => item.group === groupId && filterByDesktop(item)),
+    [groupId],
+  );
+
   return (
     <>
-      {HOTKEYS_REGISTRATION.filter((item) => item.group === groupId).map((item) => (
+      {hotkeys.map((item) => (
         <Flexbox align={'flex-start'} gap={16} horizontal key={item.id} width={'100%'}>
           <Flexbox flex={1} gap={4} justify={'space-between'}>
             <span>{t(`${item.id}.title`)}</span>

--- a/src/hooks/useHotkeys/globalScope.ts
+++ b/src/hooks/useHotkeys/globalScope.ts
@@ -1,4 +1,5 @@
 import isEqual from 'fast-deep-equal';
+import { useRouter } from 'next/navigation';
 import { parseAsBoolean, useQueryState } from 'nuqs';
 import { useHotkeys } from 'react-hotkeys-hook';
 
@@ -60,10 +61,17 @@ export const useOpenHotkeyHelperHotkey = () => {
   );
 };
 
+export const useOpenSettingHotKey = () => {
+  const router = useRouter();
+
+  return useHotkeyById(HotkeyEnum.OpenSettings, () => router.push('/settings/common'));
+};
+
 // 注册聚合
 
 export const useRegisterGlobalHotkeys = () => {
   // 全局自动注册不需要 enableScope
   useSwitchAgentHotkey();
+  useOpenSettingHotKey();
   useOpenHotkeyHelperHotkey();
 };

--- a/src/types/hotkey.ts
+++ b/src/types/hotkey.ts
@@ -91,15 +91,15 @@ export type HotkeyGroupId = (typeof HotkeyGroupEnum)[keyof typeof HotkeyGroupEnu
 export type HotkeyScopeId = (typeof HotkeyScopeEnum)[keyof typeof HotkeyScopeEnum];
 
 export interface HotkeyItem {
-  // 快捷键分组用于展示
+  /** 快捷键分组 */
   group: HotkeyGroupId;
   id: HotkeyId;
+  /** 是否是桌面端专用的快捷键 */
   isDesktop?: boolean;
-  // 是否是桌面端专用的快捷键
   keys: string;
-  // 是否为不可编辑的快捷键
+  /** 是否为不可编辑的快捷键 */
   nonEditable?: boolean;
-  // 快捷键作用域
+  /** 快捷键作用域 */
   scopes?: HotkeyScopeId[];
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

看 https://github.com/lobehub/lobe-chat/blob/f0a12afd23883eaeced2804ef79f6a0287303c58/src/types/hotkey.ts 文件存在 `HotkeyEnum.OpenSettings` 枚举定义，但是却没有实际应用这个规则。 不确定是遗漏了还是故意隐藏的。

---

看起来这个功能只是期望桌面端用， （但是我体验下来，chrome 浏览器这边只要屏蔽了默认行为，其实也可以打开导航到设置页面。

需要讨论一下是不是特定给桌面端用，还是都可以，或者是否允许桌面端不可编辑， web 可以编辑。

当前 PR 补齐了这个功能


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Implement and register the OpenSettings hotkey to navigate to the common settings page.

Bug Fixes:
- Add useOpenSettingHotKey hook that listens for HotkeyEnum.OpenSettings and routes to '/settings/common'.
- Register the OpenSettings hotkey in the global hotkey registry.