### PR TITLE
🔧 fix(database): resolve TypeScript circular reference errors in file schema

### DIFF
--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { isNotNull } from 'drizzle-orm';
 import {
+  AnyPgColumn,
   boolean,
   index,
   integer,
@@ -41,7 +42,6 @@ export type GlobalFileItem = typeof globalFiles.$inferSelect;
 /**
  * Documents table - Stores file content or web search results
  */
-// @ts-ignore
 export const documents = pgTable(
   'documents',
   {
@@ -72,15 +72,11 @@ export const documents = pgTable(
     source: text('source').notNull(), // File path or web URL
 
     // Associated file (optional)
-    // Forward reference to files table defined below
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    // @ts-expect-error - files is defined later in this file, forward reference is valid at runtime
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    fileId: text('file_id').references(() => files.id, { onDelete: 'set null' }),
+    // forward reference needs AnyPgColumn to avoid circular type inference
+    fileId: text('file_id').references(((): AnyPgColumn => files.id), { onDelete: 'set null' }),
 
     // Parent document (for folder hierarchy structure)
-    // @ts-ignore
-    parentId: varchar('parent_id', { length: 255 }).references(() => documents.id, {
+    parentId: varchar('parent_id', { length: 255 }).references(((): AnyPgColumn => documents.id), {
       onDelete: 'set null',
     }),
 
@@ -113,7 +109,6 @@ export type NewDocument = typeof documents.$inferInsert;
 export type DocumentItem = typeof documents.$inferSelect;
 export const insertDocumentSchema = createInsertSchema(documents);
 
-// @ts-ignore
 export const files = pgTable(
   'files',
   {
@@ -140,8 +135,7 @@ export const files = pgTable(
     source: text('source').$type<FileSource>(),
 
     // Parent Folder or Document
-    // @ts-ignore
-    parentId: varchar('parent_id', { length: 255 }).references(() => documents.id, {
+    parentId: varchar('parent_id', { length: 255 }).references(((): AnyPgColumn => documents.id), {
       onDelete: 'set null',
     }),
 


### PR DESCRIPTION
Fixes TypeScript errors in `packages/database/src/schemas/file.ts`

This PR resolves circular reference errors by:
- Adding AnyPgColumn import for forward references
- Removing @ts-ignore annotations
- Using proper forward reference syntax for documents.id and files.id

Closes #10400

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Fix TypeScript circular reference issues in the database file and document schemas.

Bug Fixes:
- Resolve circular reference type errors between documents and files tables by using safe forward reference definitions for foreign keys.

Enhancements:
- Remove now-unnecessary TypeScript ignore annotations from the file and document schema definitions.