### PR TITLE
 💄 style: add more OpenAI SDK Text2Image providers

### DIFF
--- a/src/config/aiModels/giteeai.ts
+++ b/src/config/aiModels/giteeai.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 const giteeaiChatModels: AIChatModelCard[] = [
   {
@@ -222,6 +222,145 @@ const giteeaiChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...giteeaiChatModels];
+const giteeaiImageModels: AIImageModelCard[] = [
+  {
+    description:
+      'FLUX.1-dev 是由 Black Forest Labs 开发的一款开源 多模态语言模型（Multimodal Language Model, MLLM），专为图文任务优化，融合了图像和文本的理解与生成能力。它建立在先进的大语言模型（如 Mistral-7B）基础上，通过精心设计的视觉编码器与多阶段指令微调，实现了图文协同处理与复杂任务推理的能力。',
+    displayName: 'FLUX.1-dev',
+    enabled: true,
+    id: 'FLUX.1-dev',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '1536x1536'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      '由 Black Forest Labs 开发的 120 亿参数文生图模型，采用潜在对抗扩散蒸馏技术，能够在 1 到 4 步内生成高质量图像。该模型性能媲美闭源替代品，并在 Apache-2.0 许可证下发布，适用于个人、科研和商业用途。',
+    displayName: 'flux-1-schnell',
+    enabled: true,
+    id: 'flux-1-schnell',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '1536x1536', '2048x2048'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'Stable Diffusion 3.5 Large Turbo 专注于高质量图像生成，具备强大的细节表现力和场景还原能力。',
+    displayName: 'stable-diffusion-3.5-large-turbo',
+    enabled: true,
+    id: 'stable-diffusion-3.5-large-turbo',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      '由 Stability AI 推出的最新文生图大模型。这一版本在继承了前代的优点上，对图像质量、文本理解和风格多样性等方面进行了显著改进，能够更准确地解读复杂的自然语言提示，并生成更为精确和多样化的图像。',
+    displayName: 'stable-diffusion-3-medium',
+    enabled: true,
+    id: 'stable-diffusion-3-medium',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      '由 Stability AI 开发并开源的文生图大模型，其创意图像生成能力位居行业前列。具备出色的指令理解能力，能够支持反向 Prompt 定义来精确生成内容。',
+    displayName: 'stable-diffusion-xl-base-1.0',
+    enabled: true,
+    id: 'stable-diffusion-xl-base-1.0',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+    {
+    description:
+      'Kolors 是由快手 Kolors 团队开发的文生图模型。由数十亿的参数训练，在视觉质量、中文语义理解和文本渲染方面有显著优势。',
+    displayName: 'Kolors',
+    enabled: true,
+    id: 'Kolors',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'hunyuandit-v1.2-distilled 是一款轻量级的文生图模型，经过蒸馏优化，能够快速生成高质量的图像，特别适用于低资源环境和实时生成任务。',
+    displayName: 'HunyuanDiT-v1.2-Diffusers-Distilled',
+    enabled: true,
+    id: 'HunyuanDiT-v1.2-Diffusers-Distilled',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'HiDream-I1 是一个全新的开源图像生成基础模型，是由国内企业智象未来开源的。拥有 170 亿参数(Flux是12B参数)，能够在几秒内实现行业领先的图像生成质量。',
+    displayName: 'HiDream-I1-Full',
+    enabled: true,
+    id: 'HiDream-I1-Full',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+];
+
+export const allModels = [...giteeaiChatModels, ...giteeaiImageModels];
 
 export default allModels;

--- a/src/config/aiModels/giteeai.ts
+++ b/src/config/aiModels/giteeai.ts
@@ -230,6 +230,7 @@ const giteeaiImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'FLUX.1-dev',
     parameters: {
+      imageUrl: { default: null },
       prompt: {
         default: '',
       },
@@ -247,6 +248,24 @@ const giteeaiImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'flux-1-schnell',
     parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '1536x1536', '2048x2048'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'FLUX.1-Kontext-dev 是由 Black Forest Labs 开发的一款基于 Rectified Flow Transformer 架构 的多模态图像生成与编辑模型，拥有 12B（120 亿）参数规模，专注于在给定上下文条件下生成、重构、增强或编辑图像。该模型结合了扩散模型的可控生成优势与 Transformer 的上下文建模能力，支持高质量图像输出，广泛适用于图像修复、图像补全、视觉场景重构等任务。',
+    displayName: 'FLUX.1-Kontext-dev',
+    enabled: true,
+    id: 'FLUX.1-Kontext-dev',
+    parameters: {
+      imageUrl: { default: null },
       prompt: {
         default: '',
       },
@@ -315,6 +334,7 @@ const giteeaiImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'Kolors',
     parameters: {
+      imageUrl: { default: null },
       prompt: {
         default: '',
       },
@@ -349,6 +369,114 @@ const giteeaiImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'HiDream-I1-Full',
     parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'HiDream-E1-Full 是由智象未来（HiDream.ai）推出的一款 开源多模态图像编辑大模型，基于先进的 Diffusion Transformer 架构，并结合强大的语言理解能力（内嵌 LLaMA 3.1-8B-Instruct），支持通过自然语言指令进行图像生成、风格迁移、局部编辑和内容重绘，具备出色的图文理解与执行能力。',
+    displayName: 'HiDream-E1-Full',
+    enabled: true,
+    id: 'HiDream-I1-Full',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'HelloMeme 是一个可以根据你提供的图片或动作，自动生成表情包、动图或短视频的 AI 工具。它不需要你有任何绘画或编程基础，只需要准备好参考图片，它就能帮你做出好看、有趣、风格一致的内容。',
+    displayName: 'HelloMeme',
+    enabled: true,
+    id: 'HelloMeme',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'OmniConsistency 通过引入大规模 Diffusion Transformers（DiTs）和配对风格化数据，提升图像到图像（Image-to-Image）任务中的风格一致性和泛化能力，避免风格退化。',
+    displayName: 'OmniConsistency',
+    enabled: true,
+    id: 'OmniConsistency',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'InstantCharacter 是由腾讯 AI 团队在 2025 年发布的一款 无需微调（tuning-free） 的个性化角色生成模型，旨在实现高保真、跨场景的一致角色生成。该模型支持仅基于 一张参考图像 对角色进行建模，并能够将该角色灵活迁移到各种风格、动作和背景中。',
+    displayName: 'InstantCharacter',
+    enabled: true,
+    id: 'InstantCharacter',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'DreamO 是由字节跳动与北京大学联合研发的开源图像定制生成模型，旨在通过统一架构支持多任务图像生成。它采用高效的组合建模方法，可根据用户指定的身份、主体、风格、背景等多个条件生成高度一致且定制化的图像。',
+    displayName: 'DreamO',
+    enabled: true,
+    id: 'DreamO',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024'],
+      },
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'AnimeSharp（又名 “4x‑AnimeSharp”） 是 Kim2091 基于 ESRGAN 架构开发的开源超分辨率模型，专注于动漫风格图像的放大与锐化。它于 2022 年 2 月重命名自 “4x-TextSharpV1”，原本也适用于文字图像但性能针对动漫内容进行了大幅优化',
+    displayName: 'AnimeSharp',
+    enabled: true,
+    id: 'AnimeSharp',
+    parameters: {
+      imageUrl: { default: null },
       prompt: {
         default: '',
       },

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 // https://siliconflow.cn/zh-cn/models
 const siliconcloudChatModels: AIChatModelCard[] = [
@@ -830,6 +830,28 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...siliconcloudChatModels];
+const siliconcloudImageModels: AIImageModelCard[] = [
+  {
+    description:
+      'Kolors 是由快手 Kolors 团队开发的基于潜在扩散的大规模文本到图像生成模型。该模型通过数十亿文本-图像对的训练，在视觉质量、复杂语义准确性以及中英文字符渲染方面展现出显著优势。它不仅支持中英文输入，在理解和生成中文特定内容方面也表现出色',
+    displayName: 'Kolors',
+    enabled: true,
+    id: 'Kwai-Kolors/Kolors',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '960x1280', '768x1024', '720x1440', '720x1280'],
+      },
+    },
+    releasedAt: '2024-07-06',
+    type: 'image',
+  },
+];
+
+export const allModels = [...siliconcloudChatModels, ...siliconcloudImageModels];
 
 export default allModels;

--- a/src/config/aiModels/stepfun.ts
+++ b/src/config/aiModels/stepfun.ts
@@ -317,6 +317,27 @@ const stepfunImageModels: AIImageModelCard[] = [
     releasedAt: '2025-07-15',
     type: 'image',
   },
+  {
+    description:
+      '该模型专注于图像编辑任务，能够根据用户提供的图片和文本描述，对图片进行修改和增强。支持多种输入格式，包括文本描述和示例图像。模型能够理解用户的意图，并生成符合要求的图像编辑结果。',
+    displayName: 'Step 1X Edit',
+    enabled: true,
+    id: 'step-1x-edit',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['512x512', '768x768', '1024x1024'],
+      },
+      steps: { default: 28, max: 100, min: 1 },
+    },
+    releasedAt: '2025-03-04',
+    type: 'image',
+  },
 ];
 
 export const allModels = [...stepfunChatModels, ...stepfunImageModels];

--- a/src/config/aiModels/stepfun.ts
+++ b/src/config/aiModels/stepfun.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 // https://platform.stepfun.com/docs/pricing/details
 
@@ -275,6 +275,50 @@ const stepfunChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...stepfunChatModels];
+const stepfunImageModels: AIImageModelCard[] = [
+  // https://platform.stepfun.com/docs/llm/image
+  {
+    description:
+      '阶跃星辰新一代生图模型,该模型专注于图像生成任务,能够根据用户提供的文本描述,生成高质量的图像。新模型生成图片质感更真实，中英文文字生成能力更强。',
+    displayName: 'Step 2X Large',
+    enabled: true,
+    id: 'step-2x-large',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['256x256', '512x512', '768x768', '1024x1024', '1280x800', '800x1280'],
+      },
+      steps: { default: 50, max: 100, min: 1 },
+    },
+    releasedAt: '2024-08-07',
+    type: 'image',
+  },
+  {
+    description:
+      '该模型拥有强大的图像生成能力，支持文本描述作为输入方式。具备原生的中文支持，能够更好的理解和处理中文文本描述，并且能够更准确地捕捉文本描述中的语义信息，并将其转化为图像特征，从而实现更精准的图像生成。模型能够根据输入生成高分辨率、高质量的图像，并具备一定的风格迁移能力。',
+    displayName: 'Step 1X Medium',
+    enabled: true,
+    id: 'step-1x-medium',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['256x256', '512x512', '768x768', '1024x1024', '1280x800', '800x1280'],
+      },
+      steps: { default: 50, max: 100, min: 1 },
+    },
+    releasedAt: '2025-07-15',
+    type: 'image',
+  },
+];
+
+export const allModels = [...stepfunChatModels, ...stepfunImageModels];
 
 export default allModels;

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -512,6 +512,7 @@ const doubaoChatModels: AIChatModelCard[] = [
 const volcengineImageModels: AIImageModelCard[] = [
   {
     /*
+    // TODO: AIImageModelCard 不支持 config.deploymentName
     config: {
       deploymentName: 'doubao-seedream-3-0-t2i-250415',
     },
@@ -534,12 +535,12 @@ const volcengineImageModels: AIImageModelCard[] = [
     releasedAt: '2025-04-15',
     type: 'image',
   },
+  /*
+  // Note: Doubao 图片编辑模型与文生图模型公用一个 Endpoint，当前如果存在 imageUrl 会切换至 edit endpoint 下
   {
-    /*
     config: {
       deploymentName: 'doubao-seededit-3-0-i2i-250628',
     },
-    */
     description:
       'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验。支持通过文本指令编辑图像，生成图像的边长在512～1536之间。',
     displayName: 'Doubao-SeedEdit-3.0-i2i',
@@ -559,6 +560,7 @@ const volcengineImageModels: AIImageModelCard[] = [
     releasedAt: '2025-06-28',
     type: 'image',
   },
+  */
 ];
 
 export const allModels = [...doubaoChatModels, ...volcengineImageModels];

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -536,14 +536,14 @@ const volcengineImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   /*
-  // Note: Doubao 图片编辑模型与文生图模型公用一个 Endpoint，当前如果存在 imageUrl 会切换至 edit endpoint 下
+  // Note: Doubao 图生图模型与文生图模型公用一个 Endpoint，当前如果存在 imageUrl 会切换至 edit endpoint 下
   {
     config: {
       deploymentName: 'doubao-seededit-3-0-i2i-250628',
     },
     description:
       'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验。支持通过文本指令编辑图像，生成图像的边长在512～1536之间。',
-    displayName: 'Doubao-SeedEdit-3.0-i2i',
+    displayName: 'Doubao SeedEdit 3.0 i2i',
     enabled: true,
     id: 'doubao-seededit-3-0-i2i-250628',
     parameters: {

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -517,7 +517,7 @@ const volcengineImageModels: AIImageModelCard[] = [
     },
     */
     description:
-      'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验',
+      'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验。基于文本提示词生成图片。',
     displayName: 'Doubao Seedream 3.0 t2i',
     enabled: true,
     id: 'doubao-seedream-3-0-t2i-250415',
@@ -532,6 +532,31 @@ const volcengineImageModels: AIImageModelCard[] = [
       },
     },
     releasedAt: '2025-04-15',
+    type: 'image',
+  },
+  {
+    /*
+    config: {
+      deploymentName: 'doubao-seededit-3-0-i2i-250628',
+    },
+    */
+    description:
+      'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验。支持通过文本指令编辑图像，生成图像的边长在512～1536之间。',
+    displayName: 'Doubao-SeedEdit-3.0-i2i',
+    enabled: true,
+    id: 'doubao-seededit-3-0-i2i-250628',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '864x1152', '1152x864', '1280x720', '720x1280', '832x1248', '1248x832', '1512x648'],
+      },
+    },
+    releasedAt: '2025-06-28',
     type: 'image',
   },
 ];

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -511,14 +511,16 @@ const doubaoChatModels: AIChatModelCard[] = [
 
 const volcengineImageModels: AIImageModelCard[] = [
   {
+    /*
     config: {
       deploymentName: 'doubao-seedream-3-0-t2i-250415',
     },
+    */
     description:
       'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验',
     displayName: 'Doubao Seedream 3.0 t2i',
     enabled: true,
-    id: 'Doubao-Seedream-3.0-t2i',
+    id: 'doubao-seedream-3-0-t2i-250415',
     parameters: {
       prompt: {
         default: '',

--- a/src/config/aiModels/volcengine.ts
+++ b/src/config/aiModels/volcengine.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 // modelInfo https://www.volcengine.com/docs/82379/1330310
 // pricing https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement
@@ -509,6 +509,31 @@ const doubaoChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...doubaoChatModels];
+const volcengineImageModels: AIImageModelCard[] = [
+  {
+    config: {
+      deploymentName: 'doubao-seedream-3-0-t2i-250415',
+    },
+    description:
+      'Doubao图片生成模型由字节跳动 Seed 团队研发，支持文字与图片输入，提供高可控、高质量的图片生成体验',
+    displayName: 'Doubao Seedream 3.0 t2i',
+    enabled: true,
+    id: 'Doubao-Seedream-3.0-t2i',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['1024x1024', '864x1152', '1152x864', '1280x720', '720x1280', '832x1248', '1248x832', '1512x648'],
+      },
+    },
+    releasedAt: '2025-04-15',
+    type: 'image',
+  },
+];
+
+export const allModels = [...doubaoChatModels, ...volcengineImageModels];
 
 export default allModels;

--- a/src/config/aiModels/wenxin.ts
+++ b/src/config/aiModels/wenxin.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 const wenxinChatModels: AIChatModelCard[] = [
   {
@@ -564,6 +564,47 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...wenxinChatModels];
+const wenxinImageModels: AIImageModelCard[] = [
+  {
+    description:
+      '百度自研的iRAG（image based RAG），检索增强的文生图技术，将百度搜索的亿级图片资源跟强大的基础模型能力相结合，就可以生成各种超真实的图片，整体效果远远超过文生图原生系统，去掉了AI味儿，而且成本很低。iRAG具备无幻觉、超真实、立等可取等特点。',
+    displayName: 'ERINE iRAG',
+    enabled: true,
+    id: 'irag-1.0',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['768x768', '1024x1024', '1536x1536', '2048x2048', '1024x768', '2048x1536', '768x1024', '1536x2048', '1024x576', '2048x1152', '576x1024', '1152x2048'],
+      },
+    },
+    releasedAt: '2025-02-05',
+    type: 'image',
+  },
+  {
+    description:
+      '具有120亿参数的修正流变换器，能够根据文本描述生成图像。',
+    displayName: 'FLUX.1-schnell',
+    enabled: true,
+    id: 'flux.1-schnell',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: ['768x768', '1024x1024', '1536x1536', '2048x2048', '1024x768', '2048x1536', '768x1024', '1536x2048', '1024x576', '2048x1152', '576x1024', '1152x2048'],
+      },
+      steps: { default: 25, max: 50, min: 1 },
+    },
+    releasedAt: '2025-03-27',
+    type: 'image',
+  },
+];
+
+export const allModels = [...wenxinChatModels, ...wenxinImageModels];
 
 export default allModels;

--- a/src/config/aiModels/wenxin.ts
+++ b/src/config/aiModels/wenxin.ts
@@ -568,7 +568,7 @@ const wenxinImageModels: AIImageModelCard[] = [
   {
     description:
       '百度自研的iRAG（image based RAG），检索增强的文生图技术，将百度搜索的亿级图片资源跟强大的基础模型能力相结合，就可以生成各种超真实的图片，整体效果远远超过文生图原生系统，去掉了AI味儿，而且成本很低。iRAG具备无幻觉、超真实、立等可取等特点。',
-    displayName: 'ERINE iRAG',
+    displayName: 'ERNIE iRAG',
     enabled: true,
     id: 'irag-1.0',
     parameters: {
@@ -586,7 +586,7 @@ const wenxinImageModels: AIImageModelCard[] = [
   {
     description:
       '百度自研的ERNIE iRAG Edit图像编辑模型支持基于图片进行erase（消除对象）、repaint（重绘对象）、variation（生成变体）等操作。',
-    displayName: 'ERINE iRAG Edit',
+    displayName: 'ERNIE iRAG Edit',
     enabled: true,
     id: 'ernie-irag-edit',
     parameters: {

--- a/src/config/aiModels/wenxin.ts
+++ b/src/config/aiModels/wenxin.ts
@@ -585,6 +585,25 @@ const wenxinImageModels: AIImageModelCard[] = [
   },
   {
     description:
+      '百度自研的ERNIE iRAG Edit图像编辑模型支持基于图片进行erase（消除对象）、repaint（重绘对象）、variation（生成变体）等操作。',
+    displayName: 'ERINE iRAG Edit',
+    enabled: true,
+    id: 'ernie-irag-edit',
+    parameters: {
+      imageUrl: { default: null },
+      prompt: {
+        default: '',
+      },
+      size: {
+        default: '1024x1024',
+        enum: ['768x768', '1024x1024', '1536x1536', '2048x2048', '1024x768', '2048x1536', '768x1024', '1536x2048', '1024x576', '2048x1152', '576x1024', '1152x2048'],
+      },
+    },
+    releasedAt: '2025-04-17',
+    type: 'image',
+  },
+  {
+    description:
       '具有120亿参数的修正流变换器，能够根据文本描述生成图像。',
     displayName: 'FLUX.1-schnell',
     enabled: true,

--- a/src/config/aiModels/xai.ts
+++ b/src/config/aiModels/xai.ts
@@ -1,4 +1,4 @@
-import { AIChatModelCard } from '@/types/aiModel';
+import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 // https://docs.x.ai/docs/models
 const xaiChatModels: AIChatModelCard[] = [
@@ -158,6 +158,23 @@ const xaiChatModels: AIChatModelCard[] = [
   },
 ];
 
-export const allModels = [...xaiChatModels];
+const xaiImageModels: AIImageModelCard[] = [
+  {
+    description:
+      '我们最新的图像生成模型可以根据文本提示生成生动逼真的图像。它在营销、社交媒体和娱乐等领域的图像生成方面表现出色。',
+    displayName: 'Grok 2 Image 1212',
+    enabled: true,
+    id: 'grok-2-image-1212',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+    },
+    releasedAt: '2024-12-12',
+    type: 'image',
+  },
+];
+
+export const allModels = [...xaiChatModels, ...xaiImageModels];
 
 export default allModels;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

1. 增加 `xai` `siliconcloud` `stepfun` `wenxin` `gitee` `volcengine` 文生图模型
2. 为部分模型增加 `seed` 及 `step` 参数
3. 更新模型描述及发布日期 ~~[TODO]~~
4. 图标更新 https://github.com/lobehub/lobe-icons/issues/148 https://github.com/lobehub/lobe-icons/pull/147

---

Note:
1. xAI 不支持设定图片大小 https://docs.x.ai/docs/guides/image-generations#parameters

---

|Provider|Model|Screenshot|
|-|-|-|
|xAI|`grok-2-image-1212`|<img width="1792" height="1294" alt="image" src="https://github.com/user-attachments/assets/becfce60-14bd-40f2-905d-027eb26cf1e7" />|
|Wenxin|`irag-1.0`|<img width="1700" height="1156" alt="image" src="https://github.com/user-attachments/assets/3cc48678-6557-420c-ad39-d95f2d89f65f" />|
|Wenxin|`flux.1-schnell`|<img width="1670" height="1170" alt="image" src="https://github.com/user-attachments/assets/516dd66b-3fca-47fc-8bf3-dfc47deb69cd" />|
|Stepfun|`step-2x-large`|<img width="1680" height="962" alt="image" src="https://github.com/user-attachments/assets/9350239b-72f3-424f-a320-5489dc49e262" />|
|Stepfun|`step-1x-medium`|<img width="1682" height="1030" alt="image" src="https://github.com/user-attachments/assets/495d3c02-cca3-4891-9e97-fba6870d10d6" />|
|Volcengine|`Doubao-Seedream-3.0-t2i`|<img width="1682" height="1224" alt="image" src="https://github.com/user-attachments/assets/c28feb5e-b7f6-42f3-a3c7-a6c584c0e8ee" />|
|Siliconcloud|`Kwai-Kolors/Kolors`|<img width="1682" height="1002" alt="image" src="https://github.com/user-attachments/assets/d1492224-c3cf-4423-b85b-7a00c3e127f1" />|
|Gitee|`FLUX.1-dev`|<img width="1690" height="1212" alt="image" src="https://github.com/user-attachments/assets/0c2a0fad-f725-49dc-a43a-865381fcbea6" />|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for new image generation models across multiple AI providers by extending the configuration with AIImageModelCard definitions and updating exports.

New Features:
- Add Wenxin image models: ERINE iRAG, Stable-Diffusion-XL, FLUX.1-schnell
- Add StepFun image models: Step 2X Large, Step 1X Edit, Step 1X Medium
- Add xAI image model: Grok 2 Image 1212
- Add SiliconCloud image model: Kolors
- Extend allModels exports to include both chat and image models

Enhancements:
- Include image providers alongside chat models in the consolidated allModels export

## Summary by Sourcery

Add and configure new text-to-image models across multiple AI providers by extending configuration files with AIImageModelCard entries, updating parameters, and merging image and chat model exports.

New Features:
- Add support for GiteeAI image models including FLUX.1-dev, flux-1-schnell, multiple Stable Diffusion variants, Kolors, HunyuanDiT, and HiDream-I1
- Add support for StepFun image models: Step 2X Large and Step 1X Medium
- Add support for Wenxin image models: ERINE iRAG and FLUX.1-schnell
- Add support for SiliconCloud image model Kolors
- Add support for xAI image model Grok 2 Image 1212

Enhancements:
- Introduce seed and steps parameters for applicable image models
- Include image models alongside chat models in allModels exports
- Update model descriptions and release dates for new image providers

## Summary by Sourcery

Register multiple AIImageModelCard entries to extend text-to-image capabilities across various providers and enhance export consolidation.

New Features:
- Add support for new text-to-image models for gitee.ai, StepFun, Wenxin, Volcengine, SiliconCloud, and xAI providers

Enhancements:
- Introduce seed and steps parameters for applicable image models
- Combine chat and image model exports in allModels for unified model listings