### PR TITLE
🐛fix: Qwen & SiliconCloud DeepSeek V3.1 Model Ability

### DIFF
--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -5,7 +5,6 @@ import { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
 const qwenChatModels: AIChatModelCard[] = [
   {
     abilities: {
-      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 131_072,

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -19,6 +19,9 @@ const qwenChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -20,6 +20,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
     type: 'chat',
   },
   {
@@ -38,6 +41,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
         { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
       ],
+    },
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
     },
     type: 'chat',
   },

--- a/packages/model-runtime/src/qwen/index.ts
+++ b/packages/model-runtime/src/qwen/index.ts
@@ -35,7 +35,7 @@ export const LobeQwenAI = createOpenAICompatibleRuntime({
               thinking_budget:
                 thinking?.budget_tokens === 0 ? 0 : thinking?.budget_tokens || undefined,
             }
-          : ['qwen3', 'qwen-turbo', 'qwen-plus'].some((keyword) =>
+          : ['qwen3', 'qwen-turbo', 'qwen-plus', 'deepseek-v3.1'].some((keyword) =>
                 model.toLowerCase().includes(keyword),
               )
             ? {

--- a/packages/model-runtime/src/siliconcloud/index.ts
+++ b/packages/model-runtime/src/siliconcloud/index.ts
@@ -45,7 +45,7 @@ export const LobeSiliconCloudAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        ...(['qwen3'].some((keyword) => model.toLowerCase().includes(keyword))
+        ...(['qwen3', 'deepseek-v3.1'].some((keyword) => model.toLowerCase().includes(keyword))
           ? {
               enable_thinking: thinking !== undefined ? thinking.type === 'enabled' : false,
               thinking_budget:


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 去掉Qwen DeepSeek V3.1模型的函数调用功能，添加思考开关
- 添加SiliconCloud DeepSeek V3.1 模型思考开关

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

[阿里云DeepSeek-V3.1（混合思考模式，默认不开启思考模式）：deepseek-v3.1](https://help.aliyun.com/zh/model-studio/deep-thinking)
[阿里云DeepSeek-V3.1不支持的功能Function Calling](https://bailian.console.aliyun.com/?tab=api#/api/?type=model&url=2868565)
[硅基流动文档](https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions#body-enable-thinking)
## Summary by Sourcery

Fix Qwen and SiliconCloud DeepSeek V3.1 models by disabling unsupported function calling and adding reasoning controls

Bug Fixes:
- Remove function calling ability from Qwen DeepSeek V3.1 chat model

Enhancements:
- Add enableReasoning and reasoningBudgetToken settings to Qwen and SiliconCloud model definitions
- Extend runtime logic to include deepseek-v3.1 for thinking features