### PR TITLE
🐛 fix: udpate discover detail tools get & more link

### DIFF
--- a/locales/ar/discover.json
+++ b/locales/ar/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "مزودو الخدمة المدعومون لهذا النموذج"
   },
   "plugins": {
+    "builtinTag": "الملحقات المدمجة",
     "community": "إضافات المجتمع",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "تثبيت الإضافة",
     "installed": "تم التثبيت",
+    "legacyTag": "الملحقات القديمة",
     "list": "قائمة الإضافات",
     "meta": {
       "description": "وصف",

--- a/locales/bg-BG/discover.json
+++ b/locales/bg-BG/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Доставчици, поддържащи този модел"
   },
   "plugins": {
+    "builtinTag": "Вграден плъгин",
     "community": "Обществени плъгини",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Инсталирай плъгин",
     "installed": "Инсталиран",
+    "legacyTag": "Остарял плъгин",
     "list": "Списък с плъгини",
     "meta": {
       "description": "Описание",

--- a/locales/de-DE/discover.json
+++ b/locales/de-DE/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Anbieter, die dieses Modell unterstützen"
   },
   "plugins": {
+    "builtinTag": "Integriertes Plugin",
     "community": "Community-Plugins",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Plugin installieren",
     "installed": "Installiert",
+    "legacyTag": "Veraltetes Plugin",
     "list": "Plugin-Liste",
     "meta": {
       "description": "Beschreibung",

--- a/locales/en-US/discover.json
+++ b/locales/en-US/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Providers Supporting This Model"
   },
   "plugins": {
+    "builtinTag": "Built-in",
     "community": "Community Plugins",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Install Plugin",
     "installed": "Installed",
+    "legacyTag": "Legacy",
     "list": "Plugin List",
     "meta": {
       "description": "Description",

--- a/locales/es-ES/discover.json
+++ b/locales/es-ES/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Proveedores que admiten este modelo"
   },
   "plugins": {
+    "builtinTag": "Complemento incorporado",
     "community": "Complementos de la comunidad",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Instalar complemento",
     "installed": "Instalado",
+    "legacyTag": "Complemento heredado",
     "list": "Lista de complementos",
     "meta": {
       "description": "Descripción",

--- a/locales/fa-IR/discover.json
+++ b/locales/fa-IR/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "ارائه‌دهندگان پشتیبانی شده برای این مدل"
   },
   "plugins": {
+    "builtinTag": "افزونه داخلی",
     "community": "پلاگین‌های انجمن",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "نصب پلاگین",
     "installed": "نصب شده",
+    "legacyTag": "افزونه قدیمی",
     "list": "فهرست پلاگین‌ها",
     "meta": {
       "description": "توضیحات",

--- a/locales/fr-FR/discover.json
+++ b/locales/fr-FR/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Fournisseurs prenant en charge ce modèle"
   },
   "plugins": {
+    "builtinTag": "Plugin intégré",
     "community": "Plugins communautaires",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Installer le plugin",
     "installed": "Installé",
+    "legacyTag": "Ancien plugin",
     "list": "Liste des plugins",
     "meta": {
       "description": "Description",

--- a/locales/it-IT/discover.json
+++ b/locales/it-IT/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Fornitori supportati da questo modello"
   },
   "plugins": {
+    "builtinTag": "Plugin integrato",
     "community": "Plugin della comunità",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Installa plugin",
     "installed": "Installato",
+    "legacyTag": "Plugin legacy",
     "list": "Elenco plugin",
     "meta": {
       "description": "Descrizione",

--- a/locales/ja-JP/discover.json
+++ b/locales/ja-JP/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "このモデルをサポートするプロバイダー"
   },
   "plugins": {
+    "builtinTag": "内蔵プラグイン",
     "community": "コミュニティプラグイン",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "プラグインをインストール",
     "installed": "インストール済み",
+    "legacyTag": "旧バージョンプラグイン",
     "list": "プラグインリスト",
     "meta": {
       "description": "説明",

--- a/locales/ko-KR/discover.json
+++ b/locales/ko-KR/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "이 모델을 지원하는 서비스 제공자"
   },
   "plugins": {
+    "builtinTag": "내장 플러그인",
     "community": "커뮤니티 플러그인",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "플러그인 설치",
     "installed": "설치됨",
+    "legacyTag": "구버전 플러그인",
     "list": "플러그인 목록",
     "meta": {
       "description": "설명",

--- a/locales/nl-NL/discover.json
+++ b/locales/nl-NL/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Providers die dit model ondersteunen"
   },
   "plugins": {
+    "builtinTag": "Ingebouwde plug-in",
     "community": "Gemeenschapsplugins",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Plugin installeren",
     "installed": "Geïnstalleerd",
+    "legacyTag": "Verouderde plug-in",
     "list": "Pluginlijst",
     "meta": {
       "description": "Beschrijving",

--- a/locales/pl-PL/discover.json
+++ b/locales/pl-PL/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Dostawcy obsługujący ten model"
   },
   "plugins": {
+    "builtinTag": "Wbudowana wtyczka",
     "community": "Wtyczki społecznościowe",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Zainstaluj wtyczkę",
     "installed": "Zainstalowane",
+    "legacyTag": "Starsza wersja wtyczki",
     "list": "Lista wtyczek",
     "meta": {
       "description": "Opis",

--- a/locales/pt-BR/discover.json
+++ b/locales/pt-BR/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Provedores que suportam este modelo"
   },
   "plugins": {
+    "builtinTag": "Plugin Integrado",
     "community": "Plugins da Comunidade",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Instalar Plugin",
     "installed": "Instalado",
+    "legacyTag": "Plugin Legado",
     "list": "Lista de Plugins",
     "meta": {
       "description": "Descrição",

--- a/locales/ru-RU/discover.json
+++ b/locales/ru-RU/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Поставщики, поддерживающие эту модель"
   },
   "plugins": {
+    "builtinTag": "Встроенный плагин",
     "community": "Сообщество плагинов",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Установить плагин",
     "installed": "Установлено",
+    "legacyTag": "Устаревший плагин",
     "list": "Список плагинов",
     "meta": {
       "description": "Описание",

--- a/locales/tr-TR/discover.json
+++ b/locales/tr-TR/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Bu modeli destekleyen sağlayıcılar"
   },
   "plugins": {
+    "builtinTag": "Yerleşik Eklenti",
     "community": "Topluluk Eklentisi",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Eklenti Yükle",
     "installed": "Yüklü",
+    "legacyTag": "Eski Sürüm Eklenti",
     "list": "Eklenti Listesi",
     "meta": {
       "description": "Açıklama",

--- a/locales/vi-VN/discover.json
+++ b/locales/vi-VN/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "Nhà cung cấp hỗ trợ mô hình này"
   },
   "plugins": {
+    "builtinTag": "Plugin tích hợp sẵn",
     "community": "Plugin cộng đồng",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "Cài đặt plugin",
     "installed": "Đã cài đặt",
+    "legacyTag": "Plugin phiên bản cũ",
     "list": "Danh sách plugin",
     "meta": {
       "description": "Mô tả",

--- a/locales/zh-CN/discover.json
+++ b/locales/zh-CN/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "支持该模型的服务商"
   },
   "plugins": {
+    "builtinTag": "内置插件",
     "community": "社区插件",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "安装插件",
     "installed": "已安装",
+    "legacyTag": "旧版插件",
     "list": "插件列表",
     "meta": {
       "description": "描述",

--- a/locales/zh-TW/discover.json
+++ b/locales/zh-TW/discover.json
@@ -616,6 +616,7 @@
     "supportedProviders": "支持該模型的服務商"
   },
   "plugins": {
+    "builtinTag": "內建外掛",
     "community": "社區插件",
     "details": {
       "settings": {
@@ -630,6 +631,7 @@
     },
     "install": "安裝插件",
     "installed": "已安裝",
+    "legacyTag": "舊版外掛",
     "list": "插件列表",
     "meta": {
       "description": "描述",

--- a/packages/types/src/discover/plugins.ts
+++ b/packages/types/src/discover/plugins.ts
@@ -46,7 +46,19 @@ export interface PluginListResponse {
   totalPages: number;
 }
 
+/**
+ * Plugin source types
+ * - legacy: From old plugin list (_getPluginList)
+ * - market: From Market SDK (getMcpDetail)
+ * - builtin: From LobeHub builtin tools
+ */
+export type PluginSource = 'legacy' | 'market' | 'builtin';
+
 export interface DiscoverPluginDetail extends Omit<DiscoverPluginItem, 'manifest'> {
   manifest?: LobeChatPluginManifest | string;
   related: DiscoverPluginItem[];
+  /**
+   * Plugin source type
+   */
+  source?: PluginSource;
 }

--- a/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/PluginItem.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/PluginItem.tsx
@@ -1,35 +1,96 @@
-import { Avatar, Block, Text } from '@lobehub/ui';
+import { PluginSource } from '@lobechat/types';
+import { Avatar, Block, Tag, Text } from '@lobehub/ui';
 import { Skeleton } from 'antd';
 import { createStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
+import urlJoin from 'url-join';
 
 import { useDiscoverStore } from '@/store/discover';
 
 const useStyles = createStyles(({ css, token }) => {
   return {
+    clickable: css`
+      cursor: pointer;
+
+      &:hover {
+        .plugin-title {
+          color: ${token.colorLink};
+        }
+      }
+    `,
     desc: css`
       flex: 1;
       margin: 0 !important;
       font-size: 14px !important;
       color: ${token.colorTextSecondary};
     `,
+    noLink: css`
+      cursor: default;
+    `,
+    tag: css`
+      flex-shrink: 0;
+    `,
     title: css`
       margin: 0 !important;
       font-size: 14px !important;
       font-weight: 500 !important;
-
-      &:hover {
-        color: ${token.colorLink};
-      }
+    `,
+    titleRow: css`
+      display: flex;
+      gap: 8px;
+      align-items: center;
     `,
   };
 });
 
-const PluginItem = memo<{ identifier: string }>(({ identifier }) => {
+interface PluginItemProps {
+  identifier: string;
+}
+
+const PluginItem = memo<PluginItemProps>(({ identifier }) => {
+  const { t } = useTranslation('discover');
   const usePluginDetail = useDiscoverStore((s) => s.usePluginDetail);
   const { data, isLoading } = usePluginDetail({ identifier, withManifest: false });
-  const { styles } = useStyles();
+  const { styles, cx } = useStyles();
+
+  const sourceConfig = useMemo(() => {
+    const source: PluginSource = data?.source || 'market';
+
+    switch (source) {
+      case 'builtin': {
+        return {
+          clickable: false,
+          href: undefined,
+          isExternal: false,
+          tagColor: 'geekblue' as const,
+          tagText: t('plugins.builtinTag'),
+        };
+      }
+      case 'legacy': {
+        return {
+          clickable: true,
+          href: data?.homepage,
+          isExternal: true,
+          tagColor: 'orange' as const,
+          tagText: t('plugins.legacyTag'),
+        };
+      }
+      // eslint-disable-next-line unicorn/no-useless-switch-case
+      case 'market':
+      default: {
+        return {
+          clickable: true,
+          href: urlJoin('/discover/plugin', identifier),
+          isExternal: false,
+          tagColor: undefined,
+          tagText: undefined,
+        };
+      }
+    }
+  }, [data?.source, data?.homepage, identifier, t]);
 
   if (isLoading || !data)
     return (
@@ -38,8 +99,15 @@ const PluginItem = memo<{ identifier: string }>(({ identifier }) => {
       </Block>
     );
 
-  return (
-    <Block gap={12} horizontal key={identifier} padding={12} variant={'outlined'}>
+  const content = (
+    <Block
+      className={cx(sourceConfig.clickable ? styles.clickable : styles.noLink)}
+      gap={12}
+      horizontal
+      key={identifier}
+      padding={12}
+      variant={'outlined'}
+    >
       <Avatar avatar={data.avatar} size={40} style={{ flex: 'none' }} />
       <Flexbox
         flex={1}
@@ -48,9 +116,16 @@ const PluginItem = memo<{ identifier: string }>(({ identifier }) => {
           overflow: 'hidden',
         }}
       >
-        <Text as={'h2'} className={styles.title} ellipsis>
-          {data.title}
-        </Text>
+        <div className={styles.titleRow}>
+          <Text as={'h2'} className={cx(styles.title, 'plugin-title')} ellipsis>
+            {data.title}
+          </Text>
+          {sourceConfig.tagText && (
+            <Tag className={styles.tag} color={sourceConfig.tagColor} size={'small'}>
+              {sourceConfig.tagText}
+            </Tag>
+          )}
+        </div>
         <Text
           as={'p'}
           className={styles.desc}
@@ -63,6 +138,27 @@ const PluginItem = memo<{ identifier: string }>(({ identifier }) => {
       </Flexbox>
     </Block>
   );
+
+  // For builtin plugins, no link wrapper
+  if (!sourceConfig.clickable) {
+    return content;
+  }
+
+  // For external links (legacy plugins), use <a> tag
+  if (sourceConfig.isExternal && sourceConfig.href) {
+    return (
+      <a href={sourceConfig.href} rel="noopener noreferrer" target="_blank">
+        {content}
+      </a>
+    );
+  }
+
+  // For internal links (market plugins), use Link component
+  if (sourceConfig.href) {
+    return <Link to={sourceConfig.href}>{content}</Link>;
+  }
+
+  return content;
 });
 
 export default PluginItem;

--- a/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/Plugins.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/features/Details/Capabilities/Plugins.tsx
@@ -1,9 +1,7 @@
 import { Block } from '@lobehub/ui';
 import { Empty } from 'antd';
-import { Link } from 'react-router-dom';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import urlJoin from 'url-join';
 
 import { useDetailContext } from '../../DetailProvider';
 import PluginItem from './PluginItem';
@@ -24,11 +22,7 @@ const Plugin = memo(() => {
         const identifier =
           typeof item === 'string' ? item : (item as { identifier: string }).identifier;
 
-        return (
-          <Link key={identifier} to={urlJoin('/discover/plugin', identifier)}>
-            <PluginItem identifier={identifier} />
-          </Link>
-        );
+        return <PluginItem identifier={identifier} key={identifier} />;
       })}
     </Flexbox>
   );

--- a/src/app/[variants]/(main)/discover/(list)/(home)/Client.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/(home)/Client.tsx
@@ -29,12 +29,12 @@ const Client = memo<{ mobile?: boolean }>(() => {
 
   return (
     <>
-      <Title more={t('home.more')} moreLink={'/assistant'}>
+      <Title more={t('home.more')} moreLink={'/discover/assistant'}>
         {t('home.featuredAssistants')}
       </Title>
       <AssistantList data={assistantList.items} rows={4} />
       <div />
-      <Title more={t('home.more')} moreLink={'/mcp'}>
+      <Title more={t('home.more')} moreLink={'/discover/mcp'}>
         {t('home.featuredTools')}
       </Title>
       <McpList data={mcpList.items} rows={4} />

--- a/src/app/[variants]/(main)/discover/(list)/(home)/index.tsx
+++ b/src/app/[variants]/(main)/discover/(list)/(home)/index.tsx
@@ -29,12 +29,12 @@ const HomePage = memo<{ mobile?: boolean }>(() => {
 
   return (
     <>
-      <Title more={t('home.more')} moreLink={'/assistant'}>
+      <Title more={t('home.more')} moreLink={'/discover/assistant'}>
         {t('home.featuredAssistants')}
       </Title>
       <AssistantList data={assistantList.items} rows={4} />
       <div />
-      <Title more={t('home.more')} moreLink={'/mcp'}>
+      <Title more={t('home.more')} moreLink={'/discover/mcp'}>
         {t('home.featuredTools')}
       </Title>
       <McpList data={mcpList.items} rows={4} />
@@ -56,4 +56,3 @@ DesktopHomePage.displayName = 'DesktopHomePage';
 
 export { DesktopHomePage, MobileHomePage };
 export default HomePage;
-

--- a/src/app/[variants]/(main)/discover/features/Title.tsx
+++ b/src/app/[variants]/(main)/discover/features/Title.tsx
@@ -48,6 +48,7 @@ const Title = memo<TitleProps>(
     // Check if it's an external link or internal discover route
     const isExternalLink = moreLink?.startsWith('http') ?? false;
     const isDiscoverRoute = moreLink?.startsWith('/discover') ?? false;
+    console.log('moreLink', moreLink);
 
     let moreLinkElement = null;
     if (moreLink) {
@@ -60,7 +61,7 @@ const Title = memo<TitleProps>(
         );
       } else if (isDiscoverRoute) {
         moreLinkElement = (
-          <RouterLink className={styles.more} to={moreLink.replace('/discover', '')}>
+          <RouterLink className={styles.more} to={moreLink}>
             <span style={{ marginRight: 4 }}>{more}</span>
             <Icon icon={ChevronRight} />
           </RouterLink>

--- a/src/locales/default/discover.ts
+++ b/src/locales/default/discover.ts
@@ -623,6 +623,7 @@ export default {
     supportedProviders: '支持该模型的服务商',
   },
   plugins: {
+    builtinTag: '内置插件',
     community: '社区插件',
     details: {
       settings: {
@@ -637,6 +638,7 @@ export default {
     },
     install: '安装插件',
     installed: '已安装',
+    legacyTag: '旧版插件',
     list: '插件列表',
     meta: {
       description: '描述',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve plugin discovery details and navigation in the Discover section.

Bug Fixes:
- Fix plugin detail resolution by prioritizing legacy plugins, then market MCP plugins, and finally builtin tools, returning correctly structured detail data for each source.
- Correct Discover home 'More' links to point to the appropriate assistant and MCP routes under /discover.
- Ensure 'More' links in Discover titles preserve /discover prefixes instead of stripping them, avoiding broken navigation.

Enhancements:
- Add support for builtin tools as a fallback source in plugin detail retrieval, including standardized metadata mapping and source tagging.
- Introduce a PluginSource type and annotate plugin details with their origin (legacy, market, builtin) for clearer handling in the UI.
- Update plugin item UI to display different link behaviors and source tags for builtin and legacy plugins, and to centralize link handling inside the item component.
- Extend Discover plugin translations with labels for builtin and legacy plugins.