### PR TITLE
🔧 fix: update Claude workflows to use oauth token

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -28,6 +28,6 @@ jobs:
         uses: anthropics/claude-code-base-action@beta
         with:
           prompt: '/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}'
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -187,7 +187,7 @@ jobs:
           prompt_file: /tmp/claude-prompts/triage-prompt.md
           allowed_tools: "Bash(gh *),Read"
           timeout_minutes: "5"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Updated `claude-issue-triage.yml` and `claude-dedupe-issues.yml` workflows to use `claude_code_oauth_token` instead of `anthropic_api_key`
- Aligns with the configuration used in `claude-translator.yml`

## Test plan
- [ ] Verify workflows use correct token parameter
- [ ] Test workflow execution with oauth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Replace anthropic_api_key with claude_code_oauth_token in claude-dedupe-issues.yml and claude-issue-triage.yml