### PR TITLE
🐛 fix: add lost like button in discover detail page

### DIFF
--- a/src/app/(backend)/market/social/[[...segments]]/route.ts
+++ b/src/app/(backend)/market/social/[[...segments]]/route.ts
@@ -158,7 +158,7 @@ export const GET = async (req: NextRequest, context: RouteContext) => {
       // Follow queries
       case 'follow-status': {
         const targetUserId = Number(segments[1]);
-        if (!accessToken) {
+        if (!accessToken && !trustedClientToken) {
           return NextResponse.json({ isFollowing: false, isMutual: false });
         }
         const result = await market.follows.checkFollowStatus(targetUserId);
@@ -193,7 +193,7 @@ export const GET = async (req: NextRequest, context: RouteContext) => {
       case 'favorite-status': {
         const targetType = segments[1] as 'agent' | 'plugin';
         const targetIdOrIdentifier = segments[2];
-        if (!accessToken) {
+        if (!accessToken && !trustedClientToken) {
           return NextResponse.json({ isFavorited: false });
         }
         // SDK accepts both number (targetId) and string (identifier)
@@ -236,7 +236,7 @@ export const GET = async (req: NextRequest, context: RouteContext) => {
       case 'like-status': {
         const targetType = segments[1] as 'agent' | 'plugin';
         const targetIdOrIdentifier = segments[2];
-        if (!accessToken) {
+        if (!accessToken && !trustedClientToken) {
           return NextResponse.json({ isLiked: false });
         }
         const isNumeric = /^\d+$/.test(targetIdOrIdentifier);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enable like interactions on the assistant discover detail page and adjust social status APIs to work with trusted client tokens.

Bug Fixes:
- Restore and wire up the like button on the assistant detail header, including status fetching, toggling, and user feedback.
- Allow follow, favorite, and like status checks to succeed when authenticated via a trusted client token instead of only an access token.