### PR TITLE
💄 style: Add cached token count to usage of GoogleAI and VertexAI

### DIFF
--- a/src/libs/model-runtime/utils/streams/google-ai.ts
+++ b/src/libs/model-runtime/utils/streams/google-ai.ts
@@ -33,10 +33,10 @@ const transformGoogleGenerativeAIStream = (
       { data: candidate.finishReason, id: context?.id, type: 'stop' },
       {
         data: {
-          // TODO: Google SDK 0.24.0 don't have promptTokensDetails types
-          inputImageTokens: usage.promptTokensDetails?.find((i: any) => i.modality === 'IMAGE')
+          inputCachedTokens: usage.cachedContentTokenCount,
+          inputImageTokens: usage.promptTokensDetails?.find((i) => i.modality === 'IMAGE')
             ?.tokenCount,
-          inputTextTokens: usage.promptTokensDetails?.find((i: any) => i.modality === 'TEXT')
+          inputTextTokens: usage.promptTokensDetails?.find((i) => i.modality === 'TEXT')
             ?.tokenCount,
           outputReasoningTokens: reasoningTokens,
           outputTextTokens,
@@ -79,7 +79,7 @@ const transformGoogleGenerativeAIStream = (
     // 首先检查是否为 reasoning 内容 (thought: true)
     if (Array.isArray(candidate.content?.parts) && candidate.content.parts.length > 0) {
       for (const part of candidate.content.parts) {
-        if (part && part.text && (part as any).thought === true) {
+        if (part && part.text && part.thought === true) {
           return { data: part.text, id: context.id, type: 'reasoning' };
         }
       }

--- a/src/libs/model-runtime/utils/streams/vertex-ai.ts
+++ b/src/libs/model-runtime/utils/streams/vertex-ai.ts
@@ -31,13 +31,11 @@ const transformVertexAIStream = (
       { data: candidate.finishReason, id: context?.id, type: 'stop' },
       {
         data: {
-          // TODO: Google SDK 0.24.0 don't have promptTokensDetails types
-          inputImageTokens: (usage as any).promptTokensDetails?.find(
-            (i: any) => i.modality === 'IMAGE',
-          )?.tokenCount,
-          inputTextTokens: (usage as any).promptTokensDetails?.find(
-            (i: any) => i.modality === 'TEXT',
-          )?.tokenCount,
+          inputCachedTokens: usage.cachedContentTokenCount,
+          inputImageTokens: usage.promptTokensDetails?.find((i) => i.modality === 'IMAGE')
+            ?.tokenCount,
+          inputTextTokens: usage.promptTokensDetails?.find((i) => i.modality === 'TEXT')
+            ?.tokenCount,
           outputReasoningTokens,
           outputTextTokens,
           totalInputTokens: usage.promptTokenCount,
@@ -56,7 +54,7 @@ const transformVertexAIStream = (
     candidate.content.parts.length > 0
   ) {
     for (const part of candidate.content.parts) {
-      if (part && part.text && (part as any).thought === true) {
+      if (part && part.text && part.thought === true) {
         return { data: part.text, id: context.id, type: 'reasoning' };
       }
     }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 补充 Google AI 和 VertexAI 的缓存 token 数量显示
- 移除因 Google SDK 类型缺失遗留的冗余 as any 类型断言

#### 📝 补充信息 | Additional Information

<img width="648" height="776" alt="2025-07-23 18 18 51" src="https://github.com/user-attachments/assets/a984e503-7d46-40f6-b804-d99149f6050b" />

## Summary by Sourcery

Add cached token count to usage events in GoogleAI and VertexAI streams and remove redundant type assertions.

Enhancements:
- Include cachedContentTokenCount as inputCachedTokens in both GoogleGenerativeAIStream and transformVertexAIStream

Tests:
- Add test case to verify handling of cached token count in the Google AI stream

Chores:
- Remove redundant 'as any' type assertions and simplify property checks