### PR TITLE
🔧 chore: increase memory limit for build analysis in package.json and…

### DIFF
--- a/.github/workflows/bundle-analyzer.yml
+++ b/.github/workflows/bundle-analyzer.yml
@@ -55,9 +55,9 @@ jobs:
         run: echo "secret=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
 
       - name: Build with bundle analyzer
-        run: bun run build:analyze || true
+        run: npm run build:analyze || true
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=81920
           KEY_VAULTS_SECRET: ${{ secrets.KEY_VAULTS_SECRET || steps.generate-secret.outputs.secret }}
 
       - name: Prepare analyzer reports

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "postbuild": "npm run build-sitemap && npm run build-migrate-db",
     "build-migrate-db": "bun run db:migrate",
     "build-sitemap": "tsx ./scripts/buildSitemapIndex/index.ts",
-    "build:analyze": "NODE_OPTIONS=--max-old-space-size=8192 ANALYZE=true next build --webpack",
+    "build:analyze": "NODE_OPTIONS=--max-old-space-size=81920 ANALYZE=true next build --webpack",
     "build:docker": "npm run prebuild && NODE_OPTIONS=--max-old-space-size=8192 DOCKER=true next build --webpack && npm run build-sitemap",
     "build:electron": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NEXT_PUBLIC_IS_DESKTOP_APP=1 tsx scripts/electronWorkflow/buildNextApp.mts",
     "build:vercel": "npm run prebuild && cross-env NODE_OPTIONS=--max-old-space-size=6144 next build --webpack && npm run postbuild",


### PR DESCRIPTION
… workflow configuration

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Increase memory allocation and adjust tooling used for bundle analysis builds.

Chores:
- Raise NODE_OPTIONS max-old-space-size for bundle analyzer builds in both workflow and npm script.
- Switch bundle analyzer GitHub workflow step from bun to npm for running the build:analyze script.