### PR TITLE
🐛fix: update search settings handling based on explicit model search abilities

### DIFF
--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -86,8 +86,8 @@ const inferProviderSearchDefaults = (
 const injectSearchSettings = (providerId: string, item: any) => {
   const abilities = item?.abilities || {};
 
-  // 模型未开启搜索能力：移除 settings 中的 search 相关字段，确保 UI 不显示启用模型内置搜索
-  if (abilities.search !== true) {
+  // 模型显式关闭搜索能力：移除 settings 中的 search 相关字段，确保 UI 不显示启用模型内置搜索
+  if (abilities.search === false) {
     if (item?.settings?.searchImpl || item?.settings?.searchProvider) {
       const next = { ...item } as any;
       if (next.settings) {
@@ -99,19 +99,25 @@ const injectSearchSettings = (providerId: string, item: any) => {
     return item;
   }
 
-  // 内置（本地）模型如果已经带了任一字段，直接保留，不覆盖
-  if (item?.settings?.searchImpl || item?.settings?.searchProvider) return item;
+  // 模型显式开启搜索能力：添加 settings 中的 search 相关字段
+  else if (abilities.search === true) {
+    // 内置（本地）模型如果已经带了任一字段，直接保留，不覆盖
+    if (item?.settings?.searchImpl || item?.settings?.searchProvider) return item;
 
-  // 否则按 providerId + modelId
-  const searchSettings = inferProviderSearchDefaults(providerId, item.id);
+    // 否则按 providerId + modelId
+    const searchSettings = inferProviderSearchDefaults(providerId, item.id);
 
-  return {
-    ...item,
-    settings: {
-      ...item.settings,
-      ...searchSettings,
-    },
-  };
+    return {
+      ...item,
+      settings: {
+        ...item.settings,
+        ...searchSettings,
+      },
+    };
+  }
+
+  // 兼容老版本中数据库没有存储 abilities.search 字段的情况
+  return item;
 };
 
 export class AiInfraRepos {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change
@arvinxx @sxjeru 此pr优先级很高，烦请尽快review

修复 pr #9022 引入的支持模型内置搜索的模型无法使用模型内置搜索的bug

已有多人反应：https://github.com/lobehub/lobe-chat/pull/9022#issuecomment-3398986449 #9756 #9742 https://github.com/lobehub/lobe-chat/discussions/9746

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

这个问题出现的原因是：之前的代码逻辑中，没有把联网搜索能力存到数据库，如果用户手动获取了模型列表或者手动更改了某个模型的配置后，数据库中联网搜索能力是缺失的。但是在对话页面，判断模型是否有联网搜索能力，是通过搜索参数来判断的，这就导致了模型没有显示搜索能力，但是可以使用模型内置搜索，如 #8760 #8099。

pr #9022 修改之后，在对话页面中，删去了没有搜索能力模型的搜索参数，这就导致了之前版本中，由手动获取模型列表或更改模型配置导致的搜索能力缺失的模型，同步删去了搜索参数，导致对话时判断没有内置搜索引擎，没有选择内置搜索的选项。

此pr合并后，删去搜索参数的逻辑改为只有在数据库中显式声明`"search": false`，才会删去。而老版数据库中，模型能力没有`"search"`字段，不会再删去搜索参数，兼容老版本。

- fix #9756 
<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix search settings handling to respect explicit model search ability flags and maintain backward compatibility

Bug Fixes:
- Only remove search settings when a model’s abilities.search is explicitly false to prevent unintended loss of built-in search options
- Preserve search settings for legacy models missing the abilities.search field to restore built-in search functionality

Enhancements:
- Inject default search settings for models with abilities.search explicitly set to true when not already defined