### PR TITLE
💄 style: Add Gemini 2.5 Pro, Flash GA models and 2.5 Flash-Lite Preview

### DIFF
--- a/src/config/aiModels/google.ts
+++ b/src/config/aiModels/google.ts
@@ -10,6 +10,31 @@ const googleChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      'Gemini 2.5 Pro 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
+    displayName: 'Gemini 2.5 Pro (Paid)',
+    id: 'gemini-2.5-pro',
+    maxOutput: 65_536,
+    pricing: {
+      input: 1.25, // prompts <= 200k tokens
+      output: 10, // prompts <= 200k tokens
+    },
+    releasedAt: '2025-06-17',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       'Gemini 2.5 Pro Preview 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
     displayName: 'Gemini 2.5 Pro Preview 06-05 (Paid)',
     id: 'gemini-2.5-pro-preview-06-05',
@@ -82,6 +107,31 @@ const googleChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 1_048_576 + 65_536,
+    description: 'Gemini 2.5 Flash 是 Google 性价比最高的模型，提供全面的功能。',
+    displayName: 'Gemini 2.5 Flash',
+    enabled: true,
+    id: 'gemini-2.5-flash',
+    maxOutput: 65_536,
+    pricing: {
+      input: 0.3,
+      output: 2.5,
+    },
+    releasedAt: '2025-06-17',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
     description: 'Gemini 2.5 Flash Preview 是 Google 性价比最高的模型，提供全面的功能。',
     displayName: 'Gemini 2.5 Flash Preview 05-20',
     enabled: true,
@@ -140,6 +190,32 @@ const googleChatModels: AIChatModelCard[] = [
       output: 3.5, // Thinking
     },
     settings: {
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000 + 64_000,
+    description:
+      'Gemini 2.5 Flash-Lite Preview 是 Google 最小、性价比最高的模型，专为大规模使用而设计。',
+    displayName: 'Gemini 2.5 Flash-Lite Preview 06-17',
+    enabled: true,
+    id: 'gemini-2.5-flash-lite-preview-06-17',
+    maxOutput: 64_000,
+    pricing: {
+      input: 0.1,
+      output: 0.4,
+    },
+    releasedAt: '2025-06-17',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
       searchImpl: 'params',
       searchProvider: 'google',
     },

--- a/src/config/aiModels/vertexai.ts
+++ b/src/config/aiModels/vertexai.ts
@@ -10,6 +10,26 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      'Gemini 2.5 Pro 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
+    displayName: 'Gemini 2.5 Pro',
+    enabled: true,
+    id: 'gemini-2.5-pro',
+    maxOutput: 65_536,
+    pricing: {
+      input: 1.25, // prompts <= 200k tokens
+      output: 10, // prompts <= 200k tokens
+    },
+    releasedAt: '2025-06-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       'Gemini 2.5 Pro Preview 是 Google 最先进的思维模型，能够对代码、数学和STEM领域的复杂问题进行推理，以及使用长上下文分析大型数据集、代码库和文档。',
     displayName: 'Gemini 2.5 Pro Preview 05-06',
     enabled: true,
@@ -48,6 +68,25 @@ const vertexaiChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 1_048_576 + 65_536,
+    description: 'Gemini 2.5 Flash 是 Google 性价比最高的模型，提供全面的功能。',
+    displayName: 'Gemini 2.5 Flash',
+    enabled: true,
+    id: 'gemini-2.5-flash',
+    maxOutput: 65_536,
+    pricing: {
+      input: 0.3,
+      output: 2.5,
+    },
+    releasedAt: '2025-06-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
     description: 'Gemini 2.5 Flash Preview 是 Google 性价比最高的模型，提供全面的功能。',
     displayName: 'Gemini 2.5 Flash Preview 04-17',
     enabled: true,
@@ -58,6 +97,26 @@ const vertexaiChatModels: AIChatModelCard[] = [
       output: 3.5, // Thinking
     },
     releasedAt: '2025-04-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000 + 64_000,
+    description:
+      'Gemini 2.5 Flash-Lite Preview 是 Google 最小、性价比最高的模型，专为大规模使用而设计。',
+    displayName: 'Gemini 2.5 Flash-Lite Preview 06-17',
+    enabled: true,
+    id: 'gemini-2.5-flash-lite-preview-06-17',
+    maxOutput: 64_000,
+    pricing: {
+      input: 0.1,
+      output: 0.4,
+    },
+    releasedAt: '2025-06-17',
     type: 'chat',
   },
   {


### PR DESCRIPTION
…view model

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- Add Gemini 2.5 Pro GA model: `gemini-2.5-pro`
- Add Gemini 2.5 Flash GA model: `gemini-2.5-flash`
- Add Gemini 2.5 Flash-Lite Preview Model: `gemini-2.5-flash-lite-preview-06-17`

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Register the three new Gemini 2.5 variants (Pro, Flash, and Flash-Lite Preview) in both Google Chat and Vertex AI model configuration files.

New Features:
- Add Gemini 2.5 Pro GA model to Google Chat and Vertex AI configurations
- Add Gemini 2.5 Flash GA model to Google Chat and Vertex AI configurations
- Add Gemini 2.5 Flash-Lite Preview model to Google Chat and Vertex AI configurations