### PR TITLE
🐛 fix: update apiMode handling in ChatService to prioritize user preferences

### DIFF
--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -1062,7 +1062,7 @@ describe('ChatService', () => {
       );
     });
 
-    it('should make a POST request without response in non-openai provider payload', async () => {
+    it('should make a POST request with chatCompletion apiMode in non-openai provider payload', async () => {
       const params: Partial<ChatStreamPayload> = {
         model: 'deepseek-reasoner',
         provider: 'deepseek',
@@ -1076,6 +1076,7 @@ describe('ChatService', () => {
         stream: true,
         ...DEFAULT_AGENT_CONFIG.params,
         messages: [],
+        apiMode: 'chatCompletion',
         provider: undefined,
       };
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -267,11 +267,14 @@ class ChatService {
       model = findDeploymentName(model, provider);
     }
 
-    const apiMode = aiProviderSelectors.isProviderEnableResponseApi(provider)(
-      getAiInfraStoreState(),
-    )
+    // When user explicitly disables Responses API, set apiMode to 'chatCompletion'
+    // This ensures the user's preference takes priority over provider's useResponseModels config
+    // When user enables Responses API, set to 'responses' to force use Responses API
+    const apiMode: 'responses' | 'chatCompletion' = aiProviderSelectors.isProviderEnableResponseApi(
+      provider,
+    )(getAiInfraStoreState())
       ? 'responses'
-      : undefined;
+      : 'chatCompletion';
 
     // Get the chat config to check streaming preference
     const chatConfig = agentChatConfigSelectors.currentChatConfig(getAgentStoreState());


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

修复 newapi 无视 Responses API 开关，强制使用 Responses API 的问题。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust API mode selection to respect user preferences while still enforcing Responses API for specific models.

Bug Fixes:
- Ensure new API no longer forces use of the Responses API when the user has disabled it.

Enhancements:
- Reorder Responses API selection logic to prioritize built-in models first and then user-defined preferences.
- Clarify and tighten apiMode handling in ChatService so user toggle explicitly maps to 'responses' or 'chatCompletion' modes.

Tests:
- Update chat service test to assert chatCompletion apiMode in non-OpenAI provider payloads.