### PR TITLE
🐛 fix(userMemories): must assign workflow id

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic-layers/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic-layers/route.ts
@@ -1,5 +1,5 @@
 import { MemorySourceType } from '@lobechat/types';
-import { createWorkflow, serveMany } from '@upstash/workflow/nextjs';
+import { serve } from '@upstash/workflow/nextjs';
 
 import {
   MemoryExtractionExecutor,
@@ -7,12 +7,8 @@ import {
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
 
-export const { POST } = serveMany({
-  'memory:user-memory:extract:users:topics:extract-layers:other-layers': createWorkflow<
-    MemoryExtractionPayloadInput,
-    { processed: number; results: any[] }
-  >(async (context) => {
-    const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
+  const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
     if (!params.userIds.length) {
       return { message: 'No user id provided for topic batch.', processed: 0, results: [] };
     }
@@ -54,5 +50,4 @@ export const { POST } = serveMany({
     }
 
     return { processed: results.length, results };
-  }),
 });

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/workflows.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/workflows/workflows.ts
@@ -4,6 +4,7 @@ import { createWorkflow } from '@upstash/workflow/nextjs';
 import {
   MemoryExtractionExecutor,
   type MemoryExtractionPayloadInput,
+  TOPIC_WORKFLOW_NAMES,
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
 
@@ -180,3 +181,8 @@ export const orchestratorWorkflow = createWorkflow<
     processedIdentity: identityIndex - (params.identityCursor ?? 0),
   };
 });
+
+// Explicitly set workflow ids to ensure context.invoke works
+cepWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.cep;
+identityWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.identity;
+orchestratorWorkflow.workflowId = TOPIC_WORKFLOW_NAMES.orchestrator;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure chat-topic user memory workflows are invoked correctly and associated with explicit workflow identifiers.

Bug Fixes:
- Fix topic layer processing route so it runs as a single workflow handler instead of a named multi-workflow mapping, avoiding incorrect workflow invocation.
- Assign stable workflow IDs to chat-topic CEP, identity, and orchestrator workflows so context.invoke can reliably resolve and call them.

Enhancements:
- Simplify the chat-topic topic-layer processing API route by using a single serve handler with normalized extraction payload parameters.