### PR TITLE
👷 ci: rename pre_job to check-duplicate-run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   # Check for duplicate runs
-  pre_job:
+  check-duplicate-run:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -26,8 +26,8 @@ jobs:
 
   # Package tests - all packages in single job to save runner resources
   test-packages:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: check-duplicate-run
+    if: needs.check-duplicate-run.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     name: Test Packages
     env:
@@ -74,8 +74,8 @@ jobs:
 
   # App tests
   test-website:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: check-duplicate-run
+    if: needs.check-duplicate-run.outputs.should_skip != 'true'
     name: Test Website
 
     runs-on: ubuntu-latest
@@ -108,8 +108,8 @@ jobs:
           flags: app
 
   test-desktop:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: check-duplicate-run
+    if: needs.check-duplicate-run.outputs.should_skip != 'true'
     name: Test Desktop App
 
     runs-on: ubuntu-latest
@@ -150,8 +150,8 @@ jobs:
           flags: desktop
 
   test-databsae:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: check-duplicate-run
+    if: needs.check-duplicate-run.outputs.should_skip != 'true'
     name: Test Database
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,14 +62,17 @@ jobs:
       - name: Upload coverage to Codecov
         if: always()
         run: |
+          curl -Os https://cli.codecov.io/latest/linux/codecov
+          chmod +x codecov
           for package in $PACKAGES; do
-            # Extract directory name: @lobechat/file-loaders -> file-loaders, model-bank -> model-bank
             dir="${package#@lobechat/}"
             if [ -f "./packages/$dir/coverage/lcov.info" ]; then
-              echo "Uploading coverage for $package..."
-              npx codecov --token=${{ secrets.CODECOV_TOKEN }} \
-                --file=./packages/$dir/coverage/lcov.info \
-                --flags=packages/$dir
+              echo "Uploading coverage for $dir..."
+              ./codecov upload-process \
+                -t ${{ secrets.CODECOV_TOKEN }} \
+                -f ./packages/$dir/coverage/lcov.info \
+                -F packages/$dir \
+                --disable-search
             fi
           done
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   # Check for duplicate runs
   check-duplicate-run:
+    name: Check Duplicate Run
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/src/business/client/hooks/useRenderBusinessChatErrorMessageExtra.tsx
+++ b/src/business/client/hooks/useRenderBusinessChatErrorMessageExtra.tsx
@@ -1,0 +1,10 @@
+import { type ChatMessageError } from '@lobechat/types';
+
+export default function useRenderBusinessChatErrorMessageExtra(
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  error: ChatMessageError | null | undefined,
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  messageId: string,
+) {
+  return null;
+}

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -1,3 +1,4 @@
+import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { AgentRuntimeErrorType, type ILobeAgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { ChatErrorType, type ChatMessageError, type ErrorType } from '@lobechat/types';
 import { type IPluginErrorType } from '@lobehub/chat-plugin-sdk';
@@ -6,6 +7,7 @@ import dynamic from 'next/dynamic';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import useRenderBusinessChatErrorMessageExtra from '@/business/client/hooks/useRenderBusinessChatErrorMessageExtra';
 import ErrorContent from '@/features/Conversation/ChatItem/components/ErrorContent';
 import { useProviderName } from '@/hooks/useProviderName';
 
@@ -103,7 +105,11 @@ interface ErrorExtraProps {
 }
 
 const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) => {
-  const error = data.error as ChatMessageError;
+  const error = data.error;
+  const businessChatErrorMessageExtra = useRenderBusinessChatErrorMessageExtra(error, data.id);
+  if (ENABLE_BUSINESS_FEATURES && businessChatErrorMessageExtra)
+    return businessChatErrorMessageExtra;
+
   if (!error?.type) return;
 
   switch (error.type) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 👷 build

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Rename `pre_job` to `check-duplicate-run` for better readability.

#### 🧪 How to Test

- [x] No tests needed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A

## Summary by Sourcery

Build:
- Rename the GitHub Actions job from `pre_job` to `check-duplicate-run` and adjust job dependencies and conditions accordingly in the test workflow.