### PR TITLE
🐛 fix: Filter out file with `sourceType` = `file`

### DIFF
--- a/packages/database/src/repositories/knowledge/index.test.ts
+++ b/packages/database/src/repositories/knowledge/index.test.ts
@@ -146,17 +146,29 @@ describe('KnowledgeRepo', () => {
       expect(regularFile?.sourceType).toBe('file');
     });
 
-    it('should show all documents in All category (no filtering)', async () => {
+    it('should exclude sourceType=file documents from All category', async () => {
       const results = await knowledgeRepo.query({ category: FilesTabs.All });
 
-      // All category should include everything
-      expect(results.length).toBeGreaterThanOrEqual(6); // 2 files + 4 documents
+      // All category should include files from files table + documents with sourceType != 'file'
+      // 2 files + 2 documents (api-pdf and web-doc)
+      // Excluded: uploaded-pdf and editor-doc both have sourceType='file'
+      expect(results.length).toBe(4);
 
+      // Should NOT include documents with sourceType='file' (globally excluded now)
       const editorDoc = results.find((item) => item.name === 'editor-doc.md');
       const uploadedPdf = results.find((item) => item.name === 'uploaded-pdf.pdf');
+      expect(editorDoc).toBeUndefined();
+      expect(uploadedPdf).toBeUndefined();
 
-      expect(editorDoc).toBeDefined();
-      expect(uploadedPdf).toBeDefined();
+      // Should include documents with sourceType != 'file'
+      const apiPdf = results.find((item) => item.name === 'api-pdf.pdf');
+      const webDoc = results.find((item) => item.name === 'web-doc.txt');
+      expect(apiPdf).toBeDefined();
+      expect(webDoc).toBeDefined();
+
+      // Should include files from files table
+      const regularFile = results.find((item) => item.name === 'regular-pdf-file.pdf');
+      expect(regularFile).toBeDefined();
     });
 
     it('should apply both filters together in Documents category', async () => {

--- a/packages/database/src/repositories/knowledge/index.ts
+++ b/packages/database/src/repositories/knowledge/index.ts
@@ -281,7 +281,10 @@ export class KnowledgeRepo {
     q,
     knowledgeBaseId,
   }: QueryFileListParams = {}): ReturnType<typeof sql> {
-    let whereConditions: any[] = [sql`${documents.userId} = ${this.userId}`];
+    let whereConditions: any[] = [
+      sql`${documents.userId} = ${this.userId}`,
+      sql`${documents.sourceType} != ${'file'}`,
+    ];
 
     // Search filter
     if (q) {
@@ -300,12 +303,9 @@ export class KnowledgeRepo {
         );
         whereConditions.push(sql`(${sql.join(orConditions, sql` OR `)})`);
 
-        // Exclude custom/document and source_type='file' from Documents category
+        // Exclude custom/document from Documents category
         if (category === FilesTabs.Documents) {
-          whereConditions.push(
-            sql`${documents.fileType} != ${'custom/document'}`,
-            sql`${documents.sourceType} != ${'file'}`,
-          );
+          whereConditions.push(sql`${documents.fileType} != ${'custom/document'}`);
         }
       } else if (fileTypePrefix) {
         whereConditions.push(sql`${documents.fileType} ILIKE ${`${fileTypePrefix}%`}`);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## Summary by Sourcery

Filter knowledge query results to globally exclude document records with sourceType="file" while keeping them available via the files table.

Bug Fixes:
- Exclude documents with sourceType="file" from the All category results in knowledge queries to prevent duplicate or unintended entries.

Tests:
- Update knowledge repository tests to assert that All category omits sourceType="file" documents but still includes other document types and regular files.