### PR TITLE
♻️ refactor: clean mcp sitemap

### DIFF
--- a/src/app/sitemap.tsx
+++ b/src/app/sitemap.tsx
@@ -17,10 +17,9 @@ export async function generateSitemaps() {
   const staticSitemaps = sitemapModule.sitemapIndexs;
 
   // 获取需要分页的类型的页数
-  const [pluginPages, assistantPages, mcpPages, modelPages] = await Promise.all([
+  const [pluginPages, assistantPages, modelPages] = await Promise.all([
     sitemapModule.getPluginPageCount(),
     sitemapModule.getAssistantPageCount(),
-    sitemapModule.getMcpPageCount(),
     sitemapModule.getModelPageCount(),
   ]);
 
@@ -30,7 +29,6 @@ export async function generateSitemaps() {
     ...Array.from({ length: assistantPages }, (_, i) => ({
       id: `assistants-${i + 1}` as SitemapType,
     })),
-    ...Array.from({ length: mcpPages }, (_, i) => ({ id: `mcp-${i + 1}` as SitemapType })),
     ...Array.from({ length: modelPages }, (_, i) => ({ id: `models-${i + 1}` as SitemapType })),
   ];
 
@@ -60,9 +58,6 @@ export default async function sitemap({ id }: { id: string }): Promise<MetadataR
     case SitemapType.Assistants: {
       return sitemapModule.getAssistants(page);
     }
-    case SitemapType.Mcp: {
-      return sitemapModule.getMcp(page);
-    }
     case SitemapType.Plugins: {
       return sitemapModule.getPlugins(page);
     }
@@ -81,10 +76,6 @@ export default async function sitemap({ id }: { id: string }): Promise<MetadataR
       if (id.startsWith('assistants-')) {
         const pageNum = parseInt(id.split('-')[1], 10);
         return sitemapModule.getAssistants(pageNum);
-      }
-      if (id.startsWith('mcp-')) {
-        const pageNum = parseInt(id.split('-')[1], 10);
-        return sitemapModule.getMcp(pageNum);
       }
       if (id.startsWith('models-')) {
         const pageNum = parseInt(id.split('-')[1], 10);

--- a/src/server/routers/lambda/market/index.ts
+++ b/src/server/routers/lambda/market/index.ts
@@ -173,20 +173,6 @@ export const marketRouter = router({
       }
     }),
 
-  getMcpIdentifiers: marketProcedure.query(async ({ ctx }) => {
-    log('getMcpIdentifiers called');
-
-    try {
-      return await ctx.discoverService.getMcpIdentifiers();
-    } catch (error) {
-      log('Error fetching mcp identifiers: %O', error);
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to fetch mcp identifiers',
-      });
-    }
-  }),
-
   getMcpList: marketProcedure
     .input(
       z

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -462,19 +462,6 @@ export class DiscoverService {
     return result;
   };
 
-  getMcpIdentifiers = async (): Promise<IdentifiersResponse> => {
-    log('getMcpIdentifiers: fetching identifiers');
-    const result = await this.market.plugins.getPublishedIdentifiers({
-      cache: 'force-cache',
-      next: {
-        revalidate: CacheRevalidate.List,
-        tags: [CacheTag.Discover, CacheTag.MCP],
-      },
-    });
-    log('getMcpIdentifiers: returning %d identifiers', result.length);
-    return result;
-  };
-
   getMcpList = async (params: McpQueryParams = {}): Promise<McpListResponse> => {
     log('getMcpList: params=%O', params);
     const { locale } = params;

--- a/src/server/sitemap.test.ts
+++ b/src/server/sitemap.test.ts
@@ -13,7 +13,6 @@ describe('Sitemap', () => {
       // Mock the page count methods to return specific values for testing
       vi.spyOn(sitemap, 'getPluginPageCount').mockResolvedValue(2);
       vi.spyOn(sitemap, 'getAssistantPageCount').mockResolvedValue(3);
-      vi.spyOn(sitemap, 'getMcpPageCount').mockResolvedValue(1);
       vi.spyOn(sitemap, 'getModelPageCount').mockResolvedValue(2);
 
       const index = await sitemap.getIndex();
@@ -31,7 +30,6 @@ describe('Sitemap', () => {
       expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/assistants-1.xml')}</loc>`);
       expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/assistants-2.xml')}</loc>`);
       expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/assistants-3.xml')}</loc>`);
-      expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/mcp-1.xml')}</loc>`);
       expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/models-1.xml')}</loc>`);
       expect(index).toContain(`<loc>${getCanonicalUrl('/sitemap/models-2.xml')}</loc>`);
 
@@ -218,46 +216,6 @@ describe('Sitemap', () => {
     });
   });
 
-  describe('getMcp', () => {
-    it('should return a valid mcp sitemap without pagination', async () => {
-      vi.spyOn(sitemap['discoverService'], 'getMcpIdentifiers').mockResolvedValue([
-        // @ts-ignore
-        { identifier: 'test-mcp', lastModified: '2023-01-01' },
-      ]);
-
-      const mcpSitemap = await sitemap.getMcp();
-      expect(mcpSitemap.length).toBe(15);
-      expect(mcpSitemap).toContainEqual(
-        expect.objectContaining({
-          url: getCanonicalUrl('/discover/mcp/test-mcp'),
-          lastModified: '2023-01-01T00:00:00.000Z',
-        }),
-      );
-      expect(mcpSitemap).toContainEqual(
-        expect.objectContaining({
-          url: getCanonicalUrl('/discover/mcp/test-mcp?hl=zh-CN'),
-          lastModified: '2023-01-01T00:00:00.000Z',
-        }),
-      );
-    });
-
-    it('should return a valid mcp sitemap with pagination', async () => {
-      const mockMcps = Array.from({ length: 80 }, (_, i) => ({
-        identifier: `test-mcp-${i}`,
-        lastModified: '2023-01-01',
-      }));
-
-      vi.spyOn(sitemap['discoverService'], 'getMcpIdentifiers').mockResolvedValue(
-        // @ts-ignore
-        mockMcps,
-      );
-
-      // Test first page (should have 80 items, all on first page)
-      const firstPageSitemap = await sitemap.getMcp(1);
-      expect(firstPageSitemap.length).toBe(80 * 15); // 80 items * 15 locales
-    });
-  });
-
   describe('getProviders', () => {
     it('should return a valid providers sitemap', async () => {
       vi.spyOn(sitemap['discoverService'], 'getProviderIdentifiers').mockResolvedValue([
@@ -301,16 +259,6 @@ describe('Sitemap', () => {
 
       const pageCount = await sitemap.getAssistantPageCount();
       expect(pageCount).toBe(3); // 250 items / 100 per page = ceil(2.5) = 3 pages
-    });
-
-    it('should return correct mcp page count', async () => {
-      vi.spyOn(sitemap['discoverService'], 'getMcpIdentifiers').mockResolvedValue(
-        // @ts-ignore
-        Array.from({ length: 50 }, (_, i) => ({ identifier: `mcp-${i}` })),
-      );
-
-      const pageCount = await sitemap.getMcpPageCount();
-      expect(pageCount).toBe(1); // 50 items / 100 per page = 1 page
     });
 
     it('should return correct model page count', async () => {

--- a/src/server/sitemap.ts
+++ b/src/server/sitemap.ts
@@ -52,12 +52,6 @@ export class Sitemap {
     return Math.ceil(list.length / ITEMS_PER_PAGE);
   }
 
-  // 获取MCP总页数
-  async getMcpPageCount(): Promise<number> {
-    const list = await this.discoverService.getMcpIdentifiers();
-    return Math.ceil(list.length / ITEMS_PER_PAGE);
-  }
-
   // 获取模型总页数
   async getModelPageCount(): Promise<number> {
     const list = await this.discoverService.getModelIdentifiers();
@@ -171,10 +165,9 @@ export class Sitemap {
     );
 
     // 获取需要分页的类型的页数
-    const [pluginPages, assistantPages, mcpPages, modelPages] = await Promise.all([
+    const [pluginPages, assistantPages, modelPages] = await Promise.all([
       this.getPluginPageCount(),
       this.getAssistantPageCount(),
-      this.getMcpPageCount(),
       this.getModelPageCount(),
     ]);
 
@@ -191,11 +184,6 @@ export class Sitemap {
             SITEMAP_BASE_URL,
             isDev ? `assistants-${i + 1}` : `assistants-${i + 1}.xml`,
           ),
-        ),
-      ),
-      ...Array.from({ length: mcpPages }, (_, i) =>
-        this._generateSitemapLink(
-          getCanonicalUrl(SITEMAP_BASE_URL, isDev ? `mcp-${i + 1}` : `mcp-${i + 1}.xml`),
         ),
       ),
       ...Array.from({ length: modelPages }, (_, i) =>
@@ -233,31 +221,6 @@ export class Sitemap {
     // 如果没有指定页数，返回所有（向后兼容）
     const sitmap = list.map((item) =>
       this._genSitemap(urlJoin('/discover/assistant', item.identifier), {
-        lastModified: item?.lastModified || LAST_MODIFIED,
-      }),
-    );
-    return flatten(sitmap);
-  }
-
-  async getMcp(page?: number): Promise<MetadataRoute.Sitemap> {
-    const list = await this.discoverService.getMcpIdentifiers();
-
-    if (page !== undefined) {
-      const startIndex = (page - 1) * ITEMS_PER_PAGE;
-      const endIndex = startIndex + ITEMS_PER_PAGE;
-      const pageMcps = list.slice(startIndex, endIndex);
-
-      const sitmap = pageMcps.map((item) =>
-        this._genSitemap(urlJoin('/discover/mcp', item.identifier), {
-          lastModified: item?.lastModified || LAST_MODIFIED,
-        }),
-      );
-      return flatten(sitmap);
-    }
-
-    // 如果没有指定页数，返回所有（向后兼容）
-    const sitmap = list.map((item) =>
-      this._genSitemap(urlJoin('/discover/mcp', item.identifier), {
         lastModified: item?.lastModified || LAST_MODIFIED,
       }),
     );

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -83,10 +83,6 @@ class DiscoverService {
     });
   };
 
-  getMcpIdentifiers = async (): Promise<IdentifiersResponse> => {
-    return lambdaClient.market.getMcpIdentifiers.query();
-  };
-
   getMcpList = async (params: McpQueryParams = {}): Promise<McpListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return lambdaClient.market.getMcpList.query({

--- a/src/store/discover/slices/mcp/action.ts
+++ b/src/store/discover/slices/mcp/action.ts
@@ -8,7 +8,6 @@ import { DiscoverStore } from '@/store/discover';
 import { globalHelpers } from '@/store/global/helpers';
 import {
   DiscoverMcpDetail,
-  IdentifiersResponse,
   McpListResponse,
   McpQueryParams,
 } from '@/types/discover';
@@ -20,7 +19,6 @@ export interface MCPAction {
   }) => SWRResponse<DiscoverMcpDetail>;
   useFetchMcpList: (params: McpQueryParams) => SWRResponse<McpListResponse>;
   useMcpCategories: (params: CategoryListQuery) => SWRResponse<CategoryItem[]>;
-  useMcpIdentifiers: () => SWRResponse<IdentifiersResponse>;
 }
 
 export const createMCPSlice: StateCreator<
@@ -60,11 +58,5 @@ export const createMCPSlice: StateCreator<
         revalidateOnFocus: false,
       },
     );
-  },
-
-  useMcpIdentifiers: () => {
-    return useClientDataSWR('mcp-identifiers', async () => discoverService.getMcpIdentifiers(), {
-      revalidateOnFocus: false,
-    });
   },
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Remove obsolete MCP sitemap functionality and cleanup related code across services, routers, tests, and client integration

Enhancements:
- Delete getMcp and getMcpPageCount methods and drop MCP pagination from sitemap generation
- Remove MCP-related tests and references in sitemap index and page routing
- Eliminate getMcpIdentifiers endpoint, service method, and client-side hooks