### PR TITLE
展示模型的displayName

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/Tags/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/Tags/index.tsx
@@ -16,6 +16,7 @@ import { authSelectors } from '@/store/user/selectors';
 import HistoryLimitTags from './HistoryLimitTags';
 import KnowledgeTag from './KnowledgeTag';
 import SearchTags from './SearchTags';
+import {aiModelSelectors, useAiInfraStore} from "@/store/aiInfra";
 
 const TitleTags = memo(() => {
   const [model, provider, hasKnowledge, isLoading] = useAgentStore((s) => [
@@ -25,6 +26,7 @@ const TitleTags = memo(() => {
     agentSelectors.isAgentConfigLoading(s),
   ]);
 
+  const currentModel = useAiInfraStore(aiModelSelectors.getEnabledModelById(model, provider));
   const plugins = useAgentStore(agentSelectors.currentAgentPlugins, isEqual);
   const enabledKnowledge = useAgentStore(agentSelectors.currentEnabledKnowledge, isEqual);
   const enableHistoryCount = useAgentStore(agentChatConfigSelectors.enableHistoryCount);
@@ -39,7 +41,7 @@ const TitleTags = memo(() => {
   ) : (
     <Flexbox align={'center'} gap={4} horizontal>
       <ModelSwitchPanel>
-        <ModelTag model={model} />
+        <ModelTag model={currentModel?.displayName || model} />
       </ModelSwitchPanel>
       {isAgentEnableSearch && <SearchTags />}
       {showPlugin && plugins?.length > 0 && <PluginTag plugins={plugins} />}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
没改之前：
<img width="305" height="100" alt="image" src="https://github.com/user-attachments/assets/368219ed-2f09-4a10-8ded-5f58add1916e" />

改了之后：
<img width="290" height="114" alt="image" src="https://github.com/user-attachments/assets/a6ea0b30-47a0-4e3d-a8f7-a82cc76d91c7" />


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enhancements:
- Fetch the enabled model from the AI infrastructure store and use its displayName when rendering the ModelTag component