### PR TITLE
💄  style: add no auto scrolling as preference

### DIFF
--- a/packages/const/src/settings/common.ts
+++ b/packages/const/src/settings/common.ts
@@ -3,6 +3,7 @@ import { UserGeneralConfig } from '@lobechat/types';
 export const DEFAULT_COMMON_SETTINGS: UserGeneralConfig = {
   animationMode: 'agile',
   // contextMenuMode not set default value, use env to calc
+  disableAutoScrollWhileGenerating: false,
   fontSize: 14,
   highlighterTheme: 'lobe-theme',
   mermaidTheme: 'lobe-theme',

--- a/packages/types/src/user/settings/general.ts
+++ b/packages/types/src/user/settings/general.ts
@@ -9,6 +9,7 @@ export type ContextMenuMode = 'disabled' | 'default';
 export interface UserGeneralConfig {
   animationMode?: AnimationMode;
   contextMenuMode?: ContextMenuMode;
+  disableAutoScrollWhileGenerating?: boolean;
   fontSize: number;
   highlighterTheme?: HighlighterProps['theme'];
   mermaidTheme?: MermaidProps['theme'];

--- a/src/app/[variants]/(main)/settings/common/features/ChatAppearance/index.tsx
+++ b/src/app/[variants]/(main)/settings/common/features/ChatAppearance/index.tsx
@@ -10,12 +10,13 @@ import {
   highlighterThemes,
   mermaidThemes,
 } from '@lobehub/ui';
-import { Skeleton } from 'antd';
+import { Skeleton, Switch } from 'antd';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon, TriangleAlert } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
 
 import { FORM_STYLE } from '@/const/layoutTokens';
 import { useUserStore } from '@/store/user';
@@ -83,6 +84,17 @@ const ChatAppearance = memo(() => {
       {
         children: <ChatPreview fontSize={general.fontSize} />,
         noStyle: true,
+      },
+      {
+        children: (
+          <Flexbox align="end">
+            <Switch />
+          </Flexbox>
+        ),
+        desc: t('settingChatAppearance.autoScroll.desc'),
+        label: t('settingChatAppearance.autoScroll.title'),
+        name: 'disableAutoScrollWhileGenerating',
+        valuePropName: 'checked',
       },
       {
         children: (

--- a/src/features/ChatList/components/AutoScroll.tsx
+++ b/src/features/ChatList/components/AutoScroll.tsx
@@ -2,6 +2,8 @@ import { memo, useEffect } from 'react';
 
 import { useChatStore } from '@/store/chat';
 import { displayMessageSelectors, operationSelectors } from '@/store/chat/selectors';
+import { useUserStore } from '@/store/user';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import BackBottom from './BackBottom';
 
@@ -14,12 +16,16 @@ const AutoScroll = memo<AutoScrollProps>(({ atBottom, isScrolling, onScrollToBot
   const trackVisibility = useChatStore(operationSelectors.isAgentRuntimeRunning);
   const str = useChatStore(displayMessageSelectors.mainAIChatsMessageString);
   const reasoningStr = useChatStore(displayMessageSelectors.mainAILatestMessageReasoningContent);
+  const disableAutoScrollWhileGenerating = useUserStore(
+    userGeneralSettingsSelectors.disableAutoScrollWhileGenerating,
+  );
 
   useEffect(() => {
+    if (disableAutoScrollWhileGenerating) return;
     if (atBottom && trackVisibility && !isScrolling) {
       onScrollToBottom?.('auto');
     }
-  }, [atBottom, trackVisibility, str, reasoningStr]);
+  }, [atBottom, trackVisibility, str, reasoningStr, disableAutoScrollWhileGenerating, isScrolling]);
 
   return <BackBottom onScrollToBottom={() => onScrollToBottom('click')} visible={!atBottom} />;
 });

--- a/src/features/ChatList/components/VirtualizedList/index.tsx
+++ b/src/features/ChatList/components/VirtualizedList/index.tsx
@@ -7,6 +7,8 @@ import { VList, VListHandle } from 'virtua';
 import WideScreenContainer from '@/features/ChatList/components/WideScreenContainer';
 import { useChatStore } from '@/store/chat';
 import { displayMessageSelectors } from '@/store/chat/selectors';
+import { useUserStore } from '@/store/user';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import AutoScroll from '../AutoScroll';
 import SkeletonList from '../SkeletonList';
@@ -30,6 +32,9 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile, dataSource, itemCo
     displayMessageSelectors.currentChatLoadingState(s),
     displayMessageSelectors.isCurrentDisplayChatLoaded(s),
   ]);
+  const disableAutoScrollWhileGenerating = useUserStore(
+    userGeneralSettingsSelectors.disableAutoScrollWhileGenerating,
+  );
 
   const atBottomThreshold = 200 * (mobile ? 2 : 1);
 
@@ -72,11 +77,12 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile, dataSource, itemCo
   useEffect(() => {
     const shouldScroll = dataSource.length > prevDataLengthRef.current;
     prevDataLengthRef.current = dataSource.length;
+    if (disableAutoScrollWhileGenerating) return;
 
     if (shouldScroll && virtuaRef.current) {
       virtuaRef.current.scrollToIndex(dataSource.length - 2, { align: 'start', smooth: true });
     }
-  }, [dataSource.length]);
+  }, [dataSource.length, disableAutoScrollWhileGenerating]);
 
   const scrollToBottom = useCallback(
     (behavior: 'auto' | 'smooth' = 'smooth') => {

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -367,6 +367,10 @@ export default {
     title: '聊天设置',
   },
   settingChatAppearance: {
+    autoScroll: {
+      desc: '启用后，当助手生成内容时将不会自动滚动到底部。',
+      title: '禁用生成时自动滚动',
+    },
     fontSize: {
       desc: '聊天内容的字体大小',
       marks: {

--- a/src/store/user/slices/settings/selectors/general.test.ts
+++ b/src/store/user/slices/settings/selectors/general.test.ts
@@ -17,6 +17,7 @@ describe('settingsSelectors', () => {
 
       expect(result).toEqual({
         animationMode: 'agile',
+        disableAutoScrollWhileGenerating: false,
         fontSize: 12,
         highlighterTheme: 'lobe-theme',
         mermaidTheme: 'lobe-theme',
@@ -137,5 +138,27 @@ describe('settingsSelectors', () => {
     const result = userGeneralSettingsSelectors.mermaidTheme(s as UserStore);
 
     expect(result).toBe('lobe-theme');
+  });
+
+  describe('disableAutoScrollWhileGenerating', () => {
+    it('should return false by default', () => {
+      const result = userGeneralSettingsSelectors.disableAutoScrollWhileGenerating(
+        initialState as UserStore,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when configured', () => {
+      const s: UserState = merge(initialState, {
+        settings: {
+          general: { disableAutoScrollWhileGenerating: true },
+        },
+      });
+
+      const result = userGeneralSettingsSelectors.disableAutoScrollWhileGenerating(s as UserStore);
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/store/user/slices/settings/selectors/general.ts
+++ b/src/store/user/slices/settings/selectors/general.ts
@@ -12,6 +12,8 @@ const highlighterTheme = (s: UserStore) => generalConfig(s).highlighterTheme;
 const mermaidTheme = (s: UserStore) => generalConfig(s).mermaidTheme;
 const transitionMode = (s: UserStore) => generalConfig(s).transitionMode;
 const animationMode = (s: UserStore) => generalConfig(s).animationMode;
+const disableAutoScrollWhileGenerating = (s: UserStore) =>
+  generalConfig(s).disableAutoScrollWhileGenerating ?? false;
 const contextMenuMode = (s: UserStore) => {
   const config = generalConfig(s).contextMenuMode;
   if (config !== undefined) return config;
@@ -22,6 +24,7 @@ export const userGeneralSettingsSelectors = {
   animationMode,
   config: generalConfig,
   contextMenuMode,
+  disableAutoScrollWhileGenerating,
   fontSize,
   highlighterTheme,
   mermaidTheme,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

- `src/app/[variants]/(main)/settings/common/features/ChatAppearance/index.tsx` ： No Auto Scrolling 设置入口
- `src/features/ChatList/components/AutoScroll.tsx`: 当启用 No Auto Scrolling 时，跳过 Auto Scrolling 


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

`/settings`

<img width="1104" height="94" alt="image" src="https://github.com/user-attachments/assets/a80f0142-9c7c-42ca-8839-b340c0962e6c" />


<!-- If this PR includes

 UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ![auto-scroll](https://github.com/user-attachments/assets/b8c5eacd-376b-4871-bfaf-e9874530ab68)   | ![no-auto-scroll](https://github.com/user-attachments/assets/4bcab6fb-c202-48ac-b2df-5b98f9ae593b) |


#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

- 另外，开关位置有待探讨：
  - 放在 Settings ，作为一种长期不变的设置，优先由用户长期偏好（例如注重推理过程、注重推理结果）。
  - 放在 Chat 视图，作为临时的设置，优先满足当前任务偏好。 例如用户在“搜索”场景下，只想要“结论”；还是说用户在“学习”等场景，需要一个从头到尾的解释。
<img width="206" height="92" alt="image" src="https://github.com/user-attachments/assets/6502a2dd-8e06-4090-ae21-629e81ba8e36" />

- 发现在默认的 auto scrolling 下，只有动画在：“no“ 或 “fade in” 时，auto scrolling 才能被打断。在 ”smooth“ 下不能被打断，有待研究。

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add a user-configurable option to disable automatic scrolling while the assistant is generating messages and wire it through chat settings and list behavior.

New Features:
- Introduce a general settings flag to disable auto scroll while generating and expose it as a toggle in Chat Appearance settings.

Enhancements:
- Respect the disable-auto-scroll setting in chat auto-scroll behavior and virtualized list scrolling during message generation.
- Extend default user settings, selectors, and localization strings to support the new auto-scroll preference.

Tests:
- Add selector tests verifying the default and configured values of the disable-auto-scroll-while-generating setting.