### PR TITLE
🔨 chore: ignore apps/mobile dir content build

### DIFF
--- a/scripts/vercelIgnoredBuildStep.js
+++ b/scripts/vercelIgnoredBuildStep.js
@@ -8,7 +8,7 @@ function shouldProceedBuild() {
   if (
     branchName === 'lighthouse' ||
     branchName.startsWith('mobile/') ||
-    branchName === 'feat/mobile-app' ||
+    branchName.startsWith('feat/mobile-app') ||
     branchName.startsWith('gru/')
   ) {
     return false;
@@ -22,6 +22,7 @@ function shouldProceedBuild() {
       ":!./Dockerfile" \
       ":!./.github" \
       ":!./.husky" \
+      ":!./apps/mobile" \
       ":!./scripts"';
 
     execSync(diffCommand);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update Vercel build script to ignore the apps/mobile directory and broaden mobile-app branch matching for build skipping.

Build:
- Add apps/mobile directory to the ignore list in the Vercel build step
- Change branch filter to skip builds for any branch starting with feat/mobile-app