### PR TITLE
🐛 fix: restore getBounds mock in Browser test beforeEach

### DIFF
--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -133,6 +133,7 @@ describe('Browser', () => {
     vi.useFakeTimers();
 
     // Reset mock behaviors
+    mockBrowserWindow.getBounds.mockReturnValue({ height: 600, width: 800, x: 0, y: 0 });
     mockBrowserWindow.isDestroyed.mockReturnValue(false);
     mockBrowserWindow.isVisible.mockReturnValue(true);
     mockBrowserWindow.isFocused.mockReturnValue(true);


### PR DESCRIPTION
## Summary

Fix failing close event handling tests in Browser.test.ts by restoring the `getBounds` mock return value in `beforeEach` after `vi.clearAllMocks()`.

## Problem

The tests were failing because `vi.clearAllMocks()` was clearing all mock return values, including the `getBounds` mock that was set during hoisting. This caused `getBounds()` to return `undefined` for the `x` and `y` properties when the close handler saved the window state, leading to test failures.

```diff
- x: 0,
- y: 0,
+ x: undefined,
+ y: undefined,
```

## Solution

Added `mockBrowserWindow.getBounds.mockReturnValue({ height: 600, width: 800, x: 0, y: 0 })` in the `beforeEach` hook to reset the mock return value after `vi.clearAllMocks()`.

## Test Results

✅ All 40 tests in Browser.test.ts now pass
✅ Type check passes

## Test plan

- [x] Run tests: `bunx vitest run --silent='passed-only' 'src/main/core/browser/__tests__/Browser.test.ts'`
- [x] Run type check: `bun run type-check`

## Summary by Sourcery

Restore Browser window bounds mock configuration in tests to ensure close event handling uses defined coordinates after clearing mocks.

Bug Fixes:
- Fix Browser close event handling tests by re-establishing the getBounds mock return value in the beforeEach hook after vi.clearAllMocks().

Tests:
- Reconfigure test setup to reset mockBrowserWindow.getBounds to a fixed bounds object before each Browser test.