### PR TITLE
🐛 fix: slove input editor on pause emit

### DIFF
--- a/packages/builtin-tool-gtd/package.json
+++ b/packages/builtin-tool-gtd/package.json
@@ -13,11 +13,11 @@
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*",
-    "@lobehub/editor": "^1",
+    "@lobehub/editor": "^3",
     "@lobehub/ui": "^4.3.1"
   },
   "peerDependencies": {
-    "@lobehub/editor": "^1",
+    "@lobehub/editor": "^3",
     "@lobehub/ui": "^4",
     "antd": "^6",
     "antd-style": "*",

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -182,5 +182,6 @@ const DragUploadZone = memo<DragUploadZoneProps>(
 
 DragUploadZone.displayName = 'DragUploadZone';
 
+export { usePasteFile } from './usePasteFile';
 export { useUploadFiles } from './useUploadFiles';
 export default DragUploadZone;

--- a/src/components/DragUploadZone/usePasteFile.ts
+++ b/src/components/DragUploadZone/usePasteFile.ts
@@ -1,0 +1,40 @@
+import { type IEditor } from '@lobehub/editor';
+import { useCallback, useEffect } from 'react';
+
+import { getFileListFromDataTransferItems } from './useLocalDragUpload';
+
+/**
+ * Hook for handling paste file uploads via @lobehub/editor.
+ * Listens to editor's onPaste event and extracts files from clipboard.
+ *
+ * @param editor - The editor instance from @lobehub/editor
+ * @param onUploadFiles - Callback when files are pasted
+ */
+export const usePasteFile = (
+  editor: IEditor | undefined,
+  onUploadFiles: (files: File[]) => void | Promise<void>,
+) => {
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent) => {
+      if (!event.clipboardData) return;
+
+      const items = Array.from(event.clipboardData.items);
+      const files = await getFileListFromDataTransferItems(items);
+
+      if (files.length === 0) return;
+
+      onUploadFiles(files);
+    },
+    [onUploadFiles],
+  );
+
+  useEffect(() => {
+    if (!editor) return;
+
+    editor.on('onPaste', handlePaste);
+
+    return () => {
+      editor.off('onPaste', handlePaste);
+    };
+  }, [editor, handlePaste]);
+};

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -20,9 +20,13 @@ import { memo, useEffect, useMemo, useRef } from 'react';
 import { useHotkeysContext } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
+import { usePasteFile, useUploadFiles } from '@/components/DragUploadZone';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors, preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
 
+import { useAgentId } from '../hooks/useAgentId';
 import { useChatInputStore, useStoreApi } from '../store';
 import Placeholder from './Placeholder';
 
@@ -54,6 +58,15 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
   const useCmdEnterToSend = useUserStore(preferenceSelectors.useCmdEnterToSend);
 
   const enableMention = !!mentionItems && mentionItems.length > 0;
+
+  // Get agent's model info for vision support check and handle paste upload
+  const agentId = useAgentId();
+  const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
+  const provider = useAgentStore((s) => agentByIdSelectors.getAgentModelProviderById(agentId)(s));
+  const { handleUploadFiles } = useUploadFiles({ model, provider });
+
+  // Listen to editor's paste event for file uploads
+  usePasteFile(editor, handleUploadFiles);
 
   useEffect(() => {
     const fn = (e: BeforeUnloadEvent) => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add clipboard paste-based file upload support to the chat input editor and align editor dependencies with the newer @lobehub/editor version.

New Features:
- Enable uploading files by pasting into the chat input editor via a new paste handling hook wired to the editor instance.

Enhancements:
- Export a reusable usePasteFile hook from the drag upload zone component for handling editor paste events.

Build:
- Update @lobehub/editor dependency to version ^3 in the builtin GTD tool package to support the new editor integration.