### PR TITLE
🐛 fix(scripts): fix syntax error in prebuild.mts

### DIFF
--- a/scripts/prebuild.mts
+++ b/scripts/prebuild.mts
@@ -15,7 +15,7 @@ const partialBuildPages = [
     name: 'backend-routes',
     disabled: isBundleAnalyzer,
     paths: ['src/app/(backend)'],
-  ],
+  },
   // no need for desktop
   // {
   //   name: 'changelog',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Correct the closing delimiter of the partialBuildPages entry in prebuild.mts to restore valid script syntax.