### PR TITLE
🐛 fix: revert V1 Mobile Input

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/ActionBar.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/ActionBar.tsx
@@ -1,0 +1,30 @@
+import { ChatInputActionBar } from '@lobehub/ui/chat';
+import { memo } from 'react';
+
+import { ActionKeys, actionMap } from '@/features/ChatInput/ActionBar/config';
+
+const RenderActionList = ({ dataSource }: { dataSource: ActionKeys[] }) => (
+  <>
+    {dataSource.map((key) => {
+      // @ts-ignore
+      const Render = actionMap[key];
+      return <Render key={key} />;
+    })}
+  </>
+);
+
+export interface ActionBarProps {
+  leftActions: ActionKeys[];
+  padding?: number | string;
+  rightActions: ActionKeys[];
+}
+
+const ActionBar = memo<ActionBarProps>(({ padding = '0 8px', leftActions, rightActions }) => (
+  <ChatInputActionBar
+    leftAddons={<RenderActionList dataSource={leftActions} />}
+    padding={padding}
+    rightAddons={<RenderActionList dataSource={rightActions} />}
+  />
+));
+
+export default ActionBar;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/Files/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/Files/index.tsx
@@ -1,0 +1,32 @@
+import { PreviewGroup } from '@lobehub/ui';
+import isEqual from 'fast-deep-equal';
+import { memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import FileItem from '@/features/ChatInput/Mobile/FilePreview/FileItem';
+import { filesSelectors, useFileStore } from '@/store/file';
+
+const Files = memo(() => {
+  const list = useFileStore(filesSelectors.chatUploadFileList, isEqual);
+
+  if (!list || list?.length === 0) return null;
+
+  return (
+    <Flexbox paddingBlock={4} style={{ position: 'relative' }}>
+      <Flexbox
+        gap={4}
+        horizontal
+        padding={'4px 8px 8px'}
+        style={{ overflow: 'scroll', width: '100%' }}
+      >
+        <PreviewGroup>
+          {list.map((i) => (
+            <FileItem {...i} key={i.id} loading={i.status === 'pending'} />
+          ))}
+        </PreviewGroup>
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+export default Files;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/InputArea/Container.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/InputArea/Container.tsx
@@ -1,0 +1,41 @@
+import { css, cx } from 'antd-style';
+import { FC, ReactNode, memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+const container = css`
+  height: inherit;
+  padding-block: 0;
+  padding-inline: 8px;
+`;
+
+interface InnerContainerProps {
+  bottomAddons?: ReactNode;
+  children: ReactNode;
+  expand?: boolean;
+  textAreaLeftAddons?: ReactNode;
+  textAreaRightAddons?: ReactNode;
+  topAddons?: ReactNode;
+}
+
+const InnerContainer: FC<InnerContainerProps> = memo(
+  ({ children, expand, textAreaRightAddons, textAreaLeftAddons, bottomAddons, topAddons }) =>
+    expand ? (
+      <Flexbox className={cx(container)} gap={8}>
+        <Flexbox gap={8} horizontal justify={'flex-end'}>
+          {textAreaLeftAddons}
+          {textAreaRightAddons}
+        </Flexbox>
+        {children}
+        {topAddons}
+        {bottomAddons}
+      </Flexbox>
+    ) : (
+      <Flexbox align={'flex-end'} className={cx(container)} gap={8} horizontal>
+        {textAreaLeftAddons}
+        {children}
+        {textAreaRightAddons}
+      </Flexbox>
+    ),
+);
+
+export default InnerContainer;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/InputArea/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/InputArea/index.tsx
@@ -1,0 +1,156 @@
+import { ActionIcon, TextArea } from '@lobehub/ui';
+import { SafeArea } from '@lobehub/ui/mobile';
+import { useSize } from 'ahooks';
+import { createStyles } from 'antd-style';
+import { TextAreaRef } from 'antd/es/input/TextArea';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { rgba } from 'polished';
+import { CSSProperties, ReactNode, forwardRef, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import InnerContainer from './Container';
+
+const useStyles = createStyles(({ css, token }) => {
+  return {
+    container: css`
+      flex: none;
+      padding-block: 12px 12px;
+      border-block-start: 1px solid ${rgba(token.colorBorder, 0.25)};
+      background: ${token.colorFillQuaternary};
+    `,
+    expand: css`
+      position: absolute;
+      height: 100%;
+    `,
+    expandButton: css`
+      position: absolute;
+      inset-inline-start: 14px;
+    `,
+    textarea: css`
+      flex: 1;
+      transition: none !important;
+    `,
+  };
+});
+
+export interface MobileChatInputAreaProps {
+  bottomAddons?: ReactNode;
+  className?: string;
+  expand?: boolean;
+  loading?: boolean;
+  onInput?: (value: string) => void;
+  onSend?: () => void;
+  safeArea?: boolean;
+  setExpand?: (expand: boolean) => void;
+  style?: CSSProperties;
+  textAreaLeftAddons?: ReactNode;
+  textAreaRightAddons?: ReactNode;
+  topAddons?: ReactNode;
+  value: string;
+}
+
+const MobileChatInputArea = forwardRef<TextAreaRef, MobileChatInputAreaProps>(
+  (
+    {
+      className,
+      style,
+      topAddons,
+      textAreaLeftAddons,
+      textAreaRightAddons,
+      bottomAddons,
+      expand = false,
+      setExpand,
+      onSend,
+      onInput,
+      loading,
+      value,
+      safeArea,
+    },
+    ref,
+  ) => {
+    const { t } = useTranslation('chat');
+    const isChineseInput = useRef(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { cx, styles } = useStyles();
+    const size = useSize(containerRef);
+    const [showFullscreen, setShowFullscreen] = useState<boolean>(false);
+    const [isFocused, setIsFocused] = useState<boolean>(false);
+
+    useEffect(() => {
+      if (!size?.height) return;
+      setShowFullscreen(size.height > 72);
+    }, [size]);
+
+    const showAddons = !expand && !isFocused;
+
+    return (
+      <Flexbox
+        className={cx(styles.container, expand && styles.expand, className)}
+        gap={12}
+        style={style}
+      >
+        {topAddons && <Flexbox style={showAddons ? {} : { display: 'none' }}>{topAddons}</Flexbox>}
+        <Flexbox
+          className={cx(expand && styles.expand)}
+          ref={containerRef}
+          style={{ position: 'relative' }}
+        >
+          {showFullscreen && (
+            <ActionIcon
+              active
+              className={styles.expandButton}
+              icon={expand ? ChevronDown : ChevronUp}
+              onClick={() => setExpand?.(!expand)}
+              size={{ blockSize: 24, borderRadius: '50%', size: 14 }}
+              style={expand ? { top: 6 } : {}}
+            />
+          )}
+          <InnerContainer
+            bottomAddons={bottomAddons}
+            expand={expand}
+            textAreaLeftAddons={textAreaLeftAddons}
+            textAreaRightAddons={textAreaRightAddons}
+            topAddons={topAddons}
+          >
+            <TextArea
+              autoSize={expand ? false : { maxRows: 6, minRows: 0 }}
+              className={styles.textarea}
+              onBlur={(e) => {
+                onInput?.(e.target.value);
+                setIsFocused(false);
+              }}
+              onChange={(e) => {
+                onInput?.(e.target.value);
+              }}
+              onCompositionEnd={() => {
+                isChineseInput.current = false;
+              }}
+              onCompositionStart={() => {
+                isChineseInput.current = true;
+              }}
+              onFocus={() => setIsFocused(true)}
+              onPressEnter={(e) => {
+                if (!loading && !isChineseInput.current && e.shiftKey) {
+                  e.preventDefault();
+                  onSend?.();
+                }
+              }}
+              placeholder={t('sendPlaceholder')}
+              ref={ref}
+              style={{ height: 36, paddingBlock: 6 }}
+              value={value}
+              variant={expand ? 'borderless' : 'filled'}
+            />
+          </InnerContainer>
+        </Flexbox>
+        {bottomAddons && (
+          <Flexbox style={showAddons ? {} : { display: 'none' }}>{bottomAddons}</Flexbox>
+        )}
+        {safeArea && !isFocused && <SafeArea position={'bottom'} />}
+      </Flexbox>
+    );
+  },
+);
+
+export default MobileChatInputArea;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/Send.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/Send.tsx
@@ -1,0 +1,33 @@
+import { ActionIcon, type ActionIconSize, Button } from '@lobehub/ui';
+import { Loader2, SendHorizontal } from 'lucide-react';
+import { memo } from 'react';
+
+export interface MobileChatSendButtonProps {
+  disabled?: boolean;
+  loading?: boolean;
+  onSend?: () => void;
+  onStop?: () => void;
+}
+
+const MobileChatSendButton = memo<MobileChatSendButtonProps>(
+  ({ loading, onStop, onSend, disabled }) => {
+    const size: ActionIconSize = {
+      blockSize: 36,
+      size: 16,
+    };
+
+    return loading ? (
+      <ActionIcon active icon={Loader2} onClick={onStop} size={size} spin />
+    ) : (
+      <Button
+        disabled={disabled}
+        icon={SendHorizontal}
+        onClick={onSend}
+        style={{ flex: 'none' }}
+        type={'primary'}
+      />
+    );
+  },
+);
+
+export default MobileChatSendButton;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Skeleton } from 'antd';
+import { useTheme } from 'antd-style';
+import { TextAreaRef } from 'antd/es/input/TextArea';
+import { memo, useRef, useState } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import { ActionKeys } from '@/features/ChatInput/ActionBar/config';
+import { useInitAgentConfig } from '@/hooks/useInitAgentConfig';
+import { useChatStore } from '@/store/chat';
+import { chatSelectors } from '@/store/chat/selectors';
+
+import ActionBar from './ActionBar';
+import Files from './Files';
+import InputArea from './InputArea';
+import SendButton from './Send';
+import { useSendMessage } from './useSend';
+
+const defaultLeftActions: ActionKeys[] = [
+  'model',
+  'search',
+  'fileUpload',
+  'knowledgeBase',
+  'tools',
+  'params',
+  'mainToken',
+];
+
+const defaultRightActions: ActionKeys[] = ['saveTopic', 'clear'];
+
+const MobileChatInput = memo(() => {
+  const theme = useTheme();
+  const ref = useRef<TextAreaRef>(null);
+  const [expand, setExpand] = useState<boolean>(false);
+  const { send: sendMessage, canSend } = useSendMessage();
+  const { isLoading } = useInitAgentConfig();
+
+  const [loading, value, onInput, onStop] = useChatStore((s) => [
+    chatSelectors.isAIGenerating(s),
+    s.inputMessage,
+    s.updateInputMessage,
+    s.stopGenerateMessage,
+  ]);
+
+  return (
+    <InputArea
+      expand={expand}
+      onInput={onInput}
+      onSend={() => {
+        setExpand(false);
+
+        sendMessage();
+      }}
+      ref={ref}
+      setExpand={setExpand}
+      style={{
+        background: theme.colorBgLayout,
+        top: expand ? 0 : undefined,
+        width: '100%',
+        zIndex: 101,
+      }}
+      textAreaRightAddons={
+        <SendButton disabled={!canSend} loading={loading} onSend={sendMessage} onStop={onStop} />
+      }
+      topAddons={
+        isLoading ? (
+          <Flexbox paddingInline={8}>
+            <Skeleton.Button active block size={'small'} />
+          </Flexbox>
+        ) : (
+          <>
+            <Files />
+            <ActionBar
+              leftActions={defaultLeftActions}
+              padding={'0 8px'}
+              rightActions={defaultRightActions}
+            />
+          </>
+        )
+      }
+      value={value}
+    />
+  );
+});
+
+MobileChatInput.displayName = 'MobileChatInput';
+
+export default MobileChatInput;

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/useSend.ts
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/V1Mobile/useSend.ts
@@ -1,0 +1,102 @@
+import { useAnalytics } from '@lobehub/analytics/react';
+import { useCallback, useMemo } from 'react';
+
+import { useGeminiChineseWarning } from '@/hooks/useGeminiChineseWarning';
+import { getAgentStoreState } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { chatSelectors, topicSelectors } from '@/store/chat/selectors';
+import { fileChatSelectors, useFileStore } from '@/store/file';
+import { getUserStoreState } from '@/store/user';
+import { SendMessageParams } from '@/types/message';
+
+export type UseSendMessageParams = Pick<
+  SendMessageParams,
+  'onlyAddUserMessage' | 'isWelcomeQuestion'
+>;
+
+export const useSendMessage = () => {
+  const [sendMessage, updateInputMessage] = useChatStore((s) => [
+    s.sendMessage,
+    s.updateInputMessage,
+  ]);
+  const { analytics } = useAnalytics();
+  const checkGeminiChineseWarning = useGeminiChineseWarning();
+
+  const clearChatUploadFileList = useFileStore((s) => s.clearChatUploadFileList);
+
+  const isUploadingFiles = useFileStore(fileChatSelectors.isUploadingFiles);
+  const isSendButtonDisabledByMessage = useChatStore(chatSelectors.isSendButtonDisabledByMessage);
+
+  const canSend = !isUploadingFiles && !isSendButtonDisabledByMessage;
+
+  const send = useCallback(async (params: UseSendMessageParams = {}) => {
+    const store = useChatStore.getState();
+    if (chatSelectors.isAIGenerating(store)) return;
+
+    // if uploading file or send button is disabled by message, then we should not send the message
+    const isUploadingFiles = fileChatSelectors.isUploadingFiles(useFileStore.getState());
+    const isSendButtonDisabledByMessage = chatSelectors.isSendButtonDisabledByMessage(
+      useChatStore.getState(),
+    );
+
+    const canSend = !isUploadingFiles && !isSendButtonDisabledByMessage;
+    if (!canSend) return;
+
+    const fileList = fileChatSelectors.chatUploadFileList(useFileStore.getState());
+    // if there is no message and no image, then we should not send the message
+    if (!store.inputMessage && fileList.length === 0) return;
+
+    // Check for Chinese text warning with Gemini model
+    const agentStore = getAgentStoreState();
+    const currentModel = agentSelectors.currentAgentModel(agentStore);
+    const shouldContinue = await checkGeminiChineseWarning({
+      model: currentModel,
+      prompt: store.inputMessage,
+      scenario: 'chat',
+    });
+
+    if (!shouldContinue) return;
+
+    sendMessage({
+      files: fileList,
+      message: store.inputMessage,
+      ...params,
+    });
+
+    updateInputMessage('');
+    clearChatUploadFileList();
+
+    // 获取分析数据
+    const userStore = getUserStoreState();
+
+    // 直接使用现有数据结构判断消息类型
+    const hasImages = fileList.some((file) => file.file?.type?.startsWith('image'));
+    const messageType = fileList.length === 0 ? 'text' : hasImages ? 'image' : 'file';
+
+    analytics?.track({
+      name: 'send_message',
+      properties: {
+        chat_id: store.activeId || 'unknown',
+        current_topic: topicSelectors.currentActiveTopic(store)?.title || null,
+        has_attachments: fileList.length > 0,
+        history_message_count: chatSelectors.activeBaseChats(store).length,
+        message: store.inputMessage,
+        message_length: store.inputMessage.length,
+        message_type: messageType,
+        selected_model: agentSelectors.currentAgentModel(agentStore),
+        session_id: store.activeId || 'inbox', // 当前活跃的会话ID
+        user_id: userStore.user?.id || 'anonymous',
+      },
+    });
+    // const hasSystemRole = agentSelectors.hasSystemRole(useAgentStore.getState());
+    // const agentSetting = useAgentStore.getState().agentSettingInstance;
+
+    // // if there is a system role, then we need to use agent setting instance to autocomplete agent meta
+    // if (hasSystemRole && !!agentSetting) {
+    //   agentSetting.autocompleteAllMeta();
+    // }
+  }, []);
+
+  return useMemo(() => ({ canSend, send }), [canSend]);
+};

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/index.tsx
@@ -1,5 +1,5 @@
 import DesktopChatInput from './Desktop';
-import MobileChatInput from './Mobile';
+import MobileChatInput from './V1Mobile';
 
 const ChatInput = ({ mobile }: { mobile: boolean }) => {
   const Input = mobile ? MobileChatInput : DesktopChatInput;

--- a/src/features/ChatInput/ActionBar/SaveTopic/index.tsx
+++ b/src/features/ChatInput/ActionBar/SaveTopic/index.tsx
@@ -5,19 +5,22 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useActionSWR } from '@/libs/swr';
 import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { HotkeyEnum } from '@/types/hotkey';
 
-const SaveTopic = memo<{ mobile?: boolean }>(({ mobile }) => {
+const SaveTopic = memo(() => {
   const { t } = useTranslation('chat');
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.SaveTopic));
   const [hasTopic, openNewTopicOrSaveTopic] = useChatStore((s) => [
     !!s.activeTopicId,
     s.openNewTopicOrSaveTopic,
   ]);
+
+  const mobile = useIsMobile();
 
   const { mutate, isValidating } = useActionSWR('openNewTopicOrSaveTopic', openNewTopicOrSaveTopic);
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Revert the mobile chat input to the previous V1 implementation by adding a dedicated V1Mobile component suite and update SaveTopic to auto-detect mobile via a hook

Enhancements:
- Revert ChatInput to use the legacy V1 mobile implementation under a new V1Mobile directory
- Introduce modular V1Mobile components including InputArea, useSend, ActionBar, Files, SendButton, and Container
- Replace SaveTopic’s mobile prop with an automated useIsMobile hook