### PR TITLE
🐛 fix: Wrong Gemini 2.5 Pro thinkbudget

### DIFF
--- a/src/config/aiModels/novita.ts
+++ b/src/config/aiModels/novita.ts
@@ -313,7 +313,7 @@ const novitaChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 163_840,
     displayName: 'Deepseek V3 0324',
     enabled: true,
     id: 'deepseek/deepseek-v3-0324',
@@ -328,7 +328,7 @@ const novitaChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 163_840,
     displayName: 'Deepseek R1 0528',
     enabled: true,
     id: 'deepseek/deepseek-r1-0528',

--- a/src/config/aiModels/novita.ts
+++ b/src/config/aiModels/novita.ts
@@ -3,6 +3,64 @@ import { AIChatModelCard } from '@/types/aiModel';
 // https://novita.ai/pricing
 const novitaChatModels: AIChatModelCard[] = [
   {
+    contextWindowTokens: 120_000,
+    displayName: 'ERNIE 4.5 0.3B',
+    id: 'baidu/ernie-4.5-0.3b',
+    pricing: {
+      input: 0,
+      output: 0,
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 120_000,
+    displayName: 'ERNIE 4.5 21B A3B',
+    id: 'baidu/ernie-4.5-21B-a3b',
+    pricing: {
+      input: 0,
+      output: 0,
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 123_000,
+    displayName: 'ERNIE 4.5 300B A47B Paddle',
+    id: 'baidu/ernie-4.5-300b-a47b-paddle',
+    pricing: {
+      input: 0.3,
+      output: 1,
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 30_000,
+    displayName: 'ERNIE 4.5 VL 28B A3B',
+    id: 'baidu/ernie-4.5-vl-28b-a3b',
+    pricing: {
+      input: 0,
+      output: 0,
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 123_000,
+    displayName: 'ERNIE 4.5 VL 424B A47B',
+    id: 'baidu/ernie-4.5-vl-424b-a47b',
+    pricing: {
+      input: 0.42,
+      output: 1.25,
+    },
+    type: 'chat',
+  },
+  {
     abilities: {
       reasoning: true,
     },
@@ -255,7 +313,7 @@ const novitaChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 128_000,
+    contextWindowTokens: 131_072,
     displayName: 'Deepseek V3 0324',
     enabled: true,
     id: 'deepseek/deepseek-v3-0324',
@@ -270,7 +328,7 @@ const novitaChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 128_000,
+    contextWindowTokens: 131_072,
     displayName: 'Deepseek R1 0528',
     enabled: true,
     id: 'deepseek/deepseek-r1-0528',

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -8,6 +8,23 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 131_072,
     description:
+      'Kimi-Dev-72B 是一款开源代码大模型，经过大规模强化学习优化，能输出稳健、可直接投产的补丁。该模型在 SWE-bench Verified 上取得 60.4 % 的新高分，刷新了开源模型在缺陷修复、代码评审等自动化软件工程任务上的纪录。',
+    displayName: 'Kimi Dev 72B',
+    id: 'moonshotai/Kimi-Dev-72B',
+    pricing: {
+      currency: 'CNY',
+      input: 2,
+      output: 8,
+    },
+    releasedAt: '2025-06-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
       'MiniMax-M1 是开源权重的大规模混合注意力推理模型，拥有 4560 亿参数，每个 Token 可激活约 459 亿参数。模型原生支持 100 万 Token 的超长上下文，并通过闪电注意力机制，在 10 万 Token 的生成任务中相比 DeepSeek R1 节省 75% 的浮点运算量。同时，MiniMax-M1 采用 MoE（混合专家）架构，结合 CISPO 算法与混合注意力设计的高效强化学习训练，在长输入推理与真实软件工程场景中实现了业界领先的性能。',
     displayName: 'MiniMax M1 80K',
     id: 'MiniMaxAI/MiniMax-M1-80k',

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -25,6 +25,23 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 131_072,
     description:
+      'Hunyuan-A13B-Instruct 参数量800 亿，激活 130 亿参数即可对标更大模型，支持“快思考/慢思考”混合推理；长文理解稳定；经 BFCL-v3 与 τ-Bench 验证，Agent 能力领先；结合 GQA 与多量化格式，实现高效推理。',
+    displayName: 'Hunyuan A13B Instruct',
+    id: 'tencent/Hunyuan-A13B-Instruct',
+    pricing: {
+      currency: 'CNY',
+      input: 1,
+      output: 4,
+    },
+    releasedAt: '2025-06-27',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
       'MiniMax-M1 是开源权重的大规模混合注意力推理模型，拥有 4560 亿参数，每个 Token 可激活约 459 亿参数。模型原生支持 100 万 Token 的超长上下文，并通过闪电注意力机制，在 10 万 Token 的生成任务中相比 DeepSeek R1 节省 75% 的浮点运算量。同时，MiniMax-M1 采用 MoE（混合专家）架构，结合 CISPO 算法与混合注意力设计的高效强化学习训练，在长输入推理与真实软件工程场景中实现了业界领先的性能。',
     displayName: 'MiniMax M1 80K',
     id: 'MiniMaxAI/MiniMax-M1-80k',

--- a/src/libs/model-runtime/google/index.ts
+++ b/src/libs/model-runtime/google/index.ts
@@ -139,7 +139,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
             } else if (model.includes('-2.5-flash')) {
               return Math.min(thinkingBudget, 24_576);
             } else if (model.includes('-2.5-pro')) {
-              return Math.max(128, Math.min(thinkingBudget, 32_768));
+              return thinkingBudget === -1 ? -1 : Math.max(128, Math.min(thinkingBudget, 32_768));
             }
             return Math.min(thinkingBudget, 24_576);
           }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- close #8294

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Preserve an unlimited thinkingBudget value (-1) for '-2.5-pro' models instead of enforcing the minimum clamp.