### PR TITLE
💄 style: Optimize OpenRouter modelFetch endpoint

### DIFF
--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -21,7 +21,7 @@ testProvider({
 });
 
 // Mock the console.error to avoid polluting test output
-vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => { });
 
 let instance: LobeOpenAICompatibleRuntime;
 
@@ -154,8 +154,8 @@ describe('LobeOpenRouterAI', () => {
 
       const list = await instance.models();
 
-      // 验证在当前实现中，当 frontend fetch 返回非 ok 时，会返回空列表
-      expect(fetch).toHaveBeenCalledWith('https://openrouter.ai/api/frontend/models');
+      // 验证在当前实现中，当 model fetch 返回非 ok 时，会返回空列表
+      expect(fetch).toHaveBeenCalledWith('https://openrouter.ai/api/v1/models');
       expect(list.length).toBe(0);
       expect(list).toEqual([]);
     });

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -74,24 +74,19 @@ export const LobeOpenRouterAI = createOpenAICompatibleRuntime({
 
       const inputModalities = architecture.input_modalities || [];
 
-      // 处理 name，智能去除冒号及其前面的内容
+      // 处理 name，默认去除冒号及其前面的内容
       let displayName = model.name;
       const colonIndex = displayName.indexOf(':');
       if (colonIndex !== -1) {
         const prefix = displayName.substring(0, colonIndex).trim();
         const suffix = displayName.substring(colonIndex + 1).trim();
 
-        // 规则1: 如果前缀是特定厂商名称，直接去掉
-        const removeProviders = ['OpenAI', 'Google', 'Anthropic'];
-        const shouldRemovePrefix = removeProviders.some(
-          provider => prefix.toLowerCase() === provider.toLowerCase()
-        );
+        const isDeepSeekPrefix = prefix.toLowerCase() === 'deepseek';
+        const suffixHasDeepSeek = suffix.toLowerCase().includes('deepseek');
 
-        // 规则2: 如果冒号后的内容包含前缀（不区分大小写），去掉重复
-        const hasRepetition = suffix.toLowerCase().includes(prefix.toLowerCase());
-
-        // 满足任一规则则去掉前缀
-        if (shouldRemovePrefix || hasRepetition) {
+        if (isDeepSeekPrefix && !suffixHasDeepSeek) {
+          displayName = model.name;
+        } else {
           displayName = suffix;
         }
       }

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -58,7 +58,7 @@ export const LobeOpenRouterAI = createOpenAICompatibleRuntime({
     let modelList: OpenRouterModelCard[] = [];
 
     try {
-      const response = await fetch('https://openrouter.ai/api/frontend/models');
+      const response = await fetch('https://openrouter.ai/api/v1/models');
       if (response.ok) {
         const data = await response.json();
         modelList = data['data'];
@@ -70,19 +70,36 @@ export const LobeOpenRouterAI = createOpenAICompatibleRuntime({
 
     // 处理前端获取的模型信息，转换为标准格式
     const formattedModels = modelList.map((model) => {
-      const { endpoint } = model;
-      const endpointModel = endpoint?.model;
+      const { top_provider, architecture, pricing, supported_parameters } = model;
 
-      const inputModalities = endpointModel?.input_modalities || model.input_modalities;
+      const inputModalities = architecture.input_modalities || [];
 
-      let displayName = model.slug?.toLowerCase().includes('deepseek') && !model.short_name?.toLowerCase().includes('deepseek')
-        ? (model.name ?? model.slug)
-        : (model.short_name ?? model.name ?? model.slug);
+      // 处理 name，智能去除冒号及其前面的内容
+      let displayName = model.name;
+      const colonIndex = displayName.indexOf(':');
+      if (colonIndex !== -1) {
+        const prefix = displayName.substring(0, colonIndex).trim();
+        const suffix = displayName.substring(colonIndex + 1).trim();
 
-      const inputPrice = formatPrice(endpoint?.pricing?.prompt);
-      const outputPrice = formatPrice(endpoint?.pricing?.completion);
-      const cachedInputPrice = formatPrice(endpoint?.pricing?.input_cache_read);
-      const writeCacheInputPrice = formatPrice(endpoint?.pricing?.input_cache_write);
+        // 规则1: 如果前缀是特定厂商名称，直接去掉
+        const removeProviders = ['OpenAI', 'Google', 'Anthropic'];
+        const shouldRemovePrefix = removeProviders.some(
+          provider => prefix.toLowerCase() === provider.toLowerCase()
+        );
+
+        // 规则2: 如果冒号后的内容包含前缀（不区分大小写），去掉重复
+        const hasRepetition = suffix.toLowerCase().includes(prefix.toLowerCase());
+
+        // 满足任一规则则去掉前缀
+        if (shouldRemovePrefix || hasRepetition) {
+          displayName = suffix;
+        }
+      }
+
+      const inputPrice = formatPrice(pricing.prompt);
+      const outputPrice = formatPrice(pricing.completion);
+      const cachedInputPrice = formatPrice(pricing.input_cache_read);
+      const writeCacheInputPrice = formatPrice(pricing.input_cache_write);
 
       const isFree = (inputPrice === 0 || outputPrice === 0) && !displayName.endsWith('(free)');
       if (isFree) {
@@ -90,14 +107,14 @@ export const LobeOpenRouterAI = createOpenAICompatibleRuntime({
       }
 
       return {
-        contextWindowTokens: endpoint?.context_length || model.context_length,
-        description: endpointModel?.description || model.description,
+        contextWindowTokens: top_provider.context_length || model.context_length,
+        description: model.description,
         displayName,
-        functionCall: endpoint?.supports_tool_parameters || false,
-        id: endpoint?.model_variant_slug || model.slug,
+        functionCall: supported_parameters.includes('tools'),
+        id: model.id,
         maxOutput:
-          typeof endpoint?.max_completion_tokens === 'number'
-            ? endpoint.max_completion_tokens
+          typeof top_provider.max_completion_tokens === 'number'
+            ? top_provider.max_completion_tokens
             : undefined,
         pricing: {
           input: inputPrice,
@@ -105,9 +122,9 @@ export const LobeOpenRouterAI = createOpenAICompatibleRuntime({
           writeCacheInput: writeCacheInputPrice,
           output: outputPrice,
         },
-        reasoning: endpoint?.supports_reasoning || false,
-        releasedAt: new Date(model.created_at).toISOString().split('T')[0],
-        vision: Array.isArray(inputModalities) && inputModalities.includes('image'),
+        reasoning: supported_parameters.includes('reasoning'),
+        releasedAt: new Date(model.created * 1000).toISOString().split('T')[0],
+        vision: inputModalities.includes('image'),
       };
     });
 

--- a/packages/model-runtime/src/providers/openrouter/type.ts
+++ b/packages/model-runtime/src/providers/openrouter/type.ts
@@ -5,37 +5,38 @@ interface ModelPricing {
   input_cache_write?: string;
   prompt: string;
   request?: string;
+  web_search?: string;
+  internal_reasoning?: string;
+}
+
+interface TopProvider {
+  context_length: number;
+  max_completion_tokens: number | null;
+  is_moderated: boolean;
+}
+
+interface Architecture {
+  modality: string;
+  input_modalities: string[];
+  output_modalities: string[];
+  tokenizer: string;
+  instruct_type: string | null;
 }
 
 export interface OpenRouterModelCard {
-  context_length: number;
-  created_at: number;
+  id: string;
+  canonical_slug: string;
+  hugging_face_id?: string;
+  name: string;
+  created: number;
   description?: string;
-  endpoint: OpenRouterModelEndpoint;
-  input_modalities?: string[];
-  name?: string;
-  output_modalities?: string[];
-  per_request_limits?: any | null;
-  short_name?: string;
-  slug: string;
-}
-
-interface OpenRouterModelEndpoint {
-  context_length?: number;
-  max_completion_tokens: number | null;
-  model?: {
-    description?: string;
-    input_modalities?: string[];
-    name?: string;
-    short_name?: string;
-    slug: string;
-  };
-  model_variant_slug?: string;
+  context_length: number;
+  architecture: Architecture;
   pricing: ModelPricing;
+  top_provider: TopProvider;
+  per_request_limits?: any | null;
   supported_parameters: string[];
-  supports_reasoning?: boolean;
-  supports_tool_parameters?: boolean;
-  variant?: 'free' | 'standard' | 'unknown';
+  default_parameters?: any | null;
 }
 
 interface OpenRouterOpenAIReasoning {


### PR DESCRIPTION
…ucture

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

- close #9649

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Optimize the OpenRouter modelFetch endpoint by migrating to the v1 API, flattening the response schema, and improving model metadata extraction

Enhancements:
- Switch OpenRouter model fetch URL to the v1 endpoint
- Restructure model mapping and type definitions to align with the new API schema (top_provider, architecture)
- Enhance displayName parsing by stripping vendor prefixes and duplicate segments
- Extract pricing, token limits, and feature flags (functionCall, reasoning, vision) from the flattened schema fields