### PR TITLE
✨ feat: add home page create group builder button

### DIFF
--- a/src/app/[variants]/(main)/home/features/InputArea/ModeHeader.tsx
+++ b/src/app/[variants]/(main)/home/features/InputArea/ModeHeader.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import { BotIcon, ImageIcon, MicroscopeIcon, PenLineIcon, X } from 'lucide-react';
+import { BotIcon, ImageIcon, MicroscopeIcon, PenLineIcon, UsersIcon, X } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -22,6 +22,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
 const modeConfig = {
   agent: { icon: BotIcon, titleKey: 'starter.createAgent' },
+  group: { icon: UsersIcon, titleKey: 'starter.createGroup' },
   image: { icon: ImageIcon, titleKey: 'starter.image' },
   research: { icon: MicroscopeIcon, titleKey: 'starter.deepResearch' },
   write: { icon: PenLineIcon, titleKey: 'starter.write' },

--- a/src/app/[variants]/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/app/[variants]/(main)/home/features/InputArea/StarterList.tsx
@@ -1,7 +1,7 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
-import { Button, ButtonProps, Center , Tooltip } from '@lobehub/ui';
+import { Button, ButtonProps, Center, Tooltip } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import { BotIcon, ImageIcon, MicroscopeIcon, PenLineIcon } from 'lucide-react';
+import { BotIcon, ImageIcon, MicroscopeIcon, PenLineIcon, UsersIcon } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -27,6 +27,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
 type StarterTitleKey =
   | 'starter.createAgent'
+  | 'starter.createGroup'
   | 'starter.write'
   | 'starter.image'
   | 'starter.deepResearch';
@@ -44,6 +45,7 @@ const StarterList = memo(() => {
   const { t } = useTranslation('home');
 
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.agentBuilder);
+  useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.groupAgentBuilder);
 
   const [inputActiveMode, setInputActiveMode] = useHomeStore((s) => [
     s.inputActiveMode,
@@ -56,6 +58,11 @@ const StarterList = memo(() => {
         icon: BotIcon,
         key: 'agent',
         titleKey: 'starter.createAgent',
+      },
+      {
+        icon: UsersIcon,
+        key: 'group',
+        titleKey: 'starter.createGroup',
       },
       {
         icon: PenLineIcon,

--- a/src/app/[variants]/(main)/home/features/InputArea/useSend.ts
+++ b/src/app/[variants]/(main)/home/features/InputArea/useSend.ts
@@ -21,7 +21,7 @@ export const useSend = () => {
     const { inputMessage, mainInputEditor } = useChatStore.getState();
     const fileList = fileChatSelectors.chatUploadFileList(useFileStore.getState());
     const contextList = fileChatSelectors.chatContextSelections(useFileStore.getState());
-    const { sendAsAgent, sendAsWrite, sendAsImage, sendAsResearch, inputActiveMode } =
+    const { sendAsAgent, sendAsGroup, sendAsWrite, sendAsImage, sendAsResearch, inputActiveMode } =
       useHomeStore.getState();
 
     // Image mode: no input content required
@@ -37,6 +37,11 @@ export const useSend = () => {
       switch (inputActiveMode) {
         case 'agent': {
           await sendAsAgent(inputMessage);
+          break;
+        }
+
+        case 'group': {
+          await sendAsGroup(inputMessage);
           break;
         }
 

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -1,9 +1,11 @@
 import type { NavigateFunction } from 'react-router-dom';
 import type { StateCreator } from 'zustand/vanilla';
 
+import { chatGroupService } from '@/services/chatGroup';
 import { documentService } from '@/services/document';
 import { getAgentStoreState } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { getChatGroupStoreState } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
 import type { HomeStore } from '@/store/home/store';
 import { setNamespace } from '@/utils/storeDebug';
@@ -15,6 +17,7 @@ const n = setNamespace('homeInput');
 export interface HomeInputAction {
   clearInputMode: () => void;
   sendAsAgent: (message: string) => Promise<string>;
+  sendAsGroup: (message: string) => Promise<string>;
   sendAsImage: () => void;
   sendAsResearch: (message: string) => Promise<void>;
   sendAsWrite: (message: string) => Promise<string>;
@@ -71,6 +74,50 @@ export const createHomeInputSlice: StateCreator<
       return result.agentId!;
     } finally {
       set({ homeInputLoading: false }, false, n('sendAsAgent/end'));
+    }
+  },
+
+  sendAsGroup: async (message) => {
+    set({ homeInputLoading: true }, false, n('sendAsGroup/start'));
+
+    try {
+      // 1. Create new Group with message as initial description
+      const { group } = await chatGroupService.createGroup({
+        config: {
+          scene: 'productive',
+          systemPrompt: message,
+        },
+        title: message?.slice(0, 50) || 'New Group',
+      });
+
+      // 2. Load groups and refresh
+      const groupStore = getChatGroupStoreState();
+      await groupStore.loadGroups();
+
+      // 3. Navigate to Group profile page
+      const { navigate } = get();
+      if (navigate) {
+        navigate(`/group/${group.id}/profile`);
+      }
+
+      // 4. Send initial message to GroupAgentBuilder
+      const agentState = getAgentStoreState();
+      const groupAgentBuilderId = builtinAgentSelectors.groupAgentBuilderId(agentState);
+
+      if (groupAgentBuilderId) {
+        const { sendMessage } = useChatStore.getState();
+        await sendMessage({
+          context: { agentId: groupAgentBuilderId, scope: 'group_agent_builder' },
+          message,
+        });
+      }
+
+      // 5. Clear mode
+      set({ inputActiveMode: null }, false, n('sendAsGroup/clearMode'));
+
+      return group.id;
+    } finally {
+      set({ homeInputLoading: false }, false, n('sendAsGroup/end'));
     }
   },
 

--- a/src/store/home/slices/homeInput/initialState.ts
+++ b/src/store/home/slices/homeInput/initialState.ts
@@ -1,6 +1,6 @@
 import type { NavigateFunction } from 'react-router-dom';
 
-export type StarterMode = 'agent' | 'write' | 'image' | 'research' | null;
+export type StarterMode = 'agent' | 'group' | 'write' | 'image' | 'research' | null;
 
 export interface HomeInputState {
   homeInputLoading: boolean;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for creating and sending messages as a new group directly from the home input area.

New Features:
- Introduce a new 'group' starter mode on the home page to create groups from the main input.
- Allow sending the home input message as a group creation request that initializes a group and navigates to its profile.
- Initialize and use a built-in group agent builder when the group starter is selected to send an initial message to configure the group.

Enhancements:
- Extend home input state, mode header, and starter list configuration to support the new group creation mode in the UI.