### PR TITLE
🐛 fix(provider): add deepseek-v3.1-terminus to THINKING_MODELS

### DIFF
--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -3,7 +3,7 @@ import { ModelProvider } from 'model-bank';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { processMultiProviderModelList } from '../../utils/modelParse';
 
-const THINKING_MODELS = ['deepseek-ai/deepseek-v3.1'];
+const THINKING_MODELS = ['deepseek-ai/deepseek-v3.1', 'deepseek-ai/deepseek-v3.1-terminus'];
 
 export interface NvidiaModelCard {
   id: string;


### PR DESCRIPTION
Add missing deepseek-ai/deepseek-v3.1-terminus model to THINKING_MODELS array to enable Deep-Think functionality for DeepSeek V3.1 Terminus via NVIDIA NIM.

Fixes #9648

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Include 'deepseek-ai/deepseek-v3.1-terminus' in THINKING_MODELS array to enable Deep-Think functionality for Terminus model