### PR TITLE
fix: preserve footnote definitions when copying messages

### DIFF
--- a/src/store/chat/slices/message/action.ts
+++ b/src/store/chat/slices/message/action.ts
@@ -26,6 +26,7 @@ import { topicService } from '@/services/topic';
 import { traceService } from '@/services/trace';
 import { ChatStore } from '@/store/chat/store';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { processMarkdownForCopy } from '@/utils/processMarkdownForCopy';
 import { Action, setNamespace } from '@/utils/storeDebug';
 import { nanoid } from '@/utils/uuid';
 
@@ -236,7 +237,8 @@ export const chatMessage: StateCreator<
     updateInputMessage('');
   },
   copyMessage: async (id, content) => {
-    await copyToClipboard(content);
+    const processedContent = processMarkdownForCopy(content);
+    await copyToClipboard(processedContent);
 
     get().internal_traceMessage(id, { eventType: TraceEventType.CopyMessage });
   },

--- a/src/utils/processMarkdownForCopy.ts
+++ b/src/utils/processMarkdownForCopy.ts
@@ -1,0 +1,44 @@
+const extractFootnoteDefinitions = (content: string): string[] => {
+  const footnoteRegex = /^\[\^(\d+)]:\s*(.+)$/gm;
+  const matches = content.match(footnoteRegex);
+  return matches || [];
+};
+
+const extractFootnoteReferences = (content: string): number[] => {
+  const referenceRegex = /\[\^(\d+)]/g;
+  const matches = content.match(referenceRegex);
+  if (!matches) return [];
+
+  return matches
+    .map((match) => {
+      const numberMatch = match.match(/\[\^(\d+)]/);
+      return numberMatch ? parseInt(numberMatch[1], 10) : 0;
+    })
+    .filter((num) => num > 0);
+};
+
+export const processMarkdownForCopy = (content: string): string => {
+  const footnoteDefinitions = extractFootnoteDefinitions(content);
+  const footnoteReferences = extractFootnoteReferences(content);
+
+  if (footnoteReferences.length === 0) {
+    return content;
+  }
+
+  const referencedFootnotes = new Set(new Set(footnoteReferences));
+
+  const relevantDefinitions = footnoteDefinitions.filter((def) => {
+    const numberMatch = def.match(/^\[\^(\d+)]:/);
+    if (!numberMatch) return false;
+    const footnoteNumber = parseInt(numberMatch[1], 10);
+    return referencedFootnotes.has(footnoteNumber);
+  });
+
+  if (relevantDefinitions.length === 0) {
+    return content;
+  }
+
+  const processedContent = content + '\n\n' + relevantDefinitions.join('\n');
+
+  return processedContent;
+};


### PR DESCRIPTION
### change Type
- [x] 🐛 fix

fixes: #9562

### Description of Change

- fixed an issue where copying messages with footnote references (like `[^1]`) would result in broken references because the footnote definitions were not included in the copied content. The copy functionality now automatically includes relevant footnote definitions when copying markdown content.

## Summary by Sourcery

Ensure copying markdown messages includes footnote definitions by integrating processMarkdownForCopy into the copyMessage flow.

Bug Fixes:
- Preserve footnote definitions when copying messages to prevent broken references.

Enhancements:
- Add processMarkdownForCopy utility to extract and append relevant footnote definitions to copied content.