### PR TITLE
💄 style: Optimized Gemini thinkingBudget configuration

### DIFF
--- a/src/config/aiModels/google.ts
+++ b/src/config/aiModels/google.ts
@@ -20,7 +20,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -45,7 +45,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-05',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -118,7 +118,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -143,7 +143,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-05-20',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -167,7 +167,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-04-17',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },
@@ -215,7 +215,7 @@ const googleChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-06-17',
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['thinkingBudget'],
       searchImpl: 'params',
       searchProvider: 'google',
     },

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -13,6 +13,7 @@ import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import ContextCachingSwitch from './ContextCachingSwitch';
 import ReasoningEffortSlider from './ReasoningEffortSlider';
 import ReasoningTokenSlider from './ReasoningTokenSlider';
+import ThinkingBudgetSlider from './ThinkingBudgetSlider';
 
 const ControlsForm = memo(() => {
   const { t } = useTranslation('chat');
@@ -92,6 +93,17 @@ const ControlsForm = memo(() => {
       style: {
         paddingBottom: 0,
       },
+    },
+    {
+      children: <ThinkingBudgetSlider />,
+      label: t('extendParams.reasoningBudgetToken.title'),
+      layout: 'vertical',
+      minWidth: 500,
+      name: 'thinkingBudget',
+      style: {
+        paddingBottom: 0,
+      },
+      tag: 'thinkingBudget',
     },
   ].filter(Boolean) as FormItemProps[];
 

--- a/src/features/ChatInput/ActionBar/Model/ThinkingBudgetSlider.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ThinkingBudgetSlider.tsx
@@ -1,0 +1,133 @@
+import { InputNumber } from '@lobehub/ui';
+import { Slider } from 'antd';
+import { memo, useMemo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+import useMergeState from 'use-merge-value';
+
+// 定义特殊值映射
+const SPECIAL_VALUES = {
+  AUTO: -1,
+  OFF: 0,
+};
+
+// 定义滑块位置到实际值的映射
+const SLIDER_TO_VALUE_MAP = [
+  SPECIAL_VALUES.AUTO, // 位置 0 -> -1 (Auto)
+  SPECIAL_VALUES.OFF, // 位置 1 -> 0 (OFF)
+  128, // 位置 2 -> 128
+  512, // 位置 3 -> 512
+  1024, // 位置 4 -> 1024
+  2048, // 位置 5 -> 2048
+  4096, // 位置 6 -> 4096
+  8192, // 位置 7 -> 8192
+  16_384, // 位置 8 -> 16384
+  24_576, // 位置 9 -> 24576
+  32_768, // 位置 10 -> 32768
+];
+
+// 从实际值获取滑块位置
+const getSliderPosition = (value: number): number => {
+  const index = SLIDER_TO_VALUE_MAP.indexOf(value);
+  return index === -1 ? 0 : index;
+};
+
+// 从滑块位置获取实际值（修复：0 不再被当作 falsy）
+const getValueFromPosition = (position: number): number => {
+  const v = SLIDER_TO_VALUE_MAP[position];
+  return v === undefined ? SPECIAL_VALUES.AUTO : v;
+};
+
+interface ThinkingBudgetSliderProps {
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  value?: number;
+}
+
+const ThinkingBudgetSlider = memo<ThinkingBudgetSliderProps>(
+  ({ value, onChange, defaultValue }) => {
+    // 首先确定初始的 budget 值
+    const initialBudget = value ?? defaultValue ?? SPECIAL_VALUES.AUTO;
+
+    const [budget, setBudget] = useMergeState(initialBudget, {
+      defaultValue,
+      onChange,
+      value,
+    });
+
+    const sliderPosition = getSliderPosition(budget);
+
+    const updateWithSliderPosition = (position: number) => {
+      const newValue = getValueFromPosition(position);
+      setBudget(newValue);
+    };
+
+    const updateWithRealValue = (value: number) => {
+      setBudget(value);
+    };
+
+    const marks = useMemo(() => {
+      return {
+        0: 'Auto',
+        1: 'OFF',
+        2: '128',
+        3: '512',
+        4: '1K',
+        5: '2K',
+        6: '4K',
+        7: '8K',
+        8: '16K',
+        9: '24K',
+        // eslint-disable-next-line sort-keys-fix/sort-keys-fix
+        10: '32K',
+      };
+    }, []);
+
+    return (
+      <Flexbox align={'center'} gap={12} horizontal paddingInline={'4px 0'}>
+        <Flexbox flex={1}>
+          <Slider
+            marks={marks}
+            max={10}
+            min={0}
+            onChange={updateWithSliderPosition}
+            step={null}
+            tooltip={{ open: false }}
+            value={sliderPosition}
+          />
+        </Flexbox>
+        <div>
+          <InputNumber
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            formatter={(value, _info) => {
+              if (value === SPECIAL_VALUES.AUTO) return 'Auto';
+              if (value === SPECIAL_VALUES.OFF) return 'OFF';
+              return `${value}`;
+            }}
+            max={32_768}
+            min={-1}
+            onChange={(e) => {
+              if (e === null || e === undefined) return;
+              updateWithRealValue(e as number);
+            }}
+            parser={(value) => {
+              if (typeof value === 'string') {
+                if (value.toLowerCase() === 'auto') return SPECIAL_VALUES.AUTO;
+                if (value.toLowerCase() === 'off') return SPECIAL_VALUES.OFF;
+                return parseInt(value.replaceAll(/[^\d-]/g, ''), 10) || 0;
+              }
+              if (typeof value === 'number') {
+                return value;
+              }
+              return SPECIAL_VALUES.AUTO;
+            }}
+            step={128}
+            style={{ width: 80 }}
+            value={budget}
+          />
+        </div>
+      </Flexbox>
+    );
+  },
+);
+
+export default ThinkingBudgetSlider;

--- a/src/libs/model-runtime/types/chat.ts
+++ b/src/libs/model-runtime/types/chat.ts
@@ -126,6 +126,7 @@ export interface ChatStreamPayload {
     budget_tokens: number;
     type: 'enabled' | 'disabled';
   };
+  thinkingBudget?: number;
   tool_choice?: string;
   tools?: ChatCompletionTool[];
   /**

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -263,6 +263,13 @@ class ChatService {
       if (modelExtendParams!.includes('reasoningEffort') && chatConfig.reasoningEffort) {
         extendParams.reasoning_effort = chatConfig.reasoningEffort;
       }
+
+      if (
+        modelExtendParams!.includes('thinkingBudget') &&
+        chatConfig.thinkingBudget !== undefined
+      ) {
+        extendParams.thinkingBudget = chatConfig.thinkingBudget;
+      }
     }
 
     return this.getChatCompletion(

--- a/src/types/agent/chatConfig.ts
+++ b/src/types/agent/chatConfig.ts
@@ -26,7 +26,7 @@ export interface LobeAgentChatConfig {
   enableReasoningEffort?: boolean;
   reasoningBudgetToken?: number;
   reasoningEffort?: 'low' | 'medium' | 'high';
-
+  thinkingBudget?: number;
   /**
    * 禁用上下文缓存
    */

--- a/src/types/aiModel.ts
+++ b/src/types/aiModel.ts
@@ -147,7 +147,8 @@ export type ExtendParamsType =
   | 'reasoningBudgetToken'
   | 'enableReasoning'
   | 'disableContextCaching'
-  | 'reasoningEffort';
+  | 'reasoningEffort'
+  | 'thinkingBudget';
 
 export interface AiModelSettings {
   extendParams?: ExtendParamsType[];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

https://ai.google.dev/gemini-api/docs/thinking#set-budget

依据文档处理参数。

![image](https://github.com/user-attachments/assets/c976f902-4770-4033-b9e0-f2a7294e25b6)


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for the Gemini thinking budget feature by introducing a new `thinkingBudget` parameter, implementing per-model budget clamping logic, updating model configurations, and exposing a slider UI control in the chat input.

New Features:
- Expose a `thinkingBudget` parameter in the Google AI chat payload and service methods
- Implement budget clamping logic per Gemini model tier following the official API guidelines
- Create a `ThinkingBudgetSlider` component and integrate it into the chat input controls

Enhancements:
- Replace legacy `enableReasoning` and `reasoningBudgetToken` extend parameters with `thinkingBudget` across Google AI model configurations
- Update type definitions (`ExtendParamsType`, chat payload, and agent config) to include `thinkingBudget`