### PR TITLE
feat(observability-otel,memory-user-memory): expand resource attributes to include Vercel & Node.js attributes

### DIFF
--- a/packages/memory-user-memory/src/services/extractExecutor.ts
+++ b/packages/memory-user-memory/src/services/extractExecutor.ts
@@ -29,6 +29,7 @@ import {
   MemoryResultRecorder,
 } from '../types';
 import { resolvePromptRoot } from '../utils/path';
+import { attributesCommon } from '@lobechat/observability-otel/node';
 
 const LAYER_ORDER: LayersEnum[] = [
   'identity' as LayersEnum,
@@ -119,6 +120,7 @@ export class MemoryExtractionService<RO> {
       source: job.source,
       status,
       user_id: job.userId,
+      ...attributesCommon(),
     };
 
     gateKeeperCallsCounter.add(1, attributes);
@@ -136,6 +138,7 @@ export class MemoryExtractionService<RO> {
       source: job.source,
       status,
       user_id: job.userId,
+      ...attributesCommon(),
     };
 
     layersCallsCounter.add(1, attributes);
@@ -152,6 +155,7 @@ export class MemoryExtractionService<RO> {
       source: job.source,
       source_id: job.sourceId,
       user_id: job.userId,
+      ...attributesCommon(),
     };
 
     return tracer.startActiveSpan(

--- a/packages/obervability-otel/src/node.ts
+++ b/packages/obervability-otel/src/node.ts
@@ -1,19 +1,68 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
-import { resourceFromAttributes } from '@opentelemetry/resources';
+import { resourceFromAttributes, DetectedResourceAttributes } from '@opentelemetry/resources';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { env } from 'node:process';
 
-export function register(options?: { debug?: true | DiagLogLevel; version?: string }) {
-  const attributes: Record<string, string> = {
+export function attributesForVercel(): DetectedResourceAttributes {
+  return {
+    // Vercel.
+    // https://vercel.com/docs/projects/environment-variables/system-environment-variables
+    // Vercel Env set as top level attribute for simplicity. One of 'production', 'preview' or 'development'.
+    env: process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV,
+
+    "vercel.branch_host":
+      process.env.VERCEL_BRANCH_URL ||
+      process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
+      undefined,
+    "vercel.deployment_id": process.env.VERCEL_DEPLOYMENT_ID || undefined,
+    "vercel.host":
+      process.env.VERCEL_URL ||
+      process.env.NEXT_PUBLIC_VERCEL_URL ||
+      undefined,
+    "vercel.project_id": process.env.VERCEL_PROJECT_ID || undefined,
+    "vercel.region": process.env.VERCEL_REGION,
+    "vercel.runtime": process.env.NEXT_RUNTIME || "nodejs",
+    "vercel.sha":
+      process.env.VERCEL_GIT_COMMIT_SHA ||
+      process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+
+    'service.version': process.env.VERCEL_DEPLOYMENT_ID,
+  }
+}
+
+export function attributesForNodejs(): DetectedResourceAttributes {
+  return {
+    // Node.
+    "node.ci": process.env.CI ? true : undefined,
+    "node.env": process.env.NODE_ENV,
+  }
+}
+
+export function attributesForEnv(): DetectedResourceAttributes {
+  return {
+    ...attributesForVercel(),
+    ...attributesForNodejs(),
+  }
+}
+
+export function attributesCommon(): DetectedResourceAttributes {
+  return {
     [ATTR_SERVICE_NAME]: 'lobe-chat',
-  };
+    ...attributesForEnv(),
+  }
+}
+
+export function register(options?: { debug?: true | DiagLogLevel; version?: string }) {
+  const attributes = attributesCommon();
+
   if (typeof options?.version !== 'undefined') {
     attributes[ATTR_SERVICE_VERSION] = options.version;
   }

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -51,6 +51,7 @@ import { S3 } from '@/server/modules/S3';
 import type { GlobalMemoryLayer } from '@/types/serverConfig';
 import type { UserKeyVaults } from '@/types/user/settings';
 import { LayersEnum, MergeStrategyEnum, TypesEnum } from '@/types/userMemory';
+import { attributesCommon } from '@lobechat/observability-otel/node';
 
 const SOURCE_ALIAS_MAP: Record<string, MemoryExtractionSourceType> = {
   chatTopic: 'chat_topic',
@@ -1121,20 +1122,22 @@ export class MemoryExtractionExecutor {
       source: job.source,
       status,
       user_id: job.userId,
+      ...attributesCommon(),
     });
     processedDurationHistogram.record(durationMs, {
       source: job.source,
       user_id: job.userId,
+      ...attributesCommon(),
     });
   }
 
   private recordLayerEntries(job: MemoryExtractionJob, layer: LayersEnum, count: number) {
-    const attributes = {
+    layerEntriesHistogram.record(count, {
       layer: LAYER_LABEL_MAP[layer],
       source: job.source,
       user_id: job.userId,
-    };
-    layerEntriesHistogram.record(count, attributes);
+      ...attributesCommon(),
+    });
   }
 
   private async persistExtraction(


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

https://github.com/vercel/otel/blob/main/packages/otel/src/sdk.ts

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enrich observability telemetry with common resource attributes derived from runtime environment variables and apply them consistently across memory extraction metrics and traces.

Enhancements:
- Introduce shared helpers in the observability package to build OpenTelemetry resource attributes from Vercel and Node.js environment variables.
- Apply the shared observability attributes to memory extraction metrics and spans in both server and package-level memory extraction services.