### PR TITLE
🐛 fix: Hide marketplace link from Plugin List when market disabled

### DIFF
--- a/src/features/AgentSetting/AgentPlugin/index.tsx
+++ b/src/features/AgentSetting/AgentPlugin/index.tsx
@@ -34,7 +34,7 @@ const AgentPlugin = memo(() => {
     s.toggleAgentPlugin,
   ]);
 
-  const { showDalle } = useServerConfigStore(featureFlagsSelectors);
+  const { showDalle, showMarket } = useServerConfigStore(featureFlagsSelectors);
   const installedPlugins = useToolStore(toolSelectors.metaList(showDalle), isEqual);
 
   const { isLoading } = useFetchInstalledPlugins();
@@ -112,16 +112,18 @@ const AgentPlugin = memo(() => {
           />
         </Tooltip>
       ) : null}
-      <Tooltip title={t('plugin.store')}>
-        <Button
-          icon={Store}
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowStore(true);
-          }}
-          size={'small'}
-        />
-      </Tooltip>
+      {showMarket ? (
+        <Tooltip title={t('plugin.store')}>
+          <Button
+            icon={Store}
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowStore(true);
+            }}
+            size={'small'}
+          />
+        </Tooltip>
+      ) : null}
     </Space.Compact>
   );
 
@@ -149,7 +151,13 @@ const AgentPlugin = memo(() => {
   );
 
   const plugin: FormGroupItemType = {
-    children: isLoading ? loadingSkeleton : isEmpty ? empty : [...deprecatedList, ...list],
+    children: isLoading
+      ? loadingSkeleton
+      : isEmpty
+        ? showMarket
+          ? empty
+          : []
+        : [...deprecatedList, ...list],
     extra,
     title: t('settingPlugin.title'),
   };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Currently, if you have the `market` feature flag disabled but `plugins` enabled - as we do, since we want our users to be able to use the built-in plugins, but not plugins published on the public marketplace - you can install built-ins but you get presented with a button that redirects you to the marketplace to install more plugins. This is unhelpful as nothing prevents the marketplace from loading when `market` is disabled.

This change prevents the link to the marketplace from rendering when the `market` feature flag is disabled.

#### 🧪 How to Test

1. Disable `market`, enable `plugins` in your `.env` file.
2. Go to "Assistant Settings" and view the "Plugin Settings" tab. 
3. Verify the link is not rendered.
4. Enable `market`, and follow the same steps.
5. Verify the link is rendered again.

- [X] Tested locally
- [ ] Added/updated tests
- [X] No tests needed

#### 📸 Screenshots / Videos

Before:
<img width="1402" height="370" alt="Screenshot 2025-10-30 at 1 16 04 pm" src="https://github.com/user-attachments/assets/def99039-69aa-4ab4-8139-edfe0d91b6cc" />


After, with `market` disabled:
<img width="1402" height="370" alt="Screenshot 2025-10-30 at 1 15 13 pm" src="https://github.com/user-attachments/assets/0a772361-0fba-4a38-8454-4668f9f194cc" />

## Summary by Sourcery

Hide the marketplace button and suppress the empty plugin placeholder when the market feature flag is disabled

Bug Fixes:
- Do not render the marketplace store button if the 'market' feature flag is turned off
- Prevent showing the empty plugin list state when no plugins are installed and the market is disabled