### PR TITLE
fix: [CRITICAL FIX] mixed message bug

### DIFF
--- a/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -33,6 +33,7 @@ import { setNamespace } from '@/utils/storeDebug';
 
 import { chatSelectors, threadSelectors, topicSelectors } from '../../../selectors';
 import { messageMapKey } from '../../../utils/messageMapKey';
+import {isNull} from "@/utils/type";
 
 const n = setNamespace('ai');
 
@@ -246,13 +247,11 @@ export const generateAIChatV2: StateCreator<
       .activeBaseChats(get())
       .filter((item) => item.id !== data.assistantMessageId)
       .filter((item) => {
-        // eslint-disable-next-line eqeqeq
-        if (activeThreadId == null) {
-          // eslint-disable-next-line eqeqeq
-          return item.threadId == null;
+        if (isNull(activeThreadId)) {
+          return isNull(item.threadId);
         }
 
-        const _isParent = isParent;
+        const _isParent = isNull(item.threadId)  && isParent;
         if (item.id === sourceMessageId) {
           isParent = false;
         }

--- a/src/store/chat/slices/message/selectors.ts
+++ b/src/store/chat/slices/message/selectors.ts
@@ -12,6 +12,7 @@ import { userProfileSelectors } from '@/store/user/selectors';
 
 import { chatHelpers } from '../../helpers';
 import type { ChatStoreState } from '../../initialState';
+import { isNull } from "@/utils/type";
 
 const getMeta = (message: UIChatMessage) => {
   switch (message.role) {
@@ -76,7 +77,8 @@ const getChatsWithThread = (s: ChatStoreState, messages: UIChatMessage[]) => {
   if (!thread) return messages.filter((m) => !m.threadId);
 
   const sourceIndex = messages.findIndex((m) => m.id === thread.sourceMessageId);
-  const sliced = messages.slice(0, sourceIndex + 1);
+  const sliced = messages.slice(0, sourceIndex + 1)
+    .filter((m) => isNull(m.threadId));
 
   return [...sliced, ...messages.filter((m) => m.threadId === s.activeThreadId)];
 };

--- a/src/store/chat/slices/thread/selectors/index.ts
+++ b/src/store/chat/slices/thread/selectors/index.ts
@@ -8,6 +8,7 @@ import { chatHelpers } from '@/store/chat/helpers';
 
 import { chatSelectors } from '../../message/selectors';
 import { genMessage } from './util';
+import {isNull} from "@/utils/type";
 
 const currentTopicThreads = (s: ChatStoreState) => {
   if (!s.activeTopicId) return [];
@@ -44,8 +45,7 @@ const getTheadParentMessages = (s: ChatStoreState, data: UIChatMessage[]) => {
   const portalThread = currentPortalThread(s);
   return (
     genMessage(data, portalThread?.sourceMessageId, portalThread?.type)
-      // eslint-disable-next-line eqeqeq
-      .filter((m) => m.threadId == null || m.threadId === portalThread?.id)
+      .filter((m) => isNull(m.threadId) || m.threadId === portalThread?.id)
   );
 };
 

--- a/src/store/chat/slices/thread/selectors/index.ts
+++ b/src/store/chat/slices/thread/selectors/index.ts
@@ -42,7 +42,11 @@ const getTheadParentMessages = (s: ChatStoreState, data: UIChatMessage[]) => {
   }
 
   const portalThread = currentPortalThread(s);
-  return genMessage(data, portalThread?.sourceMessageId, portalThread?.type);
+  return (
+    genMessage(data, portalThread?.sourceMessageId, portalThread?.type)
+      // eslint-disable-next-line eqeqeq
+      .filter((m) => m.threadId == null || m.threadId === portalThread?.id)
+  );
 };
 
 // ======= Portal Thread Display Chats ======= //

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,0 +1,3 @@
+export const isNull = (value: any): boolean => {
+  return value === undefined || value === null;
+}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue
Fixes #8327

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change
Fixes two issues related to message isolation within threaded conversations:

1. Fix issue of main topic mixing with messages from its sub-threads.
2. Fix issue where a thread carried messages from other threads under the same topic.


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A
<!-- If this PR includes UI changes, please provide screenshots or videos -->


#### 📝 Additional Information

**Impact of the Bug:**
Without this fix, users with existing conversation threads would incur significantly higher operational costs due to unnecessary token expenditure. Each request was effectively billed for double the actual required context.

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix message selection for AI responses so that threaded conversations remain isolated from each other and from the main topic.

Bug Fixes:
- Prevent main topic messages from being mixed with messages from sub-threads when generating AI responses.
- Ensure each thread only includes its own messages and relevant parent context when generating AI responses.