### PR TITLE
🐛 fix: correct claude_args quoting to prevent shell-quote parsing errors

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -30,7 +30,7 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           allowed_non_write_users: "*"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowed-tools Bash(gh *),Read"
+          claude_args: '--allowed-tools "Bash(gh *),Read"'
           prompt: |
             You're an issue triage assistant for GitHub issues. Your task is to analyze issues, apply appropriate labels, and mention the responsible team member.
 

--- a/.github/workflows/claude-translator.yml
+++ b/.github/workflows/claude-translator.yml
@@ -44,7 +44,7 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           allowed_non_write_users: "*"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowed-tools Bash(gh issue:*),Bash(gh api:repos/*/issues:*),Bash(gh api:repos/*/pulls/*/reviews/*),Bash(gh api:repos/*/pulls/comments/*)"
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh api:repos/*/issues:*),Bash(gh api:repos/*/pulls/*/reviews/*),Bash(gh api:repos/*/pulls/comments/*)"'
           prompt: |
             You are a multilingual translation assistant. You need to respond to the following four types of GitHub Webhook events:
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes #10789

#### 🔀 Description of Change

The `shell-quote` library used by `claude-code-action` incorrectly parses arguments containing `--` prefixes as CLI flags.

**Fix**: Wrap the tools list with double quotes inside single quotes to prevent the parsing issue.

**Changes**:
- `.github/workflows/claude-issue-triage.yml` - fix quoting
- `.github/workflows/claude-translator.yml` - fix quoting

#### 🧪 How to Test

- [x] No tests needed

This fix can be verified by triggering the affected workflows and confirming they no longer exit with code 1.