### PR TITLE
💄 style: Open new topic by tap Just Chat again

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Inbox/index.tsx
@@ -6,6 +6,8 @@ import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { INBOX_SESSION_ID } from '@/const/session';
 import { SESSION_CHAT_URL } from '@/const/url';
 import { useSwitchSession } from '@/hooks/useSwitchSession';
+import { getChatStoreState, useChatStore } from '@/store/chat';
+import { chatSelectors } from '@/store/chat/selectors';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useSessionStore } from '@/store/session';
 
@@ -17,13 +19,26 @@ const Inbox = memo(() => {
   const activeId = useSessionStore((s) => s.activeId);
   const switchSession = useSwitchSession();
 
+  const openNewTopicOrSaveTopic = useChatStore((s) => s.openNewTopicOrSaveTopic);
+
   return (
     <Link
       aria-label={t('inbox.title')}
       href={SESSION_CHAT_URL(INBOX_SESSION_ID, mobile)}
-      onClick={(e) => {
+      onClick={async (e) => {
         e.preventDefault();
-        switchSession(INBOX_SESSION_ID);
+
+        if (activeId === INBOX_SESSION_ID && !mobile) {
+          // If user tap the inbox again, open a new topic.
+          // Only for desktop.
+          const inboxMessages = chatSelectors.inboxActiveTopicMessages(getChatStoreState());
+
+          if (inboxMessages.length > 0) {
+            await openNewTopicOrSaveTopic();
+          }
+        } else {
+          switchSession(INBOX_SESSION_ID);
+        }
       }}
     >
       <ListItem

--- a/src/store/chat/slices/message/selectors.ts
+++ b/src/store/chat/slices/message/selectors.ts
@@ -201,6 +201,11 @@ const isSendButtonDisabledByMessage = (s: ChatStoreState) =>
   // 4. when the message is in RAG flow
   isInRAGFlow(s);
 
+const inboxActiveTopicMessages = (state: ChatStoreState) => {
+  const activeTopicId = state.activeTopicId;
+  return state.messagesMap[messageMapKey(INBOX_SESSION_ID, activeTopicId)] || [];
+};
+
 export const chatSelectors = {
   activeBaseChats,
   activeBaseChatsWithoutTool,
@@ -213,6 +218,7 @@ export const chatSelectors = {
   getMessageById,
   getMessageByToolCallId,
   getTraceIdByMessageId,
+  inboxActiveTopicMessages,
   isAIGenerating,
   isCreatingMessage,
   isCurrentChatLoaded,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable opening a new chat topic when the user taps the Inbox tab again on desktop if there are existing messages and support this with a new selector

Enhancements:
- Open a new chat topic or save the current one when re-clicking the Inbox tab on desktop
- Add inboxActiveTopicMessages selector to retrieve messages for the active inbox topic