### PR TITLE
 🔨 chore: fix an issue where some tests were failing if Branding items were updated

### DIFF
--- a/src/features/User/__tests__/UserAvatar.test.tsx
+++ b/src/features/User/__tests__/UserAvatar.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { BRANDING_NAME } from '@/const/branding';
 import { DEFAULT_USER_AVATAR_URL } from '@/const/meta';
 import { useUserStore } from '@/store/user';
 
@@ -63,8 +64,8 @@ describe('UserAvatar', () => {
       });
 
       render(<UserAvatar />);
-      expect(screen.getByAltText('LobeChat')).toBeInTheDocument();
-      expect(screen.getByAltText('LobeChat')).toHaveAttribute('src', DEFAULT_USER_AVATAR_URL);
+      expect(screen.getByAltText(BRANDING_NAME)).toBeInTheDocument();
+      expect(screen.getByAltText(BRANDING_NAME)).toHaveAttribute('src', DEFAULT_USER_AVATAR_URL);
     });
   });
 
@@ -76,8 +77,8 @@ describe('UserAvatar', () => {
       });
 
       render(<UserAvatar />);
-      expect(screen.getByAltText('LobeChat')).toBeInTheDocument();
-      expect(screen.getByAltText('LobeChat')).toHaveAttribute('src', DEFAULT_USER_AVATAR_URL);
+      expect(screen.getByAltText(BRANDING_NAME)).toBeInTheDocument();
+      expect(screen.getByAltText(BRANDING_NAME)).toHaveAttribute('src', DEFAULT_USER_AVATAR_URL);
     });
   });
 });

--- a/src/server/ld.test.ts
+++ b/src/server/ld.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
 
+import { BRANDING_NAME } from '@/const/branding';
 import { DEFAULT_LANG } from '@/const/locale';
 
 import { AUTHOR_LIST, Ld } from './ld';
@@ -57,7 +58,7 @@ describe('Ld', () => {
       });
 
       expect(webpage['@type']).toBe('WebPage');
-      expect(webpage.name).toBe('Test Page · LobeChat');
+      expect(webpage.name).toBe(`Test Page · ${BRANDING_NAME}`);
       expect(webpage.description).toBe('Test Description');
     });
   });
@@ -79,7 +80,7 @@ describe('Ld', () => {
       const website = ld.genWebSite();
 
       expect(website['@type']).toBe('WebSite');
-      expect(website.name).toBe('LobeChat');
+      expect(website.name).toBe(BRANDING_NAME);
     });
   });
 
@@ -95,7 +96,7 @@ describe('Ld', () => {
       });
 
       expect(article['@type']).toBe('Article');
-      expect(article.headline).toBe('Test Article · LobeChat');
+      expect(article.headline).toBe(`Test Article · ${BRANDING_NAME}`);
       expect(article.author['@type']).toBe('Person');
     });
   });

--- a/src/services/__tests__/chat.test.ts
+++ b/src/services/__tests__/chat.test.ts
@@ -4,6 +4,7 @@ import { merge } from 'lodash-es';
 import OpenAI from 'openai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_USER_AVATAR } from '@/const/meta';
 import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
 import {
   LobeAnthropicAI,
@@ -31,8 +32,6 @@ import { aiModelSelectors } from '@/store/aiInfra';
 import { useToolStore } from '@/store/tool';
 import { toolSelectors } from '@/store/tool/selectors';
 import { UserStore } from '@/store/user';
-import { useUserStore } from '@/store/user';
-import { modelConfigSelectors } from '@/store/user/selectors';
 import { UserSettingsState, initialSettingsState } from '@/store/user/slices/settings/initialState';
 import { DalleManifest } from '@/tools/dalle';
 import { WebBrowsingManifest } from '@/tools/web-browsing';
@@ -671,7 +670,7 @@ describe('ChatService', () => {
             updatedAt: 1702723964330,
             extra: {},
             meta: {
-              avatar: '😀',
+              avatar: DEFAULT_USER_AVATAR,
             },
           },
         ] as ChatMessage[];
@@ -913,7 +912,7 @@ describe('ChatService', () => {
             updatedAt: 1702723964330,
             extra: {},
             meta: {
-              avatar: '😀',
+              avatar: DEFAULT_USER_AVATAR,
             },
           },
         ] as ChatMessage[];

--- a/src/store/chat/slices/message/selectors.test.ts
+++ b/src/store/chat/slices/message/selectors.test.ts
@@ -91,7 +91,7 @@ const mockedChats = [
     content: 'Function Message',
     role: 'tool',
     meta: {
-      avatar: '🤯',
+      avatar: '/icons/icon-512x512.png',
       backgroundColor: 'rgba(0,0,0,0)',
       description: 'inbox.desc',
       title: 'inbox.title',
@@ -234,7 +234,7 @@ describe('chatSelectors', () => {
           content: 'Function Message',
           role: 'tool',
           meta: {
-            avatar: '🤯',
+            avatar: '/icons/icon-512x512.png',
             backgroundColor: 'rgba(0,0,0,0)',
             description: 'inbox.desc',
             title: 'inbox.title',

--- a/src/store/chat/slices/message/selectors.test.ts
+++ b/src/store/chat/slices/message/selectors.test.ts
@@ -10,7 +10,6 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { createServerConfigStore } from '@/store/serverConfig/store';
 import { LobeAgentConfig } from '@/types/agent';
 import { ChatMessage } from '@/types/message';
-import { MetaData } from '@/types/meta';
 import { merge } from '@/utils/merge';
 
 import { chatSelectors } from './selectors';
@@ -91,7 +90,7 @@ const mockedChats = [
     content: 'Function Message',
     role: 'tool',
     meta: {
-      avatar: '/icons/icon-512x512.png',
+      avatar: DEFAULT_INBOX_AVATAR,
       backgroundColor: 'rgba(0,0,0,0)',
       description: 'inbox.desc',
       title: 'inbox.title',
@@ -234,7 +233,7 @@ describe('chatSelectors', () => {
           content: 'Function Message',
           role: 'tool',
           meta: {
-            avatar: '/icons/icon-512x512.png',
+            avatar: DEFAULT_INBOX_AVATAR,
             backgroundColor: 'rgba(0,0,0,0)',
             description: 'inbox.desc',
             title: 'inbox.title',

--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { Mock, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { LOADING_FLAT } from '@/const/message';
+import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { PLUGIN_SCHEMA_API_MD5_PREFIX, PLUGIN_SCHEMA_SEPARATOR } from '@/const/plugin';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
@@ -66,7 +67,7 @@ describe('ChatPluginAction', () => {
           {
             ...toolMessage,
             meta: {
-              avatar: '/icons/icon-512x512.png',
+              avatar: DEFAULT_INBOX_AVATAR,
               backgroundColor: 'rgba(0,0,0,0)',
               description: undefined,
               title: undefined,

--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -66,7 +66,7 @@ describe('ChatPluginAction', () => {
           {
             ...toolMessage,
             meta: {
-              avatar: '🤯',
+              avatar: '/icons/icon-512x512.png',
               backgroundColor: 'rgba(0,0,0,0)',
               description: undefined,
               title: undefined,

--- a/src/store/user/slices/auth/selectors.test.ts
+++ b/src/store/user/slices/auth/selectors.test.ts
@@ -1,6 +1,7 @@
 import { t } from 'i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { BRANDING_NAME } from '@/const/branding';
 import { UserStore } from '@/store/user';
 
 import { authSelectors, userProfileSelectors } from './selectors';
@@ -44,7 +45,7 @@ describe('userProfileSelectors', () => {
         enableAuth: () => false,
       } as unknown as UserStore;
 
-      expect(userProfileSelectors.displayUserName(store)).toBe('LobeChat');
+      expect(userProfileSelectors.displayUserName(store)).toBe(BRANDING_NAME);
     });
 
     it('should return user username when auth is disabled and is desktop', () => {
@@ -202,7 +203,7 @@ describe('userProfileSelectors', () => {
         enableAuth: () => false,
       } as unknown as UserStore;
 
-      expect(userProfileSelectors.username(store)).toBe('LobeChat');
+      expect(userProfileSelectors.username(store)).toBe(BRANDING_NAME);
     });
 
     it('should return user username when auth is disabled and is desktop', () => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix failing tests by replacing hard-coded branding name and avatar values with their corresponding constants

Bug Fixes:
- Replace hard-coded branding name in tests with the BRANDING_NAME constant
- Swap hard-coded emoji avatars in tests for DEFAULT_USER_AVATAR and DEFAULT_INBOX_AVATAR constants