### PR TITLE
✨ feat: Add scroll support for pinned assistants using ScrollShadow

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
@@ -82,8 +82,8 @@ const PinList = () => {
     hasList && (
       <>
         <Divider style={{ marginBottom: 8, marginTop: 4 }} />
-        <ScrollShadow size={40} style={{ flex: 1, height: '100%' }}>
-          <Flexbox gap={12} style={{ padding: '0 8px' }}>
+        <ScrollShadow height={"100%"} hideScrollBar={true} size={40}>
+          <Flexbox gap={12} style={{ padding: '0' }}>
             {list.map((item, index) => (
               <Flexbox key={item.id} style={{ position: 'relative' }}>
                 <Tooltip

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/PinList/index.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Tooltip } from '@lobehub/ui';
+import { Avatar, ScrollShadow, Tooltip } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
@@ -82,33 +82,35 @@ const PinList = () => {
     hasList && (
       <>
         <Divider style={{ marginBottom: 8, marginTop: 4 }} />
-        <Flexbox flex={1} gap={12} height={'100%'}>
-          {list.slice(0, 9).map((item, index) => (
-            <Flexbox key={item.id} style={{ position: 'relative' }}>
-              <Tooltip
-                hotkey={hotkey.replaceAll(KeyEnum.Number, String(index + 1))}
-                placement={'right'}
-                title={sessionHelpers.getTitle(item.meta)}
-              >
-                <Flexbox
-                  className={cx(
-                    styles.ink,
-                    isPinned && activeId === item.id ? styles.inkActive : undefined,
-                  )}
+        <ScrollShadow size={40} style={{ flex: 1, height: '100%' }}>
+          <Flexbox gap={12} style={{ padding: '0 8px' }}>
+            {list.map((item, index) => (
+              <Flexbox key={item.id} style={{ position: 'relative' }}>
+                <Tooltip
+                  hotkey={index < 9 ? hotkey.replaceAll(KeyEnum.Number, String(index + 1)) : undefined}
+                  placement={'right'}
+                  title={sessionHelpers.getTitle(item.meta)}
                 >
-                  <Avatar
-                    avatar={sessionHelpers.getAvatar(item.meta)}
-                    background={item.meta.backgroundColor}
-                    onClick={() => {
-                      switchAgent(item.id);
-                    }}
-                    size={40}
-                  />
-                </Flexbox>
-              </Tooltip>
-            </Flexbox>
-          ))}
-        </Flexbox>
+                  <Flexbox
+                    className={cx(
+                      styles.ink,
+                      isPinned && activeId === item.id ? styles.inkActive : undefined,
+                    )}
+                  >
+                    <Avatar
+                      avatar={sessionHelpers.getAvatar(item.meta)}
+                      background={item.meta.backgroundColor}
+                      onClick={() => {
+                        switchAgent(item.id);
+                      }}
+                      size={40}
+                    />
+                  </Flexbox>
+                </Tooltip>
+              </Flexbox>
+            ))}
+          </Flexbox>
+        </ScrollShadow>
       </>
     )
   );

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
@@ -52,7 +52,11 @@ const Nav = memo(() => {
         }}
         topActions={
           <Suspense>
-            <div className={electronStylish.nodrag}>
+            <div className={electronStylish.nodrag} style={{
+              display: 'flex',
+              flexDirection: 'column',
+              maxHeight: "calc(100vh - 150px)"
+            }}>
               <Top />
               {showPinList && <PinList />}
             </div>


### PR DESCRIPTION
- Import ScrollShadow component from @lobehub/ui
- Wrap pinned assistants list with ScrollShadow for vertical scrolling
- Remove 9-item limitation to show all pinned assistants
- Maintain hotkey support for first 9 items
- Add proper styling and padding for consistent layout

Fixes #9316

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable vertical scrolling for the pinned assistants list using ScrollShadow, remove the nine-item display limit, preserve hotkey hints for the first nine items, and adjust padding for consistent layout

New Features:
- Wrap pinned assistants list in ScrollShadow to allow vertical scrolling
- Remove nine-item cap to display all pinned assistants

Enhancements:
- Maintain hotkey support only for the first nine items
- Add horizontal padding for consistent list styling