### PR TITLE
✨ feat: Add Claude Opus 4.5 model

### DIFF
--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -46,6 +46,7 @@ export const responsesAPIModels = new Set([
  * models support context caching
  */
 export const contextCachingModels = new Set([
+  'claude-opus-4-5-20251101',
   'claude-haiku-4-5-20251001',
   'claude-sonnet-4-5-latest',
   'claude-sonnet-4-5-20250929',
@@ -69,6 +70,7 @@ export const contextCachingModels = new Set([
 ]);
 
 export const thinkingWithToolClaudeModels = new Set([
+  'claude-opus-4-5-20251101',
   'claude-opus-4-latest',
   'claude-opus-4-20250514',
   'claude-sonnet-4-latest',

--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -67,7 +67,7 @@ export const contextCachingModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
-  'us.anthropic.claude-opus-4-5-20251101-v1:0',
+  'global.anthropic.claude-opus-4-5-20251101-v1:0',
   'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);
 
@@ -88,6 +88,6 @@ export const thinkingWithToolClaudeModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
-  'us.anthropic.claude-opus-4-5-20251101-v1:0',
+  'global.anthropic.claude-opus-4-5-20251101-v1:0',
   'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);

--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -67,6 +67,7 @@ export const contextCachingModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
+  'us.anthropic.claude-opus-4-5-20251101-v1:0',
   'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);
 
@@ -87,5 +88,6 @@ export const thinkingWithToolClaudeModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
+  'us.anthropic.claude-opus-4-5-20251101-v1:0',
   'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);

--- a/packages/const/src/models.ts
+++ b/packages/const/src/models.ts
@@ -67,6 +67,7 @@ export const contextCachingModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
+  'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);
 
 export const thinkingWithToolClaudeModels = new Set([
@@ -86,4 +87,5 @@ export const thinkingWithToolClaudeModels = new Set([
   'anthropic.claude-sonnet-4-5-20250929-v1:0',
   'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'anthropic.claude-haiku-4-5-20251001-v1:0',
+  'anthropic.claude-opus-4-5-20251101-v1:0',
 ]);

--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -598,9 +598,43 @@ const aihubmixModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 200_000,
     description:
+      'Claude Opus 4.5 是 Anthropic 的旗舰模型，结合了卓越的智能与可扩展性能，适合需要最高质量回应和推理能力的复杂任务。',
+    displayName: 'Claude Opus 4.5',
+    enabled: true,
+    id: 'claude-opus-4-5-20251101',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 10, '5m': 6.25 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2025-11-24',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
       'Claude Opus 4.1 是 Anthropic 最新的用于处理高度复杂任务的最强大模型。它在性能、智能、流畅性和理解力方面表现卓越。',
     displayName: 'Claude Opus 4.1',
-    enabled: true,
     id: 'claude-opus-4-1-20250805',
     maxOutput: 32_000,
     pricing: {

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -10,6 +10,41 @@ const anthropicChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
+    description:
+      'Claude Opus 4.5 是 Anthropic 的旗舰模型，结合了卓越的智能与可扩展性能，适合需要最高质量回应和推理能力的复杂任务。',
+    displayName: 'Claude Opus 4.5',
+    enabled: true,
+    id: 'claude-opus-4-5-20251101',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 10, '5m': 6.25 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2025-11-24',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
     description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
     displayName: 'Claude Sonnet 4.5',
     enabled: true,
@@ -39,7 +74,8 @@ const anthropicChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
-    description: 'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
+    description:
+      'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
     displayName: 'Claude Haiku 4.5',
     enabled: true,
     id: 'claude-haiku-4-5-20251001',
@@ -75,7 +111,6 @@ const anthropicChatModels: AIChatModelCard[] = [
     description:
       'Claude Opus 4.1 是 Anthropic 最新的用于处理高度复杂任务的最强大模型。它在性能、智能、流畅性和理解力方面表现卓越。',
     displayName: 'Claude Opus 4.1',
-    enabled: true,
     id: 'claude-opus-4-1-20250805',
     maxOutput: 32_000,
     pricing: {

--- a/packages/model-bank/src/aiModels/bedrock.ts
+++ b/packages/model-bank/src/aiModels/bedrock.ts
@@ -9,6 +9,30 @@ const bedrockChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
+    description:
+      'Claude Opus 4.5 是 Anthropic 的旗舰模型，结合了卓越的智能与可扩展性能，适合需要最高质量回应和推理能力的复杂任务。',
+    displayName: 'Claude Opus 4.5',
+    enabled: true,
+    id: 'us.anthropic.claude-opus-4-5-20251101-v1:0',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-24',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
     description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
     displayName: 'Claude Sonnet 4.5',
     enabled: true,
@@ -31,7 +55,8 @@ const bedrockChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
-    description: 'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
+    description:
+      'Claude Haiku 4.5 是 Anthropic 最快且最智能的 Haiku 模型，具有闪电般的速度和扩展思考能力。',
     displayName: 'Claude Haiku 4.5',
     enabled: true,
     id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
@@ -77,7 +102,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3.7 sonnet 是 Anthropic 最快的下一代模型。与 Claude 3 Haiku 相比，Claude 3.7 Sonnet 在各项技能上都有所提升，并在许多智力基准测试中超越了上一代最大的模型 Claude 3 Opus。',
     displayName: 'Claude 3.7 Sonnet',
-    enabled: true,
     id: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
     maxOutput: 8192,
     pricing: {
@@ -98,7 +122,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3.5 Sonnet 提升了行业标准，性能超过竞争对手模型和 Claude 3 Opus，在广泛的评估中表现出色，同时具有我们中等层级模型的速度和成本。',
     displayName: 'Claude 3.5 Sonnet',
-    enabled: true,
     id: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
     maxOutput: 8192,
     pricing: {
@@ -119,7 +142,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3.5 Sonnet 提升了行业标准，性能超过竞争对手模型和 Claude 3 Opus，在广泛的评估中表现出色，同时具有我们中等层级模型的速度和成本。',
     displayName: 'Claude 3.5 Sonnet v2 (Inference profile)',
-    enabled: true,
     id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
     maxOutput: 8192,
     pricing: {
@@ -140,7 +162,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3.5 Sonnet 提升了行业标准，性能超过竞争对手模型和 Claude 3 Opus，在广泛的评估中表现出色，同时具有我们中等层级模型的速度和成本。',
     displayName: 'Claude 3.5 Sonnet 0620',
-    enabled: true,
     id: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
     maxOutput: 8192,
     pricing: {
@@ -161,7 +182,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3 Haiku 是 Anthropic 最快、最紧凑的模型，提供近乎即时的响应速度。它可以快速回答简单的查询和请求。客户将能够构建模仿人类互动的无缝 AI 体验。Claude 3 Haiku 可以处理图像并返回文本输出，具有 200K 的上下文窗口。',
     displayName: 'Claude 3 Haiku',
-    enabled: true,
     id: 'anthropic.claude-3-haiku-20240307-v1:0',
     maxOutput: 4096,
     pricing: {
@@ -182,7 +202,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Anthropic 的 Claude 3 Sonnet 在智能和速度之间达到了理想的平衡——特别适合企业工作负载。它以低于竞争对手的价格提供最大的效用，并被设计成为可靠的、高耐用的主力机，适用于规模化的 AI 部署。Claude 3 Sonnet 可以处理图像并返回文本输出，具有 200K 的上下文窗口。',
     displayName: 'Claude 3 Sonnet',
-    enabled: true,
     id: 'anthropic.claude-3-sonnet-20240229-v1:0',
     pricing: {
       units: [
@@ -200,7 +219,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Claude 3 Opus 是 Anthropic 最强大的 AI 模型，具有在高度复杂任务上的最先进性能。它可以处理开放式提示和未见过的场景，具有出色的流畅性和类人的理解能力。Claude 3 Opus 展示了生成 AI 可能性的前沿。Claude 3 Opus 可以处理图像并返回文本输出，具有 200K 的上下文窗口。',
     displayName: 'Claude 3 Opus',
-    enabled: true,
     id: 'anthropic.claude-3-opus-20240229-v1:0',
     maxOutput: 4096,
     pricing: {
@@ -262,7 +280,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Meta Llama 3.1 8B Instruct 的更新版，包括扩展的 128K 上下文长度、多语言性和改进的推理能力。Llama 3.1 提供的多语言大型语言模型 (LLMs) 是一组预训练的、指令调整的生成模型，包括 8B、70B 和 405B 大小 (文本输入/输出)。Llama 3.1 指令调整的文本模型 (8B、70B、405B) 专为多语言对话用例进行了优化，并在常见的行业基准测试中超过了许多可用的开源聊天模型。Llama 3.1 旨在用于多种语言的商业和研究用途。指令调整的文本模型适用于类似助手的聊天，而预训练模型可以适应各种自然语言生成任务。Llama 3.1 模型还支持利用其模型的输出来改进其他模型，包括合成数据生成和精炼。Llama 3.1 是使用优化的变压器架构的自回归语言模型。调整版本使用监督微调 (SFT) 和带有人类反馈的强化学习 (RLHF) 来符合人类对帮助性和安全性的偏好。',
     displayName: 'Llama 3.1 8B Instruct',
-    enabled: true,
     id: 'meta.llama3-1-8b-instruct-v1:0',
     pricing: {
       units: [
@@ -280,7 +297,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Meta Llama 3.1 70B Instruct 的更新版，包括扩展的 128K 上下文长度、多语言性和改进的推理能力。Llama 3.1 提供的多语言大型语言模型 (LLMs) 是一组预训练的、指令调整的生成模型，包括 8B、70B 和 405B 大小 (文本输入/输出)。Llama 3.1 指令调整的文本模型 (8B、70B、405B) 专为多语言对话用例进行了优化，并在常见的行业基准测试中超过了许多可用的开源聊天模型。Llama 3.1 旨在用于多种语言的商业和研究用途。指令调整的文本模型适用于类似助手的聊天，而预训练模型可以适应各种自然语言生成任务。Llama 3.1 模型还支持利用其模型的输出来改进其他模型，包括合成数据生成和精炼。Llama 3.1 是使用优化的变压器架构的自回归语言模型。调整版本使用监督微调 (SFT) 和带有人类反馈的强化学习 (RLHF) 来符合人类对帮助性和安全性的偏好。',
     displayName: 'Llama 3.1 70B Instruct',
-    enabled: true,
     id: 'meta.llama3-1-70b-instruct-v1:0',
     pricing: {
       units: [
@@ -298,7 +314,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       'Meta Llama 3.1 405B Instruct 是 Llama 3.1 Instruct 模型中最大、最强大的模型，是一款高度先进的对话推理和合成数据生成模型，也可以用作在特定领域进行专业持续预训练或微调的基础。Llama 3.1 提供的多语言大型语言模型 (LLMs) 是一组预训练的、指令调整的生成模型，包括 8B、70B 和 405B 大小 (文本输入/输出)。Llama 3.1 指令调整的文本模型 (8B、70B、405B) 专为多语言对话用例进行了优化，并在常见的行业基准测试中超过了许多可用的开源聊天模型。Llama 3.1 旨在用于多种语言的商业和研究用途。指令调整的文本模型适用于类似助手的聊天，而预训练模型可以适应各种自然语言生成任务。Llama 3.1 模型还支持利用其模型的输出来改进其他模型，包括合成数据生成和精炼。Llama 3.1 是使用优化的变压器架构的自回归语言模型。调整版本使用监督微调 (SFT) 和带有人类反馈的强化学习 (RLHF) 来符合人类对帮助性和安全性的偏好。',
     displayName: 'Llama 3.1 405B Instruct',
-    enabled: true,
     id: 'meta.llama3-1-405b-instruct-v1:0',
     pricing: {
       units: [

--- a/packages/model-bank/src/aiModels/openrouter.ts
+++ b/packages/model-bank/src/aiModels/openrouter.ts
@@ -703,9 +703,36 @@ const openrouterChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
+    description:
+      'Claude Opus 4.5 是 Anthropic 的旗舰模型，结合了卓越的智能与可扩展性能，适合需要最高质量回应和推理能力的复杂任务。',
+    displayName: 'Claude Opus 4.5',
+    id: 'anthropic/claude-opus-4.5',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 6.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-24',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
     description: 'Claude Sonnet 4.5 是 Anthropic 迄今为止最智能的模型。',
     displayName: 'Claude Sonnet 4.5',
-    enabled: true,
     id: 'anthropic/claude-sonnet-4.5',
     maxOutput: 64_000,
     pricing: {

--- a/packages/model-bank/src/aiModels/zenmux.ts
+++ b/packages/model-bank/src/aiModels/zenmux.ts
@@ -19,7 +19,6 @@ const zenmuxChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image（Nano Banana Pro）是 Google 的图像生成模型，同时支持多模态对话。',
     displayName: 'Gemini 3 Pro Image (Nano Banana Pro)',
-    enabled: true,
     id: 'google/gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {
@@ -42,6 +41,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     contextWindowTokens: 65_536,
     description: 'Gemini 3 Pro Image 免费版，支持受限额度的多模态生成。',
     displayName: 'Gemini 3 Pro Image (Nano Banana) Free',
+    enabled: true,
     id: 'google/gemini-3-pro-image-preview-free',
     maxOutput: 32_768,
     pricing: {
@@ -84,6 +84,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro 免费预览版，具备与标准版相同的多模态理解与推理能力，但受免费额度与速率限制影响，更适合作为体验与低频使用。',
     displayName: 'Gemini 3 Pro Preview Free',
+    enabled: true,
     id: 'google/gemini-3-pro-preview-free',
     maxOutput: 65_530,
     pricing: {
@@ -988,6 +989,34 @@ const zenmuxChatModels: AIChatModelCard[] = [
         { name: 'textInput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.54, strategy: 'fixed', unit: 'millionTokens' },
       ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'Claude Opus 4.5 是 Anthropic 的旗舰模型，结合了卓越的智能与可扩展性能，适合需要最高质量回应和推理能力的复杂任务。',
+    displayName: 'Claude Opus 4.5',
+    id: 'claude-opus-4-5-20251101',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-24',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -252,6 +252,7 @@ export const MODEL_PARAMETER_CONFLICTS = {
     'claude-opus-4-1-20250805',
     'claude-sonnet-4-5-20250929',
     'claude-haiku-4-5-20251001',
+    'claude-opus-4-5-20251101',
   ]),
 
   /**
@@ -275,5 +276,7 @@ export const MODEL_PARAMETER_CONFLICTS = {
     'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'anthropic.claude-haiku-4-5-20251001-v1:0',
     'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'global.anthropic.claude-opus-4-5-20251101-v1:0',
+    'anthropic.claude-opus-4-5-20251101-v1:0',
   ]),
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-5


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for Anthropic Claude Opus 4.5 as a new flagship chat model and adjust Anthropic model lineup.

New Features:
- Introduce Claude Opus 4.5 chat model with reasoning, vision, search, and structured output capabilities to the Anthropic provider list.
- Expose Claude Opus 4.5 with its pricing and settings in the AIHubMix model catalog.

Enhancements:
- Demote Claude Opus 4.1 from the active Anthropic and AIHubMix model lists by removing its enabled flag.