### PR TITLE
docs: update bfl doc cover image url

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ read @.cursor/rules/project-structure.mdc
 This repository adopts a monorepo structure.
 
 - Use `pnpm` as the primary package manager for dependency management
-- Use `bun` to run npm scripts at the root level
+- Use `bun` to run npm scripts
 - Use `bunx` to run executable npm packages
 
 ### TypeScript Code Style Guide

--- a/docs/usage/providers/bfl.mdx
+++ b/docs/usage/providers/bfl.mdx
@@ -12,7 +12,7 @@ tags:
 
 # Using Black Forest Labs in LobeChat
 
-<Image alt={'Using Black Forest Labs in LobeChat'} cover src={'https://hub-apac-1.lobeobjects.space/docs/bfl-cover-image.png'} />
+<Image alt={'Using Black Forest Labs in LobeChat'} cover src={'https://hub-apac-1.lobeobjects.space/docs/c7274a5b037227f042ad7558f535b5ea.png'} />
 
 [Black Forest Labs](https://bfl.ai/) is currently the world's top-tier AI image generation research lab, having developed the FLUX series of high-quality image generation models and the FLUX Kontext series of image editing models. This document will guide you on how to use Black Forest Labs in LobeChat:
 

--- a/docs/usage/providers/bfl.zh-CN.mdx
+++ b/docs/usage/providers/bfl.zh-CN.mdx
@@ -12,7 +12,7 @@ tags:
 
 # 在 LobeChat 中使用 Black Forest Labs
 
-<Image alt={'在 LobeChat 中使用 Black Forest Labs'} cover src={'https://hub-apac-1.lobeobjects.space/docs/bfl-cover-image.png'} />
+<Image alt={'在 LobeChat 中使用 Black Forest Labs'} cover src={'https://hub-apac-1.lobeobjects.space/docs/c7274a5b037227f042ad7558f535b5ea.png'} />
 
 [Black Forest Labs](https://bfl.ai/) 是当前世界最顶级的 AI 图像生成实验室团队，研发了 FLUX 系列高质量图像生成模型，FLUX Kontext 系列图像编辑模型。本文将指导你如何在 LobeChat 中使用 Black Forest Labs：
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Update documentation to refine bun usage instruction and refresh the Black Forest Labs cover image URL.

Documentation:
- Remove “at the root level” from the bun usage guideline in CLAUDE.md
- Update the BFL cover image URL in both English and Chinese usage guides