### PR TITLE
🐛 fix: better-auth fallback next-auth providers env

### DIFF
--- a/src/envs/auth.test.ts
+++ b/src/envs/auth.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAuthConfig } from './auth';
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_WINDOW = globalThis.window;
+
+describe('getAuthConfig fallbacks', () => {
+  beforeEach(() => {
+    // reset env to a clean clone before each test
+    process.env = { ...ORIGINAL_ENV };
+    globalThis.window = ORIGINAL_WINDOW;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    globalThis.window = ORIGINAL_WINDOW;
+  });
+
+  it('should fall back to NEXT_AUTH_SSO_PROVIDERS when AUTH_SSO_PROVIDERS is empty string', () => {
+    process.env.AUTH_SSO_PROVIDERS = '';
+    process.env.NEXT_AUTH_SSO_PROVIDERS = 'logto,github';
+
+    // Simulate server runtime so @t3-oss/env treats this as server-side access
+    // (happy-dom sets window by default in Vitest)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error - allow overriding for test
+    globalThis.window = undefined;
+
+    const config = getAuthConfig();
+
+    expect(config.AUTH_SSO_PROVIDERS).toBe('logto,github');
+  });
+
+  it('should fall back to NEXT_AUTH_SECRET when AUTH_SECRET is empty string', () => {
+    process.env.AUTH_SECRET = '';
+    process.env.NEXT_AUTH_SECRET = 'nextauth-secret';
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error - allow overriding for test
+    globalThis.window = undefined;
+
+    const config = getAuthConfig();
+
+    expect(config.AUTH_SECRET).toBe('nextauth-secret');
+  });
+
+  it('should fall back to NEXTAUTH_URL origin when NEXT_PUBLIC_AUTH_URL is empty string', () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = '';
+    process.env.NEXTAUTH_URL = 'https://example.com/api/auth';
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error - allow overriding for test
+    globalThis.window = undefined;
+
+    const config = getAuthConfig();
+
+    expect(config.NEXT_PUBLIC_AUTH_URL).toBe('https://example.com');
+  });
+});

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -237,14 +237,14 @@ export const getAuthConfig = () => {
       NEXT_PUBLIC_ENABLE_BETTER_AUTH: process.env.NEXT_PUBLIC_ENABLE_BETTER_AUTH === '1',
       // Fallback to NEXTAUTH_URL origin for seamless migration from next-auth
       NEXT_PUBLIC_AUTH_URL:
-        process.env.NEXT_PUBLIC_AUTH_URL ??
+        process.env.NEXT_PUBLIC_AUTH_URL ||
         (process.env.NEXTAUTH_URL ? new URL(process.env.NEXTAUTH_URL).origin : undefined),
       NEXT_PUBLIC_AUTH_EMAIL_VERIFICATION: process.env.NEXT_PUBLIC_AUTH_EMAIL_VERIFICATION === '1',
       NEXT_PUBLIC_ENABLE_MAGIC_LINK: process.env.NEXT_PUBLIC_ENABLE_MAGIC_LINK === '1',
       // Fallback to NEXT_AUTH_SECRET for seamless migration from next-auth
-      AUTH_SECRET: process.env.AUTH_SECRET ?? process.env.NEXT_AUTH_SECRET,
+      AUTH_SECRET: process.env.AUTH_SECRET || process.env.NEXT_AUTH_SECRET,
       // Fallback to NEXT_AUTH_SSO_PROVIDERS for seamless migration from next-auth
-      AUTH_SSO_PROVIDERS: process.env.AUTH_SSO_PROVIDERS ?? process.env.NEXT_AUTH_SSO_PROVIDERS,
+      AUTH_SSO_PROVIDERS: process.env.AUTH_SSO_PROVIDERS || process.env.NEXT_AUTH_SSO_PROVIDERS,
 
       // better-auth env for Cognito provider is different from next-auth's one
       AUTH_COGNITO_DOMAIN: process.env.AUTH_COGNITO_DOMAIN,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure AUTH_URL, AUTH_SECRET, and AUTH_SSO_PROVIDERS correctly fall back to their next-auth equivalents when primary variables are unset.