### PR TITLE
🔨 chore: Add ga4 analytics provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@lobechat/electron-server-ipc": "workspace:*",
     "@lobechat/file-loaders": "workspace:*",
     "@lobechat/web-crawler": "workspace:*",
-    "@lobehub/analytics": "^1.5.1",
+    "@lobehub/analytics": "^1.6.0",
     "@lobehub/charts": "^2.0.0",
     "@lobehub/chat-plugin-sdk": "^1.32.4",
     "@lobehub/chat-plugins-gateway": "^1.9.0",

--- a/src/components/Analytics/LobeAnalyticsProvider.tsx
+++ b/src/components/Analytics/LobeAnalyticsProvider.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { createSingletonAnalytics } from '@lobehub/analytics';
+import {
+  GoogleAnalyticsProviderConfig,
+  PostHogProviderAnalyticsConfig,
+  createSingletonAnalytics,
+} from '@lobehub/analytics';
 import { AnalyticsProvider } from '@lobehub/analytics/react';
 import { ReactNode, memo, useMemo } from 'react';
 
@@ -10,16 +14,14 @@ import { isDev } from '@/utils/env';
 
 type Props = {
   children: ReactNode;
-  debugPosthog: boolean;
-  posthogEnabled: boolean;
-  posthogHost: string;
-  posthogToken: string;
+  ga4Config: GoogleAnalyticsProviderConfig;
+  postHogConfig: PostHogProviderAnalyticsConfig;
 };
 
 let analyticsInstance: ReturnType<typeof createSingletonAnalytics> | null = null;
 
 export const LobeAnalyticsProvider = memo(
-  ({ children, posthogHost, posthogToken, posthogEnabled, debugPosthog }: Props) => {
+  ({ children, ga4Config, postHogConfig }: Props) => {
     const analytics = useMemo(() => {
       if (analyticsInstance) {
         return analyticsInstance;
@@ -29,13 +31,8 @@ export const LobeAnalyticsProvider = memo(
         business: BUSINESS_LINE,
         debug: isDev,
         providers: {
-          posthog: {
-            debug: debugPosthog,
-            enabled: posthogEnabled,
-            host: posthogHost,
-            key: posthogToken,
-            person_profiles: 'always',
-          },
+          ga4: ga4Config,
+          posthog: postHogConfig,
         },
       });
 

--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
@@ -2,6 +2,7 @@ import { ReactNode, memo } from 'react';
 
 import { LobeAnalyticsProvider } from '@/components/Analytics/LobeAnalyticsProvider';
 import { analyticsEnv } from '@/config/analytics';
+import { isDev } from '@/utils/env';
 
 type Props = {
   children: ReactNode;
@@ -10,10 +11,21 @@ type Props = {
 export const LobeAnalyticsProviderWrapper = memo<Props>(({ children }) => {
   return (
     <LobeAnalyticsProvider
-      debugPosthog={analyticsEnv.DEBUG_POSTHOG_ANALYTICS}
-      posthogEnabled={analyticsEnv.ENABLED_POSTHOG_ANALYTICS}
-      posthogHost={analyticsEnv.POSTHOG_HOST}
-      posthogToken={analyticsEnv.POSTHOG_KEY ?? ''}
+      ga4Config={{
+        debug: isDev,
+        enabled: analyticsEnv.ENABLE_GOOGLE_ANALYTICS,
+        gtagConfig: {
+          debug_mode: isDev,
+        },
+        measurementId: analyticsEnv.GOOGLE_ANALYTICS_MEASUREMENT_ID ?? '',
+      }}
+      postHogConfig={{
+        debug: analyticsEnv.DEBUG_POSTHOG_ANALYTICS,
+        enabled: analyticsEnv.ENABLED_POSTHOG_ANALYTICS,
+        host: analyticsEnv.POSTHOG_HOST,
+        key: analyticsEnv.POSTHOG_KEY ?? '',
+        person_profiles: 'always',
+      }}
     >
       {children}
     </LobeAnalyticsProvider>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change
Add ga4 analytics provider

       ga4: {
            debug: isDev,
            enabled: ga4Enabled,
            gtagConfig: {
              debug_mode: isDev,
            },
            measurementId: ga4MeasurementId,
          },

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for Google Analytics 4 alongside PostHog by introducing new GA4 props and configuration, and bump the analytics library version.

New Features:
- Introduce GA4 analytics provider in LobeAnalyticsProvider with enable flag and measurement ID.
- Expose GA4 enable and measurement ID settings in the provider wrapper from environment variables.

Enhancements:
- Upgrade @lobehub/analytics dependency to v1.6.0.