### PR TITLE
🐛 fix: slove when click agentbuilder should clean topic

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Nav.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Nav.tsx
@@ -13,6 +13,7 @@ import NavItem from '@/features/NavPanel/components/NavItem';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
@@ -27,6 +28,7 @@ const Nav = memo(() => {
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
   const hideProfile = isInbox || !isAgentEditable;
+  const switchTopic = useChatStore((s) => s.switchTopic);
 
   return (
     <Flexbox gap={1} paddingInline={4}>
@@ -35,6 +37,7 @@ const Nav = memo(() => {
           active={isProfileActive}
           icon={BotPromptIcon}
           onClick={() => {
+            switchTopic(undefined, true);
             router.push(urlJoin('/agent', agentId!, 'profile'));
           }}
           title={t('tab.profile')}

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Header/Nav.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Header/Nav.tsx
@@ -11,6 +11,7 @@ import urlJoin from 'url-join';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
+import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
@@ -23,6 +24,7 @@ const Nav = memo(() => {
   const router = useQueryRoute();
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
+  const switchTopic = useChatStore((s) => s.switchTopic);
 
   return (
     <Flexbox gap={1} paddingInline={4}>
@@ -31,6 +33,7 @@ const Nav = memo(() => {
           active={isProfileActive}
           icon={BotPromptIcon}
           onClick={() => {
+            switchTopic(undefined, true);
             router.push(urlJoin('/group', groupId!, 'profile'));
           }}
           title={t('tab.groupProfile')}

--- a/src/features/AgentBuilder/AgentBuilderProvider.tsx
+++ b/src/features/AgentBuilder/AgentBuilderProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, memo, useEffect, useMemo } from 'react';
+import { type ReactNode, memo, useMemo } from 'react';
 
 import { ConversationProvider } from '@/features/Conversation';
 import { useOperationState } from '@/hooks/useOperationState';
@@ -17,19 +17,6 @@ interface AgentBuilderProviderProps {
  */
 const AgentBuilderProvider = memo<AgentBuilderProviderProps>(({ agentId, children }) => {
   const activeTopicId = useChatStore((s) => s.activeTopicId);
-  const switchTopic = useChatStore((s) => s.switchTopic);
-
-  // Reset topicId on mount and unmount to avoid stale topicId leaking
-  // when navigating from Profile page to agent conversation page
-  useEffect(() => {
-    // Mount: start with a fresh conversation (topicId = undefined)
-    switchTopic(undefined, true);
-
-    return () => {
-      // Unmount: clean up topicId to prevent state leakage
-      switchTopic(undefined, true);
-    };
-  }, [switchTopic]);
 
   // Build conversation context for agent builder
   // Using agent_builder scope for message management


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure chat topics are reset when navigating to agent and group profile views instead of within the agent builder provider.

Bug Fixes:
- Clear the active chat topic when opening the agent profile from the chat sidebar to avoid leaking the previous conversation state.
- Clear the active chat topic when opening the group profile from the chat sidebar to avoid leaking the previous conversation state.