### PR TITLE
🔧 chore: fix workflows does not contain permissions

### DIFF
--- a/.github/workflows/docker-database.yml
+++ b/.github/workflows/docker-database.yml
@@ -1,4 +1,6 @@
 name: Publish Database Docker Image
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker-pglite.yml
+++ b/.github/workflows/docker-pglite.yml
@@ -1,4 +1,6 @@
 name: Publish Docker Pglite Image
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Publish Docker Image
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,10 @@
 name: Release CI
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/sync-database-schema.yml
+++ b/.github/workflows/sync-database-schema.yml
@@ -1,4 +1,6 @@
 name: Database Schema Visualization CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lobehub/lobe-chat/security/code-scanning/39](https://github.com/lobehub/lobe-chat/security/code-scanning/39)

To fix the detected issue, you should add a `permissions:` block that restricts the permissions granted to the GITHUB_TOKEN for this workflow. This block can be added at the workflow's root level (right after `name:` and before `on:`) to apply to all jobs, or to individual jobs if you need granularity. For this use case, adding it at the root with the minimal needed permissions is safest.

Based on the workflow's steps (git checkout, building and pushing Docker images, uploading/downloading artifacts), the only required permission is likely `contents: read`. No steps suggest write operations on issues, pull requests, or repository contents. Therefore, the optimal fix is to add:
```yaml
permissions:
  contents: read
```
immediately after the `name:` line in `.github/workflows/docker-pglite.yml`.

No further code or dependencies need to be updated. If later you find that certain actions need broader permissions, you can add those sub-permissions as required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Fix security scanning alert by adding minimal permissions blocks to GitHub Actions workflows to restrict GITHUB_TOKEN scope

CI:
- Add permissions block to the Release CI workflow granting contents: write, issues: write, and pull-requests: write
- Add permissions block granting contents: read to Docker and database-related workflows