### PR TITLE
 ✨ feat: support gpt-oss in Ollama

### DIFF
--- a/src/config/aiModels/ollama.ts
+++ b/src/config/aiModels/ollama.ts
@@ -11,7 +11,7 @@ const ollamaChatModels: AIChatModelCard[] = [
       'GPT-OSS 20B 是 OpenAI 发布的开源大语言模型，采用 MXFP4 量化技术，适合在高端消费级GPU或Apple Silicon Mac上运行。该模型在对话生成、代码编写和推理任务方面表现出色，支持函数调用和工具使用。',
     displayName: 'GPT-OSS 20B',
     enabled: true,
-    id: 'gpt-oss:20b',
+    id: 'gpt-oss',
     releasedAt: '2025-08-06',
     type: 'chat',
   },

--- a/src/config/aiModels/ollama.ts
+++ b/src/config/aiModels/ollama.ts
@@ -12,7 +12,7 @@ const ollamaChatModels: AIChatModelCard[] = [
     displayName: 'GPT-OSS 20B',
     enabled: true,
     id: 'gpt-oss',
-    releasedAt: '2025-08-06',
+    releasedAt: '2025-08-05',
     type: 'chat',
   },
   {
@@ -25,7 +25,7 @@ const ollamaChatModels: AIChatModelCard[] = [
       'GPT-OSS 120B 是 OpenAI 发布的大型开源语言模型，采用 MXFP4 量化技术，为旗舰级模型。需要多GPU或高性能工作站环境运行，在复杂推理、代码生成和多语言处理方面具备卓越性能，支持高级函数调用和工具集成。',
     displayName: 'GPT-OSS 120B',
     id: 'gpt-oss:120b',
-    releasedAt: '2025-08-06',
+    releasedAt: '2025-08-05',
     type: 'chat',
   },
   {

--- a/src/config/aiModels/ollama.ts
+++ b/src/config/aiModels/ollama.ts
@@ -3,6 +3,33 @@ import { AIChatModelCard } from '@/types/aiModel';
 const ollamaChatModels: AIChatModelCard[] = [
   {
     abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'GPT-OSS 20B 是 OpenAI 发布的开源大语言模型，采用 MXFP4 量化技术，适合在高端消费级GPU或Apple Silicon Mac上运行。该模型在对话生成、代码编写和推理任务方面表现出色，支持函数调用和工具使用。',
+    displayName: 'GPT-OSS 20B',
+    enabled: true,
+    id: 'gpt-oss:20b',
+    releasedAt: '2025-08-06',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'GPT-OSS 120B 是 OpenAI 发布的大型开源语言模型，采用 MXFP4 量化技术，为旗舰级模型。需要多GPU或高性能工作站环境运行，在复杂推理、代码生成和多语言处理方面具备卓越性能，支持高级函数调用和工具集成。',
+    displayName: 'GPT-OSS 120B',
+    id: 'gpt-oss:120b',
+    releasedAt: '2025-08-06',
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
     },
     contextWindowTokens: 65_536,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Register two new GPT-OSS open-source chat models (20B and 120B) in the Ollama integration, enabling extended context windows and function calling capabilities.

New Features:
- Add GPT-OSS 20B model to Ollama AI models config with function call and reasoning support
- Add GPT-OSS 120B model to Ollama AI models config with function call and reasoning support