### PR TITLE
💄 style: update Aliyun Bailian models

### DIFF
--- a/src/config/aiModels/qwen.ts
+++ b/src/config/aiModels/qwen.ts
@@ -4,9 +4,6 @@ import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 const qwenChatModels: AIChatModelCard[] = [
   {
-    abilities: {
-      functionCall: true,
-    },
     contextWindowTokens: 131_072,
     description:
       '总参数 1T，激活参数 32B。 非思维模型中，在前沿知识、数学和编码方面达到了顶尖水平，更擅长通用 Agent 任务。 针对代理任务进行了精心优化，不仅能回答问题，还能采取行动。 最适用于即兴、通用聊天和代理体验，是一款无需长时间思考的反射级模型。',
@@ -48,6 +45,23 @@ const qwenChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+    },
+    contextWindowTokens: 262_144,
+    description: '通义千问代码模型开源版。最新的 qwen3-coder-480b-a35b-instruct 是基于 Qwen3 的代码生成模型，具有强大的Coding Agent能力，擅长工具调用和环境交互，能够实现自主编程、代码能力卓越的同时兼具通用能力。',
+    displayName: 'Qwen3 Coder 480B A35B',
+    id: 'qwen3-coder-480b-a35b-instruct',
+    maxOutput: 65_536,
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      input: 9, // tokens 32K ~ 128K
+      output: 36,
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 131_072,
@@ -84,6 +98,25 @@ const qwenChatModels: AIChatModelCard[] = [
       output: 8,
     },
     releasedAt: '2025-07-22',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      '相较上一版本（Qwen3-30B-A3B）中英文和多语言整体通用能力有大幅提升。主观开放类任务专项优化，显著更加符合用户偏好，能够提供更有帮助性的回复。',
+    displayName: 'Qwen3 30B A3B Instruct 2507',
+    id: 'qwen3-30b-a3b-instruct-2507',
+    maxOutput: 32_768,
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      input: 0.75,
+      output: 3,
+    },
+    releasedAt: '2025-07-30',
     type: 'chat',
   },
   {
@@ -795,20 +828,6 @@ const qwenChatModels: AIChatModelCard[] = [
       output: 12,
     },
     releasedAt: '2025-07-23',
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 262_144,
-    description: '通义千问代码模型开源版。最新的 qwen3-coder-480b-a35b-instruct 是基于 Qwen3 的代码生成模型，具有强大的Coding Agent能力，擅长工具调用和环境交互，能够实现自主编程、代码能力卓越的同时兼具通用能力。',
-    displayName: 'Qwen3 Coder 480B A35B',
-    id: 'qwen3-coder-480b-a35b-instruct',
-    maxOutput: 65_536,
-    organization: 'Qwen',
-    pricing: {
-      currency: 'CNY',
-      input: 9, // tokens 32K ~ 128K
-      output: 36,
-    },
     type: 'chat',
   },
   {

--- a/src/config/aiModels/qwen.ts
+++ b/src/config/aiModels/qwen.ts
@@ -4,6 +4,9 @@ import { AIChatModelCard, AIImageModelCard } from '@/types/aiModel';
 
 const qwenChatModels: AIChatModelCard[] = [
   {
+    abilities: {
+      search: true,
+    },
     contextWindowTokens: 131_072,
     description:
       '总参数 1T，激活参数 32B。 非思维模型中，在前沿知识、数学和编码方面达到了顶尖水平，更擅长通用 Agent 任务。 针对代理任务进行了精心优化，不仅能回答问题，还能采取行动。 最适用于即兴、通用聊天和代理体验，是一款无需长时间思考的反射级模型。',
@@ -18,6 +21,9 @@ const qwenChatModels: AIChatModelCard[] = [
       output: 16,
     },
     releasedAt: '2025-07-17',
+    settings: {
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {
@@ -78,6 +84,9 @@ const qwenChatModels: AIChatModelCard[] = [
       output: 20,
     },
     releasedAt: '2025-07-25',
+    settings: {
+      extendParams: ['reasoningBudgetToken'],
+    },
     type: 'chat',
   },
   {
@@ -103,11 +112,36 @@ const qwenChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      '基于Qwen3的思考模式开源模型，相较上一版本（通义千问3-30B-A3B）逻辑能力、通用能力、知识增强及创作能力均有大幅提升，适用于高难度强推理场景。',
+    displayName: 'Qwen3 30B A3B Thinking 2507',
+    enabled: true,
+    id: 'qwen3-30b-a3b-thinking-2507',
+    maxOutput: 32_768,
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      input: 0.75,
+      output: 7.5,
+    },
+    releasedAt: '2025-07-30',
+    settings: {
+      extendParams: ['reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
     },
     contextWindowTokens: 131_072,
     description:
       '相较上一版本（Qwen3-30B-A3B）中英文和多语言整体通用能力有大幅提升。主观开放类任务专项优化，显著更加符合用户偏好，能够提供更有帮助性的回复。',
     displayName: 'Qwen3 30B A3B Instruct 2507',
+    enabled: true,
     id: 'qwen3-30b-a3b-instruct-2507',
     maxOutput: 32_768,
     organization: 'Qwen',
@@ -116,7 +150,7 @@ const qwenChatModels: AIChatModelCard[] = [
       input: 0.75,
       output: 3,
     },
-    releasedAt: '2025-07-30',
+    releasedAt: '2025-07-29',
     type: 'chat',
   },
   {

--- a/src/config/aiModels/siliconcloud.ts
+++ b/src/config/aiModels/siliconcloud.ts
@@ -205,6 +205,24 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Qwen3-30B-A3B-Instruct-2507 是 Qwen3-30B-A3B 非思考模式的更新版本。这是一个拥有 305 亿总参数和 33 亿激活参数的混合专家（MoE）模型。该模型在多个方面进行了关键增强，包括显著提升了指令遵循、逻辑推理、文本理解、数学、科学、编码和工具使用等通用能力。同时，它在多语言的长尾知识覆盖范围上取得了实质性进展，并能更好地与用户在主观和开放式任务中的偏好对齐，从而能够生成更有帮助的回复和更高质量的文本。此外，该模型的长文本理解能力也增强到了 256K。此模型仅支持非思考模式，其输出中不会生成 `<think></think>` 标签。',
+    displayName: 'Qwen3 30B A3B Instruct 2507',
+    id: 'Qwen/Qwen3-30B-A3B-Instruct-2507',
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      input: 0.7,
+      output: 2.8,
+    },
+    releasedAt: '2025-07-29',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 131_072,

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -74,7 +74,7 @@ const ControlsForm = memo(() => {
       minWidth: undefined,
       name: 'enableReasoning',
     },
-    enableReasoning && {
+    (enableReasoning || modelExtendParams?.includes('reasoningBudgetToken')) && {
       children: <ReasoningTokenSlider />,
       label: t('extendParams.reasoningBudgetToken.title'),
       layout: 'vertical',

--- a/src/libs/model-runtime/qwen/index.ts
+++ b/src/libs/model-runtime/qwen/index.ts
@@ -29,15 +29,21 @@ export const LobeQwenAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        ...(['qwen3', 'qwen-turbo', 'qwen-plus'].some((keyword) =>
-          model.toLowerCase().includes(keyword),
-        )
+        ...(model.includes('-thinking')
           ? {
-              enable_thinking: thinking !== undefined ? thinking.type === 'enabled' : false,
+              enable_thinking: true,
               thinking_budget:
                 thinking?.budget_tokens === 0 ? 0 : thinking?.budget_tokens || undefined,
             }
-          : {}),
+          : ['qwen3', 'qwen-turbo', 'qwen-plus'].some((keyword) =>
+              model.toLowerCase().includes(keyword),
+            )
+            ? {
+                enable_thinking: thinking !== undefined ? thinking.type === 'enabled' : false,
+                thinking_budget:
+                  thinking?.budget_tokens === 0 ? 0 : thinking?.budget_tokens || undefined,
+              }
+            : {}),
         frequency_penalty: undefined,
         model,
         presence_penalty: QwenLegacyModels.has(model)

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -263,6 +263,12 @@ class ChatService {
             type: 'disabled',
           };
         }
+      } else if (modelExtendParams!.includes('reasoningBudgetToken')) {
+        // For models that only have reasoningBudgetToken without enableReasoning
+        extendParams.thinking = {
+          budget_tokens: chatConfig.reasoningBudgetToken || 1024,
+          type: 'enabled',
+        };
       }
 
       if (


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- close #8610
- close #8613

另支持 思考消耗 Token 设置。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Update the Qwen AI model configurations by introducing two new chat models, cleaning up duplicates, and streamlining the default model definition.

New Features:
- Add Qwen3 Coder 480B A35B chat model configuration
- Add Qwen3 30B A3B Instruct 2507 chat model configuration

Enhancements:
- Remove duplicate Qwen3 Coder 480B A35B entry
- Remove explicit abilities block from the default Qwen chat model