### PR TITLE
fix: hide providers without models in chat model selection

### DIFF
--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -108,32 +108,34 @@ const ModelSwitchPanel = memo<IProps>(({ children, onOpenChange, open }) => {
       ];
 
     // otherwise show with provider group
-    return enabledList.map((provider) => ({
-      children: getModelItems(provider),
-      key: provider.id,
-      label: (
-        <Flexbox horizontal justify="space-between">
-          <ProviderItemRender
-            logo={provider.logo}
-            name={provider.name}
-            provider={provider.id}
-            source={provider.source}
-          />
-          {showLLM && (
-            <Link
-              href={isDeprecatedEdition ? '/settings/llm' : `/settings/provider/${provider.id}`}
-            >
-              <ActionIcon
-                icon={LucideBolt}
-                size={'small'}
-                title={t('ModelSwitchPanel.goToSettings')}
-              />
-            </Link>
-          )}
-        </Flexbox>
-      ),
-      type: 'group',
-    }));
+    return enabledList
+      .filter((provider) => provider.children.length > 0)
+      .map((provider) => ({
+        children: getModelItems(provider),
+        key: provider.id,
+        label: (
+          <Flexbox horizontal justify="space-between">
+            <ProviderItemRender
+              logo={provider.logo}
+              name={provider.name}
+              provider={provider.id}
+              source={provider.source}
+            />
+            {showLLM && (
+              <Link
+                href={isDeprecatedEdition ? '/settings/llm' : `/settings/provider/${provider.id}`}
+              >
+                <ActionIcon
+                  icon={LucideBolt}
+                  size={'small'}
+                  title={t('ModelSwitchPanel.goToSettings')}
+                />
+              </Link>
+            )}
+          </Flexbox>
+        ),
+        type: 'group',
+      }));
   }, [enabledList]);
 
   const icon = <div className={styles.tag}>{children}</div>;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
before:
<img width="517" height="324" alt="Screenshot 2025-08-01 at 9 16 06 PM" src="https://github.com/user-attachments/assets/89c5fdd4-16bc-4817-bb5d-7525960ca016" />

after:
<img width="517" height="324" alt="Screenshot 2025-08-01 at 9 15 09 PM" src="https://github.com/user-attachments/assets/fa03ede2-7b57-4a23-afc2-95be88495cc0" />



#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Hide providers with zero models in the chat model selection list by filtering out those with empty children arrays.