### PR TITLE
💄 style: improve mcp plugin calling and display

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Tool/Inspector/BuiltinPluginTitle.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Inspector/BuiltinPluginTitle.tsx
@@ -33,17 +33,10 @@ interface BuiltinPluginTitleProps {
 }
 
 const BuiltinPluginTitle = memo<BuiltinPluginTitleProps>(
-  ({ messageId, index, apiName, toolCallId, icon, title }) => {
+  ({ messageId, index, apiName, icon, title }) => {
     const { styles } = useStyles();
 
-    const isLoading = useChatStore((s) => {
-      const toolMessageId = chatSelectors.getMessageByToolCallId(toolCallId)(s)?.id;
-      const isToolCallStreaming = chatSelectors.isToolCallStreaming(messageId, index)(s);
-      const isPluginApiInvoking = !toolMessageId
-        ? true
-        : chatSelectors.isPluginApiInvoking(toolMessageId)(s);
-      return isToolCallStreaming || isPluginApiInvoking;
-    });
+    const isLoading = useChatStore(chatSelectors.isInToolsCalling(messageId, index));
 
     return (
       <Flexbox align={'center'} className={isLoading ? styles.shinyText : ''} gap={4} horizontal>

--- a/src/features/Conversation/Messages/Assistant/Tool/Inspector/PluginResultJSON.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Inspector/PluginResultJSON.tsx
@@ -6,9 +6,10 @@ import { chatSelectors } from '@/store/chat/selectors';
 
 export interface FunctionMessageProps {
   toolCallId: string;
+  variant?: 'filled' | 'outlined' | 'borderless';
 }
 
-const PluginResult = memo<FunctionMessageProps>(({ toolCallId }) => {
+const PluginResult = memo<FunctionMessageProps>(({ toolCallId, variant }) => {
   const toolMessage = useChatStore(chatSelectors.getMessageByToolCallId(toolCallId));
 
   const data = useMemo(() => {
@@ -20,7 +21,11 @@ const PluginResult = memo<FunctionMessageProps>(({ toolCallId }) => {
   }, [toolMessage?.content]);
 
   return (
-    <Highlighter language={'json'} style={{ maxHeight: 200, maxWidth: 800, overflow: 'scroll' }}>
+    <Highlighter
+      language={'json'}
+      style={{ maxHeight: 200, overflow: 'scroll', width: '100%' }}
+      variant={variant}
+    >
       {data}
     </Highlighter>
   );

--- a/src/features/Conversation/Messages/Assistant/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Inspector/ToolTitle.tsx
@@ -91,8 +91,8 @@ const ToolTitle = memo<ToolTitleProps>(({ identifier, messageId, index, apiName,
   const pluginTitle = pluginHelpers.getPluginTitle(pluginMeta) ?? t('unknownPlugin');
 
   return (
-    <Flexbox align={'center'} className={isLoading ? styles.shinyText : ''} gap={4} horizontal>
-      {isLoading ? <Loader /> : <PluginAvatar identifier={identifier} size={20} />}
+    <Flexbox align={'center'} className={isLoading ? styles.shinyText : ''} gap={6} horizontal>
+      {isLoading ? <Loader /> : <PluginAvatar identifier={identifier} size={18} />}
       <div>{pluginTitle}</div>/<span className={styles.apiName}>{apiName}</span>
     </Flexbox>
   );

--- a/src/features/Conversation/Messages/Assistant/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Inspector/index.tsx
@@ -61,6 +61,7 @@ export const useStyles = createStyles(({ css, token, cx }) => ({
 interface InspectorProps {
   apiName: string;
   arguments?: string;
+  hidePluginUI?: boolean;
   id: string;
   identifier: string;
   index: number;
@@ -87,6 +88,7 @@ const Inspectors = memo<InspectorProps>(
     setShowRender,
     showPluginRender,
     setShowPluginRender,
+    hidePluginUI = false,
   }) => {
     const { t } = useTranslation('plugin');
     const { styles } = useStyles();
@@ -115,7 +117,7 @@ const Inspectors = memo<InspectorProps>(
             />
           </Flexbox>
           <Flexbox className={styles.actions} horizontal>
-            {showRender && (
+            {showRender && !hidePluginUI && (
               <ActionIcon
                 icon={showPluginRender ? LogsIcon : LayoutPanelTop}
                 onClick={() => {

--- a/src/features/Conversation/Messages/Assistant/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Inspector/index.tsx
@@ -1,13 +1,6 @@
-import { ActionIcon, Icon } from '@lobehub/ui';
+import { ActionIcon } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import {
-  ChevronDown,
-  ChevronRight,
-  LayoutPanelTop,
-  LogsIcon,
-  LucideBug,
-  LucideBugOff,
-} from 'lucide-react';
+import { LayoutPanelTop, LogsIcon, LucideBug, LucideBugOff } from 'lucide-react';
 import { CSSProperties, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -120,7 +113,6 @@ const Inspectors = memo<InspectorProps>(
               messageId={messageId}
               toolCallId={id}
             />
-            <Icon icon={showRender ? ChevronDown : ChevronRight} />
           </Flexbox>
           <Flexbox className={styles.actions} horizontal>
             {showRender && (

--- a/src/features/Conversation/Messages/Assistant/Tool/Render/Arguments/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Render/Arguments/index.tsx
@@ -16,9 +16,15 @@ const useStyles = createStyles(({ css, token, cx }) => ({
       color: ${token.colorText};
     }
   `,
+  codeContainer: css`
+    border-radius: ${token.borderRadiusLG}px;
+  `,
   container: css`
     position: relative;
 
+    overflow: auto;
+
+    max-height: 200px;
     padding-block: 4px;
     padding-inline: 12px 64px;
     border-radius: ${token.borderRadiusLG}px;
@@ -87,6 +93,14 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', shine, actions }
           </Highlighter>
         </div>
       )
+    );
+  }
+
+  if (args.length > 100) {
+    return (
+      <Highlighter language={'json'} showLanguage={false} variant={'filled'}>
+        {JSON.stringify(displayArgs, null, 2)}
+      </Highlighter>
     );
   }
 

--- a/src/features/Conversation/Messages/Assistant/Tool/Render/Arguments/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Render/Arguments/index.tsx
@@ -96,13 +96,13 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', shine, actions }
     );
   }
 
-  if (args.length > 100) {
-    return (
-      <Highlighter language={'json'} showLanguage={false} variant={'filled'}>
-        {JSON.stringify(displayArgs, null, 2)}
-      </Highlighter>
-    );
-  }
+  // if (args.length > 100) {
+  //   return (
+  //     <Highlighter language={'json'} showLanguage={false} variant={'filled'}>
+  //       {JSON.stringify(displayArgs, null, 2)}
+  //     </Highlighter>
+  //   );
+  // }
 
   const hasMinWidth = Object.keys(displayArgs).length > 1;
 
@@ -115,18 +115,29 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', shine, actions }
           {actions}
         </Flexbox>
       )}
-      {Object.entries(displayArgs).map(([key, value]) => {
-        return (
-          <ObjectEntity
-            editable={false}
-            hasMinWidth={hasMinWidth}
-            key={key}
-            objectKey={key}
-            shine={shine}
-            value={value}
-          />
-        );
-      })}
+      {args.length > 100 ? (
+        <Highlighter
+          language={'json'}
+          showLanguage={false}
+          style={{ padding: 8 }}
+          variant={'borderless'}
+        >
+          {JSON.stringify(displayArgs, null, 2)}
+        </Highlighter>
+      ) : (
+        Object.entries(displayArgs).map(([key, value]) => {
+          return (
+            <ObjectEntity
+              editable={false}
+              hasMinWidth={hasMinWidth}
+              key={key}
+              objectKey={key}
+              shine={shine}
+              value={value}
+            />
+          );
+        })
+      )}
     </div>
   );
 });

--- a/src/features/Conversation/Messages/Assistant/Tool/Render/CustomRender.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/Render/CustomRender.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import PluginResult from '@/features/Conversation/Messages/Assistant/Tool/Inspector/PluginResultJSON';
 import PluginRender from '@/features/PluginsUI/Render';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
@@ -39,6 +40,7 @@ const CustomRender = memo<CustomRenderProps>(
     showPluginRender,
     setShowPluginRender,
     pluginError,
+    tool_call_id,
   }) => {
     const { t } = useTranslation(['tool', 'common']);
     const [loading] = useChatStore((s) => [chatSelectors.isPluginApiInvoking(id)(s)]);
@@ -80,9 +82,9 @@ const CustomRender = memo<CustomRenderProps>(
 
     if (loading) return <Arguments arguments={requestArgs} shine />;
 
-    return (
-      <Flexbox gap={12} id={id} width={'100%'}>
-        {showPluginRender ? (
+    if (showPluginRender)
+      return (
+        <Flexbox gap={12} id={id} width={'100%'}>
           <PluginRender
             arguments={plugin?.arguments}
             content={content}
@@ -94,37 +96,44 @@ const CustomRender = memo<CustomRenderProps>(
             pluginState={pluginState}
             type={plugin?.type}
           />
-        ) : isEditing ? (
-          <KeyValueEditor
-            initialValue={safeParseJson(requestArgs || '')}
-            onCancel={handleCancel}
-            onFinish={handleFinish}
-          />
-        ) : (
-          <Arguments
-            actions={
-              <>
-                <ActionIcon
-                  icon={Edit3Icon}
-                  onClick={() => {
-                    setIsEditing(true);
-                  }}
-                  size={'small'}
-                  title={t('edit', { ns: 'common' })}
-                />
-                <ActionIcon
-                  icon={PlayCircleIcon}
-                  onClick={async () => {
-                    await reInvokeToolMessage(id);
-                  }}
-                  size={'small'}
-                  title={t('run', { ns: 'common' })}
-                />
-              </>
-            }
-            arguments={requestArgs}
-          />
-        )}
+        </Flexbox>
+      );
+
+    if (isEditing)
+      return (
+        <KeyValueEditor
+          initialValue={safeParseJson(requestArgs || '')}
+          onCancel={handleCancel}
+          onFinish={handleFinish}
+        />
+      );
+
+    return (
+      <Flexbox gap={12} id={id} width={'100%'}>
+        <Arguments
+          actions={
+            <>
+              <ActionIcon
+                icon={Edit3Icon}
+                onClick={() => {
+                  setIsEditing(true);
+                }}
+                size={'small'}
+                title={t('edit', { ns: 'common' })}
+              />
+              <ActionIcon
+                icon={PlayCircleIcon}
+                onClick={async () => {
+                  await reInvokeToolMessage(id);
+                }}
+                size={'small'}
+                title={t('run', { ns: 'common' })}
+              />
+            </>
+          }
+          arguments={requestArgs}
+        />
+        {tool_call_id && <PluginResult toolCallId={tool_call_id} variant={'outlined'} />}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/Assistant/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/index.tsx
@@ -29,7 +29,12 @@ const Tool = memo<InspectorProps>(
     useEffect(() => {
       if (type !== 'mcp') return;
 
-      setShowDetail(isLoading);
+      setTimeout(
+        () => {
+          setShowDetail(isLoading);
+        },
+        isLoading ? 1 : 1500,
+      );
     }, [isLoading]);
 
     return (

--- a/src/features/Conversation/Messages/Assistant/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/index.tsx
@@ -37,6 +37,8 @@ const Tool = memo<InspectorProps>(
         <Inspectors
           apiName={apiName}
           arguments={requestArgs}
+          // mcp don't have ui render
+          hidePluginUI={type === 'mcp'}
           id={id}
           identifier={identifier}
           index={index}

--- a/src/features/Conversation/Messages/Assistant/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Tool/index.tsx
@@ -1,7 +1,9 @@
-import { CSSProperties, memo, useState } from 'react';
+import { CSSProperties, memo, useEffect, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import AnimatedCollapsed from '@/components/AnimatedCollapsed';
+import { useChatStore } from '@/store/chat';
+import { chatSelectors } from '@/store/chat/selectors';
 
 import Inspectors from './Inspector';
 import Render from './Render';
@@ -15,12 +17,20 @@ export interface InspectorProps {
   messageId: string;
   payload: object;
   style?: CSSProperties;
+  type?: string;
 }
 
 const Tool = memo<InspectorProps>(
-  ({ arguments: requestArgs, apiName, messageId, id, index, identifier, style, payload }) => {
-    const [showRender, setShowRender] = useState(true);
+  ({ arguments: requestArgs, apiName, messageId, id, index, identifier, style, payload, type }) => {
+    const [showDetail, setShowDetail] = useState(type !== 'mcp');
     const [showPluginRender, setShowPluginRender] = useState(false);
+    const isLoading = useChatStore(chatSelectors.isInToolsCalling(messageId, index));
+
+    useEffect(() => {
+      if (type !== 'mcp') return;
+
+      setShowDetail(isLoading);
+    }, [isLoading]);
 
     return (
       <Flexbox gap={8} style={style}>
@@ -33,11 +43,11 @@ const Tool = memo<InspectorProps>(
           messageId={messageId}
           payload={payload}
           setShowPluginRender={setShowPluginRender}
-          setShowRender={setShowRender}
+          setShowRender={setShowDetail}
           showPluginRender={showPluginRender}
-          showRender={showRender}
+          showRender={showDetail}
         />
-        <AnimatedCollapsed open={showRender}>
+        <AnimatedCollapsed open={showDetail}>
           <Render
             messageId={messageId}
             requestArgs={requestArgs}

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -79,6 +79,7 @@ export const AssistantMessage = memo<
               key={toolCall.id}
               messageId={id}
               payload={toolCall}
+              type={toolCall.type}
             />
           ))}
         </Flexbox>

--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -77,7 +77,6 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile, dataSource, itemCo
           initialTopMostItemIndex={dataSource?.length - 1}
           isScrolling={setIsScrolling}
           itemContent={itemContent}
-          overscan={overscan}
           ref={virtuosoRef}
         />
         <AutoScroll

--- a/src/store/chat/slices/aiChat/actions/generateAIChat.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChat.ts
@@ -108,6 +108,11 @@ export interface AIGenerateAction {
     id?: string,
     action?: Action,
   ) => AbortController | undefined;
+  internal_toggleMessageInToolsCalling: (
+    loading: boolean,
+    id?: string,
+    action?: Action,
+  ) => AbortController | undefined;
   /**
    * Controls the streaming state of tool calling processes, updating the UI accordingly
    */
@@ -445,6 +450,7 @@ export const generateAIChat: StateCreator<
 
       // if it's the function call message, trigger the function method
       if (isToolsCalling) {
+        get().internal_toggleMessageInToolsCalling(true, assistantId);
         await refreshMessages();
         await triggerToolCalls(assistantId, {
           threadId: params?.threadId,
@@ -467,6 +473,7 @@ export const generateAIChat: StateCreator<
 
     // 5. if it's the function call message, trigger the function method
     if (isFunctionCall) {
+      get().internal_toggleMessageInToolsCalling(true, assistantId);
       await refreshMessages();
       await triggerToolCalls(assistantId, {
         threadId: params?.threadId,
@@ -827,6 +834,9 @@ export const generateAIChat: StateCreator<
   // ----- Loading ------- //
   internal_toggleChatLoading: (loading, id, action) => {
     return get().internal_toggleLoadingArrays('chatLoadingIds', loading, id, action);
+  },
+  internal_toggleMessageInToolsCalling: (loading, id) => {
+    return get().internal_toggleLoadingArrays('messageInToolsCallingIds', loading, id);
   },
   internal_toggleChatReasoning: (loading, id, action) => {
     return get().internal_toggleLoadingArrays('reasoningLoadingIds', loading, id, action);

--- a/src/store/chat/slices/aiChat/initialState.ts
+++ b/src/store/chat/slices/aiChat/initialState.ts
@@ -6,6 +6,7 @@ export interface ChatAIChatState {
   chatLoadingIdsAbortController?: AbortController;
   inputFiles: File[];
   inputMessage: string;
+  messageInToolsCallingIds: string[];
   /**
    * is the message is in RAG flow
    */
@@ -26,6 +27,7 @@ export const initialAiChatState: ChatAIChatState = {
   chatLoadingIds: [],
   inputFiles: [],
   inputMessage: '',
+  messageInToolsCallingIds: [],
   messageRAGLoadingIds: [],
   pluginApiLoadingIds: [],
   reasoningLoadingIds: [],

--- a/src/store/chat/slices/message/selectors.ts
+++ b/src/store/chat/slices/message/selectors.ts
@@ -177,6 +177,14 @@ const isToolCallStreaming = (id: string, index: number) => (s: ChatStoreState) =
   return isLoading[index];
 };
 
+const isInToolsCalling = (id: string, index: number) => (s: ChatStoreState) => {
+  const isStreamingToolsCalling = isToolCallStreaming(id, index)(s);
+
+  const isInvokingPluginApi = s.messageInToolsCallingIds.includes(id);
+
+  return isStreamingToolsCalling || isInvokingPluginApi;
+};
+
 const isAIGenerating = (s: ChatStoreState) =>
   s.chatLoadingIds.some((id) => mainDisplayChatIDs(s).includes(id));
 
@@ -223,6 +231,7 @@ export const chatSelectors = {
   isCreatingMessage,
   isCurrentChatLoaded,
   isHasMessageLoading,
+  isInToolsCalling,
   isMessageEditing,
   isMessageGenerating,
   isMessageInChatReasoning,

--- a/src/store/chat/slices/plugin/action.ts
+++ b/src/store/chat/slices/plugin/action.ts
@@ -283,6 +283,8 @@ export const chatPlugin: StateCreator<
 
     await Promise.all(messagePools);
 
+    await get().internal_toggleMessageInToolsCalling(false, assistantId);
+
     // only default type tool calls should trigger AI message
     if (!shouldCreateMessage) return;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

优化 Tools Calling 的整体展示效果，针对 MCP 添加特殊优化

- close https://github.com/lobehub/lobe-chat/issues/8485
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information


<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Streamline tool/plugin call rendering and loading state management to improve the UI and performance of MCP plugin interactions

New Features:
- Show plugin result JSON inline next to arguments when a tool_call_id is present

Enhancements:
- Consolidate streaming and API invoking into a single isInToolsCalling loading selector backed by messageInToolsCallingIds in the store
- Simplify CustomRender and Inspector components by standardizing the showDetail toggle and hiding plugin UI for MCP-type calls
- Enhance argument display by using a syntax-highlighted JSON block for large payloads and adding a scrollable, styled container with max-height and border-radius
- Adjust BuiltinPluginTitle and ToolTitle spacing, avatar sizing, and loading indicator for consistent visuals