### PR TITLE
🐛 fix: force plain text paste in ChatInput editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@lobehub/chat-plugin-sdk": "^1.32.4",
     "@lobehub/chat-plugins-gateway": "^1.9.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^3.8.0",
+    "@lobehub/editor": "^3.11.0",
     "@lobehub/icons": "^4.0.2",
     "@lobehub/market-sdk": "0.28.1",
     "@lobehub/tts": "^4.0.2",

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -120,6 +120,7 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       className={className}
       content={''}
       editor={editor}
+      pasteAsPlainText
       {...richRenderProps}
       mentionOption={
         enableMention


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Fixes LOBE-2657

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

This PR prevents rich text paste in the ChatInput editor by adding the `pasteAsPlainText` prop.

**Changes:**
- Add `pasteAsPlainText` prop to the ChatInput Editor component to ensure only plain text is pasted
- Upgrade `@lobehub/editor` from `^3.8.0` to `^3.11.0` to support the new `pasteAsPlainText` feature

This addresses the issue where copying rich text (e.g., from web pages) would paste with formatting in the ChatInput, which can cause unexpected behavior. Now, all pasted content will be converted to plain text automatically.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

1. Copy some rich text content from a webpage or document
2. Paste it into the ChatInput
3. Verify that only plain text is pasted without any formatting

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

N/A - Behavior change only, no visual UI changes

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

No breaking changes. This is a simple fix that improves user experience by ensuring consistent plain text input in the chat.

## Summary by Sourcery

Enforce plain-text-only pasting in the chat input editor and update the editor dependency to a version that supports this behavior.

New Features:
- Add support for forcing plain text paste in the ChatInput editor via configuration.

Bug Fixes:
- Prevent rich text content from being pasted with formatting into the ChatInput by enforcing plain-text pasting.

Build:
- Bump @lobehub/editor dependency from ^3.8.0 to ^3.11.0 to use the plain text paste capability.