### PR TITLE
♻️  refactor(ui): update @lobehub/ui and refactor Popover usage for z-index fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "@lobehub/icons": "^4.0.2",
     "@lobehub/market-sdk": "^0.25.1",
     "@lobehub/tts": "^4.0.2",
-    "@lobehub/ui": "^4.9.3",
+    "@lobehub/ui": "^4.11.4",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@neondatabase/serverless": "^1.0.2",
     "@next/third-parties": "^16.1.1",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "@lobehub/icons": "^4.0.2",
     "@lobehub/market-sdk": "^0.25.1",
     "@lobehub/tts": "^4.0.2",
-    "@lobehub/ui": "^4.11.4",
+    "@lobehub/ui": "^4.11.5",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@neondatabase/serverless": "^1.0.2",
     "@next/third-parties": "^16.1.1",

--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
@@ -1,41 +1,55 @@
-import { Flexbox } from '@lobehub/ui';
-import { Popover } from 'antd';
-import React, { type PropsWithChildren, Suspense, memo } from 'react';
+import { Flexbox, Popover } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { type PropsWithChildren, Suspense, memo, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import List from '@/app/[variants]/(main)/home/_layout/Body/Agent/List';
 import { AgentModalProvider } from '@/app/[variants]/(main)/home/_layout/Body/Agent/ModalProvider';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 
+const styles = createStaticStyles(({ cssVar, css }) => ({
+  trigger: css`
+    &[data-popup-open] {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+}));
+
 const SwitchPanel = memo<PropsWithChildren>(({ children }) => {
   const navigate = useNavigate();
+
+  const content = useMemo(
+    () => (
+      <Suspense fallback={<SkeletonList rows={6} />}>
+        <AgentModalProvider>
+          <Flexbox
+            gap={4}
+            padding={8}
+            style={{
+              maxHeight: '50vh',
+              overflowY: 'auto',
+            }}
+          >
+            <List onMoreClick={() => navigate('/')} />
+          </Flexbox>
+        </AgentModalProvider>
+      </Suspense>
+    ),
+    [navigate],
+  );
+
   return (
     <Popover
-      arrow={false}
-      content={
-        <Suspense fallback={<SkeletonList rows={6} />}>
-          <AgentModalProvider>
-            <Flexbox
-              gap={4}
-              padding={8}
-              style={{
-                maxHeight: '50vh',
-                overflowY: 'auto',
-              }}
-            >
-              <List onMoreClick={() => navigate('/')} />
-            </Flexbox>
-          </AgentModalProvider>
-        </Suspense>
-      }
-      placement={'bottomLeft'}
+      classNames={{ trigger: styles.trigger }}
+      content={content}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 0,
           width: 240,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       {children}
     </Popover>

--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Topic/List/Item/Editing.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Topic/List/Item/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useChatStore } from '@/store/chat';
@@ -47,7 +46,6 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -64,20 +62,19 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useChatStore } from '@/store/chat';
@@ -26,7 +25,6 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -43,20 +41,19 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/chat/features/Conversation/Header/HeaderActions/index.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/Header/HeaderActions/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { ActionIcon, Dropdown } from '@lobehub/ui';
-import type { MenuProps } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu } from '@lobehub/ui';
 import { MoreHorizontal } from 'lucide-react';
 import { memo } from 'react';
 
@@ -13,18 +12,9 @@ const HeaderActions = memo(() => {
   const { menuItems } = useMenu();
 
   return (
-    <Dropdown
-      arrow={false}
-      menu={{
-        items: menuItems as MenuProps['items'],
-        onClick: ({ domEvent }) => {
-          domEvent.stopPropagation();
-        },
-      }}
-      trigger={['click']}
-    >
+    <DropdownMenu items={menuItems}>
       <ActionIcon icon={MoreHorizontal} size={DESKTOP_HEADER_ICON_SIZE} />
-    </Dropdown>
+    </DropdownMenu>
   );
 });
 

--- a/src/app/[variants]/(main)/chat/features/Conversation/Header/WorkingDirectory/index.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/Header/WorkingDirectory/index.tsx
@@ -1,6 +1,5 @@
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
-import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { LaptopIcon, SquircleDashed } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
@@ -90,12 +89,11 @@ const WorkingDirectory = memo(() => {
   );
   return (
     <Popover
-      arrow={false}
       content={<WorkingDirectoryContent agentId={agentId} onClose={() => setOpen(false)} />}
       onOpenChange={setOpen}
       open={open}
       placement="bottomRight"
-      trigger={['click']}
+      trigger="click"
     >
       <div>
         {open ? (

--- a/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/AgentHeader.tsx
@@ -141,6 +141,7 @@ const AgentHeader = memo(() => {
         onChange={handleAvatarChange}
         onDelete={handleAvatarDelete}
         onUpload={handleAvatarUpload}
+        // @ts-expect-error - EmojiPicker popupProps type definition issue in @lobehub/ui
         popupProps={{
           placement: 'bottomLeft',
         }}

--- a/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/app/[variants]/(main)/chat/profile/features/ProfileEditor/AgentHeader.tsx
@@ -141,7 +141,6 @@ const AgentHeader = memo(() => {
         onChange={handleAvatarChange}
         onDelete={handleAvatarDelete}
         onUpload={handleAvatarUpload}
-        // @ts-expect-error - EmojiPicker popupProps type definition issue in @lobehub/ui
         popupProps={{
           placement: 'bottomLeft',
         }}

--- a/src/app/[variants]/(main)/community/(list)/model/features/List/Item.tsx
+++ b/src/app/[variants]/(main)/community/(list)/model/features/List/Item.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { ModelIcon, ProviderIcon } from '@lobehub/icons';
-import { Block, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Block, Flexbox, Icon, Popover, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { ClockIcon } from 'lucide-react';
@@ -155,7 +154,6 @@ const ModelItem = memo<DiscoverModelItem>(
               />
             </Flexbox>
             <Popover
-              arrow={false}
               content={
                 <Flexbox
                   gap={6}

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/GroupConfig/AgentProfilePopup.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/GroupConfig/AgentProfilePopup.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import type { AgentItem } from '@lobechat/types';
-import { Avatar, Center, Flexbox, Text, Tooltip } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Avatar, Center, Flexbox, Popover, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { type PropsWithChildren, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -167,15 +166,14 @@ const AgentProfilePopup = memo<AgentProfilePopupProps>(({ agent, groupId, childr
 
   return (
     <Popover
-      arrow={false}
       content={content}
       onOpenChange={setOpen}
       open={open}
       placement="right"
       styles={{
-        container: { overflow: 'hidden', padding: 0 },
+        content: { overflow: 'hidden', padding: 0 },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       {children}
     </Popover>

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
@@ -1,5 +1,4 @@
-import { Flexbox } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Flexbox, Popover } from '@lobehub/ui';
 import React, { type PropsWithChildren, Suspense, memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,7 +10,6 @@ const SwitchPanel = memo<PropsWithChildren>(({ children }) => {
   const navigate = useNavigate();
   return (
     <Popover
-      arrow={false}
       content={
         <Suspense fallback={<SkeletonList rows={6} />}>
           <AgentModalProvider>
@@ -28,14 +26,14 @@ const SwitchPanel = memo<PropsWithChildren>(({ children }) => {
           </AgentModalProvider>
         </Suspense>
       }
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 0,
           width: 240,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       {children}
     </Popover>

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/List/Item/Editing.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/List/Item/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useChatStore } from '@/store/chat';
@@ -47,7 +46,6 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -64,20 +62,19 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useChatStore } from '@/store/chat';
@@ -26,7 +25,6 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -43,20 +41,19 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentGroupItem/Editing.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentGroupItem/Editing.tsx
@@ -1,5 +1,4 @@
-import { Flexbox, Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Flexbox, Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useHomeStore } from '@/store/home';
@@ -38,7 +37,6 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Flexbox gap={4} horizontal onClick={(e) => e.stopPropagation()} style={{ width: 280 }}>
           <Input
@@ -53,19 +51,18 @@ const Editing = memo<EditingProps>(({ id, title, toggleEditing }) => {
           />
         </Flexbox>
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentItem/Editing.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentItem/Editing.tsx
@@ -1,5 +1,4 @@
-import { Avatar, Block, Flexbox, Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Avatar, Block, Flexbox, Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import EmojiPicker from '@/components/EmojiPicker';
@@ -55,7 +54,6 @@ const Editing = memo<EditingProps>(({ id, title, avatar, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Flexbox gap={4} horizontal onClick={(e) => e.stopPropagation()} style={{ width: 320 }}>
           <EmojiPicker
@@ -89,19 +87,18 @@ const Editing = memo<EditingProps>(({ id, title, avatar, toggleEditing }) => {
           />
         </Flexbox>
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/Editing.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/Group/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useHomeStore } from '@/store/home';
@@ -33,7 +32,6 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -50,20 +48,19 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/home/_layout/Body/Project/List/Editing.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Project/List/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useKnowledgeBaseStore } from '@/store/knowledgeBase';
@@ -26,7 +25,6 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -43,20 +41,19 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/image/_layout/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
+++ b/src/app/[variants]/(main)/image/_layout/ConfigPanel/components/ModelSelect/ImageModelItem.tsx
@@ -1,6 +1,5 @@
 import { ModelIcon } from '@lobehub/icons';
-import { Flexbox, Text } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Flexbox, Popover, Text } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { type AiModelForSelect } from 'model-bank';
 import numeral from 'numeral';
@@ -109,10 +108,6 @@ const ImageModelItem = memo<ImageModelItemProps>(
 
     return (
       <Popover
-        align={{
-          offset: [24, -10],
-        }}
-        arrow={false}
         classNames={{ root: cx(styles.popover, isDarkMode && styles.popover_dark) }}
         content={popoverContent}
         placement="rightTop"

--- a/src/app/[variants]/(main)/image/_layout/Topics/TopicItem.tsx
+++ b/src/app/[variants]/(main)/image/_layout/Topics/TopicItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ActionIcon, Avatar, Flexbox, Text } from '@lobehub/ui';
-import { App, Popover } from 'antd';
+import { ActionIcon, Avatar, Flexbox, Popover, Text } from '@lobehub/ui';
+import { App } from 'antd';
 import { cssVar } from 'antd-style';
 import { Trash } from 'lucide-react';
 import React, { memo } from 'react';
@@ -92,11 +92,10 @@ const TopicItem = memo<TopicItemProps>(({ topic, showMoreInfo, style }) => {
 
   return (
     <Popover
-      arrow={false}
       content={tooltipContent}
       placement={'left'}
       styles={{
-        container: {
+        content: {
           width: 200,
         },
       }}

--- a/src/app/[variants]/(main)/page/_layout/Body/List/Item/Editing.tsx
+++ b/src/app/[variants]/(main)/page/_layout/Body/List/Item/Editing.tsx
@@ -1,5 +1,4 @@
-import { Block, Flexbox, Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Block, Flexbox, Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -46,7 +45,6 @@ const Editing = memo<EditingProps>(({ documentId, title, currentEmoji, toggleEdi
 
   return (
     <Popover
-      arrow={false}
       content={
         <Flexbox gap={4} horizontal onClick={(e) => e.stopPropagation()} style={{ width: 320 }}>
           <EmojiPicker
@@ -71,6 +69,7 @@ const Editing = memo<EditingProps>(({ documentId, title, currentEmoji, toggleEdi
             defaultAvatar={'📄'}
             locale={locale}
             onChange={setNewEmoji}
+            onClick={(e) => e?.stopPropagation()}
             onDelete={() => setNewEmoji(undefined)}
             value={newEmoji}
           />
@@ -87,19 +86,18 @@ const Editing = memo<EditingProps>(({ documentId, title, currentEmoji, toggleEdi
           />
         </Flexbox>
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/app/[variants]/(main)/resource/(home)/_layout/Body/LibraryList/List/Item/Editing.tsx
+++ b/src/app/[variants]/(main)/resource/(home)/_layout/Body/LibraryList/List/Item/Editing.tsx
@@ -1,5 +1,4 @@
-import { Input } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Input, Popover } from '@lobehub/ui';
 import { memo, useCallback, useEffect, useState } from 'react';
 
 import { useKnowledgeBaseStore } from '@/store/knowledgeBase';
@@ -34,7 +33,6 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Input
           autoFocus
@@ -52,20 +50,19 @@ const Editing = memo<EditingProps>(({ id, name, toggleEditing }) => {
           }}
         />
       }
-      destroyOnHidden
       onOpenChange={(open) => {
         if (!open) handleUpdate();
         toggleEditing(open);
       }}
       open={editing}
-      placement={'bottomLeft'}
+      placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 4,
           width: 320,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <div />
     </Popover>

--- a/src/components/ManifestPreviewer/index.tsx
+++ b/src/components/ManifestPreviewer/index.tsx
@@ -1,5 +1,4 @@
-import { Highlighter } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Highlighter, Popover } from '@lobehub/ui';
 import { type ReactNode, memo } from 'react';
 
 interface PluginManifestPreviewerProps {
@@ -11,7 +10,6 @@ interface PluginManifestPreviewerProps {
 const ManifestPreviewer = memo<PluginManifestPreviewerProps>(
   ({ manifest, children, trigger = 'click' }) => (
     <Popover
-      arrow={false}
       content={
         <Highlighter
           language={'json'}
@@ -21,8 +19,7 @@ const ManifestPreviewer = memo<PluginManifestPreviewerProps>(
         </Highlighter>
       }
       placement={'right'}
-      style={{ width: 400 }}
-      title={'Manifest JSON'}
+      styles={{ content: { width: 400 } }}
       trigger={trigger}
     >
       {children}

--- a/src/components/TipGuide/index.tsx
+++ b/src/components/TipGuide/index.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Flexbox } from '@lobehub/ui';
-import { ConfigProvider, Popover, type TooltipProps } from 'antd';
+import { ActionIcon, Flexbox, Popover } from '@lobehub/ui';
+import { ConfigProvider, type TooltipProps } from 'antd';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { XIcon } from 'lucide-react';
 import { type CSSProperties, type FC, type ReactNode } from 'react';
@@ -111,11 +111,10 @@ const TipGuide: FC<TipGuideProps> = ({
             }}
           >
             <Popover
-              arrow={{ pointAtCenter: true }}
+              arrow={true}
               classNames={{
                 root: cx(className, styles.overlay),
               }}
-              color={'blue'}
               content={
                 <Flexbox gap={24} horizontal style={{ userSelect: 'none' }}>
                   <div>{title}</div>

--- a/src/features/ChatInput/ActionBar/Search/index.tsx
+++ b/src/features/ChatInput/ActionBar/Search/index.tsx
@@ -47,7 +47,7 @@ const Search = memo(() => {
         minWidth: 320,
         placement: 'topLeft',
         styles: {
-          container: {
+          content: {
             padding: 4,
           },
         },

--- a/src/features/ChatInput/ActionBar/components/Action.tsx
+++ b/src/features/ChatInput/ActionBar/components/Action.tsx
@@ -84,7 +84,11 @@ const Action = memo<ActionProps>(
         <ActionPopover
           onOpenChange={setShow}
           open={show}
-          trigger={trigger}
+          trigger={
+            Array.isArray(trigger)
+              ? (trigger.filter((t) => t !== 'contextMenu') as ('click' | 'hover')[])
+              : trigger
+          }
           {...popover}
           minWidth={mobile ? '100%' : popover.minWidth}
           placement={mobile ? 'top' : (dropdownPlacement ?? popover.placement)}

--- a/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Flexbox } from '@lobehub/ui';
-import { Popover, type PopoverProps } from 'antd';
+import { Flexbox, Popover, type PopoverProps } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { type ReactNode, memo } from 'react';
 
@@ -23,7 +22,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-export interface ActionPopoverProps extends Omit<PopoverProps, 'title' | 'content'> {
+export interface ActionPopoverProps extends Omit<PopoverProps, 'title' | 'content' | 'children'> {
+  children?: ReactNode;
   content?: ReactNode;
   extra?: ReactNode;
   loading?: boolean;
@@ -45,6 +45,7 @@ const ActionPopover = memo<ActionPopoverProps>(
     placement,
     loading,
     extra,
+    content,
     ...rest
   }) => {
     const isMobile = useIsMobile();
@@ -52,45 +53,48 @@ const ActionPopover = memo<ActionPopoverProps>(
     // Properly handle classNames (can be object or function)
     const resolvedClassNames =
       typeof customClassNames === 'function' ? customClassNames : customClassNames;
-    const containerClassName =
-      typeof resolvedClassNames === 'object' && resolvedClassNames?.container
-        ? cx(styles.popoverContent, resolvedClassNames.container)
+    const contentClassName =
+      typeof resolvedClassNames === 'object' && resolvedClassNames?.content
+        ? cx(styles.popoverContent, resolvedClassNames.content)
         : styles.popoverContent;
 
     // Properly handle styles (can be object or function)
     const resolvedStyles = typeof customStyles === 'function' ? customStyles : customStyles;
-    const containerStyle =
-      typeof resolvedStyles === 'object' && resolvedStyles?.container
-        ? resolvedStyles.container
-        : {};
+    const contentStyle =
+      typeof resolvedStyles === 'object' && resolvedStyles?.content ? resolvedStyles.content : {};
+
+    // Compose content with optional title
+    const popoverContent = (
+      <>
+        {title && (
+          <Flexbox gap={8} horizontal justify={'space-between'} style={{ marginBottom: 16 }}>
+            {title}
+            {extra}
+            {loading && <UpdateLoading style={{ color: cssVar.colorTextSecondary }} />}
+          </Flexbox>
+        )}
+        {content}
+      </>
+    );
 
     return (
       <Popover
-        arrow={false}
         classNames={{
           ...(typeof resolvedClassNames === 'object' ? resolvedClassNames : {}),
-          container: containerClassName,
+          content: contentClassName,
         }}
+        content={popoverContent}
         placement={isMobile ? 'top' : placement}
         styles={{
           ...(typeof resolvedStyles === 'object' ? resolvedStyles : {}),
-          container: {
+          content: {
             maxHeight,
             maxWidth: isMobile ? undefined : maxWidth,
             minWidth: isMobile ? undefined : minWidth,
             width: isMobile ? '100vw' : undefined,
-            ...containerStyle,
+            ...contentStyle,
           },
         }}
-        title={
-          title && (
-            <Flexbox gap={8} horizontal justify={'space-between'} style={{ marginBottom: 16 }}>
-              {title}
-              {extra}
-              {loading && <UpdateLoading style={{ color: cssVar.colorTextSecondary }} />}
-            </Flexbox>
-          )
-        }
         {...rest}
       >
         {children}

--- a/src/features/ChatMiniMap/MinimapIndicator.tsx
+++ b/src/features/ChatMiniMap/MinimapIndicator.tsx
@@ -1,5 +1,4 @@
-import { Block, Text } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Block, Popover, Text } from '@lobehub/ui';
 import { cx } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,13 +27,12 @@ export const MinimapIndicator = memo<MinimapIndicatorProps>(
 
     return (
       <Popover
-        arrow={false}
         content={popoverContent}
         key={id}
         mouseEnterDelay={0.1}
         placement={'left'}
         styles={{
-          container: {
+          content: {
             width: 320,
           },
         }}

--- a/src/features/ChatMiniMap/index.tsx
+++ b/src/features/ChatMiniMap/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { ActionIcon, Flexbox, PopoverGroup } from '@lobehub/ui';
 import { cx } from 'antd-style';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -36,19 +36,21 @@ const ChatMinimap = memo(() => {
           size={14}
         />
         <Flexbox className={styles.railContent}>
-          {indicators.map(({ id, width, preview, role, virtuosoIndex }, position) => (
-            <MinimapIndicator
-              activePosition={activeIndicatorPosition}
-              id={id}
-              key={id}
-              onJump={handleJump}
-              position={position}
-              preview={preview}
-              role={role}
-              virtuosoIndex={virtuosoIndex}
-              width={width}
-            />
-          ))}
+          <PopoverGroup contentLayoutAnimation>
+            {indicators.map(({ id, width, preview, role, virtuosoIndex }, position) => (
+              <MinimapIndicator
+                activePosition={activeIndicatorPosition}
+                id={id}
+                key={id}
+                onJump={handleJump}
+                position={position}
+                preview={preview}
+                role={role}
+                virtuosoIndex={virtuosoIndex}
+                width={width}
+              />
+            ))}
+          </PopoverGroup>
         </Flexbox>
         <ActionIcon
           aria-label={t('minimap.nextMessage')}

--- a/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Avatar, Flexbox, Text } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Avatar, Flexbox, Popover, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
@@ -75,7 +74,6 @@ const Render = memo<MarkdownElementProps<MentionProps>>(({ children, node }) => 
 
   return (
     <Popover
-      arrow={false}
       content={
         <Flexbox gap={12} style={{ overflow: 'hidden' }} width={320}>
           <Flexbox align="center" gap={8} horizontal>
@@ -93,7 +91,7 @@ const Render = memo<MarkdownElementProps<MentionProps>>(({ children, node }) => 
           </Flexbox>
         </Flexbox>
       }
-      trigger={['click']}
+      trigger="click"
     >
       <span className={styles.mention}>
         {'@'}

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Render/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Render/Intervention/ApprovalActions.tsx
@@ -1,5 +1,5 @@
-import { Button, Dropdown, Flexbox } from '@lobehub/ui';
-import { Input, Popover, Space } from 'antd';
+import { Button, Dropdown, Flexbox, Popover } from '@lobehub/ui';
+import { Input, Space } from 'antd';
 import { ChevronDown } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -80,7 +80,6 @@ const ApprovalActions = memo<ApprovalActionsProps>(
     return (
       <Flexbox gap={8} horizontal>
         <Popover
-          arrow={false}
           content={
             <Flexbox gap={12} style={{ width: 400 }}>
               <Flexbox align={'center'} horizontal justify={'space-between'}>

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -1,6 +1,6 @@
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
-import { Center, Flexbox, Icon } from '@lobehub/ui';
-import { Divider, Popover } from 'antd';
+import { Center, Flexbox, Icon, Popover } from '@lobehub/ui';
+import { Divider } from 'antd';
 import { cssVar } from 'antd-style';
 import { BadgeCent, CoinsIcon } from 'lucide-react';
 import { memo } from 'react';
@@ -132,7 +132,6 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
 
   return (
     <Popover
-      arrow={false}
       content={
         <Flexbox gap={8} style={{ minWidth: 200 }}>
           {modelCard && <ModelCard {...modelCard} provider={provider} />}
@@ -214,7 +213,7 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
         </Flexbox>
       }
       placement={'top'}
-      trigger={['hover']}
+      trigger="hover"
     >
       <Center
         gap={2}

--- a/src/features/LocalFile/LocalFile.tsx
+++ b/src/features/LocalFile/LocalFile.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox } from '@lobehub/ui';
-import { Popover, Space } from 'antd';
+import { Button, Flexbox, Popover } from '@lobehub/ui';
+import { Space } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLink, FolderOpen } from 'lucide-react';
 import React from 'react';
@@ -98,12 +98,11 @@ export const LocalFile = ({ name, path, isDirectory = false }: LocalFileProps) =
 
   return (
     <Popover
-      arrow={false}
       content={popoverContent}
       styles={{
-        container: { padding: 0 },
+        content: { padding: 0 },
       }}
-      trigger={['hover']}
+      trigger="hover"
     >
       {fileContent}
     </Popover>

--- a/src/features/MCPPluginDetail/Deployment/index.tsx
+++ b/src/features/MCPPluginDetail/Deployment/index.tsx
@@ -1,7 +1,17 @@
 import { SiApple, SiLinux } from '@icons-pack/react-simple-icons';
 import { Microsoft } from '@lobehub/icons';
-import { ActionIcon, Block, Collapse, Empty, Flexbox, Icon, Snippet, Tag } from '@lobehub/ui';
-import { Divider, Popover, Steps } from 'antd';
+import {
+  ActionIcon,
+  Block,
+  Collapse,
+  Empty,
+  Flexbox,
+  Icon,
+  Popover,
+  Snippet,
+  Tag,
+} from '@lobehub/ui';
+import { Divider, Steps } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { startCase } from 'es-toolkit/compat';
 import {
@@ -220,7 +230,6 @@ const Deployment = memo<{ mobile?: boolean }>(({ mobile }) => {
                               </span>
                               {dep.installInstructions && (
                                 <Popover
-                                  arrow={false}
                                   content={
                                     <Flexbox gap={8}>
                                       <Descriptions
@@ -265,7 +274,7 @@ const Deployment = memo<{ mobile?: boolean }>(({ mobile }) => {
                                       )}
                                     </Flexbox>
                                   }
-                                  trigger={['hover']}
+                                  trigger="hover"
                                 >
                                   <ActionIcon
                                     color={cssVar.colorTextDescription}

--- a/src/features/MCPPluginDetail/Score/TotalScore.tsx
+++ b/src/features/MCPPluginDetail/Score/TotalScore.tsx
@@ -1,5 +1,5 @@
-import { Block, Center, Flexbox } from '@lobehub/ui';
-import { Popover, Progress } from 'antd';
+import { Block, Center, Flexbox, Popover } from '@lobehub/ui';
+import { Progress } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -248,10 +248,15 @@ const TotalScore = memo<TotalScoreProps>(({ scoreResult, scoreItems = [], isVali
 
       <div className={styles.progressContainer}>
         <Popover
-          arrow={false}
-          content={renderTooltipContent()}
+          content={
+            <div>
+              <div style={{ fontWeight: 'bold', marginBottom: 8 }}>
+                {t('mcp.details.totalScore.popover.title')}
+              </div>
+              {renderTooltipContent()}
+            </div>
+          }
           placement="bottom"
-          title={t('mcp.details.totalScore.popover.title')}
           trigger={['hover', 'click']}
         >
           <Progress

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -1,5 +1,4 @@
-import { TooltipGroup } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { Popover, TooltipGroup } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
 import { PanelContent } from './components/PanelContent';
@@ -32,9 +31,8 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
     return (
       <TooltipGroup>
         <Popover
-          arrow={false}
           classNames={{
-            container: styles.container,
+            content: styles.container,
           }}
           content={
             <PanelContent

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -1,5 +1,4 @@
-import { ActionIcon, Block, Flexbox } from '@lobehub/ui';
-import { Popover } from 'antd';
+import { ActionIcon, Block, Flexbox, Popover } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { ChevronsUpDownIcon, Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
 import { Suspense, memo, useMemo, useState } from 'react';
@@ -108,7 +107,6 @@ const AgentSelector = memo<AgentSelectorProps>(({ agentId, onAgentChange }) => {
 
   return (
     <Popover
-      arrow={false}
       content={
         <Suspense fallback={<SkeletonList rows={6} />}>
           <AgentModalProvider>
@@ -120,12 +118,12 @@ const AgentSelector = memo<AgentSelectorProps>(({ agentId, onAgentChange }) => {
       open={open}
       placement="bottomLeft"
       styles={{
-        container: {
+        content: {
           padding: 0,
           width: 240,
         },
       }}
-      trigger={['click']}
+      trigger="click"
     >
       <Block
         align={'center'}
@@ -197,7 +195,6 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
             />
             {!hideHistory && (
               <Popover
-                arrow={false}
                 content={
                   <Flexbox
                     gap={4}
@@ -224,12 +221,12 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
                 open={topicPopoverOpen}
                 placement="bottomRight"
                 styles={{
-                  container: {
+                  content: {
                     padding: 0,
                     width: 240,
                   },
                 }}
-                trigger={['click']}
+                trigger="click"
               >
                 <ActionIcon icon={Clock3Icon} size={DESKTOP_HEADER_ICON_SIZE} />
               </Popover>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Fixes https://linear.app/lobehub/issue/LOBE-2649/antd-popover-base-ui-dropdown-层级关系

#### 🔀 Description of Change

This PR updates `@lobehub/ui` to version 4.11.5 and refactors Popover component usage across multiple components to fix z-index/layer relationship issues between antd Popover and base UI Dropdown components.

**Key Changes:**
- Updated `@lobehub/ui` dependency from 4.11.3 → 4.11.4 → 4.11.5
- Refactored Popover usage across 35+ component files for consistency
- Fixed z-index layering issues between antd Popover and base UI Dropdown
- Standardized Popover component patterns throughout the codebase

**Affected Components:**
- Agent/Topic/Thread editing components
- Chat input action bar
- Model selection panels
- MCP plugin details
- Profile editors
- Mini-map indicators
- And many more UI components using Popover

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed (UI component refactoring)

**Testing Steps:**
1. Open components with Popover overlays (e.g., agent switch panel, topic editing)
2. Verify Popover appears above base UI Dropdowns correctly
3. Check that z-index layering is correct across different UI contexts
4. Test in both light and dark modes

#### 📸 Screenshots / Videos

See original issue for visual reference: https://linear.app/lobehub/issue/LOBE-2649/antd-popover-base-ui-dropdown-层级关系

#### 📝 Additional Information

This is a dependency update with component refactoring to ensure proper UI layering. No breaking changes or migration required.

Files changed: 35 files with 194 insertions(+), 224 deletions(-)

## Summary by Sourcery

Update UI library and standardize Popover-based overlays to fix layering issues across the app.

Bug Fixes:
- Resolve z-index and layering conflicts between Popover overlays and dropdown components in multiple UI contexts.

Enhancements:
- Refactor Popover usage to use @lobehub/ui Popover consistently, updating trigger, content, and styling props across many components.
- Wrap chat minimap indicators in a shared Popover group to coordinate overlay behavior.
- Improve ActionPopover composition by unifying title and body into content and normalizing classNames/styles usage.

Build:
- Bump @lobehub/ui dependency from 4.9.3 to 4.11.5.

Chores:
- Replace ad-hoc dropdown/popover usages with higher-level components such as DropdownMenu where appropriate.