### PR TITLE
refactor: add assertions to electron workflow modifiers

### DIFF
--- a/.github/workflows/manual-build-desktop.yml
+++ b/.github/workflows/manual-build-desktop.yml
@@ -62,13 +62,9 @@ jobs:
 
       - name: Install deps
         run: bun i
-        env:
-          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Lint
         run: bun run lint
-        env:
-          NODE_OPTIONS: --max-old-space-size=6144
 
   version:
     name: Determine version

--- a/.github/workflows/verify-desktop-patch.yml
+++ b/.github/workflows/verify-desktop-patch.yml
@@ -1,0 +1,55 @@
+name: Verify Desktop Patch
+
+on:
+  push:
+    branches:
+      - main
+      - next
+      - dev
+    paths:
+      - 'scripts/electronWorkflow/**'
+      - 'src/libs/next/config/**'
+      - 'src/app/**'
+      - 'src/layout/**'
+      - 'src/components/mdx/**'
+      - 'src/features/DevPanel/**'
+      - 'src/server/translation.ts'
+  pull_request:
+    paths:
+      - 'scripts/electronWorkflow/**'
+      - 'src/libs/next/config/**'
+      - 'src/app/**'
+      - 'src/layout/**'
+      - 'src/components/mdx/**'
+      - 'src/features/DevPanel/**'
+      - 'src/server/translation.ts'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24.11.1
+  BUN_VERSION: 1.2.23
+
+jobs:
+  verify:
+    name: Desktop patch smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node & Bun
+        uses: ./.github/actions/setup-node-bun
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install deps
+        run: bun i
+
+      - name: Verify desktop patch
+        run: bun scripts/electronWorkflow/modifiers/index.mts

--- a/scripts/electronWorkflow/modifiers/cleanUp.mts
+++ b/scripts/electronWorkflow/modifiers/cleanUp.mts
@@ -1,41 +1,44 @@
 import { Lang, parse } from '@ast-grep/napi';
-import fs from 'fs-extra';
 import path from 'node:path';
 
-import { isDirectRun, runStandalone } from './utils.mjs';
+import { isDirectRun, runStandalone, updateFile } from './utils.mjs';
+
+const hasUseServerDirective = (code: string) =>
+  /^\s*['"]use server['"]\s*;?/m.test(code.trimStart());
 
 export const cleanUpCode = async (TEMP_DIR: string) => {
   // Remove 'use server'
   const filesToRemoveUseServer = [
-    'src/components/mdx/Image.tsx',
     'src/features/DevPanel/CacheViewer/getCacheEntries.ts',
     'src/server/translation.ts',
   ];
 
   for (const file of filesToRemoveUseServer) {
     const filePath = path.join(TEMP_DIR, file);
-    if (fs.existsSync(filePath)) {
-      console.log(`  Processing ${file}...`);
-      const code = await fs.readFile(filePath, 'utf8');
-      const ast = parse(Lang.TypeScript, code);
-      const root = ast.root();
+    console.log(`  Processing ${file}...`);
+    await updateFile({
+      filePath,
+      name: `cleanUpCode:removeUseServer:${file}`,
+      transformer: (code) => {
+        // Prefer a deterministic text rewrite for directive prologue:
+        // remove ONLY the top-level `'use server';` directive if present.
+        const next = code.replace(/^\s*['"]use server['"]\s*;\s*\r?\n?/, '');
+        if (next !== code) return next;
 
-      // 'use server' is usually an expression statement at the top
-      // We look for the literal string 'use server' or "use server"
-      const useServer =
-        root.find({
-          rule: {
-            pattern: "'use server'",
-          },
-        }) ||
-        root.find({
-          rule: {
-            pattern: '"use server"',
-          },
-        });
+        // Fallback to AST rewrite (in case of odd formatting)
+        const ast = parse(Lang.TypeScript, code);
+        const root = ast.root();
 
-      if (useServer) {
-        // Find the statement containing this string
+        const useServer =
+          root.find({
+            rule: { pattern: "'use server'" },
+          }) ||
+          root.find({
+            rule: { pattern: '"use server"' },
+          });
+
+        if (!useServer) return code;
+
         let curr = useServer.parent();
         while (curr) {
           if (curr.kind() === 'expression_statement') {
@@ -45,10 +48,11 @@ export const cleanUpCode = async (TEMP_DIR: string) => {
           if (curr.kind() === 'program') break;
           curr = curr.parent();
         }
-      }
 
-      await fs.writeFile(filePath, root.text());
-    }
+        return root.text();
+      },
+      assertAfter: (code) => !hasUseServerDirective(code),
+    });
   }
 };
 

--- a/scripts/electronWorkflow/modifiers/nextConfig.mts
+++ b/scripts/electronWorkflow/modifiers/nextConfig.mts
@@ -2,7 +2,7 @@ import { Lang, parse } from '@ast-grep/napi';
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import { isDirectRun, runStandalone } from './utils.mjs';
+import { invariant, isDirectRun, runStandalone, updateFile } from './utils.mjs';
 
 interface Edit {
   end: number;
@@ -11,123 +11,149 @@ interface Edit {
 }
 
 export const modifyNextConfig = async (TEMP_DIR: string) => {
-  const nextConfigPath = path.join(TEMP_DIR, 'next.config.ts');
-  if (!fs.existsSync(nextConfigPath)) return;
+  const defineConfigPath = path.join(TEMP_DIR, 'src', 'libs', 'next', 'config', 'define-config.ts');
+  const legacyNextConfigPath = path.join(TEMP_DIR, 'next.config.ts');
 
-  console.log('  Processing next.config.ts...');
-  const code = await fs.readFile(nextConfigPath, 'utf8');
-  const ast = parse(Lang.TypeScript, code);
-  const root = ast.root();
-  const edits: Edit[] = [];
+  const nextConfigPath = fs.existsSync(defineConfigPath) ? defineConfigPath : legacyNextConfigPath;
+  if (!fs.existsSync(nextConfigPath)) {
+    throw new Error(`[modifyNextConfig] next config not found: ${nextConfigPath}`);
+  }
 
-  // Find nextConfig declaration
-  const nextConfigDecl = root.find({
-    rule: {
-      pattern: 'const nextConfig: NextConfig = { $$$ }',
-    },
-  });
+  console.log(`  Processing ${path.relative(TEMP_DIR, nextConfigPath)}...`);
+  await updateFile({
+    filePath: nextConfigPath,
+    name: 'modifyNextConfig',
+    transformer: (code) => {
+      const ast = parse(Lang.TypeScript, code);
+      const root = ast.root();
+      const edits: Edit[] = [];
 
-  if (nextConfigDecl) {
-    // 1. Remove redirects
-    const redirectsProp = nextConfigDecl.find({
-      rule: {
-        kind: 'property_identifier',
-        regex: '^redirects$',
-      },
-    });
-    if (redirectsProp) {
-      let curr = redirectsProp.parent();
-      while (curr) {
-        if (curr.kind() === 'pair') {
-          const range = curr.range();
-          edits.push({ end: range.end.index, start: range.start.index, text: '' });
-          break;
-        }
-        if (curr.kind() === 'object') break;
-        curr = curr.parent();
-      }
-    }
-
-    // 2. Remove headers
-    const headersProp = nextConfigDecl.find({
-      rule: {
-        kind: 'property_identifier',
-        regex: '^headers$',
-      },
-    });
-    if (headersProp) {
-      let curr = headersProp.parent();
-      while (curr) {
-        if (curr.kind() === 'pair' || curr.kind() === 'method_definition') {
-          const range = curr.range();
-          edits.push({ end: range.end.index, start: range.start.index, text: '' });
-          break;
-        }
-        if (curr.kind() === 'object') break;
-        curr = curr.parent();
-      }
-    }
-
-    // 3. Remove spread element
-    const spread = nextConfigDecl.find({
-      rule: {
-        kind: 'spread_element',
-      },
-    });
-    if (spread) {
-      const range = spread.range();
-      edits.push({ end: range.end.index, start: range.start.index, text: '' });
-    }
-
-    // 4. Inject output: 'export'
-    const objectNode = nextConfigDecl.find({
-      rule: { kind: 'object' },
-    });
-
-    if (objectNode) {
-      const range = objectNode.range();
-      // Insert after the opening brace `{
-      edits.push({
-        end: range.start.index + 1,
-        start: range.start.index + 1,
-        text: "\n  output: 'export',",
+      // Find nextConfig declaration
+      const nextConfigDecl = root.find({
+        rule: {
+          pattern: 'const nextConfig: NextConfig = { $$$ }',
+        },
       });
-    }
-  }
+      if (!nextConfigDecl) {
+        throw new Error('[modifyNextConfig] nextConfig declaration not found');
+      }
 
-  // Remove withPWA wrapper
-  const withPWA = root.find({
-    rule: {
-      pattern: 'withPWA($A)',
+      // 1. Remove redirects
+      const redirectsPair = nextConfigDecl.find({
+        rule: {
+          pattern: 'redirects: $A',
+        },
+      });
+      if (redirectsPair) {
+        const range = redirectsPair.range();
+        edits.push({ end: range.end.index, start: range.start.index, text: '' });
+      }
+
+      // 2. Remove headers
+      const headersMethod = nextConfigDecl
+        .findAll({
+          rule: {
+            kind: 'method_definition',
+          },
+        })
+        .find((node) => {
+          const text = node.text();
+          return text.startsWith('async headers') || text.startsWith('headers');
+        });
+      if (headersMethod) {
+        const range = headersMethod.range();
+        edits.push({ end: range.end.index, start: range.start.index, text: '' });
+      }
+
+      // 3. Remove spread element
+      const spreads = nextConfigDecl.findAll({
+        rule: {
+          kind: 'spread_element',
+        },
+      });
+
+      const isObjectLevelSpread = (node: any) => node.parent()?.kind() === 'object';
+
+      const standaloneSpread = spreads.find((node) => {
+        if (!isObjectLevelSpread(node)) return false;
+        const text = node.text();
+        return text.includes('isStandaloneMode') && text.includes('standaloneConfig');
+      });
+
+      const objectLevelSpread = standaloneSpread ? null : spreads.find(isObjectLevelSpread);
+
+      const spreadToRemove = standaloneSpread || objectLevelSpread;
+      if (spreadToRemove) {
+        const range = spreadToRemove.range();
+        edits.push({ end: range.end.index, start: range.start.index, text: '' });
+      }
+
+      // 4. Inject/force output: 'export'
+      const outputPair = nextConfigDecl.find({
+        rule: {
+          pattern: 'output: $A',
+        },
+      });
+      if (outputPair) {
+        const range = outputPair.range();
+        edits.push({ end: range.end.index, start: range.start.index, text: "output: 'export'" });
+      } else {
+        const objectNode = nextConfigDecl.find({
+          rule: { kind: 'object' },
+        });
+        if (!objectNode) {
+          throw new Error('[modifyNextConfig] nextConfig object not found');
+        }
+        {
+          const range = objectNode.range();
+          // Insert after the opening brace `{
+          edits.push({
+            end: range.start.index + 1,
+            start: range.start.index + 1,
+            text: "\n  output: 'export',",
+          });
+        }
+      }
+
+      // Remove withPWA wrapper
+      const withPWA = root.find({
+        rule: {
+          pattern: 'withPWA($A)',
+        },
+      });
+      if (withPWA) {
+        const inner = withPWA.getMatch('A');
+        if (!inner) {
+          throw new Error('[modifyNextConfig] withPWA inner config not found');
+        }
+        {
+          const range = withPWA.range();
+          edits.push({ end: range.end.index, start: range.start.index, text: inner.text() });
+        }
+      }
+
+      // Apply edits
+      edits.sort((a, b) => b.start - a.start);
+      let newCode = code;
+      for (const edit of edits) {
+        newCode = newCode.slice(0, edit.start) + edit.text + newCode.slice(edit.end);
+      }
+
+      // Cleanup commas (syntax fix)
+      // 1. Double commas ,, -> , (handle spaces/newlines between)
+      newCode = newCode.replaceAll(/,(\s*,)+/g, ',');
+      // 2. Leading comma in object { , -> {
+      newCode = newCode.replaceAll(/{\s*,/g, '{');
+
+      return newCode;
     },
+    assertAfter: (code) => /output\s*:\s*['"]export['"]/.test(code) && !/withPWA\s*\(/.test(code),
   });
-  if (withPWA) {
-    const inner = withPWA.getMatch('A');
-    if (inner) {
-      const range = withPWA.range();
-      edits.push({ end: range.end.index, start: range.start.index, text: inner.text() });
-    }
-  }
-
-  // Apply edits
-  edits.sort((a, b) => b.start - a.start);
-  let newCode = code;
-  for (const edit of edits) {
-    newCode = newCode.slice(0, edit.start) + edit.text + newCode.slice(edit.end);
-  }
-
-  // Cleanup commas (syntax fix)
-  // 1. Double commas ,, -> , (handle spaces/newlines between)
-  newCode = newCode.replaceAll(/,(\s*,)+/g, ',');
-  // 2. Leading comma in object { , -> {
-  newCode = newCode.replaceAll(/{\s*,/g, '{');
-  // 3. Trailing comma before closing brace is valid in JS/TS
-
-  await fs.writeFile(nextConfigPath, newCode);
 };
 
 if (isDirectRun(import.meta.url)) {
   await runStandalone('modifyNextConfig', modifyNextConfig, [
-    { lang: Lang.TypeScript, path: process.cwd() + '/next.config.ts' },
+    { lang: Lang.TypeScript, path: 'src/libs/next/config/define-config.ts' },
+    { lang: Lang.TypeScript, path: 'next.config.ts' },
   ]);
 }

--- a/scripts/electronWorkflow/modifiers/routes.mts
+++ b/scripts/electronWorkflow/modifiers/routes.mts
@@ -1,8 +1,7 @@
 import { Lang, parse } from '@ast-grep/napi';
-import fs from 'fs-extra';
 import path from 'node:path';
 
-import { isDirectRun, runStandalone } from './utils.mjs';
+import { isDirectRun, removePathEnsuring, runStandalone, updateFile } from './utils.mjs';
 
 export const modifyRoutes = async (TEMP_DIR: string) => {
   // 1. Delete routes
@@ -40,7 +39,10 @@ export const modifyRoutes = async (TEMP_DIR: string) => {
 
   for (const file of filesToDelete) {
     const fullPath = path.join(TEMP_DIR, file);
-    await fs.remove(fullPath);
+    await removePathEnsuring({
+      name: `modifyRoutes:delete:${file}`,
+      path: fullPath,
+    });
   }
 
   // 2. Modify desktopRouter.config.tsx
@@ -48,39 +50,44 @@ export const modifyRoutes = async (TEMP_DIR: string) => {
     TEMP_DIR,
     'src/app/[variants]/router/desktopRouter.config.tsx',
   );
-  if (fs.existsSync(routerConfigPath)) {
-    console.log('  Processing src/app/[variants]/router/desktopRouter.config.tsx...');
-    const code = await fs.readFile(routerConfigPath, 'utf8');
-    const ast = parse(Lang.Tsx, code);
-    const root = ast.root();
+  console.log('  Processing src/app/[variants]/router/desktopRouter.config.tsx...');
+  await updateFile({
+    filePath: routerConfigPath,
+    name: 'modifyRoutes:desktopRouterConfig',
+    transformer: (code) => {
+      const ast = parse(Lang.Tsx, code);
+      const root = ast.root();
 
-    const changelogNode = root.find({
-      rule: {
-        pattern: "{ path: 'changelog', $$$ }",
-      },
-    });
-    if (changelogNode) {
-      changelogNode.replace('');
-    }
-
-    const changelogImport = root.find({
-      rule: {
-        pattern: "import('../(main)/changelog')",
-      },
-    });
-    if (changelogImport) {
-      // Find the closest object (route definition) and remove it
-      let curr = changelogImport.parent();
-      while (curr) {
-        if (curr.kind() === 'object') {
-          curr.replace('');
-          break;
-        }
-        curr = curr.parent();
+      const changelogNode = root.find({
+        rule: {
+          pattern: "{ path: 'changelog', $$$ }",
+        },
+      });
+      if (changelogNode) {
+        changelogNode.replace('');
       }
-    }
-    await fs.writeFile(routerConfigPath, root.text());
-  }
+
+      const changelogImport = root.find({
+        rule: {
+          pattern: "import('../(main)/changelog')",
+        },
+      });
+      if (changelogImport) {
+        // Find the closest object (route definition) and remove it
+        let curr = changelogImport.parent();
+        while (curr) {
+          if (curr.kind() === 'object') {
+            curr.replace('');
+            break;
+          }
+          curr = curr.parent();
+        }
+      }
+
+      return root.text();
+    },
+    assertAfter: (code) => !/\bchangelog\b/.test(code),
+  });
 };
 
 if (isDirectRun(import.meta.url)) {


### PR DESCRIPTION
## Summary

- Add post-condition assertions to all file modification operations in electron workflow modifiers
- Add `verify-desktop-patch.yml` workflow for CI validation of desktop patching scripts
- Add utility functions: `invariant`, `updateFile`, `writeFileEnsuring`, `removePathEnsuring`
- Improve error messages and validation in workflow scripts

## Changes

### New files
- `.github/workflows/verify-desktop-patch.yml` - CI workflow to verify desktop patch transformations

### Modified files
- `scripts/electronWorkflow/modifiers/appCode.mts` - Add assertions for each transformation step
- `scripts/electronWorkflow/modifiers/cleanUp.mts` - Add assertion for 'use server' removal
- `scripts/electronWorkflow/modifiers/nextConfig.mts` - Add assertions and handle both config locations
- `scripts/electronWorkflow/modifiers/routes.mts` - Add assertion for changelog removal
- `scripts/electronWorkflow/modifiers/utils.mts` - Add utility functions with invariant checking
- `.github/workflows/manual-build-desktop.yml` - Remove redundant NODE_OPTIONS env vars

## Test plan

- [ ] Run `bun scripts/electronWorkflow/modifiers/index.mts` locally to verify patching works
- [ ] Check CI workflow passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)