### PR TITLE
🔨 chore(userMemories): debug memory workflow keep stucking

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/batch/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/batch/route.ts
@@ -10,9 +10,20 @@ import { orchestratorWorkflow } from '../workflows';
 export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   const payload = normalizeMemoryExtractionPayload(context.requestPayload || {});
 
-  await context.invoke('memory:user-memory:extract:topics:batch', {
+  console.log('[chat-topic][batch] Starting batch topic processing workflow', {
+    topicIds: payload.topicIds,
+    userIds: payload.userIds,
+  });
+
+  const { body, isCanceled, isFailed } = await context.invoke('memory:user-memory:extract:topics:batch', {
     body: context.requestPayload,
     workflow: orchestratorWorkflow,
+  });
+
+  console.log('[chat-topic][batch] Batch topic processing workflow invoked', {
+    body,
+    isCanceled,
+    isFailed,
   });
 
   return {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve observability and cleanup configuration for the chat-topic memory workflows.

Enhancements:
- Add logging around batch, layer, and orchestrator workflows to trace memory topic processing lifecycle.
- Remove explicit workflowId assignments from chat-topic workflows now that IDs are handled elsewhere.