### PR TITLE
fix: hide ai image config item in settings category

### DIFF
--- a/src/app/(backend)/oidc/consent/route.ts
+++ b/src/app/(backend)/oidc/consent/route.ts
@@ -122,7 +122,6 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(finalRedirectUrl, {
-      headers: request.headers,
       status: 303,
     });
   } catch (error) {

--- a/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
+++ b/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
@@ -22,7 +22,7 @@ import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfi
 export const useCategory = () => {
   const { t } = useTranslation('setting');
   const mobile = useServerConfigStore((s) => s.isMobile);
-  const { showLLM, enableSTT, hideDocs } = useServerConfigStore(featureFlagsSelectors);
+  const { showLLM, enableSTT, hideDocs, showAiImage } = useServerConfigStore(featureFlagsSelectors);
 
   const cateItems: MenuProps['items'] = useMemo(
     () =>
@@ -58,7 +58,7 @@ export const useCategory = () => {
                 key: SettingsTabs.Provider,
                 label: t('tab.provider'),
               }),
-        {
+        showAiImage && {
           icon: <Icon icon={ImageIcon} />,
           key: SettingsTabs.Image,
           label: t('tab.image'),

--- a/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
+++ b/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
@@ -92,7 +92,7 @@ export const useCategory = () => {
           label: t('tab.about'),
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, showLLM, enableSTT, hideDocs, mobile],
+    [t, showLLM, enableSTT, hideDocs, mobile, showAiImage],
   );
 
   return cateItems;


### PR DESCRIPTION
fix: hide ai image config item in settings category

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

When I set `FEATURE_FLAGS=-ai_image` to disable **ai image**, the `AI Image` item still display on settings page.

So I introduced the showAiImage configuration item in the useCategory hook to control the display of the image feature. This change enables the settings page to dynamically show or hide image-related tabs based on the server configuration.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

1. set `FEATURE_FLAGS=-ai_image` to disable ai image
2. visit `http://localhost:3000/settings`
3. The `AI Image` section should be hidden

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
