### PR TITLE
refactor(userMemories): should use MemorySourceType

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic/route.ts
@@ -5,6 +5,7 @@ import {
   MemoryExtractionPayloadInput,
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
+import { MemorySourceType } from '@lobechat/types';
 
 export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
@@ -14,7 +15,7 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   if (!params.topicIds.length) {
     return { message: 'No topic ids provided for extraction.' };
   }
-  if (!params.sources.includes('chat_topic')) {
+  if (!params.sources.includes(MemorySourceType.ChatTopic)) {
     return { message: 'Source not supported in topic batch.' };
   }
 
@@ -32,7 +33,7 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
           forceTopics: params.forceTopics,
           from: params.from,
           layers: params.layers,
-          source: 'chat_topic',
+          source: MemorySourceType.ChatTopic,
           to: params.to,
           topicId,
           userId,

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics/route.ts
@@ -9,6 +9,7 @@ import {
   buildWorkflowPayloadInput,
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
+import { MemorySourceType } from '@lobechat/types';
 
 const TOPIC_PAGE_SIZE = 50;
 const TOPIC_BATCH_SIZE = 10;
@@ -18,7 +19,7 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   if (!params.userIds.length) {
     return { message: 'No user ids provided for topic processing.' };
   }
-  if (!params.sources.includes('chat_topic')) {
+  if (!params.sources.includes(MemorySourceType.ChatTopic)) {
     return { message: 'No supported sources requested, skip topic processing.' };
   }
 

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-users/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-users/route.ts
@@ -8,6 +8,7 @@ import {
   buildWorkflowPayloadInput,
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
+import { MemorySourceType } from '@lobechat/types';
 
 const USER_PAGE_SIZE = 50;
 const USER_BATCH_SIZE = 10;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enhancements:
- Standardize chat-topic memory source handling by replacing string literals with the MemorySourceType.ChatTopic enum across related workflow routes.