### PR TITLE
🐛 fix(InputEditor): ensure lexical placeholder reactively updates on locale change

### DIFF
--- a/src/features/ChatInput/InputEditor/Placeholder.tsx
+++ b/src/features/ChatInput/InputEditor/Placeholder.tsx
@@ -12,7 +12,7 @@ const Placeholder = memo(() => {
     ? KeyEnum.Enter
     : combineKeys([KeyEnum.Mod, KeyEnum.Enter]);
 
-  // Don't remove this line for i18n reactity
+  // Don't remove this line for i18n reactivity
   void useTranslation('chat');
 
   return (

--- a/src/features/ChatInput/InputEditor/Placeholder.tsx
+++ b/src/features/ChatInput/InputEditor/Placeholder.tsx
@@ -1,7 +1,7 @@
 import { KeyEnum } from '@lobechat/types';
 import { Flexbox, Hotkey, combineKeys } from '@lobehub/ui';
 import { memo } from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
@@ -11,6 +11,9 @@ const Placeholder = memo(() => {
   const wrapperShortcut = useCmdEnterToSend
     ? KeyEnum.Enter
     : combineKeys([KeyEnum.Mod, KeyEnum.Enter]);
+
+  // Don't remove this line for i18n reactity
+  void useTranslation('chat');
 
   return (
     <Flexbox align={'center'} as={'span'} gap={4} horizontal wrap={'wrap'}>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

N/A

#### 🔀 Description of Change

The Lexical editor placeholder component uses `<Trans>` for i18n but wasn't reactively updating when the user changes locale. This is because `<Trans>` alone doesn't subscribe to locale changes without an accompanying `useTranslation` hook in the component.

**Solution:** Added `useTranslation('chat')` hook to ensure the component re-renders when the locale changes, making the placeholder text update reactively.

#### 🧪 How to Test

1. Open the chat input editor
2. Change the application locale (e.g., from English to Chinese)
3. Verify the placeholder text updates immediately without needing to refresh

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A (behavior fix, no UI changes)

#### 📝 Additional Information

The comment `// Don't remove this line for i18n reactivity` was added to clarify why the seemingly unused `useTranslation` call is necessary.

## Summary by Sourcery

Bug Fixes:
- Make the Lexical chat input placeholder re-render when the application locale changes so the translated text updates immediately.