### PR TITLE
🐛 fix: fixed when change agent agentid. restore the chat & agent store

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/AgentIdSync.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/AgentIdSync.tsx
@@ -1,3 +1,4 @@
+import { useUnmount } from 'ahooks';
 import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
@@ -11,6 +12,12 @@ const AgentIdSync = () => {
 
   useStoreUpdater('activeAgentId', params.aid);
   useChatStoreUpdater('activeAgentId', params.aid ?? '');
+
+  // Clear activeAgentId when unmounting (leaving chat page)
+  useUnmount(() => {
+    useAgentStore.setState({ activeAgentId: undefined });
+    useChatStore.setState({ activeAgentId: undefined, activeTopicId: undefined });
+  });
 
   return null;
 };

--- a/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
@@ -17,7 +17,7 @@ const GroupIdSync = () => {
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {
     useAgentGroupStore.setState({ activeGroupId: undefined });
-    useChatStore.setState({ activeGroupId: undefined });
+    useChatStore.setState({ activeGroupId: undefined, activeTopicId: undefined });
   });
 
   return null;

--- a/src/features/AgentBuilder/TopicSelector.tsx
+++ b/src/features/AgentBuilder/TopicSelector.tsx
@@ -42,7 +42,7 @@ const TopicSelector = memo<TopicSelectorProps>(({ agentId }) => {
   const [activeTopicId, switchTopic, topics] = useChatStore((s) => [
     s.activeTopicId,
     s.switchTopic,
-    topicSelectors.currentTopics(s),
+    topicSelectors.getTopicsByAgentId(agentId)(s),
   ]);
 
   // Find active topic from the agent's topics list directly


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Reset chat- and agent-related state when navigating away from agent and group pages, and ensure topic selection is scoped to the current agent.

Bug Fixes:
- Clear active agent and chat topic state when leaving the agent chat page to avoid stale selections.
- Clear active group and chat topic state when leaving the group page to prevent leftover topics from other groups.
- Scope topic selection in the agent builder to topics belonging to the currently selected agent.