### PR TITLE
🐛 fix(deepseek): handle empty tools array to prevent API error

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -5,6 +5,7 @@ import {
   createOpenAICompatibleRuntime,
 } from '../../core/openaiCompatibleFactory';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
+import type { ChatStreamPayload } from '../../types';
 
 export interface DeepSeekModelCard {
   id: string;
@@ -12,6 +13,16 @@ export interface DeepSeekModelCard {
 
 export const params = {
   baseURL: 'https://api.deepseek.com/v1',
+  chatCompletion: {
+    handlePayload: (payload: ChatStreamPayload) => {
+      const { tools, ...rest } = payload;
+      // DeepSeek API doesn't accept empty tools array, so omit it if empty
+      if (tools && tools.length === 0) {
+        return rest;
+      }
+      return payload;
+    },
+  },
   debug: {
     chatCompletion: () => process.env.DEBUG_DEEPSEEK_CHAT_COMPLETION === '1',
   },
@@ -27,6 +38,16 @@ export const params = {
     return processModelList(modelList, MODEL_LIST_CONFIGS.deepseek, 'deepseek');
   },
   provider: ModelProvider.DeepSeek,
+  responses: {
+    handlePayload: (payload: ChatStreamPayload) => {
+      const { tools, ...rest } = payload;
+      // DeepSeek API doesn't accept empty tools array, so omit it if empty
+      if (tools && tools.length === 0) {
+        return rest;
+      }
+      return payload;
+    },
+  },
 } satisfies OpenAICompatibleFactoryOptions;
 
 export const LobeDeepSeekAI = createOpenAICompatibleRuntime(params);


### PR DESCRIPTION
DeepSeek API throws error when receiving empty tools array.

Add custom handlePayload functions to omit tools parameter when empty for both chat completion and responses API modes.

Fixes #9629

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Omit empty tools parameter from DeepSeek API payloads in chatCompletion and responses to avoid errors.