### PR TITLE
♻️ refactor: remove the old lobehub plugins

### DIFF
--- a/src/features/PluginStore/Content.tsx
+++ b/src/features/PluginStore/Content.tsx
@@ -10,7 +10,6 @@ import { PluginStoreTabs } from '@/store/tool/slices/oldStore';
 import AddPluginButton from './AddPluginButton';
 import InstalledList from './InstalledList';
 import McpList from './McpList';
-import PluginList from './PluginList';
 import Search from './Search';
 
 export const Content = memo(() => {
@@ -21,9 +20,8 @@ export const Content = memo(() => {
 
   const options = [
     { label: t('store.tabs.mcp'), value: PluginStoreTabs.MCP },
-    { label: t('store.tabs.old'), value: PluginStoreTabs.Plugin },
     { label: t('store.tabs.installed'), value: PluginStoreTabs.Installed },
-  ].filter(Boolean) as SegmentedOptions;
+  ] as SegmentedOptions;
 
   return (
     <Flexbox
@@ -48,7 +46,6 @@ export const Content = memo(() => {
         <Search />
       </Flexbox>
       {listType === PluginStoreTabs.MCP && <McpList />}
-      {listType === PluginStoreTabs.Plugin && <PluginList />}
       {listType === PluginStoreTabs.Installed && <InstalledList keywords={keywords} />}
     </Flexbox>
   );


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Enhancements:
- Remove the legacy plugin list tab and component from the plugin store content view, leaving only MCP and installed plugins.