### PR TITLE
📌 chore: pin electron to 38.x

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,7 +52,7 @@
     "@typescript/native-preview": "7.0.0-dev.20250711.1",
     "consola": "^3.1.0",
     "cookie": "^1.0.2",
-    "electron": "^39.1.0",
+    "electron": "^38.6.0",
     "electron-builder": "^26.0.12",
     "electron-is": "^3.0.0",
     "electron-log": "^5.3.3",


### PR DESCRIPTION
## Summary

- Pin electron version to 38.x for stability
- Downgrade from 39.1.0 to 38.6.0

## Change Type

- [x] 🔨 chore

## Test plan

- [x] Tested locally
- [x] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)