### PR TITLE
fix: fix socks5 proxy not work problem

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "electron-updater": "^6.6.2",
     "electron-window-state": "^5.0.3",
+    "fetch-socks": "^1.3.2",
     "get-port-please": "^3.1.2",
     "pdfjs-dist": "4.10.38"
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enhance the proxy dispatcher to correctly handle SOCKS5 proxies using fetch-socks while retaining existing HTTP/HTTPS support via undici ProxyAgent.

Bug Fixes:
- Fix SOCKS5 proxy support by parsing the proxy URL and routing connections through socksDispatcher for type 5 proxies

Enhancements:
- Add fetch-socks dependency for SOCKS5 proxy handling