### PR TITLE
🐛 fix: Update Responses search tool to web_search

### DIFF
--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -5,9 +5,10 @@ import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as debugStreamModule from '../../utils/debugStream';
 import officalOpenAIModels from './fixtures/openai-models.json';
 import { LobeOpenAI } from './index';
+import global from '@/styles/global';
 
 // Mock the console.error to avoid polluting test output
-vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => { });
 
 // Mock fetch for most tests, but will be restored for real network tests
 const mockFetch = vi.fn();
@@ -249,7 +250,7 @@ describe('LobeOpenAI', () => {
   });
 
   describe('responses.handlePayload', () => {
-    it('should add web_search_preview tool when enabledSearch is true', async () => {
+    it('should add web_search tool when enabledSearch is true', async () => {
       const payload = {
         messages: [{ content: 'Hello', role: 'user' as const }],
         model: 'gpt-4o', // 使用常规模型，通过 enabledSearch 触发 responses API
@@ -263,7 +264,7 @@ describe('LobeOpenAI', () => {
       const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
       expect(createCall.tools).toEqual([
         { type: 'function', name: 'test', description: 'test' },
-        { type: 'web_search_preview' },
+        { type: 'web_search' },
       ]);
     });
 

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -5,10 +5,9 @@ import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as debugStreamModule from '../../utils/debugStream';
 import officalOpenAIModels from './fixtures/openai-models.json';
 import { LobeOpenAI } from './index';
-import global from '@/styles/global';
 
 // Mock the console.error to avoid polluting test output
-vi.spyOn(console, 'error').mockImplementation(() => { });
+vi.spyOn(console, 'error').mockImplementation(() => {});
 
 // Mock fetch for most tests, but will be restored for real network tests
 const mockFetch = vi.fn();

--- a/packages/model-runtime/src/providers/openai/index.ts
+++ b/packages/model-runtime/src/providers/openai/index.ts
@@ -82,7 +82,7 @@ export const LobeOpenAI = createOpenAICompatibleRuntime({
         ? [
             ...(tools || []),
             {
-              type: 'web_search_preview',
+              type: 'web_search',
               ...(oaiSearchContextSize && {
                 search_context_size: oaiSearchContextSize,
               }),


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- close #9352

测试可用

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix the search tool type used in LobeOpenAI response payloads and update tests accordingly

Bug Fixes:
- Change Responses search tool type from 'web_search_preview' to 'web_search'

Tests:
- Update unit tests to expect 'web_search' tool instead of 'web_search_preview'