### PR TITLE
:bug: fix: handle will-prevent-unload event to allow app quit

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -184,6 +184,20 @@ export default class Browser {
     this.setupReadyToShowListener(browserWindow);
     this.setupCloseListener(browserWindow);
     this.setupFocusListener(browserWindow);
+    this.setupWillPreventUnloadListener(browserWindow);
+  }
+
+  private setupWillPreventUnloadListener(browserWindow: BrowserWindow): void {
+    logger.debug(`[${this.identifier}] Setting up 'will-prevent-unload' event listener.`);
+    browserWindow.webContents.on('will-prevent-unload', (event) => {
+      logger.debug(
+        `[${this.identifier}] 'will-prevent-unload' fired. isQuiting: ${this.app.isQuiting}`,
+      );
+      if (this.app.isQuiting) {
+        logger.info(`[${this.identifier}] App is quitting, ignoring beforeunload cancellation.`);
+        event.preventDefault();
+      }
+    });
   }
 
   private setupReadyToShowListener(browserWindow: BrowserWindow): void {

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -40,6 +40,7 @@ const { mockBrowserWindow, mockNativeTheme, mockIpcMain, mockScreen, MockBrowser
             onHeadersReceived: vi.fn(),
           },
         },
+        on: vi.fn(),
       },
     };
 
@@ -644,6 +645,37 @@ describe('Browser', () => {
       browser.reapplyVisualEffects();
 
       expect(mockBrowserWindow.setBackgroundColor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('will-prevent-unload event handling', () => {
+    let willPreventUnloadHandler: (e: any) => void;
+
+    beforeEach(() => {
+      // Get the will-prevent-unload handler registered during initialization
+      willPreventUnloadHandler = mockBrowserWindow.webContents.on.mock.calls.find(
+        (call) => call[0] === 'will-prevent-unload',
+      )?.[1];
+    });
+
+    it('should call preventDefault when app is quitting', () => {
+      (mockApp as any).isQuiting = true;
+      const mockEvent = { preventDefault: vi.fn() };
+
+      expect(willPreventUnloadHandler).toBeDefined();
+      willPreventUnloadHandler(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should not call preventDefault when app is not quitting', () => {
+      (mockApp as any).isQuiting = false;
+      const mockEvent = { preventDefault: vi.fn() };
+
+      expect(willPreventUnloadHandler).toBeDefined();
+      willPreventUnloadHandler(mockEvent);
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### 📝 Description

Fixes an issue where the desktop app update process is blocked when the input box has content.
Electron defaults to respecting the page's `beforeunload` event. When `app.quit()` is called (e.g., during an update), if the page prevents unloading (due to unsaved input), the quit process is interrupted.

This PR adds a listener for the `will-prevent-unload` event in the `Browser` class. When the app is quitting (`isQuiting` is true), it forces the window to close by ignoring the page's cancellation.

### 🚀 Changes

- Added `setupWillPreventUnloadListener` in `Browser.ts`.
- Added unit tests in `Browser.test.ts`.

### 🔗 Related Issues

- Fixes blocking update issue on Desktop.

## Summary by Sourcery

Handle Electron will-prevent-unload events so app quits correctly during shutdown, and add coverage for this behavior.

Bug Fixes:
- Ensure desktop app can complete quit/update even when the renderer has a beforeunload handler blocking unload.

Tests:
- Add unit tests verifying will-prevent-unload is ignored when the app is quitting and respected otherwise.


Resolve LOBE-3023