### PR TITLE
🐛 fix: only include input_fidelity parameter for gpt-image-1.

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -67,7 +67,7 @@ async function generateByImageMode(
   const defaultInput = {
     n: 1,
     ...(model.includes('dall-e') ? { response_format: 'b64_json' } : {}),
-    ...(isImageEdit ? { input_fidelity: 'high' } : {}),
+    ...(isImageEdit && model === 'gpt-image-1' ? { input_fidelity: 'high' } : {}),
   };
 
   const options = cleanObject({

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1220,7 +1220,6 @@ describe('LobeOpenAICompatibleFactory', () => {
         );
         expect(instance['client'].images.edit).toHaveBeenCalledWith({
           image: expect.any(File),
-          input_fidelity: 'high',
           mask: 'https://example.com/mask.jpg',
           model: 'dall-e-2',
           n: 1,
@@ -1267,7 +1266,6 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         expect(instance['client'].images.edit).toHaveBeenCalledWith({
           image: [mockFile1, mockFile2],
-          input_fidelity: 'high',
           model: 'dall-e-2',
           n: 1,
           prompt: 'Merge these images',
@@ -1295,6 +1293,39 @@ describe('LobeOpenAICompatibleFactory', () => {
         await expect((instance as any).createImage(payload)).rejects.toThrow(
           'Failed to convert image URLs to File objects: Error: Failed to download image',
         );
+      });
+
+      it('should include input_fidelity parameter for gpt-image-1 model', async () => {
+        const mockResponse = {
+          data: [{ b64_json: 'gpt-image-edited-base64' }],
+        };
+
+        const mockFile = new File(['content'], 'test-image.jpg', { type: 'image/jpeg' });
+
+        vi.mocked(openaiHelpers.convertImageUrlToFile).mockResolvedValue(mockFile);
+        vi.spyOn(instance['client'].images, 'edit').mockResolvedValue(mockResponse as any);
+
+        const payload = {
+          model: 'gpt-image-1',
+          params: {
+            imageUrl: 'https://example.com/image.jpg',
+            prompt: 'Edit this image with gpt-image-1',
+          },
+        };
+
+        const result = await (instance as any).createImage(payload);
+
+        expect(instance['client'].images.edit).toHaveBeenCalledWith({
+          image: expect.any(File),
+          input_fidelity: 'high',
+          model: 'gpt-image-1',
+          n: 1,
+          prompt: 'Edit this image with gpt-image-1',
+        });
+
+        expect(result).toEqual({
+          imageUrl: 'data:image/png;base64,gpt-image-edited-base64',
+        });
       });
     });
 
@@ -1397,7 +1428,6 @@ describe('LobeOpenAICompatibleFactory', () => {
         expect(instance['client'].images.edit).toHaveBeenCalledWith({
           customParam: 'should remain unchanged',
           image: expect.any(File),
-          input_fidelity: 'high',
           model: 'dall-e-2',
           n: 1,
           prompt: 'Test prompt',


### PR DESCRIPTION
The input_fidelity parameter was incorrectly sent to all models during image editing, causing errors with DALL-E 2 and gpt-5-image-mini.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Fixed incorrect `input_fidelity` parameter being sent to all image models. This parameter is only supported by `gpt-image-1` and was causing errors with `DALL-E 2` and `gpt-5-image-mini`.

DALL-E 2: `400 Unknown parameter: 'input_fidelity'`
gpt-image-1-mini: `400 input_fidelity 'high' is only supported for model gpt-model-1`

Modified image upload/URL components to conditionally include `input_fidelity` only for `gpt-image-1`

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| <img width="305" height="933" alt="image" src="https://github.com/user-attachments/assets/d719809e-ed1e-4f9b-be39-444781de9b8f" />    | <img width="287" height="930" alt="image" src="https://github.com/user-attachments/assets/ed6af8be-ff8d-486d-9c0d-56693cb26879" />   |

#### 📝 Additional Information

N/A

## Summary by Sourcery

Restrict the input_fidelity parameter to only the gpt-image-1 model during image editing and adjust tests accordingly

Bug Fixes:
- Stop sending input_fidelity to unsupported image models like DALL-E 2 and gpt-5-image-mini

Tests:
- Remove input_fidelity expectations from other image editing tests and add a test verifying it is included only for gpt-image-1