### PR TITLE
🐛 fix: Grok provider incorrect token calculation

### DIFF
--- a/src/libs/model-runtime/utils/usageConverter.ts
+++ b/src/libs/model-runtime/utils/usageConverter.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai';
 
 import { ModelTokensUsage } from '@/types/message';
 
-export const convertUsage = (usage: OpenAI.Completions.CompletionUsage): ModelTokensUsage => {
+export const convertUsage = (usage: OpenAI.Completions.CompletionUsage, provider?: string): ModelTokensUsage => {
   // 目前只有 pplx 才有 citation_tokens
   const inputTextTokens = usage.prompt_tokens || 0;
   const inputCitationTokens = (usage as any).citation_tokens || 0;
@@ -17,7 +17,11 @@ export const convertUsage = (usage: OpenAI.Completions.CompletionUsage): ModelTo
   const totalOutputTokens = usage.completion_tokens;
   const outputReasoning = usage.completion_tokens_details?.reasoning_tokens || 0;
   const outputAudioTokens = usage.completion_tokens_details?.audio_tokens || 0;
-  const outputTextTokens = totalOutputTokens - outputReasoning - outputAudioTokens;
+  
+  // XAI 的 completion_tokens 不包含 reasoning_tokens，需要特殊处理
+  const outputTextTokens = provider === 'xai' 
+    ? totalOutputTokens - outputAudioTokens
+    : totalOutputTokens - outputReasoning - outputAudioTokens;
 
   const totalTokens = inputCitationTokens + usage.total_tokens;
 


### PR DESCRIPTION
…ream to pass provider

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- fix #8385
- fix #8036

<img width="1109" height="440" alt="image" src="https://github.com/user-attachments/assets/314569a7-2135-4b32-945b-84130596c8a4" />

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Correct token counting for XAI providers by propagating the provider context through stream transformers into the usage converter and adjusting outputTextTokens logic accordingly.

Bug Fixes:
- Fix outputTextTokens calculation for XAI providers where completion_tokens excludes reasoning_tokens

Enhancements:
- Pass provider parameter through transformOpenAIStream and OpenAIStream pipeline to usage conversion

Tests:
- Add unit test for XAI provider token handling in convertUsage