### PR TITLE
🔨 chore: improve renovate config to not group minor & major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,44 +21,18 @@
     {
       "description": "Isolate PRs for pinned deps (exact x.y.z)",
       "matchManagers": ["npm", "pnpm", "yarn", "bun"],
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies"
-      ],
       "matchCurrentValue": "^\\d+\\.\\d+\\.\\d+([+-][0-9A-Za-z.-]+)?$",
       "groupName": null,
       "separateMinorPatch": true,
       "separateMajorMinor": true
     },
-    // 2a) Non-pinned deps: override splitting so patch+minor can be combined
+    // 2) Non-pinned deps: Patch versions, grouped together
     {
-      "description": "Non-pinned deps: allow patch+minor to group; keep majors separate",
+      "description": "Group patch versions together for non-pinned deps",
       "matchManagers": ["npm", "pnpm", "yarn", "bun"],
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies"
-      ],
       "matchCurrentValue": "/(^[~^]|[<>=| -])/", // anything that looks like a range
-      "separateMinorPatch": false,
-      "separateMajorMinor": true
-    },
-    // 2b) Non-pinned deps: actually group patch+minor together
-    {
-      "description": "Non-pinned deps: group non-major updates",
-      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies"
-      ],
-      "matchCurrentValue": "/(^[~^]|[<>=| -])/",
-      "matchUpdateTypes": ["minor", "patch"], // only non-majors
-      "groupName": "deps (non-major)"
+      "groupName": "patch dependencies",
+      "matchUpdateTypes": ["patch"]
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

#### 🔀 Description of Change

<img width="960" height="1258" alt="image" src="https://github.com/user-attachments/assets/efc96123-1e5f-4388-8757-ffd2c3d691e8" />


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Chores:
- Update renovate.json to disable grouping of minor and major dependency updates