### PR TITLE
🐛 fix: Add missing /discover prefix to all discover page links

### DIFF
--- a/src/app/[variants]/(main)/discover/(detail)/assistant/[...slugs]/features/Sidebar/Related/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/[...slugs]/features/Sidebar/Related/index.tsx
@@ -1,8 +1,9 @@
+import NextLink from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import Title from '../../../../../../features/Title';
@@ -12,6 +13,7 @@ import Item from './Item';
 const Related = memo(() => {
   const { t } = useTranslation('discover');
   const { related, category } = useDetailContext();
+  const navigate = useNavigate();
 
   return (
     <Flexbox gap={16}>
@@ -30,9 +32,17 @@ const Related = memo(() => {
         {related?.map((item, index) => {
           const link = urlJoin('/assistant', item.identifier);
           return (
-            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+            <NextLink
+              href={urlJoin('/discover/assistant', item.identifier)}
+              key={index}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(link);
+              }}
+              style={{ color: 'inherit', overflow: 'hidden' }}
+            >
               <Item {...item} />
-            </Link>
+            </NextLink>
           );
         })}
       </Flexbox>

--- a/src/app/[variants]/(main)/discover/(detail)/mcp/[slug]/features/Sidebar/Related/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/mcp/[slug]/features/Sidebar/Related/index.tsx
@@ -1,8 +1,9 @@
+import NextLink from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import { useDetailContext } from '@/features/MCPPluginDetail/DetailProvider';
@@ -13,6 +14,7 @@ import Item from './Item';
 const Related = memo(() => {
   const { t } = useTranslation('discover');
   const { related, category } = useDetailContext();
+  const navigate = useNavigate();
 
   return (
     <Flexbox gap={16}>
@@ -31,9 +33,17 @@ const Related = memo(() => {
         {related?.map((item, index) => {
           const link = urlJoin('/mcp', item.identifier);
           return (
-            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+            <NextLink
+              href={urlJoin('/discover/mcp', item.identifier)}
+              key={index}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(link);
+              }}
+              style={{ color: 'inherit', overflow: 'hidden' }}
+            >
               <Item {...item} />
-            </Link>
+            </NextLink>
           );
         })}
       </Flexbox>

--- a/src/app/[variants]/(main)/discover/(detail)/model/[...slugs]/features/Details/Related/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/model/[...slugs]/features/Details/Related/index.tsx
@@ -18,7 +18,7 @@ const Related = memo(() => {
           query: {
             category,
           },
-          url: '/discover/plugin',
+          url: '/discover/model',
         })}
       >
         {t('assistants.details.related.listTitle')}

--- a/src/app/[variants]/(main)/discover/(detail)/model/[...slugs]/features/Sidebar/Related/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/model/[...slugs]/features/Sidebar/Related/index.tsx
@@ -1,8 +1,9 @@
+import NextLink from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import Title from '../../../../../../features/Title';
@@ -12,6 +13,7 @@ import Item from './Item';
 const Related = memo(() => {
   const { t } = useTranslation('discover');
   const { related, category } = useDetailContext();
+  const navigate = useNavigate();
 
   return (
     <Flexbox gap={16}>
@@ -30,9 +32,17 @@ const Related = memo(() => {
         {related?.map((item, index) => {
           const link = urlJoin('/model', item.identifier);
           return (
-            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+            <NextLink
+              href={urlJoin('/discover/model', item.identifier)}
+              key={index}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(link);
+              }}
+              style={{ color: 'inherit', overflow: 'hidden' }}
+            >
               <Item {...item} />
-            </Link>
+            </NextLink>
           );
         })}
       </Flexbox>

--- a/src/app/[variants]/(main)/discover/(detail)/provider/[...slugs]/features/Sidebar/Related/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/provider/[...slugs]/features/Sidebar/Related/index.tsx
@@ -1,7 +1,8 @@
+import NextLink from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import Title from '../../../../../../features/Title';
@@ -11,6 +12,7 @@ import Item from './Item';
 const Related = memo(() => {
   const { t } = useTranslation('discover');
   const { related } = useDetailContext();
+  const navigate = useNavigate();
 
   return (
     <Flexbox gap={16}>
@@ -21,9 +23,17 @@ const Related = memo(() => {
         {related?.map((item, index) => {
           const link = urlJoin('/provider', item.identifier);
           return (
-            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+            <NextLink
+              href={urlJoin('/discover/provider', item.identifier)}
+              key={index}
+              onClick={(e) => {
+                e.preventDefault();
+                navigate(link);
+              }}
+              style={{ color: 'inherit', overflow: 'hidden' }}
+            >
               <Item {...item} />
-            </Link>
+            </NextLink>
           );
         })}
       </Flexbox>

--- a/src/app/[variants]/(main)/discover/(list)/(home)/HomePage.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/(home)/HomePage.tsx
@@ -29,12 +29,12 @@ const HomePage = memo<{ mobile?: boolean }>(() => {
 
   return (
     <>
-      <Title more={t('home.more')} moreLink={'/assistant'}>
+      <Title more={t('home.more')} moreLink={'/discover/assistant'}>
         {t('home.featuredAssistants')}
       </Title>
       <AssistantList data={assistantList.items} rows={4} />
       <div />
-      <Title more={t('home.more')} moreLink={'/mcp'}>
+      <Title more={t('home.more')} moreLink={'/discover/mcp'}>
         {t('home.featuredTools')}
       </Title>
       <McpList data={mcpList.items} rows={4} />

--- a/src/app/[variants]/(main)/discover/(list)/assistant/features/List/Item.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/assistant/features/List/Item.tsx
@@ -2,10 +2,11 @@ import { Github } from '@lobehub/icons';
 import { ActionIcon, Avatar, Block, Icon, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { ClockIcon } from 'lucide-react';
+import NextLink from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import PublishedTime from '@/components/PublishedTime';
@@ -119,11 +120,15 @@ const AssistantItem = memo<DiscoverAssistantItem>(
                   overflow: 'hidden',
                 }}
               >
-                <Link style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+                <NextLink
+                  href={urlJoin('/discover/assistant', identifier)}
+                  onClick={(e) => e.preventDefault()}
+                  style={{ color: 'inherit', overflow: 'hidden' }}
+                >
                   <Text as={'h2'} className={styles.title} ellipsis>
                     {title}
                   </Text>
-                </Link>
+                </NextLink>
               </Flexbox>
               {author && <div className={styles.author}>{author}</div>}
             </Flexbox>

--- a/src/app/[variants]/(main)/discover/(list)/mcp/features/List/Item.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/mcp/features/List/Item.tsx
@@ -5,10 +5,11 @@ import { ActionIcon, Avatar, Block, Icon, Tag, Text, Tooltip } from '@lobehub/ui
 import { Spotlight } from '@lobehub/ui/awesome';
 import { createStyles } from 'antd-style';
 import { ClockIcon } from 'lucide-react';
+import NextLink from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import InstallationIcon from '@/components/MCPDepsIcon';
@@ -128,11 +129,15 @@ const McpItem = memo<DiscoverMcpItem>(
                   overflow: 'hidden',
                 }}
               >
-                <Link style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+                <NextLink
+                  href={urlJoin('/discover/mcp', identifier)}
+                  onClick={(e) => e.preventDefault()}
+                  style={{ color: 'inherit', overflow: 'hidden' }}
+                >
                   <Text as={'h2'} className={styles.title} ellipsis>
                     {name}
                   </Text>
-                </Link>
+                </NextLink>
                 {isOfficial && (
                   <Tooltip title={t('isOfficial')}>
                     <OfficialIcon />

--- a/src/app/[variants]/(main)/discover/(list)/model/features/List/Item.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/model/features/List/Item.tsx
@@ -6,10 +6,11 @@ import { Popover } from 'antd';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { ClockIcon } from 'lucide-react';
+import NextLink from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import { ModelInfoTags } from '@/components/ModelSelect';
@@ -106,11 +107,15 @@ const ModelItem = memo<DiscoverModelItem>(
                   overflow: 'hidden',
                 }}
               >
-                <Link style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+                <NextLink
+                  href={urlJoin('/discover/model', identifier)}
+                  onClick={(e) => e.preventDefault()}
+                  style={{ color: 'inherit', overflow: 'hidden' }}
+                >
                   <Text as={'h2'} className={styles.title} ellipsis>
                     {displayName}
                   </Text>
-                </Link>
+                </NextLink>
               </Flexbox>
               <div className={styles.author}>{identifier}</div>
             </Flexbox>

--- a/src/app/[variants]/(main)/discover/(list)/provider/features/List/Item.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/provider/features/List/Item.tsx
@@ -2,10 +2,11 @@ import { Github, ModelTag, ProviderCombine } from '@lobehub/icons';
 import { ActionIcon, Block, MaskShadow, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { GlobeIcon } from 'lucide-react';
+import NextLink from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import { DiscoverProviderItem } from '@/types/discover';
@@ -80,9 +81,13 @@ const ProviderItem = memo<DiscoverProviderItem>(
             }}
             title={identifier}
           >
-            <Link style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
+            <NextLink
+              href={urlJoin('/discover/provider', identifier)}
+              onClick={(e) => e.preventDefault()}
+              style={{ color: 'inherit', overflow: 'hidden' }}
+            >
               <ProviderCombine provider={identifier} size={28} style={{ flex: 'none' }} />
-            </Link>
+            </NextLink>
             <div className={styles.author}>@{name}</div>
           </Flexbox>
           <Flexbox align={'center'} horizontal>
@@ -128,9 +133,13 @@ const ProviderItem = memo<DiscoverProviderItem>(
               .slice(0, 6)
               .filter(Boolean)
               .map((tag: string) => (
-                <Link key={tag} to={urlJoin('/model', tag)}>
+                <NextLink
+                  href={urlJoin('/discover/model', tag)}
+                  key={tag}
+                  onClick={(e) => e.preventDefault()}
+                >
                   <ModelTag model={tag} style={{ margin: 0 }} />
-                </Link>
+                </NextLink>
               ))}
           </MaskShadow>
         </Flexbox>


### PR DESCRIPTION
<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Links throughout discover pages were missing the /discover prefix, causing incorrect navigation paths. Updated all link generation in list items, sidebar components, and homepage to include the proper /discover prefix for assistants, models, providers, and MCP items.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Summary by Sourcery

Fix missing /discover prefix on page links and enhance URL synchronization

Bug Fixes:
- Add missing /discover prefix to all discover page links in list items, sidebar components, and homepage navigation

Enhancements:
- Limit initial URL synchronization to mount, switch to pushState for URL updates, and add handling for browser back/forward navigation in UrlSynchronizer