### PR TITLE
🐛 fix(model-runtime): handle array content in anthropic assistant messages

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -216,6 +216,33 @@ describe('anthropicHelpers', () => {
         role: 'assistant',
       });
     });
+
+    it('should correctly convert assistant message with array content but no tool_calls', async () => {
+      const message: OpenAIChatMessage = {
+        content: [
+          { thinking: 'Let me think about this...', type: 'thinking', signature: 'sig123' },
+          { type: 'text', text: 'Here is my response.' },
+        ],
+        role: 'assistant',
+      };
+      const result = await buildAnthropicMessage(message);
+      expect(result).toEqual({
+        content: [
+          { thinking: 'Let me think about this...', type: 'thinking', signature: 'sig123' },
+          { type: 'text', text: 'Here is my response.' },
+        ],
+        role: 'assistant',
+      });
+    });
+
+    it('should return undefined for assistant message with empty array content', async () => {
+      const message: OpenAIChatMessage = {
+        content: [],
+        role: 'assistant',
+      };
+      const result = await buildAnthropicMessage(message);
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('buildAnthropicMessages', () => {

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -118,8 +118,15 @@ export const buildAnthropicMessage = async (
       }
 
       // or it's a plain assistant message
+      // Handle array content (e.g., content with thinking blocks)
+      if (Array.isArray(content)) {
+        const messageContent = await buildArrayContent(content);
+        if (messageContent.length === 0) return undefined;
+        return { content: messageContent, role: 'assistant' };
+      }
+
       // Anthropic API requires non-empty content, filter out empty/whitespace-only content
-      const textContent = (content as string)?.trim();
+      const textContent = content?.trim();
       if (!textContent) return undefined;
       return { content: textContent, role: 'assistant' };
     }


### PR DESCRIPTION
## Summary

- Fix `TypeError: content?.trim is not a function` when processing Anthropic assistant messages
- Handle array content (e.g., containing thinking blocks) without tool_calls
- Add test coverage for array content scenarios

## Problem

When assistant messages have array content (such as containing thinking blocks) but no `tool_calls`, the `buildAnthropicMessage` function incorrectly attempted to call `.trim()` on the array, causing:

```
TypeError: content?.trim is not a function
```

This occurred because the code only checked for `tool_calls` before falling through to string processing, not accounting for array content without tool calls.

## Solution

Added a check for array content type before processing:

```typescript
// Handle array content (e.g., content with thinking blocks)
if (Array.isArray(content)) {
  const messageContent = await buildArrayContent(content);
  if (messageContent.length === 0) return undefined;
  return { content: messageContent, role: 'assistant' };
}
```

## Changes

- `packages/model-runtime/src/core/contextBuilders/anthropic.ts`: Add array content handling
- `packages/model-runtime/src/core/contextBuilders/anthropic.test.ts`: Add 2 test cases

## Test plan

- [x] Added test for assistant message with array content but no tool_calls
- [x] Added test for assistant message with empty array content
- [x] All 82 anthropic-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)