### PR TITLE
💄 style: Update doubao-seed-1.6-vision models

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -552,18 +552,52 @@ const aihubmixModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      reasoning: true,
     },
     contextWindowTokens: 131_072,
     description:
-      'DeepSeek-V3.1 是深度求索全新推出的混合推理模型，支持思考与非思考2种推理模式，较 DeepSeek-R1-0528 思考效率更高。经 Post-Training 优化，Agent 工具使用与智能体任务表现大幅提升。',
-    displayName: 'DeepSeek V3.1',
-    enabled: true,
+      'DeepSeek-V3.1-非思考模式；DeepSeek-V3.1 是深度求索全新推出的混合推理模型，支持思考与非思考2种推理模式，较 DeepSeek-R1-0528 思考效率更高。经 Post-Training 优化，Agent 工具使用与智能体任务表现大幅提升。',
+    displayName: 'DeepSeek V3.1 (non-Think)',
     id: 'DeepSeek-V3.1',
     pricing: {
       units: [
         { name: 'textInput', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.68, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'DeepSeek-V3.1-思考模式；DeepSeek-V3.1 是深度求索全新推出的混合推理模型，支持思考与非思考2种推理模式，较 DeepSeek-R1-0528 思考效率更高。经 Post-Training 优化，Agent 工具使用与智能体任务表现大幅提升。',
+    displayName: 'DeepSeek V3.1 (Think)',
+    id: 'DeepSeek-V3.1-Think',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.68, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'DeepSeek V3.1 Fast 是 DeepSeek V3.1版本的高TPS极速版。 混合思考模式：通过更改聊天模板，一个模型可以同时支持思考模式和非思考模式。 更智能的工具调用：通过后训练优化，模型在工具使用和代理任务中的表现显著提升。',
+    displayName: 'DeepSeek V3.1 (Fast)',
+    id: 'DeepSeek-V3.1-Fast',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.096, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.288, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/groq.ts
+++ b/packages/model-bank/src/aiModels/groq.ts
@@ -67,11 +67,29 @@ const groqChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
+    contextWindowTokens: 262_144,
+    description:
+      'kimi-k2-0905-preview 模型上下文长度为 256k，具备更强的 Agentic Coding 能力、更突出的前端代码的美观度和实用性、以及更好的上下文理解能力。',
+    displayName: 'Kimi K2 0905',
+    enabled: true,
+    id: 'moonshotai/kimi-k2-instruct-0905',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
     contextWindowTokens: 131_072,
     description:
       'kimi-k2 是一款具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
-    displayName: 'Kimi K2 Instruct',
-    enabled: true,
+    displayName: 'Kimi K2 0711',
     id: 'moonshotai/kimi-k2-instruct',
     maxOutput: 16_384,
     pricing: {

--- a/packages/model-bank/src/aiModels/groq.ts
+++ b/packages/model-bank/src/aiModels/groq.ts
@@ -7,19 +7,19 @@ const groqChatModels: AIChatModelCard[] = [
   {
     contextWindowTokens: 131_072,
     description:
-      'Compound-beta 是一个复合 AI 系统，由 GroqCloud 中已经支持的多个开放可用的模型提供支持，可以智能地、有选择地使用工具来回答用户查询。',
-    displayName: 'Compound Beta',
+      'Compound 是一个复合 AI 系统，由 GroqCloud 中已经支持的多个开放可用的模型提供支持，可以智能地、有选择地使用工具来回答用户查询。',
+    displayName: 'Compound',
     enabled: true,
-    id: 'compound-beta',
+    id: 'groq/compound',
     maxOutput: 8192,
     type: 'chat',
   },
   {
     contextWindowTokens: 131_072,
     description:
-      'Compound-beta-mini 是一个复合 AI 系统，由 GroqCloud 中已经支持的公开可用模型提供支持，可以智能地、有选择地使用工具来回答用户查询。',
-    displayName: 'Compound Beta Mini',
-    id: 'compound-beta-mini',
+      'Compound-mini 是一个复合 AI 系统，由 GroqCloud 中已经支持的公开可用模型提供支持，可以智能地、有选择地使用工具来回答用户查询。',
+    displayName: 'Compound Mini',
+    id: 'groq/compound-mini',
     maxOutput: 8192,
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/hunyuan.ts
+++ b/packages/model-bank/src/aiModels/hunyuan.ts
@@ -26,9 +26,9 @@ const hunyuanChatModels: AIChatModelCard[] = [
       reasoning: true,
       search: true,
     },
-    contextWindowTokens: 92_000,
+    contextWindowTokens: 96_000,
     description:
-      '业内首个超大规模 Hybrid-Transformer-Mamba 推理模型，扩展推理能力，超强解码速度，进一步对齐人类偏好。',
+      '大幅提升主模型慢思考模型的高难数学、复杂推理、高难代码、指令遵循、文本创作质量等能力。',
     displayName: 'Hunyuan T1',
     enabled: true,
     id: 'hunyuan-t1-latest',
@@ -40,7 +40,7 @@ const hunyuanChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-05-21',
+    releasedAt: '2025-08-22',
     settings: {
       searchImpl: 'params',
     },

--- a/packages/model-bank/src/aiModels/modelscope.ts
+++ b/packages/model-bank/src/aiModels/modelscope.ts
@@ -4,6 +4,19 @@ const modelscopeChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'kimi-k2-0905-preview 模型上下文长度为 256k，具备更强的 Agentic Coding 能力、更突出的前端代码的美观度和实用性、以及更好的上下文理解能力。',
+    displayName: 'Kimi K2 0905',
+    enabled: true,
+    id: 'moonshotai/Kimi-K2-Instruct-0905',
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 131_072,
@@ -53,7 +66,6 @@ const modelscopeChatModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description: 'Qwen3-235B-A22B是通义千问3代超大规模模型，提供顶级的AI能力。',
     displayName: 'Qwen3-235B-A22B',
-    enabled: true,
     id: 'Qwen/Qwen3-235B-A22B',
     type: 'chat',
   },
@@ -64,7 +76,6 @@ const modelscopeChatModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description: 'Qwen3-32B是通义千问3代模型，具有强大的推理和对话能力。',
     displayName: 'Qwen3-32B',
-    enabled: true,
     id: 'Qwen/Qwen3-32B',
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/moonshot.ts
+++ b/packages/model-bank/src/aiModels/moonshot.ts
@@ -6,7 +6,7 @@ const moonshotChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 256_000,
+    contextWindowTokens: 262_144,
     description:
       'kimi-k2-0905-preview 模型上下文长度为 256k，具备更强的 Agentic Coding 能力、更突出的前端代码的美观度和实用性、以及更好的上下文理解能力。',
     displayName: 'Kimi K2 0905',
@@ -47,7 +47,7 @@ const moonshotChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 256_000,
+    contextWindowTokens: 262_144,
     description:
       'kimi-k2 是一款具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
     displayName: 'Kimi K2 0905 Turbo',

--- a/packages/model-bank/src/aiModels/moonshot.ts
+++ b/packages/model-bank/src/aiModels/moonshot.ts
@@ -6,11 +6,31 @@ const moonshotChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
+    contextWindowTokens: 256_000,
+    description:
+      'kimi-k2-0905-preview 模型上下文长度为 256k，具备更强的 Agentic Coding 能力、更突出的前端代码的美观度和实用性、以及更好的上下文理解能力。',
+    displayName: 'Kimi K2 0905',
+    enabled: true,
+    id: 'kimi-k2-0905-preview',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
     contextWindowTokens: 131_072,
     description:
       'kimi-k2 是一款具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
-    displayName: 'Kimi K2',
-    enabled: true,
+    displayName: 'Kimi K2 0711',
     id: 'kimi-k2-0711-preview',
     pricing: {
       currency: 'CNY',
@@ -27,10 +47,10 @@ const moonshotChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 256_000,
     description:
       'kimi-k2 是一款具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
-    displayName: 'Kimi K2 Turbo',
+    displayName: 'Kimi K2 0905 Turbo',
     id: 'kimi-k2-turbo-preview',
     pricing: {
       currency: 'CNY',
@@ -40,7 +60,7 @@ const moonshotChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 64, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-07-11',
+    releasedAt: '2025-09-05',
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/novita.ts
+++ b/packages/model-bank/src/aiModels/novita.ts
@@ -433,8 +433,8 @@ const novitaChatModels: AIChatModelCard[] = [
     maxOutput: 8192,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/novita.ts
+++ b/packages/model-bank/src/aiModels/novita.ts
@@ -426,6 +426,20 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
+    contextWindowTokens: 131_072,
+    description: 'Gemma 3 12B 是谷歌的一款开源语言模型，以其在效率和性能方面设立了新的标准。',
+    displayName: 'Gemma 3 12B',
+    id: 'google/gemma-3-12b-it',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
     contextWindowTokens: 32_768,
     description: 'Gemma 3 1B 是谷歌的一款开源语言模型，以其在效率和性能方面设立了新的标准。',
     displayName: 'Gemma 3 1B',

--- a/packages/model-bank/src/aiModels/novita.ts
+++ b/packages/model-bank/src/aiModels/novita.ts
@@ -12,8 +12,8 @@ const novitaChatModels: AIChatModelCard[] = [
     id: 'deepseek/deepseek-v3.1',
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.55, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.66, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.27, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/novita.ts
+++ b/packages/model-bank/src/aiModels/novita.ts
@@ -5,10 +5,29 @@ const novitaChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'kimi-k2-0905-preview 模型上下文长度为 256k，具备更强的 Agentic Coding 能力、更突出的前端代码的美观度和实用性、以及更好的上下文理解能力。',
+    displayName: 'Kimi K2 0905',
+    id: 'moonshotai/kimi-k2-0905',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
     },
     contextWindowTokens: 163_840,
     displayName: 'DeepSeek V3.1',
+    enabled: true,
     id: 'deepseek/deepseek-v3.1',
     pricing: {
       units: [
@@ -128,10 +147,10 @@ const novitaChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      reasoning: true,
+      functionCall: true,
     },
     contextWindowTokens: 131_072,
-    displayName: 'Kimi K2 Instruct',
+    displayName: 'Kimi K2 0711',
     id: 'moonshotai/kimi-k2-instruct',
     pricing: {
       units: [
@@ -563,7 +582,6 @@ const novitaChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 163_840,
     displayName: 'Deepseek V3 0324',
-    enabled: true,
     id: 'deepseek/deepseek-v3-0324',
     pricing: {
       units: [
@@ -580,7 +598,6 @@ const novitaChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 163_840,
     displayName: 'Deepseek R1 0528',
-    enabled: true,
     id: 'deepseek/deepseek-r1-0528',
     pricing: {
       units: [

--- a/packages/model-bank/src/aiModels/novita.ts
+++ b/packages/model-bank/src/aiModels/novita.ts
@@ -286,12 +286,12 @@ const novitaChatModels: AIChatModelCard[] = [
     abilities: {
       reasoning: true,
     },
-    contextWindowTokens: 40_960,
+    contextWindowTokens: 32_768,
     displayName: 'Qwen3 30B A3B FP8',
     id: 'qwen/qwen3-30b-a3b-fp8',
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.09, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.45, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
@@ -413,7 +413,7 @@ const novitaChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
-    contextWindowTokens: 32_000,
+    contextWindowTokens: 32_768,
     description: 'Gemma 3 27B 是谷歌的一款开源语言模型，以其在效率和性能方面设立了新的标准。',
     displayName: 'Gemma 3 27B',
     id: 'google/gemma-3-27b-it',

--- a/packages/model-bank/src/aiModels/openrouter.ts
+++ b/packages/model-bank/src/aiModels/openrouter.ts
@@ -52,19 +52,6 @@ const openrouterChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      imageOutput: true,
-      vision: true,
-    },
-    contextWindowTokens: 32_768 + 8192,
-    description: 'Gemini 2.5 Flash 实验模型，支持图像生成',
-    displayName: 'Nano Banana (free)',
-    id: 'google/gemini-2.5-flash-image-preview:free',
-    maxOutput: 8192,
-    releasedAt: '2025-08-26',
-    type: 'chat',
-  },
-  {
-    abilities: {
       functionCall: true,
       reasoning: true,
     },

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -604,6 +604,68 @@ const qwenChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+    },
+    config: {
+      deploymentName: 'qwen3-max-preview',
+    },
+    contextWindowTokens: 262_144,
+    description:
+      '通义千问3系列Max模型Preview版本，相较2.5系列整体通用能力有大幅度提升，中英文通用文本理解能力、复杂指令遵循能力、主观开放任务能力、多语言能力、工具调用能力均显著增强；模型知识幻觉更少。',
+    displayName: 'Qwen3 Max Preview',
+    enabled: true,
+    id: 'qwen3-max-preview',
+    maxOutput: 32_768,
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 6 * 0.2,
+              '[32_000, 128_000]': 10 * 0.2,
+              '[128_000, infinity]': 15 * 0.2,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput_cacheRead',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 6,
+              '[32_000, 128_000]': 10,
+              '[128_000, infinity]': 15,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 24,
+              '[32_000, 128_000]': 40,
+              '[128_000, infinity]': 60,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       search: true,
     },
     config: {
@@ -613,7 +675,6 @@ const qwenChatModels: AIChatModelCard[] = [
     description:
       '通义千问千亿级别超大规模语言模型，支持中文、英文等不同语言输入，当前通义千问2.5产品版本背后的API模型。',
     displayName: 'Qwen Max',
-    enabled: true,
     id: 'qwen-max',
     maxOutput: 8192,
     organization: 'Qwen',

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -51,6 +51,26 @@ const siliconcloudChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Seed-OSS 是由字节跳动 Seed 团队开发的一系列开源大型语言模型，专为强大的长上下文处理、推理、智能体（agent）和通用能力而设计。该系列中的 Seed-OSS-36B-Instruct 是一个拥有 360 亿参数的指令微调模型，它原生支持超长上下文长度，使其能够一次性处理海量文档或复杂的代码库。该模型在推理、代码生成和智能体任务（如工具使用）方面进行了特别优化，同时保持了平衡且出色的通用能力。此模型的一大特色是“思考预算”（Thinking Budget）功能，允许用户根据需要灵活调整推理长度，从而在实际应用中有效提升推理效率。',
+    displayName: 'Seed OSS 36B Instruct',
+    id: 'ByteDance-Seed/Seed-OSS-36B-Instruct',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-08-20',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
       vision: true,
     },
     contextWindowTokens: 65_536,

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -111,7 +111,7 @@ const doubaoChatModels: AIChatModelCard[] = [
       vision: true,
     },
     config: {
-      deploymentName: 'doubao-seed-1-6-thinking-250615',
+      deploymentName: 'doubao-seed-1-6-thinking-250715',
     },
     contextWindowTokens: 256_000,
     description:
@@ -119,7 +119,7 @@ const doubaoChatModels: AIChatModelCard[] = [
     displayName: 'Doubao Seed 1.6 Thinking',
     enabled: true,
     id: 'doubao-seed-1.6-thinking',
-    maxOutput: 16_000,
+    maxOutput: 32_000,
     pricing: {
       currency: 'CNY',
       units: [
@@ -169,7 +169,7 @@ const doubaoChatModels: AIChatModelCard[] = [
     displayName: 'Doubao Seed 1.6',
     enabled: true,
     id: 'doubao-seed-1.6',
-    maxOutput: 16_000,
+    maxOutput: 32_000,
     pricing: {
       currency: 'CNY',
       units: [
@@ -215,7 +215,7 @@ const doubaoChatModels: AIChatModelCard[] = [
       vision: true,
     },
     config: {
-      deploymentName: 'doubao-seed-1-6-flash-250615',
+      deploymentName: 'doubao-seed-1-6-flash-250828',
     },
     contextWindowTokens: 256_000,
     description:
@@ -223,7 +223,7 @@ const doubaoChatModels: AIChatModelCard[] = [
     displayName: 'Doubao Seed 1.6 Flash',
     enabled: true,
     id: 'doubao-seed-1.6-flash',
-    maxOutput: 16_000,
+    maxOutput: 32_000,
     pricing: {
       currency: 'CNY',
       units: [

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1,7 +1,6 @@
 import { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
 
-// modelInfo https://www.volcengine.com/docs/82379/1330310
-// pricing https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement
+// https://www.volcengine.com/docs/82379/1330310
 
 const doubaoChatModels: AIChatModelCard[] = [
   {
@@ -42,7 +41,6 @@ const doubaoChatModels: AIChatModelCard[] = [
     description:
       'Kimi-K2 是一款Moonshot AI推出的具备超强代码和 Agent 能力的 MoE 架构基础模型，总参数 1T，激活参数 32B。在通用知识推理、编程、数学、Agent 等主要类别的基准性能测试中，K2 模型的性能超过其他主流开源模型。',
     displayName: 'Kimi K2',
-    enabled: true,
     id: 'kimi-k2',
     maxOutput: 16_384,
     pricing: {
@@ -51,6 +49,58 @@ const doubaoChatModels: AIChatModelCard[] = [
         { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
       ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    config: {
+      deploymentName: 'doubao-seed-1-6-vision-250815',
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Doubao-Seed-1.6-vision 视觉深度思考模型，在教育、图像审核、巡检与安防和AI 搜索问答等场景下展现出更强的通用多模态理解和推理能力。支持 256k 上下文窗口，输出长度支持最大 64k tokens。',
+    displayName: 'Doubao Seed 1.6 Vision',
+    id: 'doubao-seed-1.6-vision',
+    maxOutput: 32_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 0.8,
+              '[32_000, 128_000]': 2.4,
+              '[128_000, infinity]': 4.8,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 8,
+              '[32_000, 128_000]': 16,
+              '[128_000, infinity]': 24,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.16, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      extendParams: ['enableReasoning'],
     },
     type: 'chat',
   },
@@ -73,8 +123,33 @@ const doubaoChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 0.8,
+              '[32_000, 128_000]': 1.2,
+              '[128_000, infinity]': 2.4,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 8,
+              '[32_000, 128_000]': 16,
+              '[128_000, infinity]': 24,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.16, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',
@@ -98,8 +173,34 @@ const doubaoChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 0.8,
+              '[32_000, 128_000]': 1.2,
+              '[128_000, infinity]': 2.4,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]_[0, 8192]': 2,
+              '[0, 32_000]_[8192, infinity]': 8,
+              '[32_000, 128_000]_[0, infinity]': 16,
+              '[128_000, infinity]_[0, infinity]': 24,
+            },
+            pricingParams: ['textInputRange', 'textOutputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.16, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     settings: {
@@ -126,8 +227,33 @@ const doubaoChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 0.15,
+              '[32_000, 128_000]': 0.3,
+              '[128_000, infinity]': 0.6,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 32_000]': 1.5,
+              '[32_000, 128_000]': 3,
+              '[128_000, infinity]': 6,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     settings: {
@@ -235,7 +361,7 @@ const doubaoChatModels: AIChatModelCard[] = [
       ],
     },
     settings: {
-      extendParams: ['enableReasoning'],
+      extendParams: ['thinking'],
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Update and refine model-bank configurations across multiple providers by adding new models, standardizing pricing, updating metadata, and removing deprecated entries

New Features:
- Add Doubao Seed 1.6 Vision model with multimodal capabilities and tiered pricing
- Introduce DeepSeek V3.1 (Think) and (Fast) variants in Aihubmix
- Add Gemma 3 12B model in Novita and Seed OSS 36B Instruct in Siliconcloud

Enhancements:
- Standardize pricing strategies for doubao and related models using lookup tiers and cacheRead rates
- Update display names, IDs, descriptions, context window sizes, and release dates for existing models including Compound, Hunyuan T1, Qwen3, and Gemma 3 27B
- Rename groq models from Compound-beta to groq/compound and Compound Mini

Chores:
- Remove deprecated Nano Banana model from Openrouter
- Clean up obsolete comments and remove redundant 'enabled' flags