### PR TITLE
🐛 fix: deepseek  interleaved thinking

### DIFF
--- a/packages/context-engine/src/processors/MessageCleanup.ts
+++ b/packages/context-engine/src/processors/MessageCleanup.ts
@@ -66,6 +66,7 @@ export class MessageCleanupProcessor extends BaseProcessor {
           content: message.content,
           role: message.role,
           ...(message.tool_calls && { tool_calls: message.tool_calls }),
+          ...(message.reasoning && { reasoning: message.reasoning }),
         };
       }
 

--- a/src/services/chat/contextEngineering.test.ts
+++ b/src/services/chat/contextEngineering.test.ts
@@ -243,6 +243,10 @@ describe('contextEngineering', () => {
             type: 'text',
           },
         ],
+        reasoning: {
+          content: 'I need to calculate the answer to life, universe, and everything.',
+          signature: 'thinking_process',
+        },
         role: 'assistant',
       },
     ]);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close https://github.com/lobehub/lobe-chat/issues/10534

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve DeepSeek reasoning compatibility and strengthen SSRF-safe media fetching while refactoring SSE fetch utilities into a shared package.

New Features:
- Add support for DeepSeek interleaved reasoning by handling reasoning metadata in message payloads and OpenAI response inputs.
- Introduce a shared @lobechat/fetch-sse package for SSE utilities and error parsing, and update consumers to use it.
- Provide SSRF-safe fetch mechanisms for media URL to base64 conversion with browser/node conditional exports.

Bug Fixes:
- Ensure DeepSeek chat payloads transform reasoning objects into reasoning_content strings and default stream behavior correctly.
- Strip internal reasoning fields from outgoing OpenAI messages while preserving compatible reasoning_content metadata.
- Correct OIDC consent redirect behavior by avoiding forwarding request headers on redirect.
- Fix type imports and module paths for model parsing utilities and chat method options to prevent runtime/test issues.

Enhancements:
- Parallelize and harden image handling in Ollama and other providers, including graceful handling of failed URL-to-base64 conversions.
- Normalize system messages to developer role and extract reasoning content into dedicated reasoning items in OpenAI response inputs.
- Consolidate imageUrlToBase64 into shared utils and reuse it across multiple providers, including Google video handling and BFL images.
- Improve i18n error parsing for SSE responses and add clearer test setup for fetch error handling.
- Update plugin lists and changelog entries to reflect latest releases and DeepSeek features, and refine SSRF environment variable documentation with security guidance.
- Adjust test environments and mocks (e.g., Google, Anthropic, DeepSeek, Ollama) to cover new reasoning and media-handling behaviors.

Build:
- Add package definitions for @lobechat/fetch-sse and enhance ssrf-safe-fetch exports with browser/node-specific entry points.

Documentation:
- Expand SSRF-related environment variable documentation with detailed security notes, usage scenarios, and configuration examples in both English and Chinese.
- Update ComfyUI usage docs to host screenshots from the project CDN instead of GitHub assets.
- Refresh README plugin listings and counts to reflect the current plugin catalog.

Tests:
- Add and update tests around DeepSeek reasoning handling, OpenAI message/response conversions, Ollama message building with async image processing, and SSRF-safe media conversion.
- Refactor and extend tests for SSE error parsing, Anthropic and Google providers, BFL image generation, and server AI provider configuration.

## Summary by Sourcery

Preserve and validate reasoning metadata on assistant messages during context processing to support DeepSeek interleaved thinking.

Bug Fixes:
- Ensure the message cleanup processor keeps the reasoning field when normalizing assistant messages so reasoning metadata is not lost.

Tests:
- Extend context engineering tests to cover assistant messages that include reasoning metadata.