### PR TITLE
 🔨 chore: reducing the tracing scope

### DIFF
--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -168,7 +168,7 @@ class DiscoverService {
    * 上报插件调用结果
    */
   reportPluginCall = async (reportData: CallReportRequest) => {
-    // if user don't allow tracing , just not report installation
+    // if user don't allow tracing , just not report calling
     const allow = preferenceSelectors.userAllowTrace(useUserStore.getState());
 
     if (!allow) return;

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -143,6 +143,9 @@ class DiscoverService {
     errorCode,
     ...params
   }: InstallReportRequest) => {
+    const allow = preferenceSelectors.userAllowTrace(useUserStore.getState());
+
+    if (!allow) return;
     await this.injectMPToken();
 
     const reportData = {
@@ -164,7 +167,7 @@ class DiscoverService {
    * 上报插件调用结果
    */
   reportPluginCall = async (reportData: CallReportRequest) => {
-    const allow = useUserStore(preferenceSelectors.userAllowTrace);
+    const allow = preferenceSelectors.userAllowTrace(useUserStore.getState());
 
     if (!allow) return;
 

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -143,6 +143,7 @@ class DiscoverService {
     errorCode,
     ...params
   }: InstallReportRequest) => {
+    // if user don't allow tracing, just not report installation
     const allow = preferenceSelectors.userAllowTrace(useUserStore.getState());
 
     if (!allow) return;
@@ -167,6 +168,7 @@ class DiscoverService {
    * 上报插件调用结果
    */
   reportPluginCall = async (reportData: CallReportRequest) => {
+    // if user don't allow tracing , just not report installation
     const allow = preferenceSelectors.userAllowTrace(useUserStore.getState());
 
     if (!allow) return;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix trace reporting workflow in DiscoverService by correctly retrieving user permission via getState and skipping reports when user disallows tracing

Bug Fixes:
- Replace invalid hook usage with preferenceSelectors.userAllowTrace(useUserStore.getState()) in reportPluginCall
- Add early return in reportInstall when userAllowTrace is false