### PR TITLE
🐛 fix(memory-user-memory): populate source id, user id, langauge, tuned language of extractors

### DIFF
--- a/packages/memory-user-memory/src/extractors/base.ts
+++ b/packages/memory-user-memory/src/extractors/base.ts
@@ -132,6 +132,10 @@ export abstract class BaseMemoryExtractor<
               [ATTR_GEN_AI_REQUEST_MODEL]: this.model,
               'lobe-chat.memory.extractor.context': options?.retrievedContexts,
               'lobe-chat.memory.extractor.identities_context': options?.retrievedIdentitiesContext,
+              'lobe-chat.memory.extractor.language': options?.language,
+              'lobe-chat.memory.extractor.source_id': options?.sourceId,
+              'lobe-chat.memory.extractor.top_k': options?.topK,
+              'lobe-chat.memory.extractor.user_id': options?.userId,
             },
           },
           async (span) => {

--- a/packages/memory-user-memory/src/prompts/gatekeeper.md
+++ b/packages/memory-user-memory/src/prompts/gatekeeper.md
@@ -105,7 +105,7 @@ If uncertain about novelty, but information is relevant and clear, set `shouldEx
 For each memory layer (activity, identity, context, preference, experience), provide:
 
 - `shouldExtract`: Boolean indicating whether extraction is recommended
-- `reasoning`: Brief explanation of your decision (write in Chinese / 使用中文描述)
+- `reasoning`: Brief explanation of your decision (write in English)
 
 ## Retrieved Memory (Top {{ topK }})
 

--- a/packages/memory-user-memory/src/prompts/layers/context.md
+++ b/packages/memory-user-memory/src/prompts/layers/context.md
@@ -9,6 +9,13 @@ Available memory categories: {{ availableCategories }}
 Target layer: context
 \</user_context>
 
+## Retrieved Memory (Top {{ topK }})
+
+Use the list below to de-duplicate and decide whether you need to extract
+anything new. Do not copy these verbatim; treat them as comparison references.
+
+{{ retrievedContext }}
+
 ## Your Task
 
 Extract **ALL** context layer information from the conversation.
@@ -138,12 +145,6 @@ Choose the appropriate memoryType:
 3. Ensure all memories are self-contained (no pronouns, complete context)
 4. Return a JSON array conforming to the schema above
 5. Return `[]` if no context memories found
+6. No matter what the language of the retrieved language is, always use {{ language }} for output
 
 Respond with valid JSON and no commentary.
-
-## Retrieved Memory (Top {{ topK }})
-
-Use the list below to de-duplicate and decide whether you need to extract
-anything new. Do not copy these verbatim; treat them as comparison references.
-
-{{ retrievedContext }}

--- a/packages/memory-user-memory/src/prompts/layers/experience.md
+++ b/packages/memory-user-memory/src/prompts/layers/experience.md
@@ -8,6 +8,13 @@ Available memory categories: {{ availableCategories }}
 Target layer: experience
 \</user_context>
 
+## Retrieved Memory (Top {{ topK }})
+
+Use the list below to de-duplicate and decide whether you need to extract
+anything. Do not copy these verbatim; use them for comparison.
+
+{{ retrievedContext }}
+
 ## Your Task
 
 Extract **ALL** experience layer information from the conversation. Capture
@@ -131,12 +138,6 @@ Choose the appropriate memoryType:
 3. Ensure all memories are self-contained (no pronouns, complete context)
 4. Return a JSON array conforming to the schema above
 5. Return `[]` if you find no experience memories
+6. No matter what the language of the retrieved language is, always use {{ language }} for output
 
 Respond with valid JSON without commentary.
-
-## Retrieved Memory (Top {{ topK }})
-
-Use the list below to de-duplicate and decide whether you need to extract
-anything. Do not copy these verbatim; use them for comparison.
-
-{{ retrievedContext }}

--- a/packages/memory-user-memory/src/prompts/layers/identity.md
+++ b/packages/memory-user-memory/src/prompts/layers/identity.md
@@ -8,6 +8,13 @@ Available memory categories: {{ availableCategories }}
 Target layer: identity
 \</user_context>
 
+## Retrieved Memory (Top {{ topK }})
+
+Use the list below to de-duplicate and decide whether you need to extract
+anything. Do not copy these verbatim; use them for comparison.
+
+{{ retrievedContext }}
+
 ## Your Task
 
 Extract **ALL** identity layer information from the conversation. Capture
@@ -183,12 +190,6 @@ Choose the appropriate memoryType:
 3. Ensure all memories are self-contained (no pronouns, complete context)
 4. Return a JSON array conforming to the schema above
 5. Return `[]` if you find no identity memories
+6. No matter what the language of the retrieved language is, always use {{ language }} for output
 
 Respond with valid JSON without commentary.
-
-## Retrieved Memory (Top {{ topK }})
-
-Use the list below to de-duplicate and decide whether you need to extract
-anything. Do not copy these verbatim; use them for comparison.
-
-{{ retrievedContext }}

--- a/packages/memory-user-memory/src/prompts/layers/preference.md
+++ b/packages/memory-user-memory/src/prompts/layers/preference.md
@@ -8,6 +8,13 @@ Available memory categories: {{ availableCategories }}
 Target layer: preference
 \</user_context>
 
+## Retrieved Memory (Top {{ topK }})
+
+Use the list below to de-duplicate and decide whether you need to extract
+anything. Do not copy these verbatim; use them for comparison.
+
+{{ retrievedContext }}
+
 ## Your Task
 
 Extract **ALL** preference layer information from the conversation. Capture user
@@ -150,12 +157,6 @@ Choose the appropriate memoryType:
 3. Ensure all memories are self-contained (no pronouns, complete context)
 4. Return a JSON array conforming to the schema above
 5. Return `[]` if you find no preference memories
+6. No matter what the language of the retrieved language is, always use {{ language }} for output
 
 Respond with valid JSON without commentary.
-
-## Retrieved Memory (Top {{ topK }})
-
-Use the list below to de-duplicate and decide whether you need to extract
-anything. Do not copy these verbatim; use them for comparison.
-
-{{ retrievedContext }}

--- a/packages/memory-user-memory/src/types.ts
+++ b/packages/memory-user-memory/src/types.ts
@@ -19,6 +19,8 @@ export interface ExtractorOptions extends ExtractorTemplateProps {
     onExtractResponse?: <TOutput>(response: TOutput) => Promise<void> | void;
   };
   messageIds?: string[];
+  sourceId?: string;
+  userId?: string;
 }
 
 export interface ExtractorTemplateProps {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update memory extraction prompts and telemetry to consistently handle language, user, and source metadata across layers.

Bug Fixes:
- Ensure memory extractor spans are tagged with language, source ID, topK, and user ID to correctly populate tracing metadata.
- Clarify gatekeeper reasoning instructions to require English output instead of Chinese.
- Enforce that all layer extractors output in the configured language regardless of retrieved memory language.

Enhancements:
- Reposition retrieved memory sections in layer prompts for clearer context before extraction instructions.
- Extend extractor options to accept optional sourceId and userId fields for richer context.