### PR TITLE
💄 style: Adjust near bottom size on thinking scroll

### DIFF
--- a/src/components/Thinking/index.tsx
+++ b/src/components/Thinking/index.tsx
@@ -102,7 +102,7 @@ const Thinking = memo<ThinkingProps>((props) => {
 
     // 仅当用户接近底部时才自动滚动，避免打断用户查看上方内容
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    const isNearBottom = distanceToBottom < 60;
+    const isNearBottom = distanceToBottom < 120;
 
     if (isNearBottom) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enhancements:
- Increase the near-bottom distance threshold for auto-scrolling in the Thinking component from 60px to 120px