### PR TITLE
🐛 fix: betterauth name should mapped to fullname

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -104,14 +104,14 @@ export const auth = betterAuth({
 
   user: {
     additionalFields: {
-      fullName: {
+      username: {
         required: false,
         type: 'string',
       },
     },
     fields: {
       image: 'avatar',
-      name: 'username',
+      name: 'full_name',
     },
     modelName: 'users',
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -111,7 +111,8 @@ export const auth = betterAuth({
     },
     fields: {
       image: 'avatar',
-      name: 'full_name',
+      // NOTE: use drizzle filed instead of db field, so use fullName instead of full_name
+      name: 'fullName',
     },
     modelName: 'users',
   },

--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
@@ -31,9 +31,9 @@ const UserUpdater = memo(() => {
         // Preserve avatar from settings, don't override with auth provider value
         avatar: userAvatar || '',
         email: betterAuthUser.email,
-        fullName: betterAuthUser.fullName,
+        fullName: betterAuthUser.name,
         id: betterAuthUser.id,
-        username: betterAuthUser.name,
+        username: betterAuthUser.username,
       } as LobeUser;
 
       // Update user data in store


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Correct BetterAuth configuration to map the auth provider's display name to the local full_name field and username to the appropriate additional field.