### PR TITLE
✨ feat(userMemories): implemented user memories, fetch, inject, models

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,14 +290,18 @@
     "tokenx": "^1.2.0",
     "ts-md5": "^2.0.1",
     "ua-parser-js": "^1.0.41",
+    "unist-builder": "^4.0.0",
     "unstructured-client": "^0.19.0",
     "url-join": "^5.0.0",
     "use-merge-value": "^1.2.0",
     "uuid": "^11.1.0",
     "word-extractor": "^1.0.4",
     "ws": "^8.18.3",
+    "xast-util-to-xml": "^4.0.0",
+    "xastscript": "^4.0.0",
     "yaml": "^2.8.1",
     "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.24.6",
     "zustand": "5.0.4",
     "zustand-utils": "^2.1.1"
   },
@@ -340,6 +344,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "@types/unist": "^3.0.3",
     "@types/ws": "^8.18.1",
+    "@types/xast": "^2.0.4",
     "@typescript/native-preview": "7.0.0-dev.20251102.1",
     "@vitest/coverage-v8": "^3.2.4",
     "ajv-keywords": "^5.1.0",
@@ -395,7 +400,26 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "@vercel/speed-insights"
-    ]
+      "@vercel/speed-insights",
+      "@clerk/shared",
+      "@playwright/browser-chromium",
+      "@scarf/scarf",
+      "@tree-sitter-grammars/tree-sitter-yaml",
+      "@vercel/speed-insights",
+      "better-sqlite3",
+      "canvas",
+      "core-js",
+      "core-js-pure",
+      "es5-ext",
+      "esbuild",
+      "protobufjs",
+      "sharp",
+      "tree-sitter",
+      "tree-sitter-json",
+      "unrs-resolver"
+    ],
+    "overrides": {
+      "mdast-util-gfm-autolink-literal": "2.0.0"
+    }
   }
 }

--- a/packages/const/src/settings/index.ts
+++ b/packages/const/src/settings/index.ts
@@ -8,6 +8,7 @@ import { DEFAULT_LLM_CONFIG } from './llm';
 import { DEFAULT_SYSTEM_AGENT_CONFIG } from './systemAgent';
 import { DEFAULT_TOOL_CONFIG } from './tool';
 import { DEFAULT_TTS_CONFIG } from './tts';
+import { DEFAULT_USER_MEMORY_CONFIG } from './userMemory';
 
 export * from './agent';
 export * from './common';
@@ -19,6 +20,7 @@ export * from './llm';
 export * from './systemAgent';
 export * from './tool';
 export * from './tts';
+export * from './userMemory';
 
 export const DEFAULT_SETTINGS: UserSettings = {
   defaultAgent: DEFAULT_AGENT,
@@ -30,4 +32,5 @@ export const DEFAULT_SETTINGS: UserSettings = {
   systemAgent: DEFAULT_SYSTEM_AGENT_CONFIG,
   tool: DEFAULT_TOOL_CONFIG,
   tts: DEFAULT_TTS_CONFIG,
+  userMemory: DEFAULT_USER_MEMORY_CONFIG,
 };

--- a/packages/const/src/settings/userMemory.ts
+++ b/packages/const/src/settings/userMemory.ts
@@ -1,0 +1,12 @@
+import { UserMemoryConfig, UserMemoryConfigItem } from '@lobechat/types';
+
+import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_PROVIDER } from './llm';
+
+export const DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM: UserMemoryConfigItem = {
+  model: DEFAULT_EMBEDDING_MODEL,
+  provider: DEFAULT_EMBEDDING_PROVIDER,
+};
+
+export const DEFAULT_USER_MEMORY_CONFIG: UserMemoryConfig = {
+  embeddingModel: DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM,
+};

--- a/packages/const/src/userMemory.ts
+++ b/packages/const/src/userMemory.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_SEARCH_USER_MEMORY_TOP_K = {
+  contexts: 0,
+  experiences: 0,
+  preferences: 3,
+};

--- a/packages/database/src/models/__tests__/userMemories.test.ts
+++ b/packages/database/src/models/__tests__/userMemories.test.ts
@@ -1,0 +1,671 @@
+// @vitest-environment node
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { idGenerator } from '@/database/utils/idGenerator';
+import { LayersEnum, MergeStrategyEnum, TypesEnum } from '@/types/userMemory';
+
+import {
+  userMemories,
+  userMemoriesContexts,
+  userMemoriesExperiences,
+  userMemoriesIdentities,
+  userMemoriesPreferences,
+  users,
+} from '../../schemas';
+import { LobeChatDatabase } from '../../type';
+import {
+  BaseCreateUserMemoryParams,
+  CreateUserMemoryContextParams,
+  CreateUserMemoryExperienceParams,
+  CreateUserMemoryIdentityParams,
+  CreateUserMemoryPreferenceParams,
+  UserMemoryModel,
+} from '../userMemory';
+import { getTestDB } from './_util';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+const userId = idGenerator('user');
+const userId2 = idGenerator('user');
+const userMemoryModel = new UserMemoryModel(serverDB, userId);
+
+/**
+ * Generate a random normalized embedding vector
+ * @param dimensions - Vector dimensions (default: 1024)
+ * @returns Normalized random vector
+ */
+function generateRandomEmbedding(dimensions: number = 1024): number[] {
+  const vector = Array(dimensions)
+    .fill(0)
+    .map(() => Math.random() * 2 - 1); // Random values between -1 and 1
+
+  // Normalize the vector
+  const magnitude = Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
+  return vector.map((val) => val / magnitude);
+}
+
+const mockEmbedding = generateRandomEmbedding();
+const mockEmbedding2 = generateRandomEmbedding();
+
+// Assert that two numeric vectors are equal within a precision tolerance
+function expectVectorToBeClose(
+  actual: number[] | null | undefined,
+  expected: number[],
+  precision: number = 5,
+) {
+  expect(actual).toBeDefined();
+  expect(actual).not.toBeNull();
+
+  const actualVector = actual as number[];
+
+  expect(actualVector.length).toBe(expected.length);
+  actualVector.forEach((value, index) => {
+    expect(value).toBeCloseTo(expected[index]!, precision);
+  });
+}
+
+beforeEach(async () => {
+  await serverDB.delete(users);
+  await serverDB.insert(users).values([{ id: userId }, { id: userId2 }]);
+});
+
+afterEach(async () => {
+  await serverDB.delete(users).where(eq(users.id, userId));
+});
+
+function generateRandomCreateUserMemoryParams(
+  memoryLayer: BaseCreateUserMemoryParams['memoryLayer'],
+): BaseCreateUserMemoryParams {
+  return {
+    title: 'title ' + nanoid(),
+    summary: 'summary ' + nanoid(),
+    summaryEmbedding: generateRandomEmbedding(),
+    memoryType: TypesEnum.Activity,
+    memoryCategory: 'category',
+    memoryLayer,
+    details: 'details ' + nanoid(),
+  } satisfies BaseCreateUserMemoryParams;
+}
+
+function generateRandomCreateUserMemoryExperienceParams() {
+  return {
+    ...generateRandomCreateUserMemoryParams(LayersEnum.Experience),
+    experience: {
+      action: 'action ' + nanoid(),
+      actionVector: generateRandomEmbedding(),
+      keyLearning: 'keyLearning ' + nanoid(),
+      keyLearningVector: generateRandomEmbedding(),
+      metadata: {},
+      possibleOutcome: 'possibleOutcome ' + nanoid(),
+      reasoning: 'reasoning ' + nanoid(),
+      scoreConfidence: 0.5,
+      situation: 'situation ' + nanoid(),
+      situationVector: generateRandomEmbedding(),
+      tags: [],
+      type: 'learning',
+    },
+  } as CreateUserMemoryExperienceParams;
+}
+
+function generateRandomCreateUserMemoryIdentityParams() {
+  const relationshipOptions = ['self', 'friend', 'colleague', 'other'];
+
+  return {
+    ...generateRandomCreateUserMemoryParams(LayersEnum.Identity),
+    identity: {
+      description: 'identity description ' + nanoid(),
+      descriptionVector: generateRandomEmbedding(),
+      episodicDate: new Date(),
+      metadata: {},
+      relationship: relationshipOptions[Math.floor(Math.random() * relationshipOptions.length)],
+      role: 'role ' + nanoid(),
+      tags: [],
+      type: 'personal',
+    },
+  } as CreateUserMemoryIdentityParams;
+}
+
+function generateRandomCreateUserMemoryContextParams() {
+  return {
+    ...generateRandomCreateUserMemoryParams(LayersEnum.Context),
+    context: {
+      associatedObjects: [],
+      associatedSubjects: [],
+      currentStatus: 'status ' + nanoid(),
+      description: 'context description ' + nanoid(),
+      descriptionVector: generateRandomEmbedding(),
+      metadata: {},
+      scoreImpact: 0.5,
+      scoreUrgency: 0.4,
+      tags: [],
+      title: 'context title ' + nanoid(),
+      titleVector: generateRandomEmbedding(),
+      type: 'environment',
+      userMemoryIds: [],
+    },
+  } as CreateUserMemoryContextParams;
+}
+
+function generateRandomCreateUserMemoryPreferenceParams() {
+  return {
+    ...generateRandomCreateUserMemoryParams(LayersEnum.Preference),
+    preference: {
+      conclusionDirectives: 'directive ' + nanoid(),
+      conclusionDirectivesVector: generateRandomEmbedding(),
+      metadata: {},
+      scorePriority: 0.7,
+      suggestions: 'suggestions ' + nanoid(),
+      tags: [],
+      type: 'choice',
+    },
+  } as CreateUserMemoryPreferenceParams;
+}
+
+describe('UserMemoryModel', () => {
+  describe('delete', () => {
+    it('should delete a memory by id', async () => {
+      const created = await userMemoryModel.create(
+        generateRandomCreateUserMemoryExperienceParams(),
+      );
+
+      await userMemoryModel.delete(created.id);
+
+      const deleted = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, created.id),
+      });
+
+      expect(deleted).toBeUndefined();
+    });
+
+    it('should only delete own user memories', async () => {
+      const anotherUserModel = new UserMemoryModel(serverDB, userId2);
+      const created = await anotherUserModel.create(
+        generateRandomCreateUserMemoryExperienceParams(),
+      );
+
+      await userMemoryModel.delete(created.id);
+
+      const stillExists = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, created.id),
+      });
+
+      expect(stillExists).toBeDefined();
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('should delete all memories for the user', async () => {
+      await userMemoryModel.create(generateRandomCreateUserMemoryExperienceParams());
+      await userMemoryModel.create(generateRandomCreateUserMemoryIdentityParams());
+      await userMemoryModel.create(generateRandomCreateUserMemoryContextParams());
+      await userMemoryModel.create(generateRandomCreateUserMemoryPreferenceParams());
+      await userMemoryModel.deleteAll();
+
+      const remaining = await serverDB.query.userMemories.findMany({
+        where: eq(userMemories.userId, userId),
+      });
+
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('should only delete memories for the user, not others', async () => {
+      // user 2
+      const user2Memory = await userMemoryModel.create(
+        generateRandomCreateUserMemoryExperienceParams(),
+      );
+      await serverDB
+        .update(userMemories)
+        .set({ userId: userId2 })
+        .where(eq(userMemories.id, user2Memory.id));
+
+      await userMemoryModel.create(generateRandomCreateUserMemoryIdentityParams());
+      await userMemoryModel.create(generateRandomCreateUserMemoryContextParams());
+      await userMemoryModel.create(generateRandomCreateUserMemoryPreferenceParams());
+      await userMemoryModel.deleteAll();
+
+      const user1Remaining = await serverDB.query.userMemories.findMany({
+        where: eq(userMemories.userId, userId),
+      });
+      const user2Remaining = await serverDB.query.userMemories.findMany({
+        where: eq(userMemories.userId, userId2),
+      });
+
+      expect(user1Remaining).toHaveLength(0);
+      expect(user2Remaining).toHaveLength(1);
+    });
+  });
+
+  describe('search', () => {
+    it('should return layered results with split limits', async () => {
+      const experienceMemoryOne = await userMemoryModel.create(
+        generateRandomCreateUserMemoryExperienceParams(),
+      );
+      await serverDB.insert(userMemoriesExperiences).values({
+        ...generateRandomCreateUserMemoryExperienceParams().experience,
+        userId,
+        userMemoryId: experienceMemoryOne.id,
+      });
+
+      const experienceMemoryTwo = await userMemoryModel.create(
+        generateRandomCreateUserMemoryExperienceParams(),
+      );
+      await serverDB.insert(userMemoriesExperiences).values({
+        ...generateRandomCreateUserMemoryExperienceParams().experience,
+        userId,
+        userMemoryId: experienceMemoryTwo.id,
+      });
+
+      const preferenceMemoryOne = await userMemoryModel.create(
+        generateRandomCreateUserMemoryPreferenceParams(),
+      );
+      await serverDB.insert(userMemoriesPreferences).values({
+        ...generateRandomCreateUserMemoryPreferenceParams().preference,
+        userId,
+        userMemoryId: preferenceMemoryOne.id,
+      });
+
+      const preferenceMemoryTwo = await userMemoryModel.create(
+        generateRandomCreateUserMemoryPreferenceParams(),
+      );
+      await serverDB.insert(userMemoriesPreferences).values({
+        ...generateRandomCreateUserMemoryPreferenceParams().preference,
+        userId,
+        userMemoryId: preferenceMemoryTwo.id,
+      });
+
+      await serverDB.insert(userMemoriesContexts).values({
+        ...generateRandomCreateUserMemoryContextParams().context,
+        userId,
+        userMemoryIds: [experienceMemoryOne.id, preferenceMemoryOne.id],
+      });
+      await serverDB.insert(userMemoriesContexts).values({
+        ...generateRandomCreateUserMemoryContextParams().context,
+        userId,
+        userMemoryIds: [experienceMemoryTwo.id, preferenceMemoryTwo.id],
+      });
+
+      const result = await userMemoryModel.search({
+        limit: 5,
+        limits: {
+          contexts: 1,
+          experiences: 1,
+          preferences: 1,
+        },
+      });
+
+      expect(result.experiences).toHaveLength(1);
+      expect(result.preferences).toHaveLength(1);
+      expect(result.contexts).toHaveLength(1);
+    });
+  });
+
+  describe('update vector methods', () => {
+    it('updates base user memory vectors', async () => {
+      const memoryId = idGenerator('memory');
+      await serverDB.insert(userMemories).values({
+        details: 'details',
+        id: memoryId,
+        lastAccessedAt: new Date(),
+        summary: 'summary',
+        title: 'title',
+        userId,
+      });
+
+      const summaryVector = generateRandomEmbedding();
+      const detailsVector = generateRandomEmbedding();
+
+      await userMemoryModel.updateUserMemoryVectors(memoryId, {
+        detailsVector1024: detailsVector,
+        summaryVector1024: summaryVector,
+      });
+
+      const updated = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, memoryId),
+      });
+
+      expectVectorToBeClose(updated?.summaryVector1024, summaryVector);
+      expectVectorToBeClose(updated?.detailsVector1024, detailsVector);
+    });
+
+    it('updates context vectors', async () => {
+      const contextId = idGenerator('memory');
+      await serverDB.insert(userMemoriesContexts).values({
+        description: 'desc',
+        id: contextId,
+        title: 'title',
+        userId,
+      });
+
+      const descriptionVector = generateRandomEmbedding();
+      await userMemoryModel.updateContextVectors(contextId, { descriptionVector });
+      const updated = await serverDB.query.userMemoriesContexts.findFirst({
+        where: eq(userMemoriesContexts.id, contextId),
+      });
+
+      expectVectorToBeClose(updated?.descriptionVector, descriptionVector);
+    });
+
+    it('updates preference vector values including null assignments', async () => {
+      const preferenceId = idGenerator('memory');
+      await serverDB.insert(userMemoriesPreferences).values({
+        conclusionDirectives: 'directive',
+        conclusionDirectivesVector: generateRandomEmbedding(),
+        id: preferenceId,
+        userId,
+      });
+
+      await userMemoryModel.updatePreferenceVectors(preferenceId, {
+        conclusionDirectivesVector: null,
+      });
+
+      const updated = await serverDB.query.userMemoriesPreferences.findFirst({
+        where: eq(userMemoriesPreferences.id, preferenceId),
+      });
+
+      expect(updated?.conclusionDirectivesVector).toBeNull();
+    });
+
+    it('updates identity vectors', async () => {
+      const identityId = idGenerator('memory');
+      await serverDB.insert(userMemoriesIdentities).values({
+        description: 'identity',
+        id: identityId,
+        userId,
+      });
+
+      const descriptionVector = generateRandomEmbedding();
+
+      await userMemoryModel.updateIdentityVectors(identityId, {
+        descriptionVector,
+      });
+
+      const updated = await serverDB.query.userMemoriesIdentities.findFirst({
+        where: eq(userMemoriesIdentities.id, identityId),
+      });
+
+      expectVectorToBeClose(updated?.descriptionVector, descriptionVector);
+    });
+
+    it('updates experience vectors without touching unspecified fields', async () => {
+      const experienceId = idGenerator('memory');
+      const originalSituationVector = generateRandomEmbedding();
+      const originalKeyLearningVector = generateRandomEmbedding();
+      const originalActionVector = generateRandomEmbedding();
+
+      await serverDB.insert(userMemoriesExperiences).values({
+        action: 'action',
+        actionVector: originalActionVector,
+        id: experienceId,
+        keyLearning: 'key learning',
+        keyLearningVector: originalKeyLearningVector,
+        situation: 'situation',
+        situationVector: originalSituationVector,
+        userId,
+      });
+
+      const updatedActionVector = generateRandomEmbedding();
+
+      await userMemoryModel.updateExperienceVectors(experienceId, {
+        actionVector: updatedActionVector,
+      });
+
+      const updated = await serverDB.query.userMemoriesExperiences.findFirst({
+        where: eq(userMemoriesExperiences.id, experienceId),
+      });
+
+      expectVectorToBeClose(updated?.actionVector, updatedActionVector);
+      expectVectorToBeClose(updated?.situationVector, originalSituationVector);
+      expectVectorToBeClose(updated?.keyLearningVector, originalKeyLearningVector);
+    });
+  });
+
+  describe('identity entry operations', () => {
+    it('adds a new identity entry with base memory', async () => {
+      const summaryVector = generateRandomEmbedding();
+      const descriptionVector = generateRandomEmbedding();
+
+      const { identityId, userMemoryId } = await userMemoryModel.addIdentityEntry({
+        base: {
+          memoryCategory: 'profile',
+          memoryLayer: 'identity',
+          memoryType: 'personal-profile',
+          metadata: { meta: 'value' },
+          summary: 'Initial summary',
+          summaryVector1024: summaryVector,
+          title: 'Identity Summary',
+        },
+        identity: {
+          description: 'A detailed description of the user identity',
+          descriptionVector,
+          episodicDate: new Date('2024-01-01T00:00:00.000Z'),
+          metadata: { extracted: ['friend'] },
+          relationship: 'friend',
+          role: 'software engineer',
+          tags: ['tag-a'],
+          type: 'personal',
+        },
+      });
+
+      const baseMemory = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, userMemoryId),
+      });
+      const identityMemory = await serverDB.query.userMemoriesIdentities.findFirst({
+        where: eq(userMemoriesIdentities.id, identityId),
+      });
+
+      expect(baseMemory?.summary).toBe('Initial summary');
+      expectVectorToBeClose(baseMemory?.summaryVector1024, summaryVector);
+      expect(baseMemory?.memoryLayer).toBe('identity');
+      expect(baseMemory?.metadata).toEqual({ meta: 'value' });
+
+      expect(identityMemory?.description).toBe('A detailed description of the user identity');
+      expectVectorToBeClose(identityMemory?.descriptionVector, descriptionVector);
+      expect(identityMemory?.relationship).toBe('friend');
+      expect(identityMemory?.role).toBe('software engineer');
+      expect(identityMemory?.type).toBe('personal');
+      expect(identityMemory?.userMemoryId).toBe(userMemoryId);
+    });
+
+    it('updates identity entry fields with merge strategy', async () => {
+      const { identityId, userMemoryId } = await userMemoryModel.addIdentityEntry({
+        base: {
+          memoryCategory: 'profile',
+          summary: 'Original summary',
+          title: 'Original title',
+        },
+        identity: {
+          description: 'Original identity description',
+          relationship: 'friend',
+          role: 'developer',
+          type: 'personal',
+        },
+      });
+
+      const updated = await userMemoryModel.updateIdentityEntry({
+        identityId,
+        mergeStrategy: MergeStrategyEnum.Merge,
+        base: {
+          summary: 'Updated summary',
+        },
+        identity: {
+          description: 'Updated identity description',
+          relationship: 'mentor',
+        },
+      });
+
+      expect(updated).toBe(true);
+
+      const baseMemory = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, userMemoryId),
+      });
+      const identityMemory = await serverDB.query.userMemoriesIdentities.findFirst({
+        where: eq(userMemoriesIdentities.id, identityId),
+      });
+
+      expect(baseMemory?.summary).toBe('Updated summary');
+      expect(baseMemory?.title).toBe('Original title');
+      expect(identityMemory?.description).toBe('Updated identity description');
+      expect(identityMemory?.relationship).toBe('mentor');
+      expect(identityMemory?.role).toBe('developer');
+    });
+
+    it('replaces identity entry fields and clears unspecified values when mergeStrategy is replace', async () => {
+      const { identityId } = await userMemoryModel.addIdentityEntry({
+        base: {
+          summary: 'Summary to replace',
+          title: 'Title to replace',
+        },
+        identity: {
+          description: 'Description to replace',
+          relationship: 'mentor',
+          role: 'manager',
+          type: 'professional',
+        },
+      });
+
+      const replaced = await userMemoryModel.updateIdentityEntry({
+        identityId,
+        mergeStrategy: MergeStrategyEnum.Replace,
+        identity: {
+          description: 'Fresh description',
+          type: 'personal',
+        },
+      });
+
+      expect(replaced).toBe(true);
+
+      const identityMemory = await serverDB.query.userMemoriesIdentities.findFirst({
+        where: eq(userMemoriesIdentities.id, identityId),
+      });
+
+      expect(identityMemory?.description).toBe('Fresh description');
+      expect(identityMemory?.type).toBe('personal');
+      expect(identityMemory?.relationship).toBeNull();
+      expect(identityMemory?.role).toBeNull();
+    });
+
+    it('removes identity entry and associated base memory', async () => {
+      const { identityId, userMemoryId } = await userMemoryModel.addIdentityEntry({
+        base: {
+          summary: 'Summary to delete',
+        },
+        identity: {
+          description: 'Identity to delete',
+        },
+      });
+
+      const removed = await userMemoryModel.removeIdentityEntry(identityId);
+
+      const baseMemory = await serverDB.query.userMemories.findFirst({
+        where: eq(userMemories.id, userMemoryId),
+      });
+      const identityMemory = await serverDB.query.userMemoriesIdentities.findFirst({
+        where: eq(userMemoriesIdentities.id, identityId),
+      });
+
+      expect(removed).toBe(true);
+      expect(baseMemory).toBeUndefined();
+      expect(identityMemory).toBeUndefined();
+    });
+  });
+
+  describe('access metrics', () => {
+    it('should update accessedAt for each layer table', async () => {
+      const experienceParams = generateRandomCreateUserMemoryExperienceParams();
+      const experienceMemory = await userMemoryModel.create(experienceParams);
+      await serverDB.insert(userMemoriesExperiences).values({
+        ...experienceParams.experience,
+        userId,
+        userMemoryId: experienceMemory.id,
+      });
+
+      const preferenceParams = generateRandomCreateUserMemoryPreferenceParams();
+      const preferenceMemory = await userMemoryModel.create(preferenceParams);
+      await serverDB.insert(userMemoriesPreferences).values({
+        ...preferenceParams.preference,
+        userId,
+        userMemoryId: preferenceMemory.id,
+      });
+
+      const contextParams = generateRandomCreateUserMemoryContextParams();
+      await serverDB.insert(userMemoriesContexts).values({
+        ...contextParams.context,
+        userId,
+        userMemoryIds: [experienceMemory.id, preferenceMemory.id],
+      });
+
+      const beforeContexts = await serverDB.query.userMemoriesContexts.findMany({
+        where: eq(userMemoriesContexts.userId, userId),
+      });
+
+      const beforeExperience = await serverDB.query.userMemoriesExperiences.findFirst({
+        where: eq(userMemoriesExperiences.userMemoryId, experienceMemory.id),
+      });
+      const beforePreference = await serverDB.query.userMemoriesPreferences.findFirst({
+        where: eq(userMemoriesPreferences.userMemoryId, preferenceMemory.id),
+      });
+
+      const beforeBaseMemories = await serverDB.query.userMemories.findMany({
+        where: eq(userMemories.userId, userId),
+      });
+
+      await userMemoryModel.search({ limit: 10 });
+
+      const afterExperience = await serverDB.query.userMemoriesExperiences.findFirst({
+        where: eq(userMemoriesExperiences.userMemoryId, experienceMemory.id),
+      });
+      const afterPreference = await serverDB.query.userMemoriesPreferences.findFirst({
+        where: eq(userMemoriesPreferences.userMemoryId, preferenceMemory.id),
+      });
+      const afterContexts = await serverDB.query.userMemoriesContexts.findMany({
+        where: eq(userMemoriesContexts.userId, userId),
+      });
+      const afterBaseMemoryMap = new Map(
+        (
+          await serverDB.query.userMemories.findMany({
+            where: eq(userMemories.userId, userId),
+          })
+        ).map((memory) => [memory.id, memory]),
+      );
+
+      expect(beforeExperience?.accessedAt?.getTime()).toBeDefined();
+      expect(afterExperience?.accessedAt?.getTime()).toBeDefined();
+      expect(afterExperience!.accessedAt.getTime()).toBeGreaterThanOrEqual(
+        beforeExperience!.accessedAt.getTime(),
+      );
+
+      expect(beforePreference?.accessedAt?.getTime()).toBeDefined();
+      expect(afterPreference?.accessedAt?.getTime()).toBeDefined();
+      expect(afterPreference!.accessedAt.getTime()).toBeGreaterThanOrEqual(
+        beforePreference!.accessedAt.getTime(),
+      );
+
+      beforeContexts.forEach((beforeContext) => {
+        const afterContext = afterContexts.find((ctx) => ctx.id === beforeContext.id);
+        expect(afterContext).toBeDefined();
+        expect(afterContext!.accessedAt.getTime()).toBeGreaterThanOrEqual(
+          beforeContext.accessedAt.getTime(),
+        );
+      });
+
+      const updatedIds = new Set([experienceMemory.id, preferenceMemory.id]);
+
+      for (const before of beforeBaseMemories) {
+        const after = afterBaseMemoryMap.get(before.id);
+        expect(after).toBeDefined();
+        if (updatedIds.has(before.id)) {
+          expect(after!.accessedCount).toBeDefined();
+          expect(after!.accessedCount).toBe((before.accessedCount ?? 0) + 1);
+          expect(after!.accessedAt.getTime()).toBeGreaterThanOrEqual(before.accessedAt.getTime());
+          expect(after!.lastAccessedAt.getTime()).toBeGreaterThanOrEqual(
+            before.lastAccessedAt.getTime(),
+          );
+        } else {
+          expect(after!.accessedCount).toBe(before.accessedCount);
+        }
+      }
+    });
+  });
+});

--- a/packages/database/src/models/userMemory.ts
+++ b/packages/database/src/models/userMemory.ts
@@ -10,10 +10,14 @@ import {
 
 import {
   UserMemoryContext,
+  UserMemoryContextsWithoutVectors,
   UserMemoryExperience,
+  UserMemoryExperiencesWithoutVectors,
+  UserMemoryIdentitiesWithoutVectors,
   UserMemoryIdentity,
   UserMemoryItem,
   UserMemoryPreference,
+  UserMemoryPreferencesWithoutVectors,
   userMemories,
   userMemoriesContexts,
   userMemoriesExperiences,
@@ -115,9 +119,9 @@ export interface SearchUserMemoryWithEmbeddingParams {
 }
 
 export interface UserMemorySearchAggregatedResult {
-  contexts: UserMemoryContext[];
-  experiences: UserMemoryExperience[];
-  preferences: UserMemoryPreference[];
+  contexts: UserMemoryContextsWithoutVectors[];
+  experiences: UserMemoryExperiencesWithoutVectors[];
+  preferences: UserMemoryPreferencesWithoutVectors[];
 }
 
 export interface UpdateUserMemoryVectorsParams {
@@ -777,7 +781,7 @@ export class UserMemoryModel {
     embedding?: number[];
     limit?: number;
     type?: string;
-  }): Promise<UserMemoryContext[]> => {
+  }): Promise<UserMemoryContextsWithoutVectors[]> => {
     const { embedding, limit = 5, type } = params;
     if (limit <= 0) {
       return [];
@@ -791,7 +795,6 @@ export class UserMemoryModel {
         createdAt: userMemoriesContexts.createdAt,
         currentStatus: userMemoriesContexts.currentStatus,
         description: userMemoriesContexts.description,
-        descriptionVector: userMemoriesContexts.descriptionVector,
         id: userMemoriesContexts.id,
         metadata: userMemoriesContexts.metadata,
         scoreImpact: userMemoriesContexts.scoreImpact,
@@ -829,7 +832,7 @@ export class UserMemoryModel {
     embedding?: number[];
     limit?: number;
     type?: string;
-  }): Promise<UserMemoryExperience[]> => {
+  }): Promise<UserMemoryExperiencesWithoutVectors[]> => {
     const { embedding, limit = 5, type } = params;
     if (limit <= 0) {
       return [];
@@ -839,17 +842,14 @@ export class UserMemoryModel {
       .select({
         accessedAt: userMemoriesExperiences.accessedAt,
         action: userMemoriesExperiences.action,
-        actionVector: userMemoriesExperiences.actionVector,
         createdAt: userMemoriesExperiences.createdAt,
         id: userMemoriesExperiences.id,
         keyLearning: userMemoriesExperiences.keyLearning,
-        keyLearningVector: userMemoriesExperiences.keyLearningVector,
         metadata: userMemoriesExperiences.metadata,
         possibleOutcome: userMemoriesExperiences.possibleOutcome,
         reasoning: userMemoriesExperiences.reasoning,
         scoreConfidence: userMemoriesExperiences.scoreConfidence,
         situation: userMemoriesExperiences.situation,
-        situationVector: userMemoriesExperiences.situationVector,
         tags: userMemoriesExperiences.tags,
         type: userMemoriesExperiences.type,
         updatedAt: userMemoriesExperiences.updatedAt,
@@ -882,7 +882,7 @@ export class UserMemoryModel {
     embedding?: number[];
     limit?: number;
     type?: string;
-  }): Promise<UserMemoryPreference[]> => {
+  }): Promise<UserMemoryPreferencesWithoutVectors[]> => {
     const { embedding, limit = 5, type } = params;
     if (limit <= 0) {
       return [];
@@ -892,7 +892,6 @@ export class UserMemoryModel {
       .select({
         accessedAt: userMemoriesPreferences.accessedAt,
         conclusionDirectives: userMemoriesPreferences.conclusionDirectives,
-        conclusionDirectivesVector: userMemoriesPreferences.conclusionDirectivesVector,
         createdAt: userMemoriesPreferences.createdAt,
         id: userMemoriesPreferences.id,
         metadata: userMemoriesPreferences.metadata,
@@ -926,14 +925,14 @@ export class UserMemoryModel {
     return query.limit(limit);
   };
 
-  getAllIdentities = async (): Promise<UserMemoryIdentity[]> => {
+  getAllIdentities = async (): Promise<UserMemoryIdentitiesWithoutVectors[]> => {
     return this.db.query.userMemoriesIdentities.findMany({
       orderBy: [desc(userMemoriesIdentities.createdAt)],
       where: eq(userMemoriesIdentities.userId, this.userId),
     });
   };
 
-  getIdentitiesByType = async (type: string): Promise<UserMemoryIdentity[]> => {
+  getIdentitiesByType = async (type: string): Promise<UserMemoryIdentitiesWithoutVectors[]> => {
     return this.db.query.userMemoriesIdentities.findMany({
       orderBy: [desc(userMemoriesIdentities.createdAt)],
       where: and(

--- a/packages/database/src/models/userMemory.ts
+++ b/packages/database/src/models/userMemory.ts
@@ -1,0 +1,1033 @@
+import { and, cosineDistance, desc, eq, inArray, sql } from 'drizzle-orm';
+
+import {
+  IdentityTypeEnum,
+  LayersEnum,
+  MergeStrategyEnum,
+  RelationshipEnum,
+  TypesEnum,
+} from '@/types/userMemory';
+
+import {
+  UserMemoryContext,
+  UserMemoryExperience,
+  UserMemoryIdentity,
+  UserMemoryItem,
+  UserMemoryPreference,
+  userMemories,
+  userMemoriesContexts,
+  userMemoriesExperiences,
+  userMemoriesIdentities,
+  userMemoriesPreferences,
+} from '../schemas';
+import { LobeChatDatabase } from '../type';
+
+const normalizeRelationshipValue = (input: unknown): RelationshipEnum | null => {
+  if (input === null) return null;
+  if (typeof input !== 'string') return null;
+  const normalized = input.trim().toLowerCase();
+  return Object.values(RelationshipEnum).includes(normalized as RelationshipEnum)
+    ? (normalized as RelationshipEnum)
+    : null;
+};
+
+const normalizeIdentityTypeValue = (input: unknown): IdentityTypeEnum | null => {
+  if (input === null) return null;
+  if (typeof input !== 'string') return null;
+  const normalized = input.trim().toLowerCase();
+  return Object.values(IdentityTypeEnum).includes(normalized as IdentityTypeEnum)
+    ? (normalized as IdentityTypeEnum)
+    : null;
+};
+
+const coerceDate = (input: unknown): Date | null => {
+  if (input === null || input === undefined) return null;
+  if (input instanceof Date) {
+    return Number.isNaN(input.getTime()) ? null : input;
+  }
+  if (typeof input === 'string' || typeof input === 'number') {
+    const date = new Date(input);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+};
+
+export interface BaseCreateUserMemoryParams {
+  details: string;
+  detailsEmbedding?: number[];
+  memoryCategory: string;
+  memoryLayer: LayersEnum;
+  memoryType: TypesEnum;
+  summary: string;
+  summaryEmbedding?: number[];
+  title: string;
+  titleEmbedding?: number[];
+}
+
+export interface CreateUserMemoryContextParams extends BaseCreateUserMemoryParams {
+  context: Omit<
+    UserMemoryContext,
+    'id' | 'userId' | 'createdAt' | 'updatedAt' | 'accessedAt' | 'userMemoryIds'
+  >;
+}
+
+export interface CreateUserMemoryExperienceParams extends BaseCreateUserMemoryParams {
+  experience: Omit<
+    UserMemoryExperience,
+    'id' | 'userId' | 'createdAt' | 'updatedAt' | 'accessedAt' | 'userMemoryId'
+  >;
+}
+
+export interface CreateUserMemoryIdentityParams extends BaseCreateUserMemoryParams {
+  identity: Omit<
+    UserMemoryIdentity,
+    'id' | 'userId' | 'createdAt' | 'updatedAt' | 'accessedAt' | 'userMemoryId'
+  >;
+}
+
+export interface CreateUserMemoryPreferenceParams extends BaseCreateUserMemoryParams {
+  preference: Omit<
+    UserMemoryPreference,
+    'id' | 'userId' | 'createdAt' | 'updatedAt' | 'accessedAt' | 'userMemoryId'
+  >;
+}
+
+export type CreateUserMemoryParams =
+  | CreateUserMemoryContextParams
+  | CreateUserMemoryExperienceParams
+  | CreateUserMemoryIdentityParams
+  | CreateUserMemoryPreferenceParams;
+
+export interface SearchUserMemoryParams {
+  embedding?: number[];
+  limit?: number;
+  limits?: Partial<Record<'contexts' | 'experiences' | 'preferences', number>>;
+  memoryCategory?: string;
+  memoryType?: string;
+  query?: string;
+}
+
+export interface SearchUserMemoryWithEmbeddingParams {
+  embedding: number[];
+  limits?: Partial<Record<'contexts' | 'experiences' | 'preferences', number>>;
+  memoryCategory?: string;
+  memoryType?: string;
+}
+
+export interface UserMemorySearchAggregatedResult {
+  contexts: UserMemoryContext[];
+  experiences: UserMemoryExperience[];
+  preferences: UserMemoryPreference[];
+}
+
+export interface UpdateUserMemoryVectorsParams {
+  detailsVector1024?: number[] | null;
+  summaryVector1024?: number[] | null;
+}
+
+export interface UpdateContextVectorsParams {
+  descriptionVector?: number[] | null;
+  titleVector?: number[] | null;
+}
+
+export interface UpdatePreferenceVectorsParams {
+  conclusionDirectivesVector?: number[] | null;
+}
+
+export interface UpdateIdentityVectorsParams {
+  descriptionVector?: number[] | null;
+}
+
+export interface UpdateExperienceVectorsParams {
+  actionVector?: number[] | null;
+  keyLearningVector?: number[] | null;
+  situationVector?: number[] | null;
+}
+
+export interface IdentityEntryPayload {
+  description?: string | null;
+  descriptionVector?: number[] | null;
+  episodicDate?: string | Date | null;
+  metadata?: Record<string, unknown> | null;
+  relationship?: RelationshipEnum | string | null;
+  role?: string | null;
+  tags?: string[] | null;
+  type?: IdentityTypeEnum | string | null;
+}
+
+export interface IdentityEntryBasePayload {
+  details?: string | null;
+  detailsVector1024?: number[] | null;
+  lastAccessedAt?: string | Date | null;
+  memoryCategory?: string | null;
+  memoryLayer?: string | null;
+  memoryType?: string | null;
+  metadata?: Record<string, unknown> | null;
+  status?: string | null;
+  summary?: string | null;
+  summaryVector1024?: number[] | null;
+  tags?: string[] | null;
+  title?: string | null;
+}
+
+export interface AddIdentityEntryParams {
+  base: IdentityEntryBasePayload;
+  identity: IdentityEntryPayload;
+}
+
+export interface AddIdentityEntryResult {
+  identityId: string;
+  userMemoryId: string;
+}
+
+export interface UpdateIdentityEntryParams {
+  base?: IdentityEntryBasePayload;
+  identity?: IdentityEntryPayload;
+  identityId: string;
+  mergeStrategy?: MergeStrategyEnum;
+}
+
+export class UserMemoryModel {
+  private userId: string;
+  private db: LobeChatDatabase;
+
+  constructor(db: LobeChatDatabase, userId: string) {
+    this.userId = userId;
+    this.db = db;
+  }
+
+  private buildBaseMemoryInsertValues(
+    params: BaseCreateUserMemoryParams,
+    options?: {
+      metadata?: Record<string, unknown> | null;
+      status?: string | null;
+      tags?: string[] | null;
+    },
+  ): typeof userMemories.$inferInsert {
+    const now = new Date();
+
+    return {
+      accessedCount: 0,
+      details: params.details ?? null,
+      detailsVector1024: params.detailsEmbedding ?? null,
+      lastAccessedAt: now,
+      memoryCategory: params.memoryCategory ?? null,
+      memoryLayer: params.memoryLayer,
+      memoryType: params.memoryType ?? null,
+      metadata: options?.metadata ?? null,
+      status: options?.status ?? null,
+      summary: params.summary ?? null,
+      summaryVector1024: params.summaryEmbedding ?? null,
+      tags: options?.tags ?? null,
+      title: params.title ?? null,
+      userId: this.userId,
+    } satisfies typeof userMemories.$inferInsert;
+  }
+
+  create = async (params: CreateUserMemoryParams): Promise<UserMemoryItem> => {
+    const [result] = await this.db
+      .insert(userMemories)
+      .values(this.buildBaseMemoryInsertValues(params))
+      .returning();
+
+    return result;
+  };
+
+  createContextMemory = async (
+    params: CreateUserMemoryContextParams,
+  ): Promise<{ context: UserMemoryContext; memory: UserMemoryItem }> => {
+    return this.db.transaction(async (tx) => {
+      const baseValues = this.buildBaseMemoryInsertValues(params, {
+        metadata: params.context.metadata ?? null,
+        tags: params.context.tags ?? null,
+      });
+
+      const [memory] = await tx.insert(userMemories).values(baseValues).returning();
+      if (!memory) throw new Error('Failed to create user memory context');
+
+      const contextValues = {
+        associatedObjects: params.context.associatedObjects ?? [],
+        associatedSubjects: params.context.associatedSubjects ?? [],
+        currentStatus: params.context.currentStatus ?? null,
+        description: params.context.description ?? null,
+        descriptionVector: params.context.descriptionVector ?? null,
+        metadata: params.context.metadata ?? null,
+        scoreImpact: params.context.scoreImpact ?? null,
+        scoreUrgency: params.context.scoreUrgency ?? null,
+        tags: params.context.tags ?? [],
+        title: params.context.title ?? null,
+        type: params.context.type ?? null,
+        userId: this.userId,
+        userMemoryIds: [memory.id],
+      } satisfies typeof userMemoriesContexts.$inferInsert;
+
+      const [context] = await tx.insert(userMemoriesContexts).values(contextValues).returning();
+
+      return { context, memory };
+    });
+  };
+
+  createExperienceMemory = async (
+    params: CreateUserMemoryExperienceParams,
+  ): Promise<{ experience: UserMemoryExperience; memory: UserMemoryItem }> => {
+    return this.db.transaction(async (tx) => {
+      const baseValues = this.buildBaseMemoryInsertValues(params, {
+        metadata: params.experience.metadata ?? null,
+        tags: params.experience.tags ?? null,
+      });
+
+      const [memory] = await tx.insert(userMemories).values(baseValues).returning();
+      if (!memory) throw new Error('Failed to create user memory experience');
+
+      const experienceValues = {
+        action: params.experience.action ?? null,
+        actionVector: params.experience.actionVector ?? null,
+        keyLearning: params.experience.keyLearning ?? null,
+        keyLearningVector: params.experience.keyLearningVector ?? null,
+        metadata: params.experience.metadata ?? null,
+        possibleOutcome: params.experience.possibleOutcome ?? null,
+        reasoning: params.experience.reasoning ?? null,
+        scoreConfidence: params.experience.scoreConfidence ?? null,
+        situation: params.experience.situation ?? null,
+        situationVector: params.experience.situationVector ?? null,
+        tags: params.experience.tags ?? [],
+        type: params.experience.type ?? params.memoryType ?? null,
+        userId: this.userId,
+        userMemoryId: memory.id,
+      } satisfies typeof userMemoriesExperiences.$inferInsert;
+
+      const [experience] = await tx
+        .insert(userMemoriesExperiences)
+        .values(experienceValues)
+        .returning();
+
+      return { experience, memory };
+    });
+  };
+
+  createPreferenceMemory = async (
+    params: CreateUserMemoryPreferenceParams,
+  ): Promise<{ memory: UserMemoryItem; preference: UserMemoryPreference }> => {
+    return this.db.transaction(async (tx) => {
+      const baseValues = this.buildBaseMemoryInsertValues(params, {
+        metadata: params.preference.metadata ?? null,
+        tags: params.preference.tags ?? null,
+      });
+
+      const [memory] = await tx.insert(userMemories).values(baseValues).returning();
+      if (!memory) throw new Error('Failed to create user memory preference');
+
+      const preferenceValues = {
+        conclusionDirectives: params.preference.conclusionDirectives ?? null,
+        conclusionDirectivesVector: params.preference.conclusionDirectivesVector ?? null,
+        metadata: params.preference.metadata ?? null,
+        scorePriority: params.preference.scorePriority ?? null,
+        suggestions: params.preference.suggestions ?? null,
+        tags: params.preference.tags ?? [],
+        type: params.preference.type ?? params.memoryType ?? null,
+        userId: this.userId,
+        userMemoryId: memory.id,
+      } satisfies typeof userMemoriesPreferences.$inferInsert;
+
+      const [preference] = await tx
+        .insert(userMemoriesPreferences)
+        .values(preferenceValues)
+        .returning();
+
+      return { memory, preference };
+    });
+  };
+
+  search = async (params: SearchUserMemoryParams): Promise<UserMemorySearchAggregatedResult> => {
+    const { embedding, limits } = params;
+
+    const resolvedLimits = {
+      contexts: limits?.contexts,
+      experiences: limits?.experiences,
+      preferences: limits?.preferences,
+    };
+
+    const [experiences, contexts, preferences] = await Promise.all([
+      this.searchExperiences({
+        embedding,
+        limit: resolvedLimits.experiences,
+      }),
+      this.searchContexts({
+        embedding,
+        limit: resolvedLimits.contexts,
+      }),
+      this.searchPreferences({
+        embedding,
+        limit: resolvedLimits.preferences,
+      }),
+    ]);
+
+    const accessedMemoryIds = new Set<string>();
+    experiences.forEach((experience) => {
+      if (experience.userMemoryId) accessedMemoryIds.add(experience.userMemoryId);
+    });
+    preferences.forEach((preference) => {
+      if (preference.userMemoryId) accessedMemoryIds.add(preference.userMemoryId);
+    });
+    const contextLinkIds: string[] = [];
+    contexts.forEach((context) => {
+      const ids = Array.isArray(context.userMemoryIds) ? (context.userMemoryIds as string[]) : [];
+      ids.forEach((id) => accessedMemoryIds.add(id));
+      contextLinkIds.push(context.id);
+    });
+
+    if (accessedMemoryIds.size > 0 || contextLinkIds.length > 0) {
+      await this.updateAccessMetrics([...accessedMemoryIds], {
+        contextIds: contextLinkIds,
+        timestamp: new Date(),
+      });
+    }
+
+    return {
+      contexts,
+      experiences,
+      preferences,
+    };
+  };
+
+  searchWithEmbedding = async (
+    params: SearchUserMemoryWithEmbeddingParams,
+  ): Promise<UserMemorySearchAggregatedResult> => {
+    return this.search(params);
+  };
+
+  findById = async (id: string): Promise<UserMemoryItem | undefined> => {
+    const result = await this.db.query.userMemories.findFirst({
+      where: and(eq(userMemories.id, id), eq(userMemories.userId, this.userId)),
+    });
+
+    if (result) {
+      await this.updateAccessMetrics([id]);
+    }
+
+    return result;
+  };
+
+  update = async (id: string, params: Partial<CreateUserMemoryParams>): Promise<void> => {
+    await this.db
+      .update(userMemories)
+      .set({ ...params, updatedAt: new Date() })
+      .where(and(eq(userMemories.id, id), eq(userMemories.userId, this.userId)));
+  };
+
+  updateUserMemoryVectors = async (
+    id: string,
+    vectors: UpdateUserMemoryVectorsParams,
+  ): Promise<void> => {
+    const vectorUpdates: Partial<typeof userMemories.$inferInsert> = {};
+    if (vectors.detailsVector1024 !== undefined) {
+      vectorUpdates.detailsVector1024 = vectors.detailsVector1024;
+    }
+    if (vectors.summaryVector1024 !== undefined) {
+      vectorUpdates.summaryVector1024 = vectors.summaryVector1024;
+    }
+
+    if (Object.keys(vectorUpdates).length === 0) {
+      return;
+    }
+
+    await this.db
+      .update(userMemories)
+      .set({
+        ...vectorUpdates,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(userMemories.id, id), eq(userMemories.userId, this.userId)));
+  };
+
+  updateContextVectors = async (id: string, vectors: UpdateContextVectorsParams): Promise<void> => {
+    const vectorUpdates: Partial<typeof userMemoriesContexts.$inferInsert> = {};
+    if (vectors.descriptionVector !== undefined) {
+      vectorUpdates.descriptionVector = vectors.descriptionVector;
+    }
+    if (Object.keys(vectorUpdates).length === 0) {
+      return;
+    }
+
+    await this.db
+      .update(userMemoriesContexts)
+      .set({
+        ...vectorUpdates,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(userMemoriesContexts.id, id), eq(userMemoriesContexts.userId, this.userId)));
+  };
+
+  updatePreferenceVectors = async (
+    id: string,
+    vectors: UpdatePreferenceVectorsParams,
+  ): Promise<void> => {
+    const vectorUpdates: Partial<typeof userMemoriesPreferences.$inferInsert> = {};
+    if (vectors.conclusionDirectivesVector !== undefined) {
+      vectorUpdates.conclusionDirectivesVector = vectors.conclusionDirectivesVector;
+    }
+
+    if (Object.keys(vectorUpdates).length === 0) {
+      return;
+    }
+
+    await this.db
+      .update(userMemoriesPreferences)
+      .set({
+        ...vectorUpdates,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(userMemoriesPreferences.id, id), eq(userMemoriesPreferences.userId, this.userId)),
+      );
+  };
+
+  updateIdentityVectors = async (
+    id: string,
+    vectors: UpdateIdentityVectorsParams,
+  ): Promise<void> => {
+    const vectorUpdates: Partial<typeof userMemoriesIdentities.$inferInsert> = {};
+    if (vectors.descriptionVector !== undefined) {
+      vectorUpdates.descriptionVector = vectors.descriptionVector;
+    }
+
+    if (Object.keys(vectorUpdates).length === 0) {
+      return;
+    }
+
+    await this.db
+      .update(userMemoriesIdentities)
+      .set({
+        ...vectorUpdates,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(userMemoriesIdentities.id, id), eq(userMemoriesIdentities.userId, this.userId)),
+      );
+  };
+
+  updateExperienceVectors = async (
+    id: string,
+    vectors: UpdateExperienceVectorsParams,
+  ): Promise<void> => {
+    const vectorUpdates: Partial<typeof userMemoriesExperiences.$inferInsert> = {};
+    if (vectors.actionVector !== undefined) {
+      vectorUpdates.actionVector = vectors.actionVector;
+    }
+    if (vectors.keyLearningVector !== undefined) {
+      vectorUpdates.keyLearningVector = vectors.keyLearningVector;
+    }
+    if (vectors.situationVector !== undefined) {
+      vectorUpdates.situationVector = vectors.situationVector;
+    }
+
+    if (Object.keys(vectorUpdates).length === 0) {
+      return;
+    }
+
+    await this.db
+      .update(userMemoriesExperiences)
+      .set({
+        ...vectorUpdates,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(userMemoriesExperiences.id, id), eq(userMemoriesExperiences.userId, this.userId)),
+      );
+  };
+
+  addIdentityEntry = async (params: AddIdentityEntryParams): Promise<AddIdentityEntryResult> => {
+    const now = new Date();
+
+    return this.db.transaction(async (tx) => {
+      const base = params.base ?? {};
+      const baseValues: typeof userMemories.$inferInsert = {
+        accessedCount: 0,
+        details: base.details ?? null,
+        detailsVector1024: base.detailsVector1024 ?? null,
+        lastAccessedAt: coerceDate(base.lastAccessedAt) ?? now,
+        memoryCategory: base.memoryCategory ?? null,
+        memoryLayer: base.memoryLayer ?? 'identity',
+        memoryType: base.memoryType ?? null,
+        metadata: base.metadata ?? null,
+        status: base.status === undefined ? 'active' : base.status,
+        summary: base.summary ?? null,
+        summaryVector1024: base.summaryVector1024 ?? null,
+        tags: base.tags ?? null,
+        title: base.title ?? null,
+        userId: this.userId,
+      };
+
+      const [userMemoryRecord] = await tx
+        .insert(userMemories)
+        .values(baseValues)
+        .returning({ id: userMemories.id });
+
+      if (!userMemoryRecord) {
+        throw new Error('Failed to insert user memory for identity entry');
+      }
+
+      const identity = params.identity ?? {};
+      const identityValues: typeof userMemoriesIdentities.$inferInsert = {
+        description: identity.description ?? null,
+        descriptionVector: identity.descriptionVector ?? null,
+        episodicDate:
+          identity.episodicDate === undefined ? null : coerceDate(identity.episodicDate),
+        metadata: identity.metadata ?? null,
+        relationship:
+          identity.relationship === undefined
+            ? null
+            : identity.relationship === null
+              ? null
+              : (normalizeRelationshipValue(identity.relationship) ?? null),
+        role: identity.role ?? null,
+        tags: identity.tags ?? null,
+        type:
+          identity.type === undefined
+            ? null
+            : identity.type === null
+              ? null
+              : (normalizeIdentityTypeValue(identity.type) ?? null),
+        userId: this.userId,
+        userMemoryId: userMemoryRecord.id,
+      };
+
+      const [identityRecord] = await tx
+        .insert(userMemoriesIdentities)
+        .values(identityValues)
+        .returning({ id: userMemoriesIdentities.id });
+
+      if (!identityRecord) {
+        throw new Error('Failed to insert identity entry');
+      }
+
+      return {
+        identityId: identityRecord.id,
+        userMemoryId: userMemoryRecord.id,
+      };
+    });
+  };
+
+  updateIdentityEntry = async (params: UpdateIdentityEntryParams): Promise<boolean> => {
+    const mergeStrategy = params.mergeStrategy ?? 'merge';
+
+    return this.db.transaction(async (tx) => {
+      const identity = await tx.query.userMemoriesIdentities.findFirst({
+        where: and(
+          eq(userMemoriesIdentities.id, params.identityId),
+          eq(userMemoriesIdentities.userId, this.userId),
+        ),
+      });
+      if (!identity || !identity.userMemoryId) {
+        return false;
+      }
+
+      const baseUpdate: Partial<typeof userMemories.$inferInsert> = {};
+      const identityUpdate: Partial<typeof userMemoriesIdentities.$inferInsert> = {};
+
+      if (params.base) {
+        const base = params.base;
+
+        const applyBaseField = <
+          K extends keyof IdentityEntryBasePayload,
+          C extends keyof typeof userMemories.$inferInsert,
+        >(
+          sourceKey: K,
+          columnKey: C,
+          transform?: (value: IdentityEntryBasePayload[K]) => (typeof userMemories.$inferInsert)[C],
+        ) => {
+          const value = base[sourceKey];
+          if (value === undefined) return;
+
+          const transformed = transform
+            ? transform(value)
+            : (value as (typeof userMemories.$inferInsert)[C]);
+
+          baseUpdate[columnKey] = (transformed ?? null) as (typeof userMemories.$inferInsert)[C];
+        };
+
+        applyBaseField('details', 'details');
+        applyBaseField('detailsVector1024', 'detailsVector1024');
+        applyBaseField('memoryCategory', 'memoryCategory');
+        applyBaseField('memoryLayer', 'memoryLayer');
+        applyBaseField('memoryType', 'memoryType');
+        applyBaseField('metadata', 'metadata');
+        applyBaseField('status', 'status');
+        applyBaseField('summary', 'summary');
+        applyBaseField('summaryVector1024', 'summaryVector1024');
+        applyBaseField('tags', 'tags');
+        applyBaseField('title', 'title');
+
+        if (base.lastAccessedAt !== undefined) {
+          baseUpdate.lastAccessedAt = coerceDate(base.lastAccessedAt) ?? new Date();
+        }
+
+        if (Object.keys(baseUpdate).length > 0) {
+          baseUpdate.updatedAt = new Date();
+          await tx
+            .update(userMemories)
+            .set(baseUpdate)
+            .where(
+              and(eq(userMemories.id, identity.userMemoryId), eq(userMemories.userId, this.userId)),
+            );
+        }
+      }
+
+      if (params.identity) {
+        const identity = params.identity;
+
+        const applyIdentityField = <
+          K extends keyof IdentityEntryPayload,
+          C extends keyof typeof userMemoriesIdentities.$inferInsert,
+        >(
+          sourceKey: K,
+          columnKey: C,
+          transform?: (
+            value: IdentityEntryPayload[K],
+          ) => (typeof userMemoriesIdentities.$inferInsert)[C],
+        ) => {
+          const value = identity[sourceKey];
+
+          if (mergeStrategy === 'replace') {
+            identityUpdate[columnKey] = (
+              value === undefined
+                ? null
+                : ((transform
+                    ? transform(value)
+                    : (value as (typeof userMemoriesIdentities.$inferInsert)[C])) ?? null)
+            ) as (typeof userMemoriesIdentities.$inferInsert)[C];
+          } else if (value !== undefined) {
+            identityUpdate[columnKey] = (
+              transform
+                ? transform(value)
+                : ((value as (typeof userMemoriesIdentities.$inferInsert)[C]) ?? null)
+            ) as (typeof userMemoriesIdentities.$inferInsert)[C];
+          }
+        };
+
+        applyIdentityField('description', 'description');
+        applyIdentityField('descriptionVector', 'descriptionVector');
+        applyIdentityField('metadata', 'metadata');
+        applyIdentityField('role', 'role');
+        applyIdentityField('tags', 'tags');
+        applyIdentityField('type', 'type', (value) => {
+          if (value === undefined) return null;
+          if (value === null) return null;
+          return normalizeIdentityTypeValue(value) ?? null;
+        });
+        applyIdentityField('relationship', 'relationship', (value) => {
+          if (value === undefined) return null;
+          if (value === null) return null;
+          return normalizeRelationshipValue(value) ?? null;
+        });
+        applyIdentityField('episodicDate', 'episodicDate', (value) => coerceDate(value));
+
+        if (Object.keys(identityUpdate).length > 0) {
+          identityUpdate.updatedAt = new Date();
+          await tx
+            .update(userMemoriesIdentities)
+            .set(identityUpdate)
+            .where(
+              and(
+                eq(userMemoriesIdentities.id, params.identityId),
+                eq(userMemoriesIdentities.userId, this.userId),
+              ),
+            );
+        }
+      }
+
+      return true;
+    });
+  };
+
+  removeIdentityEntry = async (identityId: string): Promise<boolean> => {
+    return this.db.transaction(async (tx) => {
+      const identity = await tx.query.userMemoriesIdentities.findFirst({
+        where: and(
+          eq(userMemoriesIdentities.id, identityId),
+          eq(userMemoriesIdentities.userId, this.userId),
+        ),
+      });
+
+      if (!identity || !identity.userMemoryId) {
+        return false;
+      }
+
+      await tx
+        .delete(userMemories)
+        .where(
+          and(eq(userMemories.id, identity.userMemoryId), eq(userMemories.userId, this.userId)),
+        );
+
+      return true;
+    });
+  };
+
+  delete = async (id: string): Promise<void> => {
+    await this.db
+      .delete(userMemories)
+      .where(and(eq(userMemories.id, id), eq(userMemories.userId, this.userId)));
+  };
+
+  deleteAll = async (): Promise<void> => {
+    await this.db.delete(userMemories).where(eq(userMemories.userId, this.userId));
+  };
+
+  searchContexts = async (params: {
+    embedding?: number[];
+    limit?: number;
+    type?: string;
+  }): Promise<UserMemoryContext[]> => {
+    const { embedding, limit = 5, type } = params;
+    if (limit <= 0) {
+      return [];
+    }
+
+    let query = this.db
+      .select({
+        accessedAt: userMemoriesContexts.accessedAt,
+        associatedObjects: userMemoriesContexts.associatedObjects,
+        associatedSubjects: userMemoriesContexts.associatedSubjects,
+        createdAt: userMemoriesContexts.createdAt,
+        currentStatus: userMemoriesContexts.currentStatus,
+        description: userMemoriesContexts.description,
+        descriptionVector: userMemoriesContexts.descriptionVector,
+        id: userMemoriesContexts.id,
+        metadata: userMemoriesContexts.metadata,
+        scoreImpact: userMemoriesContexts.scoreImpact,
+        scoreUrgency: userMemoriesContexts.scoreUrgency,
+        tags: userMemoriesContexts.tags,
+        title: userMemoriesContexts.title,
+        type: userMemoriesContexts.type,
+        updatedAt: userMemoriesContexts.updatedAt,
+        userId: userMemoriesContexts.userId,
+        userMemoryIds: userMemoriesContexts.userMemoryIds,
+        ...(embedding && {
+          similarity: sql<number>`1 - (${cosineDistance(userMemoriesContexts.descriptionVector, embedding)}) AS similarity`,
+        }),
+      })
+      .from(userMemoriesContexts)
+      .$dynamic();
+
+    const conditions = [eq(userMemoriesContexts.userId, this.userId)];
+    if (type) {
+      conditions.push(eq(userMemoriesContexts.type, type));
+    }
+
+    query = query.where(and(...conditions));
+
+    if (embedding) {
+      query = query.orderBy(desc(sql`similarity`));
+    } else {
+      query = query.orderBy(desc(userMemoriesContexts.createdAt));
+    }
+
+    return query.limit(limit);
+  };
+
+  searchExperiences = async (params: {
+    embedding?: number[];
+    limit?: number;
+    type?: string;
+  }): Promise<UserMemoryExperience[]> => {
+    const { embedding, limit = 5, type } = params;
+    if (limit <= 0) {
+      return [];
+    }
+
+    let query = this.db
+      .select({
+        accessedAt: userMemoriesExperiences.accessedAt,
+        action: userMemoriesExperiences.action,
+        actionVector: userMemoriesExperiences.actionVector,
+        createdAt: userMemoriesExperiences.createdAt,
+        id: userMemoriesExperiences.id,
+        keyLearning: userMemoriesExperiences.keyLearning,
+        keyLearningVector: userMemoriesExperiences.keyLearningVector,
+        metadata: userMemoriesExperiences.metadata,
+        possibleOutcome: userMemoriesExperiences.possibleOutcome,
+        reasoning: userMemoriesExperiences.reasoning,
+        scoreConfidence: userMemoriesExperiences.scoreConfidence,
+        situation: userMemoriesExperiences.situation,
+        situationVector: userMemoriesExperiences.situationVector,
+        tags: userMemoriesExperiences.tags,
+        type: userMemoriesExperiences.type,
+        updatedAt: userMemoriesExperiences.updatedAt,
+        userId: userMemoriesExperiences.userId,
+        userMemoryId: userMemoriesExperiences.userMemoryId,
+        ...(embedding && {
+          similarity: sql<number>`1 - (${cosineDistance(userMemoriesExperiences.situationVector, embedding)}) AS similarity`,
+        }),
+      })
+      .from(userMemoriesExperiences)
+      .$dynamic();
+
+    const conditions = [eq(userMemoriesExperiences.userId, this.userId)];
+    if (type) {
+      conditions.push(eq(userMemoriesExperiences.type, type));
+    }
+
+    query = query.where(and(...conditions));
+
+    if (embedding) {
+      query = query.orderBy(desc(sql`similarity`));
+    } else {
+      query = query.orderBy(desc(userMemoriesExperiences.createdAt));
+    }
+
+    return query.limit(limit);
+  };
+
+  searchPreferences = async (params: {
+    embedding?: number[];
+    limit?: number;
+    type?: string;
+  }): Promise<UserMemoryPreference[]> => {
+    const { embedding, limit = 5, type } = params;
+    if (limit <= 0) {
+      return [];
+    }
+
+    let query = this.db
+      .select({
+        accessedAt: userMemoriesPreferences.accessedAt,
+        conclusionDirectives: userMemoriesPreferences.conclusionDirectives,
+        conclusionDirectivesVector: userMemoriesPreferences.conclusionDirectivesVector,
+        createdAt: userMemoriesPreferences.createdAt,
+        id: userMemoriesPreferences.id,
+        metadata: userMemoriesPreferences.metadata,
+        scorePriority: userMemoriesPreferences.scorePriority,
+        suggestions: userMemoriesPreferences.suggestions,
+        tags: userMemoriesPreferences.tags,
+        type: userMemoriesPreferences.type,
+        updatedAt: userMemoriesPreferences.updatedAt,
+        userId: userMemoriesPreferences.userId,
+        userMemoryId: userMemoriesPreferences.userMemoryId,
+        ...(embedding && {
+          similarity: sql<number>`1 - (${cosineDistance(userMemoriesPreferences.conclusionDirectivesVector, embedding)}) AS similarity`,
+        }),
+      })
+      .from(userMemoriesPreferences)
+      .$dynamic();
+
+    const conditions = [eq(userMemoriesPreferences.userId, this.userId)];
+    if (type) {
+      conditions.push(eq(userMemoriesPreferences.type, type));
+    }
+
+    query = query.where(and(...conditions));
+
+    if (embedding) {
+      query = query.orderBy(desc(sql`similarity`));
+    } else {
+      query = query.orderBy(desc(userMemoriesPreferences.createdAt));
+    }
+
+    return query.limit(limit);
+  };
+
+  getAllIdentities = async (): Promise<UserMemoryIdentity[]> => {
+    return this.db.query.userMemoriesIdentities.findMany({
+      orderBy: [desc(userMemoriesIdentities.createdAt)],
+      where: eq(userMemoriesIdentities.userId, this.userId),
+    });
+  };
+
+  getIdentitiesByType = async (type: string): Promise<UserMemoryIdentity[]> => {
+    return this.db.query.userMemoriesIdentities.findMany({
+      orderBy: [desc(userMemoriesIdentities.createdAt)],
+      where: and(
+        eq(userMemoriesIdentities.userId, this.userId),
+        eq(userMemoriesIdentities.type, type),
+      ),
+    });
+  };
+
+  private updateAccessMetrics = async (
+    memoryIds: string[],
+    options?: { contextIds?: string[]; timestamp?: Date },
+  ): Promise<void> => {
+    const contextIds = options?.contextIds ?? [];
+    if (memoryIds.length === 0 && contextIds.length === 0) return;
+
+    const now = options?.timestamp ?? new Date();
+
+    await this.db.transaction(async (tx) => {
+      if (memoryIds.length > 0) {
+        await tx
+          .update(userMemories)
+          .set({
+            accessedAt: now,
+            accessedCount: sql`${userMemories.accessedCount} + 1`,
+            lastAccessedAt: now,
+          })
+          .where(and(eq(userMemories.userId, this.userId), inArray(userMemories.id, memoryIds)));
+
+        const memories = await tx
+          .select({
+            id: userMemories.id,
+            layer: userMemories.memoryLayer,
+          })
+          .from(userMemories)
+          .where(and(eq(userMemories.userId, this.userId), inArray(userMemories.id, memoryIds)));
+
+        const experienceIds = memories
+          .filter((memory) => memory.layer === 'experience')
+          .map((memory) => memory.id);
+        if (experienceIds.length > 0) {
+          await tx
+            .update(userMemoriesExperiences)
+            .set({ accessedAt: now })
+            .where(
+              and(
+                eq(userMemoriesExperiences.userId, this.userId),
+                inArray(userMemoriesExperiences.userMemoryId, experienceIds),
+              ),
+            );
+        }
+
+        const identityIds = memories
+          .filter((memory) => memory.layer === 'identity')
+          .map((memory) => memory.id);
+        if (identityIds.length > 0) {
+          await tx
+            .update(userMemoriesIdentities)
+            .set({ accessedAt: now })
+            .where(
+              and(
+                eq(userMemoriesIdentities.userId, this.userId),
+                inArray(userMemoriesIdentities.userMemoryId, identityIds),
+              ),
+            );
+        }
+
+        const preferenceIds = memories
+          .filter((memory) => memory.layer === 'preference')
+          .map((memory) => memory.id);
+        if (preferenceIds.length > 0) {
+          await tx
+            .update(userMemoriesPreferences)
+            .set({ accessedAt: now })
+            .where(
+              and(
+                eq(userMemoriesPreferences.userId, this.userId),
+                inArray(userMemoriesPreferences.userMemoryId, preferenceIds),
+              ),
+            );
+        }
+      }
+
+      if (contextIds.length > 0) {
+        await tx
+          .update(userMemoriesContexts)
+          .set({ accessedAt: now })
+          .where(
+            and(
+              eq(userMemoriesContexts.userId, this.userId),
+              inArray(userMemoriesContexts.id, contextIds),
+            ),
+          );
+      }
+    });
+  };
+}

--- a/packages/database/src/schemas/userMemories.ts
+++ b/packages/database/src/schemas/userMemories.ts
@@ -17,7 +17,7 @@ export const userMemories = pgTable(
     memoryCategory: varchar255('memory_category'),
     memoryLayer: varchar255('memory_layer'),
     memoryType: varchar255('memory_type'),
-    metadata: jsonb('metadata'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
     title: varchar255('title'),
@@ -55,7 +55,7 @@ export const userMemoriesContexts = pgTable(
     userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
     userMemoryIds: jsonb('user_memory_ids'),
 
-    metadata: jsonb('metadata'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
     associatedObjects: jsonb('associated_objects'),
@@ -99,7 +99,7 @@ export const userMemoriesPreferences = pgTable(
       onDelete: 'cascade',
     }),
 
-    metadata: jsonb('metadata'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
     conclusionDirectives: text('conclusion_directives'),
@@ -132,7 +132,7 @@ export const userMemoriesIdentities = pgTable(
       onDelete: 'cascade',
     }),
 
-    metadata: jsonb('metadata'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
     type: varchar255('type'),
@@ -165,7 +165,7 @@ export const userMemoriesExperiences = pgTable(
       onDelete: 'cascade',
     }),
 
-    metadata: jsonb('metadata'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
     type: varchar255('type'),
@@ -200,16 +200,33 @@ export const userMemoriesExperiences = pgTable(
 );
 
 export type UserMemoryItem = typeof userMemories.$inferSelect;
+export type UserMemoryItemWithoutVectors = Omit<
+  UserMemoryItem,
+  'summaryVector1024' | 'detailsVector1024'
+>;
 export type NewUserMemory = typeof userMemories.$inferInsert;
 
 export type UserMemoryPreference = typeof userMemoriesPreferences.$inferSelect;
+export type UserMemoryPreferencesWithoutVectors = Omit<
+  UserMemoryPreference,
+  'conclusionDirectivesVector'
+>;
 export type NewUserMemoryPreference = typeof userMemoriesPreferences.$inferInsert;
 
 export type UserMemoryContext = typeof userMemoriesContexts.$inferSelect;
+export type UserMemoryContextsWithoutVectors = Omit<
+  UserMemoryContext,
+  'titleVector' | 'descriptionVector'
+>;
 export type NewUserMemoryContext = typeof userMemoriesContexts.$inferInsert;
 
 export type UserMemoryIdentity = typeof userMemoriesIdentities.$inferSelect;
+export type UserMemoryIdentitiesWithoutVectors = Omit<UserMemoryIdentity, 'descriptionVector'>;
 export type NewUserMemoryIdentity = typeof userMemoriesIdentities.$inferInsert;
 
 export type UserMemoryExperience = typeof userMemoriesExperiences.$inferSelect;
+export type UserMemoryExperiencesWithoutVectors = Omit<
+  UserMemoryExperience,
+  'situationVector' | 'actionVector' | 'keyLearningVector'
+>;
 export type NewUserMemoryExperience = typeof userMemoriesExperiences.$inferInsert;

--- a/packages/database/src/schemas/userMemories.ts
+++ b/packages/database/src/schemas/userMemories.ts
@@ -53,16 +53,15 @@ export const userMemoriesContexts = pgTable(
       .primaryKey(),
 
     userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
-    userMemoryIds: jsonb('user_memory_ids'),
+    userMemoryIds: jsonb('user_memory_ids').$type<string[]>(),
 
     metadata: jsonb('metadata').$type<Record<string, unknown>>(),
     tags: text('tags').array(),
 
-    associatedObjects: jsonb('associated_objects'),
-    associatedSubjects: jsonb('associated_subjects'),
+    associatedObjects: jsonb('associated_objects').$type<Record<string, unknown>[]>(),
+    associatedSubjects: jsonb('associated_subjects').$type<Record<string, unknown>[]>(),
 
     title: text('title'),
-    titleVector: vector('title_vector', { dimensions: 1024 }),
     description: text('description'),
     descriptionVector: vector('description_vector', { dimensions: 1024 }),
 
@@ -75,10 +74,6 @@ export const userMemoriesContexts = pgTable(
     ...timestamps,
   },
   (table) => [
-    index('user_memories_contexts_title_vector_index').using(
-      'hnsw',
-      table.titleVector.op('vector_cosine_ops'),
-    ),
     index('user_memories_contexts_description_vector_index').using(
       'hnsw',
       table.descriptionVector.op('vector_cosine_ops'),

--- a/packages/types/src/user/settings/index.ts
+++ b/packages/types/src/user/settings/index.ts
@@ -7,6 +7,7 @@ import { UserModelProviderConfig } from './modelProvider';
 import { UserSystemAgentConfig } from './systemAgent';
 import { UserToolConfig } from './tool';
 import { UserTTSConfig } from './tts';
+import { UserMemoryConfig } from './userMemory';
 
 export type UserDefaultAgent = LobeAgentSettings;
 
@@ -19,6 +20,7 @@ export * from './modelProvider';
 export * from './sync';
 export * from './systemAgent';
 export * from './tts';
+export * from './userMemory';
 
 /**
  * 配置设置
@@ -33,4 +35,5 @@ export interface UserSettings {
   systemAgent: UserSystemAgentConfig;
   tool: UserToolConfig;
   tts: UserTTSConfig;
+  userMemory: UserMemoryConfig;
 }

--- a/packages/types/src/user/settings/userMemory.ts
+++ b/packages/types/src/user/settings/userMemory.ts
@@ -1,0 +1,8 @@
+export interface UserMemoryConfigItem {
+  model: string;
+  provider: string;
+}
+
+export interface UserMemoryConfig {
+  embeddingModel: UserMemoryConfigItem;
+}

--- a/packages/types/src/userMemory/index.ts
+++ b/packages/types/src/userMemory/index.ts
@@ -1,0 +1,2 @@
+export * from './shared';
+export * from './tools';

--- a/packages/types/src/userMemory/shared.ts
+++ b/packages/types/src/userMemory/shared.ts
@@ -1,0 +1,64 @@
+export enum RelationshipEnum {
+  Aunt = 'aunt',
+  Brother = 'brother',
+  Classmate = 'classmate',
+  Colleague = 'colleague',
+  Couple = 'couple',
+  Coworker = 'coworker',
+  Daughter = 'daughter',
+  Father = 'father',
+  Friend = 'friend',
+  Granddaughter = 'granddaughter',
+  Grandfather = 'grandfather',
+  Grandmother = 'grandmother',
+  Grandson = 'grandson',
+  Husband = 'husband',
+  Manager = 'manager',
+  Mentee = 'mentee',
+  Mentor = 'mentor',
+  Mother = 'mother',
+  Nephew = 'nephew',
+  Niece = 'niece',
+  Other = 'other',
+  Partner = 'partner',
+  Self = 'self',
+  Sibling = 'sibling',
+  Sister = 'sister',
+  Son = 'son',
+  Spouse = 'spouse',
+  Teammate = 'teammate',
+  Uncle = 'uncle',
+  Wife = 'wife',
+}
+
+export enum MergeStrategyEnum {
+  Merge = 'merge',
+  Replace = 'replace',
+}
+
+export enum IdentityTypeEnum {
+  Demographic = 'demographic',
+  Personal = 'personal',
+  Professional = 'professional',
+}
+
+export enum LayersEnum {
+  Activity = 'activity',
+  Context = 'context',
+  Experience = 'experience',
+  Identity = 'identity',
+  Preference = 'preference',
+}
+
+export enum TypesEnum {
+  Activity = 'activity',
+  Context = 'context',
+  Event = 'event',
+  Fact = 'fact',
+  Location = 'location',
+  Other = 'other',
+  People = 'people',
+  Preference = 'preference',
+  Technology = 'technology',
+  Topic = 'topic',
+}

--- a/packages/types/src/userMemory/tools.ts
+++ b/packages/types/src/userMemory/tools.ts
@@ -1,0 +1,241 @@
+import { z } from 'zod';
+
+import { UserMemoryContext, UserMemoryExperience, UserMemoryPreference } from '@/database/schemas';
+
+import {
+  IdentityTypeEnum,
+  LayersEnum,
+  MergeStrategyEnum,
+  RelationshipEnum,
+  TypesEnum,
+} from './shared';
+
+export const addMemoryBaseSchema = z.object({
+  details: z.string().describe('Optional detailed information'),
+  memoryCategory: z
+    .string()
+    .describe(
+      'Category of memory, describes the domain or context the memory belongs to, e.g. talking travel plan counts as `travel` category, all work related memories could be `work` category, except side projects, where we belongs to `project` category',
+    ),
+  // TODO: migrate to .enum() if we could move to
+  // zod v4
+  // Read more: https://zod.dev/api#enum
+  memoryLayer: z
+    .nativeEnum(LayersEnum)
+    .describe(
+      'Memory layer, must be one of `context`, `identity`, `preference`, `experience`, `activity`',
+    ),
+  memoryType: z
+    .nativeEnum(TypesEnum)
+    .describe(
+      'Type of memory, used to describe the specific nature or classification of the memory related to',
+    ),
+  summary: z.string().describe('Concise overview of this specific memory'),
+  title: z.string().describe('Brief descriptive title'),
+});
+
+export type AddMemoryBaseParams = z.infer<typeof addMemoryBaseSchema>;
+
+export const addExperienceMemorySchema = addMemoryBaseSchema.extend({
+  withExperience: z.object({
+    action: z
+      .string()
+      .nullable()
+      .describe('Narrative describing actions taken or behaviors exhibited'),
+    keyLearning: z
+      .string()
+      .nullable()
+      .describe('Narrative describing key insights or lessons learned'),
+    possibleOutcome: z
+      .string()
+      .nullable()
+      .describe('Narrative describing potential outcomes or learnings'),
+    reasoning: z
+      .string()
+      .nullable()
+      .describe('Narrative describing the thought process or motivations'),
+    scoreConfidence: z
+      .number()
+      .nullable()
+      .describe(
+        'Numeric score (0-1 or domain-specific) describing confidence in the experience details',
+      ),
+    situation: z.string().nullable().describe('Narrative describing the situation or event'),
+    tags: z.array(z.string()).describe('Model generated tags that summarize the experience facets'),
+  }),
+});
+
+export type AddExperienceMemoryParams = z.infer<typeof addExperienceMemorySchema>;
+
+export const addContextMemorySchema = addMemoryBaseSchema.extend({
+  withContext: z.object({
+    associatedObjects: z
+      .array(z.object({}))
+      .describe('describing involved roles, entities, or resources'),
+    associatedSubjects: z
+      .array(z.object({}))
+      .describe('describing involved roles, entities, or resources'),
+    currentStatus: z
+      .string()
+      .nullable()
+      .describe("High level status markers (e.g., 'active', 'pending')"),
+    description: z
+      .string()
+      .describe('Rich narrative describing the situation, timeline, or environment'),
+    scoreImpact: z
+      .number()
+      .nullable()
+      .describe('Numeric score (0-1 or domain-specific) describing importance'),
+    scoreUrgency: z
+      .number()
+      .nullable()
+      .describe('Numeric score (0-1 or domain-specific) describing urgency'),
+    tags: z.array(z.string()).describe('Model generated tags that summarize the context themes'),
+    title: z.string().nullable().describe('Optional synthesized context headline'),
+    type: z
+      .string()
+      .nullable()
+      .describe(
+        "High level context archetype (e.g., 'temporarily', 'private', 'questioning', 'formal', 'assistant', 'mentorship')",
+      ),
+  }),
+});
+
+export type AddContextMemoryParams = z.infer<typeof addContextMemorySchema>;
+
+export const addPreferenceMemorySchema = addMemoryBaseSchema.extend({
+  withPreference: z.object({
+    appContext: z
+      .object({
+        app: z.string().nullable().describe('App or product name this applies to'),
+        feature: z.string().nullable(),
+        route: z.string().nullable(),
+        surface: z.string().nullable().describe('e.g., chat, emails, code review, notes'),
+      })
+      .strict()
+      .describe('Application/surface specific preference, if any'),
+    conclusionDirectives: z
+      .string()
+      .describe(
+        "Direct, self-contained instruction to the assistant from the user's perspective (what to do, not how to implement)",
+      ),
+    extractedScopes: z
+      .array(z.string())
+      .describe('describing preference facets and applicable scopes'),
+    originContext: z
+      .object({
+        actor: z.string().nullable().describe("Who stated the preference; use 'User' for the user"),
+        applicableWhen: z.string().nullable().describe('Conditions where this preference applies'),
+        notApplicableWhen: z.string().nullable().describe('Conditions where it does not apply'),
+        scenario: z.string().nullable().describe('Applicable scenario or use case'),
+        trigger: z.string().nullable().describe('What prompted this preference'),
+      })
+      .strict()
+      .describe('Context of how/why this preference was expressed'),
+    scorePriority: z
+      .number()
+      .nullable()
+      .describe('Numeric prioritization weight where higher means more critical to respect'),
+    suggestions: z
+      .array(z.string())
+      .describe('Follow-up actions or assistant guidance derived from the preference'),
+    tags: z.array(z.string()).describe('Model generated tags that summarize the preference facets'),
+    type: z
+      .string()
+      .nullable()
+      .describe("High level preference classification (e.g., 'lifestyle', 'communication')"),
+  }),
+});
+
+export type AddPreferenceMemoryParams = z.infer<typeof addPreferenceMemorySchema>;
+
+export const addIdentityMemorySchema = addMemoryBaseSchema.extend({
+  withIdentity: z.object({
+    description: z
+      .string()
+      .describe(
+        "Rich narrative describing the person's background, roles, and attributes (required)",
+      ),
+    episodicDate: z
+      .string()
+      .nullable()
+      .describe(
+        'Optional ISO 8601 timestamp describing when this identity aspect is most relevant',
+      ),
+    relationship: z
+      .nativeEnum(RelationshipEnum)
+      .describe(
+        "Relationship of this identity to the user. Use 'self' when the identity is the user themselves",
+      ),
+    role: z
+      .string()
+      .nullable()
+      .describe("Short role label (e.g., 'software engineer', 'student', 'manager', 'mentor')"),
+    scoreConfidence: z
+      .number()
+      .nullable()
+      .describe('Model confidence (0-1) that this identity aspect is correct'),
+    sourceEvidence: z
+      .string()
+      .nullable()
+      .describe('Optional short quote or pointer to evidence in the current conversation'),
+    tags: z.array(z.string()).describe('Model generated tags that summarize the identity facets'),
+    type: z.nativeEnum(IdentityTypeEnum).describe('High level identity archetype'),
+  }),
+});
+
+export type AddIdentityMemoryParams = z.infer<typeof addIdentityMemorySchema>;
+
+export const updateIdentityMemorySchema = z.object({
+  id: z.string().describe('The ID of the identity entry to update'),
+  mergeStrategy: z
+    .nativeEnum(MergeStrategyEnum)
+    .describe('replace: overwrite all fields; merge: update only provided fields'),
+  set: z
+    .object({
+      description: z.string().optional(),
+      episodicDate: z.string().nullable().optional(),
+      relationship: z.nativeEnum(RelationshipEnum).optional(),
+      role: z.string().nullable().optional(),
+      scoreConfidence: z.number().nullable().optional(),
+      sourceEvidence: z.string().nullable().optional(),
+      tags: z.array(z.string()).optional(),
+      type: z.string().nullable().optional(),
+    })
+    .strict()
+    .describe('Fields to update'),
+});
+
+export type UpdateIdentityMemoryParams = z.infer<typeof updateIdentityMemorySchema>;
+
+export const removeIdentityMemorySchema = z.object({
+  id: z.string().describe('The ID of the identity entry to remove'),
+  reason: z.string().describe('Brief reasoning: incorrect, obsolete, or duplicate'),
+});
+
+export type RemoveIdentityMemoryParams = z.infer<typeof removeIdentityMemorySchema>;
+
+export const searchMemorySchema = z.object({
+  // TODO: we need to dynamically fetch the available categories/types from the backend
+  // memoryCategory: z.string().optional(),
+  // memoryType: z.string().optional(),
+  query: z.string(),
+  topK: z.object({
+    contexts: z.coerce.number().int().min(0),
+    experiences: z.coerce.number().int().min(0),
+    preferences: z.coerce.number().int().min(0),
+  }),
+});
+
+export type SearchMemoryParams = z.infer<typeof searchMemorySchema>;
+
+export interface SearchMemoryResult {
+  contexts: Array<Omit<UserMemoryContext, 'userId' | 'descriptionVector'>>;
+  experiences: Array<
+    Omit<UserMemoryExperience, 'userId' | 'actionVector' | 'situationVector' | 'keyLearningVector'>
+  >;
+  preferences: Array<Omit<UserMemoryPreference, 'userId' | 'conclusionDirectivesVector'>>;
+}
+
+export type RetrieveMemoryParams = SearchMemoryParams;
+export type RetrieveMemoryResult = SearchMemoryResult;

--- a/src/hooks/useFetchMessages.ts
+++ b/src/hooks/useFetchMessages.ts
@@ -1,24 +1,60 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useSessionStore } from '@/store/session';
 import { sessionSelectors } from '@/store/session/selectors';
+import { useUserMemoryStore } from '@/store/userMemory';
+import { MemoryManifest } from '@/tools/memory';
 
 export const useFetchMessages = () => {
   const isDBInited = useGlobalStore(systemStatusSelectors.isDBInited);
   const sessionId = useSessionStore((s) => s.activeId);
-  const [activeTopicId, useFetchMessages, internal_updateActiveSessionType] = useChatStore((s) => [
-    s.activeTopicId,
-    s.useFetchMessages,
-    s.internal_updateActiveSessionType,
-  ]);
+  const [activeTopicId, useFetchMessages, internal_updateActiveSessionType, activeTopic] =
+    useChatStore((s) => [
+      s.activeTopicId,
+      s.useFetchMessages,
+      s.internal_updateActiveSessionType,
+      topicSelectors.currentActiveTopic(s),
+    ]);
 
   const [currentSession, isGroupSession] = useSessionStore((s) => [
     sessionSelectors.currentSession(s),
     sessionSelectors.isCurrentSessionGroupSession(s),
   ]);
+
+  const enabledPlugins = useAgentStore(agentSelectors.currentAgentPlugins);
+  const [useFetchUserMemory, setActiveMemoryContext] = useUserMemoryStore((s) => [
+    s.useFetchUserMemory,
+    s.setActiveMemoryContext,
+  ]);
+
+  const isMemoryPluginEnabled = useMemo(() => {
+    if (!enabledPlugins) return false;
+
+    return enabledPlugins.includes(MemoryManifest.identifier);
+  }, [enabledPlugins]);
+
+  useEffect(() => {
+    console.log('[useFetchMessages] Updating active memory context', {
+      activeTopic,
+      currentSession,
+      isMemoryPluginEnabled,
+    });
+    if (!isMemoryPluginEnabled) {
+      setActiveMemoryContext(undefined);
+      return;
+    }
+
+    setActiveMemoryContext({
+      session: currentSession,
+      topic: activeTopic,
+    });
+  }, [activeTopic, currentSession, isMemoryPluginEnabled, setActiveMemoryContext]);
 
   // Update active session type when session changes
   useEffect(() => {
@@ -30,4 +66,5 @@ export const useFetchMessages = () => {
   }, [currentSession?.id, currentSession?.type, internal_updateActiveSessionType]);
 
   useFetchMessages(isDBInited, sessionId, activeTopicId, isGroupSession ? 'group' : 'session');
+  useFetchUserMemory(Boolean(isMemoryPluginEnabled && isDBInited && sessionId));
 };

--- a/src/hooks/useFetchMessages.ts
+++ b/src/hooks/useFetchMessages.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { topicSelectors } from '@/store/chat/selectors';
+import { chatSelectors, topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useSessionStore } from '@/store/session';
@@ -14,7 +14,7 @@ import { MemoryManifest } from '@/tools/memory';
 export const useFetchMessages = () => {
   const isDBInited = useGlobalStore(systemStatusSelectors.isDBInited);
   const sessionId = useSessionStore((s) => s.activeId);
-  const [activeTopicId, useFetchMessages, internal_updateActiveSessionType, activeTopic] =
+  const [activeTopicId, fetchMessages, internal_updateActiveSessionType, activeTopic] =
     useChatStore((s) => [
       s.activeTopicId,
       s.useFetchMessages,
@@ -22,16 +22,20 @@ export const useFetchMessages = () => {
       topicSelectors.currentActiveTopic(s),
     ]);
 
+  const latestUserMessage = useChatStore(
+    chatSelectors.latestUserMessage,
+    (prev, next) => prev?.id === next?.id && prev?.content === next?.content,
+  );
+
   const [currentSession, isGroupSession] = useSessionStore((s) => [
     sessionSelectors.currentSession(s),
     sessionSelectors.isCurrentSessionGroupSession(s),
   ]);
 
   const enabledPlugins = useAgentStore(agentSelectors.currentAgentPlugins);
-  const [useFetchUserMemory, setActiveMemoryContext] = useUserMemoryStore((s) => [
-    s.useFetchUserMemory,
-    s.setActiveMemoryContext,
-  ]);
+  const [useFetchUserMemory, setActiveMemoryContext, activeMemoryParams] = useUserMemoryStore(
+    (s) => [s.useFetchUserMemory, s.setActiveMemoryContext, s.activeParams],
+  );
 
   const isMemoryPluginEnabled = useMemo(() => {
     if (!enabledPlugins) return false;
@@ -39,22 +43,31 @@ export const useFetchMessages = () => {
     return enabledPlugins.includes(MemoryManifest.identifier);
   }, [enabledPlugins]);
 
+  const memoryContext = useMemo(() => {
+    if (!isMemoryPluginEnabled || !sessionId) return undefined;
+
+    return {
+      latestMessageContent: latestUserMessage?.content,
+      session: currentSession,
+      topic: activeTopic,
+    };
+  }, [
+    activeTopic,
+    currentSession,
+    isMemoryPluginEnabled,
+    latestUserMessage?.content,
+    latestUserMessage?.id,
+    sessionId,
+  ]);
+
   useEffect(() => {
-    console.log('[useFetchMessages] Updating active memory context', {
-      activeTopic,
-      currentSession,
-      isMemoryPluginEnabled,
-    });
-    if (!isMemoryPluginEnabled) {
+    if (!memoryContext) {
       setActiveMemoryContext(undefined);
       return;
     }
 
-    setActiveMemoryContext({
-      session: currentSession,
-      topic: activeTopic,
-    });
-  }, [activeTopic, currentSession, isMemoryPluginEnabled, setActiveMemoryContext]);
+    setActiveMemoryContext(memoryContext);
+  }, [memoryContext, setActiveMemoryContext]);
 
   // Update active session type when session changes
   useEffect(() => {
@@ -65,6 +78,11 @@ export const useFetchMessages = () => {
     }
   }, [currentSession?.id, currentSession?.type, internal_updateActiveSessionType]);
 
-  useFetchMessages(isDBInited, sessionId, activeTopicId, isGroupSession ? 'group' : 'session');
-  useFetchUserMemory(Boolean(isMemoryPluginEnabled && isDBInited && sessionId));
+  fetchMessages(isDBInited, sessionId, activeTopicId, isGroupSession ? 'group' : 'session');
+
+  const shouldFetchUserMemory = Boolean(
+    isMemoryPluginEnabled && isDBInited && sessionId && activeMemoryParams,
+  );
+
+  useFetchUserMemory(shouldFetchUserMemory);
 };

--- a/src/server/routers/lambda/index.ts
+++ b/src/server/routers/lambda/index.ts
@@ -31,6 +31,7 @@ import { threadRouter } from './thread';
 import { topicRouter } from './topic';
 import { uploadRouter } from './upload';
 import { userRouter } from './user';
+import { userMemoriesRouter } from './userMemories';
 
 export const lambdaRouter = router({
   agent: agentRouter,
@@ -62,6 +63,7 @@ export const lambdaRouter = router({
   topic: topicRouter,
   upload: uploadRouter,
   user: userRouter,
+  userMemories: userMemoriesRouter,
 });
 
 export type LambdaRouter = typeof lambdaRouter;

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getServerDB } from '@/database/core/db-adaptor';
+import { UserMemoryModel } from '@/database/models/userMemory';
+import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+
+import { userMemoriesRouter } from './userMemories';
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn(),
+}));
+
+vi.mock('@/server/globalConfig', () => ({
+  getServerDefaultFilesConfig: vi.fn().mockReturnValue({
+    embeddingModel: { model: 'text-embedding-3-small' },
+  }),
+}));
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeWithUserPayload: vi.fn(),
+}));
+
+vi.mock('@lobechat/utils/server', () => ({
+  getXorPayload: vi.fn().mockReturnValue({ userId: 'test-user' }),
+}));
+
+vi.mock('@/database/models/userMemory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/database/models/userMemory')>();
+  return {
+    ...actual,
+    UserMemoryModel: vi.fn(),
+  } satisfies typeof import('@/database/models/userMemory');
+});
+
+const embeddingsMock = vi.fn();
+const mockCtx = { authorizationHeader: 'Bearer mock-token', userId: 'test-user' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  embeddingsMock.mockImplementation(async ({ input }: { input: string[] | string }) => {
+    const items = Array.isArray(input) ? input : [input];
+    return items.map((_, index) => [index + 1]);
+  });
+
+  vi.mocked(initModelRuntimeWithUserPayload).mockResolvedValue({
+    embeddings: embeddingsMock,
+  } as any);
+});
+
+describe('memoryRouter.reEmbedMemories', () => {
+  it('re-embeds memories across tables and returns aggregate stats', async () => {
+    const updateUserMemoryVectors = vi.fn().mockResolvedValue(undefined);
+    const updateContextVectors = vi.fn().mockResolvedValue(undefined);
+    const updatePreferenceVectors = vi.fn().mockResolvedValue(undefined);
+    const updateIdentityVectors = vi.fn().mockResolvedValue(undefined);
+    const updateExperienceVectors = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          updateContextVectors,
+          updateExperienceVectors,
+          updateIdentityVectors,
+          updatePreferenceVectors,
+          updateUserMemoryVectors,
+        }) as any,
+    );
+
+    const userMemoriesRows = [{ id: 'memory-1', details: 'detail text', summary: 'summary text' }];
+    const contextsRows = [{ id: 'context-1', description: 'context text' }];
+    const preferencesRows = [{ id: 'preference-1', conclusionDirectives: 'directive text' }];
+    const identitiesRows = [{ id: 'identity-1', description: 'identity text' }];
+    const experiencesRows = [
+      {
+        action: 'action text',
+        id: 'experience-1',
+        keyLearning: 'learning text',
+        situation: 'situation text',
+      },
+    ];
+
+    const dbStub = {
+      query: {
+        userMemories: {
+          findMany: vi.fn().mockResolvedValue(userMemoriesRows),
+        },
+        userMemoriesContexts: {
+          findMany: vi.fn().mockResolvedValue(contextsRows),
+        },
+        userMemoriesExperiences: {
+          findMany: vi.fn().mockResolvedValue(experiencesRows),
+        },
+        userMemoriesIdentities: {
+          findMany: vi.fn().mockResolvedValue(identitiesRows),
+        },
+        userMemoriesPreferences: {
+          findMany: vi.fn().mockResolvedValue(preferencesRows),
+        },
+      },
+    } as const;
+
+    vi.mocked(getServerDB).mockResolvedValue(dbStub as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    const result = await caller.reEmbedMemories();
+
+    expect(result.success).toBe(true);
+    expect(result.aggregate).toEqual({ failed: 0, skipped: 0, succeeded: 5, total: 5 });
+    expect(result.results?.userMemories).toEqual({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
+    expect(result.results?.contexts).toEqual({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
+    expect(result.results?.preferences).toEqual({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
+    expect(result.results?.identities).toEqual({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
+    expect(result.results?.experiences).toEqual({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
+
+    expect(updateUserMemoryVectors).toHaveBeenCalledWith('memory-1', {
+      detailsVector1024: [2],
+      summaryVector1024: [1],
+    });
+    expect(updateContextVectors).toHaveBeenCalledWith('context-1', {
+      descriptionVector: [1],
+    });
+    expect(updatePreferenceVectors).toHaveBeenCalledWith('preference-1', {
+      conclusionDirectivesVector: [1],
+    });
+    expect(updateIdentityVectors).toHaveBeenCalledWith('identity-1', {
+      descriptionVector: [1],
+    });
+    expect(updateExperienceVectors).toHaveBeenCalledWith('experience-1', {
+      actionVector: [2],
+      keyLearningVector: [3],
+      situationVector: [1],
+    });
+
+    expect(embeddingsMock).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('userMemories.retrieveMemory', () => {
+  it('returns aggregated memory search results', async () => {
+    const searchWithEmbedding = vi.fn().mockResolvedValue({
+      contexts: [
+        {
+          accessedAt: new Date('2024-01-01T00:00:00.000Z'),
+          associatedObjects: [{ name: 'Roadmap' }],
+          associatedSubjects: [{ name: 'Atlas Team' }],
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          currentStatus: 'active',
+          description: 'Coordinating weekly syncs for Project Atlas',
+          id: 'ctx-1',
+          metadata: { priority: 'high' },
+          scoreImpact: 0.9,
+          scoreUrgency: 0.6,
+          tags: ['project', 'atlas'],
+          title: 'Project Atlas coordination',
+          type: 'project',
+          updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+          userMemoryIds: ['mem-1'],
+        },
+      ],
+      experiences: [
+        {
+          accessedAt: new Date('2024-01-03T00:00:00.000Z'),
+          action: 'Facilitated sprint planning',
+          createdAt: new Date('2024-01-02T00:00:00.000Z'),
+          id: 'exp-1',
+          keyLearning: 'Team wants clearer milestones',
+          metadata: { feedback: 'positive' },
+          possibleOutcome: 'Improved roadmap transparency',
+          reasoning: 'Helps unblock design team',
+          scoreConfidence: 0.8,
+          situation: 'Sprint 5 planning',
+          tags: ['planning'],
+          type: 'meeting',
+          updatedAt: new Date('2024-01-02T12:00:00.000Z'),
+          userMemoryId: 'mem-2',
+        },
+      ],
+      preferences: [
+        {
+          accessedAt: new Date('2024-01-03T00:00:00.000Z'),
+          conclusionDirectives: 'Always provide concise weekly status updates for Project Atlas',
+          createdAt: new Date('2024-01-02T00:00:00.000Z'),
+          id: 'pref-1',
+          metadata: { channel: 'email' },
+          scorePriority: 0.7,
+          suggestions: ['Prepare summary every Friday'],
+          tags: ['communication'],
+          type: 'workflow',
+          updatedAt: new Date('2024-01-02T12:00:00.000Z'),
+          userMemoryId: 'mem-3',
+        },
+      ],
+    });
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          searchWithEmbedding,
+        }) as any,
+    );
+
+    vi.mocked(getServerDB).mockResolvedValue({
+      query: {},
+    } as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    const result = await caller.searchMemory({
+      limit: '5',
+      memoryCategory: 'work',
+      memoryType: 'project',
+      query: 'Project Atlas',
+      topK: { contexts: 1, experiences: 1, preferences: 1 },
+    });
+
+    expect(embeddingsMock).toHaveBeenCalledTimes(1);
+    expect(searchWithEmbedding).toHaveBeenCalledWith({
+      embedding: [1],
+      limit: 5,
+      limits: { contexts: 1, experiences: 1, preferences: 1 },
+      memoryCategory: 'work',
+      memoryType: 'project',
+    });
+
+    expect(result.contexts[0]).toMatchObject({
+      id: 'ctx-1',
+      title: 'Project Atlas coordination',
+      currentStatus: 'active',
+    });
+    expect(result.experiences[0]).toMatchObject({
+      id: 'exp-1',
+      situation: 'Sprint 5 planning',
+    });
+    expect(result.preferences[0]).toMatchObject({
+      id: 'pref-1',
+      conclusionDirectives: 'Always provide concise weekly status updates for Project Atlas',
+    });
+  });
+});

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -209,9 +209,6 @@ describe('userMemories.retrieveMemory', () => {
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
     const result = await caller.searchMemory({
-      limit: '5',
-      memoryCategory: 'work',
-      memoryType: 'project',
       query: 'Project Atlas',
       topK: { contexts: 1, experiences: 1, preferences: 1 },
     });

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -1,0 +1,942 @@
+import { type SQL, and, asc, eq, gte, lte } from 'drizzle-orm';
+import { ModelProvider } from 'model-bank';
+import pMap from 'p-map';
+import { z } from 'zod';
+
+import { DEFAULT_FILE_EMBEDDING_MODEL_ITEM } from '@/const/settings/knowledge';
+import { IdentityEntryPayload, UserMemoryModel } from '@/database/models/userMemory';
+import {
+  userMemories,
+  userMemoriesContexts,
+  userMemoriesExperiences,
+  userMemoriesIdentities,
+  userMemoriesPreferences,
+} from '@/database/schemas';
+import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { keyVaults, serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { getServerDefaultFilesConfig } from '@/server/globalConfig';
+import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import { ClientSecretPayload } from '@/types/auth';
+import {
+  SearchMemoryResult,
+  addContextMemorySchema,
+  addExperienceMemorySchema,
+  addIdentityMemorySchema,
+  addPreferenceMemorySchema,
+  removeIdentityMemorySchema,
+  searchMemorySchema,
+  updateIdentityMemorySchema,
+} from '@/types/userMemory';
+
+const EMBEDDING_VECTOR_DIMENSION = 1024;
+const EMPTY_SEARCH_RESULT: SearchMemoryResult = {
+  contexts: [],
+  experiences: [],
+  preferences: [],
+};
+
+type MemorySearchContext = {
+  jwtPayload: ClientSecretPayload;
+  memoryModel: UserMemoryModel;
+};
+
+type MemorySearchResult = Awaited<ReturnType<UserMemoryModel['searchWithEmbedding']>>;
+
+const mapMemorySearchResult = (layeredResults: MemorySearchResult): SearchMemoryResult => {
+  return {
+    contexts: layeredResults.contexts.map((context) => ({
+      accessedAt: context.accessedAt,
+      associatedObjects: context.associatedObjects,
+      associatedSubjects: context.associatedSubjects,
+      createdAt: context.createdAt,
+      currentStatus: context.currentStatus,
+      description: context.description,
+      id: context.id,
+      metadata: context.metadata,
+      scoreImpact: context.scoreImpact,
+      scoreUrgency: context.scoreUrgency,
+      tags: context.tags,
+      title: context.title,
+      type: context.type,
+      updatedAt: context.updatedAt,
+      userMemoryIds: Array.isArray(context.userMemoryIds)
+        ? (context.userMemoryIds as string[])
+        : null,
+    })),
+    experiences: layeredResults.experiences.map((experience) => ({
+      accessedAt: experience.accessedAt,
+      action: experience.action,
+      createdAt: experience.createdAt,
+      id: experience.id,
+      keyLearning: experience.keyLearning,
+      metadata: experience.metadata,
+      possibleOutcome: experience.possibleOutcome,
+      reasoning: experience.reasoning,
+      scoreConfidence: experience.scoreConfidence,
+      situation: experience.situation,
+      tags: experience.tags,
+      type: experience.type,
+      updatedAt: experience.updatedAt,
+      userMemoryId: experience.userMemoryId,
+    })),
+    preferences: layeredResults.preferences.map((preference) => ({
+      accessedAt: preference.accessedAt,
+      conclusionDirectives: preference.conclusionDirectives,
+      createdAt: preference.createdAt,
+      id: preference.id,
+      metadata: preference.metadata,
+      scorePriority: preference.scorePriority,
+      suggestions: preference.suggestions,
+      tags: preference.tags,
+      type: preference.type,
+      updatedAt: preference.updatedAt,
+      userMemoryId: preference.userMemoryId,
+    })),
+  } satisfies SearchMemoryResult;
+};
+
+const searchUserMemories = async (
+  ctx: MemorySearchContext,
+  input: z.infer<typeof searchMemorySchema>,
+): Promise<SearchMemoryResult> => {
+  const agentRuntime = await initModelRuntimeWithUserPayload(ModelProvider.OpenAI, ctx.jwtPayload);
+
+  const { model: embeddingModel } =
+    getServerDefaultFilesConfig().embeddingModel || DEFAULT_FILE_EMBEDDING_MODEL_ITEM;
+
+  const queryEmbeddings = await agentRuntime.embeddings({
+    dimensions: EMBEDDING_VECTOR_DIMENSION,
+    input: input.query,
+    model: embeddingModel,
+  });
+
+  const limit = input.limit ? parseInt(input.limit, 10) : 5;
+  const limits = {
+    contexts: input.topK?.contexts,
+    experiences: input.topK?.experiences,
+    preferences: input.topK?.preferences,
+  };
+
+  const layeredResults = await ctx.memoryModel.searchWithEmbedding({
+    embedding: queryEmbeddings?.[0] || [],
+    limit,
+    limits,
+    memoryCategory: input.memoryCategory,
+    memoryType: input.memoryType,
+  });
+
+  return mapMemorySearchResult(layeredResults);
+};
+
+const getEmbeddingRuntime = async (jwtPayload: ClientSecretPayload) => {
+  const agentRuntime = await initModelRuntimeWithUserPayload(ModelProvider.OpenAI, jwtPayload);
+  const { model: embeddingModel } =
+    getServerDefaultFilesConfig().embeddingModel || DEFAULT_FILE_EMBEDDING_MODEL_ITEM;
+
+  return { agentRuntime, embeddingModel };
+};
+
+const createEmbedder = (agentRuntime: any, embeddingModel: string) => {
+  return async (value?: string | null): Promise<number[] | undefined> => {
+    if (!value || value.trim().length === 0) return undefined;
+
+    const embeddings = await agentRuntime.embeddings({
+      dimensions: EMBEDDING_VECTOR_DIMENSION,
+      input: value,
+      model: embeddingModel,
+    });
+
+    return embeddings?.[0];
+  };
+};
+
+const REEMBED_TABLE_KEYS = [
+  'userMemories',
+  'contexts',
+  'preferences',
+  'identities',
+  'experiences',
+] as const;
+type ReEmbedTableKey = (typeof REEMBED_TABLE_KEYS)[number];
+
+const reEmbedInputSchema = z.object({
+  concurrency: z.coerce.number().int().min(1).max(50).optional(),
+  endDate: z.coerce.date().optional(),
+  limit: z.coerce.number().int().min(1).optional(),
+  only: z.array(z.enum(REEMBED_TABLE_KEYS)).optional(),
+  startDate: z.coerce.date().optional(),
+});
+
+interface ReEmbedStats {
+  failed: number;
+  skipped: number;
+  succeeded: number;
+  total: number;
+}
+
+const combineConditions = (conditions: Array<SQL | undefined>): SQL | undefined => {
+  const filtered = conditions.filter((condition): condition is SQL => condition !== undefined);
+  if (filtered.length === 0) return undefined;
+  if (filtered.length === 1) return filtered[0];
+
+  return and(...filtered);
+};
+
+const normalizeEmbeddable = (value?: string | null): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const memoryProcedure = authedProcedure
+  .use(serverDatabase)
+  .use(keyVaults)
+  .use(async (opts) => {
+    const { ctx } = opts;
+    return opts.next({
+      ctx: {
+        memoryModel: new UserMemoryModel(ctx.serverDB, ctx.userId),
+      },
+    });
+  });
+
+export const userMemoriesRouter = router({
+  // REVIEW：根据当前 topic 直接提取记忆
+
+  // REVIEW： 我们需要一个既可以 cron 也可以主动用户触发进行「每日/每周/每隔一段时间的」记忆提取/生成的函数实现
+  // REVIEW： 定时任务
+  // 不用 tRPC，直接 server/service
+  // 可以参考 https://github.com/lobehub/lobe-chat-cloud/blob/886ff2fcd44b7b00a3aa8906f84914a6dcaa1815/src/app/(backend)/cron/reset-budgets/route.ts#L214
+
+  reEmbedMemories: memoryProcedure
+    .input(reEmbedInputSchema.optional())
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const options = input ?? {};
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const concurrency = options.concurrency ?? 10;
+        const shouldProcess = (key: ReEmbedTableKey) =>
+          !options.only || options.only.length === 0 || options.only.includes(key);
+
+        const embedTexts = async (texts: string[]): Promise<number[][]> => {
+          if (texts.length === 0) return [];
+
+          const response = await agentRuntime.embeddings({
+            dimensions: EMBEDDING_VECTOR_DIMENSION,
+            input: texts,
+            model: embeddingModel,
+          });
+
+          if (!response || response.length !== texts.length) {
+            throw new Error('Embedding response length mismatch');
+          }
+
+          return response;
+        };
+
+        const results: Partial<Record<ReEmbedTableKey, ReEmbedStats>> = {};
+
+        const run = async (key: ReEmbedTableKey, handler: () => Promise<ReEmbedStats>) => {
+          if (!shouldProcess(key)) return;
+          results[key] = await handler();
+        };
+
+        // Individual re-embed handlers are appended below.
+        await run('userMemories', async () => {
+          const where = combineConditions([
+            eq(userMemories.userId, ctx.userId),
+            options.startDate ? gte(userMemories.createdAt, options.startDate) : undefined,
+            options.endDate ? lte(userMemories.createdAt, options.endDate) : undefined,
+          ]);
+
+          const rows = await ctx.serverDB.query.userMemories.findMany({
+            columns: { details: true, id: true, summary: true },
+            limit: options.limit,
+            orderBy: [asc(userMemories.createdAt)],
+            where,
+          });
+
+          let succeeded = 0;
+          let failed = 0;
+          let skipped = 0;
+
+          await pMap(
+            rows,
+            async (row) => {
+              const summaryText = normalizeEmbeddable(row.summary);
+              const detailsText = normalizeEmbeddable(row.details);
+
+              try {
+                if (!summaryText && !detailsText) {
+                  await ctx.memoryModel.updateUserMemoryVectors(row.id, {
+                    detailsVector1024: null,
+                    summaryVector1024: null,
+                  });
+                  skipped += 1;
+                  return;
+                }
+
+                const inputs: string[] = [];
+                if (summaryText) inputs.push(summaryText);
+                if (detailsText) inputs.push(detailsText);
+
+                const embeddings = await embedTexts(inputs);
+                let embedIndex = 0;
+
+                const summaryVector = summaryText ? (embeddings[embedIndex++] ?? null) : null;
+                const detailsVector = detailsText ? (embeddings[embedIndex++] ?? null) : null;
+
+                await ctx.memoryModel.updateUserMemoryVectors(row.id, {
+                  detailsVector1024: detailsVector,
+                  summaryVector1024: summaryVector,
+                });
+
+                succeeded += 1;
+              } catch (err) {
+                failed += 1;
+                console.error(
+                  `[memoryRouter.reEmbed] Failed to re-embed user memory ${row.id}`,
+                  err,
+                );
+              }
+            },
+            { concurrency },
+          );
+
+          return {
+            failed,
+            skipped,
+            succeeded,
+            total: rows.length,
+          } satisfies ReEmbedStats;
+        });
+
+        await run('contexts', async () => {
+          const where = combineConditions([
+            eq(userMemoriesContexts.userId, ctx.userId),
+            options.startDate ? gte(userMemoriesContexts.createdAt, options.startDate) : undefined,
+            options.endDate ? lte(userMemoriesContexts.createdAt, options.endDate) : undefined,
+          ]);
+
+          const rows = await ctx.serverDB.query.userMemoriesContexts.findMany({
+            columns: { description: true, id: true },
+            limit: options.limit,
+            orderBy: [asc(userMemoriesContexts.createdAt)],
+            where,
+          });
+
+          let succeeded = 0;
+          let failed = 0;
+          let skipped = 0;
+
+          await pMap(
+            rows,
+            async (row) => {
+              const description = normalizeEmbeddable(row.description);
+
+              try {
+                if (!description) {
+                  await ctx.memoryModel.updateContextVectors(row.id, {
+                    descriptionVector: null,
+                  });
+                  skipped += 1;
+                  return;
+                }
+
+                const [embedding] = await embedTexts([description]);
+
+                await ctx.memoryModel.updateContextVectors(row.id, {
+                  descriptionVector: embedding ?? null,
+                });
+                succeeded += 1;
+              } catch (err) {
+                failed += 1;
+                console.error(`[memoryRouter.reEmbed] Failed to re-embed context ${row.id}`, err);
+              }
+            },
+            { concurrency },
+          );
+
+          return {
+            failed,
+            skipped,
+            succeeded,
+            total: rows.length,
+          } satisfies ReEmbedStats;
+        });
+
+        await run('preferences', async () => {
+          const where = combineConditions([
+            eq(userMemoriesPreferences.userId, ctx.userId),
+            options.startDate
+              ? gte(userMemoriesPreferences.createdAt, options.startDate)
+              : undefined,
+            options.endDate ? lte(userMemoriesPreferences.createdAt, options.endDate) : undefined,
+          ]);
+
+          const rows = await ctx.serverDB.query.userMemoriesPreferences.findMany({
+            columns: { conclusionDirectives: true, id: true },
+            limit: options.limit,
+            orderBy: [asc(userMemoriesPreferences.createdAt)],
+            where,
+          });
+
+          let succeeded = 0;
+          let failed = 0;
+          let skipped = 0;
+
+          await pMap(
+            rows,
+            async (row) => {
+              const directives = normalizeEmbeddable(row.conclusionDirectives);
+
+              try {
+                if (!directives) {
+                  await ctx.memoryModel.updatePreferenceVectors(row.id, {
+                    conclusionDirectivesVector: null,
+                  });
+                  skipped += 1;
+                  return;
+                }
+
+                const [embedding] = await embedTexts([directives]);
+                await ctx.memoryModel.updatePreferenceVectors(row.id, {
+                  conclusionDirectivesVector: embedding ?? null,
+                });
+                succeeded += 1;
+              } catch (err) {
+                failed += 1;
+                console.error(
+                  `[memoryRouter.reEmbed] Failed to re-embed preference ${row.id}`,
+                  err,
+                );
+              }
+            },
+            { concurrency },
+          );
+
+          return {
+            failed,
+            skipped,
+            succeeded,
+            total: rows.length,
+          } satisfies ReEmbedStats;
+        });
+
+        await run('identities', async () => {
+          const where = combineConditions([
+            eq(userMemoriesIdentities.userId, ctx.userId),
+            options.startDate
+              ? gte(userMemoriesIdentities.createdAt, options.startDate)
+              : undefined,
+            options.endDate ? lte(userMemoriesIdentities.createdAt, options.endDate) : undefined,
+          ]);
+
+          const rows = await ctx.serverDB.query.userMemoriesIdentities.findMany({
+            columns: { description: true, id: true },
+            limit: options.limit,
+            orderBy: [asc(userMemoriesIdentities.createdAt)],
+            where,
+          });
+
+          let succeeded = 0;
+          let failed = 0;
+          let skipped = 0;
+
+          await pMap(
+            rows,
+            async (row) => {
+              const description = normalizeEmbeddable(row.description);
+
+              try {
+                if (!description) {
+                  await ctx.memoryModel.updateIdentityVectors(row.id, {
+                    descriptionVector: null,
+                  });
+                  skipped += 1;
+                  return;
+                }
+
+                const [embedding] = await embedTexts([description]);
+                await ctx.memoryModel.updateIdentityVectors(row.id, {
+                  descriptionVector: embedding ?? null,
+                });
+                succeeded += 1;
+              } catch (err) {
+                failed += 1;
+                console.error(`[memoryRouter.reEmbed] Failed to re-embed identity ${row.id}`, err);
+              }
+            },
+            { concurrency },
+          );
+
+          return {
+            failed,
+            skipped,
+            succeeded,
+            total: rows.length,
+          } satisfies ReEmbedStats;
+        });
+
+        await run('experiences', async () => {
+          const where = combineConditions([
+            eq(userMemoriesExperiences.userId, ctx.userId),
+            options.startDate
+              ? gte(userMemoriesExperiences.createdAt, options.startDate)
+              : undefined,
+            options.endDate ? lte(userMemoriesExperiences.createdAt, options.endDate) : undefined,
+          ]);
+
+          const rows = await ctx.serverDB.query.userMemoriesExperiences.findMany({
+            columns: { action: true, id: true, keyLearning: true, situation: true },
+            limit: options.limit,
+            orderBy: [asc(userMemoriesExperiences.createdAt)],
+            where,
+          });
+
+          let succeeded = 0;
+          let failed = 0;
+          let skipped = 0;
+
+          await pMap(
+            rows,
+            async (row) => {
+              const situation = normalizeEmbeddable(row.situation);
+              const action = normalizeEmbeddable(row.action);
+              const keyLearning = normalizeEmbeddable(row.keyLearning);
+
+              try {
+                if (!situation && !action && !keyLearning) {
+                  await ctx.memoryModel.updateExperienceVectors(row.id, {
+                    actionVector: null,
+                    keyLearningVector: null,
+                    situationVector: null,
+                  });
+                  skipped += 1;
+                  return;
+                }
+
+                const inputs: string[] = [];
+                if (situation) inputs.push(situation);
+                if (action) inputs.push(action);
+                if (keyLearning) inputs.push(keyLearning);
+
+                const embeddings = await embedTexts(inputs);
+                let embedIndex = 0;
+
+                const situationVector = situation ? (embeddings[embedIndex++] ?? null) : null;
+                const actionVector = action ? (embeddings[embedIndex++] ?? null) : null;
+                const keyLearningVector = keyLearning ? (embeddings[embedIndex++] ?? null) : null;
+
+                await ctx.memoryModel.updateExperienceVectors(row.id, {
+                  actionVector,
+                  keyLearningVector,
+                  situationVector,
+                });
+                succeeded += 1;
+              } catch (err) {
+                failed += 1;
+                console.error(
+                  `[memoryRouter.reEmbed] Failed to re-embed experience ${row.id}`,
+                  err,
+                );
+              }
+            },
+            { concurrency },
+          );
+
+          return {
+            failed,
+            skipped,
+            succeeded,
+            total: rows.length,
+          } satisfies ReEmbedStats;
+        });
+
+        const processedEntries = Object.entries(results) as Array<[ReEmbedTableKey, ReEmbedStats]>;
+
+        if (processedEntries.length === 0) {
+          return {
+            message: 'No memory records matched re-embed criteria',
+            results,
+            success: true,
+          };
+        }
+
+        const aggregate = processedEntries.reduce(
+          (acc, [, stats]) => {
+            acc.failed += stats.failed;
+            acc.skipped += stats.skipped;
+            acc.succeeded += stats.succeeded;
+            acc.total += stats.total;
+
+            return acc;
+          },
+          { failed: 0, skipped: 0, succeeded: 0, total: 0 },
+        );
+
+        const message =
+          aggregate.total === 0
+            ? 'No memory records required re-embedding'
+            : `Re-embedded ${aggregate.succeeded} of ${aggregate.total} records`;
+
+        return {
+          aggregate,
+          message,
+          results,
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to re-embed memories:', error);
+        return {
+          message: `Failed to re-embed memories: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  searchMemory: memoryProcedure.input(searchMemorySchema).query(async ({ input, ctx }) => {
+    try {
+      return await searchUserMemories(ctx, input);
+    } catch (error) {
+      console.error('Failed to retrieve memories:', error);
+      return EMPTY_SEARCH_RESULT;
+    }
+  }),
+
+  // REVIEW: 需要实现 tool memory api
+  toolAddContextMemory: memoryProcedure
+    .input(addContextMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const embed = createEmbedder(agentRuntime, embeddingModel);
+
+        const summaryEmbedding = await embed(input.summary);
+        const detailsEmbedding = await embed(input.details);
+        const contextDescriptionEmbedding = await embed(input.withContext.description);
+
+        const { context, memory } = await ctx.memoryModel.createContextMemory({
+          context: {
+            associatedObjects: input.withContext.associatedObjects,
+            associatedSubjects: input.withContext.associatedSubjects,
+            currentStatus: input.withContext.currentStatus,
+            description: input.withContext.description,
+            descriptionVector: contextDescriptionEmbedding ?? null,
+            metadata: {},
+            scoreImpact: input.withContext.scoreImpact ?? null,
+            scoreUrgency: input.withContext.scoreUrgency ?? null,
+            tags: input.withContext.tags,
+            title: input.withContext.title ?? null,
+            type: input.withContext.type ?? null,
+          },
+          details: input.details,
+          detailsEmbedding,
+          memoryCategory: input.memoryCategory,
+          memoryLayer: input.memoryLayer,
+          memoryType: input.memoryType,
+          summary: input.summary,
+          summaryEmbedding,
+          title: input.title,
+        });
+
+        return {
+          contextId: context.id,
+          memoryId: memory.id,
+          message: 'Memory saved successfully',
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to save memory:', error);
+        return {
+          message: `Failed to save memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  toolAddExperienceMemory: memoryProcedure
+    .input(addExperienceMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const embed = createEmbedder(agentRuntime, embeddingModel);
+
+        const summaryEmbedding = await embed(input.summary);
+        const detailsEmbedding = await embed(input.details);
+        const situationVector = await embed(input.withExperience.situation);
+        const actionVector = await embed(input.withExperience.action);
+        const keyLearningVector = await embed(input.withExperience.keyLearning);
+
+        const { experience, memory } = await ctx.memoryModel.createExperienceMemory({
+          details: input.details,
+          detailsEmbedding,
+          experience: {
+            action: input.withExperience.action ?? null,
+            actionVector: actionVector ?? null,
+            keyLearning: input.withExperience.keyLearning ?? null,
+            keyLearningVector: keyLearningVector ?? null,
+            metadata: {},
+            possibleOutcome: input.withExperience.possibleOutcome ?? null,
+            reasoning: input.withExperience.reasoning ?? null,
+            scoreConfidence: input.withExperience.scoreConfidence ?? null,
+            situation: input.withExperience.situation ?? null,
+            situationVector: situationVector ?? null,
+            tags: input.withExperience.tags ?? [],
+            type: input.memoryType,
+          },
+          memoryCategory: input.memoryCategory,
+          memoryLayer: input.memoryLayer,
+          memoryType: input.memoryType,
+          summary: input.summary,
+          summaryEmbedding,
+          title: input.title,
+        });
+
+        return {
+          experienceId: experience.id,
+          memoryId: memory.id,
+          message: 'Memory saved successfully',
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to save memory:', error);
+        return {
+          message: `Failed to save memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  toolAddIdentityMemory: memoryProcedure
+    .input(addIdentityMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const embed = createEmbedder(agentRuntime, embeddingModel);
+
+        const summaryEmbedding = await embed(input.summary);
+        const detailsEmbedding = await embed(input.details);
+        const descriptionEmbedding = await embed(input.withIdentity.description);
+
+        const identityMetadata: Record<string, unknown> = {};
+        if (
+          input.withIdentity.scoreConfidence !== null &&
+          input.withIdentity.scoreConfidence !== undefined
+        ) {
+          identityMetadata.scoreConfidence = input.withIdentity.scoreConfidence;
+        }
+        if (
+          input.withIdentity.sourceEvidence !== null &&
+          input.withIdentity.sourceEvidence !== undefined
+        ) {
+          identityMetadata.sourceEvidence = input.withIdentity.sourceEvidence;
+        }
+
+        const { identityId, userMemoryId } = await ctx.memoryModel.addIdentityEntry({
+          base: {
+            details: input.details,
+            detailsVector1024: detailsEmbedding ?? null,
+            memoryCategory: input.memoryCategory,
+            memoryLayer: input.memoryLayer,
+            memoryType: input.memoryType,
+            metadata: Object.keys(identityMetadata).length > 0 ? identityMetadata : undefined,
+            summary: input.summary,
+            summaryVector1024: summaryEmbedding ?? null,
+            tags: input.withIdentity.tags,
+            title: input.title,
+          },
+          identity: {
+            description: input.withIdentity.description,
+            descriptionVector: descriptionEmbedding ?? null,
+            episodicDate: input.withIdentity.episodicDate,
+            metadata: Object.keys(identityMetadata).length > 0 ? identityMetadata : undefined,
+            relationship: input.withIdentity.relationship,
+            role: input.withIdentity.role,
+            tags: input.withIdentity.tags,
+            type: input.withIdentity.type,
+          },
+        });
+
+        return {
+          identityId,
+          memoryId: userMemoryId,
+          message: 'Identity memory saved successfully',
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to save identity memory:', error);
+        return {
+          message: `Failed to save identity memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  toolAddPreferenceMemory: memoryProcedure
+    .input(addPreferenceMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const embed = createEmbedder(agentRuntime, embeddingModel);
+
+        const summaryEmbedding = await embed(input.summary);
+        const detailsEmbedding = await embed(input.details);
+        const conclusionVector = await embed(input.withPreference.conclusionDirectives);
+
+        const suggestionsText =
+          input.withPreference.suggestions.length > 0
+            ? input.withPreference.suggestions.join('\n')
+            : null;
+
+        const metadata = {
+          appContext: input.withPreference.appContext,
+          extractedScopes: input.withPreference.extractedScopes,
+          originContext: input.withPreference.originContext,
+        } satisfies Record<string, unknown>;
+
+        const { memory, preference } = await ctx.memoryModel.createPreferenceMemory({
+          details: input.details,
+          detailsEmbedding,
+          memoryCategory: input.memoryCategory,
+          memoryLayer: input.memoryLayer,
+          memoryType: input.memoryType,
+          preference: {
+            conclusionDirectives: input.withPreference.conclusionDirectives,
+            conclusionDirectivesVector: conclusionVector ?? null,
+            metadata,
+            scorePriority: input.withPreference.scorePriority ?? null,
+            suggestions: suggestionsText,
+            tags: input.withPreference.tags,
+            type: input.memoryType,
+          },
+          summary: input.summary,
+          summaryEmbedding,
+          title: input.title,
+        });
+
+        return {
+          memoryId: memory.id,
+          message: 'Memory saved successfully',
+          preferenceId: preference.id,
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to save memory:', error);
+        return {
+          message: `Failed to save memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  toolRemoveIdentityMemory: memoryProcedure
+    .input(removeIdentityMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const removed = await ctx.memoryModel.removeIdentityEntry(input.id);
+
+        if (!removed) {
+          return {
+            message: 'Identity memory not found',
+            success: false,
+          };
+        }
+
+        return {
+          identityId: input.id,
+          message: 'Identity memory removed successfully',
+          reason: input.reason,
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to remove identity memory:', error);
+        return {
+          message: `Failed to remove identity memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+
+  toolSearchMemory: memoryProcedure.input(searchMemorySchema).query(async ({ input, ctx }) => {
+    try {
+      return await searchUserMemories(ctx, input);
+    } catch (error) {
+      console.error('Failed to retrieve memories:', error);
+      return EMPTY_SEARCH_RESULT;
+    }
+  }),
+
+  toolUpdateIdentityMemory: memoryProcedure
+    .input(updateIdentityMemorySchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const { agentRuntime, embeddingModel } = await getEmbeddingRuntime(ctx.jwtPayload);
+        const embed = createEmbedder(agentRuntime, embeddingModel);
+
+        let descriptionVector: number[] | null | undefined;
+        if (input.set.description !== undefined) {
+          const vector = await embed(input.set.description);
+          descriptionVector = vector ?? null;
+        }
+
+        const metadataUpdates: Record<string, unknown> = {};
+        if (Object.prototype.hasOwnProperty.call(input.set, 'scoreConfidence')) {
+          metadataUpdates.scoreConfidence = input.set.scoreConfidence ?? null;
+        }
+        if (Object.prototype.hasOwnProperty.call(input.set, 'sourceEvidence')) {
+          metadataUpdates.sourceEvidence = input.set.sourceEvidence ?? null;
+        }
+
+        const identityPayload: Partial<IdentityEntryPayload> = {};
+        if (input.set.description !== undefined) {
+          identityPayload.description = input.set.description;
+          identityPayload.descriptionVector = descriptionVector;
+        }
+        if (input.set.episodicDate !== undefined) {
+          identityPayload.episodicDate = input.set.episodicDate;
+        }
+        if (input.set.relationship !== undefined) {
+          identityPayload.relationship = input.set.relationship;
+        }
+        if (input.set.role !== undefined) {
+          identityPayload.role = input.set.role;
+        }
+        if (input.set.tags !== undefined) {
+          identityPayload.tags = input.set.tags;
+        }
+        if (input.set.type !== undefined) {
+          identityPayload.type = input.set.type;
+        }
+        if (Object.keys(metadataUpdates).length > 0) {
+          identityPayload.metadata = metadataUpdates;
+        }
+
+        const updated = await ctx.memoryModel.updateIdentityEntry({
+          identity: Object.keys(identityPayload).length > 0 ? identityPayload : undefined,
+          identityId: input.id,
+          mergeStrategy: input.mergeStrategy,
+        });
+
+        if (!updated) {
+          return {
+            message: 'Identity memory not found',
+            success: false,
+          };
+        }
+
+        return {
+          identityId: input.id,
+          message: 'Identity memory updated successfully',
+          success: true,
+        };
+      } catch (error) {
+        console.error('Failed to update identity memory:', error);
+        return {
+          message: `Failed to update identity memory: ${(error as Error).message}`,
+          success: false,
+        };
+      }
+    }),
+});

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -110,7 +110,6 @@ const searchUserMemories = async (
     model: embeddingModel,
   });
 
-  const limit = input.limit ? parseInt(input.limit, 10) : 5;
   const limits = {
     contexts: input.topK?.contexts,
     experiences: input.topK?.experiences,
@@ -119,10 +118,7 @@ const searchUserMemories = async (
 
   const layeredResults = await ctx.memoryModel.searchWithEmbedding({
     embedding: queryEmbeddings?.[0] || [],
-    limit,
     limits,
-    memoryCategory: input.memoryCategory,
-    memoryType: input.memoryType,
   });
 
   return mapMemorySearchResult(layeredResults);

--- a/src/services/chat/contextEngineering.test.ts
+++ b/src/services/chat/contextEngineering.test.ts
@@ -5,6 +5,7 @@ import * as isCanUseFCModule from '@/helpers/isCanUseFC';
 
 import { contextEngineering } from './contextEngineering';
 import * as helpers from './helper';
+import { UserMemoryInjectorConfig } from './providers/UserMemoryInjector';
 
 // Mock VARIABLE_GENERATORS
 vi.mock('@/utils/client/parserPlaceholder', () => ({
@@ -428,6 +429,62 @@ describe('contextEngineering', () => {
       const content = result[0].content as any[];
       expect(content[0].text).toBe('Hello TestUser, today is 2023-12-25');
       expect(content[1].image_url.url).toBe('data:image/png;base64,abc123');
+    });
+
+    it('should merge custom memory placeholder variables', async () => {
+      const messages: UIChatMessage[] = [
+        {
+          role: 'system',
+          content:
+            'Memory load: available={{memory_available}}, total contexts={{memory_contexts_count}}\n{{memory_summary}}',
+          createdAt: Date.now(),
+          id: 'memory-placeholder-test',
+          meta: {},
+          updatedAt: Date.now(),
+        },
+      ];
+
+      const userMemories = {
+        memories: {
+          contexts: [
+            {
+              accessedAt: new Date('2024-01-01T00:00:00.000Z'),
+              associatedObjects: [],
+              associatedSubjects: [],
+              createdAt: new Date('2024-01-01T00:00:00.000Z'),
+              currentStatus: 'active',
+              description: 'Weekly syncs for LobeHub',
+              id: 'ctx-1',
+              metadata: {},
+              scoreImpact: 0.8,
+              scoreUrgency: 0.5,
+              tags: ['project'],
+              title: 'LobeHub',
+              type: 'project',
+              updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+              userMemoryIds: ['mem-1'],
+            },
+          ],
+          experiences: [],
+          preferences: [],
+        },
+      } satisfies UserMemoryInjectorConfig;
+
+      const result = await contextEngineering({
+        userMemories,
+        messages,
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toContain(
+        '<user_memories contexts="1" experiences="0" memory_fetched_at="{{datetime}}" preferences="0">',
+      );
+      expect(result[0].content).toContain('<context_title>LobeHub</context_title>');
+      expect(result[1].content).toBe(
+        'Memory load: available={{memory_available}}, total contexts={{memory_contexts_count}}\n{{memory_summary}}',
+      );
     });
 
     it('should handle missing placeholder variables gracefully', async () => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -22,6 +22,8 @@ import {
   userGeneralSettingsSelectors,
   userProfileSelectors,
 } from '@/store/user/selectors';
+import { getUserMemoryStoreState, userMemorySelectors } from '@/store/userMemory';
+import { MemoryManifest } from '@/tools/memory';
 import type { ChatStreamPayload, OpenAIChatMessage } from '@/types/openai/chat';
 import { fetchWithInvokeStream } from '@/utils/electron/desktopRemoteRPCFetch';
 import { createErrorResponse } from '@/utils/errorResponse';
@@ -88,7 +90,13 @@ class ChatService {
 
     // =================== 1. preprocess tools =================== //
 
-    const pluginIds = [...(enabledPlugins || [])];
+    const agentStoreState = getAgentStoreState();
+    const agentConfig = agentSelectors.currentAgentConfig(agentStoreState);
+    const chatConfig = agentChatConfigSelectors.currentChatConfig(agentStoreState);
+    const pluginIds =
+      enabledPlugins && enabledPlugins.length > 0
+        ? [...enabledPlugins]
+        : [...(agentConfig.plugins ?? [])];
 
     const toolsEngine = createChatToolsEngine({
       model: payload.model,
@@ -101,11 +109,13 @@ class ChatService {
       toolIds: pluginIds,
     });
 
-    // ============  2. preprocess messages   ============ //
+    // =================== 1.1 process user memories =================== //
 
-    const agentStoreState = getAgentStoreState();
-    const agentConfig = agentSelectors.currentAgentConfig(agentStoreState);
-    const chatConfig = agentChatConfigSelectors.currentChatConfig(agentStoreState);
+    const isMemoryPluginEnabled =
+      pluginIds.includes(MemoryManifest.identifier) ||
+      enabledToolIds.includes(MemoryManifest.identifier);
+    const userMemories =
+      userMemorySelectors.activeUserMemories(isMemoryPluginEnabled)(getUserMemoryStoreState());
 
     // Apply context engineering with preprocessing configuration
     const oaiMessages = await contextEngineering({
@@ -119,6 +129,7 @@ class ChatService {
       sessionId: options?.trace?.sessionId,
       systemRole: agentConfig.systemRole,
       tools: enabledToolIds,
+      userMemories,
     });
 
     // ============  3. process extend params   ============ //

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -9,11 +9,14 @@ import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
 import { isDesktop } from '@/const/version';
 import { getSearchConfig } from '@/helpers/getSearchConfig';
 import { createChatToolsEngine, createToolsEngine } from '@/helpers/toolEngineering';
+import { userMemoryService } from '@/services/userMemory';
 import { getAgentStoreState } from '@/store/agent';
 import { agentChatConfigSelectors, agentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
+import { getChatStoreState } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 import { getSessionStoreState } from '@/store/session';
-import { sessionMetaSelectors } from '@/store/session/selectors';
+import { sessionMetaSelectors, sessionSelectors } from '@/store/session/selectors';
 import { getToolStoreState } from '@/store/tool';
 import { pluginSelectors } from '@/store/tool/selectors';
 import { getUserStoreState, useUserStore } from '@/store/user';
@@ -22,7 +25,13 @@ import {
   userGeneralSettingsSelectors,
   userProfileSelectors,
 } from '@/store/user/selectors';
-import { getUserMemoryStoreState, userMemorySelectors } from '@/store/userMemory';
+import {
+  getUserMemoryStoreState,
+  useUserMemoryStore,
+  userMemorySelectors,
+} from '@/store/userMemory';
+import { userMemoryCacheKey } from '@/store/userMemory/utils/cacheKey';
+import { createMemorySearchParams } from '@/store/userMemory/utils/searchParams';
 import { MemoryManifest } from '@/tools/memory';
 import type { ChatStreamPayload, OpenAIChatMessage } from '@/types/openai/chat';
 import { fetchWithInvokeStream } from '@/utils/electron/desktopRemoteRPCFetch';
@@ -114,8 +123,65 @@ class ChatService {
     const isMemoryPluginEnabled =
       pluginIds.includes(MemoryManifest.identifier) ||
       enabledToolIds.includes(MemoryManifest.identifier);
-    const userMemories =
+    let userMemories =
       userMemorySelectors.activeUserMemories(isMemoryPluginEnabled)(getUserMemoryStoreState());
+
+    if (isMemoryPluginEnabled && !userMemories) {
+      const chatStoreState = getChatStoreState();
+      const sessionStoreState = getSessionStoreState();
+
+      const historyMessages = messages.slice(0, -1);
+      const latestHistoryMessage = [...historyMessages]
+        .reverse()
+        .find((item) => typeof item?.content === 'string' && item.content.trim().length > 0);
+      const pendingMessage = messages.at(-1);
+
+      const memoryContext = {
+        latestMessageContent: latestHistoryMessage?.content,
+        pendingMessageContent: pendingMessage?.content,
+        session: sessionSelectors.currentSession(sessionStoreState),
+        topic: topicSelectors.currentActiveTopic(chatStoreState),
+      };
+
+      useUserMemoryStore.getState().setActiveMemoryContext(memoryContext);
+
+      const updatedMemoryState = getUserMemoryStoreState();
+      const memoryParams =
+        updatedMemoryState.activeParams ?? createMemorySearchParams(memoryContext);
+
+      if (memoryParams) {
+        const key = userMemoryCacheKey(memoryParams);
+        const cachedMemories = updatedMemoryState.memoryMap[key];
+
+        if (cachedMemories) {
+          const cachedAt = updatedMemoryState.memoryFetchedAtMap[key] ?? Date.now();
+          userMemories = {
+            fetchedAt: cachedAt,
+            memories: cachedMemories,
+          };
+        } else {
+          const result = await userMemoryService.retrieveMemory(memoryParams);
+          const next = result ?? { contexts: [], experiences: [], preferences: [] };
+          const fetchedAt = Date.now();
+
+          useUserMemoryStore.setState((state) => ({
+            memoryFetchedAtMap: {
+              ...state.memoryFetchedAtMap,
+              [key]: fetchedAt,
+            },
+            memoryMap: {
+              ...state.memoryMap,
+              [key]: next,
+            },
+          }));
+
+          userMemories = {
+            fetchedAt,
+            memories: next,
+          };
+        }
+      }
+    }
 
     // Apply context engineering with preprocessing configuration
     const oaiMessages = await contextEngineering({

--- a/src/services/chat/providers/UserMemoryInjector.ts
+++ b/src/services/chat/providers/UserMemoryInjector.ts
@@ -1,0 +1,92 @@
+import { BaseProvider } from '@lobechat/context-engine';
+import type { PipelineContext, ProcessorOptions } from '@lobechat/context-engine';
+import { u } from 'unist-builder';
+import { toXml } from 'xast-util-to-xml';
+import { Child, x } from 'xastscript';
+
+import type { RetrieveMemoryResult } from '@/types/userMemory';
+
+export interface UserMemoryInjectorConfig {
+  fetchedAt?: number;
+  memories?: Partial<RetrieveMemoryResult>;
+}
+
+export class UserMemoryInjector extends BaseProvider {
+  readonly name = 'UserMemoryInjector';
+
+  constructor(
+    private config: UserMemoryInjectorConfig,
+    options: ProcessorOptions = {},
+  ) {
+    super(options);
+  }
+
+  protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
+    const { memories } = this.config;
+    if (!memories) return context;
+
+    const contextsCount = memories.contexts?.length || 0;
+    const experiencesCount = memories.experiences?.length || 0;
+    const preferencesCount = memories.preferences?.length || 0;
+    if (contextsCount + experiencesCount + preferencesCount === 0) return context;
+
+    const userMemoriesChildren: Child[] = [];
+    if (memories.contexts) {
+      memories.contexts.forEach((context) => {
+        userMemoriesChildren.push(
+          x('user_memories_context', { id: context.id || '' }, [
+            x('context_title', context.title || ''),
+            x('context_description', context.description || ''),
+          ]),
+        );
+      });
+    }
+    if (memories.experiences) {
+      memories.experiences.forEach((experience) => {
+        userMemoriesChildren.push(
+          x('user_memories_experience', { id: experience.id || '' }, [
+            x('experience_situation', experience.situation || ''),
+            x('experience_key_learning', experience.keyLearning || ''),
+          ]),
+        );
+      });
+    }
+    if (memories.preferences) {
+      memories.preferences.forEach((preference) => {
+        userMemoriesChildren.push(
+          x('user_memories_preference', { id: preference.id || '' }, [
+            x('preference_conclusion_directives', preference.conclusionDirectives || ''),
+          ]),
+        );
+      });
+    }
+
+    const memoryMessage = {
+      content: toXml(
+        u('root', [
+          x(
+            'user_memories',
+            {
+              contexts: contextsCount.toString(),
+              experiences: experiencesCount.toString(),
+              memory_fetched_at: new Date(this.config.fetchedAt || Date.now()).toISOString(),
+              preferences: preferencesCount.toString(),
+            },
+            ...userMemoriesChildren,
+          ),
+        ]),
+      ),
+      createdAt: Date.now(),
+      id: `user-memory-${Date.now()}`,
+      meta: { source: 'userMemory' },
+      role: 'system' as const,
+      updatedAt: Date.now(),
+    };
+
+    const clonedContext = this.cloneContext(context);
+    clonedContext.messages.unshift(memoryMessage);
+    clonedContext.metadata.userMemoryInjected = true;
+
+    return this.markAsExecuted(clonedContext);
+  }
+}

--- a/src/services/userMemory.ts
+++ b/src/services/userMemory.ts
@@ -1,0 +1,19 @@
+import { lambdaClient } from '@/libs/trpc/client';
+import {
+  RetrieveMemoryParams,
+  RetrieveMemoryResult,
+  SearchMemoryParams,
+  SearchMemoryResult,
+} from '@/types/userMemory';
+
+class UserMemoryService {
+  searchMemory = async (params: SearchMemoryParams): Promise<SearchMemoryResult> => {
+    return lambdaClient.userMemories.toolSearchMemory.query(params);
+  };
+
+  retrieveMemory = async (params: RetrieveMemoryParams): Promise<RetrieveMemoryResult> => {
+    return lambdaClient.userMemories.searchMemory.query(params);
+  };
+}
+
+export const userMemoryService = new UserMemoryService();

--- a/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -27,6 +27,8 @@ import { MainSendMessageOperation } from '@/store/chat/slices/aiChat/initialStat
 import type { ChatStore } from '@/store/chat/store';
 import { getFileStoreState } from '@/store/file/store';
 import { getSessionStoreState } from '@/store/session';
+import { sessionSelectors } from '@/store/session/selectors';
+import { useUserMemoryStore } from '@/store/userMemory';
 import { WebBrowsingManifest } from '@/tools/web-browsing';
 import { setNamespace } from '@/utils/storeDebug';
 
@@ -109,6 +111,13 @@ export const generateAIChatV2: StateCreator<
     }
 
     const messages = chatSelectors.activeBaseChats(get());
+
+    useUserMemoryStore.getState().setActiveMemoryContext({
+      session: sessionSelectors.currentSession(getSessionStoreState()),
+      topic: topicSelectors.currentActiveTopic(get()),
+      latestUserMessage: messages.at(-1)?.content,
+      sendingMessage: message,
+    });
     const chatConfig = agentChatConfigSelectors.currentChatConfig(getAgentStoreState());
     const autoCreateThreshold =
       chatConfig.autoCreateTopicThreshold ?? DEFAULT_AGENT_CHAT_CONFIG.autoCreateTopicThreshold;

--- a/src/store/chat/slices/builtinTool/actions/index.ts
+++ b/src/store/chat/slices/builtinTool/actions/index.ts
@@ -5,11 +5,13 @@ import { ChatStore } from '@/store/chat/store';
 import { ChatCodeInterpreterAction, codeInterpreterSlice } from './interpreter';
 import { LocalFileAction, localSystemSlice } from './localSystem';
 import { SearchAction, searchSlice } from './search';
+import { UserMemoryAction, userMemorySlice } from './userMemory';
 
 export interface ChatBuiltinToolAction
   extends SearchAction,
     LocalFileAction,
-    ChatCodeInterpreterAction {}
+    ChatCodeInterpreterAction,
+    UserMemoryAction {}
 
 export const chatToolSlice: StateCreator<
   ChatStore,
@@ -20,4 +22,5 @@ export const chatToolSlice: StateCreator<
   ...searchSlice(...params),
   ...localSystemSlice(...params),
   ...codeInterpreterSlice(...params),
+  ...userMemorySlice(...params),
 });

--- a/src/store/chat/slices/builtinTool/actions/userMemory.ts
+++ b/src/store/chat/slices/builtinTool/actions/userMemory.ts
@@ -1,0 +1,37 @@
+import { StateCreator } from 'zustand/vanilla';
+
+import { userMemoryService } from '@/services/userMemory';
+import { ChatStore } from '@/store/chat/store';
+import type { SearchMemoryParams } from '@/types/userMemory';
+
+export interface UserMemoryAction {
+  searchUserMemory: (id: string, params: SearchMemoryParams) => Promise<boolean>;
+}
+
+export const userMemorySlice: StateCreator<
+  ChatStore,
+  [['zustand/devtools', never]],
+  [],
+  UserMemoryAction
+> = (set, get) => ({
+  searchUserMemory: async (id, params) => {
+    const { internal_updateMessageContent } = get();
+
+    try {
+      const result = await userMemoryService.searchMemory(params);
+      await internal_updateMessageContent(id, JSON.stringify(result));
+      return true;
+    } catch (error) {
+      console.error('Failed to retrieve memories:', error);
+      const errorResult = {
+        contexts: [],
+        error: `Failed to retrieve memories: ${(error as Error).message}`,
+        experiences: [],
+        preferences: [],
+      };
+
+      await internal_updateMessageContent(id, JSON.stringify(errorResult));
+      return false;
+    }
+  },
+});

--- a/src/store/chat/slices/message/selectors/chat.ts
+++ b/src/store/chat/slices/message/selectors/chat.ts
@@ -162,6 +162,18 @@ const getTraceIdByMessageId = (id: string) => (s: ChatStoreState) => getMessageB
 
 const latestMessage = (s: ChatStoreState) => activeBaseChats(s).at(-1);
 
+const latestUserMessage = (s: ChatStoreState) => {
+  const messages = activeBaseChats(s);
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (message.role === 'user') return message;
+  }
+
+  return undefined;
+};
+
 const currentChatLoadingState = (s: ChatStoreState) => !s.messagesInit;
 
 const isCurrentChatLoaded = (s: ChatStoreState) => !!s.messagesMap[currentChatKey(s)];
@@ -262,6 +274,7 @@ export const chatSelectors = {
   isCurrentChatLoaded,
   isSupervisorLoading,
   latestMessage,
+  latestUserMessage,
   mainAIChats,
   mainAIChatsMessageString,
   mainAIChatsWithHistoryConfig,

--- a/src/store/userMemory/index.ts
+++ b/src/store/userMemory/index.ts
@@ -1,0 +1,2 @@
+export * from './selectors';
+export * from './store';

--- a/src/store/userMemory/initialState.ts
+++ b/src/store/userMemory/initialState.ts
@@ -1,0 +1,15 @@
+import type { RetrieveMemoryParams, RetrieveMemoryResult } from '@/types/userMemory';
+
+export interface UserMemoryStoreState {
+  activeParams?: RetrieveMemoryParams;
+  activeParamsKey?: string;
+  memoryFetchedAtMap: Record<string, number>;
+  memoryMap: Record<string, RetrieveMemoryResult>;
+}
+
+export const initialState: UserMemoryStoreState = {
+  activeParams: undefined,
+  activeParamsKey: undefined,
+  memoryFetchedAtMap: {},
+  memoryMap: {},
+};

--- a/src/store/userMemory/selectors.ts
+++ b/src/store/userMemory/selectors.ts
@@ -1,0 +1,59 @@
+import type { RetrieveMemoryParams, RetrieveMemoryResult } from '@/types/userMemory';
+
+import type { UserMemoryStoreState } from './initialState';
+import { userMemoryCacheKey } from './utils/cacheKey';
+
+const EMPTY_RESULT: RetrieveMemoryResult = {
+  contexts: [],
+  experiences: [],
+  preferences: [],
+};
+
+type ActiveUserMemoriesResult = {
+  fetchedAt: number;
+  memories: RetrieveMemoryResult;
+};
+
+export const userMemorySelectors = {
+  activeMemories: (state: UserMemoryStoreState): RetrieveMemoryResult | undefined => {
+    if (!state.activeParamsKey) return undefined;
+
+    return state.memoryMap[state.activeParamsKey];
+  },
+  activeMemoryFetchedAt: (state: UserMemoryStoreState): number | undefined => {
+    if (!state.activeParamsKey) return undefined;
+
+    return state.memoryFetchedAtMap[state.activeParamsKey];
+  },
+  activeParams: (state: UserMemoryStoreState): RetrieveMemoryParams | undefined =>
+    state.activeParams,
+  activeUserMemories:
+    (enabled: boolean) =>
+    (state: UserMemoryStoreState): ActiveUserMemoriesResult | undefined => {
+      if (!enabled || !state.activeParamsKey) return undefined;
+
+      const fetchedAt = state.memoryFetchedAtMap[state.activeParamsKey];
+      const memories = state.memoryMap[state.activeParamsKey];
+
+      if (fetchedAt === undefined || !memories) return undefined;
+
+      return {
+        fetchedAt,
+        memories,
+      };
+    },
+  memoriesByParams: (params?: RetrieveMemoryParams) => (state: UserMemoryStoreState) => {
+    if (!params) return EMPTY_RESULT;
+
+    const key = userMemoryCacheKey(params);
+
+    return state.memoryMap[key] ?? EMPTY_RESULT;
+  },
+  memoryFetchedAtByParams: (params?: RetrieveMemoryParams) => (state: UserMemoryStoreState) => {
+    if (!params) return undefined;
+
+    const key = userMemoryCacheKey(params);
+
+    return state.memoryFetchedAtMap[key];
+  },
+};

--- a/src/store/userMemory/store.ts
+++ b/src/store/userMemory/store.ts
@@ -1,0 +1,129 @@
+import isEqual from 'fast-deep-equal';
+import { type SWRResponse, mutate } from 'swr';
+import { subscribeWithSelector } from 'zustand/middleware';
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { type StateCreator } from 'zustand/vanilla';
+
+import { useClientDataSWR } from '@/libs/swr';
+import { userMemoryService } from '@/services/userMemory';
+import type { RetrieveMemoryParams, RetrieveMemoryResult } from '@/types/userMemory';
+import { createMemorySearchParams } from '@/utils/memory/searchParams';
+import { setNamespace } from '@/utils/storeDebug';
+
+import { createDevtools } from '../middleware/createDevtools';
+import { type UserMemoryStoreState, initialState } from './initialState';
+import { userMemoryCacheKey } from './utils/cacheKey';
+
+const SWR_FETCH_USER_MEMORY = 'SWR_FETCH_USER_MEMORY';
+const n = setNamespace('userMemory');
+
+type MemoryContext = Parameters<typeof createMemorySearchParams>[0];
+
+export interface UserMemoryStoreAction {
+  refreshUserMemory: (params: RetrieveMemoryParams) => Promise<void>;
+  setActiveMemoryContext: (context?: MemoryContext) => void;
+  useFetchUserMemory: (
+    enable: boolean,
+    params?: RetrieveMemoryParams,
+  ) => SWRResponse<RetrieveMemoryResult>;
+}
+
+export type UserMemoryStore = UserMemoryStoreAction & UserMemoryStoreState;
+
+const createStore: StateCreator<UserMemoryStore, [['zustand/devtools', never]]> = (set, get) => ({
+  ...initialState,
+
+  refreshUserMemory: async (params) => {
+    const key = userMemoryCacheKey(params);
+
+    await mutate([SWR_FETCH_USER_MEMORY, key]);
+  },
+
+  setActiveMemoryContext: (context) => {
+    const params = context ? createMemorySearchParams(context) : undefined;
+    const key = params ? userMemoryCacheKey(params) : undefined;
+
+    set(
+      {
+        activeParams: params,
+        activeParamsKey: key,
+      },
+      false,
+      n('setActiveMemoryContext', { key }),
+    );
+  },
+
+  useFetchUserMemory: (enable, params) => {
+    const resolvedParams = params ?? get().activeParams;
+    const key = resolvedParams ? userMemoryCacheKey(resolvedParams) : undefined;
+
+    return useClientDataSWR<RetrieveMemoryResult>(
+      enable && resolvedParams ? [SWR_FETCH_USER_MEMORY, key] : null,
+      () => userMemoryService.retrieveMemory(resolvedParams!),
+      {
+        onSuccess: (result) => {
+          if (!resolvedParams || !key) return;
+
+          const state = get();
+          const previous = state.memoryMap[key];
+          const next = result ?? { contexts: [], experiences: [], preferences: [] };
+          const fetchedAt = Date.now();
+
+          if (previous && isEqual(previous, next)) {
+            set(
+              {
+                memoryFetchedAtMap: {
+                  ...state.memoryFetchedAtMap,
+                  [key]: fetchedAt,
+                },
+              },
+              false,
+              n('useFetchUserMemory/refresh', {
+                key,
+                totals: {
+                  contexts: next.contexts.length,
+                  experiences: next.experiences.length,
+                  preferences: next.preferences.length,
+                },
+              }),
+            );
+
+            return;
+          }
+
+          set(
+            {
+              memoryFetchedAtMap: {
+                ...state.memoryFetchedAtMap,
+                [key]: fetchedAt,
+              },
+              memoryMap: {
+                ...state.memoryMap,
+                [key]: next,
+              },
+            },
+            false,
+            n('useFetchUserMemory/success', {
+              key,
+              totals: {
+                contexts: next.contexts.length,
+                experiences: next.experiences.length,
+                preferences: next.preferences.length,
+              },
+            }),
+          );
+        },
+      },
+    );
+  },
+});
+
+const devtools = createDevtools('userMemory');
+
+export const useUserMemoryStore = createWithEqualityFn<UserMemoryStore>()(
+  subscribeWithSelector(devtools(createStore)),
+  shallow,
+);
+
+export const getUserMemoryStoreState = () => useUserMemoryStore.getState();

--- a/src/store/userMemory/store.ts
+++ b/src/store/userMemory/store.ts
@@ -7,8 +7,8 @@ import { type StateCreator } from 'zustand/vanilla';
 
 import { useClientDataSWR } from '@/libs/swr';
 import { userMemoryService } from '@/services/userMemory';
+import { createMemorySearchParams } from '@/store/userMemory/utils/searchParams';
 import type { RetrieveMemoryParams, RetrieveMemoryResult } from '@/types/userMemory';
-import { createMemorySearchParams } from '@/utils/memory/searchParams';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { createDevtools } from '../middleware/createDevtools';

--- a/src/store/userMemory/utils/cacheKey.ts
+++ b/src/store/userMemory/utils/cacheKey.ts
@@ -1,0 +1,13 @@
+import type { RetrieveMemoryParams } from '@/types/userMemory';
+
+export const userMemoryCacheKey = (params: RetrieveMemoryParams): string => {
+  const { query, memoryCategory, memoryType, limit, topK } = params;
+
+  return JSON.stringify({
+    limit: limit ?? null,
+    memoryCategory: memoryCategory ?? null,
+    memoryType: memoryType ?? null,
+    query,
+    topK: topK ?? null,
+  });
+};

--- a/src/store/userMemory/utils/cacheKey.ts
+++ b/src/store/userMemory/utils/cacheKey.ts
@@ -1,12 +1,9 @@
 import type { RetrieveMemoryParams } from '@/types/userMemory';
 
 export const userMemoryCacheKey = (params: RetrieveMemoryParams): string => {
-  const { query, memoryCategory, memoryType, limit, topK } = params;
+  const { query, topK } = params;
 
   return JSON.stringify({
-    limit: limit ?? null,
-    memoryCategory: memoryCategory ?? null,
-    memoryType: memoryType ?? null,
     query,
     topK: topK ?? null,
   });

--- a/src/store/userMemory/utils/searchParams.ts
+++ b/src/store/userMemory/utils/searchParams.ts
@@ -1,12 +1,7 @@
 import { find, isString, trim } from 'lodash-es';
 
+import { DEFAULT_SEARCH_USER_MEMORY_TOP_K } from '@/const/userMemory';
 import type { RetrieveMemoryParams } from '@/types/userMemory';
-
-const DEFAULT_TOP_K = {
-  contexts: 3,
-  experiences: 4,
-  preferences: 3,
-};
 
 interface MemorySearchSource {
   latestUserMessage?: string | null;
@@ -46,7 +41,7 @@ export const createMemorySearchParams = (
   return {
     query,
     topK: {
-      ...DEFAULT_TOP_K,
+      ...DEFAULT_SEARCH_USER_MEMORY_TOP_K,
     },
   } as RetrieveMemoryParams;
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,9 +5,11 @@ import { isDesktop } from '@/const/version';
 import { ArtifactsManifest } from './artifacts';
 import { CodeInterpreterManifest } from './code-interpreter';
 import { LocalSystemManifest } from './local-system';
+import { MemoryManifest } from './memory';
 import { WebBrowsingManifest } from './web-browsing';
 
 export const builtinTools: LobeBuiltinTool[] = [
+  // TODO: Migrate to the extended plugin system to configure different context engineering combinations.
   {
     identifier: ArtifactsManifest.identifier,
     manifest: ArtifactsManifest,
@@ -17,6 +19,11 @@ export const builtinTools: LobeBuiltinTool[] = [
     hidden: !isDesktop,
     identifier: LocalSystemManifest.identifier,
     manifest: LocalSystemManifest,
+    type: 'builtin',
+  },
+  {
+    identifier: MemoryManifest.identifier,
+    manifest: MemoryManifest,
     type: 'builtin',
   },
   {

--- a/src/tools/memory/index.ts
+++ b/src/tools/memory/index.ts
@@ -1,0 +1,31 @@
+import { PluginSchema } from '@lobehub/chat-plugin-sdk';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { BuiltinToolManifest } from '@/types/tool';
+import { searchMemorySchema } from '@/types/userMemory';
+
+import { systemPrompt } from './systemRole';
+import { MemoryApiName as InternalMemoryApiName } from './types';
+
+export const MemoryManifest: BuiltinToolManifest = {
+  api: [
+    {
+      description:
+        'Retrieve memories based on a search query. Use this to recall previously saved information.',
+      name: InternalMemoryApiName.searchUserMemory,
+      parameters: zodToJsonSchema(searchMemorySchema) as PluginSchema,
+    },
+  ],
+  identifier: 'lobe-user-memory',
+  meta: {
+    avatar: '🧠',
+    title: 'Memory',
+  },
+  systemRole: systemPrompt,
+  type: 'builtin',
+};
+
+export const UserMemoryManifest = MemoryManifest;
+
+export type { RetrieveMemoryParams } from './types';
+export { MemoryApiName } from './types';

--- a/src/tools/memory/systemRole.ts
+++ b/src/tools/memory/systemRole.ts
@@ -1,0 +1,137 @@
+export const systemPrompt = `You are a comprehensive memory management assistant designed to help users organize, store, and retrieve important information across different contexts and timeframes.
+
+<user_context>
+Current user: {{username}}
+Session date: {{date}}
+</user_context>
+
+<core_capabilities>
+You have access to powerful memory management tools that support different workflows:
+
+1. **saveMemory**: Store important information with structured categorization
+   - title: Brief descriptive title for the memory
+   - summary: Concise overview of the information
+   - details: Optional detailed information
+   - memoryLayer: Organizational layer (e.g., "personal", "work", "project")
+   - memoryType: Type classification (e.g., "preference", "fact", "context", "activity", "event")
+   - memoryCategory: Specific category for fine-grained organization
+
+2. **retrieveMemory**: Search and recall previously stored information
+   - query: Search terms to find relevant memories
+   - limit: Maximum number of results to return
+   - memoryType: Filter by specific memory type
+   - memoryCategory: Filter by specific category
+
+5. **Advanced Memory Processing Functions** (when available):
+   - add_activity_memory: Store complete conversation or activity records
+   - run_theory_of_mind: Analyze subtle information and character insights
+   - generate_memory_suggestions: Get intelligent suggestions for memory categorization
+   - update_memory_with_suggestions: Update categories with structured suggestions
+   - link_related_memories: Create connections between related memory items
+   - cluster_memories: Organize memories into logical groupings
+</core_capabilities>
+
+<memory_formatting_guidelines>
+**CRITICAL REQUIREMENT: ALL MEMORY ITEMS MUST BE SELF-CONTAINED**
+
+When creating or processing memory items, ensure:
+- EVERY memory item is complete and standalone
+- ALWAYS include full subjects (never use "she/he/they/it")
+- NEVER use pronouns that depend on context
+- Include specific names, places, dates, and full context in each item
+- Each memory should be understandable without reading other items
+- Include all relevant details, emotions, and outcomes
+
+**GOOD EXAMPLES:**
+- "{{username}} attended a LGBTQ support group where {{username}} heard inspiring transgender stories and felt happy, thankful, accepted, and gained courage to embrace {{username}}'s true self."
+- "{{username}} discussed future career plans with Melanie, expressing keen interest in counseling and mental health work to support people with similar issues, and Melanie encouraged {{username}} saying {{username}} would be a great counselor due to {{username}}'s empathy and understanding."
+
+**BAD EXAMPLES:**
+- "She went to a support group" (uses pronoun, lacks context)
+- "They felt happy" (incomplete, no context about what caused the emotion)
+- "The discussion was helpful" (vague, no specific details)
+</memory_formatting_guidelines>
+
+<memory_processing_workflows>
+
+**Workflow 1: Activity Memory Processing**
+For storing conversation or activity records:
+1. Store complete raw conversation using add_activity_memory with full original text
+2. Run theory_of_mind analysis to extract character insights
+3. Generate memory suggestions based on extracted items
+4. Update relevant categories with new structured memory items
+5. Link related memories and cluster for organization
+
+**Workflow 2: Standard Memory Storage**
+For general information storage:
+1. Analyze the information to determine appropriate categorization
+2. Format according to self-contained memory requirements
+3. Use saveMemory with proper title, summary, and categorization
+4. Consider relationships to existing memories
+
+**Workflow 3: Memory Retrieval and Analysis**
+For finding and using stored information:
+1. Use retrieveMemory with relevant search terms
+2. Apply appropriate filters (type, category) to narrow results
+3. Analyze returned memories for relevance and completeness
+4. Suggest additional storage if gaps are identified
+
+**Workflow 4: Context & Preference Categorization**
+For building higher-level structure across multiple memories:
+1. Evaluate whether related memories form a meaningful situational context
+2. Use categorizeContext to persist the shared storyline, actors, and status
+3. Derive explicit preferences or directives and store them via categorizePreference
+4. Skip embedding/vector payloads; the platform will compute them asynchronously when needed
+5. Revisit existing context/preference entries using their IDs when new information requires refinement
+</memory_processing_workflows>
+
+<categorization_guidelines>
+**Memory Type Classifications:**
+- **activity**: Detailed conversations, interactions, events with full context
+- **profile**: Basic personal information (age, location, occupation, education, family status, demographics) - EXCLUDE events and activities
+- **event**: Specific events, dates, milestones, appointments, meetings with time references
+- **preference**: User choices, likes, dislikes, and personal preferences
+- **fact**: Objective information, data points, and factual knowledge
+- **context**: Background information, situational details, and environmental factors
+
+**Profile vs Activity/Event Distinction:**
+- Profile (CORRECT): "{{username}} lives in San Francisco", "{{username}} is 28 years old", "{{username}} works at TechFlow Solutions"
+- Profile (INCORRECT): "{{username}} went hiking" (this is activity), "{{username}} attended workshop" (this is event)
+
+**Important Notes:**
+- If information involves multiple categories, separate appropriately across categories
+- Preserve modal adverbs (perhaps, probably, likely) when they indicate uncertainty
+- Only suggest categories that exist in available_categories
+- Group related content into meaningful, comprehensive activities rather than fragmenting
+
+**Context Categorization Principles:**
+- Contexts summarize enduring situations that connect multiple memories (projects, relationships, goals)
+- Describe actors and objects explicitly so downstream agents can reason about responsibilities and resources
+- Maintain currentStatus to signal lifecycle stage (e.g., "exploring", "active", "on-hold")
+- Update existing contexts when receiving incremental progress instead of duplicating similar entries
+- Provide extractedLabels only; the platform handles business-facing labels and embeddings later downstream
+
+**Preference Categorization Principles:**
+- Preferences capture actionable rules that guide assistant behavior or decision-making
+- extractedScopes should clarify when a preference applies (time ranges, participant groups, channels, etc.)
+- conclusionDirectives must be self-contained instructions the assistant can follow directly
+- Use scorePriority to highlight preferences that should override conflicting defaults
+- Do not supply record identifiers or embeddings—the system resolves those automatically after memory creation
+</categorization_guidelines>
+
+<response_format>
+When presenting memory operations:
+- Show relevant retrieved memories with context
+- Explain categorization decisions when helpful
+- Maintain user privacy and data security
+- Use structured formatting for multiple memory items
+- Always ensure memory items follow self-contained requirements
+</response_format>
+
+<security_considerations>
+- Never store sensitive personal information like passwords, API keys, or financial data
+- Respect user privacy and data boundaries
+- Confirm before storing potentially sensitive information
+- Maintain appropriate access controls for memory retrieval
+- Handle personal information with care and discretion
+</security_considerations>`;

--- a/src/tools/memory/types.ts
+++ b/src/tools/memory/types.ts
@@ -1,0 +1,7 @@
+export type { SearchMemoryParams as RetrieveMemoryParams } from '@/types/userMemory';
+
+export const MemoryApiName = {
+  searchUserMemory: 'searchUserMemory',
+} as const;
+
+export const UserMemoryApiName = MemoryApiName;

--- a/src/utils/memory/searchParams.ts
+++ b/src/utils/memory/searchParams.ts
@@ -1,0 +1,55 @@
+import type { RetrieveMemoryParams } from '@/types/userMemory';
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_TOP_K = {
+  contexts: 3,
+  experiences: 4,
+  preferences: 3,
+};
+
+interface MemorySearchSource {
+  session?: {
+    meta?: {
+      description?: string | null;
+      title?: string | null;
+    } | null;
+  } | null;
+  topic?: {
+    historySummary?: string | null;
+    title?: string | null;
+  } | null;
+}
+
+const pickFirstNonEmpty = (values: Array<string | null | undefined>) => {
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) continue;
+
+    return trimmed;
+  }
+
+  return undefined;
+};
+
+export const createMemorySearchParams = (
+  source: MemorySearchSource,
+): RetrieveMemoryParams | undefined => {
+  const query = pickFirstNonEmpty([
+    source.topic?.historySummary,
+    source.topic?.title,
+    source.session?.meta?.title,
+    source.session?.meta?.description,
+  ]);
+
+  if (!query) return undefined;
+
+  return {
+    limit: String(DEFAULT_LIMIT),
+    query,
+    topK: {
+      ...DEFAULT_TOP_K,
+    },
+  } as RetrieveMemoryParams;
+};


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Depends on #9371 

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Implement basic memory management tools including storage, retrieval, and categorization within the chat platform.

New Features:
- Add 'Memory' as a built-in tool with saveMemory, retrieveMemory, categorizeContext, and categorizePreference APIs
- Introduce TRPC memoryRouter with authenticated procedures for memory operations
- Create Drizzle ORM models and migrations for user memories, memory contexts, preferences, identities, and experiences
- Define system prompt and plugin manifest for memory tool integration in chat UI

Enhancements:
- Integrate vector-based semantic search for memory retrieval using cosine similarity
- Extend chat store with memory slice and client-side services for memory actions
- Update pnpm configuration to include new dependencies and vector libraries

Build:
- Add zod-to-json-schema dependency and update pnpm onlyBuiltDependencies

Tests:
- Add comprehensive vitest tests for UserMemoryModel covering CRUD, search, context categorization, and preference categorization