### PR TITLE
🐛fix: update check model and mark deprecated models

### DIFF
--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -86,7 +86,7 @@ const xaiChatModels: AIChatModelCard[] = [
     description:
       '旗舰级模型，擅长数据提取、编程和文本摘要等企业级应用，拥有金融、医疗、法律和科学等领域的深厚知识。',
     displayName: 'Grok 3 (Fast mode)',
-    id: 'grok-3-fast',
+    id: 'grok-3-fast', // legacy
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
@@ -136,7 +136,7 @@ const xaiChatModels: AIChatModelCard[] = [
     description:
       '轻量级模型，回话前会先思考。运行快速、智能，适用于不需要深层领域知识的逻辑任务，并能获取原始的思维轨迹。',
     displayName: 'Grok 3 Mini (Fast mode)',
-    id: 'grok-3-mini-fast',
+    id: 'grok-3-mini-fast', // legacy
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
@@ -181,7 +181,7 @@ const xaiChatModels: AIChatModelCard[] = [
     contextWindowTokens: 32_768,
     description: '该模型在准确性、指令遵循和多语言能力方面有所改进。',
     displayName: 'Grok 2 Vision 1212',
-    id: 'grok-2-vision-1212',
+    id: 'grok-2-vision-1212', // legacy
     pricing: {
       units: [
         { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },

--- a/src/config/modelProviders/qwen.ts
+++ b/src/config/modelProviders/qwen.ts
@@ -247,7 +247,7 @@ const Qwen: ModelProviderCard = {
       releasedAt: '2025-02-05',
     },
   ],
-  checkModel: 'qwen-flash-latest',
+  checkModel: 'qwen-flash',
   description:
     '通义千问是阿里云自主研发的超大规模语言模型，具有强大的自然语言理解和生成能力。它可以回答各种问题、创作文字内容、表达观点看法、撰写代码等，在多个领域发挥作用。',
   disableBrowserRequest: true,

--- a/src/config/modelProviders/siliconcloud.ts
+++ b/src/config/modelProviders/siliconcloud.ts
@@ -419,7 +419,7 @@ const SiliconCloud: ModelProviderCard = {
       vision: true,
     },
   ],
-  checkModel: 'Pro/Qwen/Qwen2-1.5B-Instruct',
+  checkModel: 'Pro/Qwen/Qwen2-7B-Instruct',
   description: 'SiliconCloud，基于优秀开源基础模型的高性价比 GenAI 云服务',
   id: 'siliconcloud',
   modelList: { showModelFetcher: true },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- fix #9212

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

[Qwen](https://bailian.console.aliyun.com/#/model-market/detail/group-qwen-flash?modelGroup=group-qwen-flash)
<img width="1269" height="443" alt="image" src="https://github.com/user-attachments/assets/46158468-35cc-485e-8d20-f9df10c89827" />

[Siliconflow](https://cloud.siliconflow.cn/me/models?types=chat)
<img width="909" height="193" alt="image" src="https://github.com/user-attachments/assets/9f1ff9c9-166f-431a-b480-3556416a3b14" />

Grok，虽然已经标为deprecated，但是仍在提供服务
<img width="1499" height="836" alt="image" src="https://github.com/user-attachments/assets/98f7efb1-6ec8-44f8-8ecc-fd6cd9406365" />

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Remove deprecated Grok models from the XAI chat model bank and update checkModel references for Qwen, SiliconCloud, and XAI providers to match current model identifiers

Bug Fixes:
- Remove deprecated Grok models (grok-3-fast, grok-3-mini-fast, grok-2-1212, grok-2-vision-1212) from the XAI chat model list
- Update checkModel values for Qwen to "qwen-flash", SiliconCloud to "Pro/Qwen/Qwen2-7B-Instruct", and XAI to "grok-3-mini"