### PR TITLE
✨ feat(ui): move new topic button to navigation panel

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Nav.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Nav.tsx
@@ -2,7 +2,7 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { BotPromptIcon } from '@lobehub/ui/icons';
-import { SearchIcon } from 'lucide-react';
+import { MessageSquarePlusIcon, SearchIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import urlJoin from 'url-join';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
+import { useActionSWR } from '@/libs/swr';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -19,6 +20,7 @@ import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfi
 
 const Nav = memo(() => {
   const { t } = useTranslation('chat');
+  const { t: tTopic } = useTranslation('topic');
   const isInbox = useAgentStore(builtinAgentSelectors.isInboxAgent);
   const params = useParams();
   const agentId = params.aid;
@@ -29,9 +31,25 @@ const Nav = memo(() => {
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
   const hideProfile = isInbox || !isAgentEditable;
   const switchTopic = useChatStore((s) => s.switchTopic);
+  const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
+
+  const { mutate, isValidating } = useActionSWR('openNewTopicOrSaveTopic', openNewTopicOrSaveTopic);
+  const handleNewTopic = () => {
+    // If in agent sub-route, navigate back to agent chat first
+    if (isProfileActive && agentId) {
+      router.push(urlJoin('/agent', agentId));
+    }
+    mutate();
+  };
 
   return (
     <Flexbox gap={1} paddingInline={4}>
+      <NavItem
+        icon={MessageSquarePlusIcon}
+        loading={isValidating}
+        onClick={handleNewTopic}
+        title={tTopic('actions.addNewTopic')}
+      />
       {!hideProfile && (
         <NavItem
           active={isProfileActive}

--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/index.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/index.tsx
@@ -4,14 +4,13 @@ import { type PropsWithChildren, memo } from 'react';
 
 import SideBarHeaderLayout from '@/features/NavPanel/SideBarHeaderLayout';
 
-import AddTopicButon from './AddTopicButon';
 import Agent from './Agent';
 import Nav from './Nav';
 
 const HeaderInfo = memo<PropsWithChildren>(() => {
   return (
     <>
-      <SideBarHeaderLayout left={<Agent />} right={<AddTopicButon />} />
+      <SideBarHeaderLayout left={<Agent />} />
       <Nav />
     </>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR improves the UX of the chat sidebar by relocating the "Add New Topic" button from the header into the navigation panel.

**Changes:**
- Move "Add New Topic" button from sidebar header to navigation panel
- Integrate with existing `NavItem` component for consistent styling
- Add loading state indicator during topic creation
- Auto-navigate from agent profile back to chat when creating new topic
- Remove now-unused `AddTopicButton` component from header layout

**Benefits:**
- Better visual hierarchy in the sidebar
- Consistent button styling with other navigation items
- Improved discoverability alongside related navigation actions

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

**Testing steps:**
1. Open a chat with any agent
2. Verify the new topic button appears in the navigation panel
3. Click the new topic button to create a new topic
4. Verify loading state appears during creation
5. When viewing agent profile, click new topic button and verify it navigates back to chat first

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| New topic button in header | New topic button in navigation panel |

#### 📝 Additional Information

No breaking changes. This is a UI enhancement that maintains existing functionality while improving the user experience.

## Summary by Sourcery

Relocate the chat "New Topic" action into the sidebar navigation for improved UX and consistency.

New Features:
- Add a "New Topic" navigation item in the chat sidebar nav with loading feedback and topic-creation handling.

Enhancements:
- Remove the header-level "Add Topic" button and rely on the new navigation entry, including redirecting from agent profile back to chat before creating a topic.