### PR TITLE
✨ feat(userMemories): added queryMemories for searching & listing

### DIFF
--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -140,6 +140,85 @@ describe('memoryRouter.reEmbedMemories', () => {
   });
 });
 
+describe('userMemories.queryMemories', () => {
+  it('forwards filters and pagination to the model and returns the result', async () => {
+    const queryMemories = vi.fn().mockResolvedValue({
+      items: [{ id: 'mem-1' }],
+      page: 2,
+      pageSize: 5,
+      total: 1,
+    });
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          queryMemories,
+        }) as any,
+    );
+
+    vi.mocked(getServerDB).mockResolvedValue({
+      query: {},
+    } as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    const input = {
+      categories: ['work'],
+      layers: ['context'],
+      order: 'asc' as const,
+      page: 2,
+      pageSize: 5,
+      q: 'atlas',
+      sort: 'updatedAt' as const,
+      tags: ['project'],
+      types: ['topic'],
+    };
+
+    const result = await caller.queryMemories(input as any);
+
+    expect(queryMemories).toHaveBeenCalledWith({
+      ...input,
+      order: 'asc',
+      sort: 'updatedAt',
+    });
+    expect(result).toEqual({
+      items: [{ id: 'mem-1' }],
+      page: 2,
+      pageSize: 5,
+      total: 1,
+    });
+  });
+
+  it('applies default sort and order when not provided', async () => {
+    const queryMemories = vi.fn().mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 20,
+      total: 0,
+    });
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          queryMemories,
+        }) as any,
+    );
+
+    vi.mocked(getServerDB).mockResolvedValue({
+      query: {},
+    } as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    await caller.queryMemories();
+
+    expect(queryMemories).toHaveBeenCalledWith({
+      order: 'desc',
+      sort: 'createdAt',
+    });
+  });
+});
+
 describe('userMemories.retrieveMemory', () => {
   it('returns aggregated memory search results', async () => {
     const searchWithEmbedding = vi.fn().mockResolvedValue({


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add a paginated, filterable query API for user memories and expose it via the lambda router.

New Features:
- Introduce a queryMemories method on UserMemoryModel to list user memories with filtering, search, sorting, and pagination across all memory layers.
- Expose a userMemories.queryMemories endpoint in the lambda router that validates inputs and forwards them to the model with sensible defaults.

Enhancements:
- Relax associated object parsing to gracefully handle simple name-only objects when building context associations.

Tests:
- Add model-level tests covering queryMemories filtering, pagination, and handling of layered memories without explicit filters.
- Add router-level tests ensuring queryMemories forwards parameters correctly and applies default sort and order values.