### PR TITLE
💄 style: adjust ControlsForm component to adapt to mobile phone display

### DIFF
--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -36,7 +36,13 @@ const ControlsForm = memo(() => {
     {
       children: <ContextCachingSwitch />,
       desc: (
-        <span style={{ display: 'inline-block', width: 300 }}>
+        <span
+          style={{
+            display: 'block',
+            maxWidth: 300,
+            whiteSpace: 'normal',
+          }}
+        >
           <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
             单条对话生成成本最高可降低 90%，响应速度提升 4 倍（
             <Link
@@ -56,7 +62,13 @@ const ControlsForm = memo(() => {
     {
       children: <Switch />,
       desc: (
-        <span style={{ display: 'inline-block', width: 300 }}>
+        <span
+          style={{
+            display: 'block',
+            maxWidth: 300,
+            whiteSpace: 'normal',
+          }}
+        >
           <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
             基于 Claude Thinking 机制限制（
             <Link
@@ -132,14 +144,21 @@ const ControlsForm = memo(() => {
     },
     {
       children: <Switch />,
-      desc: t('extendParams.urlContext.desc'),
+      desc: (
+        <span
+          style={{
+            display: 'block',
+            maxWidth: 400,
+            whiteSpace: 'normal',
+          }}
+        >
+          {t('extendParams.urlContext.desc')}
+        </span>
+      ),
       label: t('extendParams.urlContext.title'),
       layout: 'horizontal',
       minWidth: undefined,
       name: 'urlContext',
-      style: {
-        width: 445,
-      },
       tag: 'urlContext',
     },
     {

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -1,6 +1,6 @@
 import { Form } from '@lobehub/ui';
 import type { FormItemProps } from '@lobehub/ui';
-import { Form as AntdForm, Switch } from 'antd';
+import { Form as AntdForm, Switch, Grid } from 'antd';
 import isEqual from 'fast-deep-equal';
 import Link from 'next/link';
 import { memo } from 'react';
@@ -32,17 +32,21 @@ const ControlsForm = memo(() => {
 
   const modelExtendParams = useAiInfraStore(aiModelSelectors.modelExtendParams(model, provider));
 
+  const screens = Grid.useBreakpoint();
+  const isNarrow = !screens.sm;
+
+  const descWide = { display: 'inline-block', width: 300 } as const;
+  const descNarrow = {
+    display: 'block',
+    maxWidth: '100%',
+    whiteSpace: 'normal',
+  } as const;
+
   const items = [
     {
       children: <ContextCachingSwitch />,
       desc: (
-        <span
-          style={{
-            display: 'block',
-            maxWidth: 300,
-            whiteSpace: 'normal',
-          }}
-        >
+        <span style={isNarrow ? descNarrow : descWide}>
           <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
             单条对话生成成本最高可降低 90%，响应速度提升 4 倍（
             <Link
@@ -56,19 +60,14 @@ const ControlsForm = memo(() => {
         </span>
       ),
       label: t('extendParams.disableContextCaching.title'),
+      layout: isNarrow ? 'vertical' : 'horizontal',
       minWidth: undefined,
       name: 'disableContextCaching',
     },
     {
       children: <Switch />,
       desc: (
-        <span
-          style={{
-            display: 'block',
-            maxWidth: 300,
-            whiteSpace: 'normal',
-          }}
-        >
+        <span style={isNarrow ? descNarrow : descWide}>
           <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
             基于 Claude Thinking 机制限制（
             <Link
@@ -84,7 +83,7 @@ const ControlsForm = memo(() => {
         </span>
       ),
       label: t('extendParams.enableReasoning.title'),
-      layout: 'horizontal',
+      layout: isNarrow ? 'vertical' : 'horizontal',
       minWidth: undefined,
       name: 'enableReasoning',
     },
@@ -144,21 +143,16 @@ const ControlsForm = memo(() => {
     },
     {
       children: <Switch />,
-      desc: (
-        <span
-          style={{
-            display: 'block',
-            maxWidth: 400,
-            whiteSpace: 'normal',
-          }}
-        >
-          {t('extendParams.urlContext.desc')}
-        </span>
+      desc: isNarrow ? (
+        <span style={descNarrow}>{t('extendParams.urlContext.desc')}</span>
+      ) : (
+        t('extendParams.urlContext.desc')
       ),
       label: t('extendParams.urlContext.title'),
-      layout: 'horizontal',
+      layout: isNarrow ? 'vertical' : 'horizontal',
       minWidth: undefined,
       name: 'urlContext',
+      style: isNarrow ? undefined : { width: 445 },
       tag: 'urlContext',
     },
     {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

对话窗口的模型控制组件宽度调整，在宽度减少时自动换行，适配移动端显示

修改前：

<img width="246" height="199" alt="image" src="https://github.com/user-attachments/assets/bf94dbcc-c0af-401c-87ac-13a812bbba18" style="display:inline-block; margin-right: 10px;" />

<img width="250" height="189" alt="image" src="https://github.com/user-attachments/assets/3fca2c7d-89e7-4cfc-9ba8-f97a4167570d" style="display:inline-block;" />


修改后：

<img width="281" height="229" alt="image" src="https://github.com/user-attachments/assets/4d1c82a1-f190-4704-abfd-a5e64580853b" style="display:inline-block; margin-right: 10px;" />


<img width="241" height="255" alt="image" src="https://github.com/user-attachments/assets/ac4c926f-decc-4d21-bf03-f040d041019a" style="display:inline-block;" />


- fix #8988

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Update description spans in ControlsForm to use block display, maxWidth, and normal white-space wrapping instead of fixed-width inline-block for better mobile adaptability