### PR TITLE
💄 style: fix setting window layout size

### DIFF
--- a/src/app/[variants]/(main)/settings/_layout/Desktop/index.tsx
+++ b/src/app/[variants]/(main)/settings/_layout/Desktop/index.tsx
@@ -36,8 +36,7 @@ const Layout = memo<LayoutProps>(({ children, category }) => {
       height={'100%'}
       horizontal={md}
       ref={ref}
-      style={{ background: theme.colorBgContainer, position: 'relative' }}
-      width={'100%'}
+      style={{ background: theme.colorBgContainer, flex: '1', position: 'relative', width: '0' }}
     >
       {md ? (
         <SideBar>{category}</SideBar>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- fix https://github.com/lobehub/lobe-chat/issues/8430

本质原因是在于多层 Flexbox 嵌套的情况下，子 Flexbox 直接写宽度为 width 100% 会导致计算的时候，按照外层 Flexbox 的宽度来计算。

就会导致左侧如果有占位的内容长度会被忽略，应该让所有 Flex 布局的内容按照 flex-sketch 的挤压来计算

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Use flex:1 and width:0 instead of width:100% on the container to ensure proper layout compression and prevent the right action area from being covered under small screens