### PR TITLE
🐛 fix: add handling for content_part and reasoning_part events in fetchSSE

### DIFF
--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -438,8 +438,27 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
           break;
         }
 
-        case 'reasoning_part':
+        case 'reasoning_part': {
+          // For reasoning_part, accumulate thinking content
+          if (data.partType === 'text' && data.content) {
+            thinking += data.content;
+          }
+          options.onMessageHandle?.({
+            content: data.content,
+            mimeType: data.mimeType,
+            partType: data.partType,
+            thoughtSignature: data.thoughtSignature,
+            type: ev.event,
+          });
+          break;
+        }
+
         case 'content_part': {
+          // For content_part, accumulate text content to output
+          // This is critical for Gemini 2.5 models which use content_part instead of text events
+          if (data.partType === 'text' && data.content) {
+            output += data.content;
+          }
           options.onMessageHandle?.({
             content: data.content,
             mimeType: data.mimeType,


### PR DESCRIPTION
…hSSE

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

- fix #10435

- 一并修复 gemini-2.5/3 在话题名生成、翻译等情况的空回。

----

有空可以看看下面 pr，应该也可以合了：

- #10452
- #10421

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Handle streamed content_part and reasoning_part SSE events in fetchSSE so text output and reasoning are accumulated correctly, especially for Gemini models using these events instead of plain text.

Bug Fixes:
- Accumulate text content from content_part events into the final output string instead of ignoring it.
- Accumulate text content from reasoning_part events into the reasoning buffer while still forwarding individual parts to the message handler.
- Avoid accumulating non-text content_part payloads (e.g., images) into the text output.

Tests:
- Add unit tests covering content_part text streaming, reasoning_part text streaming, and non-text content_part (image) handling to validate accumulation behavior.