### PR TITLE
📌 chore: pin eta to 4.0.1 to fix ERR_PACKAGE_PATH_NOT_EXPORTED error

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
       "eslint --fix"
     ]
   },
+  "overrides": {
+    "eta": "4.0.1"
+  },
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
     "@ant-design/pro-components": "^2.8.10",

--- a/package.json
+++ b/package.json
@@ -397,6 +397,9 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@vercel/speed-insights"
-    ]
+    ],
+    "overrides": {
+      "eta": "4.0.1"
+    }
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Fixes the `ERR_PACKAGE_PATH_NOT_EXPORTED` error caused by eta v4.x ESM-only module changes.

#### 🔀 Description of Change

Pin `eta` dependency to version 4.0.1 using pnpm overrides to resolve module export issues.

**Root Cause:**
- `eta` v4.x became ESM-only and changed its `exports` configuration
- `oidc-provider` depends on `eta/core` which is not properly exported in newer versions
- This caused `ERR_PACKAGE_PATH_NOT_EXPORTED` errors in test environments

**Solution:**
- Added `pnpm.overrides` configuration to lock `eta` at version 4.0.1
- This version maintains compatibility with `oidc-provider` while avoiding the export issues

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verify by running:
```bash
pnpm list eta
# Should show: eta 4.0.1
```

#### 📝 Additional Information

This is a temporary fix until `oidc-provider` updates its dependency or `eta` provides better backward compatibility in newer versions.