### PR TITLE
Revert "👷 build: don't sign macos desktop when missing  sign secrets …

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -7,20 +7,12 @@ const packageJSON = require('./package.json');
 
 const channel = process.env.UPDATE_CHANNEL;
 const arch = os.arch();
-const hasAppleCertificate = Boolean(process.env.APPLE_CERTIFICATE_BASE64);
 
 console.log(`🚄 Build Version ${packageJSON.version}, Channel: ${channel}`);
 console.log(`🏗️ Building for architecture: ${arch}`);
 
 const isNightly = channel === 'nightly';
 const isBeta = packageJSON.name.includes('beta');
-
-// https://www.electron.build/code-signing-mac?utm_source=openai#how-to-disable-code-signing-during-the-build-process-on-macos
-if (!hasAppleCertificate) {
-  // Disable auto discovery to keep electron-builder from searching unavailable signing identities
-  process.env.CSC_IDENTITY_AUTO_DISCOVERY = 'false';
-  console.log('⚠️ Apple certificate not found, macOS artifacts will be unsigned.');
-}
 
 // 根据版本类型确定协议 scheme
 const getProtocolScheme = () => {
@@ -95,9 +87,8 @@ const config = {
       NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
     },
     gatekeeperAssess: false,
-    hardenedRuntime: hasAppleCertificate,
-    notarize: hasAppleCertificate,
-    ...(hasAppleCertificate ? {} : { identity: null }),
+    hardenedRuntime: true,
+    notarize: true,
     target:
       // 降低构建时间，nightly 只打 dmg
       // 根据当前机器架构只构建对应架构的包


### PR DESCRIPTION
…(#9379)"

This reverts commit 20ef12443d409b09da24aff401d07c148033e461.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Restore macOS code signing and notarization by always enabling hardened runtime and notarization regardless of certificate presence.