### PR TITLE
🐛 fix: fix topic fetch not correct in custom agent

### DIFF
--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -20,7 +20,6 @@ interface QueryTopicParams {
   containerId?: string | null; // sessionId or groupId
   current?: number;
   pageSize?: number;
-  sessionId?: string | null;
 }
 
 export class TopicModel {

--- a/src/server/services/aiChat/index.test.ts
+++ b/src/server/services/aiChat/index.test.ts
@@ -32,7 +32,7 @@ describe('AiChatService', () => {
       { includeTopic: true, sessionId: 's1' },
       expect.objectContaining({ postProcessUrl: expect.any(Function) }),
     );
-    expect(mockQueryTopics).toHaveBeenCalledWith({ sessionId: 's1' });
+    expect(mockQueryTopics).toHaveBeenCalledWith({ containerId: 's1' });
     expect(res.messages).toEqual([{ id: 'm1' }]);
     expect(res.topics).toEqual([{ id: 't1' }]);
   });

--- a/src/server/services/aiChat/index.ts
+++ b/src/server/services/aiChat/index.ts
@@ -29,7 +29,7 @@ export class AiChatService {
       this.messageModel.query(params, {
         postProcessUrl: (path) => this.fileService.getFullFileUrl(path),
       }),
-      params.includeTopic ? this.topicModel.query({ sessionId: params.sessionId }) : undefined,
+      params.includeTopic ? this.topicModel.query({ containerId: params.sessionId }) : undefined,
     ]);
 
     return { messages, topics };

--- a/src/services/topic/client.ts
+++ b/src/services/topic/client.ts
@@ -38,7 +38,7 @@ export class ClientService extends BaseClientService implements ITopicService {
   getTopics: ITopicService['getTopics'] = async (params) => {
     const data = await this.topicModel.query({
       ...params,
-      sessionId: this.toDbSessionId(params.containerId),
+      containerId: this.toDbSessionId(params.containerId),
     });
     return data as unknown as Promise<ChatTopic[]>;
   };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix topic retrieval by using containerId instead of sessionId across services and remove deprecated sessionId field from topic model.

Bug Fixes:
- Use containerId instead of sessionId when querying topics in AiChatService
- Pass containerId instead of sessionId in the topic client service’s getTopics method

Enhancements:
- Remove deprecated sessionId field from QueryTopicParams in the topic database model