### PR TITLE
💄 style: add new bedrock model support

### DIFF
--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -56,6 +56,11 @@ export const contextCachingModels = new Set([
   'claude-3-5-sonnet-20240620',
   'claude-3-5-haiku-latest',
   'claude-3-5-haiku-20241022',
+  // Bedrock model IDs
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+  'anthropic.claude-sonnet-4-5-20250929-v1:0',
+  'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+  'anthropic.claude-haiku-4-5-20251001-v1:0',
 ]);
 
 export const thinkingWithToolClaudeModels = new Set([
@@ -69,4 +74,9 @@ export const thinkingWithToolClaudeModels = new Set([
   'anthropic/claude-sonnet-4.5',
   'claude-3-7-sonnet-latest',
   'claude-3-7-sonnet-20250219',
+  // Bedrock model IDs
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+  'anthropic.claude-sonnet-4-5-20250929-v1:0',
+  'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+  'anthropic.claude-haiku-4-5-20251001-v1:0',
 ]);

--- a/packages/model-bank/src/aiModels/bedrock.ts
+++ b/packages/model-bank/src/aiModels/bedrock.ts
@@ -1,6 +1,50 @@
 import { AIChatModelCard } from '../types/aiModel';
 
 const bedrockChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
+    displayName: 'Claude Sonnet 4.5',
+    enabled: true,
+    id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-29',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description: 'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
+    displayName: 'Claude Haiku 4.5',
+    enabled: true,
+    id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-10-15',
+    type: 'chat',
+  },
   /*
     // TODO: Not support for now
     {

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -263,6 +263,7 @@ export const MODEL_PARAMETER_CONFLICTS = {
     'claude-opus-4-20250514',
     'claude-sonnet-4-20250514',
     'claude-sonnet-4-5-20250929',
+    'claude-haiku-4-5-20251001',
     // Bedrock model IDs
     'anthropic.claude-opus-4-1-20250805-v1:0',
     'us.anthropic.claude-opus-4-1-20250805-v1:0',
@@ -272,5 +273,7 @@ export const MODEL_PARAMETER_CONFLICTS = {
     'us.anthropic.claude-sonnet-4-20250514-v1:0',
     'anthropic.claude-sonnet-4-5-20250929-v1:0',
     'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    'anthropic.claude-haiku-4-5-20251001-v1:0',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   ]),
 };

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -5,28 +5,6 @@ import { ModelProviderCard } from '@/types/llm';
 // ref :https://us-west-2.console.aws.amazon.com/bedrock/home?region=us-west-2#/models
 const Bedrock: ModelProviderCard = {
   chatModels: [
-    {
-      contextWindowTokens: 200_000,
-      description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
-      displayName: 'Claude Sonnet 4.5',
-      enabled: true,
-      functionCall: true,
-      id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
-      maxOutput: 64_000,
-      releasedAt: '2025-09-29',
-      vision: true,
-    },
-    {
-      contextWindowTokens: 200_000,
-      description: 'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
-      displayName: 'Claude Haiku 4.5',
-      enabled: true,
-      functionCall: true,
-      id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
-      maxOutput: 64_000,
-      releasedAt: '2025-10-15',
-      vision: true,
-    },
     /*
     // TODO: Not support for now
     {

--- a/src/config/modelProviders/bedrock.ts
+++ b/src/config/modelProviders/bedrock.ts
@@ -5,6 +5,28 @@ import { ModelProviderCard } from '@/types/llm';
 // ref :https://us-west-2.console.aws.amazon.com/bedrock/home?region=us-west-2#/models
 const Bedrock: ModelProviderCard = {
   chatModels: [
+    {
+      contextWindowTokens: 200_000,
+      description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
+      displayName: 'Claude Sonnet 4.5',
+      enabled: true,
+      functionCall: true,
+      id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      maxOutput: 64_000,
+      releasedAt: '2025-09-29',
+      vision: true,
+    },
+    {
+      contextWindowTokens: 200_000,
+      description: 'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
+      displayName: 'Claude Haiku 4.5',
+      enabled: true,
+      functionCall: true,
+      id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      maxOutput: 64_000,
+      releasedAt: '2025-10-15',
+      vision: true,
+    },
     /*
     // TODO: Not support for now
     {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Added support for the latest Claude 4.5 models on AWS Bedrock:

**Model Bank** (`packages/model-bank/src/aiModels/bedrock.ts`):
- **Claude Sonnet 4.5** (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`)
  - 200K context window, 64K max output
  - Pricing: $3/$15 per million tokens (input/output)
  - Capabilities: Function calling, reasoning, structured output, vision
  - Released: 2025-09-29

- **Claude Haiku 4.5** (`us.anthropic.claude-haiku-4-5-20251001-v1:0`)
  - 200K context window, 64K max output
  - Pricing: $1/$5 per million tokens (input/output)
  - Capabilities: Function calling, reasoning, structured output, vision
  - Released: 2025-10-15

**API Constants** (`packages/const/src/models.ts`):
- Added Bedrock model IDs to `contextCachingModels` set for cache support
- Added Bedrock model IDs to `thinkingWithToolClaudeModels` set for reasoning capabilities

**Parameter Resolver** (`packages/model-runtime/src/core/parameterResolver.ts`):
- Extended `MODEL_PARAMETER_CONFLICTS` to include the new model IDs

**Note**: As per reviewer feedback, removed the model provider configuration from `src/config/modelProviders/bedrock.ts`. The model definitions remain in the model bank and can be enabled once needed.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

These are the latest Claude 4.5 series models available on AWS Bedrock. The models are fully defined in the model bank with complete specifications, pricing, and capabilities. They can be activated in the provider configuration when ready for production use.