### PR TITLE
🔧 chore(workflow): fix desktop PR build concurrency to isolate per-PR builds

### DIFF
--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -4,9 +4,9 @@ on:
   pull_request_target:
     types: [synchronize, labeled, unlabeled] # PR 更新或标签变化时触发
 
-# 确保同一时间只运行一个相同的 workflow，取消正在进行的旧的运行
+# 确保同一 PR 同一时间只运行一个相同的 workflow，取消正在进行的旧的运行
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: pr-${{ github.event.pull_request.number }}-${{ github.workflow }}
   cancel-in-progress: true
 
 # Add default permissions


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Related to desktop PR build workflow reliability.

#### 🔀 Description of Change

Fixed the concurrency group configuration in `.github/workflows/desktop-pr-build.yml` to use PR number instead of `github.ref`. 

**Problem**: Using `github.ref` (which points to the target branch in `pull_request_target`) caused all PRs to share the same concurrency group, making different PRs cancel each other's builds.

**Solution**: Changed the concurrency group to `pr-${{ github.event.pull_request.number }}-${{ github.workflow }}`, ensuring each PR has an independent concurrency group while still canceling redundant builds within the same PR.

#### 🧪 How to Test

- [x] No tests needed

This is a configuration change that ensures:
1. Different PRs don't interfere with each other's builds
2. Multiple pushes to the same PR still cancel previous builds (as expected)

#### 📝 Additional Information

This fix improves the reliability of the desktop PR build workflow by ensuring that concurrent PR builds don't cancel each other due to shared concurrency group keys.

## Summary by Sourcery

Chores:
- Update concurrency group in desktop-pr-build GitHub Action to use "pr-${{ github.event.pull_request.number }}-${{ github.workflow }}" instead of the branch ref