### PR TITLE
🐛 fix: prevent auto navigation to profile when clicking topic

### DIFF
--- a/packages/business/const/src/index.ts
+++ b/packages/business/const/src/index.ts
@@ -4,6 +4,3 @@ export * from './llm';
 export * from './url';
 
 export const ENABLE_BUSINESS_FEATURES = false;
-export const ENABLE_TOPIC_LINK_SHARE =
-  ENABLE_BUSINESS_FEATURES ||
-  (process.env.NODE_ENV === 'development' && !!process.env.NEXT_PUBLIC_ENABLE_TOPIC_LINK_SHARE);

--- a/src/app/[variants]/(main)/agent/features/Conversation/AgentWelcome/AddButton.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/AgentWelcome/AddButton.tsx
@@ -9,7 +9,8 @@ import { useAgentStore } from '@/store/agent';
 const AddButton = memo(() => {
   const navigate = useNavigate();
   const createAgent = useAgentStore((s) => s.createAgent);
-  const { mutate, isValidating } = useActionSWR('agent.createAgent', async () => {
+  // Use a unique SWR key to avoid conflicts with useCreateMenuItems which uses 'agent.createAgent'
+  const { mutate, isValidating } = useActionSWR('agent.createAgentFromWelcome', async () => {
     const result = await createAgent({});
     navigate(`/agent/${result.agentId}/profile`);
     return result;

--- a/src/app/[variants]/(main)/agent/features/Conversation/Header/ShareButton/index.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/Header/ShareButton/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ENABLE_TOPIC_LINK_SHARE } from '@lobechat/business-const';
 import { ActionIcon } from '@lobehub/ui';
 import { Share2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -10,6 +9,8 @@ import { useTranslation } from 'react-i18next';
 import { DESKTOP_HEADER_ICON_SIZE, MOBILE_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import { useWorkspaceModal } from '@/hooks/useWorkspaceModal';
 import { useChatStore } from '@/store/chat';
+import { useServerConfigStore } from '@/store/serverConfig';
+import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 
 const ShareModal = dynamic(() => import('@/features/ShareModal'));
 const SharePopover = dynamic(() => import('@/features/SharePopover'));
@@ -24,6 +25,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
   const [isModalOpen, setIsModalOpen] = useWorkspaceModal(open, setOpen);
   const { t } = useTranslation('common');
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const enableTopicLinkShare = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   // Hide share button when no topic exists (no messages sent yet)
   if (!activeTopicId) return null;
@@ -31,7 +33,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
   const iconButton = (
     <ActionIcon
       icon={Share2}
-      onClick={ENABLE_TOPIC_LINK_SHARE ? undefined : () => setIsModalOpen(true)}
+      onClick={enableTopicLinkShare ? undefined : () => setIsModalOpen(true)}
       size={mobile ? MOBILE_HEADER_ICON_SIZE : DESKTOP_HEADER_ICON_SIZE}
       title={t('share')}
       tooltipProps={{
@@ -42,7 +44,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
 
   return (
     <>
-      {ENABLE_TOPIC_LINK_SHARE ? (
+      {enableTopicLinkShare ? (
         <SharePopover onOpenModal={() => setIsModalOpen(true)}>{iconButton}</SharePopover>
       ) : (
         iconButton

--- a/src/app/[variants]/(main)/community/(detail)/provider/features/Details/Nav.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/provider/features/Details/Nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SOCIAL_URL } from '@lobechat/business-const';
+import { BRANDING_PROVIDER, SOCIAL_URL } from '@lobechat/business-const';
 import { Flexbox, Icon, Tabs } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { BookOpenIcon, BrainCircuitIcon, ListIcon } from 'lucide-react';
@@ -38,27 +38,36 @@ const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = ProviderNavKey.O
   const { t } = useTranslation('discover');
   const { identifier } = useDetailContext();
 
+  // Hide Guide tab for branding provider as it doesn't have integration docs
+  const showGuideTab = identifier !== BRANDING_PROVIDER;
+
+  const items = [
+    {
+      icon: <Icon icon={BookOpenIcon} size={16} />,
+      key: ProviderNavKey.Overview,
+      label: t('providers.details.overview.title'),
+    },
+    ...(showGuideTab
+      ? [
+          {
+            icon: <Icon icon={BrainCircuitIcon} size={16} />,
+            key: ProviderNavKey.Guide,
+            label: t('providers.details.guide.title'),
+          },
+        ]
+      : []),
+    {
+      icon: <Icon icon={ListIcon} size={16} />,
+      key: ProviderNavKey.Related,
+      label: t('providers.details.related.title'),
+    },
+  ];
+
   const nav = (
     <Tabs
       activeKey={activeTab}
       compact={mobile}
-      items={[
-        {
-          icon: <Icon icon={BookOpenIcon} size={16} />,
-          key: ProviderNavKey.Overview,
-          label: t('providers.details.overview.title'),
-        },
-        {
-          icon: <Icon icon={BrainCircuitIcon} size={16} />,
-          key: ProviderNavKey.Guide,
-          label: t('providers.details.guide.title'),
-        },
-        {
-          icon: <Icon icon={ListIcon} size={16} />,
-          key: ProviderNavKey.Related,
-          label: t('providers.details.related.title'),
-        },
-      ]}
+      items={items}
       onChange={(key) => setActiveTab?.(key as ProviderNavKey)}
     />
   );

--- a/src/app/[variants]/(main)/group/features/Conversation/Header/ShareButton/index.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/Header/ShareButton/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ENABLE_TOPIC_LINK_SHARE } from '@lobechat/business-const';
 import { ActionIcon } from '@lobehub/ui';
 import { Share2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -10,6 +9,8 @@ import { useTranslation } from 'react-i18next';
 import { DESKTOP_HEADER_ICON_SIZE, MOBILE_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import { useWorkspaceModal } from '@/hooks/useWorkspaceModal';
 import { useChatStore } from '@/store/chat';
+import { useServerConfigStore } from '@/store/serverConfig';
+import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 
 const ShareModal = dynamic(() => import('@/features/ShareModal'));
 const SharePopover = dynamic(() => import('@/features/SharePopover'));
@@ -24,6 +25,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
   const [isModalOpen, setIsModalOpen] = useWorkspaceModal(open, setOpen);
   const { t } = useTranslation('common');
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const enableTopicLinkShare = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   // Hide share button when no topic exists (no messages sent yet)
   if (!activeTopicId) return null;
@@ -31,7 +33,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
   const iconButton = (
     <ActionIcon
       icon={Share2}
-      onClick={ENABLE_TOPIC_LINK_SHARE ? undefined : () => setIsModalOpen(true)}
+      onClick={enableTopicLinkShare ? undefined : () => setIsModalOpen(true)}
       size={mobile ? MOBILE_HEADER_ICON_SIZE : DESKTOP_HEADER_ICON_SIZE}
       title={t('share')}
       tooltipProps={{
@@ -42,7 +44,7 @@ const ShareButton = memo<ShareButtonProps>(({ mobile, setOpen, open }) => {
 
   return (
     <>
-      {ENABLE_TOPIC_LINK_SHARE ? (
+      {enableTopicLinkShare ? (
         <SharePopover onOpenModal={() => setIsModalOpen(true)}>{iconButton}</SharePopover>
       ) : (
         iconButton

--- a/src/app/[variants]/onboarding/_layout/style.ts
+++ b/src/app/[variants]/onboarding/_layout/style.ts
@@ -1,21 +1,16 @@
 import { createStaticStyles } from 'antd-style';
 
 export const styles = createStaticStyles(({ css, cssVar }) => ({
-  
-  
-// Divider 样式
-divider: css`
+  // Divider 样式
+  divider: css`
     height: 24px;
   `,
 
-  
-  
-
-// 内层容器 - 深色模式
-innerContainerDark: css`
+  // 内层容器 - 深色模式
+  innerContainerDark: css`
     position: relative;
 
-    overflow: hidden;
+    overflow: hidden auto;
 
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadius};
@@ -23,14 +18,11 @@ innerContainerDark: css`
     background: ${cssVar.colorBgContainer};
   `,
 
-  
-  
-
-// 内层容器 - 浅色模式
-innerContainerLight: css`
+  // 内层容器 - 浅色模式
+  innerContainerLight: css`
     position: relative;
 
-    overflow: hidden;
+    overflow: hidden auto;
 
     border: 1px solid ${cssVar.colorBorder};
     border-radius: ${cssVar.borderRadius};
@@ -38,10 +30,8 @@ innerContainerLight: css`
     background: ${cssVar.colorBgContainer};
   `,
 
-  
-  
-// 外层容器
-outerContainer: css`
+  // 外层容器
+  outerContainer: css`
     position: relative;
   `,
 }));

--- a/src/store/user/slices/settings/action.test.ts
+++ b/src/store/user/slices/settings/action.test.ts
@@ -84,6 +84,31 @@ describe('SettingsAction', () => {
         expect.any(AbortSignal),
       );
     });
+
+    it('should include field in diffs when user resets it to default value', async () => {
+      const { result } = renderHook(() => useUserStore());
+
+      // First, set memory.enabled to false (non-default value)
+      await act(async () => {
+        await result.current.setSettings({ memory: { enabled: false } });
+      });
+
+      expect(userService.updateUserSettings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ memory: { enabled: false } }),
+        expect.any(AbortSignal),
+      );
+
+      // Then, reset memory.enabled back to true (default value)
+      // This should still include memory in the diffs to override the previously saved value
+      await act(async () => {
+        await result.current.setSettings({ memory: { enabled: true } });
+      });
+
+      expect(userService.updateUserSettings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ memory: { enabled: true } }),
+        expect.any(AbortSignal),
+      );
+    });
   });
 
   describe('updateDefaultAgent', () => {

--- a/src/store/user/slices/settings/action.ts
+++ b/src/store/user/slices/settings/action.ts
@@ -103,6 +103,17 @@ export const createSettingsSlice: StateCreator<
     if (isEqual(prevSetting, nextSettings)) return;
 
     const diffs = difference(nextSettings, defaultSettings);
+
+    // When user resets a field to default value, we need to explicitly include it in diffs
+    // to override the previously saved non-default value in the backend
+    const changedFields = difference(nextSettings, prevSetting);
+    for (const key of Object.keys(changedFields)) {
+      // Only handle fields that were previously set by user (exist in prevSetting)
+      if (key in prevSetting && !(key in diffs)) {
+        (diffs as any)[key] = (nextSettings as any)[key];
+      }
+    }
+
     set({ settings: diffs }, false, 'optimistic_updateSettings');
 
     const abortController = get().internal_createSignal();


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

- Fixes LOBE-2457
- Fixes #11489

#### 🔀 Description of Change

**1. Mobile onboarding scroll fix**

The mobile onboarding UI had `overflow: hidden` set on the inner container, which prevented users from scrolling when content exceeded the viewport height.

This PR changes the overflow behavior to:
- `overflow-x: hidden` - prevent horizontal scrolling
- `overflow-y: auto` - enable vertical scrolling when needed

**2. Fix auto navigation to profile when clicking topic**

When clicking a topic in the sidebar, the app would unexpectedly create a new agent and navigate to its profile page. This was caused by an SWR key conflict:

- `AgentWelcome/AddButton` used `useActionSWR('agent.createAgent')`
- `useCreateMenuItems` used `useSWRMutation('agent.createAgent')`

Both hooks sharing the same SWR key caused the AddButton's fetcher to be triggered automatically when switching topics. Fixed by using a unique key `'agent.createAgentFromWelcome'` for the AddButton.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

**For mobile onboarding fix:**
1. Open the app on a mobile device or use browser dev tools to simulate mobile viewport
2. Navigate to the onboarding flow
3. Verify that you can now scroll vertically when content overflows

**For topic click fix:**
1. Open an agent with existing topics
2. Click on a topic in the sidebar
3. Verify that it opens the topic correctly without navigating to a new agent's profile page

#### 📝 Additional Information

Simple fixes with no breaking changes.