### PR TITLE
WIP: sorting pinned sessions

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/ListModal/Item.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/ListModal/Item.tsx
@@ -1,0 +1,52 @@
+import { ActionIcon, Avatar, SortableList } from '@lobehub/ui';
+import { createStyles } from 'antd-style';
+import { PinOff } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { sessionHelpers } from '@/store/session/helpers';
+import { LobeAgentSession } from '@/types/session';
+
+const useStyles = createStyles(({ css }) => ({
+  content: css`
+    position: relative;
+    overflow: hidden;
+    flex: 1;
+  `,
+  title: css`
+    flex: 1;
+    height: 32px;
+    line-height: 32px;
+    text-align: start;
+  `,
+}));
+
+const Item = memo<LobeAgentSession>((agent) => {
+  const { t } = useTranslation('chat');
+  const { styles } = useStyles();
+
+  return (
+    <>
+      <SortableList.DragHandle />
+      <Flexbox align="center" gap={8} horizontal style={{ flex: 1 }}>
+        <Avatar
+          avatar={sessionHelpers.getAvatar(agent.meta)}
+          background={agent.meta.backgroundColor}
+          size={32}
+        />
+        <span className={styles.title}>{sessionHelpers.getTitle(agent.meta)}</span>
+        <ActionIcon
+          danger
+          icon={PinOff}
+          onClick={() => {
+            console.log('Unpin session:', agent.id);
+          }}
+          size={'small'}
+        />
+      </Flexbox>
+    </>
+  );
+});
+
+export default Item;

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/ListModal/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/ListModal/index.tsx
@@ -1,0 +1,65 @@
+import { Modal, type ModalProps, SortableList } from '@lobehub/ui';
+import { createStyles } from 'antd-style';
+import isEqual from 'fast-deep-equal';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { useSessionStore } from '@/store/session';
+import { sessionSelectors } from '@/store/session/selectors';
+import { LobeAgentSession } from '@/types/session';
+import Item from './Item';
+
+const useStyles = createStyles(({ css, token }) => ({
+  container: css`
+    height: 36px;
+    padding-inline: 8px;
+    border-radius: ${token.borderRadius}px;
+    transition: background 0.2s ease-in-out;
+
+    &:hover {
+      background: ${token.colorFillTertiary};
+    }
+  `,
+}));
+
+const ListModal = memo<ModalProps>(({ open, onCancel }) => {
+  const { t } = useTranslation('chat');
+  const { styles } = useStyles();
+  const list = useSessionStore(sessionSelectors.pinnedSessions, isEqual);
+
+  return (
+    <Modal
+      allowFullscreen
+      footer={null}
+      onCancel={onCancel}
+      open={open}
+      // title={t('sessionGroup.config')}
+      width={400}
+    >
+      <Flexbox>
+        <SortableList
+          items={list}
+          onChange={(items: LobeAgentSession[]) => {
+            // updateSessionGroupSort(items);
+            console.log('onChange', items);
+          }}
+          renderItem={(item: LobeAgentSession) => (
+            <SortableList.Item
+              align={'center'}
+              className={styles.container}
+              gap={4}
+              horizontal
+              id={item.id}
+              justify={'space-between'}
+            >
+              <Item {...item} />
+            </SortableList.Item>
+          )}
+        />
+      </Flexbox>
+    </Modal>
+  );
+});
+
+export default ListModal;

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
@@ -1,4 +1,5 @@
-import { ActionIcon, Avatar, Icon, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, Tooltip } from '@lobehub/ui';
+import { useBoolean } from 'ahooks';
 import { Divider } from 'antd';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
@@ -13,6 +14,8 @@ import { sessionSelectors } from '@/store/session/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { HotkeyEnum, KeyEnum } from '@/types/hotkey';
+
+import ListModal from './ListModal';
 
 const HANDLER_WIDTH = 4;
 
@@ -88,6 +91,7 @@ const PinList = () => {
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.SwitchAgent));
   const hasList = list.length > 0;
   const [isPinned, setPinned] = useQueryState('pinned', parseAsBoolean);
+  const [isEditModalOpen, { setFalse: closeEditModal, setTrue: openEditModal }] = useBoolean(false);
 
   const switchAgent = (id: string) => {
     switchSession(id);
@@ -126,15 +130,14 @@ const PinList = () => {
           ))}
           <Center as="li">
             <ActionIcon
-              icon={<Icon icon={Settings2} />}
-              onClick={() => {
-                console.log('Edit Pinned Sessions');
-              }}
+              icon={Settings2}
+              onClick={openEditModal}
               title="Edit Pinned Sessions"
               tooltipProps={{ placement: 'right' }}
             />
           </Center>
         </Flexbox>
+        <ListModal onCancel={closeEditModal} open={isEditModalOpen} />
       </>
     )
   );

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
@@ -1,9 +1,10 @@
-import { Avatar, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Avatar, Icon, Tooltip } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
+import { Settings2 } from 'lucide-react';
 import { parseAsBoolean, useQueryState } from 'nuqs';
-import { Flexbox } from 'react-layout-kit';
+import { Center, Flexbox } from 'react-layout-kit';
 
 import { useSwitchSession } from '@/hooks/useSwitchSession';
 import { useSessionStore } from '@/store/session';
@@ -15,8 +16,8 @@ import { HotkeyEnum, KeyEnum } from '@/types/hotkey';
 
 const HANDLER_WIDTH = 4;
 
-const useStyles = createStyles(({ css, token }) => ({
-  ink: css`
+const useStyles = createStyles(({ css, token }) => {
+  const ink = css`
     &::before {
       content: '';
 
@@ -46,8 +47,9 @@ const useStyles = createStyles(({ css, token }) => ({
         opacity: 1;
       }
     }
-  `,
-  inkActive: css`
+  `;
+
+  const inkActive = css`
     &::before {
       width: ${HANDLER_WIDTH}px;
       height: 40px;
@@ -61,8 +63,22 @@ const useStyles = createStyles(({ css, token }) => ({
         opacity: 1;
       }
     }
-  `,
-}));
+  `;
+
+  const list = css`
+    padding: 0;
+    & > li:last-child {
+      opacity: 0;
+      transition: opacity 200ms ${token.motionEaseInOut};
+    }
+
+    &:hover > li:last-child {
+      opacity: 1;
+    }
+  `;
+
+  return { ink, inkActive, list };
+});
 
 const PinList = () => {
   const { styles, cx } = useStyles();
@@ -82,9 +98,9 @@ const PinList = () => {
     hasList && (
       <>
         <Divider style={{ marginBottom: 8, marginTop: 4 }} />
-        <Flexbox flex={1} gap={12} height={'100%'}>
+        <Flexbox as="ul" className={styles.list} flex={1} gap={12} height={'100%'}>
           {list.slice(0, 9).map((item, index) => (
-            <Flexbox key={item.id} style={{ position: 'relative' }}>
+            <Flexbox as="li" key={item.id} style={{ position: 'relative' }}>
               <Tooltip
                 hotkey={hotkey.replaceAll(KeyEnum.Number, String(index + 1))}
                 placement={'right'}
@@ -108,6 +124,16 @@ const PinList = () => {
               </Tooltip>
             </Flexbox>
           ))}
+          <Center as="li">
+            <ActionIcon
+              icon={<Icon icon={Settings2} />}
+              onClick={() => {
+                console.log('Edit Pinned Sessions');
+              }}
+              title="Edit Pinned Sessions"
+              tooltipProps={{ placement: 'right' }}
+            />
+          </Center>
         </Flexbox>
       </>
     )


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

resoved: https://github.com/lobehub/lobe-chat/issues/8324

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable editing and reordering of pinned sessions via a modal interface, enhance sidebar list styling, and add an edit button to open the sort dialog.

New Features:
- Add a sortable modal for managing and reordering pinned sessions
- Introduce an edit icon in the sidebar pin list to open the sorting modal

Enhancements:
- Limit pinned sessions display to the first nine items with hover reveal for the edit action
- Refactor PinList styles using createStyles and add hover effects for list items