### PR TITLE
💄 style: Update mask style

### DIFF
--- a/src/styles/antdOverride.ts
+++ b/src/styles/antdOverride.ts
@@ -1,4 +1,5 @@
 import { Theme, css } from 'antd-style';
+import { rgba } from 'polished';
 
 export default ({ token }: { prefixCls: string; token: Theme }) => css`
   .${token.prefixCls}-popover {
@@ -14,5 +15,10 @@ export default ({ token }: { prefixCls: string; token: Theme }) => css`
     .${token.prefixCls}-menu-title-content {
       color: ${token.colorText};
     }
+  }
+
+  .${token.prefixCls}-modal-mask, .${token.prefixCls}-drawer-mask {
+    background: ${rgba(token.colorBgLayout, 0.5)} !important;
+    backdrop-filter: blur(2px);
   }
 `;

--- a/src/styles/antdOverride.ts
+++ b/src/styles/antdOverride.ts
@@ -19,6 +19,5 @@ export default ({ token }: { prefixCls: string; token: Theme }) => css`
 
   .${token.prefixCls}-modal-mask, .${token.prefixCls}-drawer-mask {
     background: ${rgba(token.colorBgLayout, 0.5)} !important;
-    backdrop-filter: blur(2px);
   }
 `;

--- a/src/styles/antdOverride.ts
+++ b/src/styles/antdOverride.ts
@@ -19,5 +19,6 @@ export default ({ token }: { prefixCls: string; token: Theme }) => css`
 
   .${token.prefixCls}-modal-mask, .${token.prefixCls}-drawer-mask {
     background: ${rgba(token.colorBgLayout, 0.5)} !important;
+    backdrop-filter: blur(2px);
   }
 `;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Apply updated styling to Ant Design modal and drawer masks

Enhancements:
- Import rgba helper from polished
- Set modal and drawer masks to use a 50% semi-transparent background and 2px blur