### PR TITLE
Raise to 262k in-chat model max output tokens

### DIFF
--- a/src/features/AgentSetting/AgentModal/index.tsx
+++ b/src/features/AgentSetting/AgentModal/index.tsx
@@ -286,7 +286,7 @@ const AgentModal = memo(() => {
         children: (
           <SliderWithInput
             disabled={!enableMaxTokens}
-            max={32_000}
+            max={262_000}
             min={0}
             step={100}
             unlimitedInput


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Increased the maximum output tokens limit for chat models from 32,000 to 262,000 tokens to align with current provider capabilities.

**Changes:**
- Updated max output tokens setting from 32K to 262K in chat model configuration
- This enables users to take advantage of extended context windows now supported by many AI providers (Anthropic Claude, OpenAI, Google Gemini, Openrouter etc.)

**Rationale:**
Many modern LLM providers now support significantly larger output token limits (up to 262K tokens). This update allows users to configure their models to utilize these extended capabilities for longer-form content generation, detailed analyses, and complex multi-part responses.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

**Testing steps:**
1. Navigate to chat model settings
2. Verify that the max output tokens field now accepts values up to 262,000
3. Set a value above 32,000 (e.g., 100,000 or 262,000)
4. Confirm the setting saves correctly
5. Test with a prompt that generates a long response to verify the model respects the new limit

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Max: 32,000 tokens | Max: 262,000 tokens |

#### 📝 Additional Information

**Breaking Changes:** None. This is a backward-compatible increase to the maximum allowed value.

**Note:** Users should verify their specific model provider supports their desired output token limit. While many providers now support up to 262K tokens, actual limits vary by model and provider tier.

## Summary by Sourcery

New Features:
- Allow chat agent max output tokens to be configured up to 262,000 tokens instead of 32,000.