### PR TITLE
📝 docs(dev): clarify feature organization patterns in tutorial

### DIFF
--- a/docs/development/basic/feature-development-frontend.mdx
+++ b/docs/development/basic/feature-development-frontend.mdx
@@ -5,7 +5,9 @@ LobeChat is built on the Next.js framework and uses TypeScript as the primary de
 1. Routing: Define routes (`src/app`).
 2. Data Structure: Define data structures (`src/types`).
 3. Business Logic Implementation: Zustand store (`src/store`).
-4. Page Display: Write static components/pages (`src/app/<new-page>/features/<new-feature>.tsx`).
+4. Page Display: Write static components/pages. Create features in:
+   - `src/features/<feature-name>/` for **shared global features** (used across multiple pages)
+   - `src/app/<new-page>/features/<feature-name>/` for **page-specific features** (only used in this page)
 5. Function Binding: Bind the store with page triggers (`const [state, function] = useNewStore(s => [s.state, s.function])`).
 
 Taking the "Chat Messages" feature as an example, here are the brief steps to implement this feature:
@@ -60,7 +62,8 @@ export const useChatStore = create<ChatState>((set) => ({
 In `src/app/<new-page>/features/<new-feature>.tsx`, we need to create a new page or component to display "Chat Messages". In this file, we can use the Zustand Store created earlier and Ant Design components to build the UI:
 
 ```jsx
-// src/features/chat/index.tsx
+// src/app/chat/features/ChatPage/index.tsx
+// Note: Use src/app/<page>/features/ for page-specific components
 import { List, Typography } from 'antd';
 import { useChatStore } from 'src/store/chatStore';
 
@@ -81,6 +84,12 @@ const ChatPage = () => {
 
 export default ChatPage;
 ```
+
+> **Note on Feature Organization**: LobeChat uses two patterns for organizing features:
+> - **Global features** (`src/features/`): Shared components like `ChatInput`, `Conversation` used across the app
+> - **Page-specific features** (`src/app/<page>/features/`): Components used only within a specific page route
+>
+> Choose based on reusability. If unsure, start with page-specific and refactor to global if needed elsewhere.
 
 ## 5. Function Binding
 

--- a/docs/development/basic/feature-development-frontend.zh-CN.mdx
+++ b/docs/development/basic/feature-development-frontend.zh-CN.mdx
@@ -5,7 +5,9 @@ LobeChat 基于 Next.js 框架构建，使用 TypeScript 作为主要开发语�
 1. 路由：定义路由 (`src/app`)
 2. 数据结构： 定义数据结构 ( `src/types` )
 3. 业务功能实现： zustand store (`src/store`)
-4. 页面展示：书写静态组件 / 页面 (`src/app/<new-page>/features/<new-feature>.tsx`)
+4. 页面展示：书写静态组件 / 页面。根据以下方式创建功能组件：
+   - `src/features/<feature-name>/` 用于 **全局共享功能**（跨多个页面使用）
+   - `src/app/<new-page>/features/<feature-name>/` 用于 **页面专属功能**（仅在当前页面使用）
 5. 功能绑定：绑定 store 与页面的触发 (`const  [state,function]= useNewStore(s=>[s.state,s.function])`)
 
 我们以 "会话消息" 功能为例，以下是实现这个功能的简要步骤：
@@ -60,7 +62,8 @@ export const useChatStore = create<ChatState>((set) => ({
 在 `src/app/<new-page>/features/<new-feature>.tsx` 中，我们需要创建一个新的页面或组件来显示 "会话消息"。在这个文件中，我们可以使用上面创建的 Zustand Store，以及 Ant Design 的组件来构建 UI：
 
 ```jsx
-// src/features/chat/index.tsx
+// src/app/chat/features/ChatPage/index.tsx
+// 注意：使用 src/app/<page>/features/ 放置页面专属组件
 import { List, Typography } from 'antd';
 import { useChatStore } from 'src/store/chatStore';
 
@@ -81,6 +84,12 @@ const ChatPage = () => {
 
 export default ChatPage;
 ```
+
+> **关于功能组件组织方式的说明**：LobeChat 使用两种模式来组织功能组件：
+> - **全局功能**（`src/features/`）：跨应用共享的组件，如 `ChatInput`、`Conversation` 等
+> - **页面专属功能**（`src/app/<page>/features/`）：仅在特定页面路由中使用的组件
+>
+> 根据可复用性选择合适的方式。如果不确定，可以先放在页面专属位置，需要时再重构为全局共享。
 
 ## 5. 功能绑定
 


### PR DESCRIPTION
## 📝 Description

This PR resolves confusion in the feature development tutorial by clarifying that LobeChat uses **two distinct patterns** for organizing feature components:

- **Global features** (`src/features/`): Shared components used across multiple pages
- **Page-specific features** (`src/app/<page>/features/`): Components used only within a specific page route

### Changes Made

1. **Updated step 4 instructions** (line 8-10) to explain both organizational patterns
2. **Fixed code example comment** (line 63-64) to show page-specific pattern with clarifying note
3. **Added explanatory section** (line 85-89) with decision guidance on when to use each pattern
4. **Applied to both EN and ZH-CN** documentation files for consistency

## 🔗 Related Issue

Fixes #9585

## ✅ Type of Change

- [x] 📝 Documentation (changes to documentation)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## 📋 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code/documentation
- [x] I have made corresponding changes to the documentation (both EN and ZH-CN)
- [x] My changes generate no new warnings
- [x] The documentation is clear and addresses the reported issue

## 📸 Screenshots (if applicable)

N/A - Documentation change only

## 💬 Additional Notes

The tutorial previously showed only the page-specific pattern in instructions but used the global pattern in the code example, causing confusion for new contributors. Both patterns are valid and actively used in the codebase (verified: 46 global features in `src/features/`, multiple page-specific features in `src/app/*/features/`).

This fix provides clear guidance on when to use each pattern based on reusability needs.

## Summary by Sourcery

Clarify the feature organization patterns in the front-end feature development tutorial by distinguishing between global and page-specific features and providing guidance on when to use each.

Documentation:
- Update step 4 instructions to explain both global (`src/features/`) and page-specific (`src/app/<page>/features/`) organizational patterns
- Revise the code example comment to use the page-specific path and add a clarifying note
- Add an explanatory note on choosing between global and page-specific features based on reusability
- Apply all documentation changes consistently in both English and Chinese versions