### PR TITLE
🐛Fix: non streaming not displaying token usage and thinking content

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -392,33 +392,20 @@ describe('LobeOpenAICompatibleFactory', () => {
           stream.push(decoder.decode(value));
         }
 
-        expect(stream.length).toBe(12);
-
-        expect(stream[0]).toEqual('id: a\n');
-        expect(stream[1]).toEqual('event: text\n');
-        expect(stream[2]).toEqual('data: "Hello"\n\n');
-
-        expect(stream[3]).toEqual('id: a\n');
-        expect(stream[4]).toEqual('event: usage\n');
-        expect(stream[5]).toEqual(
+        expect(stream).toEqual([
+          'id: a\n',
+          'event: text\n',
+          'data: "Hello"\n\n',
+          'id: a\n',
+          'event: usage\n',
           'data: {"inputTextTokens":5,"outputTextTokens":5,"totalInputTokens":5,"totalOutputTokens":5,"totalTokens":10}\n\n',
-        );
-
-        expect(stream[6]).toEqual('id: output_speed\n');
-        expect(stream[7]).toEqual('event: speed\n');
-
-        //  tps ttft
-        const speedDataChunk = stream[8];
-        expect(speedDataChunk).toMatch(/^data: \{.*}\n\n$/);
-        const dataJsonString = speedDataChunk.substring('data: '.length, speedDataChunk.length - 2); // 移除 'data: ' 和 '\n\n'
-        const speedDataObject = JSON.parse(dataJsonString);
-        expect(speedDataObject).toHaveProperty('tps');
-        expect(speedDataObject).toHaveProperty('ttft');
-        expect(speedDataObject.ttft).toBeGreaterThanOrEqual(0);
-
-        expect(stream[9]).toEqual('id: a\n');
-        expect(stream[10]).toEqual('event: stop\n');
-        expect(stream[11]).toEqual('data: "stop"\n\n');
+          'id: output_speed\n',
+          'event: speed\n',
+          expect.stringMatching(/^data: \{.*"tps":.*,"ttft":.*}\n\n$/), // tps ttft 测试结果不一样
+          'id: a\n',
+          'event: stop\n',
+          'data: "stop"\n\n',
+        ]);
 
         expect((await reader.read()).done).toBe(true);
       });
@@ -468,35 +455,23 @@ describe('LobeOpenAICompatibleFactory', () => {
           stream.push(decoder.decode(value));
         }
 
-        expect(stream[0]).toEqual('id: a\n');
-        expect(stream[1]).toEqual('event: reasoning\n');
-        expect(stream[2]).toEqual('data: "Thinking content"\n\n');
-
-        expect(stream[3]).toEqual('id: a\n');
-        expect(stream[4]).toEqual('event: text\n');
-        expect(stream[5]).toEqual('data: "Hello"\n\n');
-
-        expect(stream[6]).toEqual('id: a\n');
-        expect(stream[7]).toEqual('event: usage\n');
-        expect(stream[8]).toEqual(
+        expect(stream).toEqual([
+          'id: a\n',
+          'event: reasoning\n',
+          'data: "Thinking content"\n\n',
+          'id: a\n',
+          'event: text\n',
+          'data: "Hello"\n\n',
+          'id: a\n',
+          'event: usage\n',
           'data: {"inputTextTokens":5,"outputTextTokens":5,"totalInputTokens":5,"totalOutputTokens":5,"totalTokens":10}\n\n',
-        );
-
-        expect(stream[9]).toEqual('id: output_speed\n');
-        expect(stream[10]).toEqual('event: speed\n');
-
-        //  tps ttft
-        const speedDataChunk = stream[11];
-        expect(speedDataChunk).toMatch(/^data: \{.*}\n\n$/);
-        const dataJsonString = speedDataChunk.substring('data: '.length, speedDataChunk.length - 2); // 移除 'data: ' 和 '\n\n'
-        const speedDataObject = JSON.parse(dataJsonString);
-        expect(speedDataObject).toHaveProperty('tps');
-        expect(speedDataObject).toHaveProperty('ttft');
-        expect(speedDataObject.ttft).toBeGreaterThanOrEqual(0);
-
-        expect(stream[12]).toEqual('id: a\n');
-        expect(stream[13]).toEqual('event: stop\n');
-        expect(stream[14]).toEqual('data: "stop"\n\n');
+          'id: output_speed\n',
+          'event: speed\n',
+          expect.stringMatching(/^data: \{.*"tps":.*,"ttft":.*}\n\n$/), // tps ttft 测试结果不一样
+          'id: a\n',
+          'event: stop\n',
+          'data: "stop"\n\n',
+        ]);
 
         expect((await reader.read()).done).toBe(true);
       });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -403,8 +403,9 @@ describe('LobeOpenAICompatibleFactory', () => {
 
           'id: output_speed\n',
           'event: speed\n',
-          'data: {"tps":5000,"ttft":0}\n\n',
+          'data: {"tps":5000,"ttft":1}\n\n',
 
+          'id: a\n',
           'event: stop\n',
           'data: "stop"\n\n',
         ]);
@@ -472,8 +473,9 @@ describe('LobeOpenAICompatibleFactory', () => {
 
           'id: output_speed\n',
           'event: speed\n',
-          'data: {"tps":5000,"ttft":0}\n\n',
+          'data: {"tps":1666.6666666666667,"ttft":1}\n\n',
 
+          'id: a\n',
           'event: stop\n',
           'data: "stop"\n\n',
         ]);

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -473,7 +473,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
           'id: output_speed\n',
           'event: speed\n',
-          'data: {"tps":1666.6666666666667,"ttft":1}\n\n',
+          'data: {"tps":5000,"ttft":1}\n\n',
 
           'id: a\n',
           'event: stop\n',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -392,23 +392,33 @@ describe('LobeOpenAICompatibleFactory', () => {
           stream.push(decoder.decode(value));
         }
 
-        expect(stream).toEqual([
-          'id: a\n',
-          'event: text\n',
-          'data: "Hello"\n\n',
+        expect(stream.length).toBe(12);
 
-          'id: a\n',
-          'event: usage\n',
+        expect(stream[0]).toEqual('id: a\n');
+        expect(stream[1]).toEqual('event: text\n');
+        expect(stream[2]).toEqual('data: "Hello"\n\n');
+
+        expect(stream[3]).toEqual('id: a\n');
+        expect(stream[4]).toEqual('event: usage\n');
+        expect(stream[5]).toEqual(
           'data: {"inputTextTokens":5,"outputTextTokens":5,"totalInputTokens":5,"totalOutputTokens":5,"totalTokens":10}\n\n',
+        );
 
-          'id: output_speed\n',
-          'event: speed\n',
-          'data: {"tps":5000,"ttft":1}\n\n',
+        expect(stream[6]).toEqual('id: output_speed\n');
+        expect(stream[7]).toEqual('event: speed\n');
 
-          'id: a\n',
-          'event: stop\n',
-          'data: "stop"\n\n',
-        ]);
+        //  tps ttft
+        const speedDataChunk = stream[8];
+        expect(speedDataChunk).toMatch(/^data: \{.*}\n\n$/);
+        const dataJsonString = speedDataChunk.substring('data: '.length, speedDataChunk.length - 2); // 移除 'data: ' 和 '\n\n'
+        const speedDataObject = JSON.parse(dataJsonString);
+        expect(speedDataObject).toHaveProperty('tps');
+        expect(speedDataObject).toHaveProperty('ttft');
+        expect(speedDataObject.ttft).toBeGreaterThanOrEqual(0);
+
+        expect(stream[9]).toEqual('id: a\n');
+        expect(stream[10]).toEqual('event: stop\n');
+        expect(stream[11]).toEqual('data: "stop"\n\n');
 
         expect((await reader.read()).done).toBe(true);
       });
@@ -458,27 +468,35 @@ describe('LobeOpenAICompatibleFactory', () => {
           stream.push(decoder.decode(value));
         }
 
-        expect(stream).toEqual([
-          'id: a\n',
-          'event: reasoning\n',
-          'data: "Thinking content"\n\n',
+        expect(stream[0]).toEqual('id: a\n');
+        expect(stream[1]).toEqual('event: reasoning\n');
+        expect(stream[2]).toEqual('data: "Thinking content"\n\n');
 
-          'id: a\n',
-          'event: text\n',
-          'data: "Hello"\n\n',
+        expect(stream[3]).toEqual('id: a\n');
+        expect(stream[4]).toEqual('event: text\n');
+        expect(stream[5]).toEqual('data: "Hello"\n\n');
 
-          'id: a\n',
-          'event: usage\n',
+        expect(stream[6]).toEqual('id: a\n');
+        expect(stream[7]).toEqual('event: usage\n');
+        expect(stream[8]).toEqual(
           'data: {"inputTextTokens":5,"outputTextTokens":5,"totalInputTokens":5,"totalOutputTokens":5,"totalTokens":10}\n\n',
+        );
 
-          'id: output_speed\n',
-          'event: speed\n',
-          'data: {"tps":5000,"ttft":1}\n\n',
+        expect(stream[9]).toEqual('id: output_speed\n');
+        expect(stream[10]).toEqual('event: speed\n');
 
-          'id: a\n',
-          'event: stop\n',
-          'data: "stop"\n\n',
-        ]);
+        //  tps ttft
+        const speedDataChunk = stream[11];
+        expect(speedDataChunk).toMatch(/^data: \{.*}\n\n$/);
+        const dataJsonString = speedDataChunk.substring('data: '.length, speedDataChunk.length - 2); // 移除 'data: ' 和 '\n\n'
+        const speedDataObject = JSON.parse(dataJsonString);
+        expect(speedDataObject).toHaveProperty('tps');
+        expect(speedDataObject).toHaveProperty('ttft');
+        expect(speedDataObject.ttft).toBeGreaterThanOrEqual(0);
+
+        expect(stream[12]).toEqual('id: a\n');
+        expect(stream[13]).toEqual('event: stop\n');
+        expect(stream[14]).toEqual('data: "stop"\n\n');
 
         expect((await reader.read()).done).toBe(true);
       });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -165,6 +165,7 @@ export function transformResponseToStream(data: OpenAI.ChatCompletion) {
         model: data.model,
         object: 'chat.completion.chunk',
         system_fingerprint: data.system_fingerprint,
+        ...(data.usage ? { usage: data.usage } : {}),
       } as OpenAI.ChatCompletionChunk);
       controller.close();
     },

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -172,7 +172,16 @@ export function transformResponseToStream(data: OpenAI.ChatCompletion) {
       };
 
       controller.enqueue(chunk);
-
+      if (data.usage) {
+        controller.enqueue({
+          choices: [],
+          created: data.created,
+          id: data.id,
+          model: data.model,
+          object: 'chat.completion.chunk',
+          usage: data.usage,
+        } as unknown as OpenAI.ChatCompletionChunk);
+      }
       controller.enqueue({
         choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
           delta: {
@@ -188,7 +197,6 @@ export function transformResponseToStream(data: OpenAI.ChatCompletion) {
         model: data.model,
         object: 'chat.completion.chunk',
         system_fingerprint: data.system_fingerprint,
-        ...(data.usage ? { usage: data.usage } : {}),
       } as OpenAI.ChatCompletionChunk);
       controller.close();
     },

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -343,7 +343,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
                 callbacks: streamOptions.callbacks,
                 inputStartAt,
               })
-            : OpenAIStream(stream, { ...streamOptions, inputStartAt }),
+            : OpenAIStream(stream, { ...streamOptions, enableStreaming: false, inputStartAt }),
           {
             headers: options?.headers,
           },

--- a/packages/model-runtime/src/core/streams/anthropic.ts
+++ b/packages/model-runtime/src/core/streams/anthropic.ts
@@ -240,12 +240,13 @@ export const transformAnthropicStream = (
 
 export interface AnthropicStreamOptions {
   callbacks?: ChatStreamCallbacks;
+  enableStreaming?: boolean; // 选择 TPS 计算方式（非流式时传 false）
   inputStartAt?: number;
 }
 
 export const AnthropicStream = (
   stream: Stream<Anthropic.MessageStreamEvent> | ReadableStream,
-  { callbacks, inputStartAt }: AnthropicStreamOptions = {},
+  { callbacks, inputStartAt, enableStreaming = true }: AnthropicStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: '' };
 
@@ -254,7 +255,11 @@ export const AnthropicStream = (
 
   return readableStream
     .pipeThrough(
-      createTokenSpeedCalculator(transformAnthropicStream, { inputStartAt, streamStack }),
+      createTokenSpeedCalculator(transformAnthropicStream, {
+        enableStreaming: enableStreaming,
+        inputStartAt,
+        streamStack,
+      }),
     )
     .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
     .pipeThrough(createCallbacksTransformer(callbacks));

--- a/packages/model-runtime/src/core/streams/google-ai.ts
+++ b/packages/model-runtime/src/core/streams/google-ai.ts
@@ -203,7 +203,7 @@ const transformGoogleGenerativeAIStream = (
 
 export interface GoogleAIStreamOptions {
   callbacks?: ChatStreamCallbacks;
-  enableStreaming?: boolean; // // 选择 TPS 计算方式（非流式时传 false）
+  enableStreaming?: boolean; // 选择 TPS 计算方式（非流式时传 false）
   inputStartAt?: number;
 }
 

--- a/packages/model-runtime/src/core/streams/google-ai.ts
+++ b/packages/model-runtime/src/core/streams/google-ai.ts
@@ -203,18 +203,23 @@ const transformGoogleGenerativeAIStream = (
 
 export interface GoogleAIStreamOptions {
   callbacks?: ChatStreamCallbacks;
+  enableStreaming?: boolean; // // 选择 TPS 计算方式（非流式时传 false）
   inputStartAt?: number;
 }
 
 export const GoogleGenerativeAIStream = (
   rawStream: ReadableStream<GenerateContentResponse>,
-  { callbacks, inputStartAt }: GoogleAIStreamOptions = {},
+  { callbacks, inputStartAt, enableStreaming = true }: GoogleAIStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: 'chat_' + nanoid() };
 
   return rawStream
     .pipeThrough(
-      createTokenSpeedCalculator(transformGoogleGenerativeAIStream, { inputStartAt, streamStack }),
+      createTokenSpeedCalculator(transformGoogleGenerativeAIStream, {
+        enableStreaming: enableStreaming,
+        inputStartAt,
+        streamStack,
+      }),
     )
     .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
     .pipeThrough(createCallbacksTransformer(callbacks));

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -417,13 +417,20 @@ export interface OpenAIStreamOptions {
     name: string;
   }) => ILobeAgentRuntimeErrorType | undefined;
   callbacks?: ChatStreamCallbacks;
+  enableStreaming?: boolean; // 选择 TPS 计算方式（非流式时传 false）
   inputStartAt?: number;
   provider?: string;
 }
 
 export const OpenAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-  { callbacks, provider, bizErrorTypeTransformer, inputStartAt }: OpenAIStreamOptions = {},
+  {
+    callbacks,
+    provider,
+    bizErrorTypeTransformer,
+    inputStartAt,
+    enableStreaming = true,
+  }: OpenAIStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: '' };
 
@@ -439,7 +446,13 @@ export const OpenAIStream = (
       // provider like huggingface or minimax will return error in the stream,
       // so in the first Transformer, we need to handle the error
       .pipeThrough(createFirstErrorHandleTransformer(bizErrorTypeTransformer, provider))
-      .pipeThrough(createTokenSpeedCalculator(transformWithProvider, { inputStartAt, streamStack }))
+      .pipeThrough(
+        createTokenSpeedCalculator(transformWithProvider, {
+          enableStreaming: enableStreaming,
+          inputStartAt,
+          streamStack,
+        }),
+      )
       .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
       .pipeThrough(createCallbacksTransformer(callbacks))
   );

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -185,7 +185,13 @@ const transformOpenAIStream = (
 
 export const OpenAIResponsesStream = (
   stream: Stream<OpenAI.Responses.ResponseStreamEvent> | ReadableStream,
-  { callbacks, provider, bizErrorTypeTransformer, inputStartAt }: OpenAIStreamOptions = {},
+  {
+    callbacks,
+    provider,
+    bizErrorTypeTransformer,
+    inputStartAt,
+    enableStreaming = true,
+  }: OpenAIStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: '' };
 
@@ -198,7 +204,13 @@ export const OpenAIResponsesStream = (
       // provider like huggingface or minimax will return error in the stream,
       // so in the first Transformer, we need to handle the error
       .pipeThrough(createFirstErrorHandleTransformer(bizErrorTypeTransformer, provider))
-      .pipeThrough(createTokenSpeedCalculator(transformOpenAIStream, { inputStartAt, streamStack }))
+      .pipeThrough(
+        createTokenSpeedCalculator(transformOpenAIStream, {
+          enableStreaming: enableStreaming,
+          inputStartAt,
+          streamStack,
+        }),
+      )
       .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
       .pipeThrough(createCallbacksTransformer(callbacks))
   );

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -340,7 +340,7 @@ export const createTokenSpeedCalculator = (
   {
     inputStartAt,
     streamStack,
-    enableStreaming = true, // // 选择 TPS 计算方式（非流式时传 false）
+    enableStreaming = true, // 选择 TPS 计算方式（非流式时传 false）
   }: { enableStreaming?: boolean; inputStartAt?: number; streamStack?: StreamContext } = {},
 ) => {
   let outputStartAt: number | undefined;

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -337,7 +337,11 @@ export const TOKEN_SPEED_CHUNK_ID = 'output_speed';
  */
 export const createTokenSpeedCalculator = (
   transformer: (chunk: any, stack: StreamContext) => StreamProtocolChunk | StreamProtocolChunk[],
-  { inputStartAt, streamStack }: { inputStartAt?: number; streamStack?: StreamContext } = {},
+  {
+    inputStartAt,
+    streamStack,
+    enableStreaming = true, // // 选择 TPS 计算方式（非流式时传 false）
+  }: { enableStreaming?: boolean; inputStartAt?: number; streamStack?: StreamContext } = {},
 ) => {
   let outputStartAt: number | undefined;
   let outputThinking: boolean | undefined;
@@ -374,7 +378,9 @@ export const createTokenSpeedCalculator = (
           : Math.max(0, totalOutputTokens - reasoningTokens);
       result.push({
         data: {
-          tps: (outputTokens / (Date.now() - outputStartAt)) * 1000,
+          // 非流式计算 tps 从发出请求开始算
+          tps:
+            (outputTokens / (Date.now() - (enableStreaming ? outputStartAt : inputStartAt))) * 1000,
           ttft: outputStartAt - inputStartAt,
         } as ModelSpeed,
         id: TOKEN_SPEED_CHUNK_ID,

--- a/packages/model-runtime/src/core/streams/qwen.ts
+++ b/packages/model-runtime/src/core/streams/qwen.ts
@@ -116,7 +116,11 @@ export const QwenAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
   // TODO: preserve for RFC 097
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
-  { callbacks, inputStartAt }: { callbacks?: ChatStreamCallbacks; inputStartAt?: number } = {},
+  {
+    callbacks,
+    inputStartAt,
+    enableStreaming = true,
+  }: { callbacks?: ChatStreamCallbacks; enableStreaming?: boolean; inputStartAt?: number } = {},
 ) => {
   const streamContext: StreamContext = { id: '' };
   const readableStream =
@@ -124,7 +128,11 @@ export const QwenAIStream = (
 
   return readableStream
     .pipeThrough(
-      createTokenSpeedCalculator(transformQwenStream, { inputStartAt, streamStack: streamContext }),
+      createTokenSpeedCalculator(transformQwenStream, {
+        enableStreaming: enableStreaming,
+        inputStartAt,
+        streamStack: streamContext,
+      }),
     )
     .pipeThrough(createSSEProtocolTransformer((c) => c, streamContext))
     .pipeThrough(createCallbacksTransformer(callbacks));

--- a/packages/model-runtime/src/core/streams/spark.test.ts
+++ b/packages/model-runtime/src/core/streams/spark.test.ts
@@ -114,7 +114,7 @@ describe('SparkAIStream', () => {
       chunks.push(chunk);
     }
 
-    expect(chunks).toHaveLength(2);
+    expect(chunks).toHaveLength(3);
     expect(chunks[0].choices[0].delta.tool_calls).toEqual([
       {
         function: {
@@ -126,7 +126,7 @@ describe('SparkAIStream', () => {
         type: 'function',
       },
     ]);
-    expect(chunks[1].choices[0].finish_reason).toBeDefined();
+    expect(chunks[2].choices[0].finish_reason).toBeDefined();
   });
 
   it('should transform streaming response with tool calls', async () => {

--- a/packages/model-runtime/src/core/streams/spark.ts
+++ b/packages/model-runtime/src/core/streams/spark.ts
@@ -50,7 +50,16 @@ export function transformSparkResponseToStream(data: OpenAI.ChatCompletion) {
       };
 
       controller.enqueue(chunk);
-
+      if (data.usage) {
+        controller.enqueue({
+          choices: [],
+          created: data.created,
+          id: data.id,
+          model: data.model,
+          object: 'chat.completion.chunk',
+          usage: data.usage,
+        } as unknown as OpenAI.ChatCompletionChunk);
+      }
       controller.enqueue({
         choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
           delta: {
@@ -66,7 +75,6 @@ export function transformSparkResponseToStream(data: OpenAI.ChatCompletion) {
         model: data.model,
         object: 'chat.completion.chunk',
         system_fingerprint: data.system_fingerprint,
-        ...(data.usage ? { usage: data.usage } : {}),
       } as OpenAI.ChatCompletionChunk);
       controller.close();
     },

--- a/packages/model-runtime/src/core/streams/spark.ts
+++ b/packages/model-runtime/src/core/streams/spark.ts
@@ -66,6 +66,7 @@ export function transformSparkResponseToStream(data: OpenAI.ChatCompletion) {
         model: data.model,
         object: 'chat.completion.chunk',
         system_fingerprint: data.system_fingerprint,
+        ...(data.usage ? { usage: data.usage } : {}),
       } as OpenAI.ChatCompletionChunk);
       controller.close();
     },

--- a/packages/model-runtime/src/core/streams/vertex-ai.ts
+++ b/packages/model-runtime/src/core/streams/vertex-ai.ts
@@ -143,12 +143,18 @@ const transformVertexAIStream = (
 
 export const VertexAIStream = (
   rawStream: ReadableStream<GenerateContentResponse>,
-  { callbacks, inputStartAt }: GoogleAIStreamOptions = {},
+  { callbacks, inputStartAt, enableStreaming = true }: GoogleAIStreamOptions = {},
 ) => {
   const streamStack: StreamContext = { id: 'chat_' + nanoid() };
 
   return rawStream
-    .pipeThrough(createTokenSpeedCalculator(transformVertexAIStream, { inputStartAt, streamStack }))
+    .pipeThrough(
+      createTokenSpeedCalculator(transformVertexAIStream, {
+        enableStreaming: enableStreaming,
+        inputStartAt,
+        streamStack,
+      }),
+    )
     .pipeThrough(createSSEProtocolTransformer((c) => c, streamStack))
     .pipeThrough(createCallbacksTransformer(callbacks));
 };

--- a/packages/model-runtime/src/providers/azureOpenai/index.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.ts
@@ -96,9 +96,12 @@ export class LobeAzureOpenAI implements LobeRuntimeAI {
         });
       } else {
         const stream = transformResponseToStream(response as OpenAI.ChatCompletion);
-        return StreamingResponse(OpenAIStream(stream, { callbacks: options?.callback }), {
-          headers: options?.headers,
-        });
+        return StreamingResponse(
+          OpenAIStream(stream, { callbacks: options?.callback, enableStreaming: false }),
+          {
+            headers: options?.headers,
+          },
+        );
       }
     } catch (e) {
       return this.handleError(e, model);

--- a/packages/model-runtime/src/providers/azureai/index.ts
+++ b/packages/model-runtime/src/providers/azureai/index.ts
@@ -83,9 +83,12 @@ export class LobeAzureAI implements LobeRuntimeAI {
 
         // the azure AI inference response is openai compatible
         const stream = transformResponseToStream(res.body as OpenAI.ChatCompletion);
-        return StreamingResponse(OpenAIStream(stream, { callbacks: options?.callback }), {
-          headers: options?.headers,
-        });
+        return StreamingResponse(
+          OpenAIStream(stream, { callbacks: options?.callback, enableStreaming: false }),
+          {
+            headers: options?.headers,
+          },
+        );
       }
     } catch (e) {
       let error = e as { [key: string]: any; code: string; message: string };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- 修复非流式不显示Token统计和用量，非流式tps计算时间范围从发出请求到收到消息
- 修复非流式不显示深度思考内容（部分支持输出思考内容的有：Deepseek、Volcengine、SiliconCloud等）
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- close #9001
<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Ensure non-streaming chat completions include token usage and reasoning content, and allow disabling TPS calculation when streaming is disabled

Bug Fixes:
- Include token usage events in non-streaming ChatCompletion streams
- Emit reasoning_content from models like Deepseek in non-streaming mode

Enhancements:
- Introduce enabledTps flag to disable TPS computation for non-streaming responses across various stream processors
- Update createTokenSpeedCalculator to respect enabledTps and skip TPS calculation when false

Tests:
- Add tests to verify non-streaming streams emit reasoning, text, usage, speed, and stop events
- Adjust SparkAIStream tests to expect the additional usage chunk in streaming transformations