### PR TITLE
✨ feat: add Claude Sonnet 4.5 model to AI chat models

### DIFF
--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -41,6 +41,9 @@ export const responsesAPIModels = new Set([
  * models support context caching
  */
 export const contextCachingModels = new Set([
+  'claude-sonnet-4-5-latest',
+  'claude-sonnet-4-5-20250929',
+  'anthropic/claude-sonnet-4.5',
   'claude-opus-4-latest',
   'claude-opus-4-20250514',
   'claude-sonnet-4-latest',
@@ -59,6 +62,9 @@ export const thinkingWithToolClaudeModels = new Set([
   'claude-opus-4-20250514',
   'claude-sonnet-4-latest',
   'claude-sonnet-4-20250514',
+  'claude-sonnet-4-5-latest',
+  'claude-sonnet-4-5-20250929',
+  'anthropic/claude-sonnet-4.5',
   'claude-3-7-sonnet-latest',
   'claude-3-7-sonnet-20250219',
 ]);

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -9,6 +9,34 @@ const anthropicChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
+    description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
+    displayName: 'Claude Sonnet 4.5',
+    enabled: true,
+    id: 'claude-sonnet-4-5-20250929',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-30',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
     description:
       'Claude Opus 4.1 是 Anthropic 最新的用于处理高度复杂任务的最强大模型。它在性能、智能、流畅性和理解力方面表现卓越。',
     displayName: 'Claude Opus 4.1',

--- a/packages/model-bank/src/aiModels/openrouter.ts
+++ b/packages/model-bank/src/aiModels/openrouter.ts
@@ -697,6 +697,34 @@ const openrouterChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
+    displayName: 'Claude Sonnet 4.5',
+    enabled: true,
+    id: 'anthropic/claude-sonnet-4.5',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-30',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       vision: true,
     },
     contextWindowTokens: 200_000,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for the new Claude Sonnet 4.5 model by registering its configuration in the model banks and updating the Anthropic runtime logic to handle its parameter conflicts.

New Features:
- Introduce Claude Sonnet 4.5 model card to the Anthropic model bank and OpenRouter listings

Enhancements:
- Rename opus41Models to modelsWithTempAndTopPConflict and include Claude Sonnet 4.5 in the temperature/top_p conflict handling for the Anthropic provider