### PR TITLE
🐛 fix: update OFFICIAL_URL to app.lobehub.com

### DIFF
--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-export const OFFICIAL_URL = 'https://lobechat.com';
+export const OFFICIAL_URL = 'https://app.lobehub.com';
 export const OFFICIAL_SITE = 'https://lobehub.com';
 export const OFFICIAL_DOMAIN = 'lobehub.com';
 

--- a/src/features/DesktopOnboarding/screens/Screen5.tsx
+++ b/src/features/DesktopOnboarding/screens/Screen5.tsx
@@ -4,6 +4,7 @@ import { Cloud, Server } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
+import { isDesktop } from '@/const/version';
 import { useElectronStore } from '@/store/electron';
 import { setDesktopAutoOidcFirstOpenHandled } from '@/utils/electron/autoOidc';
 
@@ -359,7 +360,7 @@ export const Screen5 = ({ onScreenConfigChange }: Screen5Props) => {
   // 处理云端登录
   const handleCloudLogin = async () => {
     // Desktop runtime guard
-    if (process.env.NEXT_PUBLIC_IS_DESKTOP_APP !== '1') {
+    if (!isDesktop) {
       setRemoteError('OIDC authorization is only available in the desktop app runtime.');
       setCloudLoginStatus('error');
       return;
@@ -379,7 +380,7 @@ export const Screen5 = ({ onScreenConfigChange }: Screen5Props) => {
   // 处理自建服务器连接
   const handleSelfhostConnect = async () => {
     // Desktop runtime guard
-    if (process.env.NEXT_PUBLIC_IS_DESKTOP_APP !== '1') {
+    if (!isDesktop) {
       setRemoteError('OIDC authorization is only available in the desktop app runtime.');
       setSelfhostLoginStatus('error');
       return;

--- a/src/layout/AuthProvider/MarketAuth/oidc.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@/const/version';
 import { MARKET_OIDC_ENDPOINTS } from '@/services/_url';
 
 import { MarketAuthError } from './errors';
@@ -183,11 +184,9 @@ export class MarketOIDC {
       });
     }
 
-    const isDesktopApp = process.env.NEXT_PUBLIC_IS_DESKTOP_APP === '1';
-
     // 在新窗口中打开授权页面
     let popup: Window | null = null;
-    if (isDesktopApp) {
+    if (isDesktop) {
       // Electron 桌面端：使用 IPC 调用主进程打开系统浏览器
       console.log('[MarketOIDC] Desktop app detected, opening system browser via IPC');
       const { remoteServerService } = await import('@/services/electron/remoteServer');


### PR DESCRIPTION
## Summary

- Update `OFFICIAL_URL` from `https://lobechat.com` to `https://app.lobehub.com`
- Also use `isDesktop()` util instead of env check for consistency in desktop runtime checks

## Test plan

- [ ] Verify the official URL is correctly updated
- [ ] Test desktop onboarding flow with updated runtime checks
- [ ] Verify market OIDC flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align desktop runtime checks with shared utilities and update the official application URL.

Bug Fixes:
- Fix desktop runtime detection in onboarding and market OIDC flows by using the shared isDesktop utility instead of environment variable checks.
- Update the OFFICIAL_URL constant to point to https://app.lobehub.com instead of the old lobechat.com domain.