### PR TITLE
🔨 chore: support Feishu OAuth Provider

### DIFF
--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -3,6 +3,7 @@ title: LobeChat Authentication Service Environment Variables
 description: >-
   Explore the essential environment variables for configuring authentication services in LobeChat, including OAuth SSO, NextAuth settings, and provider-specific details.
 
+
 tags:
   - Authentication Service
   - OAuth SSO
@@ -279,6 +280,22 @@ LobeChat provides a complete authentication service capability when deployed. Th
 - Default: `-`
 - Example: `https://your-instance.okta.com`
 
+### Feishu
+
+#### `AUTH_FEISHU_APP_ID`
+
+- Type: Required
+- Description: App ID of the Feishu application.
+- Default: `-`
+- Example: `cli_9f7b1e1e1e1e1e1e`
+
+#### `AUTH_FEISHU_APP_SECRET`
+
+- Type: Required
+- Description: App Secret of the Feishu application.
+- Default: `-`
+- Example: `AlHxxX1e1e1e1e1e1e1e1e1e1e1e1e1e`
+
 ### Generic OIDC
 
 #### `AUTH_GENERIC_OIDC_ID`
@@ -323,19 +340,3 @@ LobeChat provides a complete authentication service capability when deployed. Th
 - Description: Secret key of the Clerk application.
 - Default: `-`
 - Example: `sk_test_513Ma0P7IAWM1XMv4waxZjRYRajWTaCfJLjpEO3SD2` in dev / `sk_live_eMMlHjwJvZFUfczFljSKqZdwQtLvmczmsJSNmdrpeZ` in production
-
-## feishu
-
-### `FEISHU_APP_ID`
-
-- Type: Required
-- Description: App ID of the Feishu application.
-- Default: `-`
-- Example: `cli_9f7b1e1e1e1e1e1e`
-
-### `FEISHU_APP_SECRET`
-
-- Type: Required
-- Description: App Secret of the Feishu application.
-- Default: `-`
-- Example: `AlHxxX1e1e1e1e1e1e1e1e1e1e1e1e1e`

--- a/docs/self-hosting/environment-variables/auth.mdx
+++ b/docs/self-hosting/environment-variables/auth.mdx
@@ -323,3 +323,19 @@ LobeChat provides a complete authentication service capability when deployed. Th
 - Description: Secret key of the Clerk application.
 - Default: `-`
 - Example: `sk_test_513Ma0P7IAWM1XMv4waxZjRYRajWTaCfJLjpEO3SD2` in dev / `sk_live_eMMlHjwJvZFUfczFljSKqZdwQtLvmczmsJSNmdrpeZ` in production
+
+## feishu
+
+### `FEISHU_APP_ID`
+
+- Type: Required
+- Description: App ID of the Feishu application.
+- Default: `-`
+- Example: `cli_9f7b1e1e1e1e1e1e`
+
+### `FEISHU_APP_SECRET`
+
+- Type: Required
+- Description: App Secret of the Feishu application.
+- Default: `-`
+- Example: `AlHxxX1e1e1e1e1e1e1e1e1e1e1e1e1e`

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -42,10 +42,6 @@ declare global {
       ZITADEL_CLIENT_ID?: string;
       ZITADEL_CLIENT_SECRET?: string;
       ZITADEL_ISSUER?: string;
-
-      // feishu
-      FEISHU_APP_ID?: string;
-      FEISHU_APP_SECRET?: string;
     }
   }
 }
@@ -214,10 +210,6 @@ export const getAuthConfig = () => {
 
       // Casdoor
       CASDOOR_WEBHOOK_SECRET: z.string().optional(),
-
-      // feishu
-      FEISHU_APP_ID: z.string().optional(),
-      FEISHU_APP_SECRET: z.string().optional(),
     },
 
     runtimeEnv: {
@@ -281,10 +273,6 @@ export const getAuthConfig = () => {
 
       // Casdoor
       CASDOOR_WEBHOOK_SECRET: process.env.CASDOOR_WEBHOOK_SECRET,
-
-      // feishu
-      FEISHU_APP_ID: process.env.FEISHU_APP_ID,
-      FEISHU_APP_SECRET: process.env.FEISHU_APP_SECRET,
     },
   });
 };

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -42,6 +42,10 @@ declare global {
       ZITADEL_CLIENT_ID?: string;
       ZITADEL_CLIENT_SECRET?: string;
       ZITADEL_ISSUER?: string;
+
+      // feishu
+      FEISHU_APP_ID?: string;
+      FEISHU_APP_SECRET?: string;
     }
   }
 }
@@ -210,6 +214,10 @@ export const getAuthConfig = () => {
 
       // Casdoor
       CASDOOR_WEBHOOK_SECRET: z.string().optional(),
+
+      // feishu
+      FEISHU_APP_ID: z.string().optional(),
+      FEISHU_APP_SECRET: z.string().optional(),
     },
 
     runtimeEnv: {
@@ -273,6 +281,10 @@ export const getAuthConfig = () => {
 
       // Casdoor
       CASDOOR_WEBHOOK_SECRET: process.env.CASDOOR_WEBHOOK_SECRET,
+
+      // feishu
+      FEISHU_APP_ID: process.env.FEISHU_APP_ID,
+      FEISHU_APP_SECRET: process.env.FEISHU_APP_SECRET,
     },
   });
 };

--- a/src/libs/next-auth/sso-providers/feishu.ts
+++ b/src/libs/next-auth/sso-providers/feishu.ts
@@ -1,8 +1,6 @@
 import { customFetch } from 'next-auth';
 import type { OAuthConfig } from 'next-auth/providers';
 
-import { authEnv } from '@/config/auth';
-
 interface FeishuProfile {
   avatar_big: string;
   avatar_middle: string;
@@ -31,8 +29,6 @@ function Feishu(): OAuthConfig<FeishuProfileResponse> {
     client: {
       token_endpoint_auth_method: 'client_secret_post',
     },
-    clientId: authEnv.FEISHU_APP_ID,
-    clientSecret: authEnv.FEISHU_APP_SECRET,
     [customFetch]: (url, options = {}) => {
       if (
         url === 'https://open.feishu.cn/open-apis/authen/v2/oauth/token' &&
@@ -65,6 +61,7 @@ function Feishu(): OAuthConfig<FeishuProfileResponse> {
         id: profile.union_id,
         image: profile.avatar_url,
         name: profile.name,
+        providerAccountId: profile.union_id,
       };
     },
     style: {

--- a/src/libs/next-auth/sso-providers/feishu.ts
+++ b/src/libs/next-auth/sso-providers/feishu.ts
@@ -1,0 +1,84 @@
+import { customFetch } from 'next-auth';
+import type { OAuthConfig } from 'next-auth/providers';
+
+import { authEnv } from '@/config/auth';
+
+interface FeishuProfile {
+  avatar_big: string;
+  avatar_middle: string;
+  avatar_thumb: string;
+  avatar_url: string;
+  en_name: string;
+  name: string;
+  open_id: string;
+  tenant_key: string;
+  union_id: string;
+}
+
+interface FeishuProfileResponse {
+  data: FeishuProfile;
+}
+
+function Feishu(): OAuthConfig<FeishuProfileResponse> {
+  return {
+    authorization: {
+      params: {
+        scope: '',
+      },
+      url: 'https://accounts.feishu.cn/open-apis/authen/v1/authorize',
+    },
+    checks: ['state'],
+    client: {
+      token_endpoint_auth_method: 'client_secret_post',
+    },
+    clientId: authEnv.FEISHU_APP_ID,
+    clientSecret: authEnv.FEISHU_APP_SECRET,
+    [customFetch]: (url, options = {}) => {
+      if (
+        url === 'https://open.feishu.cn/open-apis/authen/v2/oauth/token' &&
+        options.method === 'POST'
+      ) {
+        if (options?.headers) {
+          options.headers = {
+            ...options.headers,
+            'content-type': 'application/json; charset=utf-8',
+          };
+        } else {
+          options.headers = {
+            'content-type': 'application/json; charset=utf-8',
+          };
+        }
+
+        if (options.body instanceof URLSearchParams) {
+          options.body = JSON.stringify(Object.fromEntries(options.body));
+        }
+      }
+
+      return fetch(url, options);
+    },
+    id: 'feishu',
+    name: 'Feishu',
+    profile(profileResponse) {
+      const profile = profileResponse.data;
+
+      return {
+        id: profile.union_id,
+        image: profile.avatar_url,
+        name: profile.name,
+      };
+    },
+    style: {
+      logo: 'https://p1-hera.feishucdn.com/tos-cn-i-jbbdkfciu3/268ec674a56a4510889f7f5ca14f1ba1~tplv-jbbdkfciu3-image:0:0.image',
+    },
+    token: 'https://open.feishu.cn/open-apis/authen/v2/oauth/token',
+    type: 'oauth',
+    userinfo: 'https://open.feishu.cn/open-apis/authen/v1/user_info',
+  };
+}
+
+const provider = {
+  id: 'feishu',
+  provider: Feishu(),
+};
+
+export default provider;

--- a/src/libs/next-auth/sso-providers/feishu.ts
+++ b/src/libs/next-auth/sso-providers/feishu.ts
@@ -29,6 +29,8 @@ function Feishu(): OAuthConfig<FeishuProfileResponse> {
     client: {
       token_endpoint_auth_method: 'client_secret_post',
     },
+    clientId: process.env.AUTH_FEISHU_APP_ID,
+    clientSecret: process.env.AUTH_FEISHU_APP_SECRET,
     [customFetch]: (url, options = {}) => {
       if (
         url === 'https://open.feishu.cn/open-apis/authen/v2/oauth/token' &&

--- a/src/libs/next-auth/sso-providers/index.ts
+++ b/src/libs/next-auth/sso-providers/index.ts
@@ -5,6 +5,7 @@ import AzureAD from './azure-ad';
 import Casdoor from './casdoor';
 import CloudflareZeroTrust from './cloudflare-zero-trust';
 import Cognito from './cognito';
+import Feishu from './feishu';
 import GenericOIDC from './generic-oidc';
 import Github from './github';
 import Google from './google';
@@ -32,4 +33,5 @@ export const ssoProviders = [
   Google,
   Cognito,
   Okta,
+  Feishu,
 ];


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

replace https://github.com/lobehub/lobe-chat/pull/6386

## Summary by Sourcery

Add support for Feishu as an OAuth provider by implementing a Feishu NextAuth provider and updating documentation with required environment variables.

New Features:
- Add Feishu OAuth provider integration in NextAuth
- Introduce AUTH_FEISHU_APP_ID and AUTH_FEISHU_APP_SECRET environment variables

Documentation:
- Document Feishu-specific environment variables in authentication service guide