### PR TITLE
💄 style: improve oidc layout style

### DIFF
--- a/src/app/[variants]/oauth/ResultLayout.tsx
+++ b/src/app/[variants]/oauth/ResultLayout.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Card } from 'antd';
+import { createStyles } from 'antd-style';
+import { type ReactNode, memo } from 'react';
+import { Center } from 'react-layout-kit';
+
+interface ResultLayoutProps {
+  children: ReactNode;
+}
+
+const useStyles = createStyles(({ css, responsive }) => ({
+  card: css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+    min-width: 500px;
+    min-height: 280px;
+
+    ${responsive.mobile} {
+      min-width: auto;
+    }
+  `,
+  container: css`
+    ${responsive.mobile} {
+      justify-content: flex-start;
+      width: 100%;
+      padding-block-start: 64px;
+    }
+  `,
+}));
+
+const ResultLayout = memo<ResultLayoutProps>(({ children }) => {
+  const { styles } = useStyles();
+
+  return (
+    <Center className={styles.container} height="100vh" paddingBlock={24} paddingInline={12}>
+      <Card className={styles.card}>{children}</Card>
+    </Center>
+  );
+});
+
+ResultLayout.displayName = 'ResultLayout';
+
+export default ResultLayout;

--- a/src/app/[variants]/oauth/callback/error/page.tsx
+++ b/src/app/[variants]/oauth/callback/error/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Button, Highlighter, Icon } from '@lobehub/ui';
-import { Card, Result } from 'antd';
+import { Result } from 'antd';
 import { ShieldX } from 'lucide-react';
 import Link from 'next/link';
 import { parseAsString, useQueryState } from 'nuqs';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Center, Flexbox } from 'react-layout-kit';
+import { Flexbox } from 'react-layout-kit';
 
 const FailedPage = memo(() => {
   const { t } = useTranslation('oauth');
@@ -15,38 +15,25 @@ const FailedPage = memo(() => {
   const [errorMessage] = useQueryState<string>('errorMessage', parseAsString);
 
   return (
-    <Center height="100vh">
-      <Card
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          justifyContent: 'center',
-          minHeight: 280,
-          minWidth: 500,
-          width: '100%',
-        }}
-      >
-        <Result
-          extra={
-            <Link href="/">
-              <Button type="primary">{t('error.backToHome')}</Button>
-            </Link>
-          }
-          icon={<Icon icon={ShieldX} />}
-          status="error"
-          subTitle={
-            <Flexbox gap={8}>
-              {t('error.desc', {
-                reason: t(`error.reason.${reason}` as any, { defaultValue: reason }),
-              })}
+    <Result
+      extra={
+        <Link href="/">
+          <Button type="primary">{t('error.backToHome')}</Button>
+        </Link>
+      }
+      icon={<Icon icon={ShieldX} />}
+      status="error"
+      subTitle={
+        <Flexbox gap={8}>
+          {t('error.desc', {
+            reason: t(`error.reason.${reason}` as any, { defaultValue: reason }),
+          })}
 
-              {!!errorMessage && <Highlighter language={'log'}>{errorMessage}</Highlighter>}
-            </Flexbox>
-          }
-          title={t('error.title')}
-        />
-      </Card>
-    </Center>
+          {!!errorMessage && <Highlighter language={'log'}>{errorMessage}</Highlighter>}
+        </Flexbox>
+      }
+      title={t('error.title')}
+    />
   );
 });
 

--- a/src/app/[variants]/oauth/callback/layout.tsx
+++ b/src/app/[variants]/oauth/callback/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '../ResultLayout';

--- a/src/app/[variants]/oauth/callback/success/page.tsx
+++ b/src/app/[variants]/oauth/callback/success/page.tsx
@@ -1,36 +1,22 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { Card, Result } from 'antd';
+import { Result } from 'antd';
 import { CheckCircle } from 'lucide-react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Center } from 'react-layout-kit';
 
 const SuccessPage = memo(() => {
   const { t } = useTranslation('oauth');
 
   return (
-    <Center height="100vh">
-      <Card
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          justifyContent: 'center',
-          minHeight: 280,
-          minWidth: 500,
-          width: '100%',
-        }}
-      >
-        <Result
-          icon={<Icon icon={CheckCircle} />}
-          status="success"
-          style={{ padding: 0 }}
-          subTitle={t('success.subTitle')}
-          title={t('success.title')}
-        />
-      </Card>
-    </Center>
+    <Result
+      icon={<Icon icon={CheckCircle} />}
+      status="success"
+      style={{ padding: 0 }}
+      subTitle={t('success.subTitle')}
+      title={t('success.title')}
+    />
   );
 });
 

--- a/src/app/[variants]/oauth/consent/[uid]/Consent/BuiltinConsent.tsx
+++ b/src/app/[variants]/oauth/consent/[uid]/Consent/BuiltinConsent.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { Icon } from '@lobehub/ui';
-import { Card, Result } from 'antd';
+import { Result } from 'antd';
 import { useTheme } from 'antd-style';
 import { LoaderCircle } from 'lucide-react';
 import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Center } from 'react-layout-kit';
+
+import ResultLayout from '../../../ResultLayout';
 
 interface BuiltinConsentProps {
   uid: string;
@@ -24,26 +25,15 @@ const BuiltinConsent = memo<BuiltinConsentProps>(({ uid }) => {
   const theme = useTheme();
   return (
     <>
-      <Center height="100vh">
-        <Card
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-            justifyContent: 'center',
-            minHeight: 280,
-            minWidth: 500,
-            width: '100%',
-          }}
-        >
-          <Result
-            icon={<Icon icon={LoaderCircle} spin style={{ color: theme.colorText }} />}
-            status="success"
-            style={{ padding: 0 }}
-            subTitle={t('consent.redirecting')}
-            title=""
-          />
-        </Card>
-      </Center>
+      <ResultLayout>
+        <Result
+          icon={<Icon icon={LoaderCircle} spin style={{ color: theme.colorText }} />}
+          status="success"
+          style={{ padding: 0 }}
+          subTitle={t('consent.redirecting')}
+          title=""
+        />
+      </ResultLayout>
       <form action="/oidc/consent" method="post" ref={formRef} style={{ display: 'none' }}>
         <input name="uid" type="hidden" value={uid} />
         <input name="consent" type="hidden" value="accept" />

--- a/src/app/[variants]/oauth/consent/[uid]/Consent/index.tsx
+++ b/src/app/[variants]/oauth/consent/[uid]/Consent/index.tsx
@@ -61,7 +61,10 @@ const useStyles = createStyles(({ css, token }) => ({
   container: css`
     width: 100%;
     min-height: 100vh;
+    padding-block: 12px;
+
     color: ${token.colorTextBase};
+
     background-color: ${token.colorBgLayout};
   `,
   icon: css`


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Consolidate and streamline the layout styling for OAuth-related pages by introducing a reusable ResultLayout component and updating existing pages to leverage it.

Enhancements:
- Add a new ResultLayout component with responsive centering and Card styling for consistent result page layouts
- Replace manual Center and Card wrappers in OAuth callback error/success and built-in consent pages with the shared ResultLayout
- Remove redundant imports of Card and Center from pages and adjust imports to use ResultLayout
- Apply responsive and padding-block adjustments in consent container styles for improved layout