### PR TITLE
✨ feat(userMemory): with Upstash Workflows for memory extractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "@trpc/react-query": "^11.7.2",
     "@trpc/server": "^11.7.2",
     "@upstash/redis": "^1.35.7",
+    "@upstash/workflow": "^0.2.23",
     "@vercel/analytics": "^1.5.0",
     "@vercel/edge-config": "^1.4.3",
     "@vercel/functions": "^3.3.4",

--- a/packages/memory-user-memory/src/services/extractAgentService.ts
+++ b/packages/memory-user-memory/src/services/extractAgentService.ts
@@ -1,19 +1,11 @@
 import type { LobeChatDatabase } from '@lobechat/database';
 import { ModelRuntime } from '@lobechat/model-runtime';
-import type { Embeddings } from '@lobechat/model-runtime';
 import {
   gateKeeperCallDurationHistogram,
   gateKeeperCallsCounter,
   layerCallDurationHistogram,
-  layerEntriesHistogram,
   layersCallsCounter,
-  processedDurationHistogram,
-  processedSourceCounter,
 } from '@lobechat/observability-otel/api';
-
-import { DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS } from '@/const/settings';
-import { UserMemoryModel } from '@/database/models/userMemory';
-import { LayersEnum, MergeStrategyEnum, TypesEnum } from '@/types/userMemory';
 
 import {
   ContextExtractor,
@@ -28,24 +20,16 @@ import {
   GatekeeperDecision,
   MemoryExtractionJob,
   MemoryExtractionLLMConfig,
-  MemoryExtractionLogger,
+  MemoryExtractionLayerOutputs,
   MemoryExtractionProvider,
   MemoryExtractionResult,
   MemoryExtractionSourceType,
   MemoryLayer,
-  PersistedMemoryResult,
   PreparedExtractionContext,
 } from '../types';
 import { resolvePromptRoot } from '../utils/path';
 
 const LAYER_ORDER: MemoryLayer[] = ['identity', 'context', 'preference', 'experience'];
-
-const DEFAULT_LOGGER: MemoryExtractionLogger = {
-  debug: () => {},
-  error: (message, meta) => console.error('[memory-extract]', message, meta),
-  info: () => {},
-  warn: (message, meta) => console.warn('[memory-extract]', message, meta),
-};
 
 const LAYER_LABEL_MAP: Record<MemoryLayer, string> = {
   context: 'contexts',
@@ -63,15 +47,9 @@ export interface MemoryExtractionRuntimeOptions {
 export interface MemoryExtractionServiceOptions {
   config: MemoryExtractionLLMConfig;
   db: LobeChatDatabase;
-  logger?: MemoryExtractionLogger;
   promptRoot?: string;
   providers?: MemoryExtractionProvider[];
   runtimes: MemoryExtractionRuntimeOptions;
-}
-
-interface EmbeddingRequest {
-  index: number;
-  text: string;
 }
 
 export class MemoryExtractAgentService {
@@ -85,8 +63,6 @@ export class MemoryExtractAgentService {
   private readonly providers: Map<MemoryExtractionSourceType, MemoryExtractionProvider> = new Map();
   private readonly gatekeeperRuntime: ModelRuntime;
   private readonly layerRuntime: ModelRuntime;
-  private readonly embeddingRuntime: ModelRuntime;
-  private readonly logger: MemoryExtractionLogger;
   private readonly promptRoot: string;
 
   constructor(options: MemoryExtractionServiceOptions) {
@@ -94,8 +70,6 @@ export class MemoryExtractAgentService {
     this.db = options.db;
     this.gatekeeperRuntime = options.runtimes.gatekeeper;
     this.layerRuntime = options.runtimes.layerExtractor;
-    this.embeddingRuntime = options.runtimes.embeddings ?? options.runtimes.layerExtractor;
-    this.logger = options.logger ?? DEFAULT_LOGGER;
     this.promptRoot = options.promptRoot ?? resolvePromptRoot();
 
     const gatekeeperConfig: BaseExtractorDependencies = {
@@ -132,22 +106,6 @@ export class MemoryExtractAgentService {
     });
   }
 
-  private recordJobMetrics(
-    job: MemoryExtractionJob,
-    status: 'completed' | 'failed',
-    durationMs: number,
-  ) {
-    processedSourceCounter.add(1, {
-      source: job.source,
-      status,
-      user_id: job.userId,
-    });
-    processedDurationHistogram.record(durationMs, {
-      source: job.source,
-      user_id: job.userId,
-    });
-  }
-
   private recordGatekeeperMetrics(
     job: MemoryExtractionJob,
     durationMs: number,
@@ -178,15 +136,6 @@ export class MemoryExtractAgentService {
     layerCallDurationHistogram.record(durationMs, attributes);
   }
 
-  private recordLayerEntries(job: MemoryExtractionJob, layer: MemoryLayer, count: number) {
-    const attributes = {
-      layer: LAYER_LABEL_MAP[layer],
-      source: job.source,
-      user_id: job.userId,
-    };
-    layerEntriesHistogram.record(count, attributes);
-  }
-
   private async runLayerExtractor<T>(
     job: MemoryExtractionJob,
     layer: MemoryLayer,
@@ -209,49 +158,31 @@ export class MemoryExtractAgentService {
   }
 
   async run(job: MemoryExtractionJob): Promise<MemoryExtractionResult | null> {
-    const startTime = Date.now();
     const provider = this.providers.get(job.source);
     if (!provider) {
-      this.recordJobMetrics(job, 'failed', Date.now() - startTime);
       throw new Error(`No provider registered for source ${job.source}`);
     }
 
-    let context: PreparedExtractionContext | null;
-    try {
-      context = await provider.prepare(job, {
-        db: this.db,
-        embeddingsModel: this.config.embeddingsModel,
-        runtime: this.layerRuntime,
-      });
-    } catch (error) {
-      this.recordJobMetrics(job, 'failed', Date.now() - startTime);
-      throw error;
-    }
-
+    const context = await provider.prepare(job, {
+      db: this.db,
+      embeddingsModel: this.config.embeddingsModel,
+      runtime: this.layerRuntime,
+    });
     if (!context) {
-      this.logger.debug('No extraction context returned by provider', { job });
-      this.recordJobMetrics(job, 'completed', Date.now() - startTime);
       return null;
     }
 
     try {
       const decision = await this.runGatekeeper(job, context);
-      const layersToExtract = this.resolveLayers(decision);
-
-      const userMemoryModel = new UserMemoryModel(this.db, job.userId);
-      const persisted = await this.persistLayers(job, context, layersToExtract, userMemoryModel);
-
-      await provider.complete(job, context, persisted, {
-        db: this.db,
-        embeddingsModel: this.config.embeddingsModel,
-        runtime: this.layerRuntime,
-      });
-
-      this.recordJobMetrics(job, 'completed', Date.now() - startTime);
+      const layersToExtract = this.resolveJobLayers(decision, job.layers);
+      const outputs = await this.runLayers(job, context, layersToExtract);
 
       return {
-        decisions: decision,
-        inserted: persisted,
+        context,
+        decision,
+        layers: layersToExtract,
+        outputs,
+        provider,
       };
     } catch (error) {
       await provider.fail?.(job, context, error as Error, {
@@ -259,7 +190,6 @@ export class MemoryExtractAgentService {
         embeddingsModel: this.config.embeddingsModel,
         runtime: this.layerRuntime,
       });
-      this.recordJobMetrics(job, 'failed', Date.now() - startTime);
       throw error;
     }
   }
@@ -288,367 +218,101 @@ export class MemoryExtractAgentService {
     return LAYER_ORDER.filter((layer) => decision[layer]?.shouldExtract);
   }
 
-  private async persistLayers(
+  private resolveJobLayers(decision: GatekeeperDecision, layers?: MemoryLayer[]): MemoryLayer[] {
+    if (layers && layers.length > 0) {
+      const requested = new Set<MemoryLayer>(layers);
+
+      return this.resolveLayers(decision).filter((layer) => requested.has(layer));
+    }
+
+    return this.resolveLayers(decision);
+  }
+
+  private async runLayers(
     job: MemoryExtractionJob,
     context: PreparedExtractionContext,
     layers: MemoryLayer[],
-    userMemoryModel: UserMemoryModel,
-  ): Promise<PersistedMemoryResult> {
-    const createdIds: string[] = [];
-    const perLayer: Partial<Record<MemoryLayer, number>> = {};
+  ): Promise<MemoryExtractionLayerOutputs> {
+    const outputs: MemoryExtractionLayerOutputs = {};
 
     for (const layer of layers) {
+      const result = await this.runLayer(job, context, layer);
+
       switch (layer) {
         case 'context': {
-          const result = await this.runLayerExtractor(job, 'context', () =>
-            this.contextExtractor.extract(context.conversation, context.options),
-          );
-          const ids = await this.persistContextMemories(job, context, result, userMemoryModel);
-          createdIds.push(...ids);
-          perLayer.context = ids.length;
-          this.recordLayerEntries(job, 'context', ids.length);
-
+          outputs.context = result as Awaited<ReturnType<ContextExtractor['extract']>>;
           break;
         }
         case 'experience': {
-          const result = await this.runLayerExtractor(job, 'experience', () =>
-            this.experienceExtractor.extract(context.conversation, context.options),
-          );
-          const ids = await this.persistExperienceMemories(job, context, result, userMemoryModel);
-          createdIds.push(...ids);
-          perLayer.experience = ids.length;
-          this.recordLayerEntries(job, 'experience', ids.length);
-
+          outputs.experience = result as Awaited<ReturnType<ExperienceExtractor['extract']>>;
           break;
         }
         case 'preference': {
-          const result = await this.runLayerExtractor(job, 'preference', () =>
-            this.preferenceExtractor.extract(context.conversation, context.options),
-          );
-          const ids = await this.persistPreferenceMemories(job, context, result, userMemoryModel);
-          createdIds.push(...ids);
-          perLayer.preference = ids.length;
-          this.recordLayerEntries(job, 'preference', ids.length);
-
+          outputs.preference = result as Awaited<ReturnType<PreferenceExtractor['extract']>>;
           break;
         }
         case 'identity': {
-          const identityOptions = {
-            ...context.options,
-            existingIdentitiesContext: context.existingIdentitiesContext,
-          };
-          const result = await this.runLayerExtractor(job, 'identity', () =>
-            this.identityExtractor.extract(context.conversation, identityOptions),
-          );
-          const ids = await this.persistIdentityMemories(job, context, result, userMemoryModel);
-          createdIds.push(...ids);
-          perLayer.identity = ids.length;
-          this.recordLayerEntries(job, 'identity', ids.length);
-
+          outputs.identity = result as Awaited<ReturnType<IdentityExtractor['extract']>>;
           break;
         }
-        // No default
-      }
-    }
-
-    return { createdIds, layers: perLayer };
-  }
-
-  private async persistContextMemories(
-    job: MemoryExtractionJob,
-    context: PreparedExtractionContext,
-    result: Awaited<ReturnType<ContextExtractor['extract']>>,
-    userMemoryModel: UserMemoryModel,
-  ): Promise<string[]> {
-    const insertedIds: string[] = [];
-
-    for (const item of result.memories ?? []) {
-      const [summaryVector, detailsVector] = await this.generateEmbeddings([
-        item.summary,
-        item.details,
-      ]);
-
-      const [descriptionVector] = await this.generateEmbeddings([item.withContext?.description]);
-
-      const baseMetadata = this.buildBaseMetadata(
-        job,
-        context,
-        'context',
-        item.withContext?.labels,
-      );
-
-      const { memory } = await userMemoryModel.createContextMemory({
-        context: {
-          associatedObjects: UserMemoryModel.normalizeAssociations(
-            item.withContext?.associatedObjects,
-          ),
-          associatedSubjects: UserMemoryModel.normalizeAssociations(
-            item.withContext?.associatedSubjects,
-          ),
-          currentStatus: item.withContext?.currentStatus ?? null,
-          description: item.withContext?.description ?? null,
-          descriptionVector: descriptionVector || null,
-          metadata: baseMetadata,
-          scoreImpact: item.withContext?.scoreImpact ?? null,
-          scoreUrgency: item.withContext?.scoreUrgency ?? null,
-          tags: item.withContext?.labels ?? null,
-          title: item.withContext?.title ?? null,
-          type: item.withContext?.type ?? null,
-        },
-        details: item.details ?? '',
-        detailsEmbedding: detailsVector ?? undefined,
-        memoryCategory: item.memoryCategory ?? null,
-        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Context,
-        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Context,
-        summary: item.summary ?? '',
-        summaryEmbedding: summaryVector ?? undefined,
-        title: item.title ?? '',
-      });
-
-      insertedIds.push(memory.id);
-    }
-
-    return insertedIds;
-  }
-
-  private async persistExperienceMemories(
-    job: MemoryExtractionJob,
-    context: PreparedExtractionContext,
-    result: Awaited<ReturnType<ExperienceExtractor['extract']>>,
-    userMemoryModel: UserMemoryModel,
-  ): Promise<string[]> {
-    const insertedIds: string[] = [];
-
-    for (const item of result.memories ?? []) {
-      const [summaryVector, detailsVector] = await this.generateEmbeddings([
-        item.summary,
-        item.details,
-      ]);
-
-      const [situationVector, actionVector, keyLearningVector] = await this.generateEmbeddings([
-        item.withExperience?.situation,
-        item.withExperience?.action,
-        item.withExperience?.keyLearning,
-      ]);
-
-      const baseMetadata = this.buildBaseMetadata(
-        job,
-        context,
-        'experience',
-        item.withExperience?.labels,
-      );
-
-      const { memory } = await userMemoryModel.createExperienceMemory({
-        details: item.details ?? '',
-        detailsEmbedding: detailsVector ?? undefined,
-        experience: {
-          action: item.withExperience?.action ?? null,
-          actionVector: actionVector || null,
-          keyLearning: item.withExperience?.keyLearning ?? null,
-          keyLearningVector: keyLearningVector || null,
-          metadata: baseMetadata,
-          possibleOutcome: item.withExperience?.possibleOutcome ?? null,
-          reasoning: item.withExperience?.reasoning ?? null,
-          scoreConfidence: item.withExperience?.scoreConfidence ?? null,
-          situation: item.withExperience?.situation ?? null,
-          situationVector: situationVector || null,
-          tags: item.withExperience?.labels ?? null,
-          type: item.withExperience?.type ?? null,
-        },
-        memoryCategory: item.memoryCategory ?? null,
-        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Experience,
-        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Activity,
-        summary: item.summary ?? '',
-        summaryEmbedding: summaryVector ?? undefined,
-        title: item.title ?? '',
-      });
-
-      insertedIds.push(memory.id);
-    }
-
-    return insertedIds;
-  }
-
-  private async persistPreferenceMemories(
-    job: MemoryExtractionJob,
-    context: PreparedExtractionContext,
-    result: Awaited<ReturnType<PreferenceExtractor['extract']>>,
-    userMemoryModel: UserMemoryModel,
-  ): Promise<string[]> {
-    const insertedIds: string[] = [];
-
-    for (const item of result.memories ?? []) {
-      const [summaryVector, detailsVector] = await this.generateEmbeddings([
-        item.summary,
-        item.details,
-      ]);
-
-      const [directiveVector] = await this.generateEmbeddings([
-        item.withPreference?.conclusionDirectives,
-      ]);
-
-      const baseMetadata = this.buildBaseMetadata(
-        job,
-        context,
-        'preference',
-        item.withPreference?.extractedLabels,
-      );
-
-      const { memory } = await userMemoryModel.createPreferenceMemory({
-        details: item.details ?? '',
-        detailsEmbedding: detailsVector ?? undefined,
-        memoryCategory: item.memoryCategory ?? null,
-        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Preference,
-        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Preference,
-        preference: {
-          conclusionDirectives: item.withPreference?.conclusionDirectives ?? null,
-          conclusionDirectivesVector: directiveVector ?? null,
-          metadata: {
-            ...baseMetadata,
-            scopes: item.withPreference?.extractedScopes ?? undefined,
-          },
-          scorePriority: item.withPreference?.scorePriority ?? null,
-          suggestions: item.withPreference?.suggestions?.join('\n') ?? null,
-          tags: item.withPreference?.extractedLabels ?? null,
-          type: item.withPreference?.type ?? null,
-        },
-        summary: item.summary ?? '',
-        summaryEmbedding: summaryVector ?? undefined,
-        title: item.title ?? '',
-      });
-
-      insertedIds.push(memory.id);
-    }
-
-    return insertedIds;
-  }
-
-  private async persistIdentityMemories(
-    job: MemoryExtractionJob,
-    context: PreparedExtractionContext,
-    result: Awaited<ReturnType<IdentityExtractor['extract']>>,
-    userMemoryModel: UserMemoryModel,
-  ): Promise<string[]> {
-    const insertedIds: string[] = [];
-
-    for (const action of result ?? []) {
-      if (action.name === 'addIdentity') {
-        const { arguments: args } = action;
-
-        const [summaryVector] = await this.generateEmbeddings([args.description]);
-
-        const metadata = this.buildBaseMetadata(job, context, 'identity', args.extractedLabels);
-
-        const res = await userMemoryModel.addIdentityEntry({
-          base: {
-            details: args.description,
-            detailsVector1024: summaryVector ?? undefined,
-            memoryCategory: 'people',
-            memoryLayer: LayersEnum.Identity,
-            memoryType: TypesEnum.People,
-            metadata,
-            summary: args.description,
-            summaryVector1024: summaryVector ?? undefined,
-          },
-          identity: {
-            description: args.description,
-            metadata,
-            relationship: args.relationship ?? undefined,
-            role: args.role ?? undefined,
-            tags: args.extractedLabels ?? undefined,
-            type: args.type ?? undefined,
-          },
-        });
-
-        insertedIds.push(res.userMemoryId);
-      }
-      if (action.name === 'updateIdentity') {
-        const { arguments: args } = action;
-        const [descriptionVector] = await this.generateEmbeddings([args.set.description]);
-
-        await userMemoryModel.updateIdentityEntry({
-          identity: {
-            description: args.set.description,
-            descriptionVector: descriptionVector ?? undefined,
-            metadata: args.set.extractedLabels
-              ? this.buildBaseMetadata(job, context, 'identity', args.set.extractedLabels)
-              : undefined,
-            relationship: args.set.relationship ?? undefined,
-            role: args.set.role ?? undefined,
-            type: args.set.type ?? undefined,
-          },
-          identityId: args.id,
-          mergeStrategy: args.mergeStrategy as MergeStrategyEnum,
-        });
-      }
-      if (action.name === 'removeIdentity' && action.arguments?.id) {
-        await userMemoryModel.removeIdentityEntry(action.arguments.id);
-      }
-    }
-
-    return insertedIds;
-  }
-
-  private buildBaseMetadata(
-    job: MemoryExtractionJob,
-    context: PreparedExtractionContext,
-    layer: string,
-    labels?: string[] | null,
-  ) {
-    return {
-      conversationDigest: context.metadata.conversationDigest,
-      labels: labels ?? undefined,
-      layer,
-      messageIds: context.metadata.messageIds ?? [],
-      source: job.source,
-      sourceId: job.sourceId,
-      topicId: context.topicId,
-    };
-  }
-
-  private async generateEmbeddings(
-    texts: Array<string | undefined | null>,
-  ): Promise<Array<Embeddings | null>> {
-    const model = this.config.embeddingsModel;
-    if (!model || typeof this.embeddingRuntime.embeddings !== 'function') {
-      return texts.map(() => null);
-    }
-
-    const requests: EmbeddingRequest[] = [];
-
-    texts.forEach((text, index) => {
-      if (text && text.trim().length > 0) {
-        requests.push({ index, text });
-      }
-    });
-
-    if (requests.length === 0) {
-      return texts.map(() => null);
-    }
-
-    try {
-      const response = await this.embeddingRuntime.embeddings(
-        {
-          dimensions: DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS,
-          input: requests.map((item) => item.text),
-          model,
-        },
-        { user: 'memory-extraction' },
-      );
-
-      const vectors = texts.map<Embeddings | null>(() => null);
-
-      response?.forEach((embedding, idx) => {
-        const request = requests[idx];
-        if (request) {
-          vectors[request.index] = embedding;
+        default: {
+          break;
         }
-      });
-
-      return vectors;
-    } catch (error) {
-      this.logger.warn('Failed to generate embeddings', { error });
-      return texts.map(() => null);
+      }
     }
+
+    return outputs;
+  }
+
+  private async runLayer(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    layer: MemoryLayer,
+  ) {
+    switch (layer) {
+      case 'context': {
+        return this.runContextLayer(job, context);
+      }
+      case 'experience': {
+        return this.runExperienceLayer(job, context);
+      }
+      case 'preference': {
+        return this.runPreferenceLayer(job, context);
+      }
+      case 'identity': {
+        return this.runIdentityLayer(job, context);
+      }
+      default: {
+        return [];
+      }
+    }
+  }
+
+  private async runContextLayer(job: MemoryExtractionJob, context: PreparedExtractionContext) {
+    return this.runLayerExtractor(job, 'context', () =>
+      this.contextExtractor.extract(context.conversation, context.options),
+    );
+  }
+
+  private async runExperienceLayer(job: MemoryExtractionJob, context: PreparedExtractionContext) {
+    return this.runLayerExtractor(job, 'experience', () =>
+      this.experienceExtractor.extract(context.conversation, context.options),
+    );
+  }
+
+  private async runPreferenceLayer(job: MemoryExtractionJob, context: PreparedExtractionContext) {
+    return this.runLayerExtractor(job, 'preference', () =>
+      this.preferenceExtractor.extract(context.conversation, context.options),
+    );
+  }
+
+  private async runIdentityLayer(job: MemoryExtractionJob, context: PreparedExtractionContext) {
+    const identityOptions = {
+      ...context.options,
+      existingIdentitiesContext: context.existingIdentitiesContext,
+    };
+    return this.runLayerExtractor(job, 'identity', () =>
+      this.identityExtractor.extract(context.conversation, identityOptions),
+    );
   }
 }

--- a/packages/memory-user-memory/src/types.ts
+++ b/packages/memory-user-memory/src/types.ts
@@ -1,6 +1,13 @@
 import type { LobeChatDatabase } from '@lobechat/database';
 import type { ModelRuntime } from '@lobechat/model-runtime';
 
+import type {
+  ContextExtractor,
+  ExperienceExtractor,
+  IdentityExtractor,
+  PreferenceExtractor,
+} from './extractors';
+
 export type MemoryLayer = 'context' | 'experience' | 'identity' | 'preference';
 
 export interface ExtractionMessage {
@@ -39,6 +46,7 @@ export interface MemoryExtractionLLMConfig {
 
 export interface MemoryExtractionJob {
   force?: boolean;
+  layers?: MemoryLayer[];
   source: MemoryExtractionSourceType;
   sourceId: string;
   userId: string;
@@ -94,12 +102,12 @@ export interface PersistedMemoryResult {
   layers: Partial<Record<MemoryLayer, number>>;
 }
 
-export interface MemoryExtractionLogger {
-  debug(message: string, meta?: Record<string, unknown>): void;
-  error(message: string, meta?: Record<string, unknown>): void;
-  info(message: string, meta?: Record<string, unknown>): void;
-  warn(message: string, meta?: Record<string, unknown>): void;
-}
+export type MemoryExtractionLayerOutputs = Partial<{
+  context: Awaited<ReturnType<ContextExtractor['extract']>>;
+  experience: Awaited<ReturnType<ExperienceExtractor['extract']>>;
+  identity: Awaited<ReturnType<IdentityExtractor['extract']>>;
+  preference: Awaited<ReturnType<PreferenceExtractor['extract']>>;
+}>;
 
 export interface GatekeeperDecision {
   activity: MemoryLayerDecision;
@@ -115,8 +123,11 @@ export interface MemoryLayerDecision {
 }
 
 export interface MemoryExtractionResult {
-  decisions: GatekeeperDecision;
-  inserted: PersistedMemoryResult;
+  context: PreparedExtractionContext;
+  decision: GatekeeperDecision;
+  layers: MemoryLayer[];
+  outputs: MemoryExtractionLayerOutputs;
+  provider: MemoryExtractionProvider;
 }
 
 export interface TemplateProps {

--- a/packages/obervability-otel/src/modules/memory-user-memory/extract.ts
+++ b/packages/obervability-otel/src/modules/memory-user-memory/extract.ts
@@ -1,9 +1,9 @@
 import { metrics } from '@opentelemetry/api';
 
-const meter = metrics.getMeter('server-modules-memory-user-memory-extraction');
+const meter = metrics.getMeter('server-services-memory-user-memory-extraction');
 
 export const processedSourceCounter = meter.createCounter(
-  'server_modules_memory_user_memory_extraction_processed_source',
+  'server_services_memory_user_memory_extraction_processed_source',
   {
     description:
       'Count of memory extraction jobs processed per source and user with completion status.',
@@ -12,7 +12,7 @@ export const processedSourceCounter = meter.createCounter(
 );
 
 export const processedDurationHistogram = meter.createHistogram(
-  'server_modules_memory_user_memory_extraction_processed_duration',
+  'server_services_memory_user_memory_extraction_processed_duration',
   {
     description: 'Duration of memory extraction jobs per source and user.',
     unit: 'ms',
@@ -20,7 +20,7 @@ export const processedDurationHistogram = meter.createHistogram(
 );
 
 export const gateKeeperCallsCounter = meter.createCounter(
-  'server_modules_memory_user_memory_extraction_gate_keeper_calls',
+  'server_services_memory_user_memory_extraction_gate_keeper_calls',
   {
     description: 'Gate keeper invocation count by source, user, and status.',
     unit: '{count}',
@@ -28,7 +28,7 @@ export const gateKeeperCallsCounter = meter.createCounter(
 );
 
 export const gateKeeperCallDurationHistogram = meter.createHistogram(
-  'server_modules_memory_user_memory_extraction_gate_keeper_call_duration',
+  'server_services_memory_user_memory_extraction_gate_keeper_call_duration',
   {
     description: 'Duration of gate keeper invocations by source, user, and status.',
     unit: 'ms',
@@ -36,7 +36,7 @@ export const gateKeeperCallDurationHistogram = meter.createHistogram(
 );
 
 export const layersCallsCounter = meter.createCounter(
-  'server_modules_memory_user_memory_extraction_layers_calls',
+  'server_services_memory_user_memory_extraction_layers_calls',
   {
     description: 'Layer extractor invocation count by layer, source, user, and status.',
     unit: '{count}',
@@ -44,7 +44,7 @@ export const layersCallsCounter = meter.createCounter(
 );
 
 export const layerCallDurationHistogram = meter.createHistogram(
-  'server_modules_memory_user_memory_extraction_layer_call_duration',
+  'server_services_memory_user_memory_extraction_layer_call_duration',
   {
     description: 'Duration of layer extractor calls by layer, source, user, and status.',
     unit: 'ms',
@@ -52,7 +52,7 @@ export const layerCallDurationHistogram = meter.createHistogram(
 );
 
 export const layerEntriesHistogram = meter.createHistogram(
-  'server_modules_memory_user_memory_extraction_layer_entries',
+  'server_services_memory_user_memory_extraction_layer_entries',
   {
     description: 'Number of entries produced per layer extraction by source and user.',
     unit: '{count}',

--- a/src/app/(backend)/api/webhooks/memory-extraction/route.ts
+++ b/src/app/(backend)/api/webhooks/memory-extraction/route.ts
@@ -1,373 +1,50 @@
-import { newQueue } from '@henrygd/queue';
-import { topics } from '@lobechat/database/schemas';
-import type { MemoryLayer } from '@lobechat/memory-user-memory';
-import { MemoryExtractionService, MemoryExtractionSourceType } from '@lobechat/memory-user-memory';
-import { ModelRuntime } from '@lobechat/model-runtime';
-import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
 
-import { DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM } from '@/const/settings';
-import { ListTopicsForMemoryExtractorCursor, TopicModel } from '@/database/models/topic';
-import { ListUsersForMemoryExtractorCursor, UserModel } from '@/database/models/user';
-import { getServerDB } from '@/database/server';
-import { getServerGlobalConfig } from '@/server/globalConfig';
 import {
-  MemoryAgentConfig,
-  parseMemoryExtractionConfig,
-} from '@/server/globalConfig/parseMemoryExtractionConfig';
-import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
-import type { GlobalMemoryLayer } from '@/types/serverConfig';
-import type { UserKeyVaults } from '@/types/user/settings';
-
-const RequestSchema = z.object({
-  force: z.boolean().optional(),
-  forceExtractForTopics: z.boolean().optional(),
-  from: z.coerce.date().optional(),
-  layers: z.array(z.string()).optional(),
-  source: z.string().optional(),
-  to: z.coerce.date().optional(),
-  topicId: z.string().min(1).optional(),
-  userId: z.string().min(1).optional(),
-});
-
-const SUPPORTED_SOURCES = new Set<MemoryExtractionSourceType>([
-  'chat_topic',
-  'obsidian',
-  'notion',
-  'lark',
-]);
-
-const normalizeProvider = (provider: string) => provider.toLowerCase() as keyof UserKeyVaults;
-
-const extractCredentialsFromVault = (provider: string, keyVaults?: UserKeyVaults) => {
-  const vault = keyVaults?.[normalizeProvider(provider)];
-
-  if (!vault || typeof vault !== 'object') return {};
-
-  const apiKey = 'apiKey' in vault && typeof vault.apiKey === 'string' ? vault.apiKey : undefined;
-  const baseURL =
-    'baseURL' in vault && typeof vault.baseURL === 'string' ? vault.baseURL : undefined;
-
-  return { apiKey, baseURL };
-};
-
-const resolveLayerModels = (
-  layers: Partial<Record<GlobalMemoryLayer, string>> | undefined,
-  fallback: Record<GlobalMemoryLayer, string>,
-): Record<MemoryLayer, string> => ({
-  context: layers?.context ?? fallback.context,
-  experience: layers?.experience ?? fallback.experience,
-  identity: layers?.identity ?? fallback.identity,
-  preference: layers?.preference ?? fallback.preference,
-});
-
-const initRuntimeForAgent = async (agent: MemoryAgentConfig, keyVaults?: UserKeyVaults) => {
-  const provider = agent.provider || 'openai';
-  const { apiKey: userApiKey, baseURL: userBaseURL } = extractCredentialsFromVault(
-    provider,
-    keyVaults,
-  );
-
-  const apiKey = userApiKey || agent.apiKey;
-  if (!apiKey) throw new Error(`Missing API key for ${provider} memory extraction runtime`);
-
-  return ModelRuntime.initializeWithProvider(provider, {
-    apiKey,
-    baseURL: userBaseURL || agent.baseURL,
-  });
-};
-
-const validateConcurrencyLimit = (limit?: number) => {
-  if (limit === undefined) return undefined;
-
-  const parsed = Number(limit);
-  if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
-
-  return parsed;
-};
-
-let activeExtractions = 0;
-
-type ExtractionJob = {
-  force?: boolean;
-  source: MemoryExtractionSourceType;
-  topicId: string;
-  userId: string;
-};
-type ExtractionResult =
-  | { job: ExtractionJob; result: unknown; status: 'success' }
-  | { error: string; job: ExtractionJob; status: 'failed' };
-
-const isTopicExtracted = (metadata: any): boolean => {
-  const extractStatus = metadata?.memory_user_memory_extract?.extract_status;
-  if (extractStatus) return extractStatus === 'completed';
-
-  const state = metadata?.memoryExtraction?.sources?.chat_topic;
-  return state?.status === 'completed' && !!state?.lastRunAt;
-};
-
-const PENDING_TOPICS_PAGE_SIZE = 100;
-const USERS_PAGE_SIZE = 100;
-
-type MemoryExtractionRequest = z.infer<typeof RequestSchema>;
-type MemoryExtractionConfig = ReturnType<typeof parseMemoryExtractionConfig>;
-type ServerConfig = Awaited<ReturnType<typeof getServerGlobalConfig>>;
-
-const processExtractionInBackground = async (
-  body: MemoryExtractionRequest,
-  sourceInput: MemoryExtractionSourceType,
-  serverConfig: ServerConfig,
-  privateConfig: MemoryExtractionConfig,
-  concurrencyLimit?: number,
-) => {
-  try {
-    const publicMemoryConfig = serverConfig.memory?.userMemory;
-
-    const modelConfig = {
-      embeddingsModel:
-        publicMemoryConfig?.embedding?.model ??
-        privateConfig.embedding?.model ??
-        privateConfig.agentLayerExtractor.model ??
-        DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM.model,
-      gateModel: publicMemoryConfig?.agentGateKeeper?.model ?? privateConfig.agentGateKeeper.model,
-      layerModels: resolveLayerModels(
-        publicMemoryConfig?.agentLayerExtractor.layers,
-        privateConfig.agentLayerExtractor.layers,
-      ),
-    };
-
-    const db = await getServerDB();
-
-    const runJob = async (job: ExtractionJob): Promise<ExtractionResult> => {
-      try {
-        const userModel = new UserModel(db, job.userId);
-        const userState = await userModel.getUserState(KeyVaultsGateKeeper.getUserKeyVaults);
-        const keyVaults = userState.settings?.keyVaults as UserKeyVaults | undefined;
-
-        const gatekeeperRuntime = await initRuntimeForAgent(
-          privateConfig.agentGateKeeper,
-          keyVaults,
-        );
-        const layerExtractorRuntime = await initRuntimeForAgent(
-          privateConfig.agentLayerExtractor,
-          keyVaults,
-        );
-        const embeddingRuntime = privateConfig.embedding
-          ? await initRuntimeForAgent(privateConfig.embedding, keyVaults)
-          : undefined;
-
-        const service = new MemoryExtractionService({
-          config: modelConfig,
-          db,
-          runtimes: {
-            embeddings: embeddingRuntime,
-            gatekeeper: gatekeeperRuntime,
-            layerExtractor: layerExtractorRuntime,
-          },
-        });
-
-        console.log(`[memory-extraction] running extraction for topic ${job.topicId}`);
-
-        const result = await service.run({
-          force: job.force,
-          source: job.source,
-          sourceId: job.topicId,
-          userId: job.userId,
-        });
-
-        console.log(`[memory-extraction] completed extraction for topic ${job.topicId}`);
-
-        return { job, result, status: 'success' as const };
-      } catch (error) {
-        const message = (error as Error).message;
-        console.error('[memory-extraction] job failed', { error: message, job });
-        return { error: message, job, status: 'failed' as const };
-      }
-    };
-
-    let completedJobs = 0;
-    let totalQueuedJobs = 0;
-    const logBatchProgress = (context?: string) => {
-      if (totalQueuedJobs === 0) return;
-      console.log(
-        `[memory-extraction] progress ${completedJobs}/${totalQueuedJobs}${
-          context ? ` (${context})` : ''
-        }`,
-      );
-    };
-
-    const queue = newQueue(Math.max(1, concurrencyLimit ?? 1));
-    const results: ExtractionResult[] = [];
-
-    const enqueueTopics = async (userId: string) => {
-      let cursor: ListTopicsForMemoryExtractorCursor | undefined;
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const topicModel = new TopicModel(db, userId);
-        const batch = await topicModel.listTopicsForMemoryExtractor({
-          cursor,
-          endDate: body.to,
-          ignoreExtracted: body.force || body.forceExtractForTopics,
-          limit: PENDING_TOPICS_PAGE_SIZE,
-          startDate: body.from,
-        });
-        if (!batch || batch.length === 0) {
-          break;
-        }
-
-        const tasks = batch.map(
-          (topic) => () =>
-            runJob({
-              force: body.force || body.forceExtractForTopics,
-              source: sourceInput,
-              topicId: topic.id,
-              userId: topic.userId,
-            }),
-        );
-
-        if (tasks.length > 0) {
-          console.log(`[memory-extraction] processing ${tasks.length} topics for user ${userId}`);
-
-          totalQueuedJobs += tasks.length;
-          const batchResults = await queue.all(tasks);
-          results.push(...batchResults);
-          completedJobs += tasks.length;
-          logBatchProgress(`user:${userId}`);
-        }
-
-        const last = batch.at(-1)!;
-        cursor = { createdAt: last.createdAt, id: last.id };
-      }
-    };
-
-    if (body.topicId) {
-      const topic = await db.query.topics.findFirst({
-        columns: { createdAt: true, id: true, metadata: true, userId: true },
-        where: body.userId
-          ? and(eq(topics.id, body.topicId), eq(topics.userId, body.userId))
-          : eq(topics.id, body.topicId),
-      });
-      if (!topic) {
-        console.warn(`[memory-extraction] topic ${body.topicId} not found, skip extraction.`);
-        return;
-      }
-      if ((body.from && topic.createdAt < body.from) || (body.to && topic.createdAt > body.to)) {
-        console.log(
-          `[memory-extraction] topic ${body.topicId} outside requested time range, skip extraction.`,
-        );
-        return;
-      }
-      if (!body.force && !body.forceExtractForTopics && isTopicExtracted(topic.metadata)) {
-        console.log(
-          `[memory-extraction] topic ${body.topicId} already extracted, skip extraction.`,
-        );
-        return;
-      }
-
-      const topicTasks = [
-        () =>
-          runJob({
-            force: body.force || body.forceExtractForTopics,
-            source: sourceInput,
-            topicId: topic.id,
-            userId: topic.userId,
-          }),
-      ];
-      totalQueuedJobs += topicTasks.length;
-      const topicResults = await queue.all(topicTasks);
-
-      results.push(...topicResults);
-      completedJobs += topicTasks.length;
-      logBatchProgress('single-topic');
-    } else if (body.userId) {
-      console.log(`[memory-extraction] processing user ${body.userId}`);
-      await enqueueTopics(body.userId);
-    } else {
-      let userCursor: ListUsersForMemoryExtractorCursor | undefined;
-
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const userBatch = await UserModel.listUsersForMemoryExtractor(db, {
-          cursor: userCursor,
-          limit: USERS_PAGE_SIZE,
-        });
-        if (!userBatch || userBatch.length === 0) {
-          break;
-        }
-
-        console.log(`[memory-extraction] processing for ${userBatch.length} users.`);
-        for (const user of userBatch) {
-          await enqueueTopics(user.id);
-        }
-
-        const last = userBatch.at(-1);
-        userCursor = last ? { createdAt: last.createdAt, id: last.id } : undefined;
-        console.log(`[memory-extraction] completed a batch of users.`);
-      }
-    }
-
-    if (results.length === 0) {
-      console.log('[memory-extraction] no topics need extraction.');
-      return;
-    }
-
-    console.log(`[memory-extraction] completed ${results.length} extraction jobs.`);
-  } catch (error) {
-    console.error('[memory-extraction] failed', error);
-  } finally {
-    if (activeExtractions > 0) {
-      activeExtractions -= 1;
-    }
-  }
-};
+  MemoryExtractionExecutor,
+  MemoryExtractionWorkflowService,
+  buildWorkflowPayloadInput,
+  memoryExtractionPayloadSchema,
+  normalizeMemoryExtractionPayload,
+} from '@/server/services/memory/userMemory/extract';
 
 export const POST = async (req: Request) => {
   try {
     const json = await req.json();
-    const body = RequestSchema.parse(json);
-    if (body.from && body.to && body.from > body.to) {
-      return NextResponse.json({ error: '`from` cannot be later than `to`' }, { status: 400 });
-    }
+    const origin = new URL(req.url).origin;
 
-    const [serverConfig, privateConfig] = await Promise.all([
-      getServerGlobalConfig(),
-      Promise.resolve(parseMemoryExtractionConfig()),
-    ]);
-
-    const sourceInput = (body.source ?? 'chat_topic') as MemoryExtractionSourceType;
-    if (!SUPPORTED_SOURCES.has(sourceInput)) {
+    const payload = memoryExtractionPayloadSchema.parse({
+      ...json,
+      baseUrl: json.baseUrl || origin,
+    });
+    if (payload.fromDate && payload.toDate && payload.fromDate > payload.toDate) {
       return NextResponse.json(
-        { error: `Unsupported memory extraction source: ${body.source}` },
+        { error: '`fromDate` cannot be later than `toDate`' },
         { status: 400 },
       );
     }
 
-    const concurrencyLimit = validateConcurrencyLimit(
-      serverConfig.memory?.userMemory?.concurrency ?? privateConfig.concurrency,
-    );
-    if (concurrencyLimit && activeExtractions >= concurrencyLimit) {
+    const params = normalizeMemoryExtractionPayload(payload, origin);
+    if (params.mode === 'workflow') {
+      const { workflowRunId } = await MemoryExtractionWorkflowService.triggerProcessUsers(
+        buildWorkflowPayloadInput(params),
+      );
       return NextResponse.json(
-        { error: 'Memory extraction is busy, please try again later.' },
-        { status: 429 },
+        { message: 'Memory extraction scheduled via workflow.', workflowRunId },
+        { status: 202 },
       );
     }
 
-    activeExtractions += 1;
-    void processExtractionInBackground(
-      body,
-      sourceInput,
-      serverConfig,
-      privateConfig,
-      concurrencyLimit,
-    );
+    const executor = await MemoryExtractionExecutor.create();
+    const result = await executor.runDirect(params);
 
     return NextResponse.json(
-      { message: 'Memory extraction started. Processing in background.' },
-      { status: 202 },
+      { message: 'Memory extraction executed via webhook.', result },
+      { status: 200 },
     );
   } catch (error) {
     console.error('[memory-extraction] failed', error);
+
     return NextResponse.json({ error: (error as Error).message }, { status: 500 });
   }
 };

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-topic/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-topic/route.ts
@@ -1,0 +1,46 @@
+import { serve } from '@upstash/workflow/nextjs';
+
+import {
+  MemoryExtractionExecutor,
+  MemoryExtractionPayloadInput,
+  normalizeMemoryExtractionPayload,
+} from '@/server/services/memory/userMemory/extract';
+
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
+  const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
+  if (!params.userIds.length) {
+    return { message: 'No user id provided for topic batch.' };
+  }
+  if (!params.topicIds.length) {
+    return { message: 'No topic ids provided for extraction.' };
+  }
+  if (!params.sources.includes('chat_topic')) {
+    return { message: 'Source not supported in topic batch.' };
+  }
+
+  const userId = params.userIds[0];
+  const executor = await MemoryExtractionExecutor.create();
+
+  const results: { extracted: boolean; topicId: string }[] = [];
+
+  for (const topicId of params.topicIds) {
+    const extracted = await context.run(
+      `memory:user-memory:extract:users:${userId}:topics:${topicId}:extract-topic`,
+      () =>
+        executor.extractTopic({
+          forceAll: params.forceAll,
+          forceTopics: params.forceTopics,
+          from: params.from,
+          layers: params.layers,
+          source: 'chat_topic',
+          to: params.to,
+          topicId,
+          userId,
+        }),
+    );
+
+    results.push({ extracted, topicId });
+  }
+
+  return { processed: results.length, results };
+});

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-user-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-user-topics/route.ts
@@ -1,0 +1,115 @@
+import { serve } from '@upstash/workflow/nextjs';
+import { chunk } from 'lodash-es';
+
+import type { ListTopicsForMemoryExtractorCursor } from '@/database/models/topic';
+import {
+  MemoryExtractionExecutor,
+  MemoryExtractionPayloadInput,
+  MemoryExtractionWorkflowService,
+  buildWorkflowPayloadInput,
+  normalizeMemoryExtractionPayload,
+} from '@/server/services/memory/userMemory/extract';
+
+const TOPIC_PAGE_SIZE = 50;
+const TOPIC_BATCH_SIZE = 10;
+
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
+  const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
+  if (!params.userIds.length) {
+    return { message: 'No user ids provided for topic processing.' };
+  }
+  if (!params.sources.includes('chat_topic')) {
+    return { message: 'No supported sources requested, skip topic processing.' };
+  }
+
+  const executor = await MemoryExtractionExecutor.create();
+
+  const scheduleNextPage = async (userId: string, cursorCreatedAt: Date, cursorId: string) => {
+    await MemoryExtractionWorkflowService.triggerProcessUserTopics({
+      ...buildWorkflowPayloadInput({
+        ...params,
+        topicCursor: {
+          createdAt: cursorCreatedAt.toISOString(),
+          id: cursorId,
+          userId,
+        },
+        topicIds: [],
+        userId,
+        userIds: [userId],
+      }),
+    });
+  };
+
+  for (const userId of params.userIds) {
+    const topicCursor =
+      params.topicCursor && params.topicCursor.userId === userId
+        ? {
+            createdAt: new Date(params.topicCursor.createdAt),
+            id: params.topicCursor.id,
+          }
+        : undefined;
+
+    const topicsFromPayload =
+      params.topicIds && params.topicIds.length > 0
+        ? await context.run(
+            `memory:user-memory:extract:users:${userId}:filter-topic-ids`,
+            async () => {
+              const filtered = await executor.filterTopicIdsForUser(userId, params.topicIds);
+              return filtered.length > 0 ? filtered : undefined;
+            },
+          )
+        : undefined;
+
+    const topicBatch = await context.run<{
+      cursor?: ListTopicsForMemoryExtractorCursor;
+      ids: string[];
+    }>(`memory:user-memory:extract:users:${userId}:list-topics:${topicCursor?.id || 'root'}`, () =>
+      topicsFromPayload && topicsFromPayload.length > 0
+        ? Promise.resolve({ ids: topicsFromPayload })
+        : executor.getTopicsForUser(
+            {
+              cursor: topicCursor,
+              forceAll: params.forceAll,
+              forceTopics: params.forceTopics,
+              from: params.from,
+              to: params.to,
+              userId,
+            },
+            TOPIC_PAGE_SIZE,
+          ),
+    );
+
+    const ids = topicBatch.ids;
+    if (!ids.length) {
+      continue;
+    }
+
+    const cursor = 'cursor' in topicBatch ? topicBatch.cursor : undefined;
+
+    const batches = chunk(ids, TOPIC_BATCH_SIZE);
+    await Promise.all(
+      batches.map((topicIds, index) =>
+        context.run(
+          `memory:user-memory:extract:users:${userId}:process-topics-batch:${index}`,
+          () =>
+            MemoryExtractionWorkflowService.triggerProcessTopicBatch({
+              ...buildWorkflowPayloadInput(params),
+              topicCursor: undefined,
+              topicIds,
+              userId,
+              userIds: [userId],
+            }),
+        ),
+      ),
+    );
+
+    if (!topicsFromPayload && cursor) {
+      await context.run(
+        `memory:user-memory:extract:users:${userId}:topics:${cursor.id}:schedule-next-batch`,
+        () => scheduleNextPage(userId, cursor.createdAt, cursor.id),
+      );
+    }
+  }
+
+  return { processedUsers: params.userIds.length };
+});

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-users/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-users/route.ts
@@ -1,0 +1,69 @@
+import { serve } from '@upstash/workflow/nextjs';
+import { chunk } from 'lodash-es';
+
+import {
+  MemoryExtractionExecutor,
+  MemoryExtractionPayloadInput,
+  MemoryExtractionWorkflowService,
+  buildWorkflowPayloadInput,
+  normalizeMemoryExtractionPayload,
+} from '@/server/services/memory/userMemory/extract';
+
+const USER_PAGE_SIZE = 50;
+const USER_BATCH_SIZE = 10;
+
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
+  const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
+  if (params.sources.length === 0) {
+    return { message: 'No sources provided, skip memory extraction.' };
+  }
+
+  const executor = await MemoryExtractionExecutor.create();
+  const userCursor = params.userCursor
+    ? { createdAt: new Date(params.userCursor.createdAt), id: params.userCursor.id }
+    : undefined;
+
+  const userBatch = await context.run('memory:user-memory:extract:get-users', () =>
+    params.userIds.length > 0
+      ? { ids: params.userIds }
+      : executor.getUsers(USER_PAGE_SIZE, userCursor),
+  );
+
+  const ids = userBatch.ids;
+  if (ids.length === 0) {
+    return { message: 'No users to process for memory extraction.' };
+  }
+
+  const cursor = 'cursor' in userBatch ? userBatch.cursor : undefined;
+
+  const batches = chunk(ids, USER_BATCH_SIZE);
+  await Promise.all(
+    batches.map((userIds) =>
+      context.run(`memory:user-memory:extract:users:process-topic-batches`, () =>
+        MemoryExtractionWorkflowService.triggerProcessUserTopics({
+          ...buildWorkflowPayloadInput(params),
+          topicCursor: undefined,
+          userId: userIds[0],
+          userIds,
+        }),
+      ),
+    ),
+  );
+
+  if (params.userIds.length === 0 && cursor) {
+    await context.run('memory:user-memory:extract:users:schedule-next-user-batch', () =>
+      MemoryExtractionWorkflowService.triggerProcessUsers({
+        ...buildWorkflowPayloadInput({
+          ...params,
+          userCursor: { createdAt: cursor.createdAt.toISOString(), id: cursor.id },
+        }),
+      }),
+    );
+  }
+
+  return {
+    batches: batches.length,
+    nextCursor: cursor ? cursor.id : null,
+    processedUsers: ids.length,
+  };
+});

--- a/src/server/globalConfig/parseMemoryExtractionConfig.ts
+++ b/src/server/globalConfig/parseMemoryExtractionConfig.ts
@@ -20,7 +20,7 @@ export interface MemoryExtractionPrivateConfig {
   agentGateKeeper: MemoryAgentConfig;
   agentLayerExtractor: MemoryLayerExtractorConfig;
   concurrency?: number;
-  embedding?: MemoryAgentConfig;
+  embedding: MemoryAgentConfig;
 }
 
 const parseGateKeeperAgent = (): MemoryAgentConfig => {

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -1,0 +1,942 @@
+import { topics } from '@lobechat/database/schemas';
+import { MemoryExtractionService } from '@lobechat/memory-user-memory';
+import type {
+  MemoryExtractionJob,
+  MemoryExtractionResult,
+  MemoryExtractionSourceType,
+  MemoryLayer,
+  PersistedMemoryResult,
+  PreparedExtractionContext,
+} from '@lobechat/memory-user-memory';
+import { ModelRuntime } from '@lobechat/model-runtime';
+import type { Embeddings } from '@lobechat/model-runtime';
+import {
+  layerEntriesHistogram,
+  processedDurationHistogram,
+  processedSourceCounter,
+} from '@lobechat/observability-otel/api';
+import { Client } from '@upstash/workflow';
+import { and, eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+
+import {
+  DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS,
+  DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM,
+} from '@/const/settings';
+import type { ListTopicsForMemoryExtractorCursor } from '@/database/models/topic';
+import { TopicModel } from '@/database/models/topic';
+import type { ListUsersForMemoryExtractorCursor } from '@/database/models/user';
+import { UserModel } from '@/database/models/user';
+import { UserMemoryModel } from '@/database/models/userMemory';
+import { getServerDB } from '@/database/server';
+import { getServerGlobalConfig } from '@/server/globalConfig';
+import {
+  MemoryAgentConfig,
+  parseMemoryExtractionConfig,
+} from '@/server/globalConfig/parseMemoryExtractionConfig';
+import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import type { GlobalMemoryLayer } from '@/types/serverConfig';
+import type { UserKeyVaults } from '@/types/user/settings';
+import { LayersEnum, MergeStrategyEnum, TypesEnum } from '@/types/userMemory';
+
+const SOURCE_ALIAS_MAP: Record<string, MemoryExtractionSourceType> = {
+  chatTopic: 'chat_topic',
+  chatTopics: 'chat_topic',
+  chat_topic: 'chat_topic',
+  lark: 'lark',
+  notion: 'notion',
+  obsidian: 'obsidian',
+};
+
+const LAYER_ALIAS = new Set<MemoryLayer>(['context', 'experience', 'identity', 'preference']);
+
+const LAYER_LABEL_MAP: Record<MemoryLayer, string> = {
+  context: 'contexts',
+  experience: 'experiences',
+  identity: 'identities',
+  preference: 'preferences',
+};
+
+export interface MemoryExtractionWorkflowCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface TopicWorkflowCursor extends MemoryExtractionWorkflowCursor {
+  userId: string;
+}
+
+export interface MemoryExtractionNormalizedPayload {
+  baseUrl: string;
+  forceAll: boolean;
+  forceTopics: boolean;
+  from?: Date;
+  layers: MemoryLayer[];
+  /**
+   * - `workflow` depends on Upstash Workflows to process the extraction asynchronously.
+   * - `direct` processes the extraction within the webhook request itself.
+   */
+  mode: 'workflow' | 'direct';
+  sources: MemoryExtractionSourceType[];
+  to?: Date;
+  topicCursor?: TopicWorkflowCursor;
+  topicIds: string[];
+  userCursor?: MemoryExtractionWorkflowCursor;
+  userId?: string;
+  userIds: string[];
+}
+
+export const memoryExtractionPayloadSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  execution: z.enum(['workflow', 'direct']).optional(),
+  forceAll: z.boolean().optional(),
+  forceTopics: z.boolean().optional(),
+  fromDate: z.coerce.date().optional(),
+  layers: z.array(z.string()).optional(),
+  sources: z.array(z.string()).optional(),
+  toDate: z.coerce.date().optional(),
+  topicCursor: z
+    .object({
+      createdAt: z.string(),
+      id: z.string(),
+      userId: z.string(),
+    })
+    .optional(),
+  topicIds: z.array(z.string()).optional(),
+  userCursor: z
+    .object({
+      createdAt: z.string(),
+      id: z.string(),
+    })
+    .optional(),
+  userId: z.string().optional(),
+  userIds: z.array(z.string()).optional(),
+});
+
+export type MemoryExtractionPayloadInput = z.infer<typeof memoryExtractionPayloadSchema>;
+
+const normalizeSources = (sources?: string[]): MemoryExtractionSourceType[] => {
+  if (!sources) return [];
+
+  const normalized = sources
+    .map((source) => SOURCE_ALIAS_MAP[source as keyof typeof SOURCE_ALIAS_MAP])
+    .filter(Boolean) as MemoryExtractionSourceType[];
+
+  return Array.from(new Set(normalized));
+};
+
+const normalizeLayers = (layers?: string[]): MemoryLayer[] => {
+  if (!layers) return [];
+
+  const normalized = layers
+    .map((layer) => layer.toLowerCase() as MemoryLayer)
+    .filter((layer) => LAYER_ALIAS.has(layer));
+
+  return Array.from(new Set(normalized));
+};
+
+export const normalizeMemoryExtractionPayload = (
+  payload: MemoryExtractionPayloadInput,
+  fallbackBaseUrl?: string,
+): MemoryExtractionNormalizedPayload => {
+  const parsed = memoryExtractionPayloadSchema.parse(payload);
+  const baseUrl = parsed.baseUrl || fallbackBaseUrl;
+  if (!baseUrl) throw new Error('Missing baseUrl for workflow trigger');
+
+  return {
+    baseUrl,
+    forceAll: parsed.forceAll ?? false,
+    forceTopics: parsed.forceTopics ?? false,
+    from: parsed.fromDate,
+    layers: normalizeLayers(parsed.layers),
+    mode: parsed.execution ?? 'workflow',
+    sources: normalizeSources(parsed.sources),
+    to: parsed.toDate,
+    topicCursor: parsed.topicCursor,
+    topicIds: Array.from(new Set(parsed.topicIds || [])).filter(Boolean),
+    userCursor: parsed.userCursor,
+    userId: parsed.userId ?? parsed.userIds?.[0],
+    userIds: Array.from(
+      new Set([...(parsed.userIds || []), ...(parsed.userId ? [parsed.userId] : [])]),
+    ).filter(Boolean),
+  };
+};
+
+export type UserTopicWorkflowPayload = MemoryExtractionPayloadInput;
+
+export interface TopicBatchWorkflowPayload extends MemoryExtractionPayloadInput {
+  topicIds: string[];
+  userId: string;
+}
+
+export const buildWorkflowPayloadInput = (
+  payload: MemoryExtractionNormalizedPayload,
+): MemoryExtractionPayloadInput => ({
+  baseUrl: payload.baseUrl,
+  execution: payload.mode,
+  forceAll: payload.forceAll,
+  forceTopics: payload.forceTopics,
+  fromDate: payload.from,
+  layers: payload.layers,
+  sources: payload.sources,
+  toDate: payload.to,
+  topicCursor: payload.topicCursor,
+  topicIds: payload.topicIds,
+  userCursor: payload.userCursor,
+  userId: payload.userId ?? payload.userIds[0],
+  userIds: payload.userIds,
+});
+
+const normalizeProvider = (provider: string) => provider.toLowerCase() as keyof UserKeyVaults;
+
+const extractCredentialsFromVault = (provider: string, keyVaults?: UserKeyVaults) => {
+  const vault = keyVaults?.[normalizeProvider(provider)];
+
+  if (!vault || typeof vault !== 'object') return {};
+
+  const apiKey = 'apiKey' in vault && typeof vault.apiKey === 'string' ? vault.apiKey : undefined;
+  const baseURL =
+    'baseURL' in vault && typeof vault.baseURL === 'string' ? vault.baseURL : undefined;
+
+  return { apiKey, baseURL };
+};
+
+const resolveLayerModels = (
+  layers: Partial<Record<GlobalMemoryLayer, string>> | undefined,
+  fallback: Record<GlobalMemoryLayer, string>,
+): Record<MemoryLayer, string> => ({
+  context: layers?.context ?? fallback.context,
+  experience: layers?.experience ?? fallback.experience,
+  identity: layers?.identity ?? fallback.identity,
+  preference: layers?.preference ?? fallback.preference,
+});
+
+const initRuntimeForAgent = async (agent: MemoryAgentConfig, keyVaults?: UserKeyVaults) => {
+  const provider = agent.provider || 'openai';
+  const { apiKey: userApiKey, baseURL: userBaseURL } = extractCredentialsFromVault(
+    provider,
+    keyVaults,
+  );
+
+  const apiKey = userApiKey || agent.apiKey;
+  if (!apiKey) throw new Error(`Missing API key for ${provider} memory extraction runtime`);
+
+  return ModelRuntime.initializeWithProvider(provider, {
+    apiKey,
+    baseURL: userBaseURL || agent.baseURL,
+  });
+};
+
+const isTopicExtracted = (metadata: any): boolean => {
+  const extractStatus = metadata?.memory_user_memory_extract?.extract_status;
+  if (extractStatus) return extractStatus === 'completed';
+
+  const state = metadata?.memoryExtraction?.sources?.chat_topic;
+  return state?.status === 'completed' && !!state?.lastRunAt;
+};
+
+type RuntimeBundle = {
+  embeddings: ModelRuntime;
+  gatekeeper: ModelRuntime;
+  layerExtractor: ModelRuntime;
+};
+
+export interface TopicExtractionJob {
+  forceAll: boolean;
+  forceTopics: boolean;
+  from?: Date;
+  layers: MemoryLayer[];
+  source: MemoryExtractionSourceType;
+  to?: Date;
+  topicId: string;
+  userId: string;
+}
+
+export interface TopicPaginationJob {
+  cursor?: ListTopicsForMemoryExtractorCursor;
+  forceAll: boolean;
+  forceTopics: boolean;
+  from?: Date;
+  to?: Date;
+  userId: string;
+}
+
+export interface UserPaginationResult {
+  cursor?: ListUsersForMemoryExtractorCursor;
+  ids: string[];
+}
+
+type MemoryExtractionConfig = ReturnType<typeof parseMemoryExtractionConfig>;
+type ServerConfig = Awaited<ReturnType<typeof getServerGlobalConfig>>;
+
+export class MemoryExtractionExecutor {
+  private readonly privateConfig: MemoryExtractionConfig;
+  private readonly serverConfig: ServerConfig;
+  private readonly modelConfig: {
+    embeddingsModel: string;
+    gateModel: string;
+    layerModels: Partial<Record<MemoryLayer, string>>;
+  };
+
+  private readonly runtimeCache = new Map<string, RuntimeBundle>();
+  private readonly db = getServerDB();
+
+  private constructor(serverConfig: ServerConfig, privateConfig: MemoryExtractionConfig) {
+    this.serverConfig = serverConfig;
+    this.privateConfig = privateConfig;
+
+    const publicMemoryConfig = serverConfig.memory?.userMemory;
+
+    this.modelConfig = {
+      embeddingsModel:
+        publicMemoryConfig?.embedding?.model ??
+        privateConfig.embedding?.model ??
+        privateConfig.agentLayerExtractor.model ??
+        DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM.model,
+      gateModel: publicMemoryConfig?.agentGateKeeper?.model ?? privateConfig.agentGateKeeper.model,
+      layerModels: resolveLayerModels(
+        publicMemoryConfig?.agentLayerExtractor.layers,
+        privateConfig.agentLayerExtractor.layers,
+      ),
+    };
+  }
+
+  static async create() {
+    const [serverConfig, privateConfig] = await Promise.all([
+      getServerGlobalConfig(),
+      Promise.resolve(parseMemoryExtractionConfig()),
+    ]);
+
+    return new MemoryExtractionExecutor(serverConfig, privateConfig);
+  }
+
+  private buildBaseMetadata(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    layer: MemoryLayer,
+    labels?: string[] | null,
+  ) {
+    return {
+      conversationDigest: context.metadata.conversationDigest,
+      labels: labels ?? undefined,
+      layer,
+      messageIds: context.metadata.messageIds ?? [],
+      source: job.source,
+      sourceId: job.sourceId,
+      topicId: context.topicId,
+    };
+  }
+
+  private async generateEmbeddings(
+    runtimes: ModelRuntime,
+    model: string,
+    texts: Array<string | undefined | null>,
+  ) {
+    const requests = texts
+      .map((text, index) => ({ index, text }))
+      .filter(
+        (item): item is { index: number; text: string } =>
+          typeof item.text === 'string' && item.text.trim().length > 0,
+      );
+
+    if (requests.length === 0) return texts.map(() => null);
+
+    try {
+      const response = await runtimes.embeddings(
+        {
+          dimensions: DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS,
+          input: requests.map((item) => item.text),
+          model,
+        },
+        { user: 'memory-extraction' },
+      );
+
+      const vectors = texts.map<Embeddings | null>(() => null);
+      response?.forEach((embedding, idx) => {
+        const request = requests[idx];
+        if (request) {
+          vectors[request.index] = embedding;
+        }
+      });
+
+      return vectors;
+    } catch {
+      return texts.map(() => null);
+    }
+  }
+
+  async persistContextMemories(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    result: NonNullable<MemoryExtractionResult['outputs']['context']>,
+    runtime: ModelRuntime,
+    model: string,
+    db: Awaited<ReturnType<typeof getServerDB>>,
+  ) {
+    const insertedIds: string[] = [];
+    const userMemoryModel = new UserMemoryModel(db, job.userId);
+
+    for (const item of result.memories ?? []) {
+      const [summaryVector, detailsVector, descriptionVector] = await this.generateEmbeddings(
+        runtime,
+        model,
+        [item.summary, item.details, item.withContext?.description],
+      );
+      const baseMetadata = this.buildBaseMetadata(
+        job,
+        context,
+        'context',
+        item.withContext?.labels,
+      );
+
+      const { memory } = await userMemoryModel.createContextMemory({
+        context: {
+          associatedObjects: UserMemoryModel.normalizeAssociations(
+            item.withContext?.associatedObjects,
+          ),
+          associatedSubjects: UserMemoryModel.normalizeAssociations(
+            item.withContext?.associatedSubjects,
+          ),
+          currentStatus: item.withContext?.currentStatus ?? null,
+          description: item.withContext?.description ?? null,
+          descriptionVector: descriptionVector || null,
+          metadata: baseMetadata,
+          scoreImpact: item.withContext?.scoreImpact ?? null,
+          scoreUrgency: item.withContext?.scoreUrgency ?? null,
+          tags: item.withContext?.labels ?? null,
+          title: item.withContext?.title ?? null,
+          type: item.withContext?.type ?? null,
+        },
+        details: item.details ?? '',
+        detailsEmbedding: detailsVector ?? undefined,
+        memoryCategory: item.memoryCategory ?? null,
+        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Context,
+        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Context,
+        summary: item.summary ?? '',
+        summaryEmbedding: summaryVector ?? undefined,
+        title: item.title ?? '',
+      });
+
+      insertedIds.push(memory.id);
+    }
+
+    return insertedIds;
+  }
+
+  async persistExperienceMemories(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    result: NonNullable<MemoryExtractionResult['outputs']['experience']>,
+    runtime: ModelRuntime,
+    model: string,
+    db: Awaited<ReturnType<typeof getServerDB>>,
+  ) {
+    const insertedIds: string[] = [];
+    const userMemoryModel = new UserMemoryModel(db, job.userId);
+
+    for (const item of result.memories ?? []) {
+      const [summaryVector, detailsVector, situationVector, actionVector, keyLearningVector] =
+        await this.generateEmbeddings(runtime, model, [
+          item.summary,
+          item.details,
+          item.withExperience?.situation,
+          item.withExperience?.action,
+          item.withExperience?.keyLearning,
+        ]);
+      const baseMetadata = this.buildBaseMetadata(
+        job,
+        context,
+        'experience',
+        item.withExperience?.labels,
+      );
+
+      const { memory } = await userMemoryModel.createExperienceMemory({
+        details: item.details ?? '',
+        detailsEmbedding: detailsVector ?? undefined,
+        experience: {
+          action: item.withExperience?.action ?? null,
+          actionVector: actionVector || null,
+          keyLearning: item.withExperience?.keyLearning ?? null,
+          keyLearningVector: keyLearningVector || null,
+          metadata: baseMetadata,
+          possibleOutcome: item.withExperience?.possibleOutcome ?? null,
+          reasoning: item.withExperience?.reasoning ?? null,
+          scoreConfidence: item.withExperience?.scoreConfidence ?? null,
+          situation: item.withExperience?.situation ?? null,
+          situationVector: situationVector || null,
+          tags: item.withExperience?.labels ?? null,
+          type: item.withExperience?.type ?? null,
+        },
+        memoryCategory: item.memoryCategory ?? null,
+        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Experience,
+        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Activity,
+        summary: item.summary ?? '',
+        summaryEmbedding: summaryVector ?? undefined,
+        title: item.title ?? '',
+      });
+
+      insertedIds.push(memory.id);
+    }
+
+    return insertedIds;
+  }
+
+  async persistPreferenceMemories(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    result: NonNullable<MemoryExtractionResult['outputs']['preference']>,
+    runtime: ModelRuntime,
+    model: string,
+    db: Awaited<ReturnType<typeof getServerDB>>,
+  ) {
+    const insertedIds: string[] = [];
+    const userMemoryModel = new UserMemoryModel(db, job.userId);
+
+    for (const item of result.memories ?? []) {
+      const [summaryVector, detailsVector, directiveVector] = await this.generateEmbeddings(
+        runtime,
+        model,
+        [item.summary, item.details, item.withPreference?.conclusionDirectives],
+      );
+      const baseMetadata = this.buildBaseMetadata(
+        job,
+        context,
+        'preference',
+        item.withPreference?.extractedLabels,
+      );
+
+      const { memory } = await userMemoryModel.createPreferenceMemory({
+        details: item.details ?? '',
+        detailsEmbedding: detailsVector ?? undefined,
+        memoryCategory: item.memoryCategory ?? null,
+        memoryLayer: (item.memoryLayer as LayersEnum) ?? LayersEnum.Preference,
+        memoryType: (item.memoryType as TypesEnum) ?? TypesEnum.Preference,
+        preference: {
+          conclusionDirectives: item.withPreference?.conclusionDirectives ?? null,
+          conclusionDirectivesVector: directiveVector ?? null,
+          metadata: {
+            ...baseMetadata,
+            scopes: item.withPreference?.extractedScopes ?? undefined,
+          },
+          scorePriority: item.withPreference?.scorePriority ?? null,
+          suggestions: item.withPreference?.suggestions?.join('\n') ?? null,
+          tags: item.withPreference?.extractedLabels ?? null,
+          type: item.withPreference?.type ?? null,
+        },
+        summary: item.summary ?? '',
+        summaryEmbedding: summaryVector ?? undefined,
+        title: item.title ?? '',
+      });
+
+      insertedIds.push(memory.id);
+    }
+
+    return insertedIds;
+  }
+
+  async persistIdentityMemories(
+    job: MemoryExtractionJob,
+    context: PreparedExtractionContext,
+    result: NonNullable<MemoryExtractionResult['outputs']['identity']>,
+    runtime: ModelRuntime,
+    model: string,
+    db: Awaited<ReturnType<typeof getServerDB>>,
+  ) {
+    const insertedIds: string[] = [];
+    const userMemoryModel = new UserMemoryModel(db, job.userId);
+
+    for (const action of result ?? []) {
+      if (action.name === 'addIdentity') {
+        const { arguments: args } = action;
+        const [summaryVector] = await this.generateEmbeddings(runtime, model, [args.description]);
+        const metadata = this.buildBaseMetadata(job, context, 'identity', args.extractedLabels);
+
+        const res = await userMemoryModel.addIdentityEntry({
+          base: {
+            details: args.description,
+            detailsVector1024: summaryVector ?? undefined,
+            memoryCategory: 'people',
+            memoryLayer: LayersEnum.Identity,
+            memoryType: TypesEnum.People,
+            metadata,
+            summary: args.description,
+            summaryVector1024: summaryVector ?? undefined,
+          },
+          identity: {
+            description: args.description,
+            metadata,
+            relationship: args.relationship ?? undefined,
+            role: args.role ?? undefined,
+            tags: args.extractedLabels ?? undefined,
+            type: args.type ?? undefined,
+          },
+        });
+
+        insertedIds.push(res.userMemoryId);
+      }
+
+      if (action.name === 'updateIdentity') {
+        const { arguments: args } = action;
+        const [descriptionVector] = await this.generateEmbeddings(runtime, model, [
+          args.set.description,
+        ]);
+
+        await userMemoryModel.updateIdentityEntry({
+          identity: {
+            description: args.set.description,
+            descriptionVector: descriptionVector ?? undefined,
+            metadata: args.set.extractedLabels
+              ? this.buildBaseMetadata(job, context, 'identity', args.set.extractedLabels)
+              : undefined,
+            relationship: args.set.relationship ?? undefined,
+            role: args.set.role ?? undefined,
+            type: args.set.type ?? undefined,
+          },
+          identityId: args.id,
+          mergeStrategy: args.mergeStrategy as MergeStrategyEnum,
+        });
+      }
+
+      if (action.name === 'removeIdentity' && action.arguments?.id) {
+        await userMemoryModel.removeIdentityEntry(action.arguments.id);
+      }
+    }
+
+    return insertedIds;
+  }
+
+  async extractTopic(job: TopicExtractionJob) {
+    const startTime = Date.now();
+    const db = await this.db;
+    const topic = await db.query.topics.findFirst({
+      columns: { createdAt: true, id: true, metadata: true, userId: true },
+      where: and(eq(topics.id, job.topicId), eq(topics.userId, job.userId)),
+    });
+
+    if (!topic) {
+      console.warn(`[memory-extraction] topic ${job.topicId} not found for user ${job.userId}`);
+      return false;
+    }
+    if ((job.from && topic.createdAt < job.from) || (job.to && topic.createdAt > job.to)) {
+      return false;
+    }
+    if (!job.forceAll && !job.forceTopics && isTopicExtracted(topic.metadata)) {
+      return false;
+    }
+
+    const userModel = new UserModel(db, job.userId);
+    const userState = await userModel.getUserState(KeyVaultsGateKeeper.getUserKeyVaults);
+    const keyVaults = userState.settings?.keyVaults as UserKeyVaults | undefined;
+
+    const runtimes = await this.getRuntime(job.userId, keyVaults);
+    const service = new MemoryExtractionService({
+      config: this.modelConfig,
+      db,
+      runtimes,
+    });
+
+    let extraction: MemoryExtractionResult | null = null;
+    const extractionJob: MemoryExtractionJob = {
+      force: job.forceAll || job.forceTopics,
+      layers: job.layers,
+      source: job.source,
+      sourceId: topic.id,
+      userId: job.userId,
+    };
+
+    try {
+      extraction = await service.run(extractionJob);
+      if (!extraction) {
+        this.recordJobMetrics(extractionJob, 'completed', Date.now() - startTime);
+        return false;
+      }
+
+      const persisted = await this.persistExtraction(extractionJob, extraction, runtimes, db);
+
+      await extraction.provider.complete(extractionJob, extraction.context, persisted, {
+        db,
+        embeddingsModel: this.modelConfig.embeddingsModel,
+        runtime: runtimes.layerExtractor,
+      });
+
+      this.recordJobMetrics(extractionJob, 'completed', Date.now() - startTime);
+
+      return true;
+    } catch (error) {
+      if (extraction) {
+        await extraction.provider.fail?.(extractionJob, extraction.context, error as Error, {
+          db,
+          embeddingsModel: this.modelConfig.embeddingsModel,
+          runtime: runtimes.layerExtractor,
+        });
+      }
+      this.recordJobMetrics(extractionJob, 'failed', Date.now() - startTime);
+      throw error;
+    }
+  }
+
+  async runDirect(payload: MemoryExtractionNormalizedPayload) {
+    if (!payload.sources.includes('chat_topic')) {
+      return { message: 'Direct execution currently supports chat_topic only.', processed: 0 };
+    }
+    if (!payload.userIds.length) {
+      throw new Error('Direct execution requires at least one user id.');
+    }
+    if (!payload.topicIds.length) {
+      throw new Error('Direct execution requires topicIds for chat_topic sources.');
+    }
+
+    const results: { extracted: boolean; topicId: string; userId: string }[] = [];
+
+    for (const userId of payload.userIds) {
+      const topicIds = await this.filterTopicIdsForUser(userId, payload.topicIds);
+      for (const topicId of topicIds) {
+        const extracted = await this.extractTopic({
+          forceAll: payload.forceAll,
+          forceTopics: payload.forceTopics,
+          from: payload.from,
+          layers: payload.layers,
+          source: 'chat_topic',
+          to: payload.to,
+          topicId,
+          userId,
+        });
+
+        results.push({ extracted, topicId, userId });
+      }
+    }
+
+    return { processed: results.length, results };
+  }
+
+  async getTopicsForUser(
+    job: TopicPaginationJob,
+    pageSize: number,
+  ): Promise<{ cursor?: ListTopicsForMemoryExtractorCursor; ids: string[] }> {
+    const db = await this.db;
+    const topicModel = new TopicModel(db, job.userId);
+    const rows = await topicModel.listTopicsForMemoryExtractor({
+      cursor: job.cursor,
+      endDate: job.to,
+      ignoreExtracted: job.forceAll || job.forceTopics,
+      limit: pageSize,
+      startDate: job.from,
+    });
+
+    if (!rows?.length) return { ids: [] };
+
+    const last = rows.at(-1);
+    const nextCursor = last
+      ? {
+          createdAt: last.createdAt,
+          id: last.id,
+        }
+      : undefined;
+
+    return {
+      cursor: nextCursor,
+      ids: rows.map((topic) => topic.id),
+    };
+  }
+
+  async getUsers(
+    limit: number,
+    cursor?: ListUsersForMemoryExtractorCursor,
+  ): Promise<UserPaginationResult> {
+    const db = await this.db;
+
+    const rows = await UserModel.listUsersForMemoryExtractor(db, { cursor, limit });
+    if (!rows?.length) return { ids: [] };
+
+    const last = rows.at(-1);
+
+    return {
+      cursor: last ? { createdAt: last.createdAt, id: last.id } : undefined,
+      ids: rows.map((row) => row.id),
+    };
+  }
+
+  async filterTopicIdsForUser(userId: string, topicIds: string[]) {
+    if (!topicIds.length) return [];
+
+    const db = await this.db;
+    const rows = await db.query.topics.findMany({
+      columns: { id: true },
+      where: and(eq(topics.userId, userId), inArray(topics.id, topicIds)),
+    });
+
+    return rows.map((row) => row.id);
+  }
+
+  private recordJobMetrics(
+    job: MemoryExtractionJob,
+    status: 'completed' | 'failed',
+    durationMs: number,
+  ) {
+    processedSourceCounter.add(1, {
+      source: job.source,
+      status,
+      user_id: job.userId,
+    });
+    processedDurationHistogram.record(durationMs, {
+      source: job.source,
+      user_id: job.userId,
+    });
+  }
+
+  private recordLayerEntries(job: MemoryExtractionJob, layer: MemoryLayer, count: number) {
+    const attributes = {
+      layer: LAYER_LABEL_MAP[layer],
+      source: job.source,
+      user_id: job.userId,
+    };
+    layerEntriesHistogram.record(count, attributes);
+  }
+
+  private async persistExtraction(
+    job: MemoryExtractionJob,
+    extraction: MemoryExtractionResult,
+    runtimes: RuntimeBundle,
+    db: Awaited<ReturnType<typeof getServerDB>>,
+  ): Promise<PersistedMemoryResult> {
+    const createdIds: string[] = [];
+    const perLayer: Partial<Record<MemoryLayer, number>> = {};
+
+    if (extraction.outputs.context) {
+      const ids = await this.persistContextMemories(
+        job,
+        extraction.context,
+        extraction.outputs.context,
+        runtimes.embeddings,
+        this.modelConfig.embeddingsModel,
+        db,
+      );
+      createdIds.push(...ids);
+      perLayer.context = ids.length;
+      this.recordLayerEntries(job, 'context', ids.length);
+    }
+
+    if (extraction.outputs.experience) {
+      const ids = await this.persistExperienceMemories(
+        job,
+        extraction.context,
+        extraction.outputs.experience,
+        runtimes.embeddings,
+        this.modelConfig.embeddingsModel,
+        db,
+      );
+      createdIds.push(...ids);
+      perLayer.experience = ids.length;
+      this.recordLayerEntries(job, 'experience', ids.length);
+    }
+
+    if (extraction.outputs.preference) {
+      const ids = await this.persistPreferenceMemories(
+        job,
+        extraction.context,
+        extraction.outputs.preference,
+        runtimes.embeddings,
+        this.modelConfig.embeddingsModel,
+        db,
+      );
+      createdIds.push(...ids);
+      perLayer.preference = ids.length;
+      this.recordLayerEntries(job, 'preference', ids.length);
+    }
+
+    if (extraction.outputs.identity) {
+      const ids = await this.persistIdentityMemories(
+        job,
+        extraction.context,
+        extraction.outputs.identity,
+        runtimes.embeddings,
+        this.modelConfig.embeddingsModel,
+        db,
+      );
+      createdIds.push(...ids);
+      perLayer.identity = ids.length;
+      this.recordLayerEntries(job, 'identity', ids.length);
+    }
+
+    return { createdIds, layers: perLayer };
+  }
+
+  private async getRuntime(userId: string, keyVaults?: UserKeyVaults): Promise<RuntimeBundle> {
+    const cached = this.runtimeCache.get(userId);
+    if (cached) return cached;
+
+    const runtimes: RuntimeBundle = {
+      embeddings: await initRuntimeForAgent(this.privateConfig.embedding, keyVaults),
+      gatekeeper: await initRuntimeForAgent(this.privateConfig.agentGateKeeper, keyVaults),
+      layerExtractor: await initRuntimeForAgent(this.privateConfig.agentLayerExtractor, keyVaults),
+    };
+
+    this.runtimeCache.set(userId, runtimes);
+
+    return runtimes;
+  }
+}
+
+const WORKFLOW_PATHS = {
+  topicBatch: '/api/workflows/memory-user-memory/pipelines/process-topic',
+  userTopics: '/api/workflows/memory-user-memory/pipelines/process-user-topics',
+  users: '/api/workflows/memory-user-memory/pipelines/process-users',
+} as const;
+
+const getWorkflowUrl = (path: string, baseUrl: string) => {
+  const url = new URL(path, baseUrl);
+
+  return url.toString();
+};
+
+const getWorkflowClient = () => {
+  const token = process.env.QSTASH_TOKEN;
+  if (!token) throw new Error('QSTASH_TOKEN is required to trigger workflows');
+
+  const config: ConstructorParameters<typeof Client>[0] = { token };
+
+  if (process.env.QSTASH_URL) {
+    (config as Record<string, unknown>).url = process.env.QSTASH_URL;
+  }
+
+  return new Client(config);
+};
+
+export class MemoryExtractionWorkflowService {
+  private static client: Client;
+
+  private static getClient() {
+    if (!this.client) {
+      this.client = getWorkflowClient();
+    }
+
+    return this.client;
+  }
+
+  static triggerProcessUsers(payload: MemoryExtractionPayloadInput) {
+    if (!payload.baseUrl) {
+      throw new Error('Missing baseUrl for workflow trigger');
+    }
+
+    const url = getWorkflowUrl(WORKFLOW_PATHS.users, payload.baseUrl);
+    return this.getClient().trigger({ body: payload, url });
+  }
+
+  static triggerProcessUserTopics(payload: UserTopicWorkflowPayload) {
+    if (!payload.baseUrl) {
+      throw new Error('Missing baseUrl for workflow trigger');
+    }
+
+    const url = getWorkflowUrl(WORKFLOW_PATHS.userTopics, payload.baseUrl);
+    return this.getClient().trigger({ body: payload, url });
+  }
+
+  static triggerProcessTopicBatch(payload: TopicBatchWorkflowPayload) {
+    if (!payload.baseUrl) {
+      throw new Error('Missing baseUrl for workflow trigger');
+    }
+
+    const url = getWorkflowUrl(WORKFLOW_PATHS.topicBatch, payload.baseUrl);
+    return this.getClient().trigger({ body: payload, url });
+  }
+}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Integrate a new Upstash Workflow–based execution pipeline for user memory extraction and refactor the extraction service to separate LLM extraction from persistence and support workflow and direct execution modes.

New Features:
- Add a memory extraction workflow service using Upstash Workflows to orchestrate user and topic processing via dedicated API pipelines.
- Introduce a normalized payload schema and routing for memory extraction that supports both workflow-based and direct execution paths from the webhook.
- Allow memory extraction jobs to request specific memory layers and expose raw layer outputs alongside decision metadata for downstream processing.

Enhancements:
- Refactor the in-process memory extraction API route into a thin controller that delegates to the new executor and workflow service.
- Move persistence, embedding generation, and runtime management into a centralized MemoryExtractionExecutor with per-user runtime caching and observability metrics.
- Simplify the MemoryExtractAgentService to focus on layer extraction only, returning structured outputs instead of directly persisting to the database.
- Update OpenTelemetry metric names for memory extraction to reflect their new server service context.
- Tighten private memory extraction config by making the embedding agent configuration required.

Build:
- Add @upstash/workflow as a runtime dependency for workflow-based memory extraction orchestration.