### PR TITLE
Parallel chat support

### DIFF
--- a/packages/types/src/message/index.ts
+++ b/packages/types/src/message/index.ts
@@ -18,6 +18,11 @@ export interface SendMessageParams {
   isWelcomeQuestion?: boolean;
   message: string;
   onlyAddUserMessage?: boolean;
+  /**
+   * The session ID to send this message to
+   * If not provided, defaults to the active session
+   */
+  sessionId?: string;
 }
 
 export interface SendThreadMessageParams {

--- a/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/Main.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/Main.tsx
@@ -7,6 +7,8 @@ import { Suspense, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import ParallelChat from './ParallelChat';
+
 import { useInitAgentConfig } from '@/hooks/useInitAgentConfig';
 import { useOpenChatSettings } from '@/hooks/useInterceptingRoutes';
 import { usePinnedAgentState } from '@/hooks/usePinnedAgentState';
@@ -86,6 +88,7 @@ const Main = memo<{ className?: string }>(({ className }) => {
         <div className={styles.title}>{displayTitle}</div>
         <Tags />
       </Flexbox>
+      <ParallelChat />
     </Flexbox>
   );
 });

--- a/src/features/ChatInput/useSend.ts
+++ b/src/features/ChatInput/useSend.ts
@@ -6,6 +6,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors, topicSelectors } from '@/store/chat/selectors';
 import { fileChatSelectors, useFileStore } from '@/store/file';
+import { useSessionStore } from '@/store/session';
 import { getUserStoreState } from '@/store/user';
 import { SendMessageParams } from '@/types/message';
 
@@ -30,6 +31,12 @@ export const useSendMessage = () => {
 
   const send = useCallback((params: UseSendMessageParams = {}) => {
     const store = useChatStore.getState();
+    const sessionStore = useSessionStore.getState();
+    
+    // Get the current selected session (either active session or parallel session)
+    const sessionId = sessionStore.activeId;
+    
+    // Check if we can send a message in the current context
     if (chatSelectors.isAIGenerating(store)) return;
 
     // if uploading file or send button is disabled by message, then we should not send the message
@@ -45,9 +52,11 @@ export const useSendMessage = () => {
     // if there is no message and no image, then we should not send the message
     if (!store.inputMessage && fileList.length === 0) return;
 
+    // Send message to the current session
     sendMessage({
       files: fileList,
       message: store.inputMessage,
+      sessionId,
       ...params,
     });
 

--- a/src/features/ChatInput/useSend.ts
+++ b/src/features/ChatInput/useSend.ts
@@ -37,8 +37,8 @@ export const useSendMessage = () => {
     // If a specific sessionId is provided in params, use it. Otherwise, use the active session
     const sessionId = params.sessionId || sessionStore.activeId;
     
-    // Check if we can send a message in the current context
-    if (chatSelectors.isAIGenerating(store)) return;
+    // Check if AI is generating a response specifically for this session
+    if (chatSelectors.isSessionAIGenerating(sessionId)(store)) return;
 
     // if uploading file or send button is disabled by message, then we should not send the message
     const isUploadingFiles = fileChatSelectors.isUploadingFiles(useFileStore.getState());

--- a/src/features/ChatInput/useSend.ts
+++ b/src/features/ChatInput/useSend.ts
@@ -12,7 +12,7 @@ import { SendMessageParams } from '@/types/message';
 
 export type UseSendMessageParams = Pick<
   SendMessageParams,
-  'onlyAddUserMessage' | 'isWelcomeQuestion'
+  'onlyAddUserMessage' | 'isWelcomeQuestion' | 'sessionId'
 >;
 
 export const useSendMessage = () => {
@@ -34,7 +34,8 @@ export const useSendMessage = () => {
     const sessionStore = useSessionStore.getState();
     
     // Get the current selected session (either active session or parallel session)
-    const sessionId = sessionStore.activeId;
+    // If a specific sessionId is provided in params, use it. Otherwise, use the active session
+    const sessionId = params.sessionId || sessionStore.activeId;
     
     // Check if we can send a message in the current context
     if (chatSelectors.isAIGenerating(store)) return;

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -25,6 +25,8 @@ export default {
   defaultAgent: '自定义助手',
   defaultList: '默认列表',
   defaultSession: '自定义助手',
+  parallelChat: '并行聊天',
+  parallelChats: '个并行聊天',
   duplicateSession: {
     loading: '复制中...',
     success: '复制成功',

--- a/src/store/chat/slices/aiChat/actions/generateAIChat.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChat.ts
@@ -27,11 +27,6 @@ import { ChatImageItem } from '@/types/message/image';
 import { MessageSemanticSearchChunk } from '@/types/rag';
 import { Action, setNamespace } from '@/utils/storeDebug';
 
-// Extend SendMessageParams to include sessionId
-interface ExtendedSendMessageParams extends SendMessageParams {
-  sessionId?: string;
-}
-
 import { chatSelectors, topicSelectors } from '../../../selectors';
 
 const n = setNamespace('ai');
@@ -52,7 +47,7 @@ export interface AIGenerateAction {
   /**
    * Sends a new message to the AI chat system
    */
-  sendMessage: (params: ExtendedSendMessageParams) => Promise<void>;
+  sendMessage: (params: SendMessageParams) => Promise<void>;
   /**
    * Regenerates a specific message in the chat
    */

--- a/src/store/chat/slices/message/selectors.ts
+++ b/src/store/chat/slices/message/selectors.ts
@@ -38,7 +38,22 @@ const getBaseChatsByKey =
     return messages.map((i) => ({ ...i, meta: getMeta(i) }));
   };
 
+/**
+ * Get chat key for a specific session ID
+ */
+const getChatKeyForSession = (sessionId: string, topicId?: string | null) => 
+  messageMapKey(sessionId, topicId);
+
 const currentChatKey = (s: ChatStoreState) => messageMapKey(s.activeId, s.activeTopicId);
+
+/**
+ * Get raw message list for a specific session ID
+ */
+const getSessionChats = (sessionId: string, topicId?: string | null) => (s: ChatStoreState): ChatMessage[] => {
+  if (!sessionId) return [];
+
+  return getBaseChatsByKey(getChatKeyForSession(sessionId, topicId))(s);
+};
 
 /**
  * Current active raw message list, include thread messages
@@ -223,6 +238,8 @@ export const chatSelectors = {
   currentToolMessages,
   currentUserFiles,
   getBaseChatsByKey,
+  getChatKeyForSession,
+  getSessionChats,
   getMessageById,
   getMessageByToolCallId,
   getTraceIdByMessageId,

--- a/src/store/chat/slices/message/selectors.ts
+++ b/src/store/chat/slices/message/selectors.ts
@@ -203,6 +203,18 @@ const isInToolsCalling = (id: string, index: number) => (s: ChatStoreState) => {
 const isAIGenerating = (s: ChatStoreState) =>
   s.chatLoadingIds.some((id) => mainDisplayChatIDs(s).includes(id));
 
+/**
+ * Check if AI is generating a response for a specific session
+ */
+const isSessionAIGenerating = (sessionId: string) => (s: ChatStoreState) => {
+  // Get chat IDs for this specific session
+  const sessionChats = getSessionChats(sessionId)(s);
+  const sessionChatIds = sessionChats.map(chat => chat.id);
+  
+  // Check if any of the loading messages belong to this session
+  return s.chatLoadingIds.some((id) => sessionChatIds.includes(id));
+};
+
 const isInRAGFlow = (s: ChatStoreState) =>
   s.messageRAGLoadingIds.some((id) => mainDisplayChatIDs(s).includes(id));
 
@@ -255,6 +267,7 @@ export const chatSelectors = {
   isMessageInRAGFlow,
   isMessageLoading,
   isPluginApiInvoking,
+  isSessionAIGenerating,
   isSendButtonDisabledByMessage,
   isToolCallStreaming,
   latestMessage,

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -42,6 +42,18 @@ export interface SessionAction {
    */
   switchSession: (sessionId: string) => void;
   /**
+   * Add a session to parallel chats
+   */
+  addParallelSession: (sessionId: string) => void;
+  /**
+   * Remove a session from parallel chats
+   */
+  removeParallelSession: (sessionId: string) => void;
+  /**
+   * Check if a session is in parallel chats
+   */
+  isParallelSession: (sessionId: string) => boolean;
+  /**
    * reset sessions to default
    */
   clearSessions: () => Promise<void>;
@@ -97,6 +109,39 @@ export const createSessionSlice: StateCreator<
   [],
   SessionAction
 > = (set, get) => ({
+  addParallelSession: (sessionId) => {
+    const { parallelSessionIds } = get();
+    
+    // If session is already in parallel, do nothing
+    if (parallelSessionIds.includes(sessionId)) return;
+
+    set(
+      { 
+        parallelSessionIds: [...parallelSessionIds, sessionId] 
+      }, 
+      false, 
+      n('addParallelSession', { sessionId })
+    );
+  },
+
+  removeParallelSession: (sessionId) => {
+    const { parallelSessionIds } = get();
+    
+    // Filter out the session to remove
+    set(
+      { 
+        parallelSessionIds: parallelSessionIds.filter(id => id !== sessionId) 
+      }, 
+      false, 
+      n('removeParallelSession', { sessionId })
+    );
+  },
+
+  isParallelSession: (sessionId) => {
+    const { parallelSessionIds } = get();
+    return parallelSessionIds.includes(sessionId);
+  },
+
   clearSessions: async () => {
     await sessionService.removeAllSessions();
     await get().refreshSessions();

--- a/src/store/session/slices/session/initialState.ts
+++ b/src/store/session/slices/session/initialState.ts
@@ -6,6 +6,11 @@ export interface SessionState {
    * @description 当前正在编辑或查看的会话
    */
   activeId: string;
+  /**
+   * @title 并行会话IDs
+   * @description 并行打开的多个会话的ID列表
+   */
+  parallelSessionIds: string[];
   defaultSessions: LobeAgentSession[];
   isSearching: boolean;
   isSessionsFirstFetchFinished: boolean;
@@ -21,6 +26,7 @@ export interface SessionState {
 
 export const initialSessionState: SessionState = {
   activeId: 'inbox',
+  parallelSessionIds: [],
   defaultSessions: [],
   isSearching: false,
   isSessionsFirstFetchFinished: false,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
Implements #7388. It adds sessionId to the requets and relax the lock on front-end. Therefore user can use multiple chats at the same time



#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
Haven't tested though. So it remains draft PR

## Summary by Sourcery

Enable parallel chat sessions by introducing sessionId support across the store, selectors, message flow, types, and UI.

New Features:
- Track multiple open sessions via parallelSessionIds in SessionState with add/remove/isParallelSession actions
- Extend sendMessage action, useSendMessage hook, and SendMessageParams type to accept an optional sessionId for routing messages
- Introduce getChatKeyForSession and getSessionChats selectors to retrieve messages for a given session
- Update messageMap usage to incorporate sessionId when generating and copying messages
- Integrate ParallelChat component into the ChatHeader and add corresponding i18n entries