### PR TITLE
🐛fix: update back navigation logic for provider settings in mobile view

### DIFF
--- a/src/app/[variants]/(main)/settings/_layout/Mobile/Header.tsx
+++ b/src/app/[variants]/(main)/settings/_layout/Mobile/Header.tsx
@@ -26,10 +26,14 @@ const Header = memo(() => {
   const pathname = usePathname();
   const isProvider = pathname.includes('/settings/provider/');
   const providerName = useProviderName(activeSettingsKey);
+  const isProviderList = pathname === '/settings/provider';
+  const isProviderDetail = isProvider && !isProviderList;
 
   const handleBackClick = () => {
     if (isSessionActive && showMobileWorkspace) {
       router.push('/chat');
+    } else if (isProviderDetail) {
+      router.push('/settings/provider');
     } else {
       router.push(enableAuth ? '/me/settings' : '/me');
     }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

修复：移动端从 `/settings/provider/[variants]` 返回应该跳转到 `/settings/provider`，而不是 `/me/settings`
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Navigate to '/settings/provider' when the back button is clicked on provider detail pages instead of '/me/settings'.