### PR TITLE
feat: add gemini 2.5 flash image model

### DIFF
--- a/packages/model-runtime/src/google/index.ts
+++ b/packages/model-runtime/src/google/index.ts
@@ -34,12 +34,14 @@ const modelsWithModalities = new Set([
   'gemini-2.0-flash-exp',
   'gemini-2.0-flash-exp-image-generation',
   'gemini-2.0-flash-preview-image-generation',
+  'gemini-2.5-flash-image-preview',
 ]);
 
 const modelsDisableInstuction = new Set([
   'gemini-2.0-flash-exp',
   'gemini-2.0-flash-exp-image-generation',
   'gemini-2.0-flash-preview-image-generation',
+  'gemini-2.5-flash-image-preview',
   'gemma-3-1b-it',
   'gemma-3-4b-it',
   'gemma-3-12b-it',
@@ -211,6 +213,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       };
 
       const inputStartAt = Date.now();
+
       const geminiStreamResponse = await this.client.models.generateContentStream({
         config,
         contents,

--- a/packages/types/src/aiModel.ts
+++ b/packages/types/src/aiModel.ts
@@ -121,7 +121,8 @@ export type PricingUnitName =
   | 'audioInput_cacheRead' // corresponds to ChatModelPricing.cachedAudioInput
 
   // Image-based pricing units
-  | 'imageGeneration'; // for image generation models
+  | 'imageGeneration' // for image generation models
+  | 'imageOutput';
 
 export type PricingUnitType =
   | 'millionTokens' // per 1M tokens

--- a/src/config/aiModels/google.ts
+++ b/src/config/aiModels/google.ts
@@ -315,7 +315,7 @@ const googleChatModels: AIChatModelCard[] = [
         { name: 'imageOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-05-07',
+    releasedAt: '2025-08-27',
     type: 'chat',
   },
   {
@@ -326,7 +326,6 @@ const googleChatModels: AIChatModelCard[] = [
     contextWindowTokens: 32_768 + 8192,
     description: 'Gemini 2.0 Flash 预览模型，支持图像生成',
     displayName: 'Gemini 2.0 Flash Preview Image Generation',
-    enabled: true,
     id: 'gemini-2.0-flash-preview-image-generation',
     maxOutput: 8192,
     pricing: {

--- a/src/config/aiModels/google.ts
+++ b/src/config/aiModels/google.ts
@@ -301,6 +301,28 @@ const googleChatModels: AIChatModelCard[] = [
       imageOutput: true,
       vision: true,
     },
+    contextWindowTokens: 32_768 + 32_768,
+    description:
+      'Gemini 2.5 Flash Image Preview 是 Google 最新、最快、最高效的原生多模态模型，它允许您通过对话生成和编辑图像。',
+    displayName: 'Gemini 2.5 Flash Image Preview',
+    enabled: true,
+    id: 'gemini-2.5-flash-image-preview',
+    maxOutput: 32_768,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-05-07',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      imageOutput: true,
+      vision: true,
+    },
     contextWindowTokens: 32_768 + 8192,
     description: 'Gemini 2.0 Flash 预览模型，支持图像生成',
     displayName: 'Gemini 2.0 Flash Preview Image Generation',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Register the Gemini 2.5 Flash Image Preview multimodal model in the Google AI models configuration and extend the pricing type definitions to support imageOutput.

New Features:
- Add Gemini 2.5 Flash Image Preview as a new chat model with image output and vision capabilities
- Introduce a new 'imageOutput' pricing unit to the AI pricing types