### PR TITLE
🐛 fix: slove when pwa user info have code cannot be viewed in full

### DIFF
--- a/src/features/Conversation/Messages/User/index.tsx
+++ b/src/features/Conversation/Messages/User/index.tsx
@@ -44,18 +44,8 @@ const remarkPlugins = markdownElements
   .filter(Boolean);
 
 const UserMessage = memo<UserMessageProps>((props) => {
-  const {
-    id,
-    ragQuery,
-    content,
-    createdAt,
-    error,
-    role,
-    index,
-    extra,
-    disableEditing,
-    targetId,
-  } = props;
+  const { id, ragQuery, content, createdAt, error, role, index, extra, disableEditing, targetId } =
+    props;
 
   const { t } = useTranslation('chat');
   const { mobile } = useResponsive();
@@ -71,14 +61,14 @@ const UserMessage = memo<UserMessageProps>((props) => {
   ]);
 
   const loading = isInRAGFlow || generating;
-  
+
   // Get target name for DM indicator
   const userName = useUserStore(userProfileSelectors.nickName) || 'User';
   const agents = useSessionStore(sessionSelectors.currentGroupAgents);
-  
+
   const dmIndicator = useMemo(() => {
     if (!targetId) return undefined;
-    
+
     let targetName = targetId;
     if (targetId === 'user') {
       targetName = userName;
@@ -86,7 +76,7 @@ const UserMessage = memo<UserMessageProps>((props) => {
       const targetAgent = agents?.find((agent) => agent.id === targetId);
       targetName = targetAgent?.title || targetId;
     }
-    
+
     return <Tag>{t('dm.visibleTo', { target: targetName })}</Tag>;
   }, [targetId, userName, agents, t]);
 
@@ -167,7 +157,7 @@ const UserMessage = memo<UserMessageProps>((props) => {
           direction={placement === 'left' ? 'horizontal' : 'horizontal-reverse'}
           gap={8}
         >
-          <Flexbox flex={1} style={{ minWidth: 0 }}>
+          <Flexbox flex={1} style={{ maxWidth: '100%', minWidth: 0 }}>
             <MessageContent
               editing={editing}
               id={id}


### PR DESCRIPTION
#### 💻 Change Type

https://github.com/lobehub/lobe-chat/issues/9799

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix code overflow in PWA user messages by constraining the message container width and clean up component code formatting

Bug Fixes:
- Prevent message content from overflowing by adding a maxWidth constraint to the message wrapper

Enhancements:
- Flatten props destructuring and remove trailing whitespace in UserMessage component