### PR TITLE
 🐛 fix: Add 'gemini-2.5-flash-image' to disabled models Thinking

### DIFF
--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -45,6 +45,7 @@ const modelsWithModalities = new Set([
   'gemini-2.0-flash-exp-image-generation',
   'gemini-2.0-flash-preview-image-generation',
   'gemini-2.5-flash-image-preview',
+  'gemini-2.5-flash-image',
 ]);
 
 const modelsDisableInstuction = new Set([
@@ -52,6 +53,7 @@ const modelsDisableInstuction = new Set([
   'gemini-2.0-flash-exp-image-generation',
   'gemini-2.0-flash-preview-image-generation',
   'gemini-2.5-flash-image-preview',
+  'gemini-2.5-flash-image',
   'gemma-3-1b-it',
   'gemma-3-4b-it',
   'gemma-3-12b-it',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change
A request parameter error occurred when calling Google's gemini-2.5-flash-image model because the thinkingBudget parameter was set with a non-zero value.

error message：
{ "error": { "message": "Thinking is not enabled for models/gemini-2.5-flash-image", "code": 400, "status": "INVALID ARGUMENT" }, "provider": "google" }

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Add gemini-2.5-flash-image to the sets that disable thinkingBudget and instruction enforcement