### PR TITLE
📝 docs: remove outdated nextauth server database warning

### DIFF
--- a/docs/usage/features/auth.mdx
+++ b/docs/usage/features/auth.mdx
@@ -29,11 +29,6 @@ LobeChat integrates `next-auth`, a flexible and powerful identity verification l
 - **Social Login**: Support quick login via various social platforms.
 - **Data Security**: Ensure the security and privacy of user data.
 
-<Callout type={'warning'}>
-  Due to workload constraints, integration of next-auth with a server-side database has not been
-  implemented yet. If you need to use a server-side database, please use Clerk.
-</Callout>
-
 <Callout type={'info'}>
   For information on using Next-Auth, you can refer to [Authentication Services - Next
   Auth](/docs/self-hosting/advanced/authentication#next-auth).

--- a/docs/usage/features/auth.zh-CN.mdx
+++ b/docs/usage/features/auth.zh-CN.mdx
@@ -25,11 +25,6 @@ LobeChat 集成了 `next-auth`，一个灵活且强大的身份验证库，支�
 - **社交登录**：支持多种社交平台的快捷登录。
 - **数据安全**：保障用户数据的安全性和隐私性。
 
-<Callout type={'warning'}>
-  由于工作量原因，目前还没有实现 next-auth 与服务端数据库的集成，如果需要使用服务端数据库，请使用
-  Clerk 。
-</Callout>
-
 <Callout type={'info'}>
   关于 Next-Auth 的使用，可以查阅 [身份验证服务 - Next
   Auth](/zh/docs/self-hosting/advanced/authentication#next-auth)。


### PR DESCRIPTION
#### 💻 Change Type

- [x] docs

#### 🔀 Description of Change

Removes outdated warning from authentication documentation stating that NextAuth doesn't support server-side database integration.

**Background**:
- Warning added June 18, 2024 (accurate at the time)
- NextAuth adapter implemented August 2, 2024 (PR #2935)

**Verification**:
- Adapter exists: `src/libs/next-auth/adapter/index.ts`
- Current technical docs already reflect NextAuth support
- DosuBot confirmed adapter implementation in issue comments

Fixes #9588

#### 📝 Additional Information

Updated both English (`auth.mdx`) and Chinese (`auth.zh-CN.mdx`) versions for bilingual consistency.

## Summary by Sourcery

Remove outdated NextAuth server database warning from authentication documentation following the adapter release

Documentation:
- Remove warning callout about missing server-side database integration in English auth doc
- Remove warning callout about missing server-side database integration in Chinese auth doc