### PR TITLE
🐛 fix(electron): correct next config codemod pattern matching

### DIFF
--- a/scripts/electronWorkflow/modifiers/nextConfig.mts
+++ b/scripts/electronWorkflow/modifiers/nextConfig.mts
@@ -40,13 +40,19 @@ export const modifyNextConfig = async (TEMP_DIR: string) => {
       }
 
       // 1. Remove redirects
-      const redirectsPair = nextConfigDecl.find({
-        rule: {
-          pattern: 'redirects: $A',
-        },
-      });
-      if (redirectsPair) {
-        const range = redirectsPair.range();
+      const redirectsPair = nextConfigDecl
+        .findAll({
+          rule: {
+            kind: 'pair',
+          },
+        })
+        .find((node) => {
+          const text = node.text();
+          return text.startsWith('redirects:') || text.startsWith('redirects :');
+        });
+      invariant(redirectsPair, '[modifyNextConfig] redirects pair not found');
+      {
+        const range = redirectsPair!.range();
         edits.push({ end: range.end.index, start: range.start.index, text: '' });
       }
 
@@ -61,18 +67,39 @@ export const modifyNextConfig = async (TEMP_DIR: string) => {
           const text = node.text();
           return text.startsWith('async headers') || text.startsWith('headers');
         });
-      if (headersMethod) {
-        const range = headersMethod.range();
+      invariant(headersMethod, '[modifyNextConfig] headers method not found');
+      {
+        const range = headersMethod!.range();
         edits.push({ end: range.end.index, start: range.start.index, text: '' });
       }
 
-      // 3. Remove spread element
+      // 3. Remove webVitalsAttribution
+      const webVitalsPair = nextConfigDecl
+        .findAll({
+          rule: {
+            kind: 'pair',
+          },
+        })
+        .find((node) => {
+          const text = node.text();
+          return (
+            text.startsWith('webVitalsAttribution:') || text.startsWith('webVitalsAttribution :')
+          );
+        });
+      invariant(webVitalsPair, '[modifyNextConfig] webVitalsAttribution pair not found');
+      {
+        const range = webVitalsPair!.range();
+        edits.push({ end: range.end.index, start: range.start.index, text: '' });
+      }
+
+      // 4. Remove spread element
       const spreads = nextConfigDecl.findAll({
         rule: {
           kind: 'spread_element',
         },
       });
 
+      // eslint-disable-next-line unicorn/consistent-function-scoping
       const isObjectLevelSpread = (node: any) => node.parent()?.kind() === 'object';
 
       const standaloneSpread = spreads.find((node) => {
@@ -84,12 +111,13 @@ export const modifyNextConfig = async (TEMP_DIR: string) => {
       const objectLevelSpread = standaloneSpread ? null : spreads.find(isObjectLevelSpread);
 
       const spreadToRemove = standaloneSpread || objectLevelSpread;
-      if (spreadToRemove) {
-        const range = spreadToRemove.range();
+      invariant(spreadToRemove, '[modifyNextConfig] spread element not found');
+      {
+        const range = spreadToRemove!.range();
         edits.push({ end: range.end.index, start: range.start.index, text: '' });
       }
 
-      // 4. Inject/force output: 'export'
+      // 5. Inject/force output: 'export'
       const outputPair = nextConfigDecl.find({
         rule: {
           pattern: 'output: $A',


### PR DESCRIPTION
## Summary

Fixes the electron next config codemod to correctly handle pattern matching for redirects, headers, and webVitalsAttribution removal.

### Changes

- Use `findAll` with `kind: 'pair'` instead of `find` with pattern for redirects
- Add `webVitalsAttribution` removal logic
- Improve pattern matching to handle spacing variations (e.g., `redirects:` vs `redirects :`)
- Add `invariant` checks for better error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Next.js Electron workflow config codemod to reliably remove specific configuration entries and enforce required structure.

Bug Fixes:
- Correct pattern matching for locating and removing the redirects configuration entry in next.config.
- Ensure headers removal works reliably by asserting the presence of the headers method before editing.
- Guarantee removal of spread elements by asserting their presence before mutation to avoid silent failures.

Enhancements:
- Add support for removing the webVitalsAttribution configuration entry from next.config.
- Improve robustness of pattern matching by tolerating spacing variations in configuration pairs.
- Introduce invariant checks to fail fast when expected config structures (redirects, headers, webVitalsAttribution, spreads) are not found.