### PR TITLE
feat(chatinput): Add input translation to English feature

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/ClassicChat.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/ClassicChat.tsx
@@ -21,6 +21,7 @@ const leftActions: ActionKeys[] = [
   'model',
   'search',
   'typo',
+  'inputTranslate',
   'fileUpload',
   'knowledgeBase',
   'tools',

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/GroupChat.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Desktop/GroupChat.tsx
@@ -21,6 +21,7 @@ const leftActions: ActionKeys[] = [
   'model',
   'search',
   'typo',
+  'inputTranslate',
   'fileUpload',
   'knowledgeBase',
   'tools',

--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Mobile/index.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/features/ChatInput/Mobile/index.tsx
@@ -19,6 +19,7 @@ import { useSend } from '../useSend';
 const leftActions: ActionKeys[] = [
   'model',
   'search',
+  'inputTranslate',
   'fileUpload',
   'knowledgeBase',
   'tools',

--- a/src/features/ChatInput/ActionBar/InputTranslate/index.tsx
+++ b/src/features/ChatInput/ActionBar/InputTranslate/index.tsx
@@ -1,0 +1,46 @@
+import { LanguagesIcon } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useChatInputStore } from '../../store';
+import Action from '../components/Action';
+import { useInputTranslate } from './useInputTranslate';
+
+const InputTranslate = memo(() => {
+  const { t } = useTranslation('chat');
+  const [isTranslating, setIsTranslating] = useState(false);
+  const editor = useChatInputStore((s) => s.editor);
+  const { translateToEnglish } = useInputTranslate();
+
+  const handleTranslate = async () => {
+    if (!editor || isTranslating) return;
+
+    const content = editor.getDocument('markdown') as string;
+    if (!content?.trim()) return;
+
+    setIsTranslating(true);
+    try {
+      const translatedContent = await translateToEnglish(content);
+      if (translatedContent && translatedContent !== content) {
+        editor.setDocument('markdown', translatedContent);
+      }
+    } catch (error) {
+      console.error('Translation failed:', error);
+    } finally {
+      setIsTranslating(false);
+    }
+  };
+
+  return (
+    <Action
+      icon={LanguagesIcon}
+      loading={isTranslating}
+      onClick={handleTranslate}
+      title={t('input.translateToEnglish')}
+    />
+  );
+});
+
+InputTranslate.displayName = 'InputTranslate';
+
+export default InputTranslate;

--- a/src/features/ChatInput/ActionBar/InputTranslate/useInputTranslate.ts
+++ b/src/features/ChatInput/ActionBar/InputTranslate/useInputTranslate.ts
@@ -1,0 +1,50 @@
+import { chainTranslate } from '@lobechat/prompts';
+import { TraceNameMap } from '@lobechat/types';
+import { useCallback } from 'react';
+
+import { chatService } from '@/services/chat';
+import { useChatStore } from '@/store/chat';
+import { useUserStore } from '@/store/user';
+import { systemAgentSelectors } from '@/store/user/selectors';
+import { merge } from '@/utils/merge';
+
+export const useInputTranslate = () => {
+  const getCurrentTracePayload = useChatStore((s) => s.getCurrentTracePayload);
+
+  const translateToEnglish = useCallback(
+    async (content: string): Promise<string> => {
+      return new Promise((resolve, reject) => {
+        // Get current translation settings
+        const translationSetting = systemAgentSelectors.translation(useUserStore.getState());
+        
+        let translatedContent = '';
+
+        chatService
+          .fetchPresetTaskResult({
+            onFinish: (result) => {
+              if (result && typeof result === 'string') {
+                resolve(result);
+              } else {
+                resolve(translatedContent);
+              }
+            },
+            onMessageHandle: (chunk) => {
+              if (chunk.type === 'text') {
+                translatedContent += chunk.text;
+              }
+            },
+            params: merge(translationSetting, chainTranslate(content, 'en-US')),
+            trace: getCurrentTracePayload({ traceName: TraceNameMap.Translator }),
+          })
+          .catch((error) => {
+            reject(error);
+          });
+      });
+    },
+    [getCurrentTracePayload],
+  );
+
+  return {
+    translateToEnglish,
+  };
+};

--- a/src/features/ChatInput/ActionBar/config.ts
+++ b/src/features/ChatInput/ActionBar/config.ts
@@ -1,5 +1,6 @@
 import Clear from './Clear';
 import History from './History';
+import InputTranslate from './InputTranslate';
 import Knowledge from './Knowledge';
 import Model from './Model';
 import Params from './Params';
@@ -15,6 +16,7 @@ export const actionMap = {
   clear: Clear,
   fileUpload: Upload,
   history: History,
+  inputTranslate: InputTranslate,
   knowledgeBase: Knowledge,
   mainToken: MainToken,
   model: Model,

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -78,6 +78,7 @@ export default {
     sendWithCmdEnter: '按 <key/> 键发送',
     sendWithEnter: '按 <key/> 键发送',
     stop: '停止',
+    translateToEnglish: '翻译成英文',
     warp: '换行',
   },
   intentUnderstanding: {


### PR DESCRIPTION
Add InputTranslate action component that allows users to translate their input text to English before sending for better LLM responses.

## Changes
- Add InputTranslate component with language icon (🌐)
- Integrate with existing chainTranslate from @lobechat/prompts
- Add action to Desktop and Mobile chat input configurations
- Position between typo and fileUpload actions per UI reference
- Add Chinese locale string for button tooltip

Closes #9164

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add a new input translation feature that enables users to translate their message content to English via the chat input toolbar before sending.

New Features:
- Introduce InputTranslate action component with a language icon and loading state to translate editor content
- Implement useInputTranslate hook leveraging chainTranslate and chatService to process translation tasks
- Integrate inputTranslate action into desktop (classic and group) and mobile chat input configurations between typo and file upload buttons
- Add 'translateToEnglish' locale entry for the button tooltip in the Chinese locale