### PR TITLE
🐛 fix: Implement uniform callback URL for SSO providers

### DIFF
--- a/src/libs/better-auth/sso/index.ts
+++ b/src/libs/better-auth/sso/index.ts
@@ -102,6 +102,9 @@ export const initBetterAuthSSOProviders = () => {
     const config = definition.build(env);
 
     if (config) {
+      // the generic oidc callback url is /api/auth/oauth2/callback/{providerId}
+      // different from builtin providers' /api/auth/callback/{providerId}
+      config.redirectURI = `${authEnv.NEXT_PUBLIC_AUTH_URL}/api/auth/callback/${definition.id}`;
       genericOAuthProviders.push(config);
     }
   }


### PR DESCRIPTION
Added a function to standardize the callback URL format to /api/auth/callback/{providerId} for better-auth SSO providers. This change ensures consistent handling of redirect URIs across different authentication providers.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

New Features:
- Introduce a helper to enforce a unified /api/auth/callback/{providerId} redirect URI for all configured SSO providers.