### PR TITLE
💄 style: add `MCP_TOOL_TIMEOUT` env and improve debug usage guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,4 +238,4 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 ########################################
 
 # MCP tool call timeout (milliseconds)
-MCP_TOOL_TIMEOUT=300000
+# MCP_TOOL_TIMEOUT=300000

--- a/.env.example
+++ b/.env.example
@@ -232,3 +232,10 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 
 # Specify the Embedding model and Reranker model(unImplemented)
 # DEFAULT_FILES_CONFIG="embedding_model=openai/embedding-text-3-small,reranker_model=cohere/rerank-english-v3.0,query_mode=full_text"
+
+########################################
+########## MCP Service Config ##########
+########################################
+
+# MCP tool call timeout (milliseconds)
+MCP_TOOL_TIMEOUT=300000

--- a/.env.example
+++ b/.env.example
@@ -238,4 +238,4 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 ########################################
 
 # MCP tool call timeout (milliseconds)
-# MCP_TOOL_TIMEOUT=300000
+# MCP_TOOL_TIMEOUT=60000

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -11,6 +11,8 @@ import debug from 'debug';
 import { MCPClientParams, McpTool } from './types';
 
 const log = debug('lobe-mcp:client');
+// MCP tool call timeout (milliseconds), configurable via the environment variable MCP_TOOL_TIMEOUT, default is 60000
+const MCP_TOOL_TIMEOUT = Number(process.env.MCP_TOOL_TIMEOUT) || 60_000;
 
 export class MCPClient {
   private mcp: Client;
@@ -51,7 +53,7 @@ export class MCPClient {
     log('Initializing MCP connection...');
 
     try {
-      await this.mcp.connect(this.transport, { onprogress: options.onProgress });
+      await this.mcp.connect(this.transport, { onprogress: options.onProgress, timeout: 300_000 });
       log('MCP connection initialized.');
     } catch (e) {
       if ((e as any).code === -32_000) {
@@ -87,8 +89,10 @@ export class MCPClient {
   }
 
   async callTool(toolName: string, args: any) {
-    log('Calling tool: %s with args: %O', toolName, args);
-    const result = await this.mcp.callTool({ arguments: args, name: toolName });
+    log('Calling tool: %s with args: %O, timeout: %O', toolName, args, MCP_TOOL_TIMEOUT);
+    const result = await this.mcp.callTool({ arguments: args, name: toolName }, undefined, {
+      timeout: MCP_TOOL_TIMEOUT,
+    });
     log('Tool call result: %O', result);
     return result;
   }

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -51,15 +51,13 @@ export class MCPClient {
 
   async initialize(options: { onProgress?: (progress: Progress) => void } = {}) {
     log('Initializing MCP connection...');
-
     try {
-      await this.mcp.connect(this.transport, { onprogress: options.onProgress, timeout: 300_000 });
+      await this.mcp.connect(this.transport, { onprogress: options.onProgress });
       log('MCP connection initialized.');
     } catch (e) {
       if ((e as any).code === -32_000) {
         throw new Error('Fail to connecting MCP Server, please check your configuration.');
       }
-
       log('MCP connection failed:', e);
       throw e;
     }

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -51,6 +51,7 @@ export class MCPClient {
 
   async initialize(options: { onProgress?: (progress: Progress) => void } = {}) {
     log('Initializing MCP connection...');
+
     try {
       await this.mcp.connect(this.transport, { onprogress: options.onProgress });
       log('MCP connection initialized.');
@@ -58,6 +59,7 @@ export class MCPClient {
       if ((e as any).code === -32_000) {
         throw new Error('Fail to connecting MCP Server, please check your configuration.');
       }
+
       log('MCP connection failed:', e);
       throw e;
     }

--- a/src/libs/mcp/client.ts
+++ b/src/libs/mcp/client.ts
@@ -12,7 +12,11 @@ import { MCPClientParams, McpTool } from './types';
 
 const log = debug('lobe-mcp:client');
 // MCP tool call timeout (milliseconds), configurable via the environment variable MCP_TOOL_TIMEOUT, default is 60000
-const MCP_TOOL_TIMEOUT = Number(process.env.MCP_TOOL_TIMEOUT) || 60_000;
+// Parse MCP_TOOL_TIMEOUT, only use if it's a valid positive number, otherwise fallback to default 60000
+const MCP_TOOL_TIMEOUT = (() => {
+  const val = Number(process.env.MCP_TOOL_TIMEOUT);
+  return Number.isFinite(val) && val > 0 ? val : 60_000;
+})();
 
 export class MCPClient {
   private mcp: Client;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
新增 MCP_TOOL_TIMEOUT 配置项到 [env.example]。

MCP 客户端调用工具时支持通过环境变量设置超时时间，默认 60000ms。

移除了 MCP 连接初始化时的硬编码超时参数，超时控制仅在工具调用时生效。

保持代码风格和注释与项目一致，提升可维护性。

完善 debug 日志用法说明。

Add [MCP_TOOL_TIMEOUT] config to [.env.example] .

MCP client now supports tool call timeout via environment variable, default 60000ms.

Removed hardcoded timeout from MCP connection initialization; timeout is only set for tool calls.

Code style and comments are consistent with project conventions.

Improved debug usage documentation.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Introduce an environment-based timeout mechanism for MCP tool calls, remove the hardcoded connection timeout, enhance debug logging to include the timeout, and update .env.example with the new configuration

New Features:
- Allow configuring MCP tool call timeout via MCP_TOOL_TIMEOUT environment variable (default 60000ms)

Enhancements:
- Pass the configured timeout to MCPClient.callTool instead of using a hardcoded value
- Remove hardcoded timeout parameter from MCP connection initialization
- Update debug logs to include the timeout value

Documentation:
- Document MCP_TOOL_TIMEOUT in .env.example