### PR TITLE
🐛 fix: Gemini 3 Pro does not display thought summaries

### DIFF
--- a/packages/model-runtime/src/core/streams/google/index.ts
+++ b/packages/model-runtime/src/core/streams/google/index.ts
@@ -106,10 +106,10 @@ const transformGoogleGenerativeAIStream = (
   }
 
   // Parse text from candidate.content.parts
-  // Filter out thought content (thought: true) and thoughtSignature
+  // Filter out thought content (thought: true) only, keep thoughtSignature as it's just metadata
   const text =
     candidate?.content?.parts
-      ?.filter((part: any) => part.text && !part.thought && !part.thoughtSignature)
+      ?.filter((part: any) => part.text && !part.thought)
       .map((part: any) => part.text)
       .join('') || '';
 

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -621,3 +621,99 @@ describe('resolveModelThinkingBudget', () => {
     expect(resolveModelThinkingBudget('unknown-model', 99_999)).toBe(24_576);
   });
 });
+
+describe('thinkingConfig includeThoughts logic', () => {
+  it('should enable thinking when thinkingBudget is set', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.5-pro',
+      thinkingBudget: 5000,
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig?.includeThoughts).toBe(true);
+  });
+
+  it('should enable thinking when thinkingLevel is set', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3-pro',
+      thinkingLevel: 'high',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig?.includeThoughts).toBe(true);
+  });
+
+  it('should enable thinking for gemini-3-pro-image models', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3-pro-image-preview',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig?.includeThoughts).toBe(true);
+  });
+
+  it('should enable thinking for thinking-enabled models', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.0-flash-thinking-exp',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig?.includeThoughts).toBe(true);
+  });
+
+  it('should disable thinking when resolvedThinkingBudget is 0', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.5-flash-lite',
+      thinkingBudget: 0,
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config;
+    expect(config.thinkingConfig?.includeThoughts).toBeUndefined();
+  });
+
+  it('should add thinkingLevel to config for 3.x models when provided', async () => {
+    const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3-pro',
+      thinkingLevel: 'high',
+      temperature: 0,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    expect(config.thinkingConfig?.thinkingLevel).toBe('high');
+  });
+});

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -202,7 +202,8 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       const thinkingConfig: ThinkingConfig = {
         includeThoughts:
           (!!thinkingBudget ||
-            (model && (model.includes('-2.5-') || model.includes('thinking')))) &&
+            !!thinkingLevel ||
+            (model && (model.includes('-3-pro-image') || model.includes('thinking')))) &&
           resolvedThinkingBudget !== 0
             ? true
             : undefined,


### PR DESCRIPTION
…oogle stream processing

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- fix #10313


<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change
根据下面返回样例，或许不该过滤包含 thoughtSignature 的块，这属于第一个正文返回流。

`data: {"candidates": [{"content": {"parts": [{"text": "经过搜索和仔细挑选，我为您选定了一张具有独特氛围感的猫猫图。\n\n我没有选择一张普通的网红搞怪图或单纯的大","thoughtSignature": "EssoCsgoAdHtim...09kVo7NBeSCDaw="}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 12,"candidatesTokenCount": 33,"totalTokenCount": 1137,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 12}],"thoughtsTokenCount": 1092},"modelVersion": "gemini-3-pro-image-preview","responseId": "r3AgaZThF9jUqfkPz-a7mA4"}
`

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix handling of Gemini thinking responses so thought summaries are surfaced correctly in streaming output.

Bug Fixes:
- Ensure text parts tagged with thoughtSignature are preserved in Google streaming responses instead of being filtered out as thoughts.

Enhancements:
- Adjust thought-inclusion logic to respect explicit thinking level configuration and support newer Gemini 3 Pro image models.