### PR TITLE
📝 docs: change the default modal provider list rank

### DIFF
--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -136,6 +136,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   BflProvider,
   NovitaProvider,
   PPIOProvider,
+  Ai302Provider,
   NvidiaProvider,
   TogetherAIProvider,
   FireworksAIProvider,
@@ -172,7 +173,6 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   Search1APIProvider,
   InfiniAIProvider,
   QiniuProvider,
-  Ai302Provider,
 ];
 
 export const filterEnabledModels = (provider: ModelProviderCard) => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Documentation:
- reposition Ai302Provider earlier in the default provider list