### PR TITLE
🐛 fix: fix missing messages when finish runtime

### DIFF
--- a/src/features/ChatItem/components/Title.tsx
+++ b/src/features/ChatItem/components/Title.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { memo } from 'react';
+import { CSSProperties, memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { useStyles } from '../style';
@@ -10,6 +10,7 @@ export interface TitleProps {
   className?: string;
   placement?: ChatItemProps['placement'];
   showTitle?: ChatItemProps['showTitle'];
+  style?: CSSProperties;
   time?: ChatItemProps['time'];
   titleAddon?: ChatItemProps['titleAddon'];
 }
@@ -27,21 +28,24 @@ const formatTime = (time: number): string => {
   }
 };
 
-const Title = memo<TitleProps>(({ showTitle, placement, time, avatar, titleAddon, className }) => {
-  const { styles, cx } = useStyles({ placement, showTitle, time });
+const Title = memo<TitleProps>(
+  ({ showTitle, placement, time, avatar, titleAddon, className, style }) => {
+    const { styles, cx } = useStyles({ placement, showTitle, time });
 
-  return (
-    <Flexbox
-      align={'center'}
-      className={cx(styles.name, className)}
-      direction={placement === 'left' ? 'horizontal' : 'horizontal-reverse'}
-      gap={4}
-    >
-      {showTitle ? avatar.title || 'untitled' : undefined}
-      {showTitle ? titleAddon : undefined}
-      {time && <time>{formatTime(time)}</time>}
-    </Flexbox>
-  );
-});
+    return (
+      <Flexbox
+        align={'center'}
+        className={cx(styles.name, className)}
+        direction={placement === 'left' ? 'horizontal' : 'horizontal-reverse'}
+        gap={4}
+        style={style}
+      >
+        {showTitle ? avatar.title || 'untitled' : undefined}
+        {showTitle ? titleAddon : undefined}
+        {time && <time>{formatTime(time)}</time>}
+      </Flexbox>
+    );
+  },
+);
 
 export default Title;

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -4,6 +4,7 @@ import { LOADING_FLAT } from '@lobechat/const';
 import { UIChatMessage } from '@lobechat/types';
 import { Tag } from '@lobehub/ui';
 import { useResponsive } from 'antd-style';
+import isEqual from 'fast-deep-equal';
 import { ReactNode, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -213,12 +214,12 @@ const AssistantMessage = memo<AssistantMessageProps>((props) => {
           onClick={onAvatarClick}
           placement={placement}
           size={MOBILE_AVATAR_SIZE}
-          style={{ marginTop: 6 }}
         />
         <Title
           avatar={avatar}
           placement={placement}
           showTitle
+          style={{ marginBlockEnd: 0 }}
           time={createdAt}
           titleAddon={dmIndicator}
         />
@@ -274,6 +275,6 @@ const AssistantMessage = memo<AssistantMessageProps>((props) => {
       {mobile && <BorderSpacing borderSpacing={MOBILE_AVATAR_SIZE} />}
     </Flexbox>
   );
-});
+}, isEqual);
 
 export default AssistantMessage;

--- a/src/features/Conversation/Messages/Group/index.tsx
+++ b/src/features/Conversation/Messages/Group/index.tsx
@@ -2,6 +2,7 @@
 
 import { UIChatMessage } from '@lobechat/types';
 import { useResponsive } from 'antd-style';
+import isEqual from 'fast-deep-equal';
 import { memo, useCallback } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
@@ -49,6 +50,7 @@ const GroupMessage = memo<GroupMessageProps>((props) => {
     provider,
   } = props;
   const avatar = meta;
+  console.log('render');
   const { mobile } = useResponsive();
   const placement = 'left';
   const type = useAgentStore(agentChatConfigSelectors.displayMode);
@@ -96,9 +98,14 @@ const GroupMessage = memo<GroupMessageProps>((props) => {
           onClick={onAvatarClick}
           placement={placement}
           size={MOBILE_AVATAR_SIZE}
-          style={{ marginTop: 6 }}
         />
-        <Title avatar={avatar} placement={placement} showTitle time={createdAt} />
+        <Title
+          avatar={avatar}
+          placement={placement}
+          showTitle
+          style={{ marginBlockEnd: 0 }}
+          time={createdAt}
+        />
       </Flexbox>
       {isEditing && contentId ? (
         <EditState content={lastAssistantMsg?.content} id={contentId} />
@@ -141,6 +148,6 @@ const GroupMessage = memo<GroupMessageProps>((props) => {
       {mobile && <BorderSpacing borderSpacing={MOBILE_AVATAR_SIZE} />}
     </Flexbox>
   );
-});
+}, isEqual);
 
 export default GroupMessage;

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -166,7 +166,11 @@ export const conversationLifecycle: StateCreator<
         topicId = data.topicId;
       }
 
-      get().replaceMessages(data.messages, { sessionId: activeId, topicId: topicId });
+      get().replaceMessages(data.messages, {
+        sessionId: activeId,
+        topicId: topicId,
+        action: 'sendMessage/serverResponse',
+      });
 
       if (data.isCreateNewTopic && data.topicId) {
         await get().switchTopic(data.topicId, true);
@@ -250,7 +254,9 @@ export const conversationLifecycle: StateCreator<
         .map((f) => f?.id)
         .filter(Boolean) as string[];
 
-      await getAgentStoreState().addFilesToAgent(userFiles, false);
+      if (userFiles.length > 0) {
+        await getAgentStoreState().addFilesToAgent(userFiles, false);
+      }
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -521,10 +521,7 @@ export const streamingExecutor: StateCreator<
       // Handle completion and error events
       for (const event of result.events) {
         if (event.type === 'done') {
-          log('[internal_execAgentRuntime] Received done event, syncing to database');
-          // Sync final state to database
-          const finalMessages = get().messagesMap[messageKey] || [];
-          get().replaceMessages(finalMessages);
+          log('[internal_execAgentRuntime] Received done event');
         }
 
         if (event.type === 'error') {

--- a/src/store/chat/slices/message/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/message/actions/optimisticUpdate.ts
@@ -195,7 +195,7 @@ export const messageOptimisticUpdate: StateCreator<
     );
 
     if (result && result.success && result.messages) {
-      replaceMessages(result.messages);
+      replaceMessages(result.messages, { action: 'optimisticUpdateMessageContent' });
     } else {
       await refreshMessages();
     }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix message handling to ensure no messages are dropped when streaming finishes, improve memoization of message components, extend Title component styling, and enrich message replacement calls with action metadata

Bug Fixes:
- Remove redundant replaceMessages call on streaming 'done' events to prevent dropped messages
- Include action metadata in replaceMessages calls during conversation lifecycle and optimistic updates to ensure correct message replacement

Enhancements:
- Add style prop to Title component and update its usage in GroupMessage and AssistantMessage for layout adjustments
- Wrap GroupMessage and AssistantMessage components in memo with deep equality check to reduce unnecessary re-renders
- Guard addFilesToAgent invocation in conversationLifecycle to only run when files are present

Chores:
- Replace marginTop style with marginBlockEnd in message Title usages
- Add console.log in GroupMessage for render debugging