### PR TITLE
🐛 fix: fix mcp server return image content issue

### DIFF
--- a/packages/database/src/models/file.ts
+++ b/packages/database/src/models/file.ts
@@ -25,8 +25,22 @@ export class FileModel {
     this.db = db;
   }
 
+  /**
+   * Get file by ID without userId filter (public access)
+   * Use this for scenarios like file proxy where file should be accessible by ID alone
+   *
+   * @param db - Database instance
+   * @param id - File ID
+   * @returns File record or undefined
+   */
+  static async getFileById(db: LobeChatDatabase, id: string): Promise<FileItem | undefined> {
+    return db.query.files.findFirst({
+      where: eq(files.id, id),
+    });
+  }
+
   create = async (
-    params: Omit<NewFile, 'id' | 'userId'> & { knowledgeBaseId?: string },
+    params: Omit<NewFile, 'id' | 'userId'> & { id?: string; knowledgeBaseId?: string },
     insertToGlobalFiles?: boolean,
     trx?: Transaction,
   ) => {

--- a/packages/database/src/repositories/aiInfra/index.test.ts
+++ b/packages/database/src/repositories/aiInfra/index.test.ts
@@ -25,7 +25,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
 
   repo = new AiInfraRepos(clientDB as any, userId, mockProviderConfigs);
-});
+}, 30000);
 
 describe('AiInfraRepos', () => {
   describe('getAiProviderList', () => {

--- a/packages/database/src/repositories/dataExporter/index.test.ts
+++ b/packages/database/src/repositories/dataExporter/index.test.ts
@@ -157,7 +157,7 @@ describe('DataExporterRepos', () => {
 
     // 插入测试数据
     await setupTestData();
-  });
+  }, 30000);
 
   afterEach(async () => {
     await db.delete(users);

--- a/packages/database/src/repositories/tableViewer/index.test.ts
+++ b/packages/database/src/repositories/tableViewer/index.test.ts
@@ -16,7 +16,7 @@ const mockDB = {
 beforeEach(async () => {
   await initializeDB();
   vi.clearAllMocks();
-});
+}, 30000);
 
 describe('TableViewerRepo', () => {
   describe('getAllTables', () => {

--- a/src/app/(backend)/f/[id]/route.ts
+++ b/src/app/(backend)/f/[id]/route.ts
@@ -1,56 +1,52 @@
-import { isDesktop } from '@lobechat/const';
+import debug from 'debug';
 
 import { FileModel } from '@/database/models/file';
 import { getServerDB } from '@/database/server';
 import { FileService } from '@/server/services/file';
 
-export const runtime = 'nodejs';
+const log = debug('lobe-file:proxy');
 
 type Params = Promise<{ id: string }>;
 
 /**
- * 文件代理服务
+ * File proxy service
  * GET /f/:id
  *
- * 功能：
- * - 查询数据库获取文件记录
- * - 根据平台生成访问 URL（桌面 → 本地文件，网页 → S3 预签名 URL）
- * - 返回 302 重定向
+ * Features:
+ * - Query database to get file record (without userId filter for public access)
+ * - Generate access URL based on platform (desktop → local file, web → S3 presigned URL)
+ * - Return 302 redirect
  */
 export const GET = async (_req: Request, segmentData: { params: Params }) => {
   try {
     const params = await segmentData.params;
     const { id } = params;
 
-    // 获取数据库连接
+    log('File proxy request: %s', id);
+
+    // Get database connection
     const db = await getServerDB();
 
-    // 查询文件记录
-    // 注意：这里使用 'system' 作为 userId，因为文件代理不需要用户权限验证
-    // 如果未来需要权限控制，可以从 session 中获取真实的 userId
-    const fileModel = new FileModel(db, 'system');
-    const file = await fileModel.findById(id);
+    // Query file record without userId filter (public access)
+    const file = await FileModel.getFileById(db, id);
 
     if (!file) {
+      log('File not found: %s', id);
       return new Response('File not found', {
         status: 404,
       });
     }
 
-    // 创建文件服务
-    const fileService = new FileService(db, 'system');
+    log('File found: %s, url: %s, userId: %s', id, file.url, file.userId);
 
-    let redirectUrl: string;
+    // Create file service with file owner's userId
+    const fileService = new FileService(db, file.userId);
 
-    if (isDesktop) {
-      // 桌面端：获取本地文件的 HTTP URL
-      redirectUrl = await fileService.createPreSignedUrlForPreview(file.url);
-    } else {
-      // 网页端：生成 S3 预签名 URL（5分钟有效期）
-      redirectUrl = await fileService.createPreSignedUrlForPreview(file.url, 300);
-    }
+    // Web: Generate S3 presigned URL (5 minutes expiry)
+    const redirectUrl = await fileService.createPreSignedUrlForPreview(file.url, 300);
+    log('Web S3 presigned URL generated (expires in 5 min)');
 
-    // 返回 302 重定向
+    // Return 302 redirect
     return Response.redirect(redirectUrl, 302);
   } catch (error) {
     console.error('File proxy error:', error);

--- a/src/app/(backend)/f/[id]/route.ts
+++ b/src/app/(backend)/f/[id]/route.ts
@@ -37,8 +37,6 @@ export const GET = async (_req: Request, segmentData: { params: Params }) => {
       });
     }
 
-    log('File found: %s, url: %s, userId: %s', id, file.url, file.userId);
-
     // Create file service with file owner's userId
     const fileService = new FileService(db, file.userId);
 

--- a/src/app/(backend)/f/[id]/route.ts
+++ b/src/app/(backend)/f/[id]/route.ts
@@ -1,0 +1,61 @@
+import { isDesktop } from '@lobechat/const';
+
+import { FileModel } from '@/database/models/file';
+import { getServerDB } from '@/database/server';
+import { FileService } from '@/server/services/file';
+
+export const runtime = 'nodejs';
+
+type Params = Promise<{ id: string }>;
+
+/**
+ * 文件代理服务
+ * GET /f/:id
+ *
+ * 功能：
+ * - 查询数据库获取文件记录
+ * - 根据平台生成访问 URL（桌面 → 本地文件，网页 → S3 预签名 URL）
+ * - 返回 302 重定向
+ */
+export const GET = async (_req: Request, segmentData: { params: Params }) => {
+  try {
+    const params = await segmentData.params;
+    const { id } = params;
+
+    // 获取数据库连接
+    const db = await getServerDB();
+
+    // 查询文件记录
+    // 注意：这里使用 'system' 作为 userId，因为文件代理不需要用户权限验证
+    // 如果未来需要权限控制，可以从 session 中获取真实的 userId
+    const fileModel = new FileModel(db, 'system');
+    const file = await fileModel.findById(id);
+
+    if (!file) {
+      return new Response('File not found', {
+        status: 404,
+      });
+    }
+
+    // 创建文件服务
+    const fileService = new FileService(db, 'system');
+
+    let redirectUrl: string;
+
+    if (isDesktop) {
+      // 桌面端：获取本地文件的 HTTP URL
+      redirectUrl = await fileService.createPreSignedUrlForPreview(file.url);
+    } else {
+      // 网页端：生成 S3 预签名 URL（5分钟有效期）
+      redirectUrl = await fileService.createPreSignedUrlForPreview(file.url, 300);
+    }
+
+    // 返回 302 重定向
+    return Response.redirect(redirectUrl, 302);
+  } catch (error) {
+    console.error('File proxy error:', error);
+    return new Response('Internal server error', {
+      status: 500,
+    });
+  }
+};

--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -18,7 +18,9 @@ const APP_URL = process.env.APP_URL
   ? process.env.APP_URL
   : isInVercel
     ? vercelUrl
-    : 'http://localhost:3010';
+    : process.env.NODE_ENV === 'development'
+      ? 'http://localhost:3010'
+      : 'http://localhost:3210';
 
 // INTERNAL_APP_URL is used for server-to-server calls to bypass CDN/proxy
 // Falls back to APP_URL if not set
@@ -29,15 +31,11 @@ const ASSISTANT_INDEX_URL = 'https://registry.npmmirror.com/@lobehub/agents-inde
 const PLUGINS_INDEX_URL = 'https://registry.npmmirror.com/@lobehub/plugins-index/v1/files/public';
 
 export const getAppConfig = () => {
-  const ACCESS_CODES = process.env.ACCESS_CODE?.split(',').filter(Boolean) || [];
-
   return createEnv({
     client: {
       NEXT_PUBLIC_ENABLE_SENTRY: z.boolean(),
     },
     server: {
-      ACCESS_CODES: z.any(z.string()).optional(),
-
       AGENTS_INDEX_URL: z.string().url(),
 
       DEFAULT_AGENT_CONFIG: z.string(),
@@ -46,7 +44,7 @@ export const getAppConfig = () => {
       PLUGINS_INDEX_URL: z.string().url(),
       PLUGIN_SETTINGS: z.string().optional(),
 
-      APP_URL: z.string().optional(),
+      APP_URL: z.string(),
       INTERNAL_APP_URL: z.string().optional(),
       VERCEL_EDGE_CONFIG: z.string().optional(),
       MIDDLEWARE_REWRITE_THROUGH_LOCAL: z.boolean().optional(),
@@ -63,8 +61,6 @@ export const getAppConfig = () => {
     runtimeEnv: {
       // Sentry
       NEXT_PUBLIC_ENABLE_SENTRY: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-      ACCESS_CODES: ACCESS_CODES as any,
 
       AGENTS_INDEX_URL: !!process.env.AGENTS_INDEX_URL
         ? process.env.AGENTS_INDEX_URL

--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -31,11 +31,14 @@ const ASSISTANT_INDEX_URL = 'https://registry.npmmirror.com/@lobehub/agents-inde
 const PLUGINS_INDEX_URL = 'https://registry.npmmirror.com/@lobehub/plugins-index/v1/files/public';
 
 export const getAppConfig = () => {
+  const ACCESS_CODES = process.env.ACCESS_CODE?.split(',').filter(Boolean) || [];
+
   return createEnv({
     client: {
       NEXT_PUBLIC_ENABLE_SENTRY: z.boolean(),
     },
     server: {
+      ACCESS_CODES: z.any(z.string()).optional(),
       AGENTS_INDEX_URL: z.string().url(),
 
       DEFAULT_AGENT_CONFIG: z.string(),
@@ -61,6 +64,8 @@ export const getAppConfig = () => {
     runtimeEnv: {
       // Sentry
       NEXT_PUBLIC_ENABLE_SENTRY: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+      ACCESS_CODES: ACCESS_CODES as any,
 
       AGENTS_INDEX_URL: !!process.env.AGENTS_INDEX_URL
         ? process.env.AGENTS_INDEX_URL

--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import isEqual from 'fast-deep-equal';
 import {
   ReactNode,
   forwardRef,
@@ -132,6 +133,6 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile, dataSource, itemCo
       </WideScreenContainer>
     </VirtuosoContext>
   );
-});
+}, isEqual);
 
 export default VirtualizedList;

--- a/src/features/PluginsUI/Render/MCPType/index.tsx
+++ b/src/features/PluginsUI/Render/MCPType/index.tsx
@@ -1,4 +1,4 @@
-import { Markdown } from '@lobehub/ui';
+import { Image, Markdown } from '@lobehub/ui';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
@@ -21,20 +21,40 @@ const MCPType = memo<MCPTypeProps>(({ pluginState, arguments: args }) => {
 
   const { content } = pluginState;
 
+  const hasImage = content.some((item) => item.type === 'image');
   return (
-    <Flexbox gap={8} style={{ maxHeight: 400, overflow: 'scroll', padding: 8, width: '100%' }}>
-      <div>
-        <Arguments arguments={args} />
-      </div>
+    <Flexbox
+      gap={8}
+      style={
+        !hasImage ? { maxHeight: 400, overflow: 'scroll', padding: 8, width: '100%' } : undefined
+      }
+    >
+      {args && (
+        <div>
+          <Arguments arguments={args} />
+        </div>
+      )}
       <Flexbox>
         <Flexbox>
-          {content.map((item) => {
+          {content.map((item, index) => {
             switch (item.type) {
               case 'text': {
                 return (
                   <Markdown key={item.text} variant={'chat'}>
                     {item.text}
                   </Markdown>
+                );
+              }
+
+              case 'image': {
+                return (
+                  <Image
+                    alt="MCP content"
+                    height={'auto'}
+                    key={`image-${index}`}
+                    src={item.data}
+                    width={'100%'}
+                  />
                 );
               }
 

--- a/src/server/routers/desktop/mcp.ts
+++ b/src/server/routers/desktop/mcp.ts
@@ -2,8 +2,12 @@ import { GetStreamableMcpServerManifestInputSchema } from '@lobechat/types';
 import debug from 'debug';
 import { z } from 'zod';
 
+import { ToolCallContent } from '@/libs/mcp';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { FileService } from '@/server/services/file';
 import { mcpService } from '@/server/services/mcp';
+import { processContentBlocks } from '@/server/services/mcp/contentProcessor';
 
 const log = debug('lobe-mcp:router');
 
@@ -22,7 +26,13 @@ const stdioParamsSchema = z.object({
   type: z.literal('stdio').default('stdio'),
 });
 
-const mcpProcedure = authedProcedure;
+const mcpProcedure = authedProcedure.use(serverDatabase).use(async ({ ctx, next }) => {
+  return next({
+    ctx: {
+      fileService: new FileService(ctx.serverDB, ctx.userId),
+    },
+  });
+});
 
 export const mcpRouter = router({
   getStdioMcpServerManifest: mcpProcedure.input(stdioParamsSchema).query(async ({ input }) => {
@@ -85,13 +95,18 @@ export const mcpRouter = router({
         toolName: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
-      // Pass the validated params, toolName, and args to the service
-      return await mcpService.callTool(
-        { ...input.params, env: input.env },
-        input.toolName,
-        input.args,
-      );
+    .mutation(async ({ input, ctx }) => {
+      // Create a closure that binds fileService and userId to processContentBlocks
+      const boundProcessContentBlocks = async (blocks: ToolCallContent[]) =>
+        processContentBlocks(blocks, ctx.fileService);
+
+      // Pass the validated params, toolName, args, and bound processContentBlocks to the service
+      return await mcpService.callTool({
+        clientParams: { ...input.params, env: input.env },
+        toolName: input.toolName,
+        argsStr: input.args,
+        processContentBlocks: boundProcessContentBlocks,
+      });
     }),
 
   validMcpServerInstallable: mcpProcedure

--- a/src/server/routers/tools/mcp.ts
+++ b/src/server/routers/tools/mcp.ts
@@ -6,8 +6,12 @@ import {
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { ToolCallContent } from '@/libs/mcp';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { FileService } from '@/server/services/file';
 import { mcpService } from '@/server/services/mcp';
+import { processContentBlocks } from '@/server/services/mcp/contentProcessor';
 
 // Define Zod schemas for MCP Client parameters
 const httpParamsSchema = z.object({
@@ -37,7 +41,13 @@ const checkStdioEnvironment = (params: z.infer<typeof mcpClientParamsSchema>) =>
   }
 };
 
-const mcpProcedure = authedProcedure;
+const mcpProcedure = authedProcedure.use(serverDatabase).use(async ({ ctx, next }) => {
+  return next({
+    ctx: {
+      fileService: new FileService(ctx.serverDB, ctx.userId),
+    },
+  });
+});
 
 export const mcpRouter = router({
   getStreamableMcpServerManifest: mcpProcedure
@@ -95,11 +105,21 @@ export const mcpRouter = router({
         toolName: z.string(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       // Stdio check can be done here or rely on the service/client layer
       checkStdioEnvironment(input.params);
 
-      // Pass the validated params, toolName, and args to the service
-      return await mcpService.callTool(input.params, input.toolName, input.args);
+      // Create a closure that binds fileService and userId to processContentBlocks
+      const boundProcessContentBlocks = async (blocks: ToolCallContent[]) => {
+        return processContentBlocks(blocks, ctx.fileService);
+      };
+
+      // Pass the validated params, toolName, args, and bound processContentBlocks to the service
+      return await mcpService.callTool({
+        clientParams: input.params,
+        toolName: input.toolName,
+        argsStr: input.args,
+        processContentBlocks: boundProcessContentBlocks,
+      });
     }),
 });

--- a/src/server/services/file/impls/local.ts
+++ b/src/server/services/file/impls/local.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { sha256 } from 'js-sha256';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -7,6 +8,8 @@ import { inferContentTypeFromImageUrl } from '@/utils/url';
 
 import { FileServiceImpl } from './type';
 import { extractKeyFromUrlOrReturnOriginal } from './utils';
+
+const log = debug('lobe-file:desktop-local');
 
 /**
  * 桌面应用本地文件服务实现
@@ -202,7 +205,7 @@ export class DesktopLocalFileImpl implements FileServiceImpl {
         throw new Error('Failed to upload file via Electron IPC');
       }
 
-      console.log('[DesktopLocalFileImpl] File uploaded successfully:', result.metadata);
+      log('File uploaded successfully: %O', result.metadata);
       return { key: result.metadata.path };
     } catch (error) {
       console.error('[DesktopLocalFileImpl] Failed to upload media file:', error);

--- a/src/server/services/file/index.ts
+++ b/src/server/services/file/index.ts
@@ -1,4 +1,5 @@
 import { LobeChatDatabase } from '@lobechat/database';
+import { inferContentTypeFromImageUrl, nanoid, uuid } from '@lobechat/utils';
 import { TRPCError } from '@trpc/server';
 import { sha256 } from 'js-sha256';
 
@@ -6,8 +7,6 @@ import { serverDBEnv } from '@/config/db';
 import { FileModel } from '@/database/models/file';
 import { FileItem } from '@/database/schemas';
 import { TempFileManager } from '@/server/utils/tempFileManager';
-import { inferContentTypeFromImageUrl } from '@/utils/url';
-import { nanoid, uuid } from '@/utils/uuid';
 
 import { FileServiceImpl, createFileServiceModule } from './impls';
 

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -69,7 +69,9 @@ export const processContentBlocks = async (
  * - image/audio: 提取 data 字段（通常是上传后的代理 URL）
  * - 其他: 返回空字符串
  */
-export const contentBlocksToString = (blocks: ToolCallContent[]): string => {
+export const contentBlocksToString = (blocks: ToolCallContent[] | null | undefined): string => {
+  if (!blocks) return '';
+
   return blocks
     .map((item) => {
       switch (item.type) {

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -1,0 +1,88 @@
+import debug from 'debug';
+import pMap from 'p-map';
+
+import { fileEnv } from '@/envs/file';
+import { AudioContent, ImageContent, ToolCallContent } from '@/libs/mcp';
+import { FileService } from '@/server/services/file';
+import { nanoid } from '@/utils/uuid';
+
+const log = debug('lobe-mcp:content-processor');
+
+export type ProcessContentBlocksFn = (blocks: ToolCallContent[]) => Promise<ToolCallContent[]>;
+
+/**
+ * 处理 MCP 返回的 content blocks
+ * - 上传图片/音频到存储并替换 data 为代理 URL
+ * - 保持其他类型的 block 不变
+ */
+export const processContentBlocks = async (
+  blocks: ToolCallContent[],
+  fileService: FileService,
+): Promise<ToolCallContent[]> => {
+  // Use date-based sharding for privacy compliance (GDPR, CCPA)
+  const today = new Date().toISOString().split('T')[0]; // e.g., "2025-11-08"
+
+  return pMap(blocks, async (block) => {
+    if (block.type === 'image') {
+      const imageBlock = block as ImageContent;
+
+      // Extract file extension from mimeType (e.g., "image/png" -> "png")
+      const fileExtension = imageBlock.mimeType.split('/')[1] || 'png';
+
+      // Generate unique pathname with date-based sharding
+      const pathname = `${fileEnv.NEXT_PUBLIC_S3_FILE_PATH}/mcp/images/${today}/${nanoid()}.${fileExtension}`;
+
+      // Upload base64 image and get proxy URL
+      const { url } = await fileService.uploadBase64(imageBlock.data, pathname);
+
+      log(`Image uploaded, proxy URL: ${url}`);
+
+      return { ...block, data: url };
+    }
+
+    if (block.type === 'audio') {
+      const audioBlock = block as AudioContent;
+
+      // Extract file extension from mimeType (e.g., "audio/mp3" -> "mp3")
+      const fileExtension = audioBlock.mimeType.split('/')[1] || 'mp3';
+
+      // Generate unique pathname with date-based sharding
+      const pathname = `${fileEnv.NEXT_PUBLIC_S3_FILE_PATH}/mcp/audio/${today}/${nanoid()}.${fileExtension}`;
+
+      // Upload base64 audio and get proxy URL
+      const { url } = await fileService.uploadBase64(audioBlock.data, pathname);
+
+      log(`Audio uploaded, proxy URL: ${url}`);
+
+      return { ...block, data: url };
+    }
+
+    return block;
+  });
+};
+
+/**
+ * 将 content blocks 转换为字符串
+ * - text: 提取 text 字段
+ * - image/audio: 提取 data 字段（通常是上传后的代理 URL）
+ * - 其他: 返回空字符串
+ */
+export const contentBlocksToString = (blocks: ToolCallContent[]): string => {
+  return blocks
+    .map((item) => {
+      switch (item.type) {
+        case 'text': {
+          return item.text;
+        }
+        case 'image':
+        case 'audio': {
+          return item.data;
+        }
+        default: {
+          return '';
+        }
+      }
+    })
+    .filter(Boolean)
+    .join('\n\n');
+};

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -1,6 +1,8 @@
 import debug from 'debug';
 import pMap from 'p-map';
+import urlJoin from 'url-join';
 
+import { appEnv } from '@/envs/app';
 import { fileEnv } from '@/envs/file';
 import { AudioContent, ImageContent, ToolCallContent } from '@/libs/mcp';
 import { FileService } from '@/server/services/file';
@@ -74,10 +76,19 @@ export const contentBlocksToString = (blocks: ToolCallContent[]): string => {
         case 'text': {
           return item.text;
         }
-        case 'image':
-        case 'audio': {
-          return item.data;
+
+        case 'image': {
+          return `![](${urlJoin(appEnv.APP_URL, item.data)})`;
         }
+
+        case 'audio': {
+          return `<resource type="${item.type}" url="${urlJoin(appEnv.APP_URL, item.data)}" />`;
+        }
+
+        case 'resource': {
+          return `<resource type="${item.type}">${JSON.stringify(item.resource)}</resource>}`;
+        }
+
         default: {
           return '';
         }

--- a/src/server/services/mcp/index.test.ts
+++ b/src/server/services/mcp/index.test.ts
@@ -39,7 +39,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('');
       expect(result.success).toBe(true);
@@ -52,7 +56,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('');
       expect(result.success).toBe(true);
@@ -65,7 +73,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe(JSON.stringify(jsonData));
       expect(result.success).toBe(true);
@@ -78,7 +90,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe(textData);
       expect(result.success).toBe(true);
@@ -92,7 +108,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('');
       expect(result.success).toBe(true);
@@ -111,7 +131,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('First message\n\nSecond message\n\n{"json": "data"}');
       expect(result.success).toBe(true);
@@ -129,7 +153,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('First message\n\nSecond message');
       expect(result.success).toBe(true);
@@ -144,7 +172,11 @@ describe('MCPService', () => {
 
       mockClient.callTool.mockResolvedValue(errorResult);
 
-      const result = await mcpService.callTool(mockParams, 'testTool', '{}');
+      const result = await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: '{}',
+      });
 
       expect(result.content).toBe('Error occurred');
       expect(result.success).toBe(true);
@@ -155,7 +187,13 @@ describe('MCPService', () => {
       const error = new Error('MCP client error');
       mockClient.callTool.mockRejectedValue(error);
 
-      await expect(mcpService.callTool(mockParams, 'testTool', '{}')).rejects.toThrow(TRPCError);
+      await expect(
+        mcpService.callTool({
+          clientParams: mockParams,
+          toolName: 'testTool',
+          argsStr: '{}',
+        }),
+      ).rejects.toThrow(TRPCError);
     });
 
     it('should parse args string correctly', async () => {
@@ -167,7 +205,11 @@ describe('MCPService', () => {
         isError: false,
       });
 
-      await mcpService.callTool(mockParams, 'testTool', argsString);
+      await mcpService.callTool({
+        clientParams: mockParams,
+        toolName: 'testTool',
+        argsStr: argsString,
+      });
 
       expect(mockClient.callTool).toHaveBeenCalledWith('testTool', argsObject);
     });

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -159,7 +159,7 @@ export class MCPService {
   async callTool(options: {
     argsStr: any;
     clientParams: MCPClientParams;
-    processContentBlocks: ProcessContentBlocksFn;
+    processContentBlocks?: ProcessContentBlocksFn;
     toolName: string;
   }): Promise<any> {
     const { clientParams, toolName, argsStr, processContentBlocks } = options;
@@ -180,9 +180,10 @@ export class MCPService {
       const result = await client.callTool(toolName, args); // Pass args directly
 
       // Process content blocks (upload images, etc.)
-      const newContent = result.isError
-        ? result.content
-        : await processContentBlocks(result.content);
+      const newContent =
+        result.isError || !processContentBlocks
+          ? result.content
+          : await processContentBlocks(result.content);
 
       // Convert content blocks to string
       const content = contentBlocksToString(newContent);

--- a/src/services/session/index.ts
+++ b/src/services/session/index.ts
@@ -4,14 +4,12 @@ import type { PartialDeep } from 'type-fest';
 import { lambdaClient } from '@/libs/trpc/client';
 import { LobeAgentChatConfig, LobeAgentConfig } from '@/types/agent';
 import { MetaData } from '@/types/meta';
-import { BatchTaskResult } from '@/types/service';
 import {
   ChatSessionList,
   LobeAgentSession,
   LobeSessionType,
   LobeSessions,
   SessionGroupItem,
-  SessionGroups,
   SessionRankItem,
   UpdateSessionParams,
 } from '@/types/session';
@@ -112,18 +110,6 @@ export class SessionService {
 
   createSessionGroup = (name: string, sort?: number): Promise<string> => {
     return lambdaClient.sessionGroup.createSessionGroup.mutate({ name, sort });
-  };
-
-  getSessionGroups = (): Promise<SessionGroupItem[]> => {
-    return lambdaClient.sessionGroup.getSessionGroup.query();
-  };
-
-  /**
-   * 需要废弃
-   * @deprecated
-   */
-  batchCreateSessionGroups = (groups: SessionGroups): Promise<BatchTaskResult> => {
-    return Promise.resolve({ added: 0, ids: [], skips: [], success: true });
   };
 
   removeSessionGroup = (id: string, removeChildren?: boolean) => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Introduce media processing and proxying for MCP content by uploading inline images and audio to storage, refactor MCPService.callTool and routers to support content block processing via FileService, add base64 upload utilities in FileService, implement a file proxy endpoint, and enhance UI to render image blocks.

New Features:
- Add createFileRecord and uploadBase64 methods in FileService to support base64 media uploads and database record creation
- Implement processContentBlocks and contentBlocksToString to upload inline image/audio blocks and generate proxy URLs
- Add a file proxy GET route (/f/:id) to redirect to pre-signed storage URLs
- Enable rendering of image blocks in the MCPType UI component

Bug Fixes:
- Fix MCP service image content handling so that returned image blocks are correctly processed and proxied

Enhancements:
- Refactor MCPService.callTool to accept an options object with processContentBlocks and unify content mapping and logging
- Inject FileService into MCP routers via serverDatabase middleware and bind content processing
- Update environment URL handling to default APP_URL per NODE_ENV
- Replace console logs with debug logging and extend timeouts in database tests
- Optimize VirtualizedList component with a custom memo comparator

Chores:
- Remove deprecated session service methods