### PR TITLE
💄 style: add lab to support disable rich text

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -9,6 +9,7 @@
     "test": "vitest",
     "test:coverage": "vitest --coverage --silent='passed-only'",
     "test:prompts": "pnpm test:prompts:translate && pnpm test:prompts:summary && pnpm test:prompts:lang && pnpm test:prompts:emoji && pnpm test:prompts:qa",
+    "test:prompts:abstract-chunk": "promptfoo eval -c promptfoo/abstract-chunk/eval.yaml",
     "test:prompts:emoji": "promptfoo eval -c promptfoo/emoji-picker/eval.yaml",
     "test:prompts:lang": "promptfoo eval -c promptfoo/language-detection/eval.yaml",
     "test:prompts:qa": "promptfoo eval -c promptfoo/knowledge-qa/eval.yaml",

--- a/packages/prompts/promptfoo/abstract-chunk/eval.yaml
+++ b/packages/prompts/promptfoo/abstract-chunk/eval.yaml
@@ -1,0 +1,111 @@
+description: Test chunk text summarization in different languages
+
+providers:
+  - openai:chat:gpt-5-mini
+  - openai:chat:claude-3-5-haiku-latest
+  - openai:chat:gemini-flash-latest
+  - openai:chat:deepseek-chat
+
+prompts:
+  - file://promptfoo/abstract-chunk/prompt.ts
+
+tests:
+  # English technical content
+  - vars:
+      text: "React is a JavaScript library for building user interfaces. It was developed by Facebook and is now maintained by Facebook and the community. React makes it painless to create interactive UIs. Design simple views for each state in your application, and React will efficiently update and render just the right components when your data changes. Declarative views make your code more predictable and easier to debug."
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in English, capturing the main topic about React being a JavaScript library for UIs"
+      - type: contains-any
+        value: ["React", "JavaScript", "library", "UI", "user interface"]
+      - type: javascript
+        value: "output.split(/[.!?]/).filter(s => s.trim()).length <= 2"  # At most 2 sentences
+
+  # Chinese content
+  - vars:
+      text: "深度学习是机器学习的一个分支，它使用多层神经网络来学习数据的表示。近年来，深度学习在图像识别、自然语言处理、语音识别等领域取得了突破性进展。卷积神经网络（CNN）在计算机视觉任务中表现优异，而循环神经网络（RNN）和Transformer架构在序列建模任务中非常有效。"
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in Chinese, summarizing deep learning and its applications"
+      - type: contains-any
+        value: ["深度学习", "神经网络", "机器学习"]
+      - type: not-contains
+        value: "摘要"  # Should not contain meta labels
+      - type: javascript
+        value: "output.split(/[。!?]/).filter(s => s.trim()).length <= 2"  # At most 2 sentences
+
+  # Japanese content
+  - vars:
+      text: "人工知能（AI）は、コンピュータシステムが人間の知能を模倣する技術です。AIは、学習、推論、問題解決などの認知機能を実行できます。現代のAIシステムは、大量のデータから学習し、パターンを認識して予測を行います。"
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in Japanese about artificial intelligence"
+      - type: contains-any
+        value: ["人工知能", "AI", "コンピュータ"]
+      - type: javascript
+        value: "output.split(/[。!?]/).filter(s => s.trim()).length <= 2"
+
+  # Spanish content
+  - vars:
+      text: "El cambio climático es uno de los mayores desafíos que enfrenta la humanidad en el siglo XXI. Las temperaturas globales están aumentando debido a las emisiones de gases de efecto invernadero producidas por actividades humanas como la quema de combustibles fósiles, la deforestación y la agricultura industrial. Los efectos incluyen el derretimiento de los glaciares, el aumento del nivel del mar y eventos climáticos extremos más frecuentes."
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in Spanish about climate change"
+      - type: contains-any
+        value: ["cambio climático", "temperatura", "clima"]
+      - type: javascript
+        value: "output.split(/[.!?]/).filter(s => s.trim()).length <= 2"
+
+  # Short technical content (English)
+  - vars:
+      text: "TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions to JavaScript, making code more robust and maintainable."
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in English about TypeScript"
+      - type: contains-any
+        value: ["TypeScript", "JavaScript", "type"]
+      - type: javascript
+        value: "output.split(/[.!?]/).filter(s => s.trim()).length <= 2"
+
+  # Mixed technical terms in Chinese
+  - vars:
+      text: "Docker 是一个开源的容器化平台，它允许开发者将应用程序及其依赖项打包到一个可移植的容器中。通过使用 Docker，可以确保应用在任何环境中都能一致地运行。Docker 容器比传统虚拟机更轻量级，启动速度更快，资源占用更少。"
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in Chinese, keeping 'Docker' in English"
+      - type: contains
+        value: "Docker"  # Technical term should be preserved
+      - type: contains-any
+        value: ["容器", "平台", "应用"]
+      - type: javascript
+        value: "output.split(/[。!?]/).filter(s => s.trim()).length <= 2"
+
+  # German content
+  - vars:
+      text: "Die Quantenphysik ist ein fundamentaler Zweig der Physik, der sich mit dem Verhalten von Materie und Energie auf atomarer und subatomarer Ebene befasst. Im Gegensatz zur klassischen Physik beschreibt die Quantenphysik Phänomene, bei denen Teilchen sowohl Wellen- als auch Teilcheneigenschaften aufweisen können."
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in German about quantum physics"
+      - type: contains-any
+        value: ["Quantenphysik", "Physik", "Materie"]
+      - type: javascript
+        value: "output.split(/[.!?]/).filter(s => s.trim()).length <= 2"
+
+  # Code snippet in content (English)
+  - vars:
+      text: "The useState hook in React allows you to add state to functional components. For example: const [count, setCount] = useState(0). This creates a state variable 'count' with initial value 0 and a setter function 'setCount' to update it."
+    assert:
+      - type: llm-rubric
+        provider: openai:gpt-5-mini
+        value: "The summary should be 1-2 sentences in English about useState hook, may preserve code syntax"
+      - type: contains-any
+        value: ["useState", "React", "state", "hook"]
+      - type: javascript
+        value: "output.split(/[.!?]/).filter(s => s.trim()).length <= 2"

--- a/packages/prompts/promptfoo/abstract-chunk/prompt.ts
+++ b/packages/prompts/promptfoo/abstract-chunk/prompt.ts
@@ -1,0 +1,16 @@
+// TypeScript prompt wrapper that uses actual chain implementation
+import { chainAbstractChunkText } from '@lobechat/prompts';
+
+interface PromptVars {
+  text: string;
+}
+
+export default function generatePrompt({ vars }: { vars: PromptVars }) {
+  const { text } = vars;
+
+  // Use the actual chain function from src
+  const result = chainAbstractChunkText(text);
+
+  // Return messages array as expected by promptfoo
+  return result.messages || [];
+}

--- a/packages/prompts/promptfooconfig.yaml
+++ b/packages/prompts/promptfooconfig.yaml
@@ -7,6 +7,7 @@ testPaths:
   - promptfoo/language-detection/eval.yaml
   - promptfoo/emoji-picker/eval.yaml
   - promptfoo/knowledge-qa/eval.yaml
+  - promptfoo/abstract-chunk/eval.yaml
 
 # Output configuration
 outputPath: promptfoo-results.json

--- a/packages/prompts/src/chains/__tests__/__snapshots__/abstractChunk.test.ts.snap
+++ b/packages/prompts/src/chains/__tests__/__snapshots__/abstractChunk.test.ts.snap
@@ -1,10 +1,10 @@
-import { ChatStreamPayload } from '@lobechat/types';
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-export const chainAbstractChunkText = (text: string): Partial<ChatStreamPayload> => {
-  return {
-    messages: [
-      {
-        content: `You are a summarization expert. Generate a concise summary from the provided text chunk.
+exports[`chainAbstractChunkText > should generate correct chat payload for chunk text 1`] = `
+{
+  "messages": [
+    {
+      "content": "You are a summarization expert. Generate a concise summary from the provided text chunk.
 
 Rules:
 - Output ONLY the summary text itself, nothing else
@@ -26,13 +26,13 @@ Rules:
 <input>深度学习是机器学习的一个分支...</input>
 <output>深度学习是机器学习的一个分支，使用多层神经网络学习数据表示，在图像识别、自然语言处理等领域取得突破。</output>
 </examples>
-`,
-        role: 'system',
-      },
-      {
-        content: text,
-        role: 'user',
-      },
-    ],
-  };
-};
+",
+      "role": "system",
+    },
+    {
+      "content": "This is a sample chunk of text that needs to be summarized.",
+      "role": "user",
+    },
+  ],
+}
+`;

--- a/packages/prompts/src/chains/__tests__/abstractChunk.test.ts
+++ b/packages/prompts/src/chains/__tests__/abstractChunk.test.ts
@@ -8,26 +8,7 @@ describe('chainAbstractChunkText', () => {
 
     const result = chainAbstractChunkText(testText);
 
-    expect(result).toEqual({
-      messages: [
-        {
-          content:
-            '你是一名擅长从 chunk 中提取摘要的助理，你需要将用户的会话总结为 1~2 句话的摘要，输出成 chunk 所使用的语种',
-          role: 'system',
-        },
-        {
-          content: `chunk: ${testText}`,
-          role: 'user',
-        },
-      ],
-    });
-  });
-
-  it('should handle empty text', () => {
-    const result = chainAbstractChunkText('');
-
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages![1].content).toBe('chunk: ');
+    expect(result).toMatchSnapshot();
   });
 
   it('should handle text with special characters', () => {
@@ -35,7 +16,7 @@ describe('chainAbstractChunkText', () => {
 
     const result = chainAbstractChunkText(testText);
 
-    expect(result.messages![1].content).toBe(`chunk: ${testText}`);
+    expect(result.messages![1].content).toBe(testText);
   });
 
   it('should always use system role for first message', () => {

--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon, ActionIconProps } from '@lobehub/ui';
-import { Github } from 'lucide-react';
+import { FlaskConical, Github } from 'lucide-react';
 import Link from 'next/link';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { GITHUB } from '@/const/url';
@@ -14,7 +15,8 @@ const ICON_SIZE: ActionIconProps['size'] = {
 };
 
 const BottomActions = memo(() => {
-  // const { t } = useTranslation('common');
+  const { t } = useTranslation('common');
+
   const { hideGitHub } = useServerConfigStore(featureFlagsSelectors);
 
   return (
@@ -29,14 +31,14 @@ const BottomActions = memo(() => {
           />
         </Link>
       )}
-      {/*<Link aria-label={t('labs')} href={'/labs'}>*/}
-      {/*  <ActionIcon*/}
-      {/*    icon={FlaskConical}*/}
-      {/*    size={ICON_SIZE}*/}
-      {/*    title={t('labs')}*/}
-      {/*    tooltipProps={{ placement: 'right' }}*/}
-      {/*  />*/}
-      {/*</Link>*/}
+      <Link aria-label={t('labs')} href={'/labs'}>
+        <ActionIcon
+          icon={FlaskConical}
+          size={ICON_SIZE}
+          title={t('labs')}
+          tooltipProps={{ placement: 'right' }}
+        />
+      </Link>
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/labs/components/LabCard.tsx
+++ b/src/app/[variants]/(main)/labs/components/LabCard.tsx
@@ -7,6 +7,7 @@ import { Flexbox } from 'react-layout-kit';
 
 interface LabCardProps {
   checked: boolean;
+  cover?: string;
   desc: string;
   loading: boolean;
   meta?: string;
@@ -35,14 +36,24 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   row: css`
     display: grid;
-    grid-template-columns: 240px 1fr 80px;
+    grid-template-columns: 250px 1fr 80px;
     gap: 16px;
     align-items: center;
   `,
   thumb: css`
-    height: 128px;
+    overflow: hidden;
+
+    width: 250px;
+    height: 150px;
     border-radius: ${token.borderRadiusLG}px;
+
     background: linear-gradient(135deg, ${token.colorFillTertiary}, ${token.colorFillQuaternary});
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   `,
   title: css`
     font-size: 16px;
@@ -55,14 +66,14 @@ const useStyles = createStyles(({ css, token }) => ({
 }));
 
 const LabCard = memo<PropsWithChildren<LabCardProps>>(
-  ({ title, desc, checked, onChange, meta, loading }) => {
+  ({ title, desc, checked, onChange, meta, loading, cover }) => {
     const { styles } = useStyles();
 
     return (
       <div className={styles.wrap}>
         <div className={styles.card}>
           <div className={styles.row}>
-            <div className={styles.thumb} />
+            <div className={styles.thumb}>{cover && <img alt={title} src={cover} />}</div>
             <Flexbox gap={6}>
               <div className={styles.title}>{title}</div>
               <div className={styles.desc}>{desc}</div>

--- a/src/app/[variants]/(main)/labs/page.tsx
+++ b/src/app/[variants]/(main)/labs/page.tsx
@@ -10,46 +10,73 @@ import { preferenceSelectors } from '@/store/user/selectors';
 import Hero from './components/Hero';
 import LabCard from './components/LabCard';
 
+interface LabItem {
+  checked: boolean;
+  cover?: string;
+  desc: string;
+  key: string;
+  onChange: (checked: boolean) => void;
+  title: string;
+}
+
 const LabsPage = memo(() => {
   const { t } = useTranslation('labs');
 
-  const [isPreferenceInit, inputMarkdownRender, enableGroupChat, updatePreference] = useUserStore(
-    (s) => [
-      preferenceSelectors.isPreferenceInit(s),
-      preferenceSelectors.inputMarkdownRender(s),
-      preferenceSelectors.enableGroupChat(s),
-      s.updatePreference,
-    ],
-  );
+  const [
+    isPreferenceInit,
+    inputMarkdownRender,
+    // enableGroupChat,
+    updatePreference,
+  ] = useUserStore((s) => [
+    preferenceSelectors.isPreferenceInit(s),
+    preferenceSelectors.inputMarkdownRender(s),
+    // preferenceSelectors.enableGroupChat(s),
+    s.updatePreference,
+  ]);
 
   const onToggleMarkdown = useCallback(
     (checked: boolean) => updatePreference({ disableInputMarkdownRender: !checked }),
     [updatePreference],
   );
-  const onToggleGroupChat = useCallback(
-    (checked: boolean) => updatePreference({ enableGroupChat: checked }),
-    [updatePreference],
-  );
+  // const onToggleGroupChat = useCallback(
+  //   (checked: boolean) => updatePreference({ enableGroupChat: checked }),
+  //   [updatePreference],
+  // );
+
+  const labItems: LabItem[] = [
+    {
+      checked: inputMarkdownRender,
+      cover: 'https://github.com/user-attachments/assets/0527a966-3d95-46b4-b880-c0f3fca18f02',
+      desc: t('features.inputMarkdown.desc'),
+      key: 'inputMarkdown',
+      onChange: onToggleMarkdown,
+      title: t('features.inputMarkdown.title'),
+    },
+    // {
+    //   checked: enableGroupChat,
+    //   cover: 'https://github.com/user-attachments/assets/72894d24-a96a-4d7c-a823-ff9e6a1a8b6d',
+    //   desc: t('features.groupChat.desc'),
+    //   key: 'groupChat',
+    //   onChange: onToggleGroupChat,
+    //   title: t('features.groupChat.title'),
+    // },
+  ];
 
   return (
     <Flexbox gap={16} padding={8} style={{ alignItems: 'center', width: '100%' }}>
       <Hero />
 
-      <LabCard
-        checked={inputMarkdownRender}
-        desc={t('features.inputMarkdown.desc')}
-        loading={!isPreferenceInit}
-        onChange={onToggleMarkdown}
-        title={t('features.inputMarkdown.title')}
-      />
-
-      <LabCard
-        checked={enableGroupChat}
-        desc={t('features.groupChat.desc')}
-        loading={!isPreferenceInit}
-        onChange={onToggleGroupChat}
-        title={t('features.groupChat.title')}
-      />
+      {labItems.map((item) => (
+        <LabCard
+          checked={item.checked}
+          cover={item.cover}
+          desc={item.desc}
+          key={item.key}
+          loading={!isPreferenceInit}
+          onChange={item.onChange}
+          title={item.title}
+        />
+      ))}
     </Flexbox>
   );
 });

--- a/src/store/user/slices/preference/selectors.ts
+++ b/src/store/user/slices/preference/selectors.ts
@@ -24,8 +24,7 @@ export const preferenceSelectors = {
   enableGroupChat: (s: UserStore) => s.preference.enableGroupChat || false,
   hideSettingsMoveGuide,
   hideSyncAlert,
-  // TODO: 等到 lab 样式搞完再开启
-  inputMarkdownRender: (s: UserStore) => false && !s.preference.disableInputMarkdownRender,
+  inputMarkdownRender: (s: UserStore) => !s.preference.disableInputMarkdownRender,
   isPreferenceInit,
   shouldTriggerFileInKnowledgeBaseTip,
   showUploadFileInKnowledgeBaseTip,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Standardize and enhance the abstractChunk summarization chain with detailed English instructions and examples, remove the redundant "chunk:" prefix, and update tests to use snapshots. Integrate a comprehensive promptfoo evaluation suite for multilingual summarization and add the corresponding test script and configuration.

Enhancements:
- Replace the Chinese system prompt with detailed English rules and examples for concise summarization
- Remove the "chunk:" prefix so the user message sends raw text to the chain
- Switch unit tests to snapshot-based validation and adjust assertions for the new prompt format

Build:
- Add a new "test:prompts:abstract-chunk" script in package.json
- Update promptfooconfig.yaml to include the abstract-chunk evaluation

Tests:
- Add a promptfoo eval configuration and wrapper for abstract-chunk summarization
- Introduce multilingual test cases covering English, Chinese, Japanese, Spanish, German, and code snippets