### PR TITLE
✨ feat: update create group chat use builder

### DIFF
--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/Item.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/Item.tsx
@@ -6,7 +6,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 
 import { useHomeStore } from '@/store/home';
 
-import { useCreateMenuItems, useSessionGroupMenuItems } from '../../../../hooks';
+import { useCreateMenuItems } from '../../../../hooks';
 import { useAgentModal } from '../../ModalProvider';
 import SessionList from '../List';
 import Actions from './Actions';
@@ -26,14 +26,10 @@ const GroupItem = memo<SidebarGroup>(({ items, id, name }) => {
   ]);
 
   // Modal management
-  const { openMemberSelectionModal, closeMemberSelectionModal, openConfigGroupModal } =
-    useAgentModal();
-
-  // Session group menu items
-  const { createGroupWithMembers, isCreatingGroup } = useSessionGroupMenuItems();
+  const { openConfigGroupModal } = useAgentModal();
 
   // Create menu items
-  const { isValidatingAgent } = useCreateMenuItems();
+  const { isLoading } = useCreateMenuItems();
 
   const toggleEditing = useCallback(
     (visible?: boolean) => {
@@ -42,35 +38,16 @@ const GroupItem = memo<SidebarGroup>(({ items, id, name }) => {
     [id],
   );
 
-  // Handler to open member selection modal with callbacks
-  const handleOpenMemberSelection = useCallback(() => {
-    openMemberSelectionModal({
-      onCancel: closeMemberSelectionModal,
-      onConfirm: async (selectedAgents, hostConfig, enableSupervisor) => {
-        await createGroupWithMembers(
-          selectedAgents,
-          'New Group Chat',
-          hostConfig,
-          enableSupervisor,
-        );
-        closeMemberSelectionModal();
-      },
-    });
-  }, [openMemberSelectionModal, closeMemberSelectionModal, createGroupWithMembers]);
-
   const handleOpenConfigGroupModal = useCallback(() => {
     openConfigGroupModal();
   }, [openConfigGroupModal]);
 
   const dropdownMenu = useGroupDropdownMenu({
-    handleOpenMemberSelection,
     id,
     isCustomGroup: true,
     openConfigGroupModal: handleOpenConfigGroupModal,
     toggleEditing,
   });
-
-  const isLoading = isValidatingAgent || isCreatingGroup;
 
   const groupIcon = useMemo(() => {
     if (isUpdating) {

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/useDropdownMenu.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import { useCreateMenuItems, useSessionGroupMenuItems } from '../../../../hooks';
 
 interface GroupDropdownMenuProps {
-  handleOpenMemberSelection: () => void;
   id?: string;
   isCustomGroup?: boolean;
   isPinned?: boolean;
@@ -17,10 +16,8 @@ export const useGroupDropdownMenu = ({
   isCustomGroup,
   isPinned,
   toggleEditing,
-  handleOpenMemberSelection,
   openConfigGroupModal,
 }: GroupDropdownMenuProps): MenuProps['items'] => {
-
   // Session group menu items
   const { renameGroupMenuItem, configGroupMenuItem, deleteGroupMenuItem } =
     useSessionGroupMenuItems();
@@ -30,7 +27,7 @@ export const useGroupDropdownMenu = ({
 
   return useMemo(() => {
     const createAgentItem = createAgentMenuItem({ groupId: id, isPinned });
-    const createGroupChatItem = createGroupChatMenuItem(handleOpenMemberSelection);
+    const createGroupChatItem = createGroupChatMenuItem();
     const configItem = configGroupMenuItem(openConfigGroupModal);
     const renameItem = toggleEditing ? renameGroupMenuItem(toggleEditing) : null;
     const deleteItem = id ? deleteGroupMenuItem(id) : null;
@@ -53,7 +50,6 @@ export const useGroupDropdownMenu = ({
     configGroupMenuItem,
     renameGroupMenuItem,
     deleteGroupMenuItem,
-    handleOpenMemberSelection,
     openConfigGroupModal,
   ]);
 };

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/index.tsx
@@ -22,70 +22,16 @@ const Agent = memo<AgentProps>(({ itemKey }) => {
   const { t } = useTranslation('common');
   const { isRevalidating } = useFetchAgentList();
 
-  const {
-    openGroupWizardModal,
-    closeGroupWizardModal,
-    openConfigGroupModal,
-    setGroupWizardLoading,
-  } = useAgentModal();
+  const { openConfigGroupModal } = useAgentModal();
 
   // Create menu items
-  const { createGroupFromTemplate, createGroupWithMembers, isLoading } = useCreateMenuItems();
-
-  // Adapter functions to match GroupWizard interface
-  const handleGroupWizardCreateCustom = useCallback(
-    async (
-      selectedAgents: string[],
-      hostConfig?: { model?: string; provider?: string },
-      enableSupervisor?: boolean,
-    ) => {
-      await createGroupWithMembers(selectedAgents, undefined, hostConfig, enableSupervisor);
-    },
-    [createGroupWithMembers],
-  );
-
-  const handleGroupWizardCreateFromTemplate = useCallback(
-    async (
-      templateId: string,
-      hostConfig?: { model?: string; provider?: string },
-      enableSupervisor?: boolean,
-      selectedMemberTitles?: string[],
-    ) => {
-      setGroupWizardLoading(true);
-      try {
-        await createGroupFromTemplate(
-          templateId,
-          hostConfig,
-          enableSupervisor,
-          selectedMemberTitles,
-        );
-        closeGroupWizardModal();
-      } finally {
-        setGroupWizardLoading(false);
-      }
-    },
-    [createGroupFromTemplate, setGroupWizardLoading, closeGroupWizardModal],
-  );
-
-  const handleOpenGroupWizard = useCallback(() => {
-    openGroupWizardModal({
-      onCancel: closeGroupWizardModal,
-      onCreateCustom: handleGroupWizardCreateCustom,
-      onCreateFromTemplate: handleGroupWizardCreateFromTemplate,
-    });
-  }, [
-    openGroupWizardModal,
-    closeGroupWizardModal,
-    handleGroupWizardCreateFromTemplate,
-    handleGroupWizardCreateCustom,
-  ]);
+  const { isLoading } = useCreateMenuItems();
 
   const handleOpenConfigGroupModal = useCallback(() => {
     openConfigGroupModal();
   }, [openConfigGroupModal]);
 
   const dropdownMenu = useAgentActionsDropdownMenu({
-    handleOpenGroupWizard,
     openConfigGroupModal: handleOpenConfigGroupModal,
   });
 

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/useDropdownMenu.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/useDropdownMenu.tsx
@@ -9,12 +9,10 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { useCreateMenuItems } from '../../hooks';
 
 interface AgentActionsDropdownMenuProps {
-  handleOpenGroupWizard: () => void;
   openConfigGroupModal: () => void;
 }
 
 export const useAgentActionsDropdownMenu = ({
-  handleOpenGroupWizard,
   openConfigGroupModal,
 }: AgentActionsDropdownMenuProps): MenuProps['items'] => {
   const { t } = useTranslation('common');
@@ -34,7 +32,7 @@ export const useAgentActionsDropdownMenu = ({
 
   return useMemo(() => {
     const createAgentItem = createAgentMenuItem();
-    const createGroupChatItem = createGroupChatMenuItem(handleOpenGroupWizard);
+    const createGroupChatItem = createGroupChatMenuItem();
     const createSessionGroupItem = createSessionGroupMenuItem();
     const configItem = configMenuItem(openConfigGroupModal);
 
@@ -69,7 +67,6 @@ export const useAgentActionsDropdownMenu = ({
     createGroupChatMenuItem,
     createSessionGroupMenuItem,
     configMenuItem,
-    handleOpenGroupWizard,
     openConfigGroupModal,
     t,
   ]);

--- a/src/app/[variants]/(main)/home/_layout/Header/components/AddButton.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Header/components/AddButton.tsx
@@ -8,13 +8,10 @@ import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 
-import { useAgentModal } from '../../Body/Agent/ModalProvider';
 import { useCreateMenuItems } from '../../hooks';
 
 const AddButton = memo(() => {
   const { t: tChat } = useTranslation('chat');
-
-  const { openGroupWizardModal, closeGroupWizardModal, setGroupWizardLoading } = useAgentModal();
 
   // Create menu items
   const {
@@ -22,52 +19,9 @@ const AddButton = memo(() => {
     createGroupChatMenuItem,
     createPageMenuItem,
     createAgent,
-    createGroupFromTemplate,
-    createGroupWithMembers,
     isValidatingAgent,
     isCreatingGroup,
   } = useCreateMenuItems();
-
-  const handleOpenGroupWizard = useCallback(() => {
-    openGroupWizardModal({
-      onCancel: closeGroupWizardModal,
-      onCreateCustom: async (selectedAgents, hostConfig, enableSupervisor) => {
-        await createGroupWithMembers(
-          selectedAgents,
-          tChat('defaultGroupChat'),
-          hostConfig,
-          enableSupervisor,
-        );
-        closeGroupWizardModal();
-      },
-      onCreateFromTemplate: async (
-        templateId,
-        hostConfig,
-        enableSupervisor,
-        selectedMemberTitles,
-      ) => {
-        setGroupWizardLoading(true);
-        try {
-          await createGroupFromTemplate(
-            templateId,
-            hostConfig,
-            enableSupervisor,
-            selectedMemberTitles,
-          );
-          closeGroupWizardModal();
-        } finally {
-          setGroupWizardLoading(false);
-        }
-      },
-    });
-  }, [
-    openGroupWizardModal,
-    closeGroupWizardModal,
-    createGroupWithMembers,
-    createGroupFromTemplate,
-    setGroupWizardLoading,
-    tChat,
-  ]);
 
   const handleMainIconClick = useCallback(
     (e: React.MouseEvent) => {
@@ -79,12 +33,8 @@ const AddButton = memo(() => {
   );
 
   const dropdownItems = useMemo(() => {
-    return [
-      createAgentMenuItem(),
-      createGroupChatMenuItem(handleOpenGroupWizard),
-      createPageMenuItem(),
-    ];
-  }, [createAgentMenuItem, createGroupChatMenuItem, createPageMenuItem, handleOpenGroupWizard]);
+    return [createAgentMenuItem(), createGroupChatMenuItem(), createPageMenuItem()];
+  }, [createAgentMenuItem, createGroupChatMenuItem, createPageMenuItem]);
 
   return (
     <Flexbox horizontal>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Replace the group creation wizard and member selection flows with a simpler builder-style flow that creates an empty group and navigates directly to its profile page, and wire this new behavior into all group creation entry points in the home layout.

New Features:
- Add a SWR-based empty group creation action that automatically refreshes group data and navigates to the new group’s profile page when invoked.

Enhancements:
- Unify group chat creation across header, agent actions, and group dropdown menus to use the new empty-group builder flow instead of modal-based wizards.
- Simplify group- and member-related dropdown menus by removing wizard and member-selection callbacks in favor of the centralized creation hook.
- Extend loading state handling in creation hooks to cover the new group creation flow.