### PR TITLE
🔨 chore: enhance EdgeConfig with per-user feature flags support

### DIFF
--- a/src/config/featureFlags/index.ts
+++ b/src/config/featureFlags/index.ts
@@ -1,6 +1,7 @@
 import { createEnv } from '@t3-oss/env-nextjs';
 import { z } from 'zod';
 
+import { EdgeConfig } from '@/server/modules/EdgeConfig';
 import { merge } from '@/utils/merge';
 
 import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from './schema';
@@ -19,13 +20,60 @@ const env = createEnv({
 export const getServerFeatureFlagsValue = () => {
   const flags = parseFeatureFlag(env.FEATURE_FLAGS);
 
-  return merge(DEFAULT_FEATURE_FLAGS, flags);
+  const result = merge(DEFAULT_FEATURE_FLAGS, flags);
+  return result;
 };
 
-export const serverFeatureFlags = () => {
+/**
+ * Get feature flags from EdgeConfig with fallback to environment variables
+ * @param userId - Optional user ID for user-specific feature flag evaluation
+ */
+export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
+  // Try to get feature flags from EdgeConfig first
+  if (EdgeConfig.isEnabled()) {
+    try {
+      const edgeConfig = new EdgeConfig();
+      const edgeFeatureFlags = await edgeConfig.getFeatureFlags();
+
+      if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
+        // Merge EdgeConfig flags with defaults
+        const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
+        console.log('[FeatureFlags] Using EdgeConfig flags for user:', userId || 'anonymous');
+        return mergedFlags;
+      } else {
+        console.log(
+          '[FeatureFlags] EdgeConfig returned empty/null/undefined, falling back to environment variables',
+        );
+      }
+    } catch (error) {
+      console.warn(
+        '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
+        error,
+      );
+    }
+  } else {
+    console.log('[FeatureFlags] EdgeConfig not enabled, using environment variables');
+  }
+
+  // Fallback to environment variable-based feature flags
+  const envFlags = getServerFeatureFlagsValue();
+  console.log('[FeatureFlags] Using environment variable flags for user:', userId || 'anonymous');
+  return envFlags;
+};
+
+export const serverFeatureFlags = (userId?: string) => {
   const serverConfig = getServerFeatureFlagsValue();
 
-  return mapFeatureFlagsEnvToState(serverConfig);
+  return mapFeatureFlagsEnvToState(serverConfig, userId);
+};
+
+/**
+ * Get server feature flags from EdgeConfig and map them to state with user ID
+ * @param userId - Optional user ID for user-specific feature flag evaluation
+ */
+export const getServerFeatureFlagsStateFromEdgeConfig = async (userId?: string) => {
+  const flags = await getServerFeatureFlagsFromEdgeConfig(userId);
+  return mapFeatureFlagsEnvToState(flags, userId);
 };
 
 export * from './schema';

--- a/src/config/featureFlags/index.ts
+++ b/src/config/featureFlags/index.ts
@@ -1,14 +1,10 @@
 import { createEnv } from '@t3-oss/env-nextjs';
-import createDebug from 'debug';
 import { z } from 'zod';
 
-import { EdgeConfig } from '@/server/modules/EdgeConfig';
 import { merge } from '@/utils/merge';
 
 import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from './schema';
 import { parseFeatureFlag } from './utils/parser';
-
-const debug = createDebug('lobe:featureFlags');
 
 const env = createEnv({
   runtimeEnv: {
@@ -23,58 +19,13 @@ const env = createEnv({
 export const getServerFeatureFlagsValue = () => {
   const flags = parseFeatureFlag(env.FEATURE_FLAGS);
 
-  const result = merge(DEFAULT_FEATURE_FLAGS, flags);
-  return result;
-};
-
-/**
- * Get feature flags from EdgeConfig with fallback to environment variables
- * @param userId - Optional user ID for user-specific feature flag evaluation
- */
-export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
-  // Try to get feature flags from EdgeConfig first
-  if (EdgeConfig.isEnabled()) {
-    try {
-      const edgeConfig = new EdgeConfig();
-      const edgeFeatureFlags = await edgeConfig.getFeatureFlags();
-
-      if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
-        // Merge EdgeConfig flags with defaults
-        const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
-        debug('Using EdgeConfig flags for user: %s', userId || 'anonymous');
-        return mergedFlags;
-      } else {
-        debug('EdgeConfig returned empty/null/undefined, falling back to environment variables');
-      }
-    } catch (error) {
-      console.error(
-        '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
-        error,
-      );
-    }
-  } else {
-    debug('EdgeConfig not enabled, using environment variables');
-  }
-
-  // Fallback to environment variable-based feature flags
-  const envFlags = getServerFeatureFlagsValue();
-  debug('Using environment variable flags for user: %s', userId || 'anonymous');
-  return envFlags;
+  return merge(DEFAULT_FEATURE_FLAGS, flags);
 };
 
 export const serverFeatureFlags = (userId?: string) => {
   const serverConfig = getServerFeatureFlagsValue();
 
   return mapFeatureFlagsEnvToState(serverConfig, userId);
-};
-
-/**
- * Get server feature flags from EdgeConfig and map them to state with user ID
- * @param userId - Optional user ID for user-specific feature flag evaluation
- */
-export const getServerFeatureFlagsStateFromEdgeConfig = async (userId?: string) => {
-  const flags = await getServerFeatureFlagsFromEdgeConfig(userId);
-  return mapFeatureFlagsEnvToState(flags, userId);
 };
 
 export * from './schema';

--- a/src/config/featureFlags/index.ts
+++ b/src/config/featureFlags/index.ts
@@ -1,4 +1,5 @@
 import { createEnv } from '@t3-oss/env-nextjs';
+import createDebug from 'debug';
 import { z } from 'zod';
 
 import { EdgeConfig } from '@/server/modules/EdgeConfig';
@@ -6,6 +7,8 @@ import { merge } from '@/utils/merge';
 
 import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from './schema';
 import { parseFeatureFlag } from './utils/parser';
+
+const debug = createDebug('lobe:featureFlags');
 
 const env = createEnv({
   runtimeEnv: {
@@ -38,26 +41,24 @@ export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
       if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
         // Merge EdgeConfig flags with defaults
         const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
-        console.log('[FeatureFlags] Using EdgeConfig flags for user:', userId || 'anonymous');
+        debug('Using EdgeConfig flags for user: %s', userId || 'anonymous');
         return mergedFlags;
       } else {
-        console.log(
-          '[FeatureFlags] EdgeConfig returned empty/null/undefined, falling back to environment variables',
-        );
+        debug('EdgeConfig returned empty/null/undefined, falling back to environment variables');
       }
     } catch (error) {
-      console.warn(
+      console.error(
         '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
         error,
       );
     }
   } else {
-    console.log('[FeatureFlags] EdgeConfig not enabled, using environment variables');
+    debug('EdgeConfig not enabled, using environment variables');
   }
 
   // Fallback to environment variable-based feature flags
   const envFlags = getServerFeatureFlagsValue();
-  console.log('[FeatureFlags] Using environment variable flags for user:', userId || 'anonymous');
+  debug('Using environment variable flags for user: %s', userId || 'anonymous');
   return envFlags;
 };
 

--- a/src/config/featureFlags/schema.test.ts
+++ b/src/config/featureFlags/schema.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { FeatureFlagsSchema, mapFeatureFlagsEnvToState } from './schema';
+import { FeatureFlagsSchema, evaluateFeatureFlag, mapFeatureFlagsEnvToState } from './schema';
 
 describe('FeatureFlagsSchema', () => {
-  it('should validate correct feature flags', () => {
+  it('should validate correct feature flags with boolean values', () => {
     const result = FeatureFlagsSchema.safeParse({
-      webrtc_sync: true,
       language_model_settings: false,
       openai_api_key: true,
       openai_proxy_url: false,
@@ -18,20 +17,89 @@ describe('FeatureFlagsSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should reject invalid feature flags', () => {
+  it('should validate correct feature flags with user ID arrays', () => {
     const result = FeatureFlagsSchema.safeParse({
-      edit_agent: 'yes', // Invalid type, should be boolean
+      edit_agent: ['user-123', 'user-456'],
+      create_session: ['user-789'],
+      dalle: true,
+      ai_image: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate mixed boolean and array values', () => {
+    const result = FeatureFlagsSchema.safeParse({
+      edit_agent: ['user-123'],
+      create_session: true,
+      dalle: false,
+      knowledge_base: ['user-456', 'user-789'],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid feature flags with wrong types', () => {
+    const result = FeatureFlagsSchema.safeParse({
+      edit_agent: 'yes', // Invalid type, should be boolean or array
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid feature flags with non-string array elements', () => {
+    const result = FeatureFlagsSchema.safeParse({
+      edit_agent: [123, 456], // Invalid, array should contain strings
     });
 
     expect(result.success).toBe(false);
   });
 });
 
+describe('evaluateFeatureFlag', () => {
+  it('should return true for boolean true value', () => {
+    expect(evaluateFeatureFlag(true)).toBe(true);
+    expect(evaluateFeatureFlag(true, 'user-123')).toBe(true);
+  });
+
+  it('should return false for boolean false value', () => {
+    expect(evaluateFeatureFlag(false)).toBe(false);
+    expect(evaluateFeatureFlag(false, 'user-123')).toBe(false);
+  });
+
+  it('should return undefined for undefined value', () => {
+    expect(evaluateFeatureFlag(undefined)).toBe(undefined);
+    expect(evaluateFeatureFlag(undefined, 'user-123')).toBe(undefined);
+  });
+
+  it('should return true if user ID is in the allowlist', () => {
+    const allowlist = ['user-123', 'user-456'];
+    expect(evaluateFeatureFlag(allowlist, 'user-123')).toBe(true);
+    expect(evaluateFeatureFlag(allowlist, 'user-456')).toBe(true);
+  });
+
+  it('should return false if user ID is not in the allowlist', () => {
+    const allowlist = ['user-123', 'user-456'];
+    expect(evaluateFeatureFlag(allowlist, 'user-789')).toBe(false);
+  });
+
+  it('should return false if no user ID provided with array value', () => {
+    const allowlist = ['user-123', 'user-456'];
+    expect(evaluateFeatureFlag(allowlist)).toBe(false);
+    expect(evaluateFeatureFlag(allowlist, undefined)).toBe(false);
+  });
+
+  it('should handle empty array', () => {
+    expect(evaluateFeatureFlag([], 'user-123')).toBe(false);
+    expect(evaluateFeatureFlag([])).toBe(false);
+  });
+});
+
 describe('mapFeatureFlagsEnvToState', () => {
-  it('should correctly map feature flags to state', () => {
+  it('should correctly map boolean feature flags to state', () => {
     const config = {
-      webrtc_sync: true,
       language_model_settings: false,
+      provider_settings: true,
       openai_api_key: true,
       openai_proxy_url: false,
       create_session: true,
@@ -40,22 +108,110 @@ describe('mapFeatureFlagsEnvToState', () => {
       ai_image: true,
       check_updates: true,
       welcome_suggest: true,
+      plugins: true,
+      knowledge_base: false,
+      rag_eval: true,
+      clerk_sign_up: false,
+      market: true,
+      speech_to_text: true,
+      changelog: false,
+      pin_list: true,
+      api_key_manage: false,
+      cloud_promotion: true,
+      commercial_hide_github: false,
+      commercial_hide_docs: true,
     };
 
-    const expectedState = {
+    const mappedState = mapFeatureFlagsEnvToState(config);
+
+    expect(mappedState).toMatchObject({
       isAgentEditable: false,
       showCreateSession: true,
       showLLM: false,
+      showProvider: true,
       showOpenAIApiKey: true,
       showOpenAIProxyUrl: false,
       showDalle: true,
       showAiImage: true,
       enableCheckUpdates: true,
       showWelcomeSuggest: true,
+      enablePlugins: true,
+      enableKnowledgeBase: false,
+      enableRAGEval: true,
+      enableClerkSignUp: false,
+      showMarket: true,
+      enableSTT: true,
+      showChangelog: false,
+      showPinList: true,
+      showApiKeyManage: false,
+      showCloudPromotion: true,
+      hideGitHub: false,
+      hideDocs: true,
+    });
+  });
+
+  it('should correctly evaluate user-specific flags with allowlist', () => {
+    const userId = 'user-123';
+    const config = {
+      edit_agent: ['user-123', 'user-456'],
+      create_session: ['user-789'],
+      dalle: true,
+      knowledge_base: ['user-123'],
+    };
+
+    const mappedState = mapFeatureFlagsEnvToState(config, userId);
+
+    expect(mappedState.isAgentEditable).toBe(true); // user-123 is in allowlist
+    expect(mappedState.showCreateSession).toBe(false); // user-123 is not in allowlist
+    expect(mappedState.showDalle).toBe(true); // boolean true
+    expect(mappedState.enableKnowledgeBase).toBe(true); // user-123 is in allowlist
+  });
+
+  it('should return false for array flags when user ID is not in allowlist', () => {
+    const userId = 'user-999';
+    const config = {
+      edit_agent: ['user-123', 'user-456'],
+      create_session: ['user-789'],
+      dalle: true,
+    };
+
+    const mappedState = mapFeatureFlagsEnvToState(config, userId);
+
+    expect(mappedState.isAgentEditable).toBe(false);
+    expect(mappedState.showCreateSession).toBe(false);
+    expect(mappedState.showDalle).toBe(true);
+  });
+
+  it('should return false for array flags when no user ID provided', () => {
+    const config = {
+      edit_agent: ['user-123', 'user-456'],
+      create_session: true,
     };
 
     const mappedState = mapFeatureFlagsEnvToState(config);
 
-    expect(mappedState).toEqual(expectedState);
+    expect(mappedState.isAgentEditable).toBe(false);
+    expect(mappedState.showCreateSession).toBe(true);
+  });
+
+  it('should handle mixed boolean and array values correctly', () => {
+    const userId = 'user-123';
+    const config = {
+      edit_agent: ['user-123'],
+      create_session: true,
+      dalle: false,
+      ai_image: ['user-456'],
+      knowledge_base: ['user-123', 'user-789'],
+      rag_eval: true,
+    };
+
+    const mappedState = mapFeatureFlagsEnvToState(config, userId);
+
+    expect(mappedState.isAgentEditable).toBe(true);
+    expect(mappedState.showCreateSession).toBe(true);
+    expect(mappedState.showDalle).toBe(false);
+    expect(mappedState.showAiImage).toBe(false);
+    expect(mappedState.enableKnowledgeBase).toBe(true);
+    expect(mappedState.enableRAGEval).toBe(true);
   });
 });

--- a/src/config/featureFlags/schema.ts
+++ b/src/config/featureFlags/schema.ts
@@ -1,50 +1,71 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { z } from 'zod';
 
+// Define a union type for feature flag values: either boolean or array of user IDs
+const FeatureFlagValue = z.union([z.boolean(), z.array(z.string())]);
+
 export const FeatureFlagsSchema = z.object({
-  check_updates: z.boolean().optional(),
-  pin_list: z.boolean().optional(),
+  check_updates: FeatureFlagValue.optional(),
+  pin_list: FeatureFlagValue.optional(),
 
   // settings
-  language_model_settings: z.boolean().optional(),
-  provider_settings: z.boolean().optional(),
+  language_model_settings: FeatureFlagValue.optional(),
+  provider_settings: FeatureFlagValue.optional(),
 
-  openai_api_key: z.boolean().optional(),
-  openai_proxy_url: z.boolean().optional(),
+  openai_api_key: FeatureFlagValue.optional(),
+  openai_proxy_url: FeatureFlagValue.optional(),
 
   // profile
-  api_key_manage: z.boolean().optional(),
+  api_key_manage: FeatureFlagValue.optional(),
 
-  create_session: z.boolean().optional(),
-  edit_agent: z.boolean().optional(),
+  create_session: FeatureFlagValue.optional(),
+  edit_agent: FeatureFlagValue.optional(),
 
-  plugins: z.boolean().optional(),
-  dalle: z.boolean().optional(),
-  ai_image: z.boolean().optional(),
-  speech_to_text: z.boolean().optional(),
-  token_counter: z.boolean().optional(),
+  plugins: FeatureFlagValue.optional(),
+  dalle: FeatureFlagValue.optional(),
+  ai_image: FeatureFlagValue.optional(),
+  speech_to_text: FeatureFlagValue.optional(),
+  token_counter: FeatureFlagValue.optional(),
 
-  welcome_suggest: z.boolean().optional(),
-  changelog: z.boolean().optional(),
+  welcome_suggest: FeatureFlagValue.optional(),
+  changelog: FeatureFlagValue.optional(),
 
-  clerk_sign_up: z.boolean().optional(),
+  clerk_sign_up: FeatureFlagValue.optional(),
 
-  market: z.boolean().optional(),
-  knowledge_base: z.boolean().optional(),
+  market: FeatureFlagValue.optional(),
+  knowledge_base: FeatureFlagValue.optional(),
 
-  rag_eval: z.boolean().optional(),
+  rag_eval: FeatureFlagValue.optional(),
 
   // internal flag
-  cloud_promotion: z.boolean().optional(),
+  cloud_promotion: FeatureFlagValue.optional(),
 
   // the flags below can only be used with commercial license
   // if you want to use it in the commercial usage
   // please contact us for more information: hello@lobehub.com
-  commercial_hide_github: z.boolean().optional(),
-  commercial_hide_docs: z.boolean().optional(),
+  commercial_hide_github: FeatureFlagValue.optional(),
+  commercial_hide_docs: FeatureFlagValue.optional(),
 });
 
 export type IFeatureFlags = z.infer<typeof FeatureFlagsSchema>;
+
+/**
+ * Evaluate a feature flag value against a user ID
+ * @param flagValue - The feature flag value (boolean or array of user IDs)
+ * @param userId - The current user ID
+ * @returns boolean indicating if the feature is enabled for the user
+ */
+export const evaluateFeatureFlag = (
+  flagValue: boolean | string[] | undefined,
+  userId?: string,
+): boolean => {
+  if (flagValue === undefined) return false;
+  if (typeof flagValue === 'boolean') return flagValue;
+  if (Array.isArray(flagValue)) {
+    return userId ? flagValue.includes(userId) : false;
+  }
+  return false;
+};
 
 export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
   pin_list: false,
@@ -86,39 +107,41 @@ export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
   commercial_hide_docs: false,
 };
 
-export const mapFeatureFlagsEnvToState = (config: IFeatureFlags) => {
+export const mapFeatureFlagsEnvToState = (config: IFeatureFlags, userId?: string) => {
   return {
-    isAgentEditable: config.edit_agent,
+    isAgentEditable: evaluateFeatureFlag(config.edit_agent, userId),
 
-    showCreateSession: config.create_session,
-    showLLM: config.language_model_settings,
-    showProvider: config.provider_settings,
-    showPinList: config.pin_list,
+    showCreateSession: evaluateFeatureFlag(config.create_session, userId),
+    showLLM: evaluateFeatureFlag(config.language_model_settings, userId),
+    showProvider: evaluateFeatureFlag(config.provider_settings, userId),
+    showPinList: evaluateFeatureFlag(config.pin_list, userId),
 
-    showOpenAIApiKey: config.openai_api_key,
-    showOpenAIProxyUrl: config.openai_proxy_url,
+    showOpenAIApiKey: evaluateFeatureFlag(config.openai_api_key, userId),
+    showOpenAIProxyUrl: evaluateFeatureFlag(config.openai_proxy_url, userId),
 
-    showApiKeyManage: config.api_key_manage,
+    showApiKeyManage: evaluateFeatureFlag(config.api_key_manage, userId),
 
-    enablePlugins: config.plugins,
-    showDalle: config.dalle,
-    showAiImage: config.ai_image,
-    showChangelog: config.changelog,
+    enablePlugins: evaluateFeatureFlag(config.plugins, userId),
+    showDalle: evaluateFeatureFlag(config.dalle, userId),
+    showAiImage: evaluateFeatureFlag(config.ai_image, userId),
+    showChangelog: evaluateFeatureFlag(config.changelog, userId),
 
-    enableCheckUpdates: config.check_updates,
-    showWelcomeSuggest: config.welcome_suggest,
+    enableCheckUpdates: evaluateFeatureFlag(config.check_updates, userId),
+    showWelcomeSuggest: evaluateFeatureFlag(config.welcome_suggest, userId),
 
-    enableClerkSignUp: config.clerk_sign_up,
+    enableClerkSignUp: evaluateFeatureFlag(config.clerk_sign_up, userId),
 
-    enableKnowledgeBase: config.knowledge_base,
-    enableRAGEval: config.rag_eval,
+    enableKnowledgeBase: evaluateFeatureFlag(config.knowledge_base, userId),
+    enableRAGEval: evaluateFeatureFlag(config.rag_eval, userId),
 
-    showCloudPromotion: config.cloud_promotion,
+    showCloudPromotion: evaluateFeatureFlag(config.cloud_promotion, userId),
 
-    showMarket: config.market,
-    enableSTT: config.speech_to_text,
+    showMarket: evaluateFeatureFlag(config.market, userId),
+    enableSTT: evaluateFeatureFlag(config.speech_to_text, userId),
 
-    hideGitHub: config.commercial_hide_github,
-    hideDocs: config.commercial_hide_docs,
+    hideGitHub: evaluateFeatureFlag(config.commercial_hide_github, userId),
+    hideDocs: evaluateFeatureFlag(config.commercial_hide_docs, userId),
   };
 };
+
+export type IFeatureFlagsState = ReturnType<typeof mapFeatureFlagsEnvToState>;

--- a/src/config/featureFlags/schema.ts
+++ b/src/config/featureFlags/schema.ts
@@ -58,13 +58,12 @@ export type IFeatureFlags = z.infer<typeof FeatureFlagsSchema>;
 export const evaluateFeatureFlag = (
   flagValue: boolean | string[] | undefined,
   userId?: string,
-): boolean => {
-  if (flagValue === undefined) return false;
+): boolean | undefined => {
   if (typeof flagValue === 'boolean') return flagValue;
+
   if (Array.isArray(flagValue)) {
     return userId ? flagValue.includes(userId) : false;
   }
-  return false;
 };
 
 export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {

--- a/src/server/featureFlags/index.ts
+++ b/src/server/featureFlags/index.ts
@@ -1,0 +1,56 @@
+import createDebug from 'debug';
+
+import {
+  DEFAULT_FEATURE_FLAGS,
+  getServerFeatureFlagsValue,
+  mapFeatureFlagsEnvToState,
+} from '@/config/featureFlags';
+import { merge } from '@/utils/merge';
+
+import { EdgeConfig } from '../modules/EdgeConfig';
+
+const debug = createDebug('lobe:featureFlags');
+
+/**
+ * Get feature flags from EdgeConfig with fallback to environment variables
+ * @param userId - Optional user ID for user-specific feature flag evaluation
+ */
+export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
+  // Try to get feature flags from EdgeConfig first
+  if (EdgeConfig.isEnabled()) {
+    try {
+      const edgeConfig = new EdgeConfig();
+      const edgeFeatureFlags = await edgeConfig.getFeatureFlags();
+
+      if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
+        // Merge EdgeConfig flags with defaults
+        const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
+        debug('Using EdgeConfig flags for user: %s', userId || 'anonymous');
+        return mergedFlags;
+      } else {
+        debug('EdgeConfig returned empty/null/undefined, falling back to environment variables');
+      }
+    } catch (error) {
+      console.error(
+        '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
+        error,
+      );
+    }
+  } else {
+    debug('EdgeConfig not enabled, using environment variables');
+  }
+
+  // Fallback to environment variable-based feature flags
+  const envFlags = getServerFeatureFlagsValue();
+  debug('Using environment variable flags for user: %s', userId || 'anonymous');
+  return envFlags;
+};
+
+/**
+ * Get server feature flags from EdgeConfig and map them to state with user ID
+ * @param userId - Optional user ID for user-specific feature flag evaluation
+ */
+export const getServerFeatureFlagsStateFromEdgeConfig = async (userId?: string) => {
+  const flags = await getServerFeatureFlagsFromEdgeConfig(userId);
+  return mapFeatureFlagsEnvToState(flags, userId);
+};

--- a/src/server/modules/EdgeConfig/index.ts
+++ b/src/server/modules/EdgeConfig/index.ts
@@ -2,7 +2,20 @@ import { EdgeConfigClient, createClient } from '@vercel/edge-config';
 
 import { appEnv } from '@/envs/app';
 
-import type { EdgeConfigData } from './types';
+const EdgeConfigKeys = {
+  /**
+   * Assistant whitelist
+   */
+  AssistantBlacklist: 'assistant_blacklist',
+  /**
+   * Assistant whitelist
+   */
+  AssistantWhitelist: 'assistant_whitelist',
+  /**
+   * Feature flags configuration
+   */
+  FeatureFlags: 'feature_flags',
+};
 
 export class EdgeConfig {
   get client(): EdgeConfigClient {
@@ -16,12 +29,38 @@ export class EdgeConfig {
    * Check if Edge Config is enabled
    */
   static isEnabled() {
-    return !!appEnv.VERCEL_EDGE_CONFIG;
+    const isEnabled = !!appEnv.VERCEL_EDGE_CONFIG;
+    console.log(
+      '[EdgeConfig] VERCEL_EDGE_CONFIG env var:',
+      appEnv.VERCEL_EDGE_CONFIG ? 'SET' : 'NOT SET',
+    );
+    console.log('[EdgeConfig] EdgeConfig enabled:', isEnabled);
+    return isEnabled;
   }
 
   getAgentRestrictions = async () => {
     const { assistant_blacklist: blacklist, assistant_whitelist: whitelist } =
-      await this.client.getAll<EdgeConfigData>(['assistant_whitelist', 'assistant_blacklist']);
-    return { blacklist, whitelist };
+      await this.client.getAll([
+        EdgeConfigKeys.AssistantWhitelist,
+        EdgeConfigKeys.AssistantBlacklist,
+      ]);
+
+    return { blacklist, whitelist } as {
+      blacklist: string[] | undefined;
+      whitelist: string[] | undefined;
+    };
+  };
+
+  getFlagByKey = async (key: string) => {
+    const value = await this.client.get(key);
+    return value;
+  };
+
+  getFeatureFlags = async () => {
+    const featureFlags = await this.client.get(EdgeConfigKeys.FeatureFlags);
+    console.log('[EdgeConfig] Feature flags retrieved:', featureFlags);
+    return featureFlags as Record<string, boolean | string[]> | undefined;
   };
 }
+
+export { EdgeConfigKeys };

--- a/src/server/modules/EdgeConfig/index.ts
+++ b/src/server/modules/EdgeConfig/index.ts
@@ -1,6 +1,9 @@
 import { EdgeConfigClient, createClient } from '@vercel/edge-config';
+import createDebug from 'debug';
 
 import { appEnv } from '@/envs/app';
+
+const debug = createDebug('lobe-server:edge-config');
 
 const EdgeConfigKeys = {
   /**
@@ -30,11 +33,8 @@ export class EdgeConfig {
    */
   static isEnabled() {
     const isEnabled = !!appEnv.VERCEL_EDGE_CONFIG;
-    console.log(
-      '[EdgeConfig] VERCEL_EDGE_CONFIG env var:',
-      appEnv.VERCEL_EDGE_CONFIG ? 'SET' : 'NOT SET',
-    );
-    console.log('[EdgeConfig] EdgeConfig enabled:', isEnabled);
+    debug('VERCEL_EDGE_CONFIG env var: %s', appEnv.VERCEL_EDGE_CONFIG ? 'SET' : 'NOT SET');
+    debug('EdgeConfig enabled: %s', isEnabled);
     return isEnabled;
   }
 
@@ -58,7 +58,7 @@ export class EdgeConfig {
 
   getFeatureFlags = async () => {
     const featureFlags = await this.client.get(EdgeConfigKeys.FeatureFlags);
-    console.log('[EdgeConfig] Feature flags retrieved:', featureFlags);
+    debug('Feature flags retrieved: %O', featureFlags);
     return featureFlags as Record<string, boolean | string[]> | undefined;
   };
 }


### PR DESCRIPTION
- Add EdgeConfigKeys constants for better maintainability
- Add getFeatureFlags() and getFlagByKey() methods to EdgeConfig
- Enhance isEnabled() with debugging console logs
- Implement per-user feature flag evaluation logic
- Add EdgeConfig integration for feature flags with env var fallback
- Support feature flags as boolean or array of user IDs
- Export IFeatureFlagsState type for type safety

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add per-user feature flag support with EdgeConfig integration and environment variable fallback

New Features:
- Support feature flags as boolean or list of user IDs and evaluate them per user
- Expose evaluateFeatureFlag utility and extend mapFeatureFlagsEnvToState to return user-specific flag state
- Integrate with Vercel Edge Config by adding EdgeConfigKeys constants, getFeatureFlags, getFlagByKey methods, and user-aware fetch functions
- Provide getServerFeatureFlagsFromEdgeConfig and getServerFeatureFlagsStateFromEdgeConfig for asynchronous flag retrieval with env var fallback

Enhancements:
- Improve EdgeConfig.isEnabled and feature flag fetch logging for easier debugging
- Export IFeatureFlagsState type for stronger type safety