### PR TITLE
💄 style: Pre render ModelSwitchPanel

### DIFF
--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -23,16 +23,36 @@ export interface ActionDropdownProps extends DropdownProps {
   maxHeight?: number | string;
   maxWidth?: number | string;
   minWidth?: number | string;
+  /**
+   * 是否在挂载时预渲染弹层，避免首次触发展开时的渲染卡顿
+   */
+  prefetch?: boolean;
 }
 
 const ActionDropdown = memo<ActionDropdownProps>(
-  ({ menu, maxHeight, minWidth, maxWidth, children, placement = 'top', ...rest }) => {
+  ({
+    menu,
+    maxHeight,
+    minWidth,
+    maxWidth,
+    children,
+    placement = 'top',
+    prefetch = false,
+    destroyOnHidden,
+    forceRender,
+    ...rest
+  }) => {
     const { cx, styles } = useStyles();
     const isMobile = useIsMobile();
+
+    const dropdownForceRender = prefetch ? true : forceRender;
+    const dropdownDestroyOnHidden = prefetch ? false : destroyOnHidden;
 
     return (
       <Dropdown
         arrow={false}
+        destroyOnHidden={dropdownDestroyOnHidden}
+        forceRender={dropdownForceRender}
         menu={{
           ...menu,
           className: cx(styles.dropdownMenu, menu.className),

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -161,6 +161,7 @@ const ModelSwitchPanel = memo<IProps>(({ children, onOpenChange, open }) => {
       onOpenChange={onOpenChange}
       open={open}
       placement={'topLeft'}
+      prefetch
     >
       {icon}
     </ActionDropdown>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

可以讨论下，模型切换浮窗放在加载时渲染是否更能接受。

目前体验：启用 30 个模型，每次刷新后鼠标放到模型按钮，首次需等待 2-3 秒，观感显著。

- close #9898

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable pre-rendering of dropdown panels by adding a prefetch option to ActionDropdown and applying it to ModelSwitchPanel to eliminate initial interaction delay.

Enhancements:
- Add prefetch prop to ActionDropdown to force render the popup on mount and avoid first-time render lag.
- Enable prefetch on ModelSwitchPanel dropdown for instant menu responsiveness.