### PR TITLE
👷 build: pin minio version

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         /bin/node /app/startServer.js &
         LOBE_PID=\$!
         sleep 3
-        if [ $(wget --timeout=5 --spider --server-response ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E -c 'HTTP/[0-9.]+ 200') -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
@@ -136,7 +136,7 @@ services:
           echo '了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration'
           echo ''
         else
-          if ! wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep 'issuer' | grep ${AUTH_CASDOOR_ISSUER}; then
+          if ! wget -O - --timeout=15 http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep 'issuer' | grep ${AUTH_CASDOOR_ISSUER}; then
             printf '❌Error: The Auth issuer is conflict, Issuer in OIDC configuration is: %s' \$(wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E 'issuer.*' | awk -F '\"' '{print \$4}')
             echo ' , but the issuer in .env file is: ${AUTH_CASDOOR_ISSUER} '
             echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
@@ -149,7 +149,7 @@ services:
             echo ''
           fi
         fi
-        if [ $(wget --timeout=5 --spider --server-response ${S3_ENDPOINT}/minio/health/live 2>&1 | grep -E -c 'HTTP/[0-9.]+ 200') -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:
@@ -126,7 +126,7 @@ services:
         /bin/node /app/startServer.js &
         LOBE_PID=\$!
         sleep 3
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=5 --spider --server-response ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
@@ -136,7 +136,7 @@ services:
           echo '了解更多：https://lobehub.com/zh/docs/self-hosting/server-database/docker-compose#necessary-configuration'
           echo ''
         else
-          if ! wget -O - --timeout=15 http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep 'issuer' | grep ${AUTH_CASDOOR_ISSUER}; then
+          if ! wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep 'issuer' | grep ${AUTH_CASDOOR_ISSUER}; then
             printf '❌Error: The Auth issuer is conflict, Issuer in OIDC configuration is: %s' \$(wget -O - --timeout=5 ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E 'issuer.*' | awk -F '\"' '{print \$4}')
             echo ' , but the issuer in .env file is: ${AUTH_CASDOOR_ISSUER} '
             echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
@@ -149,7 +149,7 @@ services:
             echo ''
           fi
         fi
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=5 --spider --server-response ${S3_ENDPOINT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         /bin/node /app/startServer.js &
         LOBE_PID=\$!
         sleep 3
-        if [ $(wget --timeout=5 --spider --server-response ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=5 --spider --server-response ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration 2>&1 | grep -E -c 'HTTP/[0-9.]+ 200') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
@@ -149,7 +149,7 @@ services:
             echo ''
           fi
         fi
-        if [ $(wget --timeout=5 --spider --server-response ${S3_ENDPOINT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=5 --spider --server-response ${S3_ENDPOINT}/minio/health/live 2>&1 | grep -E -c 'HTTP/[0-9.]+ 200') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         /bin/node /app/startServer.js &
         LOBE_PID=\$!
         sleep 3
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK' -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
@@ -149,7 +149,7 @@ services:
             echo ''
           fi
         fi
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK' -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         /bin/node /app/startServer.js &
         LOBE_PID=\$!
         sleep 3
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK' -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${CASDOOR_PORT}/.well-known/openid-configuration 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch OIDC configuration from Casdoor'
           echo 'Request URL: ${AUTH_CASDOOR_ISSUER}/.well-known/openid-configuration'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'
@@ -149,7 +149,7 @@ services:
             echo ''
           fi
         fi
-        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK' -eq 0 ]; then
+        if [ $(wget --timeout=15 --spider --server-response http://localhost:${MINIO_PORT}/minio/health/live 2>&1 | grep -c 'HTTP/1.1 200 OK') -eq 0 ]; then
           echo '⚠️Warning: Unable to fetch MinIO health status'
           echo 'Request URL: ${S3_ENDPOINT}/minio/health/live'
           echo 'Read more at: https://lobehub.com/docs/self-hosting/server-database/docker-compose#necessary-configuration'

--- a/docker-compose/local/logto/docker-compose.yml
+++ b/docker-compose/local/logto/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/local/logto/docker-compose.yml
+++ b/docker-compose/local/logto/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/local/zitadel/docker-compose.yml
+++ b/docker-compose/local/zitadel/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/local/zitadel/docker-compose.yml
+++ b/docker-compose/local/zitadel/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docker-compose/production/logto/docker-compose.yml
+++ b/docker-compose/production/logto/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: always
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     ports:
       - '9000:9000'

--- a/docker-compose/production/logto/docker-compose.yml
+++ b/docker-compose/production/logto/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: always
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     ports:
       - '9000:9000'

--- a/docker-compose/production/zitadel/docker-compose.yml
+++ b/docker-compose/production/zitadel/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: always
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     ports:
       - '9000:9000'

--- a/docker-compose/production/zitadel/docker-compose.yml
+++ b/docker-compose/production/zitadel/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: always
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     ports:
       - '9000:9000'

--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -754,7 +754,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -754,7 +754,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -730,7 +730,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -730,7 +730,7 @@ services:
       - lobe-network
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: lobe-minio
     network_mode: 'service:network-service'
     volumes:


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- fix #8150

1. 由于 MiniO 在最新版中取消了桶的管理功能，将 MiniO 的镜像暂时锁在最后一个完整 WebUI 的版本
![image](https://github.com/user-attachments/assets/a1ebd896-1786-4f47-8d9f-ae5004553949)


2. 在域名、反代模式中，Lobe-chat 自检查应该通过本地端口进行检查，如果检查失败才需要告知用户自行访问反代的地址，否则会出现误导性提示

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Pin the MinIO Docker image to a fixed release to preserve WebUI functionality and improve health check scripts to reliably detect OIDC and MinIO endpoints before warning users.

Bug Fixes:
- Update self-check commands to use a regex matching any HTTP version (HTTP/[0-9.]+ 200) for OIDC and MinIO health endpoints to prevent misleading warnings.

Enhancements:
- Lock MinIO image to version RELEASE.2025-04-22T22-12-26Z across all Docker Compose configurations and documentation.

Documentation:
- Reflect the pinned MinIO image version in self-hosting Docker Compose documentation.

