### PR TITLE
✨ feat: Add i18n UI locales and improve tool types

### DIFF
--- a/packages/database/src/schemas/user.ts
+++ b/packages/database/src/schemas/user.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { DEFAULT_PREFERENCE } from '@lobechat/const';
 import type { CustomPluginParams, UserOnboarding } from '@lobechat/types';
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 import { sql } from 'drizzle-orm';
 import { boolean, index, jsonb, pgTable, primaryKey, text, varchar } from 'drizzle-orm/pg-core';
 

--- a/packages/memory-user-memory/src/schemas/jsonSchemas.ts
+++ b/packages/memory-user-memory/src/schemas/jsonSchemas.ts
@@ -1,5 +1,5 @@
 import { searchMemorySchema } from '@lobechat/types';
-import { PluginSchema } from '@lobehub/chat-plugin-sdk';
+import type { PluginSchema } from '@lobehub/chat-plugin-sdk';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import { ContextMemoryItemSchema } from './context';

--- a/packages/types/src/discover/plugins.ts
+++ b/packages/types/src/discover/plugins.ts
@@ -1,5 +1,5 @@
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
-import { LobeChatPluginMeta, Meta } from '@lobehub/chat-plugin-sdk/lib/types/market';
+import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginMeta, Meta } from '@lobehub/chat-plugin-sdk/lib/types/market';
 
 export enum PluginCategory {
   All = 'all',

--- a/packages/types/src/message/common/tools.ts
+++ b/packages/types/src/message/common/tools.ts
@@ -1,4 +1,4 @@
-import { IPluginErrorType } from '@lobehub/chat-plugin-sdk';
+import type { IPluginErrorType } from '@lobehub/chat-plugin-sdk';
 import type { PartialDeep } from 'type-fest';
 import { z } from 'zod';
 

--- a/packages/types/src/tool/index.ts
+++ b/packages/types/src/tool/index.ts
@@ -1,4 +1,4 @@
-import { LobeChatPluginManifest, LobePluginType } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest, LobePluginType } from '@lobehub/chat-plugin-sdk';
 
 import { CustomPluginParams } from './plugin';
 import { LobeToolType } from './tool';

--- a/packages/types/src/tool/plugin.ts
+++ b/packages/types/src/tool/plugin.ts
@@ -1,4 +1,4 @@
-import { LobeChatPluginManifest, Meta } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest, Meta } from '@lobehub/chat-plugin-sdk';
 
 import { LobeToolType } from './tool';
 

--- a/src/app/(backend)/webapi/plugin/gateway/route.ts
+++ b/src/app/(backend)/webapi/plugin/gateway/route.ts
@@ -1,7 +1,7 @@
 import { AgentRuntimeError } from '@lobechat/model-runtime';
 import { ChatErrorType, ErrorType, TraceNameMap } from '@lobechat/types';
 import { getXorPayload } from '@lobechat/utils/server';
-import { PluginRequestPayload } from '@lobehub/chat-plugin-sdk';
+import type { PluginRequestPayload } from '@lobehub/chat-plugin-sdk';
 import { createGatewayOnEdgeRuntime } from '@lobehub/chat-plugins-gateway';
 
 import { LOBE_CHAT_AUTH_HEADER, OAUTH_AUTHORIZED, enableNextAuth } from '@/const/auth';

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -4,7 +4,7 @@
 import { ToolsEngine } from '@lobechat/context-engine';
 import type { PluginEnableChecker } from '@lobechat/context-engine';
 import { ChatCompletionTool, WorkingModel } from '@lobechat/types';
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';

--- a/src/libs/getUILocaleAndResources.test.ts
+++ b/src/libs/getUILocaleAndResources.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUILocaleAndResources } from './getUILocaleAndResources';
+
+describe('getUILocaleAndResources', () => {
+  it('should return zh-CN locale and zhCn resources for zh-CN', async () => {
+    const result = await getUILocaleAndResources('zh-CN');
+    expect(result.locale).toBe('zh-CN');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return zh-CN locale and zhCn resources for zh-TW', async () => {
+    const result = await getUILocaleAndResources('zh-TW');
+    expect(result.locale).toBe('zh-CN');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and en resources for en-US', async () => {
+    const result = await getUILocaleAndResources('en-US');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and en resources for en', async () => {
+    const result = await getUILocaleAndResources('en');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and en resources for auto', async () => {
+    const result = await getUILocaleAndResources('auto');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and custom resources for ar', async () => {
+    const result = await getUILocaleAndResources('ar');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and custom resources for de-DE', async () => {
+    const result = await getUILocaleAndResources('de-DE');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+
+  it('should return en-US locale and custom resources for es-ES', async () => {
+    const result = await getUILocaleAndResources('es-ES');
+    expect(result.locale).toBe('en-US');
+    expect(result.resources).toBeDefined();
+  });
+});

--- a/src/libs/getUILocaleAndResources.ts
+++ b/src/libs/getUILocaleAndResources.ts
@@ -11,8 +11,8 @@ const getUILocale = (locale: string): string => {
 
 const loadCustomResources = async (locale: string) => {
   try {
-    const module = await import(`@/locales/ui/${locale}.ts`);
-    return module.default;
+    const locates = await import(`@/locales/ui/${locale}.ts`);
+    return locates.default;
   } catch (error) {
     console.warn(`Failed to load UI resources for locale ${locale}:`, error);
     return null;

--- a/src/libs/getUILocaleAndResources.ts
+++ b/src/libs/getUILocaleAndResources.ts
@@ -1,0 +1,45 @@
+const loadBuiltinResources = async () => {
+  const { en, zhCn } = await import('@lobehub/ui/i18n');
+  return { en, zhCn };
+};
+
+const getUILocale = (locale: string): string => {
+  if (locale.startsWith('zh')) return 'zh-CN';
+  if (locale.startsWith('en')) return 'en-US';
+  return 'en-US';
+};
+
+const loadCustomResources = async (locale: string) => {
+  try {
+    const module = await import(`@/locales/ui/${locale}.ts`);
+    return module.default;
+  } catch (error) {
+    console.warn(`Failed to load UI resources for locale ${locale}:`, error);
+    return null;
+  }
+};
+
+export const getUILocaleAndResources = async (
+  locale: string | 'auto',
+): Promise<{ locale: string; resources: any }> => {
+  const effectiveLocale = locale === 'auto' ? 'en-US' : locale;
+  const uiLocale = getUILocale(effectiveLocale);
+
+  const { en, zhCn } = await loadBuiltinResources();
+
+  let resources;
+
+  if (effectiveLocale.startsWith('zh-CN')) {
+    resources = zhCn;
+  } else if (effectiveLocale.startsWith('en')) {
+    resources = en;
+  } else {
+    const customResources = await loadCustomResources(effectiveLocale);
+    resources = customResources || en;
+  }
+
+  return {
+    locale: uiLocale,
+    resources,
+  };
+};

--- a/src/libs/redis/upstash.ts
+++ b/src/libs/redis/upstash.ts
@@ -1,5 +1,5 @@
 import { Redis, RedisConfigNodejs } from '@upstash/redis';
-import { Buffer } from 'node:buffer';
+import { Buffer } from 'buffer';
 
 import {
   BaseRedisProvider,

--- a/src/locales/ui/ar.ts
+++ b/src/locales/ui/ar.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'الصورة الرمزية',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'تجاوز',
+    'tokenTag.remained': 'المتبقي',
+    'tokenTag.used': 'المستخدم',
+  },
+  common: {
+    'common.cancel': 'إلغاء',
+    'common.confirm': 'تأكيد',
+    'common.delete': 'حذف',
+    'common.edit': 'تحرير',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'إضافة خصائص',
+    'editableMessage.delete': 'حذف',
+    'editableMessage.input': 'إدخال',
+    'editableMessage.inputPlaceholder': 'يرجى إدخال محتوى إدخال نموذجي',
+    'editableMessage.output': 'إخراج',
+    'editableMessage.outputPlaceholder': 'يرجى إدخال محتوى إخراج نموذجي',
+    'editableMessage.system': 'النظام',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'حذف',
+    'emojiPicker.draggerDesc': 'انقر أو اسحب الصورة إلى هذه المنطقة للرفع',
+    'emojiPicker.emoji': 'رمز تعبيري',
+    'emojiPicker.fileTypeError': 'يمكنك رفع ملفات الصور فقط!',
+    'emojiPicker.upload': 'رفع',
+    'emojiPicker.uploadBtn': 'اقتصاص ورفع',
+  },
+  form: {
+    'form.reset': 'إعادة ضبط',
+    'form.submit': 'إرسال',
+    'form.unsavedChanges': 'تغييرات غير محفوظة',
+    'form.unsavedWarning': 'لديك تغييرات غير محفوظة. هل أنت متأكد أنك تريد المغادرة؟',
+  },
+  hotkey: {
+    'hotkey.conflict': 'هذا الاختصار يتعارض مع اختصار موجود.',
+    'hotkey.invalidCombination':
+      'يجب أن يتضمن الاختصار مفتاح تعديل (Ctrl أو Alt أو Shift) ومفتاحًا عاديًا واحدًا فقط.',
+    'hotkey.placeholder': 'اضغط الأزرار لتسجيل الاختصار',
+    'hotkey.reset': 'إعادة التعيين إلى الافتراضي',
+  },
+  messageModal: {
+    'messageModal.cancel': 'إلغاء',
+    'messageModal.confirm': 'تأكيد',
+    'messageModal.edit': 'تحرير',
+  },
+  sideNav: {
+    'sideNav.collapse': 'طي الشريط الجانبي',
+    'sideNav.demoActiveLabel': 'نشط',
+    'sideNav.demoFeatureAutoCollapseDesc': 'اسحب أسفل الحد للطي الذكي',
+    'sideNav.demoFeatureAutoCollapseTitle': 'طي تلقائي',
+    'sideNav.demoFeaturePerformanceDesc': 'بدون تكلفة رسوم متحركة لأداء أفضل',
+    'sideNav.demoFeaturePerformanceTitle': 'الأداء',
+    'sideNav.demoFeatureResizeDesc': 'اسحب لضبط عرض اللوحة',
+    'sideNav.demoFeatureResizeTitle': 'تغيير الحجم بمرونة',
+    'sideNav.demoFeatureSmartHandleDesc': 'مرر لإظهار زر التبديل',
+    'sideNav.demoFeatureSmartHandleTitle': 'مقبض ذكي',
+    'sideNav.demoFeaturesTitle': 'الميزات',
+    'sideNav.demoHint': 'جرّب سحب حافة اللوحة واستخدام زر التبديل ->',
+    'sideNav.demoSubtitle': 'لوحة جانبية بنمط مساحة عمل مع تغيير حجم بالسحب',
+    'sideNav.demoTitle': 'عرض DraggableSideNav',
+    'sideNav.expand': 'توسيع الشريط الجانبي',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/bg-BG.ts
+++ b/src/locales/ui/bg-BG.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'Аватар',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Превишено',
+    'tokenTag.remained': 'Остава',
+    'tokenTag.used': 'Използвано',
+  },
+  common: {
+    'common.cancel': 'Отказ',
+    'common.confirm': 'Потвърди',
+    'common.delete': 'Изтрий',
+    'common.edit': 'Редактирай',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Добави свойства',
+    'editableMessage.delete': 'Изтрий',
+    'editableMessage.input': 'Вход',
+    'editableMessage.inputPlaceholder': 'Въведете примерен вход',
+    'editableMessage.output': 'Изход',
+    'editableMessage.outputPlaceholder': 'Въведете примерен изход',
+    'editableMessage.system': 'Система',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Изтрий',
+    'emojiPicker.draggerDesc': 'Кликнете или плъзнете изображение тук за качване',
+    'emojiPicker.emoji': 'Емоджи',
+    'emojiPicker.fileTypeError': 'Можете да качвате само изображения!',
+    'emojiPicker.upload': 'Качване',
+    'emojiPicker.uploadBtn': 'Изрежи и качи',
+  },
+  form: {
+    'form.reset': 'Нулиране',
+    'form.submit': 'Изпрати',
+    'form.unsavedChanges': 'Незапазени промени',
+    'form.unsavedWarning': 'Имате незапазени промени. Сигурни ли сте, че искате да напуснете?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Тази клавишна комбинация е в конфликт със съществуваща.',
+    'hotkey.invalidCombination':
+      'Комбинацията трябва да включва модификатор (Ctrl, Alt, Shift) и само един обикновен клавиш.',
+    'hotkey.placeholder': 'Натиснете клавишите, за да запишете комбинацията',
+    'hotkey.reset': 'Възстанови по подразбиране',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Отказ',
+    'messageModal.confirm': 'Потвърди',
+    'messageModal.edit': 'Редактирай',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Свий страничната лента',
+    'sideNav.demoActiveLabel': 'Активно',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Плъзнете под прага за интелигентно свиване',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Автоматично свиване',
+    'sideNav.demoFeaturePerformanceDesc': 'Без анимационен overhead за по-добра производителност',
+    'sideNav.demoFeaturePerformanceTitle': 'Производителност',
+    'sideNav.demoFeatureResizeDesc': 'Плъзнете, за да настроите ширината на панела',
+    'sideNav.demoFeatureResizeTitle': 'Гъвкаво оразмеряване',
+    'sideNav.demoFeatureSmartHandleDesc': 'Задръжте курсора, за да се покаже бутонът',
+    'sideNav.demoFeatureSmartHandleTitle': 'Интелигентна дръжка',
+    'sideNav.demoFeaturesTitle': 'Функции',
+    'sideNav.demoHint': 'Опитайте да плъзнете ръба на панела и да използвате бутона ->',
+    'sideNav.demoSubtitle': 'Страничен панел тип работно пространство с плъзгащо оразмеряване',
+    'sideNav.demoTitle': 'Демо DraggableSideNav',
+    'sideNav.expand': 'Разгъни страничната лента',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/de-DE.ts
+++ b/src/locales/ui/de-DE.ts
@@ -1,0 +1,72 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'Avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Überlastung',
+    'tokenTag.remained': 'Verbleibend',
+    'tokenTag.used': 'Verwendet',
+  },
+  common: {
+    'common.cancel': 'Abbrechen',
+    'common.confirm': 'Bestätigen',
+    'common.delete': 'Löschen',
+    'common.edit': 'Bearbeiten',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Eigenschaften hinzufügen',
+    'editableMessage.delete': 'Löschen',
+    'editableMessage.input': 'Eingabe',
+    'editableMessage.inputPlaceholder': 'Bitte Beispiel-Eingabeinhalt eingeben',
+    'editableMessage.output': 'Ausgabe',
+    'editableMessage.outputPlaceholder': 'Bitte Beispiel-Ausgabeinhalt eingeben',
+    'editableMessage.system': 'System',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Löschen',
+    'emojiPicker.draggerDesc': 'Klicken oder Bild in diesen Bereich ziehen, um es hochzuladen',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Sie können nur Bilddateien hochladen!',
+    'emojiPicker.upload': 'Hochladen',
+    'emojiPicker.uploadBtn': 'Zuschneiden und hochladen',
+  },
+  form: {
+    'form.reset': 'Zurücksetzen',
+    'form.submit': 'Absenden',
+    'form.unsavedChanges': 'Ungespeicherte Änderungen',
+    'form.unsavedWarning':
+      'Sie haben ungespeicherte Änderungen. Möchten Sie die Seite wirklich verlassen?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Diese Tastenkombination steht im Konflikt mit einer bestehenden.',
+    'hotkey.invalidCombination':
+      'Die Tastenkombination muss eine Modifikatortaste (Ctrl, Alt, Umschalt) und nur eine normale Taste enthalten.',
+    'hotkey.placeholder': 'Tasten drücken, um die Tastenkombination aufzunehmen',
+    'hotkey.reset': 'Auf Standard zurücksetzen',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Abbrechen',
+    'messageModal.confirm': 'Bestätigen',
+    'messageModal.edit': 'Bearbeiten',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Seitenleiste einklappen',
+    'sideNav.demoActiveLabel': 'Aktiv',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Unter die Schwelle ziehen für intelligentes Einklappen',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Automatisch einklappen',
+    'sideNav.demoFeaturePerformanceDesc': 'Keine Animations-Overhead für bessere Leistung',
+    'sideNav.demoFeaturePerformanceTitle': 'Leistung',
+    'sideNav.demoFeatureResizeDesc': 'Ziehen, um die Panelbreite anzupassen',
+    'sideNav.demoFeatureResizeTitle': 'Flexibles Anpassen',
+    'sideNav.demoFeatureSmartHandleDesc': 'Zum Anzeigen der Umschaltfläche darüberfahren',
+    'sideNav.demoFeatureSmartHandleTitle': 'Intelligenter Griff',
+    'sideNav.demoFeaturesTitle': 'Funktionen',
+    'sideNav.demoHint': 'Versuchen Sie, die Panelkante zu ziehen und die Umschaltfläche zu verwenden ->',
+    'sideNav.demoSubtitle': 'Eine Arbeitsbereich-Seitenleiste mit ziehbarer Größenänderung',
+    'sideNav.demoTitle': 'DraggableSideNav Demo',
+    'sideNav.expand': 'Seitenleiste ausklappen',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/es-ES.ts
+++ b/src/locales/ui/es-ES.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Excedido',
+    'tokenTag.remained': 'Restante',
+    'tokenTag.used': 'Usado',
+  },
+  common: {
+    'common.cancel': 'Cancelar',
+    'common.confirm': 'Confirmar',
+    'common.delete': 'Eliminar',
+    'common.edit': 'Editar',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Añadir propiedades',
+    'editableMessage.delete': 'Eliminar',
+    'editableMessage.input': 'Entrada',
+    'editableMessage.inputPlaceholder': 'Introduce un contenido de entrada de ejemplo',
+    'editableMessage.output': 'Salida',
+    'editableMessage.outputPlaceholder': 'Introduce un contenido de salida de ejemplo',
+    'editableMessage.system': 'Sistema',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Eliminar',
+    'emojiPicker.draggerDesc': 'Haz clic o arrastra una imagen a esta área para subirla',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': '¡Solo puedes subir archivos de imagen!',
+    'emojiPicker.upload': 'Subir',
+    'emojiPicker.uploadBtn': 'Recortar y subir',
+  },
+  form: {
+    'form.reset': 'Restablecer',
+    'form.submit': 'Enviar',
+    'form.unsavedChanges': 'Cambios sin guardar',
+    'form.unsavedWarning': 'Tienes cambios sin guardar. ¿Seguro que quieres salir?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Este atajo entra en conflicto con uno existente.',
+    'hotkey.invalidCombination':
+      'El atajo debe incluir una tecla modificadora (Ctrl, Alt, Shift) y solo una tecla normal.',
+    'hotkey.placeholder': 'Pulsa las teclas para registrar el atajo',
+    'hotkey.reset': 'Restablecer a valores predeterminados',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Cancelar',
+    'messageModal.confirm': 'Confirmar',
+    'messageModal.edit': 'Editar',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Contraer barra lateral',
+    'sideNav.demoActiveLabel': 'Activo',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Arrastra por debajo del umbral para contraer inteligentemente',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Auto-contracción',
+    'sideNav.demoFeaturePerformanceDesc': 'Sin coste de animación para mejor rendimiento',
+    'sideNav.demoFeaturePerformanceTitle': 'Rendimiento',
+    'sideNav.demoFeatureResizeDesc': 'Arrastra para ajustar el ancho del panel',
+    'sideNav.demoFeatureResizeTitle': 'Redimensionado flexible',
+    'sideNav.demoFeatureSmartHandleDesc': 'Pasa el ratón para mostrar el botón',
+    'sideNav.demoFeatureSmartHandleTitle': 'Asa inteligente',
+    'sideNav.demoFeaturesTitle': 'Funciones',
+    'sideNav.demoHint': 'Prueba arrastrando el borde del panel y usando el botón ->',
+    'sideNav.demoSubtitle': 'Un panel lateral estilo workspace con redimensionado arrastrable',
+    'sideNav.demoTitle': 'Demo de DraggableSideNav',
+    'sideNav.expand': 'Expandir barra lateral',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/fa-IR.ts
+++ b/src/locales/ui/fa-IR.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'آواتار',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'بیش‌ازحد',
+    'tokenTag.remained': 'باقی‌مانده',
+    'tokenTag.used': 'استفاده‌شده',
+  },
+  common: {
+    'common.cancel': 'لغو',
+    'common.confirm': 'تأیید',
+    'common.delete': 'حذف',
+    'common.edit': 'ویرایش',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'افزودن ویژگی‌ها',
+    'editableMessage.delete': 'حذف',
+    'editableMessage.input': 'ورودی',
+    'editableMessage.inputPlaceholder': 'لطفاً محتوای ورودی نمونه را وارد کنید',
+    'editableMessage.output': 'خروجی',
+    'editableMessage.outputPlaceholder': 'لطفاً محتوای خروجی نمونه را وارد کنید',
+    'editableMessage.system': 'سیستم',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'حذف',
+    'emojiPicker.draggerDesc': 'برای بارگذاری کلیک کنید یا تصویر را به اینجا بکشید',
+    'emojiPicker.emoji': 'ایموجی',
+    'emojiPicker.fileTypeError': 'فقط می‌توانید فایل تصویر بارگذاری کنید!',
+    'emojiPicker.upload': 'بارگذاری',
+    'emojiPicker.uploadBtn': 'برش و بارگذاری',
+  },
+  form: {
+    'form.reset': 'بازنشانی',
+    'form.submit': 'ارسال',
+    'form.unsavedChanges': 'تغییرات ذخیره‌نشده',
+    'form.unsavedWarning': 'شما تغییرات ذخیره‌نشده دارید. آیا مطمئنید می‌خواهید خارج شوید؟',
+  },
+  hotkey: {
+    'hotkey.conflict': 'این میانبر با یک میانبر موجود تداخل دارد.',
+    'hotkey.invalidCombination':
+      'میانبر باید شامل یک کلید اصلاح‌کننده (Ctrl، Alt، Shift) و فقط یک کلید معمولی باشد.',
+    'hotkey.placeholder': 'برای ثبت میانبر کلیدها را فشار دهید',
+    'hotkey.reset': 'بازنشانی به پیش‌فرض',
+  },
+  messageModal: {
+    'messageModal.cancel': 'لغو',
+    'messageModal.confirm': 'تأیید',
+    'messageModal.edit': 'ویرایش',
+  },
+  sideNav: {
+    'sideNav.collapse': 'جمع کردن نوار کناری',
+    'sideNav.demoActiveLabel': 'فعال',
+    'sideNav.demoFeatureAutoCollapseDesc': 'برای جمع شدن هوشمند، به زیر آستانه بکشید',
+    'sideNav.demoFeatureAutoCollapseTitle': 'جمع‌شدن خودکار',
+    'sideNav.demoFeaturePerformanceDesc': 'بدون سربار انیمیشن برای عملکرد بهتر',
+    'sideNav.demoFeaturePerformanceTitle': 'عملکرد',
+    'sideNav.demoFeatureResizeDesc': 'برای تنظیم عرض پنل بکشید',
+    'sideNav.demoFeatureResizeTitle': 'تغییر اندازه انعطاف‌پذیر',
+    'sideNav.demoFeatureSmartHandleDesc': 'برای نمایش دکمه، نشانگر را نگه دارید',
+    'sideNav.demoFeatureSmartHandleTitle': 'دستگیره هوشمند',
+    'sideNav.demoFeaturesTitle': 'ویژگی‌ها',
+    'sideNav.demoHint': 'لبه پنل را بکشید و از دکمه تغییر وضعیت استفاده کنید ->',
+    'sideNav.demoSubtitle': 'پنل کناری سبک workspace با تغییر اندازه کشیدنی',
+    'sideNav.demoTitle': 'دموی DraggableSideNav',
+    'sideNav.expand': 'باز کردن نوار کناری',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/fr-FR.ts
+++ b/src/locales/ui/fr-FR.ts
@@ -1,0 +1,74 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Dépassement',
+    'tokenTag.remained': 'Restant',
+    'tokenTag.used': 'Utilisé',
+  },
+  common: {
+    'common.cancel': 'Annuler',
+    'common.confirm': 'Confirmer',
+    'common.delete': 'Supprimer',
+    'common.edit': 'Modifier',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Ajouter des propriétés',
+    'editableMessage.delete': 'Supprimer',
+    'editableMessage.input': 'Entrée',
+    'editableMessage.inputPlaceholder': "Veuillez saisir un exemple de contenu d'entrée",
+    'editableMessage.output': 'Sortie',
+    'editableMessage.outputPlaceholder': 'Veuillez saisir un exemple de contenu de sortie',
+    'editableMessage.system': 'Système',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Supprimer',
+    'emojiPicker.draggerDesc':
+      'Cliquez ou faites glisser une image dans cette zone pour la télécharger',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Vous ne pouvez télécharger que des images !',
+    'emojiPicker.upload': 'Téléverser',
+    'emojiPicker.uploadBtn': 'Rogner et téléverser',
+  },
+  form: {
+    'form.reset': 'Réinitialiser',
+    'form.submit': 'Envoyer',
+    'form.unsavedChanges': 'Modifications non enregistrées',
+    'form.unsavedWarning':
+      'Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter ?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Ce raccourci entre en conflit avec un autre.',
+    'hotkey.invalidCombination':
+      'Le raccourci doit inclure une touche modificatrice (Ctrl, Alt, Maj) et une seule touche normale.',
+    'hotkey.placeholder': 'Appuyez sur les touches pour enregistrer le raccourci',
+    'hotkey.reset': 'Réinitialiser par défaut',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Annuler',
+    'messageModal.confirm': 'Confirmer',
+    'messageModal.edit': 'Modifier',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Réduire la barre latérale',
+    'sideNav.demoActiveLabel': 'Actif',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Faites glisser sous le seuil pour une réduction intelligente',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Réduction automatique',
+    'sideNav.demoFeaturePerformanceDesc': 'Aucun coût d’animation pour de meilleures performances',
+    'sideNav.demoFeaturePerformanceTitle': 'Performances',
+    'sideNav.demoFeatureResizeDesc': 'Faites glisser pour ajuster la largeur du panneau',
+    'sideNav.demoFeatureResizeTitle': 'Redimensionnement flexible',
+    'sideNav.demoFeatureSmartHandleDesc': 'Survolez pour afficher le bouton',
+    'sideNav.demoFeatureSmartHandleTitle': 'Poignée intelligente',
+    'sideNav.demoFeaturesTitle': 'Fonctionnalités',
+    'sideNav.demoHint': 'Essayez de faire glisser le bord du panneau et d’utiliser le bouton ->',
+    'sideNav.demoSubtitle':
+      'Un panneau latéral façon workspace avec redimensionnement par glisser-déposer',
+    'sideNav.demoTitle': 'Démo DraggableSideNav',
+    'sideNav.expand': 'Développer la barre latérale',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/it-IT.ts
+++ b/src/locales/ui/it-IT.ts
@@ -1,0 +1,72 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Eccesso',
+    'tokenTag.remained': 'Rimanente',
+    'tokenTag.used': 'Usato',
+  },
+  common: {
+    'common.cancel': 'Annulla',
+    'common.confirm': 'Conferma',
+    'common.delete': 'Elimina',
+    'common.edit': 'Modifica',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Aggiungi proprietà',
+    'editableMessage.delete': 'Elimina',
+    'editableMessage.input': 'Input',
+    'editableMessage.inputPlaceholder': 'Inserisci un contenuto di input di esempio',
+    'editableMessage.output': 'Output',
+    'editableMessage.outputPlaceholder': 'Inserisci un contenuto di output di esempio',
+    'editableMessage.system': 'Sistema',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Elimina',
+    'emojiPicker.draggerDesc': "Fai clic o trascina un'immagine in quest'area per caricare",
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Puoi caricare solo file immagine!',
+    'emojiPicker.upload': 'Carica',
+    'emojiPicker.uploadBtn': 'Ritaglia e carica',
+  },
+  form: {
+    'form.reset': 'Reimposta',
+    'form.submit': 'Invia',
+    'form.unsavedChanges': 'Modifiche non salvate',
+    'form.unsavedWarning': 'Hai modifiche non salvate. Sei sicuro di voler uscire?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Questa scorciatoia è in conflitto con una esistente.',
+    'hotkey.invalidCombination':
+      'La scorciatoia deve includere un tasto modificatore (Ctrl, Alt, Maiusc) e solo un tasto normale.',
+    'hotkey.placeholder': 'Premi i tasti per registrare la scorciatoia',
+    'hotkey.reset': 'Ripristina predefinito',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Annulla',
+    'messageModal.confirm': 'Conferma',
+    'messageModal.edit': 'Modifica',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Comprimi barra laterale',
+    'sideNav.demoActiveLabel': 'Attivo',
+    'sideNav.demoFeatureAutoCollapseDesc':
+      'Trascina sotto la soglia per comprimere in modo intelligente',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Compressione automatica',
+    'sideNav.demoFeaturePerformanceDesc': 'Nessun overhead di animazione per migliori prestazioni',
+    'sideNav.demoFeaturePerformanceTitle': 'Prestazioni',
+    'sideNav.demoFeatureResizeDesc': 'Trascina per regolare la larghezza del pannello',
+    'sideNav.demoFeatureResizeTitle': 'Ridimensionamento flessibile',
+    'sideNav.demoFeatureSmartHandleDesc': 'Passa il mouse per mostrare il pulsante',
+    'sideNav.demoFeatureSmartHandleTitle': 'Maniglia intelligente',
+    'sideNav.demoFeaturesTitle': 'Funzionalità',
+    'sideNav.demoHint': 'Prova a trascinare il bordo del pannello e usare il pulsante ->',
+    'sideNav.demoSubtitle': 'Pannello laterale stile workspace con ridimensionamento trascinabile',
+    'sideNav.demoTitle': 'Demo DraggableSideNav',
+    'sideNav.expand': 'Espandi barra laterale',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/ja-JP.ts
+++ b/src/locales/ui/ja-JP.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'アバター',
+    'chat.placeholder': '...',
+    'tokenTag.overload': '超過',
+    'tokenTag.remained': '残り',
+    'tokenTag.used': '使用',
+  },
+  common: {
+    'common.cancel': 'キャンセル',
+    'common.confirm': '確認',
+    'common.delete': '削除',
+    'common.edit': '編集',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'プロパティを追加',
+    'editableMessage.delete': '削除',
+    'editableMessage.input': '入力',
+    'editableMessage.inputPlaceholder': 'サンプル入力内容を入力してください',
+    'editableMessage.output': '出力',
+    'editableMessage.outputPlaceholder': 'サンプル出力内容を入力してください',
+    'editableMessage.system': 'システム',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': '削除',
+    'emojiPicker.draggerDesc': 'クリックまたは画像をこの領域にドラッグしてアップロード',
+    'emojiPicker.emoji': '絵文字',
+    'emojiPicker.fileTypeError': '画像ファイルのみアップロードできます！',
+    'emojiPicker.upload': 'アップロード',
+    'emojiPicker.uploadBtn': '切り抜いてアップロード',
+  },
+  form: {
+    'form.reset': 'リセット',
+    'form.submit': '送信',
+    'form.unsavedChanges': '未保存の変更',
+    'form.unsavedWarning': '未保存の変更があります。移動してもよろしいですか？',
+  },
+  hotkey: {
+    'hotkey.conflict': 'このショートカットは既存のものと競合しています。',
+    'hotkey.invalidCombination':
+      'ショートカットは修飾キー（Ctrl、Alt、Shift）を含み、通常キーは1つのみです。',
+    'hotkey.placeholder': 'キーを押してショートカットを記録',
+    'hotkey.reset': '既定にリセット',
+  },
+  messageModal: {
+    'messageModal.cancel': 'キャンセル',
+    'messageModal.confirm': '確認',
+    'messageModal.edit': '編集',
+  },
+  sideNav: {
+    'sideNav.collapse': 'サイドバーを折りたたむ',
+    'sideNav.demoActiveLabel': 'アクティブ',
+    'sideNav.demoFeatureAutoCollapseDesc': 'しきい値以下にドラッグすると自動的に折りたたみ',
+    'sideNav.demoFeatureAutoCollapseTitle': '自動折りたたみ',
+    'sideNav.demoFeaturePerformanceDesc': 'アニメーション負荷なしで高性能',
+    'sideNav.demoFeaturePerformanceTitle': 'パフォーマンス',
+    'sideNav.demoFeatureResizeDesc': 'ドラッグしてパネル幅を調整',
+    'sideNav.demoFeatureResizeTitle': '柔軟なサイズ変更',
+    'sideNav.demoFeatureSmartHandleDesc': 'ホバーで切替ボタンを表示',
+    'sideNav.demoFeatureSmartHandleTitle': 'スマートハンドル',
+    'sideNav.demoFeaturesTitle': '機能',
+    'sideNav.demoHint': 'パネルの端をドラッグし、切替ボタンを試してください ->',
+    'sideNav.demoSubtitle': 'ドラッグでサイズ変更できるワークスペース風サイドパネル',
+    'sideNav.demoTitle': 'DraggableSideNav デモ',
+    'sideNav.expand': 'サイドバーを展開',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/ko-KR.ts
+++ b/src/locales/ui/ko-KR.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': '아바타',
+    'chat.placeholder': '...',
+    'tokenTag.overload': '초과',
+    'tokenTag.remained': '남음',
+    'tokenTag.used': '사용',
+  },
+  common: {
+    'common.cancel': '취소',
+    'common.confirm': '확인',
+    'common.delete': '삭제',
+    'common.edit': '편집',
+  },
+  editableMessage: {
+    'editableMessage.addProps': '속성 추가',
+    'editableMessage.delete': '삭제',
+    'editableMessage.input': '입력',
+    'editableMessage.inputPlaceholder': '예시 입력 내용을 입력하세요',
+    'editableMessage.output': '출력',
+    'editableMessage.outputPlaceholder': '예시 출력 내용을 입력하세요',
+    'editableMessage.system': '시스템',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': '삭제',
+    'emojiPicker.draggerDesc': '클릭하거나 이미지를 이 영역으로 끌어다 놓아 업로드하세요',
+    'emojiPicker.emoji': '이모지',
+    'emojiPicker.fileTypeError': '이미지 파일만 업로드할 수 있습니다!',
+    'emojiPicker.upload': '업로드',
+    'emojiPicker.uploadBtn': '자르고 업로드',
+  },
+  form: {
+    'form.reset': '재설정',
+    'form.submit': '제출',
+    'form.unsavedChanges': '저장되지 않은 변경사항',
+    'form.unsavedWarning': '저장되지 않은 변경사항이 있습니다. 정말 나가시겠습니까?',
+  },
+  hotkey: {
+    'hotkey.conflict': '이 단축키는 기존 단축키와 충돌합니다.',
+    'hotkey.invalidCombination':
+      '단축키는 수정 키(Ctrl, Alt, Shift)를 포함해야 하며 일반 키는 하나만 포함할 수 있습니다.',
+    'hotkey.placeholder': '키를 눌러 단축키를 기록하세요',
+    'hotkey.reset': '기본값으로 재설정',
+  },
+  messageModal: {
+    'messageModal.cancel': '취소',
+    'messageModal.confirm': '확인',
+    'messageModal.edit': '편집',
+  },
+  sideNav: {
+    'sideNav.collapse': '사이드바 접기',
+    'sideNav.demoActiveLabel': '활성',
+    'sideNav.demoFeatureAutoCollapseDesc': '임계값 아래로 드래그하면 스마트하게 접힘',
+    'sideNav.demoFeatureAutoCollapseTitle': '자동 접기',
+    'sideNav.demoFeaturePerformanceDesc': '애니메이션 오버헤드 없이 더 나은 성능',
+    'sideNav.demoFeaturePerformanceTitle': '성능',
+    'sideNav.demoFeatureResizeDesc': '드래그하여 패널 너비 조정',
+    'sideNav.demoFeatureResizeTitle': '유연한 크기 조정',
+    'sideNav.demoFeatureSmartHandleDesc': '호버하면 토글 버튼 표시',
+    'sideNav.demoFeatureSmartHandleTitle': '스마트 핸들',
+    'sideNav.demoFeaturesTitle': '기능',
+    'sideNav.demoHint': '패널 가장자리를 드래그하고 토글 버튼을 사용해 보세요 ->',
+    'sideNav.demoSubtitle': '드래그로 크기를 조절하는 워크스페이스 스타일 사이드 패널',
+    'sideNav.demoTitle': 'DraggableSideNav 데모',
+    'sideNav.expand': '사이드바 펼치기',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/nl-NL.ts
+++ b/src/locales/ui/nl-NL.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Overbelasting',
+    'tokenTag.remained': 'Resterend',
+    'tokenTag.used': 'Gebruikt',
+  },
+  common: {
+    'common.cancel': 'Annuleren',
+    'common.confirm': 'Bevestigen',
+    'common.delete': 'Verwijderen',
+    'common.edit': 'Bewerken',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Eigenschappen toevoegen',
+    'editableMessage.delete': 'Verwijderen',
+    'editableMessage.input': 'Invoer',
+    'editableMessage.inputPlaceholder': 'Voer voorbeeld-invoer in',
+    'editableMessage.output': 'Uitvoer',
+    'editableMessage.outputPlaceholder': 'Voer voorbeeld-uitvoer in',
+    'editableMessage.system': 'Systeem',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Verwijderen',
+    'emojiPicker.draggerDesc': 'Klik of sleep een afbeelding naar dit gebied om te uploaden',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Je kunt alleen afbeeldingsbestanden uploaden!',
+    'emojiPicker.upload': 'Uploaden',
+    'emojiPicker.uploadBtn': 'Bijsnijden en uploaden',
+  },
+  form: {
+    'form.reset': 'Resetten',
+    'form.submit': 'Verzenden',
+    'form.unsavedChanges': 'Niet-opgeslagen wijzigingen',
+    'form.unsavedWarning': 'Je hebt niet-opgeslagen wijzigingen. Weet je zeker dat je wilt vertrekken?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Deze sneltoets conflicteert met een bestaande.',
+    'hotkey.invalidCombination':
+      'Sneltoets moet een modificatietoets (Ctrl, Alt, Shift) bevatten en slechts één gewone toets.',
+    'hotkey.placeholder': 'Druk op toetsen om de sneltoets op te nemen',
+    'hotkey.reset': 'Terugzetten naar standaard',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Annuleren',
+    'messageModal.confirm': 'Bevestigen',
+    'messageModal.edit': 'Bewerken',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Zijbalk inklappen',
+    'sideNav.demoActiveLabel': 'Actief',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Sleep onder de drempel voor slim inklappen',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Automatisch inklappen',
+    'sideNav.demoFeaturePerformanceDesc': 'Geen animatie-overhead voor betere prestaties',
+    'sideNav.demoFeaturePerformanceTitle': 'Prestaties',
+    'sideNav.demoFeatureResizeDesc': 'Sleep om de paneelbreedte aan te passen',
+    'sideNav.demoFeatureResizeTitle': 'Flexibel schalen',
+    'sideNav.demoFeatureSmartHandleDesc': 'Hover om de schakelknop te tonen',
+    'sideNav.demoFeatureSmartHandleTitle': 'Slimme handgreep',
+    'sideNav.demoFeaturesTitle': 'Functies',
+    'sideNav.demoHint': 'Probeer de rand te slepen en de schakelknop te gebruiken ->',
+    'sideNav.demoSubtitle': 'Een workspace-achtige zijbalk met sleepbaar formaat',
+    'sideNav.demoTitle': 'DraggableSideNav-demo',
+    'sideNav.expand': 'Zijbalk uitklappen',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/pl-PL.ts
+++ b/src/locales/ui/pl-PL.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'awatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Przekroczono',
+    'tokenTag.remained': 'Pozostało',
+    'tokenTag.used': 'Użyto',
+  },
+  common: {
+    'common.cancel': 'Anuluj',
+    'common.confirm': 'Potwierdź',
+    'common.delete': 'Usuń',
+    'common.edit': 'Edytuj',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Dodaj właściwości',
+    'editableMessage.delete': 'Usuń',
+    'editableMessage.input': 'Wejście',
+    'editableMessage.inputPlaceholder': 'Wpisz przykładową treść wejściową',
+    'editableMessage.output': 'Wyjście',
+    'editableMessage.outputPlaceholder': 'Wpisz przykładową treść wyjściową',
+    'editableMessage.system': 'System',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Usuń',
+    'emojiPicker.draggerDesc': 'Kliknij lub przeciągnij obraz do tego obszaru, aby przesłać',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Możesz przesyłać tylko pliki obrazów!',
+    'emojiPicker.upload': 'Prześlij',
+    'emojiPicker.uploadBtn': 'Przytnij i prześlij',
+  },
+  form: {
+    'form.reset': 'Resetuj',
+    'form.submit': 'Wyślij',
+    'form.unsavedChanges': 'Niezapisane zmiany',
+    'form.unsavedWarning': 'Masz niezapisane zmiany. Czy na pewno chcesz wyjść?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Ten skrót koliduje z istniejącym.',
+    'hotkey.invalidCombination':
+      'Skrót musi zawierać klawisz modyfikujący (Ctrl, Alt, Shift) i tylko jeden zwykły klawisz.',
+    'hotkey.placeholder': 'Naciśnij klawisze, aby nagrać skrót',
+    'hotkey.reset': 'Przywróć domyślne',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Anuluj',
+    'messageModal.confirm': 'Potwierdź',
+    'messageModal.edit': 'Edytuj',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Zwiń pasek boczny',
+    'sideNav.demoActiveLabel': 'Aktywny',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Przeciągnij poniżej progu, aby inteligentnie zwinąć',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Automatyczne zwijanie',
+    'sideNav.demoFeaturePerformanceDesc': 'Brak narzutu animacji dla lepszej wydajności',
+    'sideNav.demoFeaturePerformanceTitle': 'Wydajność',
+    'sideNav.demoFeatureResizeDesc': 'Przeciągnij, aby dostosować szerokość panelu',
+    'sideNav.demoFeatureResizeTitle': 'Elastyczna zmiana rozmiaru',
+    'sideNav.demoFeatureSmartHandleDesc': 'Najedź, aby pokazać przycisk przełączania',
+    'sideNav.demoFeatureSmartHandleTitle': 'Inteligentny uchwyt',
+    'sideNav.demoFeaturesTitle': 'Funkcje',
+    'sideNav.demoHint': 'Spróbuj przeciągnąć krawędź panelu i użyć przycisku ->',
+    'sideNav.demoSubtitle': 'Boczny panel w stylu workspace z możliwością zmiany rozmiaru',
+    'sideNav.demoTitle': 'Demo DraggableSideNav',
+    'sideNav.expand': 'Rozwiń pasek boczny',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/pt-BR.ts
+++ b/src/locales/ui/pt-BR.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Excedido',
+    'tokenTag.remained': 'Restante',
+    'tokenTag.used': 'Usado',
+  },
+  common: {
+    'common.cancel': 'Cancelar',
+    'common.confirm': 'Confirmar',
+    'common.delete': 'Excluir',
+    'common.edit': 'Editar',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Adicionar propriedades',
+    'editableMessage.delete': 'Excluir',
+    'editableMessage.input': 'Entrada',
+    'editableMessage.inputPlaceholder': 'Digite um conteúdo de entrada de exemplo',
+    'editableMessage.output': 'Saída',
+    'editableMessage.outputPlaceholder': 'Digite um conteúdo de saída de exemplo',
+    'editableMessage.system': 'Sistema',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Excluir',
+    'emojiPicker.draggerDesc': 'Clique ou arraste uma imagem para esta área para enviar',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Você só pode enviar arquivos de imagem!',
+    'emojiPicker.upload': 'Enviar',
+    'emojiPicker.uploadBtn': 'Recortar e enviar',
+  },
+  form: {
+    'form.reset': 'Redefinir',
+    'form.submit': 'Enviar',
+    'form.unsavedChanges': 'Alterações não salvas',
+    'form.unsavedWarning': 'Você tem alterações não salvas. Tem certeza de que deseja sair?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Este atalho entra em conflito com um já existente.',
+    'hotkey.invalidCombination':
+      'O atalho deve incluir uma tecla modificadora (Ctrl, Alt, Shift) e apenas uma tecla normal.',
+    'hotkey.placeholder': 'Pressione as teclas para gravar o atalho',
+    'hotkey.reset': 'Restaurar padrão',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Cancelar',
+    'messageModal.confirm': 'Confirmar',
+    'messageModal.edit': 'Editar',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Recolher barra lateral',
+    'sideNav.demoActiveLabel': 'Ativo',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Arraste abaixo do limite para recolher automaticamente',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Auto-recolher',
+    'sideNav.demoFeaturePerformanceDesc': 'Sem sobrecarga de animação para melhor desempenho',
+    'sideNav.demoFeaturePerformanceTitle': 'Desempenho',
+    'sideNav.demoFeatureResizeDesc': 'Arraste para ajustar a largura do painel',
+    'sideNav.demoFeatureResizeTitle': 'Redimensionamento flexível',
+    'sideNav.demoFeatureSmartHandleDesc': 'Passe o mouse para revelar o botão',
+    'sideNav.demoFeatureSmartHandleTitle': 'Alça inteligente',
+    'sideNav.demoFeaturesTitle': 'Recursos',
+    'sideNav.demoHint': 'Tente arrastar a borda do painel e usar o botão ->',
+    'sideNav.demoSubtitle': 'Painel lateral estilo workspace com redimensionamento arrastável',
+    'sideNav.demoTitle': 'Demo do DraggableSideNav',
+    'sideNav.expand': 'Expandir barra lateral',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/ru-RU.ts
+++ b/src/locales/ui/ru-RU.ts
@@ -1,0 +1,72 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'аватар',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Превышение',
+    'tokenTag.remained': 'Осталось',
+    'tokenTag.used': 'Использовано',
+  },
+  common: {
+    'common.cancel': 'Отмена',
+    'common.confirm': 'Подтвердить',
+    'common.delete': 'Удалить',
+    'common.edit': 'Редактировать',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Добавить свойства',
+    'editableMessage.delete': 'Удалить',
+    'editableMessage.input': 'Ввод',
+    'editableMessage.inputPlaceholder': 'Введите пример входного содержимого',
+    'editableMessage.output': 'Вывод',
+    'editableMessage.outputPlaceholder': 'Введите пример выходного содержимого',
+    'editableMessage.system': 'Система',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Удалить',
+    'emojiPicker.draggerDesc': 'Нажмите или перетащите изображение сюда, чтобы загрузить',
+    'emojiPicker.emoji': 'Эмодзи',
+    'emojiPicker.fileTypeError': 'Можно загружать только изображения!',
+    'emojiPicker.upload': 'Загрузить',
+    'emojiPicker.uploadBtn': 'Обрезать и загрузить',
+  },
+  form: {
+    'form.reset': 'Сбросить',
+    'form.submit': 'Отправить',
+    'form.unsavedChanges': 'Несохранённые изменения',
+    'form.unsavedWarning': 'У вас есть несохранённые изменения. Вы уверены, что хотите уйти?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Этот ярлык конфликтует с существующим.',
+    'hotkey.invalidCombination':
+      'Сочетание должно включать модификатор (Ctrl, Alt, Shift) и только одну обычную клавишу.',
+    'hotkey.placeholder': 'Нажмите клавиши, чтобы записать сочетание',
+    'hotkey.reset': 'Сбросить по умолчанию',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Отмена',
+    'messageModal.confirm': 'Подтвердить',
+    'messageModal.edit': 'Редактировать',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Свернуть боковую панель',
+    'sideNav.demoActiveLabel': 'Активно',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Перетащите ниже порога для умного сворачивания',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Автосворачивание',
+    'sideNav.demoFeaturePerformanceDesc':
+      'Без накладных расходов на анимацию для лучшей производительности',
+    'sideNav.demoFeaturePerformanceTitle': 'Производительность',
+    'sideNav.demoFeatureResizeDesc': 'Перетащите, чтобы изменить ширину панели',
+    'sideNav.demoFeatureResizeTitle': 'Гибкое изменение размера',
+    'sideNav.demoFeatureSmartHandleDesc': 'Наведите, чтобы показать кнопку переключения',
+    'sideNav.demoFeatureSmartHandleTitle': 'Умная ручка',
+    'sideNav.demoFeaturesTitle': 'Функции',
+    'sideNav.demoHint': 'Попробуйте перетащить край панели и использовать кнопку ->',
+    'sideNav.demoSubtitle': 'Боковая панель в стиле рабочего пространства с изменяемым размером',
+    'sideNav.demoTitle': 'Демо DraggableSideNav',
+    'sideNav.expand': 'Развернуть боковую панель',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/tr-TR.ts
+++ b/src/locales/ui/tr-TR.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'avatar',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Aşım',
+    'tokenTag.remained': 'Kalan',
+    'tokenTag.used': 'Kullanılan',
+  },
+  common: {
+    'common.cancel': 'İptal',
+    'common.confirm': 'Onayla',
+    'common.delete': 'Sil',
+    'common.edit': 'Düzenle',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Özellik ekle',
+    'editableMessage.delete': 'Sil',
+    'editableMessage.input': 'Girdi',
+    'editableMessage.inputPlaceholder': 'Örnek girdi içeriği girin',
+    'editableMessage.output': 'Çıktı',
+    'editableMessage.outputPlaceholder': 'Örnek çıktı içeriği girin',
+    'editableMessage.system': 'Sistem',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Sil',
+    'emojiPicker.draggerDesc': 'Yüklemek için tıklayın veya resmi bu alana sürükleyin',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Yalnızca resim dosyası yükleyebilirsiniz!',
+    'emojiPicker.upload': 'Yükle',
+    'emojiPicker.uploadBtn': 'Kırp ve yükle',
+  },
+  form: {
+    'form.reset': 'Sıfırla',
+    'form.submit': 'Gönder',
+    'form.unsavedChanges': 'Kaydedilmemiş değişiklikler',
+    'form.unsavedWarning': 'Kaydedilmemiş değişiklikleriniz var. Ayrılmak istediğinizden emin misiniz?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Bu kısayol mevcut bir kısayolla çakışıyor.',
+    'hotkey.invalidCombination':
+      'Kısayol bir değiştirici tuş (Ctrl, Alt, Shift) içermeli ve yalnızca bir normal tuş olmalıdır.',
+    'hotkey.placeholder': 'Kısayolu kaydetmek için tuşlara basın',
+    'hotkey.reset': 'Varsayılana sıfırla',
+  },
+  messageModal: {
+    'messageModal.cancel': 'İptal',
+    'messageModal.confirm': 'Onayla',
+    'messageModal.edit': 'Düzenle',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Kenar çubuğunu daralt',
+    'sideNav.demoActiveLabel': 'Aktif',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Akıllı daraltma için eşiğin altına sürükleyin',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Otomatik daraltma',
+    'sideNav.demoFeaturePerformanceDesc': 'Daha iyi performans için animasyon yükü yok',
+    'sideNav.demoFeaturePerformanceTitle': 'Performans',
+    'sideNav.demoFeatureResizeDesc': 'Panel genişliğini ayarlamak için sürükleyin',
+    'sideNav.demoFeatureResizeTitle': 'Esnek yeniden boyutlandırma',
+    'sideNav.demoFeatureSmartHandleDesc': 'Anahtar düğmesini göstermek için üzerine gelin',
+    'sideNav.demoFeatureSmartHandleTitle': 'Akıllı tutamak',
+    'sideNav.demoFeaturesTitle': 'Özellikler',
+    'sideNav.demoHint': 'Panel kenarını sürükleyip düğmeyi kullanmayı deneyin ->',
+    'sideNav.demoSubtitle': 'Sürüklenebilir yeniden boyutlandırmalı çalışma alanı tarzı yan panel',
+    'sideNav.demoTitle': 'DraggableSideNav Demo',
+    'sideNav.expand': 'Kenar çubuğunu genişlet',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/vi-VN.ts
+++ b/src/locales/ui/vi-VN.ts
@@ -1,0 +1,71 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': 'ảnh đại diện',
+    'chat.placeholder': '...',
+    'tokenTag.overload': 'Vượt',
+    'tokenTag.remained': 'Còn lại',
+    'tokenTag.used': 'Đã dùng',
+  },
+  common: {
+    'common.cancel': 'Hủy',
+    'common.confirm': 'Xác nhận',
+    'common.delete': 'Xóa',
+    'common.edit': 'Chỉnh sửa',
+  },
+  editableMessage: {
+    'editableMessage.addProps': 'Thêm thuộc tính',
+    'editableMessage.delete': 'Xóa',
+    'editableMessage.input': 'Đầu vào',
+    'editableMessage.inputPlaceholder': 'Vui lòng nhập nội dung đầu vào mẫu',
+    'editableMessage.output': 'Đầu ra',
+    'editableMessage.outputPlaceholder': 'Vui lòng nhập nội dung đầu ra mẫu',
+    'editableMessage.system': 'Hệ thống',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': 'Xóa',
+    'emojiPicker.draggerDesc': 'Nhấp hoặc kéo ảnh vào khu vực này để tải lên',
+    'emojiPicker.emoji': 'Emoji',
+    'emojiPicker.fileTypeError': 'Bạn chỉ có thể tải lên tệp hình ảnh!',
+    'emojiPicker.upload': 'Tải lên',
+    'emojiPicker.uploadBtn': 'Cắt và tải lên',
+  },
+  form: {
+    'form.reset': 'Đặt lại',
+    'form.submit': 'Gửi',
+    'form.unsavedChanges': 'Thay đổi chưa lưu',
+    'form.unsavedWarning': 'Bạn có thay đổi chưa lưu. Bạn có chắc muốn rời đi không?',
+  },
+  hotkey: {
+    'hotkey.conflict': 'Phím tắt này xung đột với phím tắt hiện có.',
+    'hotkey.invalidCombination':
+      'Phím tắt phải bao gồm phím bổ trợ (Ctrl, Alt, Shift) và chỉ một phím thường.',
+    'hotkey.placeholder': 'Nhấn phím để ghi phím tắt',
+    'hotkey.reset': 'Đặt lại về mặc định',
+  },
+  messageModal: {
+    'messageModal.cancel': 'Hủy',
+    'messageModal.confirm': 'Xác nhận',
+    'messageModal.edit': 'Chỉnh sửa',
+  },
+  sideNav: {
+    'sideNav.collapse': 'Thu gọn thanh bên',
+    'sideNav.demoActiveLabel': 'Đang hoạt động',
+    'sideNav.demoFeatureAutoCollapseDesc': 'Kéo xuống dưới ngưỡng để tự thu gọn thông minh',
+    'sideNav.demoFeatureAutoCollapseTitle': 'Tự thu gọn',
+    'sideNav.demoFeaturePerformanceDesc': 'Không tốn chi phí hoạt ảnh, hiệu năng tốt hơn',
+    'sideNav.demoFeaturePerformanceTitle': 'Hiệu năng',
+    'sideNav.demoFeatureResizeDesc': 'Kéo để điều chỉnh độ rộng bảng',
+    'sideNav.demoFeatureResizeTitle': 'Thay đổi kích thước linh hoạt',
+    'sideNav.demoFeatureSmartHandleDesc': 'Di chuột để hiện nút chuyển',
+    'sideNav.demoFeatureSmartHandleTitle': 'Tay cầm thông minh',
+    'sideNav.demoFeaturesTitle': 'Tính năng',
+    'sideNav.demoHint': 'Hãy thử kéo cạnh bảng và dùng nút chuyển ->',
+    'sideNav.demoSubtitle': 'Bảng bên phong cách workspace với thay đổi kích thước bằng kéo',
+    'sideNav.demoTitle': 'Demo DraggableSideNav',
+    'sideNav.expand': 'Mở rộng thanh bên',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/locales/ui/zh-TW.ts
+++ b/src/locales/ui/zh-TW.ts
@@ -1,0 +1,70 @@
+import type { TranslationResourcesMap } from '@lobehub/ui/i18n';
+
+const resources = {
+  chat: {
+    'chat.avatar': '頭像',
+    'chat.placeholder': '...',
+    'tokenTag.overload': '超額',
+    'tokenTag.remained': '剩餘',
+    'tokenTag.used': '已用',
+  },
+  common: {
+    'common.cancel': '取消',
+    'common.confirm': '確認',
+    'common.delete': '刪除',
+    'common.edit': '編輯',
+  },
+  editableMessage: {
+    'editableMessage.addProps': '添加屬性',
+    'editableMessage.delete': '刪除',
+    'editableMessage.input': '輸入',
+    'editableMessage.inputPlaceholder': '請輸入示例輸入內容',
+    'editableMessage.output': '輸出',
+    'editableMessage.outputPlaceholder': '請輸入示例輸出內容',
+    'editableMessage.system': '系統',
+  },
+  emojiPicker: {
+    'emojiPicker.delete': '刪除',
+    'emojiPicker.draggerDesc': '點擊或拖動圖片到此處上傳',
+    'emojiPicker.emoji': '表情',
+    'emojiPicker.fileTypeError': '只能上傳圖片檔案！',
+    'emojiPicker.upload': '上傳',
+    'emojiPicker.uploadBtn': '裁剪並上傳',
+  },
+  form: {
+    'form.reset': '重置',
+    'form.submit': '提交',
+    'form.unsavedChanges': '未儲存的變更',
+    'form.unsavedWarning': '您有未儲存的變更。確定要離開嗎？',
+  },
+  hotkey: {
+    'hotkey.conflict': '此快捷鍵與現有快捷鍵衝突。',
+    'hotkey.invalidCombination': '快捷鍵必須包含修飾鍵（Ctrl、Alt、Shift）且只能有一個一般鍵。',
+    'hotkey.placeholder': '按鍵錄製快捷鍵',
+    'hotkey.reset': '重置為預設',
+  },
+  messageModal: {
+    'messageModal.cancel': '取消',
+    'messageModal.confirm': '確認',
+    'messageModal.edit': '編輯',
+  },
+  sideNav: {
+    'sideNav.collapse': '折疊側邊欄',
+    'sideNav.demoActiveLabel': '啟用',
+    'sideNav.demoFeatureAutoCollapseDesc': '拖動到閾值以下智慧折疊',
+    'sideNav.demoFeatureAutoCollapseTitle': '自動折疊',
+    'sideNav.demoFeaturePerformanceDesc': '無動畫開銷，效能更佳',
+    'sideNav.demoFeaturePerformanceTitle': '效能最佳化',
+    'sideNav.demoFeatureResizeDesc': '拖動調整面板寬度',
+    'sideNav.demoFeatureResizeTitle': '彈性調整',
+    'sideNav.demoFeatureSmartHandleDesc': '懸停顯示切換按鈕',
+    'sideNav.demoFeatureSmartHandleTitle': '智慧手柄',
+    'sideNav.demoFeaturesTitle': '功能特色',
+    'sideNav.demoHint': '嘗試拖動面板邊緣並使用切換按鈕 ->',
+    'sideNav.demoSubtitle': '可拖動調整的工作區風格側邊面板',
+    'sideNav.demoTitle': 'DraggableSideNav 示範',
+    'sideNav.expand': '展開側邊欄',
+  },
+} satisfies TranslationResourcesMap;
+
+export default resources;

--- a/src/server/metadata.test.ts
+++ b/src/server/metadata.test.ts
@@ -114,7 +114,7 @@ describe('Metadata', () => {
         locale: 'es-ES',
         type: 'article',
         url: 'https://example.com/og',
-        siteName: 'LobeChat',
+        siteName: BRANDING_NAME,
         alternateLocale: expect.arrayContaining([
           'ar',
           'bg-BG',

--- a/src/server/routers/lambda/klavis.ts
+++ b/src/server/routers/lambda/klavis.ts
@@ -1,4 +1,4 @@
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 import { z } from 'zod';
 
 import { PluginModel } from '@/database/models/plugin';

--- a/src/server/services/mcp/index.ts
+++ b/src/server/services/mcp/index.ts
@@ -1,6 +1,6 @@
 import { CheckMcpInstallResult, CustomPluginMetadata } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
-import { LobeChatPluginApi, LobeChatPluginManifest, PluginSchema } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginApi, LobeChatPluginManifest, PluginSchema } from '@lobehub/chat-plugin-sdk';
 import { DeploymentOption } from '@lobehub/market-sdk';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { TRPCError } from '@trpc/server';

--- a/src/server/services/pluginGateway/index.ts
+++ b/src/server/services/pluginGateway/index.ts
@@ -1,6 +1,6 @@
 import { ChatToolPayload } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
-import { PluginRequestPayload } from '@lobehub/chat-plugin-sdk';
+import type { PluginRequestPayload } from '@lobehub/chat-plugin-sdk';
 import { GatewaySuccessResponse } from '@lobehub/chat-plugins-gateway';
 import debug from 'debug';
 

--- a/src/store/tool/helpers.ts
+++ b/src/store/tool/helpers.ts
@@ -1,5 +1,5 @@
 import { LobeTool } from '@lobechat/types';
-import { PluginSchema } from '@lobehub/chat-plugin-sdk';
+import type { PluginSchema } from '@lobehub/chat-plugin-sdk';
 
 import { MetaData } from '@/types/meta';
 

--- a/src/store/tool/selectors/tool.ts
+++ b/src/store/tool/selectors/tool.ts
@@ -1,7 +1,7 @@
 import { ToolNameResolver } from '@lobechat/context-engine';
 import { pluginPrompts } from '@lobechat/prompts';
 import { RenderDisplayControl } from '@lobechat/types';
-import { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
+import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 
 import { MetaData } from '@/types/meta';
 import { LobeToolMeta } from '@/types/tool/tool';


### PR DESCRIPTION
## Summary
- Add 16 new UI locale files for better internationalization support (ar, bg-BG, de-DE, es-ES, fa-IR, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, pl-PL, pt-BR, ru-RU, tr-TR, vi-VN, zh-TW)
- Add `getUILocaleAndResources` utility function with tests
- Update tool-related type definitions
- Use type-only imports for better tree-shaking

## Test plan
- [ ] Verify new locale files load correctly
- [ ] Test `getUILocaleAndResources` utility
- [ ] Check type definitions compile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)