### PR TITLE
🐛 fix: add imageUrls to imageUrl conversion for qwen-image-edit model

### DIFF
--- a/docs/development/desktop-debugging-guide.md
+++ b/docs/development/desktop-debugging-guide.md
@@ -1,0 +1,155 @@
+# macOS Electron 调试指南
+
+本指南解决了 lobe-chat 项目中 macOS Electron 调试和 build 流程的常见问题。
+
+## 🚀 快速开始 - 自动化调试（推荐）
+
+### 使用自动化启动脚本
+
+最简单的方式是使用我们新增的自动化脚本：
+
+```bash
+npm run dev:desktop:auto
+```
+
+这个脚本会：
+- ✅ 自动启动 Next.js 开发服务器（端口 3015）
+- ✅ 等待服务器准备就绪
+- ✅ 自动启动 Electron 应用
+- ✅ 提供健康检查和错误恢复
+- ✅ 统一的日志输出和进程管理
+
+## 🔧 手动调试方式
+
+如果需要手动控制，请按以下步骤：
+
+### 1. 启动 Next.js 开发服务器
+```bash
+npm run dev:desktop
+```
+等待看到 "Ready in" 或类似的启动成功消息。
+
+### 2. 启动 Electron 应用
+在新的终端窗口中：
+```bash
+cd apps/desktop
+npm run electron:dev
+```
+
+## 🛠️ 构建和文件安全
+
+### 安全的构建流程
+
+为了防止意外的文件丢失，我们提供了安全的构建选项：
+
+```bash
+# 使用安全版本（推荐）
+npm run desktop:prepare-dist:safe
+```
+
+安全版本提供：
+- ✅ 自动备份现有文件
+- ✅ 带时间戳的备份目录
+- ✅ 失败时自动恢复
+- ✅ 自动清理旧备份（保留 3 个最新）
+
+### 传统构建流程
+
+```bash
+# 传统版本（谨慎使用）
+npm run desktop:prepare-dist
+```
+
+⚠️ **警告**: 传统版本会直接删除目标目录，无备份保护。
+
+## 🐛 故障排除
+
+### 问题 1: Electron 无法连接到 Next.js 服务器
+
+**症状**: Electron 应用打开但显示空白或连接错误
+
+**解决方案**:
+1. 确认 Next.js 服务器在 http://localhost:3015 正常运行
+2. 检查 `.env.desktop` 文件中的 `APP_URL` 配置
+3. 使用自动化脚本 `npm run dev:desktop:auto`
+
+### 问题 2: 端口冲突
+
+**症状**: Next.js 服务器启动失败，提示端口被占用
+
+**解决方案**:
+```bash
+# 查找占用端口的进程
+lsof -i :3015
+
+# 终止进程
+kill -9 <PID>
+```
+
+### 问题 3: macOS 权限问题
+
+**症状**: Electron 无法启动或出现权限错误
+
+**解决方案**:
+1. 确保 Xcode Command Line Tools 已安装:
+   ```bash
+   xcode-select --install
+   ```
+
+2. 检查 Node.js 权限:
+   ```bash
+   node --version
+   npm --version
+   ```
+
+### 问题 4: Build 过程中文件丢失
+
+**症状**: 构建后重要文件被删除
+
+**解决方案**:
+1. 查看备份目录: `apps/desktop/dist/next.backup_*`
+2. 恢复备份:
+   ```bash
+   cd apps/desktop/dist
+   mv next.backup_YYYY-MM-DD_HH-MM-SS next
+   ```
+3. 今后使用安全版本: `npm run desktop:prepare-dist:safe`
+
+## 📁 项目结构说明
+
+```
+├── apps/desktop/               # Electron 应用
+│   ├── dist/next/             # Next.js 构建输出（目标目录）
+│   ├── dist/next.backup_*/    # 自动备份目录
+│   └── package.json           # Electron 应用配置
+├── .next/standalone/          # Next.js 独立构建（源目录）
+├── .env.desktop              # Desktop 环境配置
+└── scripts/
+    ├── dev-desktop.mjs       # 自动化调试脚本
+    └── electronWorkflow/
+        ├── moveNextStandalone.ts      # 传统文件移动
+        └── moveNextStandaloneSafe.ts  # 安全文件移动
+```
+
+## 🚨 重要提示
+
+1. **备份重要**: 构建前务必备份重要的开发文件
+2. **使用安全脚本**: 优先使用 `*:safe` 版本的脚本
+3. **检查端口**: 确保 3015 端口未被其他应用占用
+4. **权限设置**: macOS 可能需要给 Electron 应用授权
+
+## 📞 获取帮助
+
+如果遇到其他问题：
+
+1. 查看控制台日志输出
+2. 检查 `apps/desktop/logs/` 目录
+3. 提交 issue 时请包含：
+   - macOS 版本
+   - Node.js 版本
+   - 完整的错误日志
+   - 重现步骤
+
+---
+
+*最后更新: 2025-01-11*

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -99,13 +99,13 @@ async function createImageEdit(
   log('Creating image edit with model: %s, endpoint: %s', model, endpoint);
 
   // Handle imageUrls to imageUrl conversion
-  let imageUrl = params.imageUrl;
-  if (!imageUrl && params.imageUrls && params.imageUrls.length > 0) {
-    imageUrl = params.imageUrls[0];
-    log('Converting imageUrls to imageUrl: using first image %s', imageUrl);
+  let inputImageUrl = params.imageUrl;
+  if (!inputImageUrl && params.imageUrls && params.imageUrls.length > 0) {
+    inputImageUrl = params.imageUrls[0];
+    log('Converting imageUrls to imageUrl: using first image %s', inputImageUrl);
   }
 
-  if (!imageUrl) {
+  if (!inputImageUrl) {
     throw new Error('imageUrl or imageUrls is required for qwen-image-edit model');
   }
 
@@ -114,7 +114,7 @@ async function createImageEdit(
       input: {
         messages: [
           {
-            content: [{ image: imageUrl }, { text: params.prompt }],
+            content: [{ image: inputImageUrl }, { text: params.prompt }],
             role: 'user',
           },
         ],
@@ -159,10 +159,10 @@ async function createImageEdit(
     throw new Error('No image found in response content');
   }
 
-  const imageUrl = imageContent.image;
-  log('Image edit generated successfully: %s', imageUrl);
+  const resultImageUrl = imageContent.image;
+  log('Image edit generated successfully: %s', resultImageUrl);
 
-  return { imageUrl };
+  return { imageUrl: resultImageUrl };
 }
 
 /**
@@ -231,11 +231,11 @@ export async function createQwenImage(
             };
           }
 
-          const imageUrl = taskStatus.output.results[0].url;
-          log('Image generated successfully: %s', imageUrl);
+          const generatedImageUrl = taskStatus.output.results[0].url;
+          log('Image generated successfully: %s', generatedImageUrl);
 
           return {
-            data: { imageUrl },
+            data: { imageUrl: generatedImageUrl },
             status: 'success',
           };
         }

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -98,8 +98,15 @@ async function createImageEdit(
   const endpoint = `https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`;
   log('Creating image edit with model: %s, endpoint: %s', model, endpoint);
 
-  if (!params.imageUrl) {
-    throw new Error('imageUrl is required for qwen-image-edit model');
+  // Handle imageUrls to imageUrl conversion
+  let imageUrl = params.imageUrl;
+  if (!imageUrl && params.imageUrls && params.imageUrls.length > 0) {
+    imageUrl = params.imageUrls[0];
+    log('Converting imageUrls to imageUrl: using first image %s', imageUrl);
+  }
+
+  if (!imageUrl) {
+    throw new Error('imageUrl or imageUrls is required for qwen-image-edit model');
   }
 
   const response = await fetch(endpoint, {
@@ -107,7 +114,7 @@ async function createImageEdit(
       input: {
         messages: [
           {
-            content: [{ image: params.imageUrl }, { text: params.prompt }],
+            content: [{ image: imageUrl }, { text: params.prompt }],
             role: 'user',
           },
         ],

--- a/scripts/dev-desktop.mjs
+++ b/scripts/dev-desktop.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import fetch from 'node-fetch';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+
+console.log('🚀 Starting LobeChat Desktop Development Environment...');
+
+let nextProcess;
+let electronProcess;
+
+// 健康检查函数
+async function checkNextServer(port = 3015, maxRetries = 30) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(`http://localhost:${port}`, { timeout: 1000 });
+      if (response.ok) {
+        return true;
+      }
+    } catch (error) {
+      // 服务器还未启动
+    }
+    
+    if (i === 0) {
+      console.log('⏳ Waiting for Next.js server to start...');
+    }
+    
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+  return false;
+}
+
+// 启动 Next.js 开发服务器
+function startNextServer() {
+  return new Promise((resolve, reject) => {
+    console.log('🌐 Starting Next.js development server...');
+    
+    nextProcess = spawn('npm', ['run', 'dev:desktop'], {
+      cwd: rootDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
+    });
+
+    nextProcess.stdout.on('data', (data) => {
+      const output = data.toString();
+      console.log('[Next.js]', output.trim());
+      
+      // 检测启动成功标志
+      if (output.includes('Ready in') || output.includes('compiled client and server')) {
+        resolve();
+      }
+    });
+
+    nextProcess.stderr.on('data', (data) => {
+      console.error('[Next.js Error]', data.toString());
+    });
+
+    nextProcess.on('error', (error) => {
+      console.error('❌ Failed to start Next.js server:', error);
+      reject(error);
+    });
+
+    // 超时保护
+    setTimeout(() => {
+      resolve(); // 即使没有检测到启动标志也继续
+    }, 10000);
+  });
+}
+
+// 启动 Electron 应用
+function startElectronApp() {
+  return new Promise((resolve, reject) => {
+    console.log('⚡ Starting Electron application...');
+    
+    const desktopDir = join(rootDir, 'apps/desktop');
+    
+    electronProcess = spawn('npm', ['run', 'electron:dev'], {
+      cwd: desktopDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
+    });
+
+    electronProcess.stdout.on('data', (data) => {
+      console.log('[Electron]', data.toString().trim());
+    });
+
+    electronProcess.stderr.on('data', (data) => {
+      const error = data.toString();
+      // 过滤一些常见的无害警告
+      if (!error.includes('Electron Security Warning')) {
+        console.error('[Electron Error]', error);
+      }
+    });
+
+    electronProcess.on('error', (error) => {
+      console.error('❌ Failed to start Electron app:', error);
+      reject(error);
+    });
+
+    electronProcess.on('exit', (code) => {
+      if (code !== 0) {
+        console.log(`📱 Electron process exited with code ${code}`);
+      }
+    });
+
+    resolve();
+  });
+}
+
+// 清理函数
+function cleanup() {
+  console.log('\n🧹 Cleaning up processes...');
+  
+  if (nextProcess) {
+    nextProcess.kill('SIGTERM');
+  }
+  
+  if (electronProcess) {
+    electronProcess.kill('SIGTERM');
+  }
+  
+  setTimeout(() => {
+    process.exit(0);
+  }, 1000);
+}
+
+// 主函数
+async function main() {
+  try {
+    // 启动 Next.js 服务器
+    await startNextServer();
+    
+    // 等待服务器完全启动
+    console.log('🔍 Checking Next.js server health...');
+    const isServerReady = await checkNextServer();
+    
+    if (isServerReady) {
+      console.log('✅ Next.js server is ready!');
+    } else {
+      console.log('⚠️  Next.js server health check failed, but continuing...');
+    }
+    
+    // 启动 Electron 应用
+    await startElectronApp();
+    
+    console.log('\n🎉 Desktop development environment is ready!');
+    console.log('📝 Tips:');
+    console.log('  - Next.js server: http://localhost:3015');
+    console.log('  - Electron DevTools: Cmd+Option+I (macOS)');
+    console.log('  - Stop: Ctrl+C');
+    
+  } catch (error) {
+    console.error('❌ Failed to start development environment:', error);
+    cleanup();
+  }
+}
+
+// 处理退出信号
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// 启动
+main();

--- a/scripts/electronWorkflow/moveNextStandaloneSafe.ts
+++ b/scripts/electronWorkflow/moveNextStandaloneSafe.ts
@@ -1,0 +1,134 @@
+/* eslint-disable unicorn/no-process-exit */
+import fs from 'fs-extra';
+import { execSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+
+const rootDir = path.resolve(__dirname, '../..');
+
+// 定义源目录和目标目录
+const sourceDir: string = path.join(rootDir, '.next/standalone');
+const targetDir: string = path.join(rootDir, 'apps/desktop/dist/next');
+const backupDir: string = path.join(rootDir, 'apps/desktop/dist/next.backup');
+
+// 生成带时间戳的备份目录名
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').split('.')[0];
+const timestampedBackupDir = `${backupDir}_${timestamp}`;
+
+console.log('🔒 Starting safe Next.js standalone move operation...');
+console.log(`📁 Source: ${sourceDir}`);
+console.log(`📁 Target: ${targetDir}`);
+console.log(`💾 Backup: ${timestampedBackupDir}`);
+
+// 向 sourceDir 写入 .env 文件
+if (fs.existsSync(sourceDir)) {
+  const envPath = path.join(rootDir, '.env.desktop');
+  if (fs.existsSync(envPath)) {
+    const env = fs.readFileSync(envPath, 'utf8');
+    fs.writeFileSync(path.join(sourceDir, '.env'), env, 'utf8');
+    console.log('⚓️ Inject .env successful');
+  } else {
+    console.warn('⚠️  .env.desktop not found, skipping injection');
+  }
+} else {
+  console.error(`❌ Source directory does not exist: ${sourceDir}`);
+  console.log('💡 Please run "npm run build:electron" first to generate the standalone build');
+  process.exit(1);
+}
+
+// 确保目标目录的父目录存在
+fs.ensureDirSync(path.dirname(targetDir));
+
+// 安全备份现有目标目录
+if (fs.existsSync(targetDir)) {
+  console.log(`💾 Backing up existing target directory...`);
+  try {
+    // 创建备份
+    fs.copySync(targetDir, timestampedBackupDir);
+    console.log(`✅ Backup created: ${timestampedBackupDir}`);
+    
+    // 删除原目录
+    fs.removeSync(targetDir);
+    console.log('✅ Old target directory removed successfully');
+  } catch (error) {
+    console.warn(`⚠️  Failed to backup/delete target directory: ${error}`);
+    console.log('🔄 Trying backup with system command...');
+    try {
+      if (os.platform() === 'win32') {
+        execSync(`xcopy "${targetDir}" "${timestampedBackupDir}" /E /I /H`, { stdio: 'inherit' });
+        execSync(`rmdir /S /Q "${targetDir}"`, { stdio: 'inherit' });
+      } else {
+        execSync(`cp -R "${targetDir}" "${timestampedBackupDir}"`, { stdio: 'inherit' });
+        execSync(`rm -rf "${targetDir}"`, { stdio: 'inherit' });
+      }
+      console.log('✅ Successfully backed up and removed old target directory');
+    } catch (cmdError) {
+      console.error(`❌ Backup/deletion failed: ${cmdError}`);
+      console.log('🚨 CRITICAL: Cannot proceed without backup. Manual intervention required.');
+      process.exit(1);
+    }
+  }
+}
+
+console.log(`🚚 Moving ${sourceDir} to ${targetDir}...`);
+
+try {
+  // 使用 fs-extra 的 move 方法
+  fs.moveSync(sourceDir, targetDir, { overwrite: true });
+  console.log('✅ Directory moved successfully!');
+} catch (error) {
+  console.error('❌ fs-extra move failed:', error);
+  console.log('🔄 Trying to move using system command...');
+
+  try {
+    // 使用系统命令进行移动
+    if (os.platform() === 'win32') {
+      execSync(`move "${sourceDir}" "${targetDir}"`, { stdio: 'inherit' });
+    } else {
+      execSync(`mv "${sourceDir}" "${targetDir}"`, { stdio: 'inherit' });
+    }
+    console.log('✅ System command move completed successfully!');
+  } catch (mvError) {
+    console.error('❌ Failed to move directory:', mvError);
+    
+    // 尝试恢复备份
+    console.log('🔄 Attempting to restore from backup...');
+    try {
+      if (fs.existsSync(timestampedBackupDir)) {
+        fs.moveSync(timestampedBackupDir, targetDir);
+        console.log('✅ Backup restored successfully');
+      }
+    } catch (restoreError) {
+      console.error('❌ Failed to restore backup:', restoreError);
+    }
+    
+    console.log('💡 Try running manually: sudo mv ' + sourceDir + ' ' + targetDir);
+    process.exit(1);
+  }
+}
+
+// 清理成功，可以删除临时备份（但保留一些最近的备份）
+console.log('🧹 Cleaning up old backups...');
+try {
+  const distDir = path.join(rootDir, 'apps/desktop/dist');
+  const backupFiles = fs.readdirSync(distDir).filter(file => file.startsWith('next.backup_'));
+  
+  // 保留最近的 3 个备份
+  if (backupFiles.length > 3) {
+    backupFiles.sort().slice(0, -3).forEach(oldBackup => {
+      const oldBackupPath = path.join(distDir, oldBackup);
+      fs.removeSync(oldBackupPath);
+      console.log(`🗑️  Removed old backup: ${oldBackup}`);
+    });
+  }
+  
+  console.log(`💾 Current backup preserved: ${path.basename(timestampedBackupDir)}`);
+} catch (cleanupError) {
+  console.warn('⚠️  Failed to cleanup old backups:', cleanupError);
+}
+
+console.log('🎉 Safe move operation completed successfully!');
+console.log('💡 Tips:');
+console.log(`  - Your previous files are backed up at: ${timestampedBackupDir}`);
+console.log('  - To restore backup: mv ' + timestampedBackupDir + ' ' + targetDir);
+console.log('  - Old backups are automatically cleaned (keeping 3 most recent)');


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The qwen-image-edit model was failing with "Unknown error occurred during image generation" because it expects an `imageUrl` parameter, but the frontend passes `imageUrls` (array) instead.

### Root Cause  
The qwen provider was missing parameter conversion logic that other providers (Google, Volcengine, Azure) already have. The `createImageEdit` function directly checked for `params.imageUrl` without handling the case where `params.imageUrls` is provided.

### Solution
Added parameter conversion logic in the `createImageEdit` function to:
- Use `imageUrl` if provided directly
- Fallback to `imageUrls[0]` (first image) if `imageUrl` is not provided but `imageUrls` exists  
- Maintain compatibility with existing usage patterns

### Changes
- Added imageUrls to imageUrl conversion in `createImageEdit` function
- Renamed internal variables to avoid conflicts
- Improved error message to mention both parameter options

### Testing
- Fixes issue #9340 where qwen-image-edit failed with both NewAPI and direct qwen provider
- Maintains backward compatibility for existing imageUrl usage
- Aligns with other providers' conversion logic

Fixes #9340

## Summary by Sourcery

Enhance developer experience by fixing the qwen-image-edit image parameter handling and introducing automated scripts and documentation for desktop development and secure build workflows.

New Features:
- Automate desktop development startup with a new dev-desktop.mjs script
- Securely move Next.js standalone build with moveNextStandaloneSafe.ts workflow

Bug Fixes:
- Support imageUrls array fallback to imageUrl in qwen-image-edit provider

Enhancements:
- Rename internal variables and improve error messages to mention both imageUrl and imageUrls

Documentation:
- Add macOS Electron debugging guide for desktop development and build troubleshooting