### PR TITLE
 🐛 fix: change the react router data mode to delcarative mode

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/AgentIdSync.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/AgentIdSync.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { useAgentStore } from '@/store/agent';
@@ -7,10 +7,10 @@ import { useChatStore } from '@/store/chat';
 const AgentIdSync = () => {
   const useStoreUpdater = createStoreUpdater(useAgentStore);
   const useChatStoreUpdater = createStoreUpdater(useChatStore);
-  const load = useLoaderData();
+  const params = useParams<{ aid?: string }>();
 
-  useStoreUpdater('activeAgentId', load?.agentId);
-  useChatStoreUpdater('activeAgentId', load?.agentId);
+  useStoreUpdater('activeAgentId', params.aid);
+  useChatStoreUpdater('activeAgentId', params.aid ?? '');
 
   return null;
 };

--- a/src/app/[variants]/(main)/discover/(detail)/assistant/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/assistant/index.tsx
@@ -2,9 +2,8 @@
 
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import type { SlugParams } from '@/app/[variants]/loaders/routeParams';
 import { useQuery } from '@/hooks/useQuery';
 import { useDiscoverStore } from '@/store/discover';
 import { AssistantMarketSource } from '@/types/discover';
@@ -22,8 +21,8 @@ interface AssistantDetailPageProps {
 }
 
 const AssistantDetailPage = memo<AssistantDetailPageProps>(({ mobile }) => {
-  const { slug } = useLoaderData() as SlugParams;
-  const identifier = decodeURIComponent(slug);
+  const params = useParams<{ slug: string }>();
+  const identifier = decodeURIComponent(params.slug ?? '');
   const { version, source } = useQuery() as { source?: AssistantMarketSource; version?: string };
 
   const useAssistantDetail = useDiscoverStore((s) => s.useAssistantDetail);

--- a/src/app/[variants]/(main)/discover/(detail)/mcp/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/mcp/index.tsx
@@ -2,9 +2,8 @@
 
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import type { SlugParams } from '@/app/[variants]/loaders/routeParams';
 import { DetailProvider } from '@/features/MCPPluginDetail/DetailProvider';
 import Header from '@/features/MCPPluginDetail/Header';
 import { useFetchInstalledPlugins } from '@/hooks/useFetchInstalledPlugins';
@@ -21,8 +20,8 @@ interface McpDetailPageProps {
 }
 
 const McpDetailPage = memo<McpDetailPageProps>(({ mobile }) => {
-  const { slug } = useLoaderData() as SlugParams;
-  const identifier = slug;
+  const params = useParams<{ slug: string }>();
+  const identifier = params.slug ?? '';
 
   const { version } = useQuery() as { version?: string };
   const useMcpDetail = useDiscoverStore((s) => s.useFetchMcpDetail);

--- a/src/app/[variants]/(main)/discover/(detail)/model/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/model/index.tsx
@@ -2,9 +2,8 @@
 
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import type { SlugParams } from '@/app/[variants]/loaders/routeParams';
 import { useDiscoverStore } from '@/store/discover';
 
 import NotFound from '../components/NotFound';
@@ -18,8 +17,8 @@ interface ModelDetailPageProps {
 }
 
 const ModelDetailPage = memo<ModelDetailPageProps>(({ mobile }) => {
-  const { slug } = useLoaderData() as SlugParams;
-  const identifier = decodeURIComponent(slug);
+  const params = useParams<{ slug: string }>();
+  const identifier = decodeURIComponent(params.slug ?? '');
 
   const useModelDetail = useDiscoverStore((s) => s.useModelDetail);
   const { data, isLoading } = useModelDetail({ identifier });

--- a/src/app/[variants]/(main)/discover/(detail)/provider/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/provider/index.tsx
@@ -2,9 +2,8 @@
 
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import type { SlugParams } from '@/app/[variants]/loaders/routeParams';
 import { useDiscoverStore } from '@/store/discover';
 
 import NotFound from '../components/NotFound';
@@ -18,8 +17,8 @@ interface ProviderDetailPageProps {
 }
 
 const ProviderDetailPage = memo<ProviderDetailPageProps>(({ mobile }) => {
-  const { slug } = useLoaderData() as SlugParams;
-  const identifier = decodeURIComponent(slug);
+  const params = useParams<{ slug: string }>();
+  const identifier = decodeURIComponent(params.slug ?? '');
 
   const useProviderDetail = useDiscoverStore((s) => s.useProviderDetail);
   const { data, isLoading } = useProviderDetail({ identifier, withReadme: true });

--- a/src/app/[variants]/(main)/discover/(detail)/user/index.tsx
+++ b/src/app/[variants]/(main)/discover/(detail)/user/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { memo, useMemo } from 'react';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import type { SlugParams } from '@/app/[variants]/loaders/routeParams';
 import { useMarketAuth, useMarketUserProfile } from '@/layout/AuthProvider/MarketAuth';
 import { useDiscoverStore } from '@/store/discover';
 
@@ -19,8 +18,8 @@ interface UserDetailPageProps {
 }
 
 const UserDetailPage = memo<UserDetailPageProps>(({ mobile }) => {
-  const { slug } = useLoaderData() as SlugParams;
-  const username = decodeURIComponent(slug);
+  const params = useParams<{ slug: string }>();
+  const username = decodeURIComponent(params.slug ?? '');
 
   const { getCurrentUserInfo, isAuthenticated, openProfileSetup } = useMarketAuth();
 

--- a/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
@@ -1,5 +1,5 @@
 import { useUnmount } from 'ahooks';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -8,11 +8,11 @@ import { useChatStore } from '@/store/chat';
 const GroupIdSync = () => {
   const useAgentGroupStoreUpdater = createStoreUpdater(useAgentGroupStore);
   const useChatStoreUpdater = createStoreUpdater(useChatStore);
-  const load = useLoaderData();
+  const params = useParams<{ gid?: string }>();
 
   // Sync groupId to agentGroupStore and chatStore
-  useAgentGroupStoreUpdater('activeGroupId', load?.groupId);
-  useChatStoreUpdater('activeGroupId', load?.groupId);
+  useAgentGroupStoreUpdater('activeGroupId', params.gid);
+  useChatStoreUpdater('activeGroupId', params.gid);
 
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {

--- a/src/app/[variants]/(main)/settings/index.tsx
+++ b/src/app/[variants]/(main)/settings/index.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { memo } from 'react';
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import { SettingsTabParams } from '@/app/[variants]/loaders/routeParams';
 import { SettingsTabs } from '@/store/global/initialState';
 
 import { LayoutProps } from './_layout/type';
 import SettingsContent from './features/SettingsContent';
 
 const Layout = memo<LayoutProps>(() => {
-  const { tab } = useLoaderData() as SettingsTabParams;
+  const params = useParams<{ tab?: string }>();
 
-  const activeTab = (tab as SettingsTabs) || SettingsTabs.Profile;
+  const activeTab = (params.tab as SettingsTabs) || SettingsTabs.Profile;
 
   return <SettingsContent activeTab={activeTab} mobile={false} />;
 });

--- a/src/app/[variants]/(main)/settings/provider/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/index.tsx
@@ -2,9 +2,8 @@
 
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { Outlet, useLoaderData, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
 
-import { ProviderIdParams } from '@/app/[variants]/loaders/routeParams';
 import { isCustomBranding } from '@/const/version';
 
 import Footer from './(list)/Footer';
@@ -41,14 +40,19 @@ ProviderLayout.displayName = 'ProviderLayout';
 
 // Detail page component that receives providerId from route params
 export const ProviderDetailPage = memo(() => {
-  const { providerId } = useLoaderData() as ProviderIdParams;
+  const params = useParams<{ providerId: string }>();
   const navigate = useNavigate();
 
   const handleProviderSelect = (providerKey: string) => {
     navigate(`/settings/provider/${providerKey}`);
   };
 
-  return <ProviderDetailPageComponent id={providerId} onProviderSelect={handleProviderSelect} />;
+  return (
+    <ProviderDetailPageComponent
+      id={params.providerId ?? ''}
+      onProviderSelect={handleProviderSelect}
+    />
+  );
 });
 
 ProviderDetailPage.displayName = 'ProviderDetailPage';

--- a/src/app/[variants]/(mobile)/router/MobileClientRouter.tsx
+++ b/src/app/[variants]/(mobile)/router/MobileClientRouter.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { RouterProvider } from 'react-router-dom';
+import { BrowserRouter, Routes } from 'react-router-dom';
 
-import { createMobileRouter } from './mobileRouter.config';
+import { renderRoutes } from '@/utils/router';
+
+import { mobileRoutes } from './mobileRouter.config';
 
 const ClientRouter = () => {
-  const router = createMobileRouter();
-  return <RouterProvider router={router} />;
+  return (
+    <BrowserRouter>
+      <Routes>{renderRoutes(mobileRoutes)}</Routes>
+    </BrowserRouter>
+  );
 };
 
 ClientRouter.displayName = 'ClientRouter';

--- a/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
+++ b/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { createBrowserRouter, redirect } from 'react-router-dom';
-
 import MobileHome from '@/app/[variants]/(mobile)/(home)/';
 import MobileHomeLayout from '@/app/[variants]/(mobile)/(home)/_layout';
 import MobileMainLayout from '@/app/[variants]/(mobile)/_layout';
@@ -9,253 +7,238 @@ import MobileChatLayout from '@/app/[variants]/(mobile)/chat/_layout';
 import MobileMeHomeLayout from '@/app/[variants]/(mobile)/me/(home)/layout';
 import MobileMeProfileLayout from '@/app/[variants]/(mobile)/me/profile/layout';
 import MobileMeSettingsLayout from '@/app/[variants]/(mobile)/me/settings/layout';
-import Loading from '@/components/Loading/BrandTextLoading';
-import { ErrorBoundary, dynamicElement } from '@/utils/router';
+import { ErrorBoundary, type RouteConfig, dynamicElement, redirectElement } from '@/utils/router';
 
-import { agentIdLoader, slugLoader } from '../../loaders/routeParams';
 import MobileSettingsLayout from '../settings/_layout';
 
-// Create mobile router configuration
-export const createMobileRouter = () =>
-  createBrowserRouter([
-    {
-      HydrateFallback: () => <Loading debugId="Mobile Router Hydration" />,
-      children: [
-        // Chat routes
-        {
-          children: [
-            {
-              index: true,
-              loader: () => redirect('/', { status: 302 }),
-            },
-            {
-              children: [
-                {
-                  element: dynamicElement(() => import('../chat'), 'Mobile > Chat'),
-                  index: true,
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../chat/settings'),
-                    'Mobile > Chat > Settings',
-                  ),
-                  path: 'settings',
-                },
-              ],
-              element: <MobileChatLayout />,
-              errorElement: <ErrorBoundary resetPath="/agent" />,
-              loader: agentIdLoader,
-              path: ':aid',
-            },
-          ],
-          path: 'agent',
-        },
+// Mobile router configuration (declarative mode)
+export const mobileRoutes: RouteConfig[] = [
+  {
+    children: [
+      // Chat routes
+      {
+        children: [
+          {
+            element: redirectElement('/'),
+            index: true,
+          },
+          {
+            children: [
+              {
+                element: dynamicElement(() => import('../chat'), 'Mobile > Chat'),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../chat/settings'),
+                  'Mobile > Chat > Settings',
+                ),
+                path: 'settings',
+              },
+            ],
+            element: <MobileChatLayout />,
+            errorElement: <ErrorBoundary resetPath="/agent" />,
+            path: ':aid',
+          },
+        ],
+        path: 'agent',
+      },
 
-        // Discover routes with nested structure
-        {
-          children: [
-            // List routes (with ListLayout)
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('../../(main)/discover/(list)/(home)'),
-                    'Mobile > Discover > List > Home',
-                  ),
-                  index: true,
-                },
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../../(main)/discover/(list)/assistant'),
-                        'Mobile > Discover > List > Assistant',
-                      ),
-                      path: 'assistant',
-                    },
-                  ],
-                },
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../../(main)/discover/(list)/model'),
-                        'Mobile > Discover > List > Model',
-                      ),
-                      path: 'model',
-                    },
-                  ],
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../../(main)/discover/(list)/provider'),
-                    'Mobile > Discover > List > Provider',
-                  ),
-                  path: 'provider',
-                },
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../../(main)/discover/(list)/mcp'),
-                        'Mobile > Discover > List > MCP',
-                      ),
-                      path: 'mcp',
-                    },
-                  ],
-                },
-              ],
-              element: dynamicElement(
-                () => import('../disocver/(list)/_layout'),
-                'Mobile > Discover > List > Layout',
-              ),
-            },
-            // Detail routes (with DetailLayout)
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () =>
-                      import('../../(main)/discover/(detail)/assistant').then(
-                        (m) => m.MobileDiscoverAssistantDetailPage,
-                      ),
-                    'Mobile > Discover > Detail > Assistant',
-                  ),
-                  loader: slugLoader,
-                  path: 'assistant/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () =>
-                      import('../../(main)/discover/(detail)/model').then((m) => m.MobileModelPage),
-                    'Mobile > Discover > Detail > Model',
-                  ),
-                  loader: slugLoader,
-                  path: 'model/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () =>
-                      import('../../(main)/discover/(detail)/provider').then(
-                        (m) => m.MobileProviderPage,
-                      ),
-                    'Mobile > Discover > Detail > Provider',
-                  ),
-                  loader: slugLoader,
-                  path: 'provider/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../../(main)/discover/(detail)/mcp').then((m) => m.MobileMcpPage),
-                    'Mobile > Discover > Detail > MCP',
-                  ),
-                  loader: slugLoader,
-                  path: 'mcp/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () =>
-                      import('../../(main)/discover/(detail)/user').then(
-                        (m) => m.MobileUserDetailPage,
-                      ),
-                    'Mobile > Discover > Detail > User',
-                  ),
-                  loader: slugLoader,
-                  path: 'user/:slug',
-                },
-              ],
-              element: dynamicElement(
-                () => import('../disocver/(detail)/_layout'),
-                'Mobile > Discover > Detail > Layout',
-              ),
-            },
-          ],
-          element: dynamicElement(
-            () => import('../disocver/_layout'),
-            'Mobile > Discover > Layout',
-          ),
-          errorElement: <ErrorBoundary resetPath="/discover" />,
-          path: 'discover',
-        },
+      // Discover routes with nested structure
+      {
+        children: [
+          // List routes (with ListLayout)
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('../../(main)/discover/(list)/(home)'),
+                  'Mobile > Discover > List > Home',
+                ),
+                index: true,
+              },
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../../(main)/discover/(list)/assistant'),
+                      'Mobile > Discover > List > Assistant',
+                    ),
+                    path: 'assistant',
+                  },
+                ],
+              },
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../../(main)/discover/(list)/model'),
+                      'Mobile > Discover > List > Model',
+                    ),
+                    path: 'model',
+                  },
+                ],
+              },
+              {
+                element: dynamicElement(
+                  () => import('../../(main)/discover/(list)/provider'),
+                  'Mobile > Discover > List > Provider',
+                ),
+                path: 'provider',
+              },
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../../(main)/discover/(list)/mcp'),
+                      'Mobile > Discover > List > MCP',
+                    ),
+                    path: 'mcp',
+                  },
+                ],
+              },
+            ],
+            element: dynamicElement(
+              () => import('../disocver/(list)/_layout'),
+              'Mobile > Discover > List > Layout',
+            ),
+          },
+          // Detail routes (with DetailLayout)
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () =>
+                    import('../../(main)/discover/(detail)/assistant').then(
+                      (m) => m.MobileDiscoverAssistantDetailPage,
+                    ),
+                  'Mobile > Discover > Detail > Assistant',
+                ),
+                path: 'assistant/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () =>
+                    import('../../(main)/discover/(detail)/model').then((m) => m.MobileModelPage),
+                  'Mobile > Discover > Detail > Model',
+                ),
+                path: 'model/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () =>
+                    import('../../(main)/discover/(detail)/provider').then(
+                      (m) => m.MobileProviderPage,
+                    ),
+                  'Mobile > Discover > Detail > Provider',
+                ),
+                path: 'provider/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../../(main)/discover/(detail)/mcp').then((m) => m.MobileMcpPage),
+                  'Mobile > Discover > Detail > MCP',
+                ),
+                path: 'mcp/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () =>
+                    import('../../(main)/discover/(detail)/user').then(
+                      (m) => m.MobileUserDetailPage,
+                    ),
+                  'Mobile > Discover > Detail > User',
+                ),
+                path: 'user/:slug',
+              },
+            ],
+            element: dynamicElement(
+              () => import('../disocver/(detail)/_layout'),
+              'Mobile > Discover > Detail > Layout',
+            ),
+          },
+        ],
+        element: dynamicElement(() => import('../disocver/_layout'), 'Mobile > Discover > Layout'),
+        errorElement: <ErrorBoundary resetPath="/discover" />,
+        path: 'discover',
+      },
 
-        // Settings routes
-        {
-          children: [
-            {
-              element: dynamicElement(() => import('../settings'), 'Mobile > Settings'),
-              index: true,
-            },
-          ],
-          element: <MobileSettingsLayout />,
-          errorElement: <ErrorBoundary resetPath="/settings" />,
-          path: 'settings',
-        },
+      // Settings routes
+      {
+        children: [
+          {
+            element: dynamicElement(() => import('../settings'), 'Mobile > Settings'),
+            index: true,
+          },
+        ],
+        element: <MobileSettingsLayout />,
+        errorElement: <ErrorBoundary resetPath="/settings" />,
+        path: 'settings',
+      },
 
-        // Me routes (mobile personal center)
-        {
-          children: [
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('@/app/[variants]/(mobile)/me/(home)'),
-                    'Mobile > Me > Home',
-                  ),
-                  index: true,
-                },
-              ],
-              element: <MobileMeHomeLayout />,
-            },
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('@/app/[variants]/(mobile)/me/profile'),
-                    'Mobile > Me > Profile',
-                  ),
-                  path: 'profile',
-                },
-              ],
-              element: <MobileMeProfileLayout />,
-            },
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('@/app/[variants]/(mobile)/me/settings'),
-                    'Mobile > Me > Settings',
-                  ),
-                  path: 'settings',
-                },
-              ],
-              element: <MobileMeSettingsLayout />,
-            },
-          ],
-          errorElement: <ErrorBoundary resetPath="/me" />,
-          path: 'me',
-        },
+      // Me routes (mobile personal center)
+      {
+        children: [
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('@/app/[variants]/(mobile)/me/(home)'),
+                  'Mobile > Me > Home',
+                ),
+                index: true,
+              },
+            ],
+            element: <MobileMeHomeLayout />,
+          },
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('@/app/[variants]/(mobile)/me/profile'),
+                  'Mobile > Me > Profile',
+                ),
+                path: 'profile',
+              },
+            ],
+            element: <MobileMeProfileLayout />,
+          },
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('@/app/[variants]/(mobile)/me/settings'),
+                  'Mobile > Me > Settings',
+                ),
+                path: 'settings',
+              },
+            ],
+            element: <MobileMeSettingsLayout />,
+          },
+        ],
+        errorElement: <ErrorBoundary resetPath="/me" />,
+        path: 'me',
+      },
 
-        // Default route - home page
-        {
-          children: [
-            {
-              element: <MobileHome />,
-              index: true,
-            },
-          ],
-          element: <MobileHomeLayout />,
-        },
+      // Default route - home page
+      {
+        children: [
+          {
+            element: <MobileHome />,
+            index: true,
+          },
+        ],
+        element: <MobileHomeLayout />,
+      },
 
-        // Catch-all route
-        {
-          loader: () => redirect('/', { status: 302 }),
-          // TODO: NEED use NotFoundPage
-          // element: <NotFoundPage />,
-          path: '*',
-        },
-      ],
-      element: <MobileMainLayout />,
-      errorElement: <ErrorBoundary resetPath="/" />,
-      path: '/',
-    },
-  ]);
+      // Catch-all route
+      {
+        element: redirectElement('/'),
+        path: '*',
+      },
+    ],
+    element: <MobileMainLayout />,
+    errorElement: <ErrorBoundary resetPath="/" />,
+    path: '/',
+  },
+];

--- a/src/app/[variants]/router/DesktopClientRouter.tsx
+++ b/src/app/[variants]/router/DesktopClientRouter.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { RouterProvider } from 'react-router-dom';
+import { BrowserRouter, Routes } from 'react-router-dom';
 
-import { createDesktopRouter } from './desktopRouter.config';
+import { renderRoutes } from '@/utils/router';
+
+import { desktopRoutes } from './desktopRouter.config';
 
 const ClientRouter = () => {
-  const router = createDesktopRouter();
-  return <RouterProvider router={router} />;
+  return (
+    <BrowserRouter>
+      <Routes>{renderRoutes(desktopRoutes)}</Routes>
+    </BrowserRouter>
+  );
 };
 
 ClientRouter.displayName = 'ClientRouter';

--- a/src/app/[variants]/router/desktopRouter.config.tsx
+++ b/src/app/[variants]/router/desktopRouter.config.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { createBrowserRouter, redirect } from 'react-router-dom';
-
-import Loading from '@/components/Loading/BrandTextLoading';
-import { ErrorBoundary, dynamicElement } from '@/utils/router';
+import { ErrorBoundary, type RouteConfig, dynamicElement, redirectElement } from '@/utils/router';
 
 import DesktopMainLayout from '../(main)/_layout';
 import DesktopChatLayout from '../(main)/chat/_layout';
@@ -13,414 +10,382 @@ import DesktopHomeLayout from '../(main)/home/_layout';
 import DesktopImageLayout from '../(main)/image/_layout';
 import DesktopMemoryLayout from '../(main)/memory/_layout';
 import DesktopPageLayout from '../(main)/page/_layout';
-import {
-  agentIdLoader,
-  groupIdLoader,
-  idLoader,
-  providerIdLoader,
-  settingsTabLoader,
-  slugLoader,
-} from '../loaders/routeParams';
 
-// Create desktop router configuration
-export const createDesktopRouter = () => {
-  return createBrowserRouter([
-    {
-      HydrateFallback: () => <Loading debugId="Desktop Router Hydration" />,
-      children: [
-        // Chat routes (agent)
-        {
-          children: [
-            {
-              index: true,
-              loader: () => redirect('/', { status: 302 }),
-            },
-            {
-              children: [
-                {
-                  element: dynamicElement(() => import('../(main)/chat'), 'Desktop > Chat'),
-                  index: true,
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/chat/profile'),
-                    'Desktop > Chat > Profile',
-                  ),
-                  path: 'profile',
-                },
-              ],
-              element: <DesktopChatLayout />,
-              errorElement: <ErrorBoundary resetPath="/agent" />,
-              loader: agentIdLoader,
-              path: ':aid',
-            },
-          ],
-          path: 'agent',
-        },
+// Desktop router configuration (declarative mode)
+export const desktopRoutes: RouteConfig[] = [
+  {
+    children: [
+      // Chat routes (agent)
+      {
+        children: [
+          {
+            element: redirectElement('/'),
+            index: true,
+          },
+          {
+            children: [
+              {
+                element: dynamicElement(() => import('../(main)/chat'), 'Desktop > Chat'),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/chat/profile'),
+                  'Desktop > Chat > Profile',
+                ),
+                path: 'profile',
+              },
+            ],
+            element: <DesktopChatLayout />,
+            errorElement: <ErrorBoundary resetPath="/agent" />,
+            path: ':aid',
+          },
+        ],
+        path: 'agent',
+      },
 
-        // Group chat routes
-        {
-          children: [
-            {
-              index: true,
-              loader: () => redirect('/', { status: 302 }),
-            },
-            {
-              children: [
-                {
-                  element: dynamicElement(() => import('../(main)/group'), 'Desktop > Agent Group'),
-                  index: true,
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/group/profile'),
-                    'Desktop > Agent Group > Profile',
-                  ),
-                  path: 'profile',
-                },
-              ],
-              element: <DesktopGroupLayout />,
-              errorElement: <ErrorBoundary resetPath="/group" />,
-              loader: groupIdLoader,
-              path: ':gid',
-            },
-          ],
-          path: 'group',
-        },
+      // Group chat routes
+      {
+        children: [
+          {
+            element: redirectElement('/'),
+            index: true,
+          },
+          {
+            children: [
+              {
+                element: dynamicElement(() => import('../(main)/group'), 'Desktop > Agent Group'),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/group/profile'),
+                  'Desktop > Agent Group > Profile',
+                ),
+                path: 'profile',
+              },
+            ],
+            element: <DesktopGroupLayout />,
+            errorElement: <ErrorBoundary resetPath="/group" />,
+            path: ':gid',
+          },
+        ],
+        path: 'group',
+      },
 
-        // Discover routes with nested structure
-        {
-          children: [
-            // List routes (with ListLayout)
-            {
-              children: [
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../(main)/discover/(list)/assistant'),
-                        'Desktop > Discover > List > Assistant',
-                      ),
-                      index: true,
-                    },
-                  ],
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(list)/assistant/_layout'),
-                    'Desktop > Discover > List > Assistant > Layout',
-                  ),
-                  path: 'assistant',
-                },
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../(main)/discover/(list)/model'),
-                        'Desktop > Discover > List > Model',
-                      ),
-                      index: true,
-                    },
-                  ],
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(list)/model/_layout'),
-                    'Desktop > Discover > List > Model > Layout',
-                  ),
-                  path: 'model',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(list)/provider'),
-                    'Desktop > Discover > List > Provider',
-                  ),
-                  path: 'provider',
-                },
-                {
-                  children: [
-                    {
-                      element: dynamicElement(
-                        () => import('../(main)/discover/(list)/mcp'),
-                        'Desktop > Discover > List > MCP',
-                      ),
-                      index: true,
-                    },
-                  ],
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(list)/mcp/_layout'),
-                    'Desktop > Discover > List > MCP > Layout',
-                  ),
-                  path: 'mcp',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(list)/(home)'),
-                    'Desktop > Discover > List > Home',
-                  ),
-                  index: true,
-                },
-              ],
-              element: dynamicElement(
-                () => import('../(main)/discover/(list)/_layout'),
-                'Desktop > Discover > List > Layout',
-              ),
-            },
-            // Detail routes (with DetailLayout)
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(detail)/assistant'),
-                    'Desktop > Discover > Detail > Assistant',
-                  ),
-                  loader: slugLoader,
-                  path: 'assistant/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(detail)/model'),
-                    'Desktop > Discover > Detail > Model',
-                  ),
-                  loader: slugLoader,
-                  path: 'model/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(detail)/provider'),
-                    'Desktop > Discover > Detail > Provider',
-                  ),
-                  loader: slugLoader,
-                  path: 'provider/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(detail)/mcp'),
-                    'Desktop > Discover > Detail > MCP',
-                  ),
-                  loader: slugLoader,
-                  path: 'mcp/:slug',
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/discover/(detail)/user'),
-                    'Desktop > Discover > Detail > User',
-                  ),
-                  loader: slugLoader,
-                  path: 'user/:slug',
-                },
-              ],
-              element: dynamicElement(
-                () => import('../(main)/discover/(detail)/_layout'),
-                'Desktop > Discover > Detail > Layout',
-              ),
-            },
-          ],
-          element: dynamicElement(
-            () => import('../(main)/discover/_layout'),
-            'Desktop > Discover > Layout',
-          ),
-          errorElement: <ErrorBoundary resetPath="/discover" />,
-          path: 'discover',
-        },
+      // Discover routes with nested structure
+      {
+        children: [
+          // List routes (with ListLayout)
+          {
+            children: [
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../(main)/discover/(list)/assistant'),
+                      'Desktop > Discover > List > Assistant',
+                    ),
+                    index: true,
+                  },
+                ],
+                element: dynamicElement(
+                  () => import('../(main)/discover/(list)/assistant/_layout'),
+                  'Desktop > Discover > List > Assistant > Layout',
+                ),
+                path: 'assistant',
+              },
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../(main)/discover/(list)/model'),
+                      'Desktop > Discover > List > Model',
+                    ),
+                    index: true,
+                  },
+                ],
+                element: dynamicElement(
+                  () => import('../(main)/discover/(list)/model/_layout'),
+                  'Desktop > Discover > List > Model > Layout',
+                ),
+                path: 'model',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(list)/provider'),
+                  'Desktop > Discover > List > Provider',
+                ),
+                path: 'provider',
+              },
+              {
+                children: [
+                  {
+                    element: dynamicElement(
+                      () => import('../(main)/discover/(list)/mcp'),
+                      'Desktop > Discover > List > MCP',
+                    ),
+                    index: true,
+                  },
+                ],
+                element: dynamicElement(
+                  () => import('../(main)/discover/(list)/mcp/_layout'),
+                  'Desktop > Discover > List > MCP > Layout',
+                ),
+                path: 'mcp',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(list)/(home)'),
+                  'Desktop > Discover > List > Home',
+                ),
+                index: true,
+              },
+            ],
+            element: dynamicElement(
+              () => import('../(main)/discover/(list)/_layout'),
+              'Desktop > Discover > List > Layout',
+            ),
+          },
+          // Detail routes (with DetailLayout)
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(detail)/assistant'),
+                  'Desktop > Discover > Detail > Assistant',
+                ),
+                path: 'assistant/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(detail)/model'),
+                  'Desktop > Discover > Detail > Model',
+                ),
+                path: 'model/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(detail)/provider'),
+                  'Desktop > Discover > Detail > Provider',
+                ),
+                path: 'provider/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(detail)/mcp'),
+                  'Desktop > Discover > Detail > MCP',
+                ),
+                path: 'mcp/:slug',
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/discover/(detail)/user'),
+                  'Desktop > Discover > Detail > User',
+                ),
+                path: 'user/:slug',
+              },
+            ],
+            element: dynamicElement(
+              () => import('../(main)/discover/(detail)/_layout'),
+              'Desktop > Discover > Detail > Layout',
+            ),
+          },
+        ],
+        element: dynamicElement(
+          () => import('../(main)/discover/_layout'),
+          'Desktop > Discover > Layout',
+        ),
+        errorElement: <ErrorBoundary resetPath="/discover" />,
+        path: 'discover',
+      },
 
-        // Resource routes
-        {
-          children: [
-            // Home routes (resource list)
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/resource/(home)'),
-                    'Desktop > Resource > Home',
-                  ),
-                  index: true,
-                },
-              ],
-              element: dynamicElement(
-                () => import('../(main)/resource/(home)/_layout'),
-                'Desktop > Resource > Home > Layout',
-              ),
-            },
-            // Library routes (knowledge base detail)
-            {
-              children: [
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/resource/library'),
-                    'Desktop > Resource > Library',
-                  ),
-                  index: true,
-                  loader: idLoader,
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/resource/library/[slug]'),
-                    'Desktop > Resource > Library > Slug',
-                  ),
-                  loader: idLoader,
-                  path: ':slug',
-                },
-              ],
+      // Resource routes
+      {
+        children: [
+          // Home routes (resource list)
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('../(main)/resource/(home)'),
+                  'Desktop > Resource > Home',
+                ),
+                index: true,
+              },
+            ],
+            element: dynamicElement(
+              () => import('../(main)/resource/(home)/_layout'),
+              'Desktop > Resource > Home > Layout',
+            ),
+          },
+          // Library routes (knowledge base detail)
+          {
+            children: [
+              {
+                element: dynamicElement(
+                  () => import('../(main)/resource/library'),
+                  'Desktop > Resource > Library',
+                ),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/resource/library/[slug]'),
+                  'Desktop > Resource > Library > Slug',
+                ),
+                path: ':slug',
+              },
+            ],
+            element: dynamicElement(
+              () => import('../(main)/resource/library/_layout'),
+              'Desktop > Resource > Library > Layout',
+            ),
+            path: 'library/:id',
+          },
+        ],
+        element: dynamicElement(
+          () => import('../(main)/resource/_layout'),
+          'Desktop > Resource > Layout',
+        ),
+        errorElement: <ErrorBoundary resetPath="/resource" />,
+        path: 'resource',
+      },
 
-              element: dynamicElement(
-                () => import('../(main)/resource/library/_layout'),
-                'Desktop > Resource > Library > Layout',
-              ),
-              path: 'library/:id',
-            },
-          ],
-          element: dynamicElement(
-            () => import('../(main)/resource/_layout'),
-            'Desktop > Resource > Layout',
-          ),
-          errorElement: <ErrorBoundary resetPath="/resource" />,
-          path: 'resource',
-        },
+      // Settings routes
+      {
+        children: [
+          {
+            element: redirectElement('/settings/profile'),
+            index: true,
+          },
+          // Provider routes with nested structure
+          {
+            children: [
+              {
+                element: redirectElement('/settings/provider/all'),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../(main)/settings/provider').then((m) => m.ProviderDetailPage),
+                  'Desktop > Settings > Provider > Detail',
+                ),
+                path: ':providerId',
+              },
+            ],
+            element: dynamicElement(
+              () => import('../(main)/settings/provider').then((m) => m.ProviderLayout),
+              'Desktop > Settings > Provider > Layout',
+            ),
+            path: 'provider',
+          },
+          // Other settings tabs
+          {
+            element: dynamicElement(() => import('../(main)/settings'), 'Desktop > Settings > Tab'),
+            path: ':tab',
+          },
+        ],
+        element: dynamicElement(
+          () => import('../(main)/settings/_layout'),
+          'Desktop > Settings > Layout',
+        ),
+        errorElement: <ErrorBoundary resetPath="/settings" />,
+        path: 'settings',
+      },
 
-        // Settings routes
-        {
-          children: [
-            {
-              index: true,
-              loader: () => redirect('/settings/profile', { status: 302 }),
-            },
-            // Provider routes with nested structure
-            {
-              children: [
-                {
-                  index: true,
-                  loader: () => redirect('/settings/provider/all', { status: 302 }),
-                },
-                {
-                  element: dynamicElement(
-                    () => import('../(main)/settings/provider').then((m) => m.ProviderDetailPage),
-                    'Desktop > Settings > Provider > Detail',
-                  ),
-                  loader: providerIdLoader,
-                  path: ':providerId',
-                },
-              ],
-              element: dynamicElement(
-                () => import('../(main)/settings/provider').then((m) => m.ProviderLayout),
-                'Desktop > Settings > Provider > Layout',
-              ),
-              path: 'provider',
-            },
-            // Other settings tabs
-            {
-              element: dynamicElement(
-                () => import('../(main)/settings'),
-                'Desktop > Settings > Tab',
-              ),
-              loader: settingsTabLoader,
-              path: ':tab',
-            },
-          ],
-          element: dynamicElement(
-            () => import('../(main)/settings/_layout'),
-            'Desktop > Settings > Layout',
-          ),
-          errorElement: <ErrorBoundary resetPath="/settings" />,
-          path: 'settings',
-        },
+      // Memory routes
+      {
+        children: [
+          {
+            element: dynamicElement(
+              () => import('../(main)/memory/(home)'),
+              'Desktop > Memory > Home',
+            ),
+            index: true,
+          },
+          {
+            element: dynamicElement(
+              () => import('../(main)/memory/identities'),
+              'Desktop > Memory > Identities',
+            ),
+            path: 'identities',
+          },
+          {
+            element: dynamicElement(
+              () => import('../(main)/memory/contexts'),
+              'Desktop > Memory > Contexts',
+            ),
+            path: 'contexts',
+          },
+          {
+            element: dynamicElement(
+              () => import('../(main)/memory/preferences'),
+              'Desktop > Memory > Preferences',
+            ),
+            path: 'preferences',
+          },
+          {
+            element: dynamicElement(
+              () => import('../(main)/memory/experiences'),
+              'Desktop > Memory > Experiences',
+            ),
+            path: 'experiences',
+          },
+        ],
+        element: <DesktopMemoryLayout />,
+        errorElement: <ErrorBoundary resetPath="/memory" />,
+        path: 'memory',
+      },
 
-        // Memory routes
-        {
-          children: [
-            {
-              element: dynamicElement(
-                () => import('../(main)/memory/(home)'),
-                'Desktop > Memory > Home',
-              ),
-              index: true,
-            },
-            {
-              element: dynamicElement(
-                () => import('../(main)/memory/identities'),
-                'Desktop > Memory > Identities',
-              ),
-              path: 'identities',
-            },
-            {
-              element: dynamicElement(
-                () => import('../(main)/memory/contexts'),
-                'Desktop > Memory > Contexts',
-              ),
-              path: 'contexts',
-            },
-            {
-              element: dynamicElement(
-                () => import('../(main)/memory/preferences'),
-                'Desktop > Memory > Preferences',
-              ),
-              path: 'preferences',
-            },
-            {
-              element: dynamicElement(
-                () => import('../(main)/memory/experiences'),
-                'Desktop > Memory > Experiences',
-              ),
-              path: 'experiences',
-            },
-          ],
-          element: <DesktopMemoryLayout />,
-          errorElement: <ErrorBoundary resetPath="/memory" />,
-          path: 'memory',
-        },
+      // Image routes
+      {
+        children: [
+          {
+            element: dynamicElement(() => import('../(main)/image'), 'Desktop > Image'),
+            index: true,
+          },
+        ],
+        element: <DesktopImageLayout />,
+        errorElement: <ErrorBoundary resetPath="/image" />,
+        path: 'image',
+      },
 
-        // Image routes
-        {
-          children: [
-            {
-              element: dynamicElement(() => import('../(main)/image'), 'Desktop > Image'),
-              index: true,
-            },
-          ],
-          element: <DesktopImageLayout />,
-          errorElement: <ErrorBoundary resetPath="/image" />,
-          path: 'image',
-        },
+      // Pages routes
+      {
+        children: [
+          {
+            element: dynamicElement(() => import('../(main)/page'), 'Desktop > Page'),
+            index: true,
+          },
+          {
+            element: dynamicElement(() => import('../(main)/page/[id]'), 'Desktop > Page > Detail'),
+            path: ':id',
+          },
+        ],
+        element: <DesktopPageLayout />,
+        errorElement: <ErrorBoundary resetPath="/page" />,
+        path: 'page',
+      },
 
-        // Pages routes
-        {
-          children: [
-            {
-              element: dynamicElement(() => import('../(main)/page'), 'Desktop > Page'),
-              index: true,
-            },
-            {
-              element: dynamicElement(
-                () => import('../(main)/page/[id]'),
-                'Desktop > Page > Detail',
-              ),
-              loader: idLoader,
-              path: ':id',
-            },
-          ],
-          element: <DesktopPageLayout />,
-          errorElement: <ErrorBoundary resetPath="/page" />,
-          path: 'page',
-        },
-
-        // Default route - home page
-        {
-          children: [
-            {
-              element: <DesktopHome />,
-              index: true,
-            },
-          ],
-          element: <DesktopHomeLayout />,
-        },
-        // Catch-all route
-        {
-          loader: () => redirect('/', { status: 302 }),
-          // TODO: Need update to NotFoundPage
-          // element: <NotFoundPage />,
-          path: '*',
-        },
-      ],
-      element: <DesktopMainLayout />,
-      errorElement: <ErrorBoundary resetPath="/" />,
-      path: '/',
-    },
-  ]);
-};
+      // Default route - home page
+      {
+        children: [
+          {
+            element: <DesktopHome />,
+            index: true,
+          },
+        ],
+        element: <DesktopHomeLayout />,
+      },
+      // Catch-all route
+      {
+        element: redirectElement('/'),
+        path: '*',
+      },
+    ],
+    element: <DesktopMainLayout />,
+    errorElement: <ErrorBoundary resetPath="/" />,
+    path: '/',
+  },
+];

--- a/src/hooks/useInitAgentConfig.ts
+++ b/src/hooks/useInitAgentConfig.ts
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { useAgentStore } from '@/store/agent';
 import { useUserStore } from '@/store/user';
@@ -16,9 +16,9 @@ export const useInitAgentConfig = () => {
 
   const isLogin = useUserStore(authSelectors.isLogin);
 
-  const load = useLoaderData();
+  const params = useParams<{ aid?: string }>();
 
-  const data = useFetchAgentConfig(isLogin, activeAgentId ?? load?.agentId);
+  const data = useFetchAgentConfig(isLogin, activeAgentId ?? params.aid ?? '');
 
   return { ...data, isLoading: data.isLoading && isLogin };
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Switch desktop routing from data router loaders to declarative BrowserRouter/Routes configuration while preserving existing navigation structure.

Bug Fixes:
- Replace data-router-based desktop navigation with declarative routing to resolve issues caused by loader-based route params and redirects.

Enhancements:
- Introduce a reusable RouteConfig type and renderRoutes helper to define routes in createBrowserRouter style while rendering them declaratively.
- Refactor settings, chat, group, discover detail, and agent config screens to read route parameters via useParams instead of loader-based params.