### PR TITLE
fix: fix virtuaso minheight was null

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/ByTimeMode/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@topic/features/TopicListContent/ByTimeMode/index.tsx
@@ -55,14 +55,11 @@ const ByTimeMode = memo(() => {
   const groupContent = useCallback(
     (index: number) => {
       if (index === 0) return <div style={{ height: 1 }} />;
-
       const topicGroup = groups[index];
       return <TopicGroupItem {...topicGroup} />;
     },
     [groups],
   );
-
-  // const activeIndex = topics.findIndex((topic) => topic.id === activeTopicId);
 
   return (
     <GroupedVirtuoso
@@ -70,6 +67,9 @@ const ByTimeMode = memo(() => {
       groupCounts={groupCounts}
       itemContent={itemContent}
       ref={virtuosoRef}
+      style={{
+        minHeight: groupCounts.length === 1 ? '0px' : '200px',
+      }}
     />
   );
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

https://github.com/lobehub/lobe-chat/issues/8408

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Set a default minHeight for GroupedVirtuoso to avoid null values