### PR TITLE
🐛 fix(memory-user-memory): do not update updated_at for topic when extracted

### DIFF
--- a/packages/memory-user-memory/src/providers/chatTopic.ts
+++ b/packages/memory-user-memory/src/providers/chatTopic.ts
@@ -162,7 +162,7 @@ export class LobeChatTopicResultRecorder implements MemoryResultRecorder<{
 
     await this.options.database
       .update(topics)
-      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .set({ metadata: updatedMetadata })
       .where(and(eq(topics.id, this.options.topicId), eq(topics.userId, job.userId)));
   }
 
@@ -195,7 +195,7 @@ export class LobeChatTopicResultRecorder implements MemoryResultRecorder<{
 
     await this.options.database
       .update(topics)
-      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .set({ metadata: updatedMetadata })
       .where(and(eq(topics.id, this.options.topicId), eq(topics.userId, job.userId)));
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Prevent unintended changes to a topic's updated_at timestamp when updating metadata during memory extraction.