### PR TITLE
🐛 fix: respect user's enableResponseApi setting in server-side SubAgent task execution

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -126,11 +126,10 @@ export const createRuntimeExecutors = (
       const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId!, provider);
 
       // Read user's provider config to determine apiMode
-      // When user explicitly disables Responses API, set apiMode to 'chatCompletion'
+      // Default to 'chatCompletion' unless user explicitly enables Responses API
       const aiProviderModel = new AiProviderModel(ctx.serverDB, ctx.userId!);
       const providerConfig = await aiProviderModel.findById(provider);
       const enableResponseApi = providerConfig?.config?.enableResponseApi;
-      // Default to false for non-OpenAI providers, true only for OpenAI with explicit enable
       const apiMode: 'responses' | 'chatCompletion' =
         enableResponseApi === true ? 'responses' : 'chatCompletion';
 

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -12,6 +12,7 @@ import { type ChatToolPayload, type MessageToolCall } from '@lobechat/types';
 import { serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
 
+import { AiProviderModel } from '@/database/models/aiProvider';
 import { type MessageModel } from '@/database/models/message';
 import { type LobeChatDatabase } from '@/database/type';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
@@ -124,8 +125,18 @@ export const createRuntimeExecutors = (
       // 初始化 ModelRuntime (从数据库读取用户的 keyVaults)
       const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId!, provider);
 
+      // Read user's provider config to determine apiMode
+      // When user explicitly disables Responses API, set apiMode to 'chatCompletion'
+      const aiProviderModel = new AiProviderModel(ctx.serverDB, ctx.userId!);
+      const providerConfig = await aiProviderModel.findById(provider);
+      const enableResponseApi = providerConfig?.config?.enableResponseApi;
+      // Default to false for non-OpenAI providers, true only for OpenAI with explicit enable
+      const apiMode: 'responses' | 'chatCompletion' =
+        enableResponseApi === true ? 'responses' : 'chatCompletion';
+
       // 构造 ChatStreamPayload
       const chatPayload = {
+        apiMode,
         messages: llmPayload.messages,
         model,
         tools: llmPayload.tools,

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -18,6 +18,12 @@ vi.mock('@lobechat/model-runtime', () => ({
   consumeStreamUntilDone: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@/database/models/aiProvider', () => ({
+  AiProviderModel: vi.fn().mockImplementation(() => ({
+    findById: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
 describe('RuntimeExecutors', () => {
   let mockMessageModel: any;
   let mockStreamManager: any;


### PR DESCRIPTION
Previously, server-side SubAgent task execution did not respect the user's 'Enable Responses API' setting from provider configuration. This caused issues when using providers like NewAPI with LiteLLM backend, where the Responses API format is not supported.

The fix reads the user's provider config from the database and sets apiMode to 'chatCompletion' by default, only using 'responses' when the user has explicitly enabled it. This ensures SubAgent tasks use the same API format as regular chat.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Respect the user’s Enable Responses API setting when determining apiMode for server-side SubAgent task execution so non-responses-compatible backends default to chat completion.