### PR TITLE
🐛 fix: Showing compatibility with both new and old versions of Plugins

### DIFF
--- a/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/Plugins.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/Plugins.tsx
@@ -1,6 +1,6 @@
 import { Block } from '@lobehub/ui';
 import { Empty } from 'antd';
-import Link from 'next/link';
+import { Link } from 'react-router-dom';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 import urlJoin from 'url-join';
@@ -20,11 +20,16 @@ const Plugin = memo(() => {
 
   return (
     <Flexbox gap={8}>
-      {config?.plugins.map((item) => (
-        <Link href={urlJoin('/discover/plugin', item)} key={item}>
-          <PluginItem identifier={item} />
-        </Link>
-      ))}
+      {config?.plugins.map((item) => {
+        const identifier =
+          typeof item === 'string' ? item : (item as { identifier: string }).identifier;
+
+        return (
+          <Link key={identifier} to={urlJoin('/discover/plugin', identifier)}>
+            <PluginItem identifier={identifier} />
+          </Link>
+        );
+      })}
     </Flexbox>
   );
 });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure plugin capability links work with both string and object-style plugin configurations.

Bug Fixes:
- Restore compatibility with older and newer plugin configurations by correctly resolving the plugin identifier from either a string or object.
- Fix plugin navigation links so they use the appropriate routing prop when linking to individual plugin detail pages.