### PR TITLE
⚡️ perf: try to fix layout flick

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/ChatAction.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/ChatAction.tsx
@@ -1,0 +1,51 @@
+import { ActionIcon, ActionIconProps } from '@lobehub/ui';
+import { MessageSquare } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import InnerLink from '@/components/InnerLink';
+import { SESSION_CHAT_URL } from '@/const/url';
+import { SidebarTabKey } from '@/store/global/initialState';
+import { useSessionStore } from '@/store/session';
+
+const ICON_SIZE: ActionIconProps['size'] = {
+  blockSize: 40,
+  size: 24,
+  strokeWidth: 2,
+};
+
+export interface ChatActionProps {
+  isPinned?: boolean | null;
+  tab?: SidebarTabKey;
+}
+
+const ChatAction = memo<ChatActionProps>(({ tab, isPinned }) => {
+  const { t } = useTranslation('common');
+  const activeId = useSessionStore((s) => s.activeId);
+
+  // 从 store 中获取需要的数据
+  const isChatActive = tab === SidebarTabKey.Chat && !isPinned;
+
+  return (
+    <InnerLink
+      aria-label={t('tab.chat')}
+      href={SESSION_CHAT_URL(activeId)}
+      onClick={(e) => {
+        // If Cmd key is pressed, let the default link behavior happen (open in new tab)
+        if (e.metaKey || e.ctrlKey) {
+          return;
+        }
+      }}
+    >
+      <ActionIcon
+        active={isChatActive}
+        icon={MessageSquare}
+        size={ICON_SIZE}
+        title={t('tab.chat')}
+        tooltipProps={{ placement: 'right' }}
+      />
+    </InnerLink>
+  );
+});
+
+export default ChatAction;

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
@@ -1,14 +1,14 @@
 import { ActionIcon, ActionIconProps } from '@lobehub/ui';
-import { Compass, FolderClosed, MessageSquare, Palette } from 'lucide-react';
-import Link from 'next/link';
+import { Compass, FolderClosed, Palette } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
-import { useGlobalStore } from '@/store/global';
+import InnerLink from '@/components/InnerLink';
 import { SidebarTabKey } from '@/store/global/initialState';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
-import { useSessionStore } from '@/store/session';
+
+import ChatAction from './ChatAction';
 
 const ICON_SIZE: ActionIconProps['size'] = {
   blockSize: 40,
@@ -23,40 +23,17 @@ export interface TopActionProps {
 
 const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
   const { t } = useTranslation('common');
-  const switchBackToChat = useGlobalStore((s) => s.switchBackToChat);
   const { showMarket, enableKnowledgeBase } = useServerConfigStore(featureFlagsSelectors);
 
-  const isChatActive = tab === SidebarTabKey.Chat && !isPinned;
   const isFilesActive = tab === SidebarTabKey.Files;
   const isDiscoverActive = tab === SidebarTabKey.Discover;
   const isImageActive = tab === SidebarTabKey.Image;
 
   return (
     <Flexbox gap={8}>
-      <Link
-        aria-label={t('tab.chat')}
-        href={'/chat'}
-        onClick={(e) => {
-          // If Cmd key is pressed, let the default link behavior happen (open in new tab)
-          if (e.metaKey || e.ctrlKey) {
-            return;
-          }
-
-          // Otherwise, prevent default and switch session within the current tab
-          e.preventDefault();
-          switchBackToChat(useSessionStore.getState().activeId);
-        }}
-      >
-        <ActionIcon
-          active={isChatActive}
-          icon={MessageSquare}
-          size={ICON_SIZE}
-          title={t('tab.chat')}
-          tooltipProps={{ placement: 'right' }}
-        />
-      </Link>
+      <ChatAction isPinned={isPinned} tab={tab} />
       {enableKnowledgeBase && (
-        <Link aria-label={t('tab.files')} href={'/files'}>
+        <InnerLink aria-label={t('tab.files')} href={'/files'}>
           <ActionIcon
             active={isFilesActive}
             icon={FolderClosed}
@@ -64,9 +41,9 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
             title={t('tab.files')}
             tooltipProps={{ placement: 'right' }}
           />
-        </Link>
+        </InnerLink>
       )}
-      <Link aria-label={t('tab.aiImage')} href={'/image'}>
+      <InnerLink aria-label={t('tab.aiImage')} href={'/image'}>
         <ActionIcon
           active={isImageActive}
           icon={Palette}
@@ -74,9 +51,9 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
           title={t('tab.aiImage')}
           tooltipProps={{ placement: 'right' }}
         />
-      </Link>
+      </InnerLink>
       {showMarket && (
-        <Link aria-label={t('tab.discover')} href={'/discover'}>
+        <InnerLink aria-label={t('tab.discover')} href={'/discover'}>
           <ActionIcon
             active={isDiscoverActive}
             icon={Compass}
@@ -84,7 +61,7 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
             title={t('tab.discover')}
             tooltipProps={{ placement: 'right' }}
           />
-        </Link>
+        </InnerLink>
       )}
     </Flexbox>
   );

--- a/src/components/InnerLink.tsx
+++ b/src/components/InnerLink.tsx
@@ -2,6 +2,7 @@
 
 import Link, { LinkProps } from 'next/link';
 import { AnchorHTMLAttributes, ReactNode } from 'react';
+import urlJoin from 'url-join';
 
 import { useServerConfigStore } from '@/store/serverConfig';
 
@@ -14,7 +15,18 @@ interface InnerLinkProps
 const InnerLink = ({ href, ...props }: InnerLinkProps) => {
   const variants = useServerConfigStore((s) => s.segmentVariants);
 
-  return <Link {...props} as={href} href={`/${variants}${href}`} />;
+  // Fallback for non-string hrefs or cases where we can't process the href
+  if (typeof href !== 'string') {
+    return <Link {...props} href={href} />;
+  }
+
+  const [pathname] = href.split('?');
+
+  const finalHref = {
+    pathname: variants ? urlJoin('/', variants, pathname) : pathname,
+  };
+
+  return <Link {...props} as={href} href={finalHref} />;
 };
 
 export default InnerLink;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

问题的根源在于 src/components/InnerLink.tsx 组件对带有查询参数（Query Parameters）的 URL 处理不当。
href 的构造：ChatAction 组件传递给 InnerLink 的 href 是通过 SESSION_CHAT_URL 生成的，结果类似于 /chat?session=inbox。
InnerLink 的实现：InnerLink 组件接收到这个 href 后，会将其加工，然后传递给底层的 next/link 组件：


问题的关键：next/link 的 href 属性用于匹配文件系统中的页面路径（例如 app/[variants]/chat/page.tsx），而 as 属性用于在浏览器地址栏中显示 URL。
当 href 是 /files 这种不带查询参数的路径时，InnerLink 构造出的 href（如 /default/files）可以正确匹配到页面文件，所以客户端跳转可以正常工作。
但是，当 href 是 /chat?session=inbox 时，InnerLink 构造出的 href 是 /[variants]/chat?session=inbox。next/link 无法在文件系统中找到一个名为 chat?session=inbox 的页面，导致路由匹配失败。
刷新原因：当 next/link 无法解析出一个有效的客户端路由时，它的后备行为 (fallback) 就是执行一个传统的 <a> 标签跳转，这导致了您看到的整个页面刷新。


<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Implement OIDC authentication support, introduce URL segment variant routing, refactor sidebar and server layouts to reduce flicker and unify link handling, and fix JWT public key import.

New Features:
- Add OIDC authentication handling by processing the new `Oidc-Auth` header in middleware and tRPC context.
- Support URL segment variants via a new `segmentVariants` property in the server config store and the `InnerLink` component.

Bug Fixes:
- Fix JWT public key import by creating a clean JWK object with only public fields and renaming the function to `getVerificationKey`.

Enhancements:
- Extract the `ChatAction` component and replace direct `next/link` usage in sidebar with `InnerLink` for consistent routing.
- Introduce `NewServerLayout` for unified desktop/mobile rendering and refactor chat workspace layout to pass props asynchronously.
- Define the `LOBE_CHAT_OIDC_AUTH_HEADER` constant for header consistency.