### PR TITLE
💄 style: modal list header sticky style

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -58,8 +58,10 @@ const ModelTitle = memo<ModelFetcherProps>(
         paddingBlock={8}
         style={{
           background: theme.colorBgContainer,
+          marginTop: mobile ? 0 : -12,
+          paddingTop: mobile ? 0 : 20,
           position: 'sticky',
-          top: mobile ? -2 : -16,
+          top: mobile ? -2 : -32,
           zIndex: 15,
         }}
       >


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<img width="1024" height="182" alt="image" src="https://github.com/user-attachments/assets/23491671-a035-4e1e-ab6f-9f3c32afa7bc" />


<img width="2080" height="234" alt="CleanShot 2025-07-21 at 4  24 12@2x" src="https://github.com/user-attachments/assets/a20172b0-eb76-49be-a01a-6dea8b9ae5cb" />

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Update ModelTitle component's sticky header style to set marginTop and paddingTop on desktop and adjust top offset for both mobile and non-mobile resolutions.