### PR TITLE
🐛 fix: solve all settings router link router error

### DIFF
--- a/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
+++ b/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
@@ -25,21 +25,16 @@ export default class BrowserWindowsCtr extends ControllerModule {
     console.log('[BrowserWindowsCtr] Received request to open settings', normalizedOptions);
 
     try {
-      const query = new URLSearchParams();
-      if (normalizedOptions.searchParams) {
-        Object.entries(normalizedOptions.searchParams).forEach(([key, value]) => {
-          if (value !== undefined) query.set(key, value);
-        });
-      }
+      let fullPath: string;
 
-      const tab = normalizedOptions.tab;
-      if (tab && tab !== 'common' && !query.has('active')) {
-        query.set('active', tab);
+      // If direct path is provided, use it directly
+      if (normalizedOptions.path) {
+        fullPath = normalizedOptions.path;
+      } else {
+        // Legacy support for tab and searchParams
+        const tab = normalizedOptions.tab;
+        fullPath = tab ? `/settings/${tab}` : '/settings/common';
       }
-
-      const queryString = query.toString();
-      const subPath = tab && !queryString ? `/${tab}` : '';
-      const fullPath = `/settings${subPath}${queryString ? `?${queryString}` : ''}`;
 
       const mainWindow = this.app.browserManager.getMainWindow();
       mainWindow.show();

--- a/apps/desktop/src/main/controllers/__tests__/BrowserWindowsCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/BrowserWindowsCtr.test.ts
@@ -83,13 +83,13 @@ describe('BrowserWindowsCtr', () => {
   });
 
   describe('openSettingsWindow', () => {
-    it('should navigate to settings in main window with the specified tab', async () => {
-      const tab = 'appearance';
-      const result = await browserWindowsCtr.openSettingsWindow(tab);
+    it('should navigate to settings in main window with the specified path', async () => {
+      const path = '/settings/common';
+      const result = await browserWindowsCtr.openSettingsWindow({ path });
       expect(mockGetMainWindow).toHaveBeenCalled();
       expect(mockShow).toHaveBeenCalled();
       expect(mockBroadcast).toHaveBeenCalledWith('navigate', {
-        path: '/settings?active=appearance',
+        path: '/settings/common',
       });
       expect(result).toEqual({ success: true });
     });
@@ -99,7 +99,7 @@ describe('BrowserWindowsCtr', () => {
       mockBroadcast.mockImplementationOnce(() => {
         throw new Error(errorMessage);
       });
-      const result = await browserWindowsCtr.openSettingsWindow('display');
+      const result = await browserWindowsCtr.openSettingsWindow({ path: '/settings/common' });
       expect(result).toEqual({ error: errorMessage, success: false });
     });
   });

--- a/e2e/src/features/routes/core-routes.feature
+++ b/e2e/src/features/routes/core-routes.feature
@@ -25,7 +25,7 @@ Feature: Core Routes Accessibility
 
   @ROUTES-002 @P0
   Scenario Outline: Access settings routes without errors
-    When I navigate to "/settings?active=<tab>"
+    When I navigate to "/settings/<tab>"
     Then the response status should be less than 400
     And the page should load without errors
     And I should see the page body
@@ -36,7 +36,7 @@ Feature: Core Routes Accessibility
       | about        |
       | agent        |
       | hotkey       |
-      | provider     |
+      | provider/all |
       | proxy        |
       | storage      |
       | tts          |

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -291,7 +291,7 @@ export class AiInfraRepos {
   };
 
   /**
-   * use in the `/settings?active=provider&provider=[id]` page
+   * use in the `/settings/provider/[id]` page
    */
   getAiProviderDetail = async (id: string, decryptor?: DecryptUserKeyVaults) => {
     const config = await this.aiProviderModel.getAiProviderById(id, decryptor);

--- a/packages/electron-client-ipc/src/events/windows.ts
+++ b/packages/electron-client-ipc/src/events/windows.ts
@@ -1,10 +1,15 @@
 export interface OpenSettingsWindowOptions {
   /**
-   * Query parameters that should be appended to the settings URL.
+   * Direct path to navigate to (e.g., '/settings/provider/openai').
+   * Takes precedence over tab and searchParams if provided.
+   */
+  path?: string;
+  /**
+   * @deprecated Use `path` instead. Query parameters that should be appended to the settings URL.
    */
   searchParams?: Record<string, string | undefined>;
   /**
-   * Settings page tab path or identifier.
+   * @deprecated Use `path` instead. Settings page tab path or identifier.
    */
   tab?: string;
 }

--- a/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
@@ -26,20 +26,14 @@ const ProviderConfig = memo(() => {
   const { url, modelsUrl, identifier } = useDetailContext();
   const navigate = useNavigate();
   const openSettings = async () => {
-    const searchParams = { active: 'provider', provider: identifier };
-    const tab = 'provider';
-
     if (isDesktop) {
       const { ensureElectronIpc } = await import('@/utils/electron/ipc');
       await ensureElectronIpc().windows.openSettingsWindow({
-        searchParams,
-        tab,
+        path: `/settings/provider/${identifier}`,
       });
       return;
     }
-    navigate(
-      `/settings?active=provider&provider=${identifier}`
-    )
+    navigate(`/settings/provider/${identifier}`);
   };
 
   const icon = <Icon icon={SquareArrowOutUpRight} size={16} />;

--- a/src/app/[variants]/(main)/image/_layout/ConfigPanel/components/ModelSelect/index.tsx
+++ b/src/app/[variants]/(main)/image/_layout/ConfigPanel/components/ModelSelect/index.tsx
@@ -63,7 +63,7 @@ const ModelSelect = memo(() => {
               </Flexbox>
             ),
             onClick: () => {
-              navigate(`/settings?active=provider&provider=${provider.id}`);
+              navigate(`/settings/provider/${provider.id}`);
             },
             value: `${provider.id}/empty`,
           },
@@ -85,7 +85,7 @@ const ModelSelect = memo(() => {
             </Flexbox>
           ),
           onClick: () => {
-            navigate('/settings?active=provider');
+            navigate('/settings/provider/all');
           },
           value: 'no-provider',
         },
@@ -110,7 +110,7 @@ const ModelSelect = memo(() => {
             icon={LucideBolt}
             onClick={(e) => {
               e.stopPropagation();
-              navigate(`/settings?active=provider&provider=${provider.id}`);
+              navigate(`/settings/provider/${provider.id}`);
             }}
             size={'small'}
             title={t('ModelSwitchPanel.goToSettings')}

--- a/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/CreateNewProvider/index.tsx
@@ -53,7 +53,7 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open }) => {
 
       await createNewAiProvider(finalValues);
       setLoading(false);
-      navigate(`/settings?active=provider&provider=${values.id}`);
+      navigate(`/settings/provider/${values.id}`);
       message.success(t('createNewAiProvider.createSuccess'));
       onClose?.();
     } catch (e) {

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
@@ -121,7 +121,7 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open, initial
                 okText: t('delete', { ns: 'common' }),
                 onOk: async () => {
                   await deleteAiProvider(id);
-                  navigate('/settings?active=provider');
+                  navigate('/settings/provider/all');
 
                   onClose?.();
                   message.success(t('updateAiProvider.deleteSuccess'));

--- a/src/app/[variants]/(mobile)/me/(home)/features/UserBanner.tsx
+++ b/src/app/[variants]/(mobile)/me/(home)/features/UserBanner.tsx
@@ -19,10 +19,10 @@ const UserBanner = memo(() => {
     <Flexbox gap={12} paddingBlock={8}>
       {!enableAuth || (enableAuth && isLoginWithAuth) ? (
         <>
-          <Link style={{ color: 'inherit' }} to="/settings?active=profile">
+          <Link style={{ color: 'inherit' }} to="/settings/profile">
             <UserInfo />
           </Link>
-          <Link style={{ color: 'inherit' }} to="/settings?active=stats">
+          <Link style={{ color: 'inherit' }} to="/settings/stats">
             <DataStatistics paddingInline={12} />
           </Link>
         </>

--- a/src/app/[variants]/(mobile)/me/profile/features/Category.tsx
+++ b/src/app/[variants]/(mobile)/me/profile/features/Category.tsx
@@ -23,19 +23,19 @@ const Category = memo(() => {
       icon: UserCircle,
       key: ProfileTabs.Profile,
       label: t('tab.profile'),
-      onClick: () => navigate('/settings?active=profile'),
+      onClick: () => navigate('/settings/profile'),
     },
     isLoginWithClerk && {
       icon: ShieldCheck,
       key: ProfileTabs.Security,
       label: t('tab.security'),
-      onClick: () => navigate('/settings?active=security'),
+      onClick: () => navigate('/settings/security'),
     },
     {
       icon: ChartColumnBigIcon,
       key: ProfileTabs.Stats,
       label: t('tab.stats'),
-      onClick: () => navigate('/settings?active=stats'),
+      onClick: () => navigate('/settings/stats'),
     },
     isLogin && {
       type: 'divider',

--- a/src/app/[variants]/(mobile)/me/settings/features/useCategory.tsx
+++ b/src/app/[variants]/(mobile)/me/settings/features/useCategory.tsx
@@ -40,6 +40,12 @@ export const useCategory = () => {
 
   return items.map((item) => ({
     ...item,
-    onClick: () => navigate(`/settings?active=${item.key}`),
+    onClick: () => {
+      if (item.key === SettingsTabs.Provider) {
+        navigate('/settings/provider/all');
+      } else {
+        navigate(`/settings/${item.key}`);
+      }
+    },
   }));
 };

--- a/src/features/MobileTabBar/index.tsx
+++ b/src/features/MobileTabBar/index.tsx
@@ -28,7 +28,7 @@ export default memo<Props>(({ className, tabBarKey }) => {
   const { styles } = useStyles();
   const router = useRouter();
   const openSettings = () => {
-    router.push('/settings?active=llm');
+    router.push('/settings/provider/all');
   };
   const { showMarket } = useServerConfigStore(featureFlagsSelectors);
 

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -129,7 +129,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
               </Flexbox>
             ),
             onClick: () => {
-              navigate('/settings?active=provider');
+              navigate('/settings/provider/all');
             },
           },
         ];

--- a/src/features/User/UserPanel/PanelContent.tsx
+++ b/src/features/User/UserPanel/PanelContent.tsx
@@ -61,7 +61,7 @@ const PanelContent = memo<{ closePopover: () => void }>(({ closePopover }) => {
         <>
           <UserInfo avatarProps={{ clickable: false }} />
 
-          <Link style={{ color: 'inherit' }} to={'/settings?active=stats'}>
+          <Link style={{ color: 'inherit' }} to={'/settings/stats'}>
             <DataStatistics />
           </Link>
         </>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Standardize settings routing to use path-based URLs and simplify Electron settings navigation.

Bug Fixes:
- Fix incorrect or failing router navigation when opening settings from desktop and web entry points.

Enhancements:
- Introduce a `path` option for opening the settings window in the Electron IPC API, deprecating the older `tab` and `searchParams` options.
- Update various UI components and hooks to use the new `/settings/...` path structure for profile, stats, and provider-related pages, including provider detail and list views.

Tests:
- Adjust existing BrowserWindowsCtr tests and core routes e2e scenarios to validate the new path-based settings URLs.