### PR TITLE
🐛 fix: fix the Worker URL cross-origin issue

### DIFF
--- a/packages/database/src/client/pglite.ts
+++ b/packages/database/src/client/pglite.ts
@@ -3,10 +3,11 @@ import { PGliteWorker } from '@electric-sql/pglite/worker';
 import { InitMeta } from './type';
 
 export const initPgliteWorker = async (meta: InitMeta) => {
-  const worker = await PGliteWorker.create(
-    new Worker(new URL('pglite.worker.ts', import.meta.url)),
-    { meta },
-  );
+  let workerURL = new URL('pglite.worker.ts', import.meta.url);
+  if (typeof location !== 'undefined' && workerURL.origin !== location.origin) {
+    workerURL = new URL(workerURL.pathname, location.origin);
+  }
+  const worker = await PGliteWorker.create(new Worker(workerURL), { meta });
 
   // 监听 worker 状态变化
   worker.onLeaderChange(() => {

--- a/packages/python-interpreter/src/interpreter.ts
+++ b/packages/python-interpreter/src/interpreter.ts
@@ -4,7 +4,11 @@ import type { PythonWorkerType } from './worker';
 
 export const PythonInterpreter = (() => {
   if (typeof Worker !== 'undefined') {
-    let worker = new Worker(new URL('worker.ts', import.meta.url), {
+    let workerURL = new URL('worker.ts', import.meta.url);
+    if (typeof location !== 'undefined' && workerURL.origin !== location.origin) {
+      workerURL = new URL(workerURL.pathname, location.origin);
+    }
+    const worker = new Worker(workerURL, {
       type: 'module',
     });
     return Comlink.wrap<PythonWorkerType>(worker);

--- a/packages/utils/src/tokenizer/client.ts
+++ b/packages/utils/src/tokenizer/client.ts
@@ -2,7 +2,11 @@ let worker: Worker | null = null;
 
 const getWorker = () => {
   if (!worker && typeof Worker !== 'undefined') {
-    worker = new Worker(new URL('tokenizer.worker.ts', import.meta.url));
+    let workerURL = new URL('tokenizer.worker.ts', import.meta.url);
+    if (typeof location !== 'undefined' && workerURL.origin !== location.origin) {
+      workerURL = new URL(workerURL.pathname, location.origin);
+    }
+    worker = new Worker(workerURL);
   }
   return worker;
 };


### PR DESCRIPTION
When the origin of the Worker script is different from the current page, reconstruct the URL relative to the current origin to avoid cross-origin errors.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

WEB安全要求Worker不能跨域加载（这一点无法通过配置跨域响应头解决），因而当配置了 **NEXT_PUBLIC_ASSET_PREFIX** 时就可能出现worker加载错误的情况，因此增加了对workerURL的处理，当其跨域时修改为同源地址，避免出现跨域错误。

<img width="663" height="42" alt="image" src="https://github.com/user-attachments/assets/74d948ca-fff8-47a1-a181-e9215811c481" />

#### 📝 Additional Information

https://developer.mozilla.org/en-US/docs/Web/API/Worker

## Summary by Sourcery

Fix Worker script URL cross-origin issue by rebuilding URLs to the current origin for all Worker instantiations

Bug Fixes:
- Rewrite pglite.worker.ts URL to same origin before creating the PGlite worker to avoid cross-origin errors
- Rebuild worker.ts URL to current origin in PythonInterpreter module to prevent cross-origin Worker load issues
- Adjust tokenizer.worker.ts URL to use the current origin when instantiating the tokenizer Worker