### PR TITLE
🔨 chore(observability-otel): interval of metrics not small enough

### DIFF
--- a/packages/obervability-otel/src/node.ts
+++ b/packages/obervability-otel/src/node.ts
@@ -8,6 +8,7 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { env } from 'node:process';
 
 export function register(options?: { debug?: true | DiagLogLevel; version?: string }) {
   const attributes: Record<string, string> = {
@@ -23,13 +24,26 @@ export function register(options?: { debug?: true | DiagLogLevel; version?: stri
     );
   }
 
+  let metricsExporterInterval = 1000;
+  if (env.OTEL_METRICS_EXPORTER_INTERVAL) {
+    const parsed = parseInt(env.OTEL_METRICS_EXPORTER_INTERVAL, 10);
+    if (!isNaN(parsed)) {
+      metricsExporterInterval = parsed;
+    }
+  }
+
   const sdk = new NodeSDK({
     instrumentations: [
       new PgInstrumentation(),
       new HttpInstrumentation(),
       getNodeAutoInstrumentations(),
     ],
-    metricReaders: [new PeriodicExportingMetricReader({ exporter: new OTLPMetricExporter() })],
+    metricReaders: [
+      new PeriodicExportingMetricReader({
+        exportIntervalMillis: metricsExporterInterval,
+        exporter: new OTLPMetricExporter(),
+      }),
+    ],
     resource: resourceFromAttributes(attributes),
     traceExporter: new OTLPTraceExporter(),
   });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None

#### 🔀 Description of Change

By default the interval of reporting metrics is 60000 milliseconds, this doesn't cover the most of the [$__rate_interval] or [15s] usage in query of metrics inside of Grafana, produces incorrect or mass overlapping data points.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust the default metrics export interval to better match common Grafana rate intervals and make it configurable via an environment variable

Bug Fixes:
- Reduce default metric export interval from 60000ms to 1000ms to avoid data overlap in Grafana queries

Enhancements:
- Add OTEL_METRICS_EXPORTER_INTERVAL environment variable to customize metrics export interval