### PR TITLE
🐛 fix(ChatInput): use input content when adding AI message

### DIFF
--- a/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -35,8 +35,10 @@ export const useSendMenuItems = (): MenuProps['items'] => {
 
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
-    // Add empty AI message placeholder
-    store.addAIMessage('');
+    const message = store.inputMessage;
+    if (!message.trim()) return;
+
+    store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();
     editor?.focus();


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #11371

#### 🔀 Description of Change

Fixed the "Add AI Message" menu action to use the actual input content instead of an empty string.

**Root Cause:**
In `useSendMenuItems.tsx`, the `handleAddAIMessage` callback was calling `store.addAIMessage('')` with a hardcoded empty string, ignoring any text the user had typed in the input field.

**Fix:**
Updated the handler to:
1. Get the input message from `store.inputMessage` (same as `handleAddUserMessage`)
2. Validate that the message is not empty before creating
3. Pass the actual content to `addAIMessage()`

Now the "Add AI Message" behavior matches "Add User Message" - both use the content from the input field.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

**Steps to reproduce the bug (before fix):**
1. Open any topic/conversation
2. Type some text in the input field
3. Click the dropdown arrow next to the send button
4. Select "Add AI Message"
5. Observe the message appears empty

**Expected behavior (after fix):**
- The AI message should contain the text that was typed in the input field
- If the input is empty, clicking "Add AI Message" should do nothing (same as "Add User Message")

#### 📸 Screenshots / Videos

N/A - The issue reporter provided a video in the original issue #11371

#### 📝 Additional Information

This is a minimal fix that aligns the AI message behavior with the existing user message behavior.

---
🤖 Generated with Claude Code

## Summary by Sourcery

Bug Fixes:
- Use the current input message content when adding an AI message from the send menu, and skip creation when the input is empty.