### PR TITLE
🐛 fix: when use agentbuilder the topic id should use new & clear topic…

### DIFF
--- a/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/index.tsx
+++ b/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/index.tsx
@@ -12,6 +12,7 @@ import ModelSelect from '@/features/ModelSelect';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
 
 import EditorCanvas from '../EditorCanvas';
 import AgentHeader from './AgentHeader';
@@ -22,6 +23,7 @@ const ProfileEditor = memo(() => {
   const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
   const updateConfig = useAgentStore((s) => s.updateAgentConfig);
   const agentId = useAgentStore((s) => s.activeAgentId);
+  const switchTopic = useChatStore((s) => s.switchTopic);
   const router = useQueryRoute();
 
   return (
@@ -63,6 +65,8 @@ const ProfileEditor = memo(() => {
             icon={PlayIcon}
             onClick={() => {
               if (!agentId) return;
+              // Clear topicId before navigating to prevent stale state
+              switchTopic(undefined, true);
               router.push(urlJoin('/agent', agentId));
             }}
             type={'primary'}

--- a/src/features/AgentBuilder/AgentBuilderProvider.tsx
+++ b/src/features/AgentBuilder/AgentBuilderProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, memo, useMemo } from 'react';
+import { type ReactNode, memo, useEffect, useMemo } from 'react';
 
 import { ConversationProvider } from '@/features/Conversation';
 import { useOperationState } from '@/hooks/useOperationState';
@@ -17,6 +17,19 @@ interface AgentBuilderProviderProps {
  */
 const AgentBuilderProvider = memo<AgentBuilderProviderProps>(({ agentId, children }) => {
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const switchTopic = useChatStore((s) => s.switchTopic);
+
+  // Reset topicId on mount and unmount to avoid stale topicId leaking
+  // when navigating from Profile page to agent conversation page
+  useEffect(() => {
+    // Mount: start with a fresh conversation (topicId = undefined)
+    switchTopic(undefined, true);
+
+    return () => {
+      // Unmount: clean up topicId to prevent state leakage
+      switchTopic(undefined, true);
+    };
+  }, [switchTopic]);
 
   // Build conversation context for agent builder
   // Using agent_builder scope for message management


### PR DESCRIPTION
…id in unmount

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure AgentBuilder starts with a fresh topic and clears the topic ID on unmount to prevent stale conversation state when navigating between profile and agent conversation pages.


FIX LOBE-2313