### PR TITLE
🐛 fix: sloved the tools & header goback

### DIFF
--- a/src/app/[variants]/(main)/community/(detail)/_layout/Header.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/_layout/Header.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import { ActionIcon } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
+import { ArrowLeft } from 'lucide-react';
 import { memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import StoreSearchBar from '@/app/[variants]/(main)/community/features/Search';
 import UserAvatar from '@/app/[variants]/(main)/community/features/UserAvatar';
@@ -9,10 +13,24 @@ import NavHeader from '@/features/NavHeader';
 
 const Header = memo(() => {
   const theme = useTheme();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Extract the path segment (assistant, model, provider, mcp)
+  const path = location.pathname.split('/').find(Boolean);
+
+  const handleGoBack = () => {
+    navigate(`/${path}`);
+  };
 
   return (
     <NavHeader
-      left={<StoreSearchBar />}
+      left={
+        <Flexbox align={'center'} gap={8} horizontal>
+          <ActionIcon icon={ArrowLeft} onClick={handleGoBack} size={'small'} />
+          <StoreSearchBar />
+        </Flexbox>
+      }
       right={<UserAvatar />}
       style={{
         borderBottom: `1px solid ${theme.colorBorderSecondary}`,

--- a/src/features/ChatInput/ActionBar/Tools/KlavisServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/KlavisServerItem.tsx
@@ -327,6 +327,7 @@ const KlavisServerItem = memo<KlavisServerItemProps>(
 
     return (
       <Flexbox
+        align={'center'}
         gap={24}
         horizontal
         justify={'space-between'}

--- a/src/features/ChatInput/ActionBar/components/CheckbokWithLoading.tsx
+++ b/src/features/ChatInput/ActionBar/components/CheckbokWithLoading.tsx
@@ -22,6 +22,7 @@ const CheckboxItem = memo<CheckboxItemProps>(({ id, onUpdate, label, checked }) 
 
   return (
     <Flexbox
+      align={'center'}
       gap={24}
       horizontal
       justify={'space-between'}

--- a/src/features/MCPPluginDetail/Nav.tsx
+++ b/src/features/MCPPluginDetail/Nav.tsx
@@ -36,6 +36,16 @@ const useStyles = createStyles(({ css, token }) => {
     nav: css`
       border-block-end: 1px solid ${token.colorBorder};
     `,
+    tabs: css`
+      scrollbar-width: none;
+      overflow-x: auto;
+      flex: 1;
+      min-width: 0;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    `,
   };
 });
 
@@ -70,6 +80,7 @@ const Nav = memo<NavProps>(
     const nav = (
       <Tabs
         activeKey={activeTab}
+        className={styles.tabs}
         compact={mobile}
         items={
           [


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add a back navigation control to the community detail header and improve layout behavior for tools and plugin navigation.

Bug Fixes:
- Restore a functional back navigation in the community detail header that routes to the parent path segment.
- Ensure MCP plugin detail tabs can scroll horizontally without visible scrollbars on smaller viewports.
- Fix misaligned layouts for Klavis server items and checkbox-with-loading components by centering their contents.