### PR TITLE
👷 ci: group internal package tests to reduce job count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ permissions:
   actions: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Check for duplicate runs
   pre_job:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
           do_not_skip: '["workflow_dispatch", "schedule"]'
 
   # Package tests - all packages in single job to save runner resources
-  test-internal-packages:
+  test-packages:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
-    name: Test Internal Packages
+    name: Test Packages
     env:
       PACKAGES: "@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/python-interpreter @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory model-bank"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,32 +16,18 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          concurrent_skipping: 'same_content_newer'
-          skip_after_successful_duplicate: 'true'
+          concurrent_skipping: "same_content_newer"
+          skip_after_successful_duplicate: "true"
           do_not_skip: '["workflow_dispatch", "schedule"]'
 
-  # Package tests - using each package's own test script
-  test-intenral-packages:
+  # Package tests - all packages in single job to save runner resources
+  test-internal-packages:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package:
-          - file-loaders
-          - prompts
-          - model-runtime
-          - web-crawler
-          - electron-server-ipc
-          - utils
-          - python-interpreter
-          - context-engine
-          - agent-runtime
-          - conversation-flow
-          - ssrf-safe-fetch
-          - memory-user-memory
-
-    name: Test package ${{ matrix.package }}
+    name: Test Internal Packages
+    env:
+      PACKAGES: "@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/python-interpreter @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory model-bank"
 
     steps:
       - uses: actions/checkout@v6
@@ -60,52 +46,27 @@ jobs:
       - name: Install deps
         run: bun i
 
-      - name: Test ${{ matrix.package }} package with coverage
-        run: bun run --filter @lobechat/${{ matrix.package }} test:coverage
+      - name: Test packages with coverage
+        run: |
+          for package in $PACKAGES; do
+            echo "::group::Testing $package"
+            bun run --filter $package test:coverage
+            echo "::endgroup::"
+          done
 
-      - name: Upload ${{ matrix.package }} coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./packages/${{ matrix.package }}/coverage/lcov.info
-          flags: packages/${{ matrix.package }}
-
-  test-packages:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [model-bank]
-
-    name: Test package ${{ matrix.package }}
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.11.1
-          package-manager-cache: false
-
-      - name: Install bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install deps
-        run: bun i
-
-      - name: Test ${{ matrix.package }} package with coverage
-        run: bun run --filter ${{ matrix.package }} test:coverage
-
-      - name: Upload ${{ matrix.package }} coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./packages/${{ matrix.package }}/coverage/lcov.info
-          flags: packages/${{ matrix.package }}
+      - name: Upload coverage to Codecov
+        if: always()
+        run: |
+          for package in $PACKAGES; do
+            # Extract directory name: @lobechat/file-loaders -> file-loaders, model-bank -> model-bank
+            dir="${package#@lobechat/}"
+            if [ -f "./packages/$dir/coverage/lcov.info" ]; then
+              echo "Uploading coverage for $package..."
+              npx codecov --token=${{ secrets.CODECOV_TOKEN }} \
+                --file=./packages/$dir/coverage/lcov.info \
+                --flags=packages/$dir
+            fi
+          done
 
   # App tests
   test-website:
@@ -198,7 +159,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s  --health-retries 5
-
 
         ports:
           - 5432:5432


### PR DESCRIPTION
#### 💻 Change Type

- [x] 👷 build

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Optimize CI workflow by consolidating all package tests into a single job:

- Merge 13 package test jobs into 1 job (12 internal packages + model-bank)
- Fix typo: `test-intenral-packages` → `test-internal-packages`
- Remove redundant `test-packages` job
- Keep per-package coverage flags for Codecov reporting

**Before:** 13 parallel jobs (12 internal + 1 model-bank), each installing deps separately (~1.5min × 13)
**After:** 1 serial job, deps installed once (~1.5min + ~9min tests = ~10.5min total)

#### 🧪 How to Test

- [x] No tests needed

CI workflow change - will be validated when the PR runs.

#### 📸 Screenshots / Videos

N/A - CI configuration change

#### 📝 Additional Information

This change reduces GitHub Actions runner consumption from 13 parallel runners to 1 runner.