### PR TITLE
 💄 style: optimize nana banana pro error message

### DIFF
--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -8,6 +8,7 @@ import { createGoogleImage } from './createImage';
 
 const provider = 'google';
 const bizErrorType = 'ProviderBizError';
+const noImageErrorType = 'ProviderNoImageGenerated';
 const invalidErrorType = 'InvalidProviderAPIKey';
 
 // Mock the console.error to avoid polluting test output
@@ -201,7 +202,7 @@ describe('createGoogleImage', () => {
         // Act & Assert - Test error behavior rather than specific text
         await expect(createGoogleImage(mockClient, provider, payload)).rejects.toEqual(
           expect.objectContaining({
-            errorType: bizErrorType,
+            errorType: noImageErrorType,
             provider,
           }),
         );
@@ -224,7 +225,7 @@ describe('createGoogleImage', () => {
         // Act & Assert
         await expect(createGoogleImage(mockClient, provider, payload)).rejects.toEqual(
           expect.objectContaining({
-            errorType: bizErrorType,
+            errorType: noImageErrorType,
             provider,
           }),
         );
@@ -251,7 +252,7 @@ describe('createGoogleImage', () => {
         // Act & Assert
         await expect(createGoogleImage(mockClient, provider, payload)).rejects.toEqual(
           expect.objectContaining({
-            errorType: bizErrorType,
+            errorType: noImageErrorType,
             provider,
           }),
         );
@@ -602,7 +603,7 @@ describe('createGoogleImage', () => {
         // Act & Assert
         await expect(createGoogleImage(mockClient, provider, payload)).rejects.toEqual(
           expect.objectContaining({
-            errorType: bizErrorType,
+            errorType: noImageErrorType,
             provider,
           }),
         );
@@ -627,7 +628,7 @@ describe('createGoogleImage', () => {
         // Act & Assert
         await expect(createGoogleImage(mockClient, provider, payload)).rejects.toEqual(
           expect.objectContaining({
-            errorType: bizErrorType,
+            errorType: noImageErrorType,
             provider,
           }),
         );

--- a/packages/model-runtime/src/types/error.ts
+++ b/packages/model-runtime/src/types/error.ts
@@ -19,14 +19,6 @@ export const AgentRuntimeErrorType = {
   OllamaBizError: 'OllamaBizError',
   OllamaServiceUnavailable: 'OllamaServiceUnavailable',
 
-  InvalidComfyUIArgs: 'InvalidComfyUIArgs',
-  ComfyUIBizError: 'ComfyUIBizError',
-  ComfyUIServiceUnavailable: 'ComfyUIServiceUnavailable',
-  ComfyUIEmptyResult: 'ComfyUIEmptyResult',
-  ComfyUIUploadFailed: 'ComfyUIUploadFailed',
-  ComfyUIWorkflowError: 'ComfyUIWorkflowError',
-  ComfyUIModelError: 'ComfyUIModelError',
-
   InvalidBedrockCredentials: 'InvalidBedrockCredentials',
   InvalidVertexCredentials: 'InvalidVertexCredentials',
   StreamChunkError: 'StreamChunkError',
@@ -34,6 +26,17 @@ export const AgentRuntimeErrorType = {
   InvalidGithubToken: 'InvalidGithubToken',
 
   ConnectionCheckFailed: 'ConnectionCheckFailed',
+
+  // ******* Image Generation Error ******* //
+  ProviderNoImageGenerated: 'ProviderNoImageGenerated',
+
+  InvalidComfyUIArgs: 'InvalidComfyUIArgs',
+  ComfyUIBizError: 'ComfyUIBizError',
+  ComfyUIServiceUnavailable: 'ComfyUIServiceUnavailable',
+  ComfyUIEmptyResult: 'ComfyUIEmptyResult',
+  ComfyUIUploadFailed: 'ComfyUIUploadFailed',
+  ComfyUIWorkflowError: 'ComfyUIWorkflowError',
+  ComfyUIModelError: 'ComfyUIModelError',
 
   /**
    * @deprecated

--- a/packages/model-runtime/src/utils/googleErrorParser.ts
+++ b/packages/model-runtime/src/utils/googleErrorParser.ts
@@ -104,6 +104,11 @@ export function parseGoogleErrorMessage(message: string): ParsedError {
     return { error: { message }, errorType: AgentRuntimeErrorType.LocationNotSupportError };
   }
 
+  const lowerMessage = message.toLowerCase();
+  if (lowerMessage.includes('no image generated') || lowerMessage.includes('no image data')) {
+    return { error: { message }, errorType: AgentRuntimeErrorType.ProviderNoImageGenerated };
+  }
+
   // Unified error type determination function
   const getErrorType = (code: number | null, message: string): ILobeAgentRuntimeErrorType => {
     if (code === 400 && message.includes('API key not valid')) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve handling and surfacing of image generation failures from providers, especially when no image is returned.

Bug Fixes:
- Normalize Google image provider responses that return 200 status but no image data so they are treated as explicit no-image errors.
- Ensure image editing requests receive clearer, context-aware error feedback when providers fail to generate an image.
- Preserve and rethrow existing typed provider errors during Google image creation so upstream logic can classify them correctly.

Enhancements:
- Introduce a dedicated ProviderNoImageGenerated error type and wire it through Google error parsing and async task error categorization to provide more precise messaging.
- Detect when an image request is editing an existing image and tailor user-facing error messages accordingly.