### PR TITLE
🐛 fix(page): fetch documents on mount to populate page sidebar

### DIFF
--- a/src/app/[variants]/(main)/page/_layout/Body/index.tsx
+++ b/src/app/[variants]/(main)/page/_layout/Body/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Accordion, AccordionItem, Dropdown, Flexbox, Text } from '@lobehub/ui';
-import React, { Suspense, memo } from 'react';
+import React, { Suspense, memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
@@ -27,10 +27,16 @@ const Body = memo(() => {
   const filteredPages = useFileStore(documentSelectors.getFilteredPagesLimited);
   const searchKeywords = useFileStore((s) => s.searchKeywords);
   const dropdownMenu = useDropdownMenu();
-  const [allPagesDrawerOpen, closeAllPagesDrawer] = useFileStore((s) => [
+  const [allPagesDrawerOpen, closeAllPagesDrawer, fetchDocuments] = useFileStore((s) => [
     s.allPagesDrawerOpen,
     s.closeAllPagesDrawer,
+    s.fetchDocuments,
   ]);
+
+  // Fetch documents on mount
+  useEffect(() => {
+    fetchDocuments({ pageOnly: true });
+  }, [fetchDocuments]);
 
   return (
     <Flexbox gap={1} paddingInline={4}>


### PR DESCRIPTION
Fixed bug where the Page section sidebar would show empty even when pages exist. The sidebar was reading from the document store but never called fetchDocuments() to populate it.

Root cause: Recent Pages on home page uses useFetchRecentPages() hook which auto-fetches data, but the Page section sidebar was missing this initialization.

Changes:
- Added useEffect to call fetchDocuments({ pageOnly: true }) on mount
- Imported useEffect from React
- Now page sidebar loads and displays pages correctly

Fixes empty page sidebar while Recent Pages section shows data correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Trigger document fetching for page-only documents when the page layout body mounts so the sidebar correctly displays existing pages.