### PR TITLE
🐛 fix(chat): collect nested message IDs from assistantGroup in topic creation

### DIFF
--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -94,10 +94,34 @@ export const chatTopic: StateCreator<
 
     const messages = displayMessageSelectors.activeDisplayMessages(get());
 
+    // Collect all message IDs including nested ones in assistantGroup
+    const allMessageIds: string[] = [];
+    for (const message of messages) {
+      // Add the message's own ID
+      allMessageIds.push(message.id);
+
+      // For assistantGroup messages, collect IDs from children and their tools
+      if (message.children && message.children.length > 0) {
+        for (const child of message.children) {
+          // Add child assistant message ID
+          allMessageIds.push(child.id);
+
+          // Add tool message IDs (result_msg_id)
+          if (child.tools && child.tools.length > 0) {
+            for (const tool of child.tools) {
+              if (tool.result_msg_id) {
+                allMessageIds.push(tool.result_msg_id);
+              }
+            }
+          }
+        }
+      }
+    }
+
     set({ creatingTopic: true }, false, n('creatingTopic/start'));
     const topicId = await internal_createTopic({
       title: t('defaultTitle', { ns: 'topic' }),
-      messages: messages.map((m) => m.id),
+      messages: allMessageIds,
       ...(activeSessionType === 'group'
         ? { groupId: groupId || activeId }
         : { sessionId: sessionId || activeId }),
@@ -114,10 +138,34 @@ export const chatTopic: StateCreator<
 
     const { activeId, activeSessionType, summaryTopicTitle, internal_createTopic } = get();
 
+    // Collect all message IDs including nested ones in assistantGroup
+    const allMessageIds: string[] = [];
+    for (const message of messages) {
+      // Add the message's own ID
+      allMessageIds.push(message.id);
+
+      // For assistantGroup messages, collect IDs from children and their tools
+      if (message.children && message.children.length > 0) {
+        for (const child of message.children) {
+          // Add child assistant message ID
+          allMessageIds.push(child.id);
+
+          // Add tool message IDs (result_msg_id)
+          if (child.tools && child.tools.length > 0) {
+            for (const tool of child.tools) {
+              if (tool.result_msg_id) {
+                allMessageIds.push(tool.result_msg_id);
+              }
+            }
+          }
+        }
+      }
+    }
+
     // 1. create topic and bind these messages
     const topicId = await internal_createTopic({
       title: t('defaultTitle', { ns: 'topic' }),
-      messages: messages.map((m) => m.id),
+      messages: allMessageIds,
       ...(activeSessionType === 'group'
         ? { groupId: groupId || activeId }
         : { sessionId: sessionId || activeId }),


### PR DESCRIPTION
…

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

在默认话题创建 functionCall 消息串后，将其新建为新话题时，functionCall 无法被一并转入新话题，成为“孤立消息”。

`该工具调用消息可能因异常原因成为孤立消息，这会影响 Agent 的正常执行，请将其移除`

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure topic creation includes all relevant chat messages, including nested assistantGroup messages and their tool results, to avoid orphaned tool messages.

Bug Fixes:
- Include nested assistantGroup child and tool result message IDs when binding messages to a newly created topic, preventing tool call messages from being left orphaned.

Tests:
- Add a unit test verifying that topic creation collects user, assistantGroup, assistant children, and nested tool result message IDs into the topic.