### PR TITLE
🐛 fix: don't include runtimeProvider in JWT for non-image operations

### DIFF
--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -84,7 +84,7 @@ const customHttpBatchLink = httpBatchLink({
     // dynamic import to avoid circular dependency
     const { createHeaderWithAuth } = await import('@/services/_auth');
 
-    let provider: ModelProvider = ModelProvider.OpenAI;
+    let provider: ModelProvider | undefined;
     // for image page, we need to get the provider from the store
     log('Getting provider from store for image page: %s', location.pathname);
     if (location.pathname === '/image') {
@@ -96,8 +96,9 @@ const customHttpBatchLink = httpBatchLink({
       log('Getting provider from store for image page: %s', provider);
     }
 
-    // TODO: we need to support provider select for chat page
-    const headers = await createHeaderWithAuth({ provider });
+    // Only include provider in JWT for image operations
+    // For other operations (like knowledge base embedding), let server use its own config
+    const headers = await createHeaderWithAuth(provider ? { provider } : undefined);
     log('Headers: %O', headers);
     return headers;
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

This fixes #9569 where users with DEFAULT_FILES_CONFIG=embedding_model=ollama/... were getting InvalidProviderAPIKey errors because JWT was forcing provider='openai'.

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

The lambdaClient was hardcoding provider='openai' and including it in the JWT for ALL operations (knowledge base, chat, etc.). This caused the user's JWT runtimeProvider to override the server's DEFAULT_FILES_CONFIG embedding provider, resulting in InvalidProviderAPIKey errors.

Root cause:
- lambdaClient headers() set provider=ModelProvider.OpenAI by default
- This was passed to createHeaderWithAuth() for all operations
- createPayloadWithKeyVaults() added runtimeProvider='openai' to JWT
- Server's embedding operations received this JWT
- initModelRuntimeWithUserPayload() used JWT's runtimeProvider instead of server config

Solution:
- Only include provider in JWT for image operations (where user can select provider)
- For other operations (knowledge base, chat), don't pass provider
- Let server use its own DEFAULT_FILES_CONFIG for embedding operations

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Summary by Sourcery

Bug Fixes:
- Only include provider in the auth JWT for image operations, allowing other operations to use the server’s default embedding provider