### PR TITLE
🐛 fix: Reduce threshold

### DIFF
--- a/src/app/[variants]/(main)/chat/components/conversation/features/ChatMinimap/index.tsx
+++ b/src/app/[variants]/(main)/chat/components/conversation/features/ChatMinimap/index.tsx
@@ -5,6 +5,7 @@ import { Popover, Tooltip } from 'antd';
 import { createStyles, useTheme } from 'antd-style';
 import debug from 'debug';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import { markdownToTxt } from 'markdown-to-txt';
 import { memo, useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
@@ -23,7 +24,7 @@ const log = debug('lobe-react:chat-minimap');
 const MIN_WIDTH = 16;
 const MAX_WIDTH = 30;
 const MAX_CONTENT_LENGTH = 320;
-const MIN_MESSAGES = 4;
+const MIN_MESSAGES = 3;
 
 const useStyles = createStyles(({ css, token }) => ({
   arrow: css`
@@ -178,7 +179,8 @@ const getIndicatorWidth = (content: string | undefined) => {
 const getPreviewText = (content: string | undefined) => {
   if (!content) return '';
 
-  const normalized = content.replaceAll(/\s+/g, ' ').trim();
+  const plainText = markdownToTxt(content);
+  const normalized = plainText.replaceAll(/\s+/g, ' ').trim();
   if (!normalized) return '';
 
   return normalized.slice(0, 100) + (normalized.length > 100 ? '…' : '');


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Fix LOBE-828

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix chat minimap behavior by reducing the message threshold for the indicator and cleaning up preview text to remove markdown formatting.

Bug Fixes:
- Lower the minimum messages threshold in the chat minimap from 4 to 3.
- Strip markdown formatting from preview text by converting content to plain text before trimming.