### PR TITLE
♻️ refactor: rename browser identifier from 'chat' to 'app'

### DIFF
--- a/apps/desktop/src/main/appBrowsers.ts
+++ b/apps/desktop/src/main/appBrowsers.ts
@@ -1,18 +1,18 @@
 import type { BrowserWindowOpts } from './core/browser/Browser';
 
 export const BrowsersIdentifiers = {
-  chat: 'chat',
+  app: 'app',
   devtools: 'devtools',
 };
 
 export const appBrowsers = {
-  chat: {
+  app: {
     autoHideMenuBar: true,
     height: 800,
-    identifier: 'chat',
+    identifier: 'app',
     keepAlive: true,
     minWidth: 400,
-    path: '/agent',
+    path: '/',
     showOnInit: true,
     titleBarStyle: 'hidden',
     vibrancy: 'under-window',
@@ -25,7 +25,7 @@ export const appBrowsers = {
     identifier: 'devtools',
     maximizable: false,
     minWidth: 400,
-    parentIdentifier: 'chat',
+    parentIdentifier: 'app',
     path: '/desktop/devtools',
     titleBarStyle: 'hiddenInset',
     vibrancy: 'under-window',
@@ -76,7 +76,7 @@ export const windowTemplates = {
     height: 600,
     keepAlive: false, // Multi-instance windows don't need to stay alive
     minWidth: 400,
-    parentIdentifier: 'chat',
+    parentIdentifier: 'app',
     titleBarStyle: 'hidden',
     vibrancy: 'under-window',
     width: 900,

--- a/apps/desktop/src/main/controllers/McpInstallCtr.ts
+++ b/apps/desktop/src/main/controllers/McpInstallCtr.ts
@@ -138,7 +138,7 @@ export default class McpInstallController extends ControllerModule {
 
       // 通过应用实例广播到前端
       if (this.app?.browserManager) {
-        this.app.browserManager.broadcastToWindow('chat', 'mcpInstallRequest', installRequest);
+        this.app.browserManager.broadcastToWindow('app', 'mcpInstallRequest', installRequest);
         logger.debug(`🔧 [McpInstall] Install request broadcasted successfully`);
         return true;
       } else {

--- a/apps/desktop/src/main/controllers/__tests__/McpInstallCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/McpInstallCtr.test.ts
@@ -84,7 +84,7 @@ describe('McpInstallController', () => {
 
       expect(result).toBe(true);
       expect(mockBrowserManager.broadcastToWindow).toHaveBeenCalledWith(
-        'chat',
+        'app',
         'mcpInstallRequest',
         {
           marketId: 'lobehub',
@@ -143,7 +143,7 @@ describe('McpInstallController', () => {
 
       expect(result).toBe(true);
       expect(mockBrowserManager.broadcastToWindow).toHaveBeenCalledWith(
-        'chat',
+        'app',
         'mcpInstallRequest',
         {
           marketId: 'third-party',
@@ -162,7 +162,7 @@ describe('McpInstallController', () => {
 
       expect(result).toBe(true);
       expect(mockBrowserManager.broadcastToWindow).toHaveBeenCalledWith(
-        'chat',
+        'app',
         'mcpInstallRequest',
         {
           marketId: 'third-party',
@@ -235,7 +235,7 @@ describe('McpInstallController', () => {
 
       expect(result).toBe(true);
       expect(mockBrowserManager.broadcastToWindow).toHaveBeenCalledWith(
-        'chat',
+        'app',
         'mcpInstallRequest',
         expect.objectContaining({
           schema: schemaWithOptionalFields,

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -5,6 +5,7 @@ import { createLogger } from '@/utils/logger';
 
 import {
   AppBrowsersIdentifiers,
+  BrowsersIdentifiers,
   WindowTemplateIdentifiers,
   appBrowsers,
   windowTemplates,
@@ -29,7 +30,7 @@ export class BrowserManager {
   }
 
   getMainWindow() {
-    return this.retrieveByIdentifier('chat');
+    return this.retrieveByIdentifier(BrowsersIdentifiers.app);
   }
 
   showMainWindow() {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Rename the main browser identifier from `'chat'` to `'app'` to better represent its purpose as the main application window. Also update the initial path from `/agent` to `/` for the root route.

**Changes:**
- `BrowsersIdentifiers.chat` → `BrowsersIdentifiers.app`
- `appBrowsers.chat` → `appBrowsers.app`
- Update all references in `BrowserManager`, `McpInstallCtr`
- Update `parentIdentifier` references from `'chat'` to `'app'`
- Change initial route from `/agent` to `/`
- Update test files accordingly

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests (existing tests updated)
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A (no UI changes)

#### 📝 Additional Information

This is a naming convention improvement to make the codebase more consistent and clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the main desktop browser identifier to `app` and adjust the main window routing accordingly.

Enhancements:
- Update browser identifiers and configuration to use `app` as the primary application window instead of `chat`.
- Change the main browser’s initial path from `/agent` to `/` and update related window templates’ parent identifiers.
- Align BrowserManager and McpInstall controller logic with the new main window identifier, including all associated tests.