### PR TITLE
💄 style: fix setting window layout when in desktop was disappear

### DIFF
--- a/src/app/[variants]/(main)/settings/_layout/Desktop/index.tsx
+++ b/src/app/[variants]/(main)/settings/_layout/Desktop/index.tsx
@@ -36,7 +36,7 @@ const Layout = memo<LayoutProps>(({ children, category }) => {
       height={'100%'}
       horizontal={md}
       ref={ref}
-      style={{ background: theme.colorBgContainer, flex: '1', position: 'relative', width: '0' }}
+      style={{ background: theme.colorBgContainer, flex: '1', position: 'relative' }}
     >
       {md ? (
         <SideBar>{category}</SideBar>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Remove width: '0' from the Desktop layout container style to prevent the settings window from disappearing on desktop