### PR TITLE
👷 build: improve renovate config to support grouping in the same way of npm does

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,22 +17,39 @@
   "ignoreDeps": [],
   "labels": ["dependencies"],
   "packageRules": [
-    // 1) Pinned deps: isolate (OK to use separate* here because there's no matchUpdateTypes)
     {
-      "description": "Isolate PRs for pinned deps (exact x.y.z)",
+      "description": "Un-group tilde ranges",
       "matchManagers": ["npm", "pnpm", "yarn", "bun"],
-      "matchCurrentValue": "^\\d+\\.\\d+\\.\\d+([+-][0-9A-Za-z.-]+)?$",
+      "matchCurrentValue": "^~.*$",
       "groupName": null,
-      "separateMinorPatch": true,
-      "separateMajorMinor": true
+      "groupSlug": null,
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
     },
-    // 2) Non-pinned deps: Patch versions, grouped together
     {
-      "description": "Group patch versions together for non-pinned deps",
+      "description": "Un-group pinned deps (exact x.y.z)",
       "matchManagers": ["npm", "pnpm", "yarn", "bun"],
-      "matchCurrentValue": "/(^[~^]|[<>=| -])/", // anything that looks like a range
-      "groupName": "patch dependencies",
-      "matchUpdateTypes": ["patch"]
+      "matchCurrentValue": "/^\\d+\\.\\d+\\.\\d+([+-][0-9A-Za-z.-]+)?$/",
+      "groupName": null,
+      "groupSlug": null,
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Un-group experimental caret ranges (^0.x)",
+      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
+      "matchCurrentValue": "^\\^0\\.\\d+(\\.\\d+)?([+-][0-9A-Za-z.-]+)?$",
+      "groupName": null,
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
+    },
+    {
+      "description": "Group ^>=1 ranges for patch/minor",
+      "matchManagers": ["npm", "pnpm", "yarn", "bun"],
+      "matchCurrentValue": "/^\\^[1-9]+[0-9]*(\\.\\d+){0,2}([+-][0-9A-Za-z.-]+)?$/",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major-dependencies"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
@@ -41,7 +58,7 @@
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",
   "schedule": "on sunday before 6:00am",
+  "separateMinorPatch": false,
   "separateMajorMinor": true,
-  "separateMultipleMajor": true,
   "timezone": "UTC"
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None. But follow up PR of #10045, #10051

#### 🔀 Description of Change

Test PR can be found at https://github.com/nekomeowww/lobe-chat-renovate/pull/4.

<img width="1284" height="1056" alt="image" src="https://github.com/user-attachments/assets/f02554dc-40ac-4c79-a2ae-bb59a86d6bdb" />

We now follow the following rules:

- We will try to group all npm/pnpm/yarn/bun packages in and out monorepo packages
- If the specified version is pinned (e.g. `1.0.1`, `0.1.1`, `1`, `100`), un-group
- If the specified version is tilde, direct update of minor may not work, un-group
- If the specified version starts with `0.` or `^0.`, un-group

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
