### PR TITLE
🐛 fix: fix webapi proxy with clerk

### DIFF
--- a/src/const/auth.ts
+++ b/src/const/auth.ts
@@ -5,6 +5,7 @@ export const enableNextAuth = authEnv.NEXT_PUBLIC_ENABLE_NEXT_AUTH;
 export const enableAuth = enableClerk || enableNextAuth || false;
 
 export const LOBE_CHAT_AUTH_HEADER = 'X-lobe-chat-auth';
+export const LOBE_CHAT_OIDC_AUTH_HEADER = 'Oidc-Auth';
 
 export const OAUTH_AUTHORIZED = 'X-oauth-authorized';
 

--- a/src/libs/oidc-provider/jwt.ts
+++ b/src/libs/oidc-provider/jwt.ts
@@ -41,10 +41,8 @@ export const getJWKS = (): object => {
   }
 };
 
-/**
- * 从环境变量中获取 JWKS 并提取第一个 RSA 密钥
- */
-const getJWKSPublicKey = async () => {
+// 我强烈建议你将这个函数改名为 getVerificationKey
+const getVerificationKey = async () => {
   try {
     const jwksString = oidcEnv.OIDC_JWKS_KEY;
 
@@ -58,20 +56,33 @@ const getJWKSPublicKey = async () => {
       throw new Error('JWKS 格式无效: 缺少或为空的 keys 数组');
     }
 
-    // 查找 RS256 算法的 RSA 密钥
-    const rsaKey = jwks.keys.find((key: any) => key.alg === 'RS256' && key.kty === 'RSA');
-
-    if (!rsaKey) {
+    const privateRsaKey = jwks.keys.find((key: any) => key.alg === 'RS256' && key.kty === 'RSA');
+    if (!privateRsaKey) {
       throw new Error('JWKS 中没有找到 RS256 算法的 RSA 密钥');
     }
 
-    // 导入 JWK 为公钥
-    const publicKey = await importJWK(rsaKey, 'RS256');
+    // --- 核心修复 ---
+    // 创建一个只包含公钥组件的“纯净”JWK对象。
+    // RSA公钥的关键字段是 kty, n, e。其他如 kid, alg, use 也是公共的。
+    const publicKeyJwk = {
+      alg: privateRsaKey.alg,
+      e: privateRsaKey.e,
+      kid: privateRsaKey.kid,
+      kty: privateRsaKey.kty,
+      n: privateRsaKey.n,
+      use: privateRsaKey.use,
+    };
 
-    return publicKey;
+    // 移除任何可能存在的 undefined 字段，保持对象干净
+    Object.keys(publicKeyJwk).forEach(
+      (key) => (publicKeyJwk as any)[key] === undefined && delete (publicKeyJwk as any)[key],
+    );
+
+    // 现在，无论在哪个环境下，`importJWK` 都会将这个对象正确地识别为一个公钥。
+    return await importJWK(publicKeyJwk, 'RS256');
   } catch (error) {
     log('获取 JWKS 公钥失败: %O', error);
-    throw new Error(`JWKS 公钥获取失败: ${(error as Error).message}`);
+    throw new Error(`JWKS 公key获取失败: ${(error as Error).message}`);
   }
 };
 
@@ -85,7 +96,7 @@ export const validateOIDCJWT = async (token: string) => {
     log('开始验证 OIDC JWT token');
 
     // 获取公钥
-    const publicKey = await getJWKSPublicKey();
+    const publicKey = await getVerificationKey();
 
     // 验证 JWT
     const { payload } = await jwtVerify(token, publicKey, {

--- a/src/libs/oidc-provider/jwt.ts
+++ b/src/libs/oidc-provider/jwt.ts
@@ -41,7 +41,6 @@ export const getJWKS = (): object => {
   }
 };
 
-// 我强烈建议你将这个函数改名为 getVerificationKey
 const getVerificationKey = async () => {
   try {
     const jwksString = oidcEnv.OIDC_JWKS_KEY;
@@ -61,7 +60,6 @@ const getVerificationKey = async () => {
       throw new Error('JWKS 中没有找到 RS256 算法的 RSA 密钥');
     }
 
-    // --- 核心修复 ---
     // 创建一个只包含公钥组件的“纯净”JWK对象。
     // RSA公钥的关键字段是 kty, n, e。其他如 kid, alg, use 也是公共的。
     const publicKeyJwk = {

--- a/src/libs/trpc/lambda/context.ts
+++ b/src/libs/trpc/lambda/context.ts
@@ -3,7 +3,13 @@ import debug from 'debug';
 import { User } from 'next-auth';
 import { NextRequest } from 'next/server';
 
-import { JWTPayload, LOBE_CHAT_AUTH_HEADER, enableClerk, enableNextAuth } from '@/const/auth';
+import {
+  JWTPayload,
+  LOBE_CHAT_AUTH_HEADER,
+  LOBE_CHAT_OIDC_AUTH_HEADER,
+  enableClerk,
+  enableNextAuth,
+} from '@/const/auth';
 import { oidcEnv } from '@/envs/oidc';
 import { ClerkAuth, IClerkAuth } from '@/libs/clerk-auth';
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
@@ -102,7 +108,7 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
   if (oidcEnv.ENABLE_OIDC) {
     log('OIDC enabled, attempting OIDC authentication');
     const standardAuthorization = request.headers.get('Authorization');
-    const oidcAuthToken = request.headers.get('Oidc-Auth');
+    const oidcAuthToken = request.headers.get(LOBE_CHAT_OIDC_AUTH_HEADER);
     log('Standard Authorization header: %s', standardAuthorization ? 'exists' : 'not found');
     log('Oidc-Auth header: %s', oidcAuthToken ? 'exists' : 'not found');
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- close #8474
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Support OIDC authentication by introducing a dedicated header, validating OIDC JWTs with a refined public key extraction, and bypassing Clerk auth checks when OIDC is used.

Enhancements:
- Refactor getVerificationKey to derive and import a clean public JWK from JWKS for RS256 verification
- Add LOBE_CHAT_OIDC_AUTH_HEADER constant and use it in context and middleware to detect OIDC tokens
- Update auth middleware to validate OIDC JWTs, merge the OIDC userId, and skip Clerk/NextAuth checks when OIDC authentication is present