### PR TITLE
🎨 style(auth): add apple sso icon and label

### DIFF
--- a/src/components/NextAuth/AuthIcons.tsx
+++ b/src/components/NextAuth/AuthIcons.tsx
@@ -11,9 +11,11 @@ import {
   NextAuth,
   Zitadel,
 } from '@lobehub/ui/icons';
+import { Apple } from 'lucide-react';
 import React from 'react';
 
 const iconComponents: { [key: string]: React.ElementType } = {
+  'apple': Apple,
   'auth0': Auth0,
   'authelia': Authelia.Color,
   'authentik': Authentik.Color,

--- a/src/locales/default/auth.ts
+++ b/src/locales/default/auth.ts
@@ -82,6 +82,7 @@ export default {
     },
     signin: {
       backToEmail: '返回修改邮箱',
+      continueWithApple: '使用 Apple 登录',
       continueWithAuth0: '使用 Auth0 登录',
       continueWithAuthelia: '使用 Authelia 登录',
       continueWithAuthentik: '使用 Authentik 登录',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change
- add Apple icon mapping for NextAuth social buttons
- add i18n label so Apple SSO displays friendly text

#### 🧪 How to Test
- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos
| Before | After |
| ------ | ----- |
| N/A | Apple icon & label shown on SSO button |

#### 📝 Additional Information
- UI-only addition; no breaking changes.

## Summary by Sourcery

Add Apple single sign-on visual support to the authentication UI.

Enhancements:
- Map the Apple provider to a dedicated icon in the NextAuth social button set.
- Add a localized "Continue with Apple" label to the authentication strings so the Apple SSO button displays friendly text.