### PR TITLE
🐛  fix(resource): should use `fileid` to perform file operations

### DIFF
--- a/packages/database/src/repositories/knowledge/index.ts
+++ b/packages/database/src/repositories/knowledge/index.ts
@@ -12,6 +12,7 @@ export interface KnowledgeItem {
   createdAt: Date;
   editorData?: Record<string, any> | null;
   embeddingTaskId?: string | null;
+  fileId?: string | null;
   fileType: string;
   id: string;
   metadata?: Record<string, any> | null;
@@ -137,6 +138,7 @@ export class KnowledgeRepo {
         createdAt: new Date(row.created_at),
         editorData,
         embeddingTaskId: row.embedding_task_id,
+        fileId: row.file_id,
         fileType: row.file_type,
         id: row.id,
         metadata,
@@ -160,6 +162,7 @@ export class KnowledgeRepo {
     const fileQuery = sql`
       SELECT
         COALESCE(d.id, f.id) as id,
+        f.id as file_id,
         f.name,
         f.file_type,
         f.size,
@@ -186,6 +189,7 @@ export class KnowledgeRepo {
     const documentQuery = sql`
       SELECT
         id,
+        ${documents.fileId} as file_id,
         COALESCE(title, filename, 'Untitled') as name,
         file_type,
         total_char_count as size,
@@ -244,6 +248,7 @@ export class KnowledgeRepo {
         createdAt: new Date(row.created_at),
         editorData,
         embeddingTaskId: row.embedding_task_id,
+        fileId: row.file_id,
         fileType: row.file_type,
         id: row.id,
         metadata,
@@ -368,6 +373,7 @@ export class KnowledgeRepo {
       return sql`
         SELECT
           COALESCE(d.id, f.id) as id,
+          f.id as file_id,
           f.name,
           f.file_type,
           f.size,
@@ -406,6 +412,7 @@ export class KnowledgeRepo {
     return sql`
       SELECT
         COALESCE(d.id, f.id) as id,
+        f.id as file_id,
         f.name,
         f.file_type,
         f.size,
@@ -474,6 +481,7 @@ export class KnowledgeRepo {
         return sql`
           SELECT
             NULL::varchar(30) as id,
+            NULL::varchar(30) as file_id,
             NULL::text as name,
             NULL::varchar(255) as file_type,
             NULL::integer as size,
@@ -535,6 +543,7 @@ export class KnowledgeRepo {
           return sql`
             SELECT
               NULL::varchar(30) as id,
+              NULL::varchar(30) as file_id,
               NULL::text as name,
               NULL::varchar(255) as file_type,
               NULL::integer as size,
@@ -564,6 +573,7 @@ export class KnowledgeRepo {
       return sql`
         SELECT
           d.id,
+          d.file_id as file_id,
           COALESCE(d.title, d.filename, 'Untitled') as name,
           d.file_type,
           d.total_char_count as size,
@@ -585,6 +595,7 @@ export class KnowledgeRepo {
     return sql`
       SELECT
         id,
+        ${documents.fileId} as file_id,
         COALESCE(title, filename, 'Untitled') as name,
         file_type,
         total_char_count as size,

--- a/packages/types/src/files/list.ts
+++ b/packages/types/src/files/list.ts
@@ -14,6 +14,10 @@ export interface FileListItem {
   editorData?: Record<string, any> | null;
   embeddingError: any | null;
   embeddingStatus?: AsyncTaskStatus | null;
+  /**
+   * The underlying files table id when the item represents a file.
+   */
+  fileId?: string | null;
   fileType: string;
   finishEmbedding: boolean;
   id: string;

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -153,7 +153,7 @@ export const useFileItemDropdown = ({
             domEvent.stopPropagation();
 
             createRawModal(MoveToFolderModal, {
-              fileId: id,
+              fileId: fileId || id,
               fileType,
               knowledgeBaseId,
             });

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -79,7 +79,8 @@ export const useFileItemDropdown = ({
       onClick: async ({ domEvent }) => {
         domEvent.stopPropagation();
         try {
-          await addFilesToKnowledgeBase(kb.id, [id]);
+          // Use fileId if available, otherwise fallback to id, ref: https://github.com/lobehub/lobe-chat/pull/11180
+          await addFilesToKnowledgeBase(kb.id, [fileId || id]);
           message.success(
             t('addToKnowledgeBase.addSuccess', {
               count: 1,
@@ -114,7 +115,8 @@ export const useFileItemDropdown = ({
                     danger: true,
                   },
                   onOk: async () => {
-                    await removeFilesFromKnowledgeBase(knowledgeBaseId, [id]);
+                    // Use fileId if available, otherwise fallback to id, ref: https://github.com/lobehub/lobe-chat/pull/11180
+                    await removeFilesFromKnowledgeBase(knowledgeBaseId, [fileId || id]);
 
                     message.success(t('FileManager.actions.removeFromKnowledgeBaseSuccess'));
                   },

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -23,8 +23,8 @@ import MoveToFolderModal from '../MoveToFolderModal';
 
 interface UseFileItemDropdownParams {
   enabled?: boolean;
+  fileId?: string | null;
   fileType: string;
-  fileId?: string;
   filename: string;
   id: string;
   knowledgeBaseId?: string;

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -24,6 +24,7 @@ import MoveToFolderModal from '../MoveToFolderModal';
 interface UseFileItemDropdownParams {
   enabled?: boolean;
   fileType: string;
+  fileId?: string;
   filename: string;
   id: string;
   knowledgeBaseId?: string;
@@ -42,6 +43,7 @@ export const useFileItemDropdown = ({
   url,
   filename,
   fileType,
+  fileId,
   sourceType,
   onRenameStart,
 }: UseFileItemDropdownParams): UseFileItemDropdownReturn => {
@@ -252,7 +254,7 @@ export const useFileItemDropdown = ({
                   await documentService.deleteDocument(id);
                   await refreshFileList();
                 } else {
-                  await removeFile(id);
+                  await removeFile(fileId || id);
                 }
               },
             });

--- a/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/ListView/ListItem/index.tsx
@@ -114,6 +114,7 @@ const FileListItem = memo<FileListItemProps>(
     url,
     name,
     fileType,
+    fileId,
     id,
     createdAt,
     selected,
@@ -324,6 +325,7 @@ const FileListItem = memo<FileListItemProps>(
     }, [pendingRenameItemId, id, isFolder, resourceManagerState]);
 
     const { menuItems } = useFileItemDropdown({
+      fileId,
       fileType,
       filename: name,
       id,

--- a/src/features/ResourceManager/components/Tree/index.tsx
+++ b/src/features/ResourceManager/components/Tree/index.tsx
@@ -122,6 +122,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 interface TreeItem {
   children?: TreeItem[];
+  fileId?: string | null;
   fileType: string;
   id: string;
   isFolder: boolean;
@@ -151,7 +152,6 @@ const FileTreeRow = memo<{
     onToggleFolder,
     onLoadFolder,
     selectedKey,
-
     folderChildrenCache,
   }) => {
     const navigate = useNavigate();
@@ -215,6 +215,7 @@ const FileTreeRow = memo<{
     }, [item.name]);
 
     const { menuItems } = useFileItemDropdown({
+      fileId: item.fileId || item.id,
       fileType: item.fileType,
       filename: item.name,
       id: item.id,
@@ -291,7 +292,8 @@ const FileTreeRow = memo<{
         : `/resource/library/${libraryId}`;
 
       setCurrentViewItemId(itemKey);
-      navigate(`${currentPath}?file=${itemKey}`);
+      // Use fileId if available to preview the file, otherwise fallback to item.id,ref: 
+      navigate(`${currentPath}?file=${item.fileId || item.id}`);
 
       if (itemKey.startsWith('doc')) {
         setMode('page');
@@ -536,6 +538,7 @@ const FileTree = memo(() => {
     if (!rootData) return [];
 
     const mappedItems: TreeItem[] = rootData.map((item) => ({
+      fileId: item.fileId || item.id,
       fileType: item.fileType,
       id: item.id,
       isFolder: item.fileType === 'custom/folder',

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -235,6 +235,7 @@ export const fileRouter = router({
 
     // Process files (add chunk info and async task status)
     const fileItems = filteredItems.filter((item) => item.sourceType === 'file');
+    // Should resolve to files table IDs, ref: https://github.com/lobehub/lobe-chat/pull/11180
     const fileIds = fileItems.map((item) => resolveFileId(item));
     const chunks = await ctx.chunkModel.countByFileIds(fileIds);
 
@@ -259,6 +260,8 @@ export const fileRouter = router({
         const embeddingTask = item.embeddingTaskId
           ? embeddingTasks.find((task) => task.id === item.embeddingTaskId)
           : null;
+
+        // Should resolve to files table IDs, ref: https://github.com/lobehub/lobe-chat/pull/11180
         const fileId = resolveFileId(item);
 
         resultItems.push({


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->



- 原因排查
  - `src/server/routers/lambda/knowledge.ts:L70`： 中选择了 `documents` 表和 `files` 表的结果，但 `documents` 表的 `id` 不能直接用来标识调用 `fileService` 的功能，因为其为 `ducoments.id` 而不是 `files.id`。
  - 因此，当使用 `id` 去操作 `document` 所链接的 `file` 时，会无法寻找到对应的文件。
- 受影响功能
  - `F1`: 
    - `/resource` 中无法 preview 文件 #11181
  - `F2`: `/resource/library` 中
    - `F2.1` 无法”移动文件到 library 中“
    - `F2.2` 删除文件 #11262
    - `F2.3` 预览文件
  - `F3`: `/resource/library` 侧栏中的文件无法正常 preview

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

- :bug: file.ts ：统一通过 `fileId` 处理分片计数与 `/f/:id` 代理，避免 document id 误用于下载
- :bug: knowledge.ts ：知识列表 API 同步改用 `fileId`，确保异步任务与链接正确关联原始文件
- :sparkles: index.ts ：查询结果新增 `file_id` 字段并向上游返回 `KnowledgeItem.fileId`
- :memo: list.ts ：`FileListItem` 增加可选 `fileId` 字段供前端、安全下载逻辑使用
- :test_tube: index.test.ts ：新增覆盖确保文件-文档混合场景下 `fileId` 正确暴露

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

|id| Before | After |
|--| ------ | ----- |
|`F1`|  ![resource-before](https://github.com/user-attachments/assets/43722af4-138f-4fb1-95b1-06847251564c)  |  ![resource-after](https://github.com/user-attachments/assets/3f825e70-a322-4106-966e-a4f31f8e717d)  |
|`F2.1`| ![resource-dropdown-move-b4](https://github.com/user-attachments/assets/b1fe328b-0b2d-48c9-a0a6-d6c70d90c408) | ![resource-dropdown-move-af](https://github.com/user-attachments/assets/04ac08a8-7f0c-495b-843a-6be1ba4ddd55) |
|`F2.2`| ![resource-dropdown-b4](https://github.com/user-attachments/assets/8b949f5a-5b4b-4cda-9d47-321270be97ae) | ![resource-dropdown-af](https://github.com/user-attachments/assets/f08d06e6-5c9e-4af4-9871-492f389f14d0) |
|`F2.3`| 因为 bug `F2.2` 无法移动文件到library，没有 before | ![resource-dropdown-move-af](https://github.com/user-attachments/assets/36add972-d7f7-4fe2-85dc-8733265f6df9) | 
|`F3`| 因为 bug `F2.2` 无法移动文件到library，没有 before | ![resource-tree-preview-af](https://github.com/user-attachments/assets/8ab0e78f-9585-4b09-b309-210f436562e9) |

#### 📝 Additional Information

TODOs 修复其他受影响的内容
- 无法正常删除
  - [x] 修复
  - [ ] 测试覆盖
- 无法正常移动到 library （含移入移出）
  - [x] 修复
  - [ ] 测试覆盖


<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure knowledge and file APIs consistently use the underlying file ID when working with file metadata, URLs, and async tasks to avoid misusing document IDs.

Bug Fixes:
- Fix file-related operations (preview, move, delete, chunk counting, and async task linkage) by resolving and propagating the correct files table ID instead of document IDs.

Enhancements:
- Expose an optional fileId field on knowledge and file list items and thread it through backend queries and frontend resource manager components for safer file operations.

Tests:
- Add repository tests to verify correct fileId resolution for files joined with documents and standalone documents.