### PR TITLE
fix: desktop avatar upload broken when sync disabled

### DIFF
--- a/src/features/User/UserAvatar.tsx
+++ b/src/features/User/UserAvatar.tsx
@@ -58,18 +58,17 @@ const UserAvatar = forwardRef<HTMLDivElement, UserAvatarProps>(
 
     const isSignedIn = useUserStore(authSelectors.isLogin);
     const remoteServerUrl = useElectronStore(electronSyncSelectors.remoteServerUrl);
+    const isSyncActive = useElectronStore(electronSyncSelectors.isSyncActive);
 
-    // Process avatar URL for desktop environment
     const avatarUrl = useMemo(() => {
       if (!isSignedIn || !avatar) return DEFAULT_USER_AVATAR_URL;
 
-      // If in desktop environment and avatar starts with /, prepend the remote server URL
-      if (isDesktop && avatar.startsWith('/') && remoteServerUrl) {
+      if (isDesktop && avatar.startsWith('/') && remoteServerUrl && isSyncActive) {
         return remoteServerUrl + avatar;
       }
 
       return avatar;
-    }, [isSignedIn, avatar, remoteServerUrl]);
+    }, [isSignedIn, avatar, remoteServerUrl, isSyncActive]);
 
     return (
       <Avatar

--- a/src/services/user/desktop.ts
+++ b/src/services/user/desktop.ts
@@ -1,0 +1,63 @@
+import { isDesktop } from '@/const/version';
+import { lambdaClient } from '@/libs/trpc/client';
+import { IUserService } from '@/services/user/type';
+import { userClientService } from '@/services/user';
+
+export class DesktopUserService implements IUserService {
+    getUserRegistrationDuration: IUserService['getUserRegistrationDuration'] = async () => {
+        return lambdaClient.user.getUserRegistrationDuration.query();
+    };
+
+    getUserState: IUserService['getUserState'] = async () => {
+        return lambdaClient.user.getUserState.query();
+    };
+
+    getUserSSOProviders: IUserService['getUserSSOProviders'] = async () => {
+        return lambdaClient.user.getUserSSOProviders.query();
+    };
+
+    unlinkSSOProvider: IUserService['unlinkSSOProvider'] = async (
+        provider: string,
+        providerAccountId: string,
+    ) => {
+        return lambdaClient.user.unlinkSSOProvider.mutate({ provider, providerAccountId });
+    };
+
+    makeUserOnboarded = async () => {
+        return lambdaClient.user.makeUserOnboarded.mutate();
+    };
+
+    updateAvatar: IUserService['updateAvatar'] = async (avatar) => {
+        const { getElectronStoreState } = await import('@/store/electron');
+        const { electronSyncSelectors } = await import('@/store/electron/selectors');
+
+        try {
+            const state = getElectronStoreState();
+            const isSyncActive = electronSyncSelectors.isSyncActive(state);
+
+            if (!isSyncActive) {
+                return userClientService.updateAvatar(avatar);
+            }
+        } catch {
+            return userClientService.updateAvatar(avatar);
+        }
+
+        return lambdaClient.user.updateAvatar.mutate(avatar);
+    };
+
+    updatePreference: IUserService['updatePreference'] = async (preference) => {
+        return lambdaClient.user.updatePreference.mutate(preference);
+    };
+
+    updateGuide: IUserService['updateGuide'] = async (guide) => {
+        return lambdaClient.user.updateGuide.mutate(guide);
+    };
+
+    updateUserSettings: IUserService['updateUserSettings'] = async (value, signal) => {
+        return lambdaClient.user.updateSettings.mutate(value, { signal });
+    };
+
+    resetUserSettings: IUserService['resetUserSettings'] = async () => {
+        return lambdaClient.user.resetSettings.mutate();
+    };
+}

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -2,14 +2,17 @@ import { isDesktop } from '@/const/version';
 
 import { ClientService as DeprecatedService } from './_deprecated';
 import { ClientService } from './client';
+import { DesktopUserService } from './desktop';
 import { ServerService } from './server';
 
 const clientService =
   process.env.NEXT_PUBLIC_CLIENT_DB === 'pglite' ? new ClientService() : new DeprecatedService();
 
 export const userService =
-  process.env.NEXT_PUBLIC_SERVICE_MODE === 'server' || isDesktop
+  process.env.NEXT_PUBLIC_SERVICE_MODE === 'server'
     ? new ServerService()
-    : clientService;
+    : isDesktop
+      ? new DesktopUserService()
+      : clientService;
 
 export const userClientService = clientService;


### PR DESCRIPTION
#### Change Type

fixes: #9503

- [x] 🐛 fix

#### Description of Change

- Fixed desktop client avatar upload failure when sync is disabled. Desktop clients now properly use local storage for avatars when sync is inactive, preventing broken avatar URLs and ensuring correct display.

#### Additional Information

- Created `DesktopUserService` to handle avatar uploads based on sync state
- Updated `UserAvatar` component to only resolve server URLs when sync is active
- Desktop clients now fallback to local storage when sync is disabled, maintaining avatar functionality

## Summary by Sourcery

Fix desktop avatar upload and display when sync is disabled by falling back to local storage and only resolving server URLs when sync is active

Bug Fixes:
- Restore avatar upload on desktop with disabled sync by using local storage fallback
- Avoid broken avatar URLs by prepending server paths only when sync is active

Enhancements:
- Introduce DesktopUserService to choose between local and remote avatar updates based on sync state
- Update userService factory to instantiate DesktopUserService for desktop environments when sync is inactive