### PR TITLE
🐛 fix: improve error handling with structured AgentStateError type

### DIFF
--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -167,10 +167,10 @@ describe('AgentRuntime', () => {
       expect(result.events).toHaveLength(1);
       expect(result.events[0]).toMatchObject({
         type: 'error',
-        error: expect.any(Error),
+        error: { message: 'Agent error', type: 'Error' },
       });
       expect(result.newState.status).toBe('error');
-      expect(result.newState.error).toBeInstanceOf(Error);
+      expect(result.newState.error).toMatchObject({ message: 'Agent error', type: 'Error' });
     });
   });
 

--- a/packages/agent-runtime/src/types/event.ts
+++ b/packages/agent-runtime/src/types/event.ts
@@ -78,7 +78,12 @@ export interface AgentEventDone {
 
 export interface AgentEventError {
   type: 'error';
-  error: any;
+  /** Structured error compatible with AgentStateError */
+  error: {
+    body?: any;
+    message: string;
+    type?: string;
+  };
 }
 
 export interface AgentEventInterrupted {

--- a/packages/agent-runtime/src/types/state.ts
+++ b/packages/agent-runtime/src/types/state.ts
@@ -102,11 +102,28 @@ export interface AgentState {
 
   // --- Metadata ---
   createdAt: string;
-  error?: any;
+  /**
+   * Error information when status is 'error'.
+   * Structured format compatible with ChatMessageError for serialization.
+   */
+  error?: AgentStateError;
   lastModified: string;
 
   // --- Extensible metadata ---
   metadata?: Record<string, any>;
+}
+
+/**
+ * Structured error type for AgentState.
+ * Compatible with ChatMessageError for consistent error handling across the system.
+ */
+export interface AgentStateError {
+  /** Detailed error body (e.g., API response, stack trace) */
+  body?: any;
+  /** Human-readable error message */
+  message: string;
+  /** Error type/category for classification */
+  type?: string;
 }
 
 /**

--- a/packages/types/src/message/ui/chat.ts
+++ b/packages/types/src/message/ui/chat.ts
@@ -60,6 +60,19 @@ interface UIMessageBranch {
 }
 
 /**
+ * Structured error type for task execution failures.
+ * Compatible with AgentStateError for consistent error handling.
+ */
+export interface TaskDetailError {
+  /** Detailed error body (e.g., API response) */
+  body?: any;
+  /** Human-readable error message */
+  message: string;
+  /** Error type/category for classification */
+  type?: string;
+}
+
+/**
  * Task execution details for role='task' messages
  * Retrieved from the associated Thread via sourceMessageId
  */
@@ -68,8 +81,8 @@ export interface TaskDetail {
   completedAt?: string;
   /** Execution duration in milliseconds */
   duration?: number;
-  /** Error message if task failed */
-  error?: Record<string, any>;
+  /** Error information if task failed */
+  error?: TaskDetailError;
   /** Task start time (ISO string) */
   startedAt?: string;
   /** Task status */

--- a/src/features/Conversation/Messages/Tasks/shared/ErrorState.tsx
+++ b/src/features/Conversation/Messages/Tasks/shared/ErrorState.tsx
@@ -56,14 +56,14 @@ const ErrorState = memo<ErrorStateProps>(({ taskDetail }) => {
       {/* Error Content */}
       <Alert
         extra={
-          error?.error?.body && (
+          error?.body && (
             <Highlighter
               actionIconSize={'small'}
               language={'json'}
               padding={8}
               variant={'borderless'}
             >
-              {JSON.stringify(error?.error?.body, null, 2)}
+              {JSON.stringify(error?.body, null, 2)}
             </Highlighter>
           )
         }

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -592,7 +592,10 @@ export const createRuntimeExecutors = (
       });
 
       events.push({
-        error: error,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          type: error instanceof Error ? error.name : 'UnknownError',
+        },
         type: 'error',
       });
 

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -2,6 +2,7 @@ import {
   AgentRuntime,
   type AgentRuntimeContext,
   type AgentState,
+  type AgentStateError,
   GeneralChatAgent,
 } from '@lobechat/agent-runtime';
 import { AgentRuntimeErrorType, ChatErrorType, type ChatMessageError } from '@lobechat/types';
@@ -43,16 +44,16 @@ import type {
 const log = debug('lobe-server:agent-runtime-service');
 
 /**
- * Formats an error into ChatMessageError structure
+ * Formats an error into AgentStateError structure
  * Handles various error formats from LLM execution and other sources
  */
-function formatErrorForState(error: unknown): ChatMessageError {
+function formatErrorForState(error: unknown): AgentStateError {
   // Handle ChatCompletionErrorPayload format from LLM errors
   // e.g., { errorType: 'InvalidProviderAPIKey', error: { ... }, provider: 'openai' }
   if (error && typeof error === 'object' && 'errorType' in error) {
     const payload = error as {
       error?: unknown;
-      errorType: ChatMessageError['type'];
+      errorType: string;
       message?: string;
     };
     return {
@@ -67,7 +68,7 @@ function formatErrorForState(error: unknown): ChatMessageError {
     return {
       body: { name: error.name },
       message: error.message,
-      type: ChatErrorType.InternalServerError,
+      type: error.name,
     };
   }
 
@@ -75,7 +76,7 @@ function formatErrorForState(error: unknown): ChatMessageError {
   return {
     body: error,
     message: String(error),
-    type: AgentRuntimeErrorType.AgentRuntimeError,
+    type: 'UnknownError',
   };
 }
 

--- a/src/server/services/agentRuntime/types.ts
+++ b/src/server/services/agentRuntime/types.ts
@@ -102,7 +102,12 @@ export interface OperationStatusResult {
   currentState: {
     cost?: any;
     costLimit?: any;
-    error?: string;
+    /** Structured error information */
+    error?: {
+      body?: any;
+      message: string;
+      type?: string;
+    };
     interruption?: any;
     lastModified: string;
     maxSteps?: number;

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -652,7 +652,13 @@ export const createAgentExecutors = (context: {
       } catch (error) {
         log('[%s][call_tool] ERROR: Tool execution failed: %O', sessionLogId, error);
 
-        events.push({ error: error, type: 'error' });
+        events.push({
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+            type: error instanceof Error ? error.name : 'UnknownError',
+          },
+          type: 'error',
+        });
 
         // Return current state on error (no state change)
         return { events, newState: state };

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -741,7 +741,13 @@ export const streamingExecutor: StateCreator<
             const currentMessages = get().messagesMap[messageKey] || [];
             const assistantMessage = currentMessages.findLast((m) => m.role === 'assistant');
             if (assistantMessage) {
-              await messageService.updateMessageError(assistantMessage.id, event.error, {
+              // Convert AgentStateError to ChatMessageError format
+              const chatError = {
+                body: event.error.body,
+                message: event.error.message,
+                type: event.error.type || 'AgentRuntimeError',
+              };
+              await messageService.updateMessageError(assistantMessage.id, chatError as any, {
                 agentId,
                 groupId,
                 topicId,


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 Bug Fix
- [x] ♻️ Code Refactoring

## 🔀 Description of Change

### Problem

1. `JSON.stringify(Error)` returns `"{}"` because Error object properties are non-enumerable, causing error information to be lost after Redis/DB storage
2. `TRPCClientError.message` can be an object instead of a string, rendering it directly causes `React Error #31: "Objects are not valid as a React child"`

### Solution

1. **Define structured error type**: Create `AgentStateError` interface aligned with `ChatMessageError`
   ```typescript
   interface AgentStateError {
     message: string;
     type?: string;
     body?: any;
   }
   ```

2. **Update error handling logic**:
   - `createErrorResult()` in runtime.ts now constructs structured error objects
   - `handleCostLimitExceeded()` returns structured error instead of `new Error()`
   - `formatErrorForState()` returns `AgentStateError` type

3. **Adapt all error consumers**:
   - `RuntimeExecutors.ts`, `createAgentExecutors.ts` construct structured error events
   - `streamingExecutor.ts` converts `AgentStateError` to `ChatMessageError`
   - `ErrorState.tsx` accesses `error.body` directly (was `error.error.body`)

4. **Fix `React Error #31`**:
   - Safely coerce `e.message` to string in `conversationLifecycle.ts`

### Data Flow

```
Error → AgentStateError → Redis/DB → TaskDetail.error → UI
              ↑                              ↓
     { message, type, body }        ChatMessageError
```

### Changed Files

| File | Change |
|------|--------|
| `packages/agent-runtime/src/types/state.ts` | Add `AgentStateError` interface |
| `packages/agent-runtime/src/types/event.ts` | Update `AgentEventError.error` type |
| `packages/types/src/message/ui/chat.ts` | Add `TaskDetailError` interface |
| `packages/agent-runtime/src/core/runtime.ts` | Update error handling logic |
| `src/server/services/agentRuntime/*.ts` | Adapt to new error structure |
| `src/store/chat/**/*.ts` | Adapt to new error structure |
| `src/features/.../ErrorState.tsx` | Update error access path |

## 📝 Additional Information

### Testing

- [x] `bunx vitest run --silent='passed-only' 'runtime.test.ts'` - 48 tests passed

## Summary by Sourcery

Standardize agent runtime error handling around a structured error type to preserve rich error information across backend, storage, and UI, and harden client error messaging to avoid React rendering issues.

Bug Fixes:
- Ensure TRPC client errors with non-string messages are safely stringified before use, preventing React "objects are not valid as a React child" errors.
- Preserve error details when storing and propagating errors by using structured error objects instead of raw Error instances.

Enhancements:
- Introduce AgentStateError and TaskDetailError structured types and update agent runtime state, events, and operation status payloads to use them.
- Normalize error events from runtime and tool execution into structured error payloads that can be serialized and later converted to ChatMessageError for UI consumption.
- Update task error UI to read error bodies directly from the structured error object and highlight them as JSON.

Tests:
- Adjust runtime tests to assert against the new structured error shape instead of raw Error instances.