### PR TITLE
🐛 fix: pin `antd@5.26.2` to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@xterm/xterm": "^5.5.0",
     "ahooks": "^3.8.5",
     "ai": "^3.4.33",
-    "antd": "^5.25.4",
+    "antd": "5.26.2",
     "antd-style": "^3.7.1",
     "brotli-wasm": "^3.0.1",
     "chroma-js": "^3.1.2",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

5.26.3 去掉了 activeKeys 的类型，会导致构建报错
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

refs: https://github.com/ant-design/ant-design/pull/54189#issuecomment-3019027451

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Work around missing activeKeys type in antd v5.26.3 by pinning to v5.26.2