### PR TITLE
🐛 fix: when the document filetype is agent/plan, not show the saveinto docs button

### DIFF
--- a/src/features/Portal/Document/Header.tsx
+++ b/src/features/Portal/Document/Header.tsx
@@ -61,15 +61,17 @@ const Header = () => {
       </Flexbox>
       <Flexbox align={'center'} gap={8} horizontal>
         <AutoSaveHint />
-        <Button
-          icon={<ExternalLink size={14} />}
-          loading={loading}
-          onClick={handleOpenInPageEditor}
-          size={'small'}
-          type={'text'}
-        >
-          {t('openInPageEditor')}
-        </Button>
+        {document.fileType !== 'agent/plan' && (
+          <Button
+            icon={<ExternalLink size={14} />}
+            loading={loading}
+            onClick={handleOpenInPageEditor}
+            size={'small'}
+            type={'text'}
+          >
+            {t('openInPageEditor')}
+          </Button>
+        )}
       </Flexbox>
     </Flexbox>
   );


### PR DESCRIPTION
…docs button

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Prevent the 'open in page editor' button from showing when the current document file type is agent/plan.