### PR TITLE
💄 style: improve provider modal height when creating custom provider

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
@@ -18,8 +18,8 @@ import { Flexbox } from 'react-layout-kit';
 import { useAiInfraStore } from '@/store/aiInfra/store';
 import { CreateAiProviderParams } from '@/types/aiProvider';
 
-import { CUSTOM_PROVIDER_SDK_OPTIONS } from '../customProviderSdkOptions';
 import { KeyVaultsConfigKey, LLMProviderApiTokenKey, LLMProviderBaseUrlKey } from '../../const';
+import { CUSTOM_PROVIDER_SDK_OPTIONS } from '../customProviderSdkOptions';
 
 interface CreateNewProviderProps {
   onClose?: () => void;
@@ -142,7 +142,6 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open }) => {
   return (
     <FormModal
       destroyOnHidden
-      height={'90%'}
       items={[
         {
           children: basicItems,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR removes the fixed `height={'90%'}` property from the `FormModal` component within the `CreateNewProvider` feature. This change allows the modal's height to dynamically adjust to its content, preventing unnecessary empty space on smaller forms and avoiding potential overflow issues. The modal is now more responsive and provides a cleaner user experience.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos
Before:
<img width="1467" height="730" alt="image" src="https://github.com/user-attachments/assets/3e8e0eb1-dd75-44f5-b198-046f5ae2bc11" />

After:
<img width="1470" height="730" alt="image" src="https://github.com/user-attachments/assets/53fc6c16-dd0e-4e0e-be18-470ce4b78316" />

#### 📝 Additional Information

This is a minor UI enhancement to improve the layout and responsiveness of the provider creation modal.

## Summary by Sourcery

Bug Fixes:
- Remove hardcoded height from the FormModal in CreateNewProvider to fix responsiveness and overflow issues