### PR TITLE
✨ feat: add budget source i18n and Seedream 4.5 model

### DIFF
--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -57,6 +57,8 @@
   "funds.packages.noPackages": "No credit packages",
   "funds.packages.purchaseFirst": "Purchase your first credit package",
   "funds.packages.purchasedOn": "Purchased on {{date}}",
+  "funds.packages.gift": "Gift",
+  "funds.packages.giftedOn": "Gifted on {{date}}",
   "funds.packages.sort.amountAsc": "Amount: Low to High",
   "funds.packages.sort.amountDesc": "Amount: High to Low",
   "funds.packages.sort.balanceAsc": "Balance: Low to High",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -57,6 +57,8 @@
   "funds.packages.noPackages": "暂无积分包",
   "funds.packages.purchaseFirst": "购买您的第一个积分包",
   "funds.packages.purchasedOn": "购买于 {{date}}",
+  "funds.packages.gift": "赠送",
+  "funds.packages.giftedOn": "赠送于 {{date}}",
   "funds.packages.sort.amountAsc": "金额：从低到高",
   "funds.packages.sort.amountDesc": "金额：从高到低",
   "funds.packages.sort.balanceAsc": "余额：从低到高",

--- a/packages/model-bank/src/aiModels/lobehub.ts
+++ b/packages/model-bank/src/aiModels/lobehub.ts
@@ -1228,9 +1228,28 @@ const lobehubImageModels: AIImageModelCard[] = [
   },
   {
     description:
+      'Seedream 4.5, built by ByteDance Seed team, supports multi-image editing and composition. Features enhanced subject consistency, precise instruction following, spatial logic understanding, aesthetic expression, poster layout and logo design with high-precision text-image rendering.',
+    displayName: 'Seedream 4.5',
+    enabled: true,
+    id: 'fal-ai/bytedance/seedream/v4.5',
+    parameters: {
+      height: { default: 2048, max: 4096, min: 1920, step: 1 },
+      imageUrls: { default: [], maxCount: 10, maxFileSize: 10 * 1024 * 1024 },
+      prompt: { default: '' },
+      seed: { default: null },
+      width: { default: 2048, max: 4096, min: 1920, step: 1 },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.04, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-12-04',
+    type: 'image',
+  },
+  {
+    description:
       'Seedream 4.0, built by ByteDance Seed, supports text and image inputs for highly controllable, high-quality image generation from prompts.',
     displayName: 'Seedream 4.0',
-    enabled: true,
+    enabled: false,
     id: 'fal-ai/bytedance/seedream/v4',
     parameters: {
       height: { default: 1024, max: 4096, min: 1024, step: 1 },

--- a/packages/model-runtime/src/providers/fal/index.test.ts
+++ b/packages/model-runtime/src/providers/fal/index.test.ts
@@ -479,7 +479,7 @@ describe('LobeFalAI', () => {
       });
     });
 
-    describe('Seedream v4 special endpoints', () => {
+    describe('Seedream and Hunyuan special endpoints', () => {
       it('should use text-to-image endpoint when no imageUrls provided', async () => {
         // Arrange
         const mockImageResponse = {
@@ -695,6 +695,181 @@ describe('LobeFalAI', () => {
             image_urls: ['https://example.com/input.jpg'],
             num_inference_steps: 30,
             guidance_scale: 8.0,
+          },
+        });
+      });
+
+      it('should use text-to-image endpoint for seedream v4.5 when no imageUrls provided', async () => {
+        // Arrange
+        const mockImageResponse = {
+          requestId: 'test-request-id',
+          data: {
+            images: [
+              {
+                url: 'https://example.com/generated.jpg',
+                width: 2048,
+                height: 2048,
+              },
+            ],
+          },
+        };
+        mockFal.subscribe.mockResolvedValue(mockImageResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'bytedance/seedream/v4.5',
+          params: {
+            prompt: 'A beautiful landscape',
+            width: 2048,
+            height: 2048,
+          },
+        };
+
+        // Act
+        await instance.createImage(payload);
+
+        // Assert
+        expect(mockFal.subscribe).toHaveBeenCalledWith(
+          'fal-ai/bytedance/seedream/v4.5/text-to-image',
+          {
+            input: {
+              enable_safety_checker: false,
+              num_images: 1,
+              prompt: 'A beautiful landscape',
+              image_size: {
+                width: 2048,
+                height: 2048,
+              },
+            },
+          },
+        );
+      });
+
+      it('should use edit endpoint for seedream v4.5 when imageUrls is provided', async () => {
+        // Arrange
+        const mockImageResponse = {
+          requestId: 'test-request-id',
+          data: {
+            images: [
+              {
+                url: 'https://example.com/edited.jpg',
+                width: 2048,
+                height: 2048,
+              },
+            ],
+          },
+        };
+        mockFal.subscribe.mockResolvedValue(mockImageResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'bytedance/seedream/v4.5',
+          params: {
+            prompt: 'Edit this image',
+            imageUrls: ['https://example.com/input.jpg'],
+            width: 2048,
+            height: 2048,
+          },
+        };
+
+        // Act
+        await instance.createImage(payload);
+
+        // Assert
+        expect(mockFal.subscribe).toHaveBeenCalledWith('fal-ai/bytedance/seedream/v4.5/edit', {
+          input: {
+            enable_safety_checker: false,
+            num_images: 1,
+            prompt: 'Edit this image',
+            image_urls: ['https://example.com/input.jpg'],
+            image_size: {
+              width: 2048,
+              height: 2048,
+            },
+          },
+        });
+      });
+
+      it('should use text-to-image endpoint for hunyuan-image v3 when no imageUrls provided', async () => {
+        // Arrange
+        const mockImageResponse = {
+          requestId: 'test-request-id',
+          data: {
+            images: [
+              {
+                url: 'https://example.com/generated.jpg',
+                width: 1024,
+                height: 1024,
+              },
+            ],
+          },
+        };
+        mockFal.subscribe.mockResolvedValue(mockImageResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'hunyuan-image/v3',
+          params: {
+            prompt: 'A scenic mountain view',
+            width: 1024,
+            height: 1024,
+          },
+        };
+
+        // Act
+        await instance.createImage(payload);
+
+        // Assert
+        expect(mockFal.subscribe).toHaveBeenCalledWith('fal-ai/hunyuan-image/v3/text-to-image', {
+          input: {
+            enable_safety_checker: false,
+            num_images: 1,
+            prompt: 'A scenic mountain view',
+            image_size: {
+              width: 1024,
+              height: 1024,
+            },
+          },
+        });
+      });
+
+      it('should use edit endpoint for hunyuan-image v3 when imageUrls is provided', async () => {
+        // Arrange
+        const mockImageResponse = {
+          requestId: 'test-request-id',
+          data: {
+            images: [
+              {
+                url: 'https://example.com/edited.jpg',
+                width: 1024,
+                height: 1024,
+              },
+            ],
+          },
+        };
+        mockFal.subscribe.mockResolvedValue(mockImageResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'hunyuan-image/v3',
+          params: {
+            prompt: 'Edit this image',
+            imageUrls: ['https://example.com/input.jpg'],
+            width: 1024,
+            height: 1024,
+          },
+        };
+
+        // Act
+        await instance.createImage(payload);
+
+        // Assert
+        expect(mockFal.subscribe).toHaveBeenCalledWith('fal-ai/hunyuan-image/v3/edit', {
+          input: {
+            enable_safety_checker: false,
+            num_images: 1,
+            prompt: 'Edit this image',
+            image_urls: ['https://example.com/input.jpg'],
+            image_size: {
+              width: 1024,
+              height: 1024,
+            },
           },
         });
       });

--- a/packages/model-runtime/src/providers/fal/index.ts
+++ b/packages/model-runtime/src/providers/fal/index.ts
@@ -71,7 +71,9 @@ export class LobeFalAI implements LobeRuntimeAI {
     // Ensure model has fal-ai/ prefix
     let endpoint = model.startsWith('fal-ai/') ? model : `fal-ai/${model}`;
     const hasImageUrls = (params.imageUrls?.length ?? 0) > 0;
-    if (['fal-ai/bytedance/seedream/v4', 'fal-ai/hunyuan-image/v3'].includes(endpoint)) {
+    if (
+      ['fal-ai/bytedance/seedream/v', 'fal-ai/hunyuan-image/v'].some((m) => endpoint.startsWith(m))
+    ) {
       endpoint += hasImageUrls ? '/edit' : '/text-to-image';
     } else if (endpoint === 'fal-ai/nano-banana' && hasImageUrls) {
       endpoint += '/edit';

--- a/src/locales/default/subscription.ts
+++ b/src/locales/default/subscription.ts
@@ -64,6 +64,8 @@ export default {
   'funds.packages.expiringSoon': 'Expiring soon',
   'funds.packages.noPackages': 'No credit packages',
   'funds.packages.purchaseFirst': 'Purchase your first credit package',
+  'funds.packages.gift': 'Gift',
+  'funds.packages.giftedOn': 'Gifted on {{date}}',
   'funds.packages.purchasedOn': 'Purchased on {{date}}',
   'funds.packages.sort.amountAsc': 'Amount: Low to High',
   'funds.packages.sort.amountDesc': 'Amount: High to Low',


### PR DESCRIPTION
## Summary
- Add i18n keys for gift budget display (`gift`, `giftedOn`) to support distinguishing gifted credit packages from purchased ones
- Add Seedream 4.5 image generation model configuration with enhanced features
- Disable Seedream 4.0 (superseded by 4.5)
- Update fal provider to use `startsWith` for seedream/hunyuan endpoint matching to support version variations

## Test plan
- [ ] Verify i18n keys are correctly loaded in subscription pages
- [ ] Verify Seedream 4.5 model appears in model selection
- [ ] Verify Seedream 4.0 is disabled and not shown
- [ ] Verify fal image generation works with new endpoint matching logic

## Summary by Sourcery

Add new Seedream 4.5 image model and update credit package display and fal image endpoint handling.

New Features:
- Introduce the Seedream 4.5 image generation model configuration with pricing and parameters.
- Add i18n strings to label gifted credit packages and their gifted date in subscription views.

Enhancements:
- Disable the deprecated Seedream 4.0 image model in favor of Seedream 4.5.
- Relax fal provider endpoint matching to use prefix checks for Seedream and Hunyuan image versions.