### PR TITLE
:lipstick: style: fix usage table display issues

### DIFF
--- a/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
@@ -7,7 +7,10 @@ export const UsageBarChart = ({ ...props }: BarChartProps) => (
     {...props}
     customTooltip={({ active, payload, label, valueFormatter }) => {
       if (active && payload) {
-        const sum = payload.reduce((acc: number, cur: any) => acc + cur.value, 0);
+        const sum = payload.reduce(
+          (acc: number, cur: any) => (typeof cur.value === 'number' ? acc + cur.value : acc),
+          0,
+        );
         return (
           <ChartTooltipFrame>
             <Flexbox horizontal justify={'space-between'} paddingBlock={8} paddingInline={16}>

--- a/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
@@ -7,34 +7,37 @@ export const UsageBarChart = ({ ...props }: BarChartProps) => (
     {...props}
     customTooltip={({ active, payload, label, valueFormatter }) => {
       if (active && payload) {
+        const sum = payload.reduce((acc: number, cur: any) => acc + cur.value, 0);
         return (
           <ChartTooltipFrame>
             <Flexbox horizontal justify={'space-between'} paddingBlock={8} paddingInline={16}>
               <Text as={'p'} ellipsis style={{ margin: 0 }}>
                 {label}
               </Text>
-              <span style={{ fontWeight: 'bold' }}>
-                {payload.reduce((acc: number, cur: any) => acc + cur.value, 0)}
-              </span>
+              {sum !== 0 && <span style={{ fontWeight: 'bold' }}> {sum} </span>}
             </Flexbox>
-            <Divider style={{ margin: 0 }} />
-            <Flexbox
-              gap={4}
-              paddingBlock={8}
-              paddingInline={16}
-              style={{ flexDirection: 'column-reverse', marginTop: 4 }}
-            >
-              {payload.map(({ value, color, name }: any, idx: number) =>
-                typeof value === 'number' && value > 0 ? (
-                  <ChartTooltipRow
-                    color={color}
-                    key={`id-${idx}`}
-                    name={name}
-                    value={(valueFormatter as any)?.(value)}
-                  />
-                ) : null,
-              )}
-            </Flexbox>
+            {sum !== 0 && (
+              <>
+                <Divider style={{ margin: 0 }} />
+                <Flexbox
+                  gap={4}
+                  paddingBlock={8}
+                  paddingInline={16}
+                  style={{ flexDirection: 'column-reverse', marginTop: 4 }}
+                >
+                  {payload.map(({ value, color, name }: any, idx: number) =>
+                    typeof value === 'number' && value > 0 ? (
+                      <ChartTooltipRow
+                        color={color}
+                        key={`id-${idx}`}
+                        name={name}
+                        value={(valueFormatter as any)?.(value)}
+                      />
+                    ) : null,
+                  )}
+                </Flexbox>
+              </>
+            )}
           </ChartTooltipFrame>
         );
       }

--- a/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
@@ -2,10 +2,16 @@ import { BarChart, type BarChartProps, ChartTooltipFrame, ChartTooltipRow } from
 import { Flexbox, Text } from '@lobehub/ui';
 import { Divider } from 'antd';
 
-export const UsageBarChart = ({ ...props }: BarChartProps) => (
+import { formatNumber, formatTokenNumber } from '@/utils/format';
+
+interface UsageBarChartProps extends BarChartProps {
+  showType: 'spend' | 'token';
+}
+
+export const UsageBarChart = ({ ...props }: UsageBarChartProps) => (
   <BarChart
     {...props}
-    customTooltip={({ active, payload, label, valueFormatter }) => {
+    customTooltip={({ active, payload, label }) => {
       if (active && payload) {
         const sum = payload.reduce(
           (acc: number, cur: any) => (typeof cur.value === 'number' ? acc + cur.value : acc),
@@ -17,7 +23,12 @@ export const UsageBarChart = ({ ...props }: BarChartProps) => (
               <Text as={'p'} ellipsis style={{ margin: 0 }}>
                 {label}
               </Text>
-              {sum !== 0 && <span style={{ fontWeight: 'bold' }}> {sum} </span>}
+              {sum !== 0 && (
+                <span style={{ fontWeight: 'bold' }}>
+                  {' '}
+                  {props.showType === 'spend' ? formatNumber(sum, 2) : formatTokenNumber(sum)}{' '}
+                </span>
+              )}
             </Flexbox>
             {sum !== 0 && (
               <>
@@ -34,7 +45,11 @@ export const UsageBarChart = ({ ...props }: BarChartProps) => (
                         color={color}
                         key={`id-${idx}`}
                         name={name}
-                        value={(valueFormatter as any)?.(value)}
+                        value={
+                          props.showType === 'spend'
+                            ? formatNumber(value, 2)
+                            : formatTokenNumber(value)
+                        }
                       />
                     ) : null,
                   )}
@@ -46,5 +61,8 @@ export const UsageBarChart = ({ ...props }: BarChartProps) => (
       }
       return null;
     }}
+    valueFormatter={(num) =>
+      props.showType === 'spend' ? formatNumber(num, 2) : formatTokenNumber(num)
+    }
   />
 );

--- a/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx
@@ -25,8 +25,7 @@ export const UsageBarChart = ({ ...props }: UsageBarChartProps) => (
               </Text>
               {sum !== 0 && (
                 <span style={{ fontWeight: 'bold' }}>
-                  {' '}
-                  {props.showType === 'spend' ? formatNumber(sum, 2) : formatTokenNumber(sum)}{' '}
+                  {props.showType === 'spend' ? formatNumber(sum, 2) : formatTokenNumber(sum)}
                 </span>
               )}
             </Flexbox>

--- a/src/app/[variants]/(main)/settings/stats/features/usage/UsageTable.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/usage/UsageTable.tsx
@@ -1,5 +1,5 @@
 import { ProviderIcon } from '@lobehub/icons';
-import { Flexbox, Tag, Text } from '@lobehub/ui';
+import { Flexbox, Tag, Text, Tooltip } from '@lobehub/ui';
 import { type TableColumnType } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, useEffect } from 'react';
@@ -53,7 +53,9 @@ const UsageTable = memo<UsageChartProps>(({ dateStrings }) => {
               marginRight: -8,
             }}
           />
-          <Text>{value?.length > 12 ? `${value.slice(0, 12)}...` : value}</Text>
+          <Tooltip title={value}>
+            <Text>{value?.length > 12 ? `${value.slice(0, 12)}...` : value}</Text>
+          </Tooltip>
         </Flexbox>
       ),
       title: t('usage.table.model'),

--- a/src/app/[variants]/(main)/settings/stats/features/usage/UsageTrends.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/usage/UsageTrends.tsx
@@ -83,9 +83,9 @@ const UsageTrends = memo<UsageChartProps>(({ isLoading, data, groupBy }) => {
   const charts =
     data &&
     (type === ShowType.Spend ? (
-      <UsageBarChart categories={spendCate} data={spendData} index="day" />
+      <UsageBarChart categories={spendCate} data={spendData} index="day" stack={true} />
     ) : (
-      <UsageBarChart categories={tokenCate} data={tokenData} index="day" />
+      <UsageBarChart categories={tokenCate} data={tokenData} index="day" stack={true} />
     ));
 
   return (

--- a/src/server/services/usage/index.ts
+++ b/src/server/services/usage/index.ts
@@ -28,7 +28,7 @@ export class UsageRecordService {
     // Set startAt and endAt
     let startAt: string;
     let endAt: string;
-    if (mo) {
+    if (mo && dayjs(mo).isValid()) {
       // mo format: "YYYY-MM"
       startAt = dayjs(mo, 'YYYY-MM').startOf('month').format('YYYY-MM-DD');
       endAt = dayjs(mo, 'YYYY-MM').endOf('month').format('YYYY-MM-DD');
@@ -89,15 +89,18 @@ export class UsageRecordService {
     // Set startAt and endAt
     let startAt: string;
     let endAt: string;
-    if (mo) {
+    let month: string;
+    if (mo && dayjs(mo).isValid()) {
       // mo format: "YYYY-MM"
       startAt = dayjs(mo, 'YYYY-MM').startOf('month').format('YYYY-MM-DD');
       endAt = dayjs(mo, 'YYYY-MM').endOf('month').format('YYYY-MM-DD');
+      month = mo;
     } else {
       startAt = dayjs().startOf('month').format('YYYY-MM-DD');
       endAt = dayjs().endOf('month').format('YYYY-MM-DD');
+      month = dayjs().format('YYYY-MM');
     }
-    const spends = await this.findByMonth(mo);
+    const spends = await this.findByMonth(month);
     // Clustering by time
     let usages = new Map<string, { date: Date; logs: UsageRecordItem[] }>();
     spends.forEach((spend) => {

--- a/src/server/services/usage/index.ts
+++ b/src/server/services/usage/index.ts
@@ -28,7 +28,7 @@ export class UsageRecordService {
     // Set startAt and endAt
     let startAt: string;
     let endAt: string;
-    if (mo && dayjs(mo).isValid()) {
+    if (mo && dayjs(mo, 'YYYY-MM', true).isValid()) {
       // mo format: "YYYY-MM"
       startAt = dayjs(mo, 'YYYY-MM').startOf('month').format('YYYY-MM-DD');
       endAt = dayjs(mo, 'YYYY-MM').endOf('month').format('YYYY-MM-DD');
@@ -90,7 +90,7 @@ export class UsageRecordService {
     let startAt: string;
     let endAt: string;
     let month: string;
-    if (mo && dayjs(mo).isValid()) {
+    if (mo && dayjs(mo, 'YYYY-MM', true).isValid()) {
       // mo format: "YYYY-MM"
       startAt = dayjs(mo, 'YYYY-MM').startOf('month').format('YYYY-MM-DD');
       endAt = dayjs(mo, 'YYYY-MM').endOf('month').format('YYYY-MM-DD');


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

- `A`:
  - `src/app/[variants]/(main)/settings/stats/features/usage/UsageTable.tsx`
  - 将 BarChart 改为堆叠
- `B` : 
  - `src/app/[variants]/(main)/settings/stats/features/components/UsageBarChart.tsx`
  - 移除 label 在没有用量显示时的多余内容
- `C` ,  `D` ：
  - 修复因为浮点数长度导致 label width 过长

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| id | Before | After |
| -- | -- | -- |
| A | <img width="1015" height="341" alt="image" src="https://github.com/user-attachments/assets/d53413e0-a22a-4e69-9177-8aa01a3ad8c5" /> | <img width="936" height="369" alt="image" src="https://github.com/user-attachments/assets/87767651-e11d-439f-ab0a-8e2e65d9d477" /> |
| B | <img width="181" height="113" alt="image" src="https://github.com/user-attachments/assets/884bf747-c960-419c-8e7f-f72c34513108" />   | <img width="144" height="70" alt="image" src="https://github.com/user-attachments/assets/5ec982e3-13a1-4f26-be8d-23e88e728158" /> |
| C |  <img width="987" height="363" alt="image" src="https://github.com/user-attachments/assets/7dc2472c-ca82-448a-aeaa-3e6abfacac86" /> | <img width="1017" height="352" alt="image" src="https://github.com/user-attachments/assets/b1f2468d-fc51-4781-bc46-8006c14ab832" />  | 
| D |  <img width="996" height="676" alt="image" src="https://github.com/user-attachments/assets/2cb903fa-6b9b-4097-8105-830521a1dfe5" />  | <img width="867" height="687" alt="image" src="https://github.com/user-attachments/assets/da6696f0-9f9e-4580-895d-08604369d9de" />|


#### 📝 Additional Information

Bug not fix:

- Bug 1 Eclipse 的点溢出了

<img width="451" height="131" alt="image" src="https://github.com/user-attachments/assets/387b9634-45c5-4267-8eb9-a38862fd0366" />




<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update styling and UI enhancements for usage chart and table components.

Enhancements:
- Reorder imports, adjust JSX formatting, and enable stacked bars by adding the stack prop in UsageBarChart.
- Wrap truncated table cell values in a Tooltip and adjust cell margin in UsageTable to reveal full text on hover.

## Summary by Sourcery

Refine usage statistics UI and fix handling of invalid or missing month parameters in usage queries.

Bug Fixes:
- Validate and safely default the month parameter when computing and querying usage records to avoid invalid date handling.
- Hide tooltip totals and breakdown rows in the usage bar chart when there is no usage data.

Enhancements:
- Render spend and token usage charts as stacked bar charts in the trends view.
- Show full, truncated model names in the usage table via hover tooltips for better readability.