### PR TITLE
⚡️perf: reduce back to home render time

### DIFF
--- a/src/app/[variants]/(main)/_layout/index.tsx
+++ b/src/app/[variants]/(main)/_layout/index.tsx
@@ -21,6 +21,8 @@ import CmdkLazy from '@/layout/GlobalProvider/CmdkLazy';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { HotkeyScopeEnum } from '@/types/hotkey';
 
+import DesktopHome from '../home';
+import DesktopHomeLayout from '../home/_layout';
 import DesktopAutoOidcOnFirstOpen from './DesktopAutoOidcOnFirstOpen';
 import DesktopLayoutContainer from './DesktopLayoutContainer';
 import RegisterHotkeys from './RegisterHotkeys';
@@ -59,6 +61,9 @@ const Layout: FC = () => {
           <NavPanel />
           <DesktopLayoutContainer>
             <MarketAuthProvider isDesktop={isDesktop}>
+              <DesktopHomeLayout>
+                <DesktopHome />
+              </DesktopHomeLayout>
               <Suspense fallback={<Loading debugId="DesktopMainLayout > Outlet" />}>
                 <Outlet />
               </Suspense>

--- a/src/app/[variants]/(main)/home/_layout/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/index.tsx
@@ -1,41 +1,66 @@
 import { Flexbox } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
-import { FC, Suspense, useEffect } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Activity, FC, ReactNode, useEffect, useState } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useHomeStore } from '@/store/home';
 
 import RecentHydration from './RecentHydration';
 import Sidebar from './Sidebar';
 
-const Layout: FC = () => {
+interface LayoutProps {
+  children?: ReactNode;
+}
+
+const Layout: FC<LayoutProps> = ({ children }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const isHomeRoute = pathname === '/';
+  const [hasActivated, setHasActivated] = useState(isHomeRoute);
   const setNavigate = useHomeStore((s) => s.setNavigate);
+  const content = children ?? <Outlet />;
 
   useEffect(() => {
     setNavigate(navigate);
   }, [navigate, setNavigate]);
 
+  useEffect(() => {
+    if (isHomeRoute) setHasActivated(true);
+  }, [isHomeRoute]);
+
+  if (!hasActivated) return null;
+
+  // Keep the Home layout alive and render it offscreen when inactive.
   return (
-    <>
-      <Sidebar />
+    <Activity mode={isHomeRoute ? 'visible' : 'hidden'} name="DesktopHomeLayout">
       <Flexbox
-        flex={1}
         height={'100%'}
         style={{
-          background: theme.isDarkMode
-            ? `linear-gradient(to bottom, ${theme.colorBgContainer}, ${theme.colorBgContainerSecondary})`
-            : theme.colorBgContainerSecondary,
-          overflow: 'hidden',
+          inset: 0,
+          pointerEvents: isHomeRoute ? 'auto' : 'none',
+          position: 'absolute',
+          visibility: isHomeRoute ? 'visible' : 'hidden',
         }}
+        width={'100%'}
       >
-        <Outlet />
-      </Flexbox>
-      <Suspense fallback={null}>
+        <Sidebar />
+        <Flexbox
+          flex={1}
+          height={'100%'}
+          style={{
+            background: theme.isDarkMode
+              ? `linear-gradient(to bottom, ${theme.colorBgContainer}, ${theme.colorBgContainerSecondary})`
+              : theme.colorBgContainerSecondary,
+            overflow: 'hidden',
+          }}
+        >
+          {content}
+        </Flexbox>
+
         <RecentHydration />
-      </Suspense>
-    </>
+      </Flexbox>
+    </Activity>
   );
 };
 

--- a/src/app/[variants]/(main)/home/_layout/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/index.tsx
@@ -38,9 +38,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
         height={'100%'}
         style={{
           inset: 0,
-          pointerEvents: isHomeRoute ? 'auto' : 'none',
           position: 'absolute',
-          visibility: isHomeRoute ? 'visible' : 'hidden',
         }}
         width={'100%'}
       >

--- a/src/app/[variants]/(main)/home/index.tsx
+++ b/src/app/[variants]/(main)/home/index.tsx
@@ -1,5 +1,6 @@
 import { Flexbox } from '@lobehub/ui';
 import { FC } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import PageTitle from '@/components/PageTitle';
 import NavHeader from '@/features/NavHeader';
@@ -9,9 +10,12 @@ import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
 import HomeContent from './features';
 
 const Home: FC = () => {
+  const { pathname } = useLocation();
+  const isHomeRoute = pathname === '/';
+
   return (
     <>
-      <PageTitle title="" />
+      {isHomeRoute && <PageTitle title="" />}
       <NavHeader right={<WideScreenButton />} />
       <Flexbox height={'100%'} style={{ overflowY: 'auto', paddingBottom: '16vh' }} width={'100%'}>
         <WideScreenContainer>

--- a/src/app/[variants]/router/desktopRouter.config.tsx
+++ b/src/app/[variants]/router/desktopRouter.config.tsx
@@ -7,8 +7,6 @@ import DesktopMainLayout from '../(main)/_layout';
 import DesktopChatLayout from '../(main)/chat/_layout';
 import DesktopOnboarding from '../(main)/desktop-onboarding';
 import DesktopGroupLayout from '../(main)/group/_layout';
-import DesktopHome from '../(main)/home';
-import DesktopHomeLayout from '../(main)/home/_layout';
 import DesktopImageLayout from '../(main)/image/_layout';
 import DesktopMemoryLayout from '../(main)/memory/_layout';
 import DesktopPageLayout from '../(main)/page/_layout';
@@ -370,15 +368,9 @@ export const desktopRoutes: RouteConfig[] = [
         path: 'page',
       },
 
-      // Default route - home page
+      // Default route - home page (handled by persistent layout)
       {
-        children: [
-          {
-            element: <DesktopHome />,
-            index: true,
-          },
-        ],
-        element: <DesktopHomeLayout />,
+        index: true,
       },
       // Catch-all route
       {

--- a/src/features/NavPanel/SideBarHeaderLayout.tsx
+++ b/src/features/NavPanel/SideBarHeaderLayout.tsx
@@ -5,6 +5,7 @@ import { Breadcrumb, BreadcrumbProps } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronRightIcon, HomeIcon } from 'lucide-react';
 import { ReactNode, memo } from 'react';
+import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import ToggleLeftPanelButton from './ToggleLeftPanelButton';
@@ -109,10 +110,11 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
           ].map((item) => ({
             ...item,
             onClick: (event) => {
-              if (item.href) {
+              const href = item.href;
+              if (href) {
                 event.preventDefault();
                 event.stopPropagation();
-                return navigate(item.href);
+                flushSync(() => navigate(href));
               }
             },
           }))}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

首屏离屏优化，回退到 home 耗时减少 ~450ms

<img width="1190" height="774" alt="image" src="https://github.com/user-attachments/assets/3aae3128-0805-481a-b7ff-509904d72254" />
<img width="1208" height="882" alt="image" src="https://github.com/user-attachments/assets/54356f01-f1de-4dbc-8c9e-525cc2148afc" />


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Optimize the desktop home experience by keeping the home layout persistently mounted and rendering it offscreen when inactive to reduce navigation latency back to home.

New Features:
- Introduce a persistent desktop home layout container that can wrap the home page content independently of routing.

Enhancements:
- Adjust home page rendering so the page title is only set on the actual home route, avoiding unnecessary updates on nested routes.
- Improve sidebar navigation responsiveness by flushing navigation updates synchronously on menu item clicks.

Build:
- Bump @lobehub/ui dependency from 3.4.1 to 3.4.2.