### PR TITLE
🐛 fix(api): Fix the issue where custom AI Providers cannot use custom APIs

### DIFF
--- a/src/services/__tests__/models.test.ts
+++ b/src/services/__tests__/models.test.ts
@@ -82,7 +82,8 @@ describe('ModelsService', () => {
       await modelsService.getModels('custom-provider');
 
       expect(mockedResolveRuntimeProvider).toHaveBeenCalledWith('custom-provider');
-      expect(fetch).toHaveBeenCalledWith('/webapi/models/openai', { headers: {} });
+      // API endpoint uses original provider, allowing server to query correct config
+      expect(fetch).toHaveBeenCalledWith('/webapi/models/custom-provider', { headers: {} });
       expect(mockedInitializeWithClientStore).not.toHaveBeenCalled();
     });
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -402,7 +402,7 @@ class ChatService {
       responseAnimation,
     ].reduce((acc, cur) => merge(acc, standardizeAnimationStyle(cur)), {});
 
-    return fetchSSE(API_ENDPOINTS.chat(sdkType), {
+    return fetchSSE(API_ENDPOINTS.chat(provider), {
       body: JSON.stringify(payload),
       fetcher: fetcher,
       headers,

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -49,7 +49,7 @@ export class ModelsService {
         return agentRuntime.models();
       }
 
-      const res = await fetch(API_ENDPOINTS.models(runtimeProvider), { headers });
+      const res = await fetch(API_ENDPOINTS.models(provider), { headers });
       if (!res.ok) return;
 
       return res.json();
@@ -87,7 +87,7 @@ export class ModelsService {
         });
         res = (await agentRuntime.pullModel({ model }, { signal }))!;
       } else {
-        res = await fetch(API_ENDPOINTS.modelPull(runtimeProvider), {
+        res = await fetch(API_ENDPOINTS.modelPull(provider), {
           body: JSON.stringify({ model }),
           headers,
           method: 'POST',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #11296 Fixes #11271 

#### 🔀 Description of Change

修复自定义 AI Provider 无法使用服务端 API 的问题。 

问题原因： 
客户端使用 sdkType（如 'azure'、'openai'）构建 API 端点路径，但服务端使用该路径作为 provider ID 从数据库查询配置。这导致服务端查询了内置 provider 的配置，而不是用户自定义 provider 的配置。 

修复方案： 
将 API 端点路径从使用 sdkType 改为使用原始的 provider 标识。这确保服务端能正确查询用户配置，然后从配置中读取 sdkType 来初始化相应的运行时。 

修改文件：
src/services/chat/index.ts：聊天 API 端点使用 provider
src/services/models.ts：模型列表和模型拉取 API 端点使用 provider

为什么客户端模式之前能正常工作： 
客户端模式不走服务器 API，而是直接在浏览器中通过 createPayloadWithKeyVaults(provider) 从 store 读取配置（使用原始 provider），然后使用 ModelRuntime.initializeWithProvider(runtimeProvider, ...) 选择 SDK（使用 sdkType）。两个参数职责清晰分离，不存在路径混淆问题。



#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure server-side AI API requests use the correct provider identifier for routing and configuration lookup.

Bug Fixes:
- Fix server-side chat streaming endpoint to address custom AI providers being unable to use their configured APIs.
- Fix model listing and model pull endpoints so custom AI providers resolve against the correct provider configuration instead of the SDK type.