### PR TITLE
🐛 fix(desktop):  prevent window resize when onboarding

### DIFF
--- a/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
+++ b/apps/desktop/src/main/controllers/BrowserWindowsCtr.ts
@@ -1,4 +1,9 @@
-import { InterceptRouteParams, OpenSettingsWindowOptions } from '@lobechat/electron-client-ipc';
+import type {
+  InterceptRouteParams,
+  OpenSettingsWindowOptions,
+  WindowResizableParams,
+  WindowSizeParams,
+} from '@lobechat/electron-client-ipc';
 import { findMatchingRoute } from '~common/routes';
 
 import { AppBrowsersIdentifiers, WindowTemplateIdentifiers } from '@/appBrowsers';
@@ -65,6 +70,20 @@ export default class BrowserWindowsCtr extends ControllerModule {
   maximizeWindow() {
     this.withSenderIdentifier((identifier) => {
       this.app.browserManager.maximizeWindow(identifier);
+    });
+  }
+
+  @IpcMethod()
+  setWindowSize(params: WindowSizeParams) {
+    this.withSenderIdentifier((identifier) => {
+      this.app.browserManager.setWindowSize(identifier, params);
+    });
+  }
+
+  @IpcMethod()
+  setWindowResizable(params: WindowResizableParams) {
+    this.withSenderIdentifier((identifier) => {
+      this.app.browserManager.setWindowResizable(identifier, params.resizable);
     });
   }
 

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -473,6 +473,11 @@ export default class Browser {
     });
   }
 
+  setWindowResizable(resizable: boolean) {
+    logger.debug(`[${this.identifier}] Setting window resizable: ${resizable}`);
+    this._browserWindow?.setResizable(resizable);
+  }
+
   broadcast = <T extends MainBroadcastEventKey>(channel: T, data?: MainBroadcastParams<T>) => {
     if (this._browserWindow.isDestroyed()) return;
 

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -244,6 +244,16 @@ export class BrowserManager {
     }
   }
 
+  setWindowSize(identifier: string, size: { height?: number; width?: number }) {
+    const browser = this.browsers.get(identifier);
+    browser?.setWindowSize(size);
+  }
+
+  setWindowResizable(identifier: string, resizable: boolean) {
+    const browser = this.browsers.get(identifier);
+    browser?.setWindowResizable(resizable);
+  }
+
   getIdentifierByWebContents(webContents: WebContents): string | null {
     return this.webContentsMap.get(webContents) || null;
   }

--- a/packages/electron-client-ipc/src/types/index.ts
+++ b/packages/electron-client-ipc/src/types/index.ts
@@ -10,3 +10,4 @@ export * from './system';
 export * from './tray';
 export * from './update';
 export * from './upload';
+export * from './window';

--- a/packages/electron-client-ipc/src/types/window.ts
+++ b/packages/electron-client-ipc/src/types/window.ts
@@ -1,0 +1,8 @@
+export interface WindowSizeParams {
+  height?: number;
+  width?: number;
+}
+
+export interface WindowResizableParams {
+  resizable: boolean;
+}

--- a/src/app/[variants]/(main)/desktop-onboarding/index.tsx
+++ b/src/app/[variants]/(main)/desktop-onboarding/index.tsx
@@ -8,13 +8,37 @@ import {
   getDesktopOnboardingCompleted,
   setDesktopOnboardingCompleted,
 } from '@/features/DesktopOnboarding/storage';
+import { electronSystemService } from '@/services/electron/system';
+import { isDev } from '@/utils/env';
 
 const DesktopOnboarding = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (isDev) return;
     if (getDesktopOnboardingCompleted()) navigate('/', { replace: true });
   }, [navigate]);
+
+  useEffect(() => {
+    const fixedSize = { height: 900, width: 1400 };
+
+    const applyWindowSettings = async () => {
+      try {
+        await electronSystemService.setWindowSize(fixedSize);
+        await electronSystemService.setWindowResizable({ resizable: false });
+      } catch (error) {
+        console.error('[DesktopOnboarding] Failed to apply window settings:', error);
+      }
+    };
+
+    applyWindowSettings();
+
+    return () => {
+      electronSystemService.setWindowResizable({ resizable: true }).catch((error) => {
+        console.error('[DesktopOnboarding] Failed to restore window settings:', error);
+      });
+    };
+  }, []);
 
   return (
     <OnboardingContainerWithTheme

--- a/src/features/DesktopOnboarding/OnboardingContainer.tsx
+++ b/src/features/DesktopOnboarding/OnboardingContainer.tsx
@@ -5,6 +5,9 @@ import { createStyles } from 'antd-style';
 import { AnimatePresence, motion } from 'motion/react';
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { TITLE_BAR_HEIGHT } from '@/features/ElectronTitlebar';
+import { electronStylish } from '@/styles/electron';
+
 import { Navigation } from './Navigation';
 import LightRays from './effects/LightRays';
 import { Screen1 } from './screens/Screen1';
@@ -56,6 +59,16 @@ const useStyles = createStyles(({ css }) => ({
   screenWrapper: css`
     width: 100%;
     height: 100%;
+  `,
+
+  titleBar: css`
+    position: fixed;
+    z-index: 1000;
+    inset-block-start: 0;
+    inset-inline: 0 0;
+
+    width: 100%;
+    height: ${TITLE_BAR_HEIGHT}px;
   `,
 }));
 
@@ -219,6 +232,9 @@ export const OnboardingContainer: React.FC<OnboardingContainerProps> = ({ onComp
 
   return (
     <div className={styles.container}>
+      {/* Title Bar Drag Region */}
+      <div className={`${styles.titleBar} ${electronStylish.draggable}`} />
+
       {/* LightRays Background Layer */}
       {renderBackground()}
 

--- a/src/services/electron/system.ts
+++ b/src/services/electron/system.ts
@@ -1,4 +1,8 @@
-import { ElectronAppState } from '@lobechat/electron-client-ipc';
+import type {
+  ElectronAppState,
+  WindowResizableParams,
+  WindowSizeParams,
+} from '@lobechat/electron-client-ipc';
 
 import { ensureElectronIpc } from '@/utils/electron/ipc';
 
@@ -26,6 +30,14 @@ class ElectronSystemService {
 
   async minimizeWindow(): Promise<void> {
     return ensureElectronIpc().windows.minimizeWindow();
+  }
+
+  async setWindowResizable(params: WindowResizableParams): Promise<void> {
+    return ensureElectronIpc().windows.setWindowResizable(params);
+  }
+
+  async setWindowSize(params: WindowSizeParams): Promise<void> {
+    return ensureElectronIpc().windows.setWindowSize(params);
   }
 
   showContextMenu = async (type: string, data?: any) => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

设定 onboarding 时的固定尺寸，并禁用 resize。增加顶部的 dragbar

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Prevent the desktop onboarding flow from allowing window resizing and ensure the window uses a fixed size during onboarding.

Bug Fixes:
- Disable window resizing during the desktop onboarding flow to avoid unintended layout changes.

Enhancements:
- Set a fixed desktop window size specifically for the onboarding experience and restore resizability afterwards.
- Add a draggable title bar region to the desktop onboarding UI for proper window dragging support.
- Expose IPC and browser-layer APIs for setting window size and resizability from the renderer via the electron system service.
- Introduce typed window-related IPC parameters in the shared electron client types.