### PR TITLE
🐛 fix: update the discover detail tools tab show

### DIFF
--- a/packages/context-engine/src/providers/AgentBuilderContextInjector.ts
+++ b/packages/context-engine/src/providers/AgentBuilderContextInjector.ts
@@ -31,7 +31,7 @@ export interface OfficialToolItem {
   installed?: boolean;
   /** Tool display name */
   name: string;
-  /** Tool type: 'builtin' for built-in tools, 'klavis' for Klavis MCP servers */
+  /** Tool type: 'builtin' for built-in tools, 'klavis' for LobeHub Mcp servers */
   type: 'builtin' | 'klavis';
 }
 

--- a/packages/context-engine/src/providers/GroupAgentBuilderContextInjector.ts
+++ b/packages/context-engine/src/providers/GroupAgentBuilderContextInjector.ts
@@ -47,7 +47,7 @@ export interface GroupOfficialToolItem {
   installed?: boolean;
   /** Tool display name */
   name: string;
-  /** Tool type: 'builtin' for built-in tools, 'klavis' for Klavis MCP servers */
+  /** Tool type: 'builtin' for built-in tools, 'klavis' for LobeHub Mcp servers */
   type: 'builtin' | 'klavis';
 }
 

--- a/src/server/routers/lambda/klavis.ts
+++ b/src/server/routers/lambda/klavis.ts
@@ -58,7 +58,7 @@ export const klavisRouter = router({
         identifier,
         meta: {
           avatar: '🔌',
-          description: `Klavis MCP Server: ${serverName}`,
+          description: `LobeHub Mcp Server: ${serverName}`,
           title: serverName,
         },
         type: 'default',
@@ -213,7 +213,7 @@ export const klavisRouter = router({
         identifier,
         meta: existingPlugin?.manifest?.meta || {
           avatar: '🔌',
-          description: `Klavis MCP Server: ${serverName}`,
+          description: `LobeHub Mcp Server: ${serverName}`,
           title: serverName,
         },
         type: 'default',

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_DISCOVER_ASSISTANT_ITEM,
   DEFAULT_DISCOVER_PLUGIN_ITEM,
   DEFAULT_DISCOVER_PROVIDER_ITEM,
+  KLAVIS_SERVER_TYPES,
   isDesktop,
 } from '@lobechat/const';
 import {
@@ -1047,6 +1048,32 @@ export class DiscoverService {
         title: builtinTool.manifest.meta.title,
       };
       log('getPluginDetail: returning builtin tool plugin');
+      return plugin;
+    }
+
+    // Step 4: Try to find in Klavis server types (builtin tools that require env config)
+    const klavisTool = KLAVIS_SERVER_TYPES.find((tool) => tool.identifier === identifier);
+    if (klavisTool) {
+      log('getPluginDetail: found Klavis tool for identifier=%s', identifier);
+
+      // Avatar is empty here because frontend will render Klavis icons using KlavisIcon component
+      // which handles both string URLs and React component icons
+      const plugin: DiscoverPluginDetail = {
+        author: 'Klavis',
+        avatar: typeof klavisTool.icon === 'string' ? klavisTool.icon : '',
+        category: undefined,
+        createdAt: '',
+        description: `LobeHub Mcp Server: ${klavisTool.label}`,
+        homepage: 'https://klavis.ai',
+        identifier: klavisTool.identifier,
+        manifest: undefined,
+        related: [],
+        schemaVersion: 1,
+        source: 'builtin',
+        tags: ['klavis', 'mcp'],
+        title: klavisTool.label,
+      };
+      log('getPluginDetail: returning Klavis tool plugin');
       return plugin;
     }
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -190,7 +190,7 @@ class ChatService {
           const server = allKlavisServers.find((s) => s.identifier === klavisType.identifier);
 
           officialTools.push({
-            description: `Klavis MCP Server: ${klavisType.label}`,
+            description: `LobeHub Mcp Server: ${klavisType.label}`,
             enabled: enabledPlugins.includes(klavisType.identifier),
             identifier: klavisType.identifier,
             installed: !!server,

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -176,7 +176,7 @@ export const contextEngineering = async ({
             const server = allKlavisServers.find((s) => s.identifier === klavisType.identifier);
 
             officialTools.push({
-              description: `Klavis MCP Server: ${klavisType.label}`,
+              description: `LobeHub Mcp Server: ${klavisType.label}`,
               enabled: enabledPlugins.includes(klavisType.identifier),
               identifier: klavisType.identifier,
               installed: !!server,

--- a/src/store/tool/slices/builtin/selectors.ts
+++ b/src/store/tool/slices/builtin/selectors.ts
@@ -33,7 +33,7 @@ const metaList = (s: ToolStoreState): LobeToolMeta[] => {
       identifier: server.identifier,
       meta: {
         avatar: '☁️',
-        description: `Klavis MCP Server: ${server.serverName}`,
+        description: `LobeHub Mcp Server: ${server.serverName}`,
         tags: ['klavis', 'mcp'],
         // title 仍然使用 serverName 显示友好名称
         title: server.serverName,

--- a/src/store/tool/slices/klavisStore/selectors.ts
+++ b/src/store/tool/slices/klavisStore/selectors.ts
@@ -106,7 +106,7 @@ export const klavisStoreSelectors = {
             identifier: server.identifier,
             meta: {
               avatar: '☁️',
-              description: `Klavis MCP Server: ${server.serverName}`,
+              description: `LobeHub Mcp Server: ${server.serverName}`,
               tags: ['klavis', 'mcp'],
               title: server.serverName,
             },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure Klavis-based tools appear correctly in the discover detail view and unify their labeling as LobeHub MCP servers across the app.

Bug Fixes:
- Add a Klavis tool fallback in plugin detail rendering so tools without API data still show up in the discover details tab.
- Handle Klavis tool avatars via a dedicated icon component that supports both URL and icon types and respects theme colors.

Enhancements:
- Expose Klavis server tools through the discover service as builtin plugins when no marketplace entry exists.
- Standardize Klavis-related descriptions and type comments from generic Klavis MCP wording to LobeHub Mcp Server across chat, context engineering, and tool selectors.