### PR TITLE
✨ feat(userMemories): added queryMemoryDetail

### DIFF
--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { LayersEnum } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getServerDB } from '@/database/core/db-adaptor';
@@ -215,6 +216,60 @@ describe('userMemories.queryMemories', () => {
     expect(queryMemories).toHaveBeenCalledWith({
       order: 'desc',
     });
+  });
+});
+
+describe('userMemories.getMemoryDetail', () => {
+  it('forwards memory id to model and returns detail', async () => {
+    const getMemoryDetail = vi.fn().mockResolvedValue({ id: 'mem-1', layer: 'experience' });
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          getMemoryDetail,
+        }) as any,
+    );
+
+    vi.mocked(getServerDB).mockResolvedValue({
+      query: {},
+    } as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    const result = await caller.getMemoryDetail({
+      id: 'mem-1',
+      layer: LayersEnum.Experience,
+    } as any);
+
+    expect(getMemoryDetail).toHaveBeenCalledWith({
+      id: 'mem-1',
+      layer: LayersEnum.Experience,
+    });
+    expect(result).toEqual({ id: 'mem-1', layer: 'experience' });
+  });
+
+  it('returns null when model throws', async () => {
+    const getMemoryDetail = vi.fn().mockRejectedValue(new Error('boom'));
+
+    vi.mocked(UserMemoryModel).mockImplementation(
+      () =>
+        ({
+          getMemoryDetail,
+        }) as any,
+    );
+
+    vi.mocked(getServerDB).mockResolvedValue({
+      query: {},
+    } as any);
+
+    const caller = userMemoriesRouter.createCaller(mockCtx as any);
+
+    const result = await caller.getMemoryDetail({
+      id: 'mem-1',
+      layer: LayersEnum.Experience,
+    } as any);
+
+    expect(result).toBeNull();
   });
 });
 

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -204,6 +204,17 @@ const memoryProcedure = authedProcedure
   });
 
 export const userMemoriesRouter = router({
+  getMemoryDetail: memoryProcedure
+    .input(z.object({ id: z.string(), layer: z.nativeEnum(LayersEnum) }))
+    .query(async ({ ctx, input }) => {
+      try {
+        return await ctx.memoryModel.getMemoryDetail(input);
+      } catch (error) {
+        console.error('Failed to retrieve memory detail:', error);
+        return null;
+      }
+    }),
+
   queryIdentityRoles: memoryProcedure
     .input(
       z

--- a/src/services/userMemory.ts
+++ b/src/services/userMemory.ts
@@ -52,6 +52,10 @@ class UserMemoryService {
     return lambdaClient.userMemories.toolRemoveIdentityMemory.mutate(params);
   };
 
+  getMemoryDetail = async (params: { id: string; layer: LayersEnum }) => {
+    return lambdaClient.userMemories.getMemoryDetail.query(params);
+  };
+
   retrieveMemory = async (params: SearchMemoryParams): Promise<SearchMemoryResult> => {
     return lambdaClient.userMemories.toolSearchMemory.query(params);
   };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for retrieving detailed user memory records by ID and layer through the model, router, and service layers, with appropriate access control and metrics updates.

New Features:
- Expose a getMemoryDetail query in the userMemories router and service to fetch detailed information for a specific memory by ID and layer.

Enhancements:
- Implement a UserMemoryModel.getMemoryDetail method that returns full layer-specific memory details while enforcing ownership, validating layer consistency, and updating access metrics.

Tests:
- Add model tests covering getMemoryDetail behavior, including access metrics updates and cross-user access restrictions.
- Add router tests verifying getMemoryDetail input forwarding and error handling behavior.