### PR TITLE
🐛 fix(ci): support tokenless codecov upload for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
         run: bun i
 
       - name: Run tests
-        run: bunx vitest --coverage --silent='passed-only' --shard=${{ matrix.shard }}/2
+        run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/2
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,26 +61,41 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           curl -Os https://cli.codecov.io/latest/linux/codecov
           chmod +x codecov
-          TOKEN="${{ secrets.CODECOV_TOKEN }}"
+
+          # Build common args
+          COMMON_ARGS="--git-service github"
+
+          # PR args setup
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            COMMON_ARGS="$COMMON_ARGS --pr ${{ github.event.pull_request.number }}"
+            COMMON_ARGS="$COMMON_ARGS --sha ${{ github.event.pull_request.head.sha }}"
+            # Fork PR needs username:branch format for tokenless upload
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              COMMON_ARGS="$COMMON_ARGS --branch ${{ github.event.pull_request.head.label }}"
+            else
+              COMMON_ARGS="$COMMON_ARGS --branch ${{ github.event.pull_request.head.ref }}"
+            fi
+          fi
+
+          # Token (if available)
+          if [ -n "$CODECOV_TOKEN" ]; then
+            COMMON_ARGS="$COMMON_ARGS -t $CODECOV_TOKEN"
+          fi
+
           for package in $PACKAGES; do
             dir="${package#@lobechat/}"
             if [ -f "./packages/$dir/coverage/lcov.info" ]; then
               echo "Uploading coverage for $dir..."
-              if [ -n "$TOKEN" ]; then
-                ./codecov upload-process \
-                  -t "$TOKEN" \
-                  -f ./packages/$dir/coverage/lcov.info \
-                  -F packages/$dir \
-                  --disable-search
-              else
-                ./codecov upload-process \
-                  -f ./packages/$dir/coverage/lcov.info \
-                  -F packages/$dir \
-                  --disable-search
-              fi
+              ./codecov upload-coverage \
+                $COMMON_ARGS \
+                --file ./packages/$dir/coverage/lcov.info \
+                --flag packages/$dir \
+                --disable-search
             fi
           done
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -92,7 +92,6 @@ export default defineConfig({
       '**/e2e/**',
     ],
     globals: true,
-    reporters: ['default', 'blob'],
     server: {
       deps: {
         inline: ['vitest-canvas-mock', '@lobehub/ui', '@lobehub/fluent-emoji'],


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Fix Codecov CLI upload error for fork PRs:
```
error - Upload failed: {"message":"Token required because branch is protected"}
```

**Root Cause:**
1. Fork PRs cannot access repository `secrets.CODECOV_TOKEN` (GitHub security policy)
2. Codecov supports tokenless uploads for fork PRs, but requires correct parameters
3. The CLI was missing required parameters (`--git-service`, `--pr`, `--sha`, `--branch`)
4. Fork PR's `--branch` must be in `username:branch-name` format to trigger tokenless upload

**Changes:**
- Use `upload-coverage` command instead of `upload-process` (matching official codecov-action)
- Add `--git-service github` parameter
- Add PR number and SHA for proper attribution
- Use `github.event.pull_request.head.label` (username:branch format) for fork PRs to enable tokenless upload

**Reference:** [codecov/codecov-action source code](https://github.com/codecov/codecov-action/blob/main/action.yml#L265-L279)

#### 🧪 How to Test

- [x] No tests needed

This change can be verified by checking fork PR CI runs after merge.

#### 📝 Additional Information

Verified against official codecov-action implementation to ensure correctness.

## Summary by Sourcery

CI:
- Update Codecov CLI invocation in the test workflow to use the upload-coverage command with GitHub-specific arguments, enabling tokenless uploads for fork PRs and falling back to token-based uploads when a CODECOV_TOKEN is present.