### PR TITLE
🔨 chore: add workflow for translating Chinese comments to English

### DIFF
--- a/.claude/prompts/translate-comments.md
+++ b/.claude/prompts/translate-comments.md
@@ -1,0 +1,89 @@
+# Code Comment Translation Assistant
+
+You are a code comment translation assistant. Your task is to find non-English comments in the codebase and translate them to English.
+
+## Target Directories
+
+- apps/desktop/src/
+- packages/\*/src/
+- src
+
+## Workflow
+
+### 1. Select a Module to Process
+
+Module granularity examples:
+
+- A single package: `packages/database`
+- A desktop module: `apps/desktop/src/modules/auth`
+- A service directory: `src/services/user`
+
+### 2. Find Non-English Comments
+
+- Search for files containing non-English characters in comments (excluding test files)
+- File types to check: `.ts`, `.tsx`
+- Exclude: `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `node_modules`, `dist`, `build`
+
+### 3. Translate Comments
+
+- Translate all non-English comments to English while preserving:
+  - Code functionality (do not change any code)
+  - Comment structure and formatting
+  - JSDoc tags and annotations
+  - Markdown formatting in comments
+- Translation guidelines:
+  - Keep technical terms accurate
+  - Maintain professional tone
+  - Preserve line breaks and indentation
+  - Keep TODO/FIXME/NOTE markers in English
+
+### 4. Limit Changes
+
+- **CRITICAL**: Ensure total changes do not exceed 500 lines
+- If a module would exceed 500 lines, process only part of it
+- Count lines using: `git diff --stat`
+- Stop processing files once approaching the 500-line limit
+
+### 5. Create Pull Request
+
+- Create a new branch: `automatic/translate-comments-[module-name]-[date]`
+- Commit changes with message format:
+  ```
+  🌐 chore: translate non-English comments to English in [module-name]
+  ```
+- Push the branch
+- Create a PR with:
+
+  - Title: `🌐 chore: translate non-English comments to English in [module-name]`
+  - Body following this template:
+
+  ```markdown
+  ## Summary
+
+  - Translated non-English comments to English in `[module-name]`
+  - Total lines changed: [number] lines
+  - Files affected: [number] files
+
+  ## Changes
+
+  - [ ] All non-English comments translated to English
+  - [ ] Code functionality unchanged
+  - [ ] Comment formatting preserved
+
+  ## Module Processed
+
+  `[module-path]`
+
+  ---
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+
+## Important Rules
+
+- **DO NOT** modify any code logic, only comments
+- **DO NOT** translate non-English strings in code (only comments)
+- **DO NOT** exceed 500 lines of changes in one PR
+- **DO NOT** process test files or generated files
+- **DO** preserve all code formatting and structure
+- **DO** ensure translations are technically accurate
+- **DO** verify changes compile without errors

--- a/.github/workflows/claude-translate-comments.yml
+++ b/.github/workflows/claude-translate-comments.yml
@@ -1,0 +1,67 @@
+name: Claude Translate Non-English Comments
+description: Automatically detect and translate non-English comments to English in codebase
+
+on:
+  schedule:
+    # Run daily at 02:00 UTC (10:00 Beijing Time)
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      target_module:
+        description: 'Specific module to translate (e.g., packages/database, apps/desktop/src/modules/auth)'
+        required: false
+        type: string
+
+concurrency:
+  group: translate-comments
+  cancel-in-progress: false
+
+jobs:
+  translate-comments:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "claude-bot[bot]"
+          git config --global user.email "claude-bot[bot]@users.noreply.github.com"
+
+      - name: Copy translation prompt
+        run: |
+          mkdir -p /tmp/claude-prompts
+          cp .claude/prompts/translate-comments.md /tmp/claude-prompts/
+
+      - name: Run Claude Code for Comment Translation
+        uses: anthropics/claude-code-action@main
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          allowed_non_write_users: "*"
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowed-tools Bash,Read,Edit,Glob,Grep"
+          prompt: |
+            Follow the translation guide located at:
+            ```bash
+            cat /tmp/claude-prompts/translate-comments.md
+            ```
+
+            ## Task Assignment
+
+            ${{ inputs.target_module && format('Process the specified module: {0}', inputs.target_module) || 'Automatically select one module from the target directories that has not been processed recently' }}
+
+            ## Environment Information
+            - Repository: ${{ github.repository }}
+            - Branch: ${{ github.ref_name }}
+            - Target Module: ${{ inputs.target_module || 'Auto-select' }}
+            - Run ID: ${{ github.run_id }}
+
+            **Start the translation process now.**


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

fix LOBE-724

#### 🔀 Description of Change

Added a new GitHub workflow to automatically detect and translate Chinese comments to English in the codebase.

**Features:**
- Daily scheduled run at 10:00 Beijing Time (02:00 UTC)
- Manual trigger with optional target module specification
- Scans code in `apps/desktop/src/`, `packages/*/src/`, and `src/`
- Limits changes to 500 lines per PR to ensure manageable reviews
- Processes one module at a time (e.g., a single package, desktop module, or service directory)

**Files added:**
- `.github/workflows/claude-translate-comments.yml` - Main workflow configuration
- `.claude/prompts/translate-comments.md` - Translation guide and instructions

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

The workflow can be tested by:
1. Manual trigger via GitHub Actions UI with a specific module
2. Or wait for the daily scheduled run

#### 📝 Additional Information

This workflow follows the same pattern as existing Claude Code workflows (`claude-translator.yml`, `claude-issue-triage.yml`). It helps maintain code quality by ensuring all comments are in English for better international collaboration.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an automated GitHub Actions workflow to translate Chinese code comments to English using Claude Code with daily scheduling, optional manual module triggers, per-module processing, and a 500-line change limit, and add a prompt guide to standardize translation rules and PR formatting.

CI:
- Add GitHub Actions workflow to automate translation of Chinese code comments to English with scheduled runs, manual triggers, module-based processing, and change size limits

Chores:
- Add translation prompt guide for Claude Code defining target directories, translation rules, and PR conventions