### PR TITLE
💄 style: Add MiniMax-M1 model

### DIFF
--- a/src/config/aiModels/minimax.ts
+++ b/src/config/aiModels/minimax.ts
@@ -5,6 +5,29 @@ const minimaxChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       search: true,
+    },
+    contextWindowTokens: 1_000_192,
+    description:
+      '在 MiniMax-01系列模型中，我们做了大胆创新：首次大规模实现线性注意力机制，传统 Transformer架构不再是唯一的选择。这个模型的参数量高达4560亿，其中单次激活459亿。模型综合性能比肩海外顶尖模型，同时能够高效处理全球最长400万token的上下文，是GPT-4o的32倍，Claude-3.5-Sonnet的20倍。',
+    displayName: 'MiniMax-M1',
+    enabled: true,
+    id: 'MiniMax-M1',
+    maxOutput: 40_000,
+    pricing: {
+      currency: 'CNY',
+      input: 1.2, // 输入长度 32-128k
+      output: 16,
+    },
+    releasedAt: '2025-01-15',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 1_000_192,
@@ -13,7 +36,7 @@ const minimaxChatModels: AIChatModelCard[] = [
     displayName: 'MiniMax-Text-01',
     enabled: true,
     id: 'MiniMax-Text-01',
-    maxOutput: 1_000_192,
+    maxOutput: 40_000,
     pricing: {
       currency: 'CNY',
       input: 1,

--- a/src/config/aiModels/minimax.ts
+++ b/src/config/aiModels/minimax.ts
@@ -8,7 +8,7 @@ const minimaxChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_192,
     description:
-      '在 MiniMax-01系列模型中，我们做了大胆创新：首次大规模实现线性注意力机制，传统 Transformer架构不再是唯一的选择。这个模型的参数量高达4560亿，其中单次激活459亿。模型综合性能比肩海外顶尖模型，同时能够高效处理全球最长400万token的上下文，是GPT-4o的32倍，Claude-3.5-Sonnet的20倍。',
+      '全新自研推理模型。全球领先：80K思维链 x 1M输入，效果比肩海外顶尖模型。',
     displayName: 'MiniMax-M1',
     enabled: true,
     id: 'MiniMax-M1',
@@ -18,7 +18,7 @@ const minimaxChatModels: AIChatModelCard[] = [
       input: 1.2, // 输入长度 32-128k
       output: 16,
     },
-    releasedAt: '2025-01-15',
+    releasedAt: '2025-06-16',
     settings: {
       searchImpl: 'params',
     },
@@ -57,7 +57,6 @@ const minimaxChatModels: AIChatModelCard[] = [
     contextWindowTokens: 245_760,
     description: '适用于广泛的自然语言处理任务，包括文本生成、对话系统等。',
     displayName: 'abab6.5s',
-    enabled: true,
     id: 'abab6.5s-chat',
     maxOutput: 245_760,
     pricing: {

--- a/src/config/aiModels/novita.ts
+++ b/src/config/aiModels/novita.ts
@@ -3,6 +3,9 @@ import { AIChatModelCard } from '@/types/aiModel';
 // https://novita.ai/pricing
 const novitaChatModels: AIChatModelCard[] = [
   {
+    abilities: {
+      reasoning: true,
+    },
     contextWindowTokens: 128_000,
     displayName: 'MiniMax M1 80K',
     id: 'minimaxai/minimax-m1-80k',
@@ -13,6 +16,9 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      reasoning: true,
+    },
     contextWindowTokens: 128_000,
     displayName: 'Qwen3 4B FP8',
     id: 'qwen/qwen3-4b-fp8',
@@ -23,6 +29,9 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      reasoning: true,
+    },
     contextWindowTokens: 40_960,
     displayName: 'Qwen3 235B A22B FP8',
     id: 'qwen/qwen3-235b-a22b-fp8',
@@ -33,6 +42,9 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      reasoning: true,
+    },
     contextWindowTokens: 40_960,
     displayName: 'Qwen3 30B A3B FP8',
     id: 'qwen/qwen3-30b-a3b-fp8',
@@ -43,6 +55,9 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      reasoning: true,
+    },
     contextWindowTokens: 40_960,
     displayName: 'Qwen3 32B FP8',
     id: 'qwen/qwen3-32b-fp8',

--- a/src/config/aiModels/novita.ts
+++ b/src/config/aiModels/novita.ts
@@ -4,6 +4,16 @@ import { AIChatModelCard } from '@/types/aiModel';
 const novitaChatModels: AIChatModelCard[] = [
   {
     contextWindowTokens: 128_000,
+    displayName: 'MiniMax M1 80K',
+    id: 'minimaxai/minimax-m1-80k',
+    pricing: {
+      input: 0.55,
+      output: 2.2,
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 128_000,
     displayName: 'Qwen3 4B FP8',
     id: 'qwen/qwen3-4b-fp8',
     pricing: {

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -8,6 +8,23 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 131_072,
     description:
+      'MiniMax-M1 是开源权重的大规模混合注意力推理模型，拥有 4560 亿参数，每个 Token 可激活约 459 亿参数。模型原生支持 100 万 Token 的超长上下文，并通过闪电注意力机制，在 10 万 Token 的生成任务中相比 DeepSeek R1 节省 75% 的浮点运算量。同时，MiniMax-M1 采用 MoE（混合专家）架构，结合 CISPO 算法与混合注意力设计的高效强化学习训练，在长输入推理与真实软件工程场景中实现了业界领先的性能。',
+    displayName: 'MiniMax M1 80K',
+    id: 'MiniMaxAI/MiniMax-M1-80k',
+    pricing: {
+      currency: 'CNY',
+      input: 4,
+      output: 16,
+    },
+    releasedAt: '2025-06-16',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
       'QwenLong-L1-32B 是首个使用强化学习训练的长上下文大型推理模型（LRM），专门针对长文本推理任务进行优化。该模型通过渐进式上下文扩展的强化学习框架，实现了从短上下文到长上下文的稳定迁移。在七个长上下文文档问答基准测试中，QwenLong-L1-32B 超越了 OpenAI-o3-mini 和 Qwen3-235B-A22B 等旗舰模型，性能可媲美 Claude-3.7-Sonnet-Thinking。该模型特别擅长数学推理、逻辑推理和多跳推理等复杂任务。',
     displayName: 'QwenLong L1 32B',
     id: 'Tongyi-Zhiwen/QwenLong-L1-32B',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

https://platform.minimaxi.com/document/Announcement


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Introduce a new MiniMax-M1 chat model and standardize token output limits for existing models.

New Features:
- Add MiniMax-M1 chat model with enhanced linear attention and extended context window.

Enhancements:
- Update MiniMax-Text-01 maxOutput limit from 1,000,192 to 40,000 tokens.

## Summary by Sourcery

Introduce the MiniMax-M1 models in both minimax and siliconcloud configurations while aligning token output limits across existing models

New Features:
- Add MiniMax-M1 chat model to the minimax configuration
- Introduce MiniMax M1 80K chat model entry in the siliconcloud configuration

Enhancements:
- Standardize MiniMax-Text-01 maxOutput limit to 40,000 tokens

Chores:
- Remove redundant `enabled` property from the abab6.5s-chat model entry