### PR TITLE
🐛 fix: OIDC error when connecting to self-host instance (#9916)

### DIFF
--- a/src/app/(backend)/oidc/consent/route.ts
+++ b/src/app/(backend)/oidc/consent/route.ts
@@ -122,7 +122,6 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(finalRedirectUrl, {
-      headers: request.headers,
       status: 303,
     });
   } catch (error) {


### PR DESCRIPTION
fix: oidc/consent redirect header

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Stop passing request.headers into NextResponse.redirect in the OIDC consent route to prevent redirect errors for self-hosted instances