### PR TITLE
🔨 chore: change the settings sub router to / path

### DIFF
--- a/src/app/[variants]/(main)/settings/_layout/Body/index.tsx
+++ b/src/app/[variants]/(main)/settings/_layout/Body/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { Accordion, AccordionItem, Text } from '@lobehub/ui';
-import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import { memo, useEffect } from 'react';
+import { memo, useMemo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { SettingsTabs } from '@/store/global/initialState';
@@ -13,44 +12,26 @@ import { SettingsGroupKey, useCategory } from '../../hooks/useCategory';
 
 const Body = memo(() => {
   const categoryGroups = useCategory();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const [activeTabState, setActiveTabState] = useMergedState(
-    {
-      active: (searchParams.get('active') as SettingsTabs)
-        ? (searchParams.get('active') as SettingsTabs)
-        : SettingsTabs.Profile,
-    },
-    {
-      onChange: (obj: { active: SettingsTabs; provider?: string }) => {
-        if (obj.provider) {
-          setSearchParams({ active: obj.active, provider: obj.provider });
-        } else {
-          searchParams.delete('provider');
-          setSearchParams({ active: obj.active });
-        }
-      },
-    },
-  );
+  // Extract current tab from pathname: /settings/profile -> profile
+  const activeTab = useMemo(() => {
+    const pathParts = location.pathname.split('/');
+    // pathname is like /settings/profile or /settings/provider/xxx
+    if (pathParts.length >= 3) {
+      return pathParts[2] as SettingsTabs;
+    }
+    return SettingsTabs.Profile;
+  }, [location.pathname]);
 
-  const setActiveTab = (tab: SettingsTabs) => {
+  const handleTabClick = (tab: SettingsTabs) => {
     if (tab === SettingsTabs.Provider) {
-      setActiveTabState({ active: tab, provider: 'all' });
+      navigate('/settings/provider/all');
     } else {
-      setActiveTabState({
-        active: tab,
-      });
+      navigate(`/settings/${tab}`);
     }
   };
-
-  useEffect(() => {
-    return () => {
-      setSearchParams((prevParams) => {
-        prevParams.delete('active');
-        return prevParams;
-      });
-    };
-  }, []);
 
   return (
     <Flexbox paddingInline={4}>
@@ -78,10 +59,10 @@ const Body = memo(() => {
             <Flexbox gap={1} paddingBlock={1}>
               {group.items.map((item) => (
                 <NavItem
-                  active={activeTabState.active === item.key}
+                  active={activeTab === item.key}
                   icon={item.icon}
                   key={item.key}
-                  onClick={() => setActiveTab(item.key)}
+                  onClick={() => handleTabClick(item.key)}
                   title={item.label}
                 />
               ))}

--- a/src/app/[variants]/(main)/settings/index.tsx
+++ b/src/app/[variants]/(main)/settings/index.tsx
@@ -1,21 +1,20 @@
 'use client';
 
 import { memo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 
+import { SettingsTabParams } from '@/app/[variants]/loaders/routeParams';
 import { SettingsTabs } from '@/store/global/initialState';
 
 import { LayoutProps } from './_layout/type';
 import SettingsContent from './features/SettingsContent';
 
 const Layout = memo<LayoutProps>(() => {
-  const [searchParams] = useSearchParams();
+  const { tab } = useLoaderData() as SettingsTabParams;
 
-  const active = (searchParams.get('active') as SettingsTabs)
-    ? (searchParams.get('active') as SettingsTabs)
-    : SettingsTabs.Profile;
+  const activeTab = (tab as SettingsTabs) || SettingsTabs.Profile;
 
-  return <SettingsContent activeTab={active} mobile={false} />;
+  return <SettingsContent activeTab={activeTab} mobile={false} />;
 });
 
 Layout.displayName = 'DesktopSettingsLayout';

--- a/src/app/[variants]/(main)/settings/provider/ProviderMenu/All.tsx
+++ b/src/app/[variants]/(main)/settings/provider/ProviderMenu/All.tsx
@@ -1,9 +1,9 @@
 import { Icon } from '@lobehub/ui';
 import { WalletCards } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { useStyles } from './Item';
 
@@ -13,8 +13,17 @@ const All = memo((props: { onClick: (activeTab: string) => void }) => {
   const { onClick } = props;
   const { t } = useTranslation('modelProvider');
   const { styles, cx } = useStyles();
-  const [searchParams] = useSearchParams();
-  const activeKey = searchParams.get('provider');
+  const location = useLocation();
+
+  // Extract providerId from pathname: /settings/provider/xxx -> xxx
+  const activeKey = useMemo(() => {
+    const pathParts = location.pathname.split('/');
+    // pathname is like /settings/provider/all or /settings/provider/openai
+    if (pathParts.length >= 4 && pathParts[2] === 'provider') {
+      return pathParts[3];
+    }
+    return null;
+  }, [location.pathname]);
 
   return (
     <div

--- a/src/app/[variants]/(main)/settings/provider/ProviderMenu/Item.tsx
+++ b/src/app/[variants]/(main)/settings/provider/ProviderMenu/Item.tsx
@@ -2,9 +2,9 @@ import { ProviderIcon } from '@lobehub/icons';
 import { Avatar } from '@lobehub/ui';
 import { Badge } from 'antd';
 import { createStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { Center, Flexbox } from 'react-layout-kit';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { AiProviderListItem, AiProviderSourceEnum } from '@/types/aiProvider';
 
@@ -42,9 +42,17 @@ interface ProviderItemProps extends AiProviderListItem {
 const ProviderItem = memo<ProviderItemProps>(
   ({ id, name, source, enabled, logo, onClick = () => {} }) => {
     const { styles, cx } = useStyles();
-    const [searchParams] = useSearchParams();
+    const location = useLocation();
 
-    const activeKey = searchParams.get('provider');
+    // Extract providerId from pathname: /settings/provider/xxx -> xxx
+    const activeKey = useMemo(() => {
+      const pathParts = location.pathname.split('/');
+      // pathname is like /settings/provider/all or /settings/provider/openai
+      if (pathParts.length >= 4 && pathParts[2] === 'provider') {
+        return pathParts[3];
+      }
+      return null;
+    }, [location.pathname]);
 
     const isCustom = source === AiProviderSourceEnum.Custom;
     return (

--- a/src/app/[variants]/(main)/settings/provider/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/index.tsx
@@ -1,11 +1,70 @@
-import Page from './(list)';
+'use client';
 
+import { memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+import { Outlet, useLoaderData, useNavigate } from 'react-router-dom';
+
+import { ProviderIdParams } from '@/app/[variants]/loaders/routeParams';
+import { isCustomBranding } from '@/const/version';
+
+import Footer from './(list)/Footer';
+import ProviderMenu from './ProviderMenu';
+import DesktopLayoutContainer from './_layout/Desktop/Container';
+import ProviderDetailPageComponent from './detail';
+
+// Layout component that wraps provider pages with navigation
+export const ProviderLayout = memo(() => {
+  const navigate = useNavigate();
+
+  const handleProviderSelect = (providerKey: string) => {
+    navigate(`/settings/provider/${providerKey}`);
+  };
+
+  return (
+    <Flexbox
+      horizontal
+      style={{
+        maxHeight: '100%',
+      }}
+      width={'100%'}
+    >
+      <ProviderMenu mobile={false} onProviderSelect={handleProviderSelect} />
+      <DesktopLayoutContainer>
+        <Outlet />
+        {!isCustomBranding && <Footer />}
+      </DesktopLayoutContainer>
+    </Flexbox>
+  );
+});
+
+ProviderLayout.displayName = 'ProviderLayout';
+
+// Detail page component that receives providerId from route params
+export const ProviderDetailPage = memo(() => {
+  const { providerId } = useLoaderData() as ProviderIdParams;
+  const navigate = useNavigate();
+
+  const handleProviderSelect = (providerKey: string) => {
+    navigate(`/settings/provider/${providerKey}`);
+  };
+
+  return <ProviderDetailPageComponent id={providerId} onProviderSelect={handleProviderSelect} />;
+});
+
+ProviderDetailPage.displayName = 'ProviderDetailPage';
+
+// Default export for backward compatibility (used by SettingsContent)
 type ProviderPageType = {
   mobile?: boolean;
 };
 
-export default (props: ProviderPageType) => {
+const ProviderPage = (props: ProviderPageType) => {
   const { mobile } = props;
 
-  return <Page mobile={mobile} />;
+  // For mobile or when used via SettingsContent, use the old Page component
+  // This is a fallback for non-router usage
+  const OldPage = require('./(list)').default;
+  return <OldPage mobile={mobile} />;
 };
+
+export default ProviderPage;

--- a/src/app/[variants]/desktopRouter.config.tsx
+++ b/src/app/[variants]/desktopRouter.config.tsx
@@ -6,7 +6,13 @@ import Loading from '@/components/Loading/BrandTextLoading';
 import { ErrorBoundary, dynamicElement } from '@/utils/router';
 
 import DesktopMainLayout from './(main)/layouts';
-import { agentIdLoader, idLoader, slugLoader } from './loaders/routeParams';
+import {
+  agentIdLoader,
+  idLoader,
+  providerIdLoader,
+  settingsTabLoader,
+  slugLoader,
+} from './loaders/routeParams';
 
 // Create desktop router configuration
 export const createDesktopRouter = () =>
@@ -191,8 +197,34 @@ export const createDesktopRouter = () =>
         {
           children: [
             {
-              element: dynamicElement(() => import('./(main)/settings')),
               index: true,
+              loader: () => redirect('/settings/profile', { status: 302 }),
+            },
+            // Provider routes with nested structure
+            {
+              children: [
+                {
+                  index: true,
+                  loader: () => redirect('/settings/provider/all', { status: 302 }),
+                },
+                {
+                  element: dynamicElement(() =>
+                    import('./(main)/settings/provider').then((m) => m.ProviderDetailPage),
+                  ),
+                  loader: providerIdLoader,
+                  path: ':providerId',
+                },
+              ],
+              element: dynamicElement(() =>
+                import('./(main)/settings/provider').then((m) => m.ProviderLayout),
+              ),
+              path: 'provider',
+            },
+            // Other settings tabs
+            {
+              element: dynamicElement(() => import('./(main)/settings')),
+              loader: settingsTabLoader,
+              path: ':tab',
             },
           ],
           element: dynamicElement(() => import('./(main)/settings/_layout')),

--- a/src/app/[variants]/loaders/routeParams.ts
+++ b/src/app/[variants]/loaders/routeParams.ts
@@ -50,3 +50,33 @@ export const idLoader = ({ params }: LoaderFunctionArgs): IdParams => {
   }
   return { id: params.id };
 };
+
+/**
+ * Specific loader for settings tab routes
+ * Returns: { tab: string }
+ */
+export interface SettingsTabParams {
+  tab: string;
+}
+
+export const settingsTabLoader = ({ params }: LoaderFunctionArgs): SettingsTabParams => {
+  if (!params.tab) {
+    throw new Error('Tab parameter is required');
+  }
+  return { tab: params.tab };
+};
+
+/**
+ * Specific loader for provider detail routes
+ * Returns: { providerId: string }
+ */
+export interface ProviderIdParams {
+  providerId: string;
+}
+
+export const providerIdLoader = ({ params }: LoaderFunctionArgs): ProviderIdParams => {
+  if (!params.providerId) {
+    throw new Error('Provider ID parameter is required');
+  }
+  return { providerId: params.providerId };
+};


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Switch settings navigation to path-based routing and introduce dedicated nested routes and loaders for settings tabs and provider details.

Enhancements:
- Route settings tabs and provider pages via pathname segments instead of query parameters for desktop.
- Add dedicated provider layout and detail components wired into the router while keeping the existing provider list page as a mobile/legacy fallback.
- Introduce route loaders for settings tabs and provider IDs and update settings components to consume loader data rather than search params.