### PR TITLE
✨ feat(database,memory-user-memory): include `traceId` of memory extraction into topic metadata

### DIFF
--- a/packages/memory-user-memory/src/providers/chatTopic.ts
+++ b/packages/memory-user-memory/src/providers/chatTopic.ts
@@ -34,6 +34,7 @@ export interface ChatTopicResultRecorderOptions {
   lastMessageAt?: string;
   messageCount?: number;
   topicId: string;
+  traceId?: string;
 }
 
 export class LobeChatTopicContextProvider implements MemoryContextProvider<
@@ -144,12 +145,14 @@ export class LobeChatTopicResultRecorder implements MemoryResultRecorder<{
       lastRunAt: now,
       messageCount: this.options.messageCount,
       processedMemoryCount: result.processedMemoryCount,
+      traceId: this.options.traceId,
     };
 
     memoryExtraction.lastMessageAt = this.options.lastMessageAt;
     memoryExtraction.lastRunAt = now;
     memoryExtraction.messageCount = this.options.messageCount;
     memoryExtraction.processedMemoryCount = result.processedMemoryCount;
+    memoryExtraction.traceId = this.options.traceId;
 
     const updatedMetadata: ChatTopicMetadata = {
       ...existingMetadata,
@@ -174,6 +177,7 @@ export class LobeChatTopicResultRecorder implements MemoryResultRecorder<{
       messageCount: this.options.messageCount,
       processedMemoryCount: 0,
       status: 'failed' as const,
+      traceId: this.options.traceId,
     };
 
     memoryExtraction.error = error.message;
@@ -181,6 +185,7 @@ export class LobeChatTopicResultRecorder implements MemoryResultRecorder<{
     memoryExtraction.lastRunAt = now;
     memoryExtraction.messageCount = this.options.messageCount;
     memoryExtraction.processedMemoryCount = 0;
+    memoryExtraction.traceId = this.options.traceId;
 
     const updatedMetadata: ChatTopicMetadata = {
       ...existingMetadata,

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -30,6 +30,7 @@ export interface TopicUserMemoryExtractRunState {
   lastRunAt?: string;
   messageCount?: number;
   processedMemoryCount?: number;
+  traceId?: string;
 }
 
 export interface ChatTopicMetadata {

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -825,6 +825,7 @@ export class MemoryExtractionExecutor {
             lastMessageAt: (conversations?.at(-1)?.createdAt || topic.updatedAt).toISOString(),
             messageCount: conversations.length,
             topicId: topic.id,
+            traceId: span.spanContext().traceId,
           });
 
           const retrievedMemories = await this.listRelevantUserMemories(


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Include memory extraction trace IDs in chat topic metadata and propagate them through the user memory extraction flow.

New Features:
- Add optional traceId to chat topic result recorder options and topic user memory extract run state.
- Store and update traceId in chat topic metadata for both successful and failed memory extraction runs.
- Populate traceId from the current tracing span when executing user memory extraction.