### PR TITLE
🔨 chore: output JSON support tools calling mode

### DIFF
--- a/packages/model-runtime/src/providers/anthropic/generateObject.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/generateObject.test.ts
@@ -4,7 +4,24 @@ import { describe, expect, it, vi } from 'vitest';
 import { createAnthropicGenerateObject } from './generateObject';
 
 describe('Anthropic generateObject', () => {
-  describe('createAnthropicGenerateObject', () => {
+  it('should throw error when neither tools nor schema is provided', async () => {
+    const mockClient = {
+      messages: {
+        create: vi.fn(),
+      },
+    };
+
+    const payload = {
+      messages: [{ content: 'Generate data', role: 'user' as const }],
+      model: 'claude-3-5-sonnet-20241022',
+    };
+
+    await expect(createAnthropicGenerateObject(mockClient as any, payload as any)).rejects.toThrow(
+      'tools or schema is required',
+    );
+  });
+
+  describe('use struct output schema', () => {
     it('should return structured data on successful API call', async () => {
       const mockClient = {
         messages: {
@@ -243,56 +260,193 @@ describe('Anthropic generateObject', () => {
         },
       });
     });
+  });
 
-    it('should propagate API errors correctly', async () => {
-      const apiError = new Error('API Error: Model not found');
-
+  describe('tools calling', () => {
+    it('should handle tools calling mode with multiple tools', async () => {
       const mockClient = {
         messages: {
-          create: vi.fn().mockRejectedValue(apiError),
+          create: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'tool_use',
+                name: 'get_weather',
+                input: { city: 'New York', unit: 'celsius' },
+              },
+              {
+                type: 'tool_use',
+                name: 'get_time',
+                input: { timezone: 'America/New_York' },
+              },
+            ],
+          }),
         },
       };
 
       const payload = {
-        messages: [{ content: 'Generate data', role: 'user' as const }],
-        schema: {
-          name: 'test_tool',
-          schema: { type: 'object' },
-        },
+        messages: [{ content: 'What is the weather and time in New York?', role: 'user' as const }],
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get weather information',
+            parameters: {
+              type: 'object' as const,
+              properties: {
+                city: { type: 'string' },
+                unit: { type: 'string' },
+              },
+              required: ['city'],
+            },
+          },
+          {
+            name: 'get_time',
+            description: 'Get current time',
+            parameters: {
+              type: 'object' as const,
+              properties: {
+                timezone: { type: 'string' },
+              },
+              required: ['timezone'],
+            },
+          },
+        ],
         model: 'claude-3-5-sonnet-20241022',
       };
 
-      await expect(
-        createAnthropicGenerateObject(mockClient as any, payload as any),
-      ).rejects.toThrow('API Error: Model not found');
+      const result = await createAnthropicGenerateObject(mockClient as any, payload as any);
+
+      expect(mockClient.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 8192,
+          messages: [{ content: 'What is the weather and time in New York?', role: 'user' }],
+          tools: [
+            {
+              name: 'get_weather',
+              description: 'Get weather information',
+              input_schema: {
+                type: 'object',
+                properties: {
+                  city: { type: 'string' },
+                  unit: { type: 'string' },
+                },
+                required: ['city'],
+              },
+            },
+            {
+              name: 'get_time',
+              description: 'Get current time',
+              input_schema: {
+                type: 'object',
+                properties: {
+                  timezone: { type: 'string' },
+                },
+                required: ['timezone'],
+              },
+            },
+          ],
+          tool_choice: {
+            type: 'any',
+          },
+        }),
+        expect.objectContaining({}),
+      );
+
+      expect(result).toEqual([
+        { arguments: { city: 'New York', unit: 'celsius' }, name: 'get_weather' },
+        { arguments: { timezone: 'America/New_York' }, name: 'get_time' },
+      ]);
     });
 
-    it('should handle abort signals correctly', async () => {
-      const apiError = new Error('Request was cancelled');
-      apiError.name = 'AbortError';
-
+    it('should handle tools calling mode with single tool', async () => {
       const mockClient = {
         messages: {
-          create: vi.fn().mockRejectedValue(apiError),
+          create: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'tool_use',
+                name: 'calculate',
+                input: { operation: 'add', a: 5, b: 3 },
+              },
+            ],
+          }),
         },
       };
 
       const payload = {
-        messages: [{ content: 'Generate data', role: 'user' as const }],
-        schema: {
-          name: 'test_tool',
-          schema: { type: 'object' },
-        },
+        messages: [{ content: 'Add 5 and 3', role: 'user' as const }],
+        tools: [
+          {
+            name: 'calculate',
+            description: 'Perform mathematical calculation',
+            parameters: {
+              type: 'object' as const,
+              properties: {
+                operation: { type: 'string' },
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+              required: ['operation', 'a', 'b'],
+            },
+          },
+        ],
         model: 'claude-3-5-sonnet-20241022',
       };
 
-      const options = {
-        signal: new AbortController().signal,
-      };
+      const result = await createAnthropicGenerateObject(mockClient as any, payload as any);
 
-      await expect(
-        createAnthropicGenerateObject(mockClient as any, payload as any, options),
-      ).rejects.toThrow();
+      expect(result).toEqual([{ arguments: { operation: 'add', a: 5, b: 3 }, name: 'calculate' }]);
     });
+  });
+
+  it('should propagate API errors correctly', async () => {
+    const apiError = new Error('API Error: Model not found');
+
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockRejectedValue(apiError),
+      },
+    };
+
+    const payload = {
+      messages: [{ content: 'Generate data', role: 'user' as const }],
+      schema: {
+        name: 'test_tool',
+        schema: { type: 'object' },
+      },
+      model: 'claude-3-5-sonnet-20241022',
+    };
+
+    await expect(createAnthropicGenerateObject(mockClient as any, payload as any)).rejects.toThrow(
+      'API Error: Model not found',
+    );
+  });
+
+  it('should handle abort signals correctly', async () => {
+    const apiError = new Error('Request was cancelled');
+    apiError.name = 'AbortError';
+
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockRejectedValue(apiError),
+      },
+    };
+
+    const payload = {
+      messages: [{ content: 'Generate data', role: 'user' as const }],
+      schema: {
+        name: 'test_tool',
+        schema: { type: 'object' },
+      },
+      model: 'claude-3-5-sonnet-20241022',
+    };
+
+    const options = {
+      signal: new AbortController().signal,
+    };
+
+    await expect(
+      createAnthropicGenerateObject(mockClient as any, payload as any, options),
+    ).rejects.toThrow();
   });
 });

--- a/packages/model-runtime/src/types/structureOutput.ts
+++ b/packages/model-runtime/src/types/structureOutput.ts
@@ -1,3 +1,5 @@
+import { ChatCompletionFunctions } from './chat';
+
 interface GenerateObjectMessage {
   content: string;
   name?: string;
@@ -20,7 +22,9 @@ export interface GenerateObjectPayload {
   messages: GenerateObjectMessage[];
   model: string;
   responseApi?: boolean;
-  schema: GenerateObjectSchema;
+  schema?: GenerateObjectSchema;
+  systemRole?: string;
+  tools?: ChatCompletionFunctions[];
 }
 
 export interface GenerateObjectOptions {

--- a/packages/types/src/aiChat.ts
+++ b/packages/types/src/aiChat.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { ChatMessage } from './message';
+import { LobeUniformTool, LobeUniformToolSchema } from './tool';
 import { ChatTopic } from './topic';
 
 export interface SendNewMessage {
@@ -58,6 +59,7 @@ export const StructureSchema = z.object({
   description: z.string().optional(),
   name: z.string(),
   schema: z.object({
+    $defs: z.any().optional(),
     additionalProperties: z.boolean().optional(),
     properties: z.record(z.string(), z.any()),
     required: z.array(z.string()).optional(),
@@ -71,13 +73,29 @@ export const StructureOutputSchema = z.object({
   messages: z.array(z.any()),
   model: z.string(),
   provider: z.string(),
-  schema: StructureSchema,
+  schema: StructureSchema.optional(),
+  systemRole: z.string().optional(),
+  tools: z.array(LobeUniformToolSchema).optional(),
 });
+
+interface IStructureSchema {
+  description: string;
+  name: string;
+  schema: {
+    additionalProperties?: boolean;
+    properties: Record<string, any>;
+    required?: string[];
+    type: 'object';
+  };
+  strict?: boolean;
+}
 
 export interface StructureOutputParams {
   keyVaultsPayload: string;
   messages: ChatMessage[];
   model: string;
   provider: string;
-  schema: any;
+  schema?: IStructureSchema;
+  systemRole?: string;
+  tools?: LobeUniformTool[];
 }

--- a/packages/types/src/tool/index.ts
+++ b/packages/types/src/tool/index.ts
@@ -28,3 +28,4 @@ export * from './crawler';
 export * from './interpreter';
 export * from './plugin';
 export * from './search';
+export * from './tool';

--- a/packages/types/src/tool/tool.ts
+++ b/packages/types/src/tool/tool.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { MetaData } from '../meta';
 
 export type LobeToolType = 'builtin' | 'customPlugin' | 'plugin';
@@ -11,3 +13,34 @@ export interface LobeToolMeta extends MetaData {
   meta: MetaData;
   type: LobeToolType;
 }
+
+export interface LobeUniformTool {
+  /**
+   * The description of what the function does.
+   */
+  description?: string;
+  /**
+   * The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.
+   */
+  name: string;
+  /**
+   * The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.
+   */
+  parameters: {
+    additionalProperties?: boolean;
+    properties: Record<string, any>;
+    required?: string[];
+    type: 'object';
+  };
+}
+
+export const LobeUniformToolSchema = z.object({
+  description: z.string().optional(),
+  name: z.string(),
+  parameters: z.object({
+    additionalProperties: z.boolean().optional(),
+    properties: z.record(z.string(), z.any()),
+    required: z.array(z.string()).optional(),
+    type: z.literal('object'),
+  }),
+});

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -60,6 +60,8 @@ export const aiChatRouter = router({
       messages: input.messages,
       model: input.model,
       schema: input.schema,
+      systemRole: input.systemRole,
+      tools: input.tools,
     });
 
     log('generateObject completed, result: %O', result);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable and test function/tool calling in generateObject across Anthropic and OpenAI runtimes by accepting a tools array and optional systemRole, refactor internal logic and types accordingly

New Features:
- Add support for tools-based function calling in generateObject for both Anthropic and OpenAI runtimes
- Allow passing an optional systemRole and tools array in the payload to trigger function/tool calls

Enhancements:
- Refactor Anthropic generateObject to unify handling of schema-based output and multiple tool calls via buildAnthropicTools
- Update OpenAI-compatible runtime to map function calls into a uniform array of name/arguments objects
- Extend types package with LobeUniformTool and Zod schema, and make schema, systemRole, and tools fields optional in payload types

Tests:
- Expand tests for tools calling mode covering multiple and single tools, systemRole injection, error propagation, and abort signals
- Update existing tool calling fallback tests to expect arrays of tool call results instead of single objects

Chores:
- Update aiChat router to forward systemRole and tools to the generateObject call