### PR TITLE
 :bug: fix: improve ollama capability and improve search config

### DIFF
--- a/packages/model-runtime/src/ollama/index.ts
+++ b/packages/model-runtime/src/ollama/index.ts
@@ -138,7 +138,7 @@ export class LobeOllamaAI implements LobeRuntimeAI {
           functionCall: knownModel?.abilities?.functionCall || false,
           id: model.name,
           reasoning: knownModel?.abilities?.functionCall || false,
-          vision: knownModel?.abilities?.functionCall || false,
+          vision: knownModel?.abilities?.vision || false,
         };
       })
       .filter(Boolean) as ChatModelCard[];

--- a/packages/model-runtime/src/ollama/index.ts
+++ b/packages/model-runtime/src/ollama/index.ts
@@ -137,7 +137,7 @@ export class LobeOllamaAI implements LobeRuntimeAI {
           enabled: knownModel?.enabled || false,
           functionCall: knownModel?.abilities?.functionCall || false,
           id: model.name,
-          reasoning: knownModel?.abilities?.functionCall || false,
+          reasoning: knownModel?.abilities?.reasoning || false,
           vision: knownModel?.abilities?.vision || false,
         };
       })

--- a/packages/types/src/aiModel.ts
+++ b/packages/types/src/aiModel.ts
@@ -52,6 +52,7 @@ const AiModelAbilitiesSchema = z.object({
   // files: z.boolean().optional(),
   functionCall: z.boolean().optional(),
   reasoning: z.boolean().optional(),
+  search: z.boolean().optional(),
   vision: z.boolean().optional(),
 });
 


### PR DESCRIPTION
- 修复Zod schema 的 search 能力的可选布尔字段
- 修正 Ollama 模型运行时中 vision 能力的选项重复/错误

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
1.修复了Zod schema 的 search 能力的可选布尔字段
添加了 search: z.boolean().optional()

2. 修复了packages/model-runtime/src/ollama/index.ts下的问题
``` 
          reasoning: knownModel?.abilities?.functionCall || false,
          vision: knownModel?.abilities?.functionCall || false,
```
现在正确为
```
          reasoning: knownModel?.abilities?.reasoning || false,
          vision: knownModel?.abilities?.vision || false,
```


#### 📝 补充信息 | Additional Information

很可能会有TypeScript测试失败风险，但理论上不影响任何功能，只是修复了一个参数缺失

## Summary by Sourcery

Fix missing search ability definition in schema and correct reasoning/vision flags in the Ollama model runtime

Bug Fixes:
- Add optional 'search' boolean field to AiModelAbilitiesSchema
- Fix reasoning and vision mappings in LobeOllamaAI to use correct ability flags instead of functionCall