### PR TITLE
🐛 fix(translation): add fallback for all English locale variants

### DIFF
--- a/src/server/translation.ts
+++ b/src/server/translation.ts
@@ -14,7 +14,7 @@ export const translation = async (ns: NS = 'common', hl: string) => {
   try {
     if (ns === 'models' || ns === 'providers') {
       i18ns = await import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);
-    } else if (lng === DEFAULT_LANG) {
+    } else if (lng === DEFAULT_LANG || lng.startsWith('en')) {
       i18ns = await import(`@/locales/default/${ns}`);
     } else {
       i18ns = await import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);


### PR DESCRIPTION
## Summary

- Fix translation system to handle all English locale variants (en-GB, en-AU, etc.)
- Previously, only `DEFAULT_LANG` (en-US) would fall back to default namespace
- Now any locale starting with 'en' will use the default English namespace

## Test plan

- [ ] Verify English locale variants (en-GB, en-AU, etc.) load translations correctly
- [ ] Verify non-English locales continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)