### PR TITLE
👷 build(deps): add transitive phantom dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,8 @@
     "@modelcontextprotocol/sdk": "^1.20.0",
     "@neondatabase/serverless": "^1.0.2",
     "@next/third-parties": "^15.5.4",
+    "@opentelemetry/exporter-jaeger": "^2.1.0",
+    "@opentelemetry/winston-transport": "^0.17.0",
     "@react-spring/web": "^9.7.5",
     "@serwist/next": "^9.2.1",
     "@t3-oss/env-nextjs": "^0.13.8",


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

There're [phantom dependencies](https://rushjs.io/pages/advanced/phantom_deps/) from deps.

- `@opentelemetry/instrumentation-winston` depends on `@opentelemetry/winston-transport`, but its only listed as `devDependencies`.
- `@opentelemetry/sdk-node` depends on `@opentelemetry/exporter-jaeger`, but its only listed as `devDependencies`.

As a temporary workaround, `@opentelemetry/winston-transport`and `@opentelemetry/exporter-jaeger` are added.

These are bugs from upstream deps. Once they're resolved, `@opentelemetry/winston-transport`and `@opentelemetry/exporter-jaeger` can be safely removed from lobe chat.

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->
