### PR TITLE
🐛 fix: add proxyUrl configuration for NEW API provider

### DIFF
--- a/src/config/modelProviders/newapi.ts
+++ b/src/config/modelProviders/newapi.ts
@@ -8,6 +8,9 @@ const NewAPI: ModelProviderCard = {
   id: 'newapi',
   name: 'New API',
   settings: {
+    proxyUrl: {
+      placeholder: 'https://your.new-api-provider.com',
+    },
     sdkType: 'router',
     showModelFetcher: true,
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

This PR fixes the missing API URL configuration field in the NEW API provider settings UI.

**Problem:**
- NEW API provider's custom URL configuration field was not visible in the settings UI
- Users could only configure the API endpoint through environment variables (NEWAPI_PROXY_URL)
- The issue occurred because the `showEndpoint` logic requires either `proxyUrl` or `isCustom` to be true

**Solution:**
- Added `proxyUrl` configuration with placeholder in NEW API provider settings
- This enables the UI display condition: `showEndpoint = \!\!proxyUrl || isCustom`
- Maintains compatibility with existing environment variable configuration

**Testing:**
- ✅ NEW API "代理地址" field now displays in provider settings
- ✅ Configuration can be saved and loaded properly  
- ✅ Compatible with existing NEWAPI_PROXY_URL environment variable
- ✅ Model fetching and connection testing work correctly

#### 📝 补充信息 | Additional Information

- Closes #9420
- This resolves a fundamental configuration issue that existed since NEW API was introduced in v1.123.0
- The fix is minimal and focused - only adds the missing configuration field needed for UI display

## Summary by Sourcery

Bug Fixes:
- Display proxyUrl input for New API provider in settings UI to allow custom API endpoint configuration while preserving existing environment variable support