### PR TITLE
📝 docs: fix outdated server-side database documentation

### DIFF
--- a/docs/development/basic/work-with-server-side-database.mdx
+++ b/docs/development/basic/work-with-server-side-database.mdx
@@ -11,13 +11,13 @@ But here is the easier approach that can reduce your pain.
 
 ### Environment Configuration
 
-First, copy the example environment file to create your development configuration:
+First, copy the example environment file to create your Docker Compose configuration:
 
 ```bash
-cp .env.example.development .env.development
+cp docker-compose/local/.env.example docker-compose/local/.env
 ```
 
-This file contains all necessary environment variables for server-side database mode and configures:
+Edit `docker-compose/local/.env` as needed for your development setup. This file contains all necessary environment variables for the Docker services and configures:
 
 - **Service Mode**: `NEXT_PUBLIC_SERVICE_MODE=server`
 - **Database**: PostgreSQL with connection string
@@ -72,7 +72,7 @@ When working with image generation features (text-to-image, image-to-image), the
 
 ### Image Generation Configuration
 
-The existing Docker Compose configuration already includes MinIO storage service and all necessary environment variables in `.env.example.development`. No additional setup is required.
+The existing Docker Compose configuration already includes MinIO storage service and all necessary environment variables in `docker-compose/local/.env.example`. No additional setup is required.
 
 ### Image Generation Architecture
 
@@ -84,7 +84,7 @@ The image generation feature requires:
 
 ### Storage Configuration
 
-The `.env.example.development` file includes all necessary S3 environment variables:
+The `docker-compose/local/.env.example` file includes all necessary S3 environment variables:
 
 ```bash
 # S3 Storage Configuration (MinIO for local development)

--- a/docs/development/basic/work-with-server-side-database.zh-CN.mdx
+++ b/docs/development/basic/work-with-server-side-database.zh-CN.mdx
@@ -11,13 +11,13 @@ LobeChat 提供了内置的客户端数据库体验。
 
 ### 环境配置
 
-首先，复制示例环境文件来创建你的开发配置：
+首先，复制示例环境文件来创建你的 Docker Compose 配置：
 
 ```bash
-cp .env.example.development .env.development
+cp docker-compose/local/.env.example docker-compose/local/.env
 ```
 
-此文件包含服务端数据库模式所需的所有环境变量，配置了：
+根据需要编辑 `docker-compose/local/.env` 文件以适应你的开发设置。此文件包含 Docker 服务所需的所有环境变量，配置了：
 
 - **服务模式**: `NEXT_PUBLIC_SERVICE_MODE=server`
 - **数据库**: 带连接字符串的 PostgreSQL
@@ -72,7 +72,7 @@ docker-compose -f docker-compose.development.yml ps
 
 ### 图像生成配置
 
-现有的 Docker Compose 配置已经包含了 MinIO 存储服务以及 `.env.example.development` 中的所有必要环境变量。无需额外配置。
+现有的 Docker Compose 配置已经包含了 MinIO 存储服务以及 `docker-compose/local/.env.example` 中的所有必要环境变量。无需额外配置。
 
 ### 图像生成架构
 
@@ -84,7 +84,7 @@ docker-compose -f docker-compose.development.yml ps
 
 ### 存储配置
 
-`.env.example.development` 文件包含所有必要的 S3 环境变量：
+`docker-compose/local/.env.example` 文件包含所有必要的 S3 环境变量：
 
 ```bash
 # S3 存储配置（本地开发使用 MinIO）


### PR DESCRIPTION
**Summary**

- Fix environment file setup instructions to use `docker-compose/local/.env.example` instead of `.env.example.development`
- Update references to environment file locations in both English and Chinese documentation
- Align documentation with actual Docker Compose configuration that uses `env_file: .env` in `docker-compose/local/` directory

**Changes**

- Updated `docs/development/basic/work-with-server-side-database.mdx`
- Updated `docs/development/basic/work-with-server-side-database.zh-CN.mdx`

**Test Plan**

Followed the updated documentation steps to verify they align with the actual Docker Compose setup.

Fixes #9525

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Fix outdated environment file instructions in server-side database documentation to align with the actual Docker Compose setup.

Documentation:
- Update English doc to reference docker-compose/local/.env.example and docker-compose/local/.env instead of .env.example.development
- Align Chinese doc to use docker-compose/local/.env.example and docker-compose/local/.env references