### PR TITLE
♻️ refactor(server/modules/s3): improved constructor to accept options without taking env directly

### DIFF
--- a/src/server/routers/lambda/upload.ts
+++ b/src/server/routers/lambda/upload.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 
 import { authedProcedure, router } from '@/libs/trpc/lambda';
-import { S3 } from '@/server/modules/S3';
+import { FileS3 } from '@/server/modules/S3';
 
 export const uploadRouter = router({
   createS3PreSignedUrl: authedProcedure
     .input(z.object({ pathname: z.string() }))
     .mutation(async ({ input }) => {
-      const s3 = new S3();
+      const s3 = new FileS3();
 
       return await s3.createPreSignedUrl(input.pathname);
     }),

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -21,7 +21,7 @@ import { pino } from '@/libs/logger';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
-import { S3 } from '@/server/modules/S3';
+import { FileS3 } from '@/server/modules/S3';
 import { FileService } from '@/server/services/file';
 import { NextAuthUserService } from '@/server/services/nextAuthUser';
 import { UserService } from '@/server/services/user';
@@ -170,7 +170,7 @@ export const userRouter = router({
         const base64Data = input.slice(commaIndex + 1);
 
         // 创建 S3 客户端
-        const s3 = new S3();
+        const s3 = new FileS3();
 
         // 使用 UUID 生成唯一文件名，防止缓存问题
         // 获取旧头像 URL, 后面删除该头像

--- a/src/server/services/file/impls/s3.test.ts
+++ b/src/server/services/file/impls/s3.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/envs/file', () => ({
 
 // 模拟 S3 类
 vi.mock('@/server/modules/S3', () => ({
-  S3: vi.fn().mockImplementation(() => ({
+  FileS3: vi.fn().mockImplementation(() => ({
     createPreSignedUrlForPreview: vi
       .fn()
       .mockResolvedValue('https://presigned.example.com/test.jpg'),

--- a/src/server/services/file/impls/s3.ts
+++ b/src/server/services/file/impls/s3.ts
@@ -1,7 +1,7 @@
 import urlJoin from 'url-join';
 
 import { fileEnv } from '@/envs/file';
-import { S3 } from '@/server/modules/S3';
+import { FileS3 } from '@/server/modules/S3';
 
 import { FileServiceImpl } from './type';
 import { extractKeyFromUrlOrReturnOriginal } from './utils';
@@ -10,10 +10,10 @@ import { extractKeyFromUrlOrReturnOriginal } from './utils';
  * S3-based file service implementation
  */
 export class S3StaticFileImpl implements FileServiceImpl {
-  private readonly s3: S3;
+  private readonly s3: FileS3;
 
   constructor() {
-    this.s3 = new S3();
+    this.s3 = new FileS3();
   }
 
   async deleteFile(key: string) {

--- a/src/server/services/user/index.ts
+++ b/src/server/services/user/index.ts
@@ -5,7 +5,7 @@ import { UserModel } from '@/database/models/user';
 import { initializeServerAnalytics } from '@/libs/analytics';
 import { pino } from '@/libs/logger';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
-import { S3 } from '@/server/modules/S3';
+import { FileS3 } from '@/server/modules/S3';
 
 type CreatedUser = {
   email?: string | null;
@@ -130,7 +130,7 @@ export class UserService {
   };
 
   getUserAvatar = async (id: string, image: string) => {
-    const s3 = new S3();
+    const s3 = new FileS3();
     const s3FileUrl = `user/avatar/${id}/${image}`;
 
     try {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Refactor the S3 module to separate environment-based configuration from the core S3 client wrapper and update consumers to use the new env-backed FileS3 class.

Enhancements:
- Change the S3 class constructor to accept explicit credentials, endpoint, and options instead of reading environment variables directly, with a default region fallback.
- Introduce a FileS3 subclass that encapsulates fileEnv-based configuration for S3 usage.
- Update S3-related tests to cover the new constructor signature and default region behavior and to validate FileS3 initialization.
- Replace direct S3 usages in upload, user, and file service layers with FileS3 to standardize environment-based S3 access.

Tests:
- Extend S3 unit tests to verify configuration when constructed with explicit options and when region is omitted, and add dedicated setup/mocking for FileS3 in file service tests.