### PR TITLE
🐛 fix: change the wrong github checkmodel name

### DIFF
--- a/src/config/modelProviders/github.ts
+++ b/src/config/modelProviders/github.ts
@@ -256,7 +256,7 @@ const Github: ModelProviderCard = {
       maxOutput: 4096,
     },
   ],
-  checkModel: 'Phi-3-mini-4k-instruct',
+  checkModel: 'microsoft/Phi-3-mini-4k-instruct',
   // Ref: https://github.blog/news-insights/product-news/introducing-github-models/
   description: '通过GitHub模型，开发人员可以成为AI工程师，并使用行业领先的AI模型进行构建。',
   id: 'github',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

github 的默认 checkmodel 模型需要加入前缀，不然会无法匹配和校验通过

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Correct the GitHub checkModel name to include the 'microsoft/' prefix for proper matching and validation