### PR TITLE
💄 style: Use ID as name if provider name is empty

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
@@ -36,7 +36,13 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open }) => {
     setLoading(true);
 
     try {
-      await createNewAiProvider(values);
+      // 如果 name 为空，使用 id 作为 name
+      const finalValues = {
+        ...values,
+        name: values.name || values.id,
+      };
+
+      await createNewAiProvider(finalValues);
       setLoading(false);
       router.push(`/settings/provider/${values.id}`);
       message.success(t('createNewAiProvider.createSuccess'));
@@ -71,7 +77,6 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open }) => {
       label: t('createNewAiProvider.name.title'),
       minWidth: 400,
       name: 'name',
-      rules: [{ message: t('createNewAiProvider.name.required'), required: true }],
     },
     {
       children: (


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

服务商名称不再必填

<img width="1170" height="535" alt="image" src="https://github.com/user-attachments/assets/0cd6728a-44f1-4ce9-be03-b94c998f8c5c" />


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Allow creating a new AI provider without explicitly providing a name by defaulting it to the provider’s ID and removing the required name validation rule

Enhancements:
- Use provider ID as the display name when name is not provided
- Remove the form validation rule making provider name mandatory