### PR TITLE
🐛 fix: fix mobile header title to loog not ellipsis

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/ChatHeaderTitle.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/_layout/Mobile/ChatHeader/ChatHeaderTitle.tsx
@@ -31,7 +31,16 @@ const ChatHeaderTitle = memo(() => {
     <ChatHeader.Title
       desc={
         <Flexbox align={'center'} gap={4} horizontal onClick={() => toggleConfig()}>
-          <span>{topic?.title || t('title', { ns: 'topic' })}</span>
+          <span
+            style={{
+              maxWidth: '60vw',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {topic?.title || t('title', { ns: 'topic' })}
+          </span>
           <ActionIcon
             active
             icon={ChevronDown}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

https://github.com/lobehub/lobe-chat/issues/8137

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Truncate long mobile chat header titles with ellipsis by setting maxWidth and overflow styles