### PR TITLE
✨ feat(database): added queryIdentityRoles model for user memory

### DIFF
--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -226,6 +226,24 @@ export const userMemoriesRouter = router({
       }
     }),
 
+  queryIdentityRoles: memoryProcedure
+    .input(
+      z
+        .object({
+          page: z.coerce.number().int().min(1).optional(),
+          size: z.coerce.number().int().min(1).max(100).optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        return await ctx.memoryModel.queryIdentityRoles(input ?? {});
+      } catch (error) {
+        console.error('Failed to query identity roles:', error);
+        return { roles: [], tags: [] };
+      }
+    }),
+
   // REVIEW：根据当前 topic 直接提取记忆
   // REVIEW： 我们需要一个既可以 cron 也可以主动用户触发进行「每日/每周/每隔一段时间的」记忆提取/生成的函数实现
   // REVIEW： 定时任务

--- a/src/services/userMemory.ts
+++ b/src/services/userMemory.ts
@@ -64,6 +64,10 @@ class UserMemoryService {
     return lambdaClient.userMemories.queryTags.query(params);
   };
 
+  queryIdentityRoles = async (params?: { page?: number; size?: number }) => {
+    return lambdaClient.userMemories.queryIdentityRoles.query(params);
+  };
+
   updateIdentityMemory = async (
     params: z.infer<typeof UpdateIdentityActionSchema>,
   ): Promise<UpdateIdentityMemoryResult> => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for querying aggregated identity roles and tags from user memories and expose it via the service and lambda router.

New Features:
- Introduce queryIdentityRoles model method to return paginated aggregated identity roles and tags for a user.
- Expose the identity roles query through the userMemories lambda router and UserMemoryService API.

Tests:
- Add unit test to verify identity roles and tags aggregation is scoped to the current user only.