### PR TITLE
🐛 fix: fix mcp calling missing array content

### DIFF
--- a/src/server/services/mcp/index.test.ts
+++ b/src/server/services/mcp/index.test.ts
@@ -1,0 +1,161 @@
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock 依赖
+vi.mock('@/libs/mcp');
+
+describe('MCPService', () => {
+  let mcpService: any;
+  let mockClient: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 动态导入服务实例
+    const { mcpService: importedService } = await import('./index');
+    mcpService = importedService;
+
+    // 创建 mock 客户端
+    mockClient = {
+      callTool: vi.fn(),
+    };
+
+    // Mock getClient 方法返回 mock 客户端
+    vi.spyOn(mcpService as any, 'getClient').mockResolvedValue(mockClient);
+  });
+
+  describe('callTool', () => {
+    const mockParams = {
+      name: 'test-mcp',
+      type: 'stdio' as const,
+      command: 'test-command',
+      args: ['--test'],
+    };
+
+    it('should return original data when content array is empty', async () => {
+      mockClient.callTool.mockResolvedValue({
+        content: [],
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return original data when content is null or undefined', async () => {
+      mockClient.callTool.mockResolvedValue({
+        content: null,
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return parsed JSON when single element contains valid JSON', async () => {
+      const jsonData = { message: 'Hello World', status: 'success' };
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(jsonData) }],
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toEqual(jsonData);
+    });
+
+    it('should return plain text when single element contains non-JSON text', async () => {
+      const textData = 'Hello World';
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: textData }],
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toBe(textData);
+    });
+
+    it('should return original data when single element has no text', async () => {
+      const contentData = [{ type: 'text', text: '' }];
+      mockClient.callTool.mockResolvedValue({
+        content: contentData,
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toEqual(contentData);
+    });
+
+    it('should return complete array when content has multiple elements', async () => {
+      const multipleContent = [
+        { type: 'text', text: 'First message' },
+        { type: 'text', text: 'Second message' },
+        { type: 'text', text: '{"json": "data"}' },
+      ];
+
+      mockClient.callTool.mockResolvedValue({
+        content: multipleContent,
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      // 应该直接返回完整的数组，不进行任何处理
+      expect(result).toEqual(multipleContent);
+    });
+
+    it('should return complete array when content has two elements', async () => {
+      const twoContent = [
+        { type: 'text', text: 'First message' },
+        { type: 'text', text: 'Second message' },
+      ];
+
+      mockClient.callTool.mockResolvedValue({
+        content: twoContent,
+        isError: false,
+      });
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toEqual(twoContent);
+    });
+
+    it('should return error result when isError is true', async () => {
+      const errorResult = {
+        content: [{ type: 'text', text: 'Error occurred' }],
+        isError: true,
+      };
+
+      mockClient.callTool.mockResolvedValue(errorResult);
+
+      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+
+      expect(result).toEqual(errorResult);
+    });
+
+    it('should throw TRPCError when client throws error', async () => {
+      const error = new Error('MCP client error');
+      mockClient.callTool.mockRejectedValue(error);
+
+      await expect(mcpService.callTool(mockParams, 'testTool', '{}')).rejects.toThrow(TRPCError);
+    });
+
+    it('should parse args string correctly', async () => {
+      const argsObject = { param1: 'value1', param2: 'value2' };
+      const argsString = JSON.stringify(argsObject);
+
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'result' }],
+        isError: false,
+      });
+
+      await mcpService.callTool(mockParams, 'testTool', argsString);
+
+      expect(mockClient.callTool).toHaveBeenCalledWith('testTool', argsObject);
+    });
+  });
+});

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -166,8 +166,11 @@ class MCPService {
 
       const data = content as { text: string; type: 'text' }[];
 
-      const text = data?.[0]?.text;
+      if (!data || data.length === 0) return data;
 
+      if (data.length > 1) return data;
+
+      const text = data[0]?.text;
       if (!text) return data;
 
       // try to get json object, which will be stringify in the client


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix incorrect handling of MCP service responses and improve external URL handling in the desktop preload script

Bug Fixes:
- Return the full data array when MCP response is empty or contains multiple items before extracting text
- Handle undefined or empty text fields to avoid unexpected results in MCPService

Enhancements:
- Override window.open in the desktop preload to intercept external URLs and delegate opening to the main process

Tests:
- Add unit tests for MCPService response handling