### PR TITLE
🐛 fix: fixed some bugs in community pages

### DIFF
--- a/src/app/[variants]/(main)/community/(detail)/assistant/features/Details/Overview/TagList.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/assistant/features/Details/Overview/TagList.tsx
@@ -2,10 +2,10 @@
 
 import { Tag } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import Link from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 
 import { useQuery } from '@/hooks/useQuery';
 import { AssistantMarketSource } from '@/types/discover';
@@ -33,7 +33,8 @@ const TagList = memo<{ tags: string[] }>(({ tags }) => {
       <Flexbox gap={8} horizontal wrap={'wrap'}>
         {tags.map((tag) => (
           <Link
-            href={qs.stringifyUrl(
+            key={tag}
+            to={qs.stringifyUrl(
               {
                 query: {
                   q: tag,
@@ -43,7 +44,6 @@ const TagList = memo<{ tags: string[] }>(({ tags }) => {
               },
               { skipNull: true },
             )}
-            key={tag}
           >
             <Tag className={styles.tag}>{tag}</Tag>
           </Link>

--- a/src/app/[variants]/(main)/community/(detail)/assistant/features/Details/SystemRole/TagList.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/assistant/features/Details/SystemRole/TagList.tsx
@@ -2,10 +2,10 @@
 
 import { Tag } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import Link from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 
 import { useQuery } from '@/hooks/useQuery';
 import { AssistantMarketSource } from '@/types/discover';
@@ -33,7 +33,8 @@ const TagList = memo<{ tags: string[] }>(({ tags }) => {
       <Flexbox gap={8} horizontal wrap={'wrap'}>
         {tags.map((tag) => (
           <Link
-            href={qs.stringifyUrl(
+            key={tag}
+            to={qs.stringifyUrl(
               {
                 query: {
                   q: tag,
@@ -43,7 +44,6 @@ const TagList = memo<{ tags: string[] }>(({ tags }) => {
               },
               { skipNull: true },
             )}
-            key={tag}
           >
             <Tag className={styles.tag}>{tag}</Tag>
           </Link>

--- a/src/app/[variants]/(main)/community/(detail)/assistant/features/Header.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/assistant/features/Header.tsx
@@ -4,12 +4,11 @@ import { MCP } from '@lobehub/icons';
 import { Avatar, Button, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createStyles, useResponsive } from 'antd-style';
 import { BookTextIcon, CoinsIcon, DotIcon } from 'lucide-react';
-import Link from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import { formatIntergerNumber } from '@/utils/format';
@@ -55,7 +54,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
 
   const cateButton = (
     <Link
-      href={qs.stringifyUrl({
+      to={qs.stringifyUrl({
         query: { category: cate?.key },
         url: '/community/assistant',
       })}
@@ -109,9 +108,9 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
           </Flexbox>
           <Flexbox align={'center'} gap={4} horizontal>
             {author && userName ? (
-              <RouterLink style={{ color: 'inherit' }} to={urlJoin('/community/user', userName)}>
+              <Link style={{ color: 'inherit' }} to={urlJoin('/community/user', userName)}>
                 {author}
-              </RouterLink>
+              </Link>
             ) : (
               author
             )}

--- a/src/app/[variants]/(main)/community/(detail)/features/Block.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/features/Block.tsx
@@ -1,9 +1,9 @@
 import { Button, Icon } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { ChevronRight } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
 import { Flexbox, FlexboxProps } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 
 const useStyles = createStyles(({ css, token }) => ({
   more: css`
@@ -33,7 +33,7 @@ const Block = memo<BlockProps>(({ title, more, moreLink, children, ...rest }) =>
       <Flexbox align={'center'} gap={16} horizontal justify={'space-between'} width={'100%'}>
         <h2 className={styles.title}>{title}</h2>
         {moreLink && (
-          <Link href={moreLink} target={moreLink.startsWith('http') ? '_blank' : undefined}>
+          <Link target={moreLink.startsWith('http') ? '_blank' : undefined} to={moreLink}>
             <Button className={styles.more} type={'text'}>
               <span>{more}</span>
               <Icon icon={ChevronRight} />

--- a/src/app/[variants]/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
@@ -4,10 +4,10 @@ import { ProviderIcon } from '@lobehub/icons';
 import { ActionIcon, Block, Icon, Tooltip } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import { BadgeCheck, BookIcon, ChevronRightIcon, KeyIcon } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import InlineTable from '@/components/InlineTable';
@@ -32,7 +32,7 @@ const ProviderList = memo(() => {
             key: 'provider',
             render: (_, record) => {
               return (
-                <Link href={urlJoin('/community/provider', record.id)} style={{ color: 'inherit' }}>
+                <Link style={{ color: 'inherit' }} to={urlJoin('/community/provider', record.id)}>
                   <Flexbox align="center" gap={8} horizontal>
                     <ProviderIcon provider={record.id} size={24} type={'avatar'} />
                     <div style={{ fontWeight: 500 }}>{record.name}</div>
@@ -157,14 +157,11 @@ const ProviderList = memo(() => {
                     </Tooltip>
                   )}
                   <Tooltip title={t('models.guide')}>
-                    <Link href={urlJoin(BASE_PROVIDER_DOC_URL, record.id)} target={'_blank'}>
+                    <a href={urlJoin(BASE_PROVIDER_DOC_URL, record.id)} rel="noreferrer" target={'_blank'}>
                       <ActionIcon icon={BookIcon} size={'small'} variant={'filled'} />
-                    </Link>
+                    </a>
                   </Tooltip>
-                  <Link
-                    href={urlJoin('/community/provider', record.id)}
-                    style={{ color: 'inherit' }}
-                  >
+                  <Link style={{ color: 'inherit' }} to={urlJoin('/community/provider', record.id)}>
                     <ActionIcon
                       color={theme.colorTextDescription}
                       icon={ChevronRightIcon}

--- a/src/app/[variants]/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
@@ -5,10 +5,9 @@ import { Button, Icon } from '@lobehub/ui';
 import { Dropdown } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronDownIcon } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link , useNavigate } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import { useDetailContext } from '../../DetailProvider';
@@ -33,7 +32,7 @@ const ChatWithModel = memo(() => {
     icon: <ProviderIcon provider={item.id} size={20} type={'avatar'} />,
     key: item.id,
     label: (
-      <Link href={urlJoin('/community/provider', item.id)}>
+      <Link to={urlJoin('/community/provider', item.id)}>
         {[item.name, t('models.guide')].join(' ')}
       </Link>
     ),
@@ -63,7 +62,7 @@ const ChatWithModel = memo(() => {
 
   if (items.length === 1)
     return (
-      <Link href={urlJoin('/community/provider', items[0].key)} style={{ flex: 1 }}>
+      <Link style={{ flex: 1 }} to={urlJoin('/community/provider', items[0].key)}>
         <Button block className={styles.button} size={'large'} type={'primary'}>
           {t('models.guide')}
         </Button>

--- a/src/app/[variants]/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/index.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import Title from '../../../../../features/Title';
@@ -21,7 +21,7 @@ const Related = memo(() => {
         {providers.slice(0, 6).map((item, index) => {
           const link = urlJoin('/community/provider', item.id);
           return (
-            <Link href={link} key={index} style={{ color: 'inherit', overflow: 'hidden' }}>
+            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
               <Item {...item} />
             </Link>
           );

--- a/src/app/[variants]/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
@@ -4,10 +4,10 @@ import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon, Block, Tooltip } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import { ChevronRightIcon } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import InlineTable from '@/components/InlineTable';
@@ -31,7 +31,7 @@ const ModelList = memo(() => {
             key: 'model',
             render: (_, record) => {
               return (
-                <Link href={urlJoin('/community/model', record.id)} style={{ color: 'inherit' }}>
+                <Link style={{ color: 'inherit' }} to={urlJoin('/community/model', record.id)}>
                   <Flexbox align="center" gap={8} horizontal>
                     <ModelIcon model={record.id} size={24} type={'avatar'} />
                     <Flexbox style={{ overflow: 'hidden' }}>
@@ -129,7 +129,7 @@ const ModelList = memo(() => {
             render: (_, record) => {
               return (
                 <Flexbox align="center" gap={4} horizontal justify={'flex-end'}>
-                  <Link href={urlJoin('/community/model', record.id)} style={{ color: 'inherit' }}>
+                  <Link style={{ color: 'inherit' }} to={urlJoin('/community/model', record.id)}>
                     <ActionIcon
                       color={theme.colorTextDescription}
                       icon={ChevronRightIcon}

--- a/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/ActionButton/ProviderConfig.tsx
@@ -5,10 +5,9 @@ import { Button, Icon } from '@lobehub/ui';
 import { Dropdown } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronDownIcon, SquareArrowOutUpRight } from 'lucide-react';
-import Link from 'next/link';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { useDetailContext } from '../../DetailProvider';
 
@@ -43,7 +42,7 @@ const ProviderConfig = memo(() => {
       icon,
       key: 'officialSite',
       label: (
-        <Link href={url} target={'_blank'}>
+        <Link target={'_blank'} to={url}>
           {t('providers.officialSite')}
         </Link>
       ),
@@ -52,7 +51,7 @@ const ProviderConfig = memo(() => {
       icon,
       key: 'modelSite',
       label: (
-        <Link href={modelsUrl} target={'_blank'}>
+        <Link target={'_blank'} to={modelsUrl}>
           {t('providers.modelSite')}
         </Link>
       ),

--- a/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/index.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import qs from 'query-string';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
+import { Link } from 'react-router-dom';
 import urlJoin from 'url-join';
 
 import Title from '../../../../../features/Title';
@@ -30,7 +30,7 @@ const Related = memo(() => {
         {models?.slice(0, 6)?.map((item, index) => {
           const link = urlJoin('/community/model', item.id);
           return (
-            <Link href={link} key={index} style={{ color: 'inherit', overflow: 'hidden' }}>
+            <Link key={index} style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
               <Item {...item} />
             </Link>
           );

--- a/src/app/[variants]/(main)/community/(detail)/user/features/DetailProvider.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/DetailProvider.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, createContext, memo, use } from 'react';
 
+import { MarketUserProfile } from '@/layout/AuthProvider/MarketAuth/types';
 import { DiscoverAssistantItem, DiscoverUserInfo } from '@/types/discover';
 
 export interface UserDetailContextConfig {
@@ -9,7 +10,7 @@ export interface UserDetailContextConfig {
   agents: DiscoverAssistantItem[];
   isOwner: boolean;
   mobile?: boolean;
-  onEditProfile?: () => void;
+  onEditProfile?: (onSuccess?: (profile: MarketUserProfile) => void) => void;
   onStatusChange?: (identifier: string, action: 'publish' | 'unpublish' | 'deprecate') => void;
   totalInstalls: number;
   user: DiscoverUserInfo;

--- a/src/app/[variants]/(main)/community/(detail)/user/features/Header/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/Header/index.tsx
@@ -45,7 +45,7 @@ const UserHeader = memo(() => {
             </Text>
           </Flexbox>
           {isOwner && onEditProfile && (
-            <Button onClick={onEditProfile} shape={'round'}>
+            <Button onClick={() => onEditProfile()} shape={'round'}>
               {t('user.editProfile')}
             </Button>
           )}

--- a/src/app/[variants]/(main)/community/features/UserAvatar/index.tsx
+++ b/src/app/[variants]/(main)/community/features/UserAvatar/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, Button , Skeleton } from '@lobehub/ui';
+import { Avatar, Button, Skeleton } from '@lobehub/ui';
 import { UserCircleIcon } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -30,7 +30,7 @@ const UserAvatar = memo(() => {
 
   const handleNavigateToProfile = useCallback(() => {
     // Use userName from profile for the URL (not OIDC sub/id)
-    const profileUserName = userProfile?.userName;
+    const profileUserName = userProfile?.userName || userProfile?.namespace;
     if (profileUserName) {
       navigate(`/community/user/${profileUserName}`);
     }

--- a/src/layout/AuthProvider/MarketAuth/types.ts
+++ b/src/layout/AuthProvider/MarketAuth/types.ts
@@ -59,7 +59,7 @@ export interface MarketAuthContextType extends MarketAuthState {
   getAccessToken: () => string | null;
   getCurrentUserInfo: () => MarketUserInfo | null;
   getRefreshToken: () => string | null;
-  openProfileSetup: () => void;
+  openProfileSetup: (onSuccess?: (profile: MarketUserProfile) => void) => void;
   refreshToken: () => Promise<boolean>;
   signIn: () => Promise<number | null>;
   signOut: () => Promise<void>;

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -1693,8 +1693,7 @@ export class DiscoverService {
       const { user, agents } = response;
 
       // Transform agents to DiscoverAssistantItem format
-      // Note: UserAgentItem doesn't have tags or tokenUsage, using defaults
-      const transformedAgents: DiscoverAssistantItem[] = (agents || []).map((agent) => ({
+      const transformedAgents: DiscoverAssistantItem[] = (agents || []).map((agent: any) => ({
         author: user.displayName || user.userName || user.namespace || '',
         avatar: agent.avatar || '',
         category: agent.category as any,
@@ -1704,12 +1703,12 @@ export class DiscoverService {
         homepage: `https://lobehub.com/discover/assistant/${agent.identifier}`,
         identifier: agent.identifier,
         installCount: agent.installCount,
-        knowledgeCount: 0,
-        pluginCount: 0,
+        knowledgeCount: agent.knowledgeCount || 0,
+        pluginCount: agent.pluginCount || 0,
         schemaVersion: 1,
-        tags: [],
+        tags: agent.tags || [],
         title: agent.name || agent.identifier,
-        tokenUsage: 0,
+        tokenUsage: agent.tokenUsage || 0,
       }));
 
       const result: DiscoverUserProfile = {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix routing, profile handling, and metadata issues across community pages to improve navigation and profile behavior.

Bug Fixes:
- Correct owner detection for community user profiles by comparing user namespaces instead of usernames.
- Ensure navigating to a user profile works even when only the namespace is available, and update the URL when a user changes their username or namespace.
- Prevent access token race conditions by deferring initial profile-setup modal display until after session state updates.
- Preserve provider and model navigation in community pages by switching to the appropriate router link components and fixing tag link keys.
- Expose accurate assistant metadata in discover results, including knowledge, plugin counts, tags, and token usage instead of defaulting to zero or empty values.

Enhancements:
- Allow the profile-setup flow to accept a success callback so callers can react to completed profile updates, such as updating navigation.