### PR TITLE
🐛 fix: missing init user after user creation

### DIFF
--- a/src/server/services/user/index.ts
+++ b/src/server/services/user/index.ts
@@ -8,11 +8,43 @@ import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { S3 } from '@/server/modules/S3';
 import { AgentService } from '@/server/services/agent';
 
+type CreatedUser = {
+  email?: string | null;
+  firstName?: string | null;
+  id: string;
+  lastName?: string | null;
+  phone?: string | null;
+  username?: string | null;
+};
+
 export class UserService {
   private db: LobeChatDatabase;
 
   constructor(db: LobeChatDatabase) {
     this.db = db;
+  }
+
+  async initUser(user: CreatedUser) {
+    const agentService = new AgentService(this.db, user.id);
+    await agentService.createInbox();
+
+    /* ↓ cloud slot ↓ */
+    /* ↑ cloud slot ↑ */
+
+    const analytics = await initializeServerAnalytics();
+    analytics?.identify(user.id, {
+      email: user.email ?? undefined,
+      firstName: user.firstName ?? undefined,
+      lastName: user.lastName ?? undefined,
+      username: user.username ?? undefined,
+    });
+    analytics?.track({
+      name: 'user_register_completed',
+      properties: {
+        spm: 'user_service.init_user.user_created',
+      },
+      userId: user.id,
+    });
   }
 
   createUser = async (id: string, params: UserJSON) => {
@@ -34,10 +66,6 @@ export class UserService {
       return index === 0;
     });
 
-    /* ↓ cloud slot ↓ */
-
-    /* ↑ cloud slot ↑ */
-
     // 2. create user in database
     await UserModel.createUser(this.db, {
       avatar: params.image_url,
@@ -50,29 +78,13 @@ export class UserService {
       username: params.username,
     });
 
-    // 3. Create an inbox session for the user
-    const agentService = new AgentService(this.db, id);
-    await agentService.createInbox();
-
-    /* ↓ cloud slot ↓ */
-
-    /* ↑ cloud slot ↑ */
-
-    //analytics
-    const analytics = await initializeServerAnalytics();
-    analytics?.identify(id, {
+    await this.initUser({
       email: email?.email_address,
       firstName: params.first_name,
+      id,
       lastName: params.last_name,
       phone: phone?.phone_number,
       username: params.username,
-    });
-    analytics?.track({
-      name: 'user_register_completed',
-      properties: {
-        spm: 'user_service.create_user.user_created',
-      },
-      userId: id,
     });
 
     return { message: 'user created', success: true };

--- a/src/server/services/user/index.ts
+++ b/src/server/services/user/index.ts
@@ -36,6 +36,7 @@ export class UserService {
       email: user.email ?? undefined,
       firstName: user.firstName ?? undefined,
       lastName: user.lastName ?? undefined,
+      phone: user.phone ?? undefined,
       username: user.username ?? undefined,
     });
     analytics?.track({


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Initialize newly created users through a shared bootstrap flow and ensure it runs for all account creation paths.

New Features:
- Add a reusable user initialization method that creates the default inbox and records analytics for new users.

Bug Fixes:
- Ensure user initialization runs for users created via Better Auth database hooks, including social and non-signup flows.

Enhancements:
- Refactor user creation logic to reuse the shared initialization routine instead of inlining inbox setup and analytics.