### PR TITLE
✨ feat: support parallel topic agent runtime

### DIFF
--- a/src/app/[variants]/(main)/chat/components/topic/features/Topic/TopicListContent/TopicItem/TopicContent.tsx
+++ b/src/app/[variants]/(main)/chat/components/topic/features/Topic/TopicListContent/TopicItem/TopicContent.tsx
@@ -97,15 +97,15 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
       },
       ...(isDesktop
         ? [
-          {
-            icon: <Icon icon={ExternalLink} />,
-            key: 'openInNewWindow',
-            label: t('actions.openInNewWindow'),
-            onClick: () => {
-              openTopicInNewWindow(activeId, id);
+            {
+              icon: <Icon icon={ExternalLink} />,
+              key: 'openInNewWindow',
+              label: t('actions.openInNewWindow'),
+              onClick: () => {
+                openTopicInNewWindow(activeId, id);
+              },
             },
-          },
-        ]
+          ]
         : []),
       {
         type: 'divider',
@@ -153,9 +153,19 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
         },
       },
     ],
-    [id, activeId, autoRenameTopicTitle, duplicateTopic, removeTopic, t, toggleEditing, openTopicInNewWindow],
+    [
+      id,
+      activeId,
+      autoRenameTopicTitle,
+      duplicateTopic,
+      removeTopic,
+      t,
+      toggleEditing,
+      openTopicInNewWindow,
+    ],
   );
 
+  console.log(title, title === LOADING_FLAT);
   return (
     <Flexbox
       align={'center'}
@@ -180,7 +190,7 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
         spin={isLoading}
       />
       {!editing ? (
-        title === LOADING_FLAT ? (
+        title === LOADING_FLAT || (isLoading && !title) ? (
           <Flexbox flex={1} height={28} justify={'center'}>
             <BubblesLoading />
           </Flexbox>
@@ -190,7 +200,7 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
             ellipsis={{ rows: 1, tooltip: { placement: 'left', title } }}
             onDoubleClick={() => {
               if (isDesktop) {
-                openTopicInNewWindow(activeId, id)
+                openTopicInNewWindow(activeId, id);
               }
             }}
             style={{ margin: 0 }}

--- a/src/app/[variants]/(main)/chat/components/topic/features/Topic/TopicListContent/TopicItem/TopicContent.tsx
+++ b/src/app/[variants]/(main)/chat/components/topic/features/Topic/TopicListContent/TopicItem/TopicContent.tsx
@@ -165,7 +165,6 @@ const TopicContent = memo<TopicContentProps>(({ id, title, fav, showMore }) => {
     ],
   );
 
-  console.log(title, title === LOADING_FLAT);
   return (
     <Flexbox
       align={'center'}

--- a/src/app/[variants]/layout.tsx
+++ b/src/app/[variants]/layout.tsx
@@ -1,6 +1,7 @@
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { ThemeAppearance } from 'antd-style';
 import { ResolvingViewport } from 'next';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { ReactNode } from 'react';
 import { isRtlLang } from 'rtl-detect';
 
@@ -13,16 +14,14 @@ import GlobalProvider from '@/layout/GlobalProvider';
 import { Locales } from '@/locales/resources';
 import { DynamicLayoutProps } from '@/types/next';
 import { RouteVariants } from '@/utils/server/routeVariants';
-import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
 const inVercel = process.env.VERCEL === '1';
 
 interface RootLayoutProps extends DynamicLayoutProps {
   children: ReactNode;
-  modal: ReactNode;
 }
 
-const RootLayout = async ({ children, params, modal }: RootLayoutProps) => {
+const RootLayout = async ({ children, params }: RootLayoutProps) => {
   const { variants } = await params;
 
   const { locale, isMobile, theme, primaryColor, neutralColor } =
@@ -50,7 +49,6 @@ const RootLayout = async ({ children, params, modal }: RootLayoutProps) => {
           >
             <AuthProvider>
               {children}
-              {!isMobile && modal}
             </AuthProvider>
             <PWAInstall />
           </GlobalProvider>

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -77,12 +77,21 @@ export class MessageService {
     return lambdaClient.message.getHeatmaps.query();
   };
 
-  updateMessageError = async (id: string, value: ChatMessageError) => {
+  updateMessageError = async (
+    id: string,
+    value: ChatMessageError,
+    options?: { sessionId?: string | null; topicId?: string | null },
+  ) => {
     const error = value.type
       ? value
       : { body: value, message: value.message, type: 'ApplicationRuntimeError' };
 
-    return lambdaClient.message.update.mutate({ id, value: { error } });
+    return lambdaClient.message.update.mutate({
+      id,
+      sessionId: options?.sessionId,
+      topicId: options?.topicId,
+      value: { error },
+    });
   };
 
   updateMessagePluginArguments = async (id: string, value: string | Record<string, any>) => {

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -36,7 +36,9 @@ export const createAgentExecutors = (context: {
     inPortalThread?: boolean;
     inSearchWorkflow?: boolean;
     ragQuery?: string;
+    sessionId?: string;
     threadId?: string;
+    topicId?: string | null;
     traceId?: string;
   };
   parentId: string;
@@ -269,10 +271,10 @@ export const createAgentExecutors = (context: {
             parentId: payload.parentMessageId,
             plugin: chatToolPayload,
             role: 'tool',
-            sessionId: context.get().activeId,
+            sessionId: state.metadata!.sessionId!,
             threadId: context.params.threadId,
             tool_call_id: chatToolPayload.id,
-            topicId: context.get().activeTopicId,
+            topicId: state.metadata?.topicId,
           };
 
           const createResult = await context.get().optimisticCreateMessage(toolMessageParams);
@@ -450,10 +452,10 @@ export const createAgentExecutors = (context: {
             },
             pluginIntervention: { status: 'pending' },
             role: 'tool',
-            sessionId: context.get().activeId,
+            sessionId: state.metadata!.sessionId!,
             threadId: context.params.threadId,
             tool_call_id: toolPayload.id,
-            topicId: context.get().activeTopicId,
+            topicId: state.metadata?.topicId,
           };
 
           const createResult = await context.get().optimisticCreateMessage(toolMessageParams);

--- a/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
@@ -387,5 +387,183 @@ describe('StreamingExecutor actions', () => {
       expect(streamSpy).toHaveBeenCalled();
       expect(result.current.refreshMessages).toHaveBeenCalled();
     });
+
+    it('should use provided sessionId/topicId for trace parameters', async () => {
+      act(() => {
+        useChatStore.setState({
+          internal_execAgentRuntime: realExecAgentRuntime,
+          activeId: 'active-session',
+          activeTopicId: 'active-topic',
+        });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+      const contextSessionId = 'context-session';
+      const contextTopicId = 'context-topic';
+      const userMessage = {
+        id: TEST_IDS.USER_MESSAGE_ID,
+        role: 'user',
+        content: TEST_CONTENT.USER_MESSAGE,
+        sessionId: contextSessionId,
+        topicId: contextTopicId,
+      } as UIChatMessage;
+
+      const streamSpy = vi.spyOn(chatService, 'createAssistantMessageStream');
+
+      await act(async () => {
+        await result.current.internal_execAgentRuntime({
+          messages: [userMessage],
+          parentMessageId: userMessage.id,
+          parentMessageType: 'user',
+          sessionId: contextSessionId,
+          topicId: contextTopicId,
+        });
+      });
+
+      // Verify trace was called with context sessionId/topicId, not active ones
+      expect(streamSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trace: expect.objectContaining({
+            sessionId: contextSessionId,
+            topicId: contextTopicId,
+          }),
+        }),
+      );
+    });
+
+    it('should pass context to optimisticUpdateMessageRAG', async () => {
+      act(() => {
+        useChatStore.setState({
+          internal_execAgentRuntime: realExecAgentRuntime,
+          activeId: 'active-session',
+          activeTopicId: 'active-topic',
+        });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+      const contextSessionId = 'context-session';
+      const contextTopicId = 'context-topic';
+      const userMessage = {
+        id: TEST_IDS.USER_MESSAGE_ID,
+        role: 'user',
+        content: TEST_CONTENT.USER_MESSAGE,
+        sessionId: contextSessionId,
+        topicId: contextTopicId,
+      } as UIChatMessage;
+
+      const ragMetadata = {
+        ragQueryId: 'query-id',
+        fileChunks: [{ id: 'chunk-1', similarity: 0.9 }],
+      };
+
+      const updateRAGSpy = vi.spyOn(result.current, 'optimisticUpdateMessageRAG');
+      const streamSpy = vi.spyOn(chatService, 'createAssistantMessageStream');
+
+      await act(async () => {
+        await result.current.internal_execAgentRuntime({
+          messages: [userMessage],
+          parentMessageId: userMessage.id,
+          parentMessageType: 'user',
+          sessionId: contextSessionId,
+          topicId: contextTopicId,
+          ragMetadata,
+        });
+      });
+
+      // Verify optimisticUpdateMessageRAG was called with context
+      await vi.waitFor(() => {
+        expect(updateRAGSpy).toHaveBeenCalledWith(expect.any(String), ragMetadata, {
+          sessionId: contextSessionId,
+          topicId: contextTopicId,
+        });
+      });
+
+      streamSpy.mockRestore();
+    });
+  });
+
+  describe('StreamingExecutor OptimisticUpdateContext isolation', () => {
+    it('should pass context to optimisticUpdateMessageContent in internal_fetchAIChatMessage', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const messages = [createMockMessage({ role: 'user' })];
+      const contextSessionId = 'context-session';
+      const contextTopicId = 'context-topic';
+
+      const updateContentSpy = vi.spyOn(result.current, 'optimisticUpdateMessageContent');
+
+      const streamSpy = vi
+        .spyOn(chatService, 'createAssistantMessageStream')
+        .mockImplementation(async ({ onMessageHandle, onFinish }) => {
+          await onMessageHandle?.({ type: 'text', text: TEST_CONTENT.AI_RESPONSE } as any);
+          await onFinish?.(TEST_CONTENT.AI_RESPONSE, {});
+        });
+
+      await act(async () => {
+        await result.current.internal_fetchAIChatMessage({
+          messages,
+          messageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          model: 'gpt-4o-mini',
+          provider: 'openai',
+          params: {
+            sessionId: contextSessionId,
+            topicId: contextTopicId,
+          },
+        });
+      });
+
+      expect(updateContentSpy).toHaveBeenCalledWith(
+        TEST_IDS.ASSISTANT_MESSAGE_ID,
+        TEST_CONTENT.AI_RESPONSE,
+        expect.any(Object),
+        {
+          sessionId: contextSessionId,
+          topicId: contextTopicId,
+        },
+      );
+
+      streamSpy.mockRestore();
+    });
+
+    it('should use activeId/activeTopicId when context not provided', async () => {
+      act(() => {
+        useChatStore.setState({
+          activeId: 'active-session',
+          activeTopicId: 'active-topic',
+        });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+      const messages = [createMockMessage({ role: 'user' })];
+
+      const updateContentSpy = vi.spyOn(result.current, 'optimisticUpdateMessageContent');
+
+      const streamSpy = vi
+        .spyOn(chatService, 'createAssistantMessageStream')
+        .mockImplementation(async ({ onMessageHandle, onFinish }) => {
+          await onMessageHandle?.({ type: 'text', text: TEST_CONTENT.AI_RESPONSE } as any);
+          await onFinish?.(TEST_CONTENT.AI_RESPONSE, {});
+        });
+
+      await act(async () => {
+        await result.current.internal_fetchAIChatMessage({
+          messages,
+          messageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          model: 'gpt-4o-mini',
+          provider: 'openai',
+        });
+      });
+
+      expect(updateContentSpy).toHaveBeenCalledWith(
+        TEST_IDS.ASSISTANT_MESSAGE_ID,
+        TEST_CONTENT.AI_RESPONSE,
+        expect.any(Object),
+        {
+          sessionId: undefined,
+          topicId: undefined,
+        },
+      );
+
+      streamSpy.mockRestore();
+    });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -183,6 +183,8 @@ export const conversationControl: StateCreator<
         messages: currentMessages,
         parentMessageId: toolMessageId, // Start from tool message
         parentMessageType: 'tool', // Type is 'tool'
+        sessionId: get().activeId,
+        topicId: get().activeTopicId,
         threadId: activeThreadId,
         initialState: state,
         initialContext: context,
@@ -239,6 +241,8 @@ export const conversationControl: StateCreator<
         messages: currentMessages,
         parentMessageId: messageId,
         parentMessageType: 'tool',
+        sessionId: get().activeId,
+        topicId: get().activeTopicId,
         threadId: activeThreadId,
         initialState: state,
         initialContext: context,

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -249,6 +249,8 @@ export const conversationLifecycle: StateCreator<
         messages: displayMessages,
         parentMessageId: data.assistantMessageId,
         parentMessageType: 'assistant',
+        sessionId: activeId,
+        topicId: data.topicId ?? activeTopicId,
         ragQuery: get().internal_shouldUseRAG() ? message : undefined,
         threadId: activeThreadId,
         skipCreateFirstMessage: true,
@@ -305,6 +307,8 @@ export const conversationLifecycle: StateCreator<
         messages: contextMessages,
         parentMessageId: id,
         parentMessageType: 'user',
+        sessionId: get().activeId,
+        topicId: get().activeTopicId,
         traceId,
         ragQuery: get().internal_shouldUseRAG() ? item.content : undefined,
         threadId: activeThreadId,
@@ -360,6 +364,8 @@ export const conversationLifecycle: StateCreator<
         messages: chats,
         parentMessageId: id,
         parentMessageType: message.role as 'assistant' | 'tool' | 'user',
+        sessionId: get().activeId,
+        topicId: get().activeTopicId,
       });
     } finally {
       // Remove message from continuing state

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -124,7 +124,7 @@ export const conversationLifecycle: StateCreator<
       imageList: tempImages.length > 0 ? tempImages : undefined,
       videoList: tempVideos.length > 0 ? tempVideos : undefined,
     });
-    get().optimisticCreateTmpMessage({
+    const tempAssistantId = get().optimisticCreateTmpMessage({
       content: LOADING_FLAT,
       role: 'assistant',
       sessionId: activeId,
@@ -159,7 +159,7 @@ export const conversationLifecycle: StateCreator<
           newTopic: shouldCreateNewTopic
             ? {
                 topicMessageIds: messages.map((m) => m.id),
-                title: t('defaultTitle', { ns: 'topic' }),
+                title: message.slice(0, 10) || t('defaultTitle', { ns: 'topic' }),
               }
             : undefined,
           sessionId: activeId === INBOX_SESSION_ID ? undefined : activeId,
@@ -200,7 +200,7 @@ export const conversationLifecycle: StateCreator<
     // remove temporally message
     if (data?.isCreateNewTopic) {
       get().internal_dispatchMessage(
-        { type: 'deleteMessage', id: tempId },
+        { type: 'deleteMessages', ids: [tempId, tempAssistantId] },
         { topicId: activeTopicId, sessionId: activeId },
       );
     }

--- a/src/store/chat/slices/builtinTool/actions/__tests__/search.test.ts
+++ b/src/store/chat/slices/builtinTool/actions/__tests__/search.test.ts
@@ -6,7 +6,7 @@ import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { searchService } from '@/services/search';
 import { useChatStore } from '@/store/chat';
-import { chatSelectors } from '@/store/chat/selectors';
+import { dbMessageSelectors } from '@/store/chat/selectors';
 import { CRAWL_CONTENT_LIMITED_COUNT } from '@/tools/web-browsing/const';
 
 // Mock services
@@ -18,8 +18,8 @@ vi.mock('@/services/search', () => ({
 }));
 
 vi.mock('@/store/chat/selectors', () => ({
-  chatSelectors: {
-    getMessageById: vi.fn(),
+  dbMessageSelectors: {
+    getDbMessageById: vi.fn(),
   },
 }));
 
@@ -38,6 +38,9 @@ describe('search actions', () => {
       optimisticAddToolToAssistantMessage: vi.fn(),
       openToolUI: vi.fn(),
     });
+
+    // Default mock for dbMessageSelectors - returns undefined to use activeId/activeTopicId
+    vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(() => () => undefined);
   });
 
   describe('search', () => {
@@ -90,6 +93,8 @@ describe('search actions', () => {
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         searchResultsPrompt(expectedContent),
+        undefined,
+        { sessionId: undefined, topicId: undefined },
       );
     });
 
@@ -126,6 +131,8 @@ describe('search actions', () => {
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         searchResultsPrompt([]),
+        undefined,
+        { sessionId: undefined, topicId: undefined },
       );
     });
 
@@ -145,15 +152,21 @@ describe('search actions', () => {
         await search(messageId, query);
       });
 
-      expect(result.current.optimisticUpdateMessagePluginError).toHaveBeenCalledWith(messageId, {
-        body: error,
-        message: 'Search failed',
-        type: 'PluginServerError',
-      });
+      expect(result.current.optimisticUpdateMessagePluginError).toHaveBeenCalledWith(
+        messageId,
+        {
+          body: error,
+          message: 'Search failed',
+          type: 'PluginServerError',
+        },
+        { sessionId: undefined, topicId: undefined },
+      );
       expect(result.current.searchLoading[messageId]).toBe(false);
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         'Search failed',
+        undefined,
+        { sessionId: undefined, topicId: undefined },
       );
     });
   });
@@ -193,6 +206,8 @@ describe('search actions', () => {
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         crawlResultsPrompt(expectedContent as any),
+        undefined,
+        { sessionId: undefined, topicId: undefined },
       );
     });
 
@@ -219,6 +234,8 @@ describe('search actions', () => {
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         crawlResultsPrompt(mockResponse.results),
+        undefined,
+        { sessionId: undefined, topicId: undefined },
       );
     });
   });
@@ -250,6 +267,8 @@ describe('search actions', () => {
       const mockMessage: Partial<UIChatMessage> = {
         id: messageId,
         parentId,
+        sessionId: undefined,
+        topicId: undefined,
         content: 'test content',
         plugin: {
           identifier: 'search',
@@ -264,7 +283,7 @@ describe('search actions', () => {
         meta: {},
       };
 
-      vi.spyOn(chatSelectors, 'getMessageById').mockImplementation(
+      vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(
         () => () => mockMessage as UIChatMessage,
       );
 
@@ -282,7 +301,10 @@ describe('search actions', () => {
           plugin: mockMessage.plugin,
           pluginState: mockMessage.pluginState,
           role: 'tool',
+          sessionId: 'session-id',
+          topicId: 'topic-id',
         }),
+        { sessionId: 'session-id', topicId: 'topic-id' },
       );
 
       expect(result.current.optimisticAddToolToAssistantMessage).toHaveBeenCalledWith(
@@ -291,11 +313,12 @@ describe('search actions', () => {
           identifier: 'search',
           type: 'default',
         }),
+        { sessionId: undefined, topicId: undefined },
       );
     });
 
     it('should not save if message not found', async () => {
-      vi.spyOn(chatSelectors, 'getMessageById').mockImplementation(() => () => undefined);
+      vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(() => () => undefined);
 
       const { result } = renderHook(() => useChatStore());
       const { saveSearchResult } = result.current;
@@ -325,6 +348,177 @@ describe('search actions', () => {
       });
 
       expect(result.current.searchLoading[messageId]).toBe(false);
+    });
+  });
+
+  describe('OptimisticUpdateContext isolation', () => {
+    it('search should pass context to optimistic methods', async () => {
+      const mockResponse: UniformSearchResponse = {
+        results: [
+          {
+            title: 'Test',
+            content: 'Content',
+            url: 'https://test.com',
+            category: 'general',
+            engines: ['google'],
+            parsedUrl: 'test.com',
+            score: 1,
+          },
+        ],
+        costTime: 1,
+        resultNumbers: 1,
+        query: 'test',
+      };
+
+      (searchService.webSearch as Mock).mockResolvedValue(mockResponse);
+
+      const messageId = 'test-message-id';
+      const contextSessionId = 'context-session-id';
+      const contextTopicId = 'context-topic-id';
+
+      const mockMessage: Partial<UIChatMessage> = {
+        id: messageId,
+        sessionId: contextSessionId,
+        topicId: contextTopicId,
+        role: 'tool',
+        content: '',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        meta: {},
+      };
+
+      vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(
+        () => () => mockMessage as UIChatMessage,
+      );
+
+      const { result } = renderHook(() => useChatStore());
+      const query: SearchQuery = { query: 'test' };
+
+      await act(async () => {
+        await result.current.search(messageId, query);
+      });
+
+      expect(result.current.optimisticUpdatePluginState).toHaveBeenCalledWith(
+        messageId,
+        expect.any(Object),
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
+      expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
+        messageId,
+        expect.any(String),
+        undefined,
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
+    });
+
+    it('crawlMultiPages should pass context to optimistic methods', async () => {
+      const mockResponse = {
+        results: [
+          {
+            data: {
+              content: 'Test content',
+              title: 'Test',
+            },
+            crawler: 'naive',
+            originalUrl: 'https://test.com',
+          },
+        ],
+      };
+
+      (searchService.crawlPages as Mock).mockResolvedValue(mockResponse);
+
+      const messageId = 'test-message-id';
+      const contextSessionId = 'context-session-id';
+      const contextTopicId = 'context-topic-id';
+
+      const mockMessage: Partial<UIChatMessage> = {
+        id: messageId,
+        sessionId: contextSessionId,
+        topicId: contextTopicId,
+        role: 'tool',
+        content: '',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        meta: {},
+      };
+
+      vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(
+        () => () => mockMessage as UIChatMessage,
+      );
+
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        await result.current.crawlMultiPages(messageId, { urls: ['https://test.com'] });
+      });
+
+      expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
+        messageId,
+        expect.any(String),
+        undefined,
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
+      expect(result.current.optimisticUpdatePluginState).toHaveBeenCalledWith(
+        messageId,
+        expect.any(Object),
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
+    });
+
+    it('saveSearchResult should pass context to optimistic methods', async () => {
+      const messageId = 'test-message-id';
+      const parentId = 'parent-message-id';
+      const contextSessionId = 'context-session-id';
+      const contextTopicId = 'context-topic-id';
+
+      const mockMessage: Partial<UIChatMessage> = {
+        id: messageId,
+        parentId,
+        sessionId: contextSessionId,
+        topicId: contextTopicId,
+        content: 'test content',
+        plugin: {
+          identifier: 'search',
+          arguments: '{}',
+          apiName: 'search',
+          type: 'default',
+        },
+        pluginState: {},
+        role: 'tool',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        meta: {},
+      };
+
+      vi.spyOn(dbMessageSelectors, 'getDbMessageById').mockImplementation(
+        () => () => mockMessage as UIChatMessage,
+      );
+
+      (useChatStore.getState().optimisticCreateMessage as Mock).mockResolvedValue({
+        id: 'new-message-id',
+      });
+
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        await result.current.saveSearchResult(messageId);
+      });
+
+      expect(result.current.optimisticAddToolToAssistantMessage).toHaveBeenCalledWith(
+        parentId,
+        expect.objectContaining({
+          identifier: 'search',
+          type: 'default',
+        }),
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
+      expect(result.current.optimisticCreateMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: contextSessionId,
+          topicId: contextTopicId,
+        }),
+        { sessionId: contextSessionId, topicId: contextTopicId },
+      );
     });
   });
 });

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -33,7 +33,7 @@ export interface MessageQueryAction {
     params?: {
       action?: any;
       sessionId?: string;
-      topicId?: string;
+      topicId?: string | null;
     },
   ) => void;
 

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -23,7 +23,7 @@ export interface MessageQueryAction {
   /**
    * Manually refresh messages from server
    */
-  refreshMessages: () => Promise<void>;
+  refreshMessages: (sessionId?: string, topicId?: string | null) => Promise<void>;
 
   /**
    * Replace current messages with new data
@@ -58,9 +58,11 @@ export const messageQuery: StateCreator<
 > = (set, get) => ({
   // TODO: The mutate should only be called once, but since we haven't merge session and group,
   // we need to call it twice
-  refreshMessages: async () => {
-    await mutate([SWR_USE_FETCH_MESSAGES, get().activeId, get().activeTopicId, 'session']);
-    await mutate([SWR_USE_FETCH_MESSAGES, get().activeId, get().activeTopicId, 'group']);
+  refreshMessages: async (sessionId?: string, topicId?: string | null) => {
+    const sid = sessionId ?? get().activeId;
+    const tid = topicId !== undefined ? topicId : get().activeTopicId;
+    await mutate([SWR_USE_FETCH_MESSAGES, sid, tid, 'session']);
+    await mutate([SWR_USE_FETCH_MESSAGES, sid, tid, 'group']);
   },
 
   replaceMessages: (messages, params) => {

--- a/src/store/chat/slices/message/selectors/dbMessage.ts
+++ b/src/store/chat/slices/message/selectors/dbMessage.ts
@@ -43,11 +43,18 @@ const activeDbMessages = (s: ChatStoreState): UIChatMessage[] => {
 // ============= DB Message Queries ========== //
 
 /**
- * Get raw message by ID from database
- * This searches in dbMessagesMap, which contains flat message structure
+ * Get raw message by ID from database (searches globally across all sessions/topics)
+ * This is essential for parallel topic agent runtime where background updates
+ * may occur after the user has switched to another chat.
  */
-const getDbMessageById = (id: string) => (s: ChatStoreState) =>
-  chatHelpers.getMessageById(activeDbMessages(s), id);
+const getDbMessageById = (id: string) => (s: ChatStoreState) => {
+  // Search across all messages in dbMessagesMap
+  for (const messages of Object.values(s.dbMessagesMap)) {
+    const message = chatHelpers.getMessageById(messages, id);
+    if (message) return message;
+  }
+  return undefined;
+};
 
 /**
  * Get raw message by tool_call_id from database

--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -257,6 +257,11 @@ describe('ChatPluginAction', () => {
       expect(storeState.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         pluginApiResponse,
+        undefined,
+        {
+          sessionId: undefined,
+          topicId: undefined,
+        },
       );
       expect(storeState.internal_togglePluginApiCalling).toHaveBeenCalledWith(
         false,
@@ -295,8 +300,14 @@ describe('ChatPluginAction', () => {
         expect.any(String),
       );
       expect(chatService.runPluginApi).toHaveBeenCalledWith(pluginPayload, { trace: {} });
-      expect(messageService.updateMessageError).toHaveBeenCalledWith(messageId, error);
-      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages);
+      expect(messageService.updateMessageError).toHaveBeenCalledWith(messageId, error, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
+      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
       expect(storeState.internal_togglePluginApiCalling).toHaveBeenCalledWith(
         false,
         'message-id',
@@ -379,50 +390,78 @@ describe('ChatPluginAction', () => {
 
       // Verify that tool messages were created for each tool call
       expect(optimisticCreateMessageMock).toHaveBeenCalledTimes(4);
-      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(1, {
-        content: '',
-        parentId: assistantId,
-        plugin: message.tools![0],
-        role: 'tool',
-        sessionId: 'session-id',
-        tool_call_id: 'tool1',
-        topicId: 'topic-id',
-        threadId: undefined,
-        groupId: undefined,
-      });
-      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(2, {
-        content: '',
-        parentId: assistantId,
-        plugin: message.tools![1],
-        role: 'tool',
-        sessionId: 'session-id',
-        tool_call_id: 'tool2',
-        topicId: 'topic-id',
-        threadId: undefined,
-        groupId: undefined,
-      });
-      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(3, {
-        content: '',
-        parentId: assistantId,
-        plugin: message.tools![2],
-        role: 'tool',
-        sessionId: 'session-id',
-        tool_call_id: 'tool3',
-        topicId: 'topic-id',
-        threadId: undefined,
-        groupId: undefined,
-      });
-      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(4, {
-        content: '',
-        parentId: assistantId,
-        plugin: message.tools![3],
-        role: 'tool',
-        sessionId: 'session-id',
-        tool_call_id: 'tool4',
-        topicId: 'topic-id',
-        threadId: undefined,
-        groupId: undefined,
-      });
+      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(
+        1,
+        {
+          content: '',
+          parentId: assistantId,
+          plugin: message.tools![0],
+          role: 'tool',
+          sessionId: 'session-id',
+          tool_call_id: 'tool1',
+          topicId: 'topic-id',
+          threadId: undefined,
+          groupId: undefined,
+        },
+        {
+          sessionId: 'session-id',
+          topicId: 'topic-id',
+        },
+      );
+      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(
+        2,
+        {
+          content: '',
+          parentId: assistantId,
+          plugin: message.tools![1],
+          role: 'tool',
+          sessionId: 'session-id',
+          tool_call_id: 'tool2',
+          topicId: 'topic-id',
+          threadId: undefined,
+          groupId: undefined,
+        },
+        {
+          sessionId: 'session-id',
+          topicId: 'topic-id',
+        },
+      );
+      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(
+        3,
+        {
+          content: '',
+          parentId: assistantId,
+          plugin: message.tools![2],
+          role: 'tool',
+          sessionId: 'session-id',
+          tool_call_id: 'tool3',
+          topicId: 'topic-id',
+          threadId: undefined,
+          groupId: undefined,
+        },
+        {
+          sessionId: 'session-id',
+          topicId: 'topic-id',
+        },
+      );
+      expect(optimisticCreateMessageMock).toHaveBeenNthCalledWith(
+        4,
+        {
+          content: '',
+          parentId: assistantId,
+          plugin: message.tools![3],
+          role: 'tool',
+          sessionId: 'session-id',
+          tool_call_id: 'tool4',
+          topicId: 'topic-id',
+          threadId: undefined,
+          groupId: undefined,
+        },
+        {
+          sessionId: 'session-id',
+          topicId: 'topic-id',
+        },
+      );
 
       // Verify that the appropriate plugin types were invoked
       expect(invokeStandaloneTypePluginMock).toHaveBeenCalledWith(
@@ -556,7 +595,10 @@ describe('ChatPluginAction', () => {
         },
       );
 
-      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages);
+      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages, {
+        sessionId: 'inbox',
+        topicId: null,
+      });
     });
   });
 
@@ -596,7 +638,10 @@ describe('ChatPluginAction', () => {
       });
 
       // 验证 replaceMessages 是否被调用
-      expect(result.current.replaceMessages).toHaveBeenCalledWith(mockMessages);
+      expect(result.current.replaceMessages).toHaveBeenCalledWith(mockMessages, {
+        sessionId: 'session-id',
+        topicId: 'topic-id',
+      });
     });
 
     it('should handle errors when message creation fails', async () => {
@@ -773,7 +818,10 @@ describe('ChatPluginAction', () => {
         type: 'PluginSettingsInvalid',
       });
 
-      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages);
+      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
     });
   });
 
@@ -848,7 +896,10 @@ describe('ChatPluginAction', () => {
         await result.current.reInvokeToolMessage(messageId);
       });
 
-      expect(internal_updateMessageErrorMock).toHaveBeenCalledWith(messageId, null);
+      expect(internal_updateMessageErrorMock).toHaveBeenCalledWith(messageId, null, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
     });
   });
 
@@ -938,6 +989,11 @@ describe('ChatPluginAction', () => {
       expect(result.current.optimisticUpdateMessageContent).toHaveBeenCalledWith(
         messageId,
         apiResponse,
+        undefined,
+        {
+          sessionId: undefined,
+          topicId: undefined,
+        },
       );
       expect(messageService.updateMessage).toHaveBeenCalledWith(messageId, { traceId: 'trace-id' });
     });
@@ -977,8 +1033,14 @@ describe('ChatPluginAction', () => {
         await result.current.internal_callPluginApi(messageId, payload);
       });
 
-      expect(messageService.updateMessageError).toHaveBeenCalledWith(messageId, error);
-      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages);
+      expect(messageService.updateMessageError).toHaveBeenCalledWith(messageId, error, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
+      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages, {
+        sessionId: undefined,
+        topicId: undefined,
+      });
     });
   });
 
@@ -1111,7 +1173,10 @@ describe('ChatPluginAction', () => {
         { error },
         { sessionId: 'inbox', topicId: null },
       );
-      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages);
+      expect(replaceMessagesSpy).toHaveBeenCalledWith(mockMessages, {
+        sessionId: 'inbox',
+        topicId: null,
+      });
     });
   });
 
@@ -1153,7 +1218,7 @@ describe('ChatPluginAction', () => {
         });
       });
 
-      expect(refreshToUpdateMessageToolsSpy).toHaveBeenCalledWith(messageId);
+      expect(refreshToUpdateMessageToolsSpy).toHaveBeenCalledWith(messageId, undefined);
     });
   });
 

--- a/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
@@ -46,12 +46,20 @@ export interface PluginOptimisticUpdateAction {
   /**
    * Add tool to assistant message with optimistic update
    */
-  optimisticAddToolToAssistantMessage: (id: string, tool: ChatToolPayload) => Promise<void>;
+  optimisticAddToolToAssistantMessage: (
+    id: string,
+    tool: ChatToolPayload,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 
   /**
    * Remove tool from assistant message with optimistic update
    */
-  optimisticRemoveToolFromAssistantMessage: (id: string, tool_call_id?: string) => Promise<void>;
+  optimisticRemoveToolFromAssistantMessage: (
+    id: string,
+    tool_call_id?: string,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 
   /**
    * Update plugin error with optimistic update
@@ -166,7 +174,7 @@ export const pluginOptimisticUpdate: StateCreator<
     }
   },
 
-  optimisticAddToolToAssistantMessage: async (id, tool) => {
+  optimisticAddToolToAssistantMessage: async (id, tool, context) => {
     const assistantMessage = displayMessageSelectors.getDisplayMessageById(id)(get());
     if (!assistantMessage) return;
 
@@ -177,10 +185,10 @@ export const pluginOptimisticUpdate: StateCreator<
       id: assistantMessage.id,
     });
 
-    await internal_refreshToUpdateMessageTools(id);
+    await internal_refreshToUpdateMessageTools(id, context);
   },
 
-  optimisticRemoveToolFromAssistantMessage: async (id, tool_call_id) => {
+  optimisticRemoveToolFromAssistantMessage: async (id, tool_call_id, context) => {
     const message = displayMessageSelectors.getDisplayMessageById(id)(get());
     if (!message || !tool_call_id) return;
 
@@ -190,7 +198,7 @@ export const pluginOptimisticUpdate: StateCreator<
     internal_dispatchMessage({ type: 'deleteMessageTool', tool_call_id, id: message.id });
 
     // update the message tools
-    await internal_refreshToUpdateMessageTools(id);
+    await internal_refreshToUpdateMessageTools(id, context);
   },
 
   optimisticUpdatePluginError: async (id, error, context) => {

--- a/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
@@ -4,6 +4,7 @@ import isEqual from 'fast-deep-equal';
 import { StateCreator } from 'zustand/vanilla';
 
 import { messageService } from '@/services/message';
+import { OptimisticUpdateContext } from '@/store/chat/slices/message/actions/optimisticUpdate';
 import { ChatStore } from '@/store/chat/store';
 import { merge } from '@/utils/merge';
 import { safeParseJSON } from '@/utils/safeParseJSON';
@@ -18,7 +19,11 @@ export interface PluginOptimisticUpdateAction {
   /**
    * Update plugin state with optimistic update
    */
-  optimisticUpdatePluginState: (id: string, value: any) => Promise<void>;
+  optimisticUpdatePluginState: (
+    id: string,
+    value: any,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 
   /**
    * Update plugin arguments with optimistic update
@@ -32,7 +37,11 @@ export interface PluginOptimisticUpdateAction {
   /**
    * Update plugin with optimistic update (generic method for any plugin field)
    */
-  optimisticUpdatePlugin: (id: string, value: Partial<MessagePluginItem>) => Promise<void>;
+  optimisticUpdatePlugin: (
+    id: string,
+    value: Partial<MessagePluginItem>,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 
   /**
    * Add tool to assistant message with optimistic update
@@ -47,12 +56,19 @@ export interface PluginOptimisticUpdateAction {
   /**
    * Update plugin error with optimistic update
    */
-  optimisticUpdatePluginError: (id: string, error: ChatMessageError) => Promise<void>;
+  optimisticUpdatePluginError: (
+    id: string,
+    error: ChatMessageError,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 
   /**
    * Use the optimistic update value to update the message tools to database
    */
-  internal_refreshToUpdateMessageTools: (id: string) => Promise<void>;
+  internal_refreshToUpdateMessageTools: (
+    id: string,
+    context?: OptimisticUpdateContext,
+  ) => Promise<void>;
 }
 
 export const pluginOptimisticUpdate: StateCreator<
@@ -61,19 +77,22 @@ export const pluginOptimisticUpdate: StateCreator<
   [],
   PluginOptimisticUpdateAction
 > = (set, get) => ({
-  optimisticUpdatePluginState: async (id, value) => {
+  optimisticUpdatePluginState: async (id, value, context) => {
     const { replaceMessages } = get();
 
     // optimistic update
     get().internal_dispatchMessage({ id, type: 'updateMessage', value: { pluginState: value } });
 
+    const sessionId = context?.sessionId ?? get().activeId;
+    const topicId = context?.topicId !== undefined ? context.topicId : get().activeTopicId;
+
     const result = await messageService.updateMessagePluginState(id, value, {
-      sessionId: get().activeId,
-      topicId: get().activeTopicId,
+      sessionId,
+      topicId,
     });
 
     if (result?.success && result.messages) {
-      replaceMessages(result.messages);
+      replaceMessages(result.messages, { sessionId, topicId });
     }
   },
 
@@ -124,7 +143,7 @@ export const pluginOptimisticUpdate: StateCreator<
     await refreshMessages();
   },
 
-  optimisticUpdatePlugin: async (id, value) => {
+  optimisticUpdatePlugin: async (id, value, context) => {
     const { replaceMessages } = get();
 
     // optimistic update
@@ -134,13 +153,16 @@ export const pluginOptimisticUpdate: StateCreator<
       value,
     });
 
+    const sessionId = context?.sessionId ?? get().activeId;
+    const topicId = context?.topicId !== undefined ? context.topicId : get().activeTopicId;
+
     const result = await messageService.updateMessagePlugin(id, value, {
-      sessionId: get().activeId,
-      topicId: get().activeTopicId,
+      sessionId,
+      topicId,
     });
 
     if (result?.success && result.messages) {
-      replaceMessages(result.messages);
+      replaceMessages(result.messages, { sessionId, topicId });
     }
   },
 
@@ -171,43 +193,50 @@ export const pluginOptimisticUpdate: StateCreator<
     await internal_refreshToUpdateMessageTools(id);
   },
 
-  optimisticUpdatePluginError: async (id, error) => {
+  optimisticUpdatePluginError: async (id, error, context) => {
     const { replaceMessages } = get();
 
     get().internal_dispatchMessage({ id, type: 'updateMessage', value: { error } });
+
+    const sessionId = context?.sessionId ?? get().activeId;
+    const topicId = context?.topicId !== undefined ? context.topicId : get().activeTopicId;
+
     const result = await messageService.updateMessage(
       id,
       { error },
       {
-        sessionId: get().activeId,
-        topicId: get().activeTopicId,
+        sessionId,
+        topicId,
       },
     );
     if (result?.success && result.messages) {
-      replaceMessages(result.messages);
+      replaceMessages(result.messages, { sessionId, topicId });
     }
   },
 
-  internal_refreshToUpdateMessageTools: async (id) => {
+  internal_refreshToUpdateMessageTools: async (id, context) => {
     const { dbMessageSelectors } = await import('../../message/selectors');
     const message = dbMessageSelectors.getDbMessageById(id)(get());
     if (!message || !message.tools) return;
 
     const { internal_toggleMessageLoading, replaceMessages } = get();
 
+    const sessionId = context?.sessionId ?? get().activeId;
+    const topicId = context?.topicId !== undefined ? context.topicId : get().activeTopicId;
+
     internal_toggleMessageLoading(true, id);
     const result = await messageService.updateMessage(
       id,
       { tools: message.tools },
       {
-        sessionId: get().activeId,
-        topicId: get().activeTopicId,
+        sessionId,
+        topicId,
       },
     );
     internal_toggleMessageLoading(false, id);
 
     if (result?.success && result.messages) {
-      replaceMessages(result.messages);
+      replaceMessages(result.messages, { sessionId, topicId });
     }
   },
 });

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -13,7 +13,7 @@ import { useToolStore } from '@/store/tool';
 import { safeParseJSON } from '@/utils/safeParseJSON';
 import { setNamespace } from '@/utils/storeDebug';
 
-import { displayMessageSelectors } from '../../message/selectors';
+import { dbMessageSelectors } from '../../message/selectors';
 
 const n = setNamespace('plugin');
 
@@ -94,6 +94,8 @@ export const pluginTypes: StateCreator<
 
     // if the plugin settings is not valid, then set the message with error type
     if (!result.valid) {
+      // Get message to extract sessionId/topicId
+      const message = dbMessageSelectors.getDbMessageById(id)(get());
       const updateResult = await messageService.updateMessageError(id, {
         body: {
           error: result.errors,
@@ -104,7 +106,10 @@ export const pluginTypes: StateCreator<
       });
 
       if (updateResult?.success && updateResult.messages) {
-        get().replaceMessages(updateResult.messages);
+        get().replaceMessages(updateResult.messages, {
+          sessionId: message?.sessionId,
+          topicId: message?.topicId,
+        });
       }
       return;
     }
@@ -119,6 +124,9 @@ export const pluginTypes: StateCreator<
       optimisticUpdateMessagePluginError,
     } = get();
     let data: MCPToolCallResult | undefined;
+
+    // Get message to extract sessionId/topicId
+    const message = dbMessageSelectors.getDbMessageById(id)(get());
 
     try {
       const abortController = internal_togglePluginApiCalling(
@@ -142,7 +150,10 @@ export const pluginTypes: StateCreator<
       if (!err.message.includes('The user aborted a request.')) {
         const result = await messageService.updateMessageError(id, error as any);
         if (result?.success && result.messages) {
-          get().replaceMessages(result.messages);
+          get().replaceMessages(result.messages, {
+            sessionId: message?.sessionId,
+            topicId: message?.topicId,
+          });
         }
       }
     }
@@ -153,11 +164,13 @@ export const pluginTypes: StateCreator<
 
     if (!data) return;
 
+    const context = { sessionId: message?.sessionId, topicId: message?.topicId };
+
     await Promise.all([
-      optimisticUpdateMessageContent(id, data.content),
+      optimisticUpdateMessageContent(id, data.content, undefined, context),
       (async () => {
-        if (data.success) await optimisticUpdatePluginState(id, data.state);
-        else await optimisticUpdateMessagePluginError(id, data.error);
+        if (data.success) await optimisticUpdatePluginState(id, data.state, context);
+        else await optimisticUpdateMessagePluginError(id, data.error, context);
       })(),
     ]);
 
@@ -168,14 +181,15 @@ export const pluginTypes: StateCreator<
     const { optimisticUpdateMessageContent, internal_togglePluginApiCalling } = get();
     let data: string;
 
+    // Get message to extract sessionId/topicId
+    const message = dbMessageSelectors.getDbMessageById(id)(get());
+
     try {
       const abortController = internal_togglePluginApiCalling(
         true,
         id,
         n('fetchPlugin/start') as string,
       );
-
-      const message = displayMessageSelectors.getDisplayMessageById(id)(get());
 
       const res = await chatService.runPluginApi(payload, {
         signal: abortController?.signal,
@@ -195,7 +209,10 @@ export const pluginTypes: StateCreator<
       if (!err.message.includes('The user aborted a request.')) {
         const result = await messageService.updateMessageError(id, error as any);
         if (result?.success && result.messages) {
-          get().replaceMessages(result.messages);
+          get().replaceMessages(result.messages, {
+            sessionId: message?.sessionId,
+            topicId: message?.topicId,
+          });
         }
       }
 
@@ -206,7 +223,10 @@ export const pluginTypes: StateCreator<
     // 如果报错则结束了
     if (!data) return;
 
-    await optimisticUpdateMessageContent(id, data);
+    await optimisticUpdateMessageContent(id, data, undefined, {
+      sessionId: message?.sessionId,
+      topicId: message?.topicId,
+    });
 
     return data;
   },

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -96,14 +96,21 @@ export const pluginTypes: StateCreator<
     if (!result.valid) {
       // Get message to extract sessionId/topicId
       const message = dbMessageSelectors.getDbMessageById(id)(get());
-      const updateResult = await messageService.updateMessageError(id, {
-        body: {
-          error: result.errors,
-          message: '[plugin] your settings is invalid with plugin manifest setting schema',
+      const updateResult = await messageService.updateMessageError(
+        id,
+        {
+          body: {
+            error: result.errors,
+            message: '[plugin] your settings is invalid with plugin manifest setting schema',
+          },
+          message: t('response.PluginSettingsInvalid', { ns: 'error' }),
+          type: PluginErrorType.PluginSettingsInvalid as any,
         },
-        message: t('response.PluginSettingsInvalid', { ns: 'error' }),
-        type: PluginErrorType.PluginSettingsInvalid as any,
-      });
+        {
+          sessionId: message?.sessionId,
+          topicId: message?.topicId,
+        },
+      );
 
       if (updateResult?.success && updateResult.messages) {
         get().replaceMessages(updateResult.messages, {
@@ -148,7 +155,10 @@ export const pluginTypes: StateCreator<
 
       // ignore the aborted request error
       if (!err.message.includes('The user aborted a request.')) {
-        const result = await messageService.updateMessageError(id, error as any);
+        const result = await messageService.updateMessageError(id, error as any, {
+          sessionId: message?.sessionId,
+          topicId: message?.topicId,
+        });
         if (result?.success && result.messages) {
           get().replaceMessages(result.messages, {
             sessionId: message?.sessionId,
@@ -207,7 +217,10 @@ export const pluginTypes: StateCreator<
 
       // ignore the aborted request error
       if (!err.message.includes('The user aborted a request.')) {
-        const result = await messageService.updateMessageError(id, error as any);
+        const result = await messageService.updateMessageError(id, error as any, {
+          sessionId: message?.sessionId,
+          topicId: message?.topicId,
+        });
         if (result?.success && result.messages) {
           get().replaceMessages(result.messages, {
             sessionId: message?.sessionId,

--- a/src/store/chat/slices/plugin/actions/publicApi.ts
+++ b/src/store/chat/slices/plugin/actions/publicApi.ts
@@ -55,9 +55,14 @@ export const pluginPublicApi: StateCreator<
     const message = displayMessageSelectors.getDisplayMessageById(id)(get());
     if (!message || message.role !== 'tool' || !message.plugin) return;
 
+    const context = {
+      sessionId: message.sessionId,
+      topicId: message.topicId,
+    };
+
     // if there is error content, then clear the error
     if (!!message.pluginError) {
-      get().optimisticUpdateMessagePluginError(id, null);
+      get().optimisticUpdateMessagePluginError(id, null, context);
     }
 
     const payload: ChatToolPayload = { ...message.plugin, id: message.tool_call_id! };

--- a/src/store/chat/slices/plugin/actions/workflow.ts
+++ b/src/store/chat/slices/plugin/actions/workflow.ts
@@ -69,6 +69,8 @@ export const pluginWorkflow: StateCreator<
       messages: chats,
       parentMessageId: parentId ?? chats.at(-1)!.id,
       parentMessageType: 'user',
+      sessionId: get().activeId,
+      topicId: get().activeTopicId,
       traceId,
       threadId,
       inPortalThread,

--- a/src/store/chat/slices/plugin/actions/workflow.ts
+++ b/src/store/chat/slices/plugin/actions/workflow.ts
@@ -46,16 +46,22 @@ export const pluginWorkflow: StateCreator<
   PluginWorkflowAction
 > = (set, get) => ({
   createAssistantMessageByPlugin: async (content, parentId) => {
+    // Get parent message to extract sessionId/topicId
+    const parentMessage = dbMessageSelectors.getDbMessageById(parentId)(get());
+
     const newMessage: CreateMessageParams = {
       content,
       parentId,
       role: 'assistant',
-      sessionId: get().activeId,
-      topicId: get().activeTopicId, // if there is activeTopicId，then add it to topicId
+      sessionId: parentMessage?.sessionId ?? get().activeId,
+      topicId: parentMessage?.topicId !== undefined ? parentMessage.topicId : get().activeTopicId,
     };
 
     const result = await messageService.createMessage(newMessage);
-    get().replaceMessages(result.messages);
+    get().replaceMessages(result.messages, {
+      sessionId: newMessage.sessionId,
+      topicId: newMessage.topicId,
+    });
   },
 
   triggerAIMessage: async ({ parentId, traceId, threadId, inPortalThread, inSearchWorkflow }) => {
@@ -90,14 +96,17 @@ export const pluginWorkflow: StateCreator<
         parentId: assistantId,
         plugin: payload,
         role: 'tool',
-        sessionId: get().activeId,
+        sessionId: message.sessionId ?? get().activeId,
         tool_call_id: payload.id,
         threadId,
-        topicId: get().activeTopicId, // if there is activeTopicId，then add it to topicId
+        topicId: message.topicId !== undefined ? message.topicId : get().activeTopicId,
         groupId: message.groupId, // Propagate groupId from parent message for group chat
       };
 
-      const result = await get().optimisticCreateMessage(toolMessage);
+      const result = await get().optimisticCreateMessage(toolMessage, {
+        sessionId: toolMessage.sessionId,
+        topicId: toolMessage.topicId,
+      });
       if (!result) return;
 
       // trigger the plugin call

--- a/src/store/chat/slices/thread/action.ts
+++ b/src/store/chat/slices/thread/action.ts
@@ -176,6 +176,8 @@ export const chatThreadMessage: StateCreator<
       messages,
       parentMessageId,
       parentMessageType: 'user',
+      sessionId: get().activeId,
+      topicId: get().activeTopicId,
       ragQuery: get().internal_shouldUseRAG() ? message : undefined,
       threadId: get().portalThreadId,
       inPortalThread: true,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Introduce explicit session and topic context to the chat store runtime and optimistic update flows, enabling parallel topic isolation and ensuring all actions, executors, and service calls propagate the correct sessionId and topicId rather than relying on global state.

New Features:
- Add OptimisticUpdateContext to allow passing explicit sessionId and topicId to optimistic update actions
- Extend streamingExecutor and internal_execAgentRuntime to accept and propagate explicit session/topic context

Enhancements:
- Refactor message and plugin slice actions to include context in create, delete, update, error, and RAG operations
- Replace chatSelectors.getMessageById with dbMessageSelectors.getDbMessageById for retrieving session/topic info
- Update messageService methods (e.g., updateMessageError) to forward sessionId and topicId to backend calls
- Modify search, pluginTypes, pluginWorkflow, conversationLifecycle, and thread actions to pass context for API interactions
- Adjust refreshMessages and replaceMessages to operate within the specified session/topic scope

Tests:
- Update existing tests and add new ones to verify optimistic update methods and streamingExecutor use provided or fallback sessionId/topicId
- Mock dbMessageSelectors.getDbMessageById default behavior and assert context isolation in plugin and search action tests