### PR TITLE
🐛 fix: the tool to fail execution on ollama when a message contains b…

### DIFF
--- a/packages/model-runtime/src/core/streams/ollama.ts
+++ b/packages/model-runtime/src/core/streams/ollama.ts
@@ -11,11 +11,6 @@ import {
 } from './protocol';
 
 const transformOllamaStream = (chunk: ChatResponse, stack: StreamContext): StreamProtocolChunk => {
-  // maybe need another structure to add support for multiple choices
-  if (chunk.done && !chunk.message.content) {
-    return { data: 'finished', id: stack.id, type: 'stop' };
-  }
-
   if (chunk.message.thinking) {
     return { data: chunk.message.thinking, id: stack.id, type: 'reasoning' };
   }
@@ -34,6 +29,11 @@ const transformOllamaStream = (chunk: ChatResponse, stack: StreamContext): Strea
       id: stack.id,
       type: 'tool_calls',
     };
+  }
+
+  // maybe need another structure to add support for multiple choices
+  if (chunk.done && !chunk.message.content) {
+    return { data: 'finished', id: stack.id, type: 'stop' };
   }
 
   // 判断是否有 <think> 或 </think> 标签，更新 thinkingInContent 状态


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #10258

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Workaround both "done" and "tool_calls" are returned in the same message

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Reposition the empty 'done' message check in the Ollama stream transformer to prevent premature termination when tool calls are included