### PR TITLE
🐛 fix: fix the Worker URL cross-origin issue

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,9 +19,11 @@ const standaloneConfig: NextConfig = {
   outputFileTracingIncludes: { '*': ['public/**/*', '.next/static/**/*'] },
 };
 
+const assetPrefix = process.env.NEXT_PUBLIC_ASSET_PREFIX;
+
 const nextConfig: NextConfig = {
   ...(isStandaloneMode ? standaloneConfig : {}),
-  assetPrefix: process.env.NEXT_PUBLIC_ASSET_PREFIX,
+  assetPrefix,
   compiler: {
     emotion: true,
   },
@@ -308,6 +310,20 @@ const nextConfig: NextConfig = {
       ...config.resolve.fallback,
       zipfile: false,
     };
+
+    if (assetPrefix && (assetPrefix.startsWith('http://') || assetPrefix.startsWith('https://'))) {
+      // fix the Worker URL cross-origin issue
+      // refs: https://github.com/lobehub/lobe-chat/pull/9624
+      config.module.rules.push({
+        generator: {
+          // @see https://webpack.js.org/configuration/module/#rulegeneratorpublicpath
+          publicPath: '/_next/',
+        },
+        test: /worker\.ts$/,
+        // @see https://webpack.js.org/guides/asset-modules/
+        type: 'asset/resource',
+      });
+    }
 
     return config;
   },


### PR DESCRIPTION
When the origin of the Worker script is different from the current page, reconstruct the URL relative to the current origin to avoid cross-origin errors.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

WEB安全要求Worker不能跨域加载（这一点无法通过配置跨域响应头解决），因而当配置了 **NEXT_PUBLIC_ASSET_PREFIX** 时就可能出现worker加载错误的情况，因此增加了对workerURL的处理，当其跨域时修改为同源地址，避免出现因跨域造成的安全错误。

<img width="663" height="42" alt="image" src="https://github.com/user-attachments/assets/74d948ca-fff8-47a1-a181-e9215811c481" />

#### 📝 Additional Information

https://developer.mozilla.org/en-US/docs/Web/API/Worker
https://webpack.js.org/configuration/module/#rulegeneratorpublicpath
https://webpack.js.org/guides/asset-modules/

## Summary by Sourcery

Fix Worker script URL cross-origin issue by rebuilding URLs to the current origin for all Worker instantiations

Bug Fixes:
- Rewrite pglite.worker.ts URL to same origin before creating the PGlite worker to avoid cross-origin errors
- Rebuild worker.ts URL to current origin in PythonInterpreter module to prevent cross-origin Worker load issues
- Adjust tokenizer.worker.ts URL to use the current origin when instantiating the tokenizer Worker

## Summary by Sourcery

Prevent cross-origin loading errors by reconstructing Worker script URLs to the current page origin before instantiation.

Bug Fixes:
- Rewrite pglite.worker.ts URL to same origin in the PGlite worker initializer
- Rebuild worker.ts URL to current origin in the PythonInterpreter module
- Adjust tokenizer.worker.ts URL to use the current origin when creating the tokenizer Worker