### PR TITLE
🐛 fix: betterauth public url auto detect from VERCEL_URL

### DIFF
--- a/docs/self-hosting/advanced/auth.mdx
+++ b/docs/self-hosting/advanced/auth.mdx
@@ -39,12 +39,18 @@ By setting the environment variables `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CL
 
 To enable Better Auth in LobeChat, set the following environment variables:
 
-| Environment Variable             | Type     | Description                                                                                                            |
-| -------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | Required | Set to `1` to enable Better Auth service                                                                               |
-| `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32`                                          |
-| `NEXT_PUBLIC_AUTH_URL`           | Optional | The URL accessible from the browser for Better Auth callbacks. Only set this if the default generated URL is incorrect |
-| `AUTH_SSO_PROVIDERS`             | Optional | Comma-separated list of enabled SSO providers, e.g., `google,github,microsoft`                                         |
+| Environment Variable             | Type     | Description                                                                                             |
+| -------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | Required | Set to `1` to enable Better Auth service                                                                |
+| `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32`                           |
+| `NEXT_PUBLIC_AUTH_URL`           | Required | The browser-accessible base URL for Better Auth (e.g., `http://localhost:3010`, `https://lobechat.com`) |
+| `AUTH_SSO_PROVIDERS`             | Optional | Comma-separated list of enabled SSO providers, e.g., `google,github,microsoft`                          |
+
+<Callout type={'error'}>
+  **Important**: Better Auth is currently only suitable for **fresh deployments**. If you are already using NextAuth or Clerk and have existing user data in your database, **do not switch to Better Auth yet**, otherwise existing users will not be able to log in.
+
+  We are developing user data migration tools from NextAuth/Clerk to Better Auth. Documentation will be updated once the migration solution is complete. For progress updates, please follow [GitHub Issue #10456](https://github.com/lobehub/lobe-chat/issues/10456).
+</Callout>
 
 <Callout type={'warning'}>
   If you build/deploy with the official Docker image, the defaults keep **NextAuth enabled** and **Better

--- a/docs/self-hosting/advanced/auth.mdx
+++ b/docs/self-hosting/advanced/auth.mdx
@@ -39,12 +39,12 @@ By setting the environment variables `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CL
 
 To enable Better Auth in LobeChat, set the following environment variables:
 
-| Environment Variable             | Type     | Description                                                                                             |
-| -------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | Required | Set to `1` to enable Better Auth service                                                                |
-| `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32`                           |
-| `NEXT_PUBLIC_AUTH_URL`           | Required | The browser-accessible base URL for Better Auth (e.g., `http://localhost:3010`, `https://lobechat.com`) |
-| `AUTH_SSO_PROVIDERS`             | Optional | Comma-separated list of enabled SSO providers, e.g., `google,github,microsoft`                          |
+| Environment Variable             | Type     | Description                                                                                                                                                                |
+| -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | Required | Set to `1` to enable Better Auth service                                                                                                                                   |
+| `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32`                                                                                              |
+| `NEXT_PUBLIC_AUTH_URL`           | Required | The browser-accessible base URL for Better Auth (e.g., `http://localhost:3010`, `https://lobechat.com`). Optional for Vercel deployments (auto-detected from `VERCEL_URL`) |
+| `AUTH_SSO_PROVIDERS`             | Optional | Comma-separated list of enabled SSO providers, e.g., `google,github,microsoft`                                                                                             |
 
 <Callout type={'error'}>
   **Important**: Better Auth is currently only suitable for **fresh deployments**. If you are already using NextAuth or Clerk and have existing user data in your database, **do not switch to Better Auth yet**, otherwise existing users will not be able to log in.

--- a/docs/self-hosting/advanced/auth.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth.zh-CN.mdx
@@ -37,12 +37,18 @@ LobeChat 与 Clerk 做了深度集成，能够为用户提供一个更加安全�
 
 要在 LobeChat 中启用 Better Auth，请设置以下环境变量：
 
-| 环境变量                             | 类型 | 描述                                               |
-| -------------------------------- | -- | ------------------------------------------------ |
-| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | 必选 | 设置为 `1` 以启用 Better Auth 服务                       |
-| `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`   |
-| `NEXT_PUBLIC_AUTH_URL`           | 可选 | 浏览器可访问的 Better Auth 回调 URL。仅在默认生成的 URL 不正确时设置    |
-| `AUTH_SSO_PROVIDERS`             | 可选 | 启用的 SSO 提供商列表，以逗号分隔，例如 `google,github,microsoft` |
+| 环境变量                             | 类型 | 描述                                                                            |
+| -------------------------------- | -- | ----------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | 必选 | 设置为 `1` 以启用 Better Auth 服务                                                    |
+| `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`                                |
+| `NEXT_PUBLIC_AUTH_URL`           | 必选 | 浏览器可访问的 Better Auth 基础 URL（例如 `http://localhost:3010`、`https://lobechat.com`） |
+| `AUTH_SSO_PROVIDERS`             | 可选 | 启用的 SSO 提供商列表，以逗号分隔，例如 `google,github,microsoft`                              |
+
+<Callout type={'error'}>
+  **重要提示**：Better Auth 目前仅适用于**全新部署**的场景。如果你已经使用 NextAuth 或 Clerk 并且数据库中存在用户数据，**请暂时不要切换到 Better Auth**，否则现有用户将无法登录。
+
+  我们正在开发从 NextAuth/Clerk 到 Better Auth 的用户数据迁移工具，迁移方案完成后会更新文档。相关进度请关注 [GitHub Issue #10456](https://github.com/lobehub/lobe-chat/issues/10456)。
+</Callout>
 
 <Callout type={'warning'}>
   若使用官方 Docker 镜像构建 / 部署，默认是 **开启 NextAuth、关闭 Better Auth**

--- a/docs/self-hosting/advanced/auth.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth.zh-CN.mdx
@@ -37,12 +37,12 @@ LobeChat 与 Clerk 做了深度集成，能够为用户提供一个更加安全�
 
 要在 LobeChat 中启用 Better Auth，请设置以下环境变量：
 
-| 环境变量                             | 类型 | 描述                                                                            |
-| -------------------------------- | -- | ----------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | 必选 | 设置为 `1` 以启用 Better Auth 服务                                                    |
-| `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`                                |
-| `NEXT_PUBLIC_AUTH_URL`           | 必选 | 浏览器可访问的 Better Auth 基础 URL（例如 `http://localhost:3010`、`https://lobechat.com`） |
-| `AUTH_SSO_PROVIDERS`             | 可选 | 启用的 SSO 提供商列表，以逗号分隔，例如 `google,github,microsoft`                              |
+| 环境变量                             | 类型 | 描述                                                                                                               |
+| -------------------------------- | -- | ---------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ENABLE_BETTER_AUTH` | 必选 | 设置为 `1` 以启用 Better Auth 服务                                                                                       |
+| `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`                                                                   |
+| `NEXT_PUBLIC_AUTH_URL`           | 必选 | 浏览器可访问的 Better Auth 基础 URL（例如 `http://localhost:3010`、`https://lobechat.com`）。Vercel 部署时可选（会自动从 `VERCEL_URL` 获取） |
+| `AUTH_SSO_PROVIDERS`             | 可选 | 启用的 SSO 提供商列表，以逗号分隔，例如 `google,github,microsoft`                                                                 |
 
 <Callout type={'error'}>
   **重要提示**：Better Auth 目前仅适用于**全新部署**的场景。如果你已经使用 NextAuth 或 Clerk 并且数据库中存在用户数据，**请暂时不要切换到 Better Auth**，否则现有用户将无法登录。

--- a/packages/const/src/auth.ts
+++ b/packages/const/src/auth.ts
@@ -1,4 +1,7 @@
-export const enableClerk = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+export const enableClerk =
+  process.env.NEXT_PUBLIC_ENABLE_CLERK_AUTH === '1'
+    ? true
+    : !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 export const enableBetterAuth = process.env.NEXT_PUBLIC_ENABLE_BETTER_AUTH === '1';
 export const enableNextAuth = process.env.NEXT_PUBLIC_ENABLE_NEXT_AUTH === '1';
 export const enableAuth = enableClerk || enableBetterAuth || enableNextAuth || false;

--- a/packages/ssrf-safe-fetch/index.ts
+++ b/packages/ssrf-safe-fetch/index.ts
@@ -4,6 +4,8 @@ import { RequestFilteringAgentOptions, useAgent as ssrfAgent } from 'request-fil
 /**
  * SSRF-safe fetch implementation for server-side use
  * Uses request-filtering-agent to prevent requests to private IP addresses
+ *
+ * @see https://lobehub.com/docs/self-hosting/environment-variables/basic#ssrf-allow-private-ip-address
  */
 // eslint-disable-next-line no-undef
 export const ssrfSafeFetch = async (url: string, options?: RequestInit): Promise<Response> => {
@@ -31,7 +33,8 @@ export const ssrfSafeFetch = async (url: string, options?: RequestInit): Promise
   } catch (error) {
     console.error('SSRF-safe fetch error:', error);
     throw new Error(
-      `SSRF-safe fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+      `SSRF-safe fetch failed: ${error instanceof Error ? error.message : String(error)}. ` +
+        'See: https://lobehub.com/docs/self-hosting/environment-variables/basic#ssrf-allow-private-ip-address',
     );
   }
 };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -32,6 +32,7 @@ export const auth = betterAuth({
   // Use renamed env vars (fallback to next-auth vars is handled in src/envs/auth.ts)
   baseURL: authEnv.NEXT_PUBLIC_AUTH_URL,
   secret: authEnv.AUTH_SECRET,
+  trustedOrigins: authEnv.NEXT_PUBLIC_AUTH_URL ? [authEnv.NEXT_PUBLIC_AUTH_URL] : undefined,
 
   database: drizzleAdapter(serverDB, {
     provider: 'pg',

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -47,6 +47,7 @@ declare global {
       NEXT_PUBLIC_AUTH_URL?: string;
       NEXT_PUBLIC_AUTH_EMAIL_VERIFICATION?: string;
       AUTH_SSO_PROVIDERS?: string;
+      AUTH_TRUSTED_ORIGINS?: string;
 
       // ===== Next Auth ===== //
       NEXT_AUTH_SECRET?: string;
@@ -165,6 +166,7 @@ export const getAuthConfig = () => {
       // ---------------------------------- better auth ----------------------------------
       AUTH_SECRET: z.string().optional(),
       AUTH_SSO_PROVIDERS: z.string().optional().default(''),
+      AUTH_TRUSTED_ORIGINS: z.string().optional(),
 
       // ---------------------------------- next auth ----------------------------------
       NEXT_AUTH_SECRET: z.string().optional(),
@@ -274,6 +276,7 @@ export const getAuthConfig = () => {
       AUTH_SECRET: process.env.AUTH_SECRET || process.env.NEXT_AUTH_SECRET,
       // Fallback to NEXT_AUTH_SSO_PROVIDERS for seamless migration from next-auth
       AUTH_SSO_PROVIDERS: process.env.AUTH_SSO_PROVIDERS || process.env.NEXT_AUTH_SSO_PROVIDERS,
+      AUTH_TRUSTED_ORIGINS: process.env.AUTH_TRUSTED_ORIGINS,
 
       // better-auth env for Cognito provider is different from next-auth's one
       AUTH_COGNITO_DOMAIN: process.env.AUTH_COGNITO_DOMAIN,

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -228,7 +228,10 @@ export const getAuthConfig = () => {
 
     runtimeEnv: {
       // Clerk
-      NEXT_PUBLIC_ENABLE_CLERK_AUTH: !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+      NEXT_PUBLIC_ENABLE_CLERK_AUTH:
+        process.env.NEXT_PUBLIC_ENABLE_CLERK_AUTH === '1'
+          ? true
+          : !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
       CLERK_WEBHOOK_SECRET: process.env.CLERK_WEBHOOK_SECRET,

--- a/src/envs/auth.ts
+++ b/src/envs/auth.ts
@@ -2,6 +2,8 @@
 import { createEnv } from '@t3-oss/env-nextjs';
 import { z } from 'zod';
 
+import { enableBetterAuth, enableClerk, enableNextAuth } from '@/const/auth';
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {
@@ -228,16 +230,13 @@ export const getAuthConfig = () => {
 
     runtimeEnv: {
       // Clerk
-      NEXT_PUBLIC_ENABLE_CLERK_AUTH:
-        process.env.NEXT_PUBLIC_ENABLE_CLERK_AUTH === '1'
-          ? true
-          : !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+      NEXT_PUBLIC_ENABLE_CLERK_AUTH: enableClerk,
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
       CLERK_WEBHOOK_SECRET: process.env.CLERK_WEBHOOK_SECRET,
 
       // ---------------------------------- better auth ----------------------------------
-      NEXT_PUBLIC_ENABLE_BETTER_AUTH: process.env.NEXT_PUBLIC_ENABLE_BETTER_AUTH === '1',
+      NEXT_PUBLIC_ENABLE_BETTER_AUTH: enableBetterAuth,
       // Fallback to NEXTAUTH_URL origin for seamless migration from next-auth
       NEXT_PUBLIC_AUTH_URL:
         process.env.NEXT_PUBLIC_AUTH_URL ||
@@ -255,7 +254,7 @@ export const getAuthConfig = () => {
       AUTH_COGNITO_USERPOOL_ID: process.env.AUTH_COGNITO_USERPOOL_ID,
 
       // ---------------------------------- next auth ----------------------------------
-      NEXT_PUBLIC_ENABLE_NEXT_AUTH: process.env.NEXT_PUBLIC_ENABLE_NEXT_AUTH === '1',
+      NEXT_PUBLIC_ENABLE_NEXT_AUTH: enableNextAuth,
       NEXT_AUTH_SSO_PROVIDERS: process.env.NEXT_AUTH_SSO_PROVIDERS,
       NEXT_AUTH_SECRET: process.env.NEXT_AUTH_SECRET,
       NEXT_AUTH_DEBUG: !!process.env.NEXT_AUTH_DEBUG,

--- a/src/libs/better-auth/sso/index.ts
+++ b/src/libs/better-auth/sso/index.ts
@@ -104,7 +104,7 @@ export const initBetterAuthSSOProviders = () => {
     if (config) {
       // the generic oidc callback url is /api/auth/oauth2/callback/{providerId}
       // different from builtin providers' /api/auth/callback/{providerId}
-      config.redirectURI = `/api/auth/callback/${definition.id}`;
+      config.redirectURI = `${authEnv.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/callback/${definition.id}`;
       genericOAuthProviders.push(config);
     }
   }

--- a/src/libs/better-auth/sso/index.ts
+++ b/src/libs/better-auth/sso/index.ts
@@ -104,7 +104,7 @@ export const initBetterAuthSSOProviders = () => {
     if (config) {
       // the generic oidc callback url is /api/auth/oauth2/callback/{providerId}
       // different from builtin providers' /api/auth/callback/{providerId}
-      config.redirectURI = `${authEnv.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/callback/${definition.id}`;
+      config.redirectURI = `/api/auth/callback/${definition.id}`;
       genericOAuthProviders.push(config);
     }
   }

--- a/src/libs/better-auth/sso/index.ts
+++ b/src/libs/better-auth/sso/index.ts
@@ -104,7 +104,7 @@ export const initBetterAuthSSOProviders = () => {
     if (config) {
       // the generic oidc callback url is /api/auth/oauth2/callback/{providerId}
       // different from builtin providers' /api/auth/callback/{providerId}
-      config.redirectURI = `${authEnv.NEXT_PUBLIC_AUTH_URL}/api/auth/callback/${definition.id}`;
+      config.redirectURI = `${authEnv.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/callback/${definition.id}`;
       genericOAuthProviders.push(config);
     }
   }

--- a/src/libs/oidc-provider/provider.test.ts
+++ b/src/libs/oidc-provider/provider.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies
 vi.mock('@/const/auth', () => ({
+  enableBetterAuth: false,
   enableClerk: false,
+  enableNextAuth: false,
 }));
 
 vi.mock('@/envs/app', () => ({

--- a/src/server/routers/lambda/__tests__/user.test.ts
+++ b/src/server/routers/lambda/__tests__/user.test.ts
@@ -29,7 +29,9 @@ vi.mock('@/server/modules/S3');
 vi.mock('@/server/services/user');
 vi.mock('@/server/services/nextAuthUser');
 vi.mock('@/const/auth', () => ({
+  enableBetterAuth: false,
   enableClerk: true,
+  enableNextAuth: false,
 }));
 
 describe('userRouter', () => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Clarify Better Auth configuration requirements and improve auth and SSRF configuration behavior and guidance.

Enhancements:
- Allow Clerk auth to be explicitly enabled via NEXT_PUBLIC_ENABLE_CLERK_AUTH regardless of whether a publishable key is set, aligning runtime config with this behavior.
- Improve SSRF-safe fetch error messaging and inline documentation by linking to the relevant SSRF configuration documentation for troubleshooting.

Documentation:
- Update Better Auth self-hosting docs (EN and zh-CN) to require an explicit browser-accessible AUTH URL and document deployment limitations for existing NextAuth/Clerk users, including a link to the migration progress issue.