### PR TITLE
🔒 fix(security): Sanitize Azure provider error responses to prevent API key exposure

### DIFF
--- a/packages/model-runtime/src/providers/azureOpenai/index.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.ts
@@ -20,6 +20,7 @@ import { AgentRuntimeError } from '../../utils/createError';
 import { debugStream } from '../../utils/debugStream';
 import { convertImageUrlToFile, convertOpenAIMessages } from '../../utils/openaiHelpers';
 import { StreamingResponse } from '../../utils/response';
+import { sanitizeError } from '../../utils/sanitizeError';
 
 const azureImageLogger = debug('lobe-image:azure');
 export class LobeAzureOpenAI implements LobeRuntimeAI {
@@ -253,9 +254,12 @@ export class LobeAzureOpenAI implements LobeRuntimeAI {
       ? AgentRuntimeErrorType.ProviderBizError
       : AgentRuntimeErrorType.AgentRuntimeError;
 
+    // Sanitize error to remove sensitive information like API keys from headers
+    const sanitizedError = sanitizeError(error);
+
     throw AgentRuntimeError.chat({
       endpoint: this.maskSensitiveUrl(this.baseURL),
-      error,
+      error: sanitizedError,
       errorType,
       provider: ModelProvider.Azure,
     });

--- a/packages/model-runtime/src/providers/azureai/index.ts
+++ b/packages/model-runtime/src/providers/azureai/index.ts
@@ -12,6 +12,7 @@ import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
 import { debugStream } from '../../utils/debugStream';
 import { StreamingResponse } from '../../utils/response';
+import { sanitizeError } from '../../utils/sanitizeError';
 
 interface AzureAIParams {
   apiKey?: string;
@@ -112,9 +113,12 @@ export class LobeAzureAI implements LobeRuntimeAI {
         ? AgentRuntimeErrorType.ProviderBizError
         : AgentRuntimeErrorType.AgentRuntimeError;
 
+      // Sanitize error to remove sensitive information like API keys from headers
+      const sanitizedError = sanitizeError(error);
+
       throw AgentRuntimeError.chat({
         endpoint: this.maskSensitiveUrl(this.baseURL),
-        error,
+        error: sanitizedError,
         errorType,
         provider: ModelProvider.Azure,
       });

--- a/packages/model-runtime/src/utils/sanitizeError.test.ts
+++ b/packages/model-runtime/src/utils/sanitizeError.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeError } from './sanitizeError';
+
+describe('sanitizeError', () => {
+  it('should remove sensitive request headers', () => {
+    const errorWithHeaders = {
+      message: 'API Error',
+      code: 401,
+      request: {
+        headers: {
+          authorization: 'Bearer sk-1234567890',
+          'content-type': 'application/json',
+          'ocp-apim-subscription-key': 'azure-key-123',
+        },
+        url: 'https://api.example.com',
+      },
+    };
+
+    const sanitized = sanitizeError(errorWithHeaders);
+
+    expect(sanitized).toEqual({
+      message: 'API Error',
+      code: 401,
+    });
+    expect(sanitized.request).toBeUndefined();
+  });
+
+  it('should remove sensitive fields at any level', () => {
+    const errorWithNestedSensitive = {
+      message: 'Error',
+      data: {
+        config: {
+          apikey: 'secret-key',
+          headers: {
+            authorization: 'Bearer token',
+          },
+        },
+        response: {
+          status: 401,
+          data: 'Unauthorized',
+        },
+      },
+    };
+
+    const sanitized = sanitizeError(errorWithNestedSensitive);
+
+    expect(sanitized).toEqual({
+      message: 'Error',
+      data: {
+        response: {
+          status: 401,
+          data: 'Unauthorized',
+        },
+      },
+    });
+    expect(sanitized.data.config).toBeUndefined();
+  });
+
+  it('should handle primitive values', () => {
+    expect(sanitizeError('string')).toBe('string');
+    expect(sanitizeError(123)).toBe(123);
+    expect(sanitizeError(true)).toBe(true);
+    expect(sanitizeError(null)).toBe(null);
+    expect(sanitizeError(undefined)).toBe(undefined);
+  });
+
+  it('should handle arrays', () => {
+    const errorArray = [
+      { message: 'Error 1', apikey: 'secret' },
+      { message: 'Error 2', status: 500 },
+    ];
+
+    const sanitized = sanitizeError(errorArray);
+
+    expect(sanitized).toEqual([{ message: 'Error 1' }, { message: 'Error 2', status: 500 }]);
+  });
+
+  it('should be case insensitive for sensitive field detection', () => {
+    const errorWithMixedCase = {
+      message: 'Error',
+      Authorization: 'Bearer token',
+      'API-KEY': 'secret',
+      Headers: { token: 'secret' },
+    };
+
+    const sanitized = sanitizeError(errorWithMixedCase);
+
+    expect(sanitized).toEqual({
+      message: 'Error',
+    });
+  });
+
+  it('should preserve safe nested structures', () => {
+    const errorWithSafeNested = {
+      message: 'Error occurred',
+      status: 401,
+      details: {
+        code: 'UNAUTHORIZED',
+        timestamp: '2024-01-01T00:00:00Z',
+        path: '/api/chat',
+      },
+    };
+
+    const sanitized = sanitizeError(errorWithSafeNested);
+
+    expect(sanitized).toEqual(errorWithSafeNested);
+  });
+});

--- a/packages/model-runtime/src/utils/sanitizeError.ts
+++ b/packages/model-runtime/src/utils/sanitizeError.ts
@@ -1,0 +1,59 @@
+/**
+ * Sanitizes error objects by removing sensitive information that could expose API keys or other credentials.
+ * This is particularly important for errors from Azure/OpenAI SDKs that may include request headers.
+ */
+export function sanitizeError(error: any): any {
+  if (!error || typeof error !== 'object') {
+    return error;
+  }
+
+  // Handle array of errors
+  if (Array.isArray(error)) {
+    return error.map(sanitizeError);
+  }
+
+  // Create a sanitized copy
+  const sanitized: any = {};
+
+  // List of sensitive fields that should be removed or masked
+  const sensitiveFields = [
+    'request',
+    'headers',
+    'authorization',
+    'apikey',
+    'api-key',
+    'ocp-apim-subscription-key',
+    'x-api-key',
+    'bearer',
+    'token',
+    'auth',
+    'credential',
+    'key',
+    'secret',
+    'password',
+    'config',
+    'options',
+  ];
+
+  // Copy safe fields and recursively sanitize nested objects
+  for (const key in error) {
+    if (error.hasOwnProperty(key)) {
+      const value = error[key];
+      const lowerKey = key.toLowerCase();
+      
+      // Skip sensitive fields entirely
+      if (sensitiveFields.indexOf(lowerKey) !== -1) {
+        continue;
+      }
+
+      // Recursively sanitize nested objects
+      if (value && typeof value === 'object') {
+        sanitized[key] = sanitizeError(value);
+      } else {
+        sanitized[key] = value;
+      }
+    }
+  }
+
+  return sanitized;
+}


### PR DESCRIPTION
## Summary
• Add sanitizeError utility to remove sensitive fields from error objects
• Update Azure providers to sanitize errors before sending to client
• Prevents API key disclosure in error messages when Azure models fail

## Test plan
- [ ] Test Azure provider error responses no longer contain sensitive headers
- [ ] Verify error messages remain informative for debugging
- [ ] Test both azureOpenai and azureai providers
- [ ] Ensure no breaking changes to existing functionality

Resolves #3141

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Introduce sanitization of error responses to strip API keys and other sensitive data from Azure provider errors by adding a sanitizeError utility and integrating it into AzureOpenAI and AzureAI providers.

New Features:
- Add sanitizeError utility to remove sensitive fields from error objects

Bug Fixes:
- Prevent API key disclosure in Azure provider error responses

Enhancements:
- Integrate sanitizeError into AzureOpenAI and AzureAI providers to sanitize errors before throwing

Tests:
- Add unit tests for sanitizeError utility