### PR TITLE
🐛 fix: fix non stream mode in OpenAI Response API

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -34,6 +34,9 @@ import { StreamingResponse } from '../../utils/response';
 import { LobeRuntimeAI } from '../BaseAI';
 import { OpenAIResponsesStream, OpenAIStream, OpenAIStreamOptions } from '../streams';
 import { createOpenAICompatibleImage } from './createImage';
+import { transformResponseAPIToStream, transformResponseToStream } from './nonStreamToStream';
+
+export * from './nonStreamToStream';
 
 // the model contains the following keywords is not a chat model, so we should filter them out
 export const CHAT_MODELS_BLOCK_LIST = [
@@ -115,92 +118,6 @@ interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = any> {
       options: ConstructorOptions<T>,
     ) => ChatStreamPayload;
   };
-}
-
-/**
- * make the OpenAI response data as a stream
- */
-export function transformResponseToStream(data: OpenAI.ChatCompletion) {
-  return new ReadableStream({
-    start(controller) {
-      const choices = data.choices || [];
-      const first = choices[0];
-      // 兼容：非流式里 DeepSeek 等会把“深度思考”放在 message.reasoning_content
-      const message: any = first?.message ?? {};
-      const reasoningText =
-        typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0
-          ? message.reasoning_content
-          : null;
-      if (reasoningText) {
-        controller.enqueue({
-          choices: [
-            {
-              delta: { content: null, reasoning_content: reasoningText, role: 'assistant' },
-              finish_reason: null,
-              index: first?.index ?? 0,
-              logprobs: first?.logprobs ?? null,
-            },
-          ],
-          created: data.created,
-          id: data.id,
-          model: data.model,
-          object: 'chat.completion.chunk',
-        } as unknown as OpenAI.ChatCompletionChunk);
-      }
-      const chunk: OpenAI.ChatCompletionChunk = {
-        choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
-          delta: {
-            content: choice.message.content,
-            role: choice.message.role,
-            tool_calls: choice.message.tool_calls?.map(
-              (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => ({
-                function: tool.function,
-                id: tool.id,
-                index,
-                type: tool.type,
-              }),
-            ),
-          },
-          finish_reason: null,
-          index: choice.index,
-          logprobs: choice.logprobs,
-        })),
-        created: data.created,
-        id: data.id,
-        model: data.model,
-        object: 'chat.completion.chunk',
-      };
-
-      controller.enqueue(chunk);
-      if (data.usage) {
-        controller.enqueue({
-          choices: [],
-          created: data.created,
-          id: data.id,
-          model: data.model,
-          object: 'chat.completion.chunk',
-          usage: data.usage,
-        } as unknown as OpenAI.ChatCompletionChunk);
-      }
-      controller.enqueue({
-        choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
-          delta: {
-            content: null,
-            role: choice.message.role,
-          },
-          finish_reason: choice.finish_reason,
-          index: choice.index,
-          logprobs: choice.logprobs,
-        })),
-        created: data.created,
-        id: data.id,
-        model: data.model,
-        object: 'chat.completion.chunk',
-        system_fingerprint: data.system_fingerprint,
-      } as OpenAI.ChatCompletionChunk);
-      controller.close();
-    },
-  });
 }
 
 export const createOpenAICompatibleRuntime = <T extends Record<string, any> = any>({
@@ -544,9 +461,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
     ): Promise<Response> {
       const inputStartAt = Date.now();
 
-      const { messages, reasoning_effort, tools, reasoning, ...res } = responses?.handlePayload
-        ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
-        : payload;
+      const { messages, reasoning_effort, tools, reasoning, responseMode, ...res } =
+        responses?.handlePayload
+          ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
+          : payload;
 
       // remove penalty params
       delete res.apiMode;
@@ -554,6 +472,8 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       delete res.presence_penalty;
 
       const input = await convertOpenAIResponseInputs(messages as any);
+
+      const isStreaming = payload.stream !== false;
 
       const postPayload = {
         ...res,
@@ -567,8 +487,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           : {}),
         input,
         store: false,
+        stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
-      } as OpenAI.Responses.ResponseCreateParamsStreaming;
+      } as OpenAI.Responses.ResponseCreateParamsStreaming | OpenAI.Responses.ResponseCreateParams;
 
       if (debug?.responses?.()) {
         console.log('[requestPayload]');
@@ -580,24 +501,43 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         signal: options?.signal,
       });
 
-      const [prod, useForDebug] = response.tee();
-
-      if (debug?.responses?.()) {
-        const useForDebugStream =
-          useForDebug instanceof ReadableStream ? useForDebug : useForDebug.toReadableStream();
-
-        debugStream(useForDebugStream).catch(console.error);
-      }
-
       const streamOptions: OpenAIStreamOptions = {
         bizErrorTypeTransformer: chatCompletion?.handleStreamBizErrorType,
         callbacks: options?.callback,
         provider: this.id,
       };
 
-      return StreamingResponse(OpenAIResponsesStream(prod, { ...streamOptions, inputStartAt }), {
-        headers: options?.headers,
-      });
+      if (isStreaming) {
+        const stream = response as Stream<OpenAI.Responses.ResponseStreamEvent>;
+        const [prod, useForDebug] = stream.tee();
+
+        if (debug?.responses?.()) {
+          const useForDebugStream =
+            useForDebug instanceof ReadableStream ? useForDebug : useForDebug.toReadableStream();
+
+          debugStream(useForDebugStream).catch(console.error);
+        }
+
+        return StreamingResponse(OpenAIResponsesStream(prod, { ...streamOptions, inputStartAt }), {
+          headers: options?.headers,
+        });
+      }
+
+      // Handle non-streaming response
+      if (debug?.responses?.()) {
+        debugResponse(response);
+      }
+
+      if (responseMode === 'json') return Response.json(response);
+
+      const stream = transformResponseAPIToStream(response as OpenAI.Responses.Response);
+
+      return StreamingResponse(
+        OpenAIResponsesStream(stream, { ...streamOptions, enableStreaming: false, inputStartAt }),
+        {
+          headers: options?.headers,
+        },
+      );
     }
 
     private convertChatCompletionToolToResponseTool = (tool: ChatCompletionTool) => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
@@ -18,6 +18,7 @@ describe('nonStreamToStream', () => {
             message: {
               role: 'assistant',
               content: 'Hello! How can I help you today?',
+              refusal: null,
             },
             finish_reason: 'stop',
             logprobs: null,
@@ -40,61 +41,59 @@ describe('nonStreamToStream', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(3);
-
-      // First chunk: content chunk
-      expect(chunks[0]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: 'Hello! How can I help you today?',
-              role: 'assistant',
-              tool_calls: undefined,
+      expect(chunks).toEqual([
+        // First chunk: content chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: 'Hello! How can I help you today?',
+                role: 'assistant',
+                tool_calls: undefined,
+              },
+              finish_reason: null,
+              index: 0,
+              logprobs: null,
             },
-            finish_reason: null,
-            index: 0,
-            logprobs: null,
-          },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-123',
-        model: 'gpt-3.5-turbo',
-        object: 'chat.completion.chunk',
-      });
-
-      // Second chunk: usage chunk
-      expect(chunks[1]).toEqual({
-        choices: [],
-        created: 1677652288,
-        id: 'chatcmpl-123',
-        model: 'gpt-3.5-turbo',
-        object: 'chat.completion.chunk',
-        usage: {
-          prompt_tokens: 13,
-          completion_tokens: 7,
-          total_tokens: 20,
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-123',
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion.chunk',
         },
-      });
-
-      // Third chunk: finish chunk
-      expect(chunks[2]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: null,
-              role: 'assistant',
-            },
-            finish_reason: 'stop',
-            index: 0,
-            logprobs: null,
+        // Second chunk: usage chunk
+        {
+          choices: [],
+          created: 1677652288,
+          id: 'chatcmpl-123',
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion.chunk',
+          usage: {
+            prompt_tokens: 13,
+            completion_tokens: 7,
+            total_tokens: 20,
           },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-123',
-        model: 'gpt-3.5-turbo',
-        object: 'chat.completion.chunk',
-        system_fingerprint: undefined,
-      });
+        },
+        // Third chunk: finish chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: null,
+                role: 'assistant',
+              },
+              finish_reason: 'stop',
+              index: 0,
+              logprobs: null,
+            },
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-123',
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion.chunk',
+          system_fingerprint: undefined,
+        },
+      ]);
     });
 
     it('should transform ChatCompletion with reasoning_content to stream events correctly', async () => {
@@ -132,81 +131,78 @@ describe('nonStreamToStream', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(4);
-
-      // First chunk: reasoning chunk
-      expect(chunks[0]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: null,
-              reasoning_content: 'Let me think about this step by step...',
-              role: 'assistant',
+      expect(chunks).toEqual([
+        // First chunk: reasoning chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: null,
+                reasoning_content: 'Let me think about this step by step...',
+                role: 'assistant',
+              },
+              finish_reason: null,
+              index: 0,
+              logprobs: null,
             },
-            finish_reason: null,
-            index: 0,
-            logprobs: null,
-          },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-reasoning-123',
-        model: 'deepseek-reasoner',
-        object: 'chat.completion.chunk',
-      });
-
-      // Second chunk: content chunk
-      expect(chunks[1]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: 'The answer is 42.',
-              role: 'assistant',
-              tool_calls: undefined,
-            },
-            finish_reason: null,
-            index: 0,
-            logprobs: null,
-          },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-reasoning-123',
-        model: 'deepseek-reasoner',
-        object: 'chat.completion.chunk',
-      });
-
-      // Third chunk: usage chunk
-      expect(chunks[2]).toEqual({
-        choices: [],
-        created: 1677652288,
-        id: 'chatcmpl-reasoning-123',
-        model: 'deepseek-reasoner',
-        object: 'chat.completion.chunk',
-        usage: {
-          prompt_tokens: 13,
-          completion_tokens: 7,
-          total_tokens: 20,
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-reasoning-123',
+          model: 'deepseek-reasoner',
+          object: 'chat.completion.chunk',
         },
-      });
-
-      // Fourth chunk: finish chunk
-      expect(chunks[3]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: null,
-              role: 'assistant',
+        // Second chunk: content chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: 'The answer is 42.',
+                role: 'assistant',
+                tool_calls: undefined,
+              },
+              finish_reason: null,
+              index: 0,
+              logprobs: null,
             },
-            finish_reason: 'stop',
-            index: 0,
-            logprobs: null,
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-reasoning-123',
+          model: 'deepseek-reasoner',
+          object: 'chat.completion.chunk',
+        },
+        // Third chunk: usage chunk
+        {
+          choices: [],
+          created: 1677652288,
+          id: 'chatcmpl-reasoning-123',
+          model: 'deepseek-reasoner',
+          object: 'chat.completion.chunk',
+          usage: {
+            prompt_tokens: 13,
+            completion_tokens: 7,
+            total_tokens: 20,
           },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-reasoning-123',
-        model: 'deepseek-reasoner',
-        object: 'chat.completion.chunk',
-        system_fingerprint: undefined,
-      });
+        },
+        // Fourth chunk: finish chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: null,
+                role: 'assistant',
+              },
+              finish_reason: 'stop',
+              index: 0,
+              logprobs: null,
+            },
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-reasoning-123',
+          model: 'deepseek-reasoner',
+          object: 'chat.completion.chunk',
+          system_fingerprint: undefined,
+        },
+      ]);
     });
 
     it('should transform ChatCompletion with tool_calls to stream events correctly', async () => {
@@ -221,6 +217,7 @@ describe('nonStreamToStream', () => {
             message: {
               role: 'assistant',
               content: 'I need to check the weather for you.',
+              refusal: null,
               tool_calls: [
                 {
                   id: 'call_abc123',
@@ -253,71 +250,69 @@ describe('nonStreamToStream', () => {
         chunks.push(value);
       }
 
-      expect(chunks).toHaveLength(3);
-
-      // First chunk: content and tool_calls chunk
-      expect(chunks[0]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: 'I need to check the weather for you.',
-              role: 'assistant',
-              tool_calls: [
-                {
-                  function: {
-                    name: 'get_weather',
-                    arguments: '{"location": "New York"}',
+      expect(chunks).toEqual([
+        // First chunk: content and tool_calls chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: 'I need to check the weather for you.',
+                role: 'assistant',
+                tool_calls: [
+                  {
+                    function: {
+                      name: 'get_weather',
+                      arguments: '{"location": "New York"}',
+                    },
+                    id: 'call_abc123',
+                    index: 0,
+                    type: 'function',
                   },
-                  id: 'call_abc123',
-                  index: 0,
-                  type: 'function',
-                },
-              ],
+                ],
+              },
+              finish_reason: null,
+              index: 0,
+              logprobs: null,
             },
-            finish_reason: null,
-            index: 0,
-            logprobs: null,
-          },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-tool-123',
-        model: 'gpt-4',
-        object: 'chat.completion.chunk',
-      });
-
-      // Second chunk: usage chunk
-      expect(chunks[1]).toEqual({
-        choices: [],
-        created: 1677652288,
-        id: 'chatcmpl-tool-123',
-        model: 'gpt-4',
-        object: 'chat.completion.chunk',
-        usage: {
-          prompt_tokens: 13,
-          completion_tokens: 7,
-          total_tokens: 20,
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-tool-123',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
         },
-      });
-
-      // Third chunk: finish chunk
-      expect(chunks[2]).toEqual({
-        choices: [
-          {
-            delta: {
-              content: null,
-              role: 'assistant',
-            },
-            finish_reason: 'tool_calls',
-            index: 0,
-            logprobs: null,
+        // Second chunk: usage chunk
+        {
+          choices: [],
+          created: 1677652288,
+          id: 'chatcmpl-tool-123',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          usage: {
+            prompt_tokens: 13,
+            completion_tokens: 7,
+            total_tokens: 20,
           },
-        ],
-        created: 1677652288,
-        id: 'chatcmpl-tool-123',
-        model: 'gpt-4',
-        object: 'chat.completion.chunk',
-        system_fingerprint: undefined,
-      });
+        },
+        // Third chunk: finish chunk
+        {
+          choices: [
+            {
+              delta: {
+                content: null,
+                role: 'assistant',
+              },
+              finish_reason: 'tool_calls',
+              index: 0,
+              logprobs: null,
+            },
+          ],
+          created: 1677652288,
+          id: 'chatcmpl-tool-123',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          system_fingerprint: undefined,
+        },
+      ]);
     });
 
     it('should handle empty choices array', async () => {
@@ -346,10 +341,8 @@ describe('nonStreamToStream', () => {
 
       expect(chunks).toHaveLength(3);
 
-      // First chunk: empty content chunk
+      // Verify all chunks have empty choices array structure
       expect(chunks[0].choices).toEqual([]);
-
-      // Second chunk: usage chunk  
       expect(chunks[1]).toEqual({
         choices: [],
         created: 1677652288,
@@ -362,8 +355,6 @@ describe('nonStreamToStream', () => {
           total_tokens: 13,
         },
       });
-
-      // Third chunk: finish chunk with empty choices
       expect(chunks[2].choices).toEqual([]);
     });
   });
@@ -372,7 +363,7 @@ describe('nonStreamToStream', () => {
     it('should transform Response API with text output to stream events correctly', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_abc123',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         output: [
@@ -386,7 +377,7 @@ describe('nonStreamToStream', () => {
               {
                 type: 'output_text',
                 text: 'Hello! How can I help you today?',
-              },
+              } as any,
             ],
           },
         ],
@@ -394,10 +385,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 20,
           input_tokens: 13,
           output_tokens: 7,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      };
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse);
       const reader = stream.getReader();
@@ -409,78 +403,75 @@ describe('nonStreamToStream', () => {
         events.push(value);
       }
 
-      expect(events).toHaveLength(4);
-
-      // First event: response.content_part.added
-      expect(events[0]).toEqual({
-        content_index: 0,
-        item_id: 'msg_001',
-        output_index: 1,
-        part: {
-          annotations: [],
+      expect(events).toEqual([
+        // First event: response.content_part.added
+        {
+          content_index: 0,
+          item_id: 'msg_001',
+          output_index: 1,
+          part: {
+            annotations: [],
+            text: 'Hello! How can I help you today?',
+            type: 'output_text',
+          },
+          sequence_number: 1,
+          type: 'response.content_part.added',
+        },
+        // Second event: response.output_text.done
+        {
+          content_index: 0,
+          item_id: 'msg_001',
+          output_index: 1,
+          sequence_number: 2,
           text: 'Hello! How can I help you today?',
-          type: 'output_text',
+          type: 'response.output_text.done',
         },
-        sequence_number: 1,
-        type: 'response.content_part.added',
-      });
-
-      // Second event: response.output_text.done
-      expect(events[1]).toEqual({
-        content_index: 0,
-        item_id: 'msg_001',
-        output_index: 1,
-        sequence_number: 2,
-        text: 'Hello! How can I help you today?',
-        type: 'response.output_text.done',
-      });
-
-      // Third event: response.content_part.done
-      expect(events[2]).toEqual({
-        content_index: 0,
-        item_id: 'msg_001',
-        output_index: 1,
-        part: {
-          annotations: [],
-          text: 'Hello! How can I help you today?',
-          type: 'output_text',
+        // Third event: response.content_part.done
+        {
+          content_index: 0,
+          item_id: 'msg_001',
+          output_index: 1,
+          part: {
+            annotations: [],
+            text: 'Hello! How can I help you today?',
+            type: 'output_text',
+          },
+          sequence_number: 3,
+          type: 'response.content_part.done',
         },
-        sequence_number: 3,
-        type: 'response.content_part.done',
-      });
-
-      // Fourth event: response.output_item.done
-      expect(events[3]).toEqual({
-        item: {
-          id: 'msg_001',
-          object: 'realtime.item',
-          type: 'message',
-          status: 'completed',
-          role: 'assistant',
-          content: [
-            {
-              type: 'output_text',
-              text: 'Hello! How can I help you today?',
-            },
-          ],
+        // Fourth event: response.output_item.done
+        {
+          item: {
+            id: 'msg_001',
+            object: 'realtime.item',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Hello! How can I help you today?',
+              },
+            ],
+          },
+          output_index: 1,
+          sequence_number: 4,
+          type: 'response.output_item.done',
         },
-        output_index: 1,
-        sequence_number: 4,
-        type: 'response.output_item.done',
-      });
+      ]);
     });
 
     it('should handle Response API without message output', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_no_message',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         output: [
           {
             id: 'audio_001',
             object: 'realtime.item',
-            type: 'audio',
+            type: 'message' as any,
             status: 'completed',
           },
         ],
@@ -488,10 +479,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 5,
           input_tokens: 5,
           output_tokens: 0,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      };
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse);
       const reader = stream.getReader();
@@ -504,13 +498,13 @@ describe('nonStreamToStream', () => {
       }
 
       // Should produce no events because there's no message with text content
-      expect(events).toHaveLength(0);
+      expect(events).toEqual([]);
     });
 
     it('should handle Response API with message but no text content', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_no_text',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         output: [
@@ -522,7 +516,7 @@ describe('nonStreamToStream', () => {
             role: 'assistant',
             content: [
               {
-                type: 'audio',
+                type: 'output_text' as any,
                 audio: 'base64encodedaudio',
               },
             ],
@@ -532,10 +526,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 5,
           input_tokens: 5,
           output_tokens: 0,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      };
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse);
       const reader = stream.getReader();
@@ -548,13 +545,13 @@ describe('nonStreamToStream', () => {
       }
 
       // Should produce no events because message has no text content
-      expect(events).toHaveLength(0);
+      expect(events).toEqual([]);
     });
 
     it('should generate proper item_id when message id is missing', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_missing_id',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         output: [
@@ -568,7 +565,7 @@ describe('nonStreamToStream', () => {
               {
                 type: 'output_text',
                 text: 'Response without message ID',
-              },
+              } as any,
             ],
           },
         ],
@@ -576,10 +573,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 15,
           input_tokens: 10,
           output_tokens: 5,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      } as OpenAI.Responses.Response;
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse);
       const reader = stream.getReader();
@@ -591,10 +591,9 @@ describe('nonStreamToStream', () => {
         events.push(value);
       }
 
-      expect(events).toHaveLength(4);
-
-      // Check that all events use the generated item_id
+      // Check that all events use the generated item_id and have correct structure
       const expectedItemId = 'msg_resp_missing_id';
+      expect(events).toHaveLength(4);
       events.forEach((event) => {
         if ('item_id' in event) {
           expect(event.item_id).toBe(expectedItemId);
@@ -605,7 +604,7 @@ describe('nonStreamToStream', () => {
     it('should handle empty output array', async () => {
       const mockResponse: OpenAI.Responses.Response = {
         id: 'resp_empty_output',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         output: [],
@@ -613,10 +612,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 5,
           input_tokens: 5,
           output_tokens: 0,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      };
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse);
       const reader = stream.getReader();
@@ -629,13 +631,13 @@ describe('nonStreamToStream', () => {
       }
 
       // Should produce no events because output array is empty
-      expect(events).toHaveLength(0);
+      expect(events).toEqual([]);
     });
 
     it('should handle missing output field', async () => {
       const mockResponse: Partial<OpenAI.Responses.Response> = {
         id: 'resp_no_output',
-        object: 'realtime.response',
+        object: 'response',
         status: 'completed',
         status_details: null,
         // output field is missing
@@ -643,10 +645,13 @@ describe('nonStreamToStream', () => {
           total_tokens: 5,
           input_tokens: 5,
           output_tokens: 0,
+          input_tokens_details: { audio_tokens: 0, cache_read_tokens: 0 },
+          output_tokens_details: { audio_tokens: 0, reasoning_tokens: 0 },
         },
         created: 1677652288,
+        created_at: 1677652288,
         model: 'gpt-4o-realtime-preview',
-      };
+      } as any;
 
       const stream = transformResponseAPIToStream(mockResponse as OpenAI.Responses.Response);
       const reader = stream.getReader();
@@ -659,7 +664,7 @@ describe('nonStreamToStream', () => {
       }
 
       // Should produce no events because output field is missing
-      expect(events).toHaveLength(0);
+      expect(events).toEqual([]);
     });
   });
 });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.test.ts
@@ -1,0 +1,665 @@
+// @vitest-environment node
+import OpenAI from 'openai';
+import { describe, expect, it } from 'vitest';
+
+import { transformResponseAPIToStream, transformResponseToStream } from './nonStreamToStream';
+
+describe('nonStreamToStream', () => {
+  describe('transformResponseToStream', () => {
+    it('should transform ChatCompletion to stream events correctly', async () => {
+      const mockResponse: OpenAI.ChatCompletion = {
+        id: 'chatcmpl-123',
+        object: 'chat.completion',
+        created: 1677652288,
+        model: 'gpt-3.5-turbo',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Hello! How can I help you today?',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      };
+
+      const stream = transformResponseToStream(mockResponse);
+      const reader = stream.getReader();
+      const chunks: OpenAI.ChatCompletionChunk[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      expect(chunks).toHaveLength(3);
+
+      // First chunk: content chunk
+      expect(chunks[0]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: 'Hello! How can I help you today?',
+              role: 'assistant',
+              tool_calls: undefined,
+            },
+            finish_reason: null,
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-123',
+        model: 'gpt-3.5-turbo',
+        object: 'chat.completion.chunk',
+      });
+
+      // Second chunk: usage chunk
+      expect(chunks[1]).toEqual({
+        choices: [],
+        created: 1677652288,
+        id: 'chatcmpl-123',
+        model: 'gpt-3.5-turbo',
+        object: 'chat.completion.chunk',
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      });
+
+      // Third chunk: finish chunk
+      expect(chunks[2]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: null,
+              role: 'assistant',
+            },
+            finish_reason: 'stop',
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-123',
+        model: 'gpt-3.5-turbo',
+        object: 'chat.completion.chunk',
+        system_fingerprint: undefined,
+      });
+    });
+
+    it('should transform ChatCompletion with reasoning_content to stream events correctly', async () => {
+      const mockResponse: unknown = {
+        id: 'chatcmpl-reasoning-123',
+        object: 'chat.completion',
+        created: 1677652288,
+        model: 'deepseek-reasoner',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'The answer is 42.',
+              reasoning_content: 'Let me think about this step by step...',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      };
+
+      const stream = transformResponseToStream(mockResponse as OpenAI.ChatCompletion);
+      const reader = stream.getReader();
+      const chunks: OpenAI.ChatCompletionChunk[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      expect(chunks).toHaveLength(4);
+
+      // First chunk: reasoning chunk
+      expect(chunks[0]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: null,
+              reasoning_content: 'Let me think about this step by step...',
+              role: 'assistant',
+            },
+            finish_reason: null,
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-reasoning-123',
+        model: 'deepseek-reasoner',
+        object: 'chat.completion.chunk',
+      });
+
+      // Second chunk: content chunk
+      expect(chunks[1]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: 'The answer is 42.',
+              role: 'assistant',
+              tool_calls: undefined,
+            },
+            finish_reason: null,
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-reasoning-123',
+        model: 'deepseek-reasoner',
+        object: 'chat.completion.chunk',
+      });
+
+      // Third chunk: usage chunk
+      expect(chunks[2]).toEqual({
+        choices: [],
+        created: 1677652288,
+        id: 'chatcmpl-reasoning-123',
+        model: 'deepseek-reasoner',
+        object: 'chat.completion.chunk',
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      });
+
+      // Fourth chunk: finish chunk
+      expect(chunks[3]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: null,
+              role: 'assistant',
+            },
+            finish_reason: 'stop',
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-reasoning-123',
+        model: 'deepseek-reasoner',
+        object: 'chat.completion.chunk',
+        system_fingerprint: undefined,
+      });
+    });
+
+    it('should transform ChatCompletion with tool_calls to stream events correctly', async () => {
+      const mockResponse: OpenAI.ChatCompletion = {
+        id: 'chatcmpl-tool-123',
+        object: 'chat.completion',
+        created: 1677652288,
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'I need to check the weather for you.',
+              tool_calls: [
+                {
+                  id: 'call_abc123',
+                  type: 'function',
+                  function: {
+                    name: 'get_weather',
+                    arguments: '{"location": "New York"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+            logprobs: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      };
+
+      const stream = transformResponseToStream(mockResponse);
+      const reader = stream.getReader();
+      const chunks: OpenAI.ChatCompletionChunk[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      expect(chunks).toHaveLength(3);
+
+      // First chunk: content and tool_calls chunk
+      expect(chunks[0]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: 'I need to check the weather for you.',
+              role: 'assistant',
+              tool_calls: [
+                {
+                  function: {
+                    name: 'get_weather',
+                    arguments: '{"location": "New York"}',
+                  },
+                  id: 'call_abc123',
+                  index: 0,
+                  type: 'function',
+                },
+              ],
+            },
+            finish_reason: null,
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-tool-123',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+      });
+
+      // Second chunk: usage chunk
+      expect(chunks[1]).toEqual({
+        choices: [],
+        created: 1677652288,
+        id: 'chatcmpl-tool-123',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 7,
+          total_tokens: 20,
+        },
+      });
+
+      // Third chunk: finish chunk
+      expect(chunks[2]).toEqual({
+        choices: [
+          {
+            delta: {
+              content: null,
+              role: 'assistant',
+            },
+            finish_reason: 'tool_calls',
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: 1677652288,
+        id: 'chatcmpl-tool-123',
+        model: 'gpt-4',
+        object: 'chat.completion.chunk',
+        system_fingerprint: undefined,
+      });
+    });
+
+    it('should handle empty choices array', async () => {
+      const mockResponse: OpenAI.ChatCompletion = {
+        id: 'chatcmpl-empty-123',
+        object: 'chat.completion',
+        created: 1677652288,
+        model: 'gpt-3.5-turbo',
+        choices: [],
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 0,
+          total_tokens: 13,
+        },
+      };
+
+      const stream = transformResponseToStream(mockResponse);
+      const reader = stream.getReader();
+      const chunks: OpenAI.ChatCompletionChunk[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+
+      expect(chunks).toHaveLength(3);
+
+      // First chunk: empty content chunk
+      expect(chunks[0].choices).toEqual([]);
+
+      // Second chunk: usage chunk  
+      expect(chunks[1]).toEqual({
+        choices: [],
+        created: 1677652288,
+        id: 'chatcmpl-empty-123',
+        model: 'gpt-3.5-turbo',
+        object: 'chat.completion.chunk',
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 0,
+          total_tokens: 13,
+        },
+      });
+
+      // Third chunk: finish chunk with empty choices
+      expect(chunks[2].choices).toEqual([]);
+    });
+  });
+
+  describe('transformResponseAPIToStream', () => {
+    it('should transform Response API with text output to stream events correctly', async () => {
+      const mockResponse: OpenAI.Responses.Response = {
+        id: 'resp_abc123',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        output: [
+          {
+            id: 'msg_001',
+            object: 'realtime.item',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Hello! How can I help you today?',
+              },
+            ],
+          },
+        ],
+        usage: {
+          total_tokens: 20,
+          input_tokens: 13,
+          output_tokens: 7,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      };
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      expect(events).toHaveLength(4);
+
+      // First event: response.content_part.added
+      expect(events[0]).toEqual({
+        content_index: 0,
+        item_id: 'msg_001',
+        output_index: 1,
+        part: {
+          annotations: [],
+          text: 'Hello! How can I help you today?',
+          type: 'output_text',
+        },
+        sequence_number: 1,
+        type: 'response.content_part.added',
+      });
+
+      // Second event: response.output_text.done
+      expect(events[1]).toEqual({
+        content_index: 0,
+        item_id: 'msg_001',
+        output_index: 1,
+        sequence_number: 2,
+        text: 'Hello! How can I help you today?',
+        type: 'response.output_text.done',
+      });
+
+      // Third event: response.content_part.done
+      expect(events[2]).toEqual({
+        content_index: 0,
+        item_id: 'msg_001',
+        output_index: 1,
+        part: {
+          annotations: [],
+          text: 'Hello! How can I help you today?',
+          type: 'output_text',
+        },
+        sequence_number: 3,
+        type: 'response.content_part.done',
+      });
+
+      // Fourth event: response.output_item.done
+      expect(events[3]).toEqual({
+        item: {
+          id: 'msg_001',
+          object: 'realtime.item',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Hello! How can I help you today?',
+            },
+          ],
+        },
+        output_index: 1,
+        sequence_number: 4,
+        type: 'response.output_item.done',
+      });
+    });
+
+    it('should handle Response API without message output', async () => {
+      const mockResponse: OpenAI.Responses.Response = {
+        id: 'resp_no_message',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        output: [
+          {
+            id: 'audio_001',
+            object: 'realtime.item',
+            type: 'audio',
+            status: 'completed',
+          },
+        ],
+        usage: {
+          total_tokens: 5,
+          input_tokens: 5,
+          output_tokens: 0,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      };
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      // Should produce no events because there's no message with text content
+      expect(events).toHaveLength(0);
+    });
+
+    it('should handle Response API with message but no text content', async () => {
+      const mockResponse: OpenAI.Responses.Response = {
+        id: 'resp_no_text',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        output: [
+          {
+            id: 'msg_no_text',
+            object: 'realtime.item',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [
+              {
+                type: 'audio',
+                audio: 'base64encodedaudio',
+              },
+            ],
+          },
+        ],
+        usage: {
+          total_tokens: 5,
+          input_tokens: 5,
+          output_tokens: 0,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      };
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      // Should produce no events because message has no text content
+      expect(events).toHaveLength(0);
+    });
+
+    it('should generate proper item_id when message id is missing', async () => {
+      const mockResponse: OpenAI.Responses.Response = {
+        id: 'resp_missing_id',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        output: [
+          {
+            // id is missing
+            object: 'realtime.item',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Response without message ID',
+              },
+            ],
+          },
+        ],
+        usage: {
+          total_tokens: 15,
+          input_tokens: 10,
+          output_tokens: 5,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      } as OpenAI.Responses.Response;
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      expect(events).toHaveLength(4);
+
+      // Check that all events use the generated item_id
+      const expectedItemId = 'msg_resp_missing_id';
+      events.forEach((event) => {
+        if ('item_id' in event) {
+          expect(event.item_id).toBe(expectedItemId);
+        }
+      });
+    });
+
+    it('should handle empty output array', async () => {
+      const mockResponse: OpenAI.Responses.Response = {
+        id: 'resp_empty_output',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        output: [],
+        usage: {
+          total_tokens: 5,
+          input_tokens: 5,
+          output_tokens: 0,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      };
+
+      const stream = transformResponseAPIToStream(mockResponse);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      // Should produce no events because output array is empty
+      expect(events).toHaveLength(0);
+    });
+
+    it('should handle missing output field', async () => {
+      const mockResponse: Partial<OpenAI.Responses.Response> = {
+        id: 'resp_no_output',
+        object: 'realtime.response',
+        status: 'completed',
+        status_details: null,
+        // output field is missing
+        usage: {
+          total_tokens: 5,
+          input_tokens: 5,
+          output_tokens: 0,
+        },
+        created: 1677652288,
+        model: 'gpt-4o-realtime-preview',
+      };
+
+      const stream = transformResponseAPIToStream(mockResponse as OpenAI.Responses.Response);
+      const reader = stream.getReader();
+      const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        events.push(value);
+      }
+
+      // Should produce no events because output field is missing
+      expect(events).toHaveLength(0);
+    });
+  });
+});

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
@@ -1,0 +1,160 @@
+import OpenAI from 'openai';
+
+/**
+ * make the OpenAI response data as a stream
+ */
+export const transformResponseToStream = (data: OpenAI.ChatCompletion) =>
+  new ReadableStream({
+    start(controller) {
+      const choices = data.choices || [];
+      const first = choices[0];
+      // 兼容：非流式里 DeepSeek 等会把“深度思考”放在 message.reasoning_content
+      const message: any = first?.message ?? {};
+      const reasoningText =
+        typeof message.reasoning_content === 'string' && message.reasoning_content.length > 0
+          ? message.reasoning_content
+          : null;
+      if (reasoningText) {
+        controller.enqueue({
+          choices: [
+            {
+              delta: { content: null, reasoning_content: reasoningText, role: 'assistant' },
+              finish_reason: null,
+              index: first?.index ?? 0,
+              logprobs: first?.logprobs ?? null,
+            },
+          ],
+          created: data.created,
+          id: data.id,
+          model: data.model,
+          object: 'chat.completion.chunk',
+        } as unknown as OpenAI.ChatCompletionChunk);
+      }
+      const chunk: OpenAI.ChatCompletionChunk = {
+        choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
+          delta: {
+            content: choice.message.content,
+            role: choice.message.role,
+            tool_calls: choice.message.tool_calls?.map(
+              (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => ({
+                function: tool.function,
+                id: tool.id,
+                index,
+                type: tool.type,
+              }),
+            ),
+          },
+          finish_reason: null,
+          index: choice.index,
+          logprobs: choice.logprobs,
+        })),
+        created: data.created,
+        id: data.id,
+        model: data.model,
+        object: 'chat.completion.chunk',
+      };
+
+      controller.enqueue(chunk);
+      if (data.usage) {
+        controller.enqueue({
+          choices: [],
+          created: data.created,
+          id: data.id,
+          model: data.model,
+          object: 'chat.completion.chunk',
+          usage: data.usage,
+        } as unknown as OpenAI.ChatCompletionChunk);
+      }
+      controller.enqueue({
+        choices: choices.map((choice: OpenAI.ChatCompletion.Choice) => ({
+          delta: {
+            content: null,
+            role: choice.message.role,
+          },
+          finish_reason: choice.finish_reason,
+          index: choice.index,
+          logprobs: choice.logprobs,
+        })),
+        created: data.created,
+        id: data.id,
+        model: data.model,
+        object: 'chat.completion.chunk',
+        system_fingerprint: data.system_fingerprint,
+      } as OpenAI.ChatCompletionChunk);
+      controller.close();
+    },
+  });
+
+/**
+ * transform the OpenAI Response API data to stream format for non-streaming responses
+ */
+export const transformResponseAPIToStream = (data: OpenAI.Responses.Response) =>
+  new ReadableStream({
+    start(controller) {
+      // For Response API, we need to create compatible streaming chunks
+      // The Response API structure is different from ChatCompletion
+
+      // Extract content from the output array - look for message type with content
+      const messageOutput = data.output?.find((output) => output.type === 'message');
+      if (messageOutput && messageOutput.type === 'message') {
+        // Find text content in the message
+        const textContent = messageOutput.content?.find(
+          (content: any) => content.type === 'output_text',
+        );
+        if (textContent && textContent.type === 'output_text') {
+          const chunk = {
+            choices: [
+              {
+                delta: {
+                  content: textContent.text,
+                  role: 'assistant',
+                },
+                finish_reason: null,
+                index: 0,
+                logprobs: null,
+              },
+            ],
+            created: Math.floor(Date.now() / 1000),
+            id: data.id,
+            model: data.model || 'unknown',
+            object: 'chat.completion.chunk',
+          } as OpenAI.ChatCompletionChunk;
+
+          controller.enqueue(chunk);
+        }
+      }
+
+      // Enqueue usage if available
+      if (data.usage) {
+        controller.enqueue({
+          choices: [],
+          created: Math.floor(Date.now() / 1000),
+          id: data.id,
+          model: data.model || 'unknown',
+          object: 'chat.completion.chunk',
+          usage: data.usage,
+        } as unknown as OpenAI.ChatCompletionChunk);
+      }
+
+      // Final chunk with finish_reason
+      controller.enqueue({
+        choices: [
+          {
+            delta: {
+              content: null,
+              role: 'assistant',
+            },
+            finish_reason: 'stop',
+            index: 0,
+            logprobs: null,
+          },
+        ],
+        created: Math.floor(Date.now() / 1000),
+        id: data.id,
+        model: data.model || 'unknown',
+        object: 'chat.completion.chunk',
+      } as OpenAI.ChatCompletionChunk);
+
+      controller.close();
+    },
+  });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix non-stream mode handling in the OpenAI-compatible runtime by centralizing response-to-stream logic and branching on the stream flag to support both streaming and non-streaming responses.

Bug Fixes:
- Enable non-stream mode by branching on payload.stream to return raw JSON or simulate streaming chunks for non-streaming API responses

Enhancements:
- Extract response-to-stream transformers into a new nonStreamToStream module
- Update createOpenAICompatibleRuntime to conditionally tee real streams, debug non-stream responses, and wrap simulated streams