### PR TITLE
🐛 fix(conversation-flow): support optimistic update for activeBranchIndex

### DIFF
--- a/packages/conversation-flow/src/transformation/BranchResolver.ts
+++ b/packages/conversation-flow/src/transformation/BranchResolver.ts
@@ -11,16 +11,21 @@ import type { IdNode, Message } from '../types';
 export class BranchResolver {
   /**
    * Get active branch ID from IdNode structure (used in contextTree building)
+   * Returns undefined for optimistic updates when the branch hasn't been created yet
    */
-  getActiveBranchId(message: Message, idNode: IdNode): string {
+  getActiveBranchId(message: Message, idNode: IdNode): string | undefined {
     // Priority 1: Try to get from metadata.activeBranchIndex (index-based)
     const activeBranchIndex = (message.metadata as any)?.activeBranchIndex;
-    if (
-      typeof activeBranchIndex === 'number' &&
-      activeBranchIndex >= 0 &&
-      activeBranchIndex < idNode.children.length
-    ) {
-      return idNode.children[activeBranchIndex].id;
+    if (typeof activeBranchIndex === 'number' && activeBranchIndex >= 0) {
+      // If index is within bounds, return the branch at that index
+      if (activeBranchIndex < idNode.children.length) {
+        return idNode.children[activeBranchIndex].id;
+      }
+      // Optimistic update: index === children.length means branch is being created
+      if (activeBranchIndex === idNode.children.length) {
+        return undefined;
+      }
+      // Invalid index (> children.length), ignore and continue to other strategies
     }
 
     // Priority 2: Infer from which branch has children
@@ -36,20 +41,25 @@ export class BranchResolver {
 
   /**
    * Get active branch ID from flat list (used in flatList building)
+   * Returns undefined for optimistic updates when the branch hasn't been created yet
    */
   getActiveBranchIdFromMetadata(
     message: Message,
     childIds: string[],
     childrenMap: Map<string | null, string[]>,
-  ): string {
+  ): string | undefined {
     // Priority 1: Try to get from metadata.activeBranchIndex (index-based)
     const activeBranchIndex = (message.metadata as any)?.activeBranchIndex;
-    if (
-      typeof activeBranchIndex === 'number' &&
-      activeBranchIndex >= 0 &&
-      activeBranchIndex < childIds.length
-    ) {
-      return childIds[activeBranchIndex];
+    if (typeof activeBranchIndex === 'number' && activeBranchIndex >= 0) {
+      // If index is within bounds, return the branch at that index
+      if (activeBranchIndex < childIds.length) {
+        return childIds[activeBranchIndex];
+      }
+      // Optimistic update: index === childIds.length means branch is being created
+      if (activeBranchIndex === childIds.length) {
+        return undefined;
+      }
+      // Invalid index (> childIds.length), ignore and continue to other strategies
     }
 
     // Priority 2: Infer from which child has descendants

--- a/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
+++ b/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
@@ -185,7 +185,12 @@ export class ContextTreeBuilder {
    */
   private createBranchNode(message: Message, idNode: IdNode): BranchNode {
     const activeBranchId = this.branchResolver.getActiveBranchId(message, idNode);
-    const activeBranchIndex = idNode.children.findIndex((child) => child.id === activeBranchId);
+
+    // For optimistic update (activeBranchId is undefined), use children.length as the index
+    // This indicates the branch is being created but doesn't exist yet
+    const activeBranchIndex = activeBranchId
+      ? idNode.children.findIndex((child) => child.id === activeBranchId)
+      : idNode.children.length;
 
     // Each branch is a tree starting from that child
     const branches = idNode.children.map((child) => {

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -165,6 +165,15 @@ export class FlatListBuilder {
           childMessages,
           this.childrenMap,
         );
+
+        // Optimistic update: activeBranchId is undefined when branch is being created
+        // In this case, just add user message without branch info and continue
+        if (!activeBranchId) {
+          flatList.push(message);
+          processedIds.add(message.id);
+          continue;
+        }
+
         const activeBranchIndex = childMessages.indexOf(activeBranchId);
         const userWithBranches = this.createUserMessageWithBranches(
           message,
@@ -247,6 +256,12 @@ export class FlatListBuilder {
         // Add the assistant message itself
         flatList.push(message);
         processedIds.add(message.id);
+
+        // Optimistic update: activeBranchId is undefined when branch is being created
+        // In this case, just add assistant message and continue (no active branch yet)
+        if (!activeBranchId) {
+          continue;
+        }
 
         // Continue with active branch and process its message
         const activeBranchMsg = this.messageMap.get(activeBranchId);

--- a/packages/conversation-flow/src/transformation/__tests__/BranchResolver.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/BranchResolver.test.ts
@@ -71,13 +71,13 @@ describe('BranchResolver', () => {
       expect(resolver.getActiveBranchId(message, idNode)).toBe('msg-2');
     });
 
-    it('should ignore invalid activeBranchIndex', () => {
+    it('should return undefined for optimistic update (activeBranchIndex === children.length)', () => {
       const message: Message = {
         content: 'test',
         createdAt: 0,
         id: 'msg-1',
         meta: {},
-        metadata: { activeBranchIndex: 5 }, // out of bounds
+        metadata: { activeBranchIndex: 2 }, // index = children.length (optimistic update)
         role: 'user',
         updatedAt: 0,
       };
@@ -90,7 +90,31 @@ describe('BranchResolver', () => {
         id: 'msg-1',
       };
 
-      // Should default to first branch
+      // When activeBranchIndex === children.length, it's an optimistic update
+      // The branch hasn't been created yet, so return undefined
+      expect(resolver.getActiveBranchId(message, idNode)).toBeUndefined();
+    });
+
+    it('should ignore activeBranchIndex when it exceeds optimistic update range', () => {
+      const message: Message = {
+        content: 'test',
+        createdAt: 0,
+        id: 'msg-1',
+        meta: {},
+        metadata: { activeBranchIndex: 5 }, // > children.length (invalid)
+        role: 'user',
+        updatedAt: 0,
+      };
+
+      const idNode: IdNode = {
+        children: [
+          { children: [], id: 'msg-2' },
+          { children: [], id: 'msg-3' },
+        ],
+        id: 'msg-1',
+      };
+
+      // activeBranchIndex > children.length should be ignored, fallback to default
       expect(resolver.getActiveBranchId(message, idNode)).toBe('msg-2');
     });
   });

--- a/packages/conversation-flow/src/transformation/__tests__/BranchResolver.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/BranchResolver.test.ts
@@ -171,5 +171,44 @@ describe('BranchResolver', () => {
 
       expect(resolver.getActiveBranchIdFromMetadata(message, childIds, childrenMap)).toBe('msg-2');
     });
+
+    it('should return undefined for optimistic update (activeBranchIndex === childIds.length)', () => {
+      const message: Message = {
+        content: 'test',
+        createdAt: 0,
+        id: 'msg-1',
+        meta: {},
+        metadata: { activeBranchIndex: 2 }, // index = childIds.length (optimistic update)
+        role: 'user',
+        updatedAt: 0,
+      };
+
+      const childIds = ['msg-2', 'msg-3'];
+      const childrenMap = new Map<string | null, string[]>();
+
+      // When activeBranchIndex === childIds.length, it's an optimistic update
+      // The branch hasn't been created yet, so return undefined
+      expect(
+        resolver.getActiveBranchIdFromMetadata(message, childIds, childrenMap),
+      ).toBeUndefined();
+    });
+
+    it('should ignore activeBranchIndex when it exceeds optimistic update range', () => {
+      const message: Message = {
+        content: 'test',
+        createdAt: 0,
+        id: 'msg-1',
+        meta: {},
+        metadata: { activeBranchIndex: 5 }, // > childIds.length (invalid)
+        role: 'user',
+        updatedAt: 0,
+      };
+
+      const childIds = ['msg-2', 'msg-3'];
+      const childrenMap = new Map<string | null, string[]>();
+
+      // activeBranchIndex > childIds.length should be ignored, fallback to default
+      expect(resolver.getActiveBranchIdFromMetadata(message, childIds, childrenMap)).toBe('msg-2');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Support optimistic update scenario where `activeBranchIndex === children.length`
- When a new branch is being created, `activeBranchIndex` may point to a not-yet-created branch
- Return `undefined` from BranchResolver in this case to indicate the branch doesn't exist yet
- Update FlatListBuilder and ContextTreeBuilder to handle this gracefully

## Changes

- `BranchResolver.ts`: Return `string | undefined`, handle `activeBranchIndex === children.length` as optimistic update
- `FlatListBuilder.ts`: Skip branch processing when `activeBranchId` is undefined
- `ContextTreeBuilder.ts`: Use `children.length` as `activeBranchIndex` for optimistic updates
- `BranchResolver.test.ts`: Add test cases for optimistic update scenarios

## Test plan

- [x] All 90 conversation-flow tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)