### PR TITLE
🩹 fix: ignore abort signal errors in TRPC client

### DIFF
--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -21,10 +21,16 @@ const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
       next(op).subscribe({
         complete: () => observer.complete(),
         error: async (err) => {
+          // Check if this is an abort error and should be ignored
+          const isAbortError = err.message.includes('aborted') || err.name === 'AbortError' || 
+                              err.cause?.name === 'AbortError' || 
+                              err.message.includes('signal is aborted without reason');
+          
           const showError = (op.context?.showNotification as boolean) ?? true;
           const status = err.data?.httpStatus as number;
 
-          if (showError) {
+          // Don't show notifications for abort errors
+          if (showError && !isAbortError) {
             const { loginRequired } = await import('@/components/Error/loginRequiredNotification');
             const { fetchErrorNotification } = await import(
               '@/components/Error/fetchErrorNotification'


### PR DESCRIPTION
Fixes ##9401

This PR addresses the issue where TRPC abort signal errors were being displayed on the settings page when users rapidly change settings.

## Changes
- Modified the error handling link in `src/libs/trpc/client/lambda.ts`
- Added detection for various abort error patterns
- Prevent showing notifications for aborted requests while maintaining error propagation

## Testing
The fix follows existing patterns used elsewhere in the codebase for handling abort errors.

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Ignore abort signal errors in TRPC client error handling link to prevent spurious notifications for aborted requests

Bug Fixes:
- Detect various abort error patterns (message includes 'aborted', name 'AbortError', cause name 'AbortError', or 'signal is aborted without reason')
- Suppress error notifications for aborted TRPC requests while preserving error propagation