### PR TITLE
📝 docs: add missing environment variables in online-search docs

### DIFF
--- a/docs/self-hosting/advanced/online-search.mdx
+++ b/docs/self-hosting/advanced/online-search.mdx
@@ -34,15 +34,15 @@ CRAWLER_IMPLS="native,search1api"
 
 Supported crawler types are listed below:
 
-| Value         | Description                                                                                                         | Environment Variable       |
-| ------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `browserless` | Headless browser crawler based on [Browserless](https://www.browserless.io/), suitable for rendering complex pages. | `BROWSERLESS_TOKEN`        |
-| `exa`         | Crawler capabilities provided by [Exa](https://exa.ai/), API required.                                              | `EXA_API_KEY`              |
-| `firecrawl`   | [Firecrawl](https://firecrawl.dev/) headless browser API, ideal for modern websites.                                | `FIRECRAWL_API_KEY`        |
-| `jina`        | Crawler service from [Jina AI](https://jina.ai/), supports fast content summarization.                              | `JINA_READER_API_KEY`      |
-| `native`      | Built-in general-purpose crawler for standard web structures.                                                       |                            |
-| `search1api`  | Page crawling capabilities from [Search1API](https://www.search1api.com), great for structured content extraction.  | `SEARCH1API_CRAWL_API_KEY` |
-| `tavily`      | Web scraping and summarization API from [Tavily](https://www.tavily.com/).                                          | `TAVILY_API_KEY`           |
+| Value         | Description                                                                                                         | Environment Variable                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `browserless` | Headless browser crawler based on [Browserless](https://www.browserless.io/), suitable for rendering complex pages. | `BROWSERLESS_TOKEN`                                                          |
+| `exa`         | Crawler capabilities provided by [Exa](https://exa.ai/), API required.                                              | `EXA_API_KEY`                                                                |
+| `firecrawl`   | [Firecrawl](https://firecrawl.dev/) headless browser API, ideal for modern websites.                                | `FIRECRAWL_API_KEY`                                                          |
+| `jina`        | Crawler service from [Jina AI](https://jina.ai/), supports fast content summarization.                              | `JINA_READER_API_KEY`                                                        |
+| `native`      | Built-in general-purpose crawler for standard web structures.                                                       |                                                                              |
+| `search1api`  | Page crawling capabilities from [Search1API](https://www.search1api.com), great for structured content extraction.  | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY`  |
+| `tavily`      | Web scraping and summarization API from [Tavily](https://www.tavily.com/).                                          | `TAVILY_API_KEY`                                                             |
 
 > 💡 Setting multiple crawlers increases success rate; the system will try different ones based on priority.
 
@@ -58,19 +58,19 @@ SEARCH_PROVIDERS="searxng"
 
 Supported search engines include:
 
-| Value        | Description                                                                             | Environment Variable                        |
-| ------------ | --------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `anspire`    | Search service provided by [Anspire](https://anspire.ai/).                              | `ANSPIRE_API_KEY`                           |
-| `bocha`      | Search service from [Bocha](https://open.bochaai.com/).                                 | `BOCHA_API_KEY`                             |
-| `brave`      | [Brave](https://search.brave.com/help/api), a privacy-friendly search source.           | `BRAVE_API_KEY`                             |
-| `exa`        | [Exa](https://exa.ai/), a search API designed for AI.                                   | `EXA_API_KEY`                               |
-| `firecrawl`  | Search capabilities via [Firecrawl](https://firecrawl.dev/).                            | `FIRECRAWL_API_KEY`                         |
-| `google`     | Uses [Google Programmable Search Engine](https://programmablesearchengine.google.com/). | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID` |
-| `jina`       | Semantic search provided by [Jina AI](https://jina.ai/).                                | `JINA_READER_API_KEY`                       |
-| `kagi`       | Premium search API by [Kagi](https://kagi.com/), requires a subscription key.           | `KAGI_API_KEY`                              |
-| `search1api` | Aggregated search capabilities from [Search1API](https://www.search1api.com).           | `SEARCH1API_CRAWL_API_KEY`                  |
-| `searxng`    | Use a self-hosted or public [SearXNG](https://searx.space/) instance.                   | `SEARXNG_URL`                               |
-| `tavily`     | [Tavily](https://www.tavily.com/), offers fast web summaries and answers.               | `TAVILY_API_KEY`                            |
+| Value        | Description                                                                             | Environment Variable                                                         |
+| ------------ | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `anspire`    | Search service provided by [Anspire](https://anspire.ai/).                              | `ANSPIRE_API_KEY`                                                            |
+| `bocha`      | Search service from [Bocha](https://open.bochaai.com/).                                 | `BOCHA_API_KEY`                                                              |
+| `brave`      | [Brave](https://search.brave.com/help/api), a privacy-friendly search source.           | `BRAVE_API_KEY`                                                              |
+| `exa`        | [Exa](https://exa.ai/), a search API designed for AI.                                   | `EXA_API_KEY`                                                                |
+| `firecrawl`  | Search capabilities via [Firecrawl](https://firecrawl.dev/).                            | `FIRECRAWL_API_KEY`                                                          |
+| `google`     | Uses [Google Programmable Search Engine](https://programmablesearchengine.google.com/). | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID`                                  |
+| `jina`       | Semantic search provided by [Jina AI](https://jina.ai/).                                | `JINA_READER_API_KEY`                                                        |
+| `kagi`       | Premium search API by [Kagi](https://kagi.com/), requires a subscription key.           | `KAGI_API_KEY`                                                               |
+| `search1api` | Aggregated search capabilities from [Search1API](https://www.search1api.com).           | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY`  |
+| `searxng`    | Use a self-hosted or public [SearXNG](https://searx.space/) instance.                   | `SEARXNG_URL`                                                                |
+| `tavily`     | [Tavily](https://www.tavily.com/), offers fast web summaries and answers.               | `TAVILY_API_KEY`                                                             |
 
 > ⚠️ Some search providers require you to apply for an API Key and configure it in your `.env` file.
 

--- a/docs/self-hosting/advanced/online-search.zh-CN.mdx
+++ b/docs/self-hosting/advanced/online-search.zh-CN.mdx
@@ -37,7 +37,7 @@ CRAWLER_IMPLS="native,search1api"
 | `firecrawl`   | [Firecrawl](https://firecrawl.dev/) 无头浏览器 API，适合现代网站抓取。          | `FIRECRAWL_API_KEY`        |
 | `jina`        | 使用 [Jina AI](https://jina.ai/) 的爬虫服务，支持快速提取摘要信息。                 | `JINA_READER_API_KEY`      |
 | `native`      | 内置通用爬虫，适用于标准网页结构。                                                |                            |
-| `search1api`  | 利用 [Search1API](https://www.search1api.com) 提供的页面抓取能力，适合结构化内容提取。 | `SEARCH1API_CRAWL_API_KEY` |
+| `search1api`  | 利用 [Search1API](https://www.search1api.com) 提供的页面抓取能力，适合结构化内容提取。 | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY` |
 | `tavily`      | 使用 [Tavily](https://www.tavily.com/) 的网页抓取与摘要 API。               | `TAVILY_API_KEY`           |
 
 > 💡 设置多个爬虫可提升成功率，系统将根据优先级尝试不同爬虫。
@@ -64,7 +64,7 @@ SEARCH_PROVIDERS="searxng"
 | `google`     | 使用 [Google Programmable Search Engine](https://programmablesearchengine.google.com/)。 | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID` |
 | `jina`       | 使用 [Jina AI](https://jina.ai/) 提供的语义搜索服务。                                             | `JINA_READER_API_KEY`                       |
 | `kagi`       | [Kagi](https://kagi.com/) 提供的高级搜索 API，需订阅 Key。                                        | `KAGI_API_KEY`                              |
-| `search1api` | 使用 [Search1API](https://www.search1api.com) 聚合搜索能力。                                   | `SEARCH1API_CRAWL_API_KEY`                  |
+| `search1api` | 使用 [Search1API](https://www.search1api.com) 聚合搜索能力。                                   | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY` |
 | `searxng`    | 使用自托管或公共 [SearXNG](https://searx.space/) 实例。                                          | `SEARXNG_URL`                               |
 | `tavily`     | [Tavily](https://www.tavily.com/)，快速网页摘要与答案返回。                                        | `TAVILY_API_KEY`                            |
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change
Update the **online search self-hosting docs** to include all required environment variables for **Search1API** in both the crawler and search-provider tables.

Files updated:
- `docs/self-hosting/advanced/online-search.mdx`
- `docs/self-hosting/advanced/online-search.zh-CN.mdx`

What’s added/adjusted:
- **Crawler section (`search1api`)**: list all keys  
  `SEARCH1API_API_KEY`, `SEARCH1API_CRAWL_API_KEY`, `SEARCH1API_SEARCH_API_KEY`.
- **Search Provider section (`search1api`)**: list all keys  
  `SEARCH1API_API_KEY`, `SEARCH1API_CRAWL_API_KEY`, `SEARCH1API_SEARCH_API_KEY`.
- Adjust the “Environment Variable” column to reflect multiple keys where applicable.
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

- The previous docs only mentioned `SEARCH1API_CRAWL_API_KEY`, which could lead to incomplete configuration when enabling Search1API for both crawling and search. This PR makes the English and Chinese docs consistent and complete.  
- Documentation-only change; no runtime/behavioral impact.

## Summary by Sourcery

Update online-search self-hosting documentation to include all required Search1API environment variables in both crawler and search provider tables for English and Chinese versions.

Documentation:
- Add missing SEARCH1API_API_KEY, SEARCH1API_CRAWL_API_KEY, and SEARCH1API_SEARCH_API_KEY entries to the crawler section in both English and Chinese docs
- Add missing SEARCH1API_API_KEY, SEARCH1API_CRAWL_API_KEY, and SEARCH1API_SEARCH_API_KEY entries to the search provider section in both English and Chinese docs
- Adjust the Environment Variable column to display multiple keys where applicable