### PR TITLE
:lipstick: style: add `xhigh` to gpt5.2 reasoning effort options

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -24,7 +24,7 @@ const aihubmixModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-12-11',
     settings: {
-      extendParams: ['gpt5_1ReasoningEffort', 'textVerbosity'],
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -41,7 +41,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-12-11',
     settings: {
-      extendParams: ['gpt5_1ReasoningEffort', 'textVerbosity'],
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/zenmux.ts
+++ b/packages/model-bank/src/aiModels/zenmux.ts
@@ -31,7 +31,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-12-11',
     settings: {
-      extendParams: ['gpt5_1ReasoningEffort', 'textVerbosity'],
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -239,6 +239,7 @@ export type ExtendParamsType =
   | 'reasoningEffort'
   | 'gpt5ReasoningEffort'
   | 'gpt5_1ReasoningEffort'
+  | 'gpt5_2ReasoningEffort'
   | 'textVerbosity'
   | 'thinking'
   | 'thinkingBudget'

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -33,6 +33,7 @@ export interface LobeAgentChatConfig {
   reasoningEffort?: 'low' | 'medium' | 'high';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   gpt5_1ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   /**
    * Output text verbosity control
    */
@@ -87,6 +88,7 @@ export const AgentChatConfigSchema = z.object({
   enableStreaming: z.boolean().optional(),
   gpt5ReasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
   gpt5_1ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
+  gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
   historyCount: z.number().optional(),
   imageAspectRatio: z.string().optional(),
   imageResolution: z.enum(['1K', '2K', '4K']).optional(),

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -13,6 +13,7 @@ import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import ContextCachingSwitch from './ContextCachingSwitch';
 import GPT5ReasoningEffortSlider from './GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
+import GPT52ReasoningEffortSlider from './GPT52ReasoningEffortSlider';
 import ImageAspectRatioSelect from './ImageAspectRatioSelect';
 import ImageResolutionSlider from './ImageResolutionSlider';
 import ReasoningEffortSlider from './ReasoningEffortSlider';
@@ -130,6 +131,17 @@ const ControlsForm = memo(() => {
       layout: 'horizontal',
       minWidth: undefined,
       name: 'gpt5_1ReasoningEffort',
+      style: {
+        paddingBottom: 0,
+      },
+    },
+    {
+      children: <GPT52ReasoningEffortSlider />,
+      desc: 'reasoning_effort',
+      label: t('extendParams.reasoningEffort.title'),
+      layout: 'horizontal',
+      minWidth: undefined,
+      name: 'gpt5_2ReasoningEffort',
       style: {
         paddingBottom: 0,
       },

--- a/src/features/ChatInput/ActionBar/Model/GPT52ReasoningEffortSlider.tsx
+++ b/src/features/ChatInput/ActionBar/Model/GPT52ReasoningEffortSlider.tsx
@@ -1,0 +1,59 @@
+import { Slider } from 'antd';
+import { memo, useCallback } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import { useAgentStore } from '@/store/agent';
+import { agentChatConfigSelectors } from '@/store/agent/selectors';
+
+const GPT52ReasoningEffortSlider = memo(() => {
+  const [config, updateAgentChatConfig] = useAgentStore((s) => [
+    agentChatConfigSelectors.currentChatConfig(s),
+    s.updateAgentChatConfig,
+  ]);
+
+  const gpt5_2ReasoningEffort = config.gpt5_2ReasoningEffort || 'none'; // Default to 'none' if not set
+
+  const marks = {
+    0: 'none',
+    1: 'low',
+    2: 'medium',
+    3: 'high',
+    4: 'xhigh',
+  };
+
+  const effortValues = ['none', 'low', 'medium', 'high', 'xhigh'];
+  const indexValue = effortValues.indexOf(gpt5_2ReasoningEffort);
+  const currentValue = indexValue === -1 ? 0 : indexValue;
+
+  const updateGPT52ReasoningEffort = useCallback(
+    (value: number) => {
+      const effort = effortValues[value] as 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+      updateAgentChatConfig({ gpt5_2ReasoningEffort: effort });
+    },
+    [updateAgentChatConfig],
+  );
+
+  return (
+    <Flexbox
+      align={'center'}
+      gap={12}
+      horizontal
+      paddingInline={'0 20px'}
+      style={{ minWidth: 200, width: '100%' }}
+    >
+      <Flexbox flex={1}>
+        <Slider
+          marks={marks}
+          max={4}
+          min={0}
+          onChange={updateGPT52ReasoningEffort}
+          step={1}
+          tooltip={{ open: false }}
+          value={currentValue}
+        />
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+export default GPT52ReasoningEffortSlider;

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -181,6 +181,13 @@ class ChatService {
         extendParams.reasoning_effort = chatConfig.gpt5_1ReasoningEffort;
       }
 
+      if (
+        modelExtendParams!.includes('gpt5_2ReasoningEffort') &&
+        chatConfig.gpt5_2ReasoningEffort
+      ) {
+        extendParams.reasoning_effort = chatConfig.gpt5_2ReasoningEffort;
+      }
+
       if (modelExtendParams!.includes('textVerbosity') && chatConfig.textVerbosity) {
         extendParams.verbosity = chatConfig.textVerbosity;
       }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

- #10606 与该 PR 类似，为模型增加了 reasoning effort 选项

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

在 [gpt-5.2的文档](https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility) 中提供了从 5.1 -> 5.2 的新增参数，其中 5.2 在 reasoning effort 中新增了 `xhigh` 选项，实测 intensity 与 5.1 中的 `high` 类似。 但由于 5.1 不支持 `xhigh` ，因此重新实现了 UI 选项。

#### 🔀 Description of Change

- `packages/model-bank/src/aiModels/*.ts`: 使 `gpt-5.2` 重新继承 5.2 的 reasoning effort options
- `src/features/ChatInput/ActionBar/Model/*.tsx`:  添加 UI 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| <img width="372" height="179" alt="image" src="https://github.com/user-attachments/assets/0dcf4247-526e-43c5-ab33-079027a0b696" /> | <img width="370" height="158" alt="image" src="https://github.com/user-attachments/assets/93ad6322-ec84-47e5-9b22-a8280a16631b" />  |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for configuring GPT‑5.2-specific reasoning effort in the chat UI and request pipeline.

New Features:
- Expose a GPT‑5.2 reasoning effort control in the chat model settings UI, including the new `xhigh` option.

Enhancements:
- Wire GPT‑5.2 reasoning effort through chat configuration, model extend params, and request construction so it is sent as `reasoning_effort` for compatible models.