### PR TITLE
 💄 style: Added `AUTH_MICROSOFT_ENTRA_ID_BASE_URL` routing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/typescript-node",
   "features": {
-    "ghcr.io/devcontainer-community/devcontainer-features/bun.sh:1": {}
-  }
+    "ghcr.io/devcontainer-community/devcontainer-features/bun.sh:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "image": "mcr.microsoft.com/devcontainers/typescript-node"
 }

--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -205,6 +205,13 @@ LobeChat provides a complete authentication service capability when deployed. Th
 
 ### Microsoft Entra ID
 
+#### `AUTH_MICROSOFT_ENTRA_ID_BASE_URL`
+
+- Type: Required
+- Description: - Description: Base URL for Azure login. Use when authenticating against other Microsoft sovereignty clouds like Azure US Government.
+- Default: `https://login.microsoftonline.com`
+- Example: `https://login.microsoftonline.us`
+
 #### `AUTH_AZURE_AD_ID`
 
 - Type: Required

--- a/src/libs/next-auth/sso-providers/microsoft-entra-id-helper.ts
+++ b/src/libs/next-auth/sso-providers/microsoft-entra-id-helper.ts
@@ -8,6 +8,10 @@ function getTenantId() {
   );
 }
 
+function getClientLoginBaseUrl() {
+  return process.env.AUTH_MICROSOFT_ENTRA_ID_BASE_URL ?? 'https://login.microsoftonline.com';
+}
+
 function getIssuer() {
   const issuer = process.env.MICROSOFT_ENTRA_ID_ISSUER;
   if (issuer) {
@@ -16,7 +20,7 @@ function getIssuer() {
   const tenantId = getTenantId();
   if (tenantId) {
     // refs: https://github.com/nextauthjs/next-auth/discussions/9154#discussioncomment-10583104
-    return `https://login.microsoftonline.com/${tenantId}/v2.0`;
+    return `${getClientLoginBaseUrl()}/${tenantId}/v2.0`;
   } else {
     return undefined;
   }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Added AUTH_MICROSOFT_ENTRA_ID_BASE_URL environment variable to support auth base url changes for national cloud deployments specified [here](https://learn.microsoft.com/en-us/graph/deployments) 

#### 📝 补充信息 | Additional Information

Change based on discussion thread #9292

## Summary by Sourcery

Enable configuring the Microsoft Entra ID login base URL via a new environment variable to support sovereign (national) cloud deployments.

New Features:
- Add AUTH_MICROSOFT_ENTRA_ID_BASE_URL environment variable to override the default Azure login endpoint for national cloud scenarios.

Enhancements:
- Update issuer URL builder to reference AUTH_MICROSOFT_ENTRA_ID_BASE_URL when constructing the Microsoft Entra ID route.

Documentation:
- Document AUTH_MICROSOFT_ENTRA_ID_BASE_URL with its type, default value, and example usage in the self-hosting environment variables guide.