### PR TITLE
🐛 fix: should install new version after quit this instance

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -141,8 +141,29 @@ export class UpdaterManager {
     // Mark application for exit
     this.app.isQuiting = true;
 
-    // Delay installation by 1 second to ensure window is closed
-    autoUpdater.quitAndInstall();
+    // Close all windows first to ensure clean exit
+    logger.info('Closing all windows before update installation...');
+    const { BrowserWindow, app } = require('electron');
+    const allWindows = BrowserWindow.getAllWindows();
+    allWindows.forEach((window) => {
+      if (!window.isDestroyed()) {
+        window.close();
+      }
+    });
+
+    // Release single instance lock before quitting
+    // This ensures the new instance can acquire the lock
+    logger.info('Releasing single instance lock...');
+    app.releaseSingleInstanceLock();
+
+    // Small delay to ensure windows are closed and lock is released
+    setTimeout(() => {
+      // quitAndInstall parameters:
+      // - isSilent: true (don't show installation UI)
+      // - isForceRunAfter: true (force start app after installation)
+      logger.info('Calling autoUpdater.quitAndInstall...');
+      autoUpdater.quitAndInstall(true, true);
+    }, 100);
   };
 
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure the updater closes all windows, releases the single instance lock, and uses a slight delay before calling quitAndInstall with silent and forced restart options to guarantee the new version installs after the app quits

Bug Fixes:
- Close all BrowserWindow instances and release the single instance lock before invoking the installer
- Delay and coordinate the quitAndInstall call to ensure the application fully exits before installing the update

Enhancements:
- Log each step of the update process for better diagnostics