### PR TITLE
🐛 fix(ShareModal): wrap ShareMessageModal with Provider in context menu

### DIFF
--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -18,8 +18,10 @@ import { sessionSelectors } from '@/store/session/selectors';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
-import ShareMessageModal from '../components/ShareMessageModal';
+import ShareMessageModal, { type ShareModalProps } from '../components/ShareMessageModal';
 import {
+  Provider,
+  createStore,
   dataSelectors,
   messageStateSelectors,
   useConversationStore,
@@ -187,13 +189,26 @@ export const useChatItemContextMenu = ({
     if (!item || item.role !== 'assistant') return;
 
     createRawModal(
-      ShareMessageModal,
+      (props: ShareModalProps) => (
+        <Provider
+          createStore={() => {
+            const state = storeApi.getState();
+            return createStore({
+              context: state.context,
+              hooks: state.hooks,
+              skipFetch: state.skipFetch,
+            });
+          }}
+        >
+          <ShareMessageModal {...props} />
+        </Provider>
+      ),
       {
         message: item,
       },
       { onCloseKey: 'onCancel', openKey: 'open' },
     );
-  }, [getMessage]);
+  }, [getMessage, storeApi]);
 
   const handleAction = useCallback(
     async (action: ContextMenuEvent) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #11382

#### 🔀 Description of Change

When sharing a message via the right-click context menu, the `ShareMessageModal` was not wrapped with the Conversation store `Provider`, causing a runtime error:

```
Error: Seems like you have not used zustand provider as an ancestor.
```

This happened because `createRawModal` renders components outside the React tree, so the zustand context was not available.

**Fix:** Wrap `ShareMessageModal` with `Provider` and `createStore` in `useChatItemContextMenu.tsx`, consistent with other Actions components (`Assistant/Actions`, `Task/Actions`, `Supervisor/Actions`, `AssistantGroup/Actions`) that already handle this correctly.

#### 🧪 How to Test

1. Open any chat conversation with assistant messages
2. Right-click on an assistant message to open context menu
3. Click "Share" option
4. Verify the share modal opens without crashing

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A - This is a bug fix for a crash, no UI changes.

#### 📝 Additional Information

The fix follows the same pattern used in other Action components in the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Fix a crash when opening the Share message modal from the assistant message context menu by ensuring it has access to the Conversation zustand store.