### PR TITLE
✨ feat(userMemories): apply userMemories.enable from settings for injecting

### DIFF
--- a/src/app/[variants]/(main)/chat/features/Conversation/ConversationArea.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/ConversationArea.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { Flexbox } from '@lobehub/ui';
 import { Suspense, memo, useEffect, useMemo } from 'react';
 
@@ -13,6 +12,8 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 import WelcomeChatItem from './AgentWelcome';
@@ -32,7 +33,6 @@ import { useAgentContext } from './useAgentContext';
 const Conversation = memo(() => {
   const context = useAgentContext();
 
-  const enabledPlugins = useAgentStore(agentSelectors.currentAgentPlugins);
   const [useFetchUserMemory, setActiveMemoryContext] = useUserMemoryStore((s) => [
     s.useFetchUserMemory,
     s.setActiveMemoryContext,
@@ -41,26 +41,18 @@ const Conversation = memo(() => {
     useAgentStore(agentSelectors.currentAgentMeta),
     useChatStore(topicSelectors.currentActiveTopic),
   ];
-
-  const isMemoryPluginEnabled = useMemo(() => {
-    if (!enabledPlugins) return false;
-
-    return enabledPlugins.includes(MemoryManifest.identifier);
-  }, [enabledPlugins]);
+  const enableUserMemories = useUserStore(settingsSelectors.memoryEnabled);
 
   useEffect(() => {
-    if (!isMemoryPluginEnabled) {
+    if (!enableUserMemories) {
       setActiveMemoryContext(undefined);
       return;
     }
 
-    setActiveMemoryContext({
-      agent: currentAgentMeta,
-      topic: activeTopic,
-    });
-  }, [activeTopic, currentAgentMeta, isMemoryPluginEnabled, setActiveMemoryContext]);
+    setActiveMemoryContext({ agent: currentAgentMeta, topic: activeTopic });
+  }, [activeTopic, currentAgentMeta, enableUserMemories, setActiveMemoryContext]);
 
-  useFetchUserMemory(Boolean(isMemoryPluginEnabled && context.agentId));
+  useFetchUserMemory(Boolean(enableUserMemories && context.agentId));
 
   // Get raw dbMessages from ChatStore for this context
   // ConversationStore will parse them internally to generate displayMessages

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -4,6 +4,8 @@ import { type ReactNode, memo, useCallback } from 'react';
 
 import { useFetchTopicMemories } from '@/hooks/useFetchMemoryForTopic';
 import { useFetchNotebookDocuments } from '@/hooks/useFetchNotebookDocuments';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
 
 import WideScreenContainer from '../../WideScreenContainer';
 import MessageItem from '../Messages';
@@ -30,6 +32,7 @@ export interface ChatListProps {
 const ChatList = memo<ChatListProps>(({ welcome, itemContent }) => {
   // Fetch messages (SWR key is null when skipFetch is true)
   const context = useConversationStore((s) => s.context);
+  const enableUserMemories = useUserStore(settingsSelectors.memoryEnabled);
   const [skipFetch, useFetchMessages] = useConversationStore((s) => [
     dataSelectors.skipFetch(s),
     s.useFetchMessages,
@@ -38,7 +41,7 @@ const ChatList = memo<ChatListProps>(({ welcome, itemContent }) => {
 
   // Fetch notebook documents when topic is selected
   useFetchNotebookDocuments(context.topicId!);
-  useFetchTopicMemories(context.topicId!);
+  useFetchTopicMemories(enableUserMemories ? context.topicId : undefined);
 
   // Use selectors for data
 

--- a/src/hooks/useFetchMemoryForTopic.ts
+++ b/src/hooks/useFetchMemoryForTopic.ts
@@ -1,6 +1,6 @@
 import { useUserMemoryStore } from '@/store/userMemory';
 
-export const useFetchTopicMemories = (topicId?: string) => {
+export const useFetchTopicMemories = (topicId?: string | null) => {
   const useFetchMemoriesForTopic = useUserMemoryStore((s) => s.useFetchMemoriesForTopic);
 
   useFetchMemoriesForTopic(topicId);

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -1,5 +1,4 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
-import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
 import type { OfficialToolItem } from '@lobechat/context-engine';
 import {
@@ -45,7 +44,11 @@ import {
   pluginSelectors,
 } from '@/store/tool/selectors';
 import { getUserStoreState, useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors, userProfileSelectors } from '@/store/user/selectors';
+import {
+  settingsSelectors,
+  userGeneralSettingsSelectors,
+  userProfileSelectors,
+} from '@/store/user/selectors';
 import type { ChatStreamPayload, OpenAIChatMessage } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
 import { createTraceHeader, getTraceId } from '@/utils/trace';
@@ -158,7 +161,7 @@ class ChatService {
 
     // =================== 1.1 process user memories =================== //
 
-    const isMemoryPluginEnabled = enabledToolIds.includes(MemoryManifest.identifier);
+    const enableUserMemories = settingsSelectors.memoryEnabled(getUserStoreState());
 
     // =================== 1.2 build agent builder context =================== //
 
@@ -233,7 +236,7 @@ class ChatService {
       agentId: targetAgentId,
       enableHistoryCount:
         chatConfigByIdSelectors.getEnableHistoryCountById(targetAgentId)(getAgentStoreState()),
-      enableUserMemories: isMemoryPluginEnabled,
+      enableUserMemories,
       groupId,
       historyCount:
         chatConfigByIdSelectors.getHistoryCountById(targetAgentId)(getAgentStoreState()) + 2,

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -353,7 +353,7 @@ export const contextEngineering = async ({
     userMemory:
       enableUserMemories && userMemoryData
         ? {
-            enabled: true,
+            enabled: enableUserMemories,
             memories: userMemoryData,
           }
         : undefined,

--- a/src/store/user/slices/settings/selectors/settings.ts
+++ b/src/store/user/slices/settings/selectors/settings.ts
@@ -31,6 +31,8 @@ const currentImageSettings = (s: UserStore) => currentSettings(s).image;
 const currentMemorySettings = (s: UserStore) =>
   merge(DEFAULT_MEMORY_SETTINGS, currentSettings(s).memory);
 
+const memoryEnabled = (s: UserStore) => currentMemorySettings(s).enabled !== false;
+
 const currentTTS = (s: UserStore) => merge(DEFAULT_TTS_CONFIG, currentSettings(s).tts);
 
 const defaultAgent = (s: UserStore) => merge(DEFAULT_AGENT, currentSettings(s).defaultAgent);
@@ -52,6 +54,7 @@ export const settingsSelectors = {
   currentSettings,
   currentSystemAgent,
   currentTTS,
+  memoryEnabled,
   defaultAgent,
   defaultAgentConfig,
   defaultAgentMeta,

--- a/src/store/userMemory/slices/agent/action.ts
+++ b/src/store/userMemory/slices/agent/action.ts
@@ -21,7 +21,7 @@ export interface AgentMemoryAction {
    * Fetch and cache memories for a specific topic
    * Uses SWR for caching and revalidation
    */
-  useFetchMemoriesForTopic: (topicId?: string) => SWRResponse<RetrieveMemoryResult>;
+  useFetchMemoriesForTopic: (topicId?: string | null) => SWRResponse<RetrieveMemoryResult>;
 }
 
 export const createAgentMemorySlice: StateCreator<


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Apply the user memory enablement setting across chat, group, and service layers to control when memories are fetched and injected into conversations.

Enhancements:
- Use a centralized settings selector to determine whether user memories are enabled instead of relying on plugin availability.
- Gate user memory fetching and topic memory retrieval on the user memory enablement setting in chat, group conversation, and chat list flows.
- Propagate the effective enableUserMemories flag into chat context engineering so memory injection reflects the user’s setting.
- Relax topic ID types to accept null where appropriate in memory-related hooks and store actions.