### PR TITLE
💄 style: Maintain the order of the model list

### DIFF
--- a/packages/const/src/utils/merge.ts
+++ b/packages/const/src/utils/merge.ts
@@ -25,43 +25,165 @@ export const mergeArrayById = <T extends MergeableItem>(defaultItems: T[], userI
     Boolean(item?.id),
   );
 
-  const defaultItemsMap = new Map(ensuredDefaultItems.map((item) => [item.id, item]));
-  const defaultIndexMap = new Map(ensuredDefaultItems.map((item, index) => [item.id, index]));
+  const defaultItemsMap = new Map(
+    ensuredDefaultItems.map((item, index) => [item.id, { index, item }]),
+  );
 
-  const invalidUserItems: T[] = [];
-  const customUserItems = new Map<string, T>();
-  const mergedDefaultItems = defaultItems.map((item) => ({ ...item }) as T);
+  // 检查是否有用户自定义排序
+  const hasCustomSort = userItems.some((item) => {
+    const sortValue = (item as any)?.sort;
+    return typeof sortValue === 'number' && Number.isFinite(sortValue);
+  });
 
+  const idlessUserItems: T[] = [];
+  const mergedMap = new Map<string, { defaultIndex?: number; item: T; userSort?: number }>();
+
+  // 第一步：处理 userItems，合并属性
   userItems.forEach((userItem) => {
     const userId = userItem?.id;
 
     if (!userId) {
-      invalidUserItems.push(userItem);
+      idlessUserItems.push(userItem);
       return;
     }
 
-    const defaultItem = defaultItemsMap.get(userId);
-    if (!defaultItem) {
-      customUserItems.set(userId, userItem);
+    const defaultMeta = defaultItemsMap.get(userId);
+    const mergedItem = defaultMeta ? ({ ...defaultMeta.item } as T) : ({ ...userItem } as T);
+
+    if (defaultMeta) {
+      Object.entries(userItem).forEach(([key, value]) => {
+        if (
+          value !== null &&
+          value !== undefined &&
+          !(typeof value === 'object' && isEmpty(value))
+        ) {
+          // @ts-expect-error
+          mergedItem[key] = value;
+        }
+
+        if (typeof value === 'object' && !isEmpty(value)) {
+          // @ts-expect-error
+          mergedItem[key] = merge(defaultMeta.item[key], value);
+        }
+      });
+    }
+
+    const sortValue = (userItem as any)?.sort;
+    const userSort =
+      typeof sortValue === 'number' && Number.isFinite(sortValue) ? sortValue : undefined;
+
+    mergedMap.set(userId, {
+      defaultIndex: defaultMeta?.index,
+      item: mergedItem,
+      userSort,
+    });
+  });
+
+  // 第二步：添加 defaultItems 中存在但 userItems 中不存在的项
+  defaultItems.forEach((item, index) => {
+    const itemId = item?.id;
+    if (!itemId) return;
+
+    if (mergedMap.has(itemId)) {
+      const entry = mergedMap.get(itemId)!;
+      if (typeof entry.defaultIndex !== 'number') entry.defaultIndex = index;
       return;
     }
 
-    const mergedItem = { ...defaultItem } as T;
-    Object.entries(userItem).forEach(([key, value]) => {
-      if (value !== null && value !== undefined && !(typeof value === 'object' && isEmpty(value))) {
-        // @ts-expect-error
-        mergedItem[key] = value;
+    mergedMap.set(itemId, {
+      defaultIndex: index,
+      item: { ...item } as T,
+    });
+  });
+
+  const entries = Array.from(mergedMap.values());
+
+  // 第三步：根据是否有自定义排序来决定最终顺序
+  if (hasCustomSort) {
+    // 有自定义排序：按 sort 排序，没有 sort 的项尝试智能插入
+    const sortedEntries = entries.filter((e) => typeof e.userSort === 'number');
+    const unsortedEntries = entries.filter((e) => typeof e.userSort !== 'number');
+
+    // 按 sort 排序
+    sortedEntries.sort((a, b) => {
+      const sortDiff = (a.userSort as number) - (b.userSort as number);
+      if (sortDiff !== 0) return sortDiff;
+      // sort 相同时，按 defaultIndex 排序
+      if (typeof a.defaultIndex === 'number' && typeof b.defaultIndex === 'number') {
+        return a.defaultIndex - b.defaultIndex;
+      }
+      return 0;
+    });
+
+    // 处理未排序的项（新启用的模型）
+    const result: T[] = [...idlessUserItems];
+    const sortedItems = sortedEntries.map((e) => e.item);
+    const sortedIds = new Set(sortedEntries.map((e) => e.item.id));
+
+    // 对每个未排序的项，尝试找到合适的插入位置
+    unsortedEntries.forEach((unsortedEntry) => {
+      if (typeof unsortedEntry.defaultIndex !== 'number') {
+        // 无法判断位置，放到最前面
+        result.unshift(unsortedEntry.item);
+        return;
       }
 
-      if (typeof value === 'object' && !isEmpty(value)) {
-        // @ts-expect-error
-        mergedItem[key] = merge(defaultItem[key], value);
+      // 在 defaultItems 中找到它前后的邻居
+      let insertIndex = -1;
+
+      // 向后查找：找到第一个在排序列表中的邻居
+      for (let i = unsortedEntry.defaultIndex + 1; i < defaultItems.length; i++) {
+        const neighborId = defaultItems[i]?.id;
+        if (neighborId && sortedIds.has(neighborId)) {
+          const neighborIndex = sortedItems.findIndex((item) => item.id === neighborId);
+          insertIndex = neighborIndex;
+          break;
+        }
+      }
+
+      // 如果向后没找到，向前查找
+      if (insertIndex === -1) {
+        for (let i = unsortedEntry.defaultIndex - 1; i >= 0; i--) {
+          const neighborId = defaultItems[i]?.id;
+          if (neighborId && sortedIds.has(neighborId)) {
+            const neighborIndex = sortedItems.findIndex((item) => item.id === neighborId);
+            insertIndex = neighborIndex + 1;
+            break;
+          }
+        }
+      }
+
+      // 如果还是没找到合适位置，放到最前面
+      if (insertIndex === -1) {
+        result.unshift(unsortedEntry.item);
+      } else {
+        sortedItems.splice(insertIndex, 0, unsortedEntry.item);
       }
     });
 
-    const index = defaultIndexMap.get(userId);
-    if (typeof index === 'number') mergedDefaultItems[index] = mergedItem;
-  });
+    return [...result, ...sortedItems];
+  } else {
+    // 没有自定义排序：完全按 defaultItems 的顺序
+    const result: T[] = [...idlessUserItems];
 
-  return [...invalidUserItems, ...customUserItems.values(), ...mergedDefaultItems];
+    // 先添加在 defaultItems 中的项（按原顺序）
+    defaultItems.forEach((defaultItem) => {
+      const itemId = defaultItem?.id;
+      if (!itemId) return;
+
+      const entry = mergedMap.get(itemId);
+      if (entry) {
+        result.push(entry.item);
+      }
+    });
+
+    // 再添加自定义的项（不在 defaultItems 中的）
+    entries.forEach((entry) => {
+      if (typeof entry.defaultIndex !== 'number') {
+        result.push(entry.item);
+      }
+    });
+
+    return result;
+  }
 };

--- a/packages/database/src/models/aiModel.ts
+++ b/packages/database/src/models/aiModel.ts
@@ -78,6 +78,7 @@ export class AiModelModel {
         parameters: aiModels.parameters,
         pricing: aiModels.pricing,
         releasedAt: aiModels.releasedAt,
+        sort: aiModels.sort,
         source: aiModels.source,
         type: aiModels.type,
       })

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -355,6 +355,7 @@ export interface AiProviderModelListItem {
   pricing?: Pricing;
   releasedAt?: string;
   settings?: AiModelSettings;
+  sort?: number;
   source?: AiModelSourceType;
   type: AiModelType;
 }

--- a/packages/utils/src/merge.test.ts
+++ b/packages/utils/src/merge.test.ts
@@ -141,6 +141,25 @@ describe('mergeArrayById', () => {
       expect(result).toContainEqual({ id: '2', name: 'User 2', value: 300 });
     });
 
+    it('should keep default order when overriding items', () => {
+      const defaultItems = [
+        { id: 'a', name: 'Default A' },
+        { id: 'b', name: 'Default B' },
+        { id: 'c', name: 'Default C' },
+      ];
+
+      const userItems = [
+        { id: 'b', enabled: false, name: 'Default B' },
+        { id: 'c', enabled: true, name: 'Default C' },
+      ];
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      expect(result.map((item) => item.id)).toEqual(['a', 'b', 'c']);
+      expect(result[1]).toMatchObject({ id: 'b', enabled: false });
+      expect(result[2]).toMatchObject({ id: 'c', enabled: true });
+    });
+
     it('should merge multiple items correctly', () => {
       const defaultItems = [
         { id: '1', name: 'Default 1', value: 100, meta: { key: 'value' } },

--- a/packages/utils/src/merge.test.ts
+++ b/packages/utils/src/merge.test.ts
@@ -355,4 +355,108 @@ describe('mergeArrayById', () => {
       },
     ]);
   });
+
+  describe('ordering with sort field', () => {
+    const idList = (items: Array<{ id?: string }>) => items.map((item) => item.id);
+
+    it('prioritizes user-defined ordering for default items', () => {
+      const defaultItems = [
+        { id: 'openai', order: 0, meta: { provider: 'openai', tags: ['official'] } },
+        { id: 'anthropic', order: 1 },
+        { id: 'google', order: 2 },
+      ] as Array<Record<string, any>>;
+      const userItems = [
+        { id: 'google', order: 2, sort: 0 },
+        { id: 'openai', meta: { description: 'customized' }, order: 0, sort: 1 },
+        // anthropic 不在 userItems 中，应该根据 modelbank 顺序智能插入
+      ] as Array<Record<string, any>>;
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      // anthropic(defaultIndex=1) 向后找到 google(defaultIndex=2, sort=0)
+      // google 在 sortedItems 的 index 是 0
+      // anthropic 应该插入到 sortedItems[0] 的位置，即 google 前面
+      // 最终顺序：anthropic(插入), google(sort=0), openai(sort=1)
+      expect(idList(result)).toEqual(['anthropic', 'google', 'openai']);
+      expect(result[2].meta).toEqual({
+        provider: 'openai',
+        tags: ['official'],
+        description: 'customized',
+      });
+    });
+
+    it('keeps model bank ordering when custom sort is not provided', () => {
+      const defaultItems = [{ id: 'alpha' }, { id: 'beta' }, { id: 'gamma' }] as Array<
+        Record<string, any>
+      >;
+      const userItems = [{ id: 'beta', enabled: true }] as Array<Record<string, any>>;
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      expect(idList(result)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('inserts newly enabled model in correct position based on model bank order', () => {
+      const defaultItems = [
+        { id: 'alpha' },
+        { id: 'beta' },
+        { id: 'gamma' },
+        { id: 'delta' },
+      ] as Array<Record<string, any>>;
+      const userItems = [
+        { id: 'alpha', sort: 0 },
+        { id: 'delta', sort: 1 },
+        // beta 和 gamma 未在 userItems 中，是新启用的
+      ] as Array<Record<string, any>>;
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      // beta 应该插在 alpha 和 delta 之间（因为 beta 在默认列表中位于 alpha 后）
+      // gamma 应该插在 delta 后（因为 gamma 在默认列表中位于 delta 前，但最近的已排序邻居是 delta）
+      expect(idList(result)).toEqual(['alpha', 'beta', 'gamma', 'delta']);
+    });
+
+    it('places custom models at the end when no sort is provided', () => {
+      const defaultItems = [
+        { id: 'openai', order: 0 },
+        { id: 'anthropic', order: 1 },
+      ] as Array<Record<string, any>>;
+      const userItems = [
+        { id: 'custom-model', order: 99 },
+        // 没有 sort 字段，说明没有自定义排序
+      ] as Array<Record<string, any>>;
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      // 没有自定义排序时，先按 defaultItems 顺序，然后是自定义模型
+      expect(idList(result)).toEqual(['openai', 'anthropic', 'custom-model']);
+    });
+
+    it('comprehensive test: custom sort with newly enabled models', () => {
+      // 模拟实际场景：用户自定义排序后，又启用了新模型
+      const defaultItems = [
+        { id: 'gpt-4' }, // 0
+        { id: 'gpt-3.5' }, // 1
+        { id: 'claude-3' }, // 2
+        { id: 'claude-2' }, // 3
+        { id: 'gemini-pro' }, // 4
+      ] as Array<Record<string, any>>;
+
+      const userItems = [
+        { id: 'claude-3', sort: 0 }, // 用户把 claude-3 放第一
+        { id: 'gpt-4', sort: 1 }, // gpt-4 放第二
+        { id: 'gemini-pro', sort: 2 }, // gemini-pro 放第三
+        // gpt-3.5 和 claude-2 是新启用的，应该智能插入
+      ] as Array<Record<string, any>>;
+
+      const result = mergeArrayById(defaultItems, userItems);
+
+      // gpt-3.5 (defaultIndex=1): 向后找到 claude-3 (defaultIndex=2, sort=0)
+      //   claude-3 在 sortedItems 的 index 是 0，所以 gpt-3.5 插到 index=0
+      // claude-2 (defaultIndex=3): 向后找到 gemini-pro (defaultIndex=4, sort=2)
+      //   gemini-pro 在 sortedItems 的 index 是 2，所以 claude-2 插到 index=2
+      // 最终：gpt-3.5, claude-3(sort=0), gpt-4(sort=1), claude-2, gemini-pro(sort=2)
+      expect(idList(result)).toEqual(['gpt-3.5', 'claude-3', 'gpt-4', 'claude-2', 'gemini-pro']);
+    });
+  });
 });

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -25,43 +25,165 @@ export const mergeArrayById = <T extends MergeableItem>(defaultItems: T[], userI
     Boolean(item?.id),
   );
 
-  const defaultItemsMap = new Map(ensuredDefaultItems.map((item) => [item.id, item]));
-  const defaultIndexMap = new Map(ensuredDefaultItems.map((item, index) => [item.id, index]));
+  const defaultItemsMap = new Map(
+    ensuredDefaultItems.map((item, index) => [item.id, { index, item }]),
+  );
 
-  const invalidUserItems: T[] = [];
-  const customUserItems = new Map<string, T>();
-  const mergedDefaultItems = defaultItems.map((item) => ({ ...item }) as T);
+  // 检查是否有用户自定义排序
+  const hasCustomSort = userItems.some((item) => {
+    const sortValue = (item as any)?.sort;
+    return typeof sortValue === 'number' && Number.isFinite(sortValue);
+  });
 
+  const idlessUserItems: T[] = [];
+  const mergedMap = new Map<string, { defaultIndex?: number; item: T; userSort?: number }>();
+
+  // 第一步：处理 userItems，合并属性
   userItems.forEach((userItem) => {
     const userId = userItem?.id;
 
     if (!userId) {
-      invalidUserItems.push(userItem);
+      idlessUserItems.push(userItem);
       return;
     }
 
-    const defaultItem = defaultItemsMap.get(userId);
-    if (!defaultItem) {
-      customUserItems.set(userId, userItem);
+    const defaultMeta = defaultItemsMap.get(userId);
+    const mergedItem = defaultMeta ? ({ ...defaultMeta.item } as T) : ({ ...userItem } as T);
+
+    if (defaultMeta) {
+      Object.entries(userItem).forEach(([key, value]) => {
+        if (
+          value !== null &&
+          value !== undefined &&
+          !(typeof value === 'object' && isEmpty(value))
+        ) {
+          // @ts-expect-error
+          mergedItem[key] = value;
+        }
+
+        if (typeof value === 'object' && !isEmpty(value)) {
+          // @ts-expect-error
+          mergedItem[key] = merge(defaultMeta.item[key], value);
+        }
+      });
+    }
+
+    const sortValue = (userItem as any)?.sort;
+    const userSort =
+      typeof sortValue === 'number' && Number.isFinite(sortValue) ? sortValue : undefined;
+
+    mergedMap.set(userId, {
+      defaultIndex: defaultMeta?.index,
+      item: mergedItem,
+      userSort,
+    });
+  });
+
+  // 第二步：添加 defaultItems 中存在但 userItems 中不存在的项
+  defaultItems.forEach((item, index) => {
+    const itemId = item?.id;
+    if (!itemId) return;
+
+    if (mergedMap.has(itemId)) {
+      const entry = mergedMap.get(itemId)!;
+      if (typeof entry.defaultIndex !== 'number') entry.defaultIndex = index;
       return;
     }
 
-    const mergedItem = { ...defaultItem } as T;
-    Object.entries(userItem).forEach(([key, value]) => {
-      if (value !== null && value !== undefined && !(typeof value === 'object' && isEmpty(value))) {
-        // @ts-expect-error
-        mergedItem[key] = value;
+    mergedMap.set(itemId, {
+      defaultIndex: index,
+      item: { ...item } as T,
+    });
+  });
+
+  const entries = Array.from(mergedMap.values());
+
+  // 第三步：根据是否有自定义排序来决定最终顺序
+  if (hasCustomSort) {
+    // 有自定义排序：按 sort 排序，没有 sort 的项尝试智能插入
+    const sortedEntries = entries.filter((e) => typeof e.userSort === 'number');
+    const unsortedEntries = entries.filter((e) => typeof e.userSort !== 'number');
+
+    // 按 sort 排序
+    sortedEntries.sort((a, b) => {
+      const sortDiff = (a.userSort as number) - (b.userSort as number);
+      if (sortDiff !== 0) return sortDiff;
+      // sort 相同时，按 defaultIndex 排序
+      if (typeof a.defaultIndex === 'number' && typeof b.defaultIndex === 'number') {
+        return a.defaultIndex - b.defaultIndex;
+      }
+      return 0;
+    });
+
+    // 处理未排序的项（新启用的模型）
+    const result: T[] = [...idlessUserItems];
+    const sortedItems = sortedEntries.map((e) => e.item);
+    const sortedIds = new Set(sortedEntries.map((e) => e.item.id));
+
+    // 对每个未排序的项，尝试找到合适的插入位置
+    unsortedEntries.forEach((unsortedEntry) => {
+      if (typeof unsortedEntry.defaultIndex !== 'number') {
+        // 无法判断位置，放到最前面
+        result.unshift(unsortedEntry.item);
+        return;
       }
 
-      if (typeof value === 'object' && !isEmpty(value)) {
-        // @ts-expect-error
-        mergedItem[key] = merge(defaultItem[key], value);
+      // 在 defaultItems 中找到它前后的邻居
+      let insertIndex = -1;
+
+      // 向后查找：找到第一个在排序列表中的邻居
+      for (let i = unsortedEntry.defaultIndex + 1; i < defaultItems.length; i++) {
+        const neighborId = defaultItems[i]?.id;
+        if (neighborId && sortedIds.has(neighborId)) {
+          const neighborIndex = sortedItems.findIndex((item) => item.id === neighborId);
+          insertIndex = neighborIndex;
+          break;
+        }
+      }
+
+      // 如果向后没找到，向前查找
+      if (insertIndex === -1) {
+        for (let i = unsortedEntry.defaultIndex - 1; i >= 0; i--) {
+          const neighborId = defaultItems[i]?.id;
+          if (neighborId && sortedIds.has(neighborId)) {
+            const neighborIndex = sortedItems.findIndex((item) => item.id === neighborId);
+            insertIndex = neighborIndex + 1;
+            break;
+          }
+        }
+      }
+
+      // 如果还是没找到合适位置，放到最前面
+      if (insertIndex === -1) {
+        result.unshift(unsortedEntry.item);
+      } else {
+        sortedItems.splice(insertIndex, 0, unsortedEntry.item);
       }
     });
 
-    const index = defaultIndexMap.get(userId);
-    if (typeof index === 'number') mergedDefaultItems[index] = mergedItem;
-  });
+    return [...result, ...sortedItems];
+  } else {
+    // 没有自定义排序：完全按 defaultItems 的顺序
+    const result: T[] = [...idlessUserItems];
 
-  return [...invalidUserItems, ...customUserItems.values(), ...mergedDefaultItems];
+    // 先添加在 defaultItems 中的项（按原顺序）
+    defaultItems.forEach((defaultItem) => {
+      const itemId = defaultItem?.id;
+      if (!itemId) return;
+
+      const entry = mergedMap.get(itemId);
+      if (entry) {
+        result.push(entry.item);
+      }
+    });
+
+    // 再添加自定义的项（不在 defaultItems 中的）
+    entries.forEach((entry) => {
+      if (typeof entry.defaultIndex !== 'number') {
+        result.push(entry.item);
+      }
+    });
+
+    return result;
+  }
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

当前模型列表顺序会被模型启用操作打乱，已启用模型会被排到最前面。

本 pr 维持了 model-bank 中的模型顺序，并兼容自定义模型和抓取的模型（排在已有模型之前）。

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Refactor mergeArrayById to preserve the original order of default items while supporting custom and invalid user items, make id optional, and add tests to verify ordering behavior.

Enhancements:
- Maintain the original order of default items when merging user overrides
- Collect and place items without valid ids at the start of the merged array
- Preserve custom user items (not present in defaults) ahead of default items

Tests:
- Add a unit test to verify that overriding default items retains their original ordering