### PR TITLE
⚡️ perf: improve  memory usage in desktop

### DIFF
--- a/apps/desktop/src/main/appBrowsers.ts
+++ b/apps/desktop/src/main/appBrowsers.ts
@@ -36,7 +36,7 @@ export const appBrowsers = {
     autoHideMenuBar: true,
     height: 800,
     identifier: 'settings',
-    keepAlive: true,
+    // keepAlive: true,
     minWidth: 600,
     parentIdentifier: 'chat',
     path: '/settings',

--- a/apps/desktop/src/main/core/BrowserManager.ts
+++ b/apps/desktop/src/main/core/BrowserManager.ts
@@ -128,9 +128,12 @@ export default class BrowserManager {
    */
   initializeBrowsers() {
     logger.info('Initializing all browsers');
-    Object.values(appBrowsers).forEach((browser) => {
+    Object.values(appBrowsers).forEach((browser: BrowserWindowOpts) => {
       logger.debug(`Initializing browser: ${browser.identifier}`);
-      this.retrieveOrInitialize(browser);
+
+      if (browser.keepAlive) {
+        this.retrieveOrInitialize(browser);
+      }
     });
   }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Only initialize desktop app browsers that are flagged to stay alive to reduce unnecessary memory usage

Enhancements:
- Add keepAlive flag check to skip initializing non-persistent browsers
- Annotate browser objects with BrowserWindowOpts type in initialization loop