### PR TITLE
👷 build: don't sign macos desktop when missing  sign secrets

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -7,12 +7,20 @@ const packageJSON = require('./package.json');
 
 const channel = process.env.UPDATE_CHANNEL;
 const arch = os.arch();
+const hasAppleCertificate = Boolean(process.env.APPLE_CERTIFICATE_BASE64);
 
 console.log(`🚄 Build Version ${packageJSON.version}, Channel: ${channel}`);
 console.log(`🏗️ Building for architecture: ${arch}`);
 
 const isNightly = channel === 'nightly';
 const isBeta = packageJSON.name.includes('beta');
+
+// https://www.electron.build/code-signing-mac?utm_source=openai#how-to-disable-code-signing-during-the-build-process-on-macos
+if (!hasAppleCertificate) {
+  // Disable auto discovery to keep electron-builder from searching unavailable signing identities
+  process.env.CSC_IDENTITY_AUTO_DISCOVERY = 'false';
+  console.log('⚠️ Apple certificate not found, macOS artifacts will be unsigned.');
+}
 
 // 根据版本类型确定协议 scheme
 const getProtocolScheme = () => {
@@ -87,8 +95,9 @@ const config = {
       NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
     },
     gatekeeperAssess: false,
-    hardenedRuntime: true,
-    notarize: true,
+    hardenedRuntime: hasAppleCertificate,
+    notarize: hasAppleCertificate,
+    ...(hasAppleCertificate ? {} : { identity: null }),
     target:
       // 降低构建时间，nightly 只打 dmg
       // 根据当前机器架构只构建对应架构的包


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

try fix https://github.com/lobehub/lobe-chat/pull/9043 desktop macos build

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Prevent macOS code signing when Apple certificate secrets are missing by disabling identity auto-discovery, skipping hardened runtime and notarization, and logging a warning.

Enhancements:
- Conditionally enable hardenedRuntime and notarize only when an Apple certificate is available and emit a warning otherwise

Build:
- Skip macOS code signing if APPLE_CERTIFICATE_BASE64 is unset by disabling CSC_IDENTITY_AUTO_DISCOVERY and setting identity to null