### PR TITLE
🐛 fix: filter out reasoning fields from messages in ChatCompletion API

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -150,6 +150,64 @@ describe('convertOpenAIMessages', () => {
 
     expect(Promise.all).toHaveBeenCalledTimes(2); // 一次用于消息数组，一次用于内容数组
   });
+
+  it('should filter out reasoning field from messages', async () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'Hello',
+        reasoning: { content: 'some reasoning', duration: 100 },
+      },
+      { role: 'user', content: 'Hi' },
+    ] as any;
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual([
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'Hi' },
+    ]);
+    // Ensure reasoning field is removed
+    expect((result[0] as any).reasoning).toBeUndefined();
+  });
+
+  it('should filter out reasoning_content field from messages', async () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'Hello',
+        reasoning_content: 'some reasoning content',
+      },
+      { role: 'user', content: 'Hi' },
+    ] as any;
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual([
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'Hi' },
+    ]);
+    // Ensure reasoning_content field is removed
+    expect((result[0] as any).reasoning_content).toBeUndefined();
+  });
+
+  it('should filter out both reasoning and reasoning_content fields from messages', async () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'Hello',
+        reasoning: { content: 'some reasoning', duration: 100 },
+        reasoning_content: 'some reasoning content',
+      },
+    ] as any;
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual([{ role: 'assistant', content: 'Hello' }]);
+    // Ensure both fields are removed
+    expect((result[0] as any).reasoning).toBeUndefined();
+    expect((result[0] as any).reasoning_content).toBeUndefined();
+  });
 });
 
 describe('convertOpenAIResponseInputs', () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -766,12 +766,12 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
       const inputStartAt = Date.now();
 
-      const { messages, reasoning_effort, tools, reasoning, responseMode, ...res } =
+      const { messages, reasoning_effort, tools, reasoning, responseMode, max_tokens, ...res } =
         responses?.handlePayload
           ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
           : payload;
 
-      // remove penalty params
+      // remove penalty params and chat completion specific params
       delete res.apiMode;
       delete res.frequency_penalty;
       delete res.presence_penalty;
@@ -797,6 +797,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             }
           : {}),
         input,
+        ...(max_tokens && { max_output_tokens: max_tokens }),
         store: false,
         stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -409,6 +409,50 @@ describe('LobeOpenAI', () => {
       const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
       expect(createCall.reasoning).toEqual({ effort: 'high', summary: 'auto' });
     });
+
+    it('should convert max_tokens to max_output_tokens for responses API', async () => {
+      const payload = {
+        max_tokens: 2048,
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'o1-pro',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.max_output_tokens).toBe(2048);
+      expect(createCall.max_tokens).toBeUndefined();
+    });
+
+    it('should not include max_output_tokens when max_tokens is undefined', async () => {
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'o1-pro',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.max_output_tokens).toBeUndefined();
+    });
+
+    it('should convert max_tokens to max_output_tokens for search-enabled models', async () => {
+      const payload = {
+        enabledSearch: true,
+        max_tokens: 4096,
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'gpt-4o',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.max_output_tokens).toBe(4096);
+      expect(createCall.max_tokens).toBeUndefined();
+    });
   });
 
   describe('supportsFlexTier', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #10193

#### 🔀 Description of Change

This PR fixes the JSON unmarshaling error that occurs when sending conversation history containing reasoning objects to the ChatCompletion API.

**Problem:**
When using models like `claude-sonnet-4-5-thinking-all`, the first request succeeds and returns a response with a `reasoning` object. However, when this message is included in the conversation history for the second request, the backend API fails with:
```
json: cannot unmarshal object into Go struct field Message.messages.reasoning of type string
```

**Solution:**
Modified `convertOpenAIMessages` function to explicitly map only valid `ChatCompletionMessageParam` fields:
- Required fields: `role`, `content`
- Optional fields: `name`, `tool_calls`, `tool_call_id`, `function_call`
- **Excluded fields:** `reasoning`, `reasoning_content`

This ensures these fields are filtered out before being sent to the API, preventing type mismatch errors.

**Changes:**
1. Rewrote `convertOpenAIMessages` to use explicit field mapping instead of spread operator
2. Added 3 test cases to verify filtering behavior
3. All 23 tests pass ✅

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Test commands:**
```bash
bunx vitest run --silent='passed-only' 'src/core/contextBuilders/openai'
```

**Manual test scenario:**
1. Start a conversation with `claude-sonnet-4-5-thinking-all` model
2. Send first message - should succeed
3. Send second message with conversation history - should now succeed (previously failed)

#### 📝 Additional Information

- This aligns with the behavior in Responses API path where `reasoning` field is already being removed
- No breaking changes
- Performance impact: negligible (just field filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix message conversion and response payload to prevent JSON unmarshaling errors and align parameter naming in the ChatCompletion and Responses APIs.

Bug Fixes:
- Filter out reasoning and reasoning_content fields from messages in convertOpenAIMessages

Enhancements:
- Convert max_tokens to max_output_tokens when sending payloads to the Responses API for both standard and search-enabled models

Tests:
- Add tests to verify filtering of reasoning fields and conversion of max_tokens to max_output_tokens