### PR TITLE
docs: Add OAuth token exchange troubleshooting guide

### DIFF
--- a/docs/self-hosting/faq/docker-oauth-token-exchange-failure.mdx
+++ b/docs/self-hosting/faq/docker-oauth-token-exchange-failure.mdx
@@ -1,0 +1,106 @@
+---
+title: OAuth Token Exchange Fails in Docker with Reverse Proxy
+description: >-
+  Troubleshooting OAuth authentication failures when using Docker deployment with reverse proxy due to MIDDLEWARE_REWRITE_THROUGH_LOCAL setting.
+tags:
+  - Docker
+  - OAuth
+  - Authentication
+  - Reverse Proxy
+  - Troubleshooting
+  - Casdoor
+---
+
+# OAuth Token Exchange Fails in Docker with Reverse Proxy
+
+## Problem Description
+
+When deploying LobeChat using Docker behind a reverse proxy (like Nginx, Caddy, or Apache), OAuth authentication may fail during the token exchange phase. This typically manifests as:
+
+- OAuth discovery and initial redirects work correctly
+- Users can successfully authenticate with the OAuth provider (e.g., Casdoor)
+- The callback to LobeChat fails with JSON parsing errors
+- Authentication appears to work but ultimately fails silently
+
+## Root Cause
+
+Docker images for LobeChat set `MIDDLEWARE_REWRITE_THROUGH_LOCAL="1"` by default. This setting rewrites internal URLs (including OAuth token exchange endpoints) to use:
+- Protocol: `http://` instead of your public domain's protocol (`https://`)
+- Host: `127.0.0.1:3210` instead of your public domain
+
+This breaks OAuth flows when LobeChat is accessed via a reverse proxy because:
+1. The OAuth provider expects callbacks to match your configured public domain
+2. Internal rewrites cause token exchanges to use localhost URLs
+3. The mismatch between expected and actual URLs causes authentication failures
+
+## Solution
+
+Set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` in your environment configuration to disable URL rewriting and preserve your domain URLs for OAuth flows.
+
+### For Docker Compose Deployments
+
+1. Locate your `.env` file in your deployment directory
+2. Add or modify the following line:
+
+```bash
+MIDDLEWARE_REWRITE_THROUGH_LOCAL=0
+```
+
+3. Restart your Docker containers:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+### For Docker Run Deployments
+
+Add the environment variable to your docker run command:
+
+```bash
+docker run -e MIDDLEWARE_REWRITE_THROUGH_LOCAL=0 \
+  # ... other environment variables ...
+  lobehub/lobe-chat-database
+```
+
+## When This Setting is Required
+
+You should set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` when:
+
+- ✅ Deploying with Docker behind a reverse proxy
+- ✅ Using custom domains with OAuth providers
+- ✅ Using HTTPS with OAuth providers
+- ✅ Experiencing OAuth token exchange failures
+
+You can keep the default setting (`MIDDLEWARE_REWRITE_THROUGH_LOCAL=1`) when:
+
+- ❌ Running Docker without reverse proxy (direct port access)
+- ❌ Using localhost-only deployments for development
+- ❌ Not using OAuth authentication
+
+## Verification
+
+After applying the fix, verify that OAuth works by:
+
+1. **Check Environment**: Ensure `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` is set
+2. **Test Authentication**: Try logging in with your OAuth provider
+3. **Monitor Logs**: Check Docker logs for any authentication errors:
+
+```bash
+docker logs -f lobe-chat
+```
+
+4. **Verify URLs**: Confirm that OAuth callbacks use your public domain, not localhost
+
+## Related Issues
+
+- This issue affects all OAuth providers behind reverse proxy setups
+- Commonly reported with Casdoor, Auth0, Google OAuth, and GitHub OAuth
+- Similar to issues [#5876](https://github.com/lobehub/lobe-chat/issues/5876), [#7170](https://github.com/lobehub/lobe-chat/issues/7170), and [#7221](https://github.com/lobehub/lobe-chat/issues/7221)
+
+## Additional Notes
+
+- This setting only affects URL rewriting behavior in middleware
+- Setting it to `0` is safe and recommended for reverse proxy deployments
+- The default `1` value is intended for containerized environments without external proxy
+- No data loss occurs when changing this setting

--- a/docs/self-hosting/faq/docker-oauth-token-exchange-failure.zh-CN.mdx
+++ b/docs/self-hosting/faq/docker-oauth-token-exchange-failure.zh-CN.mdx
@@ -1,0 +1,106 @@
+---
+title: Docker 反向代理下 OAuth 令牌交换失败
+description: >-
+  解决在使用 Docker 部署并配置反向代理时，由于 MIDDLEWARE_REWRITE_THROUGH_LOCAL 设置导致的 OAuth 认证失败问题。
+tags:
+  - Docker
+  - OAuth
+  - 认证
+  - 反向代理
+  - 故障排除
+  - Casdoor
+---
+
+# Docker 反向代理下 OAuth 令牌交换失败
+
+## 问题描述
+
+在反向代理（如 Nginx、Caddy 或 Apache）后面使用 Docker 部署 LobeChat 时，OAuth 认证可能在令牌交换阶段失败。这通常表现为：
+
+- OAuth 发现和初始重定向正常工作
+- 用户可以成功通过 OAuth 提供商（如 Casdoor）进行认证
+- 回调到 LobeChat 时出现 JSON 解析错误
+- 认证看似正常但最终静默失败
+
+## 根本原因
+
+LobeChat 的 Docker 镜像默认设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL="1"`。此设置会重写内部 URL（包括 OAuth 令牌交换端点）为：
+- 协议：`http://` 而不是您公共域名的协议（`https://`）
+- 主机：`127.0.0.1:3210` 而不是您的公共域名
+
+当通过反向代理访问 LobeChat 时，这会破坏 OAuth 流程，因为：
+1. OAuth 提供商期望回调匹配您配置的公共域名
+2. 内部重写导致令牌交换使用 localhost URL
+3. 期望 URL 和实际 URL 之间的不匹配导致认证失败
+
+## 解决方案
+
+在您的环境配置中设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` 以禁用 URL 重写并为 OAuth 流程保留您的域名 URL。
+
+### Docker Compose 部署
+
+1. 找到部署目录中的 `.env` 文件
+2. 添加或修改以下行：
+
+```bash
+MIDDLEWARE_REWRITE_THROUGH_LOCAL=0
+```
+
+3. 重启 Docker 容器：
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+### Docker Run 部署
+
+在 docker run 命令中添加环境变量：
+
+```bash
+docker run -e MIDDLEWARE_REWRITE_THROUGH_LOCAL=0 \
+  # ... 其他环境变量 ...
+  lobehub/lobe-chat-database
+```
+
+## 何时需要此设置
+
+在以下情况下应该设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0`：
+
+- ✅ 在反向代理后面使用 Docker 部署
+- ✅ 与 OAuth 提供商使用自定义域名
+- ✅ 与 OAuth 提供商使用 HTTPS
+- ✅ 遇到 OAuth 令牌交换失败
+
+在以下情况下可以保持默认设置（`MIDDLEWARE_REWRITE_THROUGH_LOCAL=1`）：
+
+- ❌ 不使用反向代理运行 Docker（直接端口访问）
+- ❌ 仅用于开发的 localhost 部署
+- ❌ 不使用 OAuth 认证
+
+## 验证
+
+应用修复后，通过以下方式验证 OAuth 是否正常工作：
+
+1. **检查环境**：确保已设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0`
+2. **测试认证**：尝试使用您的 OAuth 提供商登录
+3. **监控日志**：检查 Docker 日志是否有认证错误：
+
+```bash
+docker logs -f lobe-chat
+```
+
+4. **验证 URL**：确认 OAuth 回调使用您的公共域名，而不是 localhost
+
+## 相关问题
+
+- 此问题影响反向代理设置下的所有 OAuth 提供商
+- 经常在 Casdoor、Auth0、Google OAuth 和 GitHub OAuth 中报告
+- 类似于问题 [#5876](https://github.com/lobehub/lobe-chat/issues/5876)、[#7170](https://github.com/lobehub/lobe-chat/issues/7170) 和 [#7221](https://github.com/lobehub/lobe-chat/issues/7221)
+
+## 附加说明
+
+- 此设置仅影响中间件中的 URL 重写行为
+- 将其设置为 `0` 是安全的，建议用于反向代理部署
+- 默认值 `1` 适用于没有外部代理的容器化环境
+- 更改此设置不会造成数据丢失

--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -440,6 +440,14 @@ Solutions:
 
 - A straightforward troubleshooting method is to use the `curl` command in the LobeChat container terminal to access your authentication service at `https://auth.example.com/.well-known/openid-configuration`. If JSON format data is returned, it indicates your authentication service is functioning correctly.
 
+#### OAuth Token Exchange Failures with Reverse Proxy
+
+If OAuth authentication fails during the token exchange phase when using Docker behind a reverse proxy, this is typically caused by the default `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` setting which rewrites URLs to `127.0.0.1:3210`.
+
+**Quick Fix**: Set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` in your `.env` file and restart Docker containers.
+
+For detailed troubleshooting steps, see: [OAuth Token Exchange Fails in Docker with Reverse Proxy](/docs/self-hosting/faq/docker-oauth-token-exchange-failure)
+
 ````markdown
 ## Extended Configuration
 

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -421,6 +421,14 @@ lobe-chat      | [auth][error] TypeError: fetch failed
 
 - 一个直接的排查方式，你可以在 LobeChat 容器的终端中，使用 `curl` 命令访问你的鉴权服务 `https://auth.example.com/.well-known/openid-configuration`，如果返回了 JSON 格式的数据，则说明你的鉴权服务正常运行。
 
+#### 反向代理下 OAuth 令牌交换失败
+
+如果在反向代理后使用 Docker 时 OAuth 认证在令牌交换阶段失败，这通常是由默认的 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` 设置引起的，该设置会将 URL 重写为 `127.0.0.1:3210`。
+
+**快速修复**: 在 `.env` 文件中设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` 并重启 Docker 容器。
+
+详细的故障排除步骤，请参考：[Docker 反向代理下 OAuth 令牌交换失败](/docs/self-hosting/faq/docker-oauth-token-exchange-failure)
+
 ## 拓展配置
 
 为了完善你的 LobeChat 服务，你可以根据你的需求进行以下拓展配置。


### PR DESCRIPTION
Adds comprehensive documentation for OAuth authentication failures when using Docker deployment behind reverse proxy.

The issue occurs when MIDDLEWARE_REWRITE_THROUGH_LOCAL=1 (default) rewrites OAuth token exchange URLs to localhost, breaking authentication flow.

Fixes #10166

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Document troubleshooting for OAuth token exchange failures in Docker deployments behind a reverse proxy caused by the MIDDLEWARE_REWRITE_THROUGH_LOCAL setting.

Documentation:
- Add English and Chinese FAQ pages describing symptoms, root cause, and resolution for OAuth token exchange failures in Docker when using a reverse proxy and the MIDDLEWARE_REWRITE_THROUGH_LOCAL setting.
- Link Docker Compose deployment docs (English and Chinese) to the new OAuth token exchange troubleshooting guide and highlight the recommended environment variable change.