### PR TITLE
🔨 chore(@upstash/qstash): debug 400 error not shown issue

### DIFF
--- a/patches/@upstash__qstash.patch
+++ b/patches/@upstash__qstash.patch
@@ -1,0 +1,25 @@
+diff --git a/chunk-RQPZUJXG.mjs b/chunk-RQPZUJXG.mjs
+index d1a9b4a460efc59304ec30e6bc63a127f1aac6d6..6653a61b539aaf91253300436a8072c6c5f666ee 100644
+--- a/chunk-RQPZUJXG.mjs
++++ b/chunk-RQPZUJXG.mjs
+@@ -326,6 +326,20 @@ var HttpClient = class {
+     }
+     if (response.status < 200 || response.status >= 300) {
+       const body = await response.text();
++      // Debug aid: log non-2xx responses to trace publish failures (e.g., 400) with context
++      try {
++        console.error(
++          "[upstash-qstash] request failed",
++          JSON.stringify({
++            status: response.status,
++            url: response.url,
++            headers: Object.fromEntries(response.headers.entries()),
++            body
++          })
++        );
++      } catch {
++        // ignore logging failures to preserve original throw path
++      }
+       throw new QstashError(
+         body.length > 0 ? body : `Error: status=${response.status}`,
+         response.status

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,18 @@
 packages:
-  - 'packages/**'
-  - '.'
-  - 'e2e'
-  - 'apps/desktop/src/main'
-
-overrides:
-  jose: ^6.1.3
-  stylelint-config-clean-order: 7.0.0
-  '@lobehub/chat-plugin-sdk>swagger-client': 3.36.0
-  '@swagger-api/apidom-reference': 1.1.0
-
-patchedDependencies:
-  '@swagger-api/apidom-reference': patches/@swagger-api__apidom-reference.patch
+  - packages/**
+  - .
+  - e2e
+  - apps/desktop/src/main
 
 onlyBuiltDependencies:
   - '@vercel/speed-insights'
+
+overrides:
+  '@lobehub/chat-plugin-sdk>swagger-client': 3.36.0
+  '@swagger-api/apidom-reference': 1.1.0
+  jose: ^6.1.3
+  stylelint-config-clean-order: 7.0.0
+
+patchedDependencies:
+  '@swagger-api/apidom-reference': patches/@swagger-api__apidom-reference.patch
+  '@upstash/qstash': patches/@upstash__qstash.patch


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Configure workspace to apply a local patch for the @upstash/qstash dependency and adjust pnpm workspace configuration accordingly.

Build:
- Update pnpm-workspace.yaml formatting and structure for package globs and workspace entries.

Chores:
- Add a patched dependency entry for @upstash/qstash to enable debugging and local patching via a new patch file.