### PR TITLE
🐛 fix(memory-user-memory): should handle the exceptions loosely

### DIFF
--- a/packages/memory-user-memory/src/prompts/layers/context.md
+++ b/packages/memory-user-memory/src/prompts/layers/context.md
@@ -47,6 +47,12 @@ validates the output and includes:
 - Context-specific fields in withContext: title, description, extractedLabels,
   associatedSubjects (array of object), associatedObjects (array of object),
   currentStatus, type, scoreImpact, scoreUrgency.
+- For associatedSubjects and associatedObjects, the following fields are possible
+  to have:
+  - name (string)
+  - type (string)
+  - extra (object in JSON string, valid JSON format)
+
 
 ## Memory Formatting Guidelines
 

--- a/packages/memory-user-memory/src/schemas/context.ts
+++ b/packages/memory-user-memory/src/schemas/context.ts
@@ -4,13 +4,13 @@ import { MemoryTypeSchema } from './common';
 import { LayersEnum, UserMemoryContextObjectType, UserMemoryContextSubjectType } from '@/types/userMemory';
 
 export const AssociatedObjectSchema = z.object({
-  extra:z.string().nullable().describe('Additional metadata about the object'),
+  extra:z.string().nullable().describe('Additional metadata about the object, should always be a valid JSON string if present'),
   name: z.string().describe('Name of the associated object'),
   type: z.nativeEnum(UserMemoryContextObjectType).describe('Type/category of the associated object'),
 })
 
 export const AssociatedSubjectSchema = z.object({
-  extra:z.string().nullable().describe('Additional metadata about the subject'),
+  extra:z.string().nullable().describe('Additional metadata about the subject, should always be a valid JSON string if present'),
   name: z.string().describe('Name of the associated subject'),
   type: z.nativeEnum(UserMemoryContextSubjectType).describe('Type/category of the associated subject'),
 })

--- a/packages/memory-user-memory/src/types.ts
+++ b/packages/memory-user-memory/src/types.ts
@@ -101,10 +101,22 @@ export interface PersistedMemoryResult {
 }
 
 export type MemoryExtractionLayerOutputs = Partial<{
-  context: Awaited<ReturnType<ContextExtractor['structuredCall']>>;
-  experience: Awaited<ReturnType<ExperienceExtractor['structuredCall']>>;
-  identity: Awaited<ReturnType<IdentityExtractor['structuredCall']>>;
-  preference: Awaited<ReturnType<PreferenceExtractor['structuredCall']>>;
+  context: {
+    data?: Awaited<ReturnType<ContextExtractor['structuredCall']>>;
+    error?: unknown;
+  };
+  experience: {
+    data?: Awaited<ReturnType<ExperienceExtractor['structuredCall']>>;
+    error?: unknown;
+  };
+  identity: {
+    data?: Awaited<ReturnType<IdentityExtractor['structuredCall']>>;
+    error?: unknown;
+  }
+  preference: {
+    data?: Awaited<ReturnType<PreferenceExtractor['structuredCall']>>;
+    error?: unknown;
+  }
 }>;
 
 export interface GatekeeperDecision {
@@ -128,6 +140,7 @@ export interface MemoryExtractionResult {
   layers: LayersEnum[];
   outputs: MemoryExtractionLayerOutputs;
   processedCounts: number;
+  processedErrorsCount: Record<LayersEnum, number>;
   processedLayersCount: Record<LayersEnum, number>;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Relax error handling in memory extraction so per-layer failures are captured and aggregated without blocking other layers, while adapting result shapes and metrics to support partial successes.

Bug Fixes:
- Handle layer extraction and persistence errors per layer without aborting the entire memory extraction pipeline.
- Adjust persistence methods to work with the new per-layer output structure and avoid crashes when layer outputs are missing or malformed.

Enhancements:
- Wrap layer execution results with data and error fields and propagate error counts through MemoryExtractionResult for better observability.
- Add tracing spans and structured error normalization for memory persistence per layer.
- Document and enforce that associated subject/object metadata must be valid JSON strings in context prompts and schemas.

Documentation:
- Clarify the allowed fields and JSON format requirements for associatedSubjects and associatedObjects in the context layer prompt.