### PR TITLE
✨ feat(fal): support custom API endpoint URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 # Changelog
 
+### [Version 1.142.9](https://github.com/lobehub/lobe-chat/compare/v1.142.8...v1.142.9)
+
+<sup>Released on **2025-11-02**</sup>
+
+#### 🐛 Bug Fixes
+
+- **misc**: OIDC error when connecting to self-host instance.
+
+<br/>
+
+<details>
+<summary><kbd>Improvements and Fixes</kbd></summary>
+
+#### What's fixed
+
+- **misc**: OIDC error when connecting to self-host instance, closes [#9916](https://github.com/lobehub/lobe-chat/issues/9916) ([2e2b9c4](https://github.com/lobehub/lobe-chat/commit/2e2b9c4))
+
+</details>
+
+<div align="right">
+
+[![](https://img.shields.io/badge/-BACK_TO_TOP-151515?style=flat-square)](#readme-top)
+
+</div>
+
 ### [Version 1.142.8](https://github.com/lobehub/lobe-chat/compare/v1.142.7...v1.142.8)
 
 <sup>Released on **2025-10-30**</sup>

--- a/changelog/v1.json
+++ b/changelog/v1.json
@@ -1,5 +1,12 @@
 [
   {
+    "children": {
+      "fixes": ["OIDC error when connecting to self-host instance."]
+    },
+    "date": "2025-11-02",
+    "version": "1.142.9"
+  },
+  {
     "children": {},
     "date": "2025-10-30",
     "version": "1.142.8"

--- a/docs/usage/providers/comfyui.mdx
+++ b/docs/usage/providers/comfyui.mdx
@@ -11,7 +11,7 @@ tags:
 
 # Using ComfyUI in LobeChat
 
-<Image alt={'Using ComfyUI in LobeChat'} cover src={'https://github.com/lobehub/lobe-chat/assets/17870709/c9e5eafc-ca22-496b-a88d-cc0ae53bf720'} />
+<Image alt={'Using ComfyUI in LobeChat'} cover src={'https://hub-apac-1.lobeobjects.space/docs/e9b811f248a1db2bd1be1af888cf9b9d.png'} />
 
 This documentation will guide you on how to use [ComfyUI](https://github.com/comfyanonymous/ComfyUI) in LobeChat for high-quality AI image generation and editing.
 

--- a/docs/usage/providers/comfyui.zh-CN.mdx
+++ b/docs/usage/providers/comfyui.zh-CN.mdx
@@ -11,7 +11,7 @@ tags:
 
 # 在 LobeChat 中使用 ComfyUI
 
-<Image alt={'在 LobeChat 中使用 ComfyUI'} cover src={'https://github.com/lobehub/lobe-chat/assets/17870709/c9e5eafc-ca22-496b-a88d-cc0ae53bf720'} />
+<Image alt={'在 LobeChat 中使用 ComfyUI'} cover src={'https://hub-apac-1.lobeobjects.space/docs/e9b811f248a1db2bd1be1af888cf9b9d.png'} />
 
 本文档将指导你如何在 LobeChat 中使用 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) 进行高质量的 AI 图像生成和编辑。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/chat",
-  "version": "1.142.8",
+  "version": "1.142.9",
   "description": "Lobe Chat - an open-source, high-performance chatbot framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/packages/model-runtime/src/providers/fal/index.test.ts
+++ b/packages/model-runtime/src/providers/fal/index.test.ts
@@ -41,6 +41,17 @@ describe('LobeFalAI', () => {
       expect(instance).toBeInstanceOf(LobeFalAI);
       expect(mockFal.config).toHaveBeenCalledWith({
         credentials: 'test_api_key',
+        proxyUrl: undefined,
+      });
+    });
+
+    it('should correctly initialize with apiKey and baseURL', () => {
+      const customBaseURL = 'https://gateway.ai.cloudflare.com/v1/account/gateway/fal';
+      const instance = new LobeFalAI({ apiKey: 'test_api_key', baseURL: customBaseURL });
+      expect(instance).toBeInstanceOf(LobeFalAI);
+      expect(mockFal.config).toHaveBeenCalledWith({
+        credentials: 'test_api_key',
+        proxyUrl: customBaseURL,
       });
     });
 
@@ -53,6 +64,12 @@ describe('LobeFalAI', () => {
     it('should throw InvalidProviderAPIKey if apiKey is undefined', () => {
       expect(() => {
         new LobeFalAI({ apiKey: undefined });
+      }).toThrow();
+    });
+
+    it('should throw InvalidProviderAPIKey even if baseURL is provided without apiKey', () => {
+      expect(() => {
+        new LobeFalAI({ baseURL: 'https://custom.endpoint.com' });
       }).toThrow();
     });
   });

--- a/packages/model-runtime/src/providers/fal/index.ts
+++ b/packages/model-runtime/src/providers/fal/index.ts
@@ -2,7 +2,6 @@ import { fal } from '@fal-ai/client';
 import debug from 'debug';
 import { pick } from 'lodash-es';
 import { RuntimeImageGenParamsValue } from 'model-bank';
-import { ClientOptions } from 'openai';
 
 import { LobeRuntimeAI } from '../../core/BaseAI';
 import { AgentRuntimeErrorType } from '../../types/error';
@@ -14,14 +13,20 @@ const log = debug('lobe-image:fal');
 
 type FluxDevOutput = Awaited<ReturnType<typeof fal.subscribe<'fal-ai/flux/dev'>>>['data'];
 
+interface LobeFalAIOptions {
+  apiKey?: string;
+  baseURL?: string;
+}
+
 export class LobeFalAI implements LobeRuntimeAI {
-  constructor({ apiKey }: ClientOptions = {}) {
+  constructor({ apiKey, baseURL }: LobeFalAIOptions = {}) {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
 
     fal.config({
       credentials: apiKey,
+      proxyUrl: baseURL,
     });
-    log('FalAI initialized with apiKey: %s', apiKey ? '*****' : 'Not set');
+    log('FalAI initialized with apiKey: %s, baseURL: %s', apiKey ? '*****' : 'Not set', baseURL ?? 'default');
   }
 
   async createImage(payload: CreateImagePayload): Promise<CreateImageResponse> {

--- a/packages/types/src/user/settings/keyVaults.ts
+++ b/packages/types/src/user/settings/keyVaults.ts
@@ -5,6 +5,7 @@ export interface OpenAICompatibleKeyVault {
 
 export interface FalKeyVault {
   apiKey?: string;
+  baseURL?: string;
 }
 
 export interface AzureOpenAIKeyVault {

--- a/src/app/(backend)/oidc/consent/route.ts
+++ b/src/app/(backend)/oidc/consent/route.ts
@@ -122,7 +122,6 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(finalRedirectUrl, {
-      headers: request.headers,
       status: 303,
     });
   } catch (error) {

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -170,6 +170,7 @@ export const getLLMConfig = () => {
 
       ENABLED_FAL: z.boolean(),
       FAL_API_KEY: z.string().optional(),
+      FAL_BASE_URL: z.string().optional(),
 
       ENABLED_BFL: z.boolean(),
       BFL_API_KEY: z.string().optional(),
@@ -374,6 +375,7 @@ export const getLLMConfig = () => {
 
       ENABLED_FAL: process.env.ENABLED_FAL !== '0',
       FAL_API_KEY: process.env.FAL_API_KEY,
+      FAL_BASE_URL: process.env.FAL_BASE_URL,
 
       ENABLED_BFL: !!process.env.BFL_API_KEY,
       BFL_API_KEY: process.env.BFL_API_KEY,

--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -155,6 +155,15 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
 
       return { apiKey };
     }
+
+    case ModelProvider.Fal: {
+      const { FAL_API_KEY, FAL_BASE_URL } = llmConfig;
+
+      const apiKey = apiKeyManager.pick(payload?.apiKey || FAL_API_KEY);
+      const baseURL = payload?.baseURL || FAL_BASE_URL;
+
+      return baseURL ? { apiKey, baseURL } : { apiKey };
+    }
   }
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Closes #8949

#### 🔀 Description of Change

Add support for custom Fal API endpoint to allow users to use alternative services like Cloudflare AI Gateway.

**Changes:**
- Add `baseURL` field to `FalKeyVault` type in `packages/types/src/user/settings/keyVaults.ts`
- Update `LobeFalAI` constructor to accept `baseURL` parameter via `proxyUrl` config in `packages/model-runtime/src/providers/fal/index.ts`
- Add `FAL_BASE_URL` environment variable in `src/envs/llm.ts`
- Add Fal-specific handler in `src/server/modules/ModelRuntime/index.ts`
- Add unit tests for baseURL support

**Usage:**
```bash
# Environment variable configuration
FAL_API_KEY=your_fal_api_key
FAL_BASE_URL=https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/fal
```

Users can also configure custom API endpoint in the settings page.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Run Fal provider tests:
```bash
cd packages/model-runtime && bunx vitest run 'src/providers/fal/index.test.ts'
```

All 25 tests pass.

#### 📝 Additional Information

The implementation leverages the `@fal-ai/client` SDK's native `proxyUrl` configuration support, making it compatible with:
- Cloudflare AI Gateway
- Other Fal-compatible proxy services

## Summary by Sourcery

Add configurable base URL support to the Fal provider and update related configuration, runtime handling, and docs, while also fixing an OIDC redirect header issue and bumping the app version.

New Features:
- Allow configuring a custom Fal API base URL via environment variables and user key vault settings.

Bug Fixes:
- Fix OIDC self-host connection error by adjusting the consent redirect response headers behavior.

Enhancements:
- Extend the Fal runtime provider to accept and pass through an optional base URL to the underlying SDK configuration.
- Update ComfyUI provider documentation images to use the new hosted asset URLs.

Build:
- Bump application version to 1.142.9.

Documentation:
- Refresh ComfyUI usage docs (EN and zh-CN) with a new image asset URL.

Tests:
- Add unit tests covering Fal provider initialization with and without custom base URL and API key validation.