### PR TITLE
🐛 fix(plugin-store): Fix search functionality for old plugin store

### DIFF
--- a/src/features/PluginStore/PluginList/List/index.tsx
+++ b/src/features/PluginStore/PluginList/List/index.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@lobehub/ui';
 import { Empty } from 'antd';
 import { ServerCrash } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
 import { Virtuoso } from 'react-virtuoso';
@@ -25,6 +25,7 @@ export const List = memo(() => {
     searchLoading,
     useFetchPluginList,
     loadMorePlugins,
+    resetPluginList,
   ] = useToolStore((s) => [
     s.isPluginListInit,
     s.activePluginIdentifier,
@@ -35,7 +36,13 @@ export const List = memo(() => {
     s.pluginSearchLoading,
     s.useFetchPluginList,
     s.loadMorePlugins,
+    s.resetPluginList,
   ]);
+
+  // 当 keywords 变化时重置列表
+  useEffect(() => {
+    resetPluginList(keywords);
+  }, [keywords, resetPluginList]);
 
   const { isLoading, error } = useFetchPluginList({
     page: currentPage,

--- a/src/features/PluginStore/Search/index.tsx
+++ b/src/features/PluginStore/Search/index.tsx
@@ -4,10 +4,18 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useToolStore } from '@/store/tool';
+import { PluginStoreTabs } from '@/store/tool/slices/oldStore';
 
 export const Search = memo(() => {
   const { t } = useTranslation('plugin');
-  const [keywords] = useToolStore((s) => [s.mcpSearchKeywords]);
+  const [listType, mcpKeywords, pluginKeywords] = useToolStore((s) => [
+    s.listType,
+    s.mcpSearchKeywords,
+    s.pluginSearchKeywords,
+  ]);
+
+  // 根据当前选项卡决定使用哪个关键词
+  const keywords = listType === PluginStoreTabs.MCP ? mcpKeywords : pluginKeywords;
 
   return (
     <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
@@ -16,7 +24,11 @@ export const Search = memo(() => {
           allowClear
           defaultValue={keywords}
           onSearch={(keywords: string) => {
-            useToolStore.setState({ mcpSearchKeywords: keywords, searchLoading: true });
+            if (listType === PluginStoreTabs.MCP) {
+              useToolStore.setState({ mcpSearchKeywords: keywords, searchLoading: true });
+            } else if (listType === PluginStoreTabs.Plugin) {
+              useToolStore.setState({ pluginSearchKeywords: keywords, pluginSearchLoading: true });
+            }
           }}
           placeholder={t('store.placeholder')}
           variant={'borderless'}


### PR DESCRIPTION
- Update Search component to handle different search keywords based on current tab (MCP vs Plugin)
- Add missing useEffect in Plugin List to reset list when search keywords change
- Fixes issue where typing in search bar didn't trigger plugin filtering

Fixes #9645

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix search functionality in the old plugin store by handling separate search keywords and loading states for MCP and Plugin tabs and resetting the plugin list when search keywords change.

Bug Fixes:
- Use correct search keywords and loading state for each tab in the Search component
- Reset the plugin list on search keyword changes in the PluginList component