### PR TITLE
🐛 fix: revert editor modal 

### DIFF
--- a/src/features/EditorModal/EditorCanvas.tsx
+++ b/src/features/EditorModal/EditorCanvas.tsx
@@ -1,0 +1,62 @@
+import {
+  IEditor,
+  ReactCodePlugin,
+  ReactCodemirrorPlugin,
+  ReactHRPlugin,
+  ReactLinkPlugin,
+  ReactListPlugin,
+  ReactMathPlugin,
+  ReactTablePlugin,
+} from '@lobehub/editor';
+import { Editor } from '@lobehub/editor/react';
+import { Flexbox } from '@lobehub/ui';
+import { FC } from 'react';
+
+import TypoBar from './Typobar';
+
+interface EditorCanvasProps {
+  defaultValue?: string;
+  editor?: IEditor;
+}
+
+const EditorCanvas: FC<EditorCanvasProps> = ({ defaultValue, editor }) => {
+  return (
+    <>
+      <TypoBar editor={editor} />
+      <Flexbox
+        padding={16}
+        style={{ cursor: 'text', maxHeight: '80vh', minHeight: '50vh', overflowY: 'auto' }}
+      >
+        <Editor
+          autoFocus
+          content={''}
+          editor={editor}
+          onInit={(editor) => {
+            if (!editor || !defaultValue) return;
+            try {
+              editor?.setDocument('markdown', defaultValue);
+            } catch (e) {
+              console.error('setDocument error:', e);
+            }
+          }}
+          plugins={[
+            ReactListPlugin,
+            ReactCodePlugin,
+            ReactCodemirrorPlugin,
+            ReactHRPlugin,
+            ReactLinkPlugin,
+            ReactTablePlugin,
+            ReactMathPlugin,
+          ]}
+          style={{
+            paddingBottom: 120,
+          }}
+          type={'text'}
+          variant={'chat'}
+        />
+      </Flexbox>
+    </>
+  );
+};
+
+export default EditorCanvas;

--- a/src/features/EditorModal/TextArea.tsx
+++ b/src/features/EditorModal/TextArea.tsx
@@ -1,0 +1,30 @@
+import { TextArea } from '@lobehub/ui';
+import { FC } from 'react';
+
+interface EditorCanvasProps {
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  value?: string;
+}
+
+const EditorCanvas: FC<EditorCanvasProps> = ({ defaultValue, value, onChange }) => {
+  return (
+    <TextArea
+      defaultValue={defaultValue}
+      onChange={(e) => {
+        onChange?.(e.target.value);
+      }}
+      style={{
+        cursor: 'text',
+        maxHeight: '80vh',
+        minHeight: '50vh',
+        overflowY: 'auto',
+        padding: 16,
+      }}
+      value={value}
+      variant={'borderless'}
+    />
+  );
+};
+
+export default EditorCanvas;

--- a/src/features/EditorModal/Typobar.tsx
+++ b/src/features/EditorModal/Typobar.tsx
@@ -1,0 +1,139 @@
+import { HotkeyEnum, type IEditor, getHotkeyById } from '@lobehub/editor';
+import { useEditorState } from '@lobehub/editor/react';
+import {
+  ChatInputActionBar,
+  ChatInputActions,
+  type ChatInputActionsProps,
+} from '@lobehub/editor/react';
+import { cssVar } from 'antd-style';
+import {
+  BoldIcon,
+  CodeXmlIcon,
+  ItalicIcon,
+  ListIcon,
+  ListOrderedIcon,
+  ListTodoIcon,
+  MessageSquareQuote,
+  SigmaIcon,
+  SquareDashedBottomCodeIcon,
+  StrikethroughIcon,
+  UnderlineIcon,
+} from 'lucide-react';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
+  const { t } = useTranslation('editor');
+  const editorState = useEditorState(editor);
+
+  const items: ChatInputActionsProps['items'] = useMemo(
+    () =>
+      [
+        {
+          active: editorState.isBold,
+          icon: BoldIcon,
+          key: 'bold',
+          label: t('typobar.bold'),
+          onClick: editorState.bold,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Bold).keys },
+        },
+        {
+          active: editorState.isItalic,
+          icon: ItalicIcon,
+          key: 'italic',
+          label: t('typobar.italic'),
+          onClick: editorState.italic,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Italic).keys },
+        },
+        {
+          active: editorState.isUnderline,
+          icon: UnderlineIcon,
+          key: 'underline',
+          label: t('typobar.underline'),
+          onClick: editorState.underline,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Underline).keys },
+        },
+        {
+          active: editorState.isStrikethrough,
+          icon: StrikethroughIcon,
+          key: 'strikethrough',
+          label: t('typobar.strikethrough'),
+          onClick: editorState.strikethrough,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Strikethrough).keys },
+        },
+        {
+          type: 'divider',
+        },
+
+        {
+          icon: ListIcon,
+          key: 'bulletList',
+          label: t('typobar.bulletList'),
+          onClick: editorState.bulletList,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.BulletList).keys },
+        },
+        {
+          icon: ListOrderedIcon,
+          key: 'numberlist',
+          label: t('typobar.numberList'),
+          onClick: editorState.numberList,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.NumberList).keys },
+        },
+        {
+          icon: ListTodoIcon,
+          key: 'tasklist',
+          label: t('typobar.taskList'),
+          onClick: editorState.checkList,
+        },
+        {
+          type: 'divider',
+        },
+        {
+          active: editorState.isBlockquote,
+          icon: MessageSquareQuote,
+          key: 'blockquote',
+          label: t('typobar.blockquote'),
+          onClick: editorState.blockquote,
+        },
+        {
+          type: 'divider',
+        },
+        {
+          icon: SigmaIcon,
+          key: 'math',
+          label: t('typobar.tex'),
+          onClick: editorState.insertMath,
+        },
+        {
+          active: editorState.isCode,
+          icon: CodeXmlIcon,
+          key: 'code',
+          label: t('typobar.code'),
+          onClick: editorState.code,
+          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.CodeInline).keys },
+        },
+        {
+          icon: SquareDashedBottomCodeIcon,
+          key: 'codeblock',
+          label: t('typobar.codeblock'),
+          onClick: editorState.codeblock,
+        },
+      ].filter(Boolean) as ChatInputActionsProps['items'],
+    [editorState],
+  );
+
+  return (
+    <ChatInputActionBar
+      left={<ChatInputActions items={items} />}
+      style={{
+        background: cssVar.colorFillQuaternary,
+        borderTopLeftRadius: 8,
+        borderTopRightRadius: 8,
+      }}
+    />
+  );
+});
+
+TypoBar.displayName = 'TypoBar';
+
+export default TypoBar;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

fix LOBE-3165
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust editor modal to support both rich-text and plain-text editing modes based on user preferences while improving the embedded editor experience.

New Features:
- Introduce a rich-text toolbar and editor canvas for the editor modal using the shared editor plugins.
- Add a plain-text textarea canvas variant for the editor modal when rich input is disabled in user preferences.

Bug Fixes:
- Ensure the editor modal correctly returns the edited content for both rich-text and plain-text modes without falling back to the original value.

Enhancements:
- Wire the editor modal to user lab preferences to toggle between rich markdown rendering and simple text input.