### PR TITLE
♻️ refactor: refactor thread

### DIFF
--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -61,7 +61,6 @@ export class MessageModel {
       threadId,
     }: QueryMessageParams & { threadId?: string | null } = {},
     options: {
-      groupAssistantMessages?: boolean;
       postProcessUrl?: (path: string | null, file: { fileType: string }) => Promise<string>;
     } = {},
   ) => {

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -52,7 +52,14 @@ export class MessageModel {
 
   // **************** Query *************** //
   query = async (
-    { current = 0, pageSize = 1000, sessionId, topicId, groupId }: QueryMessageParams = {},
+    {
+      current = 0,
+      pageSize = 1000,
+      sessionId,
+      topicId,
+      groupId,
+      threadId,
+    }: QueryMessageParams & { threadId?: string | null } = {},
     options: {
       groupAssistantMessages?: boolean;
       postProcessUrl?: (path: string | null, file: { fileType: string }) => Promise<string>;
@@ -119,6 +126,7 @@ export class MessageModel {
           this.matchSession(sessionId),
           this.matchTopic(topicId),
           this.matchGroup(groupId),
+          this.matchThread(threadId),
         ),
       )
       .leftJoin(messagePlugins, eq(messagePlugins.id, messages.id))
@@ -752,4 +760,9 @@ export class MessageModel {
 
   private matchGroup = (groupId?: string | null) =>
     groupId ? eq(messages.groupId, groupId) : isNull(messages.groupId);
+
+  private matchThread = (threadId?: string | null) => {
+    if (!!threadId) return eq(messages.threadId, threadId);
+    return isNull(messages.threadId);
+  };
 }

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -31,14 +31,18 @@ export class MessageService {
     });
   };
 
-  getMessages = async (
-    sessionId: string,
-    topicId?: string,
-    groupId?: string,
-  ): Promise<UIChatMessage[]> => {
+  getMessages = async (params: {
+    groupId?: string;
+    sessionId: string;
+    threadId?: string;
+    topicId?: string;
+  }): Promise<UIChatMessage[]> => {
+    const { sessionId, topicId, groupId, threadId } = params;
+
     const data = await lambdaClient.message.getMessages.query({
       groupId,
-      sessionId: this.toDbSessionId(sessionId),
+      sessionId,
+      threadId,
       topicId,
     });
 

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -217,17 +217,11 @@ export class MessageService {
   };
 
   removeMessagesByAssistant = async (sessionId: string, topicId?: string) => {
-    return lambdaClient.message.removeMessagesByAssistant.mutate({
-      sessionId: this.toDbSessionId(sessionId),
-      topicId,
-    });
+    return lambdaClient.message.removeMessagesByAssistant.mutate({ sessionId, topicId });
   };
 
   removeMessagesByGroup = async (groupId: string, topicId?: string) => {
-    return lambdaClient.message.removeMessagesByGroup.mutate({
-      groupId,
-      topicId,
-    });
+    return lambdaClient.message.removeMessagesByGroup.mutate({ groupId, topicId });
   };
 
   removeAllMessages = async () => {

--- a/src/services/message/server.test.ts
+++ b/src/services/message/server.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { INBOX_SESSION_ID } from '@/const/session';
+import { lambdaClient } from '@/libs/trpc/client';
 
 import { MessageService } from './index';
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    message: {
+      createMessage: { mutate: vi.fn() },
+      getMessages: { query: vi.fn() },
+      removeMessagesByAssistant: { mutate: vi.fn() },
+    },
+  },
+}));
 
 describe('MessageService', () => {
   describe('toDbSessionId', () => {
@@ -20,11 +31,11 @@ describe('MessageService', () => {
     });
 
     it('should handle undefined input', () => {
-      expect(toDbSessionId(undefined)).toBeUndefined(); // Updated to match the actual behavior
+      expect(toDbSessionId(undefined)).toBeUndefined();
     });
 
     it('should handle empty string input', () => {
-      expect(toDbSessionId('')).toBe(''); // No changes needed
+      expect(toDbSessionId('')).toBe('');
     });
 
     it('should handle special characters in session id', () => {
@@ -38,7 +49,83 @@ describe('MessageService', () => {
     });
 
     it('should handle null session id', () => {
-      expect(toDbSessionId(null as any)).toBeNull(); // Cast null to any to bypass type errors
+      expect(toDbSessionId(null as any)).toBeNull();
+    });
+  });
+
+  describe('INBOX_SESSION_ID transformation in methods', () => {
+    const service = new MessageService();
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    describe('createMessage', () => {
+      it('should transform INBOX_SESSION_ID to null', async () => {
+        vi.mocked(lambdaClient.message.createMessage.mutate).mockResolvedValue({
+          id: 'msg-1',
+          messages: [],
+        });
+
+        await service.createMessage({
+          content: 'test',
+          role: 'user',
+          sessionId: INBOX_SESSION_ID,
+        });
+
+        expect(lambdaClient.message.createMessage.mutate).toHaveBeenCalledWith({
+          content: 'test',
+          role: 'user',
+          sessionId: null,
+        });
+      });
+
+      it('should keep regular sessionId unchanged', async () => {
+        vi.mocked(lambdaClient.message.createMessage.mutate).mockResolvedValue({
+          id: 'msg-1',
+          messages: [],
+        });
+
+        await service.createMessage({
+          content: 'test',
+          role: 'user',
+          sessionId: 'session-123',
+        });
+
+        expect(lambdaClient.message.createMessage.mutate).toHaveBeenCalledWith({
+          content: 'test',
+          role: 'user',
+          sessionId: 'session-123',
+        });
+      });
+    });
+
+    describe('removeMessagesByAssistant', () => {
+      it('should NOT transform INBOX_SESSION_ID (server handles it)', async () => {
+        vi.mocked(lambdaClient.message.removeMessagesByAssistant.mutate).mockResolvedValue(
+          undefined as any,
+        );
+
+        await service.removeMessagesByAssistant(INBOX_SESSION_ID);
+
+        expect(lambdaClient.message.removeMessagesByAssistant.mutate).toHaveBeenCalledWith({
+          sessionId: INBOX_SESSION_ID,
+          topicId: undefined,
+        });
+      });
+
+      it('should keep regular sessionId unchanged', async () => {
+        vi.mocked(lambdaClient.message.removeMessagesByAssistant.mutate).mockResolvedValue(
+          undefined as any,
+        );
+
+        await service.removeMessagesByAssistant('session-123', 'topic-1');
+
+        expect(lambdaClient.message.removeMessagesByAssistant.mutate).toHaveBeenCalledWith({
+          sessionId: 'session-123',
+          topicId: 'topic-1',
+        });
+      });
     });
   });
 });

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -96,7 +96,7 @@ export const messageQuery: StateCreator<
       enable ? [SWR_USE_FETCH_MESSAGES, messageContextId, activeTopicId, type] : null,
       async ([, sessionId, topicId, type]: [string, string, string | undefined, string]) =>
         type === 'session'
-          ? messageService.getMessages(sessionId, topicId)
+          ? messageService.getMessages({ sessionId, topicId })
           : messageService.getGroupMessages(sessionId, topicId),
       {
         onSuccess: (messages, key) => {

--- a/src/store/chat/slices/operation/types.ts
+++ b/src/store/chat/slices/operation/types.ts
@@ -10,6 +10,7 @@
 export type OperationType =
   // === Message sending ===
   | 'sendMessage' // Send message to server
+  | 'sendThreadMessage' // Send message in thread
   | 'createTopic' // Auto create topic
   | 'regenerate' // Regenerate message
   | 'continue' // Continue generation

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -225,7 +225,7 @@ export const chatTopic: StateCreator<
     const { activeId: sessionId, summaryTopicTitle, internal_updateTopicLoading } = get();
 
     internal_updateTopicLoading(id, true);
-    const messages = await messageService.getMessages(sessionId, id);
+    const messages = await messageService.getMessages({ sessionId, topicId: id });
 
     await summaryTopicTitle(id, messages);
     internal_updateTopicLoading(id, false);

--- a/src/store/chat/utils/messageMapKey.test.ts
+++ b/src/store/chat/utils/messageMapKey.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { messageMapKey } from './messageMapKey';
+
+describe('messageMapKey', () => {
+  describe('basic sessionId only', () => {
+    it('should generate key with sessionId only', () => {
+      const result = messageMapKey('session-1');
+      expect(result).toBe('session-1_null');
+    });
+
+    it('should handle empty string sessionId', () => {
+      const result = messageMapKey('');
+      expect(result).toBe('_null');
+    });
+
+    it('should handle sessionId with special characters', () => {
+      const result = messageMapKey('session-123-abc_def');
+      expect(result).toBe('session-123-abc_def_null');
+    });
+  });
+
+  describe('sessionId with topicId', () => {
+    it('should generate key with sessionId and topicId', () => {
+      const result = messageMapKey('session-1', 'topic-1');
+      expect(result).toBe('session-1_topic-1');
+    });
+
+    it('should handle null topicId', () => {
+      const result = messageMapKey('session-1', null);
+      expect(result).toBe('session-1_null');
+    });
+
+    it('should handle undefined topicId (same as null)', () => {
+      const result = messageMapKey('session-1', undefined);
+      expect(result).toBe('session-1_null');
+    });
+
+    it('should handle empty string topicId', () => {
+      const result = messageMapKey('session-1', '');
+      expect(result).toBe('session-1_');
+    });
+
+    it('should handle topicId with special characters', () => {
+      const result = messageMapKey('session-1', 'topic-123-abc_def');
+      expect(result).toBe('session-1_topic-123-abc_def');
+    });
+  });
+
+  describe('thread mode (highest priority)', () => {
+    it('should generate thread key with threadId', () => {
+      const result = messageMapKey('session-1', undefined, 'thread-1');
+      expect(result).toBe('session-1_thread_thread-1');
+    });
+
+    it('should prioritize threadId over topicId', () => {
+      const result = messageMapKey('session-1', 'topic-1', 'thread-1');
+      expect(result).toBe('session-1_thread_thread-1');
+    });
+
+    it('should handle null threadId (falls back to topic mode)', () => {
+      const result = messageMapKey('session-1', 'topic-1', null);
+      expect(result).toBe('session-1_topic-1');
+    });
+
+    it('should handle undefined threadId (falls back to topic mode)', () => {
+      const result = messageMapKey('session-1', 'topic-1', undefined);
+      expect(result).toBe('session-1_topic-1');
+    });
+
+    it('should handle empty string threadId', () => {
+      const result = messageMapKey('session-1', 'topic-1', '');
+      expect(result).toBe('session-1_topic-1');
+    });
+
+    it('should handle threadId with special characters', () => {
+      const result = messageMapKey('session-1', undefined, 'thread-123-abc_def');
+      expect(result).toBe('session-1_thread_thread-123-abc_def');
+    });
+  });
+
+  describe('key uniqueness', () => {
+    it('should generate different keys for different sessionIds', () => {
+      const key1 = messageMapKey('session-1', 'topic-1');
+      const key2 = messageMapKey('session-2', 'topic-1');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should generate different keys for different topicIds', () => {
+      const key1 = messageMapKey('session-1', 'topic-1');
+      const key2 = messageMapKey('session-1', 'topic-2');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should generate different keys for different threadIds', () => {
+      const key1 = messageMapKey('session-1', undefined, 'thread-1');
+      const key2 = messageMapKey('session-1', undefined, 'thread-2');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should generate different keys for topic vs thread mode', () => {
+      const topicKey = messageMapKey('session-1', 'topic-1');
+      const threadKey = messageMapKey('session-1', 'topic-1', 'thread-1');
+      expect(topicKey).not.toBe(threadKey);
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should handle inbox session without topic', () => {
+      const result = messageMapKey('inbox', undefined);
+      expect(result).toBe('inbox_null');
+    });
+
+    it('should handle inbox session with topic', () => {
+      const result = messageMapKey('inbox', 'topic-123');
+      expect(result).toBe('inbox_topic-123');
+    });
+
+    it('should handle group session', () => {
+      const result = messageMapKey('group-abc', 'topic-xyz');
+      expect(result).toBe('group-abc_topic-xyz');
+    });
+
+    it('should handle thread in group session', () => {
+      const result = messageMapKey('group-abc', 'topic-xyz', 'thread-001');
+      expect(result).toBe('group-abc_thread_thread-001');
+    });
+
+    it('should handle multiple threads in same session', () => {
+      const thread1 = messageMapKey('session-1', 'topic-1', 'thread-1');
+      const thread2 = messageMapKey('session-1', 'topic-1', 'thread-2');
+      const thread3 = messageMapKey('session-1', 'topic-1', 'thread-3');
+
+      expect(thread1).toBe('session-1_thread_thread-1');
+      expect(thread2).toBe('session-1_thread_thread-2');
+      expect(thread3).toBe('session-1_thread_thread-3');
+      expect(new Set([thread1, thread2, thread3]).size).toBe(3);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle all parameters as empty strings', () => {
+      const result = messageMapKey('', '', '');
+      expect(result).toBe('_');
+    });
+
+    it('should handle sessionId with underscore (potential conflict)', () => {
+      const result = messageMapKey('session_with_underscores', 'topic-1');
+      expect(result).toBe('session_with_underscores_topic-1');
+    });
+
+    it('should handle topicId with underscore', () => {
+      const result = messageMapKey('session-1', 'topic_with_underscores');
+      expect(result).toBe('session-1_topic_with_underscores');
+    });
+
+    it('should handle threadId with underscore', () => {
+      const result = messageMapKey('session-1', undefined, 'thread_with_underscores');
+      expect(result).toBe('session-1_thread_thread_with_underscores');
+    });
+
+    it('should be consistent when called multiple times with same params', () => {
+      const key1 = messageMapKey('session-1', 'topic-1', 'thread-1');
+      const key2 = messageMapKey('session-1', 'topic-1', 'thread-1');
+      expect(key1).toBe(key2);
+    });
+  });
+});

--- a/src/store/chat/utils/messageMapKey.ts
+++ b/src/store/chat/utils/messageMapKey.ts
@@ -1,4 +1,10 @@
-export const messageMapKey = (sessionId: string, topicId?: string | null) => {
+export const messageMapKey = (
+  sessionId: string,
+  topicId?: string | null,
+  threadId?: string | null,
+) => {
+  if (threadId) return `${sessionId}_thread_${threadId}`;
+
   let topic = topicId;
 
   if (typeof topicId === 'undefined') topic = null;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enable thread-based message querying in the database and add a new sendThreadMessage operation in the chat store with full operation lifecycle management.

Enhancements:
- Add threadId parameter to MessageModel.query and implement matchThread filter to support thread-based message queries
- Introduce sendThreadMessage operation in chat store with operationId tracking, optimistic message creation, AI runtime integration, and auto-summarization of new thread titles
- Wrap internal_execAgentRuntime call in try/catch to handle operation completion and failure for thread messages

Tests:
- Add tests for querying messages by threadId covering non-thread, combined filters, and null threadId scenarios

Chores:
- Add 'sendThreadMessage' to OperationType definitions