### PR TITLE
fix(mobile): choose agent stuck app

### DIFF
--- a/apps/mobile/app/discover/assistant/[...slugs]/index.tsx
+++ b/apps/mobile/app/discover/assistant/[...slugs]/index.tsx
@@ -2,7 +2,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { BotMessageSquare } from 'lucide-react-native';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, ScrollView, Text, View } from 'react-native';
+import { Alert, InteractionManager, ScrollView, Text, View } from 'react-native';
 
 import { Button, Icon, Markdown, PageContainer, Tag } from '@/components';
 import DetailHeader from '@/features/discover/assistant/components/DetailHeader';
@@ -59,15 +59,20 @@ const AssistantDetail = () => {
     setIsAdding(true);
     try {
       // 添加到会话列表
-      const session = await createSession({
-        config,
-        meta,
-      });
+      const session = await createSession(
+        {
+          config,
+          meta,
+        },
+        false,
+      );
       toggleDrawer();
-      // 导航到会话页面
-      router.replace({
-        params: { session: session },
-        pathname: '/chat',
+      InteractionManager.runAfterInteractions(() => {
+        // 导航到会话页面
+        router.replace({
+          params: { session: session },
+          pathname: '/chat',
+        });
       });
     } catch (err) {
       console.error(t('assistant.detail.addFailed', { ns: 'discover' }), err);
@@ -166,14 +171,6 @@ const AssistantDetail = () => {
             >
               {t('assistant.detail.addAndChat', { ns: 'discover' })}
             </Button>
-
-            {/* <Button
-              type="default"
-              size="large"
-              onPress={handleShare}
-            >
-              <Icon icon={Share2} size="small" color={token.colorText} />
-            </Button> */}
           </View>
 
           {/* 系统提示区域 */}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix agent selection flow by updating createSession parameters and deferring navigation until after UI interactions, and clean up unused share button code

Bug Fixes:
- Defer navigation to chat until after interactions complete via InteractionManager to prevent UI freezing
- Pass explicit false flag to createSession to prevent the app from getting stuck after adding an agent

Chores:
- Remove commented-out share button from the assistant detail view