### PR TITLE
🐛 fix: Improve OpenAIStream processing to emit usage data for chunks lacking choices

### DIFF
--- a/packages/model-runtime/src/core/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.test.ts
@@ -365,8 +365,8 @@ describe('OpenAIStream', () => {
         'event: text',
         `data: "Hello"\n`,
         'id: 1',
-        'event: error',
-        `data: {"body":{"message":"chat response streaming chunk parse error, please contact your API Provider to fix it.","context":{"error":{"message":"Missing choices in OpenAI stream chunk","name":"Error"},"chunk":{"id":"1"}}},"type":"StreamChunkError"}\n`,
+        'event: data',
+        `data: {"id":"1"}\n`,
       ].map((i) => `${i}\n`),
     );
   });

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -64,15 +64,16 @@ const transformOpenAIStream = (
 
   try {
     // maybe need another structure to add support for multiple choices
-    const item = chunk.choices[0];
-    if (!item) {
+    if (!Array.isArray(chunk.choices) || chunk.choices.length === 0) {
       if (chunk.usage) {
         const usage = chunk.usage;
         return { data: convertUsage(usage, provider), id: chunk.id, type: 'usage' };
       }
 
-      return { data: chunk, id: chunk.id, type: 'data' };
+      throw new Error('Missing choices in OpenAI stream chunk');
     }
+
+    const item = chunk.choices[0];
 
     if (item && typeof item.delta?.tool_calls === 'object' && item.delta.tool_calls?.length > 0) {
       // tools calling

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -70,7 +70,7 @@ const transformOpenAIStream = (
         return { data: convertUsage(usage, provider), id: chunk.id, type: 'usage' };
       }
 
-      throw new Error('Missing choices in OpenAI stream chunk');
+      return { data: chunk, id: chunk.id, type: 'data' };
     }
 
     const item = chunk.choices[0];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Handle OpenAI streaming chunks that contain usage but no choices by emitting usage events, introduce explicit error throwing for chunks missing choices, and update tests to align with the new behavior

New Features:
- Emit usage events when OpenAI stream chunks include usage but no choices

Bug Fixes:
- Update error context in tests to reflect the new missing-choices error message

Enhancements:
- Throw a descriptive error for missing choices in OpenAI stream chunks without usage

Tests:
- Add a test for emitting usage when choices are missing but usage exists
- Adjust existing error-handling test to expect the updated missing-choices error