### PR TITLE
🐛 fix: update contextMenu in group tools message

### DIFF
--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -107,7 +107,7 @@ const MessageItem = memo<MessageItemProps>(
 
     const onContextMenu = useCallback(
       async (event: MouseEvent<HTMLDivElement>) => {
-        if (!role || (role !== 'user' && role !== 'assistant')) return;
+        if (!role || (role !== 'user' && role !== 'assistant' && role !== 'assistantGroup')) return;
 
         if (!message) return;
 
@@ -118,7 +118,8 @@ const MessageItem = memo<MessageItemProps>(
             content: message.content,
             hasError: !!message.error,
             messageId: id,
-            role: message.role,
+            // For assistantGroup, we treat it as assistant for context menu purposes
+            role: message.role === 'assistantGroup' ? 'assistant' : message.role,
           });
 
           return;

--- a/src/features/Conversation/components/ContextMenu.tsx
+++ b/src/features/Conversation/components/ContextMenu.tsx
@@ -179,6 +179,26 @@ const ContextMenu = memo<ContextMenuProps>(
         return list.filter(Boolean) as MenuItem[];
       }
 
+      if (role === 'assistantGroup') {
+        if (error) {
+          return [edit, copy, divider, del, divider, regenerate].filter(Boolean) as MenuItem[];
+        }
+
+        const collapseAction = isCollapsed ? expand : collapse;
+        const list: MenuItem[] = [
+          edit,
+          copy,
+          collapseAction,
+          divider,
+          share,
+          divider,
+          regenerate,
+          del,
+        ];
+
+        return list.filter(Boolean) as MenuItem[];
+      }
+
       if (role === 'user') {
         const list: MenuItem[] = [edit, copy];
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix context menu behavior for grouped assistant messages so they expose the appropriate actions and can be opened consistently.

Bug Fixes:
- Enable context menu triggering on assistantGroup messages alongside user and assistant messages.
- Provide a dedicated context menu configuration for assistantGroup messages, including collapse/expand, share, regenerate, and delete actions while handling error states correctly.