### PR TITLE
style: Increase ModelSwitchPanel default width for better model name display

### DIFF
--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -25,7 +25,7 @@ import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
 const STORAGE_KEY = 'MODEL_SWITCH_PANEL_WIDTH';
 const STORAGE_KEY_MODE = 'MODEL_SWITCH_PANEL_MODE';
-const DEFAULT_WIDTH = 320;
+const DEFAULT_WIDTH = 430;
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 600;
 const MAX_PANEL_HEIGHT = 460;


### PR DESCRIPTION
## Summary
- Increased the default width of ModelSwitchPanel from 320px to 430px to ensure model names can be fully displayed

## Test plan
- [ ] Open the model switch panel and verify model names are fully visible
- [ ] Verify the panel still looks good on different screen sizes

Closes #11192, #11131

## Summary by Sourcery

Enhancements:
- Adjust the ModelSwitchPanel default width from 320px to 430px to improve visibility of full model names.