### PR TITLE
🐛 fix: fix not remove message with server mode

### DIFF
--- a/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -207,6 +207,26 @@ export const generateAIChatV2: StateCreator<
       .filter((item) => item.id !== data.assistantMessageId);
 
     if (data.topicId) get().internal_updateTopicLoading(data.topicId, true);
+
+    const summaryTitle = async () => {
+      // check activeTopic and then auto update topic title
+      if (data.isCreatNewTopic) {
+        await get().summaryTopicTitle(data.topicId, data.messages);
+        return;
+      }
+
+      if (!data.topicId) return;
+
+      const topic = topicSelectors.getTopicById(data.topicId)(get());
+
+      if (topic && !topic.title) {
+        const chats = chatSelectors.getBaseChatsByKey(messageMapKey(activeId, topic.id))(get());
+        await get().summaryTopicTitle(topic.id, chats);
+      }
+    };
+
+    summaryTitle().catch(console.error);
+
     try {
       await internal_execAgentRuntime({
         messages: baseMessages,
@@ -217,31 +237,12 @@ export const generateAIChatV2: StateCreator<
         threadId: activeThreadId,
       });
 
-      const summaryTitle = async () => {
-        // check activeTopic and then auto update topic title
-        if (data.isCreatNewTopic) {
-          await get().summaryTopicTitle(data.topicId, data.messages);
-          return;
-        }
-
-        if (!data.topicId) return;
-
-        const topic = topicSelectors.getTopicById(data.topicId)(get());
-
-        if (topic && !topic.title) {
-          const chats = chatSelectors.getBaseChatsByKey(messageMapKey(activeId, topic.id))(get());
-          await get().summaryTopicTitle(topic.id, chats);
-        }
-      };
       //
       // // if there is relative files, then add files to agent
       // // only available in server mode
       const userFiles = chatSelectors.currentUserFiles(get()).map((f) => f.id);
-      const addFilesToAgent = async () => {
-        await getAgentStoreState().addFilesToAgent(userFiles, false);
-      };
 
-      await Promise.all([summaryTitle(), addFilesToAgent()]);
+      await getAgentStoreState().addFilesToAgent(userFiles, false);
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -181,7 +181,13 @@ export const generateAIChatV2: StateCreator<
     }
 
     // remove temporally message
-    get().internal_dispatchMessage({ type: 'deleteMessage', id: tempId });
+    if (data?.isCreatNewTopic) {
+      get().internal_dispatchMessage(
+        { type: 'deleteMessage', id: tempId },
+        { topicId: activeTopicId, sessionId: activeId },
+      );
+    }
+
     get().internal_toggleMessageLoading(false, tempId);
     get().internal_updateSendMessageOperation(
       operationKey,

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -394,7 +394,7 @@ describe('createPreferenceSlice', () => {
     it('should update with data', async () => {
       const { result } = renderHook(() => useGlobalStore());
       vi.spyOn(useGlobalStore.getState().statusStorage, 'getFromLocalStorage').mockReturnValueOnce({
-        wideScreen: false,
+        noWideScreen: false,
       } as any);
 
       const { result: hooks } = renderHook(() => result.current.useInitSystemStatus(), {
@@ -402,7 +402,7 @@ describe('createPreferenceSlice', () => {
       });
 
       await waitFor(() => {
-        expect(hooks.current.data).toEqual({ wideScreen: false });
+        expect(hooks.current.data).toEqual({ noWideScreen: false });
       });
 
       expect(result.current.status.noWideScreen).toEqual(false);

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -252,14 +252,14 @@ describe('createPreferenceSlice', () => {
   describe('updatePreference', () => {
     it('should update status', () => {
       const { result } = renderHook(() => useGlobalStore());
-      const status = { wideScreen: false };
+      const status = { wideScreen: true };
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
         result.current.updateSystemStatus(status);
       });
 
-      expect(result.current.status.wideScreen).toEqual(false);
+      expect(result.current.status.wideScreen).toEqual(true);
     });
   });
 

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -252,14 +252,13 @@ describe('createPreferenceSlice', () => {
   describe('updatePreference', () => {
     it('should update status', () => {
       const { result } = renderHook(() => useGlobalStore());
-      const status = { wideScreen: true };
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus(status);
+        result.current.updateSystemStatus({ noWideScreen: false });
       });
 
-      expect(result.current.status.wideScreen).toEqual(true);
+      expect(result.current.status.noWideScreen).toEqual(false);
     });
   });
 
@@ -406,7 +405,7 @@ describe('createPreferenceSlice', () => {
         expect(hooks.current.data).toEqual({ wideScreen: false });
       });
 
-      expect(result.current.status.wideScreen).toEqual(false);
+      expect(result.current.status.noWideScreen).toEqual(false);
     });
   });
 

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -69,11 +69,11 @@ describe('generalActionSlice', () => {
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus({ noWideScreen: true });
+        result.current.updateSystemStatus({ noWideScreen: false });
       });
 
       expect(saveToLocalStorageSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ wideScreen: true }),
+        expect.objectContaining({ noWideScreen: false }),
       );
     });
 

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -69,11 +69,11 @@ describe('generalActionSlice', () => {
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus({ wideScreen: false });
+        result.current.updateSystemStatus({ wideScreen: true });
       });
 
       expect(saveToLocalStorageSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ wideScreen: false }),
+        expect.objectContaining({ wideScreen: true }),
       );
     });
 

--- a/src/store/global/actions/__tests__/general.test.ts
+++ b/src/store/global/actions/__tests__/general.test.ts
@@ -34,7 +34,7 @@ describe('generalActionSlice', () => {
       const { result } = renderHook(() => useGlobalStore());
 
       act(() => {
-        result.current.updateSystemStatus({ wideScreen: false });
+        result.current.updateSystemStatus({ noWideScreen: false });
       });
 
       expect(result.current.status).toEqual(initialState.status);
@@ -45,10 +45,10 @@ describe('generalActionSlice', () => {
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus({ wideScreen: false });
+        result.current.updateSystemStatus({ noWideScreen: false });
       });
 
-      expect(result.current.status.wideScreen).toBe(false);
+      expect(result.current.status.noWideScreen).toBe(false);
     });
 
     it('should not update if new status equals current status', () => {
@@ -57,7 +57,7 @@ describe('generalActionSlice', () => {
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus({ wideScreen: initialState.status.wideScreen });
+        result.current.updateSystemStatus({ noWideScreen: initialState.status.noWideScreen });
       });
 
       expect(saveToLocalStorageSpy).not.toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('generalActionSlice', () => {
 
       act(() => {
         useGlobalStore.setState({ isStatusInit: true });
-        result.current.updateSystemStatus({ wideScreen: true });
+        result.current.updateSystemStatus({ noWideScreen: true });
       });
 
       expect(saveToLocalStorageSpy).toHaveBeenCalledWith(

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -89,9 +89,9 @@ export const globalWorkspaceSlice: StateCreator<
     get().updateSystemStatus({ showSystemRole }, n('toggleMobileTopic', newValue));
   },
   toggleWideScreen: (newValue) => {
-    const wideScreen = typeof newValue === 'boolean' ? newValue : !get().status.wideScreen;
+    const wideScreen = typeof newValue === 'boolean' ? newValue : !get().status.noWideScreen;
 
-    get().updateSystemStatus({ wideScreen }, n('toggleWideScreen', newValue));
+    get().updateSystemStatus({ noWideScreen: wideScreen }, n('toggleWideScreen', newValue));
   },
   toggleZenMode: () => {
     const { status } = get();

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -73,6 +73,7 @@ export interface SystemStatus {
   latestChangelogId?: string;
   mobileShowPortal?: boolean;
   mobileShowTopic?: boolean;
+  noWideScreen?: boolean;
   portalWidth: number;
   sessionsWidth: number;
   showChatSideBar?: boolean;
@@ -87,7 +88,6 @@ export interface SystemStatus {
    * theme mode
    */
   themeMode?: ThemeMode;
-  wideScreen?: boolean;
   zenMode?: boolean;
 }
 
@@ -124,6 +124,7 @@ export const INITIAL_STATUS = {
   imagePanelWidth: 320,
   imageTopicPanelWidth: 80,
   mobileShowTopic: false,
+  noWideScreen: true,
   portalWidth: 400,
   sessionsWidth: 320,
   showChatSideBar: true,
@@ -135,7 +136,6 @@ export const INITIAL_STATUS = {
   showSystemRole: false,
   systemRoleExpandedMap: {},
   themeMode: 'auto',
-  wideScreen: false,
   zenMode: false,
 } satisfies SystemStatus;
 

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -135,7 +135,7 @@ export const INITIAL_STATUS = {
   showSystemRole: false,
   systemRoleExpandedMap: {},
   themeMode: 'auto',
-  wideScreen: true,
+  wideScreen: false,
   zenMode: false,
 } satisfies SystemStatus;
 

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -69,7 +69,7 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sessionWidth(s)).toBe(300);
       expect(systemStatusSelectors.portalWidth(s)).toBe(500);
       expect(systemStatusSelectors.filePanelWidth(s)).toBe(400);
-      expect(systemStatusSelectors.wideScreen(s)).toBe(true);
+      expect(systemStatusSelectors.wideScreen(s)).toBe(false);
     });
 
     it('should handle zen mode effects', () => {

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -28,7 +28,7 @@ const portalWidth = (s: GlobalState) => s.status.portalWidth || 400;
 const filePanelWidth = (s: GlobalState) => s.status.filePanelWidth;
 const imagePanelWidth = (s: GlobalState) => s.status.imagePanelWidth;
 const imageTopicPanelWidth = (s: GlobalState) => s.status.imageTopicPanelWidth;
-const wideScreen = (s: GlobalState) => s.status.wideScreen;
+const wideScreen = (s: GlobalState) => !s.status.noWideScreen;
 const expandInputActionbar = (s: GlobalState) => s.status.expandInputActionbar;
 const isStatusInit = (s: GlobalState) => !!s.isStatusInit;
 const isPgliteNotEnabled = (s: GlobalState) =>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix message removal in server mode and adjust global wideScreen default; enhance message dispatch context and improve topic summary execution sequencing

Bug Fixes:
- Only delete temporary messages when creating a new topic in server mode
- Correct default wideScreen status to false and update related selectors and tests

Enhancements:
- Extend internal_dispatchMessage to accept optional topicId and sessionId context
- Separate summaryTitle and addFilesToAgent calls for clearer sequencing

Tests:
- Add unit test for temporary message cleanup during new topic creation
- Update global store tests for wideScreen default and updateSystemStatus behavior