### PR TITLE
🔨 chore: fix MenuCtr test type error

### DIFF
--- a/apps/desktop/src/main/controllers/__tests__/MenuCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/MenuCtr.test.ts
@@ -29,9 +29,9 @@ describe('MenuController', () => {
     it('should call menuManager.refreshMenus', () => {
       // 模拟返回值
       mockRefreshMenus.mockReturnValueOnce(true);
-      
+
       const result = menuController.refreshAppMenu();
-      
+
       expect(mockRefreshMenus).toHaveBeenCalled();
       expect(result).toBe(true);
     });
@@ -41,9 +41,9 @@ describe('MenuController', () => {
     it('should call menuManager.showContextMenu with type only', () => {
       const menuType = 'chat';
       mockShowContextMenu.mockReturnValueOnce({ shown: true });
-      
-      const result = menuController.showContextMenu(menuType);
-      
+
+      const result = menuController.showContextMenu({ type: menuType });
+
       expect(mockShowContextMenu).toHaveBeenCalledWith(menuType, undefined);
       expect(result).toEqual({ shown: true });
     });
@@ -52,9 +52,9 @@ describe('MenuController', () => {
       const menuType = 'file';
       const menuData = { fileId: '123', filePath: '/path/to/file.txt' };
       mockShowContextMenu.mockReturnValueOnce({ shown: true });
-      
-      const result = menuController.showContextMenu(menuType, menuData);
-      
+
+      const result = menuController.showContextMenu({ type: menuType, data: menuData });
+
       expect(mockShowContextMenu).toHaveBeenCalledWith(menuType, menuData);
       expect(result).toEqual({ shown: true });
     });
@@ -63,20 +63,20 @@ describe('MenuController', () => {
   describe('setDevMenuVisibility', () => {
     it('should call menuManager.rebuildAppMenu with showDevItems true', () => {
       mockRebuildAppMenu.mockReturnValueOnce(true);
-      
+
       const result = menuController.setDevMenuVisibility(true);
-      
+
       expect(mockRebuildAppMenu).toHaveBeenCalledWith({ showDevItems: true });
       expect(result).toBe(true);
     });
 
     it('should call menuManager.rebuildAppMenu with showDevItems false', () => {
       mockRebuildAppMenu.mockReturnValueOnce(true);
-      
+
       const result = menuController.setDevMenuVisibility(false);
-      
+
       expect(mockRebuildAppMenu).toHaveBeenCalledWith({ showDevItems: false });
       expect(result).toBe(true);
     });
   });
-}); 
+});


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix type errors in MenuController tests by updating showContextMenu calls to match its new object-based signature and cleaning up whitespace in the test file

Tests:
- Update showContextMenu tests to pass a single object with type and optional data properties instead of separate arguments

Chores:
- Remove trailing whitespace and add missing newline in MenuCtr.test.ts