### PR TITLE
✨ feat: add mcp tools auth aleart

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -446,6 +446,13 @@
       "toolRejected": "This tool invocation was actively rejected"
     }
   },
+  "toolAuth": {
+    "authorize": "Authorize",
+    "authorizing": "Authorizing...",
+    "hint": "Without authorization, these tools may not work properly, which could cause the assistant to have limited functionality or errors.",
+    "signIn": "Sign In",
+    "title": "This assistant uses tools that require authorization"
+  },
   "topic": {
     "checkOpenNewTopic": "Enable new topic?",
     "checkSaveCurrentMessages": "Do you want to save the current conversation as a topic?",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -446,6 +446,13 @@
       "toolRejected": "本次工具调用被主动拒绝"
     }
   },
+  "toolAuth": {
+    "authorize": "授权",
+    "authorizing": "授权中...",
+    "hint": "如不授权或配置，这些工具将无法正常使用，可能导致助手功能缺失或报错。",
+    "signIn": "登录",
+    "title": "该助手使用了以下需要授权的工具"
+  },
   "topic": {
     "checkOpenNewTopic": "是否开启新话题?",
     "checkSaveCurrentMessages": "是否保存当前会话为话题?",

--- a/src/app/[variants]/(main)/chat/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { KLAVIS_SERVER_TYPES, KlavisServerType } from '@lobechat/const';
+import { Alert, Button, Icon, Image } from '@lobehub/ui';
+import { Typography } from 'antd';
+import { useTheme } from 'antd-style';
+import isEqual from 'fast-deep-equal';
+import { Loader2, LogIn, SquareArrowOutUpRight, TriangleAlert } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import { useToolStore } from '@/store/tool';
+import {
+  KlavisServer,
+  KlavisServerStatus,
+  klavisStoreSelectors,
+} from '@/store/tool/slices/klavisStore';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
+// Tools that require Market authentication
+const MARKET_AUTH_TOOLS = [
+  {
+    avatar:
+      'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IS0tIFVwbG9hZGVkIHRvOiBTVkcgUmVwbywgd3d3LnN2Z3JlcG8uY29tLCBHZW5lcmF0b3I6IFNWRyBSZXBvIE1peGVyIFRvb2xzIC0tPgo8c3ZnIHdpZHRoPSI4MDBweCIgaGVpZ2h0PSI4MDBweCIgdmlld0JveD0iMCAwIDMyIDMyIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPg0KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4wMTY0IDJDMTAuODE5MyAyIDkuMDM4MjUgMy43MjQ1MyA5LjAzODI1IDUuODUxODVWOC41MTg1MkgxNS45MjM1VjkuMjU5MjZINS45NzgxNEMzLjc4MTA3IDkuMjU5MjYgMiAxMC45ODM4IDIgMTMuMTExMUwyIDE4Ljg4ODlDMiAyMS4wMTYyIDMuNzgxMDcgMjIuNzQwNyA1Ljk3ODE0IDIyLjc0MDdIOC4yNzMyMlYxOS40ODE1QzguMjczMjIgMTcuMzU0MiAxMC4wNTQzIDE1LjYyOTYgMTIuMjUxNCAxNS42Mjk2SDE5LjU5NTZDMjEuNDU0NyAxNS42Mjk2IDIyLjk2MTcgMTQuMTcwNCAyMi45NjE3IDEyLjM3MDRWNS44NTE4NUMyMi45NjE3IDMuNzI0NTMgMjEuMTgwNyAyIDE4Ljk4MzYgMkgxMy4wMTY0Wk0xMi4wOTg0IDYuNzQwNzRDMTIuODU4OSA2Ljc0MDc0IDEzLjQ3NTQgNi4xNDM3OCAxMy40NzU0IDUuNDA3NDFDMTMuNDc1NCA0LjY3MTAzIDEyLjg1ODkgNC4wNzQwNyAxMi4wOTg0IDQuMDc0MDdDMTEuMzM3OCA0LjA3NDA3IDEwLjcyMTMgNC42NzEwMyAxMC43MjEzIDUuNDA3NDFDMTAuNzIxMyA2LjE0Mzc4IDExLjMzNzggNi43NDA3NCAxMi4wOTg0IDYuNzQwNzRaIiBmaWxsPSJ1cmwoI3BhaW50MF9saW5lYXJfODdfODIwNCkiLz4NCjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTguOTgzNCAzMEMyMS4xODA1IDMwIDIyLjk2MTYgMjguMjc1NSAyMi45NjE2IDI2LjE0ODJWMjMuNDgxNUwxNi4wNzYzIDIzLjQ4MTVMMTYuMDc2MyAyMi43NDA4TDI2LjAyMTcgMjIuNzQwOEMyOC4yMTg4IDIyLjc0MDggMjkuOTk5OCAyMS4wMTYyIDI5Ljk5OTggMTguODg4OVYxMy4xMTExQzI5Ljk5OTggMTAuOTgzOCAyOC4yMTg4IDkuMjU5MjggMjYuMDIxNyA5LjI1OTI4TDIzLjcyNjYgOS4yNTkyOFYxMi41MTg1QzIzLjcyNjYgMTQuNjQ1OSAyMS45NDU1IDE2LjM3MDQgMTkuNzQ4NSAxNi4zNzA0TDEyLjQwNDIgMTYuMzcwNEMxMC41NDUxIDE2LjM3MDQgOS4wMzgwOSAxNy44Mjk2IDkuMDM4MDkgMTkuNjI5Nkw5LjAzODA5IDI2LjE0ODJDOS4wMzgwOSAyOC4yNzU1IDEwLjgxOTIgMzAgMTMuMDE2MiAzMEgxOC45ODM0Wk0xOS45MDE1IDI1LjI1OTNDMTkuMTQwOSAyNS4yNTkzIDE4LjUyNDQgMjUuODU2MiAxOC41MjQ0IDI2LjU5MjZDMTguNTI0NCAyNy4zMjkgMTkuMTQwOSAyNy45MjU5IDE5LjkwMTUgMjcuOTI1OUMyMC42NjIgMjcuOTI1OSAyMS4yNzg1IDI3LjMyOSAyMS4yNzg1IDI2LjU5MjZDMjEuMjc4NSAyNS44NTYyIDIwLjY2MiAyNS4yNTkzIDE5LjkwMTUgMjUuMjU5M1oiIGZpbGw9InVybCgjcGFpbnQxX2xpbmVhcl84N184MjA0KSIvPg0KPGRlZnM+DQo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfODdfODIwNCIgeDE9IjEyLjQ4MDkiIHkxPSIyIiB4Mj0iMTIuNDgwOSIgeTI9IjIyLjc0MDciIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4NCjxzdG9wIHN0b3AtY29sb3I9IiMzMjdFQkQiLz4NCjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzE1NjVBNyIvPg0KPC9saW5lYXJHcmFkaWVudD4NCjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQxX2xpbmVhcl84N184MjA0IiB4MT0iMTkuNTE5IiB5MT0iOS4yNTkyOCIgeDI9IjE5LjUxOSIgeTI9IjMwIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+DQo8c3RvcCBzdG9wLWNvbG9yPSIjRkZEQTRCIi8+DQo8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGOUM2MDAiLz4NCjwvbGluZWFyR3JhZGllbnQ+DQo8L2RlZnM+DQo8L3N2Zz4=',
+    identifier: 'lobe-cloud-code-interpreter',
+    label: 'Cloud Code Interpreter',
+  },
+];
+
+const POLL_INTERVAL_MS = 1000;
+const POLL_TIMEOUT_MS = 15_000;
+
+interface PendingKlavisTool extends KlavisServerType {
+  authType: 'klavis';
+  server?: KlavisServer;
+}
+
+interface PendingMarketTool {
+  authType: 'market';
+  avatar: string;
+  identifier: string;
+  label: string;
+}
+
+type PendingAuthTool = PendingKlavisTool | PendingMarketTool;
+
+interface KlavisToolAuthItemProps {
+  onAuthComplete: () => void;
+  tool: PendingKlavisTool;
+}
+
+const KlavisToolAuthItem = memo<KlavisToolAuthItemProps>(({ tool, onAuthComplete }) => {
+  const { t } = useTranslation('chat');
+  const theme = useTheme();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isWaitingAuth, setIsWaitingAuth] = useState(false);
+
+  const oauthWindowRef = useRef<Window | null>(null);
+  const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const userId = useUserStore(userProfileSelectors.userId);
+  const createKlavisServer = useToolStore((s) => s.createKlavisServer);
+  const refreshKlavisServerTools = useToolStore((s) => s.refreshKlavisServerTools);
+
+  const cleanup = useCallback(() => {
+    if (windowCheckIntervalRef.current) {
+      clearInterval(windowCheckIntervalRef.current);
+      windowCheckIntervalRef.current = null;
+    }
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+    if (pollTimeoutRef.current) {
+      clearTimeout(pollTimeoutRef.current);
+      pollTimeoutRef.current = null;
+    }
+    oauthWindowRef.current = null;
+    setIsWaitingAuth(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  useEffect(() => {
+    if (tool.server?.status === KlavisServerStatus.CONNECTED && isWaitingAuth) {
+      cleanup();
+      onAuthComplete();
+    }
+  }, [tool.server?.status, isWaitingAuth, cleanup, onAuthComplete]);
+
+  const startFallbackPolling = useCallback(
+    (identifier: string) => {
+      if (pollIntervalRef.current) return;
+
+      pollIntervalRef.current = setInterval(async () => {
+        try {
+          await refreshKlavisServerTools(identifier);
+        } catch (error) {
+          console.error('[Klavis] Failed to check auth status:', error);
+        }
+      }, POLL_INTERVAL_MS);
+
+      pollTimeoutRef.current = setTimeout(() => {
+        if (pollIntervalRef.current) {
+          clearInterval(pollIntervalRef.current);
+          pollIntervalRef.current = null;
+        }
+        setIsWaitingAuth(false);
+      }, POLL_TIMEOUT_MS);
+    },
+    [refreshKlavisServerTools],
+  );
+
+  const startWindowMonitor = useCallback(
+    (oauthWindow: Window, identifier: string) => {
+      windowCheckIntervalRef.current = setInterval(() => {
+        try {
+          if (oauthWindow.closed) {
+            if (windowCheckIntervalRef.current) {
+              clearInterval(windowCheckIntervalRef.current);
+              windowCheckIntervalRef.current = null;
+            }
+            oauthWindowRef.current = null;
+            refreshKlavisServerTools(identifier);
+          }
+        } catch {
+          if (windowCheckIntervalRef.current) {
+            clearInterval(windowCheckIntervalRef.current);
+            windowCheckIntervalRef.current = null;
+          }
+          startFallbackPolling(identifier);
+        }
+      }, 500);
+    },
+    [refreshKlavisServerTools, startFallbackPolling],
+  );
+
+  const openOAuthWindow = useCallback(
+    (oauthUrl: string, identifier: string) => {
+      cleanup();
+      setIsWaitingAuth(true);
+
+      const oauthWindow = window.open(oauthUrl, '_blank', 'width=600,height=700');
+      if (oauthWindow) {
+        oauthWindowRef.current = oauthWindow;
+        startWindowMonitor(oauthWindow, identifier);
+      } else {
+        startFallbackPolling(identifier);
+      }
+    },
+    [cleanup, startWindowMonitor, startFallbackPolling],
+  );
+
+  const handleAuthorize = async () => {
+    if (!userId) return;
+
+    if (tool.server?.status === KlavisServerStatus.PENDING_AUTH && tool.server.oauthUrl) {
+      openOAuthWindow(tool.server.oauthUrl, tool.server.identifier);
+      return;
+    }
+
+    setIsConnecting(true);
+    try {
+      const newServer = await createKlavisServer({
+        identifier: tool.identifier,
+        serverName: tool.serverName,
+        userId,
+      });
+
+      if (newServer) {
+        if (newServer.isAuthenticated) {
+          await refreshKlavisServerTools(newServer.identifier);
+          onAuthComplete();
+        } else if (newServer.oauthUrl) {
+          openOAuthWindow(newServer.oauthUrl, newServer.identifier);
+        }
+      }
+    } catch (error) {
+      console.error('[ToolAuthAlert] Failed to create server:', error);
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const renderIcon = () => {
+    if (typeof tool.icon === 'string') {
+      return (
+        <Image alt={tool.label} height={20} src={tool.icon} style={{ flex: 'none' }} width={20} />
+      );
+    }
+    return <Icon fill={theme.colorText} icon={tool.icon} size={20} />;
+  };
+
+  const isLoading = isConnecting || isWaitingAuth;
+
+  return (
+    <Flexbox align="center" gap={12} horizontal justify="space-between">
+      <Flexbox align="center" gap={8} horizontal>
+        {renderIcon()}
+        <span>{tool.label}</span>
+      </Flexbox>
+      <Button
+        disabled={isLoading}
+        icon={isLoading ? <Icon icon={Loader2} spin /> : <Icon icon={SquareArrowOutUpRight} />}
+        onClick={handleAuthorize}
+        size="small"
+        type="primary"
+      >
+        {isLoading ? t('toolAuth.authorizing') : t('toolAuth.authorize')}
+      </Button>
+    </Flexbox>
+  );
+});
+
+KlavisToolAuthItem.displayName = 'KlavisToolAuthItem';
+
+interface MarketToolAuthItemProps {
+  tool: PendingMarketTool;
+}
+
+const MarketToolAuthItem = memo<MarketToolAuthItemProps>(({ tool }) => {
+  const { t } = useTranslation('chat');
+  const { signIn, isLoading } = useMarketAuth();
+
+  const handleSignIn = async () => {
+    try {
+      await signIn();
+    } catch (error) {
+      console.error('[ToolAuthAlert] Market sign in failed:', error);
+    }
+  };
+
+  return (
+    <Flexbox align="center" gap={12} horizontal justify="space-between">
+      <Flexbox align="center" gap={8} horizontal>
+        <Image alt={tool.label} height={20} src={tool.avatar} style={{ flex: 'none' }} width={20} />
+        <span>{tool.label}</span>
+      </Flexbox>
+      <Button
+        disabled={isLoading}
+        icon={isLoading ? <Icon icon={Loader2} spin /> : <Icon icon={LogIn} />}
+        onClick={handleSignIn}
+        size="small"
+        type="primary"
+      >
+        {isLoading ? t('toolAuth.authorizing') : t('toolAuth.signIn')}
+      </Button>
+    </Flexbox>
+  );
+});
+
+MarketToolAuthItem.displayName = 'MarketToolAuthItem';
+
+const ToolAuthAlert = memo(() => {
+  const { t } = useTranslation('chat');
+  const theme = useTheme();
+
+  const plugins = useAgentStore(agentSelectors.currentAgentPlugins, isEqual);
+  const klavisServers = useToolStore(klavisStoreSelectors.getServers, isEqual);
+  const { isAuthenticated: isMarketAuthenticated } = useMarketAuth();
+
+  // Filter out tools that need authorization
+  const pendingAuthTools = useMemo<PendingAuthTool[]>(() => {
+    const result: PendingAuthTool[] = [];
+
+    for (const pluginId of plugins) {
+      // Check if this is a Klavis tool
+      const klavisType = KLAVIS_SERVER_TYPES.find((t) => t.identifier === pluginId);
+      if (klavisType) {
+        const server = klavisServers.find((s) => s.identifier === pluginId);
+        // Not installed or pending auth
+        if (!server || server.status === KlavisServerStatus.PENDING_AUTH) {
+          result.push({ ...klavisType, authType: 'klavis', server });
+        }
+        continue;
+      }
+
+      // Check if this is a Market auth tool
+      const marketTool = MARKET_AUTH_TOOLS.find((t) => t.identifier === pluginId);
+      if (marketTool && !isMarketAuthenticated) {
+        result.push({ ...marketTool, authType: 'market' });
+      }
+    }
+
+    return result;
+  }, [plugins, klavisServers, isMarketAuthenticated]);
+
+  // Don't render if no pending auth tools
+  if (pendingAuthTools.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      description={
+        <Flexbox gap={12} style={{ marginTop: 8 }}>
+          {pendingAuthTools.map((tool) =>
+            tool.authType === 'klavis' ? (
+              <KlavisToolAuthItem
+                key={tool.identifier}
+                onAuthComplete={() => {
+                  // Component will re-render and tool will be removed from list
+                }}
+                tool={tool}
+              />
+            ) : (
+              <MarketToolAuthItem key={tool.identifier} tool={tool} />
+            ),
+          )}
+          <Typography.Text style={{ color: theme.colorTextSecondary, fontSize: 12 }}>
+            {t('toolAuth.hint')}
+          </Typography.Text>
+        </Flexbox>
+      }
+      message={
+        <Flexbox align="center" gap={6} horizontal>
+          <Icon icon={TriangleAlert} size={18} />
+          {t('toolAuth.title')}
+        </Flexbox>
+      }
+      showIcon={false}
+      style={{ width: '100%' }}
+      type="warning"
+    />
+  );
+});
+
+ToolAuthAlert.displayName = 'ToolAuthAlert';
+
+export default ToolAuthAlert;

--- a/src/app/[variants]/(main)/chat/features/Conversation/AgentWelcome/index.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/AgentWelcome/index.tsx
@@ -15,6 +15,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import AddButton from './AddButton';
 import OpeningQuestions from './OpeningQuestions';
+import ToolAuthAlert from './ToolAuthAlert';
 
 const InboxWelcome = memo(() => {
   const { t } = useTranslation(['welcome', 'chat']);
@@ -83,6 +84,7 @@ const InboxWelcome = memo(() => {
         {openingQuestions.length > 0 && (
           <OpeningQuestions mobile={mobile} questions={openingQuestions} />
         )}
+        <ToolAuthAlert />
       </Flexbox>
     </>
   );

--- a/src/app/[variants]/(main)/group/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
@@ -1,0 +1,2 @@
+// Re-export from chat version to avoid code duplication
+export { default } from '@/app/[variants]/(main)/chat/features/Conversation/AgentWelcome/ToolAuthAlert';

--- a/src/app/[variants]/(main)/group/features/Conversation/AgentWelcome/index.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/AgentWelcome/index.tsx
@@ -15,6 +15,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import AddButton from './AddButton';
 import OpeningQuestions from './OpeningQuestions';
+import ToolAuthAlert from './ToolAuthAlert';
 
 const InboxWelcome = memo(() => {
   const { t } = useTranslation(['welcome', 'chat']);
@@ -83,6 +84,7 @@ const InboxWelcome = memo(() => {
         {openingQuestions.length > 0 && (
           <OpeningQuestions mobile={mobile} questions={openingQuestions} />
         )}
+        <ToolAuthAlert />
       </Flexbox>
     </>
   );

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -470,6 +470,13 @@ export default {
       toolRejected: '本次工具调用被主动拒绝',
     },
   },
+  toolAuth: {
+    authorize: '授权',
+    authorizing: '授权中...',
+    hint: '如不授权或配置，这些工具将无法正常使用，可能导致助手功能缺失或报错。',
+    signIn: '登录',
+    title: '该助手使用了以下需要授权的工具',
+  },
   topic: {
     checkOpenNewTopic: '是否开启新话题?',
     checkSaveCurrentMessages: '是否保存当前会话为话题?',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add an authorization alert for tools used by assistants on the conversation welcome screen, prompting users to authenticate required MCP/Klavis and Market tools so they function correctly.

New Features:
- Introduce a ToolAuthAlert component that lists assistant tools requiring authorization and guides users through authenticating them.
- Display the tool authorization alert in both chat and group conversation welcome views when relevant tools are present.
- Add localized copy for tool authorization actions and messaging in the chat locale resources.

Enhancements:
- Reuse the chat ToolAuthAlert implementation in the group conversation view via a re-export to avoid duplication.