### PR TITLE
fix：fixed when plugins unistall & install both take problem

### DIFF
--- a/src/features/PluginStore/InstalledList/List/Item/Action.tsx
+++ b/src/features/PluginStore/InstalledList/List/Item/Action.tsx
@@ -93,9 +93,6 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
                     onClick: () => {
                       modal.confirm({
                         centered: true,
-                        content: isPluginEnabledInAgent 
-                          ? t('store.actions.confirmUninstallEnabled', { defaultValue: 'This plugin is currently enabled in this agent. Uninstalling will also disable it from this agent.' })
-                          : undefined,
                         okButtonProps: { danger: true },
                         onOk: async () => {
                           // If plugin is enabled in current agent, disable it first

--- a/src/features/PluginStore/McpList/List/Action.tsx
+++ b/src/features/PluginStore/McpList/List/Action.tsx
@@ -45,9 +45,6 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
                 onClick: () => {
                   modal.confirm({
                     centered: true,
-                    content: isPluginEnabledInAgent 
-                      ? t('store.actions.confirmUninstallEnabled', { defaultValue: 'This plugin is currently enabled in this agent. Uninstalling will also disable it from this agent.' })
-                      : undefined,
                     okButtonProps: { danger: true },
                     onOk: async () => {
                       // If plugin is enabled in current agent, disable it first

--- a/src/features/PluginStore/McpList/List/Action.tsx
+++ b/src/features/PluginStore/McpList/List/Action.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useToolStore } from '@/store/tool';
 import { mcpStoreSelectors, pluginSelectors } from '@/store/tool/selectors';
 
@@ -24,7 +25,10 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
     ]);
 
   const { t } = useTranslation('plugin');
-  const togglePlugin = useAgentStore((s) => s.togglePlugin);
+  const [togglePlugin, isPluginEnabledInAgent] = useAgentStore((s) => [
+    s.togglePlugin,
+    agentSelectors.currentAgentPlugins(s).includes(identifier),
+  ]);
   const { modal } = App.useApp();
 
   return (
@@ -41,8 +45,17 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
                 onClick: () => {
                   modal.confirm({
                     centered: true,
+                    content: isPluginEnabledInAgent 
+                      ? t('store.actions.confirmUninstallEnabled', { defaultValue: 'This plugin is currently enabled in this agent. Uninstalling will also disable it from this agent.' })
+                      : undefined,
                     okButtonProps: { danger: true },
-                    onOk: async () => unInstallPlugin(identifier),
+                    onOk: async () => {
+                      // If plugin is enabled in current agent, disable it first
+                      if (isPluginEnabledInAgent) {
+                        await togglePlugin(identifier, false);
+                      }
+                      await unInstallPlugin(identifier);
+                    },
                     title: t('store.actions.confirmUninstall'),
                     type: 'error',
                   });

--- a/src/features/PluginStore/PluginList/List/Action.tsx
+++ b/src/features/PluginStore/PluginList/List/Action.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useToolStore } from '@/store/tool';
 import { pluginSelectors, pluginStoreSelectors } from '@/store/tool/selectors';
 
@@ -22,7 +23,10 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
   ]);
 
   const { t } = useTranslation('plugin');
-  const togglePlugin = useAgentStore((s) => s.togglePlugin);
+  const [togglePlugin, isPluginEnabledInAgent] = useAgentStore((s) => [
+    s.togglePlugin,
+    agentSelectors.currentAgentPlugins(s).includes(identifier),
+  ]);
   const { modal } = App.useApp();
 
   return (
@@ -39,8 +43,17 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
                 onClick: () => {
                   modal.confirm({
                     centered: true,
+                    content: isPluginEnabledInAgent 
+                      ? t('store.actions.confirmUninstallEnabled', { defaultValue: 'This plugin is currently enabled in this agent. Uninstalling will also disable it from this agent.' })
+                      : undefined,
                     okButtonProps: { danger: true },
-                    onOk: async () => unInstallPlugin(identifier),
+                    onOk: async () => {
+                      // If plugin is enabled in current agent, disable it first
+                      if (isPluginEnabledInAgent) {
+                        await togglePlugin(identifier, false);
+                      }
+                      await unInstallPlugin(identifier);
+                    },
                     title: t('store.actions.confirmUninstall'),
                     type: 'error',
                   });

--- a/src/features/PluginStore/PluginList/List/Action.tsx
+++ b/src/features/PluginStore/PluginList/List/Action.tsx
@@ -43,9 +43,6 @@ const Actions = memo<ActionsProps>(({ identifier }) => {
                 onClick: () => {
                   modal.confirm({
                     centered: true,
-                    content: isPluginEnabledInAgent 
-                      ? t('store.actions.confirmUninstallEnabled', { defaultValue: 'This plugin is currently enabled in this agent. Uninstalling will also disable it from this agent.' })
-                      : undefined,
                     okButtonProps: { danger: true },
                     onOk: async () => {
                       // If plugin is enabled in current agent, disable it first


### PR DESCRIPTION
This PR addresses issue #9279

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Ensure plugin uninstallation first disables it in the current agent and warns the user when it’s still enabled.

Bug Fixes:
- Disable the plugin in the current agent before uninstalling to prevent it from remaining enabled after removal.

Enhancements:
- Display a confirmation message when uninstalling a plugin that is currently enabled in the agent.