### PR TITLE
🐛 fix: Solve the cache problem caused by the same dom id when sharing image

### DIFF
--- a/src/features/Conversation/components/ChatItem/ShareMessageModal/ShareImage/Preview.tsx
+++ b/src/features/Conversation/components/ChatItem/ShareMessageModal/ShareImage/Preview.tsx
@@ -21,63 +21,70 @@ import { FieldType } from './type';
 
 interface PreviewProps extends FieldType {
   message: ChatMessage;
+  previewId?: string;
   title?: string;
 }
 
-const Preview = memo<PreviewProps>(({ title, withBackground, withFooter, message }) => {
-  const [model, plugins] = useAgentStore((s) => [
-    agentSelectors.currentAgentModel(s),
-    agentSelectors.currentAgentPlugins(s),
-  ]);
+const Preview = memo<PreviewProps>(
+  ({ title, withBackground, withFooter, message, previewId = 'preview' }) => {
+    const [model, plugins] = useAgentStore((s) => [
+      agentSelectors.currentAgentModel(s),
+      agentSelectors.currentAgentPlugins(s),
+    ]);
 
-  const [isInbox, description, avatar, backgroundColor] = useSessionStore((s) => [
-    sessionSelectors.isInboxSession(s),
-    sessionMetaSelectors.currentAgentDescription(s),
-    sessionMetaSelectors.currentAgentAvatar(s),
-    sessionMetaSelectors.currentAgentBackgroundColor(s),
-  ]);
+    const [isInbox, description, avatar, backgroundColor] = useSessionStore((s) => [
+      sessionSelectors.isInboxSession(s),
+      sessionMetaSelectors.currentAgentDescription(s),
+      sessionMetaSelectors.currentAgentAvatar(s),
+      sessionMetaSelectors.currentAgentBackgroundColor(s),
+    ]);
 
-  const { t } = useTranslation('chat');
-  const { styles } = useStyles(withBackground);
-  const { styles: containerStyles } = useContainerStyles();
+    const { t } = useTranslation('chat');
+    const { styles } = useStyles(withBackground);
+    const { styles: containerStyles } = useContainerStyles();
 
-  const displayTitle = isInbox ? t('inbox.title') : title;
-  const displayDesc = isInbox ? t('inbox.desc') : description;
+    const displayTitle = isInbox ? t('inbox.title') : title;
+    const displayDesc = isInbox ? t('inbox.desc') : description;
 
-  return (
-    <div className={containerStyles.preview}>
-      <div className={withBackground ? styles.background : undefined} id={'preview'}>
-        <Flexbox className={styles.container} gap={16}>
-          <div className={styles.header}>
-            <Flexbox align={'flex-start'} gap={12} horizontal>
-              <Avatar avatar={avatar} background={backgroundColor} size={40} title={title} />
-              <ChatHeaderTitle
-                desc={displayDesc}
-                tag={
-                  <Flexbox gap={4} horizontal>
-                    <ModelTag model={model} />
-                    {plugins?.length > 0 && <PluginTag plugins={plugins} />}
-                  </Flexbox>
-                }
-                title={displayTitle}
-              />
+    return (
+      <div className={containerStyles.preview}>
+        <div className={withBackground ? styles.background : undefined} id={previewId}>
+          <Flexbox className={styles.container} gap={16}>
+            <div className={styles.header}>
+              <Flexbox align={'flex-start'} gap={12} horizontal>
+                <Avatar avatar={avatar} background={backgroundColor} size={40} title={title} />
+                <ChatHeaderTitle
+                  desc={displayDesc}
+                  tag={
+                    <Flexbox gap={4} horizontal>
+                      <ModelTag model={model} />
+                      {plugins?.length > 0 && <PluginTag plugins={plugins} />}
+                    </Flexbox>
+                  }
+                  title={displayTitle}
+                />
+              </Flexbox>
+            </div>
+            <Flexbox
+              height={'100%'}
+              style={{ paddingTop: 24, position: 'relative' }}
+              width={'100%'}
+            >
+              <ChatItem id={message.id} index={0} />
             </Flexbox>
-          </div>
-          <Flexbox height={'100%'} style={{ paddingTop: 24, position: 'relative' }} width={'100%'}>
-            <ChatItem id={message.id} index={0} />
+            {withFooter ? (
+              <Flexbox align={'center'} className={styles.footer} gap={4}>
+                <ProductLogo type={'combine'} />
+                <div className={styles.url}>{pkg.homepage}</div>
+              </Flexbox>
+            ) : (
+              <div />
+            )}
           </Flexbox>
-          {withFooter ? (
-            <Flexbox align={'center'} className={styles.footer} gap={4}>
-              <ProductLogo type={'combine'} />
-              <div className={styles.url}>{pkg.homepage}</div>
-            </Flexbox>
-          ) : (
-            <div />
-          )}
-        </Flexbox>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 export default Preview;

--- a/src/features/Conversation/components/ChatItem/ShareMessageModal/ShareImage/index.tsx
+++ b/src/features/Conversation/components/ChatItem/ShareMessageModal/ShareImage/index.tsx
@@ -23,84 +23,91 @@ const DEFAULT_FIELD_VALUE: FieldType = {
   withFooter: true,
 };
 
-const ShareImage = memo<{ message: ChatMessage; mobile?: boolean }>(({ message }) => {
-  const currentAgentTitle = useSessionStore(sessionMetaSelectors.currentAgentTitle);
-  const [fieldValue, setFieldValue] = useState<FieldType>(DEFAULT_FIELD_VALUE);
-  const { t } = useTranslation(['chat', 'common']);
-  const { styles } = useStyles();
-  const { loading, onDownload, title } = useScreenshot({
-    imageType: fieldValue.imageType,
-    title: currentAgentTitle,
-  });
-  const { loading: copyLoading, onCopy } = useImgToClipboard();
-  const settings: FormItemProps[] = [
-    {
-      children: <Switch />,
-      label: t('shareModal.withBackground'),
-      layout: 'horizontal',
-      minWidth: undefined,
-      name: 'withBackground',
-      valuePropName: 'checked',
-    },
-    {
-      children: <Switch />,
-      label: t('shareModal.withFooter'),
-      layout: 'horizontal',
-      minWidth: undefined,
-      name: 'withFooter',
-      valuePropName: 'checked',
-    },
-    {
-      children: <Segmented options={imageTypeOptions} />,
-      label: t('shareModal.imageType'),
-      layout: 'horizontal',
-      minWidth: undefined,
-      name: 'imageType',
-    },
-  ];
+const ShareImage = memo<{ message: ChatMessage; mobile?: boolean; uniqueId?: string }>(
+  ({ message, uniqueId }) => {
+    const currentAgentTitle = useSessionStore(sessionMetaSelectors.currentAgentTitle);
+    const [fieldValue, setFieldValue] = useState<FieldType>(DEFAULT_FIELD_VALUE);
+    const { t } = useTranslation(['chat', 'common']);
+    const { styles } = useStyles();
 
-  const isMobile = useIsMobile();
+    // 生成唯一的预览ID，避免DOM冲突
+    const previewId = uniqueId ? `preview-${uniqueId}` : 'preview';
 
-  const button = (
-    <>
-      <Button
-        block
-        icon={CopyIcon}
-        loading={copyLoading}
-        onClick={() => onCopy()}
-        size={isMobile ? undefined : 'large'}
-        type={'primary'}
-      >
-        {t('copy', { ns: 'common' })}
-      </Button>
-      <Button block loading={loading} onClick={onDownload} size={isMobile ? undefined : 'large'}>
-        {t('shareModal.download')}
-      </Button>
-    </>
-  );
+    const { loading, onDownload, title } = useScreenshot({
+      id: `#${previewId}`,
+      imageType: fieldValue.imageType,
+      title: currentAgentTitle,
+    });
+    const { loading: copyLoading, onCopy } = useImgToClipboard({ id: `#${previewId}` });
+    const settings: FormItemProps[] = [
+      {
+        children: <Switch />,
+        label: t('shareModal.withBackground'),
+        layout: 'horizontal',
+        minWidth: undefined,
+        name: 'withBackground',
+        valuePropName: 'checked',
+      },
+      {
+        children: <Switch />,
+        label: t('shareModal.withFooter'),
+        layout: 'horizontal',
+        minWidth: undefined,
+        name: 'withFooter',
+        valuePropName: 'checked',
+      },
+      {
+        children: <Segmented options={imageTypeOptions} />,
+        label: t('shareModal.imageType'),
+        layout: 'horizontal',
+        minWidth: undefined,
+        name: 'imageType',
+      },
+    ];
 
-  return (
-    <>
-      <Flexbox className={styles.body} gap={16} horizontal={!isMobile}>
-        <Preview title={title} {...fieldValue} message={message} />
-        <Flexbox className={styles.sidebar} gap={12}>
-          <Form
-            initialValues={DEFAULT_FIELD_VALUE}
-            items={settings}
-            itemsType={'flat'}
-            onValuesChange={(_, v) => setFieldValue(v)}
-            {...FORM_STYLE}
-          />
-          {!isMobile && button}
+    const isMobile = useIsMobile();
+
+    const button = (
+      <>
+        <Button
+          block
+          icon={CopyIcon}
+          loading={copyLoading}
+          onClick={() => onCopy()}
+          size={isMobile ? undefined : 'large'}
+          type={'primary'}
+        >
+          {t('copy', { ns: 'common' })}
+        </Button>
+        <Button block loading={loading} onClick={onDownload} size={isMobile ? undefined : 'large'}>
+          {t('shareModal.download')}
+        </Button>
+      </>
+    );
+
+    return (
+      <>
+        <Flexbox className={styles.body} gap={16} horizontal={!isMobile}>
+          <Preview title={title} {...fieldValue} message={message} previewId={previewId} />
+          <Flexbox className={styles.sidebar} gap={12}>
+            <Form
+              initialValues={DEFAULT_FIELD_VALUE}
+              items={settings}
+              itemsType={'flat'}
+              onValuesChange={(_, v) => setFieldValue(v)}
+              {...FORM_STYLE}
+            />
+            {!isMobile && button}
+          </Flexbox>
         </Flexbox>
-      </Flexbox>
-      {isMobile && (
-        <Flexbox className={styles.footer} gap={8} horizontal>
-          {button}
-        </Flexbox>
-      )}
-    </>
-  );
-});
+        {isMobile && (
+          <Flexbox className={styles.footer} gap={8} horizontal>
+            {button}
+          </Flexbox>
+        )}
+      </>
+    );
+  },
+);
 
 export default ShareImage;

--- a/src/features/Conversation/components/ChatItem/ShareMessageModal/index.tsx
+++ b/src/features/Conversation/components/ChatItem/ShareMessageModal/index.tsx
@@ -1,5 +1,5 @@
 import { Modal, Segmented, type SegmentedProps } from '@lobehub/ui';
-import { memo, useMemo, useState } from 'react';
+import { memo, useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
@@ -23,6 +23,7 @@ interface ShareModalProps {
 const ShareModal = memo<ShareModalProps>(({ onCancel, open, message }) => {
   const [tab, setTab] = useState<Tab>(Tab.Screenshot);
   const { t } = useTranslation('chat');
+  const uniqueId = useId();
 
   const options: SegmentedProps['options'] = useMemo(
     () => [
@@ -58,7 +59,9 @@ const ShareModal = memo<ShareModalProps>(({ onCancel, open, message }) => {
           value={tab}
           variant={'filled'}
         />
-        {tab === Tab.Screenshot && <ShareImage message={message} mobile={isMobile} />}
+        {tab === Tab.Screenshot && (
+          <ShareImage message={message} mobile={isMobile} uniqueId={uniqueId} />
+        )}
         {tab === Tab.Text && <ShareText item={message} />}
       </Flexbox>
     </Modal>


### PR DESCRIPTION
https://github.com/lobehub/lobe-chat/issues/8646

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Generate unique DOM identifiers for the image preview in the share modal to resolve caching conflicts when sharing multiple images

Bug Fixes:
- Assign a distinct id to each preview container to prevent stale screenshot and clipboard operations due to duplicate DOM ids

Enhancements:
- Propagate a uniqueId from ShareModal via useId into ShareImage and Preview components and supply it to screenshot and clipboard hooks