### PR TITLE
🐛 fix: Grok-4 reasoning model universal matching

### DIFF
--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -13,7 +13,7 @@ const xaiChatModels: AIChatModelCard[] = [
       '我们最新最强大的旗舰模型，在自然语言处理、数学计算和推理方面表现卓越 —— 是一款完美的全能型选手。',
     displayName: 'Grok 4 0709',
     enabled: true,
-    id: 'grok-4-0709',
+    id: 'grok-4',
     pricing: {
       cachedInput: 0.75,
       input: 3,

--- a/src/libs/model-runtime/xai/index.ts
+++ b/src/libs/model-runtime/xai/index.ts
@@ -9,8 +9,11 @@ export interface XAIModelCard {
 
 export const GrokReasoningModels = new Set([
   'grok-3-mini',
-  'grok-4-0709',
+  'grok-4',
 ]);
+
+export const isGrokReasoningModel = (model: string) =>
+  Array.from(GrokReasoningModels).some((id) => model.includes(id));
 
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
@@ -20,9 +23,9 @@ export const LobeXAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        frequency_penalty: GrokReasoningModels.has(model) ? undefined : frequency_penalty,
+        frequency_penalty: isGrokReasoningModel(model) ? undefined : frequency_penalty,
         model,
-        presence_penalty: GrokReasoningModels.has(model) ? undefined : presence_penalty,
+        presence_penalty: isGrokReasoningModel(model) ? undefined : presence_penalty,
         stream: true,
         ...(enabledSearch && {
           search_parameters: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

不只匹配 grok-4-0709，考虑 grok-4 别名。

另外 grok-4 别名会比 grok-4-0709 更通用。

- close #8389

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Use a generic grok-4 alias with a helper function to universally match all grok-4 reasoning model variants and update the penalty logic accordingly.

Bug Fixes:
- Broaden grok-4 reasoning model detection to include all variants, not just grok-4-0709

Enhancements:
- Add isGrokReasoningModel helper for flexible model matching
- Replace direct set membership checks with isGrokReasoningModel in penalty logic