### PR TITLE
🐛 fix(ci): always continue build to upload bundle analyzer report

### DIFF
--- a/.github/workflows/bundle-analyzer.yml
+++ b/.github/workflows/bundle-analyzer.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "secret=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
 
       - name: Build with bundle analyzer
-        run: bun run build:analyze
+        run: bun run build:analyze || true
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           KEY_VAULTS_SECRET: ${{ secrets.KEY_VAULTS_SECRET || steps.generate-secret.outputs.secret }}


### PR DESCRIPTION
## Summary

- Use `|| true` to ensure the build step always succeeds and continues to the report upload step
- This ensures bundle analyzer reports are uploaded even if the build fails (reports are still generated)

## Test plan

- [ ] Verify CI workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the bundle analyzer workflow to ignore failures in the build step so subsequent steps, such as report upload, still run.