### PR TITLE
🐛 fix: fix remote avatar broken in desktop again

### DIFF
--- a/src/features/ChatItem/index.tsx
+++ b/src/features/ChatItem/index.tsx
@@ -2,16 +2,39 @@
 
 import { ChatItemProps, ChatItem as ChatItemRaw } from '@lobehub/ui/chat';
 import isEqual from 'fast-deep-equal';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
+import { isDesktop } from '@/const/version';
+import { useElectronStore } from '@/store/electron';
+import { electronSyncSelectors } from '@/store/electron/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 
-const ChatItem = memo<ChatItemProps>(({ markdownProps = {}, ...rest }) => {
+const ChatItem = memo<ChatItemProps>(({ markdownProps = {}, avatar, ...rest }) => {
   const { componentProps, ...restMarkdown } = markdownProps;
   const { general } = useUserStore(settingsSelectors.currentSettings, isEqual);
+
+  const remoteServerUrl = useElectronStore(electronSyncSelectors.remoteServerUrl);
+  const processedAvatar = useMemo(() => {
+    // only process avatar in desktop environment and when avatar url starts with /
+    if (
+      !isDesktop ||
+      !remoteServerUrl ||
+      !avatar.avatar ||
+      typeof avatar.avatar !== 'string' ||
+      !avatar.avatar.startsWith('/')
+    )
+      return avatar;
+
+    return {
+      ...avatar,
+      avatar: remoteServerUrl + avatar.avatar, // prepend the remote server URL
+    };
+  }, [avatar, remoteServerUrl]);
+
   return (
     <ChatItemRaw
+      avatar={processedAvatar}
       fontSize={general.fontSize}
       markdownProps={{
         ...restMarkdown,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<img width="1503" height="912" alt="image" src="https://github.com/user-attachments/assets/545928d7-6532-4820-8005-541c548f92cc" />

#8673 仅修复了桌面端左上角的头像，未能修复聊天对话中的头像

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

两个地方的重复逻辑存在，但是两处整体差异也不小，抽离出共享逻辑感觉反而有点不值得，所以就没搞个新的 hook 出来

希望没有其他地方了……

## Summary by Sourcery

Bug Fixes:
- Prepend the remote server URL to relative avatar paths in ChatItem when running in the desktop environment to restore remote avatars in chat dialogs.