### PR TITLE
🐛 fix: export files should save into document

### DIFF
--- a/src/services/codeInterpreter.ts
+++ b/src/services/codeInterpreter.ts
@@ -4,6 +4,8 @@ import type {
   CallToolResult,
   GetExportFileUploadUrlInput,
   GetExportFileUploadUrlResult,
+  SaveExportedFileContentInput,
+  SaveExportedFileContentResult,
 } from '@/server/routers/tools/codeInterpreter';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/slices/settings/selectors/settings';
@@ -56,6 +58,17 @@ class CodeInterpreterService {
     };
 
     return toolsClient.codeInterpreter.getExportFileUploadUrl.mutate(input);
+  }
+
+  /**
+   * Save exported file content to documents table
+   * This creates a document record linked to the file for content retrieval
+   * @param params - File content and metadata
+   */
+  async saveExportedFileContent(
+    params: SaveExportedFileContentInput,
+  ): Promise<SaveExportedFileContentResult> {
+    return toolsClient.codeInterpreter.saveExportedFileContent.mutate(params);
   }
 }
 

--- a/src/tools/code-interpreter/ExecutionRuntime/index.ts
+++ b/src/tools/code-interpreter/ExecutionRuntime/index.ts
@@ -418,15 +418,19 @@ export class CodeInterpreterExecutionRuntime {
 
       // Check if the sandbox upload was successful
       const uploadSuccess = result.success && result.result?.success !== false;
-      const bytesUploaded = result.result?.bytesUploaded;
+      const fileSize = result.result?.size;
+      const mimeType = result.result?.mimeType;
+      const fileContent = result.result?.content;
 
       const state: ExportFileState = {
+        content: fileContent,
         downloadUrl: uploadSuccess ? uploadUrlResult.downloadUrl : '',
         filename,
+        mimeType,
         path: args.path,
+        size: fileSize,
         success: uploadSuccess,
       };
-
       if (!uploadSuccess) {
         return {
           content: JSON.stringify({
@@ -440,13 +444,7 @@ export class CodeInterpreterExecutionRuntime {
       }
 
       return {
-        content: JSON.stringify({
-          bytesUploaded,
-          downloadUrl: uploadUrlResult.downloadUrl,
-          filename,
-          message: `Successfully exported ${filename}`,
-          success: true,
-        }),
+        content: `File exported successfully.\n\nFilename: ${filename}\nDownload URL: ${uploadUrlResult.downloadUrl}`,
         state,
         success: true,
       };

--- a/src/tools/code-interpreter/type.ts
+++ b/src/tools/code-interpreter/type.ts
@@ -72,12 +72,18 @@ export interface GlobFilesState {
 }
 
 export interface ExportFileState {
+  /** File content for text files (only when mimeType is text-like and size <= 1MB) */
+  content?: string;
   /** The download URL for the exported file */
   downloadUrl: string;
   /** The exported file name */
   filename: string;
+  /** The MIME type of the file */
+  mimeType?: string;
   /** The original path in sandbox */
   path: string;
+  /** The file size in bytes */
+  size?: number;
   /** Whether the export was successful */
   success: boolean;
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Persist exported code-interpreter files as documents linked to their file records for later retrieval.

New Features:
- Add API endpoint and service method to save exported file content into the documents store linked to existing file records.

Bug Fixes:
- Ensure code-interpreter exported files persist their text content in the documents table instead of only storing download URLs.

Enhancements:
- Propagate file content, MIME type, and size through the code-interpreter export flow and simplify the user-facing export message.