### PR TITLE
 ✨ feat: open the send as write

### DIFF
--- a/src/app/[variants]/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/app/[variants]/(main)/home/features/InputArea/StarterList.tsx
@@ -48,6 +48,7 @@ const StarterList = memo(() => {
 
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.agentBuilder);
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.groupAgentBuilder);
+  useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.pageAgent);
 
   const [inputActiveMode, setInputActiveMode] = useHomeStore((s) => [
     s.inputActiveMode,
@@ -91,12 +92,6 @@ const StarterList = memo(() => {
       // Special case: image mode navigates to /image page
       if (key === 'image') {
         navigate('/image');
-        return;
-      }
-
-      // Special case: write mode navigates to /page
-      if (key === 'write') {
-        navigate('/page');
         return;
       }
 

--- a/src/store/session/slices/homeInput/action.ts
+++ b/src/store/session/slices/homeInput/action.ts
@@ -4,6 +4,7 @@ import { documentService } from '@/services/document';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import type { SessionStore } from '@/store/session/store';
+import { standardizeIdentifier } from '@/utils/identifier';
 import { setNamespace } from '@/utils/storeDebug';
 
 import type { StarterMode } from './initialState';
@@ -89,14 +90,14 @@ export const createHomeInputSlice: StateCreator<
     try {
       // 1. Create new Document
       const newDoc = await documentService.createDocument({
-        editorData: '',
+        editorData: '{}',
         title: message?.slice(0, 50) || 'Untitled',
       });
 
       // 2. Navigate to Page
       const navigate = useGlobalStore.getState().navigate;
       if (navigate) {
-        navigate(`/page/${newDoc.id}`);
+        navigate(`/page/${standardizeIdentifier(newDoc.id)}`);
       }
 
       // 3. Send message with document scope context


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align send-as-write flow with page documents and agent configuration.

New Features:
- Support opening a new page document from the home input send-as-write flow using the page agent.

Enhancements:
- Initialize the builtin page agent on the home starter list to ensure it is ready when entering write mode.
- Reuse the inbox agent’s model and provider configuration for the page agent before sending document-scoped messages.
- Standardize new page URLs using normalized document identifiers and initialize documents with structured editor data.