### PR TITLE
🐛 chore: fix provider data fetch time

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/(detail)/[id]/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/(detail)/[id]/index.tsx
@@ -3,6 +3,8 @@
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
+import { useAiInfraStore } from '@/store/aiInfra';
+
 import ModelList from '../../features/ModelList';
 import ProviderConfig, { ProviderConfigProps } from '../../features/ProviderConfig';
 
@@ -10,6 +12,9 @@ interface ProviderDetailProps extends ProviderConfigProps {
   showConfig?: boolean;
 }
 const ProviderDetail = memo<ProviderDetailProps>(({ showConfig = true, ...card }) => {
+  const useFetchAiProviderItem = useAiInfraStore((s) => s.useFetchAiProviderItem);
+  useFetchAiProviderItem(card.id);
+
   return (
     <Flexbox gap={24} paddingBlock={8}>
       {/* ↓ cloud slot ↓ */}

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -143,7 +143,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
     const { cx, styles, theme } = useStyles();
 
     const [
-      useFetchAiProviderItem,
+      data,
       updateAiProviderConfig,
       enabled,
       isLoading,
@@ -153,7 +153,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
       isProviderEndpointNotEmpty,
       isProviderApiKeyNotEmpty,
     ] = useAiInfraStore((s) => [
-      s.useFetchAiProviderItem,
+      aiProviderSelectors.activeProviderConfig(s),
       s.updateAiProviderConfig,
       aiProviderSelectors.isProviderEnabled(id)(s),
       aiProviderSelectors.isAiProviderConfigLoading(id)(s),
@@ -163,8 +163,6 @@ const ProviderConfig = memo<ProviderConfigProps>(
       aiProviderSelectors.isActiveProviderEndpointNotEmpty(s),
       aiProviderSelectors.isActiveProviderApiKeyNotEmpty(s),
     ]);
-
-    const { data } = useFetchAiProviderItem(id);
 
     useLayoutEffect(() => {
       if (isLoading) return;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Ensure provider configuration data is fetched early and consumed via a selector

Bug Fixes:
- Move useFetchAiProviderItem invocation from ProviderConfig to ProviderDetail to fix fetch timing

Enhancements:
- Replace direct hook usage in ProviderConfig with aiProviderSelectors.activeProviderConfig selector
- Trigger provider data fetch on detail load via useFetchAiProviderItem in ProviderDetail