### PR TITLE
🐛 fix: resolve ChatMessageError type mismatch in error handler

### DIFF
--- a/src/business/client/hooks/useRenderBusinessChatErrorMessageExtra.tsx
+++ b/src/business/client/hooks/useRenderBusinessChatErrorMessageExtra.tsx
@@ -1,0 +1,10 @@
+import { type ChatMessageError } from '@lobechat/types';
+
+export default function useRenderBusinessChatErrorMessageExtra(
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  error: ChatMessageError | null | undefined,
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  messageId: string,
+) {
+  return null;
+}

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -1,3 +1,4 @@
+import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { AgentRuntimeErrorType, type ILobeAgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { ChatErrorType, type ChatMessageError, type ErrorType } from '@lobechat/types';
 import { type IPluginErrorType } from '@lobehub/chat-plugin-sdk';
@@ -6,6 +7,7 @@ import dynamic from 'next/dynamic';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import useRenderBusinessChatErrorMessageExtra from '@/business/client/hooks/useRenderBusinessChatErrorMessageExtra';
 import ErrorContent from '@/features/Conversation/ChatItem/components/ErrorContent';
 import { useProviderName } from '@/hooks/useProviderName';
 
@@ -103,7 +105,11 @@ interface ErrorExtraProps {
 }
 
 const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) => {
-  const error = data.error as ChatMessageError;
+  const error = data.error;
+  const businessChatErrorMessageExtra = useRenderBusinessChatErrorMessageExtra(error, data.id);
+  if (ENABLE_BUSINESS_FEATURES && businessChatErrorMessageExtra)
+    return businessChatErrorMessageExtra;
+
   if (!error?.type) return;
 
   switch (error.type) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Fix type mismatch error in `ErrorMessageExtra` component:

- Add `useRenderBusinessChatErrorMessageExtra` hook using `ChatMessageError` type from `@lobechat/types` (includes `IPluginErrorType`)
- The previous type from `@lobechat/model-runtime` was missing `IPluginErrorType`, causing TS error: `Type '"PluginMarketIndexNotFound"' is not assignable to type 'ErrorType | ILobeAgentRuntimeErrorType'`

#### 🧪 How to Test

- [x] No tests needed

Type-only fix, verified with `bun run type-check`.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A

## Summary by Sourcery

Adjust error handling for conversation error messages and introduce a business-specific hook for rendering extra error content.

Bug Fixes:
- Resolve type mismatch in conversation error handling by using the correct ChatMessageError type for business-related errors.

Enhancements:
- Add a business chat hook stub to optionally render additional error message content without affecting existing behavior.