### PR TITLE
🐛 fix: prevent Vertex AI JSON credentials from being split by comma

### DIFF
--- a/src/services/__tests__/_auth.test.ts
+++ b/src/services/__tests__/_auth.test.ts
@@ -175,6 +175,20 @@ describe('getProviderAuthPayload', () => {
     });
   });
 
+  it('should return correct payload for VertexAI provider without splitting JSON credentials', () => {
+    // Vertex AI uses JSON credentials that contain commas
+    const mockVertexAIConfig = {
+      apiKey: '{"type":"service_account","project_id":"test-project","private_key":"test-key"}',
+      baseURL: 'https://us-central1-aiplatform.googleapis.com',
+    };
+
+    const payload = getProviderAuthPayload(ModelProvider.VertexAI, mockVertexAIConfig);
+    expect(payload).toEqual({
+      apiKey: mockVertexAIConfig.apiKey,
+      baseURL: mockVertexAIConfig.baseURL,
+    });
+  });
+
   it('should return an empty object or throw an error for an unknown provider', () => {
     const payload = getProviderAuthPayload('UnknownProvider', {});
     expect(payload).toEqual({});

--- a/src/services/_auth.ts
+++ b/src/services/_auth.ts
@@ -74,6 +74,11 @@ export const getProviderAuthPayload = (
       };
     }
 
+    case ModelProvider.VertexAI: {
+      // Vertex AI uses JSON credentials, should not split by comma
+      return { apiKey: keyVaults?.apiKey, baseURL: keyVaults?.baseURL };
+    }
+
     default: {
       return { apiKey: clientApiKeyManager.pick(keyVaults?.apiKey), baseURL: keyVaults?.baseURL };
     }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Fixed an issue where Vertex AI authentication would fail due to JSON credentials being incorrectly split by comma.

**Root Cause:**  
PR #9477 introduced random API key selection feature that splits API keys by comma. However, Vertex AI uses JSON format credentials (Google Cloud Service Account JSON) which naturally contain many commas. When the `clientApiKeyManager.pick()` function splits by comma, it breaks the JSON structure.

**Solution:**  
- Added special case handling for `ModelProvider.VertexAI` in `getProviderAuthPayload()` 
- Vertex AI credentials now bypass the random API key selection logic
- JSON credentials are passed through intact to the backend for proper parsing

**Changes:**
- Modified `src/services/_auth.ts` to add Vertex AI special case
- Added test case in `src/services/__tests__/_auth.test.ts` to verify JSON credentials remain intact


#### 📝 Additional Information

- fix https://github.com/lobehub/lobe-chat/issues/9604

**Testing:**
- ✅ All existing tests pass
- ✅ New test case added to verify Vertex AI JSON credentials are not split
- ✅ Pre-commit hooks (prettier, eslint, stylelint, typecheck) all pass

**Related:**
- Fixes regression introduced in #9477

🤖 Generated with [Claude Code](https://claude.com/claude-code)