### PR TITLE
🐛 fix: fix desktop chunk issue

### DIFF
--- a/src/app/[variants]/layout.tsx
+++ b/src/app/[variants]/layout.tsx
@@ -78,13 +78,6 @@ export const generateViewport = async (props: DynamicLayoutProps): ResolvingView
 };
 
 export const generateStaticParams = () => {
-  // if in dev mode or in vercel preview mode, use ISR to speed up
-  const isVercelPreview = process.env.VERCEL === '1' && process.env.VERCEL_ENV !== 'production';
-
-  if (process.env.NODE_ENV !== 'production' || isVercelPreview) {
-    return [];
-  }
-
   const themes: ThemeAppearance[] = ['dark', 'light'];
   const mobileOptions = isDesktop ? [false] : [true, false];
   // only static for serveral page, other go to dynamtic

--- a/src/server/routers/async/caller.ts
+++ b/src/server/routers/async/caller.ts
@@ -4,9 +4,13 @@ import urlJoin from 'url-join';
 
 import { serverDBEnv } from '@/config/db';
 import { JWTPayload, LOBE_CHAT_AUTH_HEADER } from '@/const/auth';
+import { isDesktop } from '@/const/version';
 import { appEnv } from '@/envs/app';
+import { createAsyncCallerFactory } from '@/libs/trpc/async';
+import { createAsyncContextInner } from '@/libs/trpc/async/context';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 
+import { asyncRouter } from './index';
 import type { AsyncRouter } from './index';
 
 export const createAsyncServerClient = async (userId: string, payload: JWTPayload) => {
@@ -29,4 +33,69 @@ export const createAsyncServerClient = async (userId: string, payload: JWTPayloa
       }),
     ],
   });
+};
+
+const helperFunc = () => {
+  const dummyCreateCaller = createAsyncCallerFactory(asyncRouter);
+  return {} as unknown as ReturnType<typeof dummyCreateCaller>;
+};
+
+export type UnifiedAsyncCaller = ReturnType<typeof helperFunc>;
+
+interface CreateCallerOptions {
+  jwtPayload: any;
+  userId: string;
+}
+
+export const createAsyncCaller = async (
+  options: CreateCallerOptions,
+): Promise<UnifiedAsyncCaller> => {
+  const { userId, jwtPayload } = options;
+
+  if (isDesktop) {
+    // Desktop 环境：使用 Server-Side Caller，直接同线程调用方法
+    const asyncContext = await createAsyncContextInner({
+      jwtPayload,
+      secret: serverDBEnv.KEY_VAULTS_SECRET,
+      userId,
+    });
+
+    const createCaller = createAsyncCallerFactory(asyncRouter);
+    const caller = createCaller(asyncContext);
+
+    return caller;
+  } else {
+    // Server 环境：使用 HTTP Client
+    const httpClient = await createAsyncServerClient(userId, jwtPayload);
+
+    const createRecursiveProxy = (client: any, path: string[]): any => {
+      // The target is a dummy function, so that 'apply' can be triggered.
+      return new Proxy(() => {}, {
+        apply: (target, thisArg, args) => {
+          // 'apply' is triggered by the function call `(...)`.
+          // The `path` at this point is the full path to the procedure.
+
+          // Traverse the original httpClient to get the actual procedure object.
+          const procedure = path.reduce((obj, key) => (obj ? obj[key] : undefined), client);
+
+          if (procedure && typeof procedure.mutate === 'function') {
+            // If we found a valid procedure, call its mutate method.
+            return procedure.mutate(...args);
+          } else {
+            // This should not happen if the call path is correct.
+            const message = `Procedure not found or not valid at path: ${path.join('.')}`;
+            throw new Error(message);
+          }
+        },
+        get: (_, property: string) => {
+          // When a property is accessed, we just extend the path and return a new proxy.
+          // This handles `caller.file.parseFileToChunks`
+          if (property === 'then') return undefined; // Prevent async/await issues
+          return createRecursiveProxy(client, [...path, property as string]);
+        },
+      });
+    };
+
+    return createRecursiveProxy(httpClient, []);
+  }
 };

--- a/src/server/routers/async/index.ts
+++ b/src/server/routers/async/index.ts
@@ -11,4 +11,5 @@ export const asyncRouter = router({
 
 export type AsyncRouter = typeof asyncRouter;
 
-export * from './caller';
+export type { UnifiedAsyncCaller } from './caller';
+export { createAsyncCaller, createAsyncServerClient } from './caller';


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- fix https://github.com/lobehub/lobe-chat/issues/8264
- 在生产环境，由于不存在真实的 server， desktop 版本用到异步路由的功能，都会调用失败

## Summary by Sourcery

Unify async procedure invocation across desktop and server environments by introducing a conditional caller factory and update services to use it, fixing desktop-side chunk handling.

Bug Fixes:
- Fix desktop-side chunk processing by using an in-process caller on desktop environment

Enhancements:
- Add `createAsyncCaller` to select between in-process and HTTP-based tRPC callers based on runtime
- Implement a recursive proxy for HTTP clients to dynamically route tRPC procedure calls without explicit `.mutate`
- Integrate `createAsyncCaller` in `ChunkService` and `ragEvalRouter`, replacing `createAsyncServerClient` and simplifying call syntax
- Add debug logging to trace caller creation and remote procedure invocations