### PR TITLE
🔨 chore(config): add assetPrefix to nextConfig for environment variable support

### DIFF
--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -145,6 +145,13 @@ For specific content, please refer to the [Feature Flags](/docs/self-hosting/adv
 - Default: `0`
 - Example: `1` or `0`
 
+### `NEXT_PUBLIC_ASSET_PREFIX`
+
+- Type: Optional
+- Description: The path access prefix for static resources can be set to the URL for CDN access. For more details, please refer to: [assetPrefix](https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix)
+- Default: -
+- Example: `https://cdn.example.com`
+
 ## Plugin Service
 
 ### `PLUGINS_INDEX_URL`

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -141,6 +141,13 @@ LobeChat 在部署时提供了一些额外的配置项，你可以使用环境�
 - 默认值：`0`
 - 示例：`1` 或 `0`
 
+### `NEXT_PUBLIC_ASSET_PREFIX`
+
+- 类型：可选
+- 描述：静态资源的路径访问前缀，你可以设置为 CDN 访问的 URL，具体可参考： [assetPrefix](https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix)
+- 默认值：-
+- 示例：`https://cdn.example.com`
+
 ## 插件服务
 
 ### `PLUGINS_INDEX_URL`

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,7 @@ const standaloneConfig: NextConfig = {
 
 const nextConfig: NextConfig = {
   ...(isStandaloneMode ? standaloneConfig : {}),
+  assetPrefix: process.env.NEXT_PUBLIC_ASSET_PREFIX,
   compiler: {
     emotion: true,
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

通过设置环境变量 **NEXT_PUBLIC_ASSET_PREFIX** 修改静态资源的路径前缀，以便引入CDN服务，加速网站访问，减缓服务器访问压力。

#### 📝 补充信息 | Additional Information

https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix

## Summary by Sourcery

New Features:
- Allow configuring Next.js assetPrefix via NEXT_PUBLIC_ASSET_PREFIX environment variable