### PR TITLE
fix(desktop): sidebar background based on systemTheme

### DIFF
--- a/apps/desktop/src/main/controllers/SystemCtr.ts
+++ b/apps/desktop/src/main/controllers/SystemCtr.ts
@@ -39,7 +39,6 @@ export default class SystemController extends ControllerModule {
       isMac: platform === 'darwin',
       isWindows: platform === 'win32',
       platform: platform as 'darwin' | 'win32' | 'linux',
-      systemAppearance: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
       userPath: {
         // User Paths (ensure keys match UserPathData / DesktopAppState interface)
         desktop: app.getPath('desktop'),
@@ -264,11 +263,6 @@ export default class SystemController extends ControllerModule {
     }
 
     logger.info('Initializing system theme listener');
-
-    // Get initial system theme
-    const initialDarkMode = nativeTheme.shouldUseDarkColors;
-    const initialSystemTheme: ThemeMode = initialDarkMode ? 'dark' : 'light';
-    logger.info(`Initial system theme: ${initialSystemTheme}`);
 
     // Listen for system theme changes
     nativeTheme.on('updated', () => {

--- a/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/SystemCtr.test.ts
@@ -72,6 +72,7 @@ vi.mock('electron', () => ({
   nativeTheme: {
     on: vi.fn(),
     shouldUseDarkColors: false,
+    themeSource: 'system',
   },
   shell: {
     openExternal: vi.fn().mockResolvedValue(undefined),
@@ -138,7 +139,6 @@ describe('SystemController', () => {
       expect(result).toMatchObject({
         arch: expect.any(String),
         platform: expect.any(String),
-        systemAppearance: 'light',
         userPath: {
           desktop: '/mock/path/desktop',
           documents: '/mock/path/documents',
@@ -150,18 +150,6 @@ describe('SystemController', () => {
           videos: '/mock/path/videos',
         },
       });
-    });
-
-    it('should return dark appearance when nativeTheme is dark', async () => {
-      const { nativeTheme } = await import('electron');
-      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', { value: true });
-
-      const result = await invokeIpc('system.getAppState');
-
-      expect(result.systemAppearance).toBe('dark');
-
-      // Reset
-      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', { value: false });
     });
   });
 

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -6,7 +6,7 @@ import {
   RouteVariants,
 } from '@lobechat/desktop-bridge';
 import { ElectronIPCEventHandler, ElectronIPCServer } from '@lobechat/electron-server-ipc';
-import { app, protocol, session } from 'electron';
+import { app, nativeTheme, protocol, session } from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { macOS, windows } from 'electron-is';
 import { pathExistsSync } from 'fs-extra';
@@ -154,7 +154,25 @@ export class App {
     // 统一处理 before-quit 事件
     app.on('before-quit', this.handleBeforeQuit);
 
+    // Initialize theme mode from store
+    this.initializeThemeMode();
+
     logger.info('App initialization completed');
+  }
+
+  /**
+   * Initialize nativeTheme.themeSource from stored themeMode preference
+   * This allows nativeTheme.shouldUseDarkColors to be used consistently everywhere
+   */
+  private initializeThemeMode() {
+    const themeMode = this.storeManager.get('themeMode');
+
+    if (themeMode) {
+      nativeTheme.themeSource = themeMode === 'auto' ? 'system' : themeMode;
+      logger.debug(
+        `Theme mode initialized to: ${themeMode} (themeSource: ${nativeTheme.themeSource})`,
+      );
+    }
   }
 
   bootstrap = async () => {

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -28,7 +28,7 @@ vi.mock('electron', () => ({
   },
   nativeTheme: {
     on: vi.fn(),
-    shouldUseDarkColors: false,
+    themeSource: 'system',
   },
   protocol: {
     registerSchemesAsPrivileged: vi.fn(),

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -78,11 +78,9 @@ export default class Browser {
   /**
    * Get platform-specific theme configuration for window creation
    */
-  private getPlatformThemeConfig(isDarkMode?: boolean): Record<string, any> {
-    const darkMode = isDarkMode ?? nativeTheme.shouldUseDarkColors;
-
+  private getPlatformThemeConfig(): Record<string, any> {
     if (isWindows) {
-      return this.getWindowsThemeConfig(darkMode);
+      return this.getWindowsThemeConfig(this.isDarkMode);
     }
 
     return {};
@@ -164,10 +162,7 @@ export default class Browser {
   }
 
   private get isDarkMode() {
-    const themeMode = this.app.storeManager.get('themeMode');
-    if (themeMode === 'auto') return nativeTheme.shouldUseDarkColors;
-
-    return themeMode === 'dark';
+    return nativeTheme.shouldUseDarkColors;
   }
 
   loadUrl = async (path: string) => {
@@ -328,13 +323,11 @@ export default class Browser {
       `[${this.identifier}] Saved window state (only size used): ${JSON.stringify(savedState)}`,
     );
 
-    const isDarkMode = nativeTheme.shouldUseDarkColors;
-
     const browserWindow = new BrowserWindow({
       ...res,
       autoHideMenuBar: true,
       backgroundColor: '#00000000',
-      darkTheme: isDarkMode,
+      darkTheme: this.isDarkMode,
       frame: false,
       height: savedState?.height || height,
       show: false,
@@ -348,7 +341,7 @@ export default class Browser {
         sandbox: false,
       },
       width: savedState?.width || width,
-      ...this.getPlatformThemeConfig(isDarkMode),
+      ...this.getPlatformThemeConfig(),
     });
 
     this._browserWindow = browserWindow;

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -53,6 +53,7 @@ const { mockBrowserWindow, mockNativeTheme, mockIpcMain, mockScreen, MockBrowser
         off: vi.fn(),
         on: vi.fn(),
         shouldUseDarkColors: false,
+        themeSource: 'system',
       },
       mockScreen: {
         getDisplayNearestPoint: vi.fn().mockReturnValue({
@@ -272,7 +273,7 @@ describe('Browser', () => {
 
   describe('theme management', () => {
     describe('getPlatformThemeConfig', () => {
-      it('should return Windows dark theme config', () => {
+      it('should return Windows dark theme config when shouldUseDarkColors is true', () => {
         mockNativeTheme.shouldUseDarkColors = true;
 
         // Create browser with dark mode
@@ -289,7 +290,7 @@ describe('Browser', () => {
         );
       });
 
-      it('should return Windows light theme config', () => {
+      it('should return Windows light theme config when shouldUseDarkColors is false', () => {
         mockNativeTheme.shouldUseDarkColors = false;
 
         expect(MockBrowserWindow).toHaveBeenCalledWith(
@@ -334,11 +335,8 @@ describe('Browser', () => {
     });
 
     describe('isDarkMode', () => {
-      it('should return true when themeMode is dark', () => {
-        mockStoreManagerGet.mockImplementation((key: string) => {
-          if (key === 'themeMode') return 'dark';
-          return undefined;
-        });
+      it('should return true when shouldUseDarkColors is true', () => {
+        mockNativeTheme.shouldUseDarkColors = true;
 
         const darkBrowser = new Browser(defaultOptions, mockApp);
         // Access private getter through handleAppThemeChange which uses isDarkMode
@@ -348,18 +346,14 @@ describe('Browser', () => {
         expect(mockBrowserWindow.setBackgroundColor).toHaveBeenCalledWith('#1a1a1a');
       });
 
-      it('should use system theme when themeMode is auto', () => {
-        mockStoreManagerGet.mockImplementation((key: string) => {
-          if (key === 'themeMode') return 'auto';
-          return undefined;
-        });
-        mockNativeTheme.shouldUseDarkColors = true;
+      it('should return false when shouldUseDarkColors is false', () => {
+        mockNativeTheme.shouldUseDarkColors = false;
 
-        const autoBrowser = new Browser(defaultOptions, mockApp);
-        autoBrowser.handleAppThemeChange();
+        const lightBrowser = new Browser(defaultOptions, mockApp);
+        lightBrowser.handleAppThemeChange();
         vi.advanceTimersByTime(0);
 
-        expect(mockBrowserWindow.setBackgroundColor).toHaveBeenCalledWith('#1a1a1a');
+        expect(mockBrowserWindow.setBackgroundColor).toHaveBeenCalledWith('#ffffff');
       });
     });
   });

--- a/apps/desktop/src/main/core/ui/TrayManager.ts
+++ b/apps/desktop/src/main/core/ui/TrayManager.ts
@@ -57,7 +57,7 @@ export class TrayManager {
     logger.debug('初始化主托盘');
     return this.retrieveOrInitialize({
       iconPath: isMac
-        ? nativeTheme.shouldUseDarkColors
+        ? nativeTheme.shouldUseDarkColorsForSystemIntegratedUI
           ? 'tray-dark.png'
           : 'tray-light.png'
         : 'tray.png',

--- a/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
@@ -8,7 +8,7 @@ import { TrayManager } from '../TrayManager';
 // Mock electron modules
 vi.mock('electron', () => ({
   nativeTheme: {
-    shouldUseDarkColors: false,
+    shouldUseDarkColorsForSystemIntegratedUI: false,
   },
 }));
 
@@ -90,7 +90,7 @@ describe('TrayManager', () => {
 
   describe('initializeMainTray', () => {
     it('should create main tray with dark icon on macOS when dark mode is enabled', () => {
-      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', {
+      Object.defineProperty(nativeTheme, 'shouldUseDarkColorsForSystemIntegratedUI', {
         value: true,
         writable: true,
         configurable: true,
@@ -110,7 +110,7 @@ describe('TrayManager', () => {
     });
 
     it('should create main tray with light icon on macOS when light mode is enabled', () => {
-      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', {
+      Object.defineProperty(nativeTheme, 'shouldUseDarkColorsForSystemIntegratedUI', {
         value: false,
         writable: true,
         configurable: true,

--- a/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
+++ b/src/features/ElectronTitlebar/hooks/useWatchThemeUpdate.ts
@@ -7,6 +7,10 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { ensureElectronIpc } from '@/utils/electron/ipc';
 
+const sidebarColors = {
+  dark: '#000',
+  light: '#f8f8f8',
+};
 export const useWatchThemeUpdate = () => {
   const [isAppStateInit, systemAppearance, updateElectronAppState, isMac] = useElectronStore(
     (s) => [
@@ -43,8 +47,9 @@ export const useWatchThemeUpdate = () => {
 
     const lobeApp = document.querySelector('#' + LOBE_THEME_APP_ID);
     if (!lobeApp) return;
-    const hexColor = getComputedStyle(lobeApp).getPropertyValue('--ant-color-bg-layout');
 
-    document.body.style.background = `color-mix(in srgb, ${hexColor} 86%, transparent)`;
+    if (systemAppearance) {
+      document.body.style.background = `color-mix(in srgb, ${sidebarColors[systemAppearance as 'dark' | 'light']} 86%, transparent)`;
+    }
   }, [systemAppearance, isAppStateInit, isMac]);
 };


### PR DESCRIPTION
## Summary

Fix sidebar background to be based on system theme instead of user preference.

## Changes

- Update sidebar styling to respect system theme settings

## Refer

https://linear.app/lobehub/issue/LOBE-2487/桌面端小bug
https://github.com/lobehub/lobe-chat/issues/11097

🤖 Generated with [Claude Code](https://claude.com/claude-code)