### PR TITLE
♻️ refactor(userMemories): added `benchmark_locomo` as source unify use the of source type

### DIFF
--- a/packages/memory-user-memory/package.json
+++ b/packages/memory-user-memory/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "test": "vitest --run",
     "build:gen-response-formats": "tsx scripts/generate-response-formats.ts",
-    "type-check": "tsgo --noEmit -p tsconfig.json",
-    "typecheck": "tsgo --noEmit -p tsconfig.json"
+    "type-check": "tsgo --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@lobechat/context-engine": "workspace:*",

--- a/packages/memory-user-memory/src/extractors/base.ts
+++ b/packages/memory-user-memory/src/extractors/base.ts
@@ -195,6 +195,7 @@ export abstract class BaseMemoryExtractor<
                 console.error('onExtractError callback error', err);
                 // ignore
               }
+
               throw error;
             } finally {
               span.end();
@@ -206,8 +207,8 @@ export abstract class BaseMemoryExtractor<
           code: SpanStatusCode.ERROR,
           message: error instanceof Error ? error.message : 'Structured call failed',
         });
-
         span.recordException(error as Error);
+
         throw error;
       } finally {
         span.end();

--- a/packages/memory-user-memory/src/providers/chatTopic.test.ts
+++ b/packages/memory-user-memory/src/providers/chatTopic.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { MemorySourceType } from '@lobechat/types';
 
 import { LobeChatTopicContextProvider } from './chatTopic';
 
 const job = {
-  source: 'chat_topic' as const,
+  source: MemorySourceType.ChatTopic,
   sourceId: 'topic-1',
   userId: 'user-1',
 };

--- a/packages/memory-user-memory/src/providers/existingUserMemory.test.ts
+++ b/packages/memory-user-memory/src/providers/existingUserMemory.test.ts
@@ -4,9 +4,10 @@ import {
   RetrievalUserMemoryContextProvider,
   RetrievalUserMemoryIdentitiesProvider,
 } from './existingUserMemory';
+import { MemorySourceType } from '@lobechat/types';
 
 const job = {
-  source: 'chat_topic' as const,
+  source: MemorySourceType.ChatTopic,
   sourceId: 'topic-1',
   userId: 'user-1',
 };

--- a/packages/memory-user-memory/src/types.ts
+++ b/packages/memory-user-memory/src/types.ts
@@ -3,7 +3,7 @@ import type {
   ModelRuntime,
   OpenAIChatMessage,
 } from '@lobechat/model-runtime';
-import type { LayersEnum } from '@lobechat/types';
+import type { LayersEnum, MemorySourceType } from '@lobechat/types';
 
 import type {
   ContextExtractor,
@@ -73,7 +73,7 @@ export interface MemoryExtractionLLMConfig {
 export interface MemoryExtractionJob {
   force?: boolean;
   layers?: LayersEnum[];
-  source: MemoryExtractionSourceType;
+  source: MemorySourceType;
   sourceId: string;
   sourceUpdatedAt?: Date;
   userId: string;
@@ -87,8 +87,6 @@ export interface MemoryExtractionSourceMetadata {
   status?: 'pending' | 'completed' | 'failed';
   version?: string;
 }
-
-export type MemoryExtractionSourceType = 'chat_topic' | 'obsidian' | 'notion' | 'lark';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export type ContextOptions<P extends Record<string, unknown>> = P;

--- a/packages/types/src/userMemory/list.ts
+++ b/packages/types/src/userMemory/list.ts
@@ -27,6 +27,7 @@ export interface TopicSource {
 export type MemorySource = TopicSource;
 
 export enum MemorySourceType {
+  BenchmarkLocomo = 'benchmark_locomo',
   ChatTopic = 'chat_topic',
 }
 

--- a/packages/types/src/userMemory/trace.ts
+++ b/packages/types/src/userMemory/trace.ts
@@ -1,4 +1,5 @@
 import type { LayersEnum } from './shared';
+import type { MemorySourceType } from './list';
 
 export type MemoryExtractionAgent =
   | 'gatekeeper'
@@ -6,8 +7,6 @@ export type MemoryExtractionAgent =
   | 'layer-experience'
   | 'layer-identity'
   | 'layer-preference';
-
-export type MemoryExtractionSourceType = 'chat_topic' | 'lark' | 'notion' | 'obsidian';
 
 export interface MemoryExtractionTraceError {
   message: string;
@@ -41,7 +40,7 @@ export interface MemoryExtractionTraceContexts {
 export interface MemoryExtractionTraceJob {
   force?: boolean;
   layers?: LayersEnum[];
-  source: MemoryExtractionSourceType;
+  source: MemorySourceType;
   sourceId: string;
   sourceUpdatedAt?: string | Date;
   userId: string;
@@ -84,7 +83,7 @@ export interface MemoryExtractionTracePayload<
   memories?: MemoryExtractionTraceMemories;
   result?: MemoryExtractionTraceResult<TExtraction>;
   source?: MemoryExtractionTraceSource;
-  sourceType?: MemoryExtractionSourceType;
+  sourceType?: MemorySourceType;
   userId?: string;
   userState?: unknown;
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Unify memory extraction source typing across user memory components and extend the set of supported memory sources.

New Features:
- Introduce a BenchmarkLocomo memory source type for user memories.

Enhancements:
- Replace local memory extraction source type aliases with the shared MemorySourceType enum across types and user-memory packages.
- Simplify memory-user-memory package scripts by removing a duplicate typecheck script.
- Minorly tidy error handling flow in the base memory extractor implementation.

Tests:
- Update memory provider tests to use the new MemorySourceType enum for chat topic sources.