### PR TITLE
🐛 fix: correct totalOutputTokens calculation for XAI provider

### DIFF
--- a/packages/model-runtime/src/utils/usageConverter.test.ts
+++ b/packages/model-runtime/src/utils/usageConverter.test.ts
@@ -271,7 +271,7 @@ describe('convertUsage', () => {
     // Assert
     expect(xaiResult).toMatchObject({
       totalInputTokens: 6103,
-      totalOutputTokens: 66,
+      totalOutputTokens: 447, // 66 + 381，xai的reasoning_tokens和completion_tokens价格一样
       outputTextTokens: 66, // 不减去 reasoning_tokens
       outputReasoningTokens: 381,
       totalTokens: 6550,

--- a/packages/model-runtime/src/utils/usageConverter.ts
+++ b/packages/model-runtime/src/utils/usageConverter.ts
@@ -27,6 +27,8 @@ export const convertUsage = (
     provider === 'xai'
       ? totalOutputTokens - outputAudioTokens
       : totalOutputTokens - outputReasoning - outputAudioTokens - outputImageTokens;
+  const totalOutputTokensNormalized =
+    provider === 'xai' ? totalOutputTokens + outputReasoning : totalOutputTokens;
 
   const totalTokens = inputCitationTokens + usage.total_tokens;
 
@@ -43,7 +45,7 @@ export const convertUsage = (
     outputTextTokens: outputTextTokens,
     rejectedPredictionTokens: usage.completion_tokens_details?.rejected_prediction_tokens,
     totalInputTokens,
-    totalOutputTokens: totalOutputTokens,
+    totalOutputTokens: totalOutputTokensNormalized,
     totalTokens,
   } satisfies ModelTokensUsage;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

**变更背景**
- 问题：Grok（xAI）返回的 completion_tokens 不包含 reasoning_tokens，在费用计算中的总输出费用（totalOutputCredit = totalOutputTokens × output 单价）不含思考 token，进而影响总计消耗。
- 现象：UI 的 Usage 明细中虽然会显示 “深度思考” 分项，但“总计消耗”未包含 reasoning，和期望不符。

**变更内容**
- 在 packages/model-runtime/src/utils/usageConverter.ts 的 convertUsage 中，对 provider === 'xai' 增加一处归一化处理：
  - totalOutputTokensNormalized = completion_tokens + reasoning_tokens（仅 xAI）
  - outputTextTokens 的计算保持不变：对 xAI 仍不减去 reasoning token（xAI 的 completion_tokens 本身不含 reasoning），只减去音频token。
  - 返回数据中将 totalOutputTokens 替换为 totalOutputTokensNormalized，其它字段不变。
- test修改

**修改之前** ：`输出`和`总计消耗`中未包含`深度思考`
<img width="502" height="599" alt="image" src="https://github.com/user-attachments/assets/19814d48-9c5b-40ca-b220-884ecea8b6f7" />

**修改之后**：`输出`和`总计消耗`中已包含`深度思考`
<img width="488" height="590" alt="image" src="https://github.com/user-attachments/assets/11ca98a9-2bc9-40f1-ae02-c588099c6b57" />

<!-- Add any other context about the Pull Request here. -->

#### 📝 补充信息 | Additional Information

[token收取费用说明](https://docs.x.ai/docs/key-information/consumption-and-rate-limits)

## Summary by Sourcery

Include reasoning tokens when calculating total output tokens for xAI provider and update related tests.

Bug Fixes:
- Add reasoning_tokens to totalOutputTokens for xAI in usageConverter to correctly reflect costs.

Tests:
- Update convertUsage tests to expect normalized totalOutputTokens including reasoning tokens for xAI.