### PR TITLE
fix: environment variable loading with dotenv-expand

### DIFF
--- a/scripts/migrateServerDB/index.ts
+++ b/scripts/migrateServerDB/index.ts
@@ -1,4 +1,5 @@
 import * as dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
 import { migrate as neonMigrate } from 'drizzle-orm/neon-serverless/migrator';
 import { migrate as nodeMigrate } from 'drizzle-orm/node-postgres/migrator';
 import { join } from 'node:path';
@@ -6,9 +7,15 @@ import { join } from 'node:path';
 // @ts-ignore tsgo handle esm import cjs and compatibility issues
 import { DB_FAIL_INIT_HINT, DUPLICATE_EMAIL_HINT, PGVECTOR_HINT } from './errorHint';
 
-// Read the `.env` file if it exists, or a file specified by the
-// dotenv_config_path parameter that's passed to Node.js
-dotenv.config();
+// Load environment variables in priority order:
+// 1. .env (lowest priority)
+// 2. .env.[env] (medium priority, overrides .env)
+// 3. .env.[env].local (highest priority, overrides previous)
+// Use dotenv-expand to support ${var} variable expansion
+const env = process.env.NODE_ENV || 'development';
+dotenvExpand.expand(dotenv.config()); // Load .env
+dotenvExpand.expand(dotenv.config({ override: true, path: `.env.${env}` })); // Load .env.[env] and override
+dotenvExpand.expand(dotenv.config({ override: true, path: `.env.${env}.local` })); // Load .env.[env].local and override
 
 const migrationsFolder = join(__dirname, '../../packages/database/migrations');
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

`database "${LOBE_DB_NAME}" does not exist`

The database migration requires environment variables to be expanded, as well as reading from `.env.[var].[local]` to overwrite.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
