### PR TITLE
🐛 fix(userMemories): use date & time for building context

### DIFF
--- a/src/app/(backend)/api/webhooks/memory-extraction/benchmark-locomo/route.ts
+++ b/src/app/(backend)/api/webhooks/memory-extraction/benchmark-locomo/route.ts
@@ -8,8 +8,9 @@ import { MemoryExtractionExecutor } from '@/server/services/memory/userMemory/ex
 import { LayersEnum } from '@/types/userMemory';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 
+
 const turnSchema = z.object({
-  createdAt: z.string().optional(),
+  createdAt: z.string(),
   diaId: z.string().optional(),
   imageCaption: z.string().optional(),
   imageUrls: z.array(z.string()).optional(),
@@ -33,12 +34,6 @@ const ingestSchema = z.object({
   sourceId: z.string().optional(),
   userId: z.string(),
 });
-
-const parseDate = (value?: string) => {
-  if (!value) return new Date();
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
-};
 
 const normalizeLayers = (layers?: string[]) => {
   if (!layers?.length) return [] as LayersEnum[];
@@ -86,7 +81,7 @@ export const POST = async (req: Request) => {
     let partCounter = 0;
     const parts = parsed.sessions.flatMap((session) => {
       return session.turns.map((turn) => {
-        const createdAt = parseDate(turn.createdAt || session.timestamp);
+        const createdAt = new Date(turn.createdAt);
         const metadata: Record<string, unknown> = {
           diaId: turn.diaId,
           imageCaption: turn.imageCaption,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update memory benchmarking endpoints to rely on explicit turn timestamps and improve observability during development.

Bug Fixes:
- Ensure memory extraction uses each turn's provided creation timestamp instead of falling back to session timestamps or current time.

Enhancements:
- Add development logging around user memory search flow to aid debugging and benchmarking of locomo dev search.