### PR TITLE
♻️ refactor: refactor message create name

### DIFF
--- a/src/server/routers/lambda/__tests__/integration/message.integration.test.ts
+++ b/src/server/routers/lambda/__tests__/integration/message.integration.test.ts
@@ -72,7 +72,7 @@ describe('Message Router Integration Tests', () => {
     it('should create message with correct sessionId and topicId', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const result = await caller.createNewMessage({
+      const result = await caller.createMessage({
         content: 'Test message',
         role: 'user',
         sessionId: testSessionId,
@@ -111,7 +111,7 @@ describe('Message Router Integration Tests', () => {
         })
         .returning()) as any;
 
-      const result = await caller.createNewMessage({
+      const result = await caller.createMessage({
         content: 'Test message in thread',
         role: 'user',
         sessionId: testSessionId,
@@ -140,7 +140,7 @@ describe('Message Router Integration Tests', () => {
     it('should create message without topicId', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const result = await caller.createNewMessage({
+      const result = await caller.createMessage({
         content: 'Test message without topic',
         role: 'user',
         sessionId: testSessionId,
@@ -160,7 +160,7 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       await expect(
-        caller.createNewMessage({
+        caller.createMessage({
           content: 'Test message',
           role: 'user',
           sessionId: 'non-existent-session',
@@ -192,7 +192,7 @@ describe('Message Router Integration Tests', () => {
 
       // 尝试在 testSessionId 下创建消息，但使用 anotherTopic 的 ID
       await expect(
-        caller.createNewMessage({
+        caller.createMessage({
           content: 'Test message',
           role: 'user',
           sessionId: testSessionId,
@@ -207,13 +207,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建多个消息
-      const msg1Result = await caller.createNewMessage({
+      const msg1Result = await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg2Result = await caller.createNewMessage({
+      const msg2Result = await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -228,7 +228,7 @@ describe('Message Router Integration Tests', () => {
         })
         .returning();
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message in another session',
         role: 'user',
         sessionId: anotherSession.id,
@@ -248,7 +248,7 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 在 topic 中创建消息
-      const msgInTopicResult = await caller.createNewMessage({
+      const msgInTopicResult = await caller.createMessage({
         content: 'Message in topic',
         role: 'user',
         sessionId: testSessionId,
@@ -256,7 +256,7 @@ describe('Message Router Integration Tests', () => {
       });
 
       // 在 session 中创建消息（不在 topic 中）
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message without topic',
         role: 'user',
         sessionId: testSessionId,
@@ -278,7 +278,7 @@ describe('Message Router Integration Tests', () => {
 
       // 创建多个消息
       for (let i = 0; i < 5; i++) {
-        await caller.createNewMessage({
+        await caller.createMessage({
           content: `Pagination test message ${i}`,
           role: 'user',
           sessionId: testSessionId,
@@ -331,7 +331,7 @@ describe('Message Router Integration Tests', () => {
         .returning();
 
       // 创建消息并设置 groupId
-      const msg1 = await caller.createNewMessage({
+      const msg1 = await caller.createMessage({
         content: 'Message 1 in group',
         role: 'assistant',
         sessionId: testSessionId,
@@ -343,7 +343,7 @@ describe('Message Router Integration Tests', () => {
         .where(eq(messages.id, msg1.id));
 
       // 创建不在 group 中的消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message without group',
         role: 'user',
         sessionId: testSessionId,
@@ -363,13 +363,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建多个消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'assistant',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -391,13 +391,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建消息
-      const msg1Result = await caller.createNewMessage({
+      const msg1Result = await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg2Result = await caller.createNewMessage({
+      const msg2Result = await caller.createMessage({
         content: 'Message 2',
         role: 'user',
         sessionId: testSessionId,
@@ -419,19 +419,19 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建消息
-      const msg1Result = await caller.createNewMessage({
+      const msg1Result = await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg2Result = await caller.createNewMessage({
+      const msg2Result = await caller.createMessage({
         content: 'Message 2',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg3Result = await caller.createNewMessage({
+      const msg3Result = await caller.createMessage({
         content: 'Message 3',
         role: 'user',
         sessionId: testSessionId,
@@ -455,7 +455,7 @@ describe('Message Router Integration Tests', () => {
     it('should remove a single message', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msgResult = await caller.createNewMessage({
+      const msgResult = await caller.createMessage({
         content: 'Message to remove',
         role: 'user',
         sessionId: testSessionId,
@@ -475,13 +475,13 @@ describe('Message Router Integration Tests', () => {
     it('should return message list when sessionId is provided', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg1Result = await caller.createNewMessage({
+      const msg1Result = await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg2Result = await caller.createNewMessage({
+      const msg2Result = await caller.createMessage({
         content: 'Message 2',
         role: 'user',
         sessionId: testSessionId,
@@ -504,7 +504,7 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建多个 session 和消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
@@ -518,7 +518,7 @@ describe('Message Router Integration Tests', () => {
         })
         .returning();
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'user',
         sessionId: anotherSession.id,
@@ -541,7 +541,7 @@ describe('Message Router Integration Tests', () => {
     it('should remove message query', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msgResult = await caller.createNewMessage({
+      const msgResult = await caller.createMessage({
         content: 'Message with query',
         role: 'user',
         sessionId: testSessionId,
@@ -575,13 +575,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建多个消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -605,7 +605,7 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 在 topic 中创建消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message in topic',
         role: 'user',
         sessionId: testSessionId,
@@ -613,7 +613,7 @@ describe('Message Router Integration Tests', () => {
       });
 
       // 在 session 中创建消息（不在 topic 中）
-      const msgOutsideTopicResult = await caller.createNewMessage({
+      const msgOutsideTopicResult = await caller.createMessage({
         content: 'Message outside topic',
         role: 'user',
         sessionId: testSessionId,
@@ -651,7 +651,7 @@ describe('Message Router Integration Tests', () => {
         .returning();
 
       // 创建消息并设置 groupId
-      const msg1 = await caller.createNewMessage({
+      const msg1 = await caller.createMessage({
         content: 'Message 1 in group',
         role: 'assistant',
         sessionId: testSessionId,
@@ -677,7 +677,7 @@ describe('Message Router Integration Tests', () => {
     it('should update message content', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const result = await caller.createNewMessage({
+      const result = await caller.createMessage({
         content: 'Original content',
         role: 'user',
         sessionId: testSessionId,
@@ -701,13 +701,13 @@ describe('Message Router Integration Tests', () => {
     it('should update message and return message list when sessionId is provided', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg1 = await caller.createNewMessage({
+      const msg1 = await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      const msg2 = await caller.createNewMessage({
+      const msg2 = await caller.createMessage({
         content: 'Message 2',
         role: 'user',
         sessionId: testSessionId,
@@ -733,13 +733,13 @@ describe('Message Router Integration Tests', () => {
     it('should search messages by keyword', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'This is a test message about TypeScript',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Another message about JavaScript',
         role: 'user',
         sessionId: testSessionId,
@@ -758,7 +758,7 @@ describe('Message Router Integration Tests', () => {
     it('should update message plugin state', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with plugin',
         role: 'assistant',
         sessionId: testSessionId,
@@ -794,7 +794,7 @@ describe('Message Router Integration Tests', () => {
     it('should update message RAG information', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with RAG',
         role: 'assistant',
         sessionId: testSessionId,
@@ -844,13 +844,13 @@ describe('Message Router Integration Tests', () => {
     it('should return message list when sessionId is provided', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg1 = await caller.createNewMessage({
+      const msg1 = await caller.createMessage({
         content: 'Message 1',
         role: 'assistant',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -895,7 +895,7 @@ describe('Message Router Integration Tests', () => {
     it('should update message metadata', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with metadata',
         role: 'user',
         sessionId: testSessionId,
@@ -921,7 +921,7 @@ describe('Message Router Integration Tests', () => {
     it('should update plugin error state', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with plugin error',
         role: 'assistant',
         sessionId: testSessionId,
@@ -953,7 +953,7 @@ describe('Message Router Integration Tests', () => {
     it('should return message list when sessionId is provided', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg1 = await caller.createNewMessage({
+      const msg1 = await caller.createMessage({
         content: 'Message 1',
         role: 'assistant',
         sessionId: testSessionId,
@@ -968,7 +968,7 @@ describe('Message Router Integration Tests', () => {
         type: 'default',
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -990,7 +990,7 @@ describe('Message Router Integration Tests', () => {
     it('should update plugin state', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with plugin state',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1019,7 +1019,7 @@ describe('Message Router Integration Tests', () => {
     it('should update TTS information', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with TTS',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1058,7 +1058,7 @@ describe('Message Router Integration Tests', () => {
     it('should delete TTS when value is false', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message with TTS to delete',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1103,7 +1103,7 @@ describe('Message Router Integration Tests', () => {
     it('should update translation information', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Hello world',
         role: 'user',
         sessionId: testSessionId,
@@ -1131,7 +1131,7 @@ describe('Message Router Integration Tests', () => {
     it('should delete translation when value is false', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Hello world',
         role: 'user',
         sessionId: testSessionId,
@@ -1166,13 +1166,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建一些消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1190,7 +1190,7 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建带有模型信息的消息
-      const msg = await caller.createNewMessage({
+      const msg = await caller.createMessage({
         content: 'Message from AI',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1211,13 +1211,13 @@ describe('Message Router Integration Tests', () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
       // 创建消息
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
       });
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 2',
         role: 'assistant',
         sessionId: testSessionId,
@@ -1231,7 +1231,7 @@ describe('Message Router Integration Tests', () => {
     it('should count messages with date range', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Message 1',
         role: 'user',
         sessionId: testSessionId,
@@ -1251,7 +1251,7 @@ describe('Message Router Integration Tests', () => {
     it('should count words', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Hello world',
         role: 'user',
         sessionId: testSessionId,
@@ -1265,7 +1265,7 @@ describe('Message Router Integration Tests', () => {
     it('should count words with date range', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 
-      await caller.createNewMessage({
+      await caller.createMessage({
         content: 'Hello world test message',
         role: 'user',
         sessionId: testSessionId,

--- a/src/server/routers/lambda/message.ts
+++ b/src/server/routers/lambda/message.ts
@@ -54,11 +54,11 @@ export const messageRouter = router({
       return ctx.messageModel.countWords(input);
     }),
 
-  createNewMessage: messageProcedure
+  createMessage: messageProcedure
     .input(CreateNewMessageParamsSchema.extend({ useGroup: z.boolean().optional() }))
     .mutation(async ({ input, ctx }) => {
       const { useGroup, ...params } = input;
-      return ctx.messageService.createNewMessage(params as any, { useGroup });
+      return ctx.messageService.createMessage(params as any, { useGroup });
     }),
 
   getHeatmaps: messageProcedure.query(async ({ ctx }) => {

--- a/src/server/services/message/__tests__/index.test.ts
+++ b/src/server/services/message/__tests__/index.test.ts
@@ -255,7 +255,7 @@ describe('MessageService', () => {
     });
   });
 
-  describe('createNewMessage', () => {
+  describe('createMessage', () => {
     it('should create message and return message list', async () => {
       const params = {
         content: 'Hello',
@@ -268,7 +268,7 @@ describe('MessageService', () => {
       vi.mocked(mockMessageModel.create).mockResolvedValue(createdMessage as any);
       vi.mocked(mockMessageModel.query).mockResolvedValue(mockMessages as any);
 
-      const result = await messageService.createNewMessage(params as any);
+      const result = await messageService.createMessage(params as any);
 
       expect(mockMessageModel.create).toHaveBeenCalledWith(params);
       expect(mockMessageModel.query).toHaveBeenCalledWith(
@@ -301,7 +301,7 @@ describe('MessageService', () => {
       vi.mocked(mockMessageModel.create).mockResolvedValue(createdMessage as any);
       vi.mocked(mockMessageModel.query).mockResolvedValue(mockMessages as any);
 
-      const result = await messageService.createNewMessage(params as any, { useGroup: true });
+      const result = await messageService.createMessage(params as any, { useGroup: true });
 
       expect(mockMessageModel.query).toHaveBeenCalledWith(
         expect.anything(),
@@ -329,7 +329,7 @@ describe('MessageService', () => {
       vi.mocked(mockMessageModel.create).mockResolvedValue(createdMessage as any);
       vi.mocked(mockMessageModel.query).mockResolvedValue(mockMessages as any);
 
-      const result = await messageService.createNewMessage(params as any);
+      const result = await messageService.createMessage(params as any);
 
       expect(mockMessageModel.query).toHaveBeenCalledWith(
         {

--- a/src/server/services/message/index.ts
+++ b/src/server/services/message/index.ts
@@ -128,7 +128,7 @@ export class MessageService {
    * This method combines message creation and querying into a single operation,
    * reducing the need for separate refresh calls and improving performance.
    */
-  async createNewMessage(
+  async createMessage(
     params: CreateMessageParams,
     options?: QueryOptions,
   ): Promise<CreateMessageResult> {

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -23,11 +23,11 @@ export class MessageService {
     return labPreferSelectors.enableAssistantMessageGroup(useUserStore.getState());
   }
 
-  createNewMessage = async ({
+  createMessage = async ({
     sessionId,
     ...params
   }: CreateMessageParams): Promise<CreateMessageResult> => {
-    return lambdaClient.message.createNewMessage.mutate({
+    return lambdaClient.message.createMessage.mutate({
       ...params,
       sessionId: sessionId ? this.toDbSessionId(sessionId) : undefined,
       useGroup: this.useGroup,

--- a/src/store/chat/slices/aiChat/actions/__tests__/generateAIChat.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/generateAIChat.test.ts
@@ -61,7 +61,7 @@ describe('chatMessage actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.USER_MESSAGE });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
         expect(result.current.internal_coreProcessMessage).not.toHaveBeenCalled();
       });
 
@@ -72,7 +72,7 @@ describe('chatMessage actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.EMPTY });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
       });
 
       it('should not send when message is empty with empty files array', async () => {
@@ -82,7 +82,7 @@ describe('chatMessage actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.EMPTY, files: [] });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
       });
     });
 
@@ -97,13 +97,13 @@ describe('chatMessage actions', () => {
           });
         });
 
-        expect(messageService.createNewMessage).toHaveBeenCalled();
+        expect(messageService.createMessage).toHaveBeenCalled();
         expect(result.current.internal_coreProcessMessage).not.toHaveBeenCalled();
       });
 
       it('should handle message creation errors gracefully', async () => {
         const { result } = renderHook(() => useChatStore());
-        vi.spyOn(messageService, 'createNewMessage').mockRejectedValue(
+        vi.spyOn(messageService, 'createMessage').mockRejectedValue(
           new Error('create message error'),
         );
 
@@ -229,7 +229,7 @@ describe('chatMessage actions', () => {
         .mockResolvedValue({ isFunctionCall: false, content: 'AI response' });
 
       const createMessageSpy = vi
-        .spyOn(messageService, 'createNewMessage')
+        .spyOn(messageService, 'createMessage')
         .mockResolvedValue({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, messages: mockMessages });
 
       const replaceMessagesSpy = vi.spyOn(result.current, 'replaceMessages');
@@ -272,7 +272,7 @@ describe('chatMessage actions', () => {
           rewriteQuery: 'rewritten query',
         });
 
-      vi.spyOn(messageService, 'createNewMessage').mockResolvedValue({
+      vi.spyOn(messageService, 'createMessage').mockResolvedValue({
         id: TEST_IDS.ASSISTANT_MESSAGE_ID,
         messages: [],
       });
@@ -306,7 +306,7 @@ describe('chatMessage actions', () => {
         .spyOn(result.current, 'internal_fetchAIChatMessage')
         .mockResolvedValue({ isFunctionCall: false, content: '' });
 
-      vi.spyOn(messageService, 'createNewMessage').mockResolvedValue(undefined as any);
+      vi.spyOn(messageService, 'createMessage').mockResolvedValue(undefined as any);
 
       await act(async () => {
         await result.current.internal_coreProcessMessage([userMessage], userMessage.id);

--- a/src/store/chat/slices/aiChat/actions/__tests__/generateAIChatV2.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/generateAIChatV2.test.ts
@@ -131,7 +131,7 @@ describe('generateAIChatV2 actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.USER_MESSAGE });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
         expect(result.current.internal_execAgentRuntime).not.toHaveBeenCalled();
       });
 
@@ -142,7 +142,7 @@ describe('generateAIChatV2 actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.EMPTY });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
       });
 
       it('should not send when message is empty with empty files array', async () => {
@@ -152,7 +152,7 @@ describe('generateAIChatV2 actions', () => {
           await result.current.sendMessage({ message: TEST_CONTENT.EMPTY, files: [] });
         });
 
-        expect(messageService.createNewMessage).not.toHaveBeenCalled();
+        expect(messageService.createMessage).not.toHaveBeenCalled();
       });
     });
 
@@ -312,7 +312,7 @@ describe('generateAIChatV2 actions', () => {
           });
         });
 
-        expect(messageService.createNewMessage).toHaveBeenCalled();
+        expect(messageService.createMessage).toHaveBeenCalled();
         expect(result.current.internal_execAgentRuntime).not.toHaveBeenCalled();
       });
 
@@ -749,7 +749,7 @@ describe('generateAIChatV2 actions', () => {
 
     beforeEach(() => {
       // Reset mocks
-      vi.spyOn(messageService, 'createNewMessage').mockResolvedValue({
+      vi.spyOn(messageService, 'createMessage').mockResolvedValue({
         id: 'new-assistant-block-id',
         messages: [] as any,
       });
@@ -814,8 +814,8 @@ describe('generateAIChatV2 actions', () => {
         }),
       );
 
-      // Verify that createNewMessage was called with message params
-      expect(messageService.createNewMessage).toHaveBeenCalledWith(
+      // Verify that createMessage was called with message params
+      expect(messageService.createMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           role: 'assistant',
           parentId: TOOL_RESULT_MSG_ID,
@@ -866,7 +866,7 @@ describe('generateAIChatV2 actions', () => {
         }),
       );
 
-      expect(messageService.createNewMessage).toHaveBeenCalledWith(
+      expect(messageService.createMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           role: 'assistant',
           parentId: 'non-existent-tool-result-id',

--- a/src/store/chat/slices/aiChat/actions/__tests__/helpers.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/helpers.ts
@@ -58,7 +58,7 @@ export const createMockAbortController = () => {
  */
 export const spyOnMessageService = () => {
   const createMessageSpy = vi
-    .spyOn(messageService, 'createNewMessage')
+    .spyOn(messageService, 'createMessage')
     .mockResolvedValue({ id: TEST_IDS.NEW_MESSAGE_ID, messages: [] });
   const updateMessageSpy = vi
     .spyOn(messageService, 'updateMessage')

--- a/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -646,7 +646,7 @@ export const generateAIChatV2: StateCreator<
           payload.type,
         );
 
-        // 2. 使用 createNewMessage 创建 tool 消息
+        // 2. 使用 createMessage 创建 tool 消息
         const toolMessage: CreateNewMessageParams = {
           content: '',
           parentId: assistantId,

--- a/src/store/chat/slices/message/action.test.ts
+++ b/src/store/chat/slices/message/action.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/services/message', () => ({
     removeMessage: vi.fn(),
     removeMessagesByAssistant: vi.fn(),
     removeMessages: vi.fn(() => Promise.resolve()),
-    createNewMessage: vi.fn(() => Promise.resolve({ id: 'new-message-id', messages: [] })),
+    createMessage: vi.fn(() => Promise.resolve({ id: 'new-message-id', messages: [] })),
     updateMessage: vi.fn(),
     removeAllMessages: vi.fn(() => Promise.resolve()),
   },
@@ -71,7 +71,7 @@ describe('chatMessage actions', () => {
         await result.current.addAIMessage();
       });
 
-      expect(messageService.createNewMessage).not.toHaveBeenCalled();
+      expect(messageService.createMessage).not.toHaveBeenCalled();
       expect(updateInputMessageSpy).not.toHaveBeenCalled();
     });
 
@@ -84,7 +84,7 @@ describe('chatMessage actions', () => {
         await result.current.addAIMessage();
       });
 
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content: inputMessage,
         role: 'assistant',
         sessionId: mockState.activeId,
@@ -113,7 +113,7 @@ describe('chatMessage actions', () => {
         await result.current.addUserMessage({ message: 'test message' });
       });
 
-      expect(messageService.createNewMessage).not.toHaveBeenCalled();
+      expect(messageService.createMessage).not.toHaveBeenCalled();
       expect(updateInputMessageSpy).not.toHaveBeenCalled();
     });
 
@@ -130,7 +130,7 @@ describe('chatMessage actions', () => {
         await result.current.addUserMessage({ message, fileList });
       });
 
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content: message,
         files: fileList,
         role: 'user',
@@ -154,7 +154,7 @@ describe('chatMessage actions', () => {
         await result.current.addUserMessage({ message });
       });
 
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content: message,
         files: undefined,
         role: 'user',
@@ -184,7 +184,7 @@ describe('chatMessage actions', () => {
         await result.current.addUserMessage({ message });
       });
 
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content: message,
         files: undefined,
         role: 'user',

--- a/src/store/chat/slices/message/action.ts
+++ b/src/store/chat/slices/message/action.ts
@@ -519,10 +519,10 @@ export const chatMessage: StateCreator<
     }
 
     try {
-      const result = await messageService.createNewMessage(message);
+      const result = await messageService.createMessage(message);
 
       if (!context?.skipRefresh) {
-        // Use the messages returned from createNewMessage (already grouped)
+        // Use the messages returned from createMessage (already grouped)
         replaceMessages(result.messages);
       }
 

--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/services/message', () => ({
     updateMessageError: vi.fn(),
     updateMessagePluginState: vi.fn(),
     updateMessagePluginArguments: vi.fn(),
-    createNewMessage: vi.fn(),
+    createMessage: vi.fn(),
   },
 }));
 
@@ -565,8 +565,8 @@ describe('ChatPluginAction', () => {
   describe('createAssistantMessageByPlugin', () => {
     it('should create an assistant message and replace messages', async () => {
       const mockMessages = [{ id: 'msg-1', content: 'test' }] as any;
-      // 模拟 messageService.createNewMessage 方法的实现
-      (messageService.createNewMessage as Mock).mockResolvedValue({
+      // 模拟 messageService.createMessage 方法的实现
+      (messageService.createMessage as Mock).mockResolvedValue({
         id: 'new-message-id',
         messages: mockMessages,
       });
@@ -588,8 +588,8 @@ describe('ChatPluginAction', () => {
         await result.current.createAssistantMessageByPlugin(content, parentId);
       });
 
-      // 验证 messageService.createNewMessage 是否被带有正确参数调用
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      // 验证 messageService.createMessage 是否被带有正确参数调用
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content,
         parentId,
         role: 'assistant',
@@ -604,7 +604,7 @@ describe('ChatPluginAction', () => {
     it('should handle errors when message creation fails', async () => {
       // 模拟 messageService.create 方法，使其抛出错误
       const errorMessage = 'Failed to create message';
-      (messageService.createNewMessage as Mock).mockRejectedValue(new Error(errorMessage));
+      (messageService.createMessage as Mock).mockRejectedValue(new Error(errorMessage));
 
       // 设置初始状态并模拟 refreshMessages 方法
       const initialState = {
@@ -626,7 +626,7 @@ describe('ChatPluginAction', () => {
       });
 
       // 验证 messageService.create 是否被带有正确参数调用
-      expect(messageService.createNewMessage).toHaveBeenCalledWith({
+      expect(messageService.createMessage).toHaveBeenCalledWith({
         content,
         parentId,
         role: 'assistant',

--- a/src/store/chat/slices/plugin/action.ts
+++ b/src/store/chat/slices/plugin/action.ts
@@ -98,7 +98,7 @@ export const chatPlugin: StateCreator<
       topicId: get().activeTopicId, // if there is activeTopicId，then add it to topicId
     };
 
-    const result = await messageService.createNewMessage(newMessage);
+    const result = await messageService.createMessage(newMessage);
     get().replaceMessages(result.messages);
   },
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Refactor message creation API by renaming createNewMessage to createMessage across the codebase

Enhancements:
- Rename service method createNewMessage to createMessage in MessageService and underlying lambdaClient calls
- Update Lambda router and GraphQL procedure to use createMessage instead of createNewMessage
- Adjust chat store actions and AI chat workflows to call messageService.createMessage
- Revise all tests and mocks to reflect the new createMessage method name

Tests:
- Update integration and unit tests to replace createNewMessage with createMessage