### PR TITLE
🐛 fix: Make agent setting autocomplete handle content_part type events

### DIFF
--- a/src/features/AgentSetting/store/action.ts
+++ b/src/features/AgentSetting/store/action.ts
@@ -1,4 +1,4 @@
-import { type MessageTextChunk } from '@lobechat/fetch-sse';
+import { type MessageContentPartChunk, type MessageTextChunk } from '@lobechat/fetch-sse';
 import {
   chainPickEmoji,
   chainSummaryAgentName,
@@ -337,11 +337,17 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
 
   streamUpdateMetaArray: (key: keyof MetaData) => {
     let value = '';
-    return (chunk: MessageTextChunk) => {
+    return (chunk: MessageTextChunk | MessageContentPartChunk) => {
       switch (chunk.type) {
         case 'text': {
           value += chunk.text;
           get().dispatchMeta({ type: 'update', value: { [key]: value.split(',') } });
+          break;
+        }
+        case 'content_part': {
+          value += chunk.content;
+          get().dispatchMeta({ type: 'update', value: { [key]: value.split(',') } });
+          break;
         }
       }
     };
@@ -349,11 +355,17 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
 
   streamUpdateMetaString: (key: keyof MetaData) => {
     let value = '';
-    return (chunk: MessageTextChunk) => {
+    return (chunk: MessageTextChunk | MessageContentPartChunk) => {
       switch (chunk.type) {
         case 'text': {
           value += chunk.text;
           get().dispatchMeta({ type: 'update', value: { [key]: value } });
+          break;
+        }
+        case 'content_part': {
+          value += chunk.content;
+          get().dispatchMeta({ type: 'update', value: { [key]: value } });
+          break;
         }
       }
     };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

自动补全助手名称和描述时，支持gemini 2.5+模型，模型以MessageContentPartChunk格式返回。
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Fix agent settings autocomplete so it correctly updates metadata when models stream MessageContentPartChunk events in addition to plain text chunks.