### PR TITLE
📝 docs: fix eslint irregular whitespace issues positioning

### DIFF
--- a/docs/development/state-management/state-management-intro.mdx
+++ b/docs/development/state-management/state-management-intro.mdx
@@ -1,5 +1,3 @@
-{/* eslint-disable no-irregular-whitespace */}
-
 # Best Practices for State Management
 
 LobeChat differs from traditional CRUD web applications in that it involves a large amount of rich interactive capabilities. Therefore, it is crucial to design a data flow architecture that is easy to develop and maintain. This document will introduce the best practices for data flow management in LobeChat.
@@ -110,6 +108,8 @@ Based on the provided directory structure of LobeChat SessionStore, we can updat
 ### Best Practices for LobeChat SessionStore Directory Structure
 
 In the LobeChat application, session management is a complex functional module, so we use the Slice pattern to organize the data flow. Below is the directory structure of LobeChat SessionStore, where each directory and file has its specific purpose:
+
+{/* eslint-disable no-irregular-whitespace */}
 
 ```bash
 src/store/session

--- a/docs/development/state-management/state-management-intro.zh-CN.mdx
+++ b/docs/development/state-management/state-management-intro.zh-CN.mdx
@@ -1,5 +1,3 @@
-{/* eslint-disable no-irregular-whitespace */}
-
 # 状态管理最佳实践
 
 LobeChat 不同于传统 CRUD 的网页，存在大量的富交互能力，如何设计一个易于开发与易于维护的数据流架构非常重要。本篇文档将介绍 LobeChat 中的数据流管理最佳实践。
@@ -110,6 +108,8 @@ LobeChat SessionStore
 ### LobeChat SessionStore 目录结构最佳实践
 
 在 LobeChat 应用中，由于会话管理是一个复杂的功能模块，因此我们采用了 [slice 模式](https://github.com/pmndrs/zustand/blob/main/docs/guides/slices-pattern.md) 来组织数据流。下面是 LobeChat SessionStore 的目录结构，其中每个目录和文件都有其特定的用途：
+
+{/* eslint-disable no-irregular-whitespace */}
 
 ```fish
 src/store/session


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<\!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Move eslint-disable comments for irregular whitespace to more appropriate positions in documentation files. The comments are now placed closer to the actual content that needs the exemption, improving code organization and ESLint rule compliance.

Files updated:
- `docs/development/state-management/state-management-intro.mdx`
- `docs/development/state-management/state-management-intro.zh-CN.mdx`

#### 📝 补充信息 | Additional Information

This change improves the positioning of ESLint disable comments without affecting the actual documentation content or functionality.

## Summary by Sourcery

Documentation:
- Move eslint-disable no-irregular-whitespace comments into MDX code blocks in state-management-intro.mdx and its Chinese version to target the specific whitespace issues