### PR TITLE
✨ feat(memory-user-memory): support to load in memory, and extract from in-memory memory sources

### DIFF
--- a/packages/database/src/models/userMemory/index.ts
+++ b/packages/database/src/models/userMemory/index.ts
@@ -3,3 +3,4 @@ export * from './experience';
 export * from './identity';
 export * from './model';
 export * from './preference';
+export * from './sources/benchmarkLoCoMo';

--- a/packages/database/src/models/userMemory/sources/benchmarkLoCoMo.ts
+++ b/packages/database/src/models/userMemory/sources/benchmarkLoCoMo.ts
@@ -1,0 +1,91 @@
+import { createNanoId } from '../../../utils/idGenerator';
+import { UserMemorySource } from './shared';
+
+export interface BenchmarkLoCoMoPart {
+  content: string;
+  createdAt?: Date;
+  metadata?: Record<string, unknown>;
+  partIndex: number;
+  sessionId?: string;
+  speaker?: string;
+}
+
+export interface UpsertBenchmarkLoCoMoParams {
+  id?: string;
+  metadata?: Record<string, unknown>;
+  sampleId?: string;
+  sourceType: string;
+}
+
+export class UserMemorySourceBenchmarkLoCoMoModel {
+  private static readonly sources = new Map<string, Map<string, UserMemorySource>>();
+  private static readonly parts = new Map<string, Map<string, BenchmarkLoCoMoPart[]>>();
+  private readonly userId: string;
+
+  constructor(userId: string) {
+    this.userId = userId;
+  }
+
+  private getSourceStore() {
+    if (!UserMemorySourceBenchmarkLoCoMoModel.sources.has(this.userId)) {
+      UserMemorySourceBenchmarkLoCoMoModel.sources.set(this.userId, new Map());
+    }
+
+    return UserMemorySourceBenchmarkLoCoMoModel.sources.get(this.userId)!;
+  }
+
+  private getPartStore() {
+    if (!UserMemorySourceBenchmarkLoCoMoModel.parts.has(this.userId)) {
+      UserMemorySourceBenchmarkLoCoMoModel.parts.set(this.userId, new Map());
+    }
+
+    return UserMemorySourceBenchmarkLoCoMoModel.parts.get(this.userId)!;
+  }
+
+  async upsertSource(params: UpsertBenchmarkLoCoMoParams) {
+    const id = params.id ?? createNanoId(16)();
+    const now = new Date();
+    const store = this.getSourceStore();
+    const existing = store.get(id);
+
+    const record: UserMemorySource = {
+      createdAt: existing?.createdAt ?? now,
+      id,
+      metadata: params.metadata,
+      sampleId: params.sampleId,
+      sourceType: params.sourceType,
+      updatedAt: now,
+      userId: this.userId,
+    };
+
+    store.set(id, record);
+
+    return { id };
+  }
+
+  async replaceParts(sourceId: string, parts: BenchmarkLoCoMoPart[]) {
+    const store = this.getPartStore();
+    store.delete(sourceId);
+    if (!parts.length) return;
+
+    const normalized = parts.map((part) => ({
+      ...part,
+      createdAt: part.createdAt ?? new Date(),
+    }));
+
+    store.set(sourceId, normalized);
+  }
+
+  async listParts(sourceId: string) {
+    const store = this.getPartStore();
+    const parts = store.get(sourceId) ?? [];
+
+    return [...parts]
+      .map((part) => ({ ...part }))
+      .sort((a, b) => {
+        if (a.partIndex !== b.partIndex) return a.partIndex - b.partIndex;
+
+        return (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0);
+      });
+  }
+}

--- a/packages/database/src/models/userMemory/sources/index.ts
+++ b/packages/database/src/models/userMemory/sources/index.ts
@@ -1,0 +1,2 @@
+export * from './benchmarkLoCoMo'
+export * from './shared';

--- a/packages/database/src/models/userMemory/sources/shared.ts
+++ b/packages/database/src/models/userMemory/sources/shared.ts
@@ -1,0 +1,9 @@
+export interface UserMemorySource {
+  createdAt: Date;
+  id: string;
+  metadata?: Record<string, unknown>;
+  sampleId?: string;
+  sourceType: string;
+  updatedAt: Date;
+  userId: string;
+}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for extracting user memory from an in-memory benchmark source alongside existing chat-based extraction.

New Features:
- Introduce a BenchmarkLoCoMo in-memory memory source with per-user storage for sources and ordered parts.
- Enable direct memory extraction from both chat topics and BenchmarkLoCoMo sources, including support for specifying sourceIds.

Enhancements:
- Extend memory extraction payload and normalization to use typed memory source enums, support sourceIds, and relax direct mode restrictions beyond chat topics.
- Add a dedicated extraction flow for BenchmarkLoCoMo sources that builds context from stored parts, runs the memory extraction service, and persists results.