### PR TITLE
🐛 fix: fix missing provider in server message

### DIFF
--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -55,6 +55,7 @@ export const aiChatRouter = router({
       const assistantMessageItem = await ctx.messageModel.create({
         content: LOADING_FLAT,
         fromModel: input.newAssistantMessage.model,
+        fromProvider: input.newAssistantMessage.provider,
         parentId: messageId,
         role: 'assistant',
         sessionId: input.sessionId!,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

- fix #9275 
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Include the fromProvider property when persisting new assistant messages in the server's aiChat router