### PR TITLE
✨ Add Replicate image provider (split from chat)

### DIFF
--- a/packages/fetch-sse/src/__tests__/headers.test.ts
+++ b/packages/fetch-sse/src/__tests__/headers.test.ts
@@ -145,7 +145,7 @@ describe('headersToRecord', () => {
     it('should handle object with special characters in values', () => {
       // Arrange
       const headersObj = {
-        'authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+        'authorization': 'Bearer test-token',
         'x-special': 'value with spaces and symbols: !@#$%',
       };
 
@@ -154,7 +154,7 @@ describe('headersToRecord', () => {
 
       // Assert
       expect(result).toEqual({
-        'authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+        'authorization': 'Bearer test-token',
         'x-special': 'value with spaces and symbols: !@#$%',
       });
     });

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -45,6 +45,7 @@ import { default as perplexity } from './perplexity';
 import { default as ppio } from './ppio';
 import { default as qiniu } from './qiniu';
 import { default as qwen } from './qwen';
+import { default as replicate } from './replicate';
 import { default as sambanova } from './sambanova';
 import { default as search1api } from './search1api';
 import { default as sensenova } from './sensenova';
@@ -133,6 +134,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   ppio,
   qiniu,
   qwen,
+  replicate,
   sambanova,
   search1api,
   sensenova,
@@ -203,6 +205,7 @@ export { default as perplexity } from './perplexity';
 export { default as ppio } from './ppio';
 export { default as qiniu } from './qiniu';
 export { default as qwen } from './qwen';
+export { default as replicate } from './replicate';
 export { default as sambanova } from './sambanova';
 export { default as search1api } from './search1api';
 export { default as sensenova } from './sensenova';

--- a/packages/model-bank/src/aiModels/replicate.ts
+++ b/packages/model-bank/src/aiModels/replicate.ts
@@ -1,0 +1,91 @@
+import { AIImageModelCard } from '../types';
+
+// Replicate image models
+// https://replicate.com/black-forest-labs
+const imageModels: AIImageModelCard[] = [
+  {
+    description:
+      'FLUX 1.1 Pro - Faster, better FLUX Pro with excellent image quality and prompt adherence.',
+    displayName: 'FLUX 1.1 Pro',
+    enabled: true,
+    id: 'black-forest-labs/flux-1.1-pro',
+    parameters: {
+      aspectRatio: {
+        default: '1:1',
+        enum: ['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21'],
+      },
+      prompt: { default: '' },
+      seed: { default: null },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.04, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2024-10-02',
+    type: 'image',
+  },
+  {
+    description: 'FLUX Schnell - Fast image generation model optimized for speed.',
+    displayName: 'FLUX Schnell',
+    enabled: true,
+    id: 'black-forest-labs/flux-schnell',
+    parameters: {
+      aspectRatio: {
+        default: '1:1',
+        enum: ['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21'],
+      },
+      prompt: { default: '' },
+      seed: { default: null },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.003, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2024-08-01',
+    type: 'image',
+  },
+  {
+    description: 'FLUX Dev - Development version of FLUX for non-commercial use.',
+    displayName: 'FLUX Dev',
+    enabled: true,
+    id: 'black-forest-labs/flux-dev',
+    parameters: {
+      aspectRatio: {
+        default: '1:1',
+        enum: ['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21'],
+      },
+      cfg: { default: 3.5, max: 10, min: 1, step: 0.1 },
+      prompt: { default: '' },
+      seed: { default: null },
+      steps: { default: 28, max: 50, min: 1 },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.025, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2024-08-01',
+    type: 'image',
+  },
+  {
+    description: 'FLUX Pro - Professional FLUX model with high quality output.',
+    displayName: 'FLUX Pro',
+    enabled: true,
+    id: 'black-forest-labs/flux-pro',
+    parameters: {
+      aspectRatio: {
+        default: '1:1',
+        enum: ['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21'],
+      },
+      cfg: { default: 3, max: 10, min: 1, step: 0.1 },
+      prompt: { default: '' },
+      seed: { default: null },
+      steps: { default: 25, max: 50, min: 1 },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.05, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2024-08-01',
+    type: 'image',
+  },
+];
+
+export const allModels = [...imageModels];
+
+export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -46,6 +46,7 @@ export enum ModelProvider {
   Perplexity = 'perplexity',
   Qiniu = 'qiniu',
   Qwen = 'qwen',
+  Replicate = 'replicate',
   SambaNova = 'sambanova',
   Search1API = 'search1api',
   SenseNova = 'sensenova',

--- a/packages/model-runtime/package.json
+++ b/packages/model-runtime/package.json
@@ -20,6 +20,7 @@
     "async-retry": "^1.3.3",
     "debug": "^4.4.3",
     "model-bank": "workspace:*",
-    "openai": "^4.104.0"
+    "openai": "^4.104.0",
+    "replicate": "^1.4.0"
   }
 }

--- a/packages/model-runtime/src/core/ModelRuntime.ts
+++ b/packages/model-runtime/src/core/ModelRuntime.ts
@@ -16,7 +16,9 @@ import {
   TextToImagePayload,
   TextToSpeechPayload,
 } from '../types';
+import { AgentRuntimeErrorType } from '../types/error';
 import { AuthenticatedImageRuntime, CreateImagePayload } from '../types/image';
+import { AgentRuntimeError } from '../utils/createError';
 import { LobeRuntimeAI } from './BaseAI';
 
 export interface AgentChatOptions {
@@ -62,7 +64,15 @@ export class ModelRuntime {
    * ```
    */
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
-    return this._runtime.chat!(payload, options);
+    if (typeof this._runtime.chat !== 'function') {
+      throw AgentRuntimeError.chat({
+        error: new Error('Chat is not supported by this provider'),
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        provider: payload.provider || 'unknown',
+      });
+    }
+
+    return this._runtime.chat(payload, options);
   }
 
   async generateObject(payload: GenerateObjectPayload) {

--- a/packages/model-runtime/src/providers/replicate/index.ts
+++ b/packages/model-runtime/src/providers/replicate/index.ts
@@ -54,7 +54,8 @@ export class LobeReplicateAI implements LobeRuntimeAI {
         throw new Error('Invalid model id for Replicate connectivity check');
       }
 
-      const [owner, nameWithVersion] = modelId.split('/');
+      const [owner, ...nameParts] = modelId.split('/');
+      const nameWithVersion = nameParts.join('/');
       const [name] = nameWithVersion.split(':'); // drop :version if present
 
       // Fast auth + existence check via SDK; no inference cost

--- a/packages/model-runtime/src/providers/replicate/index.ts
+++ b/packages/model-runtime/src/providers/replicate/index.ts
@@ -1,0 +1,373 @@
+import Replicate from 'replicate';
+
+import { LobeRuntimeAI } from '../../core/BaseAI';
+import {
+  type ChatCompletionErrorPayload,
+  ChatMethodOptions,
+  ChatStreamPayload,
+  CreateImagePayload,
+} from '../../types';
+import { AgentRuntimeErrorType } from '../../types/error';
+import { AgentRuntimeError } from '../../utils/createError';
+import { desensitizeUrl } from '../../utils/desensitizeUrl';
+import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
+
+const DEFAULT_BASE_URL = 'https://api.replicate.com';
+
+interface ReplicateAIParams {
+  apiKey?: string;
+  baseURL?: string;
+  id?: string;
+}
+
+export class LobeReplicateAI implements LobeRuntimeAI {
+  private client: Replicate;
+
+  baseURL: string;
+  apiKey?: string;
+  private id: string;
+
+  constructor({ apiKey, baseURL = DEFAULT_BASE_URL, id }: ReplicateAIParams = {}) {
+    if (!apiKey) {
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
+    }
+
+    this.client = new Replicate({
+      auth: apiKey,
+      useFileOutput: false, // Return URLs instead of binary data
+    });
+
+    this.baseURL = baseURL;
+    this.apiKey = apiKey;
+    this.id = id || 'replicate';
+  }
+
+  /**
+   * Connectivity check for Replicate (non-chat provider)
+   * We verify the model exists and stream a minimal SSE "text" event so the checker UI can pass.
+   */
+  async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
+    const modelId = payload.model;
+
+    try {
+      if (!modelId || typeof modelId !== 'string' || !modelId.includes('/')) {
+        throw new Error('Invalid model id for Replicate connectivity check');
+      }
+
+      const [owner, nameWithVersion] = modelId.split('/');
+      const [name] = nameWithVersion.split(':'); // drop :version if present
+
+      // Fast auth + existence check via SDK; no inference cost
+      await this.client.models.get(owner, name, { signal: options?.signal });
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          const textPayload = JSON.stringify(`Replicate connectivity ok for ${modelId}`);
+          const stopPayload = JSON.stringify('stop');
+          controller.enqueue(encoder.encode(`event: text\ndata: ${textPayload}\n\n`));
+          controller.enqueue(encoder.encode(`event: stop\ndata: ${stopPayload}\n\n`));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+        },
+      });
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Image generation support for LobeChat async image generation (FLUX, Stable Diffusion, etc.)
+   */
+  async createImage(payload: CreateImagePayload) {
+    try {
+      const { model, params } = payload;
+      const { prompt, width, height, cfg, steps, seed, imageUrl, aspectRatio } = params;
+
+      this.debugLog('[Replicate createImage] === START ===');
+      this.debugLog('[Replicate createImage] Model:', model);
+      this.debugLog('[Replicate createImage] Params received:', JSON.stringify(params, null, 2));
+
+      const input: Record<string, any> = {};
+
+      // Redux models don't use prompt - they only use the input image
+      if (!model.includes('redux')) {
+        input.prompt = prompt;
+        this.debugLog('[Replicate createImage] Added prompt:', prompt);
+      } else {
+        this.debugLog('[Replicate createImage] Skipping prompt (Redux model)');
+      }
+
+      // Handle image-to-image models
+      if (imageUrl) {
+        this.debugLog('[Replicate createImage] imageUrl provided:', imageUrl);
+
+        // Determine the parameter name based on model type
+        let imageParamName: string;
+        if (model.includes('redux')) {
+          imageParamName = 'redux_image';
+          this.debugLog('[Replicate createImage] Will map to redux_image');
+        } else if (model.includes('canny') || model.includes('depth')) {
+          imageParamName = 'control_image';
+          this.debugLog('[Replicate createImage] Will map to control_image');
+        } else if (model.includes('fill')) {
+          imageParamName = 'image';
+          this.debugLog('[Replicate createImage] Will map to image (fill)');
+        } else {
+          imageParamName = 'image';
+          this.debugLog('[Replicate createImage] Will map to image (generic)');
+        }
+
+        // Check if URL is accessible from internet or local
+        const isLocalUrl =
+          imageUrl.includes('localhost') ||
+          imageUrl.includes('127.0.0.1') ||
+          imageUrl.includes('.local') ||
+          imageUrl.startsWith('http://192.168.') ||
+          imageUrl.startsWith('http://10.') ||
+          imageUrl.startsWith('http://172.');
+
+        if (isLocalUrl) {
+          this.debugLog(
+            '[Replicate createImage] Local URL detected, will fetch and upload as data',
+          );
+          try {
+            const { ssrfSafeFetch } = await import('ssrf-safe-fetch');
+            const imageResponse = await ssrfSafeFetch(imageUrl);
+            if (!imageResponse.ok) {
+              throw new Error(
+                `Failed to fetch image: ${imageResponse.status} ${imageResponse.statusText}`,
+              );
+            }
+
+            // Get image as buffer
+            const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+            this.debugLog(
+              '[Replicate createImage] Fetched image, size:',
+              imageBuffer.length,
+              'bytes',
+            );
+
+            // Check size limit (100MB)
+            if (imageBuffer.length > 100 * 1024 * 1024) {
+              throw new Error(`Image too large: ${imageBuffer.length} bytes (max 100MB)`);
+            }
+
+            // Replicate SDK accepts Buffer objects directly
+            input[imageParamName] = imageBuffer;
+            this.debugLog('[Replicate createImage] Mapped to', imageParamName, 'as Buffer');
+          } catch (fetchError: any) {
+            this.debugLog('[Replicate createImage] Error fetching local image:', fetchError);
+            throw new Error(`Failed to fetch local image: ${fetchError.message}`);
+          }
+        } else {
+          // Public URL - use directly
+          input[imageParamName] = imageUrl;
+          this.debugLog('[Replicate createImage] Public URL, mapped directly to', imageParamName);
+        }
+      } else {
+        this.debugLog('[Replicate createImage] No imageUrl provided');
+      }
+
+      // Map LobeChat params to Replicate params
+      if (width && height) {
+        input.width = width;
+        input.height = height;
+        this.debugLog('[Replicate createImage] Set dimensions:', width, 'x', height);
+      }
+
+      // For FLUX models, convert to aspect_ratio
+      if (model.includes('flux')) {
+        // Use explicit aspectRatio if provided (for Redux models)
+        if (aspectRatio) {
+          input.aspect_ratio = aspectRatio;
+          console.log('[Replicate createImage] Set aspect_ratio from param:', aspectRatio);
+        } else if (width && height) {
+          if (width === height) {
+            input.aspect_ratio = '1:1';
+          } else if (width === 1280 && height === 720) {
+            input.aspect_ratio = '16:9';
+          } else if (width === 720 && height === 1280) {
+            input.aspect_ratio = '9:16';
+          } else if (width > height) {
+            input.aspect_ratio = '16:9';
+          } else {
+            input.aspect_ratio = '9:16';
+          }
+          this.debugLog('[Replicate createImage] Calculated aspect_ratio:', input.aspect_ratio);
+        }
+        // Remove width/height for FLUX models (unless it's Fill which needs dimensions)
+        if (!model.includes('fill')) {
+          delete input.width;
+          delete input.height;
+          this.debugLog('[Replicate createImage] Removed width/height (using aspect_ratio)');
+        }
+      }
+
+      // Add optional parameters
+      if (cfg !== undefined) {
+        input.guidance_scale = cfg;
+        this.debugLog('[Replicate createImage] Set guidance_scale:', cfg);
+      }
+      if (steps !== undefined) {
+        // Redux uses num_inference_steps, control models use steps
+        if (model.includes('redux')) {
+          input.num_inference_steps = steps;
+          this.debugLog('[Replicate createImage] Set num_inference_steps:', steps);
+        } else if (model.includes('canny') || model.includes('depth') || model.includes('fill')) {
+          input.steps = steps;
+          this.debugLog('[Replicate createImage] Set steps:', steps);
+        } else {
+          input.num_inference_steps = steps;
+          this.debugLog('[Replicate createImage] Set num_inference_steps:', steps);
+        }
+      }
+      if (seed !== undefined && seed !== null) {
+        input.seed = seed;
+        this.debugLog('[Replicate createImage] Set seed:', seed);
+      }
+
+      // Run prediction - with useFileOutput: false, returns URL strings
+      // Log input object without Buffer data (which would be huge)
+      const inputForLogging = { ...input };
+      for (const key in inputForLogging) {
+        if (Buffer.isBuffer(inputForLogging[key])) {
+          inputForLogging[key] = `<Buffer ${inputForLogging[key].length} bytes>`;
+        }
+      }
+      this.debugLog(
+        '[Replicate createImage] Final input object:',
+        JSON.stringify(inputForLogging, null, 2),
+      );
+      this.debugLog('[Replicate createImage] Calling client.run...');
+
+      const output = await this.client.run(model as any, { input });
+
+      this.debugLog('[Replicate createImage] Raw output:', output);
+      this.debugLog(
+        '[Replicate createImage] Output type:',
+        typeof output,
+        'Is array:',
+        Array.isArray(output),
+      );
+
+      // Extract URL from output
+      let outputImageUrl: string;
+
+      if (Array.isArray(output)) {
+        if (output.length === 0) {
+          throw new Error('Replicate returned empty array');
+        }
+        // First item should be the URL string
+        outputImageUrl = output[0];
+        this.debugLog('[Replicate] Extracted URL from array:', outputImageUrl);
+      } else if (typeof output === 'string') {
+        outputImageUrl = output;
+        this.debugLog('[Replicate] Output is direct string URL:', outputImageUrl);
+      } else {
+        throw new Error(`Unexpected output format from Replicate: ${typeof output}`);
+      }
+
+      if (typeof outputImageUrl !== 'string') {
+        throw new Error(`Expected URL string, got ${typeof outputImageUrl}: ${outputImageUrl}`);
+      }
+
+      this.debugLog('[Replicate] Final imageUrl:', outputImageUrl);
+
+      return {
+        height: height,
+        imageUrl: outputImageUrl,
+        width: width,
+      };
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Image models supported for the initial Replicate integration
+   */
+  async models() {
+    try {
+      const modelList: Array<{ created?: number; displayName?: string; id: string }> = [];
+
+      // Use paginate to collect all public models accessible with the current token
+      for await (const models of this.client.paginate(() => this.client.models.list())) {
+        models.forEach((model) => {
+          modelList.push({
+            created: model.latest_version
+              ? new Date(model.latest_version.created_at).getTime()
+              : undefined,
+            displayName: model.name,
+            id: `${model.owner}/${model.name}`,
+          });
+        });
+      }
+
+      return processModelList(modelList, MODEL_LIST_CONFIGS.replicate, 'replicate');
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Error handling
+   */
+  private handleError(error: any): ChatCompletionErrorPayload {
+    let desensitizedEndpoint = this.baseURL;
+
+    if (this.baseURL !== DEFAULT_BASE_URL) {
+      desensitizedEndpoint = desensitizeUrl(this.baseURL);
+    }
+
+    // Handle authentication errors
+    if (error?.message?.includes('authentication') || error?.message?.includes('API token')) {
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizedEndpoint,
+        error: error as any,
+        errorType: AgentRuntimeErrorType.InvalidProviderAPIKey,
+        provider: this.id,
+      });
+    }
+
+    // Handle model not found
+    if (error?.message?.includes('not found')) {
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizedEndpoint,
+        error: error as any,
+        errorType: AgentRuntimeErrorType.ModelNotFound,
+        provider: this.id,
+      });
+    }
+
+    // Generic error
+    throw AgentRuntimeError.chat({
+      endpoint: desensitizedEndpoint,
+      error: error,
+      errorType: AgentRuntimeErrorType.ProviderBizError,
+      provider: this.id,
+    });
+  }
+
+  /**
+   * Gate verbose logging to avoid noisy output in production
+   */
+  private debugLog(...args: any[]) {
+    const isReplicateDebug =
+      process.env.DEBUG_REPLICATE === '1' ||
+      process.env.DEBUG_REPLICATE_CHAT_COMPLETION === '1' ||
+      process.env.NODE_ENV !== 'production';
+
+    if (!isReplicateDebug) return;
+
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+}
+
+export default LobeReplicateAI;

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -44,6 +44,7 @@ import { LobePerplexityAI } from './providers/perplexity';
 import { LobePPIOAI } from './providers/ppio';
 import { LobeQiniuAI } from './providers/qiniu';
 import { LobeQwenAI } from './providers/qwen';
+import { LobeReplicateAI } from './providers/replicate';
 import { LobeSambaNovaAI } from './providers/sambanova';
 import { LobeSearch1API } from './providers/search1api';
 import { LobeSenseNovaAI } from './providers/sensenova';
@@ -112,6 +113,7 @@ export const providerRuntimeMap = {
   ppio: LobePPIOAI,
   qiniu: LobeQiniuAI,
   qwen: LobeQwenAI,
+  replicate: LobeReplicateAI,
   router: LobeNewAPIAI,
   sambanova: LobeSambaNovaAI,
   search1api: LobeSearch1API,

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -88,6 +88,18 @@ export const MODEL_LIST_CONFIGS = {
     reasoningKeywords: ['qvq', 'qwq', 'qwen3', '!-instruct-', '!-coder-', '!-max-'],
     visionKeywords: ['qvq', '-vl', '-omni'],
   },
+  replicate: {
+    imageOutputKeywords: [
+      'flux',
+      'stable-diffusion',
+      'sdxl',
+      'ideogram',
+      'canny',
+      'depth',
+      'fill',
+      'redux',
+    ],
+  },
   v0: {
     functionCallKeywords: ['v0'],
     reasoningKeywords: ['v0-1.5'],

--- a/packages/ssrf-safe-fetch/index.browser.ts
+++ b/packages/ssrf-safe-fetch/index.browser.ts
@@ -5,10 +5,30 @@
  */
 
 /**
+ * Options for per-call SSRF configuration overrides
+ * (ignored in browser - kept for API parity with server version)
+ */
+export interface SSRFOptions {
+  /** List of IP addresses to allow */
+  allowIPAddressList?: string[];
+  /** Whether to allow private/local IP addresses */
+  allowPrivateIPAddress?: boolean;
+}
+
+/**
  * Browser-safe fetch implementation
  * Uses native fetch API in browser environments
+ * @param url - The URL to fetch
+ * @param options - Standard fetch options
+ * @param _ssrfOptions - Ignored in browser (kept for API parity)
  */
-// eslint-disable-next-line no-undef
-export const ssrfSafeFetch = async (url: string, options?: RequestInit): Promise<Response> => {
+export const ssrfSafeFetch = async (
+  url: string,
+  // eslint-disable-next-line no-undef
+  options?: RequestInit,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _ssrfOptions?: SSRFOptions,
+  // eslint-disable-next-line no-undef
+): Promise<Response> => {
   return fetch(url, options);
 };

--- a/packages/ssrf-safe-fetch/index.ts
+++ b/packages/ssrf-safe-fetch/index.ts
@@ -2,19 +2,43 @@ import fetch from 'node-fetch';
 import { RequestFilteringAgentOptions, useAgent as ssrfAgent } from 'request-filtering-agent';
 
 /**
+ * Options for per-call SSRF configuration overrides
+ */
+export interface SSRFOptions {
+  /** List of IP addresses to allow */
+  allowIPAddressList?: string[];
+  /** Whether to allow private/local IP addresses */
+  allowPrivateIPAddress?: boolean;
+}
+
+/**
  * SSRF-safe fetch implementation for server-side use
  * Uses request-filtering-agent to prevent requests to private IP addresses
  *
+ * @param url - The URL to fetch
+ * @param options - Standard fetch options
+ * @param ssrfOptions - Optional per-call SSRF configuration overrides
  * @see https://lobehub.com/docs/self-hosting/environment-variables/basic#ssrf-allow-private-ip-address
  */
-// eslint-disable-next-line no-undef
-export const ssrfSafeFetch = async (url: string, options?: RequestInit): Promise<Response> => {
+export const ssrfSafeFetch = async (
+  url: string,
+  // eslint-disable-next-line no-undef
+  options?: RequestInit,
+  ssrfOptions?: SSRFOptions,
+  // eslint-disable-next-line no-undef
+): Promise<Response> => {
   try {
-    // Configure SSRF protection options
+    // Configure SSRF protection options with proper precedence using nullish coalescing
+    const envAllowPrivate = process.env.SSRF_ALLOW_PRIVATE_IP_ADDRESS === '1';
+    const allowPrivate = ssrfOptions?.allowPrivateIPAddress ?? envAllowPrivate;
+
     const agentOptions: RequestFilteringAgentOptions = {
-      allowIPAddressList: process.env.SSRF_ALLOW_IP_ADDRESS_LIST?.split(',') || [],
-      allowMetaIPAddress: process.env.SSRF_ALLOW_PRIVATE_IP_ADDRESS === '1',
-      allowPrivateIPAddress: process.env.SSRF_ALLOW_PRIVATE_IP_ADDRESS === '1',
+      allowIPAddressList:
+        ssrfOptions?.allowIPAddressList ??
+        process.env.SSRF_ALLOW_IP_ADDRESS_LIST?.split(',').filter(Boolean) ??
+        [],
+      allowMetaIPAddress: allowPrivate,
+      allowPrivateIPAddress: allowPrivate,
       denyIPAddressList: [],
     };
 

--- a/packages/types/src/aiProvider.ts
+++ b/packages/types/src/aiProvider.ts
@@ -31,6 +31,7 @@ export const AiProviderSDKEnum = {
   Ollama: 'ollama',
   Openai: 'openai',
   Qwen: 'qwen',
+  Replicate: 'replicate',
   Router: 'router',
   Volcengine: 'volcengine',
 } as const;
@@ -48,6 +49,7 @@ const AiProviderSdkTypes = [
   'cloudflare',
   'google',
   'huggingface',
+  'replicate',
   'router',
   'volcengine',
   'qwen',

--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -46,6 +46,7 @@ import PerplexityProvider from './perplexity';
 import PPIOProvider from './ppio';
 import QiniuProvider from './qiniu';
 import QwenProvider from './qwen';
+import ReplicateProvider from './replicate';
 import SambaNovaProvider from './sambanova';
 import Search1APIProvider from './search1api';
 import SenseNovaProvider from './sensenova';
@@ -187,6 +188,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   InfiniAIProvider,
   AkashChatProvider,
   QiniuProvider,
+  ReplicateProvider,
   NebiusProvider,
   CometAPIProvider,
   VercelAIGatewayProvider,

--- a/src/config/modelProviders/replicate.ts
+++ b/src/config/modelProviders/replicate.ts
@@ -1,0 +1,23 @@
+import { ModelProviderCard } from '@/types/llm';
+
+// Ref: https://replicate.com/docs
+const Replicate: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'black-forest-labs/flux-1.1-pro',
+  description:
+    'Replicate runs open-source image models like FLUX and Stable Diffusion through a simple cloud API.',
+  id: 'replicate',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://replicate.com/explore',
+  name: 'Replicate',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://api.replicate.com',
+    },
+    showModelFetcher: true,
+  },
+  url: 'https://replicate.com',
+};
+
+export default Replicate;

--- a/src/config/modelProviders/replicate.ts
+++ b/src/config/modelProviders/replicate.ts
@@ -15,6 +15,7 @@ const Replicate: ModelProviderCard = {
     proxyUrl: {
       placeholder: 'https://api.replicate.com',
     },
+    sdkType: 'replicate',
     showModelFetcher: true,
   },
   url: 'https://replicate.com',


### PR DESCRIPTION
## Summary\n- scope Replicate to image-only and drop chat models per review\n- gate verbose logging behind debug flags and keep ssrf-safe fetch for local image URLs\n- add targeted tests for image param mapping and local fetch buffers\n\n## Testing\n- npx vitest run --silent='passed-only' 'src/providers/replicate/index.test.ts'

## Summary by Sourcery

Add Replicate as an image-only provider and integrate it into the existing model/runtime and provider configuration.

New Features:
- Introduce a Replicate image generation provider with support for multiple text-to-image and image-to-image models.
- Expose Replicate provider and models through the model bank, runtime map, and frontend provider configuration for selection and use.

Enhancements:
- Extend ssrf-safe-fetch to accept per-call overrides for allowed IPs while preserving browser API parity.
- Add targeted tests to validate Replicate image parameter mapping and secure handling of local image URLs.