### PR TITLE
🐛 fix: fix oidc open direct issue

### DIFF
--- a/packages/utils/src/server/correctOIDCUrl.test.ts
+++ b/packages/utils/src/server/correctOIDCUrl.test.ts
@@ -1,0 +1,345 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { correctOIDCUrl } from './correctOIDCUrl';
+
+describe('correctOIDCUrl', () => {
+  let mockRequest: NextRequest;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Create a mock request with a mutable headers property
+    mockRequest = {
+      headers: {
+        get: vi.fn(),
+      },
+    } as unknown as NextRequest;
+  });
+
+  describe('when no forwarded headers are present', () => {
+    it('should return original URL when host matches and protocol is correct', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('https://example.com/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com/auth/callback');
+      expect(result).toBe(originalUrl); // Should return the same object
+    });
+
+    it('should correct localhost URLs to request host preserving port', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://example.com:3000/auth/callback');
+      expect(result.host).toBe('example.com:3000');
+      expect(result.hostname).toBe('example.com');
+      expect(result.port).toBe('3000');
+      expect(result.protocol).toBe('http:');
+    });
+
+    it('should correct 127.0.0.1 URLs to request host preserving port', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://127.0.0.1:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://example.com:3000/auth/callback');
+      expect(result.host).toBe('example.com:3000');
+      expect(result.hostname).toBe('example.com');
+    });
+
+    it('should correct 0.0.0.0 URLs to request host preserving port', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://0.0.0.0:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://example.com:3000/auth/callback');
+      expect(result.host).toBe('example.com:3000');
+      expect(result.hostname).toBe('example.com');
+    });
+
+    it('should correct mismatched hostnames', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('https://different.com/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com/auth/callback');
+      expect(result.host).toBe('example.com');
+    });
+
+    it('should handle request host with port when correcting localhost', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com:8080';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://example.com:8080/auth/callback');
+      expect(result.host).toBe('example.com:8080');
+      expect(result.hostname).toBe('example.com');
+      expect(result.port).toBe('8080');
+    });
+  });
+
+  describe('when x-forwarded-host header is present', () => {
+    it('should use x-forwarded-host over host header', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'internal.com';
+        if (header === 'x-forwarded-host') return 'proxy.example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://proxy.example.com:3000/auth/callback');
+      expect(result.host).toBe('proxy.example.com:3000');
+      expect(result.hostname).toBe('proxy.example.com');
+    });
+
+    it('should preserve path and query parameters', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'internal.com';
+        if (header === 'x-forwarded-host') return 'proxy.example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback?code=123&state=abc');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe(
+        'http://proxy.example.com:3000/auth/callback?code=123&state=abc',
+      );
+      expect(result.pathname).toBe('/auth/callback');
+      expect(result.search).toBe('?code=123&state=abc');
+    });
+  });
+
+  describe('when x-forwarded-proto header is present', () => {
+    it('should use x-forwarded-proto for protocol', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        if (header === 'x-forwarded-proto') return 'https';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:3000/auth/callback');
+      expect(result.protocol).toBe('https:');
+    });
+
+    it('should use x-forwarded-protocol as fallback', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        if (header === 'x-forwarded-protocol') return 'https';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:3000/auth/callback');
+      expect(result.protocol).toBe('https:');
+    });
+
+    it('should prioritize x-forwarded-proto over x-forwarded-protocol', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        if (header === 'x-forwarded-proto') return 'https';
+        if (header === 'x-forwarded-protocol') return 'http';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:3000/auth/callback');
+      expect(result.protocol).toBe('https:');
+    });
+  });
+
+  describe('protocol inference when no forwarded protocol', () => {
+    it('should infer https when original URL uses https', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('https://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:3000/auth/callback');
+      expect(result.protocol).toBe('https:');
+    });
+
+    it('should default to http when original URL uses http', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('http://example.com:3000/auth/callback');
+      expect(result.protocol).toBe('http:');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return original URL when host is null', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return null;
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result).toBe(originalUrl);
+      expect(result.toString()).toBe('http://localhost:3000/auth/callback');
+    });
+
+    it('should return original URL when host is "null" string', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'null';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result).toBe(originalUrl);
+      expect(result.toString()).toBe('http://localhost:3000/auth/callback');
+    });
+
+    it('should return original URL when no host header is present', () => {
+      (mockRequest.headers.get as any).mockImplementation(() => null);
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result).toBe(originalUrl);
+      expect(result.toString()).toBe('http://localhost:3000/auth/callback');
+    });
+
+    it('should handle URL construction errors gracefully', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL(
+        'http://localhost:3000/auth/callback?redirect=http://example.com',
+      );
+
+      // Spy on URL constructor to simulate an error on correction
+      const urlSpy = vi.spyOn(global, 'URL');
+      urlSpy.mockImplementationOnce((url: string | URL, base?: string | URL) => new URL(url, base)); // First call succeeds (original)
+      urlSpy.mockImplementationOnce(() => {
+        throw new Error('Invalid URL');
+      }); // Second call fails (correction)
+
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      // Should return original URL when correction fails
+      expect(result).toBe(originalUrl);
+      expect(result.toString()).toBe(
+        'http://localhost:3000/auth/callback?redirect=http://example.com',
+      );
+
+      urlSpy.mockRestore();
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle complete proxy scenario with all headers', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'internal-service:3000';
+        if (header === 'x-forwarded-host') return 'api.example.com';
+        if (header === 'x-forwarded-proto') return 'https';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:8080/api/auth/callback?code=xyz&state=def');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe(
+        'https://api.example.com:8080/api/auth/callback?code=xyz&state=def',
+      );
+      expect(result.protocol).toBe('https:');
+      expect(result.host).toBe('api.example.com:8080');
+      expect(result.hostname).toBe('api.example.com');
+      expect(result.pathname).toBe('/api/auth/callback');
+      expect(result.search).toBe('?code=xyz&state=def');
+    });
+
+    it('should preserve URL hash fragments', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        if (header === 'x-forwarded-proto') return 'https';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback#access_token=123');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:3000/auth/callback#access_token=123');
+      expect(result.hash).toBe('#access_token=123');
+    });
+
+    it('should handle URLs with ports correctly when forwarded host has port', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'internal.com:3000';
+        if (header === 'x-forwarded-host') return 'example.com:8443';
+        if (header === 'x-forwarded-proto') return 'https';
+        return null;
+      });
+
+      const originalUrl = new URL('http://localhost:3000/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result.toString()).toBe('https://example.com:8443/auth/callback');
+      expect(result.host).toBe('example.com:8443');
+      expect(result.hostname).toBe('example.com');
+      expect(result.port).toBe('8443');
+    });
+
+    it('should not need correction when URL hostname matches actual host', () => {
+      (mockRequest.headers.get as any).mockImplementation((header: string) => {
+        if (header === 'host') return 'example.com';
+        return null;
+      });
+
+      const originalUrl = new URL('http://example.com/auth/callback');
+      const result = correctOIDCUrl(mockRequest, originalUrl);
+
+      expect(result).toBe(originalUrl); // Should return the same object
+      expect(result.toString()).toBe('http://example.com/auth/callback');
+    });
+  });
+});

--- a/packages/utils/src/server/correctOIDCUrl.ts
+++ b/packages/utils/src/server/correctOIDCUrl.ts
@@ -6,10 +6,10 @@ import { validateRedirectHost } from './validateRedirectHost';
 const log = debug('lobe-oidc:correctOIDCUrl');
 
 /**
- * 修复 OIDC 重定向 URL 在代理环境下的问题
- * @param req - Next.js 请求对象
- * @param url - 要修复的 URL 对象
- * @returns 修复后的 URL 对象
+ * Fix OIDC redirect URL issues in proxy environments
+ * @param req - Next.js request object
+ * @param url - URL object to fix
+ * @returns Fixed URL object
  */
 export const correctOIDCUrl = (req: NextRequest, url: URL): URL => {
   const requestHost = req.headers.get('host');
@@ -25,23 +25,23 @@ export const correctOIDCUrl = (req: NextRequest, url: URL): URL => {
     forwardedProto,
   );
 
-  // 确定实际的主机名和协议，提供后备值
+  // Determine actual hostname and protocol with fallback values
   const actualHost = forwardedHost || requestHost;
   const actualProto = forwardedProto || (url.protocol === 'https:' ? 'https' : 'http');
 
-  // 如果无法确定有效的主机名，直接返回原URL
+  // If unable to determine valid hostname, return original URL
   if (!actualHost || actualHost === 'null') {
     log('Warning: Cannot determine valid host, returning original URL');
     return url;
   }
 
-  // 验证目标主机是否安全，防止 Open Redirect 攻击
+  // Validate target host for security, prevent Open Redirect attacks
   if (!validateRedirectHost(actualHost)) {
     log('Warning: Target host %s failed validation, returning original URL', actualHost);
     return url;
   }
 
-  // 如果 URL 指向本地地址，或者主机名与实际请求主机不匹配，则修正 URL
+  // Correct URL if it points to localhost or hostname doesn't match actual request host
   const needsCorrection =
     url.hostname === 'localhost' ||
     url.hostname === '127.0.0.1' ||

--- a/packages/utils/src/server/correctOIDCUrl.ts
+++ b/packages/utils/src/server/correctOIDCUrl.ts
@@ -1,6 +1,8 @@
 import debug from 'debug';
 import { NextRequest } from 'next/server';
 
+import { validateRedirectHost } from './validateRedirectHost';
+
 const log = debug('lobe-oidc:correctOIDCUrl');
 
 /**
@@ -30,6 +32,12 @@ export const correctOIDCUrl = (req: NextRequest, url: URL): URL => {
   // 如果无法确定有效的主机名，直接返回原URL
   if (!actualHost || actualHost === 'null') {
     log('Warning: Cannot determine valid host, returning original URL');
+    return url;
+  }
+
+  // 验证目标主机是否安全，防止 Open Redirect 攻击
+  if (!validateRedirectHost(actualHost)) {
+    log('Warning: Target host %s failed validation, returning original URL', actualHost);
     return url;
   }
 

--- a/packages/utils/src/server/validateRedirectHost.ts
+++ b/packages/utils/src/server/validateRedirectHost.ts
@@ -3,8 +3,8 @@ import debug from 'debug';
 const log = debug('lobe-oidc:validateRedirectHost');
 
 /**
- * 验证重定向主机是否在允许的白名单中
- * 防止 Open Redirect 攻击
+ * Validate if redirect host is in the allowed whitelist
+ * Prevent Open Redirect attacks
  */
 export const validateRedirectHost = (targetHost: string): boolean => {
   if (!targetHost || targetHost === 'null') {
@@ -12,7 +12,7 @@ export const validateRedirectHost = (targetHost: string): boolean => {
     return false;
   }
 
-  // 获取配置的 APP_URL 作为基准域名
+  // Get configured APP_URL as base domain
   const appUrl = process.env.APP_URL;
   if (!appUrl) {
     log('Warning: APP_URL not configured, rejecting redirect to: %s', targetHost);
@@ -25,13 +25,13 @@ export const validateRedirectHost = (targetHost: string): boolean => {
 
     log('Validating target host: %s against app host: %s', targetHost, appHost);
 
-    // 完全匹配
+    // Exact match
     if (targetHost === appHost) {
       log('Host validation passed: exact match');
       return true;
     }
 
-    // 允许 localhost 和本地地址（开发环境）
+    // Allow localhost and local addresses (development environment)
     const isLocalhost =
       targetHost === 'localhost' ||
       targetHost.startsWith('localhost:') ||
@@ -50,9 +50,9 @@ export const validateRedirectHost = (targetHost: string): boolean => {
       return true;
     }
 
-    // 检查是否为配置域名的子域名
-    const appDomain = appHost.split(':')[0]; // 移除端口号
-    const targetDomain = targetHost.split(':')[0]; // 移除端口号
+    // Check if it's a subdomain of the configured domain
+    const appDomain = appHost.split(':')[0]; // Remove port number
+    const targetDomain = targetHost.split(':')[0]; // Remove port number
 
     if (targetDomain.endsWith('.' + appDomain)) {
       log('Host validation passed: subdomain of %s', appDomain);

--- a/packages/utils/src/server/validateRedirectHost.ts
+++ b/packages/utils/src/server/validateRedirectHost.ts
@@ -1,0 +1,68 @@
+import debug from 'debug';
+
+const log = debug('lobe-oidc:validateRedirectHost');
+
+/**
+ * 验证重定向主机是否在允许的白名单中
+ * 防止 Open Redirect 攻击
+ */
+export const validateRedirectHost = (targetHost: string): boolean => {
+  if (!targetHost || targetHost === 'null') {
+    log('Invalid target host: %s', targetHost);
+    return false;
+  }
+
+  // 获取配置的 APP_URL 作为基准域名
+  const appUrl = process.env.APP_URL;
+  if (!appUrl) {
+    log('Warning: APP_URL not configured, rejecting redirect to: %s', targetHost);
+    return false;
+  }
+
+  try {
+    const appUrlObj = new URL(appUrl);
+    const appHost = appUrlObj.host;
+
+    log('Validating target host: %s against app host: %s', targetHost, appHost);
+
+    // 完全匹配
+    if (targetHost === appHost) {
+      log('Host validation passed: exact match');
+      return true;
+    }
+
+    // 允许 localhost 和本地地址（开发环境）
+    const isLocalhost =
+      targetHost === 'localhost' ||
+      targetHost.startsWith('localhost:') ||
+      targetHost === '127.0.0.1' ||
+      targetHost.startsWith('127.0.0.1:') ||
+      targetHost === '0.0.0.0' ||
+      targetHost.startsWith('0.0.0.0:');
+
+    if (
+      isLocalhost &&
+      (appHost.includes('localhost') ||
+        appHost.includes('127.0.0.1') ||
+        appHost.includes('0.0.0.0'))
+    ) {
+      log('Host validation passed: localhost environment');
+      return true;
+    }
+
+    // 检查是否为配置域名的子域名
+    const appDomain = appHost.split(':')[0]; // 移除端口号
+    const targetDomain = targetHost.split(':')[0]; // 移除端口号
+
+    if (targetDomain.endsWith('.' + appDomain)) {
+      log('Host validation passed: subdomain of %s', appDomain);
+      return true;
+    }
+
+    console.error('Host validation failed: %s is not allowed', targetHost);
+    return false;
+  } catch (error) {
+    console.error('Error parsing APP_URL %s: %O', appUrl, error);
+    return false;
+  }
+};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Prevent open redirect vulnerabilities by validating the target host before correcting OIDC callback URLs.

New Features:
- Add validateRedirectHost utility to whitelist allowed redirect hosts based on APP_URL, localhost, and subdomains.

Bug Fixes:
- Abort URL correction and return the original URL when the target host fails validation to prevent open redirects.

Enhancements:
- Integrate host validation into correctOIDCUrl to enforce safe redirect hosts.

Tests:
- Add tests for correctOIDCUrl and host validation logic.