### PR TITLE
💄 style: Add hotkey tooltip to typobar actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "@lobehub/charts": "^2.0.0",
     "@lobehub/chat-plugin-sdk": "^1.32.4",
     "@lobehub/chat-plugins-gateway": "^1.9.0",
-    "@lobehub/editor": "^1.5.8",
+    "@lobehub/editor": "^1.6.1",
     "@lobehub/icons": "^2.31.0",
     "@lobehub/market-sdk": "^0.22.7",
     "@lobehub/tts": "^2.0.1",

--- a/src/features/ChatInput/ActionBar/index.tsx
+++ b/src/features/ChatInput/ActionBar/index.tsx
@@ -1,6 +1,9 @@
 import { ChatInputActions, type ChatInputActionsProps } from '@lobehub/editor/react';
 import { memo, useMemo } from 'react';
 
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+
 import { ActionKeys, actionMap } from '../ActionBar/config';
 import { useChatInputStore } from '../store';
 
@@ -35,10 +38,25 @@ const mapActionsToItems = (keys: ActionKeys[]): ChatInputActionsProps['items'] =
   });
 
 const ActionToolbar = memo(() => {
+  const [expandInputActionbar, toggleExpandInputActionbar] = useGlobalStore((s) => [
+    systemStatusSelectors.expandInputActionbar(s),
+    s.toggleExpandInputActionbar,
+  ]);
+
   const leftActions = useChatInputStore((s) => s.leftActions);
   const mobile = useChatInputStore((s) => s.mobile);
   const items = useMemo(() => mapActionsToItems(leftActions), [leftActions]);
-  return <ChatInputActions collapseOffset={mobile ? 48 : 80} items={items} />;
+  return (
+    <ChatInputActions
+      collapseOffset={mobile ? 48 : 80}
+      defaultGroupCollapse={true}
+      groupCollapse={!expandInputActionbar}
+      items={items}
+      onGroupCollapseChange={(v) => {
+        toggleExpandInputActionbar(!v);
+      }}
+    />
+  );
 });
 
 export default ActionToolbar;

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -19,6 +19,8 @@ import FilePreview from './FilePreview';
 
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
+    margin-block-start: -5px;
+
     .show-on-hover {
       opacity: 0;
     }
@@ -87,6 +89,11 @@ const DesktopChatInput = memo<{ showFootnote?: boolean }>(({ showFootnote }) => 
           fullscreen={expand}
           header={showTypoBar && <TypoBar />}
           slashMenuRef={slashMenuRef}
+          styles={{
+            body: {
+              minHeight: 64,
+            },
+          }}
         >
           {expand && fileNode}
           <InputEditor />

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -24,7 +24,7 @@ import { preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
 
 import { useChatInputStore, useStoreApi } from '../store';
 
-const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
+const InputEditor = memo<{ defaultRows?: number }>(() => {
   const [editor, slashMenuRef, send, updateMarkdownContent, expand] = useChatInputStore((s) => [
     s.editor,
     s.slashMenuRef,
@@ -114,13 +114,14 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
         }
       }}
       placeholder={
-        <Flexbox align={'center'} gap={4} horizontal>
+        <Flexbox align={'center'} as={'span'} gap={4} horizontal>
           {t('sendPlaceholder', { ns: 'chat' }).replace('...', ', ')}
           <Trans
-            as={'div'}
+            as={'span'}
             components={{
               key: (
                 <Hotkey
+                  as={'span'}
                   keys={wrapperShortcut}
                   style={{ color: 'inherit' }}
                   styles={{ kbdStyle: { color: 'inhert' } }}
@@ -167,9 +168,6 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
                 <SlashMenu {...props} getPopupContainer={() => (slashMenuRef as any)?.current} />
               );
             },
-      }}
-      style={{
-        minHeight: defaultRows > 1 ? defaultRows * 23 : undefined,
       }}
       type={'text'}
       variant={'chat'}

--- a/src/features/ChatInput/TypoBar/index.tsx
+++ b/src/features/ChatInput/TypoBar/index.tsx
@@ -1,3 +1,4 @@
+import { HotkeyEnum, getHotkeyById } from '@lobehub/editor';
 import { useEditorState } from '@lobehub/editor/react';
 import {
   ChatInputActionBar,
@@ -20,7 +21,7 @@ import {
   StrikethroughIcon,
   UnderlineIcon,
 } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatInputStore } from '@/features/ChatInput/store';
@@ -31,112 +32,124 @@ const TypoBar = memo(() => {
   const editorState = useEditorState(editor);
   const theme = useTheme();
 
+  const items: ChatInputActionsProps['items'] = useMemo(
+    () =>
+      [
+        {
+          active: editorState.isBold,
+          icon: BoldIcon,
+          key: 'bold',
+          label: t('typobar.bold'),
+          onClick: editorState.bold,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Bold).keys },
+        },
+        {
+          active: editorState.isItalic,
+          icon: ItalicIcon,
+          key: 'italic',
+          label: t('typobar.italic'),
+          onClick: editorState.italic,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Italic).keys },
+        },
+        {
+          active: editorState.isUnderline,
+          icon: UnderlineIcon,
+          key: 'underline',
+          label: t('typobar.underline'),
+          onClick: editorState.underline,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Underline).keys },
+        },
+        {
+          active: editorState.isStrikethrough,
+          icon: StrikethroughIcon,
+          key: 'strikethrough',
+          label: t('typobar.strikethrough'),
+          onClick: editorState.strikethrough,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Strikethrough).keys },
+        },
+        {
+          type: 'divider',
+        },
+
+        {
+          icon: ListIcon,
+          key: 'bulletList',
+          label: t('typobar.bulletList'),
+          onClick: editorState.bulletList,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.BulletList).keys },
+        },
+        {
+          icon: ListOrderedIcon,
+          key: 'numberlist',
+          label: t('typobar.numberList'),
+          onClick: editorState.numberList,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.NumberList).keys },
+        },
+        {
+          icon: ListTodoIcon,
+          key: 'tasklist',
+          label: t('typobar.taskList'),
+          onClick: editorState.checkList,
+        },
+        {
+          type: 'divider',
+        },
+        {
+          active: editorState.isBlockquote,
+          icon: MessageSquareQuote,
+          key: 'blockquote',
+          label: t('typobar.blockquote'),
+          onClick: editorState.blockquote,
+        },
+        {
+          icon: LinkIcon,
+          key: 'link',
+          label: t('typobar.link'),
+          onClick: editorState.insertLink,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Link).keys },
+        },
+        {
+          type: 'divider',
+        },
+        {
+          icon: SigmaIcon,
+          key: 'math',
+          label: t('typobar.tex'),
+          onClick: editorState.insertMath,
+        },
+        {
+          active: editorState.isCode,
+          icon: CodeXmlIcon,
+          key: 'code',
+          label: t('typobar.code'),
+          onClick: editorState.code,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.CodeInline).keys },
+        },
+        {
+          icon: SquareDashedBottomCodeIcon,
+          key: 'codeblock',
+          label: t('typobar.codeblock'),
+          onClick: editorState.codeblock,
+        },
+        editorState.isCodeblock && {
+          children: (
+            <CodeLanguageSelect
+              onSelect={(value) => editorState.updateCodeblockLang(value)}
+              value={editorState.codeblockLang}
+            />
+          ),
+          disabled: !editorState.isCodeblock,
+          key: 'codeblockLang',
+        },
+      ].filter(Boolean) as ChatInputActionsProps['items'],
+    [editorState, t],
+  );
+
   return (
     <ChatInputActionBar
       left={
         <ChatInputActions
-          items={
-            [
-              {
-                active: editorState.isBold,
-                icon: BoldIcon,
-                key: 'bold',
-                label: t('typobar.bold'),
-                onClick: editorState.bold,
-              },
-              {
-                active: editorState.isItalic,
-                icon: ItalicIcon,
-                key: 'italic',
-                label: t('typobar.italic'),
-                onClick: editorState.italic,
-              },
-              {
-                active: editorState.isUnderline,
-                icon: UnderlineIcon,
-                key: 'underline',
-                label: t('typobar.underline'),
-                onClick: editorState.underline,
-              },
-              {
-                active: editorState.isStrikethrough,
-                icon: StrikethroughIcon,
-                key: 'strikethrough',
-                label: t('typobar.strikethrough'),
-                onClick: editorState.strikethrough,
-              },
-              {
-                type: 'divider',
-              },
-
-              {
-                icon: ListIcon,
-                key: 'bulletList',
-                label: t('typobar.bulletList'),
-                onClick: editorState.bulletList,
-              },
-              {
-                icon: ListOrderedIcon,
-                key: 'numberlist',
-                label: t('typobar.numberList'),
-                onClick: editorState.numberList,
-              },
-              {
-                icon: ListTodoIcon,
-                key: 'tasklist',
-                label: t('typobar.taskList'),
-                onClick: editorState.checkList,
-              },
-              {
-                type: 'divider',
-              },
-              {
-                active: editorState.isBlockquote,
-                icon: MessageSquareQuote,
-                key: 'blockquote',
-                label: t('typobar.blockquote'),
-                onClick: editorState.blockquote,
-              },
-              {
-                icon: LinkIcon,
-                key: 'link',
-                label: t('typobar.link'),
-                onClick: editorState.insertLink,
-              },
-              {
-                type: 'divider',
-              },
-              {
-                icon: SigmaIcon,
-                key: 'math',
-                label: t('typobar.tex'),
-                onClick: editorState.insertMath,
-              },
-              {
-                active: editorState.isCode,
-                icon: CodeXmlIcon,
-                key: 'code',
-                label: t('typobar.code'),
-                onClick: editorState.code,
-              },
-              {
-                icon: SquareDashedBottomCodeIcon,
-                key: 'codeblock',
-                label: t('typobar.codeblock'),
-                onClick: editorState.codeblock,
-              },
-              editorState.isCodeblock && {
-                children: (
-                  <CodeLanguageSelect
-                    onSelect={(value) => editorState.updateCodeblockLang(value)}
-                    value={editorState.codeblockLang}
-                  />
-                ),
-                disabled: !editorState.isCodeblock,
-                key: 'codeblockLang',
-              },
-            ].filter(Boolean) as ChatInputActionsProps['items']
-          }
+          items={items}
           onClick={() => {
             editor?.focus();
           }}

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -12,6 +12,7 @@ export interface GlobalWorkspacePaneAction {
   switchBackToChat: (sessionId?: string) => void;
   toggleAgentSystemRoleExpand: (agentId: string, expanded?: boolean) => void;
   toggleChatSideBar: (visible?: boolean) => void;
+  toggleExpandInputActionbar: (expand?: boolean) => void;
   toggleExpandSessionGroup: (id: string, expand: boolean) => void;
   toggleMobilePortal: (visible?: boolean) => void;
   toggleMobileTopic: (visible?: boolean) => void;
@@ -50,6 +51,12 @@ export const globalWorkspaceSlice: StateCreator<
       typeof newValue === 'boolean' ? newValue : !get().status.showChatSideBar;
 
     get().updateSystemStatus({ showChatSideBar }, n('toggleAgentPanel', newValue));
+  },
+  toggleExpandInputActionbar: (newValue) => {
+    const expandInputActionbar =
+      typeof newValue === 'boolean' ? newValue : !get().status.expandInputActionbar;
+
+    get().updateSystemStatus({ expandInputActionbar }, n('toggleExpandInputActionbar', newValue));
   },
   toggleExpandSessionGroup: (id, expand) => {
     const { status } = get();

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -47,6 +47,7 @@ export enum ProfileTabs {
 }
 
 export interface SystemStatus {
+  expandInputActionbar?: boolean;
   // which sessionGroup should expand
   expandSessionGroupKeys: string[];
   filePanelWidth: number;
@@ -114,6 +115,7 @@ export interface GlobalState {
 }
 
 export const INITIAL_STATUS = {
+  expandInputActionbar: true,
   expandSessionGroupKeys: [SessionDefaultGroup.Pinned, SessionDefaultGroup.Default],
   filePanelWidth: 320,
   hideGemini2_5FlashImagePreviewChineseWarning: false,

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -29,6 +29,7 @@ const filePanelWidth = (s: GlobalState) => s.status.filePanelWidth;
 const imagePanelWidth = (s: GlobalState) => s.status.imagePanelWidth;
 const imageTopicPanelWidth = (s: GlobalState) => s.status.imageTopicPanelWidth;
 const wideScreen = (s: GlobalState) => s.status.wideScreen;
+const expandInputActionbar = (s: GlobalState) => s.status.expandInputActionbar;
 const isStatusInit = (s: GlobalState) => !!s.isStatusInit;
 const isPgliteNotEnabled = (s: GlobalState) =>
   isUsePgliteDB && !isServerMode && isStatusInit(s) && !s.status.isEnablePglite;
@@ -62,6 +63,7 @@ const getAgentSystemRoleExpanded =
   };
 
 export const systemStatusSelectors = {
+  expandInputActionbar,
   filePanelWidth,
   getAgentSystemRoleExpanded,
   hidePWAInstaller,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add hotkey tooltips to typobar actions, centralize action items in a memoized array, and update the editor dependency

Enhancements:
- Add hotkey tooltipProps to TypoBar action buttons for bold, italic, underline, strikethrough, lists, link, and code actions
- Extract and memoize TypoBar action items using useMemo to improve performance

Build:
- Bump @lobehub/editor dependency from 1.5.8 to 1.6.1