### PR TITLE
✨ feat(electron): add custom titlebar for Electron windows

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { preloadDir, resourcesDir } from '@/const/dir';
 import { isMac } from '@/const/env';
 import { ELECTRON_BE_PROTOCOL_SCHEME } from '@/const/protocol';
+import { TITLE_BAR_HEIGHT } from '@/const/theme';
 import RemoteServerConfigCtr from '@/controllers/RemoteServerConfigCtr';
 import { backendProxyProtocolManager } from '@/core/infrastructure/BackendProxyProtocolManager';
 import { setResponseHeader } from '@/utils/http-headers';
@@ -119,6 +120,10 @@ export default class Browser {
     logger.info(`Creating new BrowserWindow instance: ${this.identifier}`);
     logger.debug(`[${this.identifier}] Resolved window state: ${JSON.stringify(resolvedState)}`);
 
+    // Calculate traffic light position to center vertically in title bar
+    // Traffic light buttons are approximately 12px tall
+    const trafficLightY = Math.round((TITLE_BAR_HEIGHT - 12) / 2);
+
     return new BrowserWindow({
       ...rest,
       autoHideMenuBar: true,
@@ -128,6 +133,7 @@ export default class Browser {
       height: resolvedState.height,
       show: false,
       title,
+      trafficLightPosition: isMac ? { x: 12, y: trafficLightY } : undefined,
       vibrancy: 'sidebar',
       visualEffectState: 'active',
       webPreferences: {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export * from './merge';
 export * from './multimodalContent';
 export * from './number';
 export * from './object';
+export * from './platform';
 export * from './pricing';
 export * from './safeParseJSON';
 export * from './sleep';

--- a/src/app/[variants]/(desktop)/desktop-onboarding/_layout/index.tsx
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/_layout/index.tsx
@@ -5,6 +5,7 @@ import { Divider } from 'antd';
 import { cx } from 'antd-style';
 import type { FC, PropsWithChildren } from 'react';
 
+import { SimpleTitleBar, TITLE_BAR_HEIGHT } from '@/features/ElectronTitlebar';
 import LangButton from '@/features/User/UserPanel/LangButton';
 import ThemeButton from '@/features/User/UserPanel/ThemeButton';
 import { useIsDark } from '@/hooks/useIsDark';
@@ -14,36 +15,43 @@ import { styles } from './style';
 const OnboardingContainer: FC<PropsWithChildren> = ({ children }) => {
   const isDarkMode = useIsDark();
   return (
-    <Flexbox className={styles.outerContainer} height={'100%'} padding={8} width={'100%'}>
+    <Flexbox height={'100%'} width={'100%'}>
+      <SimpleTitleBar />
       <Flexbox
-        className={cx(isDarkMode ? styles.innerContainerDark : styles.innerContainerLight)}
-        height={'100%'}
+        className={styles.outerContainer}
+        height={`calc(100% - ${TITLE_BAR_HEIGHT}px)`}
+        style={{ paddingBottom: 8, paddingInline: 8 }}
         width={'100%'}
       >
         <Flexbox
-          align={'center'}
-          className={cx(styles.drag)}
-          gap={8}
-          horizontal
-          justify={'space-between'}
-          padding={16}
+          className={cx(isDarkMode ? styles.innerContainerDark : styles.innerContainerLight)}
+          height={'100%'}
           width={'100%'}
         >
-          <div />
-          <Flexbox align={'center'} horizontal>
-            <LangButton placement={'bottomRight'} size={18} />
-            <Divider className={styles.divider} orientation={'vertical'} />
-            <ThemeButton placement={'bottomRight'} size={18} />
+          <Flexbox
+            align={'center'}
+            gap={8}
+            horizontal
+            justify={'space-between'}
+            padding={16}
+            width={'100%'}
+          >
+            <div />
+            <Flexbox align={'center'} horizontal>
+              <LangButton placement={'bottomRight'} size={18} />
+              <Divider className={styles.divider} orientation={'vertical'} />
+              <ThemeButton placement={'bottomRight'} size={18} />
+            </Flexbox>
           </Flexbox>
+          <Center height={'100%'} padding={16} width={'100%'}>
+            {children}
+          </Center>
+          <Center padding={24}>
+            <Text align={'center'} type={'secondary'}>
+              © 2025 LobeHub. All rights reserved.
+            </Text>
+          </Center>
         </Flexbox>
-        <Center height={'100%'} padding={16} width={'100%'}>
-          {children}
-        </Center>
-        <Center padding={24}>
-          <Text align={'center'} type={'secondary'}>
-            © 2025 LobeHub. All rights reserved.
-          </Text>
-        </Center>
       </Flexbox>
     </Flexbox>
   );

--- a/src/app/[variants]/(desktop)/desktop-onboarding/_layout/style.ts
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/_layout/style.ts
@@ -1,14 +1,13 @@
 import { createStaticStyles } from 'antd-style';
 
+import { isMacOSWithLargeWindowBorders } from '@/utils/platform';
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   // Divider 样式
   divider: css`
     height: 24px;
   `,
 
-  drag: css`
-    -webkit-app-region: drag;
-  `,
   // 内层容器 - 深色模式
   innerContainerDark: css`
     position: relative;
@@ -16,7 +15,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     overflow: hidden;
 
     border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadius};
+    border-radius: ${!isMacOSWithLargeWindowBorders()
+      ? cssVar.borderRadius
+      : `${cssVar.borderRadius} 12px ${cssVar.borderRadius} 12px`};
 
     background: ${cssVar.colorBgContainer};
   `,
@@ -28,7 +29,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     overflow: hidden;
 
     border: 1px solid ${cssVar.colorBorder};
-    border-radius: ${cssVar.borderRadius};
+    border-radius: ${!isMacOSWithLargeWindowBorders()
+      ? cssVar.borderRadius
+      : `${cssVar.borderRadius} 12px ${cssVar.borderRadius} 12px`};
 
     background: ${cssVar.colorBgContainer};
   `,

--- a/src/app/[variants]/(main)/_layout/DesktopLayoutContainer.tsx
+++ b/src/app/[variants]/(main)/_layout/DesktopLayoutContainer.tsx
@@ -6,7 +6,7 @@ import { isDesktop } from '@/const/version';
 import { useIsDark } from '@/hooks/useIsDark';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { isMacOSWithLargeWindowBorders } from '@/utils/platform';
+import { getDarwinMajorVersion, isMacOSWithLargeWindowBorders } from '@/utils/platform';
 
 import { styles } from './DesktopLayoutContainer/style';
 
@@ -24,8 +24,7 @@ const DesktopLayoutContainer: FC<PropsWithChildren> = ({ children }) => {
   );
 
   const innerCssVariables = useMemo<Record<string, string>>(() => {
-    const darwinMajorVersion =
-      typeof window !== 'undefined' ? (window.lobeEnv?.darwinMajorVersion ?? 0) : 0;
+    const darwinMajorVersion = getDarwinMajorVersion();
 
     const borderRadius = darwinMajorVersion >= 25 ? '12px' : cssVar.borderRadius;
     const borderBottomRightRadius =

--- a/src/features/ElectronTitlebar/SimpleTitleBar.tsx
+++ b/src/features/ElectronTitlebar/SimpleTitleBar.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { type FC } from 'react';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { electronStylish } from '@/styles/electron';
+
+import { TITLE_BAR_HEIGHT } from './const';
+
+/**
+ * A simple, minimal TitleBar for Electron windows.
+ * Provides draggable area without business logic (navigation, updates, etc.)
+ * Use this for secondary windows like onboarding, settings, etc.
+ */
+const SimpleTitleBar: FC = () => {
+  return (
+    <Flexbox
+      align={'center'}
+      className={electronStylish.draggable}
+      height={TITLE_BAR_HEIGHT}
+      horizontal
+      justify={'center'}
+      width={'100%'}
+    >
+      <ProductLogo size={16} type={'text'} />
+    </Flexbox>
+  );
+};
+
+export default SimpleTitleBar;

--- a/src/features/ElectronTitlebar/index.tsx
+++ b/src/features/ElectronTitlebar/index.tsx
@@ -67,3 +67,4 @@ const TitleBar = memo(() => {
 export default TitleBar;
 
 export { TITLE_BAR_HEIGHT } from './const';
+export { default as SimpleTitleBar } from './SimpleTitleBar';

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,2 @@
+// Re-export platform utilities from packages/utils
+export * from '../../packages/utils/src/platform';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Closes LOBE-3009

#### 🔀 Description of Change

This PR implements a custom titlebar for Electron windows to provide a native macOS experience:

- **SimpleTitleBar component**: A minimal, draggable titlebar for secondary windows (onboarding, settings, etc.) that displays the LobeHub logo
- **Traffic light positioning**: Configures macOS window control buttons (close, minimize, maximize) to be vertically centered within the titlebar
- **Platform detection enhancements**: 
  - Added `getDarwinMajorVersion()` utility to detect macOS version in both web and Electron environments
  - Enhanced `isMacOSWithLargeWindowBorders()` to support Electron by checking `window.lobeEnv.darwinMajorVersion`
- **Desktop onboarding layout**: Integrated SimpleTitleBar and adjusted container layout to accommodate the titlebar height
- **Border radius adjustments**: Applied proper corner radius for macOS 25+ with large window borders

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Run the desktop app on macOS
2. Verify the titlebar appears with the LobeHub logo centered
3. Verify traffic light buttons are properly positioned
4. Test the onboarding flow to ensure layout is correct
5. Test on macOS 25+ to verify large border radius is applied correctly

#### 📝 Additional Information

The SimpleTitleBar is designed for secondary windows that don't need navigation or update controls. The main window continues to use the full TitleBar component with all features.

## Summary by Sourcery

Introduce a custom Electron titlebar for desktop windows and align macOS-specific window styling and layout with large-border behavior.

New Features:
- Add a SimpleTitleBar component for secondary Electron windows that provides a minimal draggable titlebar with the product logo.
- Expose platform utilities and a getDarwinMajorVersion helper for consistent macOS version detection across web and Electron environments.

Enhancements:
- Adjust the desktop onboarding layout to accommodate the Electron titlebar height while preserving existing content and footer structure.
- Refine macOS large-window-border handling by applying asymmetric border radii to desktop onboarding containers and centralizing the logic via shared platform utilities.
- Center macOS traffic light window controls vertically within the custom titlebar for Electron BrowserWindows.
- Reuse getDarwinMajorVersion in the main desktop layout container to simplify border-radius logic.