### PR TITLE
🐛 fix: provider config checker uses outdated API key

### DIFF
--- a/.cursor/rules/testing-guide/testing-guide.mdc
+++ b/.cursor/rules/testing-guide/testing-guide.mdc
@@ -430,6 +430,22 @@ expect(result!.status).toBe('success');
 // ✅ 使用 any 类型简化复杂的 Mock 设置
 const mockStream = new ReadableStream() as any;
 mockStream.toReadableStream = () => mockStream;
+
+// ✅ 使用中括号访问私有属性和方法（推荐）
+class MyClass {
+  private _cache = new Map();
+  private getFromCache(key: string) { /* ... */ }
+}
+
+const instance = new MyClass();
+
+// 推荐：使用中括号访问私有成员
+await instance['getFromCache']('test-key');
+expect(instance['_cache'].size).toBe(1);
+
+// 避免：使用 as any 访问私有成员
+await (instance as any).getFromCache('test-key');  // ❌ 不推荐
+expect((instance as any)._cache.size).toBe(1);     // ❌ 不推荐
 ```
 
 #### 🎯 适用场景
@@ -437,11 +453,13 @@ mockStream.toReadableStream = () => mockStream;
 - **Mock 对象**: 对于测试用的 Mock 数据，使用 `as any` 避免复杂的类型定义
 - **第三方库**: 处理复杂的第三方库类型时，适当使用 `any` 提高效率
 - **测试断言**: 在确定对象存在的测试场景中，使用 `!` 非空断言
+- **私有成员访问**: 优先使用中括号 `instance['privateMethod']()` 而不是 `(instance as any).privateMethod()`
 - **临时调试**: 快速编写测试时，先用 `any` 保证功能，后续可选择性地优化类型
 
 #### ⚠️ 注意事项
 
 - **适度使用**: 不要过度依赖 `any`，核心业务逻辑的类型仍应保持严格
+- **私有成员访问优先级**: 中括号访问 > `as any` 转换，保持更好的类型安全性
 - **文档说明**: 对于使用 `any` 的复杂场景，添加注释说明原因
 - **测试覆盖**: 确保即使使用了 `any`，测试仍能有效验证功能正确性
 

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ docs/.prd/
 .claude/
 .mcp.json
 CLAUDE.md
+CLAUDE.*.md
 
 # Misc
 ./packages/lobe-ui

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ robots.txt
 vertex-ai-key.json
 
 # AI coding tools
-docs/.prd/
+.local/
 .claude/
 .mcp.json
 CLAUDE.md

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/Checker.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/Checker.tsx
@@ -46,11 +46,13 @@ export type CheckErrorRender = (props: {
 interface ConnectionCheckerProps {
   checkErrorRender?: CheckErrorRender;
   model: string;
+  onAfterCheck: () => Promise<void>;
+  onBeforeCheck: () => Promise<void>;
   provider: string;
 }
 
 const Checker = memo<ConnectionCheckerProps>(
-  ({ model, provider, checkErrorRender: CheckErrorRender }) => {
+  ({ model, provider, checkErrorRender: CheckErrorRender, onBeforeCheck, onAfterCheck }) => {
     const { t } = useTranslation('setting');
 
     const isProviderConfigUpdating = useAiInfraStore(
@@ -152,7 +154,18 @@ const Checker = memo<ConnectionCheckerProps>(
             value={checkModel}
             virtual
           />
-          <Button disabled={isProviderConfigUpdating} loading={loading} onClick={checkConnection}>
+          <Button
+            disabled={isProviderConfigUpdating}
+            loading={loading}
+            onClick={async () => {
+              await onBeforeCheck();
+              try {
+                await checkConnection();
+              } finally {
+                await onAfterCheck();
+              }
+            }}
+          >
             {t('llm.checker.button')}
           </Button>
         </Flexbox>

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -14,7 +14,7 @@ import { Skeleton, Switch } from 'antd';
 import { createStyles } from 'antd-style';
 import { Loader2Icon, LockIcon } from 'lucide-react';
 import Link from 'next/link';
-import { ReactNode, memo, useLayoutEffect } from 'react';
+import { ReactNode, memo, useCallback, useLayoutEffect, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
 import urlJoin from 'url-join';
@@ -173,7 +173,24 @@ const ProviderConfig = memo<ProviderConfigProps>(
       form.setFieldsValue(data);
     }, [isLoading, id, data]);
 
-    const { run: debouncedUpdate } = useDebounceFn(updateAiProviderConfig, { wait: 500 });
+    // 标记是否正在进行连接测试
+    const isCheckingConnection = useRef(false);
+
+    const handleValueChange = useCallback(
+      (...params: Parameters<typeof updateAiProviderConfig>) => {
+        // 虽然 debouncedHandleValueChange 早于 onBeforeCheck 执行，
+        // 但是由于 debouncedHandleValueChange 因为 debounce 的原因，本来就会晚 500ms 执行
+        // 所以 isCheckingConnection.current 这时候已经更新了
+        // 测试链接时已经出发一次了 updateAiProviderConfig ， 不应该重复更新
+        if (isCheckingConnection.current) return;
+
+        updateAiProviderConfig(...params);
+      },
+      [updateAiProviderConfig],
+    );
+    const { run: debouncedHandleValueChange } = useDebounceFn(handleValueChange, {
+      wait: 500,
+    });
 
     const isCustom = source === AiProviderSourceEnum.Custom;
 
@@ -318,6 +335,16 @@ const ProviderConfig = memo<ProviderConfigProps>(
               <Checker
                 checkErrorRender={checkErrorRender}
                 model={data?.checkModel || checkModel!}
+                onAfterCheck={async () => {
+                  // 重置连接测试状态，允许后续的 onValuesChange 更新
+                  isCheckingConnection.current = false;
+                }}
+                onBeforeCheck={async () => {
+                  // 设置连接测试状态，阻止 onValuesChange 的重复请求
+                  isCheckingConnection.current = true;
+                  // 主动保存表单最新值，确保 fetchAiProviderRuntimeState 获取最新数据
+                  await updateAiProviderConfig(id, form.getFieldsValue());
+                }}
                 provider={id}
               />
             ),
@@ -389,7 +416,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
         form={form}
         items={[model]}
         onValuesChange={(_, values) => {
-          debouncedUpdate(id, values);
+          debouncedHandleValueChange(id, values);
         }}
         variant={'borderless'}
         {...FORM_STYLE}

--- a/src/libs/model-runtime/RouterRuntime/createRuntime.test.ts
+++ b/src/libs/model-runtime/RouterRuntime/createRuntime.test.ts
@@ -1,0 +1,538 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LobeRuntimeAI } from '../BaseAI';
+import { createRouterRuntime } from './createRuntime';
+
+describe('createRouterRuntime', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe('initialization', () => {
+    it('should throw error when routers array is empty', () => {
+      expect(() => {
+        const Runtime = createRouterRuntime({
+          id: 'test-runtime',
+          routers: [],
+        });
+        new Runtime();
+      }).toThrow('empty providers');
+    });
+
+    it('should create UniformRuntime class with valid routers', () => {
+      class MockRuntime implements LobeRuntimeAI {
+        chat = vi.fn();
+        textToImage = vi.fn();
+        models = vi.fn();
+        embeddings = vi.fn();
+        textToSpeech = vi.fn();
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: { apiKey: 'test-key' },
+            runtime: MockRuntime as any,
+            models: ['gpt-4', 'gpt-3.5-turbo'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      expect(runtime).toBeDefined();
+    });
+
+    it('should merge router options with constructor options', () => {
+      const mockConstructor = vi.fn();
+
+      class MockRuntime implements LobeRuntimeAI {
+        constructor(options: any) {
+          mockConstructor(options);
+        }
+        chat = vi.fn();
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: { baseURL: 'https://api.example.com' },
+            runtime: MockRuntime as any,
+          },
+        ],
+      });
+
+      new Runtime({ apiKey: 'constructor-key' });
+
+      expect(mockConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.example.com',
+          apiKey: 'constructor-key',
+          id: 'test-runtime',
+        }),
+      );
+    });
+  });
+
+  describe('getModels', () => {
+    it('should return synchronous models array directly', async () => {
+      const mockRuntime = {
+        chat: vi.fn(),
+      } as unknown as LobeRuntimeAI;
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: mockRuntime.constructor as any,
+            models: ['model-1', 'model-2'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const models = await runtime['getModels']({
+        id: 'test',
+        models: ['model-1', 'model-2'],
+        runtime: mockRuntime,
+      });
+
+      expect(models).toEqual(['model-1', 'model-2']);
+    });
+
+    it('should call and cache asynchronous models function', async () => {
+      const mockRuntime = {
+        chat: vi.fn(),
+      } as unknown as LobeRuntimeAI;
+
+      const mockModelsFunction = vi.fn().mockResolvedValue(['async-model-1', 'async-model-2']);
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: mockRuntime.constructor as any,
+            models: mockModelsFunction,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const runtimeItem = {
+        id: 'test',
+        models: mockModelsFunction,
+        runtime: mockRuntime,
+      };
+
+      // First call
+      const models1 = await runtime['getModels'](runtimeItem);
+      expect(models1).toEqual(['async-model-1', 'async-model-2']);
+      expect(mockModelsFunction).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const models2 = await runtime['getModels'](runtimeItem);
+      expect(models2).toEqual(['async-model-1', 'async-model-2']);
+      expect(mockModelsFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty array when models is undefined', async () => {
+      const mockRuntime = {
+        chat: vi.fn(),
+      } as unknown as LobeRuntimeAI;
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: mockRuntime.constructor as any,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const models = await runtime['getModels']({
+        id: 'test',
+        runtime: mockRuntime,
+      });
+
+      expect(models).toEqual([]);
+    });
+  });
+
+  describe('getRuntimeByModel', () => {
+    it('should return runtime that supports the model', async () => {
+      class MockRuntime1 implements LobeRuntimeAI {
+        chat = vi.fn();
+      }
+
+      class MockRuntime2 implements LobeRuntimeAI {
+        chat = vi.fn();
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime1 as any,
+            models: ['gpt-4'],
+          },
+          {
+            apiType: 'anthropic',
+            options: {},
+            runtime: MockRuntime2 as any,
+            models: ['claude-3'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+
+      const result1 = await runtime.getRuntimeByModel('gpt-4');
+      expect(result1).toBe(runtime['_runtimes'][0].runtime);
+
+      const result2 = await runtime.getRuntimeByModel('claude-3');
+      expect(result2).toBe(runtime['_runtimes'][1].runtime);
+    });
+
+    it('should return last runtime when no model matches', async () => {
+      class MockRuntime1 implements LobeRuntimeAI {
+        chat = vi.fn();
+      }
+
+      class MockRuntime2 implements LobeRuntimeAI {
+        chat = vi.fn();
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime1 as any,
+            models: ['gpt-4'],
+          },
+          {
+            apiType: 'anthropic',
+            options: {},
+            runtime: MockRuntime2 as any,
+            models: ['claude-3'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const result = await runtime.getRuntimeByModel('unknown-model');
+
+      expect(result).toBe(runtime['_runtimes'][1].runtime);
+    });
+  });
+
+  describe('chat method', () => {
+    it('should call chat on the correct runtime based on model', async () => {
+      const mockChat = vi.fn().mockResolvedValue('chat-response');
+
+      class MockRuntime implements LobeRuntimeAI {
+        chat = mockChat;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['gpt-4'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const payload = { model: 'gpt-4', messages: [], temperature: 0.7 };
+
+      const result = await runtime.chat(payload);
+      expect(result).toBe('chat-response');
+      expect(mockChat).toHaveBeenCalledWith(payload, undefined);
+    });
+
+    it('should handle errors when provided with handleError', async () => {
+      const mockError = new Error('API Error');
+      const mockChat = vi.fn().mockRejectedValue(mockError);
+
+      class MockRuntime implements LobeRuntimeAI {
+        chat = mockChat;
+      }
+
+      const handleError = vi.fn().mockReturnValue({
+        errorType: 'APIError',
+        message: 'Handled error',
+      });
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['gpt-4'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime({
+        chat: {
+          handleError,
+        },
+      });
+
+      await expect(
+        runtime.chat({ model: 'gpt-4', messages: [], temperature: 0.7 }),
+      ).rejects.toEqual({
+        errorType: 'APIError',
+        message: 'Handled error',
+      });
+    });
+
+    it('should re-throw original error when handleError returns undefined', async () => {
+      const mockError = new Error('API Error');
+      const mockChat = vi.fn().mockRejectedValue(mockError);
+
+      class MockRuntime implements LobeRuntimeAI {
+        chat = mockChat;
+      }
+
+      const handleError = vi.fn().mockReturnValue(undefined);
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['gpt-4'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime({
+        chat: {
+          handleError,
+        },
+      });
+
+      await expect(runtime.chat({ model: 'gpt-4', messages: [], temperature: 0.7 })).rejects.toBe(
+        mockError,
+      );
+    });
+  });
+
+  describe('textToImage method', () => {
+    it('should call textToImage on the correct runtime based on model', async () => {
+      const mockTextToImage = vi.fn().mockResolvedValue('image-response');
+
+      class MockRuntime implements LobeRuntimeAI {
+        textToImage = mockTextToImage;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['dall-e-3'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const payload = { model: 'dall-e-3', prompt: 'test prompt' };
+
+      const result = await runtime.textToImage(payload);
+      expect(result).toBe('image-response');
+      expect(mockTextToImage).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('models method', () => {
+    it('should call models method on first runtime', async () => {
+      const mockModels = vi.fn().mockResolvedValue(['model-1', 'model-2']);
+
+      class MockRuntime implements LobeRuntimeAI {
+        models = mockModels;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const result = await runtime.models();
+
+      expect(result).toEqual(['model-1', 'model-2']);
+      expect(mockModels).toHaveBeenCalled();
+    });
+  });
+
+  describe('embeddings method', () => {
+    it('should call embeddings on the correct runtime based on model', async () => {
+      const mockEmbeddings = vi.fn().mockResolvedValue('embeddings-response');
+
+      class MockRuntime implements LobeRuntimeAI {
+        embeddings = mockEmbeddings;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['text-embedding-ada-002'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const payload = { model: 'text-embedding-ada-002', input: 'test input' };
+      const options = {} as any;
+
+      const result = await runtime.embeddings(payload, options);
+      expect(result).toBe('embeddings-response');
+      expect(mockEmbeddings).toHaveBeenCalledWith(payload, options);
+    });
+  });
+
+  describe('textToSpeech method', () => {
+    it('should call textToSpeech on the correct runtime based on model', async () => {
+      const mockTextToSpeech = vi.fn().mockResolvedValue('speech-response');
+
+      class MockRuntime implements LobeRuntimeAI {
+        textToSpeech = mockTextToSpeech;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+            models: ['tts-1'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const payload = { model: 'tts-1', input: 'Hello world', voice: 'alloy' };
+      const options = {} as any;
+
+      const result = await runtime.textToSpeech(payload, options);
+      expect(result).toBe('speech-response');
+      expect(mockTextToSpeech).toHaveBeenCalledWith(payload, options);
+    });
+  });
+
+  describe('clearModelCache method', () => {
+    it('should clear specific runtime cache when runtimeId provided', async () => {
+      const mockModelsFunction = vi.fn().mockResolvedValue(['model-1']);
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: vi.fn() as any,
+            models: mockModelsFunction,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const runtimeItem = {
+        id: 'test-id',
+        models: mockModelsFunction,
+        runtime: {} as any,
+      };
+
+      // Build cache
+      await runtime['getModels'](runtimeItem);
+      expect(mockModelsFunction).toHaveBeenCalledTimes(1);
+
+      // Clear specific cache
+      runtime.clearModelCache('test-id');
+
+      // Should call function again
+      await runtime['getModels'](runtimeItem);
+      expect(mockModelsFunction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear all cache when no runtimeId provided', async () => {
+      const mockModelsFunction1 = vi.fn().mockResolvedValue(['model-1']);
+      const mockModelsFunction2 = vi.fn().mockResolvedValue(['model-2']);
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: vi.fn() as any,
+            models: mockModelsFunction1,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      const runtimeItem1 = {
+        id: 'test-id-1',
+        models: mockModelsFunction1,
+        runtime: {} as any,
+      };
+      const runtimeItem2 = {
+        id: 'test-id-2',
+        models: mockModelsFunction2,
+        runtime: {} as any,
+      };
+
+      // Build cache for both items
+      await runtime['getModels'](runtimeItem1);
+      await runtime['getModels'](runtimeItem2);
+      expect(mockModelsFunction1).toHaveBeenCalledTimes(1);
+      expect(mockModelsFunction2).toHaveBeenCalledTimes(1);
+
+      // Clear all cache
+      runtime.clearModelCache();
+
+      // Should call functions again
+      await runtime['getModels'](runtimeItem1);
+      await runtime['getModels'](runtimeItem2);
+      expect(mockModelsFunction1).toHaveBeenCalledTimes(2);
+      expect(mockModelsFunction2).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/libs/model-runtime/RouterRuntime/createRuntime.ts
+++ b/src/libs/model-runtime/RouterRuntime/createRuntime.ts
@@ -44,11 +44,13 @@ interface ProviderIniOptions extends Record<string, any> {
   sessionToken?: string;
 }
 
+export type RuntimeClass = typeof LobeOpenAI;
+
 interface RouterInstance {
   apiType: keyof typeof baseRuntimeMap;
   models?: string[] | (() => Promise<string[]>);
   options: ProviderIniOptions;
-  runtime?: typeof LobeOpenAI;
+  runtime?: RuntimeClass;
 }
 
 type ConstructorOptions<T extends Record<string, any> = any> = ClientOptions & T;

--- a/src/libs/model-runtime/RouterRuntime/index.ts
+++ b/src/libs/model-runtime/RouterRuntime/index.ts
@@ -2,7 +2,7 @@ import { LobeRuntimeAI } from '../BaseAI';
 
 export interface RuntimeItem {
   id: string;
-  models?: string[];
+  models?: string[] | (() => Promise<string[]>);
   runtime: LobeRuntimeAI;
 }
 

--- a/src/libs/model-runtime/aihubmix/index.ts
+++ b/src/libs/model-runtime/aihubmix/index.ts
@@ -1,6 +1,5 @@
 import urlJoin from 'url-join';
 
-import { LOBE_DEFAULT_MODEL_LIST } from '@/config/aiModels';
 import AiHubMixModels from '@/config/aiModels/aihubmix';
 import type { ChatModelCard } from '@/types/llm';
 
@@ -98,14 +97,20 @@ export const LobeAiHubMixAI = createRouterRuntime({
   routers: [
     {
       apiType: 'anthropic',
-      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-        (id) => id.startsWith('claude') || id.startsWith('kimi-k2'),
-      ),
+      models: async () => {
+        const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
+        return LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+          (id) => id.startsWith('claude') || id.startsWith('kimi-k2'),
+        );
+      },
       options: { baseURL },
     },
     {
       apiType: 'google',
-      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter((id) => id.startsWith('gemini')),
+      models: async () => {
+        const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
+        return LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter((id) => id.startsWith('gemini'));
+      },
       options: { baseURL: urlJoin(baseURL, '/gemini') },
     },
     {

--- a/src/libs/model-runtime/ppio/index.test.ts
+++ b/src/libs/model-runtime/ppio/index.test.ts
@@ -1,13 +1,10 @@
 // @vitest-environment node
-import OpenAI from 'openai';
 import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { LobeDeepSeekAI, LobeOpenAICompatibleRuntime } from '@/libs/model-runtime';
+import { LobeOpenAICompatibleRuntime } from '@/libs/model-runtime';
 import { ModelProvider } from '@/libs/model-runtime';
-import { AgentRuntimeErrorType } from '@/libs/model-runtime';
 import { testProvider } from '@/libs/model-runtime/providerTestUtils';
 
-import * as debugStreamModule from '../utils/debugStream';
 import models from './fixtures/models.json';
 import { LobePPIOAI } from './index';
 
@@ -30,7 +27,7 @@ let instance: LobeOpenAICompatibleRuntime;
 beforeEach(() => {
   instance = new LobePPIOAI({ apiKey: 'test' });
 
-  // 使用 vi.spyOn 来模拟 chat.completions.create 方法
+  // Use vi.spyOn to mock the chat.completions.create method
   vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
     new ReadableStream() as any,
   );
@@ -44,7 +41,7 @@ afterEach(() => {
 describe('PPIO', () => {
   describe('models', () => {
     it('should get models', async () => {
-      // mock the models.list method
+      // Mock the models.list method
       (instance['client'].models.list as Mock).mockResolvedValue({ data: models });
 
       const list = await instance.models();

--- a/src/libs/model-runtime/utils/openaiCompatibleFactory/index.ts
+++ b/src/libs/model-runtime/utils/openaiCompatibleFactory/index.ts
@@ -489,12 +489,14 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           .filter(Boolean) as ChatModelCard[];
       }
 
-      return resultModels.map((model) => {
-        return {
-          ...model,
-          type: model.type || getModelPropertyWithFallback(model.id, 'type'),
-        };
-      }) as ChatModelCard[];
+      return (await Promise.all(
+        resultModels.map(async (model) => {
+          return {
+            ...model,
+            type: model.type || (await getModelPropertyWithFallback(model.id, 'type')),
+          };
+        }),
+      )) as ChatModelCard[];
     }
 
     async embeddings(

--- a/src/server/globalConfig/genServerAiProviderConfig.ts
+++ b/src/server/globalConfig/genServerAiProviderConfig.ts
@@ -13,11 +13,14 @@ interface ProviderSpecificConfig {
   withDeploymentName?: boolean;
 }
 
-export const genServerAiProvidersConfig = (specificConfig: Record<any, ProviderSpecificConfig>) => {
+export const genServerAiProvidersConfig = async (
+  specificConfig: Record<any, ProviderSpecificConfig>,
+) => {
   const llmConfig = getLLMConfig() as Record<string, any>;
 
-  return Object.values(ModelProvider).reduce(
-    (config, provider) => {
+  // 并发处理所有 providers
+  const providerConfigs = await Promise.all(
+    Object.values(ModelProvider).map(async (provider) => {
       const providerUpperCase = provider.toUpperCase();
       const aiModels = AiModels[provider] as AiFullModelCard[];
 
@@ -30,30 +33,39 @@ export const genServerAiProvidersConfig = (specificConfig: Record<any, ProviderS
       const modelString =
         process.env[providerConfig.modelListKey ?? `${providerUpperCase}_MODEL_LIST`];
 
-      config[provider] = {
-        enabled:
-          typeof providerConfig.enabled !== 'undefined'
-            ? providerConfig.enabled
-            : llmConfig[providerConfig.enabledKey || `ENABLED_${providerUpperCase}`],
-
-        enabledModels: extractEnabledModels(
-          provider,
-          modelString,
-          providerConfig.withDeploymentName || false,
-        ),
-        serverModelLists: transformToAiModelList({
+      // 并发处理 extractEnabledModels 和 transformToAiModelList
+      const [enabledModels, serverModelLists] = await Promise.all([
+        extractEnabledModels(provider, modelString, providerConfig.withDeploymentName || false),
+        transformToAiModelList({
           defaultModels: aiModels || [],
           modelString,
           providerId: provider,
           withDeploymentName: providerConfig.withDeploymentName || false,
         }),
-        ...(providerConfig.fetchOnClient !== undefined && {
-          fetchOnClient: providerConfig.fetchOnClient,
-        }),
-      };
+      ]);
 
-      return config;
-    },
-    {} as Record<string, ProviderConfig>,
+      return {
+        config: {
+          enabled:
+            typeof providerConfig.enabled !== 'undefined'
+              ? providerConfig.enabled
+              : llmConfig[providerConfig.enabledKey || `ENABLED_${providerUpperCase}`],
+          enabledModels,
+          serverModelLists,
+          ...(providerConfig.fetchOnClient !== undefined && {
+            fetchOnClient: providerConfig.fetchOnClient,
+          }),
+        },
+        provider,
+      };
+    }),
   );
+
+  // 将结果转换为对象
+  const config = {} as Record<string, ProviderConfig>;
+  for (const { provider, config: providerConfig } of providerConfigs) {
+    config[provider] = providerConfig;
+  }
+
+  return config;
 };

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -17,7 +17,7 @@ export const getServerGlobalConfig = async () => {
   const { ACCESS_CODES, DEFAULT_AGENT_CONFIG } = getAppConfig();
 
   const config: GlobalServerConfig = {
-    aiProvider: genServerAiProvidersConfig({
+    aiProvider: await genServerAiProvidersConfig({
       azure: {
         enabledKey: 'ENABLED_AZURE_OPENAI',
         withDeploymentName: true,

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -6,8 +6,6 @@ import matter from 'gray-matter';
 import { cloneDeep, countBy, isString, merge, uniq, uniqBy } from 'lodash-es';
 import urlJoin from 'url-join';
 
-import { LOBE_DEFAULT_MODEL_LIST } from '@/config/aiModels';
-import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import {
   DEFAULT_DISCOVER_ASSISTANT_ITEM,
   DEFAULT_DISCOVER_PLUGIN_ITEM,
@@ -728,6 +726,10 @@ export class DiscoverService {
 
   private _getProviderList = async (): Promise<DiscoverProviderItem[]> => {
     log('_getProviderList: fetching provider list');
+    const [{ LOBE_DEFAULT_MODEL_LIST }, { DEFAULT_MODEL_PROVIDER_LIST }] = await Promise.all([
+      import('@/config/aiModels'),
+      import('@/config/modelProviders'),
+    ]);
     const result = DEFAULT_MODEL_PROVIDER_LIST.map((item) => {
       const models = uniq(
         LOBE_DEFAULT_MODEL_LIST.filter((m) => m.providerId === item.id).map((m) => m.id),
@@ -751,6 +753,7 @@ export class DiscoverService {
   }): Promise<DiscoverProviderDetail | undefined> => {
     log('getProviderDetail: params=%O', params);
     const { identifier, locale, withReadme } = params;
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
     const all = await this._getProviderList();
     let provider = all.find((item) => item.identifier === identifier);
     if (!provider) {
@@ -886,6 +889,7 @@ export class DiscoverService {
 
   private _getRawModelList = async (): Promise<DiscoverModelItem[]> => {
     log('_getRawModelList: fetching raw model list');
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
     const result = LOBE_DEFAULT_MODEL_LIST.map((item) => {
       const identifier = (item.id.split('/').at(-1) || item.id).toLowerCase();
       const providers = uniq(
@@ -978,6 +982,7 @@ export class DiscoverService {
   getModelCategories = async (params: CategoryListQuery = {}): Promise<CategoryItem[]> => {
     log('getModelCategories: params=%O', params);
     const { q } = params;
+    const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
     let list = LOBE_DEFAULT_MODEL_LIST;
     if (q) {
       const originalCount = list.length;
@@ -1011,6 +1016,10 @@ export class DiscoverService {
     identifier: string;
   }): Promise<DiscoverModelDetail | undefined> => {
     log('getModelDetail: params=%O', params);
+    const [{ LOBE_DEFAULT_MODEL_LIST }, { DEFAULT_MODEL_PROVIDER_LIST }] = await Promise.all([
+      import('@/config/aiModels'),
+      import('@/config/modelProviders'),
+    ]);
     const { identifier } = params;
     const all = await this._getModelList();
     let model = all.find((item) => item.identifier.toLowerCase() === identifier.toLowerCase());

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -2,7 +2,6 @@ import { PluginRequestPayload, createHeadersWithPluginSettings } from '@lobehub/
 import { produce } from 'immer';
 import { merge } from 'lodash-es';
 
-import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import { enableAuth } from '@/const/auth';
 import { INBOX_GUIDE_SYSTEMROLE } from '@/const/guide';
 import { INBOX_SESSION_ID } from '@/const/session';
@@ -404,6 +403,7 @@ class ChatService {
       provider,
     });
 
+    const { DEFAULT_MODEL_PROVIDER_LIST } = await import('@/config/modelProviders');
     const providerConfig = DEFAULT_MODEL_PROVIDER_LIST.find((item) => item.id === provider);
 
     let sdkType = provider;

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EnabledAiModel, ModelAbilities } from '@/types/aiModel';
+
+import { getModelListByType } from '../action';
+
+// Mock getModelPropertyWithFallback
+vi.mock('@/utils/getFallbackModelProperty', () => ({
+  getModelPropertyWithFallback: vi.fn().mockReturnValue({ size: '1024x1024' }),
+}));
+
+describe('getModelListByType', () => {
+  const mockChatModels: EnabledAiModel[] = [
+    {
+      id: 'gpt-4',
+      providerId: 'openai',
+      type: 'chat',
+      abilities: { functionCall: true, files: true } as ModelAbilities,
+      contextWindowTokens: 8192,
+      displayName: 'GPT-4',
+      enabled: true,
+    },
+    {
+      id: 'gpt-3.5-turbo',
+      providerId: 'openai',
+      type: 'chat',
+      abilities: { functionCall: true } as ModelAbilities,
+      contextWindowTokens: 4096,
+      displayName: 'GPT-3.5 Turbo',
+      enabled: true,
+    },
+    {
+      id: 'claude-3-opus',
+      providerId: 'anthropic',
+      type: 'chat',
+      abilities: { functionCall: false, files: true } as ModelAbilities,
+      contextWindowTokens: 200000,
+      displayName: 'Claude 3 Opus',
+      enabled: true,
+    },
+  ];
+
+  const mockImageModels: EnabledAiModel[] = [
+    {
+      id: 'dall-e-3',
+      providerId: 'openai',
+      type: 'image',
+      abilities: {} as ModelAbilities,
+      displayName: 'DALL-E 3',
+      enabled: true,
+      parameters: { size: '1024x1024', quality: 'standard' },
+    },
+    {
+      id: 'midjourney',
+      providerId: 'midjourney',
+      type: 'image',
+      abilities: {} as ModelAbilities,
+      displayName: 'Midjourney',
+      enabled: true,
+    },
+  ];
+
+  const allModels = [...mockChatModels, ...mockImageModels];
+
+  describe('basic functionality', () => {
+    it('should filter models by providerId and type correctly', () => {
+      const result = getModelListByType(allModels, 'openai', 'chat');
+
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['gpt-4', 'gpt-3.5-turbo']);
+    });
+
+    it('should return correct model structure', () => {
+      const result = getModelListByType(allModels, 'openai', 'chat');
+
+      expect(result[0]).toEqual({
+        abilities: { functionCall: true, files: true },
+        contextWindowTokens: 8192,
+        displayName: 'GPT-4',
+        id: 'gpt-4',
+      });
+    });
+
+    it('should add parameters field for image models', () => {
+      const result = getModelListByType(allModels, 'openai', 'image');
+
+      expect(result[0]).toEqual({
+        abilities: {},
+        contextWindowTokens: undefined,
+        displayName: 'DALL-E 3',
+        id: 'dall-e-3',
+        parameters: { size: '1024x1024', quality: 'standard' },
+      });
+    });
+
+    it('should use fallback parameters for image models without parameters', () => {
+      const result = getModelListByType(allModels, 'midjourney', 'image');
+
+      expect(result[0]).toEqual({
+        abilities: {},
+        contextWindowTokens: undefined,
+        displayName: 'Midjourney',
+        id: 'midjourney',
+        parameters: { size: '1024x1024' },
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty model list', () => {
+      const result = getModelListByType([], 'openai', 'chat');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-existent providerId', () => {
+      const result = getModelListByType(allModels, 'nonexistent', 'chat');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-existent type', () => {
+      const result = getModelListByType(allModels, 'openai', 'nonexistent');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle missing displayName', () => {
+      const modelsWithoutDisplayName: EnabledAiModel[] = [
+        {
+          id: 'test-model',
+          providerId: 'test',
+          type: 'chat',
+          abilities: {} as ModelAbilities,
+          enabled: true,
+        },
+      ];
+
+      const result = getModelListByType(modelsWithoutDisplayName, 'test', 'chat');
+      expect(result[0].displayName).toBe('');
+    });
+
+    it('should handle missing abilities', () => {
+      const modelsWithoutAbilities: EnabledAiModel[] = [
+        {
+          id: 'test-model',
+          providerId: 'test',
+          type: 'chat',
+          enabled: true,
+        } as EnabledAiModel,
+      ];
+
+      const result = getModelListByType(modelsWithoutAbilities, 'test', 'chat');
+      expect(result[0].abilities).toEqual({});
+    });
+  });
+
+  describe('deduplication', () => {
+    it('should remove duplicate model IDs', () => {
+      const duplicateModels: EnabledAiModel[] = [
+        {
+          id: 'gpt-4',
+          providerId: 'openai',
+          type: 'chat',
+          abilities: { functionCall: true } as ModelAbilities,
+          displayName: 'GPT-4 Version 1',
+          enabled: true,
+        },
+        {
+          id: 'gpt-4',
+          providerId: 'openai',
+          type: 'chat',
+          abilities: { functionCall: false } as ModelAbilities,
+          displayName: 'GPT-4 Version 2',
+          enabled: true,
+        },
+      ];
+
+      const result = getModelListByType(duplicateModels, 'openai', 'chat');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].displayName).toBe('GPT-4 Version 1');
+    });
+  });
+
+  describe('type casting', () => {
+    it('should handle image model type casting correctly', () => {
+      const imageModel: EnabledAiModel[] = [
+        {
+          id: 'dall-e-3',
+          providerId: 'openai',
+          type: 'image',
+          abilities: {} as ModelAbilities,
+          displayName: 'DALL-E 3',
+          enabled: true,
+          parameters: { size: '1024x1024' },
+        } as any, // Simulate AIImageModelCard type
+      ];
+
+      const result = getModelListByType(imageModel, 'openai', 'image');
+
+      expect(result[0]).toHaveProperty('parameters');
+      expect(result[0].parameters).toEqual({ size: '1024x1024' });
+    });
+
+    it('should not add parameters field for non-image models', () => {
+      const result = getModelListByType(mockChatModels, 'openai', 'chat');
+
+      result.forEach((model) => {
+        expect(model).not.toHaveProperty('parameters');
+      });
+    });
+  });
+});

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -22,6 +22,27 @@ import {
 } from '@/types/aiProvider';
 import { getModelPropertyWithFallback } from '@/utils/getFallbackModelProperty';
 
+/**
+ * Get models by provider ID and type, with proper formatting and deduplication
+ */
+export const getModelListByType = (enabledAiModels: any[], providerId: string, type: string) => {
+  const models = enabledAiModels
+    .filter((model) => model.providerId === providerId && model.type === type)
+    .map((model) => ({
+      abilities: (model.abilities || {}) as ModelAbilities,
+      contextWindowTokens: model.contextWindowTokens,
+      displayName: model.displayName ?? '',
+      id: model.id,
+      ...(model.type === 'image' && {
+        parameters:
+          (model as AIImageModelCard).parameters ||
+          getModelPropertyWithFallback(model.id, 'parameters'),
+      }),
+    }));
+
+  return uniqBy(models, 'id');
+};
+
 enum AiProviderSwrKey {
   fetchAiProviderItem = 'FETCH_AI_PROVIDER_ITEM',
   fetchAiProviderList = 'FETCH_AI_PROVIDER',
@@ -204,34 +225,15 @@ export const createAiProviderSlice: StateCreator<
         onSuccess: (data) => {
           if (!data) return;
 
-          const getModelListByType = (providerId: string, type: string) => {
-            const models = data.enabledAiModels
-              .filter((model) => model.providerId === providerId && model.type === type)
-              .map((model) => ({
-                abilities: (model.abilities || {}) as ModelAbilities,
-                contextWindowTokens: model.contextWindowTokens,
-                displayName: model.displayName ?? '',
-                id: model.id,
-                ...(model.type === 'image' && {
-                  parameters:
-                    (model as AIImageModelCard).parameters ||
-                    getModelPropertyWithFallback(model.id, 'parameters'),
-                }),
-              }));
-
-            return uniqBy(models, 'id');
-          };
-
-          // 3. 组装最终数据结构
           const enabledChatModelList = data.enabledChatAiProviders.map((provider) => ({
             ...provider,
-            children: getModelListByType(provider.id, 'chat'),
+            children: getModelListByType(data.enabledAiModels, provider.id, 'chat'),
             name: provider.name || provider.id,
           }));
 
           const enabledImageModelList = data.enabledImageAiProviders.map((provider) => ({
             ...provider,
-            children: getModelListByType(provider.id, 'image'),
+            children: getModelListByType(data.enabledAiModels, provider.id, 'image'),
             name: provider.name || provider.id,
           }));
 

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -2,6 +2,7 @@ import { uniqBy } from 'lodash-es';
 import { SWRResponse, mutate } from 'swr';
 import { StateCreator } from 'zustand/vanilla';
 
+import { LOBE_DEFAULT_MODEL_LIST } from '@/config/aiModels';
 import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import { isDeprecatedEdition, isDesktop, isUsePgliteDB } from '@/const/version';
 import { useClientDataSWR } from '@/libs/swr';
@@ -176,7 +177,6 @@ export const createAiProviderSlice: StateCreator<
       async ([, isLogin]) => {
         if (isLogin) return aiProviderService.getAiProviderRuntimeState();
 
-        const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
         const enabledAiProviders: EnabledProvider[] = DEFAULT_MODEL_PROVIDER_LIST.filter(
           (provider) => provider.enabled,
         ).map((item) => ({ id: item.id, name: item.name, source: 'builtin' }));
@@ -201,10 +201,8 @@ export const createAiProviderSlice: StateCreator<
       },
       {
         focusThrottleInterval: isDesktop || isUsePgliteDB ? 100 : undefined,
-        onSuccess: async (data) => {
+        onSuccess: (data) => {
           if (!data) return;
-
-          const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
 
           const getModelListByType = (providerId: string, type: string) => {
             const models = data.enabledAiModels

--- a/src/store/user/slices/modelList/action.test.ts
+++ b/src/store/user/slices/modelList/action.test.ts
@@ -70,8 +70,8 @@ describe('LLMSettingsSliceAction', () => {
         });
       });
 
-      act(() => {
-        result.current.refreshDefaultModelProviderList();
+      await act(async () => {
+        await result.current.refreshDefaultModelProviderList();
       });
 
       // Assert that setModelProviderConfig was not called
@@ -79,7 +79,7 @@ describe('LLMSettingsSliceAction', () => {
       expect(azure?.chatModels).toEqual([{ id: 'abc', deploymentName: 'abc' }]);
     });
 
-    it('openai', () => {
+    it('openai', async () => {
       const { result } = renderHook(() => useUserStore());
       act(() => {
         useUserStore.setState({
@@ -109,8 +109,8 @@ describe('LLMSettingsSliceAction', () => {
         });
       });
 
-      act(() => {
-        result.current.refreshDefaultModelProviderList();
+      await act(async () => {
+        await result.current.refreshDefaultModelProviderList();
       });
 
       // Assert that setModelProviderConfig was not called

--- a/src/store/user/slices/modelList/action.ts
+++ b/src/store/user/slices/modelList/action.ts
@@ -2,7 +2,6 @@ import { produce } from 'immer';
 import useSWR, { SWRResponse } from 'swr';
 import type { StateCreator } from 'zustand/vanilla';
 
-import { DEFAULT_MODEL_PROVIDER_LIST } from '@/config/modelProviders';
 import { ModelProvider } from '@/libs/model-runtime';
 import { UserStore } from '@/store/user';
 import type { ChatModelCard, ModelProviderCard } from '@/types/llm';
@@ -28,7 +27,7 @@ export interface ModelListAction {
   /**
    * make sure the default model provider list is sync to latest state
    */
-  refreshDefaultModelProviderList: (params?: { trigger?: string }) => void;
+  refreshDefaultModelProviderList: (params?: { trigger?: string }) => Promise<void>;
   refreshModelProviderList: (params?: { trigger?: string }) => void;
   removeEnabledModels: (provider: GlobalLLMProviderKey, model: string) => Promise<void>;
   setModelProviderConfig: <T extends GlobalLLMProviderKey>(
@@ -69,7 +68,7 @@ export const createModelListSlice: StateCreator<
       remoteModelCards: [],
     });
 
-    get().refreshDefaultModelProviderList();
+    await get().refreshDefaultModelProviderList();
   },
   dispatchCustomModelCards: async (provider, payload) => {
     const prevState = settingsSelectors.providerConfig(provider)(get());
@@ -80,7 +79,7 @@ export const createModelListSlice: StateCreator<
 
     await get().setModelProviderConfig(provider, { customModelCards: nextState });
   },
-  refreshDefaultModelProviderList: (params) => {
+  refreshDefaultModelProviderList: async (params) => {
     /**
      * Because we have several model cards sources, we need to merge the model cards
      * the priority is below:
@@ -106,6 +105,7 @@ export const createModelListSlice: StateCreator<
       return providerCard.chatModels;
     };
 
+    const { DEFAULT_MODEL_PROVIDER_LIST } = await import('@/config/modelProviders');
     const defaultModelProviderList = produce(DEFAULT_MODEL_PROVIDER_LIST, (draft) => {
       Object.values(ModelProvider).forEach((id) => {
         const provider = draft.find((d) => d.id === id);

--- a/src/utils/getFallbackModelProperty.test.ts
+++ b/src/utils/getFallbackModelProperty.test.ts
@@ -56,36 +56,36 @@ vi.mock('@/config/aiModels', () => ({
 
 describe('getModelPropertyWithFallback', () => {
   describe('when providerId is specified', () => {
-    it('should return exact match value when model exists with specified provider', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'displayName', 'openai');
+    it('should return exact match value when model exists with specified provider', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'displayName', 'openai');
       expect(result).toBe('GPT-4');
     });
 
-    it('should return exact match type when model exists with specified provider', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'type', 'openai');
+    it('should return exact match type when model exists with specified provider', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'type', 'openai');
       expect(result).toBe('chat');
     });
 
-    it('should return exact match contextWindowTokens when model exists with specified provider', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'contextWindowTokens', 'azure');
+    it('should return exact match contextWindowTokens when model exists with specified provider', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'contextWindowTokens', 'azure');
       expect(result).toBe(8192);
     });
 
-    it('should fall back to other provider when exact provider match not found', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'displayName', 'fake-provider');
+    it('should fall back to other provider when exact provider match not found', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'displayName', 'fake-provider');
       expect(result).toBe('GPT-4'); // Falls back to openai provider
     });
 
-    it('should return nested property like abilities', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'abilities', 'openai');
+    it('should return nested property like abilities', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'abilities', 'openai');
       expect(result).toEqual({
         functionCall: true,
         vision: true,
       });
     });
 
-    it('should return parameters property correctly', () => {
-      const result = getModelPropertyWithFallback('dall-e-3', 'parameters', 'openai');
+    it('should return parameters property correctly', async () => {
+      const result = await getModelPropertyWithFallback('dall-e-3', 'parameters', 'openai');
       expect(result).toEqual({
         size: '1024x1024',
         quality: 'standard',
@@ -94,99 +94,106 @@ describe('getModelPropertyWithFallback', () => {
   });
 
   describe('when providerId is not specified', () => {
-    it('should return fallback match value when model exists', () => {
-      const result = getModelPropertyWithFallback('claude-3', 'displayName');
+    it('should return fallback match value when model exists', async () => {
+      const result = await getModelPropertyWithFallback('claude-3', 'displayName');
       expect(result).toBe('Claude 3');
     });
 
-    it('should return fallback match type when model exists', () => {
-      const result = getModelPropertyWithFallback('claude-3', 'type');
+    it('should return fallback match type when model exists', async () => {
+      const result = await getModelPropertyWithFallback('claude-3', 'type');
       expect(result).toBe('chat');
     });
 
-    it('should return fallback match enabled property', () => {
-      const result = getModelPropertyWithFallback('claude-3', 'enabled');
+    it('should return fallback match enabled property', async () => {
+      const result = await getModelPropertyWithFallback('claude-3', 'enabled');
       expect(result).toBe(false);
     });
   });
 
   describe('when model is not found', () => {
-    it('should return default value "chat" for type property', () => {
-      const result = getModelPropertyWithFallback('non-existent-model', 'type');
+    it('should return default value "chat" for type property', async () => {
+      const result = await getModelPropertyWithFallback('non-existent-model', 'type');
       expect(result).toBe('chat');
     });
 
-    it('should return default value "chat" for type property even with providerId', () => {
-      const result = getModelPropertyWithFallback('non-existent-model', 'type', 'fake-provider');
+    it('should return default value "chat" for type property even with providerId', async () => {
+      const result = await getModelPropertyWithFallback(
+        'non-existent-model',
+        'type',
+        'fake-provider',
+      );
       expect(result).toBe('chat');
     });
 
-    it('should return undefined for non-type properties when model not found', () => {
-      const result = getModelPropertyWithFallback('non-existent-model', 'displayName');
+    it('should return undefined for non-type properties when model not found', async () => {
+      const result = await getModelPropertyWithFallback('non-existent-model', 'displayName');
       expect(result).toBeUndefined();
     });
 
-    it('should return undefined for contextWindowTokens when model not found', () => {
-      const result = getModelPropertyWithFallback('non-existent-model', 'contextWindowTokens');
+    it('should return undefined for contextWindowTokens when model not found', async () => {
+      const result = await getModelPropertyWithFallback(
+        'non-existent-model',
+        'contextWindowTokens',
+      );
       expect(result).toBeUndefined();
     });
 
-    it('should return undefined for enabled property when model not found', () => {
-      const result = getModelPropertyWithFallback('non-existent-model', 'enabled');
+    it('should return undefined for enabled property when model not found', async () => {
+      const result = await getModelPropertyWithFallback('non-existent-model', 'enabled');
       expect(result).toBeUndefined();
     });
   });
 
   describe('provider precedence logic', () => {
-    it('should prioritize exact provider match over general match', () => {
+    it('should prioritize exact provider match over general match', async () => {
       // gpt-4 exists in both openai and azure providers with different displayNames
-      const openaiResult = getModelPropertyWithFallback('gpt-4', 'displayName', 'openai');
-      const azureResult = getModelPropertyWithFallback('gpt-4', 'displayName', 'azure');
+      const openaiResult = await getModelPropertyWithFallback('gpt-4', 'displayName', 'openai');
+      const azureResult = await getModelPropertyWithFallback('gpt-4', 'displayName', 'azure');
 
       expect(openaiResult).toBe('GPT-4');
       expect(azureResult).toBe('GPT-4 Azure');
     });
 
-    it('should fall back to first match when specified provider not found', () => {
+    it('should fall back to first match when specified provider not found', async () => {
       // When asking for 'fake-provider', should fall back to first match (openai)
-      const result = getModelPropertyWithFallback('gpt-4', 'displayName', 'fake-provider');
+      const result = await getModelPropertyWithFallback('gpt-4', 'displayName', 'fake-provider');
       expect(result).toBe('GPT-4');
     });
   });
 
   describe('property existence handling', () => {
-    it('should handle undefined properties gracefully', () => {
+    it('should handle undefined properties gracefully', async () => {
       // claude-3 doesn't have abilities property defined
-      const result = getModelPropertyWithFallback('claude-3', 'abilities');
+      const result = await getModelPropertyWithFallback('claude-3', 'abilities');
       expect(result).toBeUndefined();
     });
 
-    it('should handle properties that exist but have falsy values', () => {
+    it('should handle properties that exist but have falsy values', async () => {
       // claude-3 has enabled: false
-      const result = getModelPropertyWithFallback('claude-3', 'enabled');
+      const result = await getModelPropertyWithFallback('claude-3', 'enabled');
       expect(result).toBe(false);
     });
 
-    it('should distinguish between undefined and null values', () => {
+    it('should distinguish between undefined and null values', async () => {
       // Testing that we check for undefined specifically, not just falsy values
-      const result = getModelPropertyWithFallback('claude-3', 'contextWindowTokens');
+      const result = await getModelPropertyWithFallback('claude-3', 'contextWindowTokens');
       expect(result).toBe(200000); // Should find the defined value
     });
   });
 
   describe('edge cases', () => {
-    it('should handle empty string modelId', () => {
-      const result = getModelPropertyWithFallback('', 'type');
+    it('should handle empty string modelId', async () => {
+      const result = await getModelPropertyWithFallback('', 'type');
       expect(result).toBe('chat'); // Should fall back to default
     });
 
-    it('should handle empty string providerId', () => {
-      const result = getModelPropertyWithFallback('gpt-4', 'type', '');
+    it('should handle empty string providerId', async () => {
+      const result = await getModelPropertyWithFallback('gpt-4', 'type', '');
       expect(result).toBe('chat'); // Should still find the model via fallback
     });
 
-    it('should handle case-sensitive modelId correctly', () => {
-      const result = getModelPropertyWithFallback('GPT-4', 'type'); // Wrong case
+    it('should handle case-sensitive modelId correctly', async () => {
+      const result = await getModelPropertyWithFallback('GPT-4', 'type'); // Wrong case
       expect(result).toBe('chat'); // Should fall back to default since no match
     });
   });

--- a/src/utils/getFallbackModelProperty.ts
+++ b/src/utils/getFallbackModelProperty.ts
@@ -1,4 +1,3 @@
-import { LOBE_DEFAULT_MODEL_LIST } from '@/config/aiModels';
 import { AiFullModelCard } from '@/types/aiModel';
 
 /**
@@ -8,11 +7,13 @@ import { AiFullModelCard } from '@/types/aiModel';
  * @param providerId Optional provider ID for an exact match.
  * @returns The property value or a default value.
  */
-export const getModelPropertyWithFallback = <T>(
+export const getModelPropertyWithFallback = async <T>(
   modelId: string,
   propertyName: keyof AiFullModelCard,
   providerId?: string,
-): T => {
+): Promise<T> => {
+  const { LOBE_DEFAULT_MODEL_LIST } = await import('@/config/aiModels');
+
   // Step 1: If providerId is provided, prioritize an exact match (same provider + same id)
   if (providerId) {
     const exactMatch = LOBE_DEFAULT_MODEL_LIST.find(

--- a/src/utils/parseModels.test.ts
+++ b/src/utils/parseModels.test.ts
@@ -7,8 +7,8 @@ import { AiFullModelCard } from '@/types/aiModel';
 import { extractEnabledModels, parseModelString, transformToAiModelList } from './parseModels';
 
 describe('parseModelString', () => {
-  it('custom deletion, addition, and renaming of models', () => {
-    const result = parseModelString(
+  it('custom deletion, addition, and renaming of models', async () => {
+    const result = await parseModelString(
       'test-provider',
       '-all,+llama,+claude-2，-gpt-3.5-turbo,gpt-4-1106-preview=gpt-4-turbo,gpt-4-1106-preview=gpt-4-32k',
     );
@@ -16,22 +16,22 @@ describe('parseModelString', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('duplicate naming model', () => {
-    const result = parseModelString(
+  it('duplicate naming model', async () => {
+    const result = await parseModelString(
       'test-provider',
       'gpt-4-1106-preview=gpt-4-turbo，gpt-4-1106-preview=gpt-4-32k',
     );
     expect(result).toMatchSnapshot();
   });
 
-  it('only add the model', () => {
-    const result = parseModelString('test-provider', 'model1,model2,model3，model4');
+  it('only add the model', async () => {
+    const result = await parseModelString('test-provider', 'model1,model2,model3，model4');
 
     expect(result).toMatchSnapshot();
   });
 
-  it('empty string model', () => {
-    const result = parseModelString(
+  it('empty string model', async () => {
+    const result = await parseModelString(
       'test-provider',
       'gpt-4-1106-preview=gpt-4-turbo,,  ,\n  ，+claude-2',
     );
@@ -39,8 +39,8 @@ describe('parseModelString', () => {
   });
 
   describe('extension capabilities', () => {
-    it('with token', () => {
-      const result = parseModelString('test-provider', 'chatglm-6b=ChatGLM 6B<4096>');
+    it('with token', async () => {
+      const result = await parseModelString('test-provider', 'chatglm-6b=ChatGLM 6B<4096>');
 
       expect(result.add[0]).toEqual({
         displayName: 'ChatGLM 6B',
@@ -51,8 +51,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('token and function calling', () => {
-      const result = parseModelString('test-provider', 'spark-v3.5=讯飞星火 v3.5<8192:fc>');
+    it('token and function calling', async () => {
+      const result = await parseModelString('test-provider', 'spark-v3.5=讯飞星火 v3.5<8192:fc>');
 
       expect(result.add[0]).toEqual({
         displayName: '讯飞星火 v3.5',
@@ -65,8 +65,11 @@ describe('parseModelString', () => {
       });
     });
 
-    it('token and reasoning', () => {
-      const result = parseModelString('test-provider', 'deepseek-r1=Deepseek R1<65536:reasoning>');
+    it('token and reasoning', async () => {
+      const result = await parseModelString(
+        'test-provider',
+        'deepseek-r1=Deepseek R1<65536:reasoning>',
+      );
 
       expect(result.add[0]).toEqual({
         displayName: 'Deepseek R1',
@@ -79,8 +82,11 @@ describe('parseModelString', () => {
       });
     });
 
-    it('token and search', () => {
-      const result = parseModelString('test-provider', 'qwen-max-latest=Qwen Max<32768:search>');
+    it('token and search', async () => {
+      const result = await parseModelString(
+        'test-provider',
+        'qwen-max-latest=Qwen Max<32768:search>',
+      );
 
       expect(result.add[0]).toEqual({
         displayName: 'Qwen Max',
@@ -93,8 +99,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('token and image output', () => {
-      const result = parseModelString(
+    it('token and image output', async () => {
+      const result = await parseModelString(
         'test-provider',
         'gemini-2.0-flash-exp-image-generation=Gemini 2.0 Flash (Image Generation) Experimental<32768:imageOutput>',
       );
@@ -110,8 +116,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('multi models', () => {
-      const result = parseModelString(
+    it('multi models', async () => {
+      const result = await parseModelString(
         'test-provider',
         'gemini-1.5-flash-latest=Gemini 1.5 Flash<16000:vision>,gpt-4-all=ChatGPT Plus<128000:fc:vision:file>',
       );
@@ -140,8 +146,8 @@ describe('parseModelString', () => {
       ]);
     });
 
-    it('should have file with builtin models like gpt-4-0125-preview', () => {
-      const result = parseModelString(
+    it('should have file with builtin models like gpt-4-0125-preview', async () => {
+      const result = await parseModelString(
         'openai',
         '-all,+gpt-4-0125-preview=ChatGPT-4<128000:fc:file>,+gpt-4-turbo-2024-04-09=ChatGPT-4 Vision<128000:fc:vision:file>',
       );
@@ -170,8 +176,8 @@ describe('parseModelString', () => {
       ]);
     });
 
-    it('should handle empty extension capability value', () => {
-      const result = parseModelString('test-provider', 'model1<1024:>');
+    it('should handle empty extension capability value', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024:>');
       expect(result.add[0]).toEqual({
         abilities: {},
         type: 'chat',
@@ -180,8 +186,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle empty extension capability name', () => {
-      const result = parseModelString('test-provider', 'model1<1024::file>');
+    it('should handle empty extension capability name', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024::file>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -192,8 +198,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle duplicate extension capabilities', () => {
-      const result = parseModelString('test-provider', 'model1<1024:vision:vision>');
+    it('should handle duplicate extension capabilities', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024:vision:vision>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -204,8 +210,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle case-sensitive extension capability names', () => {
-      const result = parseModelString('test-provider', 'model1<1024:VISION:FC:file>');
+    it('should handle case-sensitive extension capability names', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024:VISION:FC:file>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -216,8 +222,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle case-sensitive extension capability values', () => {
-      const result = parseModelString('test-provider', 'model1<1024:vision:Fc:File>');
+    it('should handle case-sensitive extension capability values', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024:vision:Fc:File>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -228,44 +234,44 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle empty angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<>');
+    it('should handle empty angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<>');
       expect(result.add[0]).toEqual({ id: 'model1', abilities: {}, type: 'chat' });
     });
 
-    it('should handle not close angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<,model2');
+    it('should handle not close angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<,model2');
       expect(result.add).toEqual([
         { id: 'model1', abilities: {}, type: 'chat' },
         { id: 'model2', abilities: {}, type: 'chat' },
       ]);
     });
 
-    it('should handle multi close angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<>>,model2');
+    it('should handle multi close angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<>>,model2');
       expect(result.add).toEqual([
         { id: 'model1', abilities: {}, type: 'chat' },
         { id: 'model2', abilities: {}, type: 'chat' },
       ]);
     });
 
-    it('should handle only colon inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<:>');
+    it('should handle only colon inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<:>');
       expect(result.add[0]).toEqual({ id: 'model1', abilities: {}, type: 'chat' });
     });
 
-    it('should handle only non-digit characters inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<abc>');
+    it('should handle only non-digit characters inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<abc>');
       expect(result.add[0]).toEqual({ id: 'model1', abilities: {}, type: 'chat' });
     });
 
-    it('should handle non-digit characters followed by digits inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<abc123>');
+    it('should handle non-digit characters followed by digits inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<abc123>');
       expect(result.add[0]).toEqual({ id: 'model1', abilities: {}, type: 'chat' });
     });
 
-    it('should handle digits followed by non-colon characters inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<1024abc>');
+    it('should handle digits followed by non-colon characters inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024abc>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -274,8 +280,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle digits followed by multiple colons inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<1024::>');
+    it('should handle digits followed by multiple colons inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024::>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -284,8 +290,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle digits followed by a colon and non-letter characters inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<1024:123>');
+    it('should handle digits followed by a colon and non-letter characters inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024:123>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -294,8 +300,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle digits followed by a colon and spaces inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<1024: vision>');
+    it('should handle digits followed by a colon and spaces inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024: vision>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -304,8 +310,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle digits followed by multiple colons and spaces inside angle brackets', () => {
-      const result = parseModelString('test-provider', 'model1<1024: : vision>');
+    it('should handle digits followed by multiple colons and spaces inside angle brackets', async () => {
+      const result = await parseModelString('test-provider', 'model1<1024: : vision>');
       expect(result.add[0]).toEqual({
         id: 'model1',
         contextWindowTokens: 1024,
@@ -316,8 +322,8 @@ describe('parseModelString', () => {
   });
 
   describe('FAL image models', () => {
-    it('should correctly parse FAL image model ids with slash and custom display names', () => {
-      const result = parseModelString(
+    it('should correctly parse FAL image model ids with slash and custom display names', async () => {
+      const result = await parseModelString(
         'fal',
         '-all,+flux-kontext/dev=KontextDev,+flux-pro/kontext=KontextPro,+flux/schnell=Schnell,+imagen4/preview=Imagen4',
       );
@@ -351,8 +357,8 @@ describe('parseModelString', () => {
       expect(result.removed).toEqual(['all']);
     });
 
-    it('should correctly parse FAL image model ids with slash (no displayName)', () => {
-      const result = parseModelString('fal', '-all,+flux-kontext/dev,+flux-pro/kontext');
+    it('should correctly parse FAL image model ids with slash (no displayName)', async () => {
+      const result = await parseModelString('fal', '-all,+flux-kontext/dev,+flux-pro/kontext');
       expect(result.add).toEqual([
         {
           id: 'flux-kontext/dev',
@@ -371,8 +377,8 @@ describe('parseModelString', () => {
   });
 
   describe('deployment name', () => {
-    it('should have no deployment name', () => {
-      const result = parseModelString('test-provider', 'model1=Model 1', true);
+    it('should have no deployment name', async () => {
+      const result = await parseModelString('test-provider', 'model1=Model 1', true);
       expect(result.add[0]).toEqual({
         id: 'model1',
         displayName: 'Model 1',
@@ -381,8 +387,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should have diff deployment name as id', () => {
-      const result = parseModelString('azure', 'gpt-35-turbo->my-deploy=GPT 3.5 Turbo', true);
+    it('should have diff deployment name as id', async () => {
+      const result = await parseModelString('azure', 'gpt-35-turbo->my-deploy=GPT 3.5 Turbo', true);
       expect(result.add[0]).toEqual({
         id: 'gpt-35-turbo',
         displayName: 'GPT 3.5 Turbo',
@@ -394,8 +400,8 @@ describe('parseModelString', () => {
       });
     });
 
-    it('should handle with multi deployName', () => {
-      const result = parseModelString(
+    it('should handle with multi deployName', async () => {
+      const result = await parseModelString(
         'azure',
         'gpt-4o->id1=GPT-4o,gpt-4o-mini->id2=gpt-4o-mini,o1-mini->id3=O1 mini',
         true,
@@ -428,28 +434,28 @@ describe('parseModelString', () => {
 });
 
 describe('extractEnabledModels', () => {
-  it('should return undefined when no models are added', () => {
-    const result = extractEnabledModels('test-provider', '-all');
+  it('should return undefined when no models are added', async () => {
+    const result = await extractEnabledModels('test-provider', '-all');
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined when modelString is empty', () => {
-    const result = extractEnabledModels('test-provider', '');
+  it('should return undefined when modelString is empty', async () => {
+    const result = await extractEnabledModels('test-provider', '');
     expect(result).toBeUndefined();
   });
 
-  it('should return array of model IDs when models are added', () => {
-    const result = extractEnabledModels('test-provider', '+model1,+model2,+model3');
+  it('should return array of model IDs when models are added', async () => {
+    const result = await extractEnabledModels('test-provider', '+model1,+model2,+model3');
     expect(result).toEqual(['model1', 'model2', 'model3']);
   });
 
-  it('should handle mixed add/remove operations and return only added models', () => {
-    const result = extractEnabledModels('test-provider', '+model1,-model2,+model3');
+  it('should handle mixed add/remove operations and return only added models', async () => {
+    const result = await extractEnabledModels('test-provider', '+model1,-model2,+model3');
     expect(result).toEqual(['model1', 'model3']);
   });
 
-  it('should handle deployment names when withDeploymentName is true', () => {
-    const result = extractEnabledModels(
+  it('should handle deployment names when withDeploymentName is true', async () => {
+    const result = await extractEnabledModels(
       'azure',
       '+gpt-4->deployment1,+gpt-35-turbo->deployment2',
       true,
@@ -457,8 +463,11 @@ describe('extractEnabledModels', () => {
     expect(result).toEqual(['gpt-4', 'gpt-35-turbo']);
   });
 
-  it('should handle complex model strings with custom names', () => {
-    const result = extractEnabledModels('openai', '+gpt-4=Custom GPT-4,+claude-2=Custom Claude');
+  it('should handle complex model strings with custom names', async () => {
+    const result = await extractEnabledModels(
+      'openai',
+      '+gpt-4=Custom GPT-4,+claude-2=Custom Claude',
+    );
     expect(result).toEqual(['gpt-4', 'claude-2']);
   });
 });
@@ -469,8 +478,8 @@ describe('transformToChatModelCards', () => {
     { id: 'model2', displayName: 'Model 2', enabled: false, type: 'chat' },
   ];
 
-  it('should return undefined when modelString is empty', () => {
-    const result = transformToAiModelList({
+  it('should return undefined when modelString is empty', async () => {
+    const result = await transformToAiModelList({
       modelString: '',
       defaultModels: defaultChatModels,
       providerId: 'openai',
@@ -478,8 +487,8 @@ describe('transformToChatModelCards', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should remove all models when removeAll is true', () => {
-    const result = transformToAiModelList({
+  it('should remove all models when removeAll is true', async () => {
+    const result = await transformToAiModelList({
       modelString: '-all',
       defaultModels: defaultChatModels,
       providerId: 'openai',
@@ -487,8 +496,8 @@ describe('transformToChatModelCards', () => {
     expect(result).toEqual([]);
   });
 
-  it('should remove specified models', () => {
-    const result = transformToAiModelList({
+  it('should remove specified models', async () => {
+    const result = await transformToAiModelList({
       modelString: '-model1',
       defaultModels: defaultChatModels,
       providerId: 'openai',
@@ -498,9 +507,9 @@ describe('transformToChatModelCards', () => {
     ]);
   });
 
-  it('should add a new known model', () => {
+  it('should add a new known model', async () => {
     const knownModel = LOBE_DEFAULT_MODEL_LIST.find((m) => m.providerId === 'ai21')!;
-    const result = transformToAiModelList({
+    const result = await transformToAiModelList({
       modelString: `${knownModel.id}`,
       defaultModels: defaultChatModels,
       providerId: 'ai21',
@@ -513,9 +522,9 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should update an existing known model', () => {
+  it('should update an existing known model', async () => {
     const knownModel = LOBE_DEFAULT_MODEL_LIST.find((m) => m.providerId === 'openai')!;
-    const result = transformToAiModelList({
+    const result = await transformToAiModelList({
       modelString: `+${knownModel.id}=Updated Model`,
       defaultModels: [knownModel],
       providerId: 'openai',
@@ -528,8 +537,8 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should add a new custom model', () => {
-    const result = transformToAiModelList({
+  it('should add a new custom model', async () => {
+    const result = await transformToAiModelList({
       modelString: '+custom_model=Custom Model',
       defaultModels: defaultChatModels,
       providerId: 'openai',
@@ -543,8 +552,8 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should have file with builtin models like gpt-4-0125-preview', () => {
-    const result = transformToAiModelList({
+  it('should have file with builtin models like gpt-4-0125-preview', async () => {
+    const result = await transformToAiModelList({
       modelString:
         '-all,+gpt-4-0125-preview=ChatGPT-4<128000:fc:file>,+gpt-4-turbo-2024-04-09=ChatGPT-4 Vision<128000:fc:vision:file>',
       defaultModels: openaiChatModels,
@@ -554,12 +563,12 @@ describe('transformToChatModelCards', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('should use default deploymentName from known model when not specified in string (VolcEngine case)', () => {
+  it('should use default deploymentName from known model when not specified in string (VolcEngine case)', async () => {
     const knownModel = LOBE_DEFAULT_MODEL_LIST.find(
       (m) => m.id === 'deepseek-r1' && m.providerId === 'volcengine',
     );
     const defaultChatModels: AiFullModelCard[] = [];
-    const result = transformToAiModelList({
+    const result = await transformToAiModelList({
       modelString: '+deepseek-r1',
       defaultModels: defaultChatModels,
       providerId: 'volcengine',
@@ -571,12 +580,12 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should use deploymentName from modelString when specified (VolcEngine case)', () => {
+  it('should use deploymentName from modelString when specified (VolcEngine case)', async () => {
     const defaultChatModels: AiFullModelCard[] = [];
     const knownModel = LOBE_DEFAULT_MODEL_LIST.find(
       (m) => m.id === 'deepseek-r1' && m.providerId === 'volcengine',
     );
-    const result = transformToAiModelList({
+    const result = await transformToAiModelList({
       modelString: `+deepseek-r1->my-custom-deploy`,
       defaultModels: defaultChatModels,
       providerId: 'volcengine',
@@ -589,9 +598,9 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should set both id and deploymentName to the full string when no -> is used and withDeploymentName is true', () => {
+  it('should set both id and deploymentName to the full string when no -> is used and withDeploymentName is true', async () => {
     const defaultChatModels: AiFullModelCard[] = [];
-    const result = transformToAiModelList({
+    const result = await transformToAiModelList({
       modelString: `+my_model`,
       defaultModels: defaultChatModels,
       providerId: 'volcengine',
@@ -609,7 +618,7 @@ describe('transformToChatModelCards', () => {
     });
   });
 
-  it('should handle azure real case', () => {
+  it('should handle azure real case', async () => {
     const defaultChatModels = [
       {
         abilities: { functionCall: true, reasoning: true },
@@ -704,7 +713,7 @@ describe('transformToChatModelCards', () => {
     const modelString =
       '-all,gpt-4o->id1=GPT-4o,gpt-4o-mini->id2=GPT 4o Mini,o1-mini->id3=OpenAI o1-mini';
 
-    const data = transformToAiModelList({
+    const data = await transformToAiModelList({
       modelString,
       defaultModels: defaultChatModels,
       providerId: 'azure',


### PR DESCRIPTION
解决用户填完 apikey 后点击连接测试按钮时使用旧 apikey 的问题：

**问题根因：**

执行 checkConnection 没有等到 apiKey 更新。


**解决方案：**

简单的 await updateAiProviderConfig 再 checkConnection 目前会碰到另一个问题。
由于填完 apiKey 直接点击 checker 按钮会先触发 输入 apikey 的 input blur，进而也会执行一次 updateAiProviderConfig。

本来讲道理就不应该触发两次。 

通过状态标记避免 onValuesChange 的重复请求冲突

**技术细节：**

- 添加 onBeforeCheck/onAfterCheck 回调机制
- 使用 isCheckingConnection ref 标记测试状态
- 延迟 onValuesChange 更新以避免请求冲突

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix stale API key usage in the provider config checker by ensuring the latest form values are saved before testing and preventing overlapping TRPC requests.

Bug Fixes:
- Save the latest form values to the store before running the connection check to guarantee up-to-date configuration.
- Block onValuesChange updates during an active check using an isCheckingConnection flag to avoid TRPC batch deduplication conflicts.
- Introduce onBeforeCheck/onAfterCheck callbacks and debounce/delay config updates to prevent overlapping requests and ensure fresh runtime state.