### PR TITLE
🐛fix: add support for built-in model search in TokenTag component

### DIFF
--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -52,6 +52,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
     // need to re-render by search mode
     chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
+    chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
   ]);
 
   const maxTokens = useModelContextWindowTokens(model, provider);

--- a/src/features/LibraryModal/AssignKnowledgeBase/List.tsx
+++ b/src/features/LibraryModal/AssignKnowledgeBase/List.tsx
@@ -114,19 +114,18 @@ export const List = memo(() => {
           totalCount={data!.length}
         />
       ) : (
-        <div style={{ flex: 1, overflow: 'hidden' }}>
-          <div style={{ height: '100%', overflowY: 'auto' }}>
-            <div style={{ paddingInline: 16 }}>
-              <VirtuosoMasonry
-                ItemContent={MasonryItemWrapper}
-                columnCount={columnCount}
-                context={masonryContext}
-                data={data || []}
-                style={{
-                  gap: '16px',
-                }}
-              />
-            </div>
+        <div style={{ height: '100%', position: 'relative' }}>
+          <div style={{ inset: 0, position: 'absolute' }}>
+            <VirtuosoMasonry
+              ItemContent={MasonryItemWrapper}
+              columnCount={columnCount}
+              context={masonryContext}
+              data={data || []}
+              style={{
+                gap: '16px',
+                height: '100%',
+              }}
+            />
           </div>
         </div>
       )}

--- a/src/features/ResourceManager/components/Explorer/MasonryView/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/MasonryView/index.tsx
@@ -87,6 +87,7 @@ const MasonryView = memo<MasonryViewProps>(
             data={data || []}
             style={{
               gap: '16px',
+              overflow: 'hidden',
             }}
           />
           {isLoadingMore && (


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- [x] 修复：切换`使用模型内置搜索`开关，上下文明细不更新联网搜索插件的Token。
- [x] fix #6835 #3788 这两个已经解决了。
- [x] 修复：对话页面关联知识库"查看更多"面板，当默认打开是网格视图且非首次打开时，内容显示空。并去除多余滚动条。
- [x] 优化文件管理页面的网格视图展示，去除多余滚动条。
<!-- Link to the issue that is fixed by this PR -->

可以顺便看一下 #10683

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
|<img width="1016" height="975" alt="image" src="https://github.com/user-attachments/assets/ea5f51dc-1674-4f42-9157-40deb67e66e9" /> | <img width="1016" height="975" alt="image" src="https://github.com/user-attachments/assets/f88d5840-48be-4405-9d6b-57c8aa969716" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update UI layouts and token tracking to correctly handle grid views and model built-in search mode.

Bug Fixes:
- Ensure knowledge base grid view in the chat sidebar consistently renders content when reopened and remove redundant scroll areas.
- Refresh token usage calculation when toggling the model built-in search option so token counts stay accurate.

Enhancements:
- Tighten layout and scrolling behavior for masonry grid views in the knowledge base and file manager to avoid nested or unnecessary scrollbars.