### PR TITLE
🐛 fix: remove apiMode param from Azure and Cloudflare provider requests

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -863,17 +863,18 @@ const aihubmixModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 131_072,
     description:
-      'DeepSeek V3.2 是 DeepSeek 最新发布的通用大模型，支持混合推理架构，具备更强的 Agent 能力。',
-    displayName: 'DeepSeek V3.2 Exp',
-    id: 'DeepSeek-V3.2-Exp',
+      'DeepSeek-V3.2 是一款高效的大语言模型，具备 DSA 稀疏注意力与强化推理能力，其核心亮点在于强大的 Agent 能力——通过大规模任务合成，将推理与真实工具调用深度融合，实现更稳健、合规、可泛化的智能体表现。',
+    displayName: 'DeepSeek V3.2',
+    id: 'deepseek-chat',
     maxOutput: 8192,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.42, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.45, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-29',
+    releasedAt: '2025-12-01',
     type: 'chat',
   },
   {
@@ -884,34 +885,18 @@ const aihubmixModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description:
       'DeepSeek V3.2 思考模式。在输出最终回答之前，模型会先输出一段思维链内容，以提升最终答案的准确性。',
-    displayName: 'DeepSeek V3.2 Exp Thinking',
+    displayName: 'DeepSeek V3.2 Thinking',
     enabled: true,
-    id: 'DeepSeek-V3.2-Exp-Think',
+    id: 'deepseek-reasoner',
     maxOutput: 65_536,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.42, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.45, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-29',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 131_072,
-    description:
-      'DeepSeek-V3.1-非思考模式；DeepSeek-V3.1 是深度求索全新推出的混合推理模型，支持思考与非思考2种推理模式，较 DeepSeek-R1-0528 思考效率更高。经 Post-Training 优化，Agent 工具使用与智能体任务表现大幅提升。',
-    displayName: 'DeepSeek V3.1 (non-Think)',
-    id: 'DeepSeek-V3.1',
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.68, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
+    releasedAt: '2025-12-01',
     type: 'chat',
   },
   {
@@ -963,8 +948,8 @@ const aihubmixModels: AIChatModelCard[] = [
     id: 'DeepSeek-R1',
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.546, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.184, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -22,7 +22,7 @@ const deepseekChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-29',
+    releasedAt: '2025-12-01',
     type: 'chat',
   },
   {
@@ -45,7 +45,7 @@ const deepseekChatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-29',
+    releasedAt: '2025-12-01',
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -1012,7 +1012,7 @@ const qwenChatModels: AIChatModelCard[] = [
       search: true,
     },
     config: {
-      deploymentName: 'qwen-plus-2025-09-11',
+      deploymentName: 'qwen-plus-2025-12-01',
     },
     contextWindowTokens: 1_000_000,
     description: '通义千问超大规模语言模型增强版，支持中文、英文等不同语言输入。',

--- a/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
@@ -1,6 +1,7 @@
 import { LobeAnthropicAI } from '../../providers/anthropic';
 import { LobeAzureAI } from '../../providers/azureai';
 import { LobeCloudflareAI } from '../../providers/cloudflare';
+import { LobeDeepSeekAI } from '../../providers/deepseek';
 import { LobeFalAI } from '../../providers/fal';
 import { LobeGoogleAI } from '../../providers/google';
 import { LobeOpenAI } from '../../providers/openai';
@@ -11,6 +12,7 @@ export const baseRuntimeMap = {
   anthropic: LobeAnthropicAI,
   azure: LobeAzureAI,
   cloudflare: LobeCloudflareAI,
+  deepseek: LobeDeepSeekAI,
   fal: LobeFalAI,
   google: LobeGoogleAI,
   openai: LobeOpenAI,

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -60,6 +60,11 @@ export const params: CreateRouterRuntimeOptions = {
       options: { baseURL: urlJoin(baseURL, '/v1') },
     },
     {
+      apiType: 'deepseek',
+      models: ['deepseek-chat', 'deepseek-reasoner'],
+      options: { baseURL: urlJoin(baseURL, '/v1') },
+    },
+    {
       apiType: 'openai',
       options: {
         baseURL: urlJoin(baseURL, '/v1'),

--- a/packages/model-runtime/src/providers/azureOpenai/index.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.ts
@@ -43,7 +43,9 @@ export class LobeAzureOpenAI implements LobeRuntimeAI {
   baseURL: string;
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
-    const { messages, model, ...params } = payload;
+    // Remove internal apiMode parameter to prevent sending to Azure OpenAI API
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { messages, model, apiMode: _, ...params } = payload;
     // o1 series models on Azure OpenAI does not support streaming currently
     const enableStreaming = model.includes('o1') ? false : (params.stream ?? true);
 

--- a/packages/model-runtime/src/providers/azureai/index.ts
+++ b/packages/model-runtime/src/providers/azureai/index.ts
@@ -36,7 +36,9 @@ export class LobeAzureAI implements LobeRuntimeAI {
   baseURL: string;
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
-    const { messages, model, temperature, top_p, ...params } = payload;
+    // Remove internal apiMode parameter to prevent sending to Azure AI API
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { messages, model, temperature, top_p, apiMode: _, ...params } = payload;
     // o1 series models on Azure OpenAI does not support streaming currently
     const enableStreaming = model.includes('o1') ? false : (params.stream ?? true);
 

--- a/packages/model-runtime/src/providers/cloudflare/index.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.ts
@@ -57,7 +57,9 @@ export class LobeCloudflareAI implements LobeRuntimeAI {
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions): Promise<Response> {
     try {
-      const { model, tools, ...restPayload } = payload;
+      // Remove internal apiMode parameter to prevent sending to Cloudflare API
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { model, tools, apiMode: _, ...restPayload } = payload;
       const functions = tools?.map((tool) => tool.function);
       const headers = options?.headers || {};
       if (this.apiKey) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close #10567

完善 #10539 ，已检查所有独立实现 chat 的提供商。

另将 aihubmix 的 deepseek 3.2 路由到了 deepseek 后端处理，可以帮忙测试下思维链是否正确。

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Prevent Azure OpenAI, Azure AI, and Cloudflare AI provider requests from including the internal apiMode parameter in their upstream API calls.