### PR TITLE
✨ feat: add GPT-5 series models

### DIFF
--- a/src/config/aiModels/aihubmix.ts
+++ b/src/config/aiModels/aihubmix.ts
@@ -4,6 +4,98 @@ const aihubmixModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      imageOutput: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      '跨领域编码和代理任务的最佳模型。GPT-5 在准确性、速度、推理、上下文识别、结构化思维和问题解决方面实现了飞跃。',
+    displayName: 'GPT-5',
+    enabled: true,
+    id: 'gpt-5',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.13,
+      input: 1.25,
+      output: 10,
+    },
+    releasedAt: '2025-08-07',
+    settings: {
+      extendParams: ['reasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      '更快、更经济高效的 GPT-5 版本，适用于明确定义的任务。在保持高质量输出的同时，提供更快的响应速度。',
+    displayName: 'GPT-5 mini',
+    enabled: true,
+    id: 'gpt-5-mini',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.03,
+      input: 0.25,
+      output: 2,
+    },
+    releasedAt: '2025-08-07',
+    settings: {
+      extendParams: ['reasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description: '最快、最经济高效的 GPT-5 版本。非常适合需要快速响应且成本敏感的应用场景。',
+    displayName: 'GPT-5 nano',
+    enabled: true,
+    id: 'gpt-5-nano',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.01,
+      input: 0.05,
+      output: 0.4,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'ChatGPT 中使用的 GPT-5 模型。结合了强大的语言理解与生成能力，适合对话式交互应用。',
+    displayName: 'GPT-5 Chat',
+    enabled: true,
+    id: 'gpt-5-chat-latest',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.13,
+      input: 1.25,
+      output: 10,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
       search: true,
       vision: true,
@@ -136,7 +228,6 @@ const aihubmixModels: AIChatModelCard[] = [
     contextWindowTokens: 1_047_576,
     description: 'GPT-4.1 是我们用于复杂任务的旗舰模型。它非常适合跨领域解决问题。',
     displayName: 'GPT-4.1',
-    enabled: true,
     id: 'gpt-4.1',
     maxOutput: 32_768,
     pricing: {
@@ -199,7 +290,6 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'ChatGPT-4o 是一款动态模型，实时更新以保持当前最新版本。它结合了强大的语言理解与生成能力，适合于大规模应用场景，包括客户服务、教育和技术支持。',
     displayName: 'ChatGPT-4o',
-    enabled: true,
     id: 'chatgpt-4o-latest',
     pricing: {
       input: 5,

--- a/src/config/aiModels/openai.ts
+++ b/src/config/aiModels/openai.ts
@@ -39,6 +39,9 @@ export const openaiChatModels: AIChatModelCard[] = [
       output: 10,
     },
     releasedAt: '2025-08-07',
+    settings: {
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {
@@ -61,6 +64,9 @@ export const openaiChatModels: AIChatModelCard[] = [
       output: 2,
     },
     releasedAt: '2025-08-07',
+    settings: {
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {

--- a/src/config/aiModels/openai.ts
+++ b/src/config/aiModels/openai.ts
@@ -40,6 +40,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-08-07',
     settings: {
+      extendParams: ['reasoningEffort'],
       searchImpl: 'params',
     },
     type: 'chat',
@@ -65,6 +66,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-08-07',
     settings: {
+      extendParams: ['reasoningEffort'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/src/config/aiModels/openai.ts
+++ b/src/config/aiModels/openai.ts
@@ -21,6 +21,89 @@ export const openaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      imageOutput: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      '跨领域编码和代理任务的最佳模型。GPT-5 在准确性、速度、推理、上下文识别、结构化思维和问题解决方面实现了飞跃。',
+    displayName: 'GPT-5',
+    enabled: true,
+    id: 'gpt-5',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.13,
+      input: 1.25,
+      output: 10,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      '更快、更经济高效的 GPT-5 版本，适用于明确定义的任务。在保持高质量输出的同时，提供更快的响应速度。',
+    displayName: 'GPT-5 mini',
+    enabled: true,
+    id: 'gpt-5-mini',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.03,
+      input: 0.25,
+      output: 2,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description: '最快、最经济高效的 GPT-5 版本。非常适合需要快速响应且成本敏感的应用场景。',
+    displayName: 'GPT-5 nano',
+    id: 'gpt-5-nano',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.01,
+      input: 0.05,
+      output: 0.4,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'ChatGPT 中使用的 GPT-5 模型。结合了强大的语言理解与生成能力，适合对话式交互应用。',
+    displayName: 'GPT-5 Chat',
+    enabled: true,
+    id: 'gpt-5-chat-latest',
+    maxOutput: 128_000,
+    pricing: {
+      cachedInput: 0.13,
+      input: 1.25,
+      output: 10,
+    },
+    releasedAt: '2025-08-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
       search: true,
       vision: true,
@@ -261,7 +344,6 @@ export const openaiChatModels: AIChatModelCard[] = [
     contextWindowTokens: 1_047_576,
     description: 'GPT-4.1 是我们用于复杂任务的旗舰模型。它非常适合跨领域解决问题。',
     displayName: 'GPT-4.1',
-    enabled: true,
     id: 'gpt-4.1',
     maxOutput: 32_768,
     pricing: {
@@ -285,7 +367,6 @@ export const openaiChatModels: AIChatModelCard[] = [
     description:
       'GPT-4.1 mini 提供了智能、速度和成本之间的平衡，使其成为许多用例中有吸引力的模型。',
     displayName: 'GPT-4.1 mini',
-    enabled: true,
     id: 'gpt-4.1-mini',
     maxOutput: 32_768,
     pricing: {
@@ -516,7 +597,6 @@ export const openaiChatModels: AIChatModelCard[] = [
     description:
       'ChatGPT-4o 是一款动态模型，实时更新以保持当前最新版本。它结合了强大的语言理解与生成能力，适合于大规模应用场景，包括客户服务、教育和技术支持。',
     displayName: 'ChatGPT-4o',
-    enabled: true,
     id: 'chatgpt-4o-latest',
     pricing: {
       input: 5,

--- a/src/config/modelProviders/openai.ts
+++ b/src/config/modelProviders/openai.ts
@@ -5,11 +5,27 @@ const OpenAI: ModelProviderCard = {
   apiKeyUrl: 'https://platform.openai.com/api-keys?utm_source=lobehub',
   chatModels: [
     {
+      contextWindowTokens: 400_000,
+      description:
+        '更快、更经济高效的 GPT-5 版本，适用于明确定义的任务。在保持高质量输出的同时，提供更快的响应速度。',
+      displayName: 'GPT-5 mini',
+      enabled: true,
+      functionCall: true,
+      id: 'gpt-5-mini',
+      maxOutput: 128_000,
+      pricing: {
+        cachedInput: 0.03,
+        input: 0.25,
+        output: 2,
+      },
+      releasedAt: '2025-08-07',
+      vision: true,
+    },
+    {
       contextWindowTokens: 1_047_576,
       description:
         'GPT-4.1 mini 提供了智能、速度和成本之间的平衡，使其成为许多用例中有吸引力的模型。',
       displayName: 'GPT-4.1 mini',
-      enabled: true,
       functionCall: true,
       id: 'gpt-4.1-mini',
       maxOutput: 32_768,

--- a/src/const/models.ts
+++ b/src/const/models.ts
@@ -35,6 +35,8 @@ export const responsesAPIModels = new Set([
   'codex-mini-latest',
   'computer-use-preview',
   'computer-use-preview-2025-03-11',
+  'gpt-5',
+  'gpt-5-mini',
 ]);
 
 /**

--- a/src/const/settings/llm.ts
+++ b/src/const/settings/llm.ts
@@ -14,7 +14,7 @@ export const DEFAULT_LLM_CONFIG = genUserLLMConfig({
   },
 });
 
-export const DEFAULT_MODEL = 'gpt-4.1-mini';
+export const DEFAULT_MODEL = 'gpt-5-mini';
 
 export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_EMBEDDING_PROVIDER = ModelProvider.OpenAI;

--- a/src/libs/model-runtime/openai/index.ts
+++ b/src/libs/model-runtime/openai/index.ts
@@ -9,7 +9,7 @@ export interface OpenAIModelCard {
   id: string;
 }
 
-const prunePrefixes = ['o1', 'o3', 'o4', 'codex', 'computer-use'];
+const prunePrefixes = ['o1', 'o3', 'o4', 'codex', 'computer-use', 'gpt-5'];
 const oaiSearchContextSize = process.env.OPENAI_SEARCH_CONTEXT_SIZE; // low, medium, high
 
 export const LobeOpenAI = createOpenAICompatibleRuntime({

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,4 +1,4 @@
-import { ChatErrorType , TracePayload, TraceTagMap } from '@lobechat/types';
+import { ChatErrorType, TracePayload, TraceTagMap } from '@lobechat/types';
 import { PluginRequestPayload, createHeadersWithPluginSettings } from '@lobehub/chat-plugin-sdk';
 import { produce } from 'immer';
 import { merge } from 'lodash-es';

--- a/src/store/agent/slices/chat/selectors/__snapshots__/agent.test.ts.snap
+++ b/src/store/agent/slices/chat/selectors/__snapshots__/agent.test.ts.snap
@@ -12,7 +12,7 @@ exports[`agentSelectors > defaultAgentConfig > should merge DEFAULT_AGENT_CONFIG
     "historyCount": 20,
     "reasoningBudgetToken": 1024,
     "searchFCModel": {
-      "model": "gpt-4.1-mini",
+      "model": "gpt-5-mini",
       "provider": "openai",
     },
     "searchMode": "off",

--- a/src/store/user/slices/modelList/selectors/modelProvider.test.ts
+++ b/src/store/user/slices/modelList/selectors/modelProvider.test.ts
@@ -45,22 +45,6 @@ describe('modelProviderSelectors', () => {
   });
 
   describe('defaultEnabledProviderModels', () => {
-    it('should return enabled models for a given provider', () => {
-      const s = merge(initialState, {}) as unknown as UserStore;
-
-      const result = modelProviderSelectors.getDefaultEnabledModelsById('openai')(s);
-      expect(result).toEqual([
-        'gpt-4.1-mini',
-        'o1-mini',
-        'o1-2024-12-17',
-        'o1-preview',
-        'gpt-4o-mini',
-        'gpt-4o-2024-11-20',
-        'gpt-4o',
-        'chatgpt-4o-latest',
-      ]);
-    });
-
     it('should return undefined for a non-existing provider', () => {
       const s = merge(initialState, {}) as unknown as UserStore;
 

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -51,34 +51,34 @@ exports[`settingsSelectors > currentSettings > should merge DEFAULT_SETTINGS and
 exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AGENT_CONFIG and s.settings.systemAgent correctly 1`] = `
 {
   "agentMeta": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "enableAutoReply": true,
   "generationTopic": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "historyCompress": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "queryRewrite": {
     "enabled": true,
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "replyMessage": "Custom auto reply",
   "thread": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "topic": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
   "translation": {
-    "model": "gpt-4.1-mini",
+    "model": "gpt-5-mini",
     "provider": "openai",
   },
 }
@@ -115,7 +115,7 @@ exports[`settingsSelectors > defaultAgent > should merge DEFAULT_AGENT and s.set
       "historyCount": 20,
       "reasoningBudgetToken": 1024,
       "searchFCModel": {
-        "model": "gpt-4.1-mini",
+        "model": "gpt-5-mini",
         "provider": "openai",
       },
       "searchMode": "off",
@@ -159,7 +159,7 @@ exports[`settingsSelectors > defaultAgentConfig > should merge DEFAULT_AGENT_CON
     "historyCount": 20,
     "reasoningBudgetToken": 1024,
     "searchFCModel": {
-      "model": "gpt-4.1-mini",
+      "model": "gpt-5-mini",
       "provider": "openai",
     },
     "searchMode": "off",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for the GPT-5 series by introducing GPT-5, GPT-5 mini, GPT-5 nano, and GPT-5 Chat to the model configurations, update default model settings, adjust pruning logic, and refresh related tests and snapshots.

New Features:
- Add GPT-5, GPT-5 mini, GPT-5 nano, and GPT-5 Chat entries to aihubmix model configurations
- Add GPT-5, GPT-5 mini, GPT-5 nano, and GPT-5 Chat entries to OpenAI chat model configurations
- Include GPT-5 mini in the OpenAI provider chatModels list
- Register GPT-5 and GPT-5 mini in the API response models set

Enhancements:
- Set the default LLM model to GPT-5 mini
- Include 'gpt-5' in the prunePrefixes for model ID filtering

Tests:
- Remove obsolete test for default enabled provider models
- Update snapshots to reflect the new default model and configuration changes