### PR TITLE
🐛 fix: restore window resizable before hard reload in desktop onboarding

### DIFF
--- a/src/app/[variants]/(desktop)/desktop-onboarding/index.tsx
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/index.tsx
@@ -117,8 +117,14 @@ const DesktopOnboardingPage = memo(() => {
         case 4: {
           // 如果是第4步（LoginStep），完成 onboarding
           setDesktopOnboardingCompleted();
-          // Use hard reload instead of SPA navigation to ensure the app boots with the new desktop state.
-          window.location.replace('/');
+          // Restore window resizable before hard reload (cleanup won't run due to hard navigation)
+          electronSystemService
+            .setWindowResizable({ resizable: true })
+            .catch(console.error)
+            .finally(() => {
+              // Use hard reload instead of SPA navigation to ensure the app boots with the new desktop state.
+              window.location.replace('/');
+            });
           return prev;
         }
         default: {


### PR DESCRIPTION
## Summary

在桌面 onboarding 完成后的硬重载之前，先恢复窗口的可调整大小状态，确保应用重新启动时窗口可以正常调整大小。

## Test plan

- [x] 测试桌面端 onboarding 流程，完成后窗口可正常调整大小

resolves LOBE-2485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix desktop onboarding completion so the app window is resizable again before the post-onboarding hard reload.