### PR TITLE
🐛 fix: support audio file uploads in MCP content processing

### DIFF
--- a/packages/utils/src/url.test.ts
+++ b/packages/utils/src/url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   inferContentTypeFromImageUrl,
+  inferContentTypeFromUrl,
   inferFileExtensionFromImageUrl,
   isDesktopLocalStaticServerUrl,
   isLocalOrPrivateUrl,
@@ -539,6 +540,56 @@ describe('isLocalOrPrivateUrl', () => {
     it('should return false for invalid IP addresses', () => {
       expect(isLocalOrPrivateUrl('http://256.256.256.256')).toBe(false);
       expect(isLocalOrPrivateUrl('http://192.168.1.256')).toBe(false);
+    });
+  });
+});
+
+describe('inferContentTypeFromUrl', () => {
+  describe('image files', () => {
+    it('should return correct MIME types for common image formats', () => {
+      expect(inferContentTypeFromUrl('https://example.com/image.jpg')).toBe('image/jpeg');
+      expect(inferContentTypeFromUrl('https://example.com/image.png')).toBe('image/png');
+      expect(inferContentTypeFromUrl('https://example.com/image.webp')).toBe('image/webp');
+      expect(inferContentTypeFromUrl('https://example.com/image.gif')).toBe('image/gif');
+    });
+  });
+
+  describe('audio files', () => {
+    it('should return correct MIME types for common audio formats', () => {
+      expect(inferContentTypeFromUrl('https://example.com/audio.mp3')).toBe('audio/mp3');
+      expect(inferContentTypeFromUrl('files/mcp/audio/2025-12-14/YdRVoA3B.mp3')).toBe('audio/mp3');
+      expect(inferContentTypeFromUrl('https://example.com/sound.wav')).toBe('audio/wav');
+      expect(inferContentTypeFromUrl('https://example.com/music.ogg')).toBe('audio/ogg');
+    });
+  });
+
+  describe('case insensitive', () => {
+    it('should handle mixed case extensions', () => {
+      expect(inferContentTypeFromUrl('https://example.com/audio.MP3')).toBe('audio/mp3');
+      expect(inferContentTypeFromUrl('https://example.com/image.JPG')).toBe('image/jpeg');
+    });
+  });
+
+  describe('URLs with query parameters and fragments', () => {
+    it('should extract content type ignoring query parameters and hash fragments', () => {
+      expect(inferContentTypeFromUrl('https://example.com/audio.mp3?v=123&size=large')).toBe('audio/mp3');
+      expect(inferContentTypeFromUrl('https://example.com/audio.mp3#section')).toBe('audio/mp3');
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('should return fallback for unknown extensions', () => {
+      expect(inferContentTypeFromUrl('https://example.com/file.xyz')).toBe('application/octet-stream');
+      expect(inferContentTypeFromUrl('https://example.com/file')).toBe('application/octet-stream');
+      expect(inferContentTypeFromUrl('https://example.com/file.')).toBe('application/octet-stream');
+    });
+  });
+
+  describe('relative paths', () => {
+    it('should handle relative paths', () => {
+      expect(inferContentTypeFromUrl('files/mcp/audio/2025-12-14/test.mp3')).toBe('audio/mp3');
+      expect(inferContentTypeFromUrl('./images/photo.jpg')).toBe('image/jpeg');
+      expect(inferContentTypeFromUrl('../sounds/beep.wav')).toBe('audio/wav');
     });
   });
 });

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -125,6 +125,41 @@ export function inferContentTypeFromImageUrl(url: string) {
 }
 
 /**
+ * Infer content type (MIME type) from a file URL (supports images and audio)
+ *
+ * This function extracts the file extension from a URL and returns the corresponding MIME type.
+ * Unlike inferContentTypeFromImageUrl, this function supports both image and audio files.
+ *
+ * @param url - The file URL to analyze (can be relative, absolute, or include query parameters and hash fragments)
+ * @returns MIME type string (e.g., 'image/jpeg', 'audio/mp3') or fallback to 'application/octet-stream'
+ *
+ * @example
+ * ```typescript
+ * inferContentTypeFromUrl('https://example.com/image.jpg') // 'image/jpeg'
+ * inferContentTypeFromUrl('https://example.com/audio.mp3') // 'audio/mp3'
+ * inferContentTypeFromUrl('files/mcp/audio/2025-12-14/YdRVoA3B.mp3') // 'audio/mp3'
+ * ```
+ */
+export function inferContentTypeFromUrl(url: string): string {
+  // Use a temporary base URL for proper URL parsing and formatting (handles relative paths)
+  const tempBase = 'https://a.com';
+  const urlObj = new URL(url, tempBase);
+  const pathname = urlObj.pathname;
+
+  // Find the last dot in the pathname to get the file extension
+  const lastDotIndex = pathname.lastIndexOf('.');
+  if (lastDotIndex === -1) return 'application/octet-stream'; // No extension found
+
+  // Extract extension after the last dot and convert to lowercase
+  const extension = pathname.slice(Math.max(0, lastDotIndex + 1)).toLowerCase();
+
+  // Get MIME type using the mime library
+  const mimeType = mime.getType(extension);
+  
+  return mimeType || 'application/octet-stream';
+}
+
+/**
  *
  * Check if a URL points to desktop local static server
  *

--- a/src/server/services/file/index.ts
+++ b/src/server/services/file/index.ts
@@ -1,5 +1,5 @@
 import { type LobeChatDatabase } from '@lobechat/database';
-import { inferContentTypeFromImageUrl, nanoid, uuid } from '@lobechat/utils';
+import { inferContentTypeFromImageUrl, inferContentTypeFromUrl, nanoid, uuid } from '@lobechat/utils';
 import { TRPCError } from '@trpc/server';
 import { sha256 } from 'js-sha256';
 
@@ -150,11 +150,14 @@ export class FileService {
    * Upload base64 data and create database record
    * @param base64Data - Base64 data (supports data URI format or pure base64)
    * @param pathname - File storage path (must include file extension)
+   * @param options - Optional configuration options
+   * @param options.skipCheckFileType - Skip file type validation (useful for audio files)
    * @returns Contains key (storage path), fileId (database record ID) and url (proxy access path)
    */
   public async uploadBase64(
     base64Data: string,
     pathname: string,
+    options: { skipCheckFileType?: boolean } = {},
   ): Promise<{ fileId: string; key: string; url: string }> {
     let base64String: string;
 
@@ -181,7 +184,9 @@ export class FileService {
 
     // Calculate file metadata
     const size = buffer.length;
-    const fileType = inferContentTypeFromImageUrl(pathname) || 'application/octet-stream';
+    const fileType = options.skipCheckFileType 
+      ? inferContentTypeFromUrl(pathname)
+      : inferContentTypeFromImageUrl(pathname) || 'application/octet-stream';
     const hash = sha256(buffer);
 
     // Generate UUID for cleaner URLs

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -52,7 +52,7 @@ export const processContentBlocks = async (
       const pathname = `${fileEnv.NEXT_PUBLIC_S3_FILE_PATH}/mcp/audio/${today}/${nanoid()}.${fileExtension}`;
 
       // Upload base64 audio and get proxy URL
-      const { url } = await fileService.uploadBase64(audioBlock.data, pathname);
+      const { url } = await fileService.uploadBase64(audioBlock.data, pathname, { skipCheckFileType: true });
 
       log(`Audio uploaded, proxy URL: ${url}`);
 


### PR DESCRIPTION
Fixes the "Invalid image url" error when MCP returns audio content by bypassing image-only file type validation for audio files, following the same pattern as TTS uploads.

## Changes
- Add inferContentTypeFromUrl utility function that supports both image and audio files
- Modify FileService.uploadBase64 to accept skipCheckFileType parameter
- Update MCP content processor to use skipCheckFileType for audio files
- Add comprehensive tests for new utility function

Closes #10778

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Support MCP audio file uploads by relaxing image-only content type validation and improving MIME type inference from URLs.

New Features:
- Introduce a generic inferContentTypeFromUrl utility that infers MIME types for both image and audio file URLs.

Bug Fixes:
- Fix MCP audio uploads failing with image-only file type validation by allowing audio MIME types during file upload.

Enhancements:
- Extend FileService.uploadBase64 to accept options for skipping strict image file type checks when appropriate.
- Update MCP content processing to use the new audio-safe upload path for audio content blocks.

Tests:
- Add comprehensive unit tests for inferContentTypeFromUrl covering images, audio, case insensitivity, query parameters, fragments, unknown extensions, and relative paths.