### PR TITLE
fix: called wrong refresh token & remove dulplicate ipc listener

### DIFF
--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -209,7 +209,6 @@ export default class RemoteServerConfigCtr extends ControllerModule {
    * 使用存储的刷新令牌获取新的访问令牌
    * Handles concurrent requests by returning the existing refresh promise if one is in progress.
    */
-  @ipcClientEvent('refreshAccessToken')
   async refreshAccessToken(): Promise<{ error?: string; success: boolean }> {
     // If a refresh is already in progress, return the existing promise
     if (this.refreshPromise) {

--- a/apps/desktop/src/main/controllers/RemoteServerSyncCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerSyncCtr.ts
@@ -9,6 +9,7 @@ import { URL } from 'node:url';
 
 import { createLogger } from '@/utils/logger';
 
+import AuthCtr from './AuthCtr';
 import RemoteServerConfigCtr from './RemoteServerConfigCtr';
 import { ControllerModule, ipcClientEvent } from './index';
 
@@ -283,7 +284,7 @@ export default class RemoteServerSyncCtr extends ControllerModule {
   }
 
   /**
-   * Attempts to refresh the access token by calling the RemoteServerConfigCtr.
+   * Attempts to refresh the access token by calling the AuthCtr.
    * @returns Whether token refresh was successful
    */
   private async refreshTokenIfNeeded(callerLogPrefix: string = '[RefreshToken]'): Promise<boolean> {
@@ -292,8 +293,9 @@ export default class RemoteServerSyncCtr extends ControllerModule {
     logger.debug(`${logPrefix} Entered refreshTokenIfNeeded.`);
 
     try {
-      logger.info(`${logPrefix} Triggering refreshAccessToken in RemoteServerConfigCtr.`);
-      const result = await this.remoteServerConfigCtr.refreshAccessToken();
+      logger.info(`${logPrefix} Triggering refreshAccessToken in AuthCtr.`);
+      const authCtr = this.app.getController(AuthCtr);
+      const result = await authCtr.refreshAccessToken();
 
       if (result.success) {
         logger.info(`${logPrefix} refreshAccessToken call completed successfully.`);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

之前项目 RemoteServerSync 里调的是 RemoteServerConfigCtr 而不是 AuthCtr 里的 refreshAccessToken 

AuthCtr 里的 refreshAccessToken 是对 RemoteServerConfigCtr 进行了一层封装的，成功或失败后会 broadcast 状态

建议后面可以在 Waiting 组件内加一个 useWatchBroadcast 监听一下 refreshAccessToken 失败的事件，在前端加个交互啥的

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Correct the token refresh call to use the Auth controller and remove a duplicate IPC event listener annotation.

Bug Fixes:
- Invoke refreshAccessToken through AuthCtr instead of RemoteServerConfigCtr in RemoteServerSyncCtr to ensure correct broadcast behavior
- Remove redundant @ipcClientEvent decorator from RemoteServerConfigCtr.refreshAccessToken to prevent duplicate IPC listeners