### PR TITLE
✨ feat: support DeepSeek Interleaved thinking

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -171,7 +171,7 @@ describe('convertOpenAIMessages', () => {
     expect((result[0] as any).reasoning).toBeUndefined();
   });
 
-  it('should filter out reasoning_content field from messages', async () => {
+  it('should preserve reasoning_content field from messages (for DeepSeek compatibility)', async () => {
     const messages = [
       {
         role: 'assistant',
@@ -184,14 +184,14 @@ describe('convertOpenAIMessages', () => {
     const result = await convertOpenAIMessages(messages);
 
     expect(result).toEqual([
-      { role: 'assistant', content: 'Hello' },
+      { role: 'assistant', content: 'Hello', reasoning_content: 'some reasoning content' },
       { role: 'user', content: 'Hi' },
     ]);
-    // Ensure reasoning_content field is removed
-    expect((result[0] as any).reasoning_content).toBeUndefined();
+    // Ensure reasoning_content field is preserved
+    expect((result[0] as any).reasoning_content).toBe('some reasoning content');
   });
 
-  it('should filter out both reasoning and reasoning_content fields from messages', async () => {
+  it('should filter out reasoning but preserve reasoning_content field', async () => {
     const messages = [
       {
         role: 'assistant',
@@ -203,10 +203,12 @@ describe('convertOpenAIMessages', () => {
 
     const result = await convertOpenAIMessages(messages);
 
-    expect(result).toEqual([{ role: 'assistant', content: 'Hello' }]);
-    // Ensure both fields are removed
+    expect(result).toEqual([
+      { role: 'assistant', content: 'Hello', reasoning_content: 'some reasoning content' },
+    ]);
+    // Ensure reasoning object is removed but reasoning_content is preserved
     expect((result[0] as any).reasoning).toBeUndefined();
-    expect((result[0] as any).reasoning_content).toBeUndefined();
+    expect((result[0] as any).reasoning_content).toBe('some reasoning content');
   });
 });
 

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -49,6 +49,9 @@ export const convertOpenAIMessages = async (messages: OpenAI.ChatCompletionMessa
       if (msg.tool_call_id !== undefined) result.tool_call_id = msg.tool_call_id;
       if (msg.function_call !== undefined) result.function_call = msg.function_call;
 
+      // it's compatible for DeepSeek
+      if (msg.reasoning_content !== undefined) result.reasoning_content = msg.reasoning_content;
+
       return result;
     }),
   )) as OpenAI.ChatCompletionMessageParam[];

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -20,6 +20,92 @@ testProvider({
 });
 
 describe('LobeDeepSeekAI - custom features', () => {
+  describe('chatCompletion.handlePayload', () => {
+    it('should transform reasoning object to reasoning_content string', () => {
+      const payload = {
+        messages: [
+          { role: 'user', content: 'Hello' },
+          {
+            role: 'assistant',
+            content: 'Hi there',
+            reasoning: { content: 'Let me think...', duration: 1000 },
+          },
+          { role: 'user', content: 'How are you?' },
+        ],
+        model: 'deepseek-r1',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: 'Hi there',
+          reasoning_content: 'Let me think...',
+        },
+        { role: 'user', content: 'How are you?' },
+      ]);
+    });
+
+    it('should not modify messages without reasoning field', () => {
+      const payload = {
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there' },
+        ],
+        model: 'deepseek-chat',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual(payload.messages);
+    });
+
+    it('should handle empty reasoning content', () => {
+      const payload = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Response',
+            reasoning: { duration: 1000 },
+          },
+        ],
+        model: 'deepseek-r1',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages[0]).toEqual({
+        role: 'assistant',
+        content: 'Response',
+      });
+    });
+
+    it('should set stream to true by default', () => {
+      const payload = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'deepseek-chat',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.stream).toBe(true);
+    });
+
+    it('should preserve existing stream value', () => {
+      const payload = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'deepseek-chat',
+        stream: false,
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.stream).toBe(false);
+    });
+  });
+
   describe('Debug Configuration', () => {
     it('should disable debug by default', () => {
       delete process.env.DEBUG_DEEPSEEK_CHAT_COMPLETION;

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -12,6 +12,30 @@ export interface DeepSeekModelCard {
 
 export const params = {
   baseURL: 'https://api.deepseek.com/v1',
+  chatCompletion: {
+    handlePayload: (payload) => {
+      // Transform reasoning object to reasoning_content string for multi-turn conversations
+      const messages = payload.messages.map((message: any) => {
+        // Only transform if message has reasoning.content
+        if (message.reasoning?.content) {
+          const { reasoning, ...rest } = message;
+          return {
+            ...rest,
+            reasoning_content: reasoning.content,
+          };
+        }
+        // If message has reasoning but no content, remove reasoning field entirely
+        delete message.reasoning;
+        return message;
+      });
+
+      return {
+        ...payload,
+        messages,
+        stream: payload.stream ?? true,
+      } as any;
+    },
+  },
   debug: {
     chatCompletion: () => process.env.DEBUG_DEEPSEEK_CHAT_COMPLETION === '1',
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

DeepSeek 已支持回传 `reasoning_content` ，不会报400错了，不过目前模型行为暂时不变。
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enable support for DeepSeek’s interleaved thinking by transforming reasoning objects into reasoning_content fields in chat payloads, defaulting streaming to true, and ensuring the OpenAI message builder preserves reasoning_content for compatibility.

New Features:
- Add chatCompletion.handlePayload in DeepSeek provider to convert multi-turn reasoning objects into reasoning_content strings and default stream to true

Enhancements:
- Update OpenAI message converter to retain reasoning_content for DeepSeek compatibility

Tests:
- Add unit tests for DeepSeek handlePayload transformations and streaming options
- Update OpenAI converter tests to expect reasoning_content preservation