### PR TITLE
🐛 fix: slove desktop double click & onclick all trigger problem

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/index.tsx
@@ -19,9 +19,10 @@ import Actions from './Actions';
 
 interface SessionItemProps {
   id: string;
+  onDesktopDoubleClick?: () => void;
 }
 
-const SessionItem = memo<SessionItemProps>(({ id }) => {
+const SessionItem = memo<SessionItemProps>(({ id, onDesktopDoubleClick }) => {
   const [open, setOpen] = useState(false);
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
   const [defaultModel] = useAgentStore((s) => [agentSelectors.inboxAgentModel(s)]);
@@ -51,6 +52,7 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
 
   const handleDoubleClick = () => {
     if (isDesktop) {
+      onDesktopDoubleClick?.();
       openSessionInNewWindow(id);
     }
   };

--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/index.tsx
@@ -2,12 +2,13 @@ import { useAnalytics } from '@lobehub/analytics/react';
 import { Empty } from 'antd';
 import { createStyles } from 'antd-style';
 import Link from 'next/link';
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center } from 'react-layout-kit';
 import LazyLoad from 'react-lazy-load';
 
 import { SESSION_CHAT_URL } from '@/const/url';
+import { isDesktop } from '@/const/version';
 import { useSwitchSession } from '@/hooks/useSwitchSession';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { getSessionStoreState, useSessionStore } from '@/store/session';
@@ -25,6 +26,8 @@ const useStyles = createStyles(
     min-height: 70px;
   `,
 );
+
+const DESKTOP_DOUBLE_CLICK_DELAY = 200;
 interface SessionListProps {
   dataSource?: LobeAgentSession[];
   groupId?: string;
@@ -35,11 +38,84 @@ const SessionList = memo<SessionListProps>(({ dataSource, groupId, showAddButton
   const { analytics } = useAnalytics();
   const { styles } = useStyles();
 
+  const clickTimersRef = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
+
   const isInit = useSessionStore(sessionSelectors.isSessionListInit);
   const { showCreateSession } = useServerConfigStore(featureFlagsSelectors);
   const mobile = useServerConfigStore((s) => s.isMobile);
 
   const switchSession = useSwitchSession();
+
+  const runSwitchSession = useCallback(
+    (sessionId: string) => {
+      switchSession(sessionId);
+
+      if (!analytics) return;
+
+      const userStore = getUserStoreState();
+      const sessionStore = getSessionStoreState();
+
+      const userId = userProfileSelectors.userId(userStore);
+      const session = sessionSelectors.getSessionById(sessionId)(sessionStore);
+
+      if (!session) return;
+
+      const sessionGroupId = session.group || 'default';
+      const group = sessionGroupSelectors.getGroupById(sessionGroupId)(sessionStore);
+      const groupName = group?.name || (sessionGroupId === 'default' ? 'Default' : 'Unknown');
+
+      analytics.track({
+        name: 'switch_session',
+        properties: {
+          assistant_name: session.meta?.title || 'Untitled Agent',
+          assistant_tags: session.meta?.tags || [],
+          group_id: sessionGroupId,
+          group_name: groupName,
+          session_id: sessionId,
+          spm: 'homepage.chat.session_list_item.click',
+          user_id: userId || 'anonymous',
+        },
+      });
+    },
+    [analytics, switchSession],
+  );
+
+  const scheduleDesktopClick = useCallback(
+    (sessionId: string) => {
+      const timers = clickTimersRef.current;
+      const prevTimer = timers[sessionId];
+
+      if (prevTimer) {
+        clearTimeout(prevTimer);
+      }
+
+      timers[sessionId] = setTimeout(() => {
+        runSwitchSession(sessionId);
+        timers[sessionId] = null;
+      }, DESKTOP_DOUBLE_CLICK_DELAY);
+    },
+    [runSwitchSession],
+  );
+
+  const cancelDesktopClick = useCallback((sessionId: string) => {
+    const timers = clickTimersRef.current;
+    const timer = timers[sessionId];
+
+    if (timer) {
+      clearTimeout(timer);
+      timers[sessionId] = null;
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      const timers = clickTimersRef.current;
+      Object.values(timers).forEach((timer) => {
+        if (timer) clearTimeout(timer);
+      });
+    },
+    [],
+  );
 
   const isEmpty = !dataSource || dataSource.length === 0;
   return !isInit ? (
@@ -52,39 +128,14 @@ const SessionList = memo<SessionListProps>(({ dataSource, groupId, showAddButton
           href={SESSION_CHAT_URL(id, mobile)}
           onClick={(e) => {
             e.preventDefault();
-            switchSession(id);
-
-            // Enhanced analytics tracking
-            if (analytics) {
-              const userStore = getUserStoreState();
-              const sessionStore = getSessionStoreState();
-
-              const userId = userProfileSelectors.userId(userStore);
-              const session = sessionSelectors.getSessionById(id)(sessionStore);
-
-              if (session) {
-                const sessionGroupId = session.group || 'default';
-                const group = sessionGroupSelectors.getGroupById(sessionGroupId)(sessionStore);
-                const groupName =
-                  group?.name || (sessionGroupId === 'default' ? 'Default' : 'Unknown');
-
-                analytics?.track({
-                  name: 'switch_session',
-                  properties: {
-                    assistant_name: session.meta?.title || 'Untitled Agent',
-                    assistant_tags: session.meta?.tags || [],
-                    group_id: sessionGroupId,
-                    group_name: groupName,
-                    session_id: id,
-                    spm: 'homepage.chat.session_list_item.click',
-                    user_id: userId || 'anonymous',
-                  },
-                });
-              }
+            if (isDesktop) {
+              scheduleDesktopClick(id);
+            } else {
+              runSwitchSession(id);
             }
           }}
         >
-          <SessionItem id={id} />
+          <SessionItem id={id} onDesktopDoubleClick={() => cancelDesktopClick(id)} />
         </Link>
       </LazyLoad>
     ))


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Prevent desktop single-click and double-click handlers from interfering by debouncing clicks and extracting shared session switch logic

Bug Fixes:
- Prevent desktop double-click from triggering both session switch and opening in a new window

Enhancements:
- Debounce desktop clicks with a 200ms timeout and cancel pending click on double-click
- Extract session switch and analytics tracking into a reusable runSwitchSession callback