### PR TITLE
💄 style: Show message author in minimap

### DIFF
--- a/locales/ar/chat.json
+++ b/locales/ar/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "الانتقال إلى الرسالة رقم {{index}}",
     "nextMessage": "الرسالة التالية",
-    "previousMessage": "الرسالة السابقة"
+    "previousMessage": "الرسالة السابقة",
+    "senderAssistant": "المساعد",
+    "senderUser": "أنت"
   },
   "newAgent": "مساعد جديد",
   "newGroupChat": "إنشاء دردشة جماعية جديدة",

--- a/locales/bg-BG/chat.json
+++ b/locales/bg-BG/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Отиди до съобщение № {{index}}",
     "nextMessage": "Следващо съобщение",
-    "previousMessage": "Предишно съобщение"
+    "previousMessage": "Предишно съобщение",
+    "senderAssistant": "Асистент",
+    "senderUser": "Ти"
   },
   "newAgent": "Нов агент",
   "newGroupChat": "Създаване на нов групов чат",

--- a/locales/de-DE/chat.json
+++ b/locales/de-DE/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Zur Nachricht Nr. {{index}} springen",
     "nextMessage": "Nächste Nachricht",
-    "previousMessage": "Vorherige Nachricht"
+    "previousMessage": "Vorherige Nachricht",
+    "senderAssistant": "Assistent",
+    "senderUser": "Du"
   },
   "newAgent": "Neuer Assistent",
   "newGroupChat": "Neue Gruppe erstellen",

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Jump to message {{index}}",
     "nextMessage": "Next message",
-    "previousMessage": "Previous message"
+    "previousMessage": "Previous message",
+    "senderAssistant": "Assistant",
+    "senderUser": "You"
   },
   "newAgent": "New Assistant",
   "newGroupChat": "New Group Chat",

--- a/locales/es-ES/chat.json
+++ b/locales/es-ES/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Ir al mensaje número {{index}}",
     "nextMessage": "Mensaje siguiente",
-    "previousMessage": "Mensaje anterior"
+    "previousMessage": "Mensaje anterior",
+    "senderAssistant": "Asistente",
+    "senderUser": "Tú"
   },
   "newAgent": "Nuevo asistente",
   "newGroupChat": "Crear nuevo chat de grupo",

--- a/locales/fa-IR/chat.json
+++ b/locales/fa-IR/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "رفتن به پیام شماره {{index}}",
     "nextMessage": "پیام بعدی",
-    "previousMessage": "پیام قبلی"
+    "previousMessage": "پیام قبلی",
+    "senderAssistant": "دستیار",
+    "senderUser": "شما"
   },
   "newAgent": "دستیار جدید",
   "newGroupChat": "ایجاد چت گروهی جدید",

--- a/locales/fr-FR/chat.json
+++ b/locales/fr-FR/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Aller au message n° {{index}}",
     "nextMessage": "Message suivant",
-    "previousMessage": "Message précédent"
+    "previousMessage": "Message précédent",
+    "senderAssistant": "Assistant",
+    "senderUser": "Vous"
   },
   "newAgent": "Nouvel agent",
   "newGroupChat": "Nouveau groupe de discussion",

--- a/locales/it-IT/chat.json
+++ b/locales/it-IT/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Vai al messaggio n. {{index}}",
     "nextMessage": "Messaggio successivo",
-    "previousMessage": "Messaggio precedente"
+    "previousMessage": "Messaggio precedente",
+    "senderAssistant": "Assistente",
+    "senderUser": "Tu"
   },
   "newAgent": "Nuovo assistente",
   "newGroupChat": "Nuova chat di gruppo",

--- a/locales/ja-JP/chat.json
+++ b/locales/ja-JP/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "メッセージ {{index}} へジャンプ",
     "nextMessage": "次のメッセージ",
-    "previousMessage": "前のメッセージ"
+    "previousMessage": "前のメッセージ",
+    "senderAssistant": "アシスタント",
+    "senderUser": "あなた"
   },
   "newAgent": "新しいエージェント",
   "newGroupChat": "新しいグループチャットを作成",

--- a/locales/ko-KR/chat.json
+++ b/locales/ko-KR/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "{{index}}번째 메시지로 이동",
     "nextMessage": "다음 메시지",
-    "previousMessage": "이전 메시지"
+    "previousMessage": "이전 메시지",
+    "senderAssistant": "도우미",
+    "senderUser": "당신"
   },
   "newAgent": "새 도우미",
   "newGroupChat": "새 그룹 채팅 만들기",

--- a/locales/nl-NL/chat.json
+++ b/locales/nl-NL/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Ga naar bericht {{index}}",
     "nextMessage": "Volgend bericht",
-    "previousMessage": "Vorig bericht"
+    "previousMessage": "Vorig bericht",
+    "senderAssistant": "Assistent",
+    "senderUser": "Jij"
   },
   "newAgent": "Nieuwe assistent",
   "newGroupChat": "Nieuwe groepschat",

--- a/locales/pl-PL/chat.json
+++ b/locales/pl-PL/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Przejdź do wiadomości nr {{index}}",
     "nextMessage": "Następna wiadomość",
-    "previousMessage": "Poprzednia wiadomość"
+    "previousMessage": "Poprzednia wiadomość",
+    "senderAssistant": "Asystent",
+    "senderUser": "Ty"
   },
   "newAgent": "Nowy asystent",
   "newGroupChat": "Utwórz nowy czat grupowy",

--- a/locales/pt-BR/chat.json
+++ b/locales/pt-BR/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Ir para a mensagem nº {{index}}",
     "nextMessage": "Próxima mensagem",
-    "previousMessage": "Mensagem anterior"
+    "previousMessage": "Mensagem anterior",
+    "senderAssistant": "Assistente",
+    "senderUser": "Você"
   },
   "newAgent": "Novo Assistente",
   "newGroupChat": "Criar novo grupo",

--- a/locales/ru-RU/chat.json
+++ b/locales/ru-RU/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Перейти к сообщению № {{index}}",
     "nextMessage": "Следующее сообщение",
-    "previousMessage": "Предыдущее сообщение"
+    "previousMessage": "Предыдущее сообщение",
+    "senderAssistant": "Ассистент",
+    "senderUser": "Вы"
   },
   "newAgent": "Создать помощника",
   "newGroupChat": "Создать групповой чат",

--- a/locales/tr-TR/chat.json
+++ b/locales/tr-TR/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "{{index}} numaralı mesaja atla",
     "nextMessage": "Sonraki mesaj",
-    "previousMessage": "Önceki mesaj"
+    "previousMessage": "Önceki mesaj",
+    "senderAssistant": "Asistan",
+    "senderUser": "Sen"
   },
   "newAgent": "Yeni Asistan",
   "newGroupChat": "Yeni grup sohbeti oluştur",

--- a/locales/vi-VN/chat.json
+++ b/locales/vi-VN/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "Chuyển đến tin nhắn thứ {{index}}",
     "nextMessage": "Tin nhắn tiếp theo",
-    "previousMessage": "Tin nhắn trước"
+    "previousMessage": "Tin nhắn trước",
+    "senderAssistant": "Trợ lý",
+    "senderUser": "Bạn"
   },
   "newAgent": "Tạo trợ lý mới",
   "newGroupChat": "Tạo nhóm mới",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "跳转至第 {{index}} 条消息",
     "nextMessage": "下一条消息",
-    "previousMessage": "上一条消息"
+    "previousMessage": "上一条消息",
+    "senderAssistant": "助手",
+    "senderUser": "你"
   },
   "newAgent": "新建助手",
   "newGroupChat": "新建群聊",

--- a/locales/zh-TW/chat.json
+++ b/locales/zh-TW/chat.json
@@ -228,7 +228,9 @@
   "minimap": {
     "jumpToMessage": "跳轉至第 {{index}} 條訊息",
     "nextMessage": "下一條訊息",
-    "previousMessage": "上一條訊息"
+    "previousMessage": "上一條訊息",
+    "senderAssistant": "助理",
+    "senderUser": "您"
   },
   "newAgent": "新建助手",
   "newGroupChat": "建立群組",

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatMinimap/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatMinimap/index.tsx
@@ -23,7 +23,7 @@ const log = debug('lobe-react:chat-minimap');
 const MIN_WIDTH = 16;
 const MAX_WIDTH = 30;
 const MAX_CONTENT_LENGTH = 320;
-const MIN_MESSAGES = 6;
+const MIN_MESSAGES = 4;
 
 const useStyles = createStyles(({ css, token }) => ({
   arrow: css`

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatMinimap/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatMinimap/index.tsx
@@ -3,6 +3,7 @@
 import { Icon } from '@lobehub/ui';
 import { Popover, Tooltip } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
+import debug from 'debug';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { memo, useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +17,8 @@ import {
 } from '@/features/Conversation/components/VirtualizedList/VirtuosoContext';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
+
+const log = debug('lobe-react:chat-minimap');
 
 const MIN_WIDTH = 16;
 const MAX_WIDTH = 30;
@@ -234,8 +237,8 @@ const ChatMinimap = () => {
   const activeIndicatorPosition = useMemo(() => {
     if (activeIndex === null) return null;
 
-    console.log('> activeIndex', activeIndex);
-    console.log('> indicatorIndexMap', indicatorIndexMap);
+    log('> activeIndex', activeIndex);
+    log('> indicatorIndexMap', indicatorIndexMap);
 
     return indicatorIndexMap.get(activeIndex) ?? null;
   }, [activeIndex, indicatorIndexMap]);
@@ -261,7 +264,7 @@ const ChatMinimap = () => {
       let targetPosition: number;
 
       if (activeIndicatorPosition !== null) {
-        console.log('activeIndicatorPosition', activeIndicatorPosition);
+        log('activeIndicatorPosition', activeIndicatorPosition);
         // We're on an indicator, move to prev/next
         const delta = direction === 'prev' ? -1 : 1;
         targetPosition = Math.min(

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -247,6 +247,8 @@ export default {
     jumpToMessage: '跳转至第 {{index}} 条消息',
     nextMessage: '下一条消息',
     previousMessage: '上一条消息',
+    senderAssistant: '助手',
+    senderUser: '你',
   },
 
   newAgent: '新建助手',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

| Before | After |
| :--: | :--: |
| <img width="348" height="135" alt="Screenshot 2025-10-20 at 17 49 16" src="https://github.com/user-attachments/assets/cf568ba9-0937-4159-9f58-c112204cc2f8" /> | <img width="421" height="265" alt="Screenshot 2025-10-20 at 17 47 39" src="https://github.com/user-attachments/assets/8917d7aa-0f02-431b-aab0-209f5676766d" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Display message authors in the chat minimap popovers and refine related UI components and thresholds.

New Features:
- Annotate minimap indicators with message sender role and show sender label above the preview in popovers

Enhancements:
- Increase minimum messages required for minimap display from 4 to 6
- Replace Tooltip with Popover for minimap indicators and add custom styles for popover content

Documentation:
- Add default localization entries for 'senderUser' and 'senderAssistant' labels

Chores:
- Remove debug import and replace debug calls with console.log