### PR TITLE
💄 style: add `grok-4-0709` model from xAI

### DIFF
--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -5,13 +5,36 @@ const xaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 256_000,
+    description:
+      '我们最新最强大的旗舰模型，在自然语言处理、数学计算和推理方面表现卓越 —— 是一款完美的全能型选手。',
+    displayName: 'Grok 4 0709',
+    enabled: true,
+    id: 'grok-4-0709',
+    pricing: {
+      cachedInput: 0.75,
+      input: 3,
+      output: 15,
+    },
+    releasedAt: '2025-07-09',
+    settings: {
+      extendParams: ['reasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       search: true,
     },
     contextWindowTokens: 131_072,
     description:
       '旗舰级模型，擅长数据提取、编程和文本摘要等企业级应用，拥有金融、医疗、法律和科学等领域的深厚知识。',
     displayName: 'Grok 3',
-    enabled: true,
     id: 'grok-3',
     pricing: {
       cachedInput: 0.75,

--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -21,7 +21,8 @@ const xaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-07-09',
     settings: {
-      extendParams: ['reasoningEffort'],
+      // reasoning_effort is not supported by grok-4. Specifying reasoning_effort parameter will get an error response.
+      // extendParams: ['reasoningEffort'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/src/libs/model-runtime/xai/index.ts
+++ b/src/libs/model-runtime/xai/index.ts
@@ -7,6 +7,11 @@ export interface XAIModelCard {
   id: string;
 }
 
+export const GrokReasoningModels = new Set([
+  'grok-3-mini',
+  'grok-4-0709',
+]);
+
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
   chatCompletion: {
@@ -15,9 +20,9 @@ export const LobeXAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        frequency_penalty: model.includes('grok-3-mini') ? undefined : frequency_penalty,
+        frequency_penalty: GrokReasoningModels.has(model) ? undefined : frequency_penalty,
         model,
-        presence_penalty: model.includes('grok-3-mini') ? undefined : presence_penalty,
+        presence_penalty: GrokReasoningModels.has(model) ? undefined : presence_penalty,
         stream: true,
         ...(enabledSearch && {
           search_parameters: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 增加 `grok-4-0709` 模型
2. 禁用 `frequency_penalty` `presence_penalty` `reasoning_effort` 参数
![image](https://github.com/user-attachments/assets/2b1bf25e-9ccf-4a6b-8d24-4fd4fab8b99e)

---

Note:
1. `grok-4` 不支持返回 `reasoning_content`，会返回类似 `Thinking... Thinking...`
![image](https://github.com/user-attachments/assets/32eafc9c-a39e-459d-ba34-7b6c65de29e2)
2. `grok-4` 不支持 `reasoning_effort` 参数
![image](https://github.com/user-attachments/assets/da788503-8c83-4af4-9269-38ceda049675)
3. `reasoning` 类模型不支持 `frequency_penalty` `presence_penalty` 参数
![image](https://github.com/user-attachments/assets/dcc723dd-ab9e-4780-949e-740ffd8876c3)

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

close #8381

---

![image](https://github.com/user-attachments/assets/d128a486-172c-4df8-8d42-de9bf6d23c22)

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add the upcoming `grok-4-0709` model to the xAI models list and adjust the default availability of the `grok-3` model.

New Features:
- Introduce the new `grok-4-0709` chat model in the xAI configuration

Enhancements:
- Remove the explicit enable flag from the existing `grok-3` model