### PR TITLE
 🐛 fix: fixed the knowledge files cant open error

### DIFF
--- a/src/app/[variants]/desktopRouter.config.tsx
+++ b/src/app/[variants]/desktopRouter.config.tsx
@@ -386,6 +386,11 @@ export const createDesktopRouter = (locale: Locales) =>
               index: true,
             },
             {
+              element: <KnowledgeHome />,
+              loader: idLoader,
+              path: ':id',
+            },
+            {
               element: <KnowledgeBasesList />,
               path: 'bases',
             },

--- a/src/app/[variants]/mobileRouter.config.tsx
+++ b/src/app/[variants]/mobileRouter.config.tsx
@@ -403,6 +403,11 @@ export const createMobileRouter = (locale: Locales) =>
               index: true,
             },
             {
+              element: <KnowledgeHome />,
+              loader: idLoader,
+              path: ':id',
+            },
+            {
               element: <KnowledgeBasesList />,
               path: 'bases',
             },

--- a/src/features/KnowledgeManager/Home/index.tsx
+++ b/src/features/KnowledgeManager/Home/index.tsx
@@ -104,7 +104,7 @@ const Home = memo<HomeProps>(({ knowledgeBaseId, onOpenFile }) => {
   const handleDocumentClick = (documentId: string) => {
     // Navigate to the document in the explorer
     // The KnowledgeHomePage will automatically set category to 'documents' when it detects the id param
-    navigate(`/${documentId}`);
+    navigate(`/knowledge/${documentId}`);
   };
 
   return (


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix navigation and routing for opening individual knowledge items from the Knowledge home page.

Bug Fixes:
- Add an ID-based route to the Knowledge home in both desktop and mobile routers so knowledge files can be opened directly by ID.
- Update document click navigation to use the knowledge route prefix when opening a specific knowledge document.