### PR TITLE
✨ feat(userMemories): support to use customized Qstash client with extra header for workflows

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics/route.ts
@@ -10,13 +10,14 @@ import {
 import { forEachBatchSequential } from '@/server/services/memory/userMemory/topicBatching';
 import { MemorySourceType } from '@lobechat/types';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
+import { Client } from '@upstash/qstash'
 
 const TOPIC_PAGE_SIZE = 50;
 const TOPIC_BATCH_SIZE = 4;
 
-export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
-  const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
+const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
   if (!params.userIds.length) {
     return { message: 'No user ids provided for topic processing.' };
@@ -125,4 +126,17 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   }
 
   return { processedUsers: params.userIds.length };
+}, {
+  // NOTICE(@nekomeowww): Here as scenarios like Vercel Deployment Protection,
+  // intermediate context.run(...) won't offer customizable headers like context.trigger(...) / client.trigger(...)
+  // for passing additional headers, we have to provide a custom QStash client with the required headers here.
+  //
+  // Refer to the doc for more details:
+  // https://upstash.com/docs/workflow/troubleshooting/vercel#step-2-pass-header-when-triggering
+  qstashClient: new Client({
+    headers: {
+      ...upstashWorkflowExtraHeaders,
+    },
+    token: process.env.QSTASH_TOKEN!
+  })
 });

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-users/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-users/route.ts
@@ -1,5 +1,6 @@
 import { serve } from '@upstash/workflow/nextjs';
 import { chunk } from 'es-toolkit/compat';
+import { Client } from '@upstash/qstash'
 
 import {
   MemoryExtractionExecutor,
@@ -13,9 +14,9 @@ import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryEx
 const USER_PAGE_SIZE = 50;
 const USER_BATCH_SIZE = 10;
 
-export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
-  const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
+const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 
+export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
   const params = normalizeMemoryExtractionPayload(context.requestPayload || {});
   if (params.sources.length === 0) {
     return { message: 'No sources provided, skip memory extraction.' };
@@ -73,4 +74,17 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(async (context) => {
     nextCursor: cursor ? cursor.id : null,
     processedUsers: ids.length,
   };
+}, {
+  // NOTICE(@nekomeowww): Here as scenarios like Vercel Deployment Protection,
+  // intermediate context.run(...) won't offer customizable headers like context.trigger(...) / client.trigger(...)
+  // for passing additional headers, we have to provide a custom QStash client with the required headers here.
+  //
+  // Refer to the doc for more details:
+  // https://upstash.com/docs/workflow/troubleshooting/vercel#step-2-pass-header-when-triggering
+  qstashClient: new Client({
+    headers: {
+      ...upstashWorkflowExtraHeaders,
+    },
+    token: process.env.QSTASH_TOKEN!
+  })
 });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

New Features:
- Allow memory user workflow endpoints to use a customizable QStash client with additional headers, enabling compatibility with scenarios like Vercel Deployment Protection.