### PR TITLE
🐛fix(mobile): enable conditional fetching of AI provider list based on mobile view

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/detail/default/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/detail/default/index.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { useAiInfraStore } from '@/store/aiInfra';
+import { useServerConfigStore } from '@/store/serverConfig';
 
 import ModelList from '../../features/ModelList';
 import ProviderConfig, { ProviderConfigProps } from '../../features/ProviderConfig';
@@ -13,6 +14,10 @@ interface ProviderDetailProps extends ProviderConfigProps {
 }
 const ProviderDetail = memo<ProviderDetailProps>(({ showConfig = true, ...card }) => {
   const useFetchAiProviderItem = useAiInfraStore((s) => s.useFetchAiProviderItem);
+  const useFetchAiProviderList = useAiInfraStore((s) => s.useFetchAiProviderList);
+  const isMobile = useServerConfigStore((s) => s.isMobile);
+
+  useFetchAiProviderList({ enabled: isMobile });
   useFetchAiProviderItem(card.id);
 
   return (

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -101,7 +101,10 @@ export interface AiProviderAction {
   updateAiProviderSort: (items: AiProviderSortMap[]) => Promise<void>;
 
   useFetchAiProviderItem: (id: string) => SWRResponse<AiProviderDetailItem | undefined>;
-  useFetchAiProviderList: (params?: { suspense?: boolean }) => SWRResponse<AiProviderListItem[]>;
+  useFetchAiProviderList: (params?: {
+    enabled?: boolean;
+    suspense?: boolean;
+  }) => SWRResponse<AiProviderListItem[]>;
   /**
    * fetch provider keyVaults and user enabled model list
    * @param isLoginOnInit
@@ -211,9 +214,9 @@ export const createAiProviderSlice: StateCreator<
         },
       },
     ),
-  useFetchAiProviderList: () =>
+  useFetchAiProviderList: (opts) =>
     useClientDataSWR<AiProviderListItem[]>(
-      AiProviderSwrKey.fetchAiProviderList,
+      opts?.enabled === false ? null : AiProviderSwrKey.fetchAiProviderList,
       () => aiProviderService.getAiProviderList(),
       {
         fallbackData: [],


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

**问题**
移动端从“对话页面 -> 模型选择 -> 服务商设置”进入时，不会渲染 ProviderMenu，导致 useFetchAiProviderList 未被调用，aiProviderList 为空，isProviderEnabled(id) 误判为 false，服务商启用开关默认显示为关闭。

<img src="https://github.com/user-attachments/assets/fc9d3ef1-5ec7-4d83-a8bb-fa08273987e7" width="500">

**修改**
移动端挂载 useFetchAiProviderList，确保直接进入单个服务商详情页时能拿到最新的 aiProviderList，用于正确回显启用开关状态。非移动端不会调用。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable conditional fetching of the AI provider list on mobile views by extending the useFetchAiProviderList hook with an 'enabled' flag and invoking it within the ProviderDetail component to ensure accurate toggle states.

Bug Fixes:
- Fetch AI provider list on mobile provider detail pages to correctly display provider toggle state

Enhancements:
- Add an 'enabled' option to the useFetchAiProviderList hook to conditionally control data fetching