### PR TITLE
🐛 fix(stream): update event handling to use 'text' instead of 'content_part' in gemini 2.5 models

### DIFF
--- a/packages/model-runtime/src/core/streams/google/index.ts
+++ b/packages/model-runtime/src/core/streams/google/index.ts
@@ -120,7 +120,6 @@ const transformGoogleGenerativeAIStream = (
     const hasReasoningParts = parts.some((p: any) => p.thought === true);
     const hasImageParts = parts.some((p: any) => p.inlineData);
     const hasThoughtSignature = parts.some((p: any) => p.thoughtSignature);
-    const hasThoughtsInMetadata = (usageMetadata as any)?.thoughtsTokenCount > 0;
 
     // Check model version to determine if new format should be used
     const modelVersion = (chunk as any).modelVersion || '';
@@ -144,8 +143,7 @@ const transformGoogleGenerativeAIStream = (
     // 1. There are reasoning parts in current chunk (thought: true)
     // 2. There are multiple parts with images (multimodal content)
     // 3. There are thoughtSignature in parts (reasoning metadata attached to content)
-    // 4. There is thoughtsTokenCount in metadata (indicates response contains reasoning)
-    // 5. This is Gemini 3 model with image generation (always use new format for consistency)
+    // 4. This is Gemini 3 model with image generation (always use new format for consistency)
     // BUT NOT for:
     // - The legacy single-image scenario
     // - Grounding metadata scenario (uses legacy text + grounding events)
@@ -153,7 +151,6 @@ const transformGoogleGenerativeAIStream = (
       (hasReasoningParts ||
         (hasImageParts && parts.length > 1) ||
         hasThoughtSignature ||
-        hasThoughtsInMetadata ||
         isGemini3Model) &&
       !isSingleImageWithFinish &&
       !hasGroundingMetadata;


### PR DESCRIPTION
…

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

对于非 Gemini 3 的启用思考的 Gemini 模型，会出现丢失末尾块消息的问题。本 pr 进行简单修复。

<img width="1687" height="465" alt="image" src="https://github.com/user-attachments/assets/bd7198a3-a466-4d88-a025-e50d9d569626" />


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align GoogleGenerativeAI streaming events with Gemini 2.5 models by using simple text events instead of content_part for non-multimodal responses and tightening the conditions for enabling multimodal/reasoning output.

Bug Fixes:
- Prevent loss of trailing chunks for reasoning-enabled Gemini 2.5 responses by emitting standard text events instead of content_part when no multimodal or explicit reasoning parts are present.

Enhancements:
- Refine multimodal/reasoning detection logic to ignore thoughtsTokenCount-only metadata and rely on actual reasoning or multimodal parts and model version when selecting the new streaming format.

Tests:
- Update GoogleGenerativeAIStream tests to expect text events instead of content_part for plain text chunks and add coverage to ensure thoughtsTokenCount alone does not trigger multimodal processing.