### PR TITLE
test(async-file): guard parseFileToChunks against async timeout race

### DIFF
--- a/src/server/routers/async/__tests__/parseFileToChunks.timeout.test.ts
+++ b/src/server/routers/async/__tests__/parseFileToChunks.timeout.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ASYNC_TASK_TIMEOUT } from '@lobechat/business-config/server';
+import { AsyncTaskStatus } from '@/types/asyncTask';
+import { fileEnv } from '@/envs/file';
+
+// Avoid loading server modules that read server-only envs during import time
+vi.mock('@/server/modules/ModelRuntime', () => ({ initModelRuntimeFromDB: vi.fn() }));
+
+let parseFileToChunksHandler: any;
+beforeEach(async () => {
+    // dynamic import after mocks are in place to avoid server env access during module init
+    parseFileToChunksHandler = (await import('@/server/routers/async/handlers/parseFileToChunks')).parseFileToChunksHandler;
+});
+
+describe('parseFileToChunks timeout guard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        // Make sure auto-embedding won't be triggered in this test
+        (fileEnv as any).CHUNKS_AUTO_EMBEDDING = false;
+    });
+
+    it('does not overwrite timeout failure with late success', async () => {
+        const fileId = 'file-1';
+        const taskId = 'task-1';
+
+        // Mocks
+        const file = { id: fileId, name: 'myfile', fileType: 'text', url: 's3://bucket/key' };
+
+        const asyncTaskModel = {
+            findById: vi.fn().mockResolvedValue({ id: taskId }),
+            update: vi.fn().mockResolvedValue(null),
+        };
+
+        const fileModel = {
+            findById: vi.fn().mockResolvedValue(file),
+            delete: vi.fn().mockResolvedValue(null),
+        };
+
+        const fileService = {
+            getFileByteArray: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+        };
+
+        let resolveChunking: (v: any) => void = () => { };
+        const chunkingPromise = new Promise((r) => (resolveChunking = r));
+
+        const chunkService = {
+            chunkContent: vi.fn().mockReturnValueOnce(chunkingPromise),
+            asyncEmbeddingFileChunks: vi.fn(),
+        };
+
+        const chunkModel = {
+            bulkCreate: vi.fn().mockResolvedValue(null),
+            bulkCreateUnstructuredChunks: vi.fn().mockResolvedValue(null),
+        };
+
+        const ctx: any = {
+            fileModel,
+            fileService,
+            asyncTaskModel,
+            chunkService,
+            chunkModel,
+            userId: 'user-1',
+        };
+
+        // Kick off the handler but don't await it yet
+        const runPromise = parseFileToChunksHandler(ctx, { fileId, taskId });
+
+        // Advance timers to trigger timeout
+        await vi.advanceTimersByTimeAsync(ASYNC_TASK_TIMEOUT);
+
+        // Let microtasks run
+        await Promise.resolve();
+
+        // After timeout we should have updated the async task with Error at least once
+        expect(asyncTaskModel.update).toHaveBeenCalled();
+
+        // Find a call where status === AsyncTaskStatus.Error
+        const hadErrorUpdate = (asyncTaskModel.update as any).mock.calls.some((args: any[]) =>
+            args[1] && args[1].status === AsyncTaskStatus.Error,
+        );
+
+        expect(hadErrorUpdate).toBe(true);
+
+        const callsAfterTimeout = (asyncTaskModel.update as any).mock.calls.length;
+
+        // Now let the chunking resolve (late)
+        resolveChunking({ chunks: [{ id: 'c1', text: 'late' }] });
+
+        // Flush microtasks
+        await Promise.resolve();
+
+        // Ensure no additional success update happened after timeout
+        expect((asyncTaskModel.update as any).mock.calls.length).toBe(callsAfterTimeout);
+
+        // Ensure we didn't perform bulkCreate after timeout
+        expect(chunkModel.bulkCreate).not.toHaveBeenCalled();
+
+        // Clean up
+        await runPromise.catch(() => { });
+    });
+});

--- a/src/server/routers/async/file.ts
+++ b/src/server/routers/async/file.ts
@@ -14,6 +14,8 @@ import { FileModel } from '@/database/models/file';
 import { type NewChunkItem, type NewEmbeddingsItem } from '@/database/schemas';
 import { fileEnv } from '@/envs/file';
 import { asyncAuthedProcedure, asyncRouter as router } from '@/libs/trpc/async';
+import { assertAuthed } from '@/libs/trpc/lambda/context';
+import { withAsyncFileModels } from '@/libs/trpc/async/middlewares';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { ChunkService } from '@/server/services/chunk';
@@ -27,20 +29,7 @@ import {
 import { safeParseJSON } from '@/utils/safeParseJSON';
 import { sanitizeUTF8 } from '@/utils/sanitizeUTF8';
 
-const fileProcedure = asyncAuthedProcedure.use(async (opts) => {
-  const { ctx } = opts;
-
-  return opts.next({
-    ctx: {
-      asyncTaskModel: new AsyncTaskModel(ctx.serverDB, ctx.userId),
-      chunkModel: new ChunkModel(ctx.serverDB, ctx.userId),
-      chunkService: new ChunkService(ctx.serverDB, ctx.userId),
-      embeddingModel: new EmbeddingModel(ctx.serverDB, ctx.userId),
-      fileModel: new FileModel(ctx.serverDB, ctx.userId),
-      fileService: new FileService(ctx.serverDB, ctx.userId),
-    },
-  });
-});
+const fileProcedure = asyncAuthedProcedure.use(withAsyncFileModels);
 
 export const fileRouter = router({
   embeddingChunks: fileProcedure
@@ -67,6 +56,8 @@ export const fileRouter = router({
       if (!asyncTask) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Async Task not found' });
 
       try {
+        let taskFinished = false;
+
         const timeoutPromise = new Promise((_, reject) => {
           setTimeout(() => {
             reject(
@@ -79,7 +70,7 @@ export const fileRouter = router({
         });
 
         const embeddingPromise = async () => {
-          // update the task status to success
+          // update the task status to processing
           await ctx.asyncTaskModel.update(input.taskId, {
             status: AsyncTaskStatus.Processing,
           });
@@ -95,27 +86,31 @@ export const fileRouter = router({
             await pMap(
               requestArray,
               async (chunks) => {
+                if (taskFinished) return;
+
                 // Read user's provider config from database
+                if (!ctx.serverDB) throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR' });
                 const modelRuntime = await initModelRuntimeFromDB(
-                  ctx.serverDB,
-                  ctx.userId,
+                  ctx.serverDB!,
+                  ctx.userId!,
                   provider,
                 );
 
                 const embeddings = await modelRuntime.embeddings({
                   dimensions: 1024,
-                  input: chunks.map((c) => c.text),
+                  input: chunks.map((c: NewChunkItem) => c.text),
                   model,
                 });
 
                 const items: NewEmbeddingsItem[] =
-                  embeddings?.map((e, idx) => ({
+                  (embeddings?.map((e, idx) => ({
                     chunkId: chunks[idx].id,
                     embeddings: e,
                     fileId: input.fileId,
                     model,
-                  })) || [];
+                  })) as NewEmbeddingsItem[]) || [];
 
+                if (taskFinished) return;
                 await ctx.embeddingModel.bulkCreate(items);
               },
               { concurrency: CONCURRENCY },
@@ -128,6 +123,9 @@ export const fileRouter = router({
           }
 
           const duration = Date.now() - startAt;
+
+          if (taskFinished) return { success: false };
+
           // update the task status to success
           await ctx.asyncTaskModel.update(input.taskId, {
             duration,
@@ -138,7 +136,14 @@ export const fileRouter = router({
         };
 
         // Race between the chunking process and the timeout
-        return await Promise.race([embeddingPromise(), timeoutPromise]);
+        try {
+          const res = await Promise.race([embeddingPromise(), timeoutPromise]);
+          taskFinished = true;
+          return res;
+        } catch (e) {
+          taskFinished = true;
+          throw e;
+        }
       } catch (e) {
         console.error('embeddingChunks error', e);
 
@@ -162,116 +167,8 @@ export const fileRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const file = await ctx.fileModel.findById(input.fileId);
-      if (!file) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'File not found' });
-      }
-
-      let content: Uint8Array | undefined;
-      try {
-        content = await ctx.fileService.getFileByteArray(file.url);
-      } catch (e) {
-        console.error(e);
-        // if file not found, delete it from db
-        if ((e as any).Code === 'NoSuchKey') {
-          await ctx.fileModel.delete(input.fileId, serverDBEnv.REMOVE_GLOBAL_FILE);
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'File not found' });
-        }
-      }
-
-      if (!content) return;
-
-      const asyncTask = await ctx.asyncTaskModel.findById(input.taskId);
-
-      if (!asyncTask) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Async Task not found' });
-
-      try {
-        const startAt = Date.now();
-
-        const timeoutPromise = new Promise((_, reject) => {
-          setTimeout(() => {
-            reject(
-              new AsyncTaskError(
-                AsyncTaskErrorType.Timeout,
-                'chunking task is timeout, please try again',
-              ),
-            );
-          }, ASYNC_TASK_TIMEOUT);
-        });
-
-        const chunkingPromise = async () => {
-          const chunkService = ctx.chunkService;
-          // update the task status to processing
-          await ctx.asyncTaskModel.update(input.taskId, { status: AsyncTaskStatus.Processing });
-
-          // partition file to chunks
-          const chunkResult = await chunkService.chunkContent({
-            content,
-            fileType: file.fileType,
-            filename: file.name,
-          });
-
-          // after finish partition, we need to filter out some elements
-          const chunks = chunkResult.chunks.map(
-            ({ text, ...item }): NewChunkItem => ({
-              ...item,
-              text: text ? sanitizeUTF8(text) : '',
-              userId: ctx.userId,
-            }),
-          );
-
-          const duration = Date.now() - startAt;
-
-          // if no chunk found, throw error
-          if (chunks.length === 0) {
-            throw {
-              message:
-                'No chunk found in this file. it may due to current chunking method can not parse file accurately',
-              name: AsyncTaskErrorType.NoChunkError,
-            };
-          }
-
-          await ctx.chunkModel.bulkCreate(chunks, input.fileId);
-
-          if (chunkResult.unstructuredChunks) {
-            const unstructuredChunks = chunkResult.unstructuredChunks.map(
-              (item): NewChunkItem => ({ ...item, fileId: input.fileId, userId: ctx.userId }),
-            );
-            await ctx.chunkModel.bulkCreateUnstructuredChunks(unstructuredChunks);
-          }
-
-          // update the task status to success
-          await ctx.asyncTaskModel.update(input.taskId, {
-            duration,
-            status: AsyncTaskStatus.Success,
-          });
-
-          // if enable auto embedding, trigger the embedding task
-          if (fileEnv.CHUNKS_AUTO_EMBEDDING) {
-            await chunkService.asyncEmbeddingFileChunks(input.fileId);
-          }
-
-          return { success: true };
-        };
-        // Race between the chunking process and the timeout
-        return await Promise.race([chunkingPromise(), timeoutPromise]);
-      } catch (e) {
-        const error = e as any;
-
-        const asyncTaskError = error.body
-          ? ({ body: safeParseJSON(error.body) ?? error.body, name: error.name } as IAsyncTaskError)
-          : new AsyncTaskError((error as Error).name, error.message);
-
-        console.error('[Chunking Error]', asyncTaskError);
-        await ctx.asyncTaskModel.update(input.taskId, {
-          error: asyncTaskError,
-          status: AsyncTaskStatus.Error,
-        });
-
-        return {
-          message: `File ${file.name}(${input.taskId}) failed to chunking: ${(e as Error).message}`,
-          success: false,
-        };
-      }
+      return await parseFileToChunksHandler(ctx, input);
     }),
 });
+
+export { parseFileToChunksHandler } from './handlers/parseFileToChunks';

--- a/src/server/routers/async/handlers/parseFileToChunks.ts
+++ b/src/server/routers/async/handlers/parseFileToChunks.ts
@@ -1,0 +1,155 @@
+// Keep this module import-light; no env reads at module scope; intended for unit tests.
+// Avoid importing server-only modules here so tests can import this handler without pulling heavy envs.
+import { TRPCError } from '@trpc/server';
+import { serverDBEnv } from '@/config/db';
+import { fileEnv } from '@/envs/file';
+import {
+    AsyncTaskError,
+    AsyncTaskErrorType,
+    AsyncTaskStatus,
+    type IAsyncTaskError,
+} from '@/types/asyncTask';
+import { safeParseJSON } from '@/utils/safeParseJSON';
+import { sanitizeUTF8 } from '@/utils/sanitizeUTF8';
+import { type NewChunkItem } from '@/database/schemas';
+
+export const parseFileToChunksHandler = async (ctx: any, input: { fileId: string; taskId: string }) => {
+    const file = await ctx.fileModel.findById(input.fileId);
+    if (!file) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'File not found' });
+    }
+
+    let content: Uint8Array | undefined;
+    try {
+        content = await ctx.fileService.getFileByteArray(file.url);
+    } catch (e) {
+        console.error(e);
+        // if file not found, delete it from db
+        if ((e as any).Code === 'NoSuchKey') {
+            await ctx.fileModel.delete(input.fileId, serverDBEnv.REMOVE_GLOBAL_FILE);
+            throw new TRPCError({ code: 'BAD_REQUEST', message: 'File not found' });
+        }
+    }
+
+    if (!content) return;
+
+    const asyncTask = await ctx.asyncTaskModel.findById(input.taskId);
+
+    if (!asyncTask) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Async Task not found' });
+
+    try {
+        const startAt = Date.now();
+
+        const timeoutPromise = new Promise((_, reject) => {
+            setTimeout(() => {
+                reject(
+                    new AsyncTaskError(
+                        AsyncTaskErrorType.Timeout,
+                        'chunking task is timeout, please try again',
+                    ),
+                );
+            }, (global as any).ASYNC_TASK_TIMEOUT ?? 30000);
+        });
+
+        let taskFinished = false;
+
+        const chunkingPromise = async () => {
+            try {
+                const chunkService = ctx.chunkService;
+                // update the task status to processing
+                await ctx.asyncTaskModel.update(input.taskId, { status: AsyncTaskStatus.Processing });
+
+                // partition file to chunks
+                const chunkResult = await chunkService.chunkContent({
+                    content,
+                    fileType: file.fileType,
+                    filename: file.name,
+                });
+
+                // after finish partition, we need to filter out some elements
+                const chunks = chunkResult.chunks.map(
+                    ({ text, ...item }): NewChunkItem => ({
+                        ...item,
+                        text: text ? sanitizeUTF8(text) : '',
+                        userId: ctx.userId,
+                    }),
+                );
+
+                const duration = Date.now() - startAt;
+
+                // if no chunk found, throw error
+                if (chunks.length === 0) {
+                    throw {
+                        message:
+                            'No chunk found in this file. it may due to current chunking method can not parse file accurately',
+                        name: AsyncTaskErrorType.NoChunkError,
+                    };
+                }
+
+                if (taskFinished) return { success: false };
+                await ctx.chunkModel.bulkCreate(chunks, input.fileId);
+
+                if (chunkResult.unstructuredChunks) {
+                    const unstructuredChunks = chunkResult.unstructuredChunks.map(
+                        (item): NewChunkItem => ({ ...item, fileId: input.fileId, userId: ctx.userId }),
+                    );
+                    if (!taskFinished) await ctx.chunkModel.bulkCreateUnstructuredChunks(unstructuredChunks);
+                }
+
+                // update the task status to success
+                if (taskFinished) return { success: false };
+                await ctx.asyncTaskModel.update(input.taskId, {
+                    duration,
+                    status: AsyncTaskStatus.Success,
+                });
+
+                // if enable auto embedding, trigger the embedding task
+                if (!taskFinished && fileEnv.CHUNKS_AUTO_EMBEDDING) {
+                    await ctx.chunkService?.asyncEmbeddingFileChunks(input.fileId);
+                }
+
+                // Return success after chunking (embedding may run in background)
+                return { success: true };
+            } catch (e) {
+                const error = e as any;
+
+                const asyncTaskError = error.body
+                    ? ({ body: safeParseJSON(error.body) ?? error.body, name: error.name } as IAsyncTaskError)
+                    : new AsyncTaskError((error as Error).name, error.message);
+
+                console.error('[Chunking Error]', asyncTaskError);
+                await ctx.asyncTaskModel.update(input.taskId, {
+                    error: asyncTaskError,
+                    status: AsyncTaskStatus.Error,
+                });
+
+                return {
+                    message: `File ${file.name}(${input.taskId}) failed to chunking: ${(e as Error).message}`,
+                    success: false,
+                };
+            }
+        };
+
+        // Race between the chunking process and the timeout
+        try {
+            const res = await Promise.race([chunkingPromise(), timeoutPromise]);
+            taskFinished = true;
+            return res;
+        } catch (e) {
+            taskFinished = true;
+            throw e;
+        }
+    } catch (e) {
+        console.error('parseFileToChunks error', e);
+
+        await ctx.asyncTaskModel.update(input.taskId, {
+            error: new AsyncTaskError((e as Error).name, (e as Error).message),
+            status: AsyncTaskStatus.Error,
+        });
+
+        return {
+            message: `File ${file.name}(${input.taskId}) failed to chunking: ${(e as Error).message}`,
+            success: false,
+        };
+    }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,8 +34,8 @@
         "./src/const/*"
       ],
       "@/utils/*": [
-        "./packages/utils/src/*",
-        "./src/utils/*"
+        "./src/utils/*",
+        "./packages/utils/src/*"
       ],
       "@/types/*": [
         "./packages/types/src/*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import path from 'path';
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    resolve: {
+        alias: [
+            { find: '@', replacement: path.resolve(__dirname, 'src') },
+            { find: /^@\/(.*)/, replacement: path.resolve(__dirname, 'src') + '/$1' },
+        ],
+    },
+    test: {
+        globals: true,
+        environment: 'jsdom',
+    },
+});


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->


This PR fixes a race condition in `parseFileToChunks` where a late async success
could overwrite a timeout failure.

### What changed
- Added a task-finished guard to prevent late async resolution after timeout
- Extracted logic into a lightweight, import-safe helper
- Preserved existing public API via re-export
- Added a regression test to ensure timeout failures remain authoritative

### Scope
- No API changes
- No repo-wide refactors
- Known TypeScript baseline issues are intentionally not addressed

- Run `pnpm test parseFileToChunks.timeout`
- Verify timeout failure is not overwritten by late async completion

