### PR TITLE
📝 docs: Rustfs

### DIFF
--- a/docs/self-hosting/advanced/knowledge-base.mdx
+++ b/docs/self-hosting/advanced/knowledge-base.mdx
@@ -37,7 +37,7 @@ docker run -p 5432:5432 -d --name pg -e POSTGRES_PASSWORD=mysecretpassword pgvec
 S3 (or S3-compatible storage services) is used for storing uploaded files.
 
 - **Purpose**: Store raw files
-- **Options**: AWS S3, MinIO, or other S3-compatible services
+- **Options**: AWS S3, RustFS, ceph, or other S3-compatible services
 - **Note**: Configure appropriate access permissions and security policies
 
 ### 3. OpenAI Embedding

--- a/docs/self-hosting/advanced/knowledge-base.zh-CN.mdx
+++ b/docs/self-hosting/advanced/knowledge-base.zh-CN.mdx
@@ -35,7 +35,7 @@ docker run -p 5432:5432 -d --name pg -e POSTGRES_PASSWORD=mysecretpassword pgvec
 S3（或兼容 S3 协议的存储服务）用于存储上传的文件。
 
 - **用途**：存储原始文件
-- **选项**：可以使用 AWS S3、MinIO 或其他兼容 S3 协议的存储服务
+- **选项**：可以使用 AWS S3、RustFS、ceph 或其他兼容 S3 协议的存储服务
 - **注意事项**：配置适当的访问权限和安全策略
 
 ### 3. OpenAI Embedding

--- a/docs/self-hosting/advanced/s3/rustfs.mdx
+++ b/docs/self-hosting/advanced/s3/rustfs.mdx
@@ -1,0 +1,142 @@
+---
+title: Configure the RustFS Storage Service
+description: Step-by-step guide to configure RustFS so file storage works smoothly.
+tags:
+  - RustFS
+  - S3 Storage
+  - File Storage
+---
+
+# Configure the RustFS Storage Service
+
+We need to configure an S3-compatible storage service in the server-side database to store files.
+
+<Callout type={'info'}>
+Due to recent changes in MinIO's commercial strategy, we no longer recommend MinIO as the S3 storage backend. Please migrate to open-source solutions such as [RustFS](https://rustfs.com/) or [ceph](https://ceph.io/), or to cloud providers like Tencent Cloud Object Storage or Cloudflare R2.
+</Callout>
+
+## Configuration Steps
+
+<Steps>
+### Deploy RustFS
+
+First, pull the RustFS Docker image:
+
+```shell
+docker pull rustfs/rustfs:latest
+```
+
+You can inspect its version with the following command. We recommend version v1.0.0 or above:
+
+```shell
+docker inspect --format='{{index .Config.Labels "version"}}' rustfs/rustfs:latest
+```
+
+We recommend using Docker Compose to deploy RustFS:
+
+```yml
+services:
+    rustfs:
+        image: rustfs/rustfs:latest
+        container_name: lobe-rustfs
+        ports:
+            - '9000:9000'
+            - '9001:9001'
+        environment:
+            - RUSTFS_CONSOLE_ENABLE=true
+            - RUSTFS_ACCESS_KEY=<YOUR_ACCESS_KEY>
+            - RUSTFS_SECRET_KEY=<YOUR_SECRET_KEY>
+        volumes:
+            - rustfs-data:/data
+
+volumes:
+  rustfs-data:
+```
+
+Then start RustFS:
+
+```shell
+docker compose up -d
+```
+
+### Create a Bucket
+
+Open the RustFS WebUI (`http://localhost:9001/`) and you will be redirected to the login screen. Enter the username (`RUSTFS_ACCESS_KEY` in the `docker-compose.yml`) and password (`RUSTFS_SECRET_KEY` in the same file) to sign in.
+
+Click `Object Storage` in the left sidebar, then the `Create Bucket` button in the top-right corner to create a new bucket. This example uses the name `lobe`. Leave Versioning and Object Lock disabled (default settings).
+
+<Image alt={"Create Bucket"} src={'https://github.com/user-attachments/assets/27c37617-a813-4de5-b0bf-c7167999c856'} />
+
+Go to the bucket and click `Settings`, choose `Custom` for the policy, and paste the following JSON to make the bucket public-read/private-write:
+
+```json
+{ 
+  "ID": "", 
+  "Version": "2012-10-17", 
+  "Statement": [ 
+    { 
+      "Sid": "", 
+      "Effect": "Allow", 
+      "Principal": { 
+        "AWS": [ 
+          "*" 
+        ] 
+      }, 
+      "Action": [ 
+        "s3:GetObject" 
+      ], 
+      "NotAction": [], 
+      "Resource": [ 
+        "arn:aws:s3:::lobe/*" 
+      ], 
+      "NotResource": [], 
+      "Condition": {} 
+    } 
+  ] 
+}
+```
+
+Save the settings to apply the policy.
+
+### Configure Access Keys
+
+<Callout type={'warning'}>
+You can reuse the `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` defined in the `docker-compose.yml`, but for better security we recommend creating a dedicated access key.
+</Callout>
+
+Click `Access Key` in the left sidebar, then `Add Access Key` to create a new key. The name is arbitrary, and you can keep the default main-account policy.
+
+Copy the generated Access Key and Secret Key (the `Export` button lets you save the JSON locally). The English labels in the UI are confusing, but remember the shorter string is the Access Key and the longer string is the Secret Key (the exported JSON is correct).
+
+<Image alt={"Add Key"} src={'https://github.com/user-attachments/assets/81f18b20-3918-4f77-8571-07d0c4a79aec'} />
+
+<Image alt={"Export Key"} src={'https://github.com/user-attachments/assets/4dde41ec-985b-4781-8c77-aac65555a32f'} />
+
+### Configure Reverse Proxy
+
+You also need reverse-proxy rules so that RustFS is accessible from the LAN/public internet. Map the following ports to domains:
+
+| Domain                       | Port   | Required |
+| ---------------------------- | ------ | -------- |
+| `lobe-s3-api.example.com`    | `9000` | Yes      |
+| `lobe-s3-ui.example.com`     | `9001` |          |
+
+After completing the reverse proxy, remember to configure the corresponding SSL certificate and enable HTTPS access.
+
+### Set Environment Variables
+
+Update the LobeChat `.env` file with the following environment variables to use RustFS as the S3 backend:
+
+```shell
+# RustFS Access Key / Secret Key
+S3_ACCESS_KEY_ID=<YOUR_ACCESS_KEY>
+S3_SECRET_ACCESS_KEY=<YOUR_SECRET_KEY>
+# RustFS API endpoint
+S3_ENDPOINT=https://lobe-s3-api.example.com
+# Bucket name
+S3_BUCKET=lobe
+# Public domain for accessing the bucket
+S3_PUBLIC_DOMAIN=https://lobe-s3-api.example.com
+S3_ENABLE_PATH_STYLE=1
+```
+</Steps>

--- a/docs/self-hosting/advanced/s3/rustfs.zh-CN.mdx
+++ b/docs/self-hosting/advanced/s3/rustfs.zh-CN.mdx
@@ -1,0 +1,143 @@
+---
+title: 配置 RustFS 存储服务
+description: 详细步骤配置 RustFS 存储服务，确保文件存储顺利进行。
+tags:
+  - RustFS
+  - S3 存储
+  - 文件存储
+---
+
+# 配置 RustFS 存储服务
+
+在服务端数据库中我们需要配置 S3 存储服务来存储文件。
+
+
+<Callout type={'info'}>
+由于近期 MinIO 的商业化策略调整，我们不再推荐使用 MinIO 作为 S3 存储服务，建议所有仍在使用 MinIO 的用户迁移至 [RustFS](https://rustfs.com/) 或者 [ceph](https://ceph.io/) 等开源的 S3 存储服务或者腾讯云对象存储、Cloudflare R2 等云服务商的 S3 存储服务。
+</Callout>
+
+## 配置步骤
+
+<Steps>
+### 部署 RustFS
+
+首先，拉取 RustFS 的 Docker 镜像：
+
+```shell
+docker pull rustfs/rustfs:latest
+```
+
+你可以使用如下命令来查看其版本，建议使用 v1.0.0 及以上版本：
+
+```shell
+docker inspect --format='{{index .Config.Labels "version"}}' rustfs/rustfs:latest
+```
+
+我们推荐使用 Docker Compose 来部署 RustFS：
+
+```yml
+services:
+    rustfs:
+        image: rustfs/rustfs:latest
+        container_name: lobe-rustfs
+        ports:
+            - '9000:9000'
+            - '9001:9001'
+        environment:
+            - RUSTFS_CONSOLE_ENABLE=true
+            - RUSTFS_ACCESS_KEY=<YOUR_ACCESS_KEY>
+            - RUSTFS_SECRET_KEY=<YOUR_SECRET_KEY>
+        volumes:
+            - rustfs-data:/data
+
+volumes:
+  rustfs-data:
+```
+
+然后，启动 RustFS：
+
+```shell
+docker compose up -d
+```
+
+### 创建存储桶
+
+访问 RustFS 的 WebUI（`http://localhost:9001/`），即可自动跳转到登录页。输入账号（上述 `docker-compose.yml` 文件中的 `RUSTFS_ACCESS_KEY`）、密码（上述 `docker-compose.yml` 文件中的 `RUSTFS_SECRET_KEY`），即可登录。
+
+点击左侧边栏的 `对象存储` 菜单，右上角 `创建存储桶` 按钮，创建一个新的存储桶（Bucket）。创建存储桶时将指定其名称，下文以 `lobe` 为例。版本、对象锁依照默认配置不开启。
+
+<Image alt={"Create Bucket"} src={'https://github.com/user-attachments/assets/27c37617-a813-4de5-b0bf-c7167999c856'} />
+
+点击存储桶 - `配置` 按钮，选择策略为 `自定义`，然后填入如下 JSON，设置存储桶的权限为 `公有读私有写`：
+
+```json
+{ 
+  "ID": "", 
+  "Version": "2012-10-17", 
+  "Statement": [ 
+    { 
+      "Sid": "", 
+      "Effect": "Allow", 
+      "Principal": { 
+        "AWS": [ 
+          "*" 
+        ] 
+      }, 
+      "Action": [ 
+        "s3:GetObject" 
+      ], 
+      "NotAction": [], 
+      "Resource": [ 
+        "arn:aws:s3:::lobe/*" 
+      ], 
+      "NotResource": [], 
+      "Condition": {} 
+    } 
+  ] 
+}
+```
+
+点击保存即可。
+
+### 设置访问密钥
+
+<Callout type={'warning'}>
+  有关这部分，你可以直接使用在 `docker-compose.yml` 文件中配置的 `RUSTFS_ACCESS_KEY` 和 `RUSTFS_SECRET_KEY`，但出于安全考虑，我们推荐你手动创建一个访问密钥。
+</Callout>
+
+点击左侧边栏的 `访问密钥` 菜单，右上角 `添加访问密钥` 按钮，创建一个新的访问密钥（Access Key）。名称随意，按照默认配置使用主账号策略即可。
+
+记录好得到的访问密钥和密钥（你可以点击 `导出` 按钮以在本地保存）。这里 RustFS 的翻译有点迷惑，但你只需要记住上面那个短的是 `Access Key`，长的是 `Secret Key` 即可（导出的 JSON 中是对的）。
+
+<Image alt={"Add Key"} src={'https://github.com/user-attachments/assets/81f18b20-3918-4f77-8571-07d0c4a79aec'} />
+
+<Image alt={"Export Key"} src={'https://github.com/user-attachments/assets/4dde41ec-985b-4781-8c77-aac65555a32f'} />
+
+### 配置反向代理
+
+你还需要完成反向代理配置，并确保局域网 / 公网能访问到 RustFS 的服务。请使用反向代理将以下服务端口映射到域名：
+
+| 域名                     | 反代端口   | 是否必选 |
+| ---------------------- | ------ | ---- |
+| `lobe-s3-api.example.com`     | `9000` | 必选   |
+| `lobe-s3-ui.example.com` | `9001` |      |
+
+完成反向代理后，记得配置对应的 SSL 证书，启用 HTTPS 访问。
+
+### 设置环境变量
+
+修改 LobeChat 的 `.env` 文件，添加如下环境变量，即可完成配置，使用 RustFS 作为 S3 存储服务：
+
+```shell
+# RustFS 的鉴权 Access Key / Secret Key
+S3_ACCESS_KEY_ID=<YOUR_ACCESS_KEY>
+S3_SECRET_ACCESS_KEY=<YOUR_SECRET_KEY>
+# RustFS API 的请求端点
+S3_ENDPOINT=https://lobe-s3-api.example.com
+# 存储桶的名称
+S3_BUCKET=lobe
+# 存储桶对外的访问域名
+S3_PUBLIC_DOMAIN=https://lobe-s3-api.example.com
+S3_ENABLE_PATH_STYLE=1
+```
+</Steps>

--- a/docs/self-hosting/server-database.mdx
+++ b/docs/self-hosting/server-database.mdx
@@ -127,7 +127,7 @@ The best practice in this area is to use a file storage service (S3) to store im
 <Callout type={'info'}>
   In this documentation, S3 refers to a compatible S3 storage solution, which supports the Amazon S3
   API-compatible object storage system. Common examples include Cloudflare R2, Alibaba Cloud OSS,
-  and self-deployable Minio, all of which support the S3-compatible API.
+  and self-deployable RustFS, ceph, all of which support the S3-compatible API.
 </Callout>
 
 For detailed configuration guidelines on S3, please refer to [S3 Object Storage](/docs/self-hosting/advanced/s3) for more information.

--- a/docs/self-hosting/server-database.zh-CN.mdx
+++ b/docs/self-hosting/server-database.zh-CN.mdx
@@ -117,7 +117,7 @@ LobeChat 在 [很早以前](https://x.com/lobehub/status/1724289575672291782) �
 
 <Callout type={'info'}>
   在本文档库中，S3 所指代的是指兼容 S3 存储方案，即支持 Amazon S3 API 的对象存储系统，常见例如
-  Cloudflare R2 、阿里云 OSS，可以自部署的 minio 等均支持 S3 兼容 API。
+  Cloudflare R2 、阿里云 OSS，可以自部署的 RustFS、ceph 等均支持 S3 兼容 API。
 </Callout>
 
 关于 S3 的详细配置指南，请参阅 [S3 对象存储](/zh/docs/self-hosting/advanced/s3) 了解详情。


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

可以合了

## Summary by Sourcery

Add documentation for configuring RustFS as an S3-compatible storage backend for self-hosted deployments.

Documentation:
- Document step-by-step setup of RustFS via Docker Compose, including permission adjustments for data directories.
- Describe creating buckets, setting public-read/private-write policies, and managing access keys in RustFS WebUI.
- Explain reverse proxy configuration and required environment variables to use RustFS as the S3 storage service.