### PR TITLE
feat: add option to disable markdown rendering for input messages

### DIFF
--- a/packages/types/src/user/settings/general.ts
+++ b/packages/types/src/user/settings/general.ts
@@ -6,6 +6,7 @@ export type AnimationMode = 'disabled' | 'agile' | 'elegant';
 
 export interface UserGeneralConfig {
   animationMode?: AnimationMode;
+  disableMarkdownRender?: boolean;
   fontSize: number;
   highlighterTheme?: HighlighterProps['theme'];
   mermaidTheme?: MermaidProps['theme'];

--- a/src/app/[variants]/(main)/settings/common/features/Common/Common.tsx
+++ b/src/app/[variants]/(main)/settings/common/features/Common/Common.tsx
@@ -2,7 +2,7 @@
 
 import { Form, type FormGroupItemType, Icon, ImageSelect, InputPassword } from '@lobehub/ui';
 import { Select } from '@lobehub/ui';
-import { Segmented, Skeleton } from 'antd';
+import { Segmented, Skeleton, Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { Ban, Gauge, Loader2Icon, Monitor, Moon, Sun, Waves } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -108,7 +108,12 @@ const Common = memo(() => {
         minWidth: undefined,
         name: 'animationMode',
       },
-
+      {
+        children: <Switch />,
+        desc: t('settingCommon.disableMarkdownRender.desc'),
+        label: t('settingCommon.disableMarkdownRender.title'),
+        name: 'disableMarkdownRender',
+      },
       {
         children: (
           <InputPassword

--- a/src/features/Conversation/Messages/User/MarkdownRender/index.tsx
+++ b/src/features/Conversation/Messages/User/MarkdownRender/index.tsx
@@ -1,9 +1,20 @@
 import { Flexbox } from 'react-layout-kit';
 
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
+
 import { MarkdownCustomRender } from '../../../types';
 import ContentPreview from './ContentPreview';
 
 export const MarkdownRender: MarkdownCustomRender = ({ text, dom, id, displayMode }) => {
+  const disableMarkdownRender = useUserStore(
+    (s) => settingsSelectors.currentSettings(s).general.disableMarkdownRender,
+  );
+
+  if (disableMarkdownRender) {
+    return <div style={{ whiteSpace: 'pre-wrap' }}>{text}</div>;
+  }
+
   if (text.length > 30_000)
     return (
       <Flexbox>

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -286,6 +286,10 @@ export default {
     },
   },
   settingCommon: {
+    disableMarkdownRender: {
+      desc: '禁用输入消息的 Markdown 渲染，以纯文本形式显示',
+      title: '禁用 Markdown 渲染',
+    },
     lang: {
       autoMode: '跟随系统',
       title: '语言',


### PR DESCRIPTION
#### 💻 Change Type

fixes: #9517

- [x] ✨ feat

#### 🔀 Description of Change

- add setting option to disable markdown rendering for input messages, allowing users to view messages as plain text instead of rendered markdown.

## Summary by Sourcery

Introduce a user-configurable setting to disable markdown rendering for input messages and update related components, types, UI, and localization to support raw text display.

New Features:
- Add disableMarkdownRender option to user general settings with type definition and selectors
- Add a settings UI toggle and localization entries for disabling markdown rendering
- Update MarkdownRender component to respect disableMarkdownRender and render raw text when enabled