### PR TITLE
✨ feat(conversation): use native context menu when selection is within current ChatItem

### DIFF
--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -348,13 +348,22 @@ export const useChatItemContextMenu = ({
         return;
       }
 
+      const selection = window.getSelection();
+      const selectedText = selection?.toString().trim() || '';
+      selectedTextRef.current = selectedText;
+
+      // If there's selected text outside of current ChatItem, use native context menu
+      if (selectedText && selection?.anchorNode) {
+        const isSelectionInCurrentItem = target.contains(selection.anchorNode);
+
+        if (isSelectionInCurrentItem) {
+          return;
+        }
+      }
+
       event.preventDefault();
       event.stopPropagation();
 
-      const selection = window.getSelection();
-      selectedTextRef.current = selection?.toString().trim() || '';
-
-      console.log(contextMenuItems);
       showContextMenu(contextMenuItems);
     },
     [contextMenuItems, contextMenuMode, editing],


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Improve context menu behavior in chat messages:

- When user has selected text **within the current ChatItem**: show native browser context menu (allows copy, search, etc.)
- When no selection or selection is from **outside the current ChatItem**: show custom context menu

This provides a better UX by allowing users to use native browser copy/search functionality on selected text within the current message.

Also removed debug `console.log` statement.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Open a chat conversation
2. Right-click on a message without selecting text → custom context menu appears
3. Select text within a message and right-click → native browser context menu appears
4. Select text from another message, then right-click on a different message → custom context menu appears

#### 📸 Screenshots / Videos

N/A - behavioral change

#### 📝 Additional Information

N/A

## Summary by Sourcery

Update chat item context menu behavior to defer to the native browser menu when text is selected within the current message and otherwise show the custom menu.

New Features:
- Allow native browser context menu to appear when right-clicking selected text inside the current chat item.

Enhancements:
- Improve context menu selection handling by avoiding custom menu when the selection belongs to the current chat item.
- Remove leftover debug logging from the chat item context menu hook.