### PR TITLE
🐛 fix: delete message with parentId

### DIFF
--- a/src/features/Conversation/store/slices/message/action/crud.ts
+++ b/src/features/Conversation/store/slices/message/action/crud.ts
@@ -285,10 +285,18 @@ export const messageCRUDSlice: StateCreator<
     internal_dispatchMessage({ ids, type: 'deleteMessages' });
 
     // Persist to database
-    const result = await messageService.removeMessages(ids, {
-      agentId,
-      topicId: topicId ?? undefined,
-    });
+    // Use removeMessage for single message to properly handle parentId chain
+    // Use removeMessages for batch deletion (e.g., assistantGroup with children)
+    const result =
+      ids.length === 1
+        ? await messageService.removeMessage(ids[0], {
+            agentId,
+            topicId: topicId ?? undefined,
+          })
+        : await messageService.removeMessages(ids, {
+            agentId,
+            topicId: topicId ?? undefined,
+          });
 
     if (result?.success && result.messages) {
       replaceMessages(result.messages);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust message deletion to correctly maintain parent-child relationships and scope deletions to the owning user while routing single and batch deletes through appropriate service methods.

Bug Fixes:
- Ensure deleting a message reassigns its children to the deleted message's parent or null when deleting a root, preserving the conversation tree.
- Restrict message deletions to messages belonging to the current user to avoid cross-user data removal.
- Route single message deletions through the single-message service API to correctly handle parentId chains while using the batch API only for multi-message deletions.

Tests:
- Add database tests covering parentId reassignment for deleted messages, root deletions, and user scoping of child updates.
- Expand CRUD slice tests to verify use of the correct service method for single versus multiple message deletions.