### PR TITLE
✨ feat: enhance macOS desktop permissions and onboarding

### DIFF
--- a/apps/desktop/electron-builder.js
+++ b/apps/desktop/electron-builder.js
@@ -165,12 +165,16 @@ const config = {
           CFBundleURLSchemes: [protocolScheme],
         },
       ],
+      NSAppleEventsUsageDescription:
+        'Application needs to control System Settings to help you grant Full Disk Access automatically.',
       NSCameraUsageDescription: "Application requests access to the device's camera.",
       NSDocumentsFolderUsageDescription:
         "Application requests access to the user's Documents folder.",
       NSDownloadsFolderUsageDescription:
         "Application requests access to the user's Downloads folder.",
       NSMicrophoneUsageDescription: "Application requests access to the device's microphone.",
+      NSScreenCaptureUsageDescription:
+        'Application requests access to record and analyze screen content for AI assistance.',
     },
     gatekeeperAssess: false,
     hardenedRuntime: hasAppleCertificate,

--- a/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
@@ -44,6 +44,22 @@ vi.mock('@/utils/logger', () => ({
   }),
 }));
 
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => {
+    const handlers = new Map<string, (...args: any[]) => void>();
+    return {
+      on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+        handlers.set(event, cb);
+        return undefined;
+      }),
+    } as any;
+  }),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: any[]) => spawnMock(...args),
+}));
+
 // Mock electron
 vi.mock('electron', () => ({
   app: {
@@ -61,6 +77,8 @@ vi.mock('electron', () => ({
     openExternal: vi.fn().mockResolvedValue(undefined),
   },
   systemPreferences: {
+    askForMediaAccess: vi.fn(async () => true),
+    getMediaAccessStatus: vi.fn(() => 'not-determined'),
     isTrustedAccessibilityClient: vi.fn(() => true),
   },
 }));
@@ -73,6 +91,14 @@ vi.mock('electron-is', () => ({
 // Mock browserManager
 const mockBrowserManager = {
   broadcastToAllWindows: vi.fn(),
+  getMainWindow: vi.fn(() => ({
+    browserWindow: {
+      isDestroyed: vi.fn(() => false),
+      webContents: {
+        executeJavaScript: vi.fn(async () => true),
+      },
+    },
+  })),
   handleAppThemeChange: vi.fn(),
 };
 
@@ -160,6 +186,66 @@ describe('SystemController', () => {
 
       // Reset
       vi.mocked(macOS).mockReturnValue(true);
+    });
+  });
+
+  describe('screen recording', () => {
+    it('should request screen recording access and open System Settings on macOS', async () => {
+      const { shell, systemPreferences } = await import('electron');
+
+      const result = await invokeIpc('system.requestScreenAccess');
+
+      expect(systemPreferences.getMediaAccessStatus).toHaveBeenCalledWith('screen');
+      expect(systemPreferences.askForMediaAccess).toHaveBeenCalledWith('screen');
+      expect(mockBrowserManager.getMainWindow).toHaveBeenCalled();
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+      );
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should return true on non-macOS and not open settings', async () => {
+      const { macOS } = await import('electron-is');
+      const { shell, systemPreferences } = await import('electron');
+      vi.mocked(macOS).mockReturnValue(false);
+
+      const result = await invokeIpc('system.requestScreenAccess');
+
+      expect(result).toBe(true);
+      expect(systemPreferences.askForMediaAccess).not.toHaveBeenCalled();
+      expect(shell.openExternal).not.toHaveBeenCalled();
+
+      // Reset
+      vi.mocked(macOS).mockReturnValue(true);
+    });
+  });
+
+  describe('full disk access', () => {
+    it('should try to open Full Disk Access settings with fallbacks', async () => {
+      const { shell } = await import('electron');
+      vi.mocked(shell.openExternal)
+        .mockRejectedValueOnce(new Error('fail first'))
+        .mockResolvedValueOnce(undefined);
+
+      await invokeIpc('system.openFullDiskAccessSettings');
+
+      expect(shell.openExternal).toHaveBeenCalledWith('com.apple.settings:Privacy&path=FullDiskAccess');
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles',
+      );
+    });
+
+    it('should spawn osascript when autoAdd is enabled', async () => {
+      const { shell } = await import('electron');
+      vi.mocked(shell.openExternal).mockResolvedValueOnce(undefined);
+
+      await invokeIpc('system.openFullDiskAccessSettings', { autoAdd: true });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'osascript',
+        expect.arrayContaining(['-e', expect.any(String), expect.any(String)]),
+        expect.objectContaining({ env: expect.any(Object) }),
+      );
     });
   });
 

--- a/apps/desktop/src/main/controllers/scripts/full-disk-access.applescript
+++ b/apps/desktop/src/main/controllers/scripts/full-disk-access.applescript
@@ -1,0 +1,85 @@
+on run argv
+  set appBundlePath to item 1 of argv
+
+  set settingsBundleIds to {"com.apple.SystemSettings", "com.apple.systempreferences"}
+
+  -- Bring System Settings/Preferences to front (Ventura+ / older). If it doesn't exist, ignore.
+  repeat with bundleId in settingsBundleIds
+    try
+      tell application id bundleId to activate
+      exit repeat
+    end try
+  end repeat
+
+  tell application "System Events"
+    set settingsProcess to missing value
+    repeat 30 times
+      repeat with bundleId in settingsBundleIds
+        try
+          if exists (first process whose bundle identifier is bundleId) then
+            set settingsProcess to first process whose bundle identifier is bundleId
+            exit repeat
+          end if
+        end try
+      end repeat
+
+      if settingsProcess is not missing value then exit repeat
+      delay 0.2
+    end repeat
+
+    if settingsProcess is missing value then return "no-settings-process"
+
+    tell settingsProcess
+      set frontmost to true
+
+      repeat 30 times
+        if exists window 1 then exit repeat
+        delay 0.2
+      end repeat
+      if not (exists window 1) then return "no-window"
+
+      -- Best-effort: find an "add" button in the front window and click it.
+      set clickedAdd to false
+      repeat 30 times
+        try
+          repeat with b in (buttons of window 1)
+            set bDesc to ""
+            set bName to ""
+            set bTitle to ""
+            try set bDesc to description of b end try
+            try set bName to name of b end try
+            try set bTitle to title of b end try
+
+            if (bDesc is "Add") or (bTitle is "Add") or (bName is "+") or (bTitle is "+") then
+              click b
+              set clickedAdd to true
+              exit repeat
+            end if
+          end repeat
+        end try
+
+        if clickedAdd is true then exit repeat
+        delay 0.2
+      end repeat
+
+      if clickedAdd is false then return "no-add-button"
+
+      -- Wait for open panel / sheet
+      repeat 30 times
+        if exists sheet 1 of window 1 then exit repeat
+        delay 0.2
+      end repeat
+      if not (exists sheet 1 of window 1) then return "no-sheet"
+
+      -- Open "Go to the folder" and input the app bundle path, then confirm.
+      keystroke "G" using {command down, shift down}
+      delay 0.3
+      keystroke appBundlePath
+      key code 36
+      delay 0.6
+      -- Confirm "Open" in the panel (Enter usually triggers default)
+      key code 36
+      return "ok"
+    end tell
+  end tell
+end run

--- a/locales/en-US/desktop-onboarding.json
+++ b/locales/en-US/desktop-onboarding.json
@@ -1,4 +1,8 @@
 {
+  "authResult.failed.desc": "Please try again or switch to a different login method",
+  "authResult.failed.title": "Authorization Failed",
+  "authResult.success.desc": "Please click the Start button below to continue using LobeHub Desktop",
+  "authResult.success.title": "Authorization Successful",
   "navigation.next": "Continue",
   "screen1.description": "AI-powered productivity platform with intelligent agents",
   "screen1.navigation.next": "Start Setting Up",

--- a/locales/zh-CN/desktop-onboarding.json
+++ b/locales/zh-CN/desktop-onboarding.json
@@ -1,4 +1,8 @@
 {
+  "authResult.failed.desc": "请重试，或切换其他登录方式",
+  "authResult.failed.title": "授权失败",
+  "authResult.success.desc": "点击下方「开始」继续使用 LobeHub 桌面端",
+  "authResult.success.title": "授权成功",
   "navigation.next": "继续",
   "screen1.description": "AI 驱动的生产力平台，内置智能助理",
   "screen1.navigation.next": "开始设置",

--- a/src/app/[variants]/(main)/_layout/DesktopLayoutContainer/style.ts
+++ b/src/app/[variants]/(main)/_layout/DesktopLayoutContainer/style.ts
@@ -1,5 +1,7 @@
 import { createStaticStyles } from 'antd-style';
 
+import { isDesktop } from '@/const/version';
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   // 内层容器
   innerContainer: css`
@@ -22,6 +24,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-block-start: var(--container-padding-top, 8px);
     padding-inline-start: var(--container-padding-left, 8px);
 
-    background: ${cssVar.colorBgLayout};
+    background: ${isDesktop ? 'transparent' : cssVar.colorBgLayout};
   `,
 }));

--- a/src/features/DesktopOnboarding/common/AuthResult.tsx
+++ b/src/features/DesktopOnboarding/common/AuthResult.tsx
@@ -1,6 +1,7 @@
 import { createStaticStyles, cx } from 'antd-style';
 import { Check, X } from 'lucide-react';
 import { motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
 
 import { LogoBrand } from './LogoBrand';
 
@@ -138,10 +139,10 @@ interface AuthResultProps {
 export const AuthResult = ({ success, title, description, animated = true }: AuthResultProps) => {
   const styles = authResultStyles;
 
-  const defaultTitle = success ? 'Authorization Successful' : 'Authorization Failed';
-  const defaultDescription = success
-    ? 'Please click the Start button below to continue using LobeHub Desktop'
-    : 'Please try again or switch to a different login method';
+  const { t } = useTranslation('desktop-onboarding');
+
+  const defaultTitle = t(success ? 'authResult.success.title' : 'authResult.failed.title');
+  const defaultDescription = t(success ? 'authResult.success.desc' : 'authResult.failed.desc');
 
   const content = (
     <>

--- a/src/features/DesktopOnboarding/screens/Screen3.tsx
+++ b/src/features/DesktopOnboarding/screens/Screen3.tsx
@@ -289,7 +289,7 @@ export const Screen3 = ({ onScreenConfigChange }: Screen3Props) => {
         break;
       }
       case 2: {
-        await ipc.system.openFullDiskAccessSettings();
+        await ipc.system.openFullDiskAccessSettings({ autoAdd: true });
         break;
       }
       case 3: {

--- a/src/features/DesktopOnboarding/screens/Screen5.tsx
+++ b/src/features/DesktopOnboarding/screens/Screen5.tsx
@@ -53,7 +53,7 @@ const screen4Styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: ${cssVar.borderRadius};
 
     font-size: ${cssVar.fontSize};
-    color: ${cssVar.colorTextBase};
+    color: #fff;
 
     background: rgba(255, 255, 255, 5%);
     outline: none;
@@ -692,6 +692,12 @@ export const Screen5 = ({ onScreenConfigChange }: Screen5Props) => {
                 initial={{ opacity: 0, y: 30 }}
                 key="selfhost-input"
                 onChange={(e) => setEndpoint(e.target.value)}
+                onContextMenu={async (e) => {
+                  if (!isDesktop) return;
+                  e.preventDefault();
+                  const { electronSystemService } = await import('@/services/electron/system');
+                  await electronSystemService.showContextMenu('edit');
+                }}
                 placeholder={t('screen5.selfhost.endpointPlaceholder')}
                 transition={{ delay: 0.5, duration: 0.5 }}
                 type="text"

--- a/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
+++ b/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
@@ -41,8 +41,10 @@ export const useWatchThemeUpdate = () => {
     if (!isAppStateInit || !isMac) return;
     document.documentElement.style.background = 'none';
 
-    // https://x.com/alanblogsooo/status/1939208908993896684
+    const lobeApp = document.querySelector('#lobe-ui-theme-app');
+    if (!lobeApp) return;
+    const hexColor = getComputedStyle(lobeApp).getPropertyValue('--ant-color-bg-layout');
 
-    document.body.style.background = `color-mix(in srgb, ${cssVar.colorBgLayout} 66%, transparent)`;
+    document.body.style.background = `color-mix(in srgb, ${hexColor} 86%, transparent)`;
   }, [systemAppearance, isAppStateInit, isMac]);
 };

--- a/src/locales/default/desktop-onboarding.ts
+++ b/src/locales/default/desktop-onboarding.ts
@@ -1,4 +1,10 @@
 export default {
+  'authResult.failed.desc': 'Please try again or switch to a different login method',
+  'authResult.failed.title': 'Authorization Failed',
+  'authResult.success.desc':
+    'Please click the Start button below to continue using LobeHub Desktop',
+  'authResult.success.title': 'Authorization Successful',
+
   'navigation.next': 'Continue',
 
   'screen1.description': 'AI-powered productivity platform with intelligent agents',

--- a/src/utils/i18n/loadI18nNamespaceModule.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.ts
@@ -10,13 +10,13 @@ export interface LoadI18nNamespaceModuleParams {
 export const loadI18nNamespaceModule = async (params: LoadI18nNamespaceModuleParams) => {
   const { defaultLang, normalizeLocale, lng, ns } = params;
 
-  // Desktop-only namespaces should never be loaded in web runtime.
-  // This is a defensive guard: the desktop router already prevents reaching those pages on web.
-  if (!isDesktop && ns === 'desktop-onboarding') return { default: {} };
-
   if (lng === defaultLang) return import(`@/locales/default/${ns}`);
 
-  return import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);
+  try {
+    return import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);
+  } catch (error) {
+    return import(`@/locales/default/${ns}`);
+  }
 };
 
 export interface LoadI18nNamespaceModuleWithFallbackParams extends LoadI18nNamespaceModuleParams {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

resolves LOBE-2403, LOBE-2402

#### 🔀 Description of Change

This PR enhances the macOS desktop onboarding experience with improved permission handling:

- **Screen Recording**: Implements dual-method permission request (Electron API + `getDisplayMedia` trigger) to ensure TCC registration before opening System Settings
- **Full Disk Access**: Adds auto-add functionality using AppleScript UI automation to automatically add the app to the Full Disk Access list
- **Platform-aware Onboarding**: Makes onboarding flow intelligent - macOS users see Screen3 (permissions), while non-macOS users skip it
- **Privacy Descriptions**: Adds required `NSAppleEventsUsageDescription` and `NSScreenCaptureUsageDescription` to `electron-builder.js`
- **Comprehensive Tests**: Adds unit tests covering screen recording and full disk access permission flows

The AppleScript auto-add feature is a best-effort implementation that gracefully handles failures across different macOS versions and UI structures.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Manual Testing:**
1. Launch desktop app on macOS - verify onboarding shows Screen3 for macOS
2. Test screen recording permission flow - verify System Settings opens
3. Test Full Disk Access with auto-add - verify app is added to list
4. Launch on non-macOS - verify Screen3 is skipped

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | macOS permission flows now include auto-add automation |

#### 📝 Additional Information

The auto-add feature requires macOS "Automation" permission for System Events. If not granted, the feature silently falls back to manual setup.