### PR TITLE
🐛 fix(TokenUsage): prevent animation when toggling between token and credit display

### DIFF
--- a/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
@@ -215,10 +215,10 @@ const TokenDetail = memo<TokenDetailProps>(({ meta, model, provider }) => {
     >
       <Center gap={2} horizontal style={{ cursor: 'default' }}>
         <Icon icon={isShowCredit ? BadgeCent : CoinsIcon} />
-        {/* Force remount when switching between token/credit to prevent unwanted animation
-            See: https://github.com/lobehub/lobe-chat/pull/10098 */}
         <AnimatedNumber
           formatter={(value) => (formatShortenNumber(value) as string).toLowerCase?.()}
+          // Force remount when switching between token/credit to prevent unwanted animation
+          // See: https://github.com/lobehub/lobe-chat/pull/10098
           key={isShowCredit ? 'credit' : 'token'}
           value={totalCount}
         />

--- a/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
@@ -215,6 +215,8 @@ const TokenDetail = memo<TokenDetailProps>(({ meta, model, provider }) => {
     >
       <Center gap={2} horizontal style={{ cursor: 'default' }}>
         <Icon icon={isShowCredit ? BadgeCent : CoinsIcon} />
+        {/* Force remount when switching between token/credit to prevent unwanted animation
+            See: https://github.com/lobehub/lobe-chat/pull/10098 */}
         <AnimatedNumber
           formatter={(value) => (formatShortenNumber(value) as string).toLowerCase?.()}
           key={isShowCredit ? 'credit' : 'token'}

--- a/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/components/Extras/Usage/UsageDetail/index.tsx
@@ -217,6 +217,7 @@ const TokenDetail = memo<TokenDetailProps>(({ meta, model, provider }) => {
         <Icon icon={isShowCredit ? BadgeCent : CoinsIcon} />
         <AnimatedNumber
           formatter={(value) => (formatShortenNumber(value) as string).toLowerCase?.()}
+          key={isShowCredit ? 'credit' : 'token'}
           value={totalCount}
         />
       </Center>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #10095

#### 🔀 Description of Change

Fixed an issue where TokenUsage component would animate when toggling between token and credit display modes. 

The root cause was that `AnimatedNumber` component was receiving different values when switching between token/credit modes, triggering unwanted animation transitions. By adding a `key` prop that changes based on the display mode, the component now remounts instead of animating, preventing the unintended animation behavior.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

**Test steps:**
1. View a message with token usage
2. Toggle between token and credit display in settings
3. Verify the TokenUsage number updates instantly without animation

#### 📝 Additional Information

- Small fix with minimal impact
- Only affects UI behavior, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Stop unwanted animation on AnimatedNumber when toggling between token and credit display modes