### PR TITLE
⚡️ perf: try upstash redis for api performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "@trpc/next": "^11.4.4",
     "@trpc/react-query": "^11.4.4",
     "@trpc/server": "^11.4.4",
+    "@upstash/redis": "^1.35.3",
     "@vercel/analytics": "^1.5.0",
     "@vercel/edge-config": "^1.4.0",
     "@vercel/functions": "^2.2.8",

--- a/src/database/core/cache/index.ts
+++ b/src/database/core/cache/index.ts
@@ -1,0 +1,2 @@
+export * from './type';
+export * from './upstash';

--- a/src/database/core/cache/type.ts
+++ b/src/database/core/cache/type.ts
@@ -1,0 +1,3 @@
+import type { upstashCache } from 'drizzle-orm/cache/upstash';
+
+export type DrizzleCache = ReturnType<typeof upstashCache> | undefined;

--- a/src/database/core/cache/upstash.ts
+++ b/src/database/core/cache/upstash.ts
@@ -1,0 +1,14 @@
+import { upstashCache } from 'drizzle-orm/cache/upstash';
+
+/**
+ * Optional Upstash cache provider for Drizzle.
+ * Only enabled when UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN exist.
+ */
+export const getDrizzleCache = (): ReturnType<typeof upstashCache> | undefined => {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) return undefined;
+
+  return upstashCache({ global: true, token, url });
+};

--- a/src/database/core/cache/upstash.ts
+++ b/src/database/core/cache/upstash.ts
@@ -10,5 +10,5 @@ export const getDrizzleCache = (): ReturnType<typeof upstashCache> | undefined =
 
   if (!url || !token) return undefined;
 
-  return upstashCache({ global: true, token, url });
+  return upstashCache({ token, url });
 };

--- a/src/database/core/web-server.ts
+++ b/src/database/core/web-server.ts
@@ -9,6 +9,7 @@ import { isServerMode } from '@/const/version';
 import * as schema from '@/database/schemas';
 
 import { LobeChatDatabase } from '../type';
+import { getDrizzleCache } from './cache';
 
 export const getDBInstance = (): LobeChatDatabase => {
   if (!isServerMode) return {} as any;
@@ -30,7 +31,9 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
 
   if (serverDBEnv.DATABASE_DRIVER === 'node') {
     const client = new NodePool({ connectionString });
-    return nodeDrizzle(client, { schema });
+    const cache = getDrizzleCache();
+    const options = cache ? { cache, schema } : { schema };
+    return nodeDrizzle(client, options as any);
   }
 
   if (process.env.MIGRATION_DB === '1') {
@@ -39,5 +42,7 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
   }
 
   const client = new NeonPool({ connectionString });
-  return neonDrizzle(client, { schema });
+  const cache = getDrizzleCache();
+  const options = cache ? { cache, schema } : { schema };
+  return neonDrizzle(client, options as any);
 };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Introduce optional Upstash Redis caching for Drizzle ORM to improve API performance and update the database initialization to leverage the cache when configured.

Enhancements:
- Add an Upstash cache provider and related types for Drizzle ORM
- Update getDBInstance to conditionally include the cache in Drizzle client options

Build:
- Add @upstash/redis as a dependency