### PR TITLE
🐛 chore: clear prompt input after successful image creation

### DIFF
--- a/src/store/image/slices/createImage/action.test.ts
+++ b/src/store/image/slices/createImage/action.test.ts
@@ -95,6 +95,9 @@ describe('CreateImageAction', () => {
 
       // Verify refresh was called
       expect(mockRefreshGenerationBatches).toHaveBeenCalled();
+
+      // Verify prompt is cleared after successful image creation
+      expect(result.current.parameters?.prompt).toBe('');
     });
 
     it('should create new topic when no active topic exists', async () => {
@@ -134,6 +137,9 @@ describe('CreateImageAction', () => {
         imageNum: 4,
         params: { prompt: 'test prompt', width: 1024, height: 1024 },
       });
+
+      // Verify prompt is cleared after successful image creation
+      expect(result.current.parameters?.prompt).toBe('');
     });
 
     it('should throw error when parameters is not initialized', async () => {
@@ -193,6 +199,9 @@ describe('CreateImageAction', () => {
 
       // The service should have been called before the error
       expect(mockImageService.createImage).toHaveBeenCalled();
+
+      // Verify prompt is NOT cleared when error occurs
+      expect(result.current.parameters?.prompt).toBe('test prompt');
     });
 
     it('should handle service error with new topic', async () => {
@@ -223,6 +232,37 @@ describe('CreateImageAction', () => {
       // Verify topic was created before the error
       expect(mockCreateGenerationTopic).toHaveBeenCalled();
       expect(mockSwitchGenerationTopic).toHaveBeenCalled();
+
+      // Verify prompt is NOT cleared when error occurs
+      expect(result.current.parameters?.prompt).toBe('test prompt');
+    });
+
+    it('should clear prompt input after successful image creation', async () => {
+      const mockRefreshGenerationBatches = vi.fn().mockResolvedValue(undefined);
+      const { result } = renderHook(() => useImageStore());
+
+      // Set initial prompt value
+      act(() => {
+        useImageStore.setState({
+          parameters: { prompt: 'detailed landscape artwork', width: 1024, height: 1024 },
+          refreshGenerationBatches: mockRefreshGenerationBatches,
+        });
+      });
+
+      // Verify initial prompt is set
+      expect(result.current.parameters?.prompt).toBe('detailed landscape artwork');
+
+      // Create image
+      await act(async () => {
+        await result.current.createImage();
+      });
+
+      // Verify prompt is cleared
+      expect(result.current.parameters?.prompt).toBe('');
+
+      // Verify other parameters remain unchanged
+      expect(result.current.parameters?.width).toBe(1024);
+      expect(result.current.parameters?.height).toBe(1024);
     });
   });
 

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -85,8 +85,17 @@ export const createCreateImageSlice: StateCreator<
       if (!isNewTopic) {
         await get().refreshGenerationBatches();
       }
+
+      // 7. Clear the prompt input after successful image creation
+      set(
+        (state) => ({
+          parameters: { ...state.parameters, prompt: '' },
+        }),
+        false,
+        'createImage/clearPrompt',
+      );
     } finally {
-      // 7. Reset all creating states
+      // 8. Reset all creating states
       if (isNewTopic) {
         set(
           { isCreating: false, isCreatingWithNewTopic: false },


### PR DESCRIPTION
Fixes issue where the input field in the drawing interface was not automatically clearing after sending a drawing command. Now the prompt input will be cleared immediately after successful image creation.

Closes #8650

🤖 Generated with [Claude Code](https://claude.ai/code)

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Automatically reset the prompt input in the drawing interface once an image is created