### PR TITLE
💄 style: fix chat session part theme issue

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { DraggablePanel, DraggablePanelContainer, type DraggablePanelProps } from '@lobehub/ui';
-import { createStyles, useResponsive } from 'antd-style';
+import { createStyles, useResponsive, useThemeMode } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { PropsWithChildren, memo, useEffect, useMemo, useState } from 'react';
 
@@ -69,6 +69,8 @@ const SessionPanel = memo<PropsWithChildren>(({ children }) => {
     if (!md) updatePreference({ showSessionPanel: false });
   }, [md, cacheExpand]);
 
+  const { appearance } = useThemeMode();
+
   const SessionPanel = useMemo(() => {
     return (
       <DraggablePanel
@@ -90,7 +92,7 @@ const SessionPanel = memo<PropsWithChildren>(({ children }) => {
         </DraggablePanelContainer>
       </DraggablePanel>
     );
-  }, [sessionsWidth, md, isPinned, sessionExpandable, tmpWidth]);
+  }, [sessionsWidth, md, isPinned, sessionExpandable, tmpWidth, appearance]);
 
   return SessionPanel;
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Ensure the chat session panel updates its styling when the theme appearance changes

Enhancements:
- Fetch the current theme appearance in the desktop chat SessionPanel
- Add appearance to the useMemo dependency array to trigger rerender on theme change