### PR TITLE
fix(mobile): white border flickering

### DIFF
--- a/apps/mobile/src/features/SideBar/index.tsx
+++ b/apps/mobile/src/features/SideBar/index.tsx
@@ -3,9 +3,10 @@ import * as Haptics from 'expo-haptics';
 import { Link } from 'expo-router';
 import { CompassIcon, Sparkles } from 'lucide-react-native';
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, useWindowDimensions } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 
+import { DRAWER_WIDTH } from '@/_const/theme';
 import { useGlobalStore } from '@/store/global';
 import { isDev } from '@/utils/env';
 
@@ -15,13 +16,17 @@ import { useStyles } from './style';
 
 export default function SideBar({ children }: { children: React.ReactNode }) {
   const { styles } = useStyles();
+  const winDim = useWindowDimensions();
 
   const [drawerOpen, setDrawerOpen] = useGlobalStore((s) => [s.drawerOpen, s.setDrawerOpen]);
 
   return (
     <Drawer
       drawerPosition="left"
-      drawerStyle={styles.drawerStyle}
+      drawerStyle={[
+        styles.drawerStyle,
+        { width: Math.round(Math.min(DRAWER_WIDTH, winDim.width * 0.8)) },
+      ]}
       drawerType="slide"
       hideStatusBarOnOpen={false}
       onClose={() => {

--- a/apps/mobile/src/features/TopicDrawer/index.tsx
+++ b/apps/mobile/src/features/TopicDrawer/index.tsx
@@ -2,9 +2,10 @@ import { PageContainer } from '@lobehub/ui-rn';
 import * as Haptics from 'expo-haptics';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Text } from 'react-native';
+import { Text, useWindowDimensions } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 
+import { DRAWER_WIDTH } from '@/_const/theme';
 import { useGlobalStore } from '@/store/global';
 
 import TopicList from './components/TopicList';
@@ -16,6 +17,7 @@ import { useStyles } from './style';
  */
 const TopicDrawer = memo(({ children }: { children: React.ReactNode }) => {
   const { styles } = useStyles();
+  const winDim = useWindowDimensions();
   const { t } = useTranslation(['topic']);
 
   const [topicDrawerOpen, setTopicDrawerOpen] = useGlobalStore((s) => [
@@ -26,7 +28,10 @@ const TopicDrawer = memo(({ children }: { children: React.ReactNode }) => {
   return (
     <Drawer
       drawerPosition="right"
-      drawerStyle={styles.drawerStyle}
+      drawerStyle={[
+        styles.drawerStyle,
+        { width: Math.round(Math.min(DRAWER_WIDTH, winDim.width * 0.8)) },
+      ]}
       drawerType="slide"
       hideStatusBarOnOpen={false}
       onClose={() => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix flickering white borders in mobile drawer components by dynamically constraining their width to 80% of the window width

Bug Fixes:
- Set explicit drawer width in SideBar using window dimensions to eliminate white border flicker
- Apply the same dynamic width adjustment to TopicDrawer to prevent border flickering