### PR TITLE
🐛 fix(userMemories): workflow id build issue

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/[workflowId]/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/[workflowId]/route.ts
@@ -1,0 +1,10 @@
+import { serveMany } from '@upstash/workflow/nextjs';
+
+import { TOPIC_WORKFLOW_NAMES } from '@/server/services/memory/userMemory/extract';
+import { cepWorkflow, identityWorkflow, orchestratorWorkflow } from '../workflows';
+
+export const { POST } = serveMany({
+  [TOPIC_WORKFLOW_NAMES.orchestrator]: orchestratorWorkflow,
+  [TOPIC_WORKFLOW_NAMES.cep]: cepWorkflow,
+  [TOPIC_WORKFLOW_NAMES.identity]: identityWorkflow,
+});

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/batch/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/batch/route.ts
@@ -1,0 +1,22 @@
+import { serve } from '@upstash/workflow/nextjs';
+
+import {
+  type MemoryExtractionPayloadInput,
+  normalizeMemoryExtractionPayload,
+} from '@/server/services/memory/userMemory/extract';
+
+import { orchestratorWorkflow } from '../workflows';
+
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
+  const payload = normalizeMemoryExtractionPayload(context.requestPayload || {});
+
+  await context.invoke('memory:user-memory:extract:topics:batch', {
+    body: context.requestPayload,
+    workflow: orchestratorWorkflow,
+  });
+
+  return {
+    processedTopics: payload.topicIds.length,
+    processedUsers: payload.userIds.length,
+  };
+});

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/workflows.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/workflows.ts
@@ -1,5 +1,5 @@
 import { LayersEnum, MemorySourceType } from '@lobechat/types';
-import { createWorkflow, serveMany } from '@upstash/workflow/nextjs';
+import { createWorkflow } from '@upstash/workflow/nextjs';
 
 import {
   MemoryExtractionExecutor,
@@ -176,8 +176,7 @@ export const orchestratorWorkflow = createWorkflow<
   };
 });
 
-export const { POST } = serveMany({
-  [TOPIC_WORKFLOW_NAMES.orchestrator]: orchestratorWorkflow,
-  [TOPIC_WORKFLOW_NAMES.cep]: cepWorkflow,
-  [TOPIC_WORKFLOW_NAMES.identity]: identityWorkflow,
-});
+// Explicitly set workflow ids to keep context.invoke working even before serveMany assigns them
+cepWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.cep;
+identityWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.identity;
+orchestratorWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.orchestrator;

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -1762,15 +1762,16 @@ export class MemoryExtractionExecutor {
 }
 
 const WORKFLOW_PATHS = {
-  topicBatch: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics',
+  topicBatch:
+    '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/batch',
   userTopics: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics',
   users: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-users',
 } as const;
 
 export const TOPIC_WORKFLOW_NAMES = {
-  cep: 'process-topics/extract-layers/cep',
-  identity: 'process-topics/extract-layers/identity',
-  orchestrator: 'process-topics/extract-layers/orchestrator',
+  cep: 'process-topics-extract-layers-cep',
+  identity: 'process-topics-extract-layers-identity',
+  orchestrator: 'process-topics-extract-layers-orchestrator',
 } as const;
 
 const getWorkflowUrl = (path: string, baseUrl: string) => {
@@ -1818,6 +1819,15 @@ export class MemoryExtractionWorkflowService {
     }
 
     const url = getWorkflowUrl(WORKFLOW_PATHS.userTopics, payload.baseUrl);
+    return this.getClient().trigger({ body: payload, url });
+  }
+
+  static triggerProcessTopics(payload: MemoryExtractionPayloadInput) {
+    if (!payload.baseUrl) {
+      throw new Error('Missing baseUrl for workflow trigger');
+    }
+
+    const url = getWorkflowUrl(WORKFLOW_PATHS.topicBatch, payload.baseUrl);
     return this.getClient().trigger({ body: payload, url });
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix triggering and routing of user memory topic processing workflows by correcting workflow URLs, IDs, and invocation paths.

Bug Fixes:
- Correct the workflow path and workflow name constants used for topic batch processing to match the actual workflow routes.
- Ensure topic batch workflows are triggered via a dedicated QStash endpoint instead of relying on context.invoke path rewriting, preventing incorrect workflow URL resolution.

Enhancements:
- Introduce a dedicated batch workflow endpoint and dynamic workflowId routing for topic processing workflows to better structure workflow execution.
- Explicitly assign stable workflow IDs to topic workflows to ensure compatibility with both serveMany routing and direct workflow invocations.