### PR TITLE
🐛 fix(files): remove force-static rendering to enable session access

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,6 @@
 .DS_Store
 .editorconfig
 .idea
-.vscode
 .history
 .temp
 .env.local

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,89 +1,95 @@
 {
-    "npm.packageManager": "pnpm",
-    // don't show errors, but fix when save and git pre commit
-    "eslint.rules.customizations": [
-        { "rule": "import/order", "severity": "off" },
-        { "rule": "prettier/prettier", "severity": "off" },
-        { "rule": "react/jsx-sort-props", "severity": "off" },
-        { "rule": "sort-keys-fix/sort-keys-fix", "severity": "off" },
-        { "rule": "typescript-sort-keys/interface", "severity": "off" }
-    ],
-    "stylelint.validate": [
-        "css",
-        "postcss",
-        // make stylelint work with tsx antd-style css template string
-        "typescriptreact"
-    ],
-    "search.exclude": {
-        "**/node_modules": true,
-        // useless to search this big folder
-        "locales": true
-    },
-    "vitest.maximumConfigs": 6,
-    "workbench.editor.customLabels.patterns": {
-        "**/app/**/[[]*[]]/[[]*[]]/page.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • page component",
-        "**/app/**/[[]*[]]/page.tsx": "${dirname(1)}/${dirname} • page component",
-        "**/app/**/page.tsx": "${dirname} • page component",
+  "editor.codeActionsOnSave": {
+    "source.addMissingImports": "explicit",
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
+  },
+  "editor.formatOnSave": true,
+  // don't show errors, but fix when save and git pre commit
+  "eslint.rules.customizations": [
+    { "rule": "import/order", "severity": "off" },
+    { "rule": "prettier/prettier", "severity": "off" },
+    { "rule": "react/jsx-sort-props", "severity": "off" },
+    { "rule": "sort-keys-fix/sort-keys-fix", "severity": "off" },
+    { "rule": "typescript-sort-keys/interface", "severity": "off" }
+  ],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "markdown",
+    // support mdx
+    "mdx"
+  ],
+  "npm.packageManager": "pnpm",
+  "search.exclude": {
+    "**/node_modules": true,
+    // useless to search this big folder
+    "locales": true
+  },
+  "stylelint.validate": [
+    "css",
+    "postcss",
+    // make stylelint work with tsx antd-style css template string
+    "typescriptreact"
+  ],
+  "vitest.maximumConfigs": 10,
+  "workbench.editor.customLabels.patterns": {
+    "**/app/**/[[]*[]]/[[]*[]]/page.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • page component",
+    "**/app/**/[[]*[]]/page.tsx": "${dirname(1)}/${dirname} • page component",
+    "**/app/**/page.tsx": "${dirname} • page component",
 
-        "**/app/**/[[]*[]]/[[]*[]]/layout.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • page layout",
-        "**/app/**/[[]*[]]/layout.tsx": "${dirname(1)}/${dirname} • page layout",
-        "**/app/**/layout.tsx": "${dirname} • page layout",
+    "**/app/**/[[]*[]]/[[]*[]]/layout.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • page layout",
+    "**/app/**/[[]*[]]/layout.tsx": "${dirname(1)}/${dirname} • page layout",
+    "**/app/**/layout.tsx": "${dirname} • page layout",
 
-        "**/app/**/[[]*[]]/[[]*[]]/default.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • slot default",
-        "**/app/**/[[]*[]]/default.tsx": "${dirname(1)}/${dirname} • slot default",
-        "**/app/**/default.tsx": "${dirname} • slot default",
+    "**/app/**/[[]*[]]/[[]*[]]/default.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • slot default",
+    "**/app/**/[[]*[]]/default.tsx": "${dirname(1)}/${dirname} • slot default",
+    "**/app/**/default.tsx": "${dirname} • slot default",
 
-        "**/app/**/[[]*[]]/[[]*[]]/error.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • error component",
-        "**/app/**/[[]*[]]/error.tsx": "${dirname(1)}/${dirname} • error component",
-        "**/app/**/error.tsx": "${dirname} • error component",
+    "**/app/**/[[]*[]]/[[]*[]]/error.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • error component",
+    "**/app/**/[[]*[]]/error.tsx": "${dirname(1)}/${dirname} • error component",
+    "**/app/**/error.tsx": "${dirname} • error component",
 
-        "**/app/**/[[]*[]]/[[]*[]]/loading.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • loading component",
-        "**/app/**/[[]*[]]/loading.tsx": "${dirname(1)}/${dirname} • loading component",
-        "**/app/**/loading.tsx": "${dirname} • loading component",
+    "**/app/**/[[]*[]]/[[]*[]]/loading.tsx": "${dirname(2)}/${dirname(1)}/${dirname} • loading component",
+    "**/app/**/[[]*[]]/loading.tsx": "${dirname(1)}/${dirname} • loading component",
+    "**/app/**/loading.tsx": "${dirname} • loading component",
 
-        "**/src/**/route.ts": "${dirname(1)}/${dirname} • route",
-        "**/src/**/index.tsx": "${dirname} • component",
+    "**/src/**/route.ts": "${dirname(1)}/${dirname} • route",
+    "**/src/**/index.tsx": "${dirname} • component",
 
-        "**/src/database/repositories/*/index.ts": "${dirname} • db repository",
-        "**/src/database/models/*.ts": "${filename} • db model",
-        "**/src/database/schemas/*.ts": "${filename} • db schema",
+    "**/src/database/repositories/*/index.ts": "${dirname} • db repository",
+    "**/src/database/models/*.ts": "${filename} • db model",
+    "**/src/database/schemas/*.ts": "${filename} • db schema",
 
-        "**/src/services/*.ts": "${filename} • service",
-        "**/src/services/*/client.ts": "${dirname} • client service",
-        "**/src/services/*/server.ts": "${dirname} • server service",
-        
-        "**/src/store/*/action.ts": "${dirname} • action",
-        "**/src/store/*/slices/*/action.ts": "${dirname(2)}/${dirname} • action",
-        "**/src/store/*/slices/*/actions/*.ts": "${dirname(1)}/${dirname}/${filename} • action",
-        
-        "**/src/store/*/initialState.ts": "${dirname} • state",
-        "**/src/store/*/slices/*/initialState.ts": "${dirname(2)}/${dirname} • state",
-        
-        "**/src/store/*/selectors.ts": "${dirname} • selectors",
-        "**/src/store/*/slices/*/selectors.ts": "${dirname(2)}/${dirname} • selectors",
-        
-        "**/src/store/*/reducer.ts": "${dirname} • reducer",
-        "**/src/store/*/slices/*/reducer.ts": "${dirname(2)}/${dirname} • reducer",
-        
-        "**/src/config/modelProviders/*.ts": "${filename} • provider",
-        "**/src/config/aiModels/*.ts": "${filename} • model",
-        "**/src/config/paramsSchemas/*/*.json": "${dirname(1)}/${filename} • params",
-        "**/packages/model-runtime/src/*/index.ts": "${dirname} • runtime",
-        
-        "**/src/server/services/*/index.ts": "${dirname} • server/service",
-        "**/src/server/routers/lambda/*.ts": "${filename} • lambda",
-        "**/src/server/routers/async/*.ts": "${filename} • async",
-        "**/src/server/routers/edge/*.ts": "${filename} • edge",
+    "**/src/services/*.ts": "${filename} • service",
+    "**/src/services/*/client.ts": "${dirname} • client service",
+    "**/src/services/*/server.ts": "${dirname} • server service",
 
-        "**/src/locales/default/*.ts": "${filename} • locale",
-    },
-    "eslint.validate": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact",
-        "markdown",
-        // support mdx
-        "mdx"
-    ]
+    "**/src/store/*/action.ts": "${dirname} • action",
+    "**/src/store/*/slices/*/action.ts": "${dirname(2)}/${dirname} • action",
+    "**/src/store/*/slices/*/actions/*.ts": "${dirname(1)}/${dirname}/${filename} • action",
+
+    "**/src/store/*/initialState.ts": "${dirname} • state",
+    "**/src/store/*/slices/*/initialState.ts": "${dirname(2)}/${dirname} • state",
+
+    "**/src/store/*/selectors.ts": "${dirname} • selectors",
+    "**/src/store/*/slices/*/selectors.ts": "${dirname(2)}/${dirname} • selectors",
+
+    "**/src/store/*/reducer.ts": "${dirname} • reducer",
+    "**/src/store/*/slices/*/reducer.ts": "${dirname(2)}/${dirname} • reducer",
+
+    "**/src/config/modelProviders/*.ts": "${filename} • provider",
+    "**/src/config/aiModels/*.ts": "${filename} • model",
+    "**/src/config/paramsSchemas/*/*.json": "${dirname(1)}/${filename} • params",
+    "**/packages/model-runtime/src/*/index.ts": "${dirname} • runtime",
+
+    "**/src/server/services/*/index.ts": "${dirname} • server/service",
+    "**/src/server/routers/lambda/*.ts": "${filename} • lambda",
+    "**/src/server/routers/async/*.ts": "${filename} • async",
+    "**/src/server/routers/edge/*.ts": "${filename} • edge",
+
+    "**/src/locales/default/*.ts": "${filename} • locale"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -364,7 +364,7 @@
     "vite": "^5.4.19",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.15.0",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/src/app/[variants]/(main)/files/[id]/page.tsx
+++ b/src/app/[variants]/(main)/files/[id]/page.tsx
@@ -39,5 +39,3 @@ const FilePage = async (props: PagePropsWithId) => {
 };
 
 export default FilePage;
-
-export const dynamic = 'force-static';


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fixes issue where NextAuth session returns null in the files/[id] page due to force-static rendering.

**Problem:**
- The files/[id] page had `export const dynamic = 'force-static'` which forced static rendering at build time
- Static rendering prevents access to request-time data (cookies, headers, session)
- This caused `getUserAuth()` to always return null session, breaking user authentication

**Solution:**
- Removed `export const dynamic = 'force-static'` from `src/app/[variants]/(main)/files/[id]/page.tsx`
- Page now renders dynamically, allowing proper access to user session data
- Users can now access their files after authentication

#### 📝 补充信息 | Additional Information

Fixes #8445

This change enables the files/[id] page to properly access user session data by allowing dynamic rendering instead of forcing static generation at build time.

## Summary by Sourcery

Remove force-static rendering to enable session access on files/[id] page and bump pnpm version to 10.15.0

Bug Fixes:
- Remove force-static rendering on files/[id] page to enable dynamic rendering and restore NextAuth session access

Build:
- Upgrade pnpm packageManager version to 10.15.0