### PR TITLE
🐛 fix: type not preserved when model is sorted

### DIFF
--- a/packages/database/src/models/__tests__/aiModel.test.ts
+++ b/packages/database/src/models/__tests__/aiModel.test.ts
@@ -315,5 +315,14 @@ describe('AiModelModel', () => {
       expect(models[0].id).toBe('model2');
       expect(models[1].id).toBe('model1');
     });
+
+    it('should preserve model type when inserting order records', async () => {
+      const sortMap = [{ id: 'image-model', sort: 0, type: 'image' as const }];
+
+      await aiProviderModel.updateModelsOrder('openai', sortMap);
+
+      const model = await aiProviderModel.findById('image-model');
+      expect(model?.type).toBe('image');
+    });
   });
 });

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -369,6 +369,7 @@ export type UpdateAiModelParams = z.infer<typeof UpdateAiModelSchema>;
 export interface AiModelSortMap {
   id: string;
   sort: number;
+  type?: AiModelType;
 }
 
 export const ToggleAiModelEnableSchema = z.object({

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -75,9 +75,10 @@ const getThinkingModelCategory = (model?: string): ThinkingModelCategory => {
   const normalized = model.toLowerCase();
 
   if (normalized.includes('robotics-er-1.5-preview')) return 'robotics';
-  if (normalized.includes('-2.5-flash-lite')) return 'flashLite';
-  if (normalized.includes('-2.5-flash')) return 'flash';
-  if (normalized.includes('-2.5-pro')) return 'pro';
+  if (normalized.includes('-2.5-flash-lite') || normalized.includes('flash-lite-latest'))
+    return 'flashLite';
+  if (normalized.includes('-2.5-flash') || normalized.includes('flash-latest')) return 'flash';
+  if (normalized.includes('-2.5-pro') || normalized.includes('pro-latest')) return 'pro';
 
   return 'other';
 };

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/SortModelModal/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/SortModelModal/index.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useAiInfraStore } from '@/store/aiInfra';
-import { AiProviderModelListItem } from '../../../../../../../../../packages/model-bank/src/types/aiModel';
 
+import { AiProviderModelListItem } from '../../../../../../../../../packages/model-bank/src/types/aiModel';
 import ListItem from './ListItem';
 
 const useStyles = createStyles(({ css, token }) => ({
@@ -76,6 +76,7 @@ const SortModelModal = memo<SortModelModalProps>(({ open, onCancel, defaultItems
             const sortMap = items.map((item, index) => ({
               id: item.id,
               sort: index,
+              type: item.type,
             }));
 
             setLoading(true);

--- a/src/server/routers/lambda/aiModel.ts
+++ b/src/server/routers/lambda/aiModel.ts
@@ -7,13 +7,15 @@ import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerGlobalConfig } from '@/server/globalConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import { ProviderConfig } from '@/types/user/settings';
+
 import {
+  AiModelTypeSchema,
   AiProviderModelListItem,
   CreateAiModelSchema,
   ToggleAiModelEnableSchema,
   UpdateAiModelSchema,
 } from '../../../../packages/model-bank/src/types/aiModel';
-import { ProviderConfig } from '@/types/user/settings';
 
 const aiModelProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
@@ -121,6 +123,7 @@ export const aiModelRouter = router({
           z.object({
             id: z.string(),
             sort: z.number(),
+            type: AiModelTypeSchema.optional(),
           }),
         ),
       }),


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change


修复模型重新排序后，类型被重置为 chat 的问题。

- fix #9175

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Preserve model type when reordering AI models across database, API, and UI

Bug Fixes:
- Ensure updateModelsOrder retains and updates the model type when inserting or updating order records

Enhancements:
- Add optional type field to AiModelSortMap in type definitions and extend the API router schema to accept it
- Include the type property in the UI sort payload when mapping models in SortModelModal

Tests:
- Add unit test to verify model type is preserved after updating model order