### PR TITLE
 🐛 fix: fix ollama model output without thinking

### DIFF
--- a/src/libs/model-runtime/utils/streams/ollama.ts
+++ b/src/libs/model-runtime/utils/streams/ollama.ts
@@ -17,6 +17,10 @@ const transformOllamaStream = (chunk: ChatResponse, stack: StreamContext): Strea
     return { data: 'finished', id: stack.id, type: 'stop' };
   }
 
+  if (chunk.message.thinking) {
+    return { data: chunk.message.thinking, id: stack.id, type: 'reasoning' };
+  }
+
   if (chunk.message.tool_calls && chunk.message.tool_calls.length > 0) {
     return {
       data: chunk.message.tool_calls.map((value, index) => ({


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix support for the thinking field in OllamaStream by emitting reasoning events for chunk.message.thinking, and update tests to cover the new behavior and existing reasoning tags.

Bug Fixes:
- Handle the ChatResponse.thinking field in OllamaStream transform

Enhancements:
- Refactor OllamaStream tests to separate reasoning tag and thinking field scenarios and add callbacks

Tests:
- Add a test case for the thinking field to verify reasoning and completion events