### PR TITLE
💄 style: Price strategy supports multiple conditions

### DIFF
--- a/packages/types/src/aiModel.ts
+++ b/packages/types/src/aiModel.ts
@@ -182,16 +182,16 @@ export interface ConditionalPricingTier {
   rates: Partial<Record<PricingUnitName, number>>;
 }
 
-export interface ConditionalPricingUnit extends PricingUnitBase {
-  /**
-   * The units that are priced together in this conditional pricing
-   */
-  relatedUnits: PricingUnitName[];
+export interface ConditionalPricingUnit {
   strategy: 'conditional';
   /**
    * Array of pricing tiers based on different conditions
    */
   tiers: ConditionalPricingTier[];
+  /**
+   * The unit type for pricing calculation (e.g., 'millionTokens', 'image', etc.)
+   */
+  unit: PricingUnitType;
 }
 
 export type PricingUnit = FixedPricingUnit | TieredPricingUnit | LookupPricingUnit | ConditionalPricingUnit;

--- a/packages/types/src/aiModel.ts
+++ b/packages/types/src/aiModel.ts
@@ -130,7 +130,7 @@ export type PricingUnitType =
   | 'megapixel' // per megapixel
   | 'second'; // per second
 
-export type PricingStrategy = 'fixed' | 'tiered' | 'lookup';
+export type PricingStrategy = 'fixed' | 'tiered' | 'lookup' | 'conditional';
 
 export interface PricingUnitBase {
   name: PricingUnitName;
@@ -159,7 +159,42 @@ export interface LookupPricingUnit extends PricingUnitBase {
   strategy: 'lookup';
 }
 
-export type PricingUnit = FixedPricingUnit | TieredPricingUnit | LookupPricingUnit;
+// New conditional pricing unit for complex scenarios like GLM-4.5V
+export interface ConditionalPricingCondition {
+  /**
+   * The condition parameter name, e.g., 'inputLength', 'imageCount', etc.
+   */
+  param: string;
+  /**
+   * The range for this condition [min, max], where max can be 'infinity'
+   */
+  range: [number, number | 'infinity'];
+}
+
+export interface ConditionalPricingTier {
+  /**
+   * The conditions that must be met for this tier
+   */
+  conditions: ConditionalPricingCondition[];
+  /**
+   * The pricing rates for different units in this tier
+   */
+  rates: Partial<Record<PricingUnitName, number>>;
+}
+
+export interface ConditionalPricingUnit extends PricingUnitBase {
+  /**
+   * The units that are priced together in this conditional pricing
+   */
+  relatedUnits: PricingUnitName[];
+  strategy: 'conditional';
+  /**
+   * Array of pricing tiers based on different conditions
+   */
+  tiers: ConditionalPricingTier[];
+}
+
+export type PricingUnit = FixedPricingUnit | TieredPricingUnit | LookupPricingUnit | ConditionalPricingUnit;
 
 export interface Pricing {
   currency?: ModelPriceCurrency;

--- a/packages/types/src/aiModel.ts
+++ b/packages/types/src/aiModel.ts
@@ -160,11 +160,17 @@ export interface LookupPricingUnit extends PricingUnitBase {
 }
 
 // New conditional pricing unit for complex scenarios like GLM-4.5V
+export type ConditionalPricingConditionParam =
+  | 'inputLength'
+  | 'outputLength'
+  | 'audioLength'
+  | 'imageCount';
+
 export interface ConditionalPricingCondition {
   /**
-   * The condition parameter name, e.g., 'inputLength', 'imageCount', etc.
+   * The condition parameter name, must be one of the predefined parameter types
    */
-  param: string;
+  param: ConditionalPricingConditionParam;
   /**
    * The range for this condition [min, max], where max can be 'infinity'
    */
@@ -194,7 +200,11 @@ export interface ConditionalPricingUnit {
   unit: PricingUnitType;
 }
 
-export type PricingUnit = FixedPricingUnit | TieredPricingUnit | LookupPricingUnit | ConditionalPricingUnit;
+export type PricingUnit =
+  | FixedPricingUnit
+  | TieredPricingUnit
+  | LookupPricingUnit
+  | ConditionalPricingUnit;
 
 export interface Pricing {
   currency?: ModelPriceCurrency;

--- a/src/config/aiModels/zhipu.ts
+++ b/src/config/aiModels/zhipu.ts
@@ -5,6 +5,77 @@ const zhipuChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 65_536,
+    description:
+      '智谱新一代基于 MOE 架构的视觉推理模型，以106B的总参数量和12B激活参数量，在各类基准测试中达到全球同级别开源多模态模型 SOTA，涵盖图像、视频、文档理解及 GUI 任务等常见任务。',
+    displayName: 'GLM-4.5V',
+    enabled: true,
+    id: 'glm-4.5v',
+    maxOutput: 32_768,
+    pricing: {
+      currency: 'CNY',
+      // units: [
+      //   {
+      //     name: 'textInput',
+      //     strategy: 'tiered',
+      //     tiers: [
+      //       { rate: 7, upTo: 0 },
+      //       { rate: 14, upTo: 0.256 },
+      //       { rate: 1.2, upTo: 'infinity' },
+      //     ],
+      //     unit: 'millionTokens',
+      //   },
+      //   {
+      //     name: 'textOutput',
+      //     strategy: 'tiered',
+      //     tiers: [
+      //       { rate: 1.5, upTo: 0.128 },
+      //       { rate: 6, upTo: 0.256 },
+      //       { rate: 12, upTo: 'infinity' },
+      //     ],
+      //     unit: 'millionTokens',
+      //   },
+      //   {
+      //     name: 'textInput_cacheRead',
+      //     strategy: 'tiered',
+      //     tiers: [
+      //       { rate: 0.15 * 0.4, upTo: 0.128 },
+      //       { rate: 0.6 * 0.4, upTo: 0.256 },
+      //       { rate: 1.2 * 0.4, upTo: 'infinity' },
+      //     ],
+      //     unit: 'millionTokens',
+      //   },
+      // ],
+
+      units: [
+        {
+          strategy: 'conditional',
+          tiers: [
+            {
+              conditions: [{ param: 'inputLength', range: [0, 1] }],
+              rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 6 },
+            },
+            {
+              conditions: [{ param: 'inputLength', range: [2, 'infinity'] }],
+              rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 12 },
+            },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
       search: true,
     },
     contextWindowTokens: 128_000,
@@ -17,21 +88,31 @@ const zhipuChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-    {
-      strategy: 'conditional',
-      tiers: [
         {
-          conditions: [{ param: 'inputLength', range: [0, 32_000] }],
-          rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 6 }
+          strategy: 'conditional',
+          tiers: [
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [0, 200] },
+              ],
+              rates: { textInput: 1, textInput_cacheRead: 0.2, textOutput: 4 },
+            },
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [200, 'infinity'] },
+              ],
+              rates: { textInput: 1.5, textInput_cacheRead: 0.3, textOutput: 7 },
+            },
+            {
+              conditions: [{ param: 'inputLength', range: [32_001, 128_000] }],
+              rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 8 },
+            },
+          ],
+          unit: 'millionTokens',
         },
-        {
-          conditions: [{ param: 'inputLength', range: [32_001, 'infinity'] }],
-          rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 12 }
-        }
       ],
-      unit: 'millionTokens'
-    }
-  ]
     },
     settings: {
       extendParams: ['enableReasoning'],
@@ -53,9 +134,30 @@ const zhipuChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput_cacheRead', rate: 3.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 64, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          strategy: 'conditional',
+          tiers: [
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [0, 200] },
+              ],
+              rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 8 },
+            },
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [200, 'infinity'] },
+              ],
+              rates: { textInput: 6, textInput_cacheRead: 1.2, textOutput: 16 },
+            },
+            {
+              conditions: [{ param: 'inputLength', range: [32_001, 128_000] }],
+              rates: { textInput: 8, textInput_cacheRead: 1.6, textOutput: 32 },
+            },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     settings: {
@@ -78,9 +180,30 @@ const zhipuChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput_cacheRead', rate: 0.24, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          strategy: 'conditional',
+          tiers: [
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [0, 200] },
+              ],
+              rates: { textInput: 0.4, textInput_cacheRead: 0.08, textOutput: 1 },
+            },
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [200, 'infinity'] },
+              ],
+              rates: { textInput: 0.4, textInput_cacheRead: 0.08, textOutput: 3 },
+            },
+            {
+              conditions: [{ param: 'inputLength', range: [32_001, 128_000] }],
+              rates: { textInput: 0.6, textInput_cacheRead: 0.12, textOutput: 4 },
+            },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     settings: {
@@ -103,35 +226,30 @@ const zhipuChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput_cacheRead', rate: 1.6, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 32, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    settings: {
-      extendParams: ['enableReasoning'],
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 128_000,
-    description: 'GLM-4.5 的免费版，推理、代码、智能体等任务表现出色。',
-    displayName: 'GLM-4.5-Flash',
-    enabled: true,
-    id: 'glm-4.5-flash',
-    maxOutput: 32_768,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          strategy: 'conditional',
+          tiers: [
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [0, 200] },
+              ],
+              rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 6 },
+            },
+            {
+              conditions: [
+                { param: 'inputLength', range: [0, 32_000] },
+                { param: 'outputLength', range: [200, 'infinity'] },
+              ],
+              rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 8 },
+            },
+            {
+              conditions: [{ param: 'inputLength', range: [32_001, 128_000] }],
+              rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 16 },
+            },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     settings: {
@@ -174,7 +292,6 @@ const zhipuChatModels: AIChatModelCard[] = [
     description:
       'GLM-4.1V-Thinking 系列模型是目前已知10B级别的VLM模型中性能最强的视觉模型，融合了同级别SOTA的各项视觉语言任务，包括视频理解、图片问答、学科解题、OCR文字识别、文档和图表解读、GUI Agent、前端网页Coding、Grounding等，多项任务能力甚至超过8倍参数量的Qwen2.5-VL-72B。通过领先的强化学习技术，模型掌握了通过思维链推理的方式提升回答的准确性和丰富度，从最终效果和可解释性等维度都显著超过传统的非thinking模型。',
     displayName: 'GLM-4.1V-Thinking-Flash',
-    enabled: true,
     id: 'glm-4.1v-thinking-flash',
     maxOutput: 16_384,
     pricing: {

--- a/src/config/aiModels/zhipu.ts
+++ b/src/config/aiModels/zhipu.ts
@@ -17,10 +17,21 @@ const zhipuChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput_cacheRead', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+    {
+      strategy: 'conditional',
+      tiers: [
+        {
+          conditions: [{ param: 'inputLength', range: [0, 32_000] }],
+          rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 6 }
+        },
+        {
+          conditions: [{ param: 'inputLength', range: [32_001, 'infinity'] }],
+          rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 12 }
+        }
       ],
+      unit: 'millionTokens'
+    }
+  ]
     },
     settings: {
       extendParams: ['enableReasoning'],

--- a/src/config/aiModels/zhipu.ts
+++ b/src/config/aiModels/zhipu.ts
@@ -16,49 +16,16 @@ const zhipuChatModels: AIChatModelCard[] = [
     maxOutput: 32_768,
     pricing: {
       currency: 'CNY',
-      // units: [
-      //   {
-      //     name: 'textInput',
-      //     strategy: 'tiered',
-      //     tiers: [
-      //       { rate: 7, upTo: 0 },
-      //       { rate: 14, upTo: 0.256 },
-      //       { rate: 1.2, upTo: 'infinity' },
-      //     ],
-      //     unit: 'millionTokens',
-      //   },
-      //   {
-      //     name: 'textOutput',
-      //     strategy: 'tiered',
-      //     tiers: [
-      //       { rate: 1.5, upTo: 0.128 },
-      //       { rate: 6, upTo: 0.256 },
-      //       { rate: 12, upTo: 'infinity' },
-      //     ],
-      //     unit: 'millionTokens',
-      //   },
-      //   {
-      //     name: 'textInput_cacheRead',
-      //     strategy: 'tiered',
-      //     tiers: [
-      //       { rate: 0.15 * 0.4, upTo: 0.128 },
-      //       { rate: 0.6 * 0.4, upTo: 0.256 },
-      //       { rate: 1.2 * 0.4, upTo: 'infinity' },
-      //     ],
-      //     unit: 'millionTokens',
-      //   },
-      // ],
-
       units: [
         {
           strategy: 'conditional',
           tiers: [
             {
-              conditions: [{ param: 'inputLength', range: [0, 1] }],
+              conditions: [{ param: 'inputLength', range: [0, 32_000] }],
               rates: { textInput: 2, textInput_cacheRead: 0.4, textOutput: 6 },
             },
             {
-              conditions: [{ param: 'inputLength', range: [2, 'infinity'] }],
+              conditions: [{ param: 'inputLength', range: [32_001, 'infinity'] }],
               rates: { textInput: 4, textInput_cacheRead: 0.8, textOutput: 12 },
             },
           ],

--- a/src/features/Conversation/Extras/Usage/UsageDetail/pricing.ts
+++ b/src/features/Conversation/Extras/Usage/UsageDetail/pricing.ts
@@ -1,18 +1,24 @@
 import { Pricing } from '@/types/aiModel';
 import { ModelPriceCurrency } from '@/types/llm';
+import { ModelTokensUsage } from '@/types/message';
 import { formatPriceByCurrency } from '@/utils/format';
 import {
+  createPricingContext,
   getCachedTextInputUnitRate,
   getTextInputUnitRate,
   getTextOutputUnitRate,
   getWriteCacheInputUnitRate,
 } from '@/utils/pricing';
 
-export const getPrice = (pricing: Pricing) => {
-  const inputRate = getTextInputUnitRate(pricing);
-  const outputRate = getTextOutputUnitRate(pricing);
-  const cachedInputRate = getCachedTextInputUnitRate(pricing);
-  const writeCacheInputRate = getWriteCacheInputUnitRate(pricing);
+export const getPrice = (pricing: Pricing, usage?: ModelTokensUsage) => {
+  // Create pricing context from usage data for conditional pricing
+  const context = createPricingContext(usage);
+
+  // Get rates with context-aware pricing
+  const inputRate = getTextInputUnitRate(pricing, context);
+  const outputRate = getTextOutputUnitRate(pricing, context);
+  const cachedInputRate = getCachedTextInputUnitRate(pricing, context);
+  const writeCacheInputRate = getWriteCacheInputUnitRate(pricing, context);
 
   const inputPrice = inputRate
     ? formatPriceByCurrency(inputRate, pricing?.currency as ModelPriceCurrency)

--- a/src/features/Conversation/Extras/Usage/UsageDetail/tokens.ts
+++ b/src/features/Conversation/Extras/Usage/UsageDetail/tokens.ts
@@ -32,8 +32,8 @@ export const getDetailsToken = (
     ? usage?.inputCacheMissTokens
     : totalInputTokens - (inputCacheTokens || 0);
 
-  // Pricing
-  const formatPrice = getPrice(modelCard?.pricing || { units: [] });
+  // Pricing - pass usage data for context-aware conditional pricing
+  const formatPrice = getPrice(modelCard?.pricing || { units: [] }, usage);
 
   const inputCacheMissCredit = (
     !!inputCacheMissTokens ? calcCredit(inputCacheMissTokens, formatPrice.input) : 0

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,12 +1,60 @@
-import { Pricing, PricingUnit, PricingUnitName } from '@/types/aiModel';
+import { ConditionalPricingUnit, Pricing, PricingUnit, PricingUnitName } from '@/types/aiModel';
+
+/**
+ * Context parameters for conditional pricing evaluation
+ */
+export interface PricingContext {
+  [key: string]: number | undefined;
+  audioLength?: number;
+  imageCount?: number;
+  inputLength?: number;
+}
+
+/**
+ * Check if a value falls within a given range
+ */
+const isInRange = (value: number, range: [number, number | 'infinity']): boolean => {
+  const [min, max] = range;
+  if (max === 'infinity') {
+    return value >= min;
+  }
+  return value >= min && value <= max;
+};
+
+/**
+ * Find the matching tier for conditional pricing based on context
+ * @internal - exported for testing purposes
+ */
+export const findMatchingTier = (
+  unit: ConditionalPricingUnit,
+  context: PricingContext = {},
+): ConditionalPricingUnit['tiers'][0] | undefined => {
+  for (const tier of unit.tiers) {
+    const allConditionsMet = tier.conditions.every((condition) => {
+      const value = context[condition.param];
+      return value !== undefined && isInRange(value, condition.range);
+    });
+
+    if (allConditionsMet) {
+      return tier;
+    }
+  }
+
+  // Fallback to first tier if no conditions match
+  return unit.tiers[0];
+};
 
 /**
  * Internal helper to extract the displayed unit rate from a pricing unit by strategy
  * - fixed → rate
  * - tiered → tiers[0].rate
  * - lookup → first price value
+ * - conditional → first tier's rate for the unit, or fallback based on context
  */
-const getRateFromUnit = (unit: PricingUnit): number | undefined => {
+const getRateFromUnit = (
+  unit: PricingUnit,
+  context: PricingContext = {},
+): number | undefined => {
   switch (unit.strategy) {
     case 'fixed': {
       return unit.rate;
@@ -17,6 +65,10 @@ const getRateFromUnit = (unit: PricingUnit): number | undefined => {
     case 'lookup': {
       const prices = Object.values(unit.lookup?.prices || {});
       return prices[0];
+    }
+    case 'conditional': {
+      const matchingTier = findMatchingTier(unit, context);
+      return matchingTier?.rates[unit.name];
     }
     default: {
       return undefined;
@@ -30,11 +82,27 @@ const getRateFromUnit = (unit: PricingUnit): number | undefined => {
 export const getUnitRateByName = (
   pricing?: Pricing,
   unitName?: PricingUnitName,
+  context?: PricingContext,
 ): number | undefined => {
   if (!pricing?.units || !unitName) return undefined;
+
+  // First, check if there's a conditional pricing unit that includes this unitName in relatedUnits
+  const conditionalUnit = pricing.units.find((unit): unit is ConditionalPricingUnit => 
+    unit.strategy === 'conditional' && unit.relatedUnits.includes(unitName)
+  );
+
+  if (conditionalUnit) {
+    const matchingTier = findMatchingTier(conditionalUnit, context);
+    const rate = matchingTier?.rates[unitName];
+    if (rate !== undefined) {
+      return rate;
+    }
+  }
+
+  // Fallback to direct unit lookup
   const unit = pricing.units.find((u) => u.name === unitName);
   if (!unit) return undefined;
-  return getRateFromUnit(unit);
+  return getRateFromUnit(unit, context);
 };
 
 /**
@@ -42,49 +110,137 @@ export const getUnitRateByName = (
  * - fixed → rate
  * - tiered → tiers[0].rate
  * - lookup → Object.values(lookup.prices)[0]
+ * - conditional → rate based on context conditions
  */
-export function getTextInputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'textInput');
+export function getTextInputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'textInput', context);
 }
 
 /**
  * Get text output unit rate from pricing
  */
-export function getTextOutputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'textOutput');
+export function getTextOutputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'textOutput', context);
 }
 
 /**
  * Get audio input unit rate from pricing
  */
-export function getAudioInputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'audioInput');
+export function getAudioInputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'audioInput', context);
 }
 
 /**
  * Get audio output unit rate from pricing
  */
-export function getAudioOutputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'audioOutput');
+export function getAudioOutputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'audioOutput', context);
 }
 
 /**
  * Get cached text input unit rate from pricing
  */
-export function getCachedTextInputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'textInput_cacheRead');
+export function getCachedTextInputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'textInput_cacheRead', context);
 }
 
 /**
  * Get write cache input unit rate from pricing (TextInputCacheWrite)
  */
-export function getWriteCacheInputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'textInput_cacheWrite');
+export function getWriteCacheInputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'textInput_cacheWrite', context);
 }
 
 /**
  * Get cached audio input unit rate from pricing
  */
-export function getCachedAudioInputUnitRate(pricing?: Pricing): number | undefined {
-  return getUnitRateByName(pricing, 'audioInput_cacheRead');
+export function getCachedAudioInputUnitRate(
+  pricing?: Pricing,
+  context?: PricingContext,
+): number | undefined {
+  return getUnitRateByName(pricing, 'audioInput_cacheRead', context);
+}
+
+/**
+ * Get conditional pricing units that affect multiple related units together
+ */
+export function getConditionalPricingUnits(pricing?: Pricing): ConditionalPricingUnit[] {
+  if (!pricing?.units) return [];
+  return pricing.units.filter((unit): unit is ConditionalPricingUnit => 
+    unit.strategy === 'conditional'
+  );
+}
+
+/**
+ * Calculate rates for all related units in a conditional pricing scenario
+ */
+export function getConditionalRates(
+  pricing: Pricing,
+  context: PricingContext,
+): Partial<Record<PricingUnitName, number>> {
+  const rates: Partial<Record<PricingUnitName, number>> = {};
+  const conditionalUnits = getConditionalPricingUnits(pricing);
+
+  for (const unit of conditionalUnits) {
+    const matchingTier = findMatchingTier(unit, context);
+    if (matchingTier) {
+      // Apply rates for all related units from this tier
+      for (const relatedUnit of unit.relatedUnits) {
+        const rate = matchingTier.rates[relatedUnit];
+        if (rate !== undefined) {
+          rates[relatedUnit] = rate;
+        }
+      }
+    }
+  }
+
+  return rates;
+}
+
+/**
+ * Check if pricing configuration contains conditional pricing units
+ */
+export function hasConditionalPricing(pricing?: Pricing): boolean {
+  return getConditionalPricingUnits(pricing).length > 0;
+}
+
+/**
+ * Get context-aware rate with fallback to regular rate calculation
+ * This is the recommended function for getting rates when context might be available
+ */
+export function getContextAwareRate(
+  pricing?: Pricing,
+  unitName?: PricingUnitName,
+  context?: PricingContext,
+): number | undefined {
+  if (!pricing?.units || !unitName) return undefined;
+
+  // If context is provided and there are conditional pricing units, try conditional rates first
+  if (context && hasConditionalPricing(pricing)) {
+    const conditionalRates = getConditionalRates(pricing, context);
+    if (conditionalRates[unitName] !== undefined) {
+      return conditionalRates[unitName];
+    }
+  }
+
+  // Fallback to regular unit rate calculation
+  return getUnitRateByName(pricing, unitName, context);
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

在已有 tier 定价模式基础上，新增 conditional 模式，允许多个条件控制多个价格。

适用于需要同时根据 输入 输出 大小的定价场景，或只由输入决定输入输出两个价格的场景。

另修复 tiered 未完成的累进计算逻辑。

### 已知问题：价格签只会显示第一阶梯价格，下面的计算结果实际是正确的。

<img width="418" height="112" alt="image" src="https://github.com/user-attachments/assets/f05b75be-304c-4c6b-a851-aea48e4d5a39" />


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Introduce a conditional pricing strategy that supports multiple context-driven tiers and integrate it into existing pricing utilities and configuration

New Features:
- Add 'conditional' pricing strategy and related types (ConditionalPricingCondition, ConditionalPricingTier, ConditionalPricingUnit) to aiModel definitions
- Implement PricingContext and helper functions (findMatchingTier, getRelatedUnitsFromConditionalUnit, getConditionalPricingUnits, getConditionalRates, hasConditionalPricing, getContextAwareRate) to evaluate context-based pricing
- Extend getUnitRateByName and unit-specific rate getters to accept PricingContext and handle conditional units
- Update zhipu AI model config to replace fixed pricing with conditional pricing tiers

Tests:
- Add comprehensive tests covering conditional pricing matching, multiple conditions, fallback behavior, rate extraction, and new utility functions