### PR TITLE
🐛 fix: update gpt-5, gpt-5-nano imageOutput

### DIFF
--- a/src/config/aiModels/aihubmix.ts
+++ b/src/config/aiModels/aihubmix.ts
@@ -4,7 +4,6 @@ const aihubmixModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      imageOutput: true,
       reasoning: true,
       search: true,
       vision: true,
@@ -61,7 +60,6 @@ const aihubmixModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      imageOutput: true,
       reasoning: true,
       vision: true,
     },

--- a/src/config/aiModels/openai.ts
+++ b/src/config/aiModels/openai.ts
@@ -21,7 +21,6 @@ export const openaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      imageOutput: true,
       reasoning: true,
       search: true,
       vision: true,
@@ -78,7 +77,6 @@ export const openaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      imageOutput: true,
       reasoning: true,
       vision: true,
     },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Remove imageOutput ability flag from gpt-5 and gpt-5-nano models in AIHubMix and OpenAI configurations.