### PR TITLE
✨ refactor: export maxDuration from env module for consistency

### DIFF
--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,3 +1,6 @@
 export const isDev = process.env.NODE_ENV === 'development';
 
 export const isOnServerSide = typeof window === 'undefined';
+
+const MAX_DURATION = Number(process.env.MAX_DURATION);
+export const maxDuration = MAX_DURATION > 0 ? MAX_DURATION : 300;

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -3,4 +3,7 @@ export const isDev = process.env.NODE_ENV === 'development';
 export const isOnServerSide = typeof window === 'undefined';
 
 const MAX_DURATION = Number(process.env.MAX_DURATION);
-export const maxDuration = MAX_DURATION > 0 ? MAX_DURATION : 300;
+
+export function getMaxDuration() {
+  return MAX_DURATION > 0 ? MAX_DURATION : 300;
+}

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -8,10 +8,11 @@ import { ChatErrorType } from '@lobechat/types';
 import { checkAuth } from '@/app/(backend)/middleware/auth';
 import { createTraceOptions, initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
 import { ChatStreamPayload } from '@/types/openai/chat';
+import { getMaxDuration } from '@/utils/env';
 import { createErrorResponse } from '@/utils/errorResponse';
 import { getTracePayload } from '@/utils/trace';
 
-export { maxDuration } from '@/utils/env';
+export const maxDuration = getMaxDuration();
 
 export const POST = checkAuth(async (req: Request, { params, jwtPayload, createRuntime }) => {
   const { provider } = await params;

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -11,7 +11,7 @@ import { ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
 import { getTracePayload } from '@/utils/trace';
 
-export const maxDuration = 300;
+export { maxDuration } from '@/utils/env';
 
 export const POST = checkAuth(async (req: Request, { params, jwtPayload, createRuntime }) => {
   const { provider } = await params;

--- a/src/app/(backend)/webapi/chat/vertexai/route.ts
+++ b/src/app/(backend)/webapi/chat/vertexai/route.ts
@@ -7,7 +7,7 @@ import { safeParseJSON } from '@/utils/safeParseJSON';
 
 import { POST as UniverseRoute } from '../[provider]/route';
 
-export const maxDuration = 300;
+export { maxDuration } from '@/utils/env';
 // due to the Chinese region does not support accessing Google
 // we need to use proxy to access it
 // refs: https://github.com/google/generative-ai-js/issues/29#issuecomment-1866246513

--- a/src/app/(backend)/webapi/chat/vertexai/route.ts
+++ b/src/app/(backend)/webapi/chat/vertexai/route.ts
@@ -3,11 +3,12 @@ import { LobeVertexAI } from '@lobechat/model-runtime/vertexai';
 import { ModelProvider } from 'model-bank';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { getMaxDuration } from '@/utils/env';
 import { safeParseJSON } from '@/utils/safeParseJSON';
 
 import { POST as UniverseRoute } from '../[provider]/route';
 
-export { maxDuration } from '@/utils/env';
+export const maxDuration = getMaxDuration();
 // due to the Chinese region does not support accessing Google
 // we need to use proxy to access it
 // refs: https://github.com/google/generative-ai-js/issues/29#issuecomment-1866246513


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

在vercel平台，对于免费的Hobby计划其函数的最大持续时间是60s。目前代码中此数值固定为300，导致我的项目永远无法部署成功。为了兼容性考虑，我将此变量提取为环境变量MAX_DURATION以便在构建过程中动态配置，在未配置的情况下默认值依旧为300。

<img width="1338" height="540" alt="image" src="https://github.com/user-attachments/assets/c21c0453-1a94-4477-bb7d-ae4493d65c01" />
Error: Builder returned invalid maxDuration value for Serverless Function "webapi/chat/[provider]". Serverless Functions must have a maxDuration between 1 and 60 for plan hobby. : https://vercel.com/docs/concepts/limits/overview#serverless-function-execution-timeout


#### 📝 补充信息 | Additional Information

https://vercel.com/docs/functions/limitations#max-duration

## Summary by Sourcery

Centralize the maxDuration setting into the env module and make it configurable via the MAX_DURATION environment variable with a default of 300 seconds, then update chat route handlers to use the new export.

Enhancements:
- Export maxDuration from env module based on MAX_DURATION env var with a 300-second fallback
- Replace hardcoded maxDuration values in chat route files with the centralized env export