### PR TITLE
💄 style: Enable thinkingBudget control for Vertex Gemini 2.5 models

### DIFF
--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -25,6 +25,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -94,6 +95,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -162,6 +164,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-07-22',
     settings: {
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -187,6 +190,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -132,35 +132,38 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const payload = this.buildPayload(rawPayload);
       const { model, thinkingBudget } = payload;
 
+      // https://ai.google.dev/gemini-api/docs/thinking#set-budget
+      const resolvedThinkingBudget = (() => {
+        if (thinkingBudget !== undefined && thinkingBudget !== null) {
+          if (model.includes('-2.5-flash-lite')) {
+            if (thinkingBudget === 0 || thinkingBudget === -1) {
+              return thinkingBudget;
+            }
+            return Math.max(512, Math.min(thinkingBudget, 24_576));
+          } else if (model.includes('-2.5-flash')) {
+            return Math.min(thinkingBudget, 24_576);
+          } else if (model.includes('-2.5-pro')) {
+            return thinkingBudget === -1 ? -1 : Math.max(128, Math.min(thinkingBudget, 32_768));
+          }
+          return Math.min(thinkingBudget, 24_576);
+        }
+
+        if (model.includes('-2.5-pro') || model.includes('-2.5-flash')) {
+          return -1;
+        } else if (model.includes('-2.5-flash-lite')) {
+          return 0;
+        }
+        return undefined;
+      })();
+
       const thinkingConfig: ThinkingConfig = {
         includeThoughts:
-          !!thinkingBudget ||
-          (!thinkingBudget && model && (model.includes('-2.5-') || model.includes('thinking')))
+          (!!thinkingBudget ||
+            (model && (model.includes('-2.5-') || model.includes('thinking')))) &&
+          resolvedThinkingBudget !== 0
             ? true
             : undefined,
-        // https://ai.google.dev/gemini-api/docs/thinking#set-budget
-        thinkingBudget: (() => {
-          if (thinkingBudget !== undefined && thinkingBudget !== null) {
-            if (model.includes('-2.5-flash-lite')) {
-              if (thinkingBudget === 0 || thinkingBudget === -1) {
-                return thinkingBudget;
-              }
-              return Math.max(512, Math.min(thinkingBudget, 24_576));
-            } else if (model.includes('-2.5-flash')) {
-              return Math.min(thinkingBudget, 24_576);
-            } else if (model.includes('-2.5-pro')) {
-              return thinkingBudget === -1 ? -1 : Math.max(128, Math.min(thinkingBudget, 32_768));
-            }
-            return Math.min(thinkingBudget, 24_576);
-          }
-
-          if (model.includes('-2.5-pro') || model.includes('-2.5-flash')) {
-            return -1;
-          } else if (model.includes('-2.5-flash-lite')) {
-            return 0;
-          }
-          return undefined;
-        })(),
+        thinkingBudget: resolvedThinkingBudget,
       };
 
       const contents = await this.buildGoogleMessages(payload.messages);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- Enable thinkingBudget control for Vertex Gemini 2.5 models
- **Fix includeThoughts error for Vertex when thinkingBudget is 0**


#### 📝 补充信息 | Additional Information

Vertex AI error:

```json
{
  "error": {
    "code": 400,
    "message": "Unable to submit request because Thinking_config.include_thoughts is only enabled when thinking is enabled.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",
    "status": "INVALID_ARGUMENT"
  }
}
```

## Summary by Sourcery

Enable and configure thinkingBudget and reasoning controls for Vertex Gemini 2.5 models, fix includeThoughts behavior for zero budgets, and default to the global Vertex AI endpoint

New Features:
- Enable thinkingBudget control for Vertex Gemini 2.5 Flash-Lite and Pro models
- Expose enableReasoning and reasoningBudgetToken as extendParams in Vertex model settings

Bug Fixes:
- Prevent includeThoughts from being set when thinkingBudget is zero for Vertex

Enhancements:
- Default Vertex AI endpoint location to global when unspecified