### PR TITLE
🐛 fix(memory-user-memory): existing memory not being passed as context of gatekeeper

### DIFF
--- a/packages/memory-user-memory/src/extractors/base.ts
+++ b/packages/memory-user-memory/src/extractors/base.ts
@@ -130,8 +130,6 @@ export abstract class BaseMemoryExtractor<
             attributes: {
               [ATTR_GEN_AI_OPERATION_NAME]: 'generate_content',
               [ATTR_GEN_AI_REQUEST_MODEL]: this.model,
-              'gen_ai.input.openai.messages': serializeForSpan(payload.messages),
-              'gen_ai.input.openai.schema': serializeForSpan(payload.schema),
               'lobe-chat.memory.extractor.context': options?.retrievedContexts,
               'lobe-chat.memory.extractor.identities_context': options?.retrievedIdentitiesContext,
             },

--- a/packages/memory-user-memory/src/services/extractExecutor.ts
+++ b/packages/memory-user-memory/src/services/extractExecutor.ts
@@ -235,6 +235,7 @@ export class MemoryExtractionService<RO> {
     try {
       const decision = await this.gatekeeper.check({
         language: options.language ?? 'English',
+        retrievedContexts: options.retrievedContexts,
       });
       this.recordGatekeeperMetrics(job, Date.now() - start, 'ok');
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure memory extraction gatekeeper receives the retrieved context and streamline telemetry attributes for extractor spans.

Bug Fixes:
- Pass retrieved memory contexts into the gatekeeper check so gating decisions consider existing user context.

Enhancements:
- Remove detailed OpenAI input and schema fields from extractor tracing attributes to simplify telemetry payloads.