### PR TITLE
fix: non-Latin characters in PDF viewer

### DIFF
--- a/src/features/FileViewer/Renderer/PDF/index.tsx
+++ b/src/features/FileViewer/Renderer/PDF/index.tsx
@@ -17,8 +17,8 @@ import useResizeObserver from './useResizeObserver';
 pdfjs.GlobalWorkerOptions.workerSrc = `https://registry.npmmirror.com/pdfjs-dist/${pdfjs.version}/files/build/pdf.worker.min.mjs`;
 
 const options = {
-  cMapUrl: '/cmaps/',
-  standardFontDataUrl: '/standard_fonts/',
+  cMapUrl: `https://registry.npmmirror.com/pdfjs-dist/${pdfjs.version}/files/cmaps/`,
+  standardFontDataUrl: `https://registry.npmmirror.com/pdfjs-dist/${pdfjs.version}/files/standard_fonts/`,
 };
 
 const maxWidth = 1200;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

参考：https://github.com/wojtekmaj/react-pdf/tree/main?tab=readme-ov-file#setting-up-react-pdf

<!-- Add any other context about the Pull Request here. -->

close #6119

## Summary by Sourcery

Fix PDF viewer non-Latin character rendering by pointing cMap and standard font URLs to the npmmirror CDN.

Bug Fixes:
- Configure PDF.js to load CMaps from the npmmirror CDN instead of local `/cmaps/` path
- Configure PDF.js to load standard fonts from the npmmirror CDN instead of local `/standard_fonts/` path