### PR TITLE
🔨 chore: Support Interleaved thinking in kimi-k2-thinking

### DIFF
--- a/packages/model-bank/src/aiModels/moonshot.ts
+++ b/packages/model-bank/src/aiModels/moonshot.ts
@@ -5,6 +5,52 @@ const moonshotChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 262_144,
+    description: 'K2 长思考模型，支持 256k 上下文，支持多步工具调用与思考，擅长解决更复杂的问题。',
+    displayName: 'Kimi K2 Thinking',
+    enabled: true,
+    id: 'kimi-k2-thinking',
+    maxOutput: 65_536,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-06',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'K2 长思考模型的高速版本，支持 256k 上下文，擅长深度推理，输出速度提升至每秒 60-100 tokens 。',
+    displayName: 'Kimi K2 Thinking Turbo',
+    id: 'kimi-k2-thinking-turbo',
+    maxOutput: 65_536,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 58, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-06',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       structuredOutput: true,
     },
     contextWindowTokens: 262_144,

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -49,7 +49,7 @@ export const convertOpenAIMessages = async (messages: OpenAI.ChatCompletionMessa
       if (msg.tool_call_id !== undefined) result.tool_call_id = msg.tool_call_id;
       if (msg.function_call !== undefined) result.function_call = msg.function_call;
 
-      // it's compatible for DeepSeek
+      // it's compatible for DeepSeek & Moonshot
       if (msg.reasoning_content !== undefined) result.reasoning_content = msg.reasoning_content;
 
       return result;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

和 deepseek 类似的 Interleaved thinking 处理方法。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add two new Moonshot chat models (Kimi K2 Thinking and Turbo) and enable interleaved thinking flows by mapping reasoning fields into reasoning_content and updating message conversion for Moonshot support.

New Features:
- Introduce 'Kimi K2 Thinking' and 'Kimi K2 Thinking Turbo' models in the Moonshot catalog with extended context windows and pricing

Enhancements:
- Support interleaved thinking by extracting assistant message reasoning into reasoning_content in Moonshot payloads
- Extend OpenAI message conversion to recognize reasoning_content compatibility for Moonshot alongside DeepSeek