### PR TITLE
🐛 fix: Google Gemini tools declarations

### DIFF
--- a/src/libs/model-runtime/google/index.test.ts
+++ b/src/libs/model-runtime/google/index.test.ts
@@ -560,6 +560,58 @@ describe('LobeGoogleAI', () => {
           },
         ]);
       });
+
+      it('should correctly convert function response message', async () => {
+        const messages: OpenAIChatMessage[] = [
+          {
+            content: '',
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_1',
+                function: {
+                  name: 'get_current_weather',
+                  arguments: JSON.stringify({ location: 'London', unit: 'celsius' }),
+                },
+                type: 'function',
+              },
+            ],
+          },
+          {
+            content: '{"success":true,"data":{"temperature":"14°C"}}',
+            name: 'get_current_weather',
+            role: 'tool',
+            tool_call_id: 'call_1',
+          },
+        ];
+
+        const contents = await instance['buildGoogleMessages'](messages);
+        expect(contents).toHaveLength(2);
+        expect(contents).toEqual([
+          {
+            parts: [
+              {
+                functionCall: {
+                  args: { location: 'London', unit: 'celsius' },
+                  name: 'get_current_weather',
+                },
+              },
+            ],
+            role: 'model',
+          },
+          {
+            parts: [
+              {
+                functionResponse: {
+                  name: 'get_current_weather',
+                  response: { result: '{"success":true,"data":{"temperature":"14°C"}}' },
+                },
+              },
+            ],
+            role: 'user',
+          },
+        ]);
+      });
     });
 
     describe('buildGoogleTools', () => {

--- a/src/libs/model-runtime/google/index.test.ts
+++ b/src/libs/model-runtime/google/index.test.ts
@@ -742,7 +742,7 @@ describe('LobeGoogleAI', () => {
 
         const converted = await instance['convertOAIMessagesToGoogleMessage'](message);
         expect(converted).toEqual({
-          role: 'function',
+          role: 'model',
           parts: [
             {
               functionCall: {

--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -493,12 +493,18 @@ export class LobeGoogleAI implements LobeRuntimeAI {
   ): GoogleFunctionCallTool[] | undefined {
     // 目前 Tools (例如 googleSearch) 无法与其他 FunctionCall 同时使用
     if (payload?.messages?.some((m) => m.tool_calls?.length)) {
-      return; // 若历史消息中已有 function calling，则不再注入任何 Tools
+      return this.buildFunctionDeclarations(tools);
     }
     if (payload?.enabledSearch) {
       return [{ googleSearch: {} } as GoogleSearchRetrievalTool];
     }
 
+    return this.buildFunctionDeclarations(tools);
+  }
+
+  private buildFunctionDeclarations(
+    tools: ChatCompletionTool[] | undefined,
+  ): GoogleFunctionCallTool[] | undefined {
     if (!tools || tools.length === 0) return;
 
     return [

--- a/src/libs/model-runtime/utils/streams/google-ai.test.ts
+++ b/src/libs/model-runtime/utils/streams/google-ai.test.ts
@@ -7,7 +7,7 @@ import { GoogleGenerativeAIStream } from './google-ai';
 
 describe('GoogleGenerativeAIStream', () => {
   it('should transform Google Generative AI stream to protocol stream', async () => {
-    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1');
+    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1').mockReturnValueOnce('abcd1234');
 
     const mockGenerateContentResponse = (text: string, functionCalls?: any[]) =>
       ({
@@ -59,7 +59,7 @@ describe('GoogleGenerativeAIStream', () => {
       // tool call
       'id: chat_1\n',
       'event: tool_calls\n',
-      `data: [{"function":{"arguments":"{\\"arg1\\":\\"value1\\"}","name":"testFunction"},"id":"testFunction_0","index":0,"type":"function"}]\n\n`,
+      `data: [{"function":{"arguments":"{\\"arg1\\":\\"value1\\"}","name":"testFunction"},"id":"testFunction_0_abcd1234","index":0,"type":"function"}]\n\n`,
 
       // text
       'id: chat_1\n',

--- a/src/libs/model-runtime/utils/streams/ollama.test.ts
+++ b/src/libs/model-runtime/utils/streams/ollama.test.ts
@@ -30,7 +30,7 @@ describe('OllamaStream', () => {
       });
 
       const protocolStream = OllamaStream(mockOllamaStream);
-    
+
       const decoder = new TextDecoder();
       const chunks = [];
 
@@ -62,7 +62,7 @@ describe('OllamaStream', () => {
           'id: chat_2',
           'event: stop',
           `data: "finished"\n`,
-        ].map((line) => `${line}\n`)
+        ].map((line) => `${line}\n`),
       );
     });
 
@@ -116,7 +116,7 @@ describe('OllamaStream', () => {
     });
 
     it('tools use', async () => {
-      vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1');
+      vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1').mockReturnValueOnce('abcd1234');
 
       const mockOllamaStream = new ReadableStream<ChatResponse>({
         start(controller) {
@@ -178,7 +178,7 @@ describe('OllamaStream', () => {
         [
           'id: chat_1',
           'event: tool_calls',
-          `data: [{"function":{"arguments":"{\\"city\\":\\"杭州\\"}","name":"realtime-weather____fetchCurrentWeather"},"id":"realtime-weather____fetchCurrentWeather_0","index":0,"type":"function"}]\n`,
+          `data: [{"function":{"arguments":"{\\"city\\":\\"杭州\\"}","name":"realtime-weather____fetchCurrentWeather"},"id":"realtime-weather____fetchCurrentWeather_0_abcd1234","index":0,"type":"function"}]\n`,
           'id: chat_1',
           'event: stop',
           `data: "finished"\n`,

--- a/src/libs/model-runtime/utils/streams/protocol.ts
+++ b/src/libs/model-runtime/utils/streams/protocol.ts
@@ -1,5 +1,6 @@
 import { CitationItem, ModelSpeed, ModelTokensUsage } from '@/types/message';
 import { safeParseJSON } from '@/utils/safeParseJSON';
+import { nanoid } from '@/utils/uuid';
 
 import { AgentRuntimeErrorType } from '../../error';
 import { parseToolCalls } from '../../helpers';
@@ -98,7 +99,7 @@ export interface StreamProtocolToolCallChunk {
 }
 
 export const generateToolCallId = (index: number, functionName?: string) =>
-  `${functionName || 'unknown_tool_call'}_${index}_${Math.random().toString(36).slice(2, 10)}`;
+  `${functionName || 'unknown_tool_call'}_${index}_${nanoid()}`;
 
 const chatStreamable = async function* <T>(stream: AsyncIterable<T>) {
   for await (const response of stream) {

--- a/src/libs/model-runtime/utils/streams/protocol.ts
+++ b/src/libs/model-runtime/utils/streams/protocol.ts
@@ -98,7 +98,7 @@ export interface StreamProtocolToolCallChunk {
 }
 
 export const generateToolCallId = (index: number, functionName?: string) =>
-  `${functionName || 'unknown_tool_call'}_${index}`;
+  `${functionName || 'unknown_tool_call'}_${index}_${Math.random().toString(36).slice(2, 10)}`;
 
 const chatStreamable = async function* <T>(stream: AsyncIterable<T>) {
   for await (const response of stream) {

--- a/src/libs/model-runtime/utils/streams/vertex-ai.test.ts
+++ b/src/libs/model-runtime/utils/streams/vertex-ai.test.ts
@@ -137,7 +137,7 @@ describe('VertexAIStream', () => {
   });
 
   it('tool_calls', async () => {
-    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1');
+    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('1').mockReturnValueOnce('abcd1234');
 
     const rawChunks = [
       {
@@ -227,7 +227,7 @@ describe('VertexAIStream', () => {
       // text
       'id: chat_1\n',
       'event: tool_calls\n',
-      `data: [{"function":{"arguments":"{\\"city\\":\\"杭州\\"}","name":"realtime-weather____fetchCurrentWeather"},"id":"realtime-weather____fetchCurrentWeather_0","index":0,"type":"function"}]\n\n`,
+      `data: [{"function":{"arguments":"{\\"city\\":\\"杭州\\"}","name":"realtime-weather____fetchCurrentWeather"},"id":"realtime-weather____fetchCurrentWeather_0_abcd1234","index":0,"type":"function"}]\n\n`,
       'id: chat_1\n',
       'event: stop\n',
       'data: "STOP"\n\n',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 根据[官方文档](https://ai.google.dev/gemini-api/docs/function-calling)调整响应使用 `{ functionResponse: { name: tool_call.name, response: { result } }` 格式
- functionCall 的 role 修改为 `model`
- 已经存在 tool_calls (已经调用过 FunctionCall) 时，也需要声明 `tools`，否则，会导致后续调用不正常
- 生成 `ToolCallId` 添加随机数，解决多次调用与响应不匹配的问题，解决后续 functionResponse 无法正确返回的问题

#### 📝 补充信息 | Additional Information

使用 Gemini + Function Call(联网搜索/MCP...) 时，经常会出现调用 tool 出错。开始以为是模型问题，后来试了不管是 2.5 Flash-Lite 、2.5-Flash 还是 2.5 Pro 都会报错。

可能关联的 issues:

- close #7902
- close #7298

#### 实际问题举例

**多次调用的情况(ToolCallId 未修正时)**

第一次调用，问题不大:

![gemini-1st-msgs](https://github.com/user-attachments/assets/323cce70-1168-47fb-aa86-42f9c4fbbb4c)
![gemini-1st-call](https://github.com/user-attachments/assets/e7680b47-c0a2-4ebf-ae9f-c1bf2add8958)

❗第二次就有问题了:

![gemini-2nd-msgs](https://github.com/user-attachments/assets/914ea795-73ad-4172-8c1e-7d070fbdbd07)

最后一条 message 应该是 role: tool 的，但是到 assistant 就没了

![gemini-2nd-call](https://github.com/user-attachments/assets/1d0a9643-5a7f-425d-b99f-ef219ca75a2d)

导致模型直接返回空响应:

![gemini-2nd-resp](https://github.com/user-attachments/assets/461189bc-bd28-49ba-9a21-1d44cb87d742)

**而且因为 ToolCallId 的重复，显示也会异常**

第一次调用正确的应该是 Vercel AI 相关的结果:

![first-mcp-tool-results](https://github.com/user-attachments/assets/1150115a-f2dd-42e3-b054-183cf7a91339)

经过第二次调用之后，前面第一次的“返回结果”变成了第二次的结果:

![second-mcp-tool-results](https://github.com/user-attachments/assets/e93ea3fd-4bd7-4faa-971a-bf72403ea45d)

而且会导致不停调用 tools:

![duplicate-tool-calls](https://github.com/user-attachments/assets/d4411aea-4179-42d0-afb3-19e10d744853)

## Summary by Sourcery

Fix Google Gemini tools integration by correcting message conversion, ensuring tool declarations persist, and preventing tool-call ID collisions

Bug Fixes:
- Convert tool responses to functionResponse parts with proper result wrapping
- Use 'model' role for functionCall messages instead of 'function'
- Always declare tools even when past function calls exist to maintain subsequent call behavior
- Add randomness to generated ToolCallId to avoid ID collisions across multiple calls

Enhancements:
- Extract helper buildFunctionDeclarations to centralize tool declaration logic

Tests:
- Add unit test to verify correct conversion of function response messages