### PR TITLE
♻️ refactor: refactor to use trpc client link chain 

### DIFF
--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -17,7 +17,7 @@ const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
       next(op).subscribe({
         complete: () => observer.complete(),
         error: async (err) => {
-          const showError = (op.context?.showError as boolean) ?? true;
+          const showError = (op.context?.showNotification as boolean) ?? true;
 
           if (showError) {
             const status = err.data?.httpStatus as number;

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -1,81 +1,94 @@
 import { ModelProvider } from '@lobechat/model-runtime';
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { TRPCLink, createTRPCClient, httpBatchLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
+import { observable } from '@trpc/server/observable';
 import debug from 'debug';
 import superjson from 'superjson';
 
 import { isDesktop } from '@/const/version';
 import type { LambdaRouter } from '@/server/routers/lambda';
 
-import { ErrorResponse } from './types';
-
 const log = debug('lobe-image:lambda-client');
 
-const links = [
-  httpBatchLink({
-    fetch: async (input, init) => {
-      if (isDesktop) {
-        const { desktopRemoteRPCFetch } = await import('@/utils/electron/desktopRemoteRPCFetch');
+// handle error
+const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
+  return ({ op, next }) =>
+    observable((observer) =>
+      next(op).subscribe({
+        complete: () => observer.complete(),
+        error: async (err) => {
+          const showError = (op.context?.showError as boolean) ?? true;
 
-        // eslint-disable-next-line no-undef
-        const res = await desktopRemoteRPCFetch(input as string, init as RequestInit);
+          if (showError) {
+            const status = err.data?.httpStatus as number;
 
-        if (res) return res;
-      }
+            const { loginRequired } = await import('@/components/Error/loginRequiredNotification');
+            const { fetchErrorNotification } = await import(
+              '@/components/Error/fetchErrorNotification'
+            );
+
+            switch (status) {
+              case 401: {
+                loginRequired.redirect();
+                break;
+              }
+
+              default: {
+                fetchErrorNotification.error({ errorMessage: err.message, status });
+              }
+            }
+          }
+
+          observer.error(err);
+        },
+        next: (value) => observer.next(value),
+      }),
+    );
+};
+
+// 2. httpBatchLink
+const customHttpBatchLink = httpBatchLink({
+  fetch: async (input, init) => {
+    if (isDesktop) {
+      const { desktopRemoteRPCFetch } = await import('@/utils/electron/desktopRemoteRPCFetch');
 
       // eslint-disable-next-line no-undef
-      const response = await fetch(input, init as RequestInit);
+      const res = await desktopRemoteRPCFetch(input as string, init as RequestInit);
 
-      if (response.ok) return response;
+      if (res) return res;
+    }
 
-      const errorRes: ErrorResponse = await response.clone().json();
+    // eslint-disable-next-line no-undef
+    return await fetch(input, init as RequestInit);
+  },
+  headers: async () => {
+    // dynamic import to avoid circular dependency
+    const { createHeaderWithAuth } = await import('@/services/_auth');
 
-      const { loginRequired } = await import('@/components/Error/loginRequiredNotification');
-      const { fetchErrorNotification } = await import('@/components/Error/fetchErrorNotification');
+    let provider: ModelProvider = ModelProvider.OpenAI;
+    // for image page, we need to get the provider from the store
+    log('Getting provider from store for image page: %s', location.pathname);
+    if (location.pathname === '/image') {
+      const { getImageStoreState } = await import('@/store/image');
+      const { imageGenerationConfigSelectors } = await import(
+        '@/store/image/slices/generationConfig/selectors'
+      );
+      provider = imageGenerationConfigSelectors.provider(getImageStoreState()) as ModelProvider;
+      log('Getting provider from store for image page: %s', provider);
+    }
 
-      errorRes.forEach((item) => {
-        const errorData = item.error.json;
-        const status = errorData.data.httpStatus;
+    // TODO: we need to support provider select for chat page
+    const headers = await createHeaderWithAuth({ provider });
+    log('Headers: %O', headers);
+    return headers;
+  },
+  maxURLLength: 2083,
+  transformer: superjson,
+  url: '/trpc/lambda',
+});
 
-        switch (status) {
-          case 401: {
-            loginRequired.redirect();
-            break;
-          }
-          default: {
-            fetchErrorNotification.error({ errorMessage: errorData.message, status });
-          }
-        }
-      });
-
-      return response;
-    },
-    headers: async () => {
-      // dynamic import to avoid circular dependency
-      const { createHeaderWithAuth } = await import('@/services/_auth');
-
-      let provider: ModelProvider = ModelProvider.OpenAI;
-      // for image page, we need to get the provider from the store
-      log('Getting provider from store for image page: %s', location.pathname);
-      if (location.pathname === '/image') {
-        const { getImageStoreState } = await import('@/store/image');
-        const { imageGenerationConfigSelectors } = await import(
-          '@/store/image/slices/generationConfig/selectors'
-        );
-        provider = imageGenerationConfigSelectors.provider(getImageStoreState()) as ModelProvider;
-        log('Getting provider from store for image page: %s', provider);
-      }
-
-      // TODO: we need to support provider select for chat page
-      const headers = await createHeaderWithAuth({ provider });
-      log('Headers: %O', headers);
-      return headers;
-    },
-    maxURLLength: 2083,
-    transformer: superjson,
-    url: '/trpc/lambda',
-  }),
-];
+// 3. assembly links
+const links = [errorHandlingLink, customHttpBatchLink];
 
 export const lambdaClient = createTRPCClient<LambdaRouter>({
   links,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

默认情况下 trpc 的所有报错会显示一个 error notification：

<img width="1133" height="452" alt="image" src="https://github.com/user-attachments/assets/642e329a-548d-46d7-8726-5b77d525d604" />


但之前这个实现会有一个问题是没有办法在前端控制是否需要显示这个 error notification。

本次重构利用  tRPC 的 Link 链（Link chain） 机制，将 error handling 的实现变得更加优雅与灵活。


现在只需要在第二个字段中添加 context 既可隐藏该 notification

```ts
lambdaClient.aiChat.sendMessageInServer.mutate(params, {
  context: { showNotification: false }, // 👈 context 在这里被定义
});
```


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
