### PR TITLE
🐛 fix(@upstash/qstash): should properly extract Error message from thrown one

### DIFF
--- a/patches/@upstash__qstash.patch
+++ b/patches/@upstash__qstash.patch
@@ -1,5 +1,5 @@
 diff --git a/chunk-RQPZUJXG.mjs b/chunk-RQPZUJXG.mjs
-index d1a9b4a460efc59304ec30e6bc63a127f1aac6d6..6653a61b539aaf91253300436a8072c6c5f666ee 100644
+index d1a9b4a460efc59304ec30e6bc63a127f1aac6d6..4303089796e63297f79926fc9f9bd976029b1a8e 100644
 --- a/chunk-RQPZUJXG.mjs
 +++ b/chunk-RQPZUJXG.mjs
 @@ -326,6 +326,20 @@ var HttpClient = class {
@@ -23,3 +23,15 @@ index d1a9b4a460efc59304ec30e6bc63a127f1aac6d6..6653a61b539aaf91253300436a8072c6
        throw new QstashError(
          body.length > 0 ? body : `Error: status=${response.status}`,
          response.status
+@@ -1841,8 +1855,10 @@ var AutoExecutor = class _AutoExecutor {
+           if (error instanceof QStashWorkflowAbort) {
+             throw error;
+           }
++
++          const errorMessage = error instanceof Error ? error.message : typeof error === "object" ? JSON.stringify(error) : String(error);
+           throw new QStashWorkflowError(
+-            `Error submitting steps to QStash in partial parallel step execution: ${error}`
++            `Error submitting steps to QStash in partial parallel step execution: ${errorMessage}`
+           );
+         }
+         break;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure error messages are correctly extracted from thrown errors when using the @upstash/qstash integration.