### PR TITLE
🐛 fix(gtd): fix frozen object mutation in updateTodos

### DIFF
--- a/packages/builtin-tool-gtd/src/executor/index.ts
+++ b/packages/builtin-tool-gtd/src/executor/index.ts
@@ -127,110 +127,124 @@ class GTDExecutor extends BaseExecutor<typeof GTDApiNameEnum> {
     params: UpdateTodosParams,
     ctx: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
-    console.log('[updateTodos] called with params:', params);
-    console.log('[updateTodos] context: topicId=%s, messageId=%s', ctx.topicId, ctx.messageId);
+    try {
+      console.log('[updateTodos] called with params:', params);
+      console.log('[updateTodos] context: topicId=%s, messageId=%s', ctx.topicId, ctx.messageId);
 
-    const { operations } = params;
+      const { operations } = params;
 
-    if (!operations || operations.length === 0) {
-      console.log('[updateTodos] no operations provided, returning early');
-      return {
-        content: 'No operations provided.',
-        success: false,
-      };
-    }
-
-    console.log('[updateTodos] processing %d operations', operations.length);
-
-    const existingTodos = getTodosFromContext(ctx);
-    console.log('[updateTodos] existingTodos count=%d, items=', existingTodos.length, existingTodos);
-
-    let updatedTodos = [...existingTodos];
-    const results: string[] = [];
-
-    for (const op of operations) {
-      console.log('[updateTodos] processing operation type=%s, op=', op.type, op);
-      switch (op.type) {
-        case 'add': {
-          if (op.text) {
-            console.log('[updateTodos] [add] adding text=%s', op.text);
-            updatedTodos.push({ completed: false, text: op.text });
-            results.push(`Added: "${op.text}"`);
-          } else {
-            console.log('[updateTodos] [add] skipped - no text provided');
-          }
-          break;
-        }
-        case 'update': {
-          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-            console.log('[updateTodos] [update] updating index=%d, newText=%s, completed=%s', op.index, op.newText, op.completed);
-            const item = updatedTodos[op.index];
-            if (op.newText !== undefined) {
-              item.text = op.newText;
-            }
-            if (op.completed !== undefined) {
-              item.completed = op.completed;
-            }
-            results.push(`Updated item ${op.index + 1}`);
-          } else {
-            console.log('[updateTodos] [update] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-          }
-          break;
-        }
-        case 'remove': {
-          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-            console.log('[updateTodos] [remove] removing index=%d', op.index);
-            const removed = updatedTodos.splice(op.index, 1)[0];
-            results.push(`Removed: "${removed.text}"`);
-          } else {
-            console.log('[updateTodos] [remove] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-          }
-          break;
-        }
-        case 'complete': {
-          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-            console.log('[updateTodos] [complete] completing index=%d', op.index);
-            updatedTodos[op.index].completed = true;
-            results.push(`Completed: "${updatedTodos[op.index].text}"`);
-          } else {
-            console.log('[updateTodos] [complete] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-          }
-          break;
-        }
+      if (!operations || operations.length === 0) {
+        console.log('[updateTodos] no operations provided, returning early');
+        return {
+          content: 'No operations provided.',
+          success: false,
+        };
       }
+
+      console.log('[updateTodos] processing %d operations', operations.length);
+
+      const existingTodos = getTodosFromContext(ctx);
+      console.log('[updateTodos] existingTodos count=%d, items=', existingTodos.length, existingTodos);
+
+      let updatedTodos = [...existingTodos];
+      const results: string[] = [];
+
+      for (const op of operations) {
+        console.log('[updateTodos] processing operation type=%s, op=', op.type, op);
+        switch (op.type) {
+          case 'add': {
+            if (op.text) {
+              console.log('[updateTodos] [add] adding text=%s', op.text);
+              updatedTodos.push({ completed: false, text: op.text });
+              results.push(`Added: "${op.text}"`);
+            } else {
+              console.log('[updateTodos] [add] skipped - no text provided');
+            }
+            break;
+          }
+          case 'update': {
+            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+              console.log('[updateTodos] [update] updating index=%d, newText=%s, completed=%s', op.index, op.newText, op.completed);
+              const item = updatedTodos[op.index];
+              console.log('[updateTodos] [update] item before update:', item);
+              // Create a new object to avoid mutating frozen/immutable objects from store
+              const updatedItem = { ...item };
+              if (op.newText !== undefined) {
+                updatedItem.text = op.newText;
+              }
+              if (op.completed !== undefined) {
+                updatedItem.completed = op.completed;
+              }
+              updatedTodos[op.index] = updatedItem;
+              console.log('[updateTodos] [update] item after update:', updatedItem);
+              results.push(`Updated item ${op.index + 1}`);
+              console.log('[updateTodos] [update] results.push done');
+            } else {
+              console.log('[updateTodos] [update] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
+            }
+            break;
+          }
+          case 'remove': {
+            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+              console.log('[updateTodos] [remove] removing index=%d', op.index);
+              const removed = updatedTodos.splice(op.index, 1)[0];
+              results.push(`Removed: "${removed.text}"`);
+            } else {
+              console.log('[updateTodos] [remove] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
+            }
+            break;
+          }
+          case 'complete': {
+            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+              console.log('[updateTodos] [complete] completing index=%d', op.index);
+              // Create a new object to avoid mutating frozen/immutable objects from store
+              updatedTodos[op.index] = { ...updatedTodos[op.index], completed: true };
+              results.push(`Completed: "${updatedTodos[op.index].text}"`);
+            } else {
+              console.log('[updateTodos] [complete] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
+            }
+            break;
+          }
+        }
+        console.log('[updateTodos] operation done, moving to next');
+      }
+
+      console.log('[updateTodos] for loop completed');
+      console.log('[updateTodos] operations completed, results=', results);
+      console.log('[updateTodos] updatedTodos count=%d, items=', updatedTodos.length, updatedTodos);
+
+      const now = new Date().toISOString();
+
+      // Format response: action summary + todo state
+      const actionSummary =
+        results.length > 0
+          ? `🔄 Applied ${results.length} operation${results.length > 1 ? 's' : ''}:\n${results.map((r) => `- ${r}`).join('\n')}`
+          : 'No operations applied.';
+
+      const todoState = { items: updatedTodos, updatedAt: now };
+      console.log('[updateTodos] todoState created:', todoState);
+
+      // Sync todos to Plan document if topic exists
+      if (ctx.topicId) {
+        console.log('[updateTodos] syncing todos to plan, topicId=%s', ctx.topicId);
+        await syncTodosToPlan(ctx.topicId, todoState);
+        console.log('[updateTodos] syncTodosToPlan completed');
+      } else {
+        console.log('[updateTodos] skipping syncTodosToPlan - no topicId');
+      }
+
+      console.log('[updateTodos] returning success');
+      return {
+        content: actionSummary + '\n\n' + formatTodoStateSummary(updatedTodos, now),
+        state: {
+          todos: todoState,
+        },
+        success: true,
+      };
+    } catch (error) {
+      console.error('[updateTodos] ERROR caught:', error);
+      throw error;
     }
-
-    console.log('[updateTodos] operations completed, results=', results);
-    console.log('[updateTodos] updatedTodos count=%d, items=', updatedTodos.length, updatedTodos);
-
-    const now = new Date().toISOString();
-
-    // Format response: action summary + todo state
-    const actionSummary =
-      results.length > 0
-        ? `🔄 Applied ${results.length} operation${results.length > 1 ? 's' : ''}:\n${results.map((r) => `- ${r}`).join('\n')}`
-        : 'No operations applied.';
-
-    const todoState = { items: updatedTodos, updatedAt: now };
-    console.log('[updateTodos] todoState created:', todoState);
-
-    // Sync todos to Plan document if topic exists
-    if (ctx.topicId) {
-      console.log('[updateTodos] syncing todos to plan, topicId=%s', ctx.topicId);
-      await syncTodosToPlan(ctx.topicId, todoState);
-      console.log('[updateTodos] syncTodosToPlan completed');
-    } else {
-      console.log('[updateTodos] skipping syncTodosToPlan - no topicId');
-    }
-
-    console.log('[updateTodos] returning success');
-    return {
-      content: actionSummary + '\n\n' + formatTodoStateSummary(updatedTodos, now),
-      state: {
-        todos: todoState,
-      },
-      success: true,
-    };
   };
 
   /**

--- a/packages/builtin-tool-gtd/src/executor/index.ts
+++ b/packages/builtin-tool-gtd/src/executor/index.ts
@@ -127,124 +127,83 @@ class GTDExecutor extends BaseExecutor<typeof GTDApiNameEnum> {
     params: UpdateTodosParams,
     ctx: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
-    try {
-      console.log('[updateTodos] called with params:', params);
-      console.log('[updateTodos] context: topicId=%s, messageId=%s', ctx.topicId, ctx.messageId);
+    const { operations } = params;
 
-      const { operations } = params;
-
-      if (!operations || operations.length === 0) {
-        console.log('[updateTodos] no operations provided, returning early');
-        return {
-          content: 'No operations provided.',
-          success: false,
-        };
-      }
-
-      console.log('[updateTodos] processing %d operations', operations.length);
-
-      const existingTodos = getTodosFromContext(ctx);
-      console.log('[updateTodos] existingTodos count=%d, items=', existingTodos.length, existingTodos);
-
-      let updatedTodos = [...existingTodos];
-      const results: string[] = [];
-
-      for (const op of operations) {
-        console.log('[updateTodos] processing operation type=%s, op=', op.type, op);
-        switch (op.type) {
-          case 'add': {
-            if (op.text) {
-              console.log('[updateTodos] [add] adding text=%s', op.text);
-              updatedTodos.push({ completed: false, text: op.text });
-              results.push(`Added: "${op.text}"`);
-            } else {
-              console.log('[updateTodos] [add] skipped - no text provided');
-            }
-            break;
-          }
-          case 'update': {
-            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-              console.log('[updateTodos] [update] updating index=%d, newText=%s, completed=%s', op.index, op.newText, op.completed);
-              const item = updatedTodos[op.index];
-              console.log('[updateTodos] [update] item before update:', item);
-              // Create a new object to avoid mutating frozen/immutable objects from store
-              const updatedItem = { ...item };
-              if (op.newText !== undefined) {
-                updatedItem.text = op.newText;
-              }
-              if (op.completed !== undefined) {
-                updatedItem.completed = op.completed;
-              }
-              updatedTodos[op.index] = updatedItem;
-              console.log('[updateTodos] [update] item after update:', updatedItem);
-              results.push(`Updated item ${op.index + 1}`);
-              console.log('[updateTodos] [update] results.push done');
-            } else {
-              console.log('[updateTodos] [update] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-            }
-            break;
-          }
-          case 'remove': {
-            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-              console.log('[updateTodos] [remove] removing index=%d', op.index);
-              const removed = updatedTodos.splice(op.index, 1)[0];
-              results.push(`Removed: "${removed.text}"`);
-            } else {
-              console.log('[updateTodos] [remove] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-            }
-            break;
-          }
-          case 'complete': {
-            if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
-              console.log('[updateTodos] [complete] completing index=%d', op.index);
-              // Create a new object to avoid mutating frozen/immutable objects from store
-              updatedTodos[op.index] = { ...updatedTodos[op.index], completed: true };
-              results.push(`Completed: "${updatedTodos[op.index].text}"`);
-            } else {
-              console.log('[updateTodos] [complete] skipped - invalid index=%d, todosLength=%d', op.index, updatedTodos.length);
-            }
-            break;
-          }
-        }
-        console.log('[updateTodos] operation done, moving to next');
-      }
-
-      console.log('[updateTodos] for loop completed');
-      console.log('[updateTodos] operations completed, results=', results);
-      console.log('[updateTodos] updatedTodos count=%d, items=', updatedTodos.length, updatedTodos);
-
-      const now = new Date().toISOString();
-
-      // Format response: action summary + todo state
-      const actionSummary =
-        results.length > 0
-          ? `🔄 Applied ${results.length} operation${results.length > 1 ? 's' : ''}:\n${results.map((r) => `- ${r}`).join('\n')}`
-          : 'No operations applied.';
-
-      const todoState = { items: updatedTodos, updatedAt: now };
-      console.log('[updateTodos] todoState created:', todoState);
-
-      // Sync todos to Plan document if topic exists
-      if (ctx.topicId) {
-        console.log('[updateTodos] syncing todos to plan, topicId=%s', ctx.topicId);
-        await syncTodosToPlan(ctx.topicId, todoState);
-        console.log('[updateTodos] syncTodosToPlan completed');
-      } else {
-        console.log('[updateTodos] skipping syncTodosToPlan - no topicId');
-      }
-
-      console.log('[updateTodos] returning success');
+    if (!operations || operations.length === 0) {
       return {
-        content: actionSummary + '\n\n' + formatTodoStateSummary(updatedTodos, now),
-        state: {
-          todos: todoState,
-        },
-        success: true,
+        content: 'No operations provided.',
+        success: false,
       };
-    } catch (error) {
-      console.error('[updateTodos] ERROR caught:', error);
-      throw error;
     }
+
+    const existingTodos = getTodosFromContext(ctx);
+    let updatedTodos = [...existingTodos];
+    const results: string[] = [];
+
+    for (const op of operations) {
+      switch (op.type) {
+        case 'add': {
+          if (op.text) {
+            updatedTodos.push({ completed: false, text: op.text });
+            results.push(`Added: "${op.text}"`);
+          }
+          break;
+        }
+        case 'update': {
+          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+            // Create a new object to avoid mutating frozen/immutable objects from store
+            const updatedItem = { ...updatedTodos[op.index] };
+            if (op.newText !== undefined) {
+              updatedItem.text = op.newText;
+            }
+            if (op.completed !== undefined) {
+              updatedItem.completed = op.completed;
+            }
+            updatedTodos[op.index] = updatedItem;
+            results.push(`Updated item ${op.index + 1}`);
+          }
+          break;
+        }
+        case 'remove': {
+          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+            const removed = updatedTodos.splice(op.index, 1)[0];
+            results.push(`Removed: "${removed.text}"`);
+          }
+          break;
+        }
+        case 'complete': {
+          if (op.index !== undefined && op.index >= 0 && op.index < updatedTodos.length) {
+            // Create a new object to avoid mutating frozen/immutable objects from store
+            updatedTodos[op.index] = { ...updatedTodos[op.index], completed: true };
+            results.push(`Completed: "${updatedTodos[op.index].text}"`);
+          }
+          break;
+        }
+      }
+    }
+
+    const now = new Date().toISOString();
+
+    // Format response: action summary + todo state
+    const actionSummary =
+      results.length > 0
+        ? `🔄 Applied ${results.length} operation${results.length > 1 ? 's' : ''}:\n${results.map((r) => `- ${r}`).join('\n')}`
+        : 'No operations applied.';
+
+    const todoState = { items: updatedTodos, updatedAt: now };
+
+    // Sync todos to Plan document if topic exists
+    if (ctx.topicId) {
+      await syncTodosToPlan(ctx.topicId, todoState);
+    }
+
+    return {
+      content: actionSummary + '\n\n' + formatTodoStateSummary(updatedTodos, now),
+      state: {
+        todos: todoState,
+      },
+      success: true,
+    };
   };
 
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [*] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #11135 

#### 🔀 Description of Change

Fix `updateTodos` failing silently when trying to mutate frozen/immutable objects from Zustand store.

Problem
When `updateTodos` executes `update` or `complete` operations, it attempts to directly modify `TodoItem` objects:
```typescript
item.text = op.newText;  // ❌ Throws on frozen objects
item.completed = true;   // ❌ Throws on frozen objects
```

These objects returns references from Zustand store state. Since Zustand (with immer) freezes state objects, direct mutation throws TypeError: Cannot assign to read only property.


Solution
Create new objects instead of mutating existing ones:
```
// update operation
const updatedItem = { ...updatedTodos[op.index] };
updatedItem.text = op.newText;
updatedTodos[op.index] = updatedItem;

// complete operation
updatedTodos[op.index] = { ...updatedTodos[op.index], completed: true };
```

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
