### PR TITLE
🐛 fix: move builtin agent default plugins to persist config for user visibility and control

### DIFF
--- a/packages/builtin-agents/src/agents/group-supervisor/index.ts
+++ b/packages/builtin-agents/src/agents/group-supervisor/index.ts
@@ -39,9 +39,10 @@ export const GROUP_SUPERVISOR: BuiltinAgentDefinition = {
       return { systemRole: '' };
     }
 
-    // Ensure GroupManagementIdentifier is included without duplicates
-    // GroupManagement is required for supervisor functionality, always injected
+    // Get user plugins from database (backfill handled by database layer)
     const userPlugins = ctx.plugins || [];
+
+    // GroupManagement is required for supervisor - inject if not already present
     const plugins = userPlugins.includes(GroupManagementIdentifier)
       ? userPlugins
       : [GroupManagementIdentifier, ...userPlugins];

--- a/packages/builtin-agents/src/agents/inbox/index.ts
+++ b/packages/builtin-agents/src/agents/inbox/index.ts
@@ -9,11 +9,23 @@ import { systemRole } from './systemRole';
  * Inbox Agent - the default assistant agent for general conversations
  *
  * Note: model and provider are intentionally undefined to use user's default settings
+ *
+ * Default Plugins:
+ * - GTD and Notebook are included as default plugins via persist config
+ * - These will be stored in database and visible in UI, allowing users to disable them
+ * - Users can see these tools are enabled and choose to turn them off if desired
  */
 export const INBOX: BuiltinAgentDefinition = {
   avatar: '/avatars/lobe-ai.png',
+
+  // Persist config - default plugins stored in database, visible and controllable by user
+  persist: {
+    plugins: [GTDIdentifier, NotebookIdentifier],
+  },
+
   runtime: (ctx) => ({
-    plugins: [GTDIdentifier, NotebookIdentifier, ...(ctx.plugins || [])],
+    // Use plugins from ctx (which comes from database, including user modifications)
+    plugins: ctx.plugins || [],
     systemRole: systemRole,
   }),
 

--- a/packages/builtin-agents/src/agents/inbox/index.ts
+++ b/packages/builtin-agents/src/agents/inbox/index.ts
@@ -25,6 +25,7 @@ export const INBOX: BuiltinAgentDefinition = {
 
   runtime: (ctx) => ({
     // Use plugins from ctx (which comes from database, including user modifications)
+    // Database layer handles backfill of default plugins for existing users
     plugins: ctx.plugins || [],
     systemRole: systemRole,
   }),

--- a/packages/builtin-agents/src/types.ts
+++ b/packages/builtin-agents/src/types.ts
@@ -23,6 +23,8 @@ export interface BuiltinAgentPersistConfig {
   chatConfig?: Partial<LobeAgentChatConfig>;
   /** Default model */
   model?: string;
+  /** Default plugins - will be stored in database and visible to user */
+  plugins?: string[];
   /** Default provider */
   provider?: string;
 }

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -3,6 +3,7 @@ import { INBOX_SESSION_ID } from '@lobechat/const';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { getTestDB } from '../../core/getTestDB';
 import {
   agents,
   agentsFiles,
@@ -16,7 +17,6 @@ import {
 } from '../../schemas';
 import { LobeChatDatabase } from '../../type';
 import { AgentModel } from '../agent';
-import { getTestDB } from '../../core/getTestDB';
 
 const serverDB: LobeChatDatabase = await getTestDB();
 
@@ -1099,6 +1099,18 @@ describe('AgentModel', () => {
         expect(result).toBeDefined();
         expect(result?.slug).toBe(INBOX_SESSION_ID);
         expect(result?.virtual).toBe(true);
+      });
+
+      it('should create new inbox agent with default plugins from persist config', async () => {
+        const result = await agentModel.getBuiltinAgent(INBOX_SESSION_ID);
+
+        expect(result).toBeDefined();
+        // Inbox agent should have default plugins (GTD and Notebook) from persist config
+        // These defaults make the tools visible and controllable by users in UI
+        expect(result?.plugins).toEqual([
+          'lobe-gtd', // GTDIdentifier
+          'lobe-notebook', // NotebookIdentifier
+        ]);
       });
 
       it('should return the same agent on subsequent calls (idempotent)', async () => {

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -488,10 +488,12 @@ export class AgentModel {
     if (!persistConfig) return null;
 
     // 4. Create the builtin agent with persist config
+    // Include default plugins so they are visible and controllable by user in UI
     const result = await this.db
       .insert(agents)
       .values({
         model: persistConfig.model,
+        plugins: persistConfig.plugins,
         provider: persistConfig.provider,
         slug: persistConfig.slug,
         userId: this.userId,


### PR DESCRIPTION
Previously, Inbox and Group Supervisor agents hardcoded GTD/Notebook tools in their runtime plugins array. This caused two issues:
1. Users couldn't see these default tools in the UI
2. Users couldn't disable these tools even when they wanted to

### Solution

Move default plugins from `runtime` to `persist.plugins`:

| Agent | Required Tool (Runtime) | Default Tools (Persist) |
|-------|------------------------|-------------------------|
| Inbox | - | GTD, Notebook |
| Group Supervisor | GroupManagement | GTD |

**Key changes:**
- Add `plugins` field to `BuiltinAgentPersistConfig` type
- Default plugins are now stored in database, visible and controllable by users in UI
- Required tools (like `GroupManagement`) remain runtime-injected with deduplication logic
- Update database model to include `persist.plugins` when creating builtin agents

### Benefits
- ✅ Users can see default tools are enabled in the UI
- ✅ Users can choose to disable default tools if desired
- ✅ Required tools for core functionality are still guaranteed
- ✅ Prevents duplicate tool registration

### Note
This change only affects **newly created** builtin agents. Existing users' inbox/supervisor configurations remain unchanged in the database.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align builtin Inbox and Group Supervisor agents with user-configured plugin settings instead of hardcoding specific tools.

Bug Fixes:
- Ensure the Inbox agent only uses GTD, Notebook, and other tools when they are enabled in the user's plugin configuration.
- Ensure the Group Supervisor agent only includes GTD and other optional tools when they are enabled via ctx.plugins, while always retaining the required group management tool.

## Summary by Sourcery

Persist default plugins for builtin Inbox and Group Supervisor agents so they are stored in the database, visible and configurable in the UI, while still enforcing required runtime tools.

Bug Fixes:
- Ensure the Inbox builtin agent uses plugins from the persisted configuration (via runtime ctx.plugins) so default GTD and Notebook tools are user-visible and can be disabled.
- Ensure the Group Supervisor builtin agent always includes the required GroupManagement tool at runtime without duplication while treating GTD as a user-controllable default plugin.

Enhancements:
- Extend builtin agent persist configuration and database model to store default plugins for new builtin agents, exposing them in the UI as regular, user-editable plugins.

Tests:
- Add and update tests to verify builtin agent configs read plugins from runtime/database, respect user-disabled plugins, and create new Inbox agents with the expected default plugins.