### PR TITLE
🐛 fix: can not input empty group name

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -64,7 +64,7 @@ const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
           onChangeEnd={async (input) => {
             if (name !== input) {
               if (!input) return;
-              if (input.length === 0 || input.length > 20)
+              if (input.length === 0 || input.length > 20 || input.trim() === '')
                 return message.warning(t('sessionGroup.tooLong'));
 
               await updateSessionGroupName(id, input);

--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/CreateGroupModal.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/Modals/CreateGroupModal.tsx
@@ -35,7 +35,7 @@ const CreateGroupModal = memo<CreateGroupModalProps>(
             onCancel?.(e);
           }}
           onOk={async (e: MouseEvent<HTMLButtonElement>) => {
-            if (input.length === 0 || input.length > 20)
+            if (input.length === 0 || input.length > 20 || input.trim() === '')
               return message.warning(t('sessionGroup.tooLong'));
 
             setLoading(true);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change


![img_v3_02qg_c9bbaef7-dd5e-4ff2-a968-da74dbe999cg](https://github.com/user-attachments/assets/394ddac1-537e-48c7-bb1b-caedd17085af)


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Reject group names that consist solely of whitespace in create and rename modals