### PR TITLE
 🔨 chore(model-runtime): openai stream error not inherited correctly

### DIFF
--- a/packages/model-runtime/src/core/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.test.ts
@@ -362,7 +362,7 @@ describe('OpenAIStream', () => {
     expect(chunks).toEqual([
       'id: first_chunk_error\n',
       'event: error\n',
-      `data: {"body":{"errorType":"ProviderBizError","message":"Test error"},"type":"ProviderBizError"}\n\n`,
+      `data: {"body":{"errorType":"ProviderBizError","message":"Test error"},"message":"Test error","type":"ProviderBizError"}\n\n`,
     ]);
   });
 
@@ -393,7 +393,7 @@ describe('OpenAIStream', () => {
     expect(chunks).toEqual([
       'id: first_chunk_error\n',
       'event: error\n',
-      `data: {"body":{"message":"Custom error","errorType":"PermissionDenied","provider":"grok"},"type":"PermissionDenied"}\n\n`,
+      `data: {"body":{"message":"Custom error","errorType":"PermissionDenied","provider":"grok"},"message":"Custom error","type":"PermissionDenied"}\n\n`,
     ]);
   });
 

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -57,8 +57,9 @@ const transformOpenAIStream = (
 
     const errorData = {
       body: chunk,
-      type: 'errorType' in chunk ? chunk.errorType : AgentRuntimeErrorType.ProviderBizError,
-    } as ChatMessageError;
+      message: 'message' in chunk ? typeof chunk.message === 'string' ? chunk.message : JSON.stringify(chunk) : JSON.stringify(chunk),
+      type: 'errorType' in chunk ? chunk.errorType as typeof AgentRuntimeErrorType.ProviderBizError : AgentRuntimeErrorType.ProviderBizError,
+    } satisfies ChatMessageError;
     return { data: errorData, id: 'first_chunk_error', type: 'error' };
   }
 

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -45,8 +45,9 @@ const transformOpenAIStream = (
 
     const errorData = {
       body: chunk,
-      type: 'errorType' in chunk ? chunk.errorType : AgentRuntimeErrorType.ProviderBizError,
-    } as ChatMessageError;
+      message: 'message' in chunk ? typeof chunk.message === 'string' ? chunk.message : JSON.stringify(chunk) : JSON.stringify(chunk),
+      type: 'errorType' in chunk ? chunk.errorType as typeof AgentRuntimeErrorType.ProviderBizError : AgentRuntimeErrorType.ProviderBizError,
+    } satisfies ChatMessageError;
     return { data: errorData, id: 'first_chunk_error', type: 'error' };
   }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

Partial #9101

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change



#### 📝 补充信息 | Additional Information

Before

<img width="1174" height="519" alt="image" src="https://github.com/user-attachments/assets/c34412b5-8b15-47bb-be9b-314c168af79b" />

<img width="730" height="210" alt="image" src="https://github.com/user-attachments/assets/15081588-ce6b-425d-bdd7-bec904ffe57f" />

After

<img width="1435" height="238" alt="image" src="https://github.com/user-attachments/assets/14414e4b-8e18-4dd7-ac84-2eda20d33b13" />

## Summary by Sourcery

Fix error transformation in OpenAI streaming utilities to correctly propagate the original error message and enforce ChatMessageError type constraints

Bug Fixes:
- Capture and include the actual "message" field from OpenAI error chunks instead of omitting it
- Mirror the corrected error handling logic in both openai/openai.ts and openai/responsesStream.ts

Enhancements:
- Use TypeScript’s "satisfies" operator instead of "as" for ChatMessageError to improve type safety