### PR TITLE
🐛 fix: Try fix authorization code exchange & pin next-auto to `beta.29`

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "modern-screenshot": "^4.6.0",
     "nanoid": "^5.1.5",
     "next": "~15.3.3",
-    "next-auth": "5.0.0-beta.25",
+    "next-auth": "5.0.0-beta.29",
     "next-mdx-remote": "^5.0.0",
     "nextjs-toploader": "^3.8.16",
     "node-machine-id": "^1.1.12",

--- a/src/app/[variants]/(auth)/next-auth/signin/AuthSignInBox.tsx
+++ b/src/app/[variants]/(auth)/next-auth/signin/AuthSignInBox.tsx
@@ -75,8 +75,8 @@ export default memo(() => {
 
   const searchParams = useSearchParams();
 
-  // Redirect back to the page url
-  const callbackUrl = searchParams.get('callbackUrl') ?? '';
+  // Redirect back to the page url, fallback to '/' if failed
+  const callbackUrl = searchParams.get('callbackUrl') ?? '/';
 
   const handleSignIn = async (provider: string) => {
     try {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 🐛 `src/app/[variants]/(auth)/next-auth/signin/AuthSignInBox.tsx`: 猜测 callback 设置问题。强制设置空 callback 时为 `/` ，防止重定向到 `Refer` 头地址 。[next-auth@39dd3bd](https://github.com/nextauthjs/next-auth/blob/39dd3b92de194c1a835f2d87631f4deb9d9fdf65/packages/next-auth/src/lib/actions.ts#L105)
- 📌  `package.json`：更新 `next-auth` 到 `5.0.0-beta.29` ，因为 `next-auth` 的 `beta` 发版曾经多次造成 CI 失败，因此没有直接设为 `beta` 版本。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- 尝试解决 #8494 问题 1 
  - 问题成因：根据同样问题在 logto 后台的 audit 记录，怀疑是重复使用 code exchange token 导致。
<img width="1196" height="238" alt="image" src="https://github.com/user-attachments/assets/006aa640-6646-4762-9380-68b35fae17d2" />

  - 问题定位：尝试在 `beat.25` 上清除 `authjs*` 的 cookie，但没有效果。没有直接证据证明 cookie 是造成该问题的原因。
  - 解决方法：
    - 若没有设置 callback ，fallback 回 `/`
    - 更新 `next-auth`
  - ~~若仍然没有解决，若 #8188 合并后解决，则推测为双 `next-auth` 实例造成该问题~~。

- `v1.101.1` 版本下问题依然复现，若 #8188 仍然没法解决，则尝试使用白盒 SSO Provider 对线上运行实例 debug，当前问题在 dev 环境下无法复现。
<img width="1283" height="287" alt="image" src="https://github.com/user-attachments/assets/41b74877-4479-424a-9185-330c8900c95b" />


<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix the authorization code exchange flow by enforcing a default callback URL and updating NextAuth to a stable beta version

Bug Fixes:
- Force callbackUrl fallback to "/" to prevent invalid redirects during sign-in

Build:
- Pin next-auth dependency to 5.0.0-beta.29 to stabilize CI and address related issues