### PR TITLE
feat: add soft delete account

### DIFF
--- a/packages/database/src/models/user.ts
+++ b/packages/database/src/models/user.ts
@@ -66,6 +66,7 @@ export class UserModel {
         email: users.email,
         firstName: users.firstName,
         fullName: users.fullName,
+        isDeleted: users.isDeleted,
         isOnboarded: users.isOnboarded,
         lastName: users.lastName,
         preference: users.preference,
@@ -89,6 +90,14 @@ export class UserModel {
     }
 
     const state = result[0];
+
+    // Check if user account is deleted
+    if (state.isDeleted) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Account has been deleted'
+      });
+    }
 
     // Decrypt keyVaults
     let decryptKeyVaults = {};
@@ -185,6 +194,13 @@ export class UserModel {
     return this.db
       .update(users)
       .set({ preference: { ...prevPreference, guide: merge(prevPreference.guide || {}, value) } })
+      .where(eq(users.id, this.userId));
+  };
+
+  deleteAccount = async () => {
+    return this.db
+      .update(users)
+      .set({ isDeleted: true, updatedAt: new Date() })
       .where(eq(users.id, this.userId));
   };
 

--- a/packages/database/src/schemas/user.ts
+++ b/packages/database/src/schemas/user.ts
@@ -19,6 +19,7 @@ export const users = pgTable('users', {
   fullName: text('full_name'),
 
   isOnboarded: boolean('is_onboarded').default(false),
+  isDeleted: boolean('is_deleted').default(false),
   // Time user was created in Clerk
   clerkCreatedAt: timestamptz('clerk_created_at'),
 

--- a/src/app/[variants]/(main)/profile/(home)/Client.tsx
+++ b/src/app/[variants]/(main)/profile/(home)/Client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Form, type FormGroupItemType, Input } from '@lobehub/ui';
-import { Skeleton } from 'antd';
-import { memo } from 'react';
+import { Button, Skeleton } from 'antd';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { enableAuth } from '@/const/auth';
@@ -11,8 +11,12 @@ import AvatarWithUpload from '@/features/AvatarWithUpload';
 import UserAvatar from '@/features/User/UserAvatar';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
+import { handleAccountDeleted } from '@/utils/account';
 
+import DeleteAccountModal from '../features/DeleteAccountModal';
 import SSOProvidersList from './features/SSOProvidersList';
+
+const handleDeleteAccountConfirm = async () => await handleAccountDeleted();
 
 const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
   const [isLoginWithNextAuth, isLogin] = useUserStore((s) => [
@@ -27,6 +31,7 @@ const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
   ]);
 
   const [form] = Form.useForm();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { t } = useTranslation('auth');
 
   if (loading)
@@ -68,18 +73,48 @@ const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
     ],
     title: t('tab.profile'),
   };
+
+  const dangerZone: FormGroupItemType = {
+    children: [
+      {
+        children: (
+          <Button
+            danger
+            onClick={() => setShowDeleteModal(true)}
+            style={{ marginTop: 16 }}
+            type="primary"
+          >
+            删除账户
+          </Button>
+        ),
+        label: '危险操作',
+        layout: 'vertical',
+        minWidth: undefined,
+      },
+    ],
+    title: '账户管理',
+  };
+
   return (
-    <Form
-      form={form}
-      initialValues={{
-        email: userProfile?.email || '--',
-        username: nickname || username,
-      }}
-      items={[profile]}
-      itemsType={'group'}
-      variant={'borderless'}
-      {...FORM_STYLE}
-    />
+    <>
+      <Form
+        form={form}
+        initialValues={{
+          email: userProfile?.email || '--',
+          username: nickname || username,
+        }}
+        items={[profile, dangerZone]}
+        itemsType={'group'}
+        variant={'borderless'}
+        {...FORM_STYLE}
+      />
+
+      <DeleteAccountModal
+        onCancel={() => setShowDeleteModal(false)}
+        onConfirm={handleDeleteAccountConfirm}
+        open={showDeleteModal}
+      />
+    </>
   );
 });
 

--- a/src/app/[variants]/(main)/profile/features/ClerkProfile.tsx
+++ b/src/app/[variants]/(main)/profile/features/ClerkProfile.tsx
@@ -2,8 +2,13 @@
 
 import { UserProfile } from '@clerk/nextjs';
 import { ElementsConfig } from '@clerk/types';
+import { Button } from 'antd';
 import { createStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useState } from 'react';
+
+import { handleAccountDeleted } from '@/utils/account';
+
+import DeleteAccountModal from './DeleteAccountModal';
 
 export const useStyles = createStyles(
   ({ css, responsive, token }) =>
@@ -53,16 +58,37 @@ export const useStyles = createStyles(
     }) as Partial<Record<keyof ElementsConfig, any>>,
 );
 
+const handleDeleteAccountConfirm = async () => {
+  await handleAccountDeleted();
+};
+
 const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { styles } = useStyles(mobile);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   return (
-    <UserProfile
-      appearance={{
-        elements: styles,
-      }}
-      path={'/profile'}
-    />
+    <div>
+      <UserProfile
+        appearance={{
+          elements: styles,
+        }}
+        path={'/profile'}
+      />
+
+      <Button
+        danger
+        onClick={() => setShowDeleteModal(true)}
+        type="primary"
+      >
+        注销账户
+      </Button>
+
+      <DeleteAccountModal
+        onCancel={() => setShowDeleteModal(false)}
+        onConfirm={handleDeleteAccountConfirm}
+        open={showDeleteModal}
+      />
+    </div>
   );
 });
 

--- a/src/app/[variants]/(main)/profile/features/DeleteAccountModal/index.tsx
+++ b/src/app/[variants]/(main)/profile/features/DeleteAccountModal/index.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Button, Modal, Typography } from 'antd';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { lambdaClient } from '@/libs/trpc/client';
+import { handleAccountDeleted } from '@/utils/account';
+
+const { Title, Paragraph, Text } = Typography;
+
+interface DeleteAccountModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteAccountModal = ({ open, onCancel, onConfirm }: DeleteAccountModalProps) => {
+  const { t } = useTranslation('auth');
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await lambdaClient.user.deleteAccount.mutate();
+      // Use the unified account deletion handler
+      await handleAccountDeleted();
+      onConfirm();
+    } catch (error) {
+      console.error('Failed to delete account:', error);
+      setLoading(false);
+    }
+  };
+
+
+  return (
+    <Modal
+      centered
+      open={open}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel}>
+          取消
+        </Button>,
+        <Button 
+          key="confirm" 
+          type="primary" 
+          danger 
+          loading={loading}
+          onClick={handleConfirm}
+        >
+          确认删除账户
+        </Button>,
+      ]}
+      title={
+        <Title level={4} style={{ margin: 0, color: '#ff4d4f' }}>
+          账户注销：重要须知
+        </Title>
+      }
+      width={600}
+    >
+      <div style={{ padding: '16px 0' }}>
+        <Paragraph>
+          在您做出最终决定前，请仔细阅读以下信息。注销账户是一个 <Text strong style={{ color: '#ff4d4f' }}>永久性且不可逆</Text> 的操作。
+        </Paragraph>
+
+        <Title level={5}>1. 账户与身份的永久消失</Title>
+        <Paragraph>
+          • <Text strong>无法恢复</Text>: 一旦注销，您的账户将被永久删除，我们无法为您恢复任何数据。<br />
+          • <Text strong>身份失效</Text>: 您将无法再使用当前的邮箱或第三方身份（例如，通过 Google / GitHub 关联的账户）登录或重新注册。
+        </Paragraph>
+
+        <Title level={5}>2. 您所有数据的永久清除</Title>
+        <Paragraph>
+          • <Text strong>个人数据</Text>: 您的个人资料、设置偏好、操作历史等信息将被完全抹除。<br />
+          • <Text strong>业务数据</Text>: 您创建的所有内容（例如：项目、文档、上传的文件等）都将被永久删除，请务必提前备份好您需要保留的重要资料。
+        </Paragraph>
+
+        <Title level={5}>3. 财务相关的处理</Title>
+        <Paragraph>
+          • <Text strong>订阅与服务</Text>: 任何有效的订阅计划将立即终止，剩余的服务期限会自动作废。<br />
+          • <Text strong>积分与余额</Text>: 账户中所有未使用的积分、代金券或预付余额将全部清零。<br />
+          • <Text strong>无退款</Text>: 根据我们的服务条款，针对已终止的订阅和已清零的积分/余额，我们<Text strong>不会提供任何形式的退款或补偿</Text>。
+        </Paragraph>
+
+        <Title level={5} style={{ color: '#1890ff' }}>真的要离开我们吗？</Title>
+        <Paragraph>
+          • 如果您只是不想再接收我们的邮件，可以前往 [邮件设置] 取消订阅。<br />
+          • 如果觉得当前套餐不合适，或许可以考虑 [降级套餐] 或暂停订阅。
+        </Paragraph>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteAccountModal;

--- a/src/app/[variants]/(main)/profile/features/DeleteAccountModal/index.tsx
+++ b/src/app/[variants]/(main)/profile/features/DeleteAccountModal/index.tsx
@@ -2,21 +2,18 @@
 
 import { Button, Modal, Typography } from 'antd';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-
 import { lambdaClient } from '@/libs/trpc/client';
 import { handleAccountDeleted } from '@/utils/account';
 
 const { Title, Paragraph, Text } = Typography;
 
 interface DeleteAccountModalProps {
-  open: boolean;
   onCancel: () => void;
   onConfirm: () => void;
+  open: boolean;
 }
 
 const DeleteAccountModal = ({ open, onCancel, onConfirm }: DeleteAccountModalProps) => {
-  const { t } = useTranslation('auth');
   const [loading, setLoading] = useState(false);
 
   const handleConfirm = async () => {
@@ -36,24 +33,24 @@ const DeleteAccountModal = ({ open, onCancel, onConfirm }: DeleteAccountModalPro
   return (
     <Modal
       centered
-      open={open}
-      onCancel={onCancel}
       footer={[
         <Button key="cancel" onClick={onCancel}>
           取消
         </Button>,
         <Button 
-          key="confirm" 
-          type="primary" 
           danger 
-          loading={loading}
+          key="confirm" 
+          loading={loading} 
           onClick={handleConfirm}
+          type="primary"
         >
           确认删除账户
         </Button>,
       ]}
+      onCancel={onCancel}
+      open={open}
       title={
-        <Title level={4} style={{ margin: 0, color: '#ff4d4f' }}>
+        <Title level={4} style={{ color: '#ff4d4f', margin: 0 }}>
           账户注销：重要须知
         </Title>
       }

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -33,17 +33,31 @@ const links = [
       const { loginRequired } = await import('@/components/Error/loginRequiredNotification');
       const { fetchErrorNotification } = await import('@/components/Error/fetchErrorNotification');
 
-      errorRes.forEach((item) => {
+      errorRes.forEach(async (item) => {
         const errorData = item.error.json;
         const status = errorData.data.httpStatus;
+        const message = errorData.message;
+
+        // Check for account deletion error
+        if (message === 'Account has been deleted') {
+          const { handleAccountDeleted } = await import('@/utils/account');
+          await handleAccountDeleted();
+          return;
+        }
 
         switch (status) {
           case 401: {
+            // Additional check for deleted account in 401 errors
+            if (message === 'Account has been deleted') {
+              const { handleAccountDeleted } = await import('@/utils/account');
+              await handleAccountDeleted();
+              return;
+            }
             loginRequired.redirect();
             break;
           }
           default: {
-            fetchErrorNotification.error({ errorMessage: errorData.message, status });
+            fetchErrorNotification.error({ errorMessage: message, status });
           }
         }
       });

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -37,6 +37,10 @@ const userProcedure = authedProcedure.use(serverDatabase).use(async ({ ctx, next
 });
 
 export const userRouter = router({
+  deleteAccount: userProcedure.mutation(async ({ ctx }) => {
+    return ctx.userModel.deleteAccount();
+  }),
+  
   getUserRegistrationDuration: userProcedure.query(async ({ ctx }) => {
     return ctx.userModel.getUserRegistrationDuration();
   }),
@@ -52,13 +56,13 @@ export const userRouter = router({
     while (!state) {
       try {
         state = await ctx.userModel.getUserState(KeyVaultsGateKeeper.getUserKeyVaults);
-        
+
         // Check if user is deleted
         const user = await UserModel.findById(ctx.serverDB, ctx.userId);
         if (user?.isDeleted) {
-          throw new TRPCError({ 
-            code: 'UNAUTHORIZED', 
-            message: 'Account has been deleted' 
+          throw new TRPCError({
+            code: 'UNAUTHORIZED',
+            message: 'Account has been deleted'
           });
         }
       } catch (error) {
@@ -243,9 +247,6 @@ export const userRouter = router({
       return ctx.userModel.updateSetting(nextValue);
     }),
 
-  deleteAccount: userProcedure.mutation(async ({ ctx }) => {
-    return ctx.userModel.deleteAccount();
-  }),
 });
 
 export type UserRouter = typeof userRouter;

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,10 +1,5 @@
-import { useClerk } from '@clerk/nextjs';
-
 import { enableClerk } from '@/const/auth';
 
-/**
- * 清理浏览器中的所有账户相关数据
- */
 export const clearAccountData = () => {
   if (typeof window === 'undefined') return;
 
@@ -40,8 +35,10 @@ export const handleAccountDeleted = async () => {
   clearAccountData();
 
   // For Clerk users, also sign out
+  // @ts-ignore
   if (enableClerk && typeof window.Clerk !== 'undefined') {
     try {
+      // @ts-ignore
       await window.Clerk.signOut();
     } catch (error) {
       console.warn('Failed to sign out from Clerk:', error);
@@ -52,27 +49,4 @@ export const handleAccountDeleted = async () => {
   const loginUrl = new URL('/login', window.location.origin);
   loginUrl.searchParams.set('deleted', 'true');
   window.location.href = loginUrl.toString();
-};
-
-export const useHandleAccountDeleted = () => {
-  const clerk = useClerk();
-
-  return async () => {
-    // Clear all browser data
-    clearAccountData();
-
-    // For Clerk users, also sign out
-    if (enableClerk && clerk) {
-      try {
-        await clerk.signOut();
-      } catch (error) {
-        console.warn('Failed to sign out from Clerk:', error);
-      }
-    }
-
-    // Redirect to login page with deleted account flag
-    const loginUrl = new URL('/login', window.location.origin);
-    loginUrl.searchParams.set('deleted', 'true');
-    window.location.href = loginUrl.toString();
-  };
 };

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,0 +1,78 @@
+import { useClerk } from '@clerk/nextjs';
+
+import { enableClerk } from '@/const/auth';
+
+/**
+ * 清理浏览器中的所有账户相关数据
+ */
+export const clearAccountData = () => {
+  if (typeof window === 'undefined') return;
+
+  // Clear localStorage
+  localStorage.clear();
+
+  // Clear sessionStorage
+  sessionStorage.clear();
+
+  // Clear cookies
+  document.cookie.split(";").forEach((c) => {
+    const eqPos = c.indexOf("=");
+    const name = eqPos > -1 ? c.slice(0, eqPos).trim() : c.trim();
+    const expires = "expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    const path = "path=/";
+    const domain1 = `domain=${window.location.hostname}`;
+    const domain2 = `domain=.${window.location.hostname}`;
+
+    // Clear cookie for current domain
+    if (document && document.cookie) {
+      // eslint-disable-next-line unicorn/no-document-cookie
+      document.cookie = `${name}=;${expires};${path}`;
+      // eslint-disable-next-line unicorn/no-document-cookie
+      document.cookie = `${name}=;${expires};${path};${domain1}`;
+      // eslint-disable-next-line unicorn/no-document-cookie
+      document.cookie = `${name}=;${expires};${path};${domain2}`;
+    }
+  });
+};
+
+export const handleAccountDeleted = async () => {
+  // Clear all browser data
+  clearAccountData();
+
+  // For Clerk users, also sign out
+  if (enableClerk && typeof window.Clerk !== 'undefined') {
+    try {
+      await window.Clerk.signOut();
+    } catch (error) {
+      console.warn('Failed to sign out from Clerk:', error);
+    }
+  }
+
+  // Redirect to login page with deleted account flag
+  const loginUrl = new URL('/login', window.location.origin);
+  loginUrl.searchParams.set('deleted', 'true');
+  window.location.href = loginUrl.toString();
+};
+
+export const useHandleAccountDeleted = () => {
+  const clerk = useClerk();
+
+  return async () => {
+    // Clear all browser data
+    clearAccountData();
+
+    // For Clerk users, also sign out
+    if (enableClerk && clerk) {
+      try {
+        await clerk.signOut();
+      } catch (error) {
+        console.warn('Failed to sign out from Clerk:', error);
+      }
+    }
+
+    // Redirect to login page with deleted account flag
+    const loginUrl = new URL('/login', window.location.origin);
+    loginUrl.searchParams.set('deleted', 'true');
+    window.location.href = loginUrl.toString();
+  };
+};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add full soft-delete support for user accounts, including database schema changes, backend mutation, error interception, front-end UI for confirming deletion, and a unified client-side cleanup and redirect handler

New Features:
- Introduce soft delete for user accounts by adding an isDeleted flag, a deleteAccount method in the user model, and throwing an unauthorized error when accessing a deleted account
- Expose a deleteAccount mutation in the userRouter and intercept deletion errors in the TRPC client to trigger client-side cleanup
- Add a DeleteAccountModal component and 
- Add Delete Account buttons in both main profile client and ClerkProfile views to open the deletion modal and invoke the deletion flow
- Implement a unified handleAccountDeleted utility (and hook) to clear browser data, sign out, and redirect users upon account deletion

Enhancements:
- Improve error handling in the TRPC lambda client to detect 'Account has been deleted' messages and call the unified cleanup handler