### PR TITLE
💄 style: revert background style

### DIFF
--- a/src/app/[variants]/(main)/chat/components/WorkspaceLayout.tsx
+++ b/src/app/[variants]/(main)/chat/components/WorkspaceLayout.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from 'antd-style';
 import { Suspense, memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
@@ -19,38 +18,30 @@ interface WorkspaceLayoutProps {
   mobile?: boolean;
 }
 
-const DesktopWorkspace = memo(() => {
-  const theme = useTheme();
-
-  return (
-    <>
-      <ChatHeaderDesktop />
-      <Flexbox
-        height={'100%'}
-        horizontal
-        style={{ overflow: 'hidden', position: 'relative' }}
-        width={'100%'}
-      >
-        <Flexbox
-          height={'100%'}
-          style={{ background: theme.colorBgContainer, overflow: 'hidden', position: 'relative' }}
-          width={'100%'}
-        >
-          <ConversationArea mobile={false} />
-        </Flexbox>
-        <Portal>
-          <Suspense fallback={<BrandTextLoading />}>
-            <PortalPanel mobile={false} />
-          </Suspense>
-        </Portal>
-        <TopicPanel>
-          <TopicSidebar mobile={false} />
-        </TopicPanel>
+const DesktopWorkspace = memo(() => (
+  <>
+    <ChatHeaderDesktop />
+    <Flexbox
+      height={'100%'}
+      horizontal
+      style={{ overflow: 'hidden', position: 'relative' }}
+      width={'100%'}
+    >
+      <Flexbox height={'100%'} style={{ overflow: 'hidden', position: 'relative' }} width={'100%'}>
+        <ConversationArea mobile={false} />
       </Flexbox>
-      <MainInterfaceTracker />
-    </>
-  );
-});
+      <Portal>
+        <Suspense fallback={<BrandTextLoading />}>
+          <PortalPanel mobile={false} />
+        </Suspense>
+      </Portal>
+      <TopicPanel>
+        <TopicSidebar mobile={false} />
+      </TopicPanel>
+    </Flexbox>
+    <MainInterfaceTracker />
+  </>
+));
 
 DesktopWorkspace.displayName = 'DesktopWorkspace';
 

--- a/src/features/Conversation/Messages/User/index.tsx
+++ b/src/features/Conversation/Messages/User/index.tsx
@@ -1,6 +1,6 @@
 import { UIChatMessage } from '@lobechat/types';
 import { Tag } from '@lobehub/ui';
-import { createStyles, useResponsive } from 'antd-style';
+import { useResponsive } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ReactNode, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -45,13 +45,6 @@ const remarkPlugins = markdownElements
   .map((element) => element.remarkPlugin)
   .filter(Boolean);
 
-const useUserStyles = createStyles(({ css, token }) => ({
-  messageContainer: css`
-    border: none;
-    background: ${token.colorFillTertiary};
-  `,
-}));
-
 const UserMessage = memo<UserMessageProps>(({ id, disableEditing, index }) => {
   const item = useChatStore(
     displayMessageSelectors.getDisplayMessageById(id),
@@ -63,8 +56,6 @@ const UserMessage = memo<UserMessageProps>(({ id, disableEditing, index }) => {
   const { t } = useTranslation('chat');
   const { mobile } = useResponsive();
   const avatar = useUserAvatar();
-  const { styles: userStyles } = useUserStyles();
-
   const title = useUserStore(userProfileSelectors.displayUserName);
 
   const displayMode = useAgentStore(agentChatConfigSelectors.displayMode);
@@ -174,7 +165,6 @@ const UserMessage = memo<UserMessageProps>(({ id, disableEditing, index }) => {
           >
             <Flexbox flex={1} style={{ maxWidth: '100%', minWidth: 0 }}>
               <MessageContent
-                className={userStyles.messageContainer}
                 editing={editing}
                 id={id}
                 markdownProps={markdownProps}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Revert previous style modifications in workspace layout and user messages to restore original component structure and styling

Enhancements:
- Simplify DesktopWorkspace by returning JSX directly, restore original nesting and move MainInterfaceTracker outside the inner Flexbox
- Remove useUserStyles hook and associated messageContainer styling from the UserMessage component