### PR TITLE
🐛 fix(ChatInput): add missing STT and History actions to input bar

### DIFF
--- a/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/index.tsx
@@ -14,7 +14,8 @@ const leftActions: ActionKeys[] = [
   'fileUpload',
   'tools',
   '---',
-  ['typo', 'params', 'clear'],
+  ['typo', 'params', 'history', 'clear'],
+  'stt',
   'mainToken',
 ];
 

--- a/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
@@ -14,7 +14,8 @@ const leftActions: ActionKeys[] = [
   'typo',
   'fileUpload',
   '---',
-  ['tools', 'params', 'clear'],
+  ['tools', 'params', 'history', 'clear'],
+  'stt',
   'mainToken',
 ];
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #11364

#### 🔀 Description of Change

The input function bar was missing the **speech-to-text (STT)** and **history message limit** features that were available in v1.

Both features already exist in the codebase (`src/features/ChatInput/ActionBar/STT/` and `src/features/ChatInput/ActionBar/History/`), but were not included in the `leftActions` configuration for the main chat input.

**Changes:**
- Added `'history'` to the dropdown menu (grouped with tools, params, clear)
- Added `'stt'` as a standalone action button for easy voice input access

#### 🧪 How to Test

1. Open any chat conversation
2. Look at the input action bar (bottom left icons)
3. Verify:
   - A microphone icon (STT) appears for voice input
   - The settings dropdown now includes a "History" option for limiting message context

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A - Adding existing components to the UI configuration.

#### 📝 Additional Information

The components were already fully implemented, this fix simply adds them to the default action bar configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add missing speech-to-text and history limit actions to the main chat input action bar configuration.

New Features:
- Expose speech-to-text as a standalone action button in the main chat input bar.
- Include the conversation history limit control in the chat input settings dropdown.