### PR TITLE
🐛 fix(userMemories): should use `context.invoke` for workflow instead of `context.run`

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
@@ -28,7 +28,7 @@ const intersectLayers = (requested: LayersEnum[], allowed: LayersEnum[]) => {
   return allowed.filter((layer) => requestedSet.has(layer));
 };
 
-const createLayerWorkflow = (allowedLayers: LayersEnum[]) =>
+export const createLayerWorkflow = (allowedLayers: LayersEnum[]) =>
   createWorkflow<MemoryExtractionPayloadInput, { processed: number; results: ExtractionResult[] }>(
     async (context) => {
       const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
@@ -82,10 +82,10 @@ const createLayerWorkflow = (allowedLayers: LayersEnum[]) =>
     },
   );
 
-const cepWorkflow = createLayerWorkflow(CEP_LAYERS);
-const identityWorkflow = createLayerWorkflow(IDENTITY_LAYERS);
+export const cepWorkflow = createLayerWorkflow(CEP_LAYERS);
+export const identityWorkflow = createLayerWorkflow(IDENTITY_LAYERS);
 
-const orchestratorWorkflow = createWorkflow<
+export const orchestratorWorkflow = createWorkflow<
   MemoryExtractionPayloadInput,
   {
     nextIdentityCursor: number | null;

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -1820,17 +1820,4 @@ export class MemoryExtractionWorkflowService {
     const url = getWorkflowUrl(WORKFLOW_PATHS.userTopics, payload.baseUrl);
     return this.getClient().trigger({ body: payload, url });
   }
-
-  static triggerProcessTopicBatch(payload: TopicBatchWorkflowPayload) {
-    if (!payload.baseUrl) {
-      throw new Error('Missing baseUrl for workflow trigger');
-    }
-
-    const url = getWorkflowUrl(WORKFLOW_PATHS.topicBatch, payload.baseUrl);
-    return this.getClient().trigger({
-      body: payload,
-      headers: { 'Upstash-Workflow-Name': TOPIC_WORKFLOW_NAMES.orchestrator },
-      url,
-    });
-  }
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Use workflow invocation for processing user memory topics batches and expose the orchestrator and layer workflows for reuse.

Bug Fixes:
- Replace direct topic batch processing calls with workflow invocations when processing user topics.

Enhancements:
- Export orchestrator and layer workflows so they can be invoked from other workflow routes.