### PR TITLE
💄 style: solve when desktop the sider agent list too long

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/index.tsx
@@ -27,12 +27,13 @@ const Top = () => {
 
 const Nav = memo(() => {
   const theme = useTheme();
-  const isSingleMode = useIsSingleMode()
+  const isSingleMode = useIsSingleMode();
   const inZenMode = useGlobalStore(systemStatusSelectors.inZenMode);
   const { showPinList } = useServerConfigStore(featureFlagsSelectors);
 
   return (
-    !inZenMode && !isSingleMode && (
+    !inZenMode &&
+    !isSingleMode && (
       <SideNav
         avatar={
           <div className={electronStylish.nodrag}>
@@ -54,11 +55,14 @@ const Nav = memo(() => {
         }}
         topActions={
           <Suspense>
-            <div className={electronStylish.nodrag} style={{
-              display: 'flex',
-              flexDirection: 'column',
-              maxHeight: "calc(100vh - 150px)"
-            }}>
+            <div
+              className={electronStylish.nodrag}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                maxHeight: isDesktop ? 'calc(100vh - 180px)' : 'calc(100vh - 150px)',
+              }}
+            >
               <Top />
               {showPinList && <PinList />}
             </div>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix sidebar list overflow on desktop by adjusting the maxHeight calculation and update conditional rendering formatting.

Bug Fixes:
- Use a larger vertical offset (180px) for the desktop sidebar’s topActions maxHeight to prevent the agent list from growing too long.

Enhancements:
- Add missing semicolon to the isSingleMode hook call and reformat the conditional render for readability.