### PR TITLE
💄 style: fix Discover plugin link

### DIFF
--- a/src/app/[variants]/(main)/discover/(list)/(home)/Client.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/(home)/Client.tsx
@@ -34,7 +34,7 @@ const Client = memo<{ mobile?: boolean }>(() => {
       </Title>
       <AssistantList data={assistantList.items} rows={4} />
       <div />
-      <Title more={t('home.more')} moreLink={'/discover/plugin'}>
+      <Title more={t('home.more')} moreLink={'/discover/mcp'}>
         {t('home.featuredTools')}
       </Title>
       <McpList data={mcpList.items} rows={4} />


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
复Discover首页页面 推荐插件 [发现更多]按钮的路由错误
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
复Discover首页页面 推荐插件 [发现更多]按钮的路由错误
<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Correct the ‘Discover More’ button link from `/discover/plugin` to `/discover/mcp` on the Discover home page.