### PR TITLE
:bug: fix: request to gpt5 series should not with `top_p`, temperature when reasoning effort  is not none

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -156,8 +156,14 @@ export const pruneReasoningPayload = (payload: ChatStreamPayload) => {
     stream: shouldStream,
     // Only include stream_options when stream is enabled
     ...(shouldStream && stream_options && { stream_options }),
-    temperature: isEffortNone ? payload.temperature : 1,
-    top_p: isEffortNone ? payload.top_p : 1,
+
+    /**
+     *  In openai docs: https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
+     *  Fields like `top_p`, `temperature` and `logprobs` only supported to
+     *  GPT-5 series (e.g. 5-mini 5-nano ) when reasoning effort is none
+     */
+    temperature: isEffortNone ? payload.temperature : undefined,
+    top_p: isEffortNone ? payload.top_p : undefined,
   };
 };
 

--- a/packages/model-runtime/src/providers/github/index.test.ts
+++ b/packages/model-runtime/src/providers/github/index.test.ts
@@ -86,8 +86,8 @@ describe('LobeGithubAI - custom features', () => {
 
         expect(result.model).toBe('o1-preview');
         expect(result.stream).toBe(false);
-        expect(result.temperature).toBe(1);
-        expect(result.top_p).toBe(1);
+        expect(result.temperature).toBe(undefined);
+        expect(result.top_p).toBe(undefined);
         expect(result.frequency_penalty).toBe(0);
         expect(result.presence_penalty).toBe(0);
       });
@@ -117,8 +117,8 @@ describe('LobeGithubAI - custom features', () => {
 
         expect(result.model).toBe('o3-preview');
         expect(result.stream).toBe(false);
-        expect(result.temperature).toBe(1);
-        expect(result.top_p).toBe(1);
+        expect(result.temperature).toBe(undefined);
+        expect(result.top_p).toBe(undefined);
       });
 
       it('should handle o3-mini models', () => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

- :bug: `packages/model-runtime/src/core/contextBuilders/openai.ts`: prune parameter when enable reasoning effort. [gpt-5-2-parameter-compatibility | openai.com](https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility)
-  🧪 `packages/model-runtime/src/providers/github/index.test.ts`: should not use temperature with reasoning model 


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested on preview
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| <img width="594" height="503" alt="image" src="https://github.com/user-attachments/assets/6e1c5594-9966-478e-a15d-e207daa067ef" /> | <img width="707" height="399" alt="image" src="https://github.com/user-attachments/assets/2c364314-ca4b-4f21-9123-2af43ee01aa4" />  |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Avoid sending temperature and top_p parameters to GPT-5 series models when reasoning effort is not none, aligning with OpenAI API requirements.