### PR TITLE
🐛 fix: fix subscription plan tag display

### DIFF
--- a/src/features/User/UserInfo.tsx
+++ b/src/features/User/UserInfo.tsx
@@ -30,9 +30,10 @@ export interface UserInfoProps extends FlexboxProps {
 const UserInfo = memo<UserInfoProps>(({ avatarProps, onClick, ...rest }) => {
   const { styles, theme } = useStyles();
   const isSignedIn = useUserStore(authSelectors.isLogin);
-  const [nickname, username] = useUserStore((s) => [
+  const [nickname, username, subscriptionPlan] = useUserStore((s) => [
     userProfileSelectors.nickName(s),
     userProfileSelectors.username(s),
+    s.subscriptionPlan,
   ]);
 
   return (
@@ -52,7 +53,7 @@ const UserInfo = memo<UserInfoProps>(({ avatarProps, onClick, ...rest }) => {
           <div className={styles.username}>{username}</div>
         </Flexbox>
       </Flexbox>
-      {isSignedIn && <PlanTag />}
+      {isSignedIn && <PlanTag type={subscriptionPlan} />}
     </Flexbox>
   );
 });

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -113,6 +113,7 @@ export const createCommonSlice: StateCreator<
                 preference,
                 serverLanguageModel: serverConfig.languageModel,
                 settings: data.settings || {},
+                subscriptionPlan: data.subscriptionPlan,
                 user,
               },
               false,

--- a/src/store/user/slices/common/initialState.ts
+++ b/src/store/user/slices/common/initialState.ts
@@ -1,9 +1,12 @@
+import { Plans } from '@/types/subscription';
+
 export interface CommonState {
   isOnboard: boolean;
   isShowPWAGuide: boolean;
   isUserCanEnableTrace: boolean;
   isUserHasConversation: boolean;
   isUserStateInit: boolean;
+  subscriptionPlan?: Plans;
 }
 
 export const initialCommonState: CommonState = {

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -1,6 +1,7 @@
 import type { PartialDeep } from 'type-fest';
 import { z } from 'zod';
 
+import { Plans } from '@/types/subscription';
 import { TopicDisplayMode } from '@/types/topic';
 import { UserSettings } from '@/types/user/settings';
 
@@ -56,6 +57,7 @@ export interface UserInitializationState {
   lastName?: string;
   preference: UserPreference;
   settings: PartialDeep<UserSettings>;
+  subscriptionPlan?: Plans;
   userId?: string;
   username?: string;
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Integrate subscriptionPlan into user store and display logic

Bug Fixes:
- Pass subscriptionPlan to PlanTag in UserInfo component

Enhancements:
- Add subscriptionPlan field to CommonState and UserInitializationState with corresponding type definitions
- Populate subscriptionPlan in common slice actions during user initialization