### PR TITLE
🔧 chore: Migrating from Sentry NextJS SDK 7.x to 10.x

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -340,9 +340,6 @@ const withSentry =
           // Automatically tree-shake Sentry logger statements to reduce bundle size
           disableLogger: true,
 
-          // Hides source maps from generated client bundles
-          hideSourceMaps: true,
-
           org: process.env.SENTRY_ORG,
 
           project: process.env.SENTRY_PROJECT,

--- a/next.config.ts
+++ b/next.config.ts
@@ -330,44 +330,38 @@ const hasSentry = !!process.env.NEXT_PUBLIC_SENTRY_DSN;
 const withSentry =
   isProd && hasSentry
     ? (c: NextConfig) =>
-        withSentryConfig(
-          c,
-          {
-            org: process.env.SENTRY_ORG,
+        withSentryConfig(c, {
+          // Enables automatic instrumentation of Vercel Cron Monitors.
+          // See the following for more information:
+          // https://docs.sentry.io/product/crons/
+          // https://vercel.com/docs/cron-jobs
+          automaticVercelMonitors: true,
 
-            project: process.env.SENTRY_PROJECT,
-            // For all available options, see:
-            // https://github.com/getsentry/sentry-webpack-plugin#options
-            // Suppresses source map uploading logs during build
-            silent: true,
-          },
-          {
-            // Enables automatic instrumentation of Vercel Cron Monitors.
-            // See the following for more information:
-            // https://docs.sentry.io/product/crons/
-            // https://vercel.com/docs/cron-jobs
-            automaticVercelMonitors: true,
+          // Automatically tree-shake Sentry logger statements to reduce bundle size
+          disableLogger: true,
 
-            // Automatically tree-shake Sentry logger statements to reduce bundle size
-            disableLogger: true,
+          // Hides source maps from generated client bundles
+          hideSourceMaps: true,
 
-            // Hides source maps from generated client bundles
-            hideSourceMaps: true,
+          org: process.env.SENTRY_ORG,
 
-            // Transpiles SDK to be compatible with IE11 (increases bundle size)
-            transpileClientSDK: true,
+          project: process.env.SENTRY_PROJECT,
 
-            // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers. (increases server load)
-            // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-            // side errors will fail.
-            tunnelRoute: '/monitoring',
+          // For all available options, see:
+          // https://github.com/getsentry/sentry-webpack-plugin#options
+          // Suppresses source map uploading logs during build
+          silent: true,
 
-            // For all available options, see:
-            // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
-            // Upload a larger set of source maps for prettier stack traces (increases build time)
-            widenClientFileUpload: true,
-          },
-        )
+          // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers. (increases server load)
+          // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+          // side errors will fail.
+          tunnelRoute: '/monitoring',
+
+          // For all available options, see:
+          // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+          // Upload a larger set of source maps for prettier stack traces (increases build time)
+          widenClientFileUpload: true,
+        })
     : noWrapper;
 
 export default withBundleAnalyzer(withPWA(withSentry(nextConfig) as NextConfig));

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@neondatabase/serverless": "^1.0.1",
     "@next/third-parties": "^15.5.3",
     "@react-spring/web": "^9.7.5",
-    "@sentry/nextjs": "^7.120.4",
+    "@sentry/nextjs": "^8.55.0",
     "@serwist/next": "^9.2.1",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@tanstack/react-query": "^5.87.4",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@neondatabase/serverless": "^1.0.1",
     "@next/third-parties": "^15.5.3",
     "@react-spring/web": "^9.7.5",
-    "@sentry/nextjs": "^8.55.0",
+    "@sentry/nextjs": "^10.11.0",
     "@serwist/next": "^9.2.1",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@tanstack/react-query": "^5.87.4",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -11,6 +11,7 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_DSN) {
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     // You can remove this option if you're not planning to use the Sentry Session Replay feature:
     integrations: [
+      Sentry.browserTracingIntegration(),
       Sentry.replayIntegration({
         blockAllMedia: true,
         // Additional Replay configuration goes in here, for example:

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,10 @@
+// ref: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('../sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('../sentry.edge.config');
+  }
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Migrate project from Sentry JavaScript SDK v7 to v8 by updating configuration API, bumping the package version, and adding a runtime instrumentation loader.

New Features:
- Add instrumentation.ts to dynamically register server or edge Sentry configurations based on Next.js runtime

Enhancements:
- Update Next.js Sentry plugin configuration to use the new v8 single-object API with automatic Vercel monitors, disabled logger, and other options consolidated
- Bump @sentry/nextjs dependency from version 7.x to 8.x