### PR TITLE
fix: ensure chat config defaults for Auto Create Topic

### DIFF
--- a/src/store/agent/slices/chat/selectors/chatConfig.ts
+++ b/src/store/agent/slices/chat/selectors/chatConfig.ts
@@ -5,8 +5,10 @@ import { LobeAgentChatConfig } from '@/types/agent';
 
 import { currentAgentConfig } from './agent';
 
-export const currentAgentChatConfig = (s: AgentStoreState): LobeAgentChatConfig =>
-  currentAgentConfig(s).chatConfig || {};
+export const currentAgentChatConfig = (s: AgentStoreState): LobeAgentChatConfig => {
+  const agentConfig = currentAgentConfig(s);
+  return agentConfig.chatConfig ? { ...DEFAULT_AGENT_CHAT_CONFIG, ...agentConfig.chatConfig } : DEFAULT_AGENT_CHAT_CONFIG;
+};
 
 const agentSearchMode = (s: AgentStoreState) => currentAgentChatConfig(s).searchMode || 'off';
 const isAgentEnableSearch = (s: AgentStoreState) => agentSearchMode(s) !== 'off';


### PR DESCRIPTION
Fix the issue where 'Auto Create Topic' setting was being ignored when no specific chatConfig was defined for an agent. The currentAgentChatConfig selector was returning an empty object {} instead of merging with defaults, causing enableAutoCreateTopic to be undefined instead of true.

Fixes #9322

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Fix ignored 'Auto Create Topic' setting by merging DEFAULT_AGENT_CHAT_CONFIG in currentAgentChatConfig when chatConfig is undefined