### PR TITLE
🔨  chore: remove async router max duration limit

### DIFF
--- a/src/app/(backend)/trpc/async/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/async/[trpc]/route.ts
@@ -9,6 +9,10 @@ export const maxDuration = 60;
 
 const handler = (req: NextRequest) =>
   fetchRequestHandler({
+    // 避免请求之间互相影响
+    // https://github.com/lobehub/lobe-chat/discussions/7442#discussioncomment-13658563
+    allowBatching: false,
+
     /**
      * @link https://trpc.io/docs/v11/context
      */

--- a/src/app/(backend)/trpc/async/[trpc]/route.ts
+++ b/src/app/(backend)/trpc/async/[trpc]/route.ts
@@ -5,8 +5,6 @@ import { pino } from '@/libs/logger';
 import { createAsyncRouteContext } from '@/libs/trpc/async/context';
 import { asyncRouter } from '@/server/routers/async';
 
-export const maxDuration = 60;
-
 const handler = (req: NextRequest) =>
   fetchRequestHandler({
     // 避免请求之间互相影响

--- a/src/server/routers/async/caller.ts
+++ b/src/server/routers/async/caller.ts
@@ -1,4 +1,4 @@
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCClient, httpLink } from '@trpc/client';
 import superjson from 'superjson';
 import urlJoin from 'url-join';
 
@@ -26,7 +26,7 @@ export const createAsyncServerClient = async (userId: string, payload: JWTPayloa
 
   return createTRPCClient<AsyncRouter>({
     links: [
-      httpBatchLink({
+      httpLink({
         headers,
         transformer: superjson,
         url: urlJoin(appEnv.APP_URL!, '/trpc/async'),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

https://trpc.io/docs/client/links/httpBatchLink#disabling-request-batching

## Summary by Sourcery

Remove the async router's max duration limit and disable HTTP request batching for async TRPC routes

Enhancements:
- Remove the maxDuration limit from the async TRPC route
- Disable HTTP request batching by setting allowBatching to false and switching from httpBatchLink to httpLink