### PR TITLE
🐛 fix: fix standalone plugin rerender issue

### DIFF
--- a/src/features/PluginsUI/Render/StandaloneType/index.tsx
+++ b/src/features/PluginsUI/Render/StandaloneType/index.tsx
@@ -20,7 +20,8 @@ const PluginDefaultType = memo<PluginStandaloneTypeProps>(({ payload, id, name =
   const ui = manifest.ui;
 
   if (!ui.url) return;
-
+  // if the id start with "tmp", return directly to avoid duplicate rendering
+  if (id.startsWith('tmp')) return;
   return (
     <IFrameRender
       height={ui.height}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

- fix #9396

父组件的重新渲染，key 的取自msg_id，msg_id在調用插件的過程中，會生成不同的值。第一次 msg_id 如tmp_7QUqQmd8
第二次 msg_id 如: msg_LCUh4wuqO7zw3y导致 IFrameRender 组件本身也被重新创建，从而使得其中的 iframe 被销毁并重新挂载了两次。所以修改該bug直接把第一次臨時的msgId直接返回即可。

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Prevent StandaloneType plugin from rendering twice by skipping temporary message IDs