### PR TITLE
🐛 fix(userMemories): Upstash Workflows will serialize into `JSON`, causes the `Date` being incorrectly used

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-users/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/process-users/route.ts
@@ -19,6 +19,10 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   }
 
   const executor = await MemoryExtractionExecutor.create();
+
+  // NOTICE: Upstash Workflow only supports serializable data into plain JSON,
+  // this causes the Date object to be converted into string when passed as parameter from
+  // context to child workflow. So we need to convert it back to Date object here.
   const userCursor = params.userCursor
     ? { createdAt: new Date(params.userCursor.createdAt), id: params.userCursor.id }
     : undefined;

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -736,8 +736,9 @@ export class MemoryExtractionExecutor {
       limit: pageSize,
       startDate: job.from,
     });
-
-    if (!rows?.length) return { ids: [] };
+    if (!rows?.length) {
+      return { ids: [] };
+    }
 
     const last = rows.at(-1);
     const nextCursor = last
@@ -764,12 +765,20 @@ export class MemoryExtractionExecutor {
       limit,
       whitelist: this.privateConfig.whitelistUsers,
     });
-    if (!rows?.length) return { ids: [] };
+    if (!rows?.length) {
+      return { ids: [] };
+    }
 
     const last = rows.at(-1);
+    const nextCursor = last
+      ? {
+          createdAt: last.createdAt,
+          id: last.id,
+        }
+      : undefined;
 
     return {
-      cursor: last ? { createdAt: last.createdAt, id: last.id } : undefined,
+      cursor: nextCursor,
       ids: rows.map((row) => row.id),
     };
   }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Handle JSON-serialized cursor dates correctly in memory extraction workflows to prevent invalid Date usage when scheduling subsequent processing batches.

Bug Fixes:
- Convert JSON-serialized cursor createdAt values back into validated Date objects before triggering child workflows in user memory topic processing.
- Normalize handling of user cursor data in the users processing workflow to account for Date fields being passed as plain JSON.

Enhancements:
- Improve clarity of cursor construction and empty-result handling in memory extraction executor methods.