### PR TITLE
🐛 fix(database,userMemories): cursor paginated topic iteration will cause infinite loop for memory extraction task

### DIFF
--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -11,11 +11,12 @@ import {
   inArray,
   isNull,
   lte,
+  ne,
   or,
   sql,
 } from 'drizzle-orm';
 
-import { TopicItem, agents, agentsToSessions, messages, topics } from '../schemas';
+import { TopicItem, agentsToSessions, messages, topics } from '../schemas';
 import { LobeChatDatabase } from '../type';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
 import { idGenerator } from '../utils/idGenerator';
@@ -540,9 +541,12 @@ export class TopicModel {
     } = {},
   ) => {
     const cursorCondition = options.cursor
-      ? or(
-          gt(topics.createdAt, options.cursor.createdAt),
-          and(eq(topics.createdAt, options.cursor.createdAt), gt(topics.id, options.cursor.id)),
+      ? and(
+          ne(topics.id, options.cursor.id),
+          or(
+            gt(topics.createdAt, options.cursor.createdAt),
+            and(eq(topics.createdAt, options.cursor.createdAt), gt(topics.id, options.cursor.id)),
+          ),
         )
       : undefined;
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix cursor-based pagination for topic iteration used by the memory extraction task to prevent infinite loops and ensure correct forward pagination from a given cursor.

Bug Fixes:
- Ensure topics pagination excludes the cursor item itself while including only items created after it or with the same timestamp but a greater ID to avoid infinite loops in the memory extraction task.

Tests:
- Add a regression test verifying that cursor-based pagination skips the cursor topic and returns only subsequent topics for the same user.