### PR TITLE
Fix issue to avoid sync error in forked repos

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,8 +30,8 @@ jobs:
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
           upstream_sync_repo: lobehub/lobe-chat
-          upstream_sync_branch: main
-          target_sync_branch: main
+          upstream_sync_branch: next
+          target_sync_branch: next
           target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
           test_mode: false
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

> None.

#### 🔀 Description of Change

The original warehouse synchronization script targets the contents of the `main` branch, but the default branch of the current warehouse is the `next` branch, which will cause the CI process of synchronizing the upstream repository to always fail.


#### 📝 Additional Information

This PR changes the default branch for the sync script to `next` to avoid this issue.

## Summary by Sourcery

CI:
- Adjust the GitHub Actions sync workflow to use the `next` branch for both upstream and target synchronization.