### PR TITLE
🔧 refactor: improve Tools popover component structure and fix UI consistency

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
@@ -42,6 +42,7 @@ const SwitchPanel = memo<PropsWithChildren>(({ children }) => {
     <Popover
       classNames={{ trigger: styles.trigger }}
       content={content}
+      nativeButton={false}
       placement="bottomLeft"
       styles={{
         content: {

--- a/src/app/[variants]/(main)/chat/features/Conversation/Header/HeaderActions/index.tsx
+++ b/src/app/[variants]/(main)/chat/features/Conversation/Header/HeaderActions/index.tsx
@@ -12,7 +12,7 @@ const HeaderActions = memo(() => {
   const { menuItems } = useMenu();
 
   return (
-    <DropdownMenu items={menuItems}>
+    <DropdownMenu items={menuItems} nativeButton={false}>
       <ActionIcon icon={MoreHorizontal} size={DESKTOP_HEADER_ICON_SIZE} />
     </DropdownMenu>
   );

--- a/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
@@ -9,7 +9,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
-import CheckboxItem from '../components/CheckbokWithLoading';
+import CheckboxItem from '../components/CheckboxWithLoading';
 
 export const useControls = ({
   setModalOpen,

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -1,0 +1,75 @@
+import { Flexbox, Icon, type ItemType, Segmented, usePopoverContext } from '@lobehub/ui';
+import { ChevronRight, Store } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ToolsList, { toolsListStyles } from './ToolsList';
+
+type TabType = 'all' | 'installed';
+
+interface PopoverContentProps {
+  activeTab: TabType;
+  currentItems: ItemType[];
+  enableKlavis: boolean;
+  onOpenStore: () => void;
+  onTabChange: (tab: TabType) => void;
+}
+
+const PopoverContent = memo<PopoverContentProps>(
+  ({ activeTab, currentItems, enableKlavis, onTabChange, onOpenStore }) => {
+    const { t } = useTranslation('setting');
+
+    const { close: closePopover } = usePopoverContext();
+
+    return (
+      <Flexbox gap={0}>
+        <div style={{ borderBottom: '1px solid var(--ant-color-border-secondary)', padding: 8 }}>
+          <Segmented
+            block
+            onChange={(v) => onTabChange(v as TabType)}
+            options={[
+              {
+                label: t('tools.tabs.all', { defaultValue: 'all' }),
+                value: 'all',
+              },
+              {
+                label: t('tools.tabs.installed', { defaultValue: 'Installed' }),
+                value: 'installed',
+              },
+            ]}
+            size="small"
+            value={activeTab}
+          />
+        </div>
+        <div
+          style={{
+            maxHeight: 500,
+            minHeight: enableKlavis ? 500 : undefined,
+            overflowY: 'auto',
+          }}
+        >
+          <ToolsList items={currentItems} />
+        </div>
+        <div style={{ borderTop: '1px solid var(--ant-color-border-secondary)', padding: 4 }}>
+          <div
+            className={toolsListStyles.item}
+            onClick={() => {
+              closePopover();
+              onOpenStore();
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            <Icon icon={Store} size={20} />
+            <div className={toolsListStyles.itemContent}>{t('tools.plugins.store')}</div>
+            <Icon icon={ChevronRight} size={16} style={{ opacity: 0.5 }} />
+          </div>
+        </div>
+      </Flexbox>
+    );
+  },
+);
+
+PopoverContent.displayName = 'PopoverContent';
+
+export default PopoverContent;

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -1,9 +1,24 @@
 import { Flexbox, Icon, type ItemType, Segmented, usePopoverContext } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { ChevronRight, Store } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ToolsList, { toolsListStyles } from './ToolsList';
+
+const styles = createStaticStyles(({ css }) => ({
+  footer: css`
+    padding: 4px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  header: css`
+    padding: 8px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  trailingIcon: css`
+    opacity: 0.5;
+  `,
+}));
 
 type TabType = 'all' | 'installed';
 
@@ -23,7 +38,7 @@ const PopoverContent = memo<PopoverContentProps>(
 
     return (
       <Flexbox gap={0}>
-        <div style={{ borderBottom: '1px solid var(--ant-color-border-secondary)', padding: 8 }}>
+        <div className={styles.header}>
           <Segmented
             block
             onChange={(v) => onTabChange(v as TabType)}
@@ -50,7 +65,7 @@ const PopoverContent = memo<PopoverContentProps>(
         >
           <ToolsList items={currentItems} />
         </div>
-        <div style={{ borderTop: '1px solid var(--ant-color-border-secondary)', padding: 4 }}>
+        <div className={styles.footer}>
           <div
             className={toolsListStyles.item}
             onClick={() => {
@@ -60,9 +75,11 @@ const PopoverContent = memo<PopoverContentProps>(
             role="button"
             tabIndex={0}
           >
-            <Icon icon={Store} size={20} />
+            <div className={toolsListStyles.itemIcon}>
+              <Icon icon={Store} size={20} />
+            </div>
             <div className={toolsListStyles.itemContent}>{t('tools.plugins.store')}</div>
-            <Icon icon={ChevronRight} size={16} style={{ opacity: 0.5 }} />
+            <Icon className={styles.trailingIcon} icon={ChevronRight} size={16} />
           </div>
         </div>
       </Flexbox>

--- a/src/features/ChatInput/ActionBar/Tools/ToolItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolItem.tsx
@@ -13,6 +13,7 @@ const ToolItem = memo<CheckboxItemProps>(({ id, onUpdate, label, checked }) => {
   return (
     <CheckboxItem
       checked={checked}
+      hasPadding={false}
       id={id}
       label={
         <Flexbox align={'center'} gap={8} horizontal>

--- a/src/features/ChatInput/ActionBar/Tools/ToolItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolItem.tsx
@@ -5,7 +5,7 @@ import PluginTag from '@/components/Plugins/PluginTag';
 import { useToolStore } from '@/store/tool';
 import { customPluginSelectors } from '@/store/tool/selectors';
 
-import CheckboxItem, { type CheckboxItemProps } from '../components/CheckbokWithLoading';
+import CheckboxItem, { type CheckboxItemProps } from '../components/CheckboxWithLoading';
 
 const ToolItem = memo<CheckboxItemProps>(({ id, onUpdate, label, checked }) => {
   const isCustom = useToolStore((s) => customPluginSelectors.isCustomPlugin(id)(s));

--- a/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
@@ -18,7 +18,7 @@ export const toolsListStyles = createStaticStyles(({ css }) => ({
 
     padding-block: 8px;
     padding-inline: 12px;
-    border-radius: 8px;
+    border-radius: 6px;
 
     transition: background-color 0.2s;
 
@@ -29,6 +29,15 @@ export const toolsListStyles = createStaticStyles(({ css }) => ({
   itemContent: css`
     flex: 1;
     min-width: 0;
+  `,
+  itemIcon: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    width: 24px;
+    height: 24px;
   `,
 }));
 
@@ -81,7 +90,7 @@ const ToolsList = memo<ToolsListProps>(({ items }) => {
         role="button"
         tabIndex={0}
       >
-        {iconNode}
+        {iconNode && <div className={toolsListStyles.itemIcon}>{iconNode}</div>}
         <div className={toolsListStyles.itemContent}>{item.label}</div>
         {item.extra}
       </div>

--- a/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
@@ -1,0 +1,98 @@
+import { Flexbox, Icon, type ItemType, Text } from '@lobehub/ui';
+import { Divider } from 'antd';
+import { createStaticStyles, cssVar } from 'antd-style';
+import type { ReactNode } from 'react';
+import { Fragment, isValidElement, memo } from 'react';
+
+export const toolsListStyles = createStaticStyles(({ css }) => ({
+  groupLabel: css`
+    padding-block: 4px;
+    padding-inline: 12px;
+  `,
+  item: css`
+    cursor: pointer;
+
+    display: flex;
+    gap: 12px;
+    align-items: center;
+
+    padding-block: 8px;
+    padding-inline: 12px;
+    border-radius: 8px;
+
+    transition: background-color 0.2s;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  itemContent: css`
+    flex: 1;
+    min-width: 0;
+  `,
+}));
+
+interface ToolItemData {
+  children?: ToolItemData[];
+  extra?: ReactNode;
+  icon?: ReactNode;
+  key?: string;
+  label?: ReactNode;
+  onClick?: () => void;
+  type?: 'group' | 'divider';
+}
+
+interface ToolsListProps {
+  items: ItemType[];
+}
+
+const ToolsList = memo<ToolsListProps>(({ items }) => {
+  const renderItem = (item: ToolItemData, index: number) => {
+    if (item.type === 'divider') {
+      return <Divider key={`divider-${index}`} style={{ margin: '4px 0' }} />;
+    }
+
+    if (item.type === 'group') {
+      return (
+        <Fragment key={item.key || `group-${index}`}>
+          <Text className={toolsListStyles.groupLabel} fontSize={12} type="secondary">
+            {item.label}
+          </Text>
+          {item.children?.map((child, childIndex) => renderItem(child, childIndex))}
+        </Fragment>
+      );
+    }
+
+    // Regular item
+    // icon can be: ReactNode (already rendered), LucideIcon/ForwardRef (needs Icon wrapper), or undefined
+    const iconNode = item.icon ? (
+      isValidElement(item.icon) ? (
+        item.icon
+      ) : (
+        <Icon icon={item.icon as any} size={20} />
+      )
+    ) : null;
+
+    return (
+      <div
+        className={toolsListStyles.item}
+        key={item.key || `item-${index}`}
+        onClick={item.onClick}
+        role="button"
+        tabIndex={0}
+      >
+        {iconNode}
+        <div className={toolsListStyles.itemContent}>{item.label}</div>
+        {item.extra}
+      </div>
+    );
+  };
+
+  return (
+    <Flexbox gap={0} padding={4}>
+      {items.map((item, index) => renderItem(item as ToolItemData, index))}
+    </Flexbox>
+  );
+});
+
+export default ToolsList;

--- a/src/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/index.tsx
@@ -1,5 +1,4 @@
-import { Flexbox, Icon, Segmented } from '@lobehub/ui';
-import { Blocks, ChevronRight, Store } from 'lucide-react';
+import { Blocks } from 'lucide-react';
 import { Suspense, memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,7 +10,7 @@ import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfi
 
 import { useAgentId } from '../../hooks/useAgentId';
 import Action from '../components/Action';
-import ToolsList, { toolsListStyles } from './ToolsList';
+import PopoverContent from './PopoverContent';
 import { useControls } from './useControls';
 
 type TabType = 'all' | 'installed';
@@ -49,57 +48,21 @@ const Tools = memo(() => {
   const effectiveTab = activeTab ?? 'all';
   const currentItems = effectiveTab === 'all' ? marketItems : installedPluginItems;
 
-  const popoverContent = (
-    <Flexbox gap={0}>
-      <div style={{ borderBottom: '1px solid var(--ant-color-border-secondary)', padding: 8 }}>
-        <Segmented
-          block
-          onChange={(v) => setActiveTab(v as TabType)}
-          options={[
-            {
-              label: t('tools.tabs.all', { defaultValue: 'all' }),
-              value: 'all',
-            },
-            {
-              label: t('tools.tabs.installed', { defaultValue: 'Installed' }),
-              value: 'installed',
-            },
-          ]}
-          size="small"
-          value={effectiveTab}
-        />
-      </div>
-      <div
-        style={{
-          maxHeight: 500,
-          minHeight: enableKlavis ? 500 : undefined,
-          overflowY: 'auto',
-        }}
-      >
-        <ToolsList items={currentItems} />
-      </div>
-      <div style={{ borderTop: '1px solid var(--ant-color-border-secondary)', padding: 4 }}>
-        <div
-          className={toolsListStyles.item}
-          onClick={() => setModalOpen(true)}
-          role="button"
-          tabIndex={0}
-        >
-          <Icon icon={Store} size={20} />
-          <div className={toolsListStyles.itemContent}>{t('tools.plugins.store')}</div>
-          <Icon icon={ChevronRight} size={16} style={{ opacity: 0.5 }} />
-        </div>
-      </div>
-    </Flexbox>
-  );
-
   return (
     <Suspense fallback={<Action disabled icon={Blocks} title={t('tools.title')} />}>
       <Action
         icon={Blocks}
         loading={updating}
         popover={{
-          content: popoverContent,
+          content: (
+            <PopoverContent
+              activeTab={effectiveTab}
+              currentItems={currentItems}
+              enableKlavis={enableKlavis}
+              onOpenStore={() => setModalOpen(true)}
+              onTabChange={setActiveTab}
+            />
+          ),
           maxWidth: 320,
           minWidth: 320,
           styles: {

--- a/src/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/index.tsx
@@ -1,6 +1,5 @@
-import { Segmented } from '@lobehub/ui';
-import { createStaticStyles, cssVar } from 'antd-style';
-import { Blocks } from 'lucide-react';
+import { Flexbox, Icon, Segmented } from '@lobehub/ui';
+import { Blocks, ChevronRight, Store } from 'lucide-react';
 import { Suspense, memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -12,38 +11,10 @@ import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfi
 
 import { useAgentId } from '../../hooks/useAgentId';
 import Action from '../components/Action';
+import ToolsList, { toolsListStyles } from './ToolsList';
 import { useControls } from './useControls';
 
 type TabType = 'all' | 'installed';
-
-const prefixCls = 'ant';
-
-const styles = createStaticStyles(({ css }) => ({
-  dropdown: css`
-    overflow: hidden;
-
-    width: 100%;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusLG};
-
-    background: ${cssVar.colorBgElevated};
-    box-shadow: ${cssVar.boxShadowSecondary};
-
-    .${prefixCls}-dropdown-menu {
-      border-radius: 0 !important;
-      background: transparent !important;
-      box-shadow: none !important;
-    }
-  `,
-  header: css`
-    padding: ${cssVar.paddingXS};
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
-    background: transparent;
-  `,
-  scroller: css`
-    overflow: hidden auto;
-  `,
-}));
 
 const Tools = memo(() => {
   const { t } = useTranslation('setting');
@@ -51,7 +22,6 @@ const Tools = memo(() => {
   const [updating, setUpdating] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType | null>(null);
   const { marketItems, installedPluginItems } = useControls({
-    setModalOpen,
     setUpdating,
   });
 
@@ -79,55 +49,65 @@ const Tools = memo(() => {
   const effectiveTab = activeTab ?? 'all';
   const currentItems = effectiveTab === 'all' ? marketItems : installedPluginItems;
 
+  const popoverContent = (
+    <Flexbox gap={0}>
+      <div style={{ borderBottom: '1px solid var(--ant-color-border-secondary)', padding: 8 }}>
+        <Segmented
+          block
+          onChange={(v) => setActiveTab(v as TabType)}
+          options={[
+            {
+              label: t('tools.tabs.all', { defaultValue: 'all' }),
+              value: 'all',
+            },
+            {
+              label: t('tools.tabs.installed', { defaultValue: 'Installed' }),
+              value: 'installed',
+            },
+          ]}
+          size="small"
+          value={effectiveTab}
+        />
+      </div>
+      <div
+        style={{
+          maxHeight: 500,
+          minHeight: enableKlavis ? 500 : undefined,
+          overflowY: 'auto',
+        }}
+      >
+        <ToolsList items={currentItems} />
+      </div>
+      <div style={{ borderTop: '1px solid var(--ant-color-border-secondary)', padding: 4 }}>
+        <div
+          className={toolsListStyles.item}
+          onClick={() => setModalOpen(true)}
+          role="button"
+          tabIndex={0}
+        >
+          <Icon icon={Store} size={20} />
+          <div className={toolsListStyles.itemContent}>{t('tools.plugins.store')}</div>
+          <Icon icon={ChevronRight} size={16} style={{ opacity: 0.5 }} />
+        </div>
+      </div>
+    </Flexbox>
+  );
+
   return (
     <Suspense fallback={<Action disabled icon={Blocks} title={t('tools.title')} />}>
       <Action
-        dropdown={{
-          maxWidth: 320,
-          menu: {
-            items: [...currentItems],
-            style: {
-              // let only the custom scroller scroll
-              maxHeight: 'unset',
-              overflowY: 'visible',
-            },
-          },
-          minHeight: enableKlavis ? 500 : undefined,
-          minWidth: 320,
-          popupRender: (menu) => (
-            <div className={styles.dropdown}>
-              <div className={styles.header}>
-                <Segmented
-                  block
-                  onChange={(v) => setActiveTab(v as TabType)}
-                  options={[
-                    {
-                      label: t('tools.tabs.all', { defaultValue: 'all' }),
-                      value: 'all',
-                    },
-                    {
-                      label: t('tools.tabs.installed', { defaultValue: 'Installed' }),
-                      value: 'installed',
-                    },
-                  ]}
-                  size="small"
-                  value={effectiveTab}
-                />
-              </div>
-              <div
-                className={styles.scroller}
-                style={{
-                  maxHeight: 500,
-                  minHeight: enableKlavis ? 500 : undefined,
-                }}
-              >
-                {menu}
-              </div>
-            </div>
-          ),
-        }}
         icon={Blocks}
         loading={updating}
+        popover={{
+          content: popoverContent,
+          maxWidth: 320,
+          minWidth: 320,
+          styles: {
+            content: {
+              padding: 0,
+            },
+          },
+        }}
         showTooltip={false}
         title={t('tools.title')}
       />

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -7,7 +7,7 @@ import {
 import { Avatar, Flexbox, Icon, Image, type ItemType } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { ArrowRight, Store, ToyBrick } from 'lucide-react';
+import { ToyBrick } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -61,13 +61,7 @@ const LobehubSkillIcon = memo<Pick<LobehubSkillProviderType, 'icon' | 'label'>>(
 
 LobehubSkillIcon.displayName = 'LobehubSkillIcon';
 
-export const useControls = ({
-  setModalOpen,
-  setUpdating,
-}: {
-  setModalOpen: (open: boolean) => void;
-  setUpdating: (updating: boolean) => void;
-}) => {
+export const useControls = ({ setUpdating }: { setUpdating: (updating: boolean) => void }) => {
   const { t } = useTranslation('setting');
   const agentId = useAgentId();
   const list = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
@@ -233,18 +227,6 @@ export const useControls = ({
         </Flexbox>
       ),
       type: 'group',
-    },
-    {
-      type: 'divider',
-    },
-    {
-      extra: <Icon icon={ArrowRight} />,
-      icon: Store,
-      key: 'plugin-store',
-      label: t('tools.plugins.store'),
-      onClick: () => {
-        setModalOpen(true);
-      },
     },
   ];
 

--- a/src/features/ChatInput/ActionBar/Upload/ServerMode.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/ServerMode.tsx
@@ -21,7 +21,7 @@ import { preferenceSelectors } from '@/store/user/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import Action from '../components/Action';
-import CheckboxItem from '../components/CheckbokWithLoading';
+import CheckboxItem from '../components/CheckboxWithLoading';
 
 const hotArea = css`
   &::before {

--- a/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
@@ -84,6 +84,7 @@ const ActionPopover = memo<ActionPopoverProps>(
           content: contentClassName,
         }}
         content={popoverContent}
+        nativeButton={false}
         placement={isMobile ? 'top' : placement}
         styles={{
           ...(typeof resolvedStyles === 'object' ? resolvedStyles : {}),

--- a/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
+++ b/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
@@ -1,4 +1,4 @@
-import { Center, Flexbox, Icon , Checkbox } from '@lobehub/ui';
+import { Center, Checkbox, Flexbox, Icon } from '@lobehub/ui';
 import { Loader2 } from 'lucide-react';
 import { type ReactNode, memo, useState } from 'react';
 

--- a/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
+++ b/src/features/ChatInput/ActionBar/components/CheckboxWithLoading.tsx
@@ -4,50 +4,57 @@ import { type ReactNode, memo, useState } from 'react';
 
 export interface CheckboxItemProps {
   checked?: boolean;
+  hasPadding?: boolean;
   id: string;
   label?: ReactNode;
   onUpdate: (id: string, enabled: boolean) => Promise<void>;
 }
 
-const CheckboxItem = memo<CheckboxItemProps>(({ id, onUpdate, label, checked }) => {
-  const [loading, setLoading] = useState(false);
+const CheckboxItem = memo<CheckboxItemProps>(
+  ({ id, onUpdate, label, checked, hasPadding = true }) => {
+    const [loading, setLoading] = useState(false);
 
-  const updateState = async () => {
-    setLoading(true);
-    await onUpdate(id, !checked);
-    setLoading(false);
-  };
+    const updateState = async () => {
+      setLoading(true);
+      await onUpdate(id, !checked);
+      setLoading(false);
+    };
 
-  return (
-    <Flexbox
-      align={'center'}
-      gap={24}
-      horizontal
-      justify={'space-between'}
-      onClick={async (e) => {
-        e.stopPropagation();
-        updateState();
-      }}
-      style={{
-        paddingLeft: 8,
-      }}
-    >
-      {label || id}
-      {loading ? (
-        <Center width={18}>
-          <Icon icon={Loader2} spin />
-        </Center>
-      ) : (
-        <Checkbox
-          checked={checked}
-          onClick={async (e) => {
-            e.stopPropagation();
-            await updateState();
-          }}
-        />
-      )}
-    </Flexbox>
-  );
-});
+    return (
+      <Flexbox
+        align={'center'}
+        gap={24}
+        horizontal
+        justify={'space-between'}
+        onClick={async (e) => {
+          e.stopPropagation();
+          updateState();
+        }}
+        style={
+          hasPadding
+            ? {
+                paddingLeft: 8,
+              }
+            : void 0
+        }
+      >
+        {label || id}
+        {loading ? (
+          <Center width={18}>
+            <Icon icon={Loader2} spin />
+          </Center>
+        ) : (
+          <Checkbox
+            checked={checked}
+            onClick={async (e) => {
+              e.stopPropagation();
+              await updateState();
+            }}
+          />
+        )}
+      </Flexbox>
+    );
+  },
+);
 
 export default CheckboxItem;

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -43,6 +43,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
               provider={providerProp}
             />
           }
+          nativeButton={false}
           onOpenChange={handleOpenChange}
           open={isOpen}
           placement={placement}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Fixes LOBE-2881

#### 🔀 Description of Change

This PR refactors the Tools popover component for better maintainability and fixes UI consistency issues:

**Structural Improvements:**
- Extract `PopoverContent` component from main Tools component for better separation of concerns
- Create new `ToolsList` component with shared styles for rendering tool items consistently
- Simplify the main `Tools/index.tsx` by delegating content rendering to dedicated components

**UI Consistency Fixes:**
- Add `nativeButton={false}` prop to `Popover` and `DropdownMenu` components across multiple files for consistent button behavior
- Fix `CheckboxWithLoading` component import (corrected typo from `CheckbokWithLoading`)

**Files Changed:**
- `src/features/ChatInput/ActionBar/Tools/index.tsx` - Simplified, uses new components
- `src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx` - New component for popover content
- `src/features/ChatInput/ActionBar/Tools/ToolsList.tsx` - New component for tools list rendering
- Multiple files updated with `nativeButton={false}` prop for UI consistency

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Navigate to chat input area
2. Click on the Tools (Blocks) icon in the action bar
3. Verify the popover opens correctly with tabs (All/Installed)
4. Verify tool items display correctly with proper styling
5. Verify clicking "Plugin Store" navigates to the store correctly

#### 📸 Screenshots / Videos

N/A - Internal refactoring with no visual changes

#### 📝 Additional Information

This is a structural refactoring to improve code maintainability. The visual behavior should remain unchanged.

## Summary by Sourcery

Refactor the chat Tools action popover into dedicated components and align related popover/dropdown behaviors and checkbox imports for more consistent UI and maintainability.

Bug Fixes:
- Correct the CheckboxWithLoading component import name across several action bar components to fix a typo and ensure the proper checkbox-with-loading UI is used.

Enhancements:
- Extract a dedicated PopoverContent component and a reusable ToolsList for the Tools action to simplify the main Tools entry component and centralize list rendering and styling.
- Adjust the Tools action to use the new popover-based layout instead of antd dropdown menus, keeping existing behavior while clarifying responsibilities between hooks and UI components.
- Update multiple popover and dropdown usages to pass a consistent nativeButton={false} configuration for unified trigger behavior across the app.