### PR TITLE
🔨 chore: refactor the prompt engineering

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -14,6 +14,7 @@
     "test:prompts:lang": "promptfoo eval -c promptfoo/language-detection/eval.yaml",
     "test:prompts:qa": "promptfoo eval -c promptfoo/knowledge-qa/eval.yaml",
     "test:prompts:summary": "promptfoo eval -c promptfoo/summary-title/eval.yaml",
+    "test:prompts:supervisor": "promptfoo eval -c promptfoo/supervisor/productive/eval.yaml",
     "test:prompts:translate": "promptfoo eval -c promptfoo/translate/eval.yaml",
     "test:update": "vitest -u"
   },
@@ -21,7 +22,7 @@
     "@lobechat/types": "workspace:*"
   },
   "devDependencies": {
-    "promptfoo": "^0.118.11",
+    "promptfoo": "^0.118.17",
     "tsx": "^4.20.4"
   }
 }

--- a/packages/prompts/promptfoo/supervisor/productive/eval.yaml
+++ b/packages/prompts/promptfoo/supervisor/productive/eval.yaml
@@ -1,0 +1,51 @@
+description: Test supervisor prompt generation for group chat orchestration
+
+prompts:
+  - file://promptfoo/supervisor/productive/prompt.ts
+
+providers:
+  - id: openai:chat:gpt-5
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+  - id: openai:chat:claude-sonnet-4-5-20250929
+    config:
+      tools: file://./tools.json
+      tool_choice:
+        type: any
+
+  - id: openai:chat:claude-haiku-4-5-20251001
+    config:
+      tools: file://./tools.json
+      tool_choice:
+        type: any
+
+  - id: openai:chat:gemini-2.5-pro
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+  - id: openai:chat:deepseek-chat
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+  - id: openai:chat:gpt-5-mini
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+  - id: openai:chat:o3
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+  - id: openai:chat:gpt-4.1-mini
+    config:
+      tools: file://./tools.json
+      tool_choice: required
+
+tests:
+  - file://./tests/basic-case.ts
+#  - file://./tests/role.ts

--- a/packages/prompts/promptfoo/supervisor/productive/prompt.ts
+++ b/packages/prompts/promptfoo/supervisor/productive/prompt.ts
@@ -1,0 +1,18 @@
+// TypeScript prompt wrapper that uses actual buildSupervisorPrompt implementation
+import { type SupervisorPromptParams, buildSupervisorPrompt } from '../../../src';
+
+const generatePrompt = ({
+  vars,
+}: {
+  vars: Omit<SupervisorPromptParams, 'allowDM' | 'scene'> & { role: string };
+}) => {
+  const prompt = buildSupervisorPrompt(vars);
+
+  // Return messages and tools for promptfoo
+  // Note: tools must be at top level for is-valid-openai-tools-call assertion to work
+  // The assertion reads from provider.config.tools, and promptfoo merges top-level
+  // properties into provider config
+  return [{ content: prompt, role: vars.role || 'user' }];
+};
+
+export default generatePrompt;

--- a/packages/prompts/promptfoo/supervisor/productive/tests/basic-case.ts
+++ b/packages/prompts/promptfoo/supervisor/productive/tests/basic-case.ts
@@ -1,0 +1,54 @@
+const testCases = [
+  // Tool Calling Test 1: Basic trigger_agent usage
+  {
+    assert: [
+      { type: 'is-valid-openai-tools-call' },
+      {
+        provider: 'openai:gpt-5-mini',
+        type: 'llm-rubric',
+        value:
+          'Should call trigger_agent tool to ask coder or designer to help with the login page task',
+      },
+    ],
+    vars: {
+      availableAgents: [
+        { id: 'coder', title: 'Code Wizard' },
+        { id: 'designer', title: 'UI Designer' },
+      ],
+      conversationHistory: 'User: I need help building a login page',
+      systemPrompt: 'You are coordinating a software development team',
+      userName: 'Bobs',
+    },
+  },
+  // just say hi - should only trigger_agent, no todo operations
+  {
+    assert: [
+      { type: 'is-valid-openai-tools-call' },
+      {
+        type: 'javascript',
+        value: `
+          // Ensure ONLY trigger_agent tool is called, no create_todo, finish_todo, etc.
+          const toolCalls = Array.isArray(output) ? output : [];
+          return toolCalls.length > 0 && toolCalls.every(call => call.function?.name === 'trigger_agent');
+        `,
+      },
+      {
+        provider: 'openai:gpt-5-mini',
+        type: 'llm-rubric',
+        value:
+          'Should call trigger_agent tool to greet the user or ask how to help. Should NOT include any create_todo or finish_todo calls.',
+      },
+    ],
+    vars: {
+      availableAgents: [
+        { id: 'agt_J34pj8igq5Hk', title: '全栈工程师' },
+        { id: 'agt_5xSoLVNHOjQj', title: '产品经理' },
+      ],
+      conversationHistory: '<message author="user">hi</message>',
+      role: 'user',
+      userName: 'Rene Wang',
+    },
+  },
+];
+
+export default testCases;

--- a/packages/prompts/promptfoo/supervisor/productive/tests/role.ts
+++ b/packages/prompts/promptfoo/supervisor/productive/tests/role.ts
@@ -1,0 +1,58 @@
+const assert = [
+  { type: 'is-valid-openai-tools-call' },
+  {
+    type: 'javascript',
+    value: `
+          // Debug: log the actual output structure
+          console.log('DEBUG output:', JSON.stringify(output, null, 2));
+
+          // Ensure ONLY trigger_agent tool is called, no create_todo, finish_todo, etc.
+          const toolCalls = Array.isArray(output) ? output : [];
+          if (toolCalls.length === 0) {
+            console.log('DEBUG: No tool calls found');
+            return false;
+          }
+
+          for (const call of toolCalls) {
+            const toolName = call.tool_name || call.function?.name || call.name;
+            console.log('DEBUG tool name:', toolName);
+
+            if (toolName !== 'trigger_agent') {
+              console.log('DEBUG: Found non-trigger_agent tool:', toolName);
+              return false;
+            }
+          }
+
+          console.log('DEBUG: All', toolCalls.length, 'calls are trigger_agent');
+          return true;
+        `,
+  },
+  {
+    provider: 'openai:gpt-5-mini',
+    type: 'llm-rubric',
+    value:
+      'Should call trigger_agent tool to greet the user or ask how to help. Should NOT include any create_todo or finish_todo calls.',
+  },
+];
+const vars = {
+  availableAgents: [
+    { id: 'agt_J34pj8igq5Hk', title: '全栈工程师' },
+    { id: 'agt_5xSoLVNHOjQj', title: '产品经理' },
+  ],
+  conversationHistory: '<message author="user">hi</message>',
+  role: 'user',
+  userName: 'Rene Wang',
+};
+
+const testCases = [
+  {
+    assert,
+    vars: { ...vars, role: 'user' },
+  },
+  {
+    assert,
+    vars: { ...vars, role: 'system' },
+  },
+];
+
+export default testCases;

--- a/packages/prompts/promptfoo/supervisor/productive/tools.json
+++ b/packages/prompts/promptfoo/supervisor/productive/tools.json
@@ -1,0 +1,80 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "trigger_agent",
+      "description": "Trigger an agent to speak (group message).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The agent id to trigger."
+          },
+          "instruction": {
+            "type": "string"
+          }
+        },
+        "required": ["instruction", "id"],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "wait_for_user_input",
+      "description": "Wait for user input. Use this when the conversation history looks likes fine for now, or agents are waiting for user input.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Optional reason for pausing the conversation."
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "create_todo",
+      "description": "Create a new todo item",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "type": "string",
+            "description": "Who will do the todo. Can be agent id or empty."
+          },
+          "content": {
+            "type": "string",
+            "description": "The todo content or description."
+          }
+        },
+        "required": ["content", "assignee"],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "finish_todo",
+      "description": "Finish a todo by index or all todos",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "number"
+          }
+        },
+        "required": ["index"],
+        "additionalProperties": false
+      }
+    }
+  }
+]

--- a/packages/prompts/src/contexts/index.ts
+++ b/packages/prompts/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './supervisor';

--- a/packages/prompts/src/contexts/supervisor/index.ts
+++ b/packages/prompts/src/contexts/supervisor/index.ts
@@ -1,0 +1,2 @@
+export * from './makeDecision';
+export * from './tools';

--- a/packages/prompts/src/contexts/supervisor/makeDecision.ts
+++ b/packages/prompts/src/contexts/supervisor/makeDecision.ts
@@ -1,0 +1,68 @@
+import { ChatCompletionTool, ChatMessage, ChatStreamPayload } from '@lobechat/types';
+
+import { groupChatPrompts, groupSupervisorPrompts } from '../../prompts';
+import { SupervisorToolName, SupervisorTools } from './tools';
+
+interface SupervisorTodoItem {
+  // optional assigned owner (agent id or name)
+  assignee?: string;
+  content: string;
+  finished: boolean;
+}
+
+interface AgentItem {
+  id: string;
+  title?: string | null;
+}
+export interface SupervisorContext {
+  allowDM?: boolean;
+  availableAgents: AgentItem[];
+  messages: ChatMessage[];
+  // Group scene controls which tools are exposed (e.g., todos only in 'productive')
+  scene?: 'casual' | 'productive';
+  systemPrompt?: string;
+  todoList?: SupervisorTodoItem[];
+  userName?: string;
+}
+
+export const contextSupervisorMakeDecision = ({
+  allowDM,
+  scene,
+  systemPrompt,
+  availableAgents,
+  todoList,
+  userName,
+  messages,
+}: SupervisorContext) => {
+  const conversationHistory = groupSupervisorPrompts(messages);
+  const prompt = groupChatPrompts.buildSupervisorPrompt({
+    allowDM,
+    availableAgents: availableAgents.filter((agent) => agent.id),
+    conversationHistory,
+    scene,
+    systemPrompt,
+    todoList,
+    userName,
+  });
+
+  const tools = SupervisorTools.filter((tool) => {
+    if (tool.name === SupervisorToolName.trigger_agent_dm) {
+      return allowDM;
+    }
+
+    if ([SupervisorToolName.finish_todo, SupervisorToolName.create_todo].includes(tool.name)) {
+      return scene === 'productive';
+    }
+
+    return true;
+  }).map<ChatCompletionTool>((tool) => ({
+    function: tool,
+    type: 'function',
+  }));
+
+  return {
+    messages: [{ content: prompt, role: 'user' }],
+    temperature: 0.3,
+    tools,
+  } satisfies Partial<ChatStreamPayload>;
+};

--- a/packages/prompts/src/contexts/supervisor/tools.ts
+++ b/packages/prompts/src/contexts/supervisor/tools.ts
@@ -1,0 +1,102 @@
+import { LobeUniformTool } from '@lobechat/types';
+
+export const SupervisorToolName = {
+  create_todo: 'create_todo',
+  finish_todo: 'finish_todo',
+  trigger_agent: 'trigger_agent',
+  trigger_agent_dm: 'trigger_agent_dm',
+  wait_for_user_input: 'wait_for_user_input',
+};
+
+export const SupervisorTools: LobeUniformTool[] = [
+  {
+    description: 'Trigger an agent to speak (group message).',
+    name: SupervisorToolName.trigger_agent,
+    parameters: {
+      properties: {
+        id: {
+          description: 'The agent id to trigger.',
+          type: 'string',
+        },
+        instruction: {
+          description:
+            'The instruction or message for the agent. No longer than 10 words. Always use English.',
+          type: 'string',
+        },
+      },
+      required: ['id', 'instruction'],
+      type: 'object',
+    },
+  },
+  {
+    description:
+      'Wait for user input. Use this when the conversation history looks likes fine for now, or agents are waiting for user input.',
+    name: SupervisorToolName.wait_for_user_input,
+    parameters: {
+      properties: {
+        reason: {
+          description: 'Optional reason for pausing the conversation.',
+          type: 'string',
+        },
+      },
+      required: [],
+      type: 'object',
+    },
+  },
+
+  {
+    description: 'Trigger an agent to DM another agent or user.',
+    name: SupervisorToolName.trigger_agent_dm,
+    parameters: {
+      additionalProperties: false,
+      properties: {
+        id: {
+          description: 'The agent id to trigger.',
+          type: 'string',
+        },
+        instruction: {
+          type: 'string',
+        },
+        target: {
+          description: 'The target agent id. Only used when need DM.',
+          type: 'string',
+        },
+      },
+      required: ['instruction', 'id', 'target'],
+      type: 'object',
+    },
+  },
+  {
+    description: 'Create a new todo item',
+    name: SupervisorToolName.create_todo,
+    parameters: {
+      additionalProperties: false,
+      properties: {
+        assignee: {
+          description: 'Who will do the todo. Can be agent id or empty.',
+          type: 'string',
+        },
+        content: {
+          description: 'The todo content or description.',
+          type: 'string',
+        },
+      },
+      required: ['content', 'assignee'],
+      type: 'object',
+    },
+  },
+  {
+    description: 'Finish a todo by index or all todos',
+    name: SupervisorToolName.finish_todo,
+    parameters: {
+      additionalProperties: false,
+      properties: {
+        index: {
+          type: 'number',
+        },
+      },
+      required: ['index'],
+      type: 'object',
+    },
+  },
+];

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './chains';
+export * from './contexts';
 export * from './prompts';

--- a/packages/types/src/aiChat.ts
+++ b/packages/types/src/aiChat.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { ChatMessage } from './message';
+import { OpenAIChatMessage } from './openai/chat';
 import { LobeUniformTool, LobeUniformToolSchema } from './tool';
 import { ChatTopic } from './topic';
 
@@ -75,7 +76,9 @@ export const StructureOutputSchema = z.object({
   provider: z.string(),
   schema: StructureSchema.optional(),
   systemRole: z.string().optional(),
-  tools: z.array(LobeUniformToolSchema).optional(),
+  tools: z
+    .array(z.object({ function: LobeUniformToolSchema, type: z.literal('function') }))
+    .optional(),
 });
 
 interface IStructureSchema {
@@ -92,10 +95,13 @@ interface IStructureSchema {
 
 export interface StructureOutputParams {
   keyVaultsPayload: string;
-  messages: ChatMessage[];
+  messages: OpenAIChatMessage[];
   model: string;
   provider: string;
   schema?: IStructureSchema;
   systemRole?: string;
-  tools?: LobeUniformTool[];
+  tools?: {
+    function: LobeUniformTool;
+    type: 'function';
+  }[];
 }

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -61,7 +61,7 @@ export const aiChatRouter = router({
       model: input.model,
       schema: input.schema,
       systemRole: input.systemRole,
-      tools: input.tools,
+      tools: input.tools?.map((item) => item.function),
     });
 
     log('generateObject completed, result: %O', result);

--- a/src/store/chat/slices/message/supervisor.test.ts
+++ b/src/store/chat/slices/message/supervisor.test.ts
@@ -5,10 +5,17 @@ import { aiChatService } from '@/services/aiChat';
 import { GroupChatSupervisor, type SupervisorContext } from './supervisor';
 
 vi.mock('@lobechat/prompts', () => ({
-  groupChatPrompts: {
-    buildSupervisorPrompt: vi.fn(() => 'structured-supervisor-prompt'),
-  },
-  groupSupervisorPrompts: vi.fn(() => 'conversation-history'),
+  contextSupervisorMakeDecision: vi.fn(() => ({
+    messages: [{ content: 'structured-supervisor-prompt', role: 'user' }],
+    temperature: 0.3,
+    tools: [
+      { function: { name: 'trigger_agent' }, type: 'function' },
+      { function: { name: 'wait_for_user_input' }, type: 'function' },
+      { function: { name: 'trigger_agent_dm' }, type: 'function' },
+      { function: { name: 'create_todo' }, type: 'function' },
+      { function: { name: 'finish_todo' }, type: 'function' },
+    ],
+  })),
 }));
 
 vi.mock('@/services/aiChat', () => ({
@@ -76,7 +83,7 @@ describe('GroupChatSupervisor', () => {
       temperature: 0.3,
     });
 
-    const toolNames = (payload.tools ?? []).map((tool: any) => tool.name);
+    const toolNames = (payload.tools ?? []).map((tool: any) => tool.function.name);
     expect(toolNames).toEqual(
       expect.arrayContaining([
         'trigger_agent',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Refactor the prompt engineering workflow by extracting supervisor prompt logic into reusable modules, standardizing project structure and TypeScript-based testing in documentation, simplifying the GroupChatSupervisor implementation, updating tool schemas and exports, and adding new promptfoo supervisor tests and scripts

New Features:
- Introduce contextSupervisorMakeDecision and SupervisorTools modules to encapsulate supervisor prompt and tool generation
- Add promptfoo supervisor/productive prompt definitions, tests, and eval configuration for group chat orchestration

Enhancements:
- Simplify GroupChatSupervisor and its callLLMForDecision method by delegating prompt and tool setup to the new context module
- Update aiChat type definitions to wrap tools as function objects and adjust server router mapping and exports
- Export new contexts in packages/prompts and reorganize imports to include supervisor tooling

Build:
- Bump promptfoo dependency to ^0.118.17 and add test:prompts:supervisor npm script

Documentation:
- Expand CLAUDE.md with standardized project structure, file descriptions, and best practices for prompt engineering and testing

Tests:
- Update supervisor unit tests to assert against function-wrapped tools
- Add TypeScript-based promptfoo supervisor/productive test cases covering basic and role scenarios