### PR TITLE
🔨 chore: fix type in some scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
     "stylelint": "^15.11.0",
     "tsx": "~4.19.4",
     "type-fest": "^4.41.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "vite": "^5.4.19",

--- a/scripts/cdnWorkflow/utils.ts
+++ b/scripts/cdnWorkflow/utils.ts
@@ -81,7 +81,7 @@ export const fetchImageAsFile = async (url: string, width: number) => {
     const filename = Date.now().toString() + type;
 
     // Step 3: Create a file from the blob
-    const file: File = new File([buffer], filename, {
+    const file: File = new File([buffer as ArrayBuffer], filename, {
       lastModified: Date.now(),
       type: type === '.webp' ? 'image/webp' : blob.type,
     });

--- a/src/libs/trpc/client/async.ts
+++ b/src/libs/trpc/client/async.ts
@@ -9,7 +9,8 @@ export const asyncClient = createTRPCClient<AsyncRouter>({
   links: [
     httpBatchLink({
       fetch: isDesktop
-        ? (input, init) => fetchWithDesktopRemoteRPC(input as string, init)
+        ? // eslint-disable-next-line no-undef
+          (input, init) => fetchWithDesktopRemoteRPC(input as string, init as RequestInit)
         : undefined,
       maxURLLength: 2083,
       transformer: superjson,

--- a/src/libs/trpc/client/edge.ts
+++ b/src/libs/trpc/client/edge.ts
@@ -10,7 +10,8 @@ export const edgeClient = createTRPCClient<EdgeRouter>({
   links: [
     httpBatchLink({
       fetch: isDesktop
-        ? (input, init) => fetchWithDesktopRemoteRPC(input as string, init)
+        ? // eslint-disable-next-line no-undef
+          (input, init) => fetchWithDesktopRemoteRPC(input as string, init as RequestInit)
         : undefined,
       headers: async () => {
         // dynamic import to avoid circular dependency

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -17,12 +17,14 @@ const links = [
       if (isDesktop) {
         const { desktopRemoteRPCFetch } = await import('@/utils/electron/desktopRemoteRPCFetch');
 
-        const res = await desktopRemoteRPCFetch(input as string, init);
+        // eslint-disable-next-line no-undef
+        const res = await desktopRemoteRPCFetch(input as string, init as RequestInit);
 
         if (res) return res;
       }
 
-      const response = await fetch(input, init);
+      // eslint-disable-next-line no-undef
+      const response = await fetch(input, init as RequestInit);
 
       if (response.ok) return response;
 

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -9,7 +9,8 @@ export const toolsClient = createTRPCClient<ToolsRouter>({
   links: [
     httpBatchLink({
       fetch: isDesktop
-        ? (input, init) => fetchWithDesktopRemoteRPC(input as string, init)
+        ? // eslint-disable-next-line no-undef
+          (input, init) => fetchWithDesktopRemoteRPC(input as string, init as RequestInit)
         : undefined,
       headers: async () => {
         // dynamic import to avoid circular dependency


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

TS 5.9.x 版本对 File 类型有特殊处理

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Upgrade TypeScript to version 5.9.2 and update buffer handling in cdnWorkflow utils to satisfy the new File type requirements

Chores:
- Bump TypeScript to ^5.9.2
- Cast buffer to ArrayBuffer for File constructor in scripts/cdnWorkflow/utils.ts