### PR TITLE
✨ feat: update the sandbox export files & save files way

### DIFF
--- a/packages/builtin-tool-cloud-sandbox/src/types.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/types.ts
@@ -90,10 +90,10 @@ export interface GlobFilesState {
 }
 
 export interface ExportFileState {
-  /** File content for text files (only when mimeType is text-like and size <= 1MB) */
-  content?: string;
-  /** The download URL for the exported file */
+  /** The download URL for the exported file (permanent /f/:id URL) */
   downloadUrl: string;
+  /** The file ID in database (returned from server) */
+  fileId?: string;
   /** The exported file name */
   filename: string;
   /** The MIME type of the file */

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -149,7 +149,7 @@ export class DiscoverService {
     apiParams: Record<string, any>;
     identifier: string;
     toolName: string;
-    userAccessToken: string;
+    userAccessToken?: string;
   }) {
     log('callCloudMcpEndpoint: params=%O', {
       apiParams: params.apiParams,
@@ -159,7 +159,14 @@ export class DiscoverService {
     });
 
     try {
-      // Call cloud gateway with user access token in Authorization header
+      // Build headers - only include Authorization if userAccessToken is provided
+      // When userAccessToken is not provided, MarketSDK will use trustedClientToken for authentication
+      const headers: Record<string, string> = {};
+      if (params.userAccessToken) {
+        headers.Authorization = `Bearer ${params.userAccessToken}`;
+      }
+
+      // Call cloud gateway with optional user access token in Authorization header
       const result = await this.market.plugins.callCloudGateway(
         {
           apiParams: params.apiParams,
@@ -167,9 +174,7 @@ export class DiscoverService {
           toolName: params.toolName,
         },
         {
-          headers: {
-            Authorization: `Bearer ${params.userAccessToken}`,
-          },
+          headers,
         },
       );
 

--- a/src/services/codeInterpreter.ts
+++ b/src/services/codeInterpreter.ts
@@ -2,10 +2,8 @@ import { toolsClient } from '@/libs/trpc/client';
 import type {
   CallCodeInterpreterToolInput,
   CallToolResult,
-  GetExportFileUploadUrlInput,
-  GetExportFileUploadUrlResult,
-  SaveExportedFileContentInput,
-  SaveExportedFileContentResult,
+  ExportAndUploadFileInput,
+  ExportAndUploadFileResult,
 } from '@/server/routers/tools/market';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/slices/settings/selectors/settings';
@@ -44,31 +42,25 @@ class CodeInterpreterService {
   }
 
   /**
-   * Get a pre-signed upload URL for exporting a file from the sandbox
+   * Export a file from sandbox and upload to S3, then create a persistent file record
+   * This is a single call that combines: getUploadUrl + callTool(exportFile) + createFileRecord
+   * Returns a permanent /f/:id URL instead of a temporary pre-signed URL
+   * @param path - The file path in the sandbox
    * @param filename - The name of the file to export
    * @param topicId - The topic ID for organizing files
    */
-  async getExportFileUploadUrl(
+  async exportAndUploadFile(
+    path: string,
     filename: string,
     topicId: string,
-  ): Promise<GetExportFileUploadUrlResult> {
-    const input: GetExportFileUploadUrlInput = {
+  ): Promise<ExportAndUploadFileResult> {
+    const input: ExportAndUploadFileInput = {
       filename,
+      path,
       topicId,
     };
 
-    return toolsClient.market.getExportFileUploadUrl.mutate(input);
-  }
-
-  /**
-   * Save exported file content to documents table
-   * This creates a document record linked to the file for content retrieval
-   * @param params - File content and metadata
-   */
-  async saveExportedFileContent(
-    params: SaveExportedFileContentInput,
-  ): Promise<SaveExportedFileContentResult> {
-    return toolsClient.market.saveExportedFileContent.mutate(params);
+    return toolsClient.market.exportAndUploadFile.mutate(input);
   }
 }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Combine sandbox file export, upload, and file record creation into a single server-driven operation and update authentication to support trusted client flows.

New Features:
- Add a unified exportAndUploadFile API that exports sandbox files to S3 and creates persistent file records, returning permanent file URLs and metadata.

Enhancements:
- Refactor cloud sandbox export flow to remove client-side file creation and document saving logic, delegating these responsibilities to the server.
- Extend cloud MCP endpoint and gateway calls to optionally use trusted client authentication instead of always requiring a user access token.
- Update cloud sandbox execution runtime and plugin handling to rely on the new exportAndUploadFile workflow and to associate existing file records with assistant messages.
- Improve file key sharding strategy using date-based prefixes for better privacy and organization.
- Populate the cloud sandbox execution runtime with the real user identifier from the user store instead of a placeholder.