### PR TITLE
💄 style: fix discover translation

### DIFF
--- a/src/app/[variants]/(main)/discover/(list)/(home)/page.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/(home)/page.tsx
@@ -10,9 +10,9 @@ export const generateMetadata = async (props: DynamicLayoutProps) => {
   const { locale, t } = await parsePageMetaProps(props);
   return metadataModule.generate({
     alternate: true,
-    description: t('discover.home.description'),
+    description: t('discover.description'),
     locale,
-    title: t('discover.home.title'),
+    title: t('discover.title'),
     url: '/discover',
   });
 };
@@ -21,9 +21,9 @@ const Page = async (props: DynamicLayoutProps) => {
   const { locale, t, isMobile } = await parsePageMetaProps(props);
 
   const ld = ldModule.generate({
-    description: t('discover.home.description'),
+    description: t('discover.description'),
     locale,
-    title: t('discover.home.title'),
+    title: t('discover.title'),
     url: '/discover',
     webpage: {
       enable: true,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix translation key paths for the discover page metadata and structured data

Bug Fixes:
- Use discover.description instead of discover.home.description for metadata description
- Use discover.title instead of discover.home.title for metadata title