### PR TITLE
✨ feat: add a white waitlist in edge config env

### DIFF
--- a/locales/en-US/error.json
+++ b/locales/en-US/error.json
@@ -143,5 +143,9 @@
   "upload.networkError": "Please check your network connection and ensure that the file storage service's cross-origin configuration is correct.",
   "upload.title": "File upload failed. Please check your network connection or try again later",
   "upload.unknownError": "Error reason: {{reason}}",
-  "upload.uploadFailed": "File upload failed."
+  "upload.uploadFailed": "File upload failed.",
+  "waitlist.currentEmail": "Current account: {{email}}",
+  "waitlist.desc": "Your account is not on the whitelist. Please contact the administrator to request access.",
+  "waitlist.switchAccount": "Switch Account",
+  "waitlist.title": "Access Restricted"
 }

--- a/locales/zh-CN/error.json
+++ b/locales/zh-CN/error.json
@@ -143,5 +143,9 @@
   "upload.networkError": "网络异常或跨域配置不正确。请检查文件存储服务的 CORS 设置后重试",
   "upload.title": "上传未能完成",
   "upload.unknownError": "原因：{{reason}}",
-  "upload.uploadFailed": "上传未能完成"
+  "upload.uploadFailed": "上传未能完成",
+  "waitlist.currentEmail": "当前账号：{{email}}",
+  "waitlist.desc": "您的账号不在白名单范围内，请联系管理员申请访问权限。",
+  "waitlist.switchAccount": "切换账号",
+  "waitlist.title": "访问受限"
 }

--- a/packages/edge-config/src/index.ts
+++ b/packages/edge-config/src/index.ts
@@ -45,6 +45,17 @@ export class EdgeConfig {
     debug('Feature flags retrieved: %O', featureFlags);
     return featureFlags;
   };
+
+  /**
+   * Get user whitelist from EdgeConfig
+   * @returns Array of allowed email addresses
+   */
+  getWhitelist = async () => {
+    const whitelist = await this.getValue('lobehub_whitelist');
+    console.log('[EdgeConfig.getWhitelist] whitelist:', whitelist);
+    debug('Whitelist retrieved: %O', whitelist);
+    return whitelist;
+  };
 }
 
 export * from './types';

--- a/packages/edge-config/src/types.ts
+++ b/packages/edge-config/src/types.ts
@@ -18,6 +18,11 @@ export interface EdgeConfigData extends BusinessEdgeConfigData {
    * Feature flags configuration
    */
   feature_flags?: Record<string, boolean | string[]>;
+
+  /**
+   * LobeHub user whitelist - array of allowed email addresses
+   */
+  lobehub_whitelist?: string[];
 }
 
 export type EdgeConfigKeys = keyof EdgeConfigData;

--- a/src/app/[variants]/(main)/_layout/index.tsx
+++ b/src/app/[variants]/(main)/_layout/index.tsx
@@ -16,6 +16,7 @@ import TitleBar, { TITLE_BAR_HEIGHT } from '@/features/ElectronTitlebar';
 import HotkeyHelperPanel from '@/features/HotkeyHelperPanel';
 import NavPanel from '@/features/NavPanel';
 import { usePlatform } from '@/hooks/usePlatform';
+import { useWhitelistCheck } from '@/hooks/useWhitelistCheck';
 import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import CmdkLazy from '@/layout/GlobalProvider/CmdkLazy';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
@@ -33,6 +34,12 @@ const Layout: FC = () => {
   const { isPWA } = usePlatform();
   const theme = useTheme();
   const { showCloudPromotion } = useServerConfigStore(featureFlagsSelectors);
+  const { isChecking } = useWhitelistCheck();
+
+  // Show loading while checking whitelist
+  if (isChecking) {
+    return <Loading debugId="DesktopMainLayout > WhitelistCheck" />;
+  }
 
   return (
     <HotkeysProvider initiallyActiveScopes={[HotkeyScopeEnum.Global]}>

--- a/src/app/[variants]/(mobile)/_layout/index.tsx
+++ b/src/app/[variants]/(mobile)/_layout/index.tsx
@@ -5,6 +5,7 @@ import { type FC, Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
+import { useWhitelistCheck } from '@/hooks/useWhitelistCheck';
 import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { NavigatorRegistrar } from '@/utils/router';
@@ -28,6 +29,13 @@ const MobileMainLayout: FC = () => {
   const location = useLocation();
   const pathname = location.pathname;
   const showNav = MOBILE_NAV_ROUTES.has(pathname);
+  const { isChecking } = useWhitelistCheck();
+
+  // Show loading while checking whitelist
+  if (isChecking) {
+    return <Loading debugId="MobileMainLayout > WhitelistCheck" />;
+  }
+
   return (
     <>
       <NavigatorRegistrar />

--- a/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
+++ b/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
@@ -247,4 +247,10 @@ export const mobileRoutes: RouteConfig[] = [
     errorElement: <ErrorBoundary resetPath="/" />,
     path: '/onboarding',
   },
+  // Waitlist route (outside main layout)
+  {
+    element: dynamicElement(() => import('../../waitlist'), 'Mobile > Waitlist'),
+    errorElement: <ErrorBoundary resetPath="/" />,
+    path: '/waitlist',
+  },
 ];

--- a/src/app/[variants]/router/desktopRouter.config.tsx
+++ b/src/app/[variants]/router/desktopRouter.config.tsx
@@ -388,6 +388,12 @@ export const desktopRoutes: RouteConfig[] = [
     errorElement: <ErrorBoundary resetPath="/" />,
     path: '/onboarding',
   },
+  // Waitlist route (outside main layout)
+  {
+    element: dynamicElement(() => import('../waitlist'), 'Desktop > Waitlist'),
+    errorElement: <ErrorBoundary resetPath="/" />,
+    path: '/waitlist',
+  },
 ];
 
 // Desktop onboarding route (SPA-only)

--- a/src/app/[variants]/waitlist/index.tsx
+++ b/src/app/[variants]/waitlist/index.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Button, Center, Flexbox, FluentEmoji, Text } from '@lobehub/ui';
+import { Divider } from 'antd';
+import { useTheme } from 'antd-style';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import Loading from '@/components/Loading/BrandTextLoading';
+import { MAX_WIDTH } from '@/const/layoutTokens';
+import LangButton from '@/features/User/UserPanel/LangButton';
+import ThemeButton from '@/features/User/UserPanel/ThemeButton';
+import { useUserStore } from '@/store/user';
+import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
+
+const WaitlistPage = memo(() => {
+  const { t } = useTranslation('error');
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const [isLogin, isLoaded, email, signOut] = useUserStore((s) => [
+    authSelectors.isLogin(s),
+    authSelectors.isLoaded(s),
+    userProfileSelectors.email(s),
+    s.logout,
+  ]);
+
+  // Redirect to home if not logged in
+  useEffect(() => {
+    if (isLoaded && !isLogin) {
+      navigate('/', { replace: true });
+    }
+  }, [isLoaded, isLogin, navigate]);
+
+  const handleSwitchAccount = useCallback(async () => {
+    setIsLoggingOut(true);
+    await signOut();
+    setTimeout(() => {
+      window.location.href = '/home';
+    }, 1500);
+  }, [signOut]);
+
+  // Show loading while checking auth state
+  if (!isLoaded || !isLogin) {
+    return <Loading debugId="WaitlistPage > AuthCheck" />;
+  }
+
+  return (
+    <Flexbox
+      height={'100%'}
+      padding={8}
+      style={{
+        position: 'relative',
+      }}
+      width={'100%'}
+    >
+      <Flexbox
+        height={'100%'}
+        style={{
+          background: theme.colorBgContainer,
+          border: `1px solid ${theme.isDarkMode ? theme.colorBorderSecondary : theme.colorBorder}`,
+          borderRadius: theme.borderRadius,
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+        width={'100%'}
+      >
+        <Flexbox
+          align={'center'}
+          gap={8}
+          horizontal
+          justify={'space-between'}
+          padding={16}
+          width={'100%'}
+        >
+          <div />
+          <Flexbox align={'center'} horizontal>
+            <LangButton placement={'bottomRight'} size={18} />
+            <Divider
+              style={{
+                height: 24,
+              }}
+              type={'vertical'}
+            />
+            <ThemeButton placement={'bottomRight'} size={18} />
+          </Flexbox>
+        </Flexbox>
+        <Center height={'100%'} padding={16} width={'100%'}>
+          <Flexbox align={'center'} gap={24} style={{ maxWidth: MAX_WIDTH }}>
+            <FluentEmoji emoji={'🎫'} size={64} />
+            <h2 style={{ fontWeight: 'bold', margin: 0, textAlign: 'center' }}>
+              {t('waitlist.title')}
+            </h2>
+            <div style={{ lineHeight: '1.8', textAlign: 'center' }}>
+              <div>{t('waitlist.desc')}</div>
+              {isLogin && email && (
+                <div style={{ color: theme.colorTextSecondary, marginTop: '0.5em' }}>
+                  {t('waitlist.currentEmail', { email })}
+                </div>
+              )}
+            </div>
+            {isLogin && (
+              <Button loading={isLoggingOut} onClick={handleSwitchAccount} type={'primary'}>
+                {t('waitlist.switchAccount')}
+              </Button>
+            )}
+          </Flexbox>
+        </Center>
+        <Center padding={24}>
+          <Text align={'center'} type={'secondary'}>
+            © 2025 LobeHub, Inc. All rights reserved.
+          </Text>
+        </Center>
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+WaitlistPage.displayName = 'WaitlistPage';
+
+export default WaitlistPage;

--- a/src/hooks/useWhitelistCheck.ts
+++ b/src/hooks/useWhitelistCheck.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useSWR from 'swr';
+
+import { globalService } from '@/services/global';
+import { useUserStore } from '@/store/user';
+import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
+
+/**
+ * Hook to check if the current user's email is in the whitelist.
+ * If not, redirects to the waitlist page.
+ * @returns isChecking - true while the whitelist check is in progress
+ */
+export const useWhitelistCheck = () => {
+  const navigate = useNavigate();
+  const [isChecking, setIsChecking] = useState(true);
+
+  const [isLogin, email, isLoaded] = useUserStore((s) => [
+    authSelectors.isLogin(s),
+    userProfileSelectors.email(s),
+    authSelectors.isLoaded(s),
+  ]);
+
+  const { data: whitelist, isLoading } = useSWR('whitelist', globalService.getWhitelist, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+
+  console.log('[useWhitelistCheck] whitelist:', whitelist);
+
+  useEffect(() => {
+    // Wait for user state to load
+    if (!isLoaded) return;
+
+    // If user is not logged in, allow access (no whitelist check needed)
+    if (!isLogin) {
+      setIsChecking(false);
+      return;
+    }
+
+    // Wait for whitelist to load
+    if (isLoading) return;
+
+    // If whitelist is empty or not configured, allow access
+    if (!whitelist || whitelist.length === 0) {
+      setIsChecking(false);
+      return;
+    }
+
+    // Check if user's email is in the whitelist
+    const isInWhitelist = whitelist.some(
+      (allowedEmail) => allowedEmail.toLowerCase() === email.toLowerCase(),
+    );
+
+    if (!isInWhitelist) {
+      navigate('/waitlist', { replace: true });
+    } else {
+      setIsChecking(false);
+    }
+  }, [isLoaded, isLoading, isLogin, email, whitelist, navigate]);
+
+  return { isChecking };
+};

--- a/src/locales/default/error.ts
+++ b/src/locales/default/error.ts
@@ -234,4 +234,9 @@ export default {
   'upload.title': 'File upload failed. Please check your network connection or try again later',
   'upload.unknownError': 'Error reason: {{reason}}',
   'upload.uploadFailed': 'File upload failed.',
+  'waitlist.currentEmail': 'Current account: {{email}}',
+  'waitlist.desc':
+    'Your account is not on the whitelist. Please contact the administrator to request access.',
+  'waitlist.switchAccount': 'Switch Account',
+  'waitlist.title': 'Access Restricted',
 };

--- a/src/server/routers/lambda/config/index.ts
+++ b/src/server/routers/lambda/config/index.ts
@@ -1,3 +1,4 @@
+import { EdgeConfig } from '@lobechat/edge-config';
 import debug from 'debug';
 
 import { getServerFeatureFlagsStateFromEdgeConfig } from '@/config/featureFlags';
@@ -33,5 +34,25 @@ export const configRouter = router({
     );
 
     return result;
+  }),
+
+  /**
+   * Get user whitelist from EdgeConfig
+   */
+  getWhitelist: publicProcedure.query(async () => {
+    if (!EdgeConfig.isEnabled()) {
+      log('[Whitelist] EdgeConfig not enabled, returning empty whitelist');
+      return [];
+    }
+
+    try {
+      const edgeConfig = new EdgeConfig();
+      const whitelist = await edgeConfig.getWhitelist();
+      log('[Whitelist] Retrieved whitelist with %d entries', whitelist?.length ?? 0);
+      return whitelist ?? [];
+    } catch (error) {
+      log('[Whitelist] Failed to fetch whitelist:', error);
+      return [];
+    }
   }),
 });

--- a/src/services/global.ts
+++ b/src/services/global.ts
@@ -24,6 +24,13 @@ class GlobalService {
   getDefaultAgentConfig = async (): Promise<PartialDeep<LobeAgentConfig>> => {
     return lambdaClient.config.getDefaultAgentConfig.query();
   };
+
+  /**
+   * Get user whitelist from EdgeConfig
+   */
+  getWhitelist = async (): Promise<string[]> => {
+    return lambdaClient.config.getWhitelist.query();
+  };
 }
 
 export const globalService = new GlobalService();


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add edge-config–backed email whitelist enforcement and a dedicated waitlist experience for non-whitelisted users.

New Features:
- Expose a backend endpoint and client service to fetch an email whitelist from EdgeConfig.
- Introduce a whitelist-check hook that gates main mobile and desktop layouts and redirects non-whitelisted users to a waitlist page.
- Add dedicated waitlist routes and page UI for logged-in users without whitelist access, including account switch flow.

Enhancements:
- Extend EdgeConfig schema and API to store and retrieve a lobehub email whitelist.
- Show loading states in main mobile and desktop layouts while whitelist checks are in progress.
- Add localized error copy for the waitlist access restriction experience.