### PR TITLE
✨ feat: bypass auth provider for debugging locally

### DIFF
--- a/src/libs/next-auth/auth.config.ts
+++ b/src/libs/next-auth/auth.config.ts
@@ -1,20 +1,25 @@
+import type { Provider } from '@auth/core/providers';
 import type { NextAuthConfig } from 'next-auth';
 
 import { authEnv } from '@/config/auth';
 
 import { ssoProviders } from './sso-providers';
 
-export const initSSOProviders = () => {
-  return authEnv.NEXT_PUBLIC_ENABLE_NEXT_AUTH
-    ? authEnv.NEXT_AUTH_SSO_PROVIDERS.split(/[,，]/).map((provider) => {
-        const validProvider = ssoProviders.find((item) => item.id === provider.trim());
+export function initSSOProviders() {
+  const enabledFlag = authEnv.NEXT_PUBLIC_ENABLE_NEXT_AUTH;
+  const providers: Provider[] = [];
 
-        if (validProvider) return validProvider.provider;
+  if (!enabledFlag) return providers;
 
-        throw new Error(`[NextAuth] provider ${provider} is not supported`);
-      })
-    : [];
-};
+  const enabledKeys = authEnv.NEXT_AUTH_SSO_PROVIDERS.split(/[,，]/);
+  for (const key of enabledKeys) {
+    const provider = ssoProviders[key];
+    if (!provider) throw new Error(`[NextAuth] provider ${key} is not supported`);
+    providers.push(provider);
+  }
+
+  return providers;
+}
 
 // Notice this is only an object, not a full Auth.js instance
 export default {

--- a/src/libs/next-auth/sso-providers/auth0.ts
+++ b/src/libs/next-auth/sso-providers/auth0.ts
@@ -4,28 +4,23 @@ import { authEnv } from '@/config/auth';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'auth0',
-  provider: Auth0({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    // all scopes in Auth0 ref: https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims
-    authorization: { params: { scope: 'openid email profile' } },
-    // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
-    clientId: authEnv.AUTH0_CLIENT_ID ?? process.env.AUTH_AUTH0_ID,
-    clientSecret: authEnv.AUTH0_CLIENT_SECRET ?? process.env.AUTH_AUTH0_SECRET,
-    issuer: authEnv.AUTH0_ISSUER ?? process.env.AUTH_AUTH0_ISSUER,
-    // Remove End
-    profile(profile) {
-      return {
-        email: profile.email,
-        id: profile.sub,
-        image: profile.picture,
-        name: profile.name,
-        providerAccountId: profile.sub,
-      };
-    },
-  }),
-};
-
-export default provider;
+export const auth0 = Auth0({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  // all scopes in Auth0 ref: https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims
+  authorization: { params: { scope: 'openid email profile' } },
+  // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
+  clientId: authEnv.AUTH0_CLIENT_ID ?? process.env.AUTH_AUTH0_ID,
+  clientSecret: authEnv.AUTH0_CLIENT_SECRET ?? process.env.AUTH_AUTH0_SECRET,
+  issuer: authEnv.AUTH0_ISSUER ?? process.env.AUTH_AUTH0_ISSUER,
+  // Remove End
+  profile(profile) {
+    return {
+      email: profile.email,
+      id: profile.sub,
+      image: profile.picture,
+      name: profile.name,
+      providerAccountId: profile.sub,
+    };
+  },
+});

--- a/src/libs/next-auth/sso-providers/authelia.ts
+++ b/src/libs/next-auth/sso-providers/authelia.ts
@@ -15,27 +15,22 @@ export type AutheliaProfile = {
   sub: string; // The users id
 };
 
-const provider = {
+export const authelia = {
+  ...CommonProviderConfig,
+  authorization: { params: { scope: 'openid email profile' } },
+  checks: ['state', 'pkce'],
+  clientId: authEnv.AUTHELIA_CLIENT_ID ?? process.env.AUTH_AUTHELIA_ID,
+  clientSecret: authEnv.AUTHELIA_CLIENT_SECRET ?? process.env.AUTH_AUTHELIA_SECRET,
   id: 'authelia',
-  provider: {
-    ...CommonProviderConfig,
-    authorization: { params: { scope: 'openid email profile' } },
-    checks: ['state', 'pkce'],
-    clientId: authEnv.AUTHELIA_CLIENT_ID ?? process.env.AUTH_AUTHELIA_ID,
-    clientSecret: authEnv.AUTHELIA_CLIENT_SECRET ?? process.env.AUTH_AUTHELIA_SECRET,
-    id: 'authelia',
-    issuer: authEnv.AUTHELIA_ISSUER ?? process.env.AUTH_AUTHELIA_ISSUER,
-    name: 'Authelia',
-    profile(profile) {
-      return {
-        email: profile.email,
-        id: profile.sub,
-        name: profile.name,
-        providerAccountId: profile.sub,
-      };
-    },
-    type: 'oidc',
-  } satisfies OIDCConfig<AutheliaProfile>,
-};
-
-export default provider;
+  issuer: authEnv.AUTHELIA_ISSUER ?? process.env.AUTH_AUTHELIA_ISSUER,
+  name: 'Authelia',
+  profile(profile) {
+    return {
+      email: profile.email,
+      id: profile.sub,
+      name: profile.name,
+      providerAccountId: profile.sub,
+    };
+  },
+  type: 'oidc',
+} satisfies OIDCConfig<AutheliaProfile>;

--- a/src/libs/next-auth/sso-providers/authentik.ts
+++ b/src/libs/next-auth/sso-providers/authentik.ts
@@ -4,29 +4,24 @@ import { authEnv } from '@/config/auth';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'authentik',
-  provider: Authentik({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    // all scopes in Authentik ref: https://goauthentik.io/docs/providers/oauth2
-    authorization: { params: { scope: 'openid email profile' } },
-    // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
-    clientId: authEnv.AUTHENTIK_CLIENT_ID ?? process.env.AUTH_AUTHENTIK_ID,
-    clientSecret: authEnv.AUTHENTIK_CLIENT_SECRET ?? process.env.AUTH_AUTHENTIK_SECRET,
-    issuer: authEnv.AUTHENTIK_ISSUER ?? process.env.AUTH_AUTHENTIK_ISSUER,
-    // Remove end
-    // TODO(NextAuth): map unique user id to `providerAccountId` field
-    //  profile(profile) {
-    //   return {
-    //     email: profile.email,
-    //     image: profile.picture,
-    //     name: profile.name,
-    //     providerAccountId: profile.user_id,
-    //     id: profile.user_id,
-    //   };
-    // },
-  }),
-};
-
-export default provider;
+export const authentik = Authentik({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  // all scopes in Authentik ref: https://goauthentik.io/docs/providers/oauth2
+  authorization: { params: { scope: 'openid email profile' } },
+  // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
+  clientId: authEnv.AUTHENTIK_CLIENT_ID ?? process.env.AUTH_AUTHENTIK_ID,
+  clientSecret: authEnv.AUTHENTIK_CLIENT_SECRET ?? process.env.AUTH_AUTHENTIK_SECRET,
+  issuer: authEnv.AUTHENTIK_ISSUER ?? process.env.AUTH_AUTHENTIK_ISSUER,
+  // Remove end
+  // TODO(NextAuth): map unique user id to `providerAccountId` field
+  //  profile(profile) {
+  //   return {
+  //     email: profile.email,
+  //     image: profile.picture,
+  //     name: profile.name,
+  //     providerAccountId: profile.user_id,
+  //     id: profile.user_id,
+  //   };
+  // },
+});

--- a/src/libs/next-auth/sso-providers/azure-ad.ts
+++ b/src/libs/next-auth/sso-providers/azure-ad.ts
@@ -5,29 +5,24 @@ import { authEnv } from '@/config/auth';
 import { getMicrosoftEntraIdIssuer } from './microsoft-entra-id-helper';
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'azure-ad',
-  provider: AzureAD({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    // all scopes in Azure AD ref: https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes
-    authorization: { params: { scope: 'openid email profile' } },
-    // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
-    clientId: authEnv.AZURE_AD_CLIENT_ID ?? process.env.AUTH_AZURE_AD_ID,
-    clientSecret: authEnv.AZURE_AD_CLIENT_SECRET ?? process.env.AUTH_AZURE_AD_SECRET,
-    issuer: getMicrosoftEntraIdIssuer(),
-    // Remove end
-    // TODO(NextAuth): map unique user id to `providerAccountId` field
-    // profile(profile) {
-    //   return {
-    //     email: profile.email,
-    //     image: profile.picture,
-    //     name: profile.name,
-    //     providerAccountId: profile.user_id,
-    //     id: profile.user_id,
-    //   };
-    // },
-  }),
-};
-
-export default provider;
+export const azureAd = AzureAD({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  // all scopes in Azure AD ref: https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes
+  authorization: { params: { scope: 'openid email profile' } },
+  // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
+  clientId: authEnv.AZURE_AD_CLIENT_ID ?? process.env.AUTH_AZURE_AD_ID,
+  clientSecret: authEnv.AZURE_AD_CLIENT_SECRET ?? process.env.AUTH_AZURE_AD_SECRET,
+  issuer: getMicrosoftEntraIdIssuer(),
+  // Remove end
+  // TODO(NextAuth): map unique user id to `providerAccountId` field
+  // profile(profile) {
+  //   return {
+  //     email: profile.email,
+  //     image: profile.picture,
+  //     name: profile.name,
+  //     providerAccountId: profile.user_id,
+  //     id: profile.user_id,
+  //   };
+  // },
+});

--- a/src/libs/next-auth/sso-providers/bypass.ts
+++ b/src/libs/next-auth/sso-providers/bypass.ts
@@ -5,43 +5,38 @@ import { UserModel } from '@/database/models/user';
 import { serverDB } from '@/database/server';
 import { AgentService } from '@/server/services/agent';
 
-const provider = {
-  id: 'bypass',
-  provider: Credential({
-    async authorize() {
-      const { NEXT_PUBLIC_ENABLED_SERVER_SERVICE } = getServerDBConfig();
+export const bypass = Credential({
+  async authorize() {
+    const { NEXT_PUBLIC_ENABLED_SERVER_SERVICE } = getServerDBConfig();
 
-      // Ensure the user exists, since credentials provider won't trigger the db adapter.
-      if (NEXT_PUBLIC_ENABLED_SERVER_SERVICE && process.env.NEXT_RUNTIME === 'nodejs') {
-        const id = 'bYpaSsusER';
-        const email = 'bypass@lobehub.com';
-        const avatar = '/icons/icon-192x192.png';
-        const fullName = 'Bypass User';
+    // Ensure the user exists, since credentials provider won't trigger the db adapter.
+    if (NEXT_PUBLIC_ENABLED_SERVER_SERVICE && process.env.NEXT_RUNTIME === 'nodejs') {
+      const id = 'bYpaSsusER';
+      const email = 'bypass@lobehub.com';
+      const avatar = '/icons/icon-192x192.png';
+      const fullName = 'Bypass User';
 
-        const existingUser = await UserModel.findById(serverDB, id);
+      const existingUser = await UserModel.findById(serverDB, id);
 
-        if (!existingUser) {
-          await UserModel.createUser(serverDB, {
-            avatar,
-            email,
-            emailVerifiedAt: new Date(),
-            fullName,
-            id,
-          });
+      if (!existingUser) {
+        await UserModel.createUser(serverDB, {
+          avatar,
+          email,
+          emailVerifiedAt: new Date(),
+          fullName,
+          id,
+        });
 
-          const agentService = new AgentService(serverDB, id);
-          await agentService.createInbox();
-        }
-        return { email, id, image: avatar, name: fullName };
-      } else {
-        throw new Error(
-          'Bypass authentication is only available in server mode with Node.js runtime',
-        );
+        const agentService = new AgentService(serverDB, id);
+        await agentService.createInbox();
       }
-    },
-    id: 'bypass',
-    name: 'Development Bypass',
-  }),
-};
-
-export default provider;
+      return { email, id, image: avatar, name: fullName };
+    } else {
+      throw new Error(
+        'Bypass authentication is only available in server mode with Node.js runtime',
+      );
+    }
+  },
+  id: 'bypass',
+  name: 'Development Bypass',
+});

--- a/src/libs/next-auth/sso-providers/bypass.ts
+++ b/src/libs/next-auth/sso-providers/bypass.ts
@@ -1,0 +1,47 @@
+import Credential from 'next-auth/providers/credentials';
+
+import { getServerDBConfig } from '@/config/db';
+import { UserModel } from '@/database/models/user';
+import { serverDB } from '@/database/server';
+import { AgentService } from '@/server/services/agent';
+
+const provider = {
+  id: 'bypass',
+  provider: Credential({
+    async authorize() {
+      const { NEXT_PUBLIC_ENABLED_SERVER_SERVICE } = getServerDBConfig();
+
+      // Ensure the user exists, since credentials provider won't trigger the db adapter.
+      if (NEXT_PUBLIC_ENABLED_SERVER_SERVICE && process.env.NEXT_RUNTIME === 'nodejs') {
+        const id = 'bYpaSsusER';
+        const email = 'bypass@lobehub.com';
+        const avatar = '/icons/icon-192x192.png';
+        const fullName = 'Bypass User';
+
+        const existingUser = await UserModel.findById(serverDB, id);
+
+        if (!existingUser) {
+          await UserModel.createUser(serverDB, {
+            avatar,
+            email,
+            emailVerifiedAt: new Date(),
+            fullName,
+            id,
+          });
+
+          const agentService = new AgentService(serverDB, id);
+          await agentService.createInbox();
+        }
+        return { email, id, image: avatar, name: fullName };
+      } else {
+        throw new Error(
+          'Bypass authentication is only available in server mode with Node.js runtime',
+        );
+      }
+    },
+    id: 'bypass',
+    name: 'Development Bypass',
+  }),
+};
+
+export default provider;

--- a/src/libs/next-auth/sso-providers/casdoor.ts
+++ b/src/libs/next-auth/sso-providers/casdoor.ts
@@ -35,16 +35,11 @@ function LobeCasdoorProvider(config: OIDCUserConfig<CasdoorProfile>): OIDCConfig
   };
 }
 
-const provider = {
-  id: 'casdoor',
-  provider: LobeCasdoorProvider({
-    authorization: {
-      params: { scope: 'openid profile email' },
-    },
-    clientId: process.env.AUTH_CASDOOR_ID,
-    clientSecret: process.env.AUTH_CASDOOR_SECRET,
-    issuer: process.env.AUTH_CASDOOR_ISSUER,
-  }),
-};
-
-export default provider;
+export const casdoor = LobeCasdoorProvider({
+  authorization: {
+    params: { scope: 'openid profile email' },
+  },
+  clientId: process.env.AUTH_CASDOOR_ID,
+  clientSecret: process.env.AUTH_CASDOOR_SECRET,
+  issuer: process.env.AUTH_CASDOOR_ISSUER,
+});

--- a/src/libs/next-auth/sso-providers/cloudflare-zero-trust.ts
+++ b/src/libs/next-auth/sso-providers/cloudflare-zero-trust.ts
@@ -10,28 +10,23 @@ export type CloudflareZeroTrustProfile = {
   sub: string;
 };
 
-const provider = {
+export const cloudflareZeroTrust = {
+  ...CommonProviderConfig,
+  authorization: { params: { scope: 'openid email profile' } },
+  checks: ['state', 'pkce'],
+  clientId: authEnv.CLOUDFLARE_ZERO_TRUST_CLIENT_ID ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_ID,
+  clientSecret:
+    authEnv.CLOUDFLARE_ZERO_TRUST_CLIENT_SECRET ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_SECRET,
   id: 'cloudflare-zero-trust',
-  provider: {
-    ...CommonProviderConfig,
-    authorization: { params: { scope: 'openid email profile' } },
-    checks: ['state', 'pkce'],
-    clientId: authEnv.CLOUDFLARE_ZERO_TRUST_CLIENT_ID ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_ID,
-    clientSecret:
-      authEnv.CLOUDFLARE_ZERO_TRUST_CLIENT_SECRET ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_SECRET,
-    id: 'cloudflare-zero-trust',
-    issuer: authEnv.CLOUDFLARE_ZERO_TRUST_ISSUER ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_ISSUER,
-    name: 'Cloudflare Zero Trust',
-    profile(profile) {
-      return {
-        email: profile.email,
-        id: profile.sub,
-        name: profile.name ?? profile.email,
-        providerAccountId: profile.sub,
-      };
-    },
-    type: 'oidc',
-  } satisfies OIDCConfig<CloudflareZeroTrustProfile>,
-};
-
-export default provider;
+  issuer: authEnv.CLOUDFLARE_ZERO_TRUST_ISSUER ?? process.env.AUTH_CLOUDFLARE_ZERO_TRUST_ISSUER,
+  name: 'Cloudflare Zero Trust',
+  profile(profile) {
+    return {
+      email: profile.email,
+      id: profile.sub,
+      name: profile.name ?? profile.email,
+      providerAccountId: profile.sub,
+    };
+  },
+  type: 'oidc',
+} satisfies OIDCConfig<CloudflareZeroTrustProfile>;

--- a/src/libs/next-auth/sso-providers/cognito.ts
+++ b/src/libs/next-auth/sso-providers/cognito.ts
@@ -1,12 +1,7 @@
 import Cognito from 'next-auth/providers/cognito';
 
-const provider = {
-  id: 'cognito',
-  provider: Cognito({
-    clientId: process.env.AUTH_COGNITO_ID,
-    clientSecret: process.env.AUTH_COGNITO_SECRET,
-    issuer: process.env.AUTH_COGNITO_ISSUER,
-  }),
-};
-
-export default provider;
+export const cognito = Cognito({
+  clientId: process.env.AUTH_COGNITO_ID,
+  clientSecret: process.env.AUTH_COGNITO_SECRET,
+  issuer: process.env.AUTH_COGNITO_ISSUER,
+});

--- a/src/libs/next-auth/sso-providers/generic-oidc.ts
+++ b/src/libs/next-auth/sso-providers/generic-oidc.ts
@@ -13,28 +13,23 @@ export type GenericOIDCProfile = {
   username?: string;
 };
 
-const provider = {
+export const genericOidc = {
+  ...CommonProviderConfig,
+  authorization: { params: { scope: 'email openid profile' } },
+  checks: ['state', 'pkce'],
+  clientId: authEnv.GENERIC_OIDC_CLIENT_ID ?? process.env.AUTH_GENERIC_OIDC_ID,
+  clientSecret: authEnv.GENERIC_OIDC_CLIENT_SECRET ?? process.env.AUTH_GENERIC_OIDC_SECRET,
   id: 'generic-oidc',
-  provider: {
-    ...CommonProviderConfig,
-    authorization: { params: { scope: 'email openid profile' } },
-    checks: ['state', 'pkce'],
-    clientId: authEnv.GENERIC_OIDC_CLIENT_ID ?? process.env.AUTH_GENERIC_OIDC_ID,
-    clientSecret: authEnv.GENERIC_OIDC_CLIENT_SECRET ?? process.env.AUTH_GENERIC_OIDC_SECRET,
-    id: 'generic-oidc',
-    issuer: authEnv.GENERIC_OIDC_ISSUER ?? process.env.AUTH_GENERIC_OIDC_ISSUER,
-    name: 'Generic OIDC',
-    profile(profile) {
-      return {
-        email: profile.email,
-        id: profile.sub,
-        image: profile.picture,
-        name: profile.name ?? profile.username ?? profile.email,
-        providerAccountId: profile.sub,
-      };
-    },
-    type: 'oidc',
-  } satisfies OIDCConfig<GenericOIDCProfile>,
-};
-
-export default provider;
+  issuer: authEnv.GENERIC_OIDC_ISSUER ?? process.env.AUTH_GENERIC_OIDC_ISSUER,
+  name: 'Generic OIDC',
+  profile(profile) {
+    return {
+      email: profile.email,
+      id: profile.sub,
+      image: profile.picture,
+      name: profile.name ?? profile.username ?? profile.email,
+      providerAccountId: profile.sub,
+    };
+  },
+  type: 'oidc',
+} satisfies OIDCConfig<GenericOIDCProfile>;

--- a/src/libs/next-auth/sso-providers/github.ts
+++ b/src/libs/next-auth/sso-providers/github.ts
@@ -4,26 +4,21 @@ import { authEnv } from '@/config/auth';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'github',
-  provider: GitHub({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    authorization: { params: { scope: 'read:user user:email' } },
-    // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
-    clientId: authEnv.GITHUB_CLIENT_ID ?? process.env.AUTH_GITHUB_ID,
-    clientSecret: authEnv.GITHUB_CLIENT_SECRET ?? process.env.AUTH_GITHUB_SECRET,
-    // Remove end
-    profile: (profile) => {
-      return {
-        email: profile.email,
-        id: profile.id.toString(),
-        image: profile.avatar_url,
-        name: profile.name,
-        providerAccountId: profile.id.toString(),
-      };
-    },
-  }),
-};
-
-export default provider;
+export const github = GitHub({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  authorization: { params: { scope: 'read:user user:email' } },
+  // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
+  clientId: authEnv.GITHUB_CLIENT_ID ?? process.env.AUTH_GITHUB_ID,
+  clientSecret: authEnv.GITHUB_CLIENT_SECRET ?? process.env.AUTH_GITHUB_SECRET,
+  // Remove end
+  profile: (profile) => {
+    return {
+      email: profile.email,
+      id: profile.id.toString(),
+      image: profile.avatar_url,
+      name: profile.name,
+      providerAccountId: profile.id.toString(),
+    };
+  },
+});

--- a/src/libs/next-auth/sso-providers/google.ts
+++ b/src/libs/next-auth/sso-providers/google.ts
@@ -2,19 +2,14 @@ import Google from 'next-auth/providers/google';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'google',
-  provider: Google({
-    ...CommonProviderConfig,
-    authorization: {
-      params: {
-        scope:
-          'openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid',
-      },
+export const google = Google({
+  ...CommonProviderConfig,
+  authorization: {
+    params: {
+      scope:
+        'openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid',
     },
-    clientId: process.env.AUTH_GOOGLE_CLIENT_ID,
-    clientSecret: process.env.AUTH_GOOGLE_CLIENT_SECRET,
-  }),
-};
-
-export default provider;
+  },
+  clientId: process.env.AUTH_GOOGLE_CLIENT_ID,
+  clientSecret: process.env.AUTH_GOOGLE_CLIENT_SECRET,
+});

--- a/src/libs/next-auth/sso-providers/index.ts
+++ b/src/libs/next-auth/sso-providers/index.ts
@@ -1,41 +1,46 @@
-import Auth0 from './auth0';
-import Authelia from './authelia';
-import Authentik from './authentik';
-import AzureAD from './azure-ad';
-import Bypass from './bypass';
-import Casdoor from './casdoor';
-import CloudflareZeroTrust from './cloudflare-zero-trust';
-import Cognito from './cognito';
-import GenericOIDC from './generic-oidc';
-import Github from './github';
-import Google from './google';
-import Keycloak from './keycloak';
-import Logto from './logto';
-import MicrosoftEntraID from './microsoft-entra-id';
-import WeChat from './wechat';
-import Zitadel from './zitadel';
+import type { Provider } from '@auth/core/providers';
 
-const ssoProviders = [
-  Auth0,
-  Authentik,
-  AzureAD,
-  GenericOIDC,
-  Github,
-  Zitadel,
-  Authelia,
-  Logto,
-  CloudflareZeroTrust,
-  Casdoor,
-  MicrosoftEntraID,
-  WeChat,
-  Keycloak,
-  Google,
-  Cognito,
-  Bypass,
-];
+import { auth0 } from './auth0';
+import { authelia } from './authelia';
+import { authentik } from './authentik';
+import { azureAd } from './azure-ad';
+import { bypass } from './bypass';
+import { casdoor } from './casdoor';
+import { cloudflareZeroTrust } from './cloudflare-zero-trust';
+import { cognito } from './cognito';
+import { genericOidc } from './generic-oidc';
+import { github } from './github';
+import { google } from './google';
+import { keycloak } from './keycloak';
+import { logto } from './logto';
+import { microsoftEntraId } from './microsoft-entra-id';
+import { wechat } from './wechat';
+import { zitadel } from './zitadel';
 
-if (process.env.NODE_ENV === 'development') {
-  ssoProviders.push(Bypass);
+function createSSOProviders() {
+  const providers: Record<string, Provider> = {
+    auth0,
+    authelia,
+    authentik,
+    azureAd,
+    casdoor,
+    'cloudflare-zero-trust': cloudflareZeroTrust,
+    cognito,
+    'generic-oidc': genericOidc,
+    github,
+    google,
+    keycloak,
+    logto,
+    'microsoft-entra-id': microsoftEntraId,
+    wechat,
+    zitadel,
+  };
+
+  if (process.env.NODE_ENV === 'development') {
+    providers.bypass = bypass;
+  }
+
+  return providers;
 }
 
-export { ssoProviders };
+export const ssoProviders = createSSOProviders();

--- a/src/libs/next-auth/sso-providers/index.ts
+++ b/src/libs/next-auth/sso-providers/index.ts
@@ -2,8 +2,10 @@ import Auth0 from './auth0';
 import Authelia from './authelia';
 import Authentik from './authentik';
 import AzureAD from './azure-ad';
+import Bypass from './bypass';
 import Casdoor from './casdoor';
 import CloudflareZeroTrust from './cloudflare-zero-trust';
+import Cognito from './cognito';
 import GenericOIDC from './generic-oidc';
 import Github from './github';
 import Google from './google';
@@ -12,9 +14,8 @@ import Logto from './logto';
 import MicrosoftEntraID from './microsoft-entra-id';
 import WeChat from './wechat';
 import Zitadel from './zitadel';
-import Cognito from "./cognito";
 
-export const ssoProviders = [
+const ssoProviders = [
   Auth0,
   Authentik,
   AzureAD,
@@ -29,5 +30,12 @@ export const ssoProviders = [
   WeChat,
   Keycloak,
   Google,
-  Cognito
+  Cognito,
+  Bypass,
 ];
+
+if (process.env.NODE_ENV === 'development') {
+  ssoProviders.push(Bypass);
+}
+
+export { ssoProviders };

--- a/src/libs/next-auth/sso-providers/keycloak.ts
+++ b/src/libs/next-auth/sso-providers/keycloak.ts
@@ -2,24 +2,19 @@ import Keycloak from 'next-auth/providers/keycloak';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'keycloak',
-  provider: Keycloak({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    authorization: { params: { scope: 'openid email profile' } },
-    clientId: process.env.AUTH_KEYCLOAK_ID,
-    clientSecret: process.env.AUTH_KEYCLOAK_SECRET,
-    issuer: process.env.AUTH_KEYCLOAK_ISSUER,
-    profile(profile) {
-      return {
-        email: profile.email,
-        id: profile.sub,
-        name: profile.name,
-        providerAccountId: profile.sub,
-      };
-    },
-  }),
-};
-
-export default provider;
+export const keycloak = Keycloak({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  authorization: { params: { scope: 'openid email profile' } },
+  clientId: process.env.AUTH_KEYCLOAK_ID,
+  clientSecret: process.env.AUTH_KEYCLOAK_SECRET,
+  issuer: process.env.AUTH_KEYCLOAK_ISSUER,
+  profile(profile) {
+    return {
+      email: profile.email,
+      id: profile.sub,
+      name: profile.name,
+      providerAccountId: profile.sub,
+    };
+  },
+});

--- a/src/libs/next-auth/sso-providers/logto.ts
+++ b/src/libs/next-auth/sso-providers/logto.ts
@@ -33,18 +33,13 @@ function LobeLogtoProvider(config: OIDCUserConfig<LogtoProfile>): OIDCConfig<Log
   };
 }
 
-const provider = {
-  id: 'logto',
-  provider: LobeLogtoProvider({
-    authorization: {
-      params: { scope: 'openid offline_access profile email' },
-    },
-    // You can get the issuer value from the Logto Application Details page,
-    // in the field "Issuer endpoint"
-    clientId: authEnv.LOGTO_CLIENT_ID ?? process.env.AUTH_LOGTO_ID,
-    clientSecret: authEnv.LOGTO_CLIENT_SECRET ?? process.env.AUTH_LOGTO_SECRET,
-    issuer: authEnv.LOGTO_ISSUER ?? process.env.AUTH_LOGTO_ISSUER,
-  }),
-};
-
-export default provider;
+export const logto = LobeLogtoProvider({
+  authorization: {
+    params: { scope: 'openid offline_access profile email' },
+  },
+  // You can get the issuer value from the Logto Application Details page,
+  // in the field "Issuer endpoint"
+  clientId: authEnv.LOGTO_CLIENT_ID ?? process.env.AUTH_LOGTO_ID,
+  clientSecret: authEnv.LOGTO_CLIENT_SECRET ?? process.env.AUTH_LOGTO_SECRET,
+  issuer: authEnv.LOGTO_ISSUER ?? process.env.AUTH_LOGTO_ISSUER,
+});

--- a/src/libs/next-auth/sso-providers/microsoft-entra-id.ts
+++ b/src/libs/next-auth/sso-providers/microsoft-entra-id.ts
@@ -3,17 +3,12 @@ import MicrosoftEntraID from 'next-auth/providers/microsoft-entra-id';
 import { getMicrosoftEntraIdIssuer } from './microsoft-entra-id-helper';
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'microsoft-entra-id',
-  provider: MicrosoftEntraID({
-    ...CommonProviderConfig,
-    // Specify auth scope, at least include 'openid email'
-    // all scopes in Azure AD ref: https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes
-    authorization: { params: { scope: 'openid email profile' } },
-    clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID ?? process.env.AUTH_AZURE_AD_ID,
-    clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET ?? process.env.AUTH_AZURE_AD_SECRET,
-    issuer: getMicrosoftEntraIdIssuer(),
-  }),
-};
-
-export default provider;
+export const microsoftEntraId = MicrosoftEntraID({
+  ...CommonProviderConfig,
+  // Specify auth scope, at least include 'openid email'
+  // all scopes in Azure AD ref: https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes
+  authorization: { params: { scope: 'openid email profile' } },
+  clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID ?? process.env.AUTH_AZURE_AD_ID,
+  clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET ?? process.env.AUTH_AZURE_AD_SECRET,
+  issuer: getMicrosoftEntraIdIssuer(),
+});

--- a/src/libs/next-auth/sso-providers/wechat.ts
+++ b/src/libs/next-auth/sso-providers/wechat.ts
@@ -2,35 +2,30 @@ import WeChat, { WeChatProfile } from '@auth/core/providers/wechat';
 
 import { CommonProviderConfig } from './sso.config';
 
-const provider = {
-  id: 'wechat',
-  provider: WeChat({
-    ...CommonProviderConfig,
-    clientId: process.env.AUTH_WECHAT_ID,
-    clientSecret: process.env.AUTH_WECHAT_SECRET,
-    platformType: 'WebsiteApp',
-    profile: (profile: WeChatProfile) => {
-      return {
-        email: null,
-        id: profile.unionid,
-        image: profile.headimgurl,
-        name: profile.nickname,
-        providerAccountId: profile.unionid,
-      };
+export const wechat = WeChat({
+  ...CommonProviderConfig,
+  clientId: process.env.AUTH_WECHAT_ID,
+  clientSecret: process.env.AUTH_WECHAT_SECRET,
+  platformType: 'WebsiteApp',
+  profile: (profile: WeChatProfile) => {
+    return {
+      email: null,
+      id: profile.unionid,
+      image: profile.headimgurl,
+      name: profile.nickname,
+      providerAccountId: profile.unionid,
+    };
+  },
+  style: { bg: '#fff', logo: 'https://authjs.dev/img/providers/wechat.svg', text: '#000' },
+  token: {
+    async conform(response: Response) {
+      const data = await response.json();
+      console.log('wechat data:', data);
+      return new Response(JSON.stringify({ ...data, token_type: 'bearer' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
     },
-    style: { bg: '#fff', logo: 'https://authjs.dev/img/providers/wechat.svg', text: '#000' },
-    token: {
-      async conform(response: Response) {
-        const data = await response.json();
-        console.log('wechat data:', data);
-        return new Response(JSON.stringify({ ...data, token_type: 'bearer' }), {
-          headers: { 'Content-Type': 'application/json' },
-        });
-      },
-      params: { appid: process.env.AUTH_WECHAT_ID, secret: process.env.AUTH_WECHAT_SECRET },
-      url: 'https://api.weixin.qq.com/sns/oauth2/access_token',
-    },
-  }),
-};
-
-export default provider;
+    params: { appid: process.env.AUTH_WECHAT_ID, secret: process.env.AUTH_WECHAT_SECRET },
+    url: 'https://api.weixin.qq.com/sns/oauth2/access_token',
+  },
+});

--- a/src/libs/next-auth/sso-providers/zitadel.ts
+++ b/src/libs/next-auth/sso-providers/zitadel.ts
@@ -2,27 +2,22 @@ import Zitadel from 'next-auth/providers/zitadel';
 
 import { authEnv } from '@/config/auth';
 
-const provider = {
-  id: 'zitadel',
-  provider: Zitadel({
-    // Available scopes in ZITADEL: https://zitadel.com/docs/apis/openidoauth/scopes
-    authorization: { params: { scope: 'openid email profile' } },
-    // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
-    clientId: authEnv.ZITADEL_CLIENT_ID ?? process.env.AUTH_ZITADEL_ID,
-    clientSecret: authEnv.ZITADEL_CLIENT_SECRET ?? process.env.AUTH_ZITADEL_SECRET,
-    issuer: authEnv.ZITADEL_ISSUER ?? process.env.AUTH_ZITADEL_ISSUER,
-    // Remove end
-    // TODO(NextAuth): map unique user id to `providerAccountId` field
-    // profile(profile) {
-    //   return {
-    //     email: profile.email,
-    //     image: profile.picture,
-    //     name: profile.name,
-    //     providerAccountId: profile.user_id,
-    //     id: profile.user_id,
-    //   };
-    // },
-  }),
-};
-
-export default provider;
+export const zitadel = Zitadel({
+  // Available scopes in ZITADEL: https://zitadel.com/docs/apis/openidoauth/scopes
+  authorization: { params: { scope: 'openid email profile' } },
+  // TODO(NextAuth ENVs Migration): Remove once nextauth envs migration time end
+  clientId: authEnv.ZITADEL_CLIENT_ID ?? process.env.AUTH_ZITADEL_ID,
+  clientSecret: authEnv.ZITADEL_CLIENT_SECRET ?? process.env.AUTH_ZITADEL_SECRET,
+  issuer: authEnv.ZITADEL_ISSUER ?? process.env.AUTH_ZITADEL_ISSUER,
+  // Remove end
+  // TODO(NextAuth): map unique user id to `providerAccountId` field
+  // profile(profile) {
+  //   return {
+  //     email: profile.email,
+  //     image: profile.picture,
+  //     name: profile.name,
+  //     providerAccountId: profile.user_id,
+  //     id: profile.user_id,
+  //   };
+  // },
+});


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Add new bypass auth provider for simplifying debug locally. Now we don't need to setup a clerk or any other OAuth provider in development. Just set `NEXT_AUTH_SSO_PROVIDERS=bypass` and use the stub auth provider.

The bypass provider manually calls the database for user persistence because it uses NextAuth's credentials provider instead of OAuth providers. Which won't trigger the `LobeNextAuthDbAdapter`.

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Introduce a development-only bypass authentication provider to simplify local debugging without external OAuth setup

New Features:
- Add a bypass SSO provider using NextAuth credentials that creates a stub user and session for development
- Automatically include the bypass provider in the ssoProviders array when running in development mode

Enhancements:
- Refactor ssoProviders export to support conditional provider injection based on environment