### PR TITLE
✨ feat: support tool intervention

### DIFF
--- a/packages/agent-runtime/src/core/InterventionChecker.ts
+++ b/packages/agent-runtime/src/core/InterventionChecker.ts
@@ -17,36 +17,25 @@ export class InterventionChecker {
    * @returns Policy to apply
    */
   static shouldIntervene(params: ShouldInterveneParams): HumanInterventionPolicy {
-    const { config, toolArgs = {}, confirmedHistory = [], toolKey } = params;
+    const { config, toolArgs = {} } = params;
 
     // No config means never intervene (auto-execute)
     if (!config) return 'never';
 
     // Simple policy string
     if (typeof config === 'string') {
-      // For 'first' policy, check if already confirmed
-      if (config === 'first' && toolKey && confirmedHistory.includes(toolKey)) {
-        return 'never';
-      }
       return config;
     }
 
     // Array of rules - find first matching rule
     for (const rule of config) {
       if (this.matchesRule(rule, toolArgs)) {
-        const policy = rule.policy;
-
-        // For 'first' policy, check if already confirmed
-        if (policy === 'first' && toolKey && confirmedHistory.includes(toolKey)) {
-          return 'never';
-        }
-
-        return policy;
+        return rule.policy;
       }
     }
 
-    // No rule matched - default to always for safety
-    return 'always';
+    // No rule matched - default to require for safety
+    return 'require';
   }
 
   /**
@@ -151,7 +140,7 @@ export class InterventionChecker {
   }
 
   /**
-   * Generate simple hash of arguments for 'once' policy
+   * Generate simple hash of arguments for tool tracking
    *
    * @param args - Tool call arguments
    * @returns Hash string

--- a/packages/agent-runtime/src/core/__tests__/InterventionChecker.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/InterventionChecker.test.ts
@@ -12,43 +12,16 @@ describe('InterventionChecker', () => {
 
     it('should return the policy when config is a simple string', () => {
       expect(InterventionChecker.shouldIntervene({ config: 'never', toolArgs: {} })).toBe('never');
-      expect(InterventionChecker.shouldIntervene({ config: 'always', toolArgs: {} })).toBe(
-        'always',
+      expect(InterventionChecker.shouldIntervene({ config: 'require', toolArgs: {} })).toBe(
+        'require',
       );
-      expect(InterventionChecker.shouldIntervene({ config: 'first', toolArgs: {} })).toBe('first');
-    });
-
-    it('should handle "first" policy with confirmed history', () => {
-      const toolKey = 'web-browsing/crawlSinglePage';
-      const confirmedHistory = [toolKey];
-
-      const result = InterventionChecker.shouldIntervene({
-        config: 'first',
-        toolArgs: {},
-        confirmedHistory,
-        toolKey,
-      });
-      expect(result).toBe('never');
-    });
-
-    it('should require intervention for "first" policy without confirmation', () => {
-      const toolKey = 'web-browsing/crawlSinglePage';
-      const confirmedHistory: string[] = [];
-
-      const result = InterventionChecker.shouldIntervene({
-        config: 'first',
-        toolArgs: {},
-        confirmedHistory,
-        toolKey,
-      });
-      expect(result).toBe('first');
     });
 
     it('should match rules in order and return first match', () => {
       const config: HumanInterventionConfig = [
         { match: { command: 'ls:*' }, policy: 'never' },
-        { match: { command: 'git commit:*' }, policy: 'first' },
-        { policy: 'always' }, // Default rule
+        { match: { command: 'git commit:*' }, policy: 'require' },
+        { policy: 'require' }, // Default rule
       ];
 
       expect(InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'ls:' } })).toBe(
@@ -56,20 +29,20 @@ describe('InterventionChecker', () => {
       );
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'git commit:' } }),
-      ).toBe('first');
+      ).toBe('require');
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'rm -rf /' } }),
-      ).toBe('always');
+      ).toBe('require');
     });
 
-    it('should return always as default when no rule matches', () => {
+    it('should return require as default when no rule matches', () => {
       const config: HumanInterventionConfig = [{ match: { command: 'ls:*' }, policy: 'never' }];
 
       const result = InterventionChecker.shouldIntervene({
         config,
         toolArgs: { command: 'rm -rf /' },
       });
-      expect(result).toBe('always');
+      expect(result).toBe('require');
     });
 
     it('should handle multiple parameter matching', () => {
@@ -81,7 +54,7 @@ describe('InterventionChecker', () => {
           },
           policy: 'never',
         },
-        { policy: 'always' },
+        { policy: 'require' },
       ];
 
       // Both match
@@ -104,20 +77,20 @@ describe('InterventionChecker', () => {
             path: '/tmp/file.ts',
           },
         }),
-      ).toBe('always');
+      ).toBe('require');
     });
 
     it('should handle default rule without match', () => {
       const config: HumanInterventionConfig = [
         { match: { command: 'ls:*' }, policy: 'never' },
-        { policy: 'first' }, // Default rule
+        { policy: 'require' }, // Default rule
       ];
 
       const result = InterventionChecker.shouldIntervene({
         config,
         toolArgs: { command: 'anything' },
       });
-      expect(result).toBe('first');
+      expect(result).toBe('require');
     });
   });
 
@@ -249,10 +222,10 @@ describe('InterventionChecker', () => {
     it('should handle Bash tool scenario', () => {
       const config: HumanInterventionConfig = [
         { match: { command: 'ls:*' }, policy: 'never' },
-        { match: { command: 'git add:*' }, policy: 'first' },
-        { match: { command: 'git commit:*' }, policy: 'first' },
-        { match: { command: 'rm:*' }, policy: 'always' },
-        { policy: 'always' },
+        { match: { command: 'git add:*' }, policy: 'require' },
+        { match: { command: 'git commit:*' }, policy: 'require' },
+        { match: { command: 'rm:*' }, policy: 'require' },
+        { policy: 'require' },
       ];
 
       // Safe commands - never
@@ -260,27 +233,27 @@ describe('InterventionChecker', () => {
         'never',
       );
 
-      // Git commands - first
+      // Git commands - require
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'git add:.' } }),
-      ).toBe('first');
+      ).toBe('require');
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'git commit:-m' } }),
-      ).toBe('first');
+      ).toBe('require');
 
-      // Dangerous commands - always
+      // Dangerous commands - require
       expect(InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'rm:-rf' } })).toBe(
-        'always',
+        'require',
       );
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { command: 'npm install' } }),
-      ).toBe('always');
+      ).toBe('require');
     });
 
     it('should handle LocalSystem tool scenario', () => {
       const config: HumanInterventionConfig = [
         { match: { path: '/Users/project/*' }, policy: 'never' },
-        { policy: 'first' },
+        { policy: 'require' },
       ];
 
       // Project directory - never
@@ -291,44 +264,18 @@ describe('InterventionChecker', () => {
         }),
       ).toBe('never');
 
-      // Outside project - first
+      // Outside project - require
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { path: '/tmp/file.ts' } }),
-      ).toBe('first');
+      ).toBe('require');
     });
 
     it('should handle Web Browsing tool with simple policy', () => {
-      const config: HumanInterventionConfig = 'always';
+      const config: HumanInterventionConfig = 'require';
 
       expect(
         InterventionChecker.shouldIntervene({ config, toolArgs: { url: 'https://example.com' } }),
-      ).toBe('always');
-    });
-
-    it('should handle first policy with confirmation history', () => {
-      const config: HumanInterventionConfig = [
-        { match: { command: 'git add:*' }, policy: 'first' },
-        { policy: 'always' },
-      ];
-
-      const toolKey = 'bash/bash#abc123';
-      const args = { command: 'git add:.' };
-
-      // First time - requires intervention
-      expect(
-        InterventionChecker.shouldIntervene({
-          config,
-          toolArgs: args,
-          confirmedHistory: [],
-          toolKey,
-        }),
-      ).toBe('first');
-
-      // After confirmation - never
-      const confirmedHistory = [toolKey];
-      expect(
-        InterventionChecker.shouldIntervene({ config, toolArgs: args, confirmedHistory, toolKey }),
-      ).toBe('never');
+      ).toBe('require');
     });
   });
 });

--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -344,9 +344,11 @@ describe('AgentRuntime', () => {
             type: 'request_human_approve',
             pendingToolsCalling: [
               {
+                apiName: 'test_tool',
+                arguments: '{}',
                 id: 'call_123',
-                type: 'function',
-                function: { name: 'test_tool', arguments: '{}' },
+                identifier: 'test_tool',
+                type: 'default',
               },
             ],
           }),
@@ -357,13 +359,10 @@ describe('AgentRuntime', () => {
 
         const result = await runtime.step(state);
 
-        expect(result.events).toHaveLength(2);
+        expect(result.events).toHaveLength(1);
         expect(result.events[0]).toMatchObject({
           type: 'human_approve_required',
           sessionId: 'test-session',
-        });
-        expect(result.events[1]).toMatchObject({
-          type: 'tool_pending',
         });
 
         expect(result.newState.status).toBe('waiting_for_human');
@@ -1021,10 +1020,10 @@ describe('AgentRuntime', () => {
       // Step 2: Approve and execute tool call
       const pendingToolCall = result.newState.pendingToolsCalling![0];
       const toolCall = {
+        apiName: pendingToolCall.apiName,
+        arguments: pendingToolCall.arguments,
         id: pendingToolCall.id,
-        apiName: pendingToolCall.function.name,
-        identifier: pendingToolCall.function.name,
-        arguments: pendingToolCall.function.arguments,
+        identifier: pendingToolCall.identifier,
         type: 'default' as const,
       };
       result = await runtime.approveToolCall(result.newState, toolCall);
@@ -1203,9 +1202,11 @@ describe('AgentRuntime', () => {
               {
                 pendingToolsCalling: [
                   {
+                    apiName: 'danger_tool',
+                    arguments: '{}',
                     id: 'call_danger',
-                    type: 'function' as const,
-                    function: { name: 'danger_tool', arguments: '{}' },
+                    identifier: 'danger_tool',
+                    type: 'default' as const,
                   },
                 ],
                 type: 'request_human_approve' as const,
@@ -1233,7 +1234,7 @@ describe('AgentRuntime', () => {
 
       // Should have pending tool calls
       expect(result.newState.pendingToolsCalling).toHaveLength(1);
-      expect(result.newState.pendingToolsCalling![0].function.name).toBe('danger_tool');
+      expect(result.newState.pendingToolsCalling![0].apiName).toBe('danger_tool');
 
       // Should have both tool_result and human_approve_required events
       expect(result.events).toContainEqual(expect.objectContaining({ type: 'tool_result' }));

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -538,7 +538,6 @@ export class AgentRuntime {
           sessionId: newState.sessionId,
           type: 'human_approve_required',
         },
-        { toolCalls: pendingToolsCalling, type: 'tool_pending' },
       ];
 
       return { events, newState };

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -85,12 +85,17 @@ export class AgentRuntime {
 
       // Handle human approved tool calls
       if (runtimeContext.phase === 'human_approved_tool') {
-        const approvedPayload = runtimeContext.payload as { approvedToolCall: ChatToolPayload };
+        const approvedPayload = runtimeContext.payload as {
+          approvedToolCall: ChatToolPayload;
+          parentMessageId: string;
+          skipCreateToolMessage: boolean;
+        };
         const toolCalling = approvedPayload.approvedToolCall;
 
         rawInstructions = {
           payload: {
-            parentMessageId: '', // Not required for approval flow
+            parentMessageId: approvedPayload.parentMessageId,
+            skipCreateToolMessage: approvedPayload.skipCreateToolMessage,
             toolCalling,
           },
           type: 'call_tool',

--- a/packages/agent-runtime/src/types/event.ts
+++ b/packages/agent-runtime/src/types/event.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import type { AgentState, ToolsCalling } from './state';
+import { ChatToolPayload } from '@/types/message';
 
 export interface AgentEventInit {
   type: 'init';
@@ -33,7 +34,7 @@ export interface AgentEventToolResult {
 
 export interface AgentEventHumanApproveRequired {
   type: 'human_approve_required';
-  pendingToolsCalling: ToolsCalling[];
+  pendingToolsCalling: ChatToolPayload[];
   sessionId: string;
 }
 

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -18,6 +18,7 @@ export interface GeneralAgentCallLLMResultPayload {
 
 export interface GeneralAgentCallingToolInstructionPayload {
   parentMessageId: string;
+  skipCreateToolMessage?: boolean;
   toolCalling: ChatToolPayload;
 }
 

--- a/packages/agent-runtime/src/types/instruction.ts
+++ b/packages/agent-runtime/src/types/instruction.ts
@@ -1,7 +1,7 @@
 import { ChatToolPayload, ModelUsage } from '@lobechat/types';
 
 import type { FinishReason } from './event';
-import { AgentState, ToolRegistry, ToolsCalling } from './state';
+import { AgentState, ToolRegistry } from './state';
 import type { Cost, CostCalculationContext, Usage } from './usage';
 
 /**
@@ -137,7 +137,7 @@ export interface AgentInstructionRequestHumanSelect {
 }
 
 export interface AgentInstructionRequestHumanApprove {
-  pendingToolsCalling: ToolsCalling[];
+  pendingToolsCalling: ChatToolPayload[];
   reason?: string;
   type: 'request_human_approve';
 }

--- a/packages/agent-runtime/src/types/instruction.ts
+++ b/packages/agent-runtime/src/types/instruction.ts
@@ -139,6 +139,7 @@ export interface AgentInstructionRequestHumanSelect {
 export interface AgentInstructionRequestHumanApprove {
   pendingToolsCalling: ChatToolPayload[];
   reason?: string;
+  skipCreateToolMessage?: boolean;
   type: 'request_human_approve';
 }
 

--- a/packages/agent-runtime/src/types/state.ts
+++ b/packages/agent-runtime/src/types/state.ts
@@ -1,4 +1,6 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
+import { ChatToolPayload } from '@/types/message';
+
 import type { Cost, CostLimit, Usage } from './usage';
 
 /**
@@ -49,7 +51,7 @@ export interface AgentState {
    * When status is 'waiting_for_human', this stores pending requests
    * for human-in-the-loop operations.
    */
-  pendingToolsCalling?: ToolsCalling[];
+  pendingToolsCalling?: ChatToolPayload[];
   pendingHumanPrompt?: { metadata?: Record<string, unknown>; prompt: string };
   pendingHumanSelect?: {
     metadata?: Record<string, unknown>;

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -427,11 +427,14 @@ export class FlatListBuilder {
             if (toolMsg.error) result.error = toolMsg.error;
             if (toolMsg.pluginState) result.state = toolMsg.pluginState;
 
-            return {
+            const toolWithResult: ChatToolPayloadWithResult = {
               ...tool,
+              intervention: toolMsg.pluginIntervention,
               result,
               result_msg_id: toolMsg.id,
             };
+
+            return toolWithResult;
           }
           return tool;
         }) || [];

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -97,6 +97,7 @@ export class MessageModel {
           type: messagePlugins.type,
         },
         pluginError: messagePlugins.error,
+        pluginIntervention: messagePlugins.intervention,
         pluginState: messagePlugins.state,
 
         translate: {
@@ -462,6 +463,7 @@ export class MessageModel {
       provider: fromProvider,
       files,
       plugin,
+      pluginIntervention,
       pluginState,
       fileChunks,
       ragQueryId,
@@ -496,6 +498,7 @@ export class MessageModel {
           arguments: plugin?.arguments,
           id,
           identifier: plugin?.identifier,
+          intervention: pluginIntervention,
           state: pluginState,
           toolCallId: message.tool_call_id,
           type: plugin?.type,

--- a/packages/types/src/message/common/base.ts
+++ b/packages/types/src/message/common/base.ts
@@ -9,13 +9,13 @@ import { ErrorType } from '../../fetch';
  */
 export interface ChatMessageError {
   body?: any;
-  message: string;
+  message?: string;
   type: ErrorType | IPluginErrorType | ILobeAgentRuntimeErrorType;
 }
 
 export const ChatMessageErrorSchema = z.object({
   body: z.any().optional(),
-  message: z.string(),
+  message: z.string().optional(),
   type: z.union([z.string(), z.number()]),
 });
 

--- a/packages/types/src/message/common/tools.ts
+++ b/packages/types/src/message/common/tools.ts
@@ -2,12 +2,30 @@ import { IPluginErrorType } from '@lobehub/chat-plugin-sdk';
 import type { PartialDeep } from 'type-fest';
 import { z } from 'zod';
 
+
+
 import { LobeToolRenderType } from '../../tool';
+
+
+
+
+
+// ToolIntervention must be defined first to avoid circular dependency
+export interface ToolIntervention {
+  rejectedReason?: string;
+  status?: 'pending' | 'approved' | 'rejected' | 'none';
+}
+
+export const ToolInterventionSchema = z.object({
+  rejectedReason: z.string().optional(),
+  status: z.enum(['pending', 'approved', 'rejected', 'none']).optional(),
+});
 
 export interface ChatPluginPayload {
   apiName: string;
   arguments: string;
   identifier: string;
+  intervention?: ToolIntervention;
   type: LobeToolRenderType;
 }
 
@@ -16,6 +34,7 @@ export interface ChatToolPayload {
   arguments: string;
   id: string;
   identifier: string;
+  intervention?: ToolIntervention;
   result_msg_id?: string;
   type: LobeToolRenderType;
 }
@@ -34,6 +53,7 @@ export interface ChatToolResult {
  * Chat tool payload with merged execution result
  */
 export interface ChatToolPayloadWithResult extends ChatToolPayload {
+  intervention?: ToolIntervention;
   result?: ChatToolResult;
 }
 
@@ -91,6 +111,7 @@ export const ChatToolPayloadSchema = z.object({
   arguments: z.string(),
   id: z.string(),
   identifier: z.string(),
+  intervention: ToolInterventionSchema.optional(),
   result_msg_id: z.string().optional(),
   type: z.string(),
 });
@@ -103,13 +124,3 @@ export interface ChatMessagePluginError {
   message: string;
   type: IPluginErrorType;
 }
-
-export interface ToolIntervention {
-  rejectedReason?: string;
-  status?: 'pending' | 'approved' | 'rejected' | 'none';
-}
-
-export const ToolInterventionSchema = z.object({
-  rejectedReason: z.string().optional(),
-  status: z.enum(['pending', 'approved', 'rejected', 'none']).optional(),
-});

--- a/packages/types/src/message/common/tools.ts
+++ b/packages/types/src/message/common/tools.ts
@@ -2,13 +2,7 @@ import { IPluginErrorType } from '@lobehub/chat-plugin-sdk';
 import type { PartialDeep } from 'type-fest';
 import { z } from 'zod';
 
-
-
 import { LobeToolRenderType } from '../../tool';
-
-
-
-
 
 // ToolIntervention must be defined first to avoid circular dependency
 export interface ToolIntervention {
@@ -55,6 +49,7 @@ export interface ChatToolResult {
 export interface ChatToolPayloadWithResult extends ChatToolPayload {
   intervention?: ToolIntervention;
   result?: ChatToolResult;
+  result_msg_id?: string;
 }
 
 export interface ToolsCallingContext {

--- a/packages/types/src/message/ui/chat.ts
+++ b/packages/types/src/message/ui/chat.ts
@@ -8,7 +8,12 @@ import {
   ModelReasoning,
   ModelUsage,
 } from '../common';
-import { ChatPluginPayload, ChatToolPayload, ChatToolPayloadWithResult } from '../common/tools';
+import {
+  ChatPluginPayload,
+  ChatToolPayload,
+  ChatToolPayloadWithResult,
+  ToolIntervention,
+} from '../common/tools';
 import { ChatMessageExtra } from './extra';
 import { ChatFileChunk } from './rag';
 import { ChatVideoItem } from './video';
@@ -95,6 +100,7 @@ export interface UIChatMessage {
   performance?: ModelPerformance;
   plugin?: ChatPluginPayload;
   pluginError?: any;
+  pluginIntervention?: ToolIntervention;
   pluginState?: any;
   provider?: string | null;
   /**

--- a/packages/types/src/tool/intervention.ts
+++ b/packages/types/src/tool/intervention.ts
@@ -150,17 +150,3 @@ export const ShouldInterveneParamsSchema = z.object({
   toolArgs: z.record(z.string(), z.any()).optional(),
   toolKey: z.string().optional(),
 });
-
-/**
- * Tool Intervention Status
- * Tracks the approval status of a tool execution
- */
-export interface ToolIntervention {
-  rejectedReason?: string;
-  status?: 'pending' | 'approved' | 'rejected' | 'none';
-}
-
-export const ToolInterventionSchema = z.object({
-  rejectedReason: z.string().optional(),
-  status: z.enum(['pending', 'approved', 'rejected', 'none']).optional(),
-});

--- a/packages/types/src/tool/intervention.ts
+++ b/packages/types/src/tool/intervention.ts
@@ -5,10 +5,9 @@ import { z } from 'zod';
  */
 export type HumanInterventionPolicy =
   | 'never' // Never intervene, auto-execute
-  | 'always' // Always require intervention
-  | 'first'; // Require intervention on first call only
+  | 'require'; // Always require intervention
 
-export const HumanInterventionPolicySchema = z.enum(['never', 'always', 'first']);
+export const HumanInterventionPolicySchema = z.enum(['never', 'require']);
 
 /**
  * Argument Matcher for parameter-level filtering
@@ -150,4 +149,18 @@ export const ShouldInterveneParamsSchema = z.object({
   confirmedHistory: z.array(z.string()).optional(),
   toolArgs: z.record(z.string(), z.any()).optional(),
   toolKey: z.string().optional(),
+});
+
+/**
+ * Tool Intervention Status
+ * Tracks the approval status of a tool execution
+ */
+export interface ToolIntervention {
+  rejectedReason?: string;
+  status?: 'pending' | 'approved' | 'rejected' | 'none';
+}
+
+export const ToolInterventionSchema = z.object({
+  rejectedReason: z.string().optional(),
+  status: z.enum(['pending', 'approved', 'rejected', 'none']).optional(),
 });

--- a/packages/types/src/user/settings/tool.ts
+++ b/packages/types/src/user/settings/tool.ts
@@ -1,42 +1,29 @@
-import type { HumanInterventionConfig } from '../../tool';
-
 export interface UserToolConfig {
+  /**
+   * Tool approval mode
+   * - auto-run: Automatically approve all tools without user consent
+   * - allow-list: Only approve tools in the allow list
+   * - manual: Require manual approval for each tool execution
+   */
+  approvalMode?: 'auto-run' | 'allow-list' | 'manual';
+
   dalle: {
     autoGenerate: boolean;
   };
+
   /**
-   * Human intervention configuration
+   * Tool intervention configuration
    */
   humanIntervention?: {
     /**
-     * List of confirmed tool calls (for 'once' policy)
-     * Format: "identifier/apiName" or "identifier/apiName#argsHash"
+     * Allow list of approved tools (used in 'allow-list' mode)
+     * Format: "identifier/apiName"
      *
      * Examples:
      * - "web-browsing/crawlSinglePage"
-     * - "bash/bash#a1b2c3d4"
+     * - "bash/bash"
+     * - "search/search"
      */
-    confirmed?: string[];
-
-    /**
-     * Whether human intervention is enabled globally
-     * @default true
-     */
-    enabled: boolean;
-
-    /**
-     * Per-tool intervention policy overrides
-     * Key format: "identifier/apiName"
-     *
-     * Example:
-     * {
-     *   "web-browsing/crawlSinglePage": "confirm",
-     *   "bash/bash": [
-     *     { match: { command: "git add:*" }, policy: "auto" },
-     *     { policy: "confirm" }
-     *   ]
-     * }
-     */
-    overrides?: Record<string, HumanInterventionConfig>;
+    allowList?: string[];
   };
 }

--- a/src/features/Conversation/Messages/Group/GroupChildren.tsx
+++ b/src/features/Conversation/Messages/Group/GroupChildren.tsx
@@ -1,9 +1,10 @@
 import { AssistantContentBlock } from '@lobechat/types';
 import { createStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
+import { GroupMessageContext } from './GroupContext';
 import GroupItem from './GroupItem';
 
 const useStyles = createStyles(({ css }) => {
@@ -28,21 +29,25 @@ const GroupChildren = memo<GroupChildrenProps>(
   ({ blocks, contentId, disableEditing, messageIndex, id }) => {
     const { styles } = useStyles();
 
+    const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
+
     return (
-      <Flexbox className={styles.container} gap={8}>
-        {blocks.map((item, index) => {
-          return (
-            <GroupItem
-              {...item}
-              contentId={contentId}
-              disableEditing={disableEditing}
-              index={index}
-              key={`${id}_${index}`}
-              messageIndex={messageIndex}
-            />
-          );
-        })}
-      </Flexbox>
+      <GroupMessageContext value={contextValue}>
+        <Flexbox className={styles.container} gap={8}>
+          {blocks.map((item, index) => {
+            return (
+              <GroupItem
+                {...item}
+                contentId={contentId}
+                disableEditing={disableEditing}
+                index={index}
+                key={`${id}_${index}`}
+                messageIndex={messageIndex}
+              />
+            );
+          })}
+        </Flexbox>
+      </GroupMessageContext>
     );
   },
   isEqual,

--- a/src/features/Conversation/Messages/Group/GroupContext.tsx
+++ b/src/features/Conversation/Messages/Group/GroupContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+interface GroupMessageContextValue {
+  assistantGroupId: string;
+}
+
+export const GroupMessageContext = createContext<GroupMessageContextValue | null>(null);
+
+export const useGroupMessage = () => {
+  const context = useContext(GroupMessageContext);
+  if (!context) {
+    throw new Error('useGroupMessage must be used within GroupMessageContext');
+  }
+  return context;
+};

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/BuiltinPluginTitle.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/BuiltinPluginTitle.tsx
@@ -23,19 +23,17 @@ export const useStyles = createStyles(({ css, token }) => ({
 
 interface BuiltinPluginTitleProps {
   apiName: string;
-  hasResult?: boolean;
   icon?: ReactNode;
   identifier: string;
   index: number;
+  isLoading?: boolean;
   messageId: string;
   title: string;
   toolCallId: string;
 }
 
-const BuiltinPluginTitle = memo<BuiltinPluginTitleProps>(({ apiName, title, hasResult }) => {
+const BuiltinPluginTitle = memo<BuiltinPluginTitleProps>(({ apiName, title, isLoading }) => {
   const { styles } = useStyles();
-
-  const isLoading = !hasResult;
 
   return (
     <Flexbox align={'center'} className={isLoading ? styles.shinyText : ''} gap={4} horizontal>

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/ToolTitle.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/ToolTitle.tsx
@@ -31,19 +31,17 @@ export const useStyles = createStyles(({ css, token }) => ({
 
 interface ToolTitleProps {
   apiName: string;
-  hasResult?: boolean;
   identifier: string;
   index: number;
+  isLoading?: boolean;
   messageId: string;
   toolCallId: string;
 }
 
 const ToolTitle = memo<ToolTitleProps>(
-  ({ identifier, apiName, hasResult, index, toolCallId, messageId }) => {
+  ({ identifier, apiName, isLoading, index, toolCallId, messageId }) => {
     const { t } = useTranslation('plugin');
     const { styles } = useStyles();
-
-    const isLoading = !hasResult;
 
     const pluginMeta = useToolStore(toolSelectors.getMetaById(identifier), isEqual);
 
@@ -69,9 +67,9 @@ const ToolTitle = memo<ToolTitleProps>(
       return (
         <BuiltinPluginTitle
           {...builtinPluginTitle}
-          hasResult={hasResult}
           identifier={identifier}
           index={index}
+          isLoading={isLoading}
           messageId={messageId}
           toolCallId={toolCallId}
         />

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
@@ -1,6 +1,6 @@
-import { ActionIcon } from '@lobehub/ui';
+import { ActionIcon, Icon, Tooltip } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import { Check, LayoutPanelTop, LogsIcon, LucideBug, LucideBugOff, X } from 'lucide-react';
+import { Ban, Check, LayoutPanelTop, LogsIcon, LucideBug, LucideBugOff, X } from 'lucide-react';
 import { CSSProperties, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -154,10 +154,14 @@ const Inspectors = memo<InspectorProps>(
             </Flexbox>
             {hasResult && (
               <Flexbox align={'center'} gap={4} horizontal style={{ fontSize: 12 }}>
-                {hasError ? (
-                  <X color={theme.colorError} size={14} />
+                {intervention?.status === 'rejected' ? (
+                  <Tooltip title={t('toolRejected', { ns: 'chat' })}>
+                    <Icon color={theme.colorTextTertiary} icon={Ban} />
+                  </Tooltip>
+                ) : hasError ? (
+                  <Icon color={theme.colorError} icon={X} />
                 ) : (
-                  <Check color={theme.colorSuccess} size={14} />
+                  <Icon color={theme.colorSuccess} icon={Check} />
                 )}
               </Flexbox>
             )}

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
@@ -105,7 +105,8 @@ const Inspectors = memo<InspectorProps>(
 
     const hasResult = hasSuccessResult || hasError;
 
-    const isTitleLoading = !hasResult && intervention?.status !== 'pending';
+    const isPending = intervention?.status === 'pending';
+    const isTitleLoading = !hasResult && !isPending;
 
     return (
       <Flexbox className={styles.container} gap={4}>
@@ -131,7 +132,7 @@ const Inspectors = memo<InspectorProps>(
           </Flexbox>
           <Flexbox align={'center'} gap={8} horizontal>
             <Flexbox className={styles.actions} horizontal>
-              {showRender && (
+              {showRender && !isPending && (
                 <ActionIcon
                   icon={showPluginRender ? LogsIcon : LayoutPanelTop}
                   onClick={() => {

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
@@ -7,6 +7,7 @@ import { Flexbox } from 'react-layout-kit';
 
 import { LOADING_FLAT } from '@/const/message';
 import { shinyTextStylish } from '@/styles/loading';
+import { ToolIntervention } from '@/types/message';
 
 import Debug from './Debug';
 import Settings from './Settings';
@@ -66,6 +67,7 @@ interface InspectorProps {
   id: string;
   identifier: string;
   index: number;
+  intervention?: ToolIntervention;
   messageId: string;
   result?: { content: string | null; error?: any; state?: any };
   setShowPluginRender: (show: boolean) => void;
@@ -91,6 +93,7 @@ const Inspectors = memo<InspectorProps>(
     showPluginRender,
     setShowPluginRender,
     type,
+    intervention,
   }) => {
     const { t } = useTranslation('plugin');
     const { styles, theme } = useStyles();
@@ -101,6 +104,8 @@ const Inspectors = memo<InspectorProps>(
     const hasSuccessResult = !!result?.content && result.content !== LOADING_FLAT;
 
     const hasResult = hasSuccessResult || hasError;
+
+    const isTitleLoading = !hasResult && intervention?.status !== 'pending';
 
     return (
       <Flexbox className={styles.container} gap={4}>
@@ -117,9 +122,9 @@ const Inspectors = memo<InspectorProps>(
           >
             <ToolTitle
               apiName={apiName}
-              hasResult={hasResult}
               identifier={identifier}
               index={index}
+              isLoading={isTitleLoading}
               messageId={messageId}
               toolCallId={id}
             />

--- a/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Inspector/index.tsx
@@ -106,8 +106,10 @@ const Inspectors = memo<InspectorProps>(
     const hasResult = hasSuccessResult || hasError;
 
     const isPending = intervention?.status === 'pending';
+    const isReject = intervention?.status === 'rejected';
     const isTitleLoading = !hasResult && !isPending;
 
+    const showCustomPluginRender = showRender && !isPending && !isReject;
     return (
       <Flexbox className={styles.container} gap={4}>
         <Flexbox align={'center'} distribution={'space-between'} gap={8} horizontal>
@@ -132,7 +134,7 @@ const Inspectors = memo<InspectorProps>(
           </Flexbox>
           <Flexbox align={'center'} gap={8} horizontal>
             <Flexbox className={styles.actions} horizontal>
-              {showRender && !isPending && (
+              {showCustomPluginRender && (
                 <ActionIcon
                   icon={showPluginRender ? LogsIcon : LayoutPanelTop}
                   onClick={() => {
@@ -154,8 +156,8 @@ const Inspectors = memo<InspectorProps>(
             </Flexbox>
             {hasResult && (
               <Flexbox align={'center'} gap={4} horizontal style={{ fontSize: 12 }}>
-                {intervention?.status === 'rejected' ? (
-                  <Tooltip title={t('toolRejected', { ns: 'chat' })}>
+                {isReject ? (
+                  <Tooltip title={t('tool.intervention.toolRejected', { ns: 'chat' })}>
                     <Icon color={theme.colorTextTertiary} icon={Ban} />
                   </Tooltip>
                 ) : hasError ? (

--- a/src/features/Conversation/Messages/Group/Tool/Render/Arguments/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Arguments/index.tsx
@@ -115,18 +115,20 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', shine, actions }
           {actions}
         </Flexbox>
       )}
-      {Object.entries(displayArgs).map(([key, value]) => {
-        return (
-          <ObjectEntity
-            editable={false}
-            hasMinWidth={hasMinWidth}
-            key={key}
-            objectKey={key}
-            shine={shine}
-            value={value}
-          />
-        );
-      })}
+      <Flexbox>
+        {Object.entries(displayArgs).map(([key, value]) => {
+          return (
+            <ObjectEntity
+              editable={false}
+              hasMinWidth={hasMinWidth}
+              key={key}
+              objectKey={key}
+              shine={shine}
+              value={value}
+            />
+          );
+        })}
+      </Flexbox>
     </div>
   );
 });

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
@@ -5,86 +5,108 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import { useChatStore } from '@/store/chat';
+import { useUserStore } from '@/store/user';
+
 import { ApprovalMode } from './index';
 
 interface ApprovalActionsProps {
+  apiName: string;
   approvalMode: ApprovalMode;
-  onApprove?: (mode: ApprovalMode, remember?: boolean) => void;
-  onReject?: (mode: ApprovalMode, reason?: string) => void;
+  identifier: string;
+  messageId: string;
+  toolCallId: string;
 }
 
-const ApprovalActions = memo<ApprovalActionsProps>(({ approvalMode, onApprove, onReject }) => {
-  const { t } = useTranslation(['chat', 'common']);
-  const [rejectReason, setRejectReason] = useState('');
-  const [rejectPopoverOpen, setRejectPopoverOpen] = useState(false);
+const ApprovalActions = memo<ApprovalActionsProps>(
+  ({ approvalMode, messageId, toolCallId, identifier, apiName }) => {
+    const { t } = useTranslation(['chat', 'common']);
+    const [rejectReason, setRejectReason] = useState('');
+    const [rejectPopoverOpen, setRejectPopoverOpen] = useState(false);
 
-  return (
-    <Flexbox gap={8} horizontal>
-      <Popover
-        arrow={false}
-        content={
-          <Flexbox gap={12} style={{ width: 400 }}>
-            <Flexbox horizontal justify={'space-between'}>
-              <div>{t('tool.intervention.rejectTitle')}</div>
+    const [approveToolIntervention, rejectToolIntervention] = useChatStore((s) => [
+      s.approveToolCalling,
+      s.rejectToolCalling,
+    ]);
+    const addToolToAllowList = useUserStore((s) => s.addToolToAllowList);
 
-              <Button
-                onClick={() => {
-                  onReject?.(approvalMode, rejectReason);
-                  setRejectPopoverOpen(false);
-                  setRejectReason('');
-                }}
-                size="small"
-                type="primary"
-              >
-                {t('confirm', { ns: 'common' })}
-              </Button>
+    const handleApprove = async (remember?: boolean) => {
+      // 1. Update intervention status
+      await approveToolIntervention(messageId, toolCallId);
+
+      // 2. If remember, add to allowList
+      if (remember) {
+        const toolKey = `${identifier}/${apiName}`;
+        await addToolToAllowList(toolKey);
+      }
+    };
+
+    const handleReject = async (reason?: string) => {
+      await rejectToolIntervention(messageId, reason);
+      setRejectPopoverOpen(false);
+      setRejectReason('');
+    };
+
+    return (
+      <Flexbox gap={8} horizontal>
+        <Popover
+          arrow={false}
+          content={
+            <Flexbox gap={12} style={{ width: 400 }}>
+              <Flexbox horizontal justify={'space-between'}>
+                <div>{t('tool.intervention.rejectTitle')}</div>
+
+                <Button onClick={() => handleReject(rejectReason)} size="small" type="primary">
+                  {t('confirm', { ns: 'common' })}
+                </Button>
+              </Flexbox>
+              <Input.TextArea
+                autoFocus
+                onChange={(e) => setRejectReason(e.target.value)}
+                placeholder={t('tool.intervention.rejectReasonPlaceholder')}
+                rows={3}
+                value={rejectReason}
+                variant={'filled'}
+              />
             </Flexbox>
-            <Input.TextArea
-              autoFocus
-              onChange={(e) => setRejectReason(e.target.value)}
-              placeholder={t('tool.intervention.rejectReasonPlaceholder')}
-              rows={3}
-              value={rejectReason}
-              variant={'filled'}
-            />
-          </Flexbox>
-        }
-        onOpenChange={setRejectPopoverOpen}
-        open={rejectPopoverOpen}
-        placement="bottomRight"
-        trigger="click"
-      >
-        <Button size="small" type="default">
-          {t('tool.intervention.reject')}
-        </Button>
-      </Popover>
-
-      {approvalMode === 'allow-list' ? (
-        <Space.Compact>
-          <Button onClick={() => onApprove?.(approvalMode, true)} size="small" type="primary">
-            {t('tool.intervention.approveAndRemember')}
+          }
+          onOpenChange={setRejectPopoverOpen}
+          open={rejectPopoverOpen}
+          placement="bottomRight"
+          trigger="click"
+        >
+          <Button size="small" type="default">
+            {t('tool.intervention.reject')}
           </Button>
-          <Dropdown
-            menu={{
-              items: [
-                {
-                  key: 'once',
-                  label: t('tool.intervention.approveOnce'),
-                  onClick: () => onApprove?.(approvalMode, false),
-                },
-              ],
-            }}
-          >
-            <Button icon={ChevronDown} size="small" type="primary" />
-          </Dropdown>
-        </Space.Compact>
-      ) : (
-        <Button onClick={() => onApprove?.(approvalMode)} size="small" type="primary">
-          {t('tool.intervention.approve')}
-        </Button>
-      )}
-    </Flexbox>
-  );
-});
+        </Popover>
+
+        {approvalMode === 'allow-list' ? (
+          <Space.Compact>
+            <Button onClick={() => handleApprove(true)} size="small" type="primary">
+              {t('tool.intervention.approveAndRemember')}
+            </Button>
+            <Dropdown
+              menu={{
+                items: [
+                  {
+                    key: 'once',
+                    label: t('tool.intervention.approveOnce'),
+                    onClick: () => handleApprove(false),
+                  },
+                ],
+              }}
+            >
+              <Button icon={ChevronDown} size="small" type="primary" />
+            </Dropdown>
+          </Space.Compact>
+        ) : (
+          <Button onClick={() => handleApprove()} size="small" type="primary">
+            {t('tool.intervention.approve')}
+          </Button>
+        )}
+      </Flexbox>
+    );
+  },
+);
 
 export default ApprovalActions;

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
@@ -23,6 +23,7 @@ const ApprovalActions = memo<ApprovalActionsProps>(
     const { t } = useTranslation(['chat', 'common']);
     const [rejectReason, setRejectReason] = useState('');
     const [rejectPopoverOpen, setRejectPopoverOpen] = useState(false);
+    const [rejectLoading, setRejectLoading] = useState(false);
 
     const [approveToolIntervention, rejectToolIntervention] = useChatStore((s) => [
       s.approveToolCalling,
@@ -42,7 +43,9 @@ const ApprovalActions = memo<ApprovalActionsProps>(
     };
 
     const handleReject = async (reason?: string) => {
+      setRejectLoading(true);
       await rejectToolIntervention(messageId, reason);
+      setRejectLoading(false);
       setRejectPopoverOpen(false);
       setRejectReason('');
     };
@@ -53,10 +56,15 @@ const ApprovalActions = memo<ApprovalActionsProps>(
           arrow={false}
           content={
             <Flexbox gap={12} style={{ width: 400 }}>
-              <Flexbox horizontal justify={'space-between'}>
+              <Flexbox align={'center'} horizontal justify={'space-between'}>
                 <div>{t('tool.intervention.rejectTitle')}</div>
 
-                <Button onClick={() => handleReject(rejectReason)} size="small" type="primary">
+                <Button
+                  loading={rejectLoading}
+                  onClick={() => handleReject(rejectReason)}
+                  size="small"
+                  type="primary"
+                >
                   {t('confirm', { ns: 'common' })}
                 </Button>
               </Flexbox>
@@ -70,7 +78,11 @@ const ApprovalActions = memo<ApprovalActionsProps>(
               />
             </Flexbox>
           }
-          onOpenChange={setRejectPopoverOpen}
+          onOpenChange={(open) => {
+            if (rejectLoading) return;
+
+            setRejectPopoverOpen(open);
+          }}
           open={rejectPopoverOpen}
           placement="bottomRight"
           trigger="click"

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
@@ -5,6 +5,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import { useGroupMessage } from '@/features/Conversation/Messages/Group/GroupContext';
 import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 
@@ -19,12 +20,13 @@ interface ApprovalActionsProps {
 }
 
 const ApprovalActions = memo<ApprovalActionsProps>(
-  ({ approvalMode, messageId, toolCallId, identifier, apiName }) => {
+  ({ approvalMode, messageId, identifier, apiName }) => {
     const { t } = useTranslation(['chat', 'common']);
     const [rejectReason, setRejectReason] = useState('');
     const [rejectPopoverOpen, setRejectPopoverOpen] = useState(false);
     const [rejectLoading, setRejectLoading] = useState(false);
 
+    const { assistantGroupId } = useGroupMessage();
     const [approveToolIntervention, rejectToolIntervention] = useChatStore((s) => [
       s.approveToolCalling,
       s.rejectToolCalling,
@@ -33,9 +35,9 @@ const ApprovalActions = memo<ApprovalActionsProps>(
 
     const handleApprove = async (remember?: boolean) => {
       // 1. Update intervention status
-      await approveToolIntervention(messageId, toolCallId);
+      await approveToolIntervention(messageId, assistantGroupId);
 
-      // 2. If remember, add to allowList
+      // 2. If remembered, add to allowList
       if (remember) {
         const toolKey = `${identifier}/${apiName}`;
         await addToolToAllowList(toolKey);

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ApprovalActions.tsx
@@ -1,0 +1,90 @@
+import { Button, Dropdown } from '@lobehub/ui';
+import { Input, Popover, Space } from 'antd';
+import { ChevronDown } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { ApprovalMode } from './index';
+
+interface ApprovalActionsProps {
+  approvalMode: ApprovalMode;
+  onApprove?: (mode: ApprovalMode, remember?: boolean) => void;
+  onReject?: (mode: ApprovalMode, reason?: string) => void;
+}
+
+const ApprovalActions = memo<ApprovalActionsProps>(({ approvalMode, onApprove, onReject }) => {
+  const { t } = useTranslation(['chat', 'common']);
+  const [rejectReason, setRejectReason] = useState('');
+  const [rejectPopoverOpen, setRejectPopoverOpen] = useState(false);
+
+  return (
+    <Flexbox gap={8} horizontal>
+      <Popover
+        arrow={false}
+        content={
+          <Flexbox gap={12} style={{ width: 400 }}>
+            <Flexbox horizontal justify={'space-between'}>
+              <div>{t('tool.intervention.rejectTitle')}</div>
+
+              <Button
+                onClick={() => {
+                  onReject?.(approvalMode, rejectReason);
+                  setRejectPopoverOpen(false);
+                  setRejectReason('');
+                }}
+                size="small"
+                type="primary"
+              >
+                {t('confirm', { ns: 'common' })}
+              </Button>
+            </Flexbox>
+            <Input.TextArea
+              autoFocus
+              onChange={(e) => setRejectReason(e.target.value)}
+              placeholder={t('tool.intervention.rejectReasonPlaceholder')}
+              rows={3}
+              value={rejectReason}
+              variant={'filled'}
+            />
+          </Flexbox>
+        }
+        onOpenChange={setRejectPopoverOpen}
+        open={rejectPopoverOpen}
+        placement="bottomRight"
+        trigger="click"
+      >
+        <Button size="small" type="default">
+          {t('tool.intervention.reject')}
+        </Button>
+      </Popover>
+
+      {approvalMode === 'allow-list' ? (
+        <Space.Compact>
+          <Button onClick={() => onApprove?.(approvalMode, true)} size="small" type="primary">
+            {t('tool.intervention.approveAndRemember')}
+          </Button>
+          <Dropdown
+            menu={{
+              items: [
+                {
+                  key: 'once',
+                  label: t('tool.intervention.approveOnce'),
+                  onClick: () => onApprove?.(approvalMode, false),
+                },
+              ],
+            }}
+          >
+            <Button icon={ChevronDown} size="small" type="primary" />
+          </Dropdown>
+        </Space.Compact>
+      ) : (
+        <Button onClick={() => onApprove?.(approvalMode)} size="small" type="primary">
+          {t('tool.intervention.approve')}
+        </Button>
+      )}
+    </Flexbox>
+  );
+});
+
+export default ApprovalActions;

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/KeyValueEditor.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/KeyValueEditor.tsx
@@ -1,0 +1,213 @@
+import { ActionIcon, Button, Icon, Input } from '@lobehub/ui';
+import { App, Form, FormInstance } from 'antd';
+import { createStyles } from 'antd-style';
+import { LucidePlus, LucideTrash } from 'lucide-react';
+import { memo, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+const useStyles = createStyles(({ css, token }) => ({
+  form: css`
+    position: relative;
+
+    width: 100%;
+    min-width: 600px;
+    padding: 8px;
+    border-radius: ${token.borderRadiusLG}px;
+  `,
+  formItem: css`
+    margin-block-end: 4px !important;
+  `,
+  input: css`
+    font-family: ${token.fontFamilyCode};
+    font-size: 12px;
+  `,
+  row: css`
+    position: relative;
+  `,
+  title: css`
+    margin-block-end: 4px;
+    color: ${token.colorTextTertiary};
+  `,
+}));
+
+interface KeyValueItem {
+  id: string;
+  key?: string;
+  value?: string;
+}
+
+interface KeyValueEditorProps {
+  initialValue?: Record<string, any>;
+  onCancel?: () => void;
+  onFinish?: (value: Record<string, any>) => Promise<void>;
+}
+
+const recordToFormList = (record: Record<string, any>): KeyValueItem[] =>
+  Object.entries(record)
+    .map(([key, val], index) => ({
+      id: `${key}-${index}`,
+      key,
+      value: typeof val === 'string' ? val : JSON.stringify(val),
+    }))
+    .filter((item) => item.key);
+
+const formListToRecord = (list: KeyValueItem[]): Record<string, any> => {
+  const record: Record<string, any> = {};
+  list.forEach((item) => {
+    if (item.key) {
+      try {
+        record[item.key] = JSON.parse(item.value || '""');
+      } catch {
+        record[item.key] = item.value || '';
+      }
+    }
+  });
+  return record;
+};
+
+const KeyValueEditor = memo<KeyValueEditorProps>(({ initialValue = {}, onFinish, onCancel }) => {
+  const { styles } = useStyles();
+  const { t } = useTranslation(['tool', 'common']);
+  const [form] = Form.useForm();
+  const { message } = App.useApp();
+  const formRef = useRef<FormInstance>(null);
+
+  useEffect(() => {
+    form.setFieldsValue({ items: recordToFormList(initialValue) });
+  }, [initialValue, form]);
+
+  const [updating, setUpdating] = useState(false);
+  const handleFinish = async () => {
+    setUpdating(true);
+    try {
+      await form.validateFields();
+      const values = form.getFieldsValue();
+      const record = formListToRecord(values.items || []);
+      await onFinish?.(record);
+    } catch (errorInfo) {
+      console.error('Validation Failed:', errorInfo);
+      message.error(t('updateArgs.formValidationFailed') || 'Please check the form for errors.');
+    }
+    setUpdating(false);
+  };
+
+  const handleCancel = () => {
+    onCancel?.();
+  };
+
+  const validateKeys = (_: any, item: KeyValueItem, items: KeyValueItem[]) => {
+    if (!item?.key) {
+      return Promise.resolve();
+    }
+    const keys = items.map((i) => i?.key).filter(Boolean);
+    if (keys.filter((k) => k === item.key).length > 1) {
+      return Promise.reject(new Error(t('updateArgs.duplicateKeyError')));
+    }
+
+    return Promise.resolve();
+  };
+
+  return (
+    <Form
+      autoComplete="off"
+      className={styles.form}
+      form={form}
+      initialValues={{ items: recordToFormList(initialValue) }}
+      ref={formRef}
+    >
+      <Flexbox className={styles.title} gap={8} horizontal>
+        <Flexbox flex={1}>key</Flexbox>
+        <Flexbox flex={4}>value</Flexbox>
+      </Flexbox>
+      <Form.List name="items">
+        {(fields, { add, remove }) => (
+          <Flexbox width={'100%'}>
+            {fields.map(({ key, name, ...restField }, index) => (
+              <Flexbox
+                align="center"
+                className={styles.row}
+                gap={8}
+                horizontal
+                key={key}
+                width={'100%'}
+              >
+                <Form.Item
+                  {...restField}
+                  className={styles.formItem}
+                  name={[name, 'key']}
+                  rules={[
+                    { message: t('updateArgs.keyRequired'), required: true },
+                    {
+                      validator: (rule) =>
+                        validateKeys(
+                          rule,
+                          form.getFieldValue(['items', index]),
+                          form.getFieldValue('items'),
+                        ),
+                    },
+                  ]}
+                  style={{ flex: 1 }}
+                  validateTrigger={['onChange', 'onBlur']}
+                >
+                  <Input
+                    allowClear
+                    className={styles.input}
+                    placeholder={t('updateArgs.form.key')}
+                    variant={'filled'}
+                  />
+                </Form.Item>
+                <Form.Item
+                  {...restField}
+                  className={styles.formItem}
+                  name={[name, 'value']}
+                  style={{ flex: 4 }}
+                >
+                  <Input
+                    allowClear
+                    className={styles.input}
+                    placeholder={t('updateArgs.form.value')}
+                    variant={'filled'}
+                  />
+                </Form.Item>
+                <ActionIcon
+                  icon={LucideTrash}
+                  onClick={() => remove(name)}
+                  size={'small'}
+                  style={{
+                    marginBottom: 6,
+                  }}
+                  title={t('delete', { ns: 'common' })}
+                />
+              </Flexbox>
+            ))}
+            <Form.Item style={{ marginBottom: 0, marginTop: 8 }}>
+              <Flexbox gap={8} horizontal justify={'space-between'}>
+                <Button
+                  color={'default'}
+                  icon={<Icon icon={LucidePlus} />}
+                  onClick={() => add({ id: `new-${Date.now()}`, key: '', value: '' })}
+                  size={'small'}
+                  variant="filled"
+                >
+                  {t('updateArgs.form.add')}
+                </Button>
+
+                <Flexbox gap={8} horizontal>
+                  <Button onClick={handleCancel} size={'small'}>
+                    {t('cancel', { ns: 'common' })}
+                  </Button>
+                  <Button loading={updating} onClick={handleFinish} size={'small'} type={'primary'}>
+                    {t('save', { ns: 'common' })}
+                  </Button>
+                </Flexbox>
+              </Flexbox>
+            </Form.Item>
+          </Flexbox>
+        )}
+      </Form.List>
+    </Form>
+  );
+});
+
+export default KeyValueEditor;

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ModeSelector.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/ModeSelector.tsx
@@ -1,0 +1,134 @@
+import { Button, Dropdown, Icon, type MenuProps } from '@lobehub/ui';
+import { createStyles } from 'antd-style';
+import { ChevronDown, Hand, ListChecks, Zap } from 'lucide-react';
+import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Center } from 'react-layout-kit';
+
+import { useUserStore } from '@/store/user';
+
+import { ApprovalMode } from './index';
+
+const useStyles = createStyles(({ css, token }) => ({
+  icon: css`
+    border: 1px solid ${token.colorFillTertiary};
+    border-radius: ${token.borderRadius}px;
+    background: ${token.colorBgElevated};
+  `,
+  modeButton: css`
+    font-size: ${token.fontSizeSM}px;
+    color: ${token.colorTextSecondary};
+  `,
+  modeDesc: css`
+    margin-block-start: 2px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: ${token.colorTextDescription};
+  `,
+  modeItem: css`
+    min-width: 160px;
+  `,
+  modeLabel: css`
+    font-size: ${token.fontSize}px;
+    font-weight: 500;
+    line-height: 1.4;
+    color: ${token.colorText};
+  `,
+}));
+
+const ModeSelector = memo(() => {
+  const { t } = useTranslation('chat');
+  const { styles } = useStyles();
+  const [approvalMode, setSettings] = useUserStore((s) => [
+    s.settings.tool?.approvalMode || 'manual',
+    s.setSettings,
+  ]);
+
+  const modeLabels = useMemo(
+    () => ({
+      'allow-list': t('tool.intervention.mode.allowList'),
+      'auto-run': t('tool.intervention.mode.autoRun'),
+      'manual': t('tool.intervention.mode.manual'),
+    }),
+    [t],
+  );
+
+  const handleModeChange = useCallback(
+    async (mode: ApprovalMode) => {
+      await setSettings({ tool: { approvalMode: mode } });
+    },
+    [setSettings],
+  );
+
+  const menuItems = useMemo<MenuProps['items']>(
+    () => [
+      {
+        icon: (
+          <Center className={styles.icon} height={32} width={32}>
+            <Icon icon={Zap} />
+          </Center>
+        ),
+        key: 'auto-run',
+        label: (
+          <div className={styles.modeItem}>
+            <div className={styles.modeLabel}>{modeLabels['auto-run']}</div>
+            <div className={styles.modeDesc}>{t('tool.intervention.mode.autoRunDesc')}</div>
+          </div>
+        ),
+        onClick: () => handleModeChange('auto-run'),
+      },
+      {
+        icon: (
+          <Center className={styles.icon} height={32} width={32}>
+            <Icon icon={ListChecks} />
+          </Center>
+        ),
+        key: 'allow-list',
+        label: (
+          <div className={styles.modeItem}>
+            <div className={styles.modeLabel}>{modeLabels['allow-list']}</div>
+            <div className={styles.modeDesc}>{t('tool.intervention.mode.allowListDesc')}</div>
+          </div>
+        ),
+        onClick: () => handleModeChange('allow-list'),
+      },
+      {
+        icon: (
+          <Center className={styles.icon} height={32} width={32}>
+            <Icon icon={Hand} />
+          </Center>
+        ),
+        key: 'manual',
+        label: (
+          <div className={styles.modeItem}>
+            <div className={styles.modeLabel}>{modeLabels.manual}</div>
+            <div className={styles.modeDesc}>{t('tool.intervention.mode.manualDesc')}</div>
+          </div>
+        ),
+        onClick: () => handleModeChange('manual'),
+      },
+    ],
+    [modeLabels, handleModeChange, styles, t],
+  );
+
+  return (
+    <Dropdown
+      // @ts-expect-error activeKey 没在 Dropdown key 里很奇怪
+      menu={{ activeKey: approvalMode, items: menuItems }}
+      placement="bottomLeft"
+    >
+      <Button
+        className={styles.modeButton}
+        color={'default'}
+        icon={ChevronDown}
+        iconPosition="end"
+        size="small"
+        variant={'text'}
+      >
+        {modeLabels[approvalMode]}
+      </Button>
+    </Dropdown>
+  );
+});
+
+export default ModeSelector;

--- a/src/features/Conversation/Messages/Group/Tool/Render/Intervention/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/Intervention/index.tsx
@@ -1,0 +1,112 @@
+import { safeParseJSON } from '@lobechat/utils';
+import { ActionIcon, Button } from '@lobehub/ui';
+import { Checkbox } from 'antd';
+import { createStyles } from 'antd-style';
+import { Edit3Icon } from 'lucide-react';
+import { memo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { useChatStore } from '@/store/chat';
+
+import Arguments from '../Arguments';
+import KeyValueEditor from './KeyValueEditor';
+
+const useStyles = createStyles(({ css, token }) => ({
+  actions: css`
+    gap: ${token.marginSM}px;
+  `,
+  checkbox: css`
+    font-size: ${token.fontSizeSM}px;
+    color: ${token.colorTextSecondary};
+
+    .ant-checkbox {
+      margin-inline-end: ${token.marginXS}px;
+    }
+  `,
+}));
+
+interface InterventionProps {
+  id: string;
+  onApprove?: (remember: boolean) => void;
+  onReject?: (remember: boolean) => void;
+  requestArgs: string;
+}
+
+const Intervention = memo<InterventionProps>(({ requestArgs, onApprove, onReject, id }) => {
+  const { t } = useTranslation('chat');
+  const { styles } = useStyles();
+  const [remember, setRemember] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [optimisticUpdatePluginArguments] = useChatStore((s) => [
+    s.optimisticUpdatePluginArguments,
+  ]);
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  const handleFinish = useCallback(
+    async (editedObject: Record<string, any>) => {
+      if (!id) return;
+
+      try {
+        const newArgsString = JSON.stringify(editedObject, null, 2);
+
+        if (newArgsString !== requestArgs) {
+          await optimisticUpdatePluginArguments(id, editedObject, true);
+        }
+        setIsEditing(false);
+      } catch (error) {
+        console.error('Error stringifying arguments:', error);
+      }
+    },
+    [requestArgs, id],
+  );
+
+  if (isEditing)
+    return (
+      <KeyValueEditor
+        initialValue={safeParseJSON(requestArgs || '')}
+        onCancel={handleCancel}
+        onFinish={handleFinish}
+      />
+    );
+
+  return (
+    <Flexbox gap={12}>
+      <Arguments
+        actions={
+          <ActionIcon
+            icon={Edit3Icon}
+            onClick={() => {
+              setIsEditing(true);
+            }}
+            size={'small'}
+            title={t('edit', { ns: 'common' })}
+          />
+        }
+        arguments={requestArgs}
+      />
+
+      <Flexbox horizontal justify={'space-between'}>
+        <Checkbox
+          checked={remember}
+          className={styles.checkbox}
+          onChange={(e) => setRemember(e.target.checked)}
+        >
+          {t('tool.intervention.rememberDecision', { ns: 'chat' })}
+        </Checkbox>
+        <Flexbox className={styles.actions} gap={8} horizontal>
+          <Button onClick={() => onReject?.(remember)} size="small" type="default">
+            {t('tool.intervention.reject', { ns: 'chat' })}
+          </Button>
+          <Button onClick={() => onApprove?.(remember)} size="small" type="primary">
+            {t('tool.intervention.approve', { ns: 'chat' })}
+          </Button>
+        </Flexbox>
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+export default Intervention;

--- a/src/features/Conversation/Messages/Group/Tool/Render/RejectedResponse.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/RejectedResponse.tsx
@@ -1,0 +1,45 @@
+import { Icon } from '@lobehub/ui';
+import { createStyles } from 'antd-style';
+import { AlertTriangle } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+const useStyles = createStyles(({ css, token }) => ({
+  container: css`
+    padding-block: 8px;
+    padding-inline: 6px;
+  `,
+  reason: css`
+    font-size: 12px;
+    color: ${token.colorTextTertiary};
+  `,
+  title: css`
+    font-size: 14px;
+    color: ${token.colorTextSecondary};
+  `,
+}));
+
+interface RejectedResponseProps {
+  reason?: string;
+}
+
+const RejectedResponse = memo<RejectedResponseProps>(({ reason }) => {
+  const { t } = useTranslation('chat');
+  const { styles, theme } = useStyles();
+
+  return (
+    <Flexbox className={styles.container} gap={8}>
+      <Flexbox align={'center'} gap={8} horizontal>
+        <Icon color={theme.colorWarning} icon={AlertTriangle} size={16} />
+        <div className={styles.title}>
+          {reason
+            ? t('tool.intervention.rejectedWithReason', { reason })
+            : t('tool.intervention.toolRejected')}
+        </div>
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+export default RejectedResponse;

--- a/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
@@ -6,6 +6,7 @@ import CustomRender from './CustomRender';
 import ErrorResponse from './ErrorResponse';
 import Intervention from './Intervention';
 import LoadingPlaceholder from './LoadingPlaceholder';
+import RejectedResponse from './RejectedResponse';
 
 interface RenderProps {
   apiName: string;
@@ -54,6 +55,10 @@ const Render = memo<RenderProps>(
           toolCallId={toolCallId}
         />
       );
+    }
+
+    if (intervention?.status === 'rejected') {
+      return <RejectedResponse reason={intervention.rejectedReason} />;
     }
 
     if (!result) return null;

--- a/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
@@ -1,15 +1,17 @@
 import { LOADING_FLAT } from '@lobechat/const';
-import { ChatToolResult } from '@lobechat/types';
+import { ChatToolResult, ToolIntervention } from '@lobechat/types';
 import { Suspense, memo } from 'react';
 
 import CustomRender from './CustomRender';
 import ErrorResponse from './ErrorResponse';
+import Intervention from './Intervention';
 import LoadingPlaceholder from './LoadingPlaceholder';
 
 interface RenderProps {
   apiName: string;
   arguments?: string;
   identifier: string;
+  intervention?: ToolIntervention;
   /**
    * ContentBlock ID (not the group message ID)
    */
@@ -38,7 +40,12 @@ const Render = memo<RenderProps>(
     apiName,
     result,
     type,
+    intervention,
   }) => {
+    if (intervention?.status) {
+      return <Intervention id={messageId} requestArgs={requestArgs || ''} />;
+    }
+
     if (!result) return null;
 
     // Handle error state

--- a/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/Render/index.tsx
@@ -20,6 +20,7 @@ interface RenderProps {
   setShowPluginRender: (show: boolean) => void;
   showPluginRender: boolean;
   toolCallId: string;
+  toolMessageId?: string;
   type?: string;
 }
 
@@ -41,9 +42,18 @@ const Render = memo<RenderProps>(
     result,
     type,
     intervention,
+    toolMessageId,
   }) => {
-    if (intervention?.status) {
-      return <Intervention id={messageId} requestArgs={requestArgs || ''} />;
+    if (toolMessageId && intervention?.status === 'pending') {
+      return (
+        <Intervention
+          apiName={apiName}
+          id={toolMessageId}
+          identifier={identifier}
+          requestArgs={requestArgs || ''}
+          toolCallId={toolCallId}
+        />
+      );
     }
 
     if (!result) return null;

--- a/src/features/Conversation/Messages/Group/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/index.tsx
@@ -10,16 +10,17 @@ import Render from './Render';
 export interface GroupToolProps {
   apiName: string;
   arguments?: string;
+  /**
+   * ContentBlock ID (not the group message ID)
+   */
+  assistantMessageId: string;
   id: string;
   identifier: string;
   index: number;
   intervention?: ToolIntervention;
-  /**
-   * ContentBlock ID (not the group message ID)
-   */
-  messageId: string;
   result?: ChatToolResult;
   style?: CSSProperties;
+  toolMessageId?: string;
   type?: string;
 }
 
@@ -33,7 +34,7 @@ const Tool = memo<GroupToolProps>(
   ({
     arguments: requestArgs,
     apiName,
-    messageId,
+    assistantMessageId,
     id,
     intervention,
     index,
@@ -41,6 +42,7 @@ const Tool = memo<GroupToolProps>(
     style,
     result,
     type,
+    toolMessageId,
   }) => {
     // Default to false since group messages are all completed
 
@@ -62,7 +64,7 @@ const Tool = memo<GroupToolProps>(
           identifier={identifier}
           index={index}
           intervention={intervention}
-          messageId={messageId}
+          messageId={assistantMessageId}
           result={result}
           setShowPluginRender={setShowCustomPluginUI}
           setShowRender={setShowToolDetail}
@@ -76,11 +78,12 @@ const Tool = memo<GroupToolProps>(
             arguments={requestArgs}
             identifier={identifier}
             intervention={intervention}
-            messageId={messageId}
+            messageId={assistantMessageId}
             result={result}
             setShowPluginRender={setShowCustomPluginUI}
             showPluginRender={showCustomPluginUI}
             toolCallId={id}
+            toolMessageId={toolMessageId}
             type={type}
           />
         </AnimatedCollapsed>

--- a/src/features/Conversation/Messages/Group/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/index.tsx
@@ -47,7 +47,6 @@ const Tool = memo<GroupToolProps>(
     const [showToolContent, setShowToolDetail] = useState(false);
     const [showCustomPluginUI, setShowCustomPluginUI] = useState(false);
 
-    console.log(intervention);
     useEffect(() => {
       if (intervention?.status === 'pending') {
         setShowToolDetail(true);

--- a/src/features/Conversation/Messages/Group/Tool/index.tsx
+++ b/src/features/Conversation/Messages/Group/Tool/index.tsx
@@ -1,5 +1,5 @@
-import { ChatToolResult } from '@lobechat/types';
-import { CSSProperties, memo, useState } from 'react';
+import { ChatToolResult, ToolIntervention } from '@lobechat/types';
+import { CSSProperties, memo, useEffect, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import AnimatedCollapsed from '@/components/AnimatedCollapsed';
@@ -13,6 +13,7 @@ export interface GroupToolProps {
   id: string;
   identifier: string;
   index: number;
+  intervention?: ToolIntervention;
   /**
    * ContentBlock ID (not the group message ID)
    */
@@ -29,10 +30,29 @@ export interface GroupToolProps {
  * so we always show the results directly.
  */
 const Tool = memo<GroupToolProps>(
-  ({ arguments: requestArgs, apiName, messageId, id, index, identifier, style, result, type }) => {
+  ({
+    arguments: requestArgs,
+    apiName,
+    messageId,
+    id,
+    intervention,
+    index,
+    identifier,
+    style,
+    result,
+    type,
+  }) => {
     // Default to false since group messages are all completed
-    const [showDetail, setShowDetail] = useState(false);
-    const [showPluginRender, setShowPluginRender] = useState(false);
+
+    const [showToolContent, setShowToolDetail] = useState(false);
+    const [showCustomPluginUI, setShowCustomPluginUI] = useState(false);
+
+    console.log(intervention);
+    useEffect(() => {
+      if (intervention?.status === 'pending') {
+        setShowToolDetail(true);
+      }
+    }, [intervention?.status]);
 
     return (
       <Flexbox gap={8} style={style}>
@@ -42,23 +62,25 @@ const Tool = memo<GroupToolProps>(
           id={id}
           identifier={identifier}
           index={index}
+          intervention={intervention}
           messageId={messageId}
           result={result}
-          setShowPluginRender={setShowPluginRender}
-          setShowRender={setShowDetail}
-          showPluginRender={showPluginRender}
-          showRender={showDetail}
+          setShowPluginRender={setShowCustomPluginUI}
+          setShowRender={setShowToolDetail}
+          showPluginRender={showCustomPluginUI}
+          showRender={showToolContent}
           type={type}
         />
-        <AnimatedCollapsed open={showDetail} width={{ collapsed: 'auto' }}>
+        <AnimatedCollapsed open={showToolContent} width={{ collapsed: 'auto' }}>
           <Render
             apiName={apiName}
             arguments={requestArgs}
             identifier={identifier}
+            intervention={intervention}
             messageId={messageId}
             result={result}
-            setShowPluginRender={setShowPluginRender}
-            showPluginRender={showPluginRender}
+            setShowPluginRender={setShowCustomPluginUI}
+            showPluginRender={showCustomPluginUI}
             toolCallId={id}
             type={type}
           />

--- a/src/features/Conversation/Messages/Group/Tools.tsx
+++ b/src/features/Conversation/Messages/Group/Tools.tsx
@@ -32,13 +32,14 @@ export const Tools = memo<ToolsRendererProps>(({ messageId, tools }) => {
         <Tool
           apiName={tool.apiName}
           arguments={tool.arguments}
+          assistantMessageId={messageId}
           id={tool.id}
           identifier={tool.identifier}
           index={index}
           intervention={tool.intervention}
           key={tool.id}
-          messageId={messageId}
           result={tool.result}
+          toolMessageId={tool.result_msg_id}
           type={tool.type}
         />
       ))}

--- a/src/features/Conversation/Messages/Group/Tools.tsx
+++ b/src/features/Conversation/Messages/Group/Tools.tsx
@@ -35,6 +35,7 @@ export const Tools = memo<ToolsRendererProps>(({ messageId, tools }) => {
           id={tool.id}
           identifier={tool.identifier}
           index={index}
+          intervention={tool.intervention}
           key={tool.id}
           messageId={messageId}
           result={tool.result}

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -401,8 +401,19 @@ export default {
   tool: {
     intervention: {
       approve: '批准',
+      approveAndRemember: '批准并记住',
+      approveOnce: '仅本次批准',
+      mode: {
+        allowList: '白名单',
+        allowListDesc: '仅自动执行已批准的工具',
+        autoRun: '自动批准',
+        autoRunDesc: '自动批准所有工具执行',
+        manual: '手动',
+        manualDesc: '每次调用都需要手动批准',
+      },
       reject: '拒绝',
-      rememberDecision: '记住决策',
+      rejectReasonPlaceholder: '输入拒绝原因将帮助 Agent 理解并优化后续行动',
+      rejectTitle: '拒绝本次工具调用',
     },
   },
   topic: {

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -398,6 +398,13 @@ export default {
     remained: '剩余',
     used: '使用',
   },
+  tool: {
+    intervention: {
+      approve: '批准',
+      reject: '拒绝',
+      rememberDecision: '记住决策',
+    },
+  },
   topic: {
     checkOpenNewTopic: '是否开启新话题?',
     checkSaveCurrentMessages: '是否保存当前会话为话题?',

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -416,6 +416,7 @@ export default {
       rejectTitle: '拒绝本次工具调用',
     },
   },
+  toolRejected: '本次工具调用被主动拒绝',
   topic: {
     checkOpenNewTopic: '是否开启新话题?',
     checkSaveCurrentMessages: '是否保存当前会话为话题?',

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -414,9 +414,10 @@ export default {
       reject: '拒绝',
       rejectReasonPlaceholder: '输入拒绝原因将帮助 Agent 理解并优化后续行动',
       rejectTitle: '拒绝本次工具调用',
+      rejectedWithReason: '本次工具调用被主动拒绝:{{reason}}',
+      toolRejected: '本次工具调用被主动拒绝',
     },
   },
-  toolRejected: '本次工具调用被主动拒绝',
   topic: {
     checkOpenNewTopic: '是否开启新话题?',
     checkSaveCurrentMessages: '是否保存当前会话为话题?',

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -138,6 +138,7 @@ export default {
     },
   },
   close: '关闭',
+  confirm: '确认',
   contact: '联系我们',
   copy: '复制',
   copyFail: '复制失败',

--- a/src/server/routers/lambda/message.ts
+++ b/src/server/routers/lambda/message.ts
@@ -179,11 +179,14 @@ export const messageRouter = router({
     .input(
       z.object({
         id: z.string(),
+        sessionId: z.string().nullable().optional(),
+        topicId: z.string().nullable().optional(),
         value: UpdateMessagePluginSchema.partial(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      return ctx.messageModel.updateMessagePlugin(input.id, input.value);
+      const { id, value, ...options } = input;
+      return ctx.messageService.updateMessagePlugin(id, value, options);
     }),
 
   updateMessageRAG: messageProcedure

--- a/src/server/services/message/index.ts
+++ b/src/server/services/message/index.ts
@@ -151,6 +151,19 @@ export class MessageService {
   }
 
   /**
+   * Update message plugin and return message list
+   * Pattern: update + conditional query
+   */
+  async updateMessagePlugin(
+    id: string,
+    value: any,
+    options: QueryOptions,
+  ): Promise<{ messages?: UIChatMessage[], success: boolean; }> {
+    await this.messageModel.updateMessagePlugin(id, value);
+    return this.queryWithSuccess(options);
+  }
+
+  /**
    * Update message and return message list
    * Pattern: update + conditional query
    */

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -6,6 +6,7 @@ import {
   CreateMessageParams,
   CreateMessageResult,
   MessageMetadata,
+  MessagePluginItem,
   ModelRankItem,
   UIChatMessage,
   UpdateMessageParams,
@@ -77,8 +78,9 @@ export class MessageService {
   };
 
   updateMessageError = async (id: string, value: ChatMessageError) => {
-    const error = value.type ? value : { body: value, message: value.message, type: 'ApplicationRuntimeError' };
-
+    const error = value.type
+      ? value
+      : { body: value, message: value.message, type: 'ApplicationRuntimeError' };
 
     return lambdaClient.message.update.mutate({ id, value: { error } });
   };
@@ -155,7 +157,7 @@ export class MessageService {
 
   updateMessagePlugin = async (
     id: string,
-    value: Record<string, any>,
+    value: Partial<Omit<MessagePluginItem, 'id'>>,
     options?: { sessionId?: string | null; topicId?: string | null },
   ): Promise<UpdateMessageResult> => {
     return lambdaClient.message.updateMessagePlugin.mutate({

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -153,6 +153,19 @@ export class MessageService {
     });
   };
 
+  updateMessagePlugin = async (
+    id: string,
+    value: Record<string, any>,
+    options?: { sessionId?: string | null; topicId?: string | null },
+  ): Promise<UpdateMessageResult> => {
+    return lambdaClient.message.updateMessagePlugin.mutate({
+      id,
+      sessionId: options?.sessionId,
+      topicId: options?.topicId,
+      value,
+    });
+  };
+
   updateMessageRAG = async (
     id: string,
     data: UpdateMessageRAGParams,

--- a/src/store/chat/agents/GeneralChatAgent.ts
+++ b/src/store/chat/agents/GeneralChatAgent.ts
@@ -213,6 +213,7 @@ export class GeneralChatAgent implements Agent {
           return {
             pendingToolsCalling: pendingTools,
             reason: 'Some tools still pending approval',
+            skipCreateToolMessage: true,
             type: 'request_human_approve',
           };
         }

--- a/src/store/chat/agents/GeneralChatAgent.ts
+++ b/src/store/chat/agents/GeneralChatAgent.ts
@@ -9,26 +9,85 @@ import {
   GeneralAgentCallToolsBatchInstructionPayload,
   GeneralAgentCallingToolInstructionPayload,
   GeneralAgentConfig,
+  InterventionChecker,
 } from '@lobechat/agent-runtime';
+import type { ChatToolPayload, HumanInterventionConfig } from '@lobechat/types';
 
 /**
  * ChatAgent - The "Brain" of the chat agent
  *
  * This agent implements a simple but powerful decision loop:
  * 1. user_input → call_llm (with optional RAG/Search preprocessing)
- * 2. llm_result → check for tool_calls
- *    - If has tool_calls → call_tools_batch (parallel execution)
- *    - If no tool_calls → finish
+ * 2. llm_result → check for tool_calls and intervention requirements
+ *    - Tools not requiring intervention → call_tools_batch (execute immediately)
+ *    - Tools requiring intervention → request_human_approve (wait for approval)
+ *    - Mixed (both types) → [call_tools_batch, request_human_approve] (execute safe ones first, then request approval)
+ *    - No tool_calls → finish
  * 3. tools_batch_result → call_llm (process tool results)
  *
- * Note: RAG and Search workflow preprocessing are handled externally
- * before creating the agent runtime, keeping the agent logic simple.
  */
 export class GeneralChatAgent implements Agent {
   private config: GeneralAgentConfig;
 
   constructor(config: GeneralAgentConfig) {
     this.config = config;
+  }
+
+  /**
+   * Get intervention configuration for a specific tool call
+   */
+  private getToolInterventionConfig(
+    toolCalling: ChatToolPayload,
+    state: AgentState,
+  ): HumanInterventionConfig | undefined {
+    const { identifier, apiName } = toolCalling;
+    const manifest = state.toolManifestMap[identifier];
+
+    if (!manifest) return undefined;
+
+    // Find the specific API in the manifest
+    const api = manifest.api?.find((a: any) => a.name === apiName);
+
+    // API-level config takes precedence over tool-level config
+    return api?.humanIntervention ?? manifest.humanIntervention;
+  }
+
+  /**
+   * Check if tool calls need human intervention
+   * Returns [toolsNeedingIntervention, toolsToExecute]
+   */
+  private checkInterventionNeeded(
+    toolsCalling: ChatToolPayload[],
+    state: AgentState,
+  ): [ChatToolPayload[], ChatToolPayload[]] {
+    const toolsNeedingIntervention: ChatToolPayload[] = [];
+    const toolsToExecute: ChatToolPayload[] = [];
+
+    for (const toolCalling of toolsCalling) {
+      const config = this.getToolInterventionConfig(toolCalling, state);
+
+      // Parse arguments for intervention checking
+      let toolArgs: Record<string, any> = {};
+      try {
+        toolArgs = JSON.parse(toolCalling.arguments || '{}');
+      } catch {
+        // Invalid JSON, treat as empty args
+      }
+
+      const policy = InterventionChecker.shouldIntervene({
+        config,
+        toolArgs,
+      });
+
+      if (policy === 'never') {
+        toolsToExecute.push(toolCalling);
+      } else {
+        // 'require' or 'first' (when not confirmed) requires intervention
+        toolsNeedingIntervention.push(toolCalling);
+      }
+    }
+
+    return [toolsNeedingIntervention, toolsToExecute];
   }
 
   async runner(
@@ -55,26 +114,47 @@ export class GeneralChatAgent implements Agent {
           context.payload as GeneralAgentCallLLMResultPayload;
 
         if (hasToolsCalling && toolsCalling && toolsCalling.length > 0) {
-          // No intervention needed, proceed with tool execution
-          // Use batch execution for multiple tool calls to improve performance
-          if (toolsCalling.length > 1) {
-            return {
-              payload: {
-                parentMessageId,
-                toolsCalling,
-              } as GeneralAgentCallToolsBatchInstructionPayload,
-              type: 'call_tools_batch',
-            };
-          } else if (toolsCalling.length === 1) {
-            // Single tool executes directly
-            return {
-              payload: {
-                parentMessageId,
-                toolCalling: toolsCalling[0],
-              } as GeneralAgentCallingToolInstructionPayload,
-              type: 'call_tool',
-            };
+          // Check which tools need human intervention
+          const [toolsNeedingIntervention, toolsToExecute] = this.checkInterventionNeeded(
+            toolsCalling,
+            state,
+          );
+
+          const instructions: AgentInstruction[] = [];
+
+          // Execute tools that don't need intervention first
+          // These will run immediately before any approval requests
+          if (toolsToExecute.length > 0) {
+            if (toolsToExecute.length > 1) {
+              instructions.push({
+                payload: {
+                  parentMessageId,
+                  toolsCalling: toolsToExecute,
+                } as GeneralAgentCallToolsBatchInstructionPayload,
+                type: 'call_tools_batch',
+              });
+            } else {
+              instructions.push({
+                payload: {
+                  parentMessageId,
+                  toolCalling: toolsToExecute[0],
+                } as GeneralAgentCallingToolInstructionPayload,
+                type: 'call_tool',
+              });
+            }
           }
+
+          // Request approval for tools that need intervention
+          // Runtime will execute this after safe tools and pause with status='waiting_for_human'
+          if (toolsNeedingIntervention.length > 0) {
+            instructions.push({
+              pendingToolsCalling: toolsNeedingIntervention,
+              reason: 'human_intervention_required',
+              type: 'request_human_approve',
+            });
+          }
+
+          return instructions;
         }
 
         // No tool calls, conversation is complete

--- a/src/store/chat/agents/GeneralChatAgent.ts
+++ b/src/store/chat/agents/GeneralChatAgent.ts
@@ -168,6 +168,23 @@ export class GeneralChatAgent implements Agent {
       case 'tool_result': {
         const { parentMessageId } = context.payload as GeneralAgentCallToolResultPayload;
 
+        // Check if there are still pending tool messages waiting for approval
+        const pendingToolMessages = state.messages.filter(
+          (m: any) => m.role === 'tool' && m.pluginIntervention?.status === 'pending',
+        );
+
+        // If there are pending tools, wait for human approval
+        if (pendingToolMessages.length > 0) {
+          const pendingTools = pendingToolMessages.map((m: any) => m.plugin).filter(Boolean);
+
+          return {
+            pendingToolsCalling: pendingTools,
+            reason: 'Some tools still pending approval',
+            type: 'request_human_approve',
+          };
+        }
+
+        // No pending tools, continue to call LLM with tool results
         return {
           payload: {
             messages: state.messages,
@@ -182,6 +199,24 @@ export class GeneralChatAgent implements Agent {
 
       case 'tools_batch_result': {
         const { parentMessageId } = context.payload as GeneralAgentCallToolResultPayload;
+
+        // Check if there are still pending tool messages waiting for approval
+        const pendingToolMessages = state.messages.filter(
+          (m: any) => m.role === 'tool' && m.pluginIntervention?.status === 'pending',
+        );
+
+        // If there are pending tools, wait for human approval
+        if (pendingToolMessages.length > 0) {
+          const pendingTools = pendingToolMessages.map((m: any) => m.plugin).filter(Boolean);
+
+          return {
+            pendingToolsCalling: pendingTools,
+            reason: 'Some tools still pending approval',
+            type: 'request_human_approve',
+          };
+        }
+
+        // No pending tools, continue to call LLM with tool results
         return {
           payload: {
             messages: state.messages,

--- a/src/store/chat/agents/GeneralChatAgent.ts
+++ b/src/store/chat/agents/GeneralChatAgent.ts
@@ -180,6 +180,7 @@ export class GeneralChatAgent implements Agent {
           return {
             pendingToolsCalling: pendingTools,
             reason: 'Some tools still pending approval',
+            skipCreateToolMessage: true,
             type: 'request_human_approve',
           };
         }

--- a/src/store/chat/agents/__tests__/GeneralChatAgent.test.ts
+++ b/src/store/chat/agents/__tests__/GeneralChatAgent.test.ts
@@ -397,6 +397,7 @@ describe('GeneralChatAgent', () => {
         type: 'request_human_approve',
         pendingToolsCalling: [pendingPlugin],
         reason: 'Some tools still pending approval',
+        skipCreateToolMessage: true,
       });
     });
   });
@@ -477,6 +478,7 @@ describe('GeneralChatAgent', () => {
         type: 'request_human_approve',
         pendingToolsCalling: [pendingPlugin],
         reason: 'Some tools still pending approval',
+        skipCreateToolMessage: true,
       });
     });
   });

--- a/src/store/chat/agents/__tests__/GeneralChatAgent.test.ts
+++ b/src/store/chat/agents/__tests__/GeneralChatAgent.test.ts
@@ -1,0 +1,603 @@
+import { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
+import { ChatToolPayload } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { GeneralChatAgent } from '../GeneralChatAgent';
+
+describe('GeneralChatAgent', () => {
+  const mockModelRuntimeConfig = {
+    model: 'gpt-4o-mini',
+    provider: 'openai',
+  };
+
+  const createMockState = (overrides?: Partial<AgentState>): AgentState => ({
+    sessionId: 'test-session',
+    status: 'running',
+    messages: [],
+    toolManifestMap: {},
+    stepCount: 0,
+    usage: {
+      llm: { apiCalls: 0, processingTimeMs: 0, tokens: { input: 0, output: 0, total: 0 } },
+      tools: { totalCalls: 0, totalTimeMs: 0, byTool: [] },
+      humanInteraction: {
+        approvalRequests: 0,
+        promptRequests: 0,
+        selectRequests: 0,
+        totalWaitingTimeMs: 0,
+      },
+    },
+    cost: {
+      calculatedAt: new Date().toISOString(),
+      currency: 'USD',
+      llm: { byModel: [], currency: 'USD', total: 0 },
+      tools: { byTool: [], currency: 'USD', total: 0 },
+      total: 0,
+    },
+    createdAt: new Date().toISOString(),
+    lastModified: new Date().toISOString(),
+    ...overrides,
+  });
+
+  const createMockContext = (
+    phase: AgentRuntimeContext['phase'],
+    payload?: any,
+  ): AgentRuntimeContext => ({
+    phase,
+    payload,
+    session: {
+      sessionId: 'test-session',
+      messageCount: 0,
+      status: 'running',
+      stepCount: 0,
+    },
+  });
+
+  describe('init and user_input phase', () => {
+    it('should return call_llm instruction for init phase', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        messages: [{ role: 'user', content: 'Hello' }] as any,
+      });
+      const context = createMockContext('init', { model: 'gpt-4o-mini', provider: 'openai' });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          provider: 'openai',
+        },
+      });
+    });
+
+    it('should return call_llm instruction for user_input phase', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        messages: [{ role: 'user', content: 'What is the weather?' }] as any,
+      });
+      const context = createMockContext('user_input', {
+        message: { role: 'user', content: 'What is the weather?' },
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          message: { role: 'user', content: 'What is the weather?' },
+        },
+      });
+    });
+  });
+
+  describe('llm_result phase', () => {
+    it('should return finish when no tool calls', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState();
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: false,
+        toolsCalling: [],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'finish',
+        reason: 'completed',
+        reasonDetail: 'LLM response completed without tool calls',
+      });
+    });
+
+    it('should return call_tool for single tool that does not need intervention', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const toolCall: ChatToolPayload = {
+        id: 'call-1',
+        identifier: 'test-plugin',
+        apiName: 'test-api',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        toolManifestMap: {
+          'test-plugin': {
+            identifier: 'test-plugin',
+            // No humanIntervention config = no intervention needed
+          },
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: [toolCall],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual([
+        {
+          type: 'call_tool',
+          payload: {
+            parentMessageId: 'msg-1',
+            toolCalling: toolCall,
+          },
+        },
+      ]);
+    });
+
+    it('should return call_tools_batch for multiple tools that do not need intervention', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const toolCalls: ChatToolPayload[] = [
+        {
+          id: 'call-1',
+          identifier: 'plugin-1',
+          apiName: 'api-1',
+          arguments: '{}',
+          type: 'default',
+        },
+        {
+          id: 'call-2',
+          identifier: 'plugin-2',
+          apiName: 'api-2',
+          arguments: '{}',
+          type: 'default',
+        },
+      ];
+
+      const state = createMockState({
+        toolManifestMap: {
+          'plugin-1': { identifier: 'plugin-1' },
+          'plugin-2': { identifier: 'plugin-2' },
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: toolCalls,
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual([
+        {
+          type: 'call_tools_batch',
+          payload: {
+            parentMessageId: 'msg-1',
+            toolsCalling: toolCalls,
+          },
+        },
+      ]);
+    });
+
+    it('should return request_human_approve for tools requiring intervention', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const toolCall: ChatToolPayload = {
+        id: 'call-1',
+        identifier: 'dangerous-plugin',
+        apiName: 'delete-api',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        toolManifestMap: {
+          'dangerous-plugin': {
+            identifier: 'dangerous-plugin',
+            humanIntervention: 'require', // Always require approval
+          },
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: [toolCall],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual([
+        {
+          type: 'request_human_approve',
+          pendingToolsCalling: [toolCall],
+          reason: 'human_intervention_required',
+        },
+      ]);
+    });
+
+    it('should return both call_tools_batch and request_human_approve for mixed tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const safeTool: ChatToolPayload = {
+        id: 'call-1',
+        identifier: 'safe-plugin',
+        apiName: 'read-api',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const dangerousTool: ChatToolPayload = {
+        id: 'call-2',
+        identifier: 'dangerous-plugin',
+        apiName: 'delete-api',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        toolManifestMap: {
+          'safe-plugin': {
+            identifier: 'safe-plugin',
+            // No intervention
+          },
+          'dangerous-plugin': {
+            identifier: 'dangerous-plugin',
+            humanIntervention: 'require',
+          },
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: [safeTool, dangerousTool],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual([
+        {
+          type: 'call_tool',
+          payload: {
+            parentMessageId: 'msg-1',
+            toolCalling: safeTool,
+          },
+        },
+        {
+          type: 'request_human_approve',
+          pendingToolsCalling: [dangerousTool],
+          reason: 'human_intervention_required',
+        },
+      ]);
+    });
+  });
+
+  describe('tool_result phase', () => {
+    it('should return call_llm when no pending tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '', tools: [] },
+          { role: 'tool', content: 'Result', tool_call_id: 'call-1' },
+        ] as any,
+      });
+
+      const context = createMockContext('tool_result', {
+        parentMessageId: 'tool-msg-1',
+        result: { data: 'result' },
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-1',
+          provider: 'openai',
+          tools: undefined,
+        },
+      });
+    });
+
+    it('should return request_human_approve when there are pending tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const pendingPlugin: ChatToolPayload = {
+        id: 'call-2',
+        identifier: 'plugin-2',
+        apiName: 'api-2',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '', tools: [] },
+          { role: 'tool', content: 'Result', tool_call_id: 'call-1' },
+          {
+            role: 'tool',
+            content: '',
+            tool_call_id: 'call-2',
+            plugin: pendingPlugin,
+            pluginIntervention: { status: 'pending' },
+          },
+        ] as any,
+      });
+
+      const context = createMockContext('tool_result', {
+        parentMessageId: 'tool-msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'request_human_approve',
+        pendingToolsCalling: [pendingPlugin],
+        reason: 'Some tools still pending approval',
+      });
+    });
+  });
+
+  describe('tools_batch_result phase', () => {
+    it('should return call_llm when no pending tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '', tools: [] },
+          { role: 'tool', content: 'Result 1', tool_call_id: 'call-1' },
+          { role: 'tool', content: 'Result 2', tool_call_id: 'call-2' },
+        ] as any,
+      });
+
+      const context = createMockContext('tools_batch_result', {
+        parentMessageId: 'tool-msg-2',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-2',
+          provider: 'openai',
+          tools: undefined,
+        },
+      });
+    });
+
+    it('should return request_human_approve when there are pending tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const pendingPlugin: ChatToolPayload = {
+        id: 'call-3',
+        identifier: 'plugin-3',
+        apiName: 'api-3',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '', tools: [] },
+          { role: 'tool', content: 'Result 1', tool_call_id: 'call-1' },
+          { role: 'tool', content: 'Result 2', tool_call_id: 'call-2' },
+          {
+            role: 'tool',
+            content: '',
+            tool_call_id: 'call-3',
+            plugin: pendingPlugin,
+            pluginIntervention: { status: 'pending' },
+          },
+        ] as any,
+      });
+
+      const context = createMockContext('tools_batch_result', {
+        parentMessageId: 'tool-msg-2',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'request_human_approve',
+        pendingToolsCalling: [pendingPlugin],
+        reason: 'Some tools still pending approval',
+      });
+    });
+  });
+
+  describe('error phase', () => {
+    it('should return finish instruction with error details', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState();
+      const errorMessage = 'Network timeout';
+      const context = createMockContext('error', {
+        error: new Error(errorMessage),
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'finish',
+        reason: 'error_recovery',
+        reasonDetail: errorMessage,
+      });
+    });
+
+    it('should handle error without message', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState();
+      const context = createMockContext('error', { error: {} });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'finish',
+        reason: 'error_recovery',
+        reasonDetail: 'Unknown error occurred',
+      });
+    });
+  });
+
+  describe('unknown phase', () => {
+    it('should return finish instruction for unknown phase', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState();
+      const context = createMockContext('unknown_phase' as any);
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'finish',
+        reason: 'agent_decision',
+        reasonDetail: 'Unknown phase: unknown_phase',
+      });
+    });
+  });
+
+  describe('intervention checking', () => {
+    it('should check intervention at API level when configured', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        sessionId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const toolCall: ChatToolPayload = {
+        id: 'call-1',
+        identifier: 'plugin',
+        apiName: 'dangerous-api',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        toolManifestMap: {
+          plugin: {
+            identifier: 'plugin',
+            // Tool-level config
+            humanIntervention: 'never',
+            api: [
+              {
+                name: 'safe-api',
+                // Safe API
+              },
+              {
+                name: 'dangerous-api',
+                // API-level config overrides tool-level
+                humanIntervention: 'require',
+              },
+            ],
+          },
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: [toolCall],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      // Should require approval because API-level config overrides
+      expect(result).toEqual([
+        {
+          type: 'request_human_approve',
+          pendingToolsCalling: [toolCall],
+          reason: 'human_intervention_required',
+        },
+      ]);
+    });
+  });
+});

--- a/src/store/chat/agents/createToolEngine.ts
+++ b/src/store/chat/agents/createToolEngine.ts
@@ -1,0 +1,22 @@
+import { WorkingModel } from '@lobechat/types';
+
+import { getSearchConfig } from '@/helpers/getSearchConfig';
+import { createToolsEngine } from '@/helpers/toolEngineering';
+import { WebBrowsingManifest } from '@/tools/web-browsing';
+
+export const createAgentToolsEngine = (workingModel: WorkingModel) =>
+  createToolsEngine({
+    // Add WebBrowsingManifest as default tool
+    defaultToolIds: [WebBrowsingManifest.identifier],
+    // Create search-aware enableChecker for this request
+    enableChecker: ({ pluginId }) => {
+      // For WebBrowsingManifest, apply search logic
+      if (pluginId === WebBrowsingManifest.identifier) {
+        const searchConfig = getSearchConfig(workingModel.model, workingModel.provider);
+        return searchConfig.useApplicationBuiltinSearchTool;
+      }
+
+      // For all other plugins, enable by default
+      return true;
+    },
+  });

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -1,12 +1,17 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 // Disable the auto sort key eslint rule to make the code more logic and readable
+import { AgentRuntime, type AgentRuntimeContext } from '@lobechat/agent-runtime';
 import { MESSAGE_CANCEL_FLAT } from '@lobechat/const';
 import { produce } from 'immer';
 import { StateCreator } from 'zustand/vanilla';
 
+import { getAgentStoreState } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/slices/chat';
+import { createAgentToolsEngine } from '@/store/chat/agents/createToolEngine';
 import { ChatStore } from '@/store/chat/store';
 import { setNamespace } from '@/utils/storeDebug';
 
+import { displayMessageSelectors } from '../../../selectors';
 import { messageMapKey } from '../../../utils/messageMapKey';
 import { dbMessageSelectors } from '../../message/selectors';
 import { MainSendMessageOperation } from '../initialState';
@@ -141,10 +146,78 @@ export const conversationControl: StateCreator<
     }
   },
   approveToolCalling: async (toolMessageId) => {
-    // Optimistic update - update intervention status to approved
-    await get().optimisticUpdatePlugin(toolMessageId, {
-      intervention: { status: 'approved' },
+    const { activeId, activeTopicId, activeThreadId, internal_execAgentRuntime } = get();
+
+    // 1. Get tool message and verify it exists
+    const toolMessage = dbMessageSelectors.getDbMessageById(toolMessageId)(get());
+    if (!toolMessage) return;
+
+    // 2. Update intervention status to approved
+    await get().optimisticUpdatePlugin(toolMessageId, { intervention: { status: 'approved' } });
+
+    // 3. Get current messages for state construction
+    const currentMessages = displayMessageSelectors.mainAIChats(get());
+
+    // 4. Get agent configuration and tools information
+    const agentStoreState = getAgentStoreState();
+    const agentConfigData = agentSelectors.currentAgentConfig(agentStoreState);
+
+    const toolsEngine = createAgentToolsEngine({
+      model: agentConfigData.model,
+      provider: agentConfigData.provider!,
     });
+    const { enabledToolIds } = toolsEngine.generateToolsDetailed({
+      model: agentConfigData.model,
+      provider: agentConfigData.provider!,
+      toolIds: agentConfigData.plugins,
+    });
+    const toolManifestMap = Object.fromEntries(
+      toolsEngine.getEnabledPluginManifests(enabledToolIds).entries(),
+    );
+
+    // 5. Construct AgentState
+    const state = AgentRuntime.createInitialState({
+      sessionId: activeId,
+      messages: currentMessages,
+      maxSteps: 400,
+      metadata: {
+        sessionId: activeId,
+        topicId: activeTopicId,
+        threadId: activeThreadId,
+      },
+      toolManifestMap,
+    });
+
+    console.log('toolMessage:', toolMessage);
+    // 6. Construct AgentRuntimeContext with 'human_approved_tool' phase
+    const context: AgentRuntimeContext = {
+      phase: 'human_approved_tool',
+      payload: {
+        approvedToolCall: toolMessage.plugin,
+        parentMessageId: toolMessageId,
+        skipCreateToolMessage: true,
+      },
+      session: {
+        sessionId: activeId,
+        messageCount: currentMessages.length,
+        status: 'running',
+        stepCount: 0,
+      },
+    };
+
+    // 7. Execute agent runtime from tool message position
+    try {
+      await internal_execAgentRuntime({
+        messages: currentMessages,
+        parentMessageId: toolMessageId, // Start from tool message
+        parentMessageType: 'tool', // Type is 'tool'
+        threadId: activeThreadId,
+        initialState: state,
+        initialContext: context,
+      });
+    } catch (error) {
+      console.error('[approveToolCalling] Error executing agent runtime:', error);
+    }
   },
 
   rejectToolCalling: async (messageId, reason) => {

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -33,6 +33,14 @@ export interface ConversationControlAction {
    */
   switchMessageBranch: (messageId: string, branchIndex: number) => Promise<void>;
   /**
+   * Approve tool intervention
+   */
+  approveToolCalling: (messageId: string, toolCallId: string) => Promise<void>;
+  /**
+   * Reject tool intervention
+   */
+  rejectToolCalling: (messageId: string, reason?: string) => Promise<void>;
+  /**
    * Toggle sendMessage operation state
    */
   internal_toggleSendMessageOperation: (

--- a/src/store/chat/slices/message/reducer.ts
+++ b/src/store/chat/slices/message/reducer.ts
@@ -3,6 +3,7 @@ import {
   ChatPluginPayload,
   ChatToolPayload,
   CreateMessageParams,
+  MessagePluginItem,
   UIChatMessage,
 } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
@@ -47,7 +48,7 @@ interface UpdatePluginState {
 interface UpdateMessagePlugin {
   id: string;
   type: 'updateMessagePlugin';
-  value: Partial<ChatPluginPayload>;
+  value: Partial<MessagePluginItem>;
 }
 
 interface UpdateMessageTools {

--- a/src/store/user/slices/settings/action.ts
+++ b/src/store/user/slices/settings/action.ts
@@ -18,6 +18,7 @@ import { difference } from '@/utils/difference';
 import { merge } from '@/utils/merge';
 
 export interface UserSettingsAction {
+  addToolToAllowList: (toolKey: string) => Promise<void>;
   importAppSettings: (settings: UserSettings) => Promise<void>;
   importUrlShareSettings: (settingsParams: string | null) => Promise<void>;
   internal_createSignal: () => AbortController;
@@ -39,6 +40,20 @@ export const createSettingsSlice: StateCreator<
   [],
   UserSettingsAction
 > = (set, get) => ({
+  addToolToAllowList: async (toolKey) => {
+    const currentAllowList = get().settings.tool?.humanIntervention?.allowList || [];
+
+    if (currentAllowList.includes(toolKey)) return;
+
+    await get().setSettings({
+      tool: {
+        humanIntervention: {
+          allowList: [...currentAllowList, toolKey],
+        },
+      },
+    });
+  },
+
   importAppSettings: async (importAppSettings) => {
     const { setSettings } = get();
 

--- a/src/tools/web-browsing/index.ts
+++ b/src/tools/web-browsing/index.ts
@@ -14,7 +14,6 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
     {
       description:
         'a search service. Useful for when you need to answer questions about current events. Input should be a search query. Output is a JSON array of the query results',
-      humanIntervention: 'require',
       name: WebBrowsingApiName.search,
       parameters: {
         properties: {

--- a/src/tools/web-browsing/index.ts
+++ b/src/tools/web-browsing/index.ts
@@ -14,6 +14,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
     {
       description:
         'a search service. Useful for when you need to answer questions about current events. Input should be a search query. Output is a JSON array of the query results',
+      humanIntervention: 'require',
       name: WebBrowsingApiName.search,
       parameters: {
         properties: {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add human-in-the-loop support for tool invocations: introduce approval workflows in the agent runtime, expose new settings and UI controls for tool approval modes, and enable resuming execution after manual approval or rejection.

New Features:
- Add human intervention flow for tool calls in the agent runtime, including a 'request_human_approve' instruction and resume capability with 'human_approved_tool' phase
- Implement user-configurable tool approval modes (auto-run, allow-list, manual) and a persistent allow-list setting
- Introduce UI components (ModeSelector, Intervention panel, ApprovalActions, RejectedResponse, KeyValueEditor) for in-chat approval and rejection of tool invocations
- Extend conversation control actions with approveToolCalling and rejectToolCalling to drive the approval workflow

Enhancements:
- Refactor tool executor to reuse or create tool messages based on skipCreateToolMessage flag and support optimistic plugin updates
- Extend streamingExecutor to accept initialState and initialContext parameters for runtime resumption
- Simplify InterventionChecker to default to 'require' policy for unmatched rules and update its tests accordingly

Documentation:
- Add localization strings for tool intervention UI under chat.tool.intervention

Tests:
- Update InterventionChecker and AgentRuntime unit tests to align with new 'require' policy and human approval flows