### PR TITLE
✨ feat: change the klavis Linear to LobeHub oauth Linear

### DIFF
--- a/locales/en-US/oauth.json
+++ b/locales/en-US/oauth.json
@@ -32,5 +32,6 @@
   "login.title": "Login to {{clientName}}",
   "login.userWelcome": "Welcome back, ",
   "success.subTitle": "You have successfully authorized the application to access your account. You may now close this page.",
+  "success.subTitleWithCountdown": "Authorization successful. Auto-closing in {{countdown}}s...",
   "success.title": "Authorization Successful"
 }

--- a/locales/zh-CN/oauth.json
+++ b/locales/zh-CN/oauth.json
@@ -32,5 +32,6 @@
   "login.title": "登录 {{clientName}}",
   "login.userWelcome": "欢迎回来，",
   "success.subTitle": "应用已获得授权。你可以关闭此页面了",
+  "success.subTitleWithCountdown": "应用已获得授权。{{countdown}}秒后自动关闭…",
   "success.title": "授权完成"
 }

--- a/packages/const/src/klavis.ts
+++ b/packages/const/src/klavis.ts
@@ -1,4 +1,4 @@
-import { IconType, SiCaldotcom, SiGithub, SiLinear } from '@icons-pack/react-simple-icons';
+import { IconType, SiCaldotcom, SiGithub } from '@icons-pack/react-simple-icons';
 import { Klavis } from 'klavis';
 
 export interface KlavisServerType {
@@ -39,12 +39,6 @@ export const KLAVIS_SERVER_TYPES: KlavisServerType[] = [
     identifier: 'airtable',
     label: 'Airtable',
     serverName: Klavis.McpServerName.Airtable,
-  },
-  {
-    icon: SiLinear,
-    identifier: 'linear',
-    label: 'Linear',
-    serverName: Klavis.McpServerName.Linear,
   },
   {
     icon: 'https://hub-apac-1.lobeobjects.space/assets/logos/googlesheets.svg',

--- a/src/app/[variants]/(auth)/oauth/callback/success/page.tsx
+++ b/src/app/[variants]/(auth)/oauth/callback/success/page.tsx
@@ -2,11 +2,48 @@
 
 import { FluentEmoji, Text } from '@lobehub/ui';
 import { Result } from 'antd';
-import React, { memo } from 'react';
+import { useSearchParams } from 'next/navigation';
+import React, { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const SuccessPage = memo(() => {
   const { t } = useTranslation('oauth');
+  const searchParams = useSearchParams();
+  const [countdown, setCountdown] = useState(3);
+
+  useEffect(() => {
+    // Check if this is a LobeHub Skill OAuth callback
+    const provider = searchParams.get('provider');
+
+    if (provider && window.opener) {
+      // Notify parent window about successful OAuth
+      window.opener.postMessage(
+        {
+          provider,
+          type: 'LOBEHUB_SKILL_AUTH_SUCCESS',
+        },
+        window.location.origin,
+      );
+
+      // Start countdown and close window after 3 seconds
+      let timeLeft = 3;
+      setCountdown(timeLeft);
+
+      const countdownTimer = setInterval(() => {
+        timeLeft -= 1;
+        setCountdown(timeLeft);
+
+        if (timeLeft <= 0) {
+          clearInterval(countdownTimer);
+          window.close();
+        }
+      }, 1000);
+
+      return () => clearInterval(countdownTimer);
+    }
+  }, [searchParams]);
+
+  const provider = searchParams.get('provider');
 
   return (
     <Result
@@ -14,7 +51,12 @@ const SuccessPage = memo(() => {
       status="success"
       subTitle={
         <Text fontSize={16} type="secondary">
-          {t('success.subTitle')}
+          {provider
+            ? t('success.subTitleWithCountdown', {
+                countdown,
+                defaultValue: `You may close this page. Auto-closing in ${countdown}s...`,
+              })
+            : t('success.subTitle')}
         </Text>
       }
       title={


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Integrate LobeHub Skill OAuth flow with the generic OAuth success callback page and streamline plugin activation after authorization.

New Features:
- Notify the opener window from the OAuth success callback page and auto-close the window with a countdown for LobeHub Skill OAuth flows.
- Automatically refresh Lobehub Skill server connection status and enable the corresponding plugin after successful OAuth via postMessage integration.
- Use a dedicated redirect URI (/oauth/callback/success with provider parameter) when initiating Lobehub Skill OAuth to support the new auto-activation flow.

Enhancements:
- Update OAuth success messaging to show a dynamic countdown when used as a LobeHub Skill callback.
- Remove the Linear Klavis server type configuration that is no longer needed.