### PR TITLE
🔨 chore: improve renovate config separate major versions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,9 +30,7 @@
       "matchCurrentValue": "^\\d+\\.\\d+\\.\\d+([+-][0-9A-Za-z.-]+)?$",
       "groupName": null,
       "separateMinorPatch": true,
-      "separateMajorMinor": true,
-      "separateMultipleMinor": true,
-      "separateMultipleMajor": true
+      "separateMajorMinor": true
     },
     // 2a) Non-pinned deps: override splitting so patch+minor can be combined
     {
@@ -70,9 +68,6 @@
   "rebaseWhen": "conflicted",
   "schedule": "on sunday before 6:00am",
   "separateMajorMinor": true,
-  // Global defaults are fine; rule 2a overrides minor/patch splitting for ranged deps
-  "separateMinorPatch": true,
   "separateMultipleMajor": true,
-  "separateMultipleMinor": true,
   "timezone": "UTC"
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Do not toggle on `separateMultipleMinor` and `separateMinorPatch`, this will cause multiple minor and patch versions split into PRs.

I kept [`separateMajorMinor`](https://docs.renovatebot.com/configuration-options/#separatemajorminor), and [`separateMultipleMajor`](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor):

> `separateMajorMinor`: default behavior
>
> `separateMultipleMajor`: If this setting is true then you would get one PR for webpack@v2 and one for webpack@v3.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Refine Renovate bot configuration to only separate PRs for major version updates and disable splitting for minor and patch releases

Chores:
- Remove `separateMultipleMinor` and `separateMinorPatch` settings from renovate.json
- Retain `separateMajorMinor` and `separateMultipleMajor` options