### PR TITLE
🐛 fix: `type` not preserved when model is disabled

### DIFF
--- a/packages/database/src/models/__tests__/aiModel.test.ts
+++ b/packages/database/src/models/__tests__/aiModel.test.ts
@@ -211,16 +211,19 @@ describe('AiModelModel', () => {
         id: 'model1',
         providerId: 'openai',
         enabled: true,
+        type: 'image',
       });
 
       await aiProviderModel.toggleModelEnabled({
         id: model.id,
         providerId: 'openai',
         enabled: false,
+        type: 'image',
       });
 
       const updatedModel = await aiProviderModel.findById(model.id);
       expect(updatedModel?.enabled).toBe(false);
+      expect(updatedModel?.type).toBe('image');
     });
   });
 

--- a/packages/database/src/models/aiModel.ts
+++ b/packages/database/src/models/aiModel.ts
@@ -122,11 +122,27 @@ export class AiModelModel {
   };
 
   toggleModelEnabled = async (value: ToggleAiModelEnableParams) => {
+    const now = new Date();
+    const insertValues = {
+      ...value,
+      updatedAt: now,
+      userId: this.userId,
+    } as typeof aiModels.$inferInsert;
+
+    if (value.type) insertValues.type = value.type;
+
+    const updateValues: Partial<typeof aiModels.$inferInsert> = {
+      enabled: value.enabled,
+      updatedAt: now,
+    };
+
+    if (value.type) updateValues.type = value.type;
+
     return this.db
       .insert(aiModels)
-      .values({ ...value, updatedAt: new Date(), userId: this.userId })
+      .values(insertValues)
       .onConflictDoUpdate({
-        set: { enabled: value.enabled, updatedAt: new Date() },
+        set: updateValues,
         target: [aiModels.id, aiModels.providerId, aiModels.userId],
       });
   };

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -12,15 +12,18 @@ export const AiModelSourceEnum = {
 
 export type AiModelSourceType = (typeof AiModelSourceEnum)[keyof typeof AiModelSourceEnum];
 
-export type AiModelType =
-  | 'chat'
-  | 'embedding'
-  | 'tts'
-  | 'stt'
-  | 'image'
-  | 'text2video'
-  | 'text2music'
-  | 'realtime';
+export const AiModelTypeSchema = z.enum([
+  'chat',
+  'embedding',
+  'tts',
+  'stt',
+  'image',
+  'text2video',
+  'text2music',
+  'realtime',
+] as const);
+
+export type AiModelType = z.infer<typeof AiModelTypeSchema>;
 
 export interface ModelAbilities {
   /**
@@ -373,6 +376,7 @@ export const ToggleAiModelEnableSchema = z.object({
   id: z.string(),
   providerId: z.string(),
   source: z.enum(['builtin', 'custom', 'remote']).optional(),
+  type: AiModelTypeSchema.optional(),
 });
 
 export type ToggleAiModelEnableParams = z.infer<typeof ToggleAiModelEnableSchema>;

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -10,7 +10,6 @@ import { Flexbox } from 'react-layout-kit';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
-import { AiModelSourceEnum, AiProviderModelListItem } from '../../../../../../../../packages/model-bank/src/types/aiModel';
 import { formatPriceByCurrency } from '@/utils/format';
 import {
   getAudioInputUnitRate,
@@ -18,6 +17,10 @@ import {
   getTextOutputUnitRate,
 } from '@/utils/pricing';
 
+import {
+  AiModelSourceEnum,
+  AiProviderModelListItem,
+} from '../../../../../../../../packages/model-bank/src/types/aiModel';
 import ModelConfigModal from './ModelConfigModal';
 import { ProviderSettingsContext } from './ProviderSettingsContext';
 
@@ -243,7 +246,7 @@ const ModelItem = memo<ModelItemProps>(
             loading={isModelLoading}
             onChange={async (e) => {
               setChecked(e);
-              await toggleModelEnabled({ enabled: e, id, source });
+              await toggleModelEnabled({ enabled: e, id, source, type });
             }}
             size={'small'}
           />
@@ -334,7 +337,7 @@ const ModelItem = memo<ModelItemProps>(
             loading={isModelLoading}
             onChange={async (e) => {
               setChecked(e);
-              await toggleModelEnabled({ enabled: e, id, source });
+              await toggleModelEnabled({ enabled: e, id, source, type });
             }}
             size={'small'}
           />

--- a/src/server/routers/lambda/aiModel.test.ts
+++ b/src/server/routers/lambda/aiModel.test.ts
@@ -151,12 +151,14 @@ describe('aiModelRouter', () => {
       id: 'model-1',
       providerId: 'provider-1',
       enabled: true,
+      type: 'embedding',
     });
 
     expect(mockToggle).toHaveBeenCalledWith({
       id: 'model-1',
       providerId: 'provider-1',
       enabled: true,
+      type: 'embedding',
     });
   });
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

修复非 chat 类型模型禁用后，类型被重置为 chat 的问题。



#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Ensure AI model's type attribute is retained when toggling its enabled state or reordering by extending schemas, database operations, API handlers, and UI components to pass and persist the type field.

Bug Fixes:
- Preserve model type when toggling enabled state by including the type field in the toggle schema, database upsert, router handler, and UI calls.

Enhancements:
- Define AiModelType as a Zod enum for stronger type validation.

Tests:
- Add and update tests to verify the type attribute remains unchanged after toggling model enablement in database and router.