### PR TITLE
💄 style: nano banana support `aspect_ratio`

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -1,4 +1,4 @@
-import { ModelParamsSchema } from '../standard-parameters';
+import { CHAT_MODEL_IMAGE_GENERATION_PARAMS, ModelParamsSchema } from '../standard-parameters';
 import { AIChatModelCard, AIImageModelCard } from '../types';
 
 /**
@@ -233,6 +233,28 @@ const googleChatModels: AIChatModelCard[] = [
       'Nano Banana 是 Google 最新、最快、最高效的原生多模态模型，它允许您通过对话生成和编辑图像。',
     displayName: 'Nano Banana',
     enabled: true,
+    id: 'gemini-2.5-flash-image',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-08-26',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      imageOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768 + 8192,
+    description:
+      'Nano Banana 是 Google 最新、最快、最高效的原生多模态模型，它允许您通过对话生成和编辑图像。',
+    displayName: 'Nano Banana (Preview)',
     id: 'gemini-2.5-flash-image-preview',
     maxOutput: 8192,
     pricing: {
@@ -672,7 +694,7 @@ const nanoBananaParameters: ModelParamsSchema = {
 const googleImageModels: AIImageModelCard[] = [
   {
     displayName: 'Nano Banana',
-    id: 'gemini-2.5-flash-image-preview:image',
+    id: 'gemini-2.5-flash-image:image',
     enabled: true,
     type: 'image',
     description:
@@ -683,7 +705,23 @@ const googleImageModels: AIImageModelCard[] = [
       units: [
         { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'imageOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+  },
+  {
+    displayName: 'Nano Banana (Preview)',
+    id: 'gemini-2.5-flash-image-preview:image',
+    type: 'image',
+    description:
+      'Nano Banana 是 Google 最新、最快、最高效的原生多模态模型，它允许您通过对话生成和编辑图像。',
+    releasedAt: '2025-08-26',
+    parameters: CHAT_MODEL_IMAGE_GENERATION_PARAMS,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
   },

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -1,4 +1,4 @@
-import { CHAT_MODEL_IMAGE_GENERATION_PARAMS, ModelParamsSchema } from '../standard-parameters';
+import { ModelParamsSchema } from '../standard-parameters';
 import { AIChatModelCard, AIImageModelCard } from '../types';
 
 /**
@@ -644,6 +644,30 @@ const imagenBaseParameters: ModelParamsSchema = {
   prompt: { default: '' },
 };
 
+const NANO_BANANA_ASPECT_RATIOS = [
+  '1:1', // 1024x1024
+  '2:3', // 832x1248
+  '3:2', // 1248x832
+  '3:4', // 864x1184
+  '4:3', // 1184x864
+  '4:5', // 896x1152
+  '5:4', // 1152x896
+  '9:16', // 768x1344
+  '16:9', // 1344x768
+  '21:9', // 1536x672
+];
+
+const nanoBananaParameters: ModelParamsSchema = {
+  aspectRatio: {
+    default: '1:1',
+    enum: NANO_BANANA_ASPECT_RATIOS,
+  },
+  imageUrls: {
+    default: [],
+  },
+  prompt: { default: '' },
+};
+
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 const googleImageModels: AIImageModelCard[] = [
   {
@@ -654,7 +678,7 @@ const googleImageModels: AIImageModelCard[] = [
     description:
       'Nano Banana 是 Google 最新、最快、最高效的原生多模态模型，它允许您通过对话生成和编辑图像。',
     releasedAt: '2025-08-26',
-    parameters: CHAT_MODEL_IMAGE_GENERATION_PARAMS,
+    parameters: nanoBananaParameters,
     pricing: {
       units: [
         { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -1,4 +1,4 @@
-import { Content, GoogleGenAI, Part } from '@google/genai';
+import { Content, GenerateContentConfig, GoogleGenAI, Part } from '@google/genai';
 
 import { convertGoogleAIUsage } from '../../core/usageConverters/google-ai';
 import { CreateImagePayload, CreateImageResponse } from '../../types/image';
@@ -141,10 +141,19 @@ async function generateImageByChatModel(
     },
   ];
 
+  const config: GenerateContentConfig = {
+    responseModalities: ['Image'],
+    ...(params.aspectRatio
+      ? {
+          imageConfig: {
+            aspectRatio: params.aspectRatio,
+          },
+        }
+      : {}),
+  };
+
   const response = await client.models.generateContent({
-    config: {
-      responseModalities: ['Image'],
-    },
+    config,
     contents,
     model: actualModel,
   });


### PR DESCRIPTION
…config

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

本地无数据库环境没法测试，麻烦能帮忙构建一版测试下。

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for aspect_ratio in Google Nano Banana image model by defining ratio options in the model parameters and passing the selected aspect ratio through the content generation request.

New Features:
- Define a set of supported aspect_ratio values for Nano Banana and expose it in the model parameters
- Replace the generic image generation parameters with a dedicated schema for Nano Banana including aspect_ratio dropdown

Enhancements:
- Include the selected aspect_ratio in the GenerateContent API request config for image generation