### PR TITLE
🐛 fix: Support base64 image from markdown image syntax

### DIFF
--- a/packages/model-runtime/src/utils/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/utils/streams/openai/openai.test.ts
@@ -2399,7 +2399,7 @@ describe('OpenAIStream', () => {
     expect(chunks).toEqual([
       'id: chatcmpl-test\n',
       'event: text\n',
-      `data: "这有一张图片： ![image](${base64})"\n\n`,
+      `data: "这有一张图片："\n\n`,
       'id: chatcmpl-test\n',
       'event: base64_image\n',
       `data: "${base64}"\n\n`,
@@ -2439,7 +2439,7 @@ describe('OpenAIStream', () => {
     expect(chunks).toEqual([
       'id: chatcmpl-multi\n',
       'event: text\n',
-      `data: "![img1](${base64_1}) and ![img2](${base64_2})"\n\n`,
+      `data: "and"\n\n`, // Remove all markdown base64 image segments
       'id: chatcmpl-multi\n',
       'event: base64_image\n',
       `data: "${base64_1}"\n\n`,

--- a/packages/model-runtime/src/utils/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/utils/streams/openai/openai.test.ts
@@ -163,7 +163,7 @@ describe('OpenAIStream', () => {
     );
   });
 
-  it('should emit base64_image when markdown contains data:image in normal text delta', async () => {
+  it('should emit base64_image and strip markdown data:image from text', async () => {
     const data = [
       {
         id: 'img-1',
@@ -208,9 +208,6 @@ describe('OpenAIStream', () => {
         'id: img-1',
         'event: text',
         `data: "这是一张图片： "\n`,
-        'id: img-1',
-        'event: text',
-        `data: "![image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAAB3D1E1AA==)"\n`,
         'id: img-1',
         'event: base64_image',
         `data: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAAB3D1E1AA=="\n`,

--- a/packages/model-runtime/src/utils/streams/openai/openai.ts
+++ b/packages/model-runtime/src/utils/streams/openai/openai.ts
@@ -329,6 +329,17 @@ const transformOpenAIStream = (
           }
         }
 
+        // 非思考模式下，额外解析 markdown 中的 base64 图片，按顺序输出 text -> base64_image
+        if (!streamContext?.thinkingInContent) {
+          const urls = extractBase64ImageUrlsFromMarkdown(thinkingContent);
+          if (urls.length > 0) {
+            return [
+              { data: thinkingContent, id: chunk.id, type: 'text' },
+              ...urls.map((url) => ({ data: url, id: chunk.id, type: 'base64_image' as const })),
+            ];
+          }
+        }
+
         // 根据当前思考模式确定返回类型
         return {
           data: thinkingContent,


### PR DESCRIPTION
…thin OpenAI stream

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

测试可用

<img width="1577" height="726" alt="image" src="https://github.com/user-attachments/assets/682ed088-5982-4692-8250-85781fffddf7" />


- close #9035

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Support base64 images embedded in markdown syntax by extracting them and emitting separate base64_image events in OpenAIStream

Bug Fixes:
- Emit separate base64_image protocol events for embedded base64 image URLs in markdown content

Enhancements:
- Add extractBase64ImageUrlsFromMarkdown utility to parse base64 image URLs from markdown

Tests:
- Add tests to verify handling of single and multiple markdown-embedded base64 images in OpenAIStream