### PR TITLE
🐛 fix: TokenDetail components unable to switch

### DIFF
--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -123,6 +123,75 @@ const doubaoChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     config: {
+      deploymentName: 'glm-4-7-251222',
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'GLM-4.7 is the latest flagship model from Zhipu AI. GLM-4.7 enhances coding capabilities, long-term task planning, and tool collaboration for Agentic Coding scenarios, achieving leading performance among open-source models in multiple public benchmarks. General capabilities are improved, with more concise and natural responses, and more immersive writing. In complex agent tasks, instruction following is stronger during tool calls, and the aesthetics of Artifacts and Agentic Coding frontend, as well as long-term task completion efficiency, are further enhanced. • Stronger programming capabilities: Significantly improved multi-language coding and terminal agent performance; GLM-4.7 can now implement "think first, then act" mechanisms in programming frameworks like Claude Code, Kilo Code, TRAE, Cline, and Roo Code, with more stable performance on complex tasks. • Frontend aesthetics improvement: GLM-4.7 shows significant progress in frontend generation quality, capable of generating websites, PPTs, and posters with better visual appeal. • Stronger tool calling capabilities: GLM-4.7 enhances tool calling abilities, scoring 67 in BrowseComp web task evaluation; achieving 84.7 in τ²-Bench interactive tool calling evaluation, surpassing Claude Sonnet 4.5 as the open-source SOTA. • Reasoning capability improvement: Significantly enhanced math and reasoning abilities, scoring 42.8% in the HLE ("Humanity\'s Last Exam") benchmark, a 41% improvement over GLM-4.6, surpassing GPT-5.1. • General capability enhancement: GLM-4.7 conversations are more concise, intelligent, and humane; writing and role-playing are more literary and immersive.',
+    displayName: 'GLM-4.7',
+    id: 'glm-4-7',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]_[0, 0.0002]': 2,
+              '[0, 0.032]_[0.0002, infinity]': 3,
+              '[0.032, 0.2]_[0, infinity]': 4,
+            },
+            pricingParams: ['textInputRange', 'textOutputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]_[0, 0.0002]': 8,
+              '[0, 0.032]_[0.0002, infinity]': 14,
+              '[0.032, 0.2]_[0, infinity]': 16,
+            },
+            pricingParams: ['textInputRange', 'textOutputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]_[0, 0.0002]': 0.4,
+              '[0, 0.032]_[0.0002, infinity]': 0.6,
+              '[0.032, 0.2]_[0, infinity]': 0.8,
+            },
+            pricingParams: ['textInputRange', 'textOutputRange'],
+          },
+          name: 'textInput_cacheRead',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 0.017 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    config: {
       deploymentName: 'deepseek-v3-2-251201',
     },
     contextWindowTokens: 131_072,

--- a/packages/model-bank/src/aiModels/wenxin.ts
+++ b/packages/model-bank/src/aiModels/wenxin.ts
@@ -193,7 +193,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 131_072,
-    description: 'ERNIE Speed 128K is a no-I/O-fee model for long-text understanding and large-scale trials.',
+    description:
+      'ERNIE Speed 128K is a no-I/O-fee model for long-text understanding and large-scale trials.',
     displayName: 'ERNIE Speed 128K',
     id: 'ernie-speed-128k',
     maxOutput: 4096,
@@ -274,7 +275,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 8192,
-    description: 'ERNIE Tiny 8K is ultra-lightweight for simple QA, classification, and low-cost inference.',
+    description:
+      'ERNIE Tiny 8K is ultra-lightweight for simple QA, classification, and low-cost inference.',
     displayName: 'ERNIE Tiny 8K',
     id: 'ernie-tiny-8k',
     maxOutput: 2048,
@@ -337,7 +339,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 8192,
-    description: 'ERNIE Novel 8K is built for long-form novels and IP plots with multi-character narratives.',
+    description:
+      'ERNIE Novel 8K is built for long-form novels and IP plots with multi-character narratives.',
     displayName: 'ERNIE Novel 8K',
     id: 'ernie-novel-8k',
     maxOutput: 2048,
@@ -352,7 +355,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 131_072,
-    description: 'ERNIE 4.5 0.3B is an open-source lightweight model for local and customized deployment.',
+    description:
+      'ERNIE 4.5 0.3B is an open-source lightweight model for local and customized deployment.',
     displayName: 'ERNIE 4.5 0.3B',
     id: 'ernie-4.5-0.3b',
     maxOutput: 8192,
@@ -443,7 +447,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 32_768,
-    description: 'Qianfan 70B is a large Chinese model for high-quality generation and complex reasoning.',
+    description:
+      'Qianfan 70B is a large Chinese model for high-quality generation and complex reasoning.',
     displayName: 'Qianfan 70B',
     id: 'qianfan-70b',
     maxOutput: 16_384,
@@ -628,7 +633,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 32_768,
-    description: 'Qianfan Composition is a multimodal creation model for mixed image-text understanding and generation.',
+    description:
+      'Qianfan Composition is a multimodal creation model for mixed image-text understanding and generation.',
     displayName: 'Qianfan Composition',
     id: 'qianfan-composition',
     maxOutput: 8192,
@@ -758,7 +764,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 4096,
-    description: 'Qianfan EngCard VL is a multimodal recognition model focused on English scenarios.',
+    description:
+      'Qianfan EngCard VL is a multimodal recognition model focused on English scenarios.',
     displayName: 'Qianfan EngCard VL',
     id: 'qianfan-engcard-vl',
     maxOutput: 4000,
@@ -776,7 +783,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 4096,
-    description: 'Qianfan SinglePicOCR is a single-image OCR model with high-accuracy character recognition.',
+    description:
+      'Qianfan SinglePicOCR is a single-image OCR model with high-accuracy character recognition.',
     displayName: 'Qianfan SinglePicOCR',
     id: 'qianfan-singlepicocr',
     maxOutput: 4096,
@@ -794,7 +802,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 32_768,
-    description: 'InternVL3 38B is a large open-source multimodal model for high-accuracy image-text understanding.',
+    description:
+      'InternVL3 38B is a large open-source multimodal model for high-accuracy image-text understanding.',
     displayName: 'InternVL3 38B',
     id: 'internvl3-38b',
     maxOutput: 8192,
@@ -830,7 +839,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 32_768,
-    description: 'InternVL3 1B is a lightweight multimodal model for resource-constrained deployment.',
+    description:
+      'InternVL3 1B is a lightweight multimodal model for resource-constrained deployment.',
     displayName: 'InternVL3 1B',
     id: 'internvl3-1b',
     maxOutput: 8192,
@@ -848,7 +858,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 32_768,
-    description: 'InternVL2.5 38B MPO is a multimodal pretrained model for complex image-text reasoning.',
+    description:
+      'InternVL2.5 38B MPO is a multimodal pretrained model for complex image-text reasoning.',
     displayName: 'InternVL2.5 38B MPO',
     id: 'internvl2.5-38b-mpo',
     maxOutput: 4096,
@@ -1056,7 +1067,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 65_536,
-    description: 'GLM-4.5V is a multimodal vision-language model for general image understanding and QA.',
+    description:
+      'GLM-4.5V is a multimodal vision-language model for general image understanding and QA.',
     displayName: 'GLM-4.5V',
     id: 'glm-4.5v',
     maxOutput: 16_384,
@@ -1096,7 +1108,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 4096,
-    description: 'DeepSeek VL2 is a multimodal model for image-text understanding and fine-grained visual QA.',
+    description:
+      'DeepSeek VL2 is a multimodal model for image-text understanding and fine-grained visual QA.',
     displayName: 'DeepSeek VL2',
     id: 'deepseek-vl2',
     maxOutput: 2048,
@@ -1114,7 +1127,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 4096,
-    description: 'DeepSeek VL2 Small is a lightweight multimodal version for resource-constrained and high-concurrency use.',
+    description:
+      'DeepSeek VL2 Small is a lightweight multimodal version for resource-constrained and high-concurrency use.',
     displayName: 'DeepSeek VL2 Small',
     id: 'deepseek-vl2-small',
     maxOutput: 2048,
@@ -1181,7 +1195,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       search: true,
     },
     contextWindowTokens: 144_000,
-    description: 'DeepSeek V3.2 Think is a full deep-thinking model with stronger long-chain reasoning.',
+    description:
+      'DeepSeek V3.2 Think is a full deep-thinking model with stronger long-chain reasoning.',
     displayName: 'DeepSeek V3.2 Think',
     enabled: true,
     id: 'deepseek-v3.2-think',
@@ -1334,8 +1349,7 @@ const wenxinChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 32_768,
-    description:
-      'DeepSeek R1 Distill Llama 70B combines R1 reasoning with the Llama ecosystem.',
+    description: 'DeepSeek R1 Distill Llama 70B combines R1 reasoning with the Llama ecosystem.',
     displayName: 'DeepSeek R1 Distill Llama 70B',
     id: 'deepseek-r1-distill-llama-70b',
     maxOutput: 8192,
@@ -1440,7 +1454,8 @@ const wenxinChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 131_072,
-    description: 'Qwen3 235B A22B Thinking 2507 is an ultra-large thinking model for hard reasoning.',
+    description:
+      'Qwen3 235B A22B Thinking 2507 is an ultra-large thinking model for hard reasoning.',
     displayName: 'Qwen3 235B A22B Thinking 2507',
     id: 'qwen3-235b-a22b-thinking-2507',
     maxOutput: 32_768,
@@ -1675,7 +1690,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 32_768,
-    description: 'Qwen3 8B is a lightweight model with flexible deployment for high-concurrency workloads.',
+    description:
+      'Qwen3 8B is a lightweight model with flexible deployment for high-concurrency workloads.',
     displayName: 'Qwen3 8B',
     id: 'qwen3-8b',
     maxOutput: 8192,
@@ -1729,7 +1745,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 32_768,
-    description: 'Qwen3 0.6B is an entry-level model for simple reasoning and very constrained environments.',
+    description:
+      'Qwen3 0.6B is an entry-level model for simple reasoning and very constrained environments.',
     displayName: 'Qwen3 0.6B',
     id: 'qwen3-0.6b',
     maxOutput: 8192,
@@ -1747,7 +1764,8 @@ const wenxinChatModels: AIChatModelCard[] = [
   },
   {
     contextWindowTokens: 32_768,
-    description: 'Qwen2.5 7B Instruct is a mature open-source instruct model for multi-scenario chat and generation.',
+    description:
+      'Qwen2.5 7B Instruct is a mature open-source instruct model for multi-scenario chat and generation.',
     displayName: 'Qwen2.5 7B Instruct',
     id: 'qwen2.5-7b-instruct',
     maxOutput: 8192,
@@ -1756,22 +1774,6 @@ const wenxinChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_768,
-    description:
-      'GLM-4 32B 0414 is a general GLM model supporting multi-task text generation and understanding.',
-    displayName: 'GLM-4 32B 0414',
-    id: 'glm-4-32b-0414',
-    maxOutput: 8192,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',
@@ -1851,7 +1853,8 @@ const wenxinImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   {
-    description: 'FLUX.1-schnell is a high-performance image generation model for fast multi-style outputs.',
+    description:
+      'FLUX.1-schnell is a high-performance image generation model for fast multi-style outputs.',
     displayName: 'FLUX.1-schnell',
     enabled: true,
     id: 'flux.1-schnell',

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
@@ -12,6 +12,9 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 
 import { getPrice } from './pricing';
 
+// Popover 内部 Tooltip 需要更高的 z-index 以避免被遮挡
+const TOOLTIP_ZINDEX = 1200;
+
 export const styles = createStaticStyles(({ css, cssVar }) => {
   return {
     container: css`
@@ -61,24 +64,25 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
         </Flexbox>
         {!!pricing && (
           <Flexbox>
-            <Segmented
-              onChange={(value) => {
-                updateSystemStatus({ isShowCredit: value === 'credit' });
-              }}
-              options={[
-                { label: 'Token', value: 'token' },
-                {
-                  label: (
-                    <Tooltip title={t('messages.modelCard.creditTooltip')}>
-                      {t('messages.modelCard.credit')}
-                    </Tooltip>
-                  ),
-                  value: 'credit',
-                },
-              ]}
-              size={'small'}
-              value={isShowCredit ? 'credit' : 'token'}
-            />
+            <Tooltip
+              title={isShowCredit ? undefined : t('messages.modelCard.creditTooltip')}
+              zIndex={TOOLTIP_ZINDEX}
+            >
+              <Segmented
+                onChange={(value) => {
+                  updateSystemStatus({ isShowCredit: value === 'credit' });
+                }}
+                options={[
+                  { label: 'Token', value: 'token' },
+                  {
+                    label: t('messages.modelCard.credit'),
+                    value: 'credit',
+                  },
+                ]}
+                size={'small'}
+                value={isShowCredit ? 'credit' : 'token'}
+              />
+            </Tooltip>
           </Flexbox>
         )}
       </Flexbox>
@@ -92,6 +96,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
                 title={t('messages.modelCard.pricing.inputCachedTokens', {
                   amount: formatPrice.cachedInput,
                 })}
+                zIndex={TOOLTIP_ZINDEX}
               >
                 <Flexbox gap={2} horizontal>
                   <Icon icon={CircleFadingArrowUp} />
@@ -104,6 +109,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
                 title={t('messages.modelCard.pricing.writeCacheInputTokens', {
                   amount: formatPrice.writeCacheInput,
                 })}
+                zIndex={TOOLTIP_ZINDEX}
               >
                 <Flexbox gap={2} horizontal>
                   <Icon icon={BookUp2Icon} />
@@ -113,6 +119,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
             )}
             <Tooltip
               title={t('messages.modelCard.pricing.inputTokens', { amount: formatPrice.input })}
+              zIndex={TOOLTIP_ZINDEX}
             >
               <Flexbox gap={2} horizontal>
                 <Icon icon={ArrowUpFromDot} />
@@ -121,6 +128,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
             </Tooltip>
             <Tooltip
               title={t('messages.modelCard.pricing.outputTokens', { amount: formatPrice.output })}
+              zIndex={TOOLTIP_ZINDEX}
             >
               <Flexbox gap={2} horizontal>
                 <Icon icon={ArrowDownToDot} />

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -192,7 +192,10 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     <div style={{ color: cssVar.colorTextSecondary }}>
                       {t('messages.tokenDetails.speed.tps.title')}
                     </div>
-                    <InfoTooltip title={t('messages.tokenDetails.speed.tps.tooltip')} />
+                    <InfoTooltip
+                      title={t('messages.tokenDetails.speed.tps.tooltip')}
+                      zIndex={1200}
+                    />
                   </Flexbox>
                   <div style={{ fontWeight: 500 }}>{tps}</div>
                 </Flexbox>
@@ -203,7 +206,10 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     <div style={{ color: cssVar.colorTextSecondary }}>
                       {t('messages.tokenDetails.speed.ttft.title')}
                     </div>
-                    <InfoTooltip title={t('messages.tokenDetails.speed.ttft.tooltip')} />
+                    <InfoTooltip
+                      title={t('messages.tokenDetails.speed.ttft.tooltip')}
+                      zIndex={1200}
+                    />
                   </Flexbox>
                   <div style={{ fontWeight: 500 }}>{ttft}s</div>
                 </Flexbox>


### PR DESCRIPTION
…nd TokenDetail components

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

修复 token 统计面板无法切换到 积分 的问题。

<img width="642" height="193" alt="image" src="https://github.com/user-attachments/assets/a85c4f08-8dca-4ae6-8f37-7410263cd259" />


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix token usage detail panel switching and ensure tooltips render correctly within popovers.

Bug Fixes:
- Resolve inability to switch between token and credit views in the token statistics panel.

Enhancements:
- Standardize and raise tooltip z-index in usage detail and model card views so tooltips are not obscured within popovers.