### PR TITLE
fix: updater not work on Windows

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -1,7 +1,7 @@
 import log from 'electron-log';
 import { autoUpdater } from 'electron-updater';
 
-import { isDev } from '@/const/env';
+import { isDev, isWindows } from '@/const/env';
 import { UPDATE_CHANNEL as channel, updaterConfig } from '@/modules/updater/configs';
 import { createLogger } from '@/utils/logger';
 
@@ -144,12 +144,16 @@ export class UpdaterManager {
     // Close all windows first to ensure clean exit
     logger.info('Closing all windows before update installation...');
     const { BrowserWindow, app } = require('electron');
-    const allWindows = BrowserWindow.getAllWindows();
-    allWindows.forEach((window) => {
-      if (!window.isDestroyed()) {
-        window.close();
-      }
-    });
+    // do not close windows and quit first
+    // on Windows, window-all-closed -> app.quit()` can terminate the process before the timer fires
+    if (!isWindows) {
+      const allWindows = BrowserWindow.getAllWindows();
+      allWindows.forEach((window) => {
+        if (!window.isDestroyed()) {
+          window.close();
+        }
+      });
+    }
 
     // Release single instance lock before quitting
     // This ensures the new instance can acquire the lock


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

https://github.com/lobehub/lobe-chat/issues/10411
https://github.com/lobehub/lobe-chat/pull/10064

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Prevent the Windows updater from failing due to the app quitting before the update timer fires by avoiding premature window closure on Windows.