### PR TITLE
🔨 chore: improve renovate config to split pinned deps while keeping grouped

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,28 +15,64 @@
     "workarounds:all"
   ],
   "ignoreDeps": [],
-  "labels": [
-    "dependencies"
-  ],
+  "labels": ["dependencies"],
   "packageRules": [
+    // 1) Pinned deps: isolate (OK to use separate* here because there's no matchUpdateTypes)
     {
-      "groupName": "all non-minor dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackageNames": [
-        "*"
+      "description": "Isolate PRs for pinned deps (exact x.y.z)",
+      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies"
       ],
-      "matchUpdateTypes": [
-        "patch"
-      ]
+      "matchCurrentValue": "^\\d+\\.\\d+\\.\\d+([+-][0-9A-Za-z.-]+)?$",
+      "groupName": null,
+      "separateMinorPatch": true,
+      "separateMajorMinor": true,
+      "separateMultipleMinor": true,
+      "separateMultipleMajor": true
+    },
+    // 2a) Non-pinned deps: override splitting so patch+minor can be combined
+    {
+      "description": "Non-pinned deps: allow patch+minor to group; keep majors separate",
+      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "matchCurrentValue": "/(^[~^]|[<>=| -])/", // anything that looks like a range
+      "separateMinorPatch": false,
+      "separateMajorMinor": true
+    },
+    // 2b) Non-pinned deps: actually group patch+minor together
+    {
+      "description": "Non-pinned deps: group non-major updates",
+      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "matchCurrentValue": "/(^[~^]|[<>=| -])/",
+      "matchUpdateTypes": ["minor", "patch"], // only non-majors
+      "groupName": "deps (non-major)"
     }
   ],
-  "postUpdateOptions": [
-    "yarnDedupeHighest"
-  ],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 30,
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",
   "schedule": "on sunday before 6:00am",
+  "separateMajorMinor": true,
+  // Global defaults are fine; rule 2a overrides minor/patch splitting for ranged deps
+  "separateMinorPatch": true,
+  "separateMultipleMajor": true,
+  "separateMultipleMinor": true,
   "timezone": "UTC"
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Updated renovate config to support to split out pinned versions.

Tested in my own repository https://github.com/nekomeowww/iconify-inspector

<img width="935" height="948" alt="image" src="https://github.com/user-attachments/assets/08fbcf1b-e009-44db-b3d2-79b45e0c6c31" />

```
{
  "devDependencies": {
    "@iconify-json/devicon": "1.2.45",
    "@iconify-json/logos": "1.2.9",
    "@iconify-json/ph": "1.2.2",
    "@iconify-json/simple-icons": "^1.2.55",
    "@iconify-json/solar": "^1.2.4",
    "@iconify-json/svg-spinners": "~1.2.4",
  }
}
```

This will produce:

- @iconify-json/svg-spinners to latest v1 compatible
- @iconify-json/solar to v1.2 compatible
- grouped with above two, @iconify-json/simple-icons

- split PR for @iconify-json/devicon
- split PR for @iconify-json/logos
- split PR for @iconify-json/ph

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

## Summary by Sourcery

Improve the Renovate configuration to generate separate pull requests for pinned dependencies while preserving grouped updates for compatible version ranges

Enhancements:
- Configure Renovate to split out pinned-version dependencies into their own PRs
- Maintain grouping of dependencies using version ranges for bulk updates