### PR TITLE
chore: add new badge for image model list

### DIFF
--- a/packages/database/src/models/aiModel.ts
+++ b/packages/database/src/models/aiModel.ts
@@ -104,6 +104,7 @@ export class AiModelModel {
         id: aiModels.id,
         parameters: aiModels.parameters,
         providerId: aiModels.providerId,
+        releasedAt: aiModels.releasedAt,
         sort: aiModels.sort,
         source: aiModels.source,
         type: aiModels.type,

--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -1057,6 +1057,7 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     displayName: 'Nano Banana Pro',
+    enabled: true,
     id: 'gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -184,6 +184,7 @@ const googleChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     displayName: 'Nano Banana Pro',
+    enabled: true,
     id: 'gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {
@@ -891,6 +892,7 @@ const googleImageModels: AIImageModelCard[] = [
     displayName: 'Nano Banana Pro',
     id: 'gemini-3-pro-image-preview:image',
     type: 'image',
+    enabled: true,
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     releasedAt: '2025-11-18',

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -14,6 +14,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     displayName: 'Nano Banana Pro',
+    enabled: true,
     id: 'gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {

--- a/packages/model-bank/src/aiModels/zenmux.ts
+++ b/packages/model-bank/src/aiModels/zenmux.ts
@@ -19,6 +19,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     displayName: 'Gemini 3 Pro Image (Nano Banana Pro)',
+    enabled: true,
     id: 'google/gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -412,6 +412,7 @@ export interface AiModelForSelect {
    */
   pricePerImage?: number;
   pricing?: Pricing;
+  releasedAt?: string;
 }
 
 export interface EnabledAiModel {

--- a/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
+++ b/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
@@ -7,6 +7,8 @@ import numeral from 'numeral';
 import { memo, useMemo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
+import NewModelBadge from '@/features/ModelSelect/components/NewModelBadge';
+
 const POPOVER_MAX_WIDTH = 320;
 
 const useStyles = createStyles(({ css, token, isDarkMode }) => ({
@@ -67,6 +69,7 @@ const ImageModelItem = memo<ImageModelItemProps>(
         <Text ellipsis title={model.displayName || model.id}>
           {model.displayName || model.id}
         </Text>
+        <NewModelBadge releasedAt={model.releasedAt} />
       </Flexbox>
     );
 

--- a/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
+++ b/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
@@ -28,6 +28,11 @@ const useStyles = createStyles(({ css, token, isDarkMode }) => ({
 
 type ImageModelItemProps = AiModelForSelect & {
   /**
+   * Whether to show new model badge
+   * @default true
+   */
+  showBadge?: boolean;
+  /**
    * Whether to show popover on hover
    * @default true
    */
@@ -35,7 +40,14 @@ type ImageModelItemProps = AiModelForSelect & {
 };
 
 const ImageModelItem = memo<ImageModelItemProps>(
-  ({ approximatePricePerImage, description, pricePerImage, showPopover = true, ...model }) => {
+  ({
+    approximatePricePerImage,
+    description,
+    pricePerImage,
+    showPopover = true,
+    showBadge = true,
+    ...model
+  }) => {
     const { styles } = useStyles();
 
     const priceLabel = useMemo(() => {
@@ -69,7 +81,7 @@ const ImageModelItem = memo<ImageModelItemProps>(
         <Text ellipsis title={model.displayName || model.id}>
           {model.displayName || model.id}
         </Text>
-        <NewModelBadge releasedAt={model.releasedAt} />
+        {showBadge && <NewModelBadge releasedAt={model.releasedAt} />}
       </Flexbox>
     );
 

--- a/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/index.tsx
+++ b/src/app/[variants]/(main)/image/@menu/features/ConfigPanel/components/ModelSelect/index.tsx
@@ -129,7 +129,7 @@ const ModelSelect = memo(() => {
 
     if (!modelInfo) return props.label;
 
-    return <ImageModelItem {...modelInfo} showPopover={false} />;
+    return <ImageModelItem {...modelInfo} showBadge={false} showPopover={false} />;
   };
 
   return (

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { ModelInfoTags } from '@/components/ModelSelect';
+import NewModelBadge from '@/features/ModelSelect/components/NewModelBadge';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { formatPriceByCurrency } from '@/utils/format';
@@ -17,7 +18,6 @@ import {
   getTextInputUnitRate,
   getTextOutputUnitRate,
 } from '@/utils/pricing';
-import { isNewReleaseDate } from '@/utils/time';
 
 import ModelConfigModal from './ModelConfigModal';
 import { ProviderSettingsContext } from './ProviderSettingsContext';
@@ -163,12 +163,7 @@ const ModelItem = memo<ModelItemProps>(
 
     const isMobile = useIsMobile();
 
-    const NewTag =
-      releasedAt && isNewReleaseDate(releasedAt) ? (
-        <Tag color="blue" style={{ marginLeft: 8 }}>
-          {t('new', { ns: 'common' })}
-        </Tag>
-      ) : null;
+    const NewTag = <NewModelBadge releasedAt={releasedAt} />;
 
     const ModelIdTag = (
       <Tag onClick={copyModelId} style={{ cursor: 'pointer', marginRight: 0 }}>

--- a/src/features/ModelSelect/components/NewModelBadge.tsx
+++ b/src/features/ModelSelect/components/NewModelBadge.tsx
@@ -1,0 +1,23 @@
+import { Tag } from '@lobehub/ui';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { isNewReleaseDate } from '@/utils/time';
+
+interface NewModelBadgeProps {
+  releasedAt?: string;
+}
+
+const NewModelBadge = memo<NewModelBadgeProps>(({ releasedAt }) => {
+  const { t } = useTranslation('common');
+
+  if (!releasedAt || !isNewReleaseDate(releasedAt)) return null;
+
+  return (
+    <Tag color="blue" style={{ marginLeft: 8 }}>
+      {t('new')}
+    </Tag>
+  );
+});
+
+export default NewModelBadge;

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -40,6 +40,7 @@ export type ProviderModelListItem = {
   parameters?: ModelParamsSchema;
   pricePerImage?: number;
   pricing?: Pricing;
+  releasedAt?: string;
 };
 
 type ModelNormalizer = (model: EnabledAiModel) => Promise<ProviderModelListItem>;
@@ -67,6 +68,7 @@ export const normalizeChatModel = (model: EnabledAiModel): ProviderModelListItem
   contextWindowTokens: model.contextWindowTokens,
   displayName: model.displayName ?? '',
   id: model.id,
+  releasedAt: model.releasedAt,
 });
 
 export const normalizeImageModel = async (
@@ -107,6 +109,7 @@ export const normalizeImageModel = async (
     contextWindowTokens: model.contextWindowTokens,
     displayName: model.displayName ?? '',
     id: model.id,
+    releasedAt: model.releasedAt,
     ...(parameters && { parameters }),
     ...(description && { description }),
     ...(pricing && { pricing }),


### PR DESCRIPTION
## 💻 Change Type

- [x] ✨ feat

## 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

## 🔀 Description of Change

Enable support for Nano Banana Pro models in the image generation feature.

**Changes included:**
- Add NewModelBadge component to display new models
- Integrate badge into ModelSelect and ModelList components
- Pass releasedAt field to model list items
- Add showBadge prop to control badge visibility in select fields (hidden in field label, visible in dropdown options)
- Add support for Nano Banana Pro models in the model configuration

## 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

## 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

## 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable Nano Banana Pro image models and surface new model badges in model selection and settings views.

New Features:
- Add support for Nano Banana Pro models across Google, Vertex AI, AIHubMix, and Zenmux providers for both chat and image use cases.
- Introduce a reusable NewModelBadge component to highlight newly released models in the UI.

Enhancements:
- Propagate releasedAt metadata through model types, normalization, and database mapping so model recency can be displayed consistently.
- Update image model selection and provider model list UIs to optionally show or hide the new model badge in labels and dropdown options.