### PR TITLE
👷 build(observability-otel): support to trace and meter for tRPC

### DIFF
--- a/packages/obervability-otel/package.json
+++ b/packages/obervability-otel/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "exports": {
-    "./node": "./src/node.ts"
+    "./node": "./src/node.ts",
+    "./api": "./src/api.ts",
+    "./trpc": "./src/trpc/index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/obervability-otel/src/api.ts
+++ b/packages/obervability-otel/src/api.ts
@@ -1,0 +1,2 @@
+export type { Attributes, Span } from '@opentelemetry/api';
+export { diag, metrics, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';

--- a/packages/obervability-otel/src/trpc/convention.ts
+++ b/packages/obervability-otel/src/trpc/convention.ts
@@ -1,0 +1,16 @@
+export enum TRPCAttribute {
+  RPC_METHOD = 'rpc.method',
+  RPC_SERVICE = 'rpc.service',
+  RPC_SYSTEM = 'rpc.system',
+  RPC_TRPC_PATH = 'rpc.trpc.path',
+  RPC_TRPC_STATUS_CODE = 'rpc.trpc.status_code',
+  RPC_TRPC_SUCCESS = 'rpc.trpc.success',
+  RPC_TRPC_TYPE = 'rpc.trpc.type',
+}
+
+export {
+  ATTR_ERROR_TYPE,
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';

--- a/packages/obervability-otel/src/trpc/index.test.ts
+++ b/packages/obervability-otel/src/trpc/index.test.ts
@@ -1,0 +1,38 @@
+import { parseTRPCPath, tRPCConventionFromPathAndType } from './';
+
+describe('splitRpcPath', () => {
+  it('should split path into service and method with url', () => {
+    const { method, service } = parseTRPCPath('/trpc/lambda/someService.someMethod');
+    expect(method).toBe('someMethod');
+    expect(service).toBe('someService');
+  });
+
+  it('should split path into service and method without url', () => {
+    const { method, service } = parseTRPCPath('someService.someMethod');
+    expect(method).toBe('someMethod');
+    expect(service).toBe('someService');
+  });
+});
+
+describe('createBaseAttributes', () => {
+  it('should create base attributes with service and method', () => {
+    const attributes = tRPCConventionFromPathAndType('someService.someMethod', 'query');
+    expect(attributes).toEqual({
+      'rpc.system': 'trpc',
+      'rpc.trpc.path': 'someService.someMethod',
+      'rpc.trpc.type': 'query',
+      'rpc.service': 'someService',
+      'rpc.method': 'someMethod',
+    });
+  });
+
+  it('should create base attributes without service', () => {
+    const attributes = tRPCConventionFromPathAndType('someMethod', 'mutation');
+    expect(attributes).toEqual({
+      'rpc.system': 'trpc',
+      'rpc.trpc.path': 'someMethod',
+      'rpc.trpc.type': 'mutation',
+      'rpc.method': 'someMethod',
+    });
+  });
+});

--- a/packages/obervability-otel/src/trpc/index.ts
+++ b/packages/obervability-otel/src/trpc/index.ts
@@ -1,0 +1,62 @@
+import { Attributes } from '@opentelemetry/api';
+
+import { TRPCAttribute } from './convention';
+
+export const DEFAULT_ERROR_CODE = 'UNKNOWN_ERROR';
+export const DEFAULT_SUCCESS_STATUS = 'OK';
+
+const textEncoder = new TextEncoder();
+
+export function parseTRPCPath(path: string) {
+  const parts = path?.split('.') ?? [];
+  if (parts.length <= 1) {
+    return { method: path, service: undefined };
+  }
+
+  const method = parts.at(-1);
+  const service = parts.slice(0, -1).join('.').split('/').pop();
+  return { method, service };
+}
+
+export function tRPCConventionFromPathAndType(path: string, type: string): Attributes {
+  const { method, service } = parseTRPCPath(path);
+
+  const attributes: Attributes = {
+    [TRPCAttribute.RPC_SYSTEM]: 'trpc',
+    [TRPCAttribute.RPC_TRPC_PATH]: path,
+    [TRPCAttribute.RPC_TRPC_TYPE]: type,
+  };
+
+  if (service) {
+    attributes[TRPCAttribute.RPC_SERVICE] = service;
+  }
+  if (method) {
+    attributes[TRPCAttribute.RPC_METHOD] = method;
+  }
+
+  return attributes;
+}
+
+export const getPayloadSize = (payload: unknown): number | undefined => {
+  if (payload === undefined || payload === null) return undefined;
+
+  try {
+    const serialized = JSON.stringify(payload);
+    return textEncoder.encode(serialized).length;
+  } catch {
+    return undefined;
+  }
+};
+
+export const createAttributesForMetrics = (
+  baseAttributes: Attributes,
+  statusCode: string,
+  extraAttributes?: Attributes,
+): Attributes => ({
+  ...baseAttributes,
+  [TRPCAttribute.RPC_TRPC_STATUS_CODE]: statusCode,
+  ...extraAttributes,
+});
+
+export * from './convention';
+export * from './metrics';

--- a/packages/obervability-otel/src/trpc/metrics.ts
+++ b/packages/obervability-otel/src/trpc/metrics.ts
@@ -1,0 +1,31 @@
+import { metrics } from '@opentelemetry/api';
+
+const meter = metrics.getMeter('trpc-server');
+
+export const serverDurationHistogram = meter.createHistogram('rpc.server.duration', {
+  description: 'Measures the duration of inbound RPC.',
+  unit: 'ms',
+});
+
+export const serverRequestSizeHistogram = meter.createHistogram('rpc.server.request.size', {
+  description: 'Measures the size of RPC request messages (uncompressed).',
+  unit: 'By',
+});
+
+export const serverResponseSizeHistogram = meter.createHistogram('rpc.server.response.size', {
+  description: 'Measures the size of RPC response messages (uncompressed).',
+  unit: 'By',
+});
+
+export const serverRequestsPerRpcHistogram = meter.createHistogram('rpc.server.requests_per_rpc', {
+  description: 'Measures the number of messages received per RPC.',
+  unit: '{count}',
+});
+
+export const serverResponsesPerRpcHistogram = meter.createHistogram(
+  'rpc.server.responses_per_rpc',
+  {
+    description: 'Measures the number of messages sent per RPC.',
+    unit: '{count}',
+  },
+);

--- a/src/libs/trpc/lambda/index.ts
+++ b/src/libs/trpc/lambda/index.ts
@@ -10,6 +10,7 @@
 import { DESKTOP_USER_ID } from '@/const/desktop';
 import { isDesktop } from '@/const/version';
 
+import { openTelemetry } from '../middleware/openTelemetry';
 import { userAuth } from '../middleware/userAuth';
 import { trpc } from './init';
 import { oidcAuth } from './middleware/oidcAuth';
@@ -24,14 +25,16 @@ export const router = trpc.router;
  * Create an unprotected procedure
  * @link https://trpc.io/docs/v11/procedures
  **/
-export const publicProcedure = trpc.procedure.use(({ next, ctx }) => {
+const baseProcedure = trpc.procedure.use(openTelemetry);
+
+export const publicProcedure = baseProcedure.use(({ next, ctx }) => {
   return next({
     ctx: { ...ctx, userId: isDesktop ? DESKTOP_USER_ID : ctx.userId },
   });
 });
 
 // procedure that asserts that the user is logged in
-export const authedProcedure = trpc.procedure.use(oidcAuth).use(userAuth);
+export const authedProcedure = baseProcedure.use(oidcAuth).use(userAuth);
 
 /**
  * Create a server-side caller

--- a/src/libs/trpc/middleware/openTelemetry.ts
+++ b/src/libs/trpc/middleware/openTelemetry.ts
@@ -1,0 +1,141 @@
+import type { Attributes, Span } from '@lobechat/observability-otel/api';
+import { SpanKind, SpanStatusCode, diag, trace } from '@lobechat/observability-otel/api';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  DEFAULT_ERROR_CODE,
+  DEFAULT_SUCCESS_STATUS,
+  TRPCAttribute,
+  createAttributesForMetrics,
+  getPayloadSize,
+  serverDurationHistogram,
+  serverRequestSizeHistogram,
+  serverRequestsPerRpcHistogram,
+  serverResponseSizeHistogram,
+  serverResponsesPerRpcHistogram,
+  tRPCConventionFromPathAndType,
+} from '@lobechat/observability-otel/trpc';
+import { TRPCError } from '@trpc/server';
+import { env } from 'node:process';
+
+import { name } from '../../../../package.json';
+import { trpc } from '../lambda/init';
+
+const tracer = trace.getTracer('trpc-server');
+
+const recordRpcServerMetrics = ({
+  attributes,
+  durationMs,
+  requestSize,
+  responseSize,
+}: {
+  attributes: Attributes;
+  durationMs: number;
+  requestSize?: number;
+  responseSize?: number;
+}) => {
+  serverDurationHistogram.record(durationMs, attributes);
+  serverRequestsPerRpcHistogram.record(1, attributes);
+  serverResponsesPerRpcHistogram.record(1, attributes);
+
+  if (typeof requestSize === 'number') {
+    serverRequestSizeHistogram.record(requestSize, attributes);
+  }
+
+  if (typeof responseSize === 'number') {
+    serverResponseSizeHistogram.record(responseSize, attributes);
+  }
+};
+
+const finalizeSpanWithError = (span: Span, error: unknown) => {
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: error instanceof Error ? error.message : 'Unknown error',
+  });
+
+  if (error instanceof Error) {
+    span.recordException(error);
+    span.setAttribute(ATTR_ERROR_TYPE, error.constructor.name);
+    span.setAttribute(ATTR_EXCEPTION_MESSAGE, error.message);
+    span.setAttribute(ATTR_EXCEPTION_STACKTRACE, error.stack || '');
+  }
+};
+
+export const openTelemetry = trpc.middleware(async ({ path, type, next, getRawInput }) => {
+  if (!env.ENABLE_TELEMETRY) {
+    diag.debug(name, 'telemetry disabled', env.ENABLE_TELEMETRY);
+
+    return next();
+  }
+
+  diag.debug(name, 'tRPC instrumentation', 'incomingRequest');
+
+  const spanName = `tRPC ${type.toUpperCase()} ${path}`;
+  const baseAttributes = tRPCConventionFromPathAndType(path, type);
+  const input = getRawInput();
+  const requestSize = getPayloadSize(input);
+
+  const span = tracer.startSpan(spanName, {
+    attributes: baseAttributes,
+    kind: SpanKind.SERVER,
+  });
+
+  const startTimestamp = Date.now();
+
+  try {
+    const result = await next();
+    diag.debug(name, 'tRPC instrumentation', 'requestHandled');
+
+    const responseSize = getPayloadSize(result.ok ? result.data : result.error);
+
+    const durationMs = Date.now() - startTimestamp;
+    const statusCode = result.ok ? DEFAULT_SUCCESS_STATUS : result.error.code;
+    span.setAttribute(TRPCAttribute.RPC_TRPC_STATUS_CODE, statusCode);
+
+    if (result.ok) {
+      span.setStatus({ code: SpanStatusCode.OK });
+    } else {
+      finalizeSpanWithError(span, result.error);
+    }
+
+    recordRpcServerMetrics({
+      attributes: createAttributesForMetrics(baseAttributes, statusCode, {
+        [TRPCAttribute.RPC_TRPC_SUCCESS]: result.ok,
+        ...(result.ok ? undefined : { [ATTR_ERROR_TYPE]: result.error.code }),
+      }),
+      durationMs,
+      requestSize,
+      responseSize,
+    });
+
+    diag.debug(name, 'tRPC instrumentation', 'metrics recorded');
+
+    return result;
+  } catch (error) {
+    diag.error(name, 'tRPC instrumentation', 'requestError', error);
+
+    const durationMs = Date.now() - startTimestamp;
+    const trpcError = error instanceof TRPCError ? error : undefined;
+    const statusCode = trpcError ? trpcError.code : DEFAULT_ERROR_CODE;
+
+    span.setAttribute(TRPCAttribute.RPC_TRPC_STATUS_CODE, statusCode);
+    finalizeSpanWithError(span, error);
+
+    recordRpcServerMetrics({
+      attributes: createAttributesForMetrics(baseAttributes, statusCode, {
+        [TRPCAttribute.RPC_TRPC_SUCCESS]: false,
+        ...(trpcError ? { [ATTR_ERROR_TYPE]: trpcError.code } : undefined),
+      }),
+      durationMs,
+      requestSize,
+      responseSize: getPayloadSize(trpcError ? trpcError : error),
+    });
+
+    diag.error(name, 'tRPC instrumentation', 'metrics recorded with error', error);
+
+    throw error;
+  } finally {
+    span.end();
+  }
+});


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

#### 🔀 Description of Change

There's no existing tRPC OpenTelemetry integration for reporting gRPC like metrics that follows the [OpenTelemetry conventions of RPC section](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/), but a few exists for traces, [baselime made one for traces](https://github.com/baselime/trpc-opentelemetry-middleware/blob/main/src/index.ts) but it's not possible to have metrics as traces happens right inside of tRPC middlewares.

Integrated one, parse tRPC requests as expected with unit tests, tested locally to build this kind of Grafana dashboard for better o11y.

<img width="2708" height="1500" alt="image" src="https://github.com/user-attachments/assets/f56e486f-08f7-4e67-99ea-ddffabecbff6" />

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Introduce OpenTelemetry instrumentation for tRPC to enable distributed tracing and RPC metrics

New Features:
- Add a new observability-otel package exporting OpenTelemetry APIs, tRPC conventions, and metrics definitions
- Implement a tRPC middleware that starts spans, records RPC server histograms (duration, request/response sizes and counts), and captures errors per OpenTelemetry RPC conventions
- Integrate the OpenTelemetry middleware into lambda-based tRPC public and authenticated procedures to automatically instrument all RPC calls
- Provide utilities for parsing tRPC paths, calculating payload sizes, and assembling metric attributes

Tests:
- Add unit tests for tRPC path parsing and conventions