### PR TITLE
🐛 fix(modelProvider): add lmstudio to provider whitelist to enable fetchOnClient toggle

### DIFF
--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -25,7 +25,7 @@ const activeProviderConfig = (s: AIProviderStoreState) => s.aiProviderDetail;
 const isAiProviderConfigLoading = (id: string) => (s: AIProviderStoreState) =>
   s.activeAiProvider !== id;
 
-const providerWhitelist = new Set(['ollama']);
+const providerWhitelist = new Set(['ollama', 'lmstudio']);
 
 const activeProviderKeyVaults = (s: AIProviderStoreState) => activeProviderConfig(s)?.keyVaults;
 

--- a/src/store/user/slices/modelList/selectors/modelConfig.ts
+++ b/src/store/user/slices/modelList/selectors/modelConfig.ts
@@ -9,7 +9,7 @@ import { keyVaultsConfigSelectors } from './keyVaults';
 const isProviderEnabled = (provider: GlobalLLMProviderKey) => (s: UserStore) =>
   getProviderConfigById(provider)(s)?.enabled || false;
 
-const providerWhitelist = new Set(['ollama']);
+const providerWhitelist = new Set(['ollama', 'lmstudio']);
 /**
  * @description The conditions to enable client fetch
  * 1. If no baseUrl and apikey input, force on Server.


### PR DESCRIPTION
- Add 'lmstudio' to providerWhitelist in both user and aiInfra store selectors
- Fix issue where LMStudio's client fetch mode toggle was non-functional
- Users can now properly control client/server request mode for LMStudio
- Resolves forced client mode when only baseURL is configured

Fixes client request mode control for LMStudio provider

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Allow LMStudio provider to respect client/server fetch mode toggle by whitelisting it in relevant selectors

Bug Fixes:
- Add 'lmstudio' to providerWhitelist in AI provider and model config selectors
- Restore client/server request mode control for LMStudio by removing forced client mode when only baseURL is configured