### PR TITLE
Fix local startup: move docker-compose.development.yml to docker-compose/local and update docs

### DIFF
--- a/docker-compose/local/docker-compose.development.yml
+++ b/docker-compose/local/docker-compose.development.yml
@@ -17,54 +17,54 @@ services:
 
   postgresql:
     extends:
-      file: docker-compose/local/docker-compose.yml
+      file: docker-compose.yml
       service: postgresql
   minio:
     extends:
-      file: docker-compose/local/docker-compose.yml
+      file: docker-compose.yml
       service: minio
   casdoor:
     extends:
-      file: docker-compose/local/docker-compose.yml
+      file: docker-compose.yml
       service: casdoor
   searxng:
     extends:
-      file: docker-compose/local/docker-compose.yml
+      file: docker-compose.yml
       service: searxng
 
   grafana:
     profiles:
       - otel
     extends:
-      file: docker-compose/local/grafana/docker-compose.yml
+      file: grafana/docker-compose.yml
       service: grafana
 
   tempo:
     profiles:
       - otel
     extends:
-      file: docker-compose/local/grafana/docker-compose.yml
+      file: grafana/docker-compose.yml
       service: tempo
 
   prometheus:
     profiles:
       - otel
     extends:
-      file: docker-compose/local/grafana/docker-compose.yml
+      file: grafana/docker-compose.yml
       service: prometheus
 
   otel-collector:
     profiles:
       - otel
     extends:
-      file: docker-compose/local/grafana/docker-compose.yml
+      file: grafana/docker-compose.yml
       service: otel-collector
 
   otel-tracing-test:
     profiles:
       - otel-test
     extends:
-      file: docker-compose/local/grafana/docker-compose.yml
+      file: grafana/docker-compose.yml
       service: otel-tracing-test
 
 volumes:

--- a/docs/development/basic/work-with-server-side-database.mdx
+++ b/docs/development/basic/work-with-server-side-database.mdx
@@ -144,7 +144,7 @@ When running with Docker Compose development setup:
 
 - **PostgreSQL**: `postgres://postgres@localhost:5432/lobechat`
 - **MinIO API**: `http://localhost:9000`
-- **MinIO Console**: `http://localhost:9001` (admin/CHANGE\_THIS\_PASSWORD\_IN\_PRODUCTION)
+- **MinIO Console**: `http://localhost:9001` (admin/CHANGE_THIS_PASSWORD_IN_PRODUCTION)
 - **Application**: `http://localhost:3010`
 
 ### Reset Services

--- a/docs/development/basic/work-with-server-side-database.mdx
+++ b/docs/development/basic/work-with-server-side-database.mdx
@@ -30,7 +30,7 @@ Edit `docker-compose/local/.env` as needed for your development setup. This file
 Start all required services using Docker Compose:
 
 ```bash
-docker-compose -f docker-compose.development.yml up -d
+docker-compose -f docker-compose/local/docker-compose.development.yml up -d
 ```
 
 This will start the following services:
@@ -63,7 +63,7 @@ The server will start on `http://localhost:3010`
 And you can check all Docker services are running by running:
 
 ```bash
-docker-compose -f docker-compose.development.yml ps
+docker-compose -f docker-compose/local/docker-compose.development.yml ps
 ```
 
 ## Image Generation Development
@@ -138,14 +138,13 @@ await fetch(uploadUrl, {
 });
 ```
 
-
 ### Service URLs
 
 When running with Docker Compose development setup:
 
 - **PostgreSQL**: `postgres://postgres@localhost:5432/lobechat`
 - **MinIO API**: `http://localhost:9000`
-- **MinIO Console**: `http://localhost:9001` (admin/CHANGE_THIS_PASSWORD_IN_PRODUCTION)
+- **MinIO Console**: `http://localhost:9001` (admin/CHANGE\_THIS\_PASSWORD\_IN\_PRODUCTION)
 - **Application**: `http://localhost:3010`
 
 ### Reset Services
@@ -154,16 +153,15 @@ If you encounter issues, you can reset the entire stack:
 
 ```bash
 # Stop and remove all containers
-docker-compose -f docker-compose.development.yml down
+docker-compose -f docker-compose/local/docker-compose.development.yml down
 
 # Remove volumes (this will delete all data)
-docker-compose -f docker-compose.development.yml down -v
+docker-compose -f docker-compose/local/docker-compose.development.yml down -v
 
 # Start fresh
-docker-compose -f docker-compose.development.yml up -d
+docker-compose -f docker-compose/local/docker-compose.development.yml up -d
 pnpm db:migrate
 ```
-
 
 ### Troubleshooting
 

--- a/docs/development/basic/work-with-server-side-database.zh-CN.mdx
+++ b/docs/development/basic/work-with-server-side-database.zh-CN.mdx
@@ -144,7 +144,7 @@ await fetch(uploadUrl, {
 
 - **PostgreSQL**：`postgres://postgres@localhost:5432/lobechat`
 - **MinIO API**：`http://localhost:9000`
-- **MinIO 控制台**：`http://localhost:9001` (admin/CHANGE\_THIS\_PASSWORD\_IN\_PRODUCTION)
+- **MinIO 控制台**：`http://localhost:9001` (admin/CHANGE_THIS_PASSWORD_IN_PRODUCTION)
 - **应用程序**：`http://localhost:3010`
 
 ### 重置服务

--- a/docs/development/basic/work-with-server-side-database.zh-CN.mdx
+++ b/docs/development/basic/work-with-server-side-database.zh-CN.mdx
@@ -30,7 +30,7 @@ cp docker-compose/local/.env.example docker-compose/local/.env
 使用 Docker Compose 启动所有必需的服务：
 
 ```bash
-docker-compose -f docker-compose.development.yml up -d
+docker-compose -f docker-compose/local/docker-compose.development.yml up -d
 ```
 
 这将启动以下服务：
@@ -63,7 +63,7 @@ pnpm dev
 可以通过运行以下命令检查所有 Docker 服务运行状态：
 
 ```bash
-docker-compose -f docker-compose.development.yml ps
+docker-compose -f docker-compose/local/docker-compose.development.yml ps
 ```
 
 ## 图像生成开发
@@ -138,14 +138,13 @@ await fetch(uploadUrl, {
 });
 ```
 
-
 ### 服务地址
 
 运行 Docker Compose 开发环境时：
 
 - **PostgreSQL**：`postgres://postgres@localhost:5432/lobechat`
 - **MinIO API**：`http://localhost:9000`
-- **MinIO 控制台**：`http://localhost:9001` (admin/CHANGE_THIS_PASSWORD_IN_PRODUCTION)
+- **MinIO 控制台**：`http://localhost:9001` (admin/CHANGE\_THIS\_PASSWORD\_IN\_PRODUCTION)
 - **应用程序**：`http://localhost:3010`
 
 ### 重置服务
@@ -154,16 +153,15 @@ await fetch(uploadUrl, {
 
 ```bash
 # 停止并删除所有容器
-docker-compose -f docker-compose.development.yml down
+docker-compose -f docker-compose/local/docker-compose.development.yml down
 
 # 删除卷（这将删除所有数据）
-docker-compose -f docker-compose.development.yml down -v
+docker-compose -f docker-compose/local/docker-compose.development.yml down -v
 
 # 重新启动
-docker-compose -f docker-compose.development.yml up -d
+docker-compose -f docker-compose/local/docker-compose.development.yml up -d
 pnpm db:migrate
 ```
-
 
 ### 故障排除
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

Summary
- Problem: Following the docs with docker-compose.development.yml at the repo root didn’t load docker-compose/local/.env, so containers failed to start.
- Fix: Move docker-compose.development.yml into docker-compose/local so .env is picked up. Update docs accordingly.

Changes
- Move: docker-compose.development.yml → docker-compose/local/docker-compose.development.yml
- Docs: update docs/work-with-server-side-database.mdx and docs/work-with-server-side-database.zh-CN.mdx (paths/commands)

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Move the development Docker Compose configuration into the docker-compose/local directory to pick up the .env file, adjust service reference paths accordingly, and update corresponding documentation examples in both English and Chinese.

Bug Fixes:
- Fix local Docker Compose startup by moving docker-compose.development.yml into docker-compose/local

Enhancements:
- Update service extends in the moved compose file to reference docker-compose.yml and grafana/docker-compose.yml

Documentation:
- Revise English and Chinese documentation to use docker-compose/local/docker-compose.development.yml paths for startup and teardown commands