### PR TITLE
🐛 fix: model name display in the assistant panel disappears

### DIFF
--- a/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/index.tsx
+++ b/src/app/[variants]/(main)/chat/@session/features/SessionListContent/List/Item/index.tsx
@@ -4,9 +4,8 @@ import { Flexbox } from 'react-layout-kit';
 import { shallow } from 'zustand/shallow';
 
 import { DEFAULT_AVATAR } from '@/const/meta';
+import { INBOX_SESSION_ID } from '@/const/session';
 import { isDesktop } from '@/const/version';
-import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { chatSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -28,7 +27,6 @@ interface SessionItemProps {
 const SessionItem = memo<SessionItemProps>(({ id }) => {
   const [open, setOpen] = useState(false);
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
-  const [defaultModel] = useAgentStore((s) => [agentSelectors.inboxAgentModel(s)]);
 
   const openSessionInNewWindow = useGlobalStore((s) => s.openSessionInNewWindow);
 
@@ -53,7 +51,8 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
       ];
     });
 
-  const showModel = sessionType === 'agent' && model && model !== defaultModel;
+  // Only hide the model tag for the inbox session itself (随便聊聊)
+  const showModel = sessionType === 'agent' && model && id !== INBOX_SESSION_ID;
 
   const handleDoubleClick = () => {
     if (isDesktop) {


### PR DESCRIPTION
…d imports

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

应当仅 “随便聊聊” 的模型名 tag 会隐藏。

- close #9768
- close #8536

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix model name display in session list so that model tags show for all agent sessions except the default inbox session

Bug Fixes:
- Only hide the model tag for the default “随便聊聊” inbox session, restoring model display for other agent sessions

Enhancements:
- Remove unused defaultModel state hook from SessionItem