### PR TITLE
🐛 fix: restore history count control in chat input action bar

### DIFF
--- a/src/app/[variants]/(main)/chat/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/MainChatInput/index.tsx
@@ -14,7 +14,7 @@ const leftActions: ActionKeys[] = [
   'typo',
   'fileUpload',
   '---',
-  ['tools', 'params', 'clear'],
+  ['tools', 'history', 'params', 'clear'],
   'mainToken',
 ];
 

--- a/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/GroupChat.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/GroupChat.tsx
@@ -22,7 +22,7 @@ const leftActions: ActionKeys[] = [
   'typo',
   'fileUpload',
   '---',
-  ['tools', 'params', 'clear'],
+  ['tools', 'history', 'params', 'clear'],
   'mainToken',
 ];
 

--- a/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
@@ -14,7 +14,7 @@ const leftActions: ActionKeys[] = [
   'typo',
   'fileUpload',
   '---',
-  ['tools', 'params', 'clear'],
+  ['tools', 'history', 'params', 'clear'],
   'mainToken',
 ];
 


### PR DESCRIPTION
The history (context turn limit) button was missing from the chat input action bar in the next branch. Added 'history' action to leftActions in:
- chat/MainChatInput
- group/MainChatInput
- group/GroupChat

This restores the ability to control conversation context history limit that was available in previous versions.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Re-add the history/context turn limit action to the left action bar in main and group chat inputs so users can again control conversation history.