### PR TITLE
[wip]: feat: 修改最后输出的 ChatItem 的滚动渲染逻辑，改为默认占高度的逻辑

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatList/ChatItem/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatList/ChatItem/index.tsx
@@ -21,6 +21,9 @@ const useStyles = createStyles(({ css, token, isDarkMode }) => {
         border-end-end-radius: 8px;
       }
     `,
+    lastItem: css`
+      min-height: calc(100vh - 335px);
+    `,
     line: css`
       &::after {
         content: '';
@@ -66,10 +69,14 @@ const MainChatItem = memo<ThreadChatItemProps>(({ id, index }) => {
 
   const actionBar = useMemo(() => <ActionsBar id={id} index={index} />, [id]);
 
+  const isLastItem = index === historyLength - 1;
+  const threadClassName = showThread ? cx(styles.line, styles[placement]) : '';
+  const lastItemClassName = isLastItem && userRole !== 'user' ? cx(styles.lastItem) : '';
+
   return (
     <ChatItem
       actionBar={actionBar}
-      className={showThread ? cx(styles.line, styles[placement]) : ''}
+      className={cx(threadClassName, lastItemClassName)}
       enableHistoryDivider={enableHistoryDivider}
       endRender={
         showThread && (


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Implement new scroll rendering logic so that the final ChatItem by default occupies the remaining vertical space

New Features:
- Add a lastItem style that sets a minimum height to fill the remaining viewport
- Apply the lastItem class to the final ChatItem for non-user roles to adjust scroll rendering