### PR TITLE
🔨 chore(ci): Improve Claude translator prompt to prevent hallucination

### DIFF
--- a/.github/workflows/claude-translator.yml
+++ b/.github/workflows/claude-translator.yml
@@ -86,7 +86,19 @@ jobs:
                  [Original content]
                  </details>
 
-            4. Update using gh tool:
+            4. CRITICAL RULES to prevent hallucination and ensure accuracy:
+
+               - The "Original Content" section MUST contain the EXACT, UNMODIFIED original text byte-for-byte. NEVER add, remove, modify, or hallucinate ANY content in this section.
+               - Code blocks, error logs, JSON structures, and other technical content MUST appear in BOTH the translated section AND the original content section WITHOUT ANY MODIFICATION.
+               - When translating content with code/logs/JSON:
+                 * Copy the code/logs/JSON blocks identically to both sections
+                 * Only translate the natural language text (e.g., Chinese, Japanese) surrounding the code blocks
+                 * Keep all technical content (URLs, variable names, error messages in English) unchanged
+               - ALWAYS verify the "Original Content" section matches the source text exactly before updating
+               - If you detect any discrepancy, retrieve the original content again to ensure accuracy
+               - Pay special attention to the end of comments - do not drop or hallucinate the last sentences
+
+            5. Update using gh tool:
 
                - Choose the correct command based on the Event type in environment information:
                  - If Event is 'issues': gh issue edit [ISSUE_NUMBER] --title "[English title]" --body "[Translated content + Original content]"


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

Add critical rules in `.github/workflows/claude-translator.yml` to prevent translation hallucination issues:
- Enforce exact preservation of original content without modification
- Ensure code blocks, error logs, and JSON appear in both sections
- Clarify that only natural language should be translated
- Add verification step to check original content accuracy
- Prevent dropping or hallucinating end-of-comment sentences

This addresses issues where the translator was hallucinating content in the "Original Content" section and incorrectly handling large technical blocks like error logs and JSON structures.

#### 📝 Additional Information

My [comment](https://github.com/lobehub/lobe-chat/issues/9603#issuecomment-3393888128) in a issue of this repo was wrongly translated by the claude-translator action. The translation changed the original meaning of my comment and even copied the "Original Content" wrongly because of LLM hallucinations.

## Summary by Sourcery

Strengthen the Claude translator CI workflow to prevent hallucination by enforcing exact original content, preserving technical blocks, limiting translation to natural language, verifying source accuracy, and avoiding dropped or altered sentences.

Bug Fixes:
- Add critical rules to the Claude translator workflow to enforce exact preservation of original text, prevent hallucination, and preserve code blocks, logs, and JSON structures unchanged.

CI:
- Update .github/workflows/claude-translator.yml to include verification steps and strict rules for content accuracy in translations.