### PR TITLE
🐛 fix(database): fix deleteMessagesBySession incorrectly deleting all messages

### DIFF
--- a/packages/database/src/models/__tests__/message.test.ts
+++ b/packages/database/src/models/__tests__/message.test.ts
@@ -1922,6 +1922,63 @@ describe('MessageModel', () => {
       expect(remainingMessages).toHaveLength(1);
       expect(remainingMessages[0].id).toBe('2');
     });
+
+    it('should delete only non-topic messages when topicId is null', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([
+        { id: 'topic1', sessionId: 'session1', userId },
+        { id: 'topic2', sessionId: 'session1', userId },
+      ]);
+
+      await serverDB.insert(messages).values([
+        {
+          id: '1',
+          userId,
+          sessionId: 'session1',
+          topicId: null,
+          role: 'user',
+          content: 'message without topic 1',
+        },
+        {
+          id: '2',
+          userId,
+          sessionId: 'session1',
+          topicId: null,
+          role: 'assistant',
+          content: 'message without topic 2',
+        },
+        {
+          id: '3',
+          userId,
+          sessionId: 'session1',
+          topicId: 'topic1',
+          role: 'user',
+          content: 'message in topic1',
+        },
+        {
+          id: '4',
+          userId,
+          sessionId: 'session1',
+          topicId: 'topic2',
+          role: 'assistant',
+          content: 'message in topic2',
+        },
+      ]);
+
+      // Delete messages in session1 with null topicId
+      await messageModel.deleteMessagesBySession('session1', null);
+
+      const remainingMessages = await serverDB
+        .select()
+        .from(messages)
+        .where(eq(messages.userId, userId))
+        .orderBy(messages.id);
+
+      // Should only keep messages with topics
+      expect(remainingMessages).toHaveLength(2);
+      expect(remainingMessages[0].id).toBe('3');
+      expect(remainingMessages[1].id).toBe('4');
+    });
   });
 
   describe('genId', () => {

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -768,19 +768,17 @@ export class MessageModel {
     sessionId?: string | null,
     topicId?: string | null,
     groupId?: string | null,
-  ) => {
-    const conditions = [eq(messages.userId, this.userId), this.matchSession(sessionId)];
-
-    // For deletion: only filter by topicId/groupId if explicitly provided
-    if (topicId !== undefined && topicId !== null) {
-      conditions.push(eq(messages.topicId, topicId));
-    }
-    if (groupId !== undefined && groupId !== null) {
-      conditions.push(eq(messages.groupId, groupId));
-    }
-
-    return this.db.delete(messages).where(and(...conditions));
-  };
+  ) =>
+    this.db
+      .delete(messages)
+      .where(
+        and(
+          eq(messages.userId, this.userId),
+          this.matchSession(sessionId),
+          this.matchTopic(topicId),
+          this.matchGroup(groupId),
+        ),
+      );
 
   deleteAllMessages = async () => {
     return this.db.delete(messages).where(eq(messages.userId, this.userId));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

This fixes a critical data loss bug introduced in #10080 (commit b95e74171)

#### 🔀 Description of Change

**Problem:**
The `deleteMessagesBySession` method in `MessageModel` was incorrectly modified to delete ALL messages in a session when `topicId` was `null`, instead of only deleting messages without a topic. This caused users to lose all their messages including those in topics.

**Root Cause:**
The implementation stopped using `matchTopic()` and `matchGroup()` helper methods when parameters were `null`. These helpers correctly generate `isNull()` conditions, but the new code skipped adding any topic/group filters entirely when the values were `null`, causing over-deletion.

**Before (buggy):**
```typescript
// When topicId is null, no filter is added → deletes ALL messages
if (topicId !== undefined && topicId !== null) {
  conditions.push(eq(messages.topicId, topicId));
}
```

**After (fixed):**
```typescript
// When topicId is null, adds isNull(messages.topicId) → only deletes non-topic messages
this.matchTopic(topicId)
```

**Changes:**
- Reverted `deleteMessagesBySession` to use `matchTopic()` and `matchGroup()` helpers (packages/database/src/models/message.ts:767)
- Added comprehensive test case covering the `topicId: null` scenario (packages/database/src/models/__tests__/message.test.ts:1926)

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Test coverage:**
```bash
cd packages/database && bunx vitest run --silent='passed-only' 'message.test.ts' -t "deleteMessagesBySession"
```

The new test case verifies that when deleting with `topicId: null`, only messages without topics are deleted, while messages in topics remain intact.

#### 📝 Additional Information

**Severity:** Critical - Causes irreversible data loss for users

**Impact:** Users calling `removeMessagesByAssistant({ sessionId, topicId: null })` would lose ALL their messages in that session, including messages in all topics.

**Why tests didn't catch this:** The original test suite only covered:
- ✅ Delete entire session
- ✅ Delete specific topic

But was missing:
- ❌ Delete session messages with `topicId: null` (only non-topic messages)

This gap allowed the bug to slip through in #10080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)