### PR TITLE
🐛 fix: filter empty assistant messages for Anthropic API

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -155,9 +155,9 @@ describe('anthropicHelpers', () => {
         role: 'user',
       };
       const result = await buildAnthropicMessage(message);
-      expect(result.role).toBe('user');
-      expect(result.content).toHaveLength(2);
-      expect((result.content[1] as any).type).toBe('image');
+      expect(result!.role).toBe('user');
+      expect(result!.content).toHaveLength(2);
+      expect((result!.content[1] as any).type).toBe('image');
     });
 
     it('should correctly convert tool message', async () => {
@@ -167,8 +167,8 @@ describe('anthropicHelpers', () => {
         tool_call_id: 'tool123',
       };
       const result = await buildAnthropicMessage(message);
-      expect(result.role).toBe('user');
-      expect(result.content).toEqual([
+      expect(result!.role).toBe('user');
+      expect(result!.content).toEqual([
         {
           content: 'Tool result content',
           tool_use_id: 'tool123',
@@ -193,8 +193,8 @@ describe('anthropicHelpers', () => {
         ],
       };
       const result = await buildAnthropicMessage(message);
-      expect(result.role).toBe('assistant');
-      expect(result.content).toEqual([
+      expect(result!.role).toBe('assistant');
+      expect(result!.content).toEqual([
         { text: 'Here is the result:', type: 'text' },
         {
           id: 'call1',
@@ -266,14 +266,34 @@ describe('anthropicHelpers', () => {
 
         const contents = await buildAnthropicMessages(messages);
 
+        // Empty assistant messages should be filtered out
         expect(contents).toEqual([
           {
             content: '## Tools\n\nYou can use these tools',
             role: 'user',
           },
+        ]);
+      });
+
+      it('should filter out assistant message with whitespace-only content', async () => {
+        const messages: OpenAIChatMessage[] = [
           {
-            content: '',
+            content: 'Hello',
+            role: 'user',
+          },
+          {
+            content: '   \n\t  ',
             role: 'assistant',
+          },
+        ];
+
+        const contents = await buildAnthropicMessages(messages);
+
+        // Whitespace-only assistant messages should be filtered out
+        expect(contents).toEqual([
+          {
+            content: 'Hello',
+            role: 'user',
           },
         ]);
       });

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -62,7 +62,7 @@ const buildArrayContent = async (content: UserMessageContentPart[]) => {
 
 export const buildAnthropicMessage = async (
   message: OpenAIChatMessage,
-): Promise<Anthropic.Messages.MessageParam> => {
+): Promise<Anthropic.Messages.MessageParam | undefined> => {
   const content = message.content as string | UserMessageContentPart[];
 
   switch (message.role) {
@@ -118,7 +118,10 @@ export const buildAnthropicMessage = async (
       }
 
       // or it's a plain assistant message
-      return { content: content as string, role: 'assistant' };
+      // Anthropic API requires non-empty content, filter out empty/whitespace-only content
+      const textContent = (content as string)?.trim();
+      if (!textContent) return undefined;
+      return { content: textContent, role: 'assistant' };
     }
 
     case 'function': {
@@ -176,7 +179,10 @@ export const buildAnthropicMessages = async (
       }
     } else {
       const anthropicMessage = await buildAnthropicMessage(message);
-      messages.push({ ...anthropicMessage, role: anthropicMessage.role });
+      // Filter out undefined messages (e.g., empty assistant messages)
+      if (anthropicMessage) {
+        messages.push(anthropicMessage);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Filter out empty or whitespace-only assistant messages when building Anthropic API requests
- Trim assistant message content to prevent trailing whitespace errors
- Prevents Anthropic API error: `final assistant content cannot end with trailing whitespace`

## Changes

- Modified `buildAnthropicMessage` to return `undefined` for empty/whitespace-only assistant content
- Updated `buildAnthropicMessages` to filter out undefined messages
- Added test case for whitespace-only content handling

## Related Issues

Closes #3960
Closes #4805

🤖 Generated with [Claude Code](https://claude.com/claude-code)