### PR TITLE
feat: add aws profile support for bedrock

### DIFF
--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -46,6 +46,11 @@
     "checker": {
       "desc": "Test if AccessKeyId / SecretAccessKey are filled in correctly"
     },
+    "profile": {
+      "desc": "Enter AWS profile name from your ~/.aws/credentials file. If provided, access keys are not required. Make sure the AWS CLI is properly configured with this profile.",
+      "placeholder": "AWS Profile Name",
+      "title": "AWS Profile (optional)"
+    },
     "region": {
       "desc": "Enter AWS Region",
       "placeholder": "AWS Region",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -46,6 +46,11 @@
     "checker": {
       "desc": "测试 AccessKeyId / SecretAccessKey 是否填写正确"
     },
+    "profile": {
+      "desc": "输入您 ~/.aws/credentials 文件中的 AWS 配置文件名称。如果提供了配置文件，则无需输入访问密钥。请确保已使用此配置文件正确配置 AWS CLI。",
+      "placeholder": "AWS 配置文件名称",
+      "title": "AWS 配置文件（可选）"
+    },
     "region": {
       "desc": "填入 AWS Region",
       "placeholder": "AWS Region",

--- a/src/app/(backend)/webapi/chat/bedrock/route.ts
+++ b/src/app/(backend)/webapi/chat/bedrock/route.ts
@@ -1,0 +1,7 @@
+import { POST as UniverseRoute } from '../[provider]/route';
+
+// Explicitly set Node.js runtime for AWS profile support
+export const runtime = 'nodejs';
+
+export const POST = async (req: Request) =>
+  UniverseRoute(req, { params: Promise.resolve({ provider: 'bedrock' }) });

--- a/src/app/[variants]/(main)/settings/provider/(detail)/bedrock/page.tsx
+++ b/src/app/[variants]/(main)/settings/provider/(detail)/bedrock/page.tsx
@@ -3,7 +3,7 @@
 import { Select } from '@lobehub/ui';
 import { useTranslation } from 'react-i18next';
 
-import { FormPassword } from '@/components/FormInput';
+import { FormInput, FormPassword } from '@/components/FormInput';
 import { BedrockProviderCard } from '@/config/modelProviders';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { GlobalLLMProviderKey } from '@/types/user/settings';
@@ -23,6 +23,16 @@ const useBedrockCard = (): ProviderItem => {
   return {
     ...BedrockProviderCard,
     apiKeyItems: [
+      {
+        children: isLoading ? (
+          <SkeletonInput />
+        ) : (
+          <FormInput placeholder={t(`${providerKey}.profile.placeholder`)} />
+        ),
+        desc: t(`${providerKey}.profile.desc`),
+        label: t(`${providerKey}.profile.title`),
+        name: [KeyVaultsConfigKey, 'profile'],
+      },
       {
         children: isLoading ? (
           <SkeletonInput />

--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -66,6 +66,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: z.string().optional(),
       AWS_SECRET_ACCESS_KEY: z.string().optional(),
       AWS_SESSION_TOKEN: z.string().optional(),
+      AWS_PROFILE: z.string().optional(),
 
       ENABLED_WENXIN: z.boolean(),
       WENXIN_API_KEY: z.string().optional(),
@@ -240,6 +241,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
       AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
       AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+      AWS_PROFILE: process.env.AWS_PROFILE,
 
       ENABLED_WENXIN: !!process.env.WENXIN_API_KEY,
       WENXIN_API_KEY: process.env.WENXIN_API_KEY,

--- a/src/const/auth.ts
+++ b/src/const/auth.ts
@@ -32,6 +32,7 @@ export interface ClientSecretPayload {
   azureApiVersion?: string;
 
   awsAccessKeyId?: string;
+  awsProfile?: string;
   awsRegion?: string;
   awsSecretAccessKey?: string;
   awsSessionToken?: string;

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -47,6 +47,11 @@ export default {
     checker: {
       desc: '测试 AccessKeyId / SecretAccessKey 是否填写正确',
     },
+    profile: {
+      desc: '填入 AWS Profile 名称，例如 default。如果你不确定，请留空',
+      placeholder: 'AWS Profile 名称',
+      title: 'AWS Profile',
+    },
     region: {
       desc: '填入 AWS Region',
       placeholder: 'AWS Region',

--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -53,19 +53,36 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
     }
 
     case ModelProvider.Bedrock: {
-      const { AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_REGION, AWS_SESSION_TOKEN } = llmConfig;
+      const {
+        AWS_SECRET_ACCESS_KEY,
+        AWS_ACCESS_KEY_ID,
+        AWS_REGION,
+        AWS_SESSION_TOKEN,
+        AWS_PROFILE,
+      } = llmConfig;
       let accessKeyId: string | undefined = AWS_ACCESS_KEY_ID;
       let accessKeySecret: string | undefined = AWS_SECRET_ACCESS_KEY;
-      let region = AWS_REGION;
+      let region = AWS_REGION || 'us-east-1';
       let sessionToken: string | undefined = AWS_SESSION_TOKEN;
-      // if the payload has the api key, use user
+      // In Node.js Runtime, we can use profiles
+      let profile: string | undefined = AWS_PROFILE;
+
+      // if the payload has the api key, use user credentials
       if (payload.apiKey) {
-        accessKeyId = payload?.awsAccessKeyId;
-        accessKeySecret = payload?.awsSecretAccessKey;
-        sessionToken = payload?.awsSessionToken;
-        region = payload?.awsRegion;
+        profile = payload?.awsProfile || profile;
+        accessKeyId = payload?.awsAccessKeyId || accessKeyId;
+        accessKeySecret = payload?.awsSecretAccessKey || accessKeySecret;
+        sessionToken = payload?.awsSessionToken || sessionToken;
+        region = payload.awsRegion;
       }
-      return { accessKeyId, accessKeySecret, region, sessionToken };
+
+      return {
+        accessKeyId,
+        accessKeySecret,
+        profile,
+        region,
+        sessionToken,
+      };
     }
 
     case ModelProvider.Cloudflare: {

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -34,20 +34,15 @@ export const getProviderAuthPayload = (
         accessKeySecret: awsSecretAccessKey,
         apiKey,
         /** @deprecated */
-awsAccessKeyId,
-        
+        awsAccessKeyId,
         /** @deprecated */
-awsProfile,
-        
+        awsProfile,
         /** @deprecated */
-awsRegion: region,
-        
+        awsRegion: region,
         /** @deprecated */
-awsSecretAccessKey,
-        
+        awsSecretAccessKey,
         /** @deprecated */
-awsSessionToken: sessionToken,
-        
+        awsSessionToken: sessionToken,
         profile,
         region,
         sessionToken,

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -21,25 +21,34 @@ export const getProviderAuthPayload = (
 ) => {
   switch (provider) {
     case ModelProvider.Bedrock: {
-      const { accessKeyId, region, secretAccessKey, sessionToken } = keyVaults;
+      const { accessKeyId, profile, region, secretAccessKey, sessionToken } = keyVaults;
 
       const awsSecretAccessKey = secretAccessKey;
       const awsAccessKeyId = accessKeyId;
+      const awsProfile = profile;
 
-      const apiKey = (awsSecretAccessKey || '') + (awsAccessKeyId || '');
+      const apiKey = (awsSecretAccessKey || '') + (awsAccessKeyId || '') + (profile || '');
 
       return {
         accessKeyId,
         accessKeySecret: awsSecretAccessKey,
         apiKey,
         /** @deprecated */
-        awsAccessKeyId,
+awsAccessKeyId,
+        
         /** @deprecated */
-        awsRegion: region,
+awsProfile,
+        
         /** @deprecated */
-        awsSecretAccessKey,
+awsRegion: region,
+        
         /** @deprecated */
-        awsSessionToken: sessionToken,
+awsSecretAccessKey,
+        
+        /** @deprecated */
+awsSessionToken: sessionToken,
+        
+        profile,
         region,
         sessionToken,
       };

--- a/src/types/user/settings/keyVaults.ts
+++ b/src/types/user/settings/keyVaults.ts
@@ -19,6 +19,7 @@ export interface AzureOpenAIKeyVault {
 
 export interface AWSBedrockKeyVault {
   accessKeyId?: string;
+  profile?: string;
   region?: string;
   secretAccessKey?: string;
   sessionToken?: string;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
Trying to add aws profile support for bedrock provider

https://github.com/lobehub/lobe-chat/issues/7260

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable AWS_PROFILE-based credential loading across the Bedrock provider by extending client initialization, configuration schema, server route, UI settings, and related types

New Features:
- Add AWS profile support for the Bedrock AI client and payload configuration
- Expose AWS_PROFILE in environment config, key vault types, and auth payload
- Add a profile input field to the Bedrock provider settings UI
- Introduce a Node.js runtime chat route for the Bedrock provider

Enhancements:
- Wrap Bedrock client initialization in a try-catch block and relay errors through AgentRuntimeError