### PR TITLE
💄 style: force gpt-5.2 use response api

### DIFF
--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -40,6 +40,7 @@ export const responsesAPIModels = new Set([
   'gpt-5-pro-2025-10-06',
   'gpt-5.1-codex',
   'gpt-5.1-codex-mini',
+  'gpt-5.2',
   'gpt-5.2-pro-2025-12-11',
   'gpt-5.2-pro',
 ]);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enhancements:
- Align gpt-5.2 with other responsesAPIModels so it consistently uses the Responses API.