### PR TITLE
🌐 chore: translate non-English comments to English in chat service

### DIFF
--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -52,12 +52,12 @@ interface FetchAITaskResultParams extends FetchSSEOptions {
   abortController?: AbortController;
   onError?: (e: Error, rawError?: any) => void;
   /**
-   * 加载状态变化处理函数
-   * @param loading - 是否处于加载状态
+   * Loading state change handler function
+   * @param loading - Whether in loading state
    */
   onLoadingChange?: (loading: boolean) => void;
   /**
-   * 请求对象
+   * Request object
    */
   params: ChatStreamInputParams;
   trace?: TracePayload;


### PR DESCRIPTION
## Summary

- Translated non-English comments to English in `src/services/chat`
- Total lines changed: 3 lines
- Files affected: 1 file

## Changes

- [x] All non-English comments translated to English
- [x] Code functionality unchanged
- [x] Comment formatting preserved

## Module Processed

`src/services/chat`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable automated translation of non-English comments by translating existing Chinese comments in the chat service and adding a translation prompt and scheduled GitHub Actions workflow.

New Features:
- Add a scheduled GitHub Actions workflow to automatically detect and translate non-English comments

Enhancements:
- Introduce a translation guide prompt file to standardize comment translations

CI:
- Add `claude-translate-comments.yml` workflow to run daily or on-demand translation jobs