### PR TITLE
🔨 chore: sync some small fix changes form cloud

### DIFF
--- a/src/features/ChatItem/components/ErrorContent.tsx
+++ b/src/features/ChatItem/components/ErrorContent.tsx
@@ -14,6 +14,11 @@ export interface ErrorContentProps {
 const ErrorContent = memo<ErrorContentProps>(({ message, error, placement }) => {
   const { styles } = useStyles({ placement });
 
+  if (!error?.message) {
+    if (!message) return null;
+    return <Flexbox className={styles.errorContainer}>{message}</Flexbox>;
+  }
+
   return (
     <Flexbox className={styles.errorContainer}>
       <Alert closable={false} extra={message} showIcon type={'error'} {...error} />

--- a/src/features/Conversation/Error/style.tsx
+++ b/src/features/Conversation/Error/style.tsx
@@ -16,7 +16,11 @@ export const useStyles = createStyles(({ css, token }) => ({
   `,
   form: css`
     width: 100%;
-    max-width: 300px;
+    max-width: 360px;
+
+    @media (max-width: 768px) {
+      max-width: 90%;
+    }
   `,
 }));
 

--- a/src/store/image/slices/createImage/action.test.ts
+++ b/src/store/image/slices/createImage/action.test.ts
@@ -54,6 +54,9 @@ describe('CreateImageAction', () => {
             provider: 'batch-provider',
             model: 'batch-model',
             config: { prompt: 'batch prompt' },
+            generations: [{}, {}, {}, {}], // 4 generations to match expected imageNum
+            createdAt: new Date(),
+            prompt: 'batch prompt',
           } as any,
         ],
       },
@@ -280,6 +283,10 @@ describe('CreateImageAction', () => {
         });
       });
 
+      // Get batch to verify imageNum uses batch.generations.length
+      const batch = result.current.generationBatchesMap['active-topic-id']?.[0];
+      const expectedImageNum = batch?.generations.length ?? 0;
+
       await act(async () => {
         await result.current.recreateImage('batch-id');
       });
@@ -290,12 +297,12 @@ describe('CreateImageAction', () => {
       // Verify batch removal
       expect(mockRemoveGenerationBatch).toHaveBeenCalledWith('batch-id', 'active-topic-id');
 
-      // Verify service call
+      // Verify service call uses batch.generations.length for imageNum
       expect(mockImageService.createImage).toHaveBeenCalledWith({
         generationTopicId: 'active-topic-id',
         provider: 'batch-provider',
         model: 'batch-model',
-        imageNum: 4,
+        imageNum: expectedImageNum,
         params: { prompt: 'batch prompt' },
       });
 

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -112,10 +112,12 @@ export const createCreateImageSlice: StateCreator<
     set({ isCreating: true }, false, 'recreateImage/startCreateImage');
 
     const store = get();
-    const imageNum = imageGenerationConfigSelectors.imageNum(store);
     const activeGenerationTopicId = generationTopicSelectors.activeGenerationTopicId(store);
     const batch = generationBatchSelectors.getGenerationBatchByBatchId(generationBatchId)(store)!;
     const { removeGenerationBatch } = store;
+
+    // Use batch.generations.length to preserve original imageNum (not UI config)
+    const imageNum = batch.generations.length;
 
     if (!activeGenerationTopicId) {
       throw new Error('No active generation topic');

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -113,15 +113,15 @@ export const createCreateImageSlice: StateCreator<
 
     const store = get();
     const activeGenerationTopicId = generationTopicSelectors.activeGenerationTopicId(store);
-    const batch = generationBatchSelectors.getGenerationBatchByBatchId(generationBatchId)(store)!;
-    const { removeGenerationBatch } = store;
-
-    // Use batch.generations.length to preserve original imageNum (not UI config)
-    const imageNum = batch.generations.length;
-
     if (!activeGenerationTopicId) {
       throw new Error('No active generation topic');
     }
+
+    const { removeGenerationBatch } = store;
+    const batch = generationBatchSelectors.getGenerationBatchByBatchId(generationBatchId)(store)!;
+
+    // Use batch.generations.length to preserve original imageNum (not UI config)
+    const imageNum = batch.generations.length;
 
     try {
       // 1. Delete generation batch


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Sync small fixes from cloud: adjust conversation error form styling, improve error content rendering fallback, and correct image count calculation in image creation slice

Bug Fixes:
- Add fallback rendering in ChatItem error content when error.message is absent
- Compute imageNum in createImage action from batch.generations.length to preserve original count

Enhancements:
- Increase max-width of conversation error form to 360px and add responsive media query for smaller viewports