### PR TITLE
🐛 fix add lost portal locals files

### DIFF
--- a/locales/zh-CN/portal.json
+++ b/locales/zh-CN/portal.json
@@ -17,5 +17,6 @@
   "notebook.delete": "删除",
   "notebook.empty": "暂无文档，当前话题关联的文档将会显示在这里",
   "notebook.title": "Notebook",
+  "openInPageEditor": "在文稿中编辑",
   "title": "工作区"
 }

--- a/src/features/Portal/Document/Header.tsx
+++ b/src/features/Portal/Document/Header.tsx
@@ -17,7 +17,7 @@ import { oneLineEllipsis } from '@/styles';
 import AutoSaveHint from './AutoSaveHint';
 
 const Header = () => {
-  const { t } = useTranslation('file');
+  const { t } = useTranslation('portal');
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
 
@@ -67,7 +67,7 @@ const Header = () => {
           size={'small'}
           type={'text'}
         >
-          {t('portal.openInPageEditor')}
+          {t('openInPageEditor')}
         </Button>
       </Flexbox>
     </Flexbox>

--- a/src/locales/default/portal.ts
+++ b/src/locales/default/portal.ts
@@ -18,5 +18,6 @@ export default {
   "notebook.delete": "Delete",
   "notebook.empty": "No pages yet. Pages linked to this Topic will show up here.",
   "notebook.title": "Notebook",
+  "openInPageEditor": "Edit in Page",
   "title": "Workspace"
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Correct the portal document header translations by switching to the portal namespace and adding the missing "openInPageEditor" locale entry.