### PR TITLE
feat: Remove `docs_` prefix from URL

### DIFF
--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "أدخل سؤالك في الحقل أعلاه لبدء المحادثة مع الذكاء الاصطناعي",
     "aiModeHint": "اضغط Enter لطرح سؤال على Lobe AI",
     "aiModePlaceholder": "اطرح سؤالاً على الذكاء الاصطناعي...",
+    "askAI": "اسأل الذكاء الاصطناعي",
     "community": "المجتمع",
     "communitySupport": "دعم المجتمع",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "الإعدادات"
     },
     "discover": "استكشاف",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "الذاكرة",
     "navigate": "التنقل",
     "newAgent": "إنشاء مساعد جديد",

--- a/locales/bg-BG/common.json
+++ b/locales/bg-BG/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Въведете въпроса си в полето по-горе, за да започнете разговор с AI",
     "aiModeHint": "Натиснете Enter, за да попитате Lobe AI",
     "aiModePlaceholder": "Задайте въпрос на AI...",
+    "askAI": "Попитай AI",
     "community": "Общност",
     "communitySupport": "Общностна поддръжка",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Настройки"
     },
     "discover": "Открий",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Памет",
     "navigate": "Навигация",
     "newAgent": "Създай агент",

--- a/locales/de-DE/common.json
+++ b/locales/de-DE/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Gib deine Frage oben ein, um mit der KI zu chatten",
     "aiModeHint": "Drücken Sie Enter, um Lobe AI zu fragen",
     "aiModePlaceholder": "Stelle der KI eine Frage...",
+    "askAI": "KI fragen",
     "community": "Community",
     "communitySupport": "Community-Support",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Einstellungen"
     },
     "discover": "Entdecken",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Erinnerung",
     "navigate": "Navigieren",
     "newAgent": "Neuen Assistenten erstellen",

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Type your question above to start chatting with AI",
     "aiModeHint": "Press Enter to ask Lobe AI",
     "aiModePlaceholder": "Ask AI anything...",
+    "askAI": "Ask AI",
     "community": "Community",
     "communitySupport": "Community Support",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Settings"
     },
     "discover": "Discover",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Memory",
     "navigate": "Navigate",
     "newAgent": "Create New Assistant",

--- a/locales/es-ES/common.json
+++ b/locales/es-ES/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Escribe tu pregunta en el cuadro de arriba para comenzar a conversar con la IA",
     "aiModeHint": "Presiona Enter para preguntar a Lobe AI",
     "aiModePlaceholder": "Hazle una pregunta a la IA...",
+    "askAI": "Preguntar a la IA",
     "community": "Comunidad",
     "communitySupport": "Soporte de la comunidad",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Configuración"
     },
     "discover": "Descubrir",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Memoria",
     "navigate": "Navegar",
     "newAgent": "Nuevo asistente",

--- a/locales/fa-IR/common.json
+++ b/locales/fa-IR/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "برای شروع گفتگو با هوش مصنوعی، سوال خود را در کادر بالا وارد کنید",
     "aiModeHint": "Enter را فشار دهید تا از Lobe AI بپرسید",
     "aiModePlaceholder": "سوالی از هوش مصنوعی بپرسید...",
+    "askAI": "پرسیدن از هوش مصنوعی",
     "community": "انجمن",
     "communitySupport": "پشتیبانی جامعه",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "تنظیمات"
     },
     "discover": "کشف",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "حافظه",
     "navigate": "ناوبری",
     "newAgent": "دستیار جدید",

--- a/locales/fr-FR/common.json
+++ b/locales/fr-FR/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Saisissez votre question dans le champ ci-dessus pour commencer à discuter avec l'IA",
     "aiModeHint": "Appuyez sur Entrée pour interroger Lobe AI",
     "aiModePlaceholder": "Posez une question à l'IA...",
+    "askAI": "Demander à l'IA",
     "community": "Communauté",
     "communitySupport": "Support communautaire",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Paramètres"
     },
     "discover": "Découvrir",
+    "keyboard": {
+      "ESC": "ÉCHAP",
+      "Tab": "Tab"
+    },
     "memory": "Mémoire",
     "navigate": "Naviguer",
     "newAgent": "Nouvel assistant",

--- a/locales/it-IT/common.json
+++ b/locales/it-IT/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Inserisci la tua domanda nel campo sopra per iniziare a conversare con l'AI",
     "aiModeHint": "Premi Invio per chiedere a Lobe AI",
     "aiModePlaceholder": "Fai una domanda all'AI...",
+    "askAI": "Chiedi all'AI",
     "community": "Comunità",
     "communitySupport": "Supporto della comunità",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Impostazioni"
     },
     "discover": "Scopri",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Memoria",
     "navigate": "Naviga",
     "newAgent": "Nuovo assistente",

--- a/locales/ja-JP/common.json
+++ b/locales/ja-JP/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "上の入力欄に質問を入力して、AIとの対話を始めましょう",
     "aiModeHint": "EnterキーでLobe AIに質問",
     "aiModePlaceholder": "AIに質問する...",
+    "askAI": "AIに質問する",
     "community": "コミュニティ",
     "communitySupport": "コミュニティサポート",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "設定"
     },
     "discover": "発見",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "メモリー",
     "navigate": "ナビゲート",
     "newAgent": "新しいエージェントを作成",

--- a/locales/ko-KR/common.json
+++ b/locales/ko-KR/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "위의 입력창에 질문을 입력하여 AI와 대화를 시작하세요",
     "aiModeHint": "Enter 키를 눌러 Lobe AI에게 질문하세요",
     "aiModePlaceholder": "AI에게 질문하기...",
+    "askAI": "AI에게 질문하기",
     "community": "커뮤니티",
     "communitySupport": "커뮤니티 지원",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "설정"
     },
     "discover": "탐색",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "기억",
     "navigate": "탐색",
     "newAgent": "새 에이전트 만들기",

--- a/locales/nl-NL/common.json
+++ b/locales/nl-NL/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Typ je vraag in het invoerveld hierboven om een gesprek met de AI te starten",
     "aiModeHint": "Druk op Enter om Lobe AI te vragen",
     "aiModePlaceholder": "Stel een vraag aan de AI...",
+    "askAI": "Vraag het aan AI",
     "community": "Community",
     "communitySupport": "Communityondersteuning",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Instellingen"
     },
     "discover": "Ontdekken",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Geheugen",
     "navigate": "Navigeren",
     "newAgent": "Nieuwe Assistent",

--- a/locales/pl-PL/common.json
+++ b/locales/pl-PL/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Wpisz swoje pytanie w polu powyżej, aby rozpocząć rozmowę z AI",
     "aiModeHint": "Naciśnij Enter, aby zapytać Lobe AI",
     "aiModePlaceholder": "Zadaj pytanie AI...",
+    "askAI": "Zapytaj AI",
     "community": "Społeczność",
     "communitySupport": "Wsparcie społeczności",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Ustawienia"
     },
     "discover": "Odkrywaj",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Pamięć",
     "navigate": "Nawigacja",
     "newAgent": "Nowy asystent",

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Digite sua pergunta na caixa acima para começar a conversar com a IA",
     "aiModeHint": "Pressione Enter para perguntar ao Lobe AI",
     "aiModePlaceholder": "Pergunte algo à IA...",
+    "askAI": "Perguntar à IA",
     "community": "Comunidade",
     "communitySupport": "Suporte da Comunidade",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Configurações"
     },
     "discover": "Descobrir",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Memória",
     "navigate": "Navegar",
     "newAgent": "Novo Assistente",

--- a/locales/ru-RU/common.json
+++ b/locales/ru-RU/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Введите свой вопрос в поле выше, чтобы начать диалог с ИИ",
     "aiModeHint": "Нажмите Enter, чтобы задать вопрос Lobe AI",
     "aiModePlaceholder": "Задайте вопрос ИИ...",
+    "askAI": "Спросить ИИ",
     "community": "Сообщество",
     "communitySupport": "Поддержка сообщества",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Настройки"
     },
     "discover": "Обзор",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Память",
     "navigate": "Навигация",
     "newAgent": "Создать помощника",

--- a/locales/tr-TR/common.json
+++ b/locales/tr-TR/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Yukarıdaki giriş kutusuna sorunuzu yazarak yapay zeka ile sohbet etmeye başlayın",
     "aiModeHint": "Enter tuşuna basarak Lobe AI'ye sor",
     "aiModePlaceholder": "Yapay zekaya soru sor...",
+    "askAI": "Yapay Zekaya Sor",
     "community": "Topluluk",
     "communitySupport": "Topluluk Desteği",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Ayarlar"
     },
     "discover": "Keşfet",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Hafıza",
     "navigate": "Gezin",
     "newAgent": "Yeni Asistan Oluştur",

--- a/locales/vi-VN/common.json
+++ b/locales/vi-VN/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "Nhập câu hỏi của bạn vào ô phía trên để bắt đầu trò chuyện với AI",
     "aiModeHint": "Nhấn Enter để hỏi Lobe AI",
     "aiModePlaceholder": "Đặt câu hỏi cho AI...",
+    "askAI": "Hỏi AI",
     "community": "Cộng đồng",
     "communitySupport": "Hỗ trợ cộng đồng",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "Cài đặt"
     },
     "discover": "Khám phá",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "Ký ức",
     "navigate": "Điều hướng",
     "newAgent": "Tạo trợ lý mới",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "在上方输入框中输入你的问题，开始与 AI 对话",
     "aiModeHint": "Enter to ask Lobe AI",
     "aiModePlaceholder": "向 AI 提问...",
+    "askAI": "问 AI",
     "community": "社区",
     "communitySupport": "社区支持",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "设置"
     },
     "discover": "发现",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "记忆",
     "navigate": "导航",
     "newAgent": "新建助手",

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -140,6 +140,7 @@
     "aiModeEmptyState": "在上方輸入框中輸入你的問題，開始與 AI 對話",
     "aiModeHint": "按 Enter 向 Lobe AI 詢問",
     "aiModePlaceholder": "向 AI 提問...",
+    "askAI": "詢問 AI",
     "community": "社群",
     "communitySupport": "社群支援",
     "context": {
@@ -154,6 +155,10 @@
       "settings": "設定"
     },
     "discover": "探索",
+    "keyboard": {
+      "ESC": "ESC",
+      "Tab": "Tab"
+    },
     "memory": "記憶",
     "navigate": "導覽",
     "newAgent": "新增助手",

--- a/packages/builtin-agents/src/agents/page-agent/systemRole.ts
+++ b/packages/builtin-agents/src/agents/page-agent/systemRole.ts
@@ -5,9 +5,7 @@
  */
 export const systemRoleTemplate = `You are a helpful document (page) editing assistant. Your role is to:
 - Help users write, edit, and improve their pages
-- Provide suggestions for better clarity, structure, and style
 - Answer questions about the page content
 - Help with formatting and organization
-- Summarize or expand on sections as needed
 
 Be concise and helpful. Focus on improving the page quality.`;

--- a/src/app/[variants]/(main)/page/_layout/Body/useDropdownMenu.tsx
+++ b/src/app/[variants]/(main)/page/_layout/Body/useDropdownMenu.tsx
@@ -2,7 +2,7 @@
 
 import { Icon } from '@lobehub/ui';
 import type { MenuProps } from '@lobehub/ui';
-import { Check, Hash, LucideCheck } from 'lucide-react';
+import { Hash, LucideCheck } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -32,21 +32,21 @@ export const useDropdownMenu = (): MenuProps['items'] => {
     }));
 
     return [
-      {
-        icon: <Icon icon={Check} style={{ opacity: !showOnlyPagesNotInLibrary ? 1 : 0 }} />,
-        key: 'all',
-        label: t('pageList.filter.all'),
-        onClick: () => setShowOnlyPagesNotInLibrary(false),
-      },
-      {
-        icon: <Icon icon={Check} style={{ opacity: showOnlyPagesNotInLibrary ? 1 : 0 }} />,
-        key: 'onlyInPages',
-        label: t('pageList.filter.onlyInPages'),
-        onClick: () => setShowOnlyPagesNotInLibrary(true),
-      },
-      {
-        type: 'divider' as const,
-      },
+      // {
+      //   icon: <Icon icon={Check} style={{ opacity: !showOnlyPagesNotInLibrary ? 1 : 0 }} />,
+      //   key: 'all',
+      //   label: t('pageList.filter.all'),
+      //   onClick: () => setShowOnlyPagesNotInLibrary(false),
+      // },
+      // {
+      //   icon: <Icon icon={Check} style={{ opacity: showOnlyPagesNotInLibrary ? 1 : 0 }} />,
+      //   key: 'onlyInPages',
+      //   label: t('pageList.filter.onlyInPages'),
+      //   onClick: () => setShowOnlyPagesNotInLibrary(true),
+      // },
+      // {
+      //   type: 'divider' as const,
+      // },
       {
         children: pageSizeItems,
         icon: <Icon icon={Hash} />,

--- a/src/app/[variants]/(main)/page/index.tsx
+++ b/src/app/[variants]/(main)/page/index.tsx
@@ -15,7 +15,7 @@ const PagesPage = memo(() => {
 
   return (
     <Suspense fallback={<Loading debugId="PagesPage" />}>
-      <PageExplorer pageId={id} />
+      <PageExplorer pageId={`docs_${id}`} />
     </Suspense>
   );
 });

--- a/src/app/[variants]/(main)/settings/about/index.tsx
+++ b/src/app/[variants]/(main)/settings/about/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SiDiscord, SiGithub, SiMedium, SiRss, SiX } from '@icons-pack/react-simple-icons';
+import { SiDiscord, SiGithub, SiRss, SiX, SiYoutube } from '@icons-pack/react-simple-icons';
 import { Flexbox, Form } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { createStyles } from 'antd-style';
@@ -92,10 +92,10 @@ const Page = memo<{ mobile?: boolean }>(({ mobile }) => {
               },
 
               {
-                href: SOCIAL_URL.medium,
-                icon: SiMedium,
-                label: 'Medium',
-                value: 'medium',
+                href: SOCIAL_URL.youtube,
+                icon: SiYoutube,
+                label: 'YouTube',
+                value: 'youtube',
               },
             ]}
           />

--- a/src/features/CommandMenu/components/CommandInput.tsx
+++ b/src/features/CommandMenu/components/CommandInput.tsx
@@ -84,11 +84,11 @@ const CommandInput = memo(() => {
         />
         {viewMode !== 'ai-chat' && search.trim() ? (
           <>
-            <span style={{ fontSize: '14px', opacity: 0.6 }}>Ask AI</span>
-            <Tag>Tab</Tag>
+            <span style={{ fontSize: '14px', opacity: 0.6 }}>{t('cmdk.askAI')}</span>
+            <Tag>{t('cmdk.keyboard.Tab')}</Tag>
           </>
         ) : (
-          <Tag>ESC</Tag>
+          <Tag>{t('cmdk.keyboard.ESC')}</Tag>
         )}
       </div>
     </>

--- a/src/features/CommandMenu/useCommandMenu.ts
+++ b/src/features/CommandMenu/useCommandMenu.ts
@@ -1,6 +1,6 @@
 import { useDebounce } from 'ahooks';
 import { useEffect, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
 
 import type { SearchResult } from '@/database/repositories/search';
@@ -34,7 +34,6 @@ export const useCommandMenu = () => {
   } = useCommandMenuContext();
 
   const navigate = useNavigate();
-  const location = useLocation();
   const switchThemeMode = useGlobalStore((s) => s.switchThemeMode);
   const createAgent = useAgentStore((s) => s.createAgent);
   const refreshAgentList = useHomeStore((s) => s.refreshAgentList);

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -143,6 +143,7 @@ export default {
     aiModeEmptyState: '在上方输入框中输入你的问题，开始与 AI 对话',
     aiModeHint: 'Enter to ask Lobe AI',
     aiModePlaceholder: '向 AI 提问...',
+    askAI: '问 AI',
     community: '社区',
     communitySupport: '社区支持',
     context: {
@@ -157,6 +158,10 @@ export default {
       settings: '设置',
     },
     discover: '发现',
+    keyboard: {
+      ESC: 'ESC',
+      Tab: 'Tab',
+    },
     memory: '记忆',
     navigate: '导航',
     newAgent: '新建助手',

--- a/src/store/file/slices/document/action.ts
+++ b/src/store/file/slices/document/action.ts
@@ -16,7 +16,9 @@ const ALLOWED_DOCUMENT_FILE_TYPES = new Set(['custom/document', 'application/pdf
 const EDITOR_DOCUMENT_FILE_TYPE = 'custom/document';
 
 const updateUrl = (docId: string | null) => {
-  const newPath = docId ? `/page/${docId}` : '/page';
+  const dryPageId = docId?.replace('docs_', '');
+
+  const newPath = dryPageId ? `/page/${dryPageId}` : '/page';
   window.history.replaceState({}, '', newPath);
 };
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update page routing to hide the internal `docs_` prefix in URLs while preserving internal IDs, and improve UI/i18n around command hints and settings links.

New Features:
- Support localized labels for the command input "Ask AI" hint and keyboard shortcuts.
- Add a YouTube social link entry in the About settings page in place of the previous Medium link.

Bug Fixes:
- Normalize document URLs by stripping the internal `docs_` prefix from the browser-visible page path while still resolving pages correctly via prefixed IDs.

Enhancements:
- Simplify the page list dropdown by disabling the library filter options.
- Refine the page-editing system prompt to be more concise and focused.
- Extend common locale files with new command menu and keyboard-related translation keys.