### PR TITLE
✨ feat(desktop): macOS About menu should navigate to Settings About tab

### DIFF
--- a/apps/desktop/src/main/menus/impls/macOS.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.ts
@@ -69,8 +69,12 @@ export class MacOSMenu extends BaseMenuPlatform implements IMenuPlatform {
         label: appName,
         submenu: [
           {
+            click: async () => {
+              const mainWindow = this.app.browserManager.getMainWindow();
+              mainWindow.show();
+              mainWindow.broadcast('navigate', { path: '/settings/about' });
+            },
             label: t('macOS.about', { appName }),
-            role: 'about',
           },
           {
             click: () => {


### PR DESCRIPTION
## Summary

- Changed the macOS app menu's "About" action from using the default Electron about dialog to navigating to the Settings page's About tab
- This provides a more consistent user experience by opening the app and showing the About information in the settings

## Test plan

- [x] Build the desktop app on macOS
- [x] Click "About LobeChat" in the app menu
- [x] Verify the app window shows and navigates to `/settings/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Route the macOS app menu About action to the in-app Settings About page, ensuring the main window is shown and navigated to the About tab.