### PR TITLE
🐛 fix: add separate border-radius for bottom-right corner on macOS 26 Chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ The project follows a well-organized monorepo structure:
 - **Dev**: Translate `locales/zh-CN/namespace.json` locale file only for preview
 - DON'T run `pnpm i18n`, let CI auto handle it
 
+## Linear Issue Management
+
+Follow [Linear rules in CLAUDE.md](CLAUDE.md#linear-issue-management-ignore-if-not-installed-linear-mcp) when working with Linear issues.
+
 ## Project Rules Index
 
 All following rules are saved under `.cursor/rules/` directory:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ When creating new Linear issues using `mcp__linear-server__create_issue`, **MUST
 - Code review context
 - Future reference and debugging
 
+### PR Linear Issue Association (REQUIRED)
+
+**When creating PRs for Linear issues, MUST include magic keywords in PR body:** `Fixes LOBE-123`, `Closes LOBE-123`, or `Resolves LOBE-123`
+
 ### IMPORTANT: Per-Issue Completion Rule
 
 **When working on multiple issues (e.g., parent issue with sub-issues), you MUST update status and add comment for EACH issue IMMEDIATELY after completing it.** Do NOT wait until all issues are done to update them in batch.

--- a/packages/utils/src/platform.test.ts
+++ b/packages/utils/src/platform.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isArc, isSonomaOrLaterSafari } from './platform';
+import { isArc, isMacOSWithLargeWindowBorders, isSonomaOrLaterSafari } from './platform';
 
 describe('isSonomaOrLaterSafari', () => {
   beforeEach(() => {
@@ -9,6 +9,31 @@ describe('isSonomaOrLaterSafari', () => {
       userAgent:
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15',
       maxTouchPoints: 0,
+    });
+  });
+
+  describe('isMacOSWithLargeWindowBorders', () => {
+    it('should return true for macOS 10.15+', () => {
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
+      });
+
+      expect(isMacOSWithLargeWindowBorders()).toBe(true);
+    });
+
+    it('should return false for non-macOS userAgent', () => {
+      vi.stubGlobal('navigator', { userAgent: 'Windows NT 10.0; Win64; x64' });
+      expect(isMacOSWithLargeWindowBorders()).toBe(false);
+    });
+
+    it('should return false in Electron', () => {
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Electron/30.0.0 Safari/537.36',
+      });
+
+      expect(isMacOSWithLargeWindowBorders()).toBe(false);
     });
   });
 

--- a/packages/utils/src/platform.ts
+++ b/packages/utils/src/platform.ts
@@ -25,6 +25,28 @@ export const browserInfo = {
 
 export const isMacOS = () => getPlatform() === 'Mac OS';
 
+/**
+ *
+ * We can't use it to detect the macOS real version, and we also don't know if it's macOS 26, only an estimated value.
+ * @returns true if the current browser is macOS and the version is 10.15 or later
+ */
+export const isMacOSWithLargeWindowBorders = () => {
+  if (isOnServerSide || typeof navigator === 'undefined') return false;
+
+  // keep consistent with the original logic: only for macOS on web (exclude Electron)
+  const isElectron =
+    /Electron\//.test(navigator.userAgent) || Boolean((window as any)?.process?.type);
+  if (isElectron || !isMacOS()) return false;
+
+  const match = navigator.userAgent.match(/Mac OS X (\d+)[._](\d+)/);
+  if (!match) return false;
+
+  const majorVersion = parseInt(match[1], 10);
+  const minorVersion = parseInt(match[2], 10);
+
+  return majorVersion >= 10 && minorVersion >= 15;
+};
+
 export const isArc = () => {
   if (isOnServerSide) return false;
   return (

--- a/src/app/[variants]/(main)/_layout/DesktopLayoutContainer.tsx
+++ b/src/app/[variants]/(main)/_layout/DesktopLayoutContainer.tsx
@@ -6,6 +6,7 @@ import { isDesktop } from '@/const/version';
 import { useIsDark } from '@/hooks/useIsDark';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
+import { isMacOSWithLargeWindowBorders } from '@/utils/platform';
 
 import { styles } from './DesktopLayoutContainer/style';
 
@@ -23,12 +24,15 @@ const DesktopLayoutContainer: FC<PropsWithChildren> = ({ children }) => {
   );
 
   const innerCssVariables = useMemo<Record<string, string>>(() => {
-    const borderRadius =
-      typeof window !== 'undefined' && (window.lobeEnv?.darwinMajorVersion ?? 0) >= 25
-        ? '12px'
-        : cssVar.borderRadius;
+    const darwinMajorVersion =
+      typeof window !== 'undefined' ? (window.lobeEnv?.darwinMajorVersion ?? 0) : 0;
+
+    const borderRadius = darwinMajorVersion >= 25 ? '12px' : cssVar.borderRadius;
+    const borderBottomRightRadius =
+      darwinMajorVersion >= 26 || isMacOSWithLargeWindowBorders() ? '12px' : borderRadius;
 
     return {
+      '--container-border-bottom-right-radius': borderBottomRightRadius,
       '--container-border-color': isDarkMode ? cssVar.colorBorderSecondary : cssVar.colorBorder,
       '--container-border-radius': borderRadius,
     };

--- a/src/app/[variants]/(main)/_layout/DesktopLayoutContainer/style.ts
+++ b/src/app/[variants]/(main)/_layout/DesktopLayoutContainer/style.ts
@@ -11,6 +11,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     border: 1px solid var(--container-border-color, ${cssVar.colorBorder});
     border-radius: var(--container-border-radius, ${cssVar.borderRadius});
+    border-end-end-radius: var(
+      --container-border-bottom-right-radius,
+      var(--container-border-radius, ${cssVar.borderRadius})
+    );
 
     background: ${cssVar.colorBgContainer};
   `,


### PR DESCRIPTION
## Summary

Fix issue where the main container's bottom-right corner radius was not applied correctly on macOS 26 Chrome.

### Changes

- Added `isMacOSWithLargeWindowBorders()` utility function to detect macOS 10.15+ browsers (excluding Electron)
- Added separate CSS variable `--container-border-bottom-right-radius` for the bottom-right corner
- Updated `DesktopLayoutContainer` to set different border-radius for bottom-right corner based on macOS version

resolves LOBE-2776

## Test plan

- [x] Type check passed
- [ ] Test the fix on macOS 26 Chrome browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust desktop layout container border radii to correctly handle macOS Chrome window border behavior on newer macOS versions.

New Features:
- Introduce isMacOSWithLargeWindowBorders utility to detect macOS 10.15+ browsers with larger window borders while excluding Electron environments.

Bug Fixes:
- Fix incorrect bottom-right corner border radius of the main desktop container on newer macOS Chrome versions by using a dedicated CSS variable.

Enhancements:
- Refine desktop layout container CSS variables to support distinct bottom-right corner radius based on detected macOS/window border configuration.

Tests:
- Add unit tests for isMacOSWithLargeWindowBorders to validate behavior across macOS, non-macOS, and Electron user agents.