### PR TITLE
📝 docs(self-hosting): add OAuth token exchange troubleshooting for Docker reverse proxy

### DIFF
--- a/docs/self-hosting/server-database/docker-compose.mdx
+++ b/docs/self-hosting/server-database/docker-compose.mdx
@@ -440,6 +440,17 @@ Solutions:
 
 - A straightforward troubleshooting method is to use the `curl` command in the LobeChat container terminal to access your authentication service at `https://auth.example.com/.well-known/openid-configuration`. If JSON format data is returned, it indicates your authentication service is functioning correctly.
 
+#### OAuth Token Exchange Failures with Reverse Proxy
+
+If OAuth authentication fails during the token exchange phase when using Docker behind a reverse proxy, this is typically caused by the default `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` setting which rewrites URLs to `127.0.0.1:3210`.
+
+**Solution**: Set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` in your `.env` file and restart Docker containers:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
 ````markdown
 ## Extended Configuration
 

--- a/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/server-database/docker-compose.zh-CN.mdx
@@ -421,6 +421,17 @@ lobe-chat      | [auth][error] TypeError: fetch failed
 
 - 一个直接的排查方式，你可以在 LobeChat 容器的终端中，使用 `curl` 命令访问你的鉴权服务 `https://auth.example.com/.well-known/openid-configuration`，如果返回了 JSON 格式的数据，则说明你的鉴权服务正常运行。
 
+#### 反向代理下 OAuth 令牌交换失败
+
+如果在反向代理后使用 Docker 时 OAuth 认证在令牌交换阶段失败，这通常是由默认的 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` 设置引起的，该设置会将 URL 重写为 `127.0.0.1:3210`。
+
+**解决方案**: 在 `.env` 文件中设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` 并重启 Docker 容器：
+
+```bash
+docker compose down
+docker compose up -d
+```
+
 ## 拓展配置
 
 为了完善你的 LobeChat 服务，你可以根据你的需求进行以下拓展配置。

--- a/packages/model-bank/src/aiModels/lobehub.ts
+++ b/packages/model-bank/src/aiModels/lobehub.ts
@@ -862,6 +862,34 @@ const lobehubChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Our newest and strongest flagship model, excelling in NLP, math, and reasoning—an ideal all-rounder.',
+    displayName: 'Grok 4',
+    enabled: true,
+    id: 'grok-4',
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-07-09',
+    settings: {
+      // reasoning_effort is not supported by grok-4. Specifying reasoning_effort parameter will get an error response.
+      // extendParams: ['reasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       imageOutput: true,
       vision: true,
     },


### PR DESCRIPTION
Add troubleshooting section for OAuth authentication failures when using Docker deployment behind reverse proxy. The issue occurs when MIDDLEWARE_REWRITE_THROUGH_LOCAL=1 (default) rewrites OAuth token exchange URLs to localhost.

Fixes #10166

## Summary

- Add OAuth token exchange troubleshooting section to Docker Compose deployment docs (English and Chinese)
- Explain the root cause: `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` rewrites URLs to `127.0.0.1:3210`
- Provide solution: set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` and restart containers

## Test plan

- [ ] Verify documentation renders correctly on the docs site

## Summary by Sourcery

Document troubleshooting steps for OAuth token exchange failures when running the Docker Compose deployment behind a reverse proxy.

Documentation:
- Add English documentation explaining OAuth token exchange failures with reverse proxies and how to resolve them by adjusting MIDDLEWARE_REWRITE_THROUGH_LOCAL.
- Add equivalent Chinese documentation for OAuth token exchange troubleshooting in Docker reverse proxy setups.