### PR TITLE
🔧 chore: export plugin module and clean up imports in toolCall

### DIFF
--- a/packages/const/src/index.ts
+++ b/packages/const/src/index.ts
@@ -6,6 +6,7 @@ export * from './guide';
 export * from './layoutTokens';
 export * from './message';
 export * from './meta';
+export * from './plugin';
 export * from './session';
 export * from './settings';
 export * from './trace';

--- a/packages/utils/src/toolCall.ts
+++ b/packages/utils/src/toolCall.ts
@@ -1,6 +1,5 @@
+import { PLUGIN_SCHEMA_API_MD5_PREFIX, PLUGIN_SCHEMA_SEPARATOR } from '@lobechat/const';
 import { Md5 } from 'ts-md5';
-
-import { PLUGIN_SCHEMA_API_MD5_PREFIX, PLUGIN_SCHEMA_SEPARATOR } from '@/const/plugin';
 
 // OpenAI GPT function_call name can't be longer than 64 characters
 // So we need to use md5 to shorten the name


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Export plugin module and clean up imports in toolCall

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Export the plugin module from the const package and update toolCall to use the centralized exports

Chores:
- Add plugin module export in the const package index
- Refactor toolCall imports to pull plugin constants from '@lobechat/const'