### PR TITLE
fix(mobile): input multiple line issue

### DIFF
--- a/apps/mobile/src/features/chat/ChatInput/index.tsx
+++ b/apps/mobile/src/features/chat/ChatInput/index.tsx
@@ -58,7 +58,7 @@ const ChatInput = memo(({ style }: ChatInputProps) => {
           autoCorrect={false}
           keyboardType="default"
           multiline={true}
-          numberOfLines={4}
+          numberOfLines={8}
           onChangeText={handleInputChange}
           onSubmitEditing={handleSubmit}
           placeholder={t('placeholder', { ns: 'chat' })}

--- a/apps/mobile/src/features/chat/ChatInput/style.ts
+++ b/apps/mobile/src/features/chat/ChatInput/style.ts
@@ -7,8 +7,9 @@ export const useStyles = createStyles((token) => ({
     borderColor: token.colorBorder,
     borderRadius: token.borderRadius * 4,
     borderWidth: 0.5,
-    height: CHAT_INPUT_HEIGHT,
+    height: 'auto',
     marginHorizontal: token.marginXXS,
+    minHeight: CHAT_INPUT_HEIGHT,
     paddingHorizontal: token.padding,
     paddingVertical: token.paddingSM,
     // ...token.boxShadowCard,
@@ -30,7 +31,6 @@ export const useStyles = createStyles((token) => ({
   },
   input: {
     flex: 1,
-    maxHeight: 96,
   },
   inputArea: {
     alignItems: 'center',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix mobile chat input to properly support multiple lines by making its container dynamically resize and increasing line limit.

Bug Fixes:
- Change input container height to auto with a minimum height instead of a fixed value
- Remove maxHeight restriction on the input component
- Increase the numberOfLines property from 4 to 8 to allow more visible lines