### PR TITLE
🐛 fix: add vision support to Grok 4

### DIFF
--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -145,7 +145,6 @@ const xaiChatModels: AIChatModelCard[] = [
     contextWindowTokens: 32_768,
     description: '该模型在准确性、指令遵循和多语言能力方面有所改进。',
     displayName: 'Grok 2 Vision 1212',
-    enabled: true,
     id: 'grok-2-vision-1212',
     pricing: {
       input: 2,

--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -7,6 +7,7 @@ const xaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      vision: true,
     },
     contextWindowTokens: 256_000,
     description:


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- Grok 4支持图片输入
- 去掉Grok 2 Vision 1212 的默认启用

<img width="2237" height="1339" alt="image" src="https://github.com/user-attachments/assets/cfef0410-88d2-43dd-85e6-27436d1a7eb5" />

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

New Features:
- Enable vision support for the Grok 4 AI chat model by adding the vision flag