### PR TITLE
fix: sub topic fetch branching topic id was used dynmic get

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -54,6 +54,7 @@ export const AssistantActionsBar = memo<AssistantActionsProps>(({ id, data, inde
 
   const { t } = useTranslation('common');
   const searchParams = useSearchParams();
+  const topic = searchParams.get('topic');
   const [
     deleteMessage,
     regenerateMessage,
@@ -98,7 +99,6 @@ export const AssistantActionsBar = memo<AssistantActionsProps>(({ id, data, inde
           break;
         }
         case 'branching': {
-          const topic = searchParams.get('topic');
           if (!topic) {
             message.warning(t('branchingRequiresSavedTopic'));
             break;
@@ -155,7 +155,7 @@ export const AssistantActionsBar = memo<AssistantActionsProps>(({ id, data, inde
         translateMessage(id, lang);
       }
     },
-    [data],
+    [data, topic],
   );
 
   if (error) return <ErrorActionsBar onActionClick={onActionClick} />;

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -54,7 +54,6 @@ export const AssistantActionsBar = memo<AssistantActionsProps>(({ id, data, inde
 
   const { t } = useTranslation('common');
   const searchParams = useSearchParams();
-  const topic = searchParams.get('topic');
   const [
     deleteMessage,
     regenerateMessage,
@@ -99,6 +98,7 @@ export const AssistantActionsBar = memo<AssistantActionsProps>(({ id, data, inde
           break;
         }
         case 'branching': {
+          const topic = searchParams.get('topic');
           if (!topic) {
             message.warning(t('branchingRequiresSavedTopic'));
             break;

--- a/src/features/Conversation/Messages/User/Actions.tsx
+++ b/src/features/Conversation/Messages/User/Actions.tsx
@@ -66,8 +66,6 @@ export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
     [inThread],
   );
 
-  const topic = searchParams.get('topic');
-
   const { message } = App.useApp();
 
   // remove line breaks in artifact tag to make the ast transform easier
@@ -92,6 +90,7 @@ export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
         }
 
         case 'branching': {
+          const topic = searchParams.get('topic');
           if (!topic) {
             message.warning(t('branchingRequiresSavedTopic'));
             break;
@@ -138,7 +137,12 @@ export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
         translateMessage(id, lang);
       }
     },
-    [data.content, data.error, inPortalThread],
+    [
+      data.content,
+      data.error,
+      inPortalThread,
+      // ,topic
+    ],
   );
 
   return (

--- a/src/features/Conversation/Messages/User/Actions.tsx
+++ b/src/features/Conversation/Messages/User/Actions.tsx
@@ -23,6 +23,7 @@ interface UserActionsProps {
 export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
   const { t } = useTranslation('common');
   const searchParams = useSearchParams();
+  const topic = searchParams.get('topic');
 
   const [
     isThreadMode,
@@ -90,7 +91,6 @@ export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
         }
 
         case 'branching': {
-          const topic = searchParams.get('topic');
           if (!topic) {
             message.warning(t('branchingRequiresSavedTopic'));
             break;
@@ -137,12 +137,7 @@ export const UserActionsBar = memo<UserActionsProps>(({ id, data, index }) => {
         translateMessage(id, lang);
       }
     },
-    [
-      data.content,
-      data.error,
-      inPortalThread,
-      // ,topic
-    ],
+    [data.content, data.error, inPortalThread, topic],
   );
 
   return (


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fetch the topic id dynamically within the branching action handlers instead of capturing it once at module load time to ensure correct topic context.

Bug Fixes:
- Move searchParams.get('topic') inside the 'branching' case in UserActionsBar to fetch the topic id at the time of branching.
- Move searchParams.get('topic') inside the 'branching' case in AssistantActionsBar to fetch the topic id at the time of branching.
- Remove the top-level topic constant and adjust related dependencies to prevent stale topic values.