### PR TITLE
🐛 fix: allow zero-byte files and add business hooks for error handling

### DIFF
--- a/src/business/client/hooks/useBusinessErrorAlertConfig.ts
+++ b/src/business/client/hooks/useBusinessErrorAlertConfig.ts
@@ -1,10 +1,6 @@
 import type { ErrorType } from '@lobechat/types';
 import type { AlertProps } from '@lobehub/ui';
 
-/**
- * Business hook to extend error alert config for subscription-related errors.
- * Override this in cloud repo to customize alert appearance.
- */
 export default function useBusinessErrorAlertConfig(
   // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
   errorType?: ErrorType,

--- a/src/business/client/hooks/useBusinessErrorAlertConfig.ts
+++ b/src/business/client/hooks/useBusinessErrorAlertConfig.ts
@@ -1,0 +1,13 @@
+import type { ErrorType } from '@lobechat/types';
+import type { AlertProps } from '@lobehub/ui';
+
+/**
+ * Business hook to extend error alert config for subscription-related errors.
+ * Override this in cloud repo to customize alert appearance.
+ */
+export default function useBusinessErrorAlertConfig(
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  errorType?: ErrorType,
+): AlertProps | undefined {
+  return undefined;
+}

--- a/src/business/client/hooks/useBusinessErrorContent.ts
+++ b/src/business/client/hooks/useBusinessErrorContent.ts
@@ -1,22 +1,10 @@
 import type { ErrorType } from '@lobechat/types';
 
 export interface BusinessErrorContentResult {
-  /**
-   * Modified error type for i18n key lookup.
-   * Return undefined to use the original error type.
-   */
   errorType?: string;
-  /**
-   * Whether to hide the error message.
-   * Useful when subscription status changes and error is no longer relevant.
-   */
   hideMessage?: boolean;
 }
 
-/**
- * Business hook to customize error content based on subscription status.
- * Override this in cloud repo to implement subscription-aware error messages.
- */
 export default function useBusinessErrorContent(
   // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
   errorType?: ErrorType | string,

--- a/src/business/client/hooks/useBusinessErrorContent.ts
+++ b/src/business/client/hooks/useBusinessErrorContent.ts
@@ -1,0 +1,25 @@
+import type { ErrorType } from '@lobechat/types';
+
+export interface BusinessErrorContentResult {
+  /**
+   * Modified error type for i18n key lookup.
+   * Return undefined to use the original error type.
+   */
+  errorType?: string;
+  /**
+   * Whether to hide the error message.
+   * Useful when subscription status changes and error is no longer relevant.
+   */
+  hideMessage?: boolean;
+}
+
+/**
+ * Business hook to customize error content based on subscription status.
+ * Override this in cloud repo to implement subscription-aware error messages.
+ */
+export default function useBusinessErrorContent(
+  // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
+  errorType?: ErrorType | string,
+): BusinessErrorContentResult {
+  return {};
+}

--- a/src/business/server/lambda-routers/file.ts
+++ b/src/business/server/lambda-routers/file.ts
@@ -6,13 +6,7 @@ export interface BusinessFileUploadCheckParams {
   userId: string;
 }
 
-/**
- * Business check for file upload validation.
- * Override this in cloud repo to implement risk control for malicious uploads.
- */
 export async function businessFileUploadCheck(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   params: BusinessFileUploadCheckParams,
-): Promise<void> {
-  // no-op in open source version
-}
+): Promise<void> {}

--- a/src/business/server/lambda-routers/file.ts
+++ b/src/business/server/lambda-routers/file.ts
@@ -1,0 +1,18 @@
+export interface BusinessFileUploadCheckParams {
+  actualSize: number;
+  clientIp?: string;
+  inputSize: number;
+  url: string;
+  userId: string;
+}
+
+/**
+ * Business check for file upload validation.
+ * Override this in cloud repo to implement risk control for malicious uploads.
+ */
+export async function businessFileUploadCheck(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  params: BusinessFileUploadCheckParams,
+): Promise<void> {
+  // no-op in open source version
+}

--- a/src/server/routers/lambda/__tests__/file.test.ts
+++ b/src/server/routers/lambda/__tests__/file.test.ts
@@ -273,7 +273,7 @@ describe('fileRouter', () => {
       );
     });
 
-    it('should throw error when getFileMetadata fails and input size is less than 1', async () => {
+    it('should throw error when getFileMetadata fails and input size is negative', async () => {
       mockFileModelCheckHash.mockResolvedValue({ isExist: false });
       mockFileServiceGetFileMetadata.mockRejectedValue(new Error('File not found in S3'));
 
@@ -282,11 +282,11 @@ describe('fileRouter', () => {
           hash: 'test-hash',
           fileType: 'text',
           name: 'test.txt',
-          size: 0,
+          size: -1,
           url: 'files/non-existent.txt',
           metadata: {},
         }),
-      ).rejects.toThrow('File size must be at least 1 byte');
+      ).rejects.toThrow('File size cannot be negative');
     });
 
     it('should use input size when getFileMetadata returns contentLength less than 1', async () => {
@@ -315,10 +315,10 @@ describe('fileRouter', () => {
       );
     });
 
-    it('should throw error when both getFileMetadata contentLength and input size are less than 1', async () => {
+    it('should throw error when both getFileMetadata contentLength and input size are negative', async () => {
       mockFileModelCheckHash.mockResolvedValue({ isExist: false });
       mockFileServiceGetFileMetadata.mockResolvedValue({
-        contentLength: 0,
+        contentLength: -1,
         contentType: 'text/plain',
       });
 
@@ -327,11 +327,11 @@ describe('fileRouter', () => {
           hash: 'test-hash',
           fileType: 'text',
           name: 'test.txt',
-          size: 0,
+          size: -1,
           url: 'files/test.txt',
           metadata: {},
         }),
-      ).rejects.toThrow('File size must be at least 1 byte');
+      ).rejects.toThrow('File size cannot be negative');
     });
   });
 

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -74,8 +74,8 @@ export const fileRouter = router({
         // If metadata fetch fails, use original size from input
       }
 
-      if (actualSize < 1) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'File size must be at least 1 byte' });
+      if (actualSize < 0) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'File size cannot be negative' });
       }
 
       const { id } = await ctx.fileModel.create(

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { businessFileUploadCheck } from '@/business/server/lambda-routers/file';
 import { checkFileStorageUsage } from '@/business/server/trpc-middlewares/lambda';
 import { serverDBEnv } from '@/config/db';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
@@ -73,6 +74,14 @@ export const fileRouter = router({
       } catch {
         // If metadata fetch fails, use original size from input
       }
+
+      await businessFileUploadCheck({
+        actualSize,
+        clientIp: ctx.clientIp ?? undefined,
+        inputSize: input.size,
+        url: input.url,
+        userId: ctx.userId,
+      });
 
       if (actualSize < 0) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'File size cannot be negative' });
@@ -367,7 +376,7 @@ export const fileRouter = router({
 
     if (!file) return;
 
-    // delele the file from remove from S3 if it is not used by other files
+    // delete the file from S3 if it is not used by other files
     await ctx.fileService.deleteFile(file.url!);
   }),
 


### PR DESCRIPTION
## Summary
- Add `useBusinessErrorAlertConfig` hook for customizing error alert appearance in cloud deployments
- Add `useBusinessErrorContent` hook for subscription-aware error messages
- Integrate hooks into `Error/index.tsx` `useErrorContent` function
- Fix file upload validation to allow zero-byte files (change `< 1` to `< 0`)

## Test plan
- [ ] Verify error display works correctly in open-source version (hooks return default values)
- [ ] Verify cloud deployment can override hooks for subscription error handling
- [ ] Verify zero-byte file uploads are accepted

## Summary by Sourcery

Introduce extensible business hooks for customizing error alert configuration and content, and relax file upload validation to allow zero-byte files.

New Features:
- Add a business hook to override error alert configuration in client error handling.
- Add a business hook to customize error content, including error type mapping and message visibility.

Bug Fixes:
- Adjust file upload validation to allow zero-byte files by only rejecting negative sizes.

Enhancements:
- Wire the new business hooks into the conversation error UI so cloud deployments can override default error messaging and alert behavior.