### PR TITLE
🐛 fix: fix db migration snapshot not align with db schema

### DIFF
--- a/docs/development/database-schema.dbml
+++ b/docs/development/database-schema.dbml
@@ -187,6 +187,7 @@ table documents {
   user_id text [not null]
   client_id text
   editor_data jsonb
+  slug varchar(255)
   accessed_at "timestamp with time zone" [not null, default: `now()`]
   created_at "timestamp with time zone" [not null, default: `now()`]
   updated_at "timestamp with time zone" [not null, default: `now()`]
@@ -197,6 +198,7 @@ table documents {
     file_id [name: 'documents_file_id_idx']
     parent_id [name: 'documents_parent_id_idx']
     (client_id, user_id) [name: 'documents_client_id_user_id_unique', unique]
+    (slug, user_id) [name: 'documents_slug_user_id_unique', unique]
   }
 }
 
@@ -214,7 +216,6 @@ table files {
   metadata jsonb
   chunk_task_id uuid
   embedding_task_id uuid
-  slug text [unique]
   accessed_at "timestamp with time zone" [not null, default: `now()`]
   created_at "timestamp with time zone" [not null, default: `now()`]
   updated_at "timestamp with time zone" [not null, default: `now()`]

--- a/packages/database/migrations/0047_add_slug_document.sql
+++ b/packages/database/migrations/0047_add_slug_document.sql
@@ -1,6 +1,2 @@
 ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "slug" varchar(255);--> statement-breakpoint
-DO $$ BEGIN
- CREATE UNIQUE INDEX IF NOT EXISTS "documents_slug_user_id_unique" ON "documents" ("slug","user_id") WHERE "slug" IS NOT NULL;
-EXCEPTION
- WHEN duplicate_object THEN null;
-END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS "documents_slug_user_id_unique" ON "documents" USING btree ("slug","user_id") WHERE "documents"."slug" is not null;

--- a/packages/database/migrations/meta/0047_snapshot.json
+++ b/packages/database/migrations/meta/0047_snapshot.json
@@ -6,7 +6,7 @@
   },
   "dialect": "postgresql",
   "enums": {},
-  "id": "8a423b68-c609-44e1-bd48-f2ed62fec5ef",
+  "id": "20a4c30c-04f0-4993-b493-0ae6a3144f9e",
   "policies": {},
   "prevId": "abe0cb47-a970-4ec0-a29f-1afa9bd2fe02",
   "roles": {},
@@ -1259,6 +1259,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
         "accessed_at": {
           "name": "accessed_at",
           "type": "timestamp with time zone",
@@ -1359,6 +1365,28 @@
             }
           ],
           "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_slug_user_id_unique": {
+          "name": "documents_slug_user_id_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"documents\".\"slug\" is not null",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -1478,12 +1506,6 @@
         "embedding_task_id": {
           "name": "embedding_task_id",
           "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "slug": {
-          "name": "slug",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -1610,13 +1632,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "files_slug_unique": {
-          "name": "files_slug_unique",
-          "nullsNotDistinct": false,
-          "columns": ["slug"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -333,7 +333,7 @@
     {
       "idx": 47,
       "version": "7",
-      "when": 1763535087148,
+      "when": 1763987922211,
       "tag": "0047_add_slug_document",
       "breakpoints": true
     }

--- a/packages/database/src/core/migrations.json
+++ b/packages/database/src/core/migrations.json
@@ -791,11 +791,11 @@
   },
   {
     "sql": [
-      "ALTER TABLE \"documents\" ADD COLUMN IF NOT EXISTS \"slug\" varchar(255);",
-      "\nDO $$ BEGIN\n CREATE UNIQUE INDEX IF NOT EXISTS \"documents_slug_user_id_unique\" ON \"documents\" (\"slug\",\"user_id\") WHERE \"slug\" IS NOT NULL;\nEXCEPTION\n WHEN duplicate_object THEN null;\nEND $$;"
+      "ALTER TABLE \"documents\" ADD COLUMN \"slug\" varchar(255);",
+      "\nCREATE UNIQUE INDEX \"documents_slug_user_id_unique\" ON \"documents\" USING btree (\"slug\",\"user_id\") WHERE \"documents\".\"slug\" is not null;"
     ],
     "bps": true,
-    "folderMillis": 1763535087148,
-    "hash": "57a82ce14d96ffa9f140ff63f00af994e91a74703f4d2378286e36be259f117b"
+    "folderMillis": 1763987922211,
+    "hash": "29e3a4a075bca278db70cad98932e7f8d1b3092027b94ef46910b196dec6b5c3"
   }
 ]

--- a/packages/database/src/core/migrations.json
+++ b/packages/database/src/core/migrations.json
@@ -791,11 +791,11 @@
   },
   {
     "sql": [
-      "ALTER TABLE \"documents\" ADD COLUMN \"slug\" varchar(255);",
-      "\nCREATE UNIQUE INDEX \"documents_slug_user_id_unique\" ON \"documents\" USING btree (\"slug\",\"user_id\") WHERE \"documents\".\"slug\" is not null;"
+      "ALTER TABLE \"documents\" ADD COLUMN IF NOT EXISTS \"slug\" varchar(255);",
+      "\nCREATE UNIQUE INDEX IF NOT EXISTS \"documents_slug_user_id_unique\" ON \"documents\" USING btree (\"slug\",\"user_id\") WHERE \"documents\".\"slug\" is not null;\n"
     ],
     "bps": true,
     "folderMillis": 1763987922211,
-    "hash": "29e3a4a075bca278db70cad98932e7f8d1b3092027b94ef46910b196dec6b5c3"
+    "hash": "f823b521f4d25e5dc5ab238b372727d2d2d7f0aed27b5eabc8a9608ce4e50568"
   }
 ]


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust database migration for document slug column to avoid problematic index creation.

Bug Fixes:
- Remove conditional creation of the documents slug/user_id unique index from migration 0047 to prevent migration failures due to duplicate index handling logic.

Enhancements:
- Update database schema documentation and migration metadata to reflect the simplified slug column migration.