### PR TITLE
💄 style(settings): broadcast locale changes and update switchLocale action

### DIFF
--- a/apps/desktop/src/main/controllers/SystemCtr.ts
+++ b/apps/desktop/src/main/controllers/SystemCtr.ts
@@ -77,6 +77,7 @@ export default class SystemController extends ControllerModule {
 
     // 更新i18n实例的语言
     await this.app.i18n.changeLanguage(locale === 'auto' ? app.getLocale() : locale);
+    this.app.browserManager.broadcastToAllWindows('localeChanged', { locale });
 
     return { success: true };
   }

--- a/packages/electron-client-ipc/src/events/system.ts
+++ b/packages/electron-client-ipc/src/events/system.ts
@@ -18,6 +18,7 @@ export interface SystemDispatchEvents {
 }
 
 export interface SystemBroadcastEvents {
+  localeChanged: (data: { locale: string }) => void;
   systemThemeChanged: (data: { themeMode: ThemeAppearance }) => void;
   themeChanged: (data: { themeMode: ThemeMode }) => void;
 }

--- a/src/app/[variants]/(main)/settings/common/features/Common/Common.tsx
+++ b/src/app/[variants]/(main)/settings/common/features/Common/Common.tsx
@@ -17,6 +17,7 @@ import { useServerConfigStore } from '@/store/serverConfig';
 import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
+import { LocaleMode } from '@/types/locale';
 
 const Common = memo(() => {
   const { t } = useTranslation('setting');
@@ -32,6 +33,10 @@ const Common = memo(() => {
     s.isStatusInit,
   ]);
   const [loading, setLoading] = useState(false);
+
+  const handleLangChange = (value: LocaleMode) => {
+    switchLocale(value);
+  };
 
   if (!(isStatusInit && isUserStateInit))
     return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
@@ -75,7 +80,7 @@ const Common = memo(() => {
         children: (
           <Select
             defaultValue={language}
-            onChange={switchLocale}
+            onChange={handleLangChange}
             options={[{ label: t('settingCommon.lang.autoMode'), value: 'auto' }, ...localeOptions]}
           />
         ),

--- a/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
+++ b/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
@@ -15,12 +15,19 @@ export const useWatchThemeUpdate = () => {
       s.appState.isMac,
     ],
   );
-  const switchThemeMode = useGlobalStore((s) => s.switchThemeMode);
+  const [switchThemeMode, switchLocale] = useGlobalStore((s) => [
+    s.switchThemeMode,
+    s.switchLocale,
+  ]);
 
   const theme = useTheme();
 
   useWatchBroadcast('themeChanged', ({ themeMode }) => {
     switchThemeMode(themeMode, { skipBroadcast: true });
+  });
+
+  useWatchBroadcast('localeChanged', ({ locale }) => {
+    switchLocale(locale as any, { skipBroadcast: true });
   });
 
   useWatchBroadcast('systemThemeChanged', ({ themeMode }) => {

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -22,7 +22,7 @@ const n = setNamespace('g');
 export interface GlobalGeneralAction {
   openSessionInNewWindow: (sessionId: string) => Promise<void>;
   openTopicInNewWindow: (sessionId: string, topicId: string) => Promise<void>;
-  switchLocale: (locale: LocaleMode) => void;
+  switchLocale: (locale: LocaleMode, params?: { skipBroadcast?: boolean }) => void;
   switchThemeMode: (themeMode: ThemeMode, params?: { skipBroadcast?: boolean }) => void;
   updateSystemStatus: (status: Partial<SystemStatus>, action?: any) => void;
   useCheckLatestVersion: (enabledCheck?: boolean) => SWRResponse<string>;
@@ -79,12 +79,12 @@ export const generalActionSlice: StateCreator<
     }
   },
 
-  switchLocale: (locale) => {
+  switchLocale: (locale, { skipBroadcast } = {}) => {
     get().updateSystemStatus({ language: locale });
 
     switchLang(locale);
 
-    if (isDesktop) {
+    if (isDesktop && !skipBroadcast) {
       (async () => {
         try {
           const { dispatch } = await import('@lobechat/electron-client-ipc');


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

照葫芦画瓢给多语言加入了广播，看看有没有必要。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Broadcast locale changes across Electron windows and update the switchLocale action to support a skipBroadcast parameter and prevent rebroadcast loops.

Enhancements:
- Add a new localeChanged broadcast event in the main Electron controller and client IPC events
- Extend switchLocale action to accept an optional skipBroadcast flag and only broadcast when flag is false
- Listen for localeChanged broadcasts in the renderer to apply locale updates with skipBroadcast to avoid loops
- Wrap the language select onChange in settings with a handleLangChange function that calls switchLocale