### PR TITLE
🐛 fix: avatar in desktop version

### DIFF
--- a/src/features/User/UserAvatar.tsx
+++ b/src/features/User/UserAvatar.tsx
@@ -2,10 +2,13 @@
 
 import { Avatar, type AvatarProps } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 
 import { BRANDING_NAME } from '@/const/branding';
 import { DEFAULT_USER_AVATAR_URL } from '@/const/meta';
+import { isDesktop } from '@/const/version';
+import { useElectronStore } from '@/store/electron';
+import { electronSyncSelectors } from '@/store/electron/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
@@ -54,11 +57,24 @@ const UserAvatar = forwardRef<HTMLDivElement, UserAvatarProps>(
     ]);
 
     const isSignedIn = useUserStore(authSelectors.isLogin);
+    const remoteServerUrl = useElectronStore(electronSyncSelectors.remoteServerUrl);
+
+    // Process avatar URL for desktop environment
+    const avatarUrl = useMemo(() => {
+      if (!isSignedIn || !avatar) return DEFAULT_USER_AVATAR_URL;
+
+      // If in desktop environment and avatar starts with /, prepend the remote server URL
+      if (isDesktop && avatar.startsWith('/') && remoteServerUrl) {
+        return remoteServerUrl + avatar;
+      }
+
+      return avatar;
+    }, [isSignedIn, avatar, remoteServerUrl]);
 
     return (
       <Avatar
         alt={isSignedIn && !!username ? username : BRANDING_NAME}
-        avatar={isSignedIn && !!avatar ? avatar : DEFAULT_USER_AVATAR_URL}
+        avatar={avatarUrl}
         background={isSignedIn && avatar ? background : 'transparent'}
         className={cx(clickable && styles.clickable, className)}
         ref={ref}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

在自部署版本中，在请求 user.getUserState 时，至少存在一个 auth provider 会返回指向 /webapi/user/avatar/... 的头像

在之前的版本中，前端（侧边栏处）直接引用了这一 URL

在 web 环境下，没有问题 —— 因为会正确的请求 {Backend URL}/webapi/user/avatar/...

但是在 desktop 环境下，这会导致请求 http://localhost:3015/webapi/user/avatar/... 进而由 electron 返回 500

本 PR 修复了这一问题

#### 📝 补充信息 | Additional Information

Fixes #7734, Fixes #8406, Fixes #8566

## Summary by Sourcery

Bug Fixes:
- Prefix relative avatar URLs with the remote server URL in desktop environment to prevent local "404/500" errors