### PR TITLE
🐛 fix(groq): Enable streaming for tool calls and add Kimi K2 model

### DIFF
--- a/src/config/aiModels/groq.ts
+++ b/src/config/aiModels/groq.ts
@@ -24,6 +24,23 @@ const groqChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'kimi-k2 是一款具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
+    displayName: 'Kimi K2 Instruct',
+    enabled: true,
+    id: 'moonshotai/kimi-k2-instruct',
+    pricing: {
+      input: 1,
+      output: 3,
+    },
+    releasedAt: '2025-07-11',
+    type: 'chat',
+  },
+  {
     contextWindowTokens: 131_072,
     displayName: 'Llama 4 Scout (17Bx16E)',
     enabled: true,

--- a/src/libs/model-runtime/groq/index.test.ts
+++ b/src/libs/model-runtime/groq/index.test.ts
@@ -34,25 +34,7 @@ afterEach(() => {
 
 describe('LobeGroqAI Temperature Tests', () => {
   describe('handlePayload option', () => {
-    it('should set stream to false when payload contains tools', async () => {
-      const mockCreateMethod = vi
-        .spyOn(instance['client'].chat.completions, 'create')
-        .mockResolvedValue({
-          id: 'chatcmpl-8xDx5AETP8mESQN7UB30GxTN2H1SO',
-          object: 'chat.completion',
-          created: 1709125675,
-          model: 'mistralai/mistral-7b-instruct:free',
-          system_fingerprint: 'fp_86156a94a0',
-          choices: [
-            {
-              index: 0,
-              message: { role: 'assistant', content: 'hello', refusal: null },
-              logprobs: null,
-              finish_reason: 'stop',
-            },
-          ],
-        });
-
+    it('should not set stream to false when payload contains tools', async () => {
       await instance.chat({
         messages: [{ content: 'Hello', role: 'user' }],
         model: 'mistralai/mistral-7b-instruct:free',
@@ -65,8 +47,8 @@ describe('LobeGroqAI Temperature Tests', () => {
         ],
       });
 
-      expect(mockCreateMethod).toHaveBeenCalledWith(
-        expect.objectContaining({ stream: false }),
+      expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true }),
         expect.anything(),
       );
     });

--- a/src/libs/model-runtime/groq/index.ts
+++ b/src/libs/model-runtime/groq/index.ts
@@ -21,8 +21,7 @@ export const LobeGroq = createOpenAICompatibleRuntime({
       const { temperature, ...restPayload } = payload;
       return {
         ...restPayload,
-        // disable stream for tools due to groq dont support
-        stream: !payload.tools,
+        stream: payload.stream ?? true,
 
         temperature: temperature <= 0 ? undefined : temperature,
       } as any;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- Groq 支持 Streaming Tool Use
- 给 Groq 添加 moonshotai/kimi-k2-instruct 模型

#### 📝 补充信息 | Additional Information

从相关信息看，应该是大概两个月前，Groq 开始支持 Steaming Tool Use:

- https://community.groq.com/groq-updates-2/announcements-115

<img width="1404" height="494" alt="2025-07-21 13 26 10" src="https://github.com/user-attachments/assets/6946cb13-7b80-4db4-9ae8-f39eee83cbd2" />

## Summary by Sourcery

Enable streaming for tool calls in the Groq AI runtime and add the Kimi K2 Instruct model

New Features:
- Allow streaming for tool-enabled requests in the Groq model runtime
- Register the moonshotai/kimi-k2-instruct chat model with function calling support

Tests:
- Update Groq runtime test to expect stream=true for payloads with tools