### PR TITLE
💄 style: add more AWS regions

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/detail/bedrock/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/detail/bedrock/index.tsx
@@ -15,6 +15,40 @@ import ProviderDetail from '../default';
 
 const providerKey: GlobalLLMProviderKey = 'bedrock';
 
+const AWS_REGIONS: string[] = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+  'ca-central-1',
+  'us-gov-east-1',
+  'us-gov-west-1',
+  'sa-east-1',
+  'eu-north-1',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'eu-central-1',
+  'eu-central-2',
+  'eu-south-1',
+  'eu-south-2',
+  'me-south-1',
+  'me-central-1',
+  'af-south-1',
+  'ap-south-1',
+  'ap-south-2',
+  'ap-east-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-southeast-3',
+  'ap-southeast-4',
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-northeast-3',
+  'cn-north-1',
+  'cn-northwest-1',
+];
+
 const useBedrockCard = (): ProviderItem => {
   const { t } = useTranslation('modelProvider');
 
@@ -68,11 +102,11 @@ const useBedrockCard = (): ProviderItem => {
         ) : (
           <Select
             allowClear
-            options={['us-east-1', 'us-west-2', 'ap-southeast-1', 'eu-central-1'].map((i) => ({
+            options={AWS_REGIONS.map((i) => ({
               label: i,
               value: i,
             }))}
-            placeholder={'us-east-1'}
+            placeholder={AWS_REGIONS[0]}
           />
         ),
         desc: t(`${providerKey}.region.desc`),


### PR DESCRIPTION
#### 🔀 Description of Change

Add all possible AWS regions as option for bedrock

#### 📝 Additional Information
 
Region selection for bedrock is important. Please consider this or add the option to manually enter the region in the UI.

## Summary by Sourcery

Provide a comprehensive list of AWS regions for the Bedrock provider and refactor the region selector to use it

New Features:
- Allow selection of all AWS regions for the Bedrock provider

Enhancements:
- Replace hardcoded region options with the AWS_REGIONS constant
- Set the default placeholder dynamically to the first entry in AWS_REGIONS