### PR TITLE
🐛 fix: fixed the agent settings plugins pages error problem

### DIFF
--- a/src/features/AgentSetting/AgentPlugin/index.tsx
+++ b/src/features/AgentSetting/AgentPlugin/index.tsx
@@ -4,7 +4,7 @@ import { Avatar, Button, Form, type FormGroupItemType, Tag, Tooltip } from '@lob
 import { Empty, Space, Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { LucideTrash2, Store } from 'lucide-react';
-import Link from 'next/link';
+import { Link, useNavigate } from 'react-router-dom';
 import { memo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
@@ -28,6 +28,8 @@ const AgentPlugin = memo(() => {
   const { t } = useTranslation('setting');
 
   const [showStore, setShowStore] = useState(false);
+
+  const navigate = useNavigate();
 
   const [userEnabledPlugins, toggleAgentPlugin] = useStore((s) => [
     s.config.plugins || [],
@@ -134,11 +136,13 @@ const AgentPlugin = memo(() => {
           <Trans i18nKey={'plugin.empty'} ns={'setting'}>
             暂无安装插件，
             <Link
-              href={'/'}
               onClick={(e) => {
+                e.stopPropagation();
                 e.preventDefault();
                 setShowStore(true);
+                navigate('/discover/mcp');
               }}
+              to={'/discover/mcp'}
             >
               前往插件市场
             </Link>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure the "go to plugin marketplace" link on the empty agent plugins page correctly routes users to the plugin discovery view instead of causing an error.