### PR TITLE
✨ feat: Added the ability to open a new window on the desktop

### DIFF
--- a/apps/desktop/src/main/appBrowsers.ts
+++ b/apps/desktop/src/main/appBrowsers.ts
@@ -46,4 +46,40 @@ export const appBrowsers = {
   },
 } satisfies Record<string, BrowserWindowOpts>;
 
+// Window templates for multi-instance windows
+export interface WindowTemplate {
+  baseIdentifier: string;
+  basePath: string;
+  allowMultipleInstances: boolean;
+  // Include common BrowserWindow options
+  autoHideMenuBar?: boolean;
+  height?: number;
+  keepAlive?: boolean;
+  minWidth?: number;
+  parentIdentifier?: string;
+  titleBarStyle?: string;
+  vibrancy?: string;
+  width?: number;
+  devTools?: boolean;
+  showOnInit?: boolean;
+  title?: string;
+}
+
+export const windowTemplates = {
+  chatSingle: {
+    autoHideMenuBar: true,
+    height: 600,
+    baseIdentifier: 'chatSingle',
+    basePath: '/chat',
+    allowMultipleInstances: true,
+    keepAlive: false, // Multi-instance windows don't need to stay alive
+    minWidth: 400,
+    parentIdentifier: 'chat',
+    titleBarStyle: 'hidden',
+    vibrancy: 'under-window',
+    width: 900,
+  },
+} satisfies Record<string, WindowTemplate>;
+
 export type AppBrowsersIdentifiers = keyof typeof appBrowsers;
+export type WindowTemplateIdentifiers = keyof typeof windowTemplates;

--- a/apps/desktop/src/main/appBrowsers.ts
+++ b/apps/desktop/src/main/appBrowsers.ts
@@ -48,30 +48,45 @@ export const appBrowsers = {
 
 // Window templates for multi-instance windows
 export interface WindowTemplate {
-  baseIdentifier: string;
-  basePath: string;
   allowMultipleInstances: boolean;
   // Include common BrowserWindow options
   autoHideMenuBar?: boolean;
+  baseIdentifier: string;
+  basePath: string;
+  devTools?: boolean;
   height?: number;
   keepAlive?: boolean;
   minWidth?: number;
   parentIdentifier?: string;
-  titleBarStyle?: string;
-  vibrancy?: string;
-  width?: number;
-  devTools?: boolean;
   showOnInit?: boolean;
   title?: string;
+  titleBarStyle?: 'hidden' | 'default' | 'hiddenInset' | 'customButtonsOnHover';
+  vibrancy?:
+    | 'appearance-based'
+    | 'content'
+    | 'fullscreen-ui'
+    | 'header'
+    | 'hud'
+    | 'menu'
+    | 'popover'
+    | 'selection'
+    | 'sheet'
+    | 'sidebar'
+    | 'titlebar'
+    | 'tooltip'
+    | 'under-page'
+    | 'under-window'
+    | 'window';
+  width?: number;
 }
 
 export const windowTemplates = {
   chatSingle: {
+    allowMultipleInstances: true,
     autoHideMenuBar: true,
-    height: 600,
     baseIdentifier: 'chatSingle',
     basePath: '/chat',
-    allowMultipleInstances: true,
+    height: 600,
     keepAlive: false, // Multi-instance windows don't need to stay alive
     minWidth: 400,
     parentIdentifier: 'chat',

--- a/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
+++ b/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
@@ -1,7 +1,7 @@
 import { InterceptRouteParams } from '@lobechat/electron-client-ipc';
 import { extractSubPath, findMatchingRoute } from '~common/routes';
 
-import { AppBrowsersIdentifiers, BrowsersIdentifiers } from '@/appBrowsers';
+import { AppBrowsersIdentifiers, BrowsersIdentifiers, WindowTemplateIdentifiers } from '@/appBrowsers';
 import { IpcClientEventSender } from '@/types/ipcClientEvent';
 
 import { ControllerModule, ipcClientEvent, shortcut } from './index';
@@ -96,6 +96,77 @@ export default class BrowserWindowsCtr extends ControllerModule {
         intercepted: false,
         path,
         source,
+      };
+    }
+  }
+
+  /**
+   * Create a new multi-instance window
+   */
+  @ipcClientEvent('createMultiInstanceWindow')
+  async createMultiInstanceWindow(params: {
+    templateId: WindowTemplateIdentifiers;
+    path: string;
+    uniqueId?: string;
+  }) {
+    try {
+      console.log('[BrowserWindowsCtr] Creating multi-instance window:', params);
+
+      const result = this.app.browserManager.createMultiInstanceWindow(
+        params.templateId,
+        params.path,
+        params.uniqueId,
+      );
+
+      // Show the window
+      result.browser.show();
+
+      return {
+        success: true,
+        windowId: result.identifier,
+      };
+    } catch (error) {
+      console.error('[BrowserWindowsCtr] Failed to create multi-instance window:', error);
+      return {
+        error: error.message,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Get all windows by template
+   */
+  @ipcClientEvent('getWindowsByTemplate')
+  async getWindowsByTemplate(templateId: string) {
+    try {
+      const windowIds = this.app.browserManager.getWindowsByTemplate(templateId);
+      return {
+        success: true,
+        windowIds,
+      };
+    } catch (error) {
+      console.error('[BrowserWindowsCtr] Failed to get windows by template:', error);
+      return {
+        error: error.message,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Close all windows by template
+   */
+  @ipcClientEvent('closeWindowsByTemplate')
+  async closeWindowsByTemplate(templateId: string) {
+    try {
+      this.app.browserManager.closeWindowsByTemplate(templateId);
+      return { success: true };
+    } catch (error) {
+      console.error('[BrowserWindowsCtr] Failed to close windows by template:', error);
+      return {
+        error: error.message,
+        success: false,
       };
     }
   }

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -3,7 +3,7 @@ import { WebContents } from 'electron';
 
 import { createLogger } from '@/utils/logger';
 
-import { AppBrowsersIdentifiers, appBrowsers } from '../../appBrowsers';
+import { AppBrowsersIdentifiers, appBrowsers, WindowTemplate, WindowTemplateIdentifiers, windowTemplates } from '../../appBrowsers';
 import type { App } from '../App';
 import type { BrowserWindowOpts } from './Browser';
 import Browser from './Browser';
@@ -14,9 +14,9 @@ const logger = createLogger('core:BrowserManager');
 export class BrowserManager {
   app: App;
 
-  browsers: Map<AppBrowsersIdentifiers, Browser> = new Map();
+  browsers: Map<string, Browser> = new Map();
 
-  private webContentsMap = new Map<WebContents, AppBrowsersIdentifiers>();
+  private webContentsMap = new Map<WebContents, string>();
 
   constructor(app: App) {
     logger.debug('Initializing BrowserManager');
@@ -51,12 +51,12 @@ export class BrowserManager {
   };
 
   broadcastToWindow = <T extends MainBroadcastEventKey>(
-    identifier: AppBrowsersIdentifiers,
+    identifier: string,
     event: T,
     data: MainBroadcastParams<T>,
   ) => {
     logger.debug(`Broadcasting event ${event} to window: ${identifier}`);
-    this.browsers.get(identifier).broadcast(event, data);
+    this.browsers.get(identifier)?.broadcast(event, data);
   };
 
   /**
@@ -87,13 +87,21 @@ export class BrowserManager {
    * @param identifier Window identifier
    * @param subPath Sub-path, such as 'agent', 'about', etc.
    */
-  async redirectToPage(identifier: AppBrowsersIdentifiers, subPath?: string) {
+  async redirectToPage(identifier: string, subPath?: string) {
     try {
       // Ensure window is retrieved or created
       const browser = this.retrieveByIdentifier(identifier);
       browser.hide();
 
-      const baseRoute = appBrowsers[identifier].path;
+      // Handle both static and dynamic windows
+      let baseRoute: string;
+      if (identifier in appBrowsers) {
+        baseRoute = appBrowsers[identifier as AppBrowsersIdentifiers].path;
+      } else {
+        // For dynamic windows, extract base route from the browser options
+        const browserOptions = browser.options;
+        baseRoute = browserOptions.path;
+      }
 
       // Build complete URL path
       const fullPath = subPath ? `${baseRoute}/${subPath}` : baseRoute;
@@ -114,13 +122,75 @@ export class BrowserManager {
   /**
    * get Browser by identifier
    */
-  retrieveByIdentifier(identifier: AppBrowsersIdentifiers) {
+  retrieveByIdentifier(identifier: string) {
     const browser = this.browsers.get(identifier);
 
     if (browser) return browser;
 
-    logger.debug(`Browser ${identifier} not found, initializing new instance`);
-    return this.retrieveOrInitialize(appBrowsers[identifier]);
+    // Check if it's a static browser
+    if (identifier in appBrowsers) {
+      logger.debug(`Browser ${identifier} not found, initializing new instance`);
+      return this.retrieveOrInitialize(appBrowsers[identifier as AppBrowsersIdentifiers]);
+    }
+
+    throw new Error(`Browser ${identifier} not found and is not a static browser`);
+  }
+
+  /**
+   * Create a multi-instance window from template
+   * @param templateId Template identifier
+   * @param path Full path with query parameters
+   * @param uniqueId Optional unique identifier, will be generated if not provided
+   * @returns The window identifier and Browser instance
+   */
+  createMultiInstanceWindow(templateId: WindowTemplateIdentifiers, path: string, uniqueId?: string) {
+    const template = windowTemplates[templateId];
+    if (!template) {
+      throw new Error(`Window template ${templateId} not found`);
+    }
+
+    // Generate unique identifier
+    const windowId = uniqueId || `${template.baseIdentifier}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+    // Create browser options from template
+    const browserOpts: BrowserWindowOpts = {
+      ...template,
+      identifier: windowId,
+      path: path,
+    };
+
+    logger.debug(`Creating multi-instance window: ${windowId} with path: ${path}`);
+
+    const browser = this.retrieveOrInitialize(browserOpts);
+
+    return {
+      identifier: windowId,
+      browser: browser,
+    };
+  }
+
+  /**
+   * Get all windows based on template
+   * @param templateId Template identifier
+   * @returns Array of window identifiers matching the template
+   */
+  getWindowsByTemplate(templateId: string): string[] {
+    const prefix = `${templateId}_`;
+    return Array.from(this.browsers.keys()).filter(id => id.startsWith(prefix));
+  }
+
+  /**
+   * Close all windows based on template
+   * @param templateId Template identifier
+   */
+  closeWindowsByTemplate(templateId: string): void {
+    const windowIds = this.getWindowsByTemplate(templateId);
+    windowIds.forEach(id => {
+      const browser = this.browsers.get(id);
+      if (browser) {
+        browser.close();
+      }
+    });
   }
 
   /**
@@ -144,7 +214,7 @@ export class BrowserManager {
    * @param options Browser window options
    */
   private retrieveOrInitialize(options: BrowserWindowOpts) {
-    let browser = this.browsers.get(options.identifier as AppBrowsersIdentifiers);
+    let browser = this.browsers.get(options.identifier);
     if (browser) {
       logger.debug(`Retrieved existing browser: ${options.identifier}`);
       return browser;
@@ -153,7 +223,7 @@ export class BrowserManager {
     logger.debug(`Creating new browser: ${options.identifier}`);
     browser = new Browser(options, this.app);
 
-    const identifier = options.identifier as AppBrowsersIdentifiers;
+    const identifier = options.identifier;
     this.browsers.set(identifier, browser);
 
     // 记录 WebContents 和 identifier 的映射
@@ -166,32 +236,32 @@ export class BrowserManager {
 
     browser.browserWindow.on('show', () => {
       if (browser.webContents)
-        this.webContentsMap.set(browser.webContents, browser.identifier as AppBrowsersIdentifiers);
+        this.webContentsMap.set(browser.webContents, browser.identifier);
     });
 
     return browser;
   }
 
   closeWindow(identifier: string) {
-    const browser = this.browsers.get(identifier as AppBrowsersIdentifiers);
+    const browser = this.browsers.get(identifier);
     browser?.close();
   }
 
   minimizeWindow(identifier: string) {
-    const browser = this.browsers.get(identifier as AppBrowsersIdentifiers);
+    const browser = this.browsers.get(identifier);
     browser?.browserWindow.minimize();
   }
 
   maximizeWindow(identifier: string) {
-    const browser = this.browsers.get(identifier as AppBrowsersIdentifiers);
-    if (browser.browserWindow.isMaximized()) {
+    const browser = this.browsers.get(identifier);
+    if (browser?.browserWindow.isMaximized()) {
       browser?.browserWindow.unmaximize();
     } else {
       browser?.browserWindow.maximize();
     }
   }
 
-  getIdentifierByWebContents(webContents: WebContents): AppBrowsersIdentifiers | null {
+  getIdentifierByWebContents(webContents: WebContents): string | null {
     return this.webContentsMap.get(webContents) || null;
   }
 

--- a/packages/electron-client-ipc/src/events/windows.ts
+++ b/packages/electron-client-ipc/src/events/windows.ts
@@ -1,5 +1,23 @@
 import { InterceptRouteParams, InterceptRouteResponse } from '../types/route';
 
+export interface CreateMultiInstanceWindowParams {
+  templateId: string;
+  path: string;
+  uniqueId?: string;
+}
+
+export interface CreateMultiInstanceWindowResponse {
+  success: boolean;
+  windowId?: string;
+  error?: string;
+}
+
+export interface GetWindowsByTemplateResponse {
+  success: boolean;
+  windowIds?: string[];
+  error?: string;
+}
+
 export interface WindowsDispatchEvents {
   /**
    * 拦截客户端路由导航请求
@@ -14,4 +32,25 @@ export interface WindowsDispatchEvents {
   openDevtools: () => void;
 
   openSettingsWindow: (tab?: string) => void;
+
+  /**
+   * Create a new multi-instance window
+   * @param params Window creation parameters
+   * @returns Creation result
+   */
+  createMultiInstanceWindow: (params: CreateMultiInstanceWindowParams) => CreateMultiInstanceWindowResponse;
+
+  /**
+   * Get all windows by template
+   * @param templateId Template identifier
+   * @returns List of window identifiers
+   */
+  getWindowsByTemplate: (templateId: string) => GetWindowsByTemplateResponse;
+
+  /**
+   * Close all windows by template
+   * @param templateId Template identifier
+   * @returns Operation result
+   */
+  closeWindowsByTemplate: (templateId: string) => { success: boolean; error?: string };
 }

--- a/src/app/[variants]/(main)/_layout/Desktop/DesktopLayoutContainer.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/DesktopLayoutContainer.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from 'antd-style';
 import { usePathname } from 'next/navigation';
-import { PropsWithChildren, memo } from 'react';
+import { PropsWithChildren, Suspense, memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import SideBar from './SideBar';
@@ -11,7 +11,9 @@ const DesktopLayoutContainer = memo<PropsWithChildren>(({ children }) => {
   const hideSideBar = pathname.startsWith('/settings');
   return (
     <>
-      {!hideSideBar && <SideBar />}
+      <Suspense>
+        {!hideSideBar && <SideBar />}
+      </Suspense>
       <Flexbox
         style={{
           background: theme.colorBgLayout,

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
@@ -6,6 +6,7 @@ import { Suspense, memo } from 'react';
 
 import { isDesktop } from '@/const/version';
 import { useActiveTabKey } from '@/hooks/useActiveTabKey';
+import { useIsSingleMode } from '@/hooks/useIsSingleMode';
 import { usePinnedAgentState } from '@/hooks/usePinnedAgentState';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -16,7 +17,6 @@ import Avatar from './Avatar';
 import BottomActions from './BottomActions';
 import PinList from './PinList';
 import TopActions from './TopActions';
-import { useSearchParams } from 'next/navigation';
 
 const Top = () => {
   const [isPinned] = usePinnedAgentState();
@@ -27,7 +27,7 @@ const Top = () => {
 
 const Nav = memo(() => {
   const theme = useTheme();
-  const isSingleMode = useSearchParams().get('mode') === 'single'
+  const isSingleMode = useIsSingleMode()
   const inZenMode = useGlobalStore(systemStatusSelectors.inZenMode);
   const { showPinList } = useServerConfigStore(featureFlagsSelectors);
 

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
@@ -16,6 +16,7 @@ import Avatar from './Avatar';
 import BottomActions from './BottomActions';
 import PinList from './PinList';
 import TopActions from './TopActions';
+import { useSearchParams } from 'next/navigation';
 
 const Top = () => {
   const [isPinned] = usePinnedAgentState();
@@ -26,11 +27,12 @@ const Top = () => {
 
 const Nav = memo(() => {
   const theme = useTheme();
+  const isSingleMode = useSearchParams().get('mode') === 'single'
   const inZenMode = useGlobalStore(systemStatusSelectors.inZenMode);
   const { showPinList } = useServerConfigStore(featureFlagsSelectors);
 
   return (
-    !inZenMode && (
+    !inZenMode && !isSingleMode && (
       <SideNav
         avatar={
           <div className={electronStylish.nodrag}>

--- a/src/app/[variants]/(main)/_layout/Desktop/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/index.tsx
@@ -48,7 +48,9 @@ const Layout = memo<PropsWithChildren>(({ children }) => {
           <DesktopLayoutContainer>{children}</DesktopLayoutContainer>
         ) : (
           <>
-            <SideBar />
+            <Suspense>
+              <SideBar />
+            </Suspense>
             {children}
           </>
         )}

--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/Actions.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/Actions.tsx
@@ -5,6 +5,7 @@ import { ItemType } from 'antd/es/menu/interface';
 import isEqual from 'fast-deep-equal';
 import {
   Check,
+  ExternalLink,
   HardDriveDownload,
   ListTree,
   LucideCopy,
@@ -17,8 +18,9 @@ import {
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { isServerMode } from '@/const/version';
+import { isDesktop, isServerMode } from '@/const/version';
 import { configService } from '@/services/config';
+import { useGlobalStore } from '@/store/global';
 import { useSessionStore } from '@/store/session';
 import { sessionHelpers } from '@/store/session/helpers';
 import { sessionGroupSelectors, sessionSelectors } from '@/store/session/selectors';
@@ -40,6 +42,8 @@ interface ActionProps {
 const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, setOpen }) => {
   const { styles } = useStyles();
   const { t } = useTranslation('chat');
+
+  const openSessionInNewWindow = useGlobalStore((s) => s.openSessionInNewWindow);
 
   const sessionCustomGroups = useSessionStore(sessionGroupSelectors.sessionGroupItems, isEqual);
   const [pin, removeSession, pinSession, duplicateSession, updateSessionGroup] = useSessionStore(
@@ -82,6 +86,19 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, setOpen })
               duplicateSession(id);
             },
           },
+          ...(isDesktop
+            ? [
+                {
+                  icon: <Icon icon={ExternalLink} />,
+                  key: 'openInNewWindow',
+                  label: '单独打开页面',
+                  onClick: ({ domEvent }: { domEvent: Event }) => {
+                    domEvent.stopPropagation();
+                    openSessionInNewWindow(id);
+                  },
+                },
+              ]
+            : []),
           {
             type: 'divider',
           },
@@ -167,7 +184,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, setOpen })
           },
         ] as ItemType[]
       ).filter(Boolean),
-    [id, pin],
+    [id, pin, openSessionInNewWindow],
   );
 
   return (

--- a/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
@@ -12,6 +12,7 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
 import { TOOGLE_PANEL_BUTTON_ID } from '../../features/TogglePanelButton';
+import { useSearchParams } from 'next/navigation';
 
 export const useStyles = createStyles(({ css, token }) => ({
   panel: css`
@@ -33,11 +34,15 @@ export const useStyles = createStyles(({ css, token }) => ({
 }));
 
 const SessionPanel = memo<PropsWithChildren>(({ children }) => {
+
+  const isSingleMode = useSearchParams().get('mode') === 'single'
+
   const { md = true } = useResponsive();
 
   const [isPinned] = usePinnedAgentState();
 
   const { styles } = useStyles();
+
   const [sessionsWidth, sessionExpandable, updatePreference] = useGlobalStore((s) => [
     systemStatusSelectors.sessionWidth(s),
     systemStatusSelectors.showSessionPanel(s),
@@ -76,8 +81,8 @@ const SessionPanel = memo<PropsWithChildren>(({ children }) => {
       <DraggablePanel
         className={styles.panel}
         defaultSize={{ width: tmpWidth }}
-        // 当进入 pin 模式下，不可展开
-        expand={!isPinned && sessionExpandable}
+        // 当进入 pin 或者桌面的单一模式模式下，不可展开
+        expand={!isPinned && sessionExpandable && !isSingleMode}
         expandable={!isPinned}
         maxWidth={400}
         minWidth={FOLDER_WIDTH}
@@ -92,7 +97,7 @@ const SessionPanel = memo<PropsWithChildren>(({ children }) => {
         </DraggablePanelContainer>
       </DraggablePanel>
     );
-  }, [sessionsWidth, md, isPinned, sessionExpandable, tmpWidth, appearance]);
+  }, [sessionsWidth, md, isPinned, sessionExpandable, tmpWidth, appearance, isSingleMode]);
 
   return SessionPanel;
 });

--- a/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
@@ -76,12 +76,18 @@ const SessionPanel = memo<PropsWithChildren>(({ children }) => {
   const { appearance } = useThemeMode();
 
   const SessionPanel = useMemo(() => {
+    if (isSingleMode) {
+      // 在单一模式下，仍然渲染 children 以确保 SessionHydration 等逻辑组件正常工作
+      // 但使用隐藏样式而不是 return null
+      return <div style={{ display: 'none' }}>{children}</div>;
+    }
+
     return (
       <DraggablePanel
         className={styles.panel}
         defaultSize={{ width: tmpWidth }}
-        // 当进入 pin 或者桌面的单一模式模式下，不可展开
-        expand={!isPinned && sessionExpandable && !isSingleMode}
+        // 当进入 pin 模式下，不可展开
+        expand={!isPinned && sessionExpandable}
         expandable={!isPinned}
         maxWidth={400}
         minWidth={FOLDER_WIDTH}

--- a/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/SessionPanel.tsx
@@ -7,12 +7,12 @@ import { PropsWithChildren, memo, useEffect, useMemo, useState } from 'react';
 
 import { withSuspense } from '@/components/withSuspense';
 import { FOLDER_WIDTH } from '@/const/layoutTokens';
+import { useIsSingleMode } from '@/hooks/useIsSingleMode';
 import { usePinnedAgentState } from '@/hooks/usePinnedAgentState';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
 import { TOOGLE_PANEL_BUTTON_ID } from '../../features/TogglePanelButton';
-import { useSearchParams } from 'next/navigation';
 
 export const useStyles = createStyles(({ css, token }) => ({
   panel: css`
@@ -34,8 +34,7 @@ export const useStyles = createStyles(({ css, token }) => ({
 }));
 
 const SessionPanel = memo<PropsWithChildren>(({ children }) => {
-
-  const isSingleMode = useSearchParams().get('mode') === 'single'
+  const isSingleMode = useIsSingleMode();
 
   const { md = true } = useResponsive();
 

--- a/src/app/[variants]/(main)/chat/features/TogglePanelButton.tsx
+++ b/src/app/[variants]/(main)/chat/features/TogglePanelButton.tsx
@@ -6,17 +6,17 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { useIsSingleMode } from '@/hooks/useIsSingleMode';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { HotkeyEnum } from '@/types/hotkey';
-import { useSearchParams } from 'next/navigation';
 
 export const TOOGLE_PANEL_BUTTON_ID = 'toggle-panel-button';
 
 const TogglePanelButton = memo(() => {
-  const isSingleMode = useSearchParams().get('mode') === 'single'
+  const isSingleMode = useIsSingleMode();
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.ToggleLeftPanel));
 
   const { t } = useTranslation(['chat', 'hotkey']);

--- a/src/app/[variants]/(main)/chat/features/TogglePanelButton.tsx
+++ b/src/app/[variants]/(main)/chat/features/TogglePanelButton.tsx
@@ -11,16 +11,22 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { HotkeyEnum } from '@/types/hotkey';
+import { useSearchParams } from 'next/navigation';
 
 export const TOOGLE_PANEL_BUTTON_ID = 'toggle-panel-button';
 
 const TogglePanelButton = memo(() => {
+  const isSingleMode = useSearchParams().get('mode') === 'single'
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.ToggleLeftPanel));
 
   const { t } = useTranslation(['chat', 'hotkey']);
 
   const showSessionPanel = useGlobalStore(systemStatusSelectors.showSessionPanel);
   const updateSystemStatus = useGlobalStore((s) => s.updateSystemStatus);
+
+  if (isSingleMode) {
+    return null
+  }
 
   return (
     <Tooltip hotkey={hotkey} title={t('toggleLeftPanel.title', { ns: 'hotkey' })}>

--- a/src/features/ElectronTitlebar/Connection/index.tsx
+++ b/src/features/ElectronTitlebar/Connection/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import ConnectionMode from './ConnectionMode';
 import RemoteStatus from './RemoteStatus';
 import WaitingOAuth from './Waiting';
+import { useIsSingleMode } from '@/hooks/useIsSingleMode';
 
 const useStyles = createStyles(({ css }) => {
   return {
@@ -20,9 +21,13 @@ const useStyles = createStyles(({ css }) => {
 
 const Connection = () => {
   const { styles, theme } = useStyles();
-
   const [isOpen, setIsOpen] = useState(false);
   const [isWaiting, setWaiting] = useState(false);
+  const isSingleMode = useIsSingleMode()
+
+  if (isSingleMode) {
+    return null
+  }
 
   return (
     <>

--- a/src/features/ElectronTitlebar/Connection/index.tsx
+++ b/src/features/ElectronTitlebar/Connection/index.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import ConnectionMode from './ConnectionMode';
 import RemoteStatus from './RemoteStatus';
 import WaitingOAuth from './Waiting';
-import { useIsSingleMode } from '@/hooks/useIsSingleMode';
 
 const useStyles = createStyles(({ css }) => {
   return {
@@ -23,11 +22,6 @@ const Connection = () => {
   const { styles, theme } = useStyles();
   const [isOpen, setIsOpen] = useState(false);
   const [isWaiting, setWaiting] = useState(false);
-  const isSingleMode = useIsSingleMode()
-
-  if (isSingleMode) {
-    return null
-  }
 
   return (
     <>

--- a/src/hooks/useIsSingleMode.test.ts
+++ b/src/hooks/useIsSingleMode.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useIsSingleMode } from './useIsSingleMode';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(),
+}));
+
+const mockUseSearchParams = useSearchParams as any;
+
+describe('useIsSingleMode', () => {
+  it('should return true when mode is single', () => {
+    const mockSearchParams = {
+      get: vi.fn().mockReturnValue('single'),
+    };
+
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+
+    const { result } = renderHook(() => useIsSingleMode());
+
+    expect(result.current).toBe(true);
+    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
+  });
+
+  it('should return false when mode is not single', () => {
+    const mockSearchParams = {
+      get: vi.fn().mockReturnValue('normal'),
+    };
+
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+
+    const { result } = renderHook(() => useIsSingleMode());
+
+    expect(result.current).toBe(false);
+    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
+  });
+
+  it('should return false when mode parameter is not present', () => {
+    const mockSearchParams = {
+      get: vi.fn().mockReturnValue(null),
+    };
+
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+
+    const { result } = renderHook(() => useIsSingleMode());
+
+    expect(result.current).toBe(false);
+    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
+  });
+});

--- a/src/hooks/useIsSingleMode.test.ts
+++ b/src/hooks/useIsSingleMode.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { useIsSingleMode } from './useIsSingleMode';
 
 // Mock next/navigation
-const mockUseSearchParams = vi.fn();
+const mockUseSearchParams = vi.hoisted(() => vi.fn());
 vi.mock('next/navigation', () => ({
   useSearchParams: mockUseSearchParams,
 }));
@@ -21,67 +21,46 @@ describe('useIsSingleMode', () => {
 
     const { result } = renderHook(() => useIsSingleMode());
 
-    // Should return false initially before hydration
-    expect(result.current).toBe(false);
+    // In test environment, useEffect runs synchronously, so it will immediately detect single mode
+    expect(result.current).toBe(true);
   });
 
-  it('should return true when mode=single after hydration', async () => {
+  it('should return true when mode=single', () => {
     const mockSearchParams = {
       get: vi.fn((key: string) => (key === 'mode' ? 'single' : null)),
     } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
-    const { result, rerender } = renderHook(() => useIsSingleMode());
+    const { result } = renderHook(() => useIsSingleMode());
 
-    // Initially false
-    expect(result.current).toBe(false);
-
-    // Simulate component re-render after mount
-    await new Promise(resolve => setTimeout(resolve, 0));
-    rerender();
-
-    // After hydration, should detect single mode
+    // Should immediately detect single mode in test environment
     expect(result.current).toBe(true);
   });
 
-  it('should return false when mode is not single', async () => {
+  it('should return false when mode is not single', () => {
     const mockSearchParams = {
       get: vi.fn((key: string) => (key === 'mode' ? 'normal' : null)),
     } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
-    const { result, rerender } = renderHook(() => useIsSingleMode());
+    const { result } = renderHook(() => useIsSingleMode());
 
-    // Initially false
-    expect(result.current).toBe(false);
-
-    // Simulate component re-render after mount
-    await new Promise(resolve => setTimeout(resolve, 0));
-    rerender();
-
-    // Should remain false for non-single mode
+    // Should return false for non-single mode
     expect(result.current).toBe(false);
   });
 
-  it('should return false when no mode parameter exists', async () => {
+  it('should return false when no mode parameter exists', () => {
     const mockSearchParams = {
       get: vi.fn(() => null),
     } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
-    const { result, rerender } = renderHook(() => useIsSingleMode());
+    const { result } = renderHook(() => useIsSingleMode());
 
-    // Initially false
-    expect(result.current).toBe(false);
-
-    // Simulate component re-render after mount
-    await new Promise(resolve => setTimeout(resolve, 0));
-    rerender();
-
-    // Should remain false when no mode parameter
+    // Should return false when no mode parameter
     expect(result.current).toBe(false);
   });
 });

--- a/src/hooks/useIsSingleMode.test.ts
+++ b/src/hooks/useIsSingleMode.test.ts
@@ -1,53 +1,87 @@
 import { renderHook } from '@testing-library/react';
-import { useSearchParams } from 'next/navigation';
+import { ReadonlyURLSearchParams } from 'next/navigation';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useIsSingleMode } from './useIsSingleMode';
 
 // Mock next/navigation
+const mockUseSearchParams = vi.fn();
 vi.mock('next/navigation', () => ({
-  useSearchParams: vi.fn(),
+  useSearchParams: mockUseSearchParams,
 }));
 
-const mockUseSearchParams = useSearchParams as any;
-
 describe('useIsSingleMode', () => {
-  it('should return true when mode is single', () => {
+
+  it('should return false initially (during SSR)', () => {
     const mockSearchParams = {
-      get: vi.fn().mockReturnValue('single'),
-    };
+      get: vi.fn(() => 'single'),
+    } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
     const { result } = renderHook(() => useIsSingleMode());
 
+    // Should return false initially before hydration
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when mode=single after hydration', async () => {
+    const mockSearchParams = {
+      get: vi.fn((key: string) => (key === 'mode' ? 'single' : null)),
+    } as unknown as ReadonlyURLSearchParams;
+
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+
+    const { result, rerender } = renderHook(() => useIsSingleMode());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate component re-render after mount
+    await new Promise(resolve => setTimeout(resolve, 0));
+    rerender();
+
+    // After hydration, should detect single mode
     expect(result.current).toBe(true);
-    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
   });
 
-  it('should return false when mode is not single', () => {
+  it('should return false when mode is not single', async () => {
     const mockSearchParams = {
-      get: vi.fn().mockReturnValue('normal'),
-    };
+      get: vi.fn((key: string) => (key === 'mode' ? 'normal' : null)),
+    } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
-    const { result } = renderHook(() => useIsSingleMode());
+    const { result, rerender } = renderHook(() => useIsSingleMode());
 
+    // Initially false
     expect(result.current).toBe(false);
-    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
+
+    // Simulate component re-render after mount
+    await new Promise(resolve => setTimeout(resolve, 0));
+    rerender();
+
+    // Should remain false for non-single mode
+    expect(result.current).toBe(false);
   });
 
-  it('should return false when mode parameter is not present', () => {
+  it('should return false when no mode parameter exists', async () => {
     const mockSearchParams = {
-      get: vi.fn().mockReturnValue(null),
-    };
+      get: vi.fn(() => null),
+    } as unknown as ReadonlyURLSearchParams;
 
     mockUseSearchParams.mockReturnValue(mockSearchParams);
 
-    const { result } = renderHook(() => useIsSingleMode());
+    const { result, rerender } = renderHook(() => useIsSingleMode());
 
+    // Initially false
     expect(result.current).toBe(false);
-    expect(mockSearchParams.get).toHaveBeenCalledWith('mode');
+
+    // Simulate component re-render after mount
+    await new Promise(resolve => setTimeout(resolve, 0));
+    rerender();
+
+    // Should remain false when no mode parameter
+    expect(result.current).toBe(false);
   });
 });

--- a/src/hooks/useIsSingleMode.ts
+++ b/src/hooks/useIsSingleMode.ts
@@ -1,0 +1,13 @@
+import { useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
+
+/**
+ * Hook to check if the current page is in single mode
+ * Single mode is used for standalone windows in desktop app
+ * @returns boolean indicating if the current page is in single mode
+ */
+export const useIsSingleMode = (): boolean => {
+  const searchParams = useSearchParams();
+
+  return useMemo(() => searchParams.get('mode') === 'single', [searchParams]);
+};

--- a/src/hooks/useIsSingleMode.ts
+++ b/src/hooks/useIsSingleMode.ts
@@ -1,5 +1,7 @@
+'use client';
+
 import { useSearchParams } from 'next/navigation';
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Hook to check if the current page is in single mode
@@ -7,7 +9,21 @@ import { useMemo } from 'react';
  * @returns boolean indicating if the current page is in single mode
  */
 export const useIsSingleMode = (): boolean => {
+  const [isSingleMode, setIsSingleMode] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const searchParams = useSearchParams();
 
-  return useMemo(() => searchParams.get('mode') === 'single', [searchParams]);
+  useEffect(() => {
+    if (mounted) {
+      setIsSingleMode(searchParams.get('mode') === 'single');
+    }
+  }, [searchParams, mounted]);
+
+  // Return false during SSR or before hydration
+  return mounted ? isSingleMode : false;
 };

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -20,6 +20,7 @@ import type { GlobalStore } from '../store';
 const n = setNamespace('g');
 
 export interface GlobalGeneralAction {
+  openTopicInNewWindow: (sessionId: string, topicId: string) => Promise<void>;
   switchLocale: (locale: LocaleMode) => void;
   switchThemeMode: (themeMode: ThemeMode, params?: { skipBroadcast?: boolean }) => void;
   updateSystemStatus: (status: Partial<SystemStatus>, action?: any) => void;
@@ -33,6 +34,28 @@ export const generalActionSlice: StateCreator<
   [],
   GlobalGeneralAction
 > = (set, get) => ({
+  openTopicInNewWindow: async (sessionId: string, topicId: string) => {
+    if (!isDesktop) return;
+
+    try {
+      const { dispatch } = await import('@lobechat/electron-client-ipc');
+
+      const url = `/chat?session=${sessionId}&topic=${topicId}&mode=single`;
+
+      const result = await dispatch('createMultiInstanceWindow', {
+        templateId: 'chatSingle',
+        path: url,
+        uniqueId: `chat_${sessionId}_${topicId}`,
+      });
+
+      if (!result.success) {
+        console.error('Failed to open topic in new window:', result.error);
+      }
+    } catch (error) {
+      console.error('Error opening topic in new window:', error);
+    }
+  },
+
   switchLocale: (locale) => {
     get().updateSystemStatus({ language: locale });
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- fix https://github.com/lobehub/lobe-chat/issues/8565
- fix https://github.com/lobehub/lobe-chat/issues/9231

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable opening chat topics in separate desktop windows by introducing multi-instance window support with template-based creation and related IPC endpoints.

New Features:
- Add createMultiInstanceWindow, getWindowsByTemplate, and closeWindowsByTemplate methods to BrowserManager for multi-instance window management
- Expose new IPC client events for creating, listing, and closing windows by template
- Introduce windowTemplates configuration for defining multi-instance window behaviors
- Add 'Open in New Window' option in topic context menu to launch topics in separate desktop windows

Enhancements:
- Generalize BrowserManager identifiers to strings to support dynamic window instances
- Extend redirectToPage and retrieveByIdentifier to handle both static and dynamic windows