### PR TITLE
📝 docs: add info callout for desktop client access in Cloudflare R2 configuration

### DIFF
--- a/docs/self-hosting/advanced/s3/cloudflare-r2.mdx
+++ b/docs/self-hosting/advanced/s3/cloudflare-r2.mdx
@@ -84,12 +84,16 @@ We need to configure an S3 storage service in the server-side database to store 
 
   <Image alt={'Configure allowed site domain'} src={'https://github.com/lobehub/lobe-chat/assets/28616219/dfcc2cb3-2958-4498-a8a4-51bec584fe7d'} />
 
+  <Callout type={'info'}>
+    If you also plan to use the desktop client, add <code>http://localhost:3015</code> to <code>AllowedOrigins</code> so the desktop client (running locally) can access R2.
+  </Callout>
+
   Example configuration is as follows:
 
   ```json
   [
     {
-      "AllowedOrigins": ["https://your-project.vercel.app"],
+      "AllowedOrigins": ["https://your-project.vercel.app", "http://localhost:3015"],
       "AllowedMethods": ["GET", "PUT", "HEAD", "POST", "DELETE"],
       "AllowedHeaders": ["*"]
     }

--- a/docs/self-hosting/advanced/s3/cloudflare-r2.zh-CN.mdx
+++ b/docs/self-hosting/advanced/s3/cloudflare-r2.zh-CN.mdx
@@ -82,13 +82,17 @@ tags:
   添加跨域规则，允许你的域名（在上文是 `https://your-project.vercel.app`）来源的请求：
 
   <Image alt={'配置允许你的站点域名'} src={'https://github.com/lobehub/lobe-chat/assets/28616219/dfcc2cb3-2958-4498-a8a4-51bec584fe7d'} />
+  <Callout type={'info'}>
+    如果你还需要在桌面端使用，请在 <code>AllowedOrigins</code> 中额外添加 <code>http://localhost:3015</code>，以便桌面端（本地运行）能够访问 R2。
+  </Callout>
+
 
   示例配置如下：
 
   ```json
   [
     {
-      "AllowedOrigins": ["https://your-project.vercel.app"],
+      "AllowedOrigins": ["https://your-project.vercel.app", "http://localhost:3015"],
       "AllowedMethods": ["GET", "PUT", "HEAD", "POST", "DELETE"],
       "AllowedHeaders": ["*"]
     }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->
- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
This pull request updates the Cloudflare R2 S3 storage configuration documentation for both English and Chinese guides to improve support for the desktop client. The main change is the addition of instructions and configuration to allow the locally running desktop client to access R2 storage.

Documentation improvements for desktop client support:

* Added a callout in both `cloudflare-r2.mdx` and `cloudflare-r2.zh-CN.mdx` to instruct users to include `http://localhost:3015` in the `AllowedOrigins` for CORS settings, enabling desktop client access to R2. [[1]](diffhunk://#diff-8f0883c88234a4c636a7493438005fbd5c700ea4c0d874fcc949890b7483c129R87-R96) [[2]](diffhunk://#diff-df3dd688865e27c9ede7ab442e999cf56a971e5d6d8785496a8c4ab8f5b1809bR85-R95)
* Updated the example CORS configuration in both guides to include `http://localhost:3015` alongside the production domain in the `AllowedOrigins` array. [[1]](diffhunk://#diff-8f0883c88234a4c636a7493438005fbd5c700ea4c0d874fcc949890b7483c129R87-R96) [[2]](diffhunk://#diff-df3dd688865e27c9ede7ab442e999cf56a971e5d6d8785496a8c4ab8f5b1809bR85-R95)
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Documentation:
- Add callout and update CORS example to include http://localhost:3015 in AllowedOrigins for desktop client support in Cloudflare R2 docs