### PR TITLE
feat: add auto updater modal controll switch in settings page

### DIFF
--- a/apps/desktop/src/main/const/store.ts
+++ b/apps/desktop/src/main/const/store.ts
@@ -25,6 +25,7 @@ export const defaultProxySettings: NetworkProxySettings = {
  * 存储默认值
  */
 export const STORE_DEFAULTS: ElectronMainStore = {
+  autoUpdateNotificationEnabled: true,
   dataSyncConfig: { storageMode: 'local' },
   encryptedTokens: {},
   locale: 'auto',

--- a/apps/desktop/src/main/controllers/DownloadCtr.ts
+++ b/apps/desktop/src/main/controllers/DownloadCtr.ts
@@ -1,0 +1,41 @@
+import { createLogger } from '@/utils/logger';
+
+import { ControllerModule, ipcClientEvent } from './index';
+
+// Create logger
+const logger = createLogger('controllers:DownloadCtr');
+
+/**
+ * 下载控制器
+ * 处理桌面应用的下载相关功能，包括自动更新通知设置
+ */
+export default class DownloadCtr extends ControllerModule {
+  /**
+   * 获取自动更新通知设置
+   */
+  @ipcClientEvent('getAutoUpdateNotificationEnabled')
+  async getAutoUpdateNotificationEnabled(): Promise<boolean> {
+    try {
+      const enabled = this.app.storeManager.get('autoUpdateNotificationEnabled', true);
+      logger.debug('Retrieved auto update notification setting:', enabled);
+      return enabled;
+    } catch (error) {
+      logger.error('Failed to get auto update notification setting:', error);
+      return true; // 默认启用
+    }
+  }
+
+  /**
+   * 设置自动更新通知
+   */
+  @ipcClientEvent('setAutoUpdateNotificationEnabled')
+  async setAutoUpdateNotificationEnabled(enabled: boolean): Promise<void> {
+    try {
+      this.app.storeManager.set('autoUpdateNotificationEnabled', enabled);
+      logger.info('Auto update notification setting updated:', enabled);
+    } catch (error) {
+      logger.error('Failed to set auto update notification setting:', error);
+      throw error;
+    }
+  }
+}

--- a/apps/desktop/src/main/types/store.ts
+++ b/apps/desktop/src/main/types/store.ts
@@ -1,6 +1,7 @@
 import { DataSyncConfig, NetworkProxySettings } from '@lobechat/electron-client-ipc';
 
 export interface ElectronMainStore {
+  autoUpdateNotificationEnabled: boolean;
   dataSyncConfig: DataSyncConfig;
   encryptedTokens: {
     accessToken?: string;

--- a/packages/const/src/settings/common.ts
+++ b/packages/const/src/settings/common.ts
@@ -6,4 +6,5 @@ export const DEFAULT_COMMON_SETTINGS: UserGeneralConfig = {
   highlighterTheme: 'lobe-theme',
   mermaidTheme: 'lobe-theme',
   transitionMode: 'fadeIn',
+  autoUpdateNotificationEnabled: true,
 };

--- a/packages/electron-client-ipc/src/events/settings.ts
+++ b/packages/electron-client-ipc/src/events/settings.ts
@@ -1,7 +1,9 @@
 import { NetworkProxySettings } from '../types';
 
 export interface DesktopSettingsDispatchEvents {
+  getAutoUpdateNotificationEnabled: () => boolean;
   getProxySettings: () => NetworkProxySettings;
+  setAutoUpdateNotificationEnabled: (enabled: boolean) => void;
   setProxySettings: (settings: Partial<NetworkProxySettings>) => void;
   testProxyConfig: (data: { config: NetworkProxySettings; testUrl?: string }) => Promise<{
     message?: string;

--- a/packages/types/src/user/settings/general.ts
+++ b/packages/types/src/user/settings/general.ts
@@ -12,4 +12,6 @@ export interface UserGeneralConfig {
   neutralColor?: NeutralColors;
   primaryColor?: PrimaryColors;
   transitionMode?: ResponseAnimationStyle;
+  // Desktop-specific settings
+  autoUpdateNotificationEnabled?: boolean;
 }

--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -1,4 +1,5 @@
 import { Block, Button, Tag } from '@lobehub/ui';
+import { Divider, Switch } from 'antd';
 import { createStyles } from 'antd-style';
 import Link from 'next/link';
 import { memo } from 'react';
@@ -8,9 +9,10 @@ import { Flexbox } from 'react-layout-kit';
 import { ProductLogo } from '@/components/Branding';
 import { BRANDING_NAME } from '@/const/branding';
 import { CHANGELOG_URL, MANUAL_UPGRADE_URL, OFFICIAL_SITE } from '@/const/url';
-import { CURRENT_VERSION } from '@/const/version';
+import { CURRENT_VERSION, isDesktop } from '@/const/version';
 import { useNewVersion } from '@/features/User/UserPanel/useNewVersion';
 import { useGlobalStore } from '@/store/global';
+import { useUserStore } from '@/store/user';
 
 const useStyles = createStyles(({ css, token }) => ({
   logo: css`
@@ -21,54 +23,97 @@ const useStyles = createStyles(({ css, token }) => ({
 const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
   const hasNewVersion = useNewVersion();
   const [latestVersion] = useGlobalStore((s) => [s.latestVersion]);
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(['common', 'electron']);
   const { styles } = useStyles();
 
+  const [autoUpdateNotificationEnabled, updateGeneralConfig] = useUserStore((s) => [
+    s.settings.general?.autoUpdateNotificationEnabled ?? true,
+    s.updateGeneralConfig,
+  ]);
+
+  const handleAutoUpdateNotificationToggle = (checked: boolean) => {
+    updateGeneralConfig({ autoUpdateNotificationEnabled: checked });
+  };
+
   return (
-    <Flexbox
-      align={mobile ? 'stretch' : 'center'}
-      gap={16}
-      horizontal={!mobile}
-      justify={'space-between'}
-      width={'100%'}
-    >
-      <Flexbox align={'center'} flex={'none'} gap={16} horizontal>
-        <Link href={OFFICIAL_SITE} target={'_blank'}>
-          <Block
-            align={'center'}
-            className={styles.logo}
-            clickable
-            height={64}
-            justify={'center'}
-            width={64}
-          >
-            <ProductLogo size={52} />
-          </Block>
-        </Link>
-        <Flexbox align={'flex-start'} gap={6}>
-          <div style={{ fontSize: 18, fontWeight: 'bolder' }}>{BRANDING_NAME}</div>
-          <div>
-            <Tag>v{CURRENT_VERSION}</Tag>
-            {hasNewVersion && (
-              <Tag color={'info'}>
-                {t('upgradeVersion.newVersion', { version: `v${latestVersion}` })}
-              </Tag>
-            )}
-          </div>
+    <Flexbox gap={16} width={'100%'}>
+      <Flexbox
+        align={mobile ? 'stretch' : 'center'}
+        gap={16}
+        horizontal={!mobile}
+        justify={'space-between'}
+        width={'100%'}
+      >
+        <Flexbox align={'center'} flex={'none'} gap={16} horizontal>
+          <Link href={OFFICIAL_SITE} target={'_blank'}>
+            <Block
+              align={'center'}
+              className={styles.logo}
+              clickable
+              height={64}
+              justify={'center'}
+              width={64}
+            >
+              <ProductLogo size={52} />
+            </Block>
+          </Link>
+          <Flexbox align={'flex-start'} gap={6}>
+            <div style={{ fontSize: 18, fontWeight: 'bolder' }}>{BRANDING_NAME}</div>
+            <div>
+              <Tag>v{CURRENT_VERSION}</Tag>
+              {hasNewVersion && (
+                <Tag color={'info'}>
+                  {t('upgradeVersion.newVersion', { version: `v${latestVersion}` })}
+                </Tag>
+              )}
+            </div>
+          </Flexbox>
+        </Flexbox>
+        <Flexbox flex={mobile ? 1 : undefined} gap={8} horizontal>
+          <Link href={CHANGELOG_URL} style={{ flex: 1 }} target={'_blank'}>
+            <Button block={mobile}>{t('changelog')}</Button>
+          </Link>
+          {hasNewVersion && (
+            <Link href={MANUAL_UPGRADE_URL} style={{ flex: 1 }} target={'_blank'}>
+              <Button block={mobile} type={'primary'}>
+                {t('upgradeVersion.action')}
+              </Button>
+            </Link>
+          )}
         </Flexbox>
       </Flexbox>
-      <Flexbox flex={mobile ? 1 : undefined} gap={8} horizontal>
-        <Link href={CHANGELOG_URL} style={{ flex: 1 }} target={'_blank'}>
-          <Button block={mobile}>{t('changelog')}</Button>
-        </Link>
-        {hasNewVersion && (
-          <Link href={MANUAL_UPGRADE_URL} style={{ flex: 1 }} target={'_blank'}>
-            <Button block={mobile} type={'primary'}>
-              {t('upgradeVersion.action')}
-            </Button>
-          </Link>
-        )}
-      </Flexbox>
+
+      {/* Desktop-only auto update notification setting */}
+      {isDesktop && (
+        <>
+          <Divider style={{ margin: '8px 0' }} />
+          <Flexbox
+            align={'center'}
+            horizontal
+            justify={'space-between'}
+            style={{ padding: '0 4px' }}
+          >
+            <Flexbox gap={4}>
+              <div style={{ fontSize: 14, fontWeight: 'medium' }}>
+                {t('updater.autoUpdateNotification', { ns: 'electron' })}
+              </div>
+              <div
+                style={{
+                  color: 'var(--ant-color-text-secondary)',
+                  fontSize: 12,
+                }}
+              >
+                {t('updater.autoUpdateNotificationDesc', { ns: 'electron' })}
+              </div>
+            </Flexbox>
+            <Switch
+              checked={autoUpdateNotificationEnabled}
+              onChange={handleAutoUpdateNotificationToggle}
+              size="small"
+            />
+          </Flexbox>
+        </>
+      )}
     </Flexbox>
   );
 });

--- a/src/features/ElectronTitlebar/UpdateModal.tsx
+++ b/src/features/ElectronTitlebar/UpdateModal.tsx
@@ -5,7 +5,7 @@ import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { autoUpdateService } from '@/services/electron/autoUpdate';
-import { useUserStore } from '@/store/user';
+import { useElectronStore } from '@/store/electron';
 import { formatSpeed } from '@/utils/format';
 
 export const UpdateModal = memo(() => {
@@ -19,10 +19,8 @@ export const UpdateModal = memo(() => {
   const [latestVersionInfo, setLatestVersionInfo] = useState<UpdateInfo | null>(null); // State for latest version modal
   const { modal } = App.useApp();
 
-  // Get user settings for auto update notifications
-  const autoUpdateNotificationEnabled = useUserStore(
-    (s) => s.settings.general?.autoUpdateNotificationEnabled ?? true,
-  );
+  // Get auto update notification setting from electron store
+  const autoUpdateNotificationEnabled = useElectronStore((s) => s.autoUpdateNotificationEnabled);
   // --- Event Listeners ---
 
   useWatchBroadcast('manualUpdateCheckStart', () => {
@@ -92,12 +90,12 @@ export const UpdateModal = memo(() => {
     // This event implies a download finished, likely the one we started manually
     setIsChecking(false);
     setIsDownloading(false);
-    
+
     // Only show the modal if auto update notifications are enabled
     if (autoUpdateNotificationEnabled) {
       setDownloadedInfo(info);
     }
-    
+
     setProgress(null); // Clear progress
     setLatestVersionInfo(null); // Ensure other modals are closed
     setUpdateAvailableInfo(null);

--- a/src/features/ElectronTitlebar/UpdateModal.tsx
+++ b/src/features/ElectronTitlebar/UpdateModal.tsx
@@ -5,6 +5,7 @@ import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { autoUpdateService } from '@/services/electron/autoUpdate';
+import { useUserStore } from '@/store/user';
 import { formatSpeed } from '@/utils/format';
 
 export const UpdateModal = memo(() => {
@@ -17,6 +18,11 @@ export const UpdateModal = memo(() => {
   const [progress, setProgress] = useState<ProgressInfo | null>(null);
   const [latestVersionInfo, setLatestVersionInfo] = useState<UpdateInfo | null>(null); // State for latest version modal
   const { modal } = App.useApp();
+
+  // Get user settings for auto update notifications
+  const autoUpdateNotificationEnabled = useUserStore(
+    (s) => s.settings.general?.autoUpdateNotificationEnabled ?? true,
+  );
   // --- Event Listeners ---
 
   useWatchBroadcast('manualUpdateCheckStart', () => {
@@ -86,7 +92,12 @@ export const UpdateModal = memo(() => {
     // This event implies a download finished, likely the one we started manually
     setIsChecking(false);
     setIsDownloading(false);
-    setDownloadedInfo(info);
+    
+    // Only show the modal if auto update notifications are enabled
+    if (autoUpdateNotificationEnabled) {
+      setDownloadedInfo(info);
+    }
+    
     setProgress(null); // Clear progress
     setLatestVersionInfo(null); // Ensure other modals are closed
     setUpdateAvailableInfo(null);

--- a/src/locales/default/electron.ts
+++ b/src/locales/default/electron.ts
@@ -84,6 +84,8 @@ const electron = {
     },
   },
   updater: {
+    autoUpdateNotification: '自动更新提示',
+    autoUpdateNotificationDesc: '当有新版本可用时，是否显示弹窗提示更新',
     checkingUpdate: '检查新版本',
     checkingUpdateDesc: '正在获取版本信息...',
     downloadNewVersion: '下载新版本',

--- a/src/services/electron/settings.ts
+++ b/src/services/electron/settings.ts
@@ -6,6 +6,20 @@ import {
 
 class DesktopSettingsService {
   /**
+   * 获取自动更新通知设置
+   */
+  getAutoUpdateNotificationEnabled = async (): Promise<boolean> => {
+    return dispatch('getAutoUpdateNotificationEnabled');
+  };
+
+  /**
+   * 设置自动更新通知
+   */
+  setAutoUpdateNotificationEnabled = async (enabled: boolean): Promise<void> => {
+    return dispatch('setAutoUpdateNotificationEnabled', enabled);
+  };
+
+  /**
    * 获取远程服务器配置
    */
   getProxySettings = async () => {

--- a/src/store/electron/initialState.ts
+++ b/src/store/electron/initialState.ts
@@ -17,6 +17,7 @@ export const defaultProxySettings: NetworkProxySettings = {
 
 export interface ElectronState {
   appState: ElectronAppState;
+  autoUpdateNotificationEnabled: boolean;
   dataSyncConfig: DataSyncConfig;
   desktopHotkeys: Record<string, string>;
   isAppStateInit?: boolean;
@@ -30,6 +31,7 @@ export interface ElectronState {
 
 export const initialState: ElectronState = {
   appState: {},
+  autoUpdateNotificationEnabled: true,
   dataSyncConfig: { storageMode: 'local' },
   desktopHotkeys: {},
   isAppStateInit: false,

--- a/src/store/user/slices/settings/selectors/general.test.ts
+++ b/src/store/user/slices/settings/selectors/general.test.ts
@@ -17,6 +17,7 @@ describe('settingsSelectors', () => {
 
       expect(result).toEqual({
         animationMode: 'agile',
+        autoUpdateNotificationEnabled: true,
         fontSize: 12,
         highlighterTheme: 'lobe-theme',
         mermaidTheme: 'lobe-theme',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

https://github.com/lobehub/lobe-chat/discussions/9097

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add a desktop-only toggle for auto update notifications in the settings page, persist its state via the Electron store and IPC, synchronize it with SWR hooks, and conditionally show the update modal based on the setting.

New Features:
- Add a desktop-only switch in the settings page to toggle auto update notifications
- Persist the auto update notification preference in the Electron store and expose it via IPC events
- Fetch and synchronize the notification setting using SWR hooks
- Update the update modal to display only when auto update notifications are enabled