### PR TITLE
🐛 fix(topic): clear activeTopicId when switching agents or groups

### DIFF
--- a/src/app/[variants]/(main)/agent/_layout/AgentIdSync.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/AgentIdSync.tsx
@@ -1,4 +1,4 @@
-import { useUnmount } from 'ahooks';
+import { useUnmount, useUpdateEffect } from 'ahooks';
 import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
@@ -12,6 +12,12 @@ const AgentIdSync = () => {
 
   useStoreUpdater('activeAgentId', params.aid);
   useChatStoreUpdater('activeAgentId', params.aid ?? '');
+
+  // Clear activeTopicId when switching agents (params.aid changes after initial mount)
+  // This ensures new conversations get saved to a new topic instead of the previous agent's topic
+  useUpdateEffect(() => {
+    useChatStore.setState({ activeThreadId: undefined, activeTopicId: undefined });
+  }, [params.aid]);
 
   // Clear activeAgentId when unmounting (leaving chat page)
   useUnmount(() => {

--- a/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
@@ -1,4 +1,4 @@
-import { useUnmount } from 'ahooks';
+import { useUnmount, useUpdateEffect } from 'ahooks';
 import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
@@ -13,6 +13,12 @@ const GroupIdSync = () => {
   // Sync groupId to agentGroupStore and chatStore
   useAgentGroupStoreUpdater('activeGroupId', params.gid);
   useChatStoreUpdater('activeGroupId', params.gid);
+
+  // Clear activeTopicId when switching groups (params.gid changes after initial mount)
+  // This ensures new conversations get saved to a new topic instead of the previous group's topic
+  useUpdateEffect(() => {
+    useChatStore.setState({ activeThreadId: undefined, activeTopicId: undefined });
+  }, [params.gid]);
 
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #11395

#### 🔀 Description of Change

**Problem:**
After switching agents, new conversations were not being saved to topic history. Users had to manually click "Start New Topic" for topics to save correctly.

**Root Cause:**
When switching agents via navigation, only `activeAgentId` was updated in the stores. The `activeTopicId` still referenced the previous agent's topic. The message-sending logic checks if `topicId` exists before creating a new topic, so messages were incorrectly associated with the previous topic instead of creating a new one.

**Solution:**
Added `useUpdateEffect` hook (from ahooks) to detect when `params.aid` changes *after* initial mount and clear both `activeTopicId` and `activeThreadId`. This ensures:
- New conversations get saved to a new topic for the current agent
- The fix doesn't trigger on initial page load (only on agent switch)
- Thread state is also cleared for consistency

The same fix was applied to `GroupIdSync.tsx` for group switching consistency.

#### 🧪 How to Test

**Steps to reproduce the bug (before fix):**
1. Open any agent (Agent A) and start a conversation
2. Observe a new topic appearing in the topic history
3. Switch to a different agent (Agent B)
4. In the empty chat window, send a message and receive a response
5. **[Bug]** No new topic appears in Agent B's topic history
6. Click "Start New Topic", then send another message
7. The topic is now saved correctly

**Expected behavior (after fix):**
- Step 5 should create a new topic automatically in Agent B's history
- No manual intervention needed to save topics after switching agents

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A - The issue reporter provided a video in the original issue #11395

#### 📝 Additional Information

This fix follows the existing pattern in the codebase where `activeTopicId` is cleared on unmount. The `useUpdateEffect` hook ensures the clearing only happens when the agent ID actually changes, not on initial mount.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Ensure chat topic and thread state is reset when switching agents or groups so new conversations are correctly scoped.

Bug Fixes:
- Reset active topic and thread IDs on agent change so new messages create topics under the correct agent instead of reusing the previous agent's topic.
- Reset active topic and thread IDs on group change so new messages create topics under the correct group instead of reusing the previous group's topic.