### PR TITLE
为 o4-mini、o3 和 o3-pro 模型启用 web_search_preview 功能（draft）

### DIFF
--- a/src/config/aiModels/openai.ts
+++ b/src/config/aiModels/openai.ts
@@ -12,6 +12,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
@@ -34,6 +35,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
@@ -58,6 +60,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
@@ -652,7 +655,8 @@ export const openaiChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
-    description: 'codex-mini-latest 是 o4-mini 的微调版本，专门用于 Codex CLI。对于直接通过 API 使用，我们推荐从 gpt-4.1 开始。',
+    description:
+      'codex-mini-latest 是 o4-mini 的微调版本，专门用于 Codex CLI。对于直接通过 API 使用，我们推荐从 gpt-4.1 开始。',
     displayName: 'Codex mini',
     id: 'codex-mini-latest',
     maxOutput: 100_000,
@@ -673,7 +677,8 @@ export const openaiChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 8192,
-    description: 'computer-use-preview 模型是专为“计算机使用工具”设计的专用模型，经过训练以理解并执行计算机相关任务。',
+    description:
+      'computer-use-preview 模型是专为“计算机使用工具”设计的专用模型，经过训练以理解并执行计算机相关任务。',
     displayName: 'Computer Use Preview',
     id: 'computer-use-preview',
     maxOutput: 1024,

--- a/src/const/models.ts
+++ b/src/const/models.ts
@@ -31,6 +31,9 @@ export const responsesAPIModels = new Set([
   'codex-mini-latest',
   'computer-use-preview',
   'computer-use-preview-2025-03-11',
+  'o4-mini',
+  'o3',
+  'o3-pro',
 ]);
 
 /**

--- a/src/libs/model-runtime/openai/index.ts
+++ b/src/libs/model-runtime/openai/index.ts
@@ -17,7 +17,10 @@ export const LobeOpenAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.openai.com/v1',
   chatCompletion: {
     handlePayload: (payload) => {
-      const { enabledSearch, model, ...rest } = payload;
+      const { enabledSearch: originalEnabledSearch, model, ...rest } = payload;
+      const enabledSearch = ['o4-mini', 'o3', 'o3-pro'].includes(model)
+        ? true
+        : originalEnabledSearch;
 
       if (responsesAPIModels.has(model) || enabledSearch) {
         return { ...rest, apiMode: 'responses', enabledSearch, model } as ChatStreamPayload;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore


#### 🔀 变更说明 | Description of Change


为 `o4-mini`、`o3`、`o3-pro` 三款模型在 Chat Completion 与 Responses 逻辑中默认开启 `web_search_preview` 功能，强制将 `enabledSearch` 置为 `true` 并注入相应工具配置。

#### 📝 补充信息 | Additional Information

* 本次修改仅为最低限度的 POC（Proof of Concept），目的是验证搜索工具注入流程是否可行。
* 尚未涵盖完整的错误处理、边界检测或性能优化，**不适合作为生产环境代码**。
* 后续需完善：

  * 类型定义及接口契约校正
  * `pruneReasoningPayload` 与工具列表合并的可靠性测试
  * 日志与调试开关整合
  * 单元测试与集成测试覆盖
  * 安全性与性能评估

## Summary by Sourcery

Enable web_search_preview by default for o4-mini, o3, and o3-pro models in chat completion and response flows as a proof-of-concept, updating model configs and adding debug logging.

New Features:
- Enable web_search_preview by overriding the enabledSearch flag for o4-mini, o3, and o3-pro in chat completion handler
- Inject search tool configurations by default for o4-mini, o3, and o3-pro in the response handler
- Add the 'search' ability to o4-mini, o3, and o3-pro entries in the AI model configuration

Enhancements:
- Add console logging for payload details, model names, and assigned tools in chat completion and response handlers