### PR TITLE
📝 docs: renamed license to LobeHub Community License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
-Apache License Version 2.0
+LobeHub Community License
 
 Copyright (c) 2024/06/17 - current LobeHub LLC. All rights reserved.
 
 ----------
 
-From 1.0, LobeChat is licensed under the Apache License 2.0, with the following additional conditions:
+From 1.0, LobeChat is licensed under the LobeHub Community License, based on Apache License 2.0 with the following additional conditions:
 
 1. The commercial usage of LobeChat:
 
@@ -22,17 +22,3 @@ Please contact hello@lobehub.com by email to inquire about licensing matters.
   b. Your contributed code may be used for commercial purposes, including but not limited to its cloud edition.
 
 Apart from the specific conditions mentioned above, all other rights and restrictions follow the Apache License 2.0. Detailed information about the Apache License 2.0 can be found at http://www.apache.org/licenses/LICENSE-2.0.
-
-----------
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

as #9325 said, LobeChat v1 is not the pure Apache 2.0 license, so we need to rename it to the right name
<!-- Thank you for your Pull Request. Please provide a description above. -->

close #9325
#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Documentation:
- Update LICENSE file heading and content to use the LobeHub Community License name