### PR TITLE
⚡️ perf: refactor Typography to Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@lobehub/chat-plugins-gateway": "^1.9.0",
     "@lobehub/icons": "^2.2.0",
     "@lobehub/tts": "^2.0.1",
-    "@lobehub/ui": "^2.1.15",
+    "@lobehub/ui": "^2.5.6",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@neondatabase/serverless": "^1.0.0",
     "@next/third-parties": "^15.3.3",
@@ -186,6 +186,7 @@
     "file-type": "^20.5.0",
     "framer-motion": "^12.15.0",
     "gpt-tokenizer": "^2.9.0",
+    "gray-matter": "^4.0.3",
     "html-to-text": "^9.0.5",
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.1.0",
@@ -202,6 +203,7 @@
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.509.0",
     "mammoth": "^1.9.1",
+    "markdown-to-txt": "^2.0.1",
     "mdast-util-to-markdown": "^2.1.2",
     "modern-screenshot": "^4.6.0",
     "nanoid": "^5.1.5",
@@ -232,7 +234,7 @@
     "react-confetti": "^6.4.0",
     "react-dom": "^19.1.0",
     "react-fast-marquee": "^1.6.5",
-    "react-hotkeys-hook": "^4.6.2",
+    "react-hotkeys-hook": "^5.1.0",
     "react-i18next": "^15.5.2",
     "react-layout-kit": "^1.9.1",
     "react-lazy-load": "^4.0.1",
@@ -276,7 +278,7 @@
     "@commitlint/cli": "^19.8.1",
     "@edge-runtime/vm": "^5.0.0",
     "@huggingface/tasks": "^0.15.9",
-    "@lobehub/i18n-cli": "^1.22.0",
+    "@lobehub/i18n-cli": "^1.23.0",
     "@lobehub/lint": "^1.26.2",
     "@lobehub/seo-cli": "^1.6.0",
     "@next/bundle-analyzer": "^15.3.3",
@@ -325,14 +327,12 @@
     "fake-indexeddb": "^6.0.1",
     "fs-extra": "^11.3.0",
     "glob": "^11.0.2",
-    "gray-matter": "^4.0.3",
     "happy-dom": "^17.5.6",
     "husky": "^9.1.7",
     "just-diff": "^6.0.2",
     "lint-staged": "^15.5.2",
     "lodash": "^4.17.21",
     "markdown-table": "^3.0.4",
-    "markdown-to-txt": "^2.0.1",
     "mcp-hello-world": "^1.1.2",
     "mime": "^4.0.7",
     "node-fetch": "^3.3.2",
@@ -366,13 +366,6 @@
     ],
     "overrides": {
       "mdast-util-gfm-autolink-literal": "2.0.0"
-    },
-    "packageExtensions": {
-      "@inkjs/ui": {
-        "dependencies": {
-          "react": "^18"
-        }
-      }
     }
   }
 }

--- a/src/app/[variants]/(auth)/next-auth/signin/AuthSignInBox.tsx
+++ b/src/app/[variants]/(auth)/next-auth/signin/AuthSignInBox.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Button } from '@lobehub/ui';
+import { Button, Text } from '@lobehub/ui';
 import { LobeChat } from '@lobehub/ui/brand';
-import { Col, Flex, Row, Skeleton, Typography } from 'antd';
+import { Col, Flex, Row, Skeleton } from 'antd';
 import { createStyles } from 'antd-style';
 import { AuthError } from 'next-auth';
 import { signIn } from 'next-auth/react';
@@ -14,8 +14,6 @@ import BrandWatermark from '@/components/BrandWatermark';
 import AuthIcons from '@/components/NextAuth/AuthIcons';
 import { DOCUMENTS_REFER_URL, PRIVACY_URL, TERMS_URL } from '@/const/url';
 import { useUserStore } from '@/store/user';
-
-const { Title, Paragraph } = Typography;
 
 const useStyles = createStyles(({ css, token }) => ({
   button: css`
@@ -111,13 +109,15 @@ export default memo(() => {
         <Flex gap="large" vertical>
           {/* Header */}
           <div className={styles.text}>
-            <Title className={styles.title} level={4}>
+            <Text as={'h4'} className={styles.title}>
               <div>
                 <LobeChat size={48} />
               </div>
               {t('signIn.start.title', { applicationName: 'LobeChat' })}
-            </Title>
-            <Paragraph className={styles.description}>{t('signIn.start.subtitle')}</Paragraph>
+            </Text>
+            <Text as={'p'} className={styles.description}>
+              {t('signIn.start.subtitle')}
+            </Text>
           </div>
           {/* Content */}
           <Flex gap="small" vertical>

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Mobile/Files/FileItem/File.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Mobile/Files/FileItem/File.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { Trash } from 'lucide-react';
 import { memo } from 'react';
@@ -53,7 +52,7 @@ const FileItem = memo<FileItemProps>(({ id, onRemove, file, status, uploadState,
     <Flexbox align={'center'} className={styles.container} gap={12} horizontal key={id}>
       <FileIcon fileName={file.name} fileType={file.type} />
       <Flexbox style={{ overflow: 'hidden' }}>
-        <Typography.Text ellipsis={{ tooltip: false }}>{file.name}</Typography.Text>
+        <Text ellipsis>{file.name}</Text>
         <UploadDetail size={file.size} status={status} tasks={tasks} uploadState={uploadState} />
       </Flexbox>
       <ActionIcon

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatList/ChatItem/Thread.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatList/ChatItem/Thread.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { CSSProperties, memo } from 'react';
@@ -44,10 +44,10 @@ const Thread = memo<ThreadProps>(({ id, placement, style }) => {
       <div style={{ width: 40 }} />
       <Flexbox className={styles.container} gap={4} padding={4} style={{ width: 'fit-content' }}>
         <Flexbox gap={8} horizontal paddingInline={6}>
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {t('thread.title')}
             {threads.length}
-          </Typography.Text>
+          </Text>
         </Flexbox>
         <Flexbox>
           {threads.map((thread) => (

--- a/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/SearchResult/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/SearchResult/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import React, { memo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,7 +37,7 @@ const SearchResult = memo(() => {
   if (topics.length === 0)
     return (
       <Center paddingBlock={12}>
-        <Typography.Text type={'secondary'}>{t('searchResultEmpty')}</Typography.Text>
+        <Text type={'secondary'}>{t('searchResultEmpty')}</Text>
       </Center>
     );
 

--- a/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/ThreadItem/Content.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/ThreadItem/Content.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps } from '@lobehub/ui';
-import { App, Typography } from 'antd';
+import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps, Text } from '@lobehub/ui';
+import { App } from 'antd';
 import { createStyles } from 'antd-style';
 import { MoreVertical, PencilLine, Trash } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -30,7 +30,6 @@ const useStyles = createStyles(({ css, token }) => ({
     text-align: start;
   `,
 }));
-const { Paragraph } = Typography;
 
 interface TopicContentProps {
   active?: boolean;
@@ -109,13 +108,14 @@ const Content = memo<TopicContentProps>(({ id, title, active, showMore }) => {
             <BubblesLoading />
           </Flexbox>
         ) : (
-          <Paragraph
+          <Text
+            as={'p'}
             className={cx(styles.title, active && styles.active)}
             ellipsis={{ rows: 1, tooltip: { placement: 'left', title } }}
             style={{ margin: 0 }}
           >
             {title}
-          </Paragraph>
+          </Text>
         )
       ) : (
         <EditableText

--- a/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/TopicItem/DefaultContent.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/TopicItem/DefaultContent.tsx
@@ -1,12 +1,9 @@
-import { Icon, Tag } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Icon, Tag, Text } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import { MessageSquareDashed } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-
-const { Paragraph } = Typography;
 
 const DefaultContent = memo(() => {
   const { t } = useTranslation('topic');
@@ -18,9 +15,9 @@ const DefaultContent = memo(() => {
       <Flexbox align={'center'} height={24} justify={'center'} width={24}>
         <Icon color={theme.colorTextDescription} icon={MessageSquareDashed} />
       </Flexbox>
-      <Paragraph ellipsis={{ rows: 1 }} style={{ margin: 0 }}>
+      <Text ellipsis={{ rows: 1 }} style={{ margin: 0 }}>
         {t('defaultTitle')}
-      </Paragraph>
+      </Text>
       <Tag>{t('temp')}</Tag>
     </Flexbox>
   );

--- a/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/TopicItem/TopicContent.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/TopicItem/TopicContent.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps } from '@lobehub/ui';
-import { App, Typography } from 'antd';
+import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps, Text } from '@lobehub/ui';
+import { App } from 'antd';
 import { createStyles } from 'antd-style';
 import {
   LucideCopy,
@@ -32,7 +32,6 @@ const useStyles = createStyles(({ css }) => ({
     text-align: start;
   `,
 }));
-const { Paragraph } = Typography;
 
 interface TopicContentProps {
   fav?: boolean;
@@ -167,13 +166,13 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
             <BubblesLoading />
           </Flexbox>
         ) : (
-          <Paragraph
+          <Text
             className={styles.title}
             ellipsis={{ rows: 1, tooltip: { placement: 'left', title } }}
             style={{ margin: 0 }}
           >
             {title}
-          </Paragraph>
+          </Text>
         )
       ) : (
         <EditableText

--- a/src/app/[variants]/(main)/chat/@session/features/SessionSearchBar.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionSearchBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SearchBar } from '@lobehub/ui';
-import { memo } from 'react';
+import { type ChangeEvent, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSessionStore } from '@/store/session';
@@ -11,6 +11,7 @@ import { HotkeyEnum } from '@/types/hotkey';
 
 const SessionSearchBar = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { t } = useTranslation('chat');
+  const isLoaded = useUserStore((s) => s.isLoaded);
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.Search));
 
   const [keywords, useSearchSessions, updateSearchKeywords] = useSessionStore((s) => [
@@ -21,14 +22,19 @@ const SessionSearchBar = memo<{ mobile?: boolean }>(({ mobile }) => {
 
   const { isValidating } = useSearchSessions(keywords);
 
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      updateSearchKeywords(e.target.value);
+    },
+    [updateSearchKeywords],
+  );
+
   return (
     <SearchBar
       allowClear
       enableShortKey={!mobile}
-      loading={isValidating}
-      onChange={(e) => {
-        updateSearchKeywords(e.target.value);
-      }}
+      loading={!isLoaded || isValidating}
+      onChange={handleChange}
       placeholder={t('searchAgentPlaceholder')}
       shortKey={hotkey}
       spotlight={!mobile}

--- a/src/app/[variants]/(main)/files/(content)/@menu/features/KnowledgeBase/Item/Content.tsx
+++ b/src/app/[variants]/(main)/files/(content)/@menu/features/KnowledgeBase/Item/Content.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps } from '@lobehub/ui';
-import { App, Typography } from 'antd';
+import { ActionIcon, Dropdown, EditableText, Icon, type MenuProps, Text } from '@lobehub/ui';
+import { App } from 'antd';
 import { createStyles } from 'antd-style';
 import { LucideLoader2, MoreVertical, PencilLine, Trash } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -30,8 +30,6 @@ const useStyles = createStyles(({ css }) => ({
     text-align: start;
   `,
 }));
-
-const { Paragraph } = Typography;
 
 interface KnowledgeBaseItemProps {
   id: string;
@@ -118,13 +116,13 @@ const Content = memo<KnowledgeBaseItemProps>(({ id, name, showMore }) => {
             <BubblesLoading />
           </Flexbox>
         ) : (
-          <Paragraph
+          <Text
             className={styles.title}
             ellipsis={{ rows: 1, tooltip: { placement: 'left', title: name } }}
             style={{ margin: 0, opacity: isLoading ? 0.6 : undefined }}
           >
             {name}
-          </Paragraph>
+          </Text>
         )
       ) : (
         <EditableText

--- a/src/app/[variants]/(main)/files/(content)/NotSupportClient.tsx
+++ b/src/app/[variants]/(main)/files/(content)/NotSupportClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Icon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Icon, Text } from '@lobehub/ui';
 import { createStyles, useTheme } from 'antd-style';
 import { Database, FileImage, FileText, FileUpIcon, LibraryBig, SearchCheck } from 'lucide-react';
 import Link from 'next/link';
@@ -128,8 +127,10 @@ const NotSupportClient = () => {
       </Flexbox>
 
       <Flexbox justify={'center'} style={{ textAlign: 'center' }}>
-        <Typography.Title>{t('notSupportGuide.title')}</Typography.Title>
-        <Typography.Text type={'secondary'}>
+        <Text as={'h1'} style={{ fontSize: 32 }}>
+          {t('notSupportGuide.title')}
+        </Text>
+        <Text type={'secondary'}>
           <Trans i18nKey={'notSupportGuide.desc'} ns={'file'}>
             当前部署实例为客户端数据库模式，无法使用文件管理功能。请切换到
             <Link href={DATABASE_SELF_HOSTING_URL}>服务端数据库部署模式</Link>
@@ -140,7 +141,7 @@ const NotSupportClient = () => {
               {LOBE_CHAT_CLOUD}
             </Link>
           </Trans>
-        </Typography.Text>
+        </Text>
       </Flexbox>
 
       <Flexbox style={{ marginTop: 40 }}>

--- a/src/app/[variants]/(main)/files/[id]/Header.tsx
+++ b/src/app/[variants]/(main)/files/[id]/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ActionIcon, Button } from '@lobehub/ui';
-import { Divider, Typography } from 'antd';
+import { ActionIcon, Button, Text } from '@lobehub/ui';
+import { Divider } from 'antd';
 import { useTheme } from 'antd-style';
 import { ArrowLeftIcon, DownloadIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -42,12 +42,12 @@ const Header = memo<HeaderProps>(({ filename, url }) => {
           {t('back')}
         </Button>
         <Divider type={'vertical'} />
-        <Typography.Title
-          level={1}
+        <Text
+          as={'h1'}
           style={{ fontSize: 16, lineHeight: 1.5, marginBottom: 0, paddingInlineStart: 8 }}
         >
           {filename}
-        </Typography.Title>
+        </Text>
       </Flexbox>
       <Flexbox>
         <ActionIcon

--- a/src/app/[variants]/(main)/repos/[id]/evals/dataset/DatasetDetail/index.tsx
+++ b/src/app/[variants]/(main)/repos/[id]/evals/dataset/DatasetDetail/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ProColumns, ProTable } from '@ant-design/pro-components';
-import { ActionIcon, Button } from '@lobehub/ui';
-import { Typography, Upload } from 'antd';
+import { ActionIcon, Button, Text } from '@lobehub/ui';
+import { Upload } from 'antd';
 import { createStyles } from 'antd-style';
 import { Edit2Icon, Trash2Icon } from 'lucide-react';
 import { parseAsInteger, useQueryState } from 'nuqs';
@@ -64,7 +64,7 @@ const DatasetDetail = () => {
               {referenceFiles?.map((file) => (
                 <Flexbox gap={4} horizontal key={file.id}>
                   <FileIcon fileName={file.name} fileType={file.fileType} size={20} />
-                  <Typography.Text ellipsis={{ tooltip: true }}>{file.name}</Typography.Text>
+                  <Text ellipsis={{ tooltip: true }}>{file.name}</Text>
                 </Flexbox>
               ))}
             </Flexbox>

--- a/src/app/[variants]/(main)/repos/[id]/evals/evaluation/EvaluationList/index.tsx
+++ b/src/app/[variants]/(main)/repos/[id]/evals/evaluation/EvaluationList/index.tsx
@@ -2,9 +2,10 @@
 
 import { ActionType, ProColumns, ProTable } from '@ant-design/pro-components';
 import { ActionIcon, Button, ButtonProps, Icon } from '@lobehub/ui';
-import { App, Typography } from 'antd';
+import { App } from 'antd';
 import { createStyles } from 'antd-style';
 import { DownloadIcon, PlayIcon, RotateCcwIcon, Trash2Icon } from 'lucide-react';
+import Link from 'next/link';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -57,13 +58,13 @@ const EvaluationList = ({ knowledgeBaseId }: { knowledgeBaseId: string }) => {
       dataIndex: ['dataset', 'id'],
       render: (dom, entity) => {
         return (
-          <Typography.Link
+          <Link
             href={`/repos/${knowledgeBaseId}/evals/dataset?id=${entity.dataset.id}`}
             style={{ color: 'initial' }}
             target={'_blank'}
           >
             {entity.dataset.name}
-          </Typography.Link>
+          </Link>
         );
       },
       title: t('evaluation.table.columns.datasetId.title'),

--- a/src/app/[variants]/(main)/repos/[id]/features/Menu/Head/index.tsx
+++ b/src/app/[variants]/(main)/repos/[id]/features/Menu/Head/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { memo } from 'react';
 import { Center, Flexbox } from 'react-layout-kit';
 
@@ -16,7 +16,9 @@ const Head = memo<{ name?: string }>(({ name }) => {
           <RepoIcon />
         </Center>
 
-        <Typography.Text style={{ fontSize: 16, fontWeight: 'bold' }}>{name}</Typography.Text>
+        <Text ellipsis strong style={{ fontSize: 16 }}>
+          {name}
+        </Text>
       </Flexbox>
     </Flexbox>
   );

--- a/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/CustomModelOption.tsx
+++ b/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/CustomModelOption.tsx
@@ -1,6 +1,6 @@
 import { ModelIcon } from '@lobehub/icons';
-import { ActionIcon, Icon } from '@lobehub/ui';
-import { App, Typography } from 'antd';
+import { ActionIcon, Icon, Text } from '@lobehub/ui';
+import { App } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { LucideArrowRight, LucideSettings, LucideTrash2 } from 'lucide-react';
 import { memo } from 'react';
@@ -45,10 +45,10 @@ const CustomModelOption = memo<CustomModelOptionProps>(({ id, provider }) => {
         <ModelIcon model={id} size={32} />
         <Flexbox direction={'vertical'} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox align={'center'} gap={8} horizontal>
-            <Typography.Text ellipsis>{modelCard?.displayName || id}</Typography.Text>
+            <Text ellipsis>{modelCard?.displayName || id}</Text>
             <ModelInfoTags id={id} {...modelCard} isCustom />
           </Flexbox>
-          <Typography.Text ellipsis style={{ fontSize: 12, marginTop: '4px' }} type={'secondary'}>
+          <Text ellipsis style={{ fontSize: 12, marginTop: '4px' }} type={'secondary'}>
             {id}
             {!!modelCard?.deploymentName && (
               <>
@@ -56,7 +56,7 @@ const CustomModelOption = memo<CustomModelOptionProps>(({ id, provider }) => {
                 {modelCard?.deploymentName}
               </>
             )}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       </Flexbox>
 

--- a/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/ModelFetcher.tsx
+++ b/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/ModelFetcher.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon, Icon, Tooltip } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import isEqual from 'fast-deep-equal';
@@ -61,7 +60,7 @@ const ModelFetcher = memo<ModelFetcherProps>(({ provider }) => {
   const { mutate, isValidating } = useFetchProviderModelList(provider, enabledAutoFetch);
 
   return (
-    <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+    <Text style={{ fontSize: 12 }} type={'secondary'}>
       <Flexbox align={'center'} gap={0} horizontal justify={'space-between'}>
         <div style={{ display: 'flex', lineHeight: '24px' }}>
           {t('llm.modelList.total', { count: totalModels })}
@@ -100,7 +99,7 @@ const ModelFetcher = memo<ModelFetcherProps>(({ provider }) => {
           </Flexbox>
         </Tooltip>
       </Flexbox>
-    </Typography.Text>
+    </Text>
   );
 });
 export default ModelFetcher;

--- a/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/Option.tsx
+++ b/src/app/[variants]/(main)/settings/llm/components/ProviderModelList/Option.tsx
@@ -1,6 +1,5 @@
 import { ModelIcon } from '@lobehub/icons';
-import { ActionIcon, Tooltip } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text, Tooltip } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { Recycle } from 'lucide-react';
@@ -47,9 +46,9 @@ const OptionRender = memo<OptionRenderProps>(({ displayName, id, provider, isAzu
             {displayName}
             <ModelInfoTags directionReverse placement={'top'} {...model!} />
           </Flexbox>
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {id}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       </Flexbox>
       {removed && (

--- a/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
+++ b/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
@@ -1,6 +1,6 @@
 import { ProviderCombine, ProviderIcon } from '@lobehub/icons';
-import { Avatar } from '@lobehub/ui';
-import { Divider, Skeleton, Typography } from 'antd';
+import { Avatar, Text } from '@lobehub/ui';
+import { Divider, Skeleton } from 'antd';
 import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,8 +10,6 @@ import { AiProviderListItem } from '@/types/aiProvider';
 
 import EnableSwitch from './EnableSwitch';
 import { useStyles } from './style';
-
-const { Paragraph } = Typography;
 
 interface ProviderCardProps extends AiProviderListItem {
   loading?: boolean;
@@ -57,23 +55,18 @@ const ProviderCard = memo<ProviderCardProps>(
                         type={'avatar'}
                       />
                     )}
-                    <Typography.Text style={{ fontSize: 16, fontWeight: 'bold' }}>
-                      {name || id}
-                    </Typography.Text>
+                    <Text style={{ fontSize: 16, fontWeight: 'bold' }}>{name || id}</Text>
                   </Flexbox>
                 )}
               </Flexbox>
-              <Paragraph
+              <Text
                 className={styles.desc}
                 ellipsis={{
                   rows: 2,
-                  tooltip: {
-                    arrow: false,
-                  },
                 }}
               >
                 {source === 'custom' ? description : t(`${id}.description`)}
-              </Paragraph>
+              </Text>
             </Flexbox>
           </Link>
           <Divider style={{ margin: '4px 0' }} />

--- a/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Grid, Tag } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Grid, Tag, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,9 +24,9 @@ const List = memo(() => {
     return (
       <Flexbox gap={24} paddingBlock={'0 16px'}>
         <Flexbox align={'center'} gap={4} horizontal>
-          <Typography.Text style={{ fontSize: 16, fontWeight: 'bold' }}>
+          <Text strong style={{ fontSize: 16 }}>
             {t('list.title.enabled')}
-          </Typography.Text>
+          </Text>
         </Flexbox>
         <Grid gap={16} rows={3}>
           {loadingArr.map((item) => (
@@ -41,9 +40,9 @@ const List = memo(() => {
     <>
       <Flexbox gap={24}>
         <Flexbox align={'center'} gap={8} horizontal>
-          <Typography.Text style={{ fontSize: 18, fontWeight: 'bold' }}>
+          <Text strong style={{ fontSize: 18 }}>
             {t('list.title.enabled')}
-          </Typography.Text>
+          </Text>
           <Tag>{enabledList.length}</Tag>
         </Flexbox>
         <Grid gap={16} rows={3}>
@@ -54,9 +53,9 @@ const List = memo(() => {
       </Flexbox>
       <Flexbox gap={24}>
         <Flexbox align={'center'} gap={8} horizontal>
-          <Typography.Text style={{ fontSize: 18, fontWeight: 'bold' }}>
+          <Text strong style={{ fontSize: 18 }}>
             {t('list.title.disabled')}
-          </Typography.Text>
+          </Text>
           <Tag>{disabledList.length}</Tag>
         </Flexbox>
         <Grid gap={16} rows={3}>

--- a/src/app/[variants]/(main)/settings/provider/ProviderMenu/List.tsx
+++ b/src/app/[variants]/(main)/settings/provider/ProviderMenu/List.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { ActionIcon, ScrollShadow } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, ScrollShadow, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { ArrowDownUpIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -39,9 +38,9 @@ const ProviderList = () => {
         justify={'space-between'}
         style={{ fontSize: 12, marginTop: 8 }}
       >
-        <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+        <Text style={{ fontSize: 12 }} type={'secondary'}>
           {t('menu.list.enabled')}
-        </Typography.Text>
+        </Text>
         <ActionIcon
           icon={ArrowDownUpIcon}
           onClick={() => {
@@ -63,9 +62,9 @@ const ProviderList = () => {
       {enabledModelProviderList.map((item) => (
         <ProviderItem {...item} key={item.id} />
       ))}
-      <Typography.Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
+      <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
         {t('menu.list.disabled')}
-      </Typography.Text>
+      </Text>
       {disabledModelProviderList.map((item) => (
         <ProviderItem {...item} key={item.id} />
       ))}

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/DisabledModels.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/DisabledModels.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Button, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { ChevronDown } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -22,9 +21,9 @@ const DisabledModels = memo(() => {
   return (
     disabledModels.length > 0 && (
       <Flexbox>
-        <Typography.Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
+        <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
           {t('providerModels.list.disabled')}
-        </Typography.Text>
+        </Text>
         {displayModels.map((item) => (
           <ModelItem {...item} key={item.id} />
         ))}

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/EnabledModelList/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/EnabledModelList/index.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { ArrowDownUpIcon, ToggleLeft } from 'lucide-react';
 import { useState } from 'react';
@@ -24,9 +23,9 @@ const EnabledModelList = () => {
   return (
     <>
       <Flexbox horizontal justify={'space-between'}>
-        <Typography.Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
+        <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
           {t('providerModels.list.enabled')}
-        </Typography.Text>
+        </Text>
         {!isEmpty && (
           <Flexbox horizontal>
             <ActionIcon
@@ -66,9 +65,9 @@ const EnabledModelList = () => {
       </Flexbox>
       {isEmpty ? (
         <Center padding={12}>
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {t('providerModels.list.enabledEmpty')}
-          </Typography.Text>
+          </Text>
         </Center>
       ) : (
         <Flexbox gap={2}>

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -1,6 +1,6 @@
 import { ModelIcon } from '@lobehub/icons';
-import { ActionIcon, Tag, copyToClipboard } from '@lobehub/ui';
-import { App, Switch, Typography } from 'antd';
+import { ActionIcon, Tag, Text, copyToClipboard } from '@lobehub/ui';
+import { App, Switch } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { LucidePencil, TrashIcon } from 'lucide-react';
 import { memo, use, useState } from 'react';
@@ -297,11 +297,9 @@ const ModelItem = memo<ModelItemProps>(
             </Flexbox>
             <Flexbox align={'baseline'} gap={8} horizontal>
               {content.length > 0 && (
-                <Typography.Text
-                  style={{ color: theme.colorTextSecondary, fontSize: 12, marginBottom: 0 }}
-                >
+                <Text style={{ color: theme.colorTextSecondary, fontSize: 12, marginBottom: 0 }}>
                   {content.join(' · ')}
-                </Typography.Text>
+                </Text>
               )}
             </Flexbox>
           </Flexbox>

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Button, Dropdown } from '@lobehub/ui';
-import { App, Skeleton, Space, Typography } from 'antd';
+import { ActionIcon, Button, Dropdown, Text } from '@lobehub/ui';
+import { App, Skeleton, Space } from 'antd';
 import { useTheme } from 'antd-style';
 import { CircleX, EllipsisVertical, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -65,14 +65,14 @@ const ModelTitle = memo<ModelFetcherProps>(
       >
         <Flexbox align={'center'} gap={0} horizontal justify={'space-between'}>
           <Flexbox align={'center'} gap={8} horizontal>
-            <Typography.Text style={{ fontSize: 16, fontWeight: 'bold' }}>
+            <Text strong style={{ fontSize: 16 }}>
               {t('providerModels.list.title')}
-            </Typography.Text>
+            </Text>
 
             {isLoading ? (
               <Skeleton.Button active style={{ height: 22 }} />
             ) : (
-              <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+              <Text style={{ fontSize: 12 }} type={'secondary'}>
                 <div style={{ display: 'flex', lineHeight: '24px' }}>
                   {t('providerModels.list.total', { count: totalModels })}
                   {hasRemoteModels && (
@@ -89,7 +89,7 @@ const ModelTitle = memo<ModelFetcherProps>(
                     />
                   )}
                 </div>
-              </Typography.Text>
+              </Text>
             )}
           </Flexbox>
           {isLoading ? (

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { ActionIcon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { ToggleRightIcon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -26,9 +25,9 @@ const SearchResult = memo(() => {
   return (
     <>
       <Flexbox horizontal justify={'space-between'}>
-        <Typography.Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
+        <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
           {t('providerModels.list.searchResult', { count: filteredModels.length })}
-        </Typography.Text>
+        </Text>
         {!isEmpty && (
           <Flexbox horizontal>
             <ActionIcon

--- a/src/app/[variants]/(main)/settings/sync/features/DeviceInfo/DeviceName.tsx
+++ b/src/app/[variants]/(main)/settings/sync/features/DeviceInfo/DeviceName.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { EditableText } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { EditableText, Text } from '@lobehub/ui';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -39,7 +38,7 @@ const DeviceName = memo(() => {
           }}
           style={{ cursor: 'pointer' }}
         >
-          <Typography.Text type={'secondary'}>{t('sync.device.deviceName.hint')}</Typography.Text>
+          <Text type={'secondary'}>{t('sync.device.deviceName.hint')}</Text>
         </Flexbox>
       )}
       <EditableText

--- a/src/app/[variants]/(main)/settings/sync/features/DeviceInfo/index.tsx
+++ b/src/app/[variants]/(main)/settings/sync/features/DeviceInfo/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { rgba } from 'polished';
 import { memo } from 'react';
@@ -65,9 +65,9 @@ const DeviceCard = memo<DeviceCardProps>(({ browser, os }) => {
       <Flexbox className={styles.container} padding={4}>
         <Flexbox horizontal paddingBlock={8} paddingInline={12}>
           <div>
-            <Typography style={{ fontSize: 18, fontWeight: 'bold' }}>
+            <Text strong style={{ fontSize: 18 }}>
               {t('sync.device.title')}
-            </Typography>
+            </Text>
           </div>
         </Flexbox>
         <Flexbox

--- a/src/app/[variants]/(main)/settings/sync/features/WebRTC/index.tsx
+++ b/src/app/[variants]/(main)/settings/sync/features/WebRTC/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { SiWebrtc } from '@icons-pack/react-simple-icons';
-import { Form, type FormGroupItemType, Input, InputPassword, Tooltip } from '@lobehub/ui';
-import { Form as AntForm, Switch, Typography } from 'antd';
+import { Form, type FormGroupItemType, Input, InputPassword, Text, Tooltip } from '@lobehub/ui';
+import { Form as AntForm, Switch } from 'antd';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -80,9 +80,9 @@ const WebRTC = memo(() => {
           <SiWebrtc style={{ flex: 'none' }} />
           {t('sync.webrtc.title')}
         </Flexbox>
-        <Typography.Text style={{ fontWeight: 'normal' }} type={'secondary'}>
+        <Text style={{ fontWeight: 'normal' }} type={'secondary'}>
           {t('sync.webrtc.desc')}
-        </Typography.Text>
+        </Text>
       </Flexbox>
     ),
   };

--- a/src/app/[variants]/oauth/consent/[uid]/ClientError.tsx
+++ b/src/app/[variants]/oauth/consent/[uid]/ClientError.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import React, { memo } from 'react';
 import { Center } from 'react-layout-kit';
@@ -11,8 +11,6 @@ interface ClientProps {
     title: string;
   };
 }
-
-const { Title, Paragraph } = Typography;
 
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
@@ -32,10 +30,10 @@ const ConsentClientError = memo<ClientProps>(({ error }) => {
   return (
     <Center className={styles.container}>
       <div className={styles.error}>
-        <Title level={2} style={{ color: 'inherit' }}>
+        <Text as={'h2'} style={{ color: 'inherit' }}>
           {error.title}
-        </Title>
-        <Paragraph style={{ color: 'inherit' }}>{error.message}</Paragraph>
+        </Text>
+        <Text style={{ color: 'inherit' }}>{error.message}</Text>
       </div>
     </Center>
   );

--- a/src/app/[variants]/oauth/consent/[uid]/Consent.tsx
+++ b/src/app/[variants]/oauth/consent/[uid]/Consent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button } from '@lobehub/ui';
-import { Card, Divider, Typography } from 'antd';
+import { Button, Text } from '@lobehub/ui';
+import { Card, Divider } from 'antd';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,8 +21,6 @@ interface ClientProps {
   scopes: string[];
   uid: string;
 }
-
-const { Title, Text, Paragraph } = Typography;
 
 const useStyles = createStyles(({ css, token }) => ({
   authButton: css`
@@ -106,6 +104,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   title: css`
     margin-block-end: ${token.marginLG}px;
+    font-size: 24px;
     color: ${token.colorTextBase};
     text-align: center;
   `,
@@ -132,17 +131,17 @@ const ConsentClient = memo<ClientProps>(
             isFirstParty={clientMetadata.isFirstParty}
             logoUrl={clientMetadata.logo}
           />
-          <Title className={styles.title} level={3}>
+          <Text as={'h3'} className={styles.title}>
             {t('consent.title', { clientName: clientDisplayName })}
-          </Title>
+          </Text>
         </Flexbox>
         <Card className={styles.card}>
           <Flexbox gap={8}>
             <Flexbox gap={12}>
-              <Paragraph>{t('consent.description', { clientName: clientDisplayName })}</Paragraph>
+              <Text>{t('consent.description', { clientName: clientDisplayName })}</Text>
 
               <div className={styles.scopes}>
-                <Paragraph type={'secondary'}>{t('consent.permissionsTitle')}</Paragraph>
+                <Text type={'secondary'}>{t('consent.permissionsTitle')}</Text>
                 {scopes.map((scope) => (
                   <div className={styles.scope} key={scope}>
                     <Text>{getScopeDescription(scope, t)}</Text>

--- a/src/app/[variants]/oauth/consent/[uid]/Login.tsx
+++ b/src/app/[variants]/oauth/consent/[uid]/Login.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Avatar, Button } from '@lobehub/ui';
-import { Card, Skeleton, Typography } from 'antd';
+import { Avatar, Button, Text } from '@lobehub/ui';
+import { Card, Skeleton } from 'antd';
 import { createStyles } from 'antd-style';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,8 +20,6 @@ interface LoginConfirmProps {
   };
   uid: string;
 }
-
-const { Title } = Typography;
 
 const useStyles = createStyles(({ css, token }) => ({
   authButton: css`
@@ -75,9 +73,9 @@ const LoginConfirmClient = memo<LoginConfirmProps>(({ uid, clientMetadata }) => 
           logoUrl={clientMetadata.logo}
         />
       </Flexbox>
-      <Title className={styles.title} level={3}>
+      <Text as={'h3'} className={styles.title}>
         {titleText}
-      </Title>
+      </Text>
 
       <Card className={styles.card}>
         <Flexbox gap={64}>

--- a/src/app/[variants]/oauth/handoff/Client.tsx
+++ b/src/app/[variants]/oauth/handoff/Client.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { Spin, Typography } from 'antd';
+import { Text } from '@lobehub/ui';
+import { Spin } from 'antd';
 import { createStyles } from 'antd-style';
 import { useSearchParams } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
-
-const { Title, Paragraph } = Typography;
 
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
@@ -30,6 +29,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   title: css`
     margin-block-end: ${token.marginLG}px;
+    font-size: 24px;
   `,
 }));
 
@@ -86,10 +86,10 @@ const AuthHandoffPage = () => {
     <Center className={styles.container} gap={12}>
       {!isError && <Spin size="large" />}
       <Flexbox align="center" className={styles.content} gap={16}>
-        <Title className={styles.title} level={3}>
+        <Text as={'h3'} className={styles.title}>
           {status.title}
-        </Title>
-        <Paragraph className={styles.message}>{status.desc}</Paragraph>
+        </Text>
+        <Text className={styles.message}>{status.desc}</Text>
       </Flexbox>
     </Center>
   );

--- a/src/components/InitProgress/index.tsx
+++ b/src/components/InitProgress/index.tsx
@@ -1,5 +1,5 @@
-import { Icon } from '@lobehub/ui';
-import { Progress, Typography } from 'antd';
+import { Icon, Text } from '@lobehub/ui';
+import { Progress } from 'antd';
 import { useTheme } from 'antd-style';
 import { Loader2 } from 'lucide-react';
 import { ReactNode, memo } from 'react';
@@ -33,7 +33,7 @@ const InitProgress = memo<InitingProps>(({ activeStage, stages }) => {
       />
       <Flexbox align={'center'} gap={4} horizontal>
         {stage?.icon ? stage?.icon : <Icon icon={Loader2} spin />}
-        <Typography.Text type={'secondary'}>{stage?.text}</Typography.Text>
+        <Text type={'secondary'}>{stage?.text}</Text>
       </Flexbox>
     </Center>
   );

--- a/src/components/Loading/CircleLoading/index.tsx
+++ b/src/components/Loading/CircleLoading/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Icon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Icon, Text } from '@lobehub/ui';
 import { LoaderCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
@@ -14,9 +13,9 @@ export default () => {
         <div>
           <Icon icon={LoaderCircle} size={'large'} spin />
         </div>
-        <Typography.Text style={{ letterSpacing: '0.1em' }} type={'secondary'}>
+        <Text style={{ letterSpacing: '0.1em' }} type={'secondary'}>
           {t('loading')}
-        </Typography.Text>
+        </Text>
       </Flexbox>
     </Center>
   );

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -1,6 +1,5 @@
 import { IconAvatarProps, ModelIcon, ProviderIcon } from '@lobehub/icons';
-import { Avatar, Icon, Tag, Tooltip } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Avatar, Icon, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStyles, useResponsive } from 'antd-style';
 import {
   Infinity,
@@ -188,11 +187,9 @@ export const ModelItemRender = memo<ModelItemRenderProps>(({ showInfoTag = true,
         style={{ flexShrink: 1, minWidth: 0, overflow: 'hidden' }}
       >
         <ModelIcon model={model.id} size={20} />
-        <Typography.Text
-          style={mobile ? { maxWidth: '60vw', overflowX: 'auto', whiteSpace: 'nowrap' } : {}}
-        >
+        <Text style={mobile ? { maxWidth: '60vw', overflowX: 'auto', whiteSpace: 'nowrap' } : {}}>
           {model.displayName || model.id}
-        </Typography.Text>
+        </Text>
       </Flexbox>
       {showInfoTag && <ModelInfoTags {...model} />}
     </Flexbox>

--- a/src/components/StatisticCard/TitleWithPercentage.tsx
+++ b/src/components/StatisticCard/TitleWithPercentage.tsx
@@ -1,12 +1,9 @@
-import { Tag } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Tag, Text } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import { CSSProperties, memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { calcGrowthPercentage } from './growthPercentage';
-
-const { Title } = Typography;
 
 interface TitleWithPercentageProps {
   count?: number;
@@ -43,9 +40,9 @@ const TitleWithPercentage = memo<TitleWithPercentageProps>(
           position: 'inherit',
         }}
       >
-        <Title
+        <Text
+          as={'h2'}
           ellipsis={{ rows: 1, tooltip: title }}
-          level={2}
           style={{
             fontSize: 'inherit',
             fontWeight: 'inherit',
@@ -55,7 +52,7 @@ const TitleWithPercentage = memo<TitleWithPercentageProps>(
           }}
         >
           {title}
-        </Title>
+        </Text>
         {count && prvCount && percentage && percentage !== 0 ? (
           <Tag
             style={{

--- a/src/components/StatisticCard/index.tsx
+++ b/src/components/StatisticCard/index.tsx
@@ -2,12 +2,11 @@ import {
   StatisticCard as AntdStatisticCard,
   StatisticCardProps as AntdStatisticCardProps,
 } from '@ant-design/pro-components';
-import { Spin, Typography } from 'antd';
+import { Text } from '@lobehub/ui';
+import { Spin } from 'antd';
 import { createStyles, useResponsive } from 'antd-style';
 import { adjustHue } from 'polished';
 import { memo } from 'react';
-
-const { Title } = Typography;
 
 const useStyles = createStyles(
   ({ isDarkMode, css, token, prefixCls, responsive }, highlight: string = '#000') => ({
@@ -182,9 +181,9 @@ const StatisticCard = memo<StatisticCardProps>(
         extra={loading ? <Spin percent={'auto'} size={'small'} /> : extra}
         title={
           typeof title === 'string' ? (
-            <Title
-              ellipsis={{ rows: 1, tooltip: title }}
-              level={2}
+            <Text
+              as={'h2'}
+              ellipsis={{ rows: 1, tooltip: true }}
               style={{
                 fontSize: 'inherit',
                 fontWeight: 'inherit',
@@ -194,7 +193,7 @@ const StatisticCard = memo<StatisticCardProps>(
               }}
             >
               {title}
-            </Title>
+            </Text>
           ) : (
             title
           )

--- a/src/features/AgentSetting/AgentPlugin/index.tsx
+++ b/src/features/AgentSetting/AgentPlugin/index.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { Avatar, Button, Form, type FormGroupItemType, Tag, Tooltip } from '@lobehub/ui';
-import { Empty, Space, Switch, Typography } from 'antd';
+import { Empty, Space, Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { LucideTrash2, Store } from 'lucide-react';
+import Link from 'next/link';
 import { memo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
@@ -130,7 +131,7 @@ const AgentPlugin = memo(() => {
         description={
           <Trans i18nKey={'plugin.empty'} ns={'setting'}>
             暂无安装插件，
-            <Typography.Link
+            <Link
               href={'/'}
               onClick={(e) => {
                 e.preventDefault();
@@ -138,7 +139,7 @@ const AgentPlugin = memo(() => {
               }}
             >
               前往插件市场
-            </Typography.Link>
+            </Link>
             安装
           </Trans>
         }

--- a/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
+++ b/src/features/ChatInput/Desktop/FilePreview/FileItem/index.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { Trash2Icon } from 'lucide-react';
 import { memo } from 'react';
@@ -64,9 +63,9 @@ const FileItem = memo<FileItemProps>((props) => {
         <Content {...props} />
       </Center>
       <Flexbox flex={1} gap={4} style={{ paddingBottom: 4, paddingInline: 4 }}>
-        <Typography.Text ellipsis={{ tooltip: true }} style={{ fontSize: 12, maxWidth: 100 }}>
+        <Text ellipsis={{ tooltip: true }} style={{ fontSize: 12, maxWidth: 100 }}>
           {file.name}
-        </Typography.Text>
+        </Text>
 
         <UploadDetail size={file.size} status={status} tasks={tasks} uploadState={uploadState} />
       </Flexbox>

--- a/src/features/ChatInput/components/UploadDetail/UploadStatus.tsx
+++ b/src/features/ChatInput/components/UploadDetail/UploadStatus.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleFilled } from '@ant-design/icons';
-import { Icon } from '@lobehub/ui';
-import { Progress, Typography } from 'antd';
+import { Icon, Text } from '@lobehub/ui';
+import { Progress } from 'antd';
 import { useTheme } from 'antd-style';
 import { Loader2Icon } from 'lucide-react';
 import { memo } from 'react';
@@ -26,9 +26,9 @@ const UploadStatus = memo<UploadStateProps>(({ status, size, uploadState }) => {
       return (
         <Flexbox align={'center'} gap={4} horizontal>
           <Icon icon={Loader2Icon} size={12} spin />
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {t('upload.preview.status.pending')}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       );
     }
@@ -37,9 +37,9 @@ const UploadStatus = memo<UploadStateProps>(({ status, size, uploadState }) => {
       return (
         <Flexbox align={'center'} gap={4} horizontal>
           <Progress percent={uploadState?.progress} size={14} type="circle" />
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size * ((uploadState?.progress || 0) / 100), 0)} / {formatSize(size)}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       );
     }
@@ -48,9 +48,9 @@ const UploadStatus = memo<UploadStateProps>(({ status, size, uploadState }) => {
       return (
         <Flexbox align={'center'} gap={4} horizontal>
           <Progress percent={uploadState?.progress} size={14} type="circle" />
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size)}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       );
     }
@@ -59,9 +59,9 @@ const UploadStatus = memo<UploadStateProps>(({ status, size, uploadState }) => {
       return (
         <Flexbox align={'center'} gap={4} horizontal>
           <CheckCircleFilled style={{ color: theme.colorSuccess, fontSize: 12 }} />
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size)}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       );
     }

--- a/src/features/ChatInput/components/UploadDetail/index.tsx
+++ b/src/features/ChatInput/components/UploadDetail/index.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -34,9 +34,9 @@ const UploadDetail = memo<UploadDetailProps>(({ uploadState, status, size, tasks
     <Flexbox align={'center'} gap={8} height={22} horizontal>
       <UploadStatus size={size} status={status} uploadState={uploadState} />
       {!!tasks && Object.keys(tasks).length === 0 ? (
-        <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+        <Text style={{ fontSize: 12 }} type={'secondary'}>
           {t('upload.preview.prepareTasks')}
-        </Typography.Text>
+        </Text>
       ) : (
         <div>
           <FileParsingStatus {...tasks} className={styles.status} hideEmbeddingButton />

--- a/src/features/Conversation/Messages/Assistant/FileChunks/Item/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/FileChunks/Item/index.tsx
@@ -1,5 +1,4 @@
-import { Tooltip } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Text, Tooltip } from '@lobehub/ui';
 import { memo } from 'react';
 import { Center, Flexbox } from 'react-layout-kit';
 
@@ -33,7 +32,7 @@ const ChunkItem = memo<ChunkItemProps>(({ id, fileId, similarity, text, filename
     >
       <FileIcon fileName={filename} fileType={fileType} size={20} variant={'raw'} />
       <Flexbox gap={12} horizontal justify={'space-between'} style={{ maxWidth: 200 }}>
-        <Typography.Text ellipsis={{ tooltip: false }}>{filename}</Typography.Text>
+        <Text ellipsis>{filename}</Text>
         {/*<Typography.Text*/}
         {/*  ellipsis={{ suffix: '...' }}*/}
         {/*  style={{ fontSize: 12, lineHeight: 1 }}*/}

--- a/src/features/Conversation/Messages/User/BelowMessage.tsx
+++ b/src/features/Conversation/Messages/User/BelowMessage.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { RotateCwIcon, Trash2 } from 'lucide-react';
@@ -50,9 +49,9 @@ export const UserBelowMessage = memo<ChatMessage>(({ ragQuery, content, id }) =>
     !isEqual(ragQuery, content) && (
       <Flexbox className={styles.container}>
         <Flexbox align={'center'} className={styles.content} gap={4} horizontal>
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {ragQuery}
-          </Typography.Text>
+          </Text>
         </Flexbox>
         <Flexbox className={styles.action} horizontal>
           <ActionIcon

--- a/src/features/Conversation/Messages/User/FileListViewer/Item.tsx
+++ b/src/features/Conversation/Messages/User/FileListViewer/Item.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
@@ -43,8 +43,8 @@ const FileItem = memo<ChatFileItem>(({ id, fileType, size, name }) => {
     >
       <FileIcon fileName={name} fileType={fileType} />
       <Flexbox style={{ overflow: 'hidden' }}>
-        <Typography.Text ellipsis>{name}</Typography.Text>
-        <Typography.Text type={'secondary'}>{formatSize(size)}</Typography.Text>
+        <Text ellipsis>{name}</Text>
+        <Text type={'secondary'}>{formatSize(size)}</Text>
       </Flexbox>
     </Flexbox>
   );

--- a/src/features/Conversation/components/History/index.tsx
+++ b/src/features/Conversation/components/History/index.tsx
@@ -1,6 +1,5 @@
 import { ModelTag } from '@lobehub/icons';
-import { Icon, Markdown } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Icon, Markdown, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { ScrollText } from 'lucide-react';
 import { memo } from 'react';
@@ -50,7 +49,7 @@ const History = memo(() => {
             <Center height={20} width={20}>
               <Icon icon={ScrollText} size={16} style={{ color: theme.colorTextDescription }} />
             </Center>
-            <Typography.Text type={'secondary'}>{t('historySummary')}</Typography.Text>
+            <Text type={'secondary'}>{t('historySummary')}</Text>
             {model && (
               <div>
                 <ModelTag model={model} />

--- a/src/features/DataImporter/ImportDetail.tsx
+++ b/src/features/DataImporter/ImportDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, Modal } from '@lobehub/ui';
-import { Table, Typography } from 'antd';
+import { Button, Modal, Text } from '@lobehub/ui';
+import { Table } from 'antd';
 import { createStyles } from 'antd-style';
 import { Info } from 'lucide-react';
 import { useState } from 'react';
@@ -9,8 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { ImportPgDataStructure } from '@/types/export';
-
-const { Text } = Typography;
 
 const getNonEmptyTables = (data: ImportPgDataStructure) => {
   const result = [];

--- a/src/features/ElectronTitlebar/Connection/Waiting.tsx
+++ b/src/features/ElectronTitlebar/Connection/Waiting.tsx
@@ -1,16 +1,13 @@
 'use client';
 
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { Button, Icon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Button, Icon, Text } from '@lobehub/ui';
 import { createStyles, cx, keyframes } from 'antd-style';
 import { WifiIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useElectronStore } from '@/store/electron';
-
-const { Text, Title } = Typography;
 
 const airdropPulse = keyframes`
     0% {
@@ -189,9 +186,9 @@ const WaitingOAuth = memo<WaitingOAuthProps>(({ setWaiting, setIsOpen }) => {
 
           <Icon className={styles.radarIcon} icon={WifiIcon} size={40} />
         </div>
-        <Title className={styles.title} level={4}>
+        <Text as={'h4'} className={styles.title}>
           {t('waitingOAuth.title')}
-        </Title>
+        </Text>
         <Text className={styles.description}>{t('waitingOAuth.description')}</Text>
         <Button onClick={handleCancel}>{t('waitingOAuth.cancel')}</Button>{' '}
         <Text className={styles.helpText}>{t('waitingOAuth.helpText')}</Text>

--- a/src/features/FileManager/FileList/EmptyStatus.tsx
+++ b/src/features/FileManager/FileList/EmptyStatus.tsx
@@ -1,5 +1,5 @@
-import { FileTypeIcon, Icon } from '@lobehub/ui';
-import { Typography, Upload } from 'antd';
+import { FileTypeIcon, Icon, Text } from '@lobehub/ui';
+import { Upload } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import { ArrowUpIcon, PlusIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -76,8 +76,8 @@ const EmptyStatus = ({ showKnowledgeBase, knowledgeBaseId }: EmptyStatusProps) =
   return (
     <Center gap={24} height={'100%'} style={{ paddingBottom: 100 }} width={'100%'}>
       <Flexbox justify={'center'} style={{ textAlign: 'center' }}>
-        <Typography.Title level={4}>{t('FileManager.emptyStatus.title')}</Typography.Title>
-        <Typography.Text type={'secondary'}>{t('FileManager.emptyStatus.or')}</Typography.Text>
+        <Text as={'h4'}>{t('FileManager.emptyStatus.title')}</Text>
+        <Text type={'secondary'}>{t('FileManager.emptyStatus.or')}</Text>
       </Flexbox>
       <Flexbox gap={12} horizontal>
         {showKnowledgeBase && (

--- a/src/features/FileManager/FileList/index.tsx
+++ b/src/features/FileManager/FileList/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { useQueryState } from 'nuqs';
 import { rgba } from 'polished';
@@ -109,9 +109,9 @@ const FileList = memo<FileListProps>(({ knowledgeBaseId, category }) => {
           components={{
             Footer: () => (
               <Center style={{ height: 64 }}>
-                <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+                <Text style={{ fontSize: 12 }} type={'secondary'}>
                   {t('FileManager.bottom')}
-                </Typography.Text>
+                </Text>
               </Center>
             ),
           }}

--- a/src/features/FileManager/UploadDock/Item.tsx
+++ b/src/features/FileManager/UploadDock/Item.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { ReactNode, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,41 +52,41 @@ const UploadItem = memo<UploadItemProps>(({ file, status, uploadState }) => {
         ].filter(Boolean);
 
         return (
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {uploadState?.progress ? formatSize(size * (uploadState.progress / 100)) : '-'}/
             {formatSize(size)}
             {textArray.length === 0 ? '' : ' · ' + textArray.join(' · ')}
-          </Typography.Text>
+          </Text>
         );
       }
       case 'pending': {
         return (
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size)} · {t('uploadDock.body.item.pending')}
-          </Typography.Text>
+          </Text>
         );
       }
 
       case 'processing': {
         return (
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size)} · {t('uploadDock.body.item.processing')}
-          </Typography.Text>
+          </Text>
         );
       }
 
       case 'success': {
         return (
-          <Typography.Text style={{ fontSize: 12 }} type={'secondary'}>
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
             {formatSize(size)} · {t('uploadDock.body.item.done')}
-          </Typography.Text>
+          </Text>
         );
       }
       case 'error': {
         return (
-          <Typography.Text style={{ fontSize: 12 }} type={'danger'}>
+          <Text style={{ fontSize: 12 }} type={'danger'}>
             {formatSize(size)} · {t('uploadDock.body.item.error')}
-          </Typography.Text>
+          </Text>
         );
       }
       default: {

--- a/src/features/FileManager/UploadDock/index.tsx
+++ b/src/features/FileManager/UploadDock/index.tsx
@@ -1,6 +1,5 @@
 import { CheckCircleFilled, CloseCircleFilled } from '@ant-design/icons';
-import { ActionIcon, Icon } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Icon, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { UploadIcon, XIcon } from 'lucide-react';
@@ -149,7 +148,7 @@ const UploadDock = memo(() => {
             ))}
           </Flexbox>
           <Center style={{ height: 40, minHeight: 40 }}>
-            <Typography.Text
+            <Text
               onClick={() => {
                 setExpand(false);
               }}
@@ -157,7 +156,7 @@ const UploadDock = memo(() => {
               type={'secondary'}
             >
               {t('uploadDock.body.collapse')}
-            </Typography.Text>
+            </Text>
           </Center>
         </Flexbox>
       ) : (

--- a/src/features/FileManager/index.tsx
+++ b/src/features/FileManager/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import dynamic from 'next/dynamic';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
@@ -21,11 +21,9 @@ const FileManager = memo<FileManagerProps>(({ title, knowledgeBaseId, category }
     <>
       <Header knowledgeBaseId={knowledgeBaseId} />
       <Flexbox gap={12} height={'100%'}>
-        <Typography.Text
-          style={{ fontSize: 16, fontWeight: 'bold', marginBlock: 16, marginInline: 24 }}
-        >
+        <Text strong style={{ fontSize: 16, marginBlock: 16, marginInline: 24 }}>
           {title}
-        </Typography.Text>
+        </Text>
         <FileList category={category} knowledgeBaseId={knowledgeBaseId} />
       </Flexbox>
       <UploadDock />

--- a/src/tools/local-system/Render/ReadLocalFile/ReadFileView.tsx
+++ b/src/tools/local-system/Render/ReadLocalFile/ReadFileView.tsx
@@ -1,6 +1,5 @@
 import { LocalReadFileResult } from '@lobechat/electron-client-ipc';
-import { ActionIcon, Icon, Markdown } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { ActionIcon, Icon, Markdown, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { AlignLeft, Asterisk, ChevronDownIcon, ExternalLink, FolderOpen } from 'lucide-react';
 import React, { memo, useState } from 'react';
@@ -118,9 +117,9 @@ const ReadFileView = memo<ReadFileViewProps>(
           <Flexbox align={'center'} flex={1} gap={0} horizontal style={{ overflow: 'hidden' }}>
             <FileIcon fileName={filename} fileType={fileType} size={24} variant={'raw'} />
             <Flexbox horizontal>
-              <Typography.Text className={styles.fileName} ellipsis>
+              <Text className={styles.fileName} ellipsis>
                 {filename}
-              </Typography.Text>
+              </Text>
               {/* Actions on Hover */}
               <Flexbox className={styles.actions} gap={2} horizontal style={{ marginLeft: 8 }}>
                 <ActionIcon
@@ -174,9 +173,9 @@ const ReadFileView = memo<ReadFileViewProps>(
         </Flexbox>
 
         {/* Path */}
-        <Typography.Text className={styles.path} ellipsis type={'secondary'}>
+        <Text className={styles.path} ellipsis type={'secondary'}>
           {path}
-        </Typography.Text>
+        </Text>
 
         {isExpanded && (
           <Flexbox className={styles.previewBox} style={{ maxHeight: 240, overflow: 'auto' }}>

--- a/src/tools/web-browsing/Portal/PageContent/index.tsx
+++ b/src/tools/web-browsing/Portal/PageContent/index.tsx
@@ -1,5 +1,5 @@
-import { Alert, CopyButton, Highlighter, Icon, Markdown, Segmented } from '@lobehub/ui';
-import { Descriptions, Typography } from 'antd';
+import { Alert, CopyButton, Highlighter, Icon, Markdown, Segmented, Text } from '@lobehub/ui';
+import { Descriptions } from 'antd';
 import { createStyles } from 'antd-style';
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
@@ -148,12 +148,9 @@ const PageContent = memo<PageContentProps>(({ result }) => {
           </Flexbox>
         </Flexbox>
         {description && (
-          <Typography.Paragraph
-            className={styles.description}
-            ellipsis={{ expandable: false, rows: 4 }}
-          >
+          <Text className={styles.description} ellipsis={{ rows: 4 }}>
             {description}
-          </Typography.Paragraph>
+          </Text>
         )}
         <Flexbox align={'center'} className={styles.url} gap={4} horizontal>
           {result.data.siteName && <div>{result.data.siteName} · </div>}

--- a/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/TitleExtra.tsx
+++ b/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/TitleExtra.tsx
@@ -1,5 +1,4 @@
-import { Tag, Tooltip } from '@lobehub/ui';
-import { Typography } from 'antd';
+import { Tag, Text, Tooltip } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -27,12 +26,12 @@ const TitleExtra = memo<TitleExtraProps>(({ category, score, highlight, engines 
             {score.toFixed(1)}
           </Tag>
         ) : (
-          <Typography.Text
+          <Text
             style={{ textAlign: 'center', width: 32, wordBreak: 'keep-all' }}
             type={'secondary'}
           >
             {score.toFixed(1)}
-          </Typography.Text>
+          </Text>
         )}
       </Tooltip>
       <CategoryAvatar category={category || 'general'} />

--- a/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/Video.tsx
+++ b/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/Video.tsx
@@ -1,4 +1,5 @@
-import { Avatar as AntAvatar, Typography } from 'antd';
+import { Text } from '@lobehub/ui';
+import { Avatar as AntAvatar } from 'antd';
 import { createStyles } from 'antd-style';
 import { memo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
@@ -122,9 +123,9 @@ const VideoItem = memo<SearchResultProps>(
                   score={score}
                 />
               </Flexbox>
-              <Typography.Text className={styles.url} type={'secondary'}>
+              <Text className={styles.url} type={'secondary'}>
                 {url}
-              </Typography.Text>
+              </Text>
               <Flexbox className={styles.desc}>{content}</Flexbox>
             </Flexbox>
           </Flexbox>

--- a/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/index.tsx
+++ b/src/tools/web-browsing/Portal/Search/ResultList/SearchItem/index.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
@@ -78,9 +78,9 @@ const SearchItem = memo<SearchResultProps>((props) => {
               score={score}
             />
           </Flexbox>
-          <Typography.Text className={styles.url} type={'secondary'}>
+          <Text className={styles.url} type={'secondary'}>
             {url}
-          </Typography.Text>
+          </Text>
           <Flexbox className={styles.desc}>{content}</Flexbox>
         </Flexbox>
       </Flexbox>

--- a/src/tools/web-browsing/Render/PageContent/Result.tsx
+++ b/src/tools/web-browsing/Render/PageContent/Result.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { CrawlErrorResult, CrawlSuccessResult } from '@lobechat/web-crawler';
-import { Alert, Highlighter, Icon } from '@lobehub/ui';
-import { Descriptions, Typography } from 'antd';
+import { Alert, Highlighter, Icon, Text } from '@lobehub/ui';
+import { Descriptions } from 'antd';
 import { createStyles } from 'antd-style';
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
@@ -12,8 +12,6 @@ import { Center, Flexbox } from 'react-layout-kit';
 
 import { useChatStore } from '@/store/chat';
 import { WebBrowsingManifest } from '@/tools/web-browsing';
-
-const { Paragraph } = Typography;
 
 const useStyles = createStyles(({ token, css }) => {
   return {
@@ -146,9 +144,9 @@ const CrawlerResultCard = memo<CrawlerData>(({ result, messageId, crawler, origi
             </Center>
           </Link>
         </Flexbox>
-        <Paragraph className={styles.description} ellipsis={{ expandable: false, rows: 2 }}>
+        <Text className={styles.description} ellipsis={{ rows: 2 }}>
           {description || result.content?.slice(0, 40)}
-        </Paragraph>
+        </Text>
       </Flexbox>
       <div className={styles.footer}>
         <Descriptions

--- a/src/tools/web-browsing/Render/Search/SearchResult/SearchResultItem.tsx
+++ b/src/tools/web-browsing/Render/Search/SearchResult/SearchResultItem.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import Link from 'next/link';
 import { memo } from 'react';
@@ -54,9 +54,9 @@ const SearchResultItem = memo<UniformSearchResult>(({ url, title }) => {
         <div className={styles.title}>{title}</div>
         <Flexbox align={'center'} gap={4} horizontal>
           <WebFavicon size={14} title={title} url={url} />
-          <Typography.Text className={styles.url} type={'secondary'}>
+          <Text className={styles.url} type={'secondary'}>
             {host.replace('www.', '')}
-          </Typography.Text>
+          </Text>
         </Flexbox>
       </Flexbox>
     </Link>

--- a/src/tools/web-browsing/components/SearchBar.tsx
+++ b/src/tools/web-browsing/components/SearchBar.tsx
@@ -1,5 +1,5 @@
-import { Button, Input, Select, Tooltip } from '@lobehub/ui';
-import { Checkbox, Radio, Space, Typography } from 'antd';
+import { Button, Input, Select, Text, Tooltip } from '@lobehub/ui';
+import { Checkbox, Radio, Space } from 'antd';
 import { SearchIcon } from 'lucide-react';
 import { ReactNode, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -115,9 +115,9 @@ const SearchBar = memo<SearchBarProps>(
           />
         ) : (
           <Flexbox align={'flex-start'} gap={8} horizontal>
-            <Typography.Text style={{ marginTop: 2, wordBreak: 'keep-all' }} type={'secondary'}>
+            <Text style={{ marginTop: 2, wordBreak: 'keep-all' }} type={'secondary'}>
               {t('search.searchEngine.title')}
-            </Typography.Text>
+            </Text>
             <Checkbox.Group
               onChange={(checkedValue) => {
                 setEngines(checkedValue);
@@ -164,9 +164,9 @@ const SearchBar = memo<SearchBarProps>(
           />
         ) : (
           <Flexbox align="flex-start" gap={8} horizontal>
-            <Typography.Text style={{ marginTop: 2, wordBreak: 'keep-all' }} type={'secondary'}>
+            <Text style={{ marginTop: 2, wordBreak: 'keep-all' }} type={'secondary'}>
               {t('search.searchCategory.title')}
-            </Typography.Text>
+            </Text>
             <Checkbox.Group
               onChange={(checkedValue) => setCategories(checkedValue)}
               options={Object.keys(CATEGORY_ICON_MAP).map((item) => ({
@@ -184,7 +184,7 @@ const SearchBar = memo<SearchBarProps>(
         )}
 
         <Flexbox align={'center'} gap={16} horizontal wrap={'wrap'}>
-          <Typography.Text type={'secondary'}>{t('search.searchTimeRange.title')}</Typography.Text>
+          <Text type={'secondary'}>{t('search.searchTimeRange.title')}</Text>
           <Radio.Group
             onChange={(e) => setTimeRange(e.target.value)}
             optionType="button"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Refactor typography usage to a unified Text component, update dependencies, and improve session search bar loading behavior

Enhancements:
- Replace Ant Design Typography elements (Title, Text, Paragraph, Link, etc.) with a unified Text component from @lobehub/ui across the codebase
- Modify SessionSearchBar to defer loading until user store is initialized and extract a dedicated onChange handler

Build:
- Upgrade @lobehub/ui to 2.5.6 and bump other libraries (react-hotkeys-hook, @lobehub/i18n-cli), add gray-matter and markdown-to-txt dependencies, and clean up obsolete package override entries