### PR TITLE
💄 style: fix `MiniMax-M1` reasoning tag missing

### DIFF
--- a/src/config/aiModels/minimax.ts
+++ b/src/config/aiModels/minimax.ts
@@ -4,6 +4,7 @@ const minimaxChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
       search: true,
     },
     contextWindowTokens: 1_000_192,
@@ -45,44 +46,6 @@ const minimaxChatModels: AIChatModelCard[] = [
     releasedAt: '2025-01-15',
     settings: {
       searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-      vision: true,
-    },
-    contextWindowTokens: 245_760,
-    description: '适用于广泛的自然语言处理任务，包括文本生成、对话系统等。',
-    displayName: 'abab6.5s',
-    id: 'abab6.5s-chat',
-    maxOutput: 245_760,
-    pricing: {
-      currency: 'CNY',
-      input: 1,
-      output: 1,
-    },
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-    },
-    contextWindowTokens: 64_000,
-    description:
-      'DeepSeek 推出的推理模型。在输出最终回答之前，模型会先输出一段思维链内容，以提升最终答案的准确性。',
-    displayName: 'DeepSeek R1',
-    id: 'DeepSeek-R1',
-    maxOutput: 64_000,
-    pricing: {
-      currency: 'CNY',
-      input: 4,
-      output: 16,
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 修正 `MiniMax-M1` Reasoning 标签丢失
2. 移除无效模型列表，见 API 文档

![image](https://github.com/user-attachments/assets/40d81377-fefb-447f-b091-c22037f4645f)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

ref: https://platform.minimaxi.com/document/%E5%AF%B9%E8%AF%9D?key=66701d281d57f38758d581d0#QklxsNSbaf6kM4j6wjO5eEek

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix the missing reasoning flag on the MiniMax-M1 model and clean up obsolete model entries from the configuration

Bug Fixes:
- Restore the reasoning ability flag for the MiniMax-M1 model

Enhancements:
- Remove unsupported `abab6.5s-chat` and `DeepSeek-R1` models per API documentation