### PR TITLE
✨ feat: update the agent profiles tools check & agentbuilder tools & publish to market button

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -265,6 +265,7 @@
   "plugin.settings.title": "{{id}} Skill Configuration",
   "plugin.settings.tooltip": "Skill Configuration",
   "plugin.store": "Skill Store",
+  "publishToCommunity": "Publish to Community",
   "settingAgent.avatar.sizeExceeded": "Image size exceeds 1MB limit, please choose a smaller image",
   "settingAgent.avatar.title": "Avatar",
   "settingAgent.backgroundColor.title": "Background Color",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -265,6 +265,7 @@
   "plugin.settings.title": "{{id}} 技能配置",
   "plugin.settings.tooltip": "技能配置",
   "plugin.store": "技能商店",
+  "publishToCommunity": "发布到社区",
   "settingAgent.avatar.sizeExceeded": "图片大小超过 1MB 限制，请选择更小的图片",
   "settingAgent.avatar.title": "助理头像",
   "settingAgent.backgroundColor.title": "头像背景色",

--- a/packages/builtin-tool-agent-builder/src/client/Intervention/InstallPlugin.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Intervention/InstallPlugin.tsx
@@ -1,16 +1,21 @@
 'use client';
 
-import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
+import { KLAVIS_SERVER_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
 import { BuiltinInterventionProps } from '@lobechat/types';
-import { Avatar , Flexbox } from '@lobehub/ui';
+import { Avatar, Flexbox } from '@lobehub/ui';
 import { CheckCircle } from 'lucide-react';
 import Image from 'next/image';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useToolStore } from '@/store/tool';
-import { klavisStoreSelectors, pluginSelectors } from '@/store/tool/selectors';
+import {
+  klavisStoreSelectors,
+  lobehubSkillStoreSelectors,
+  pluginSelectors,
+} from '@/store/tool/selectors';
 import { KlavisServerStatus } from '@/store/tool/slices/klavisStore/types';
+import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
 
 import type { InstallPluginParams } from '../../types';
 
@@ -34,9 +39,18 @@ const InstallPluginIntervention = memo<BuiltinInterventionProps<InstallPluginPar
       klavisStoreSelectors.getServers(s).find((srv) => srv.identifier === identifier),
     );
 
+    // Get LobehubSkill server state
+    const lobehubSkillServer = useToolStore((s) =>
+      lobehubSkillStoreSelectors.getServers(s).find((srv) => srv.identifier === identifier),
+    );
+
     // Check if it's a Klavis tool
     const klavisTypeInfo = KLAVIS_SERVER_TYPES.find((t) => t.identifier === identifier);
     const isKlavis = source === 'official' && !!klavisTypeInfo;
+
+    // Check if it's a LobehubSkill provider
+    const lobehubSkillProviderInfo = LOBEHUB_SKILL_PROVIDERS.find((p) => p.id === identifier);
+    const isLobehubSkill = source === 'official' && !!lobehubSkillProviderInfo;
 
     // Render success state (already installed)
     if (isPluginInstalled) {
@@ -54,12 +68,12 @@ const InstallPluginIntervention = memo<BuiltinInterventionProps<InstallPluginPar
           <CheckCircle size={20} style={{ color: 'var(--lobe-success-6)' }} />
           <Flexbox gap={4}>
             <span style={{ fontWeight: 600 }}>
-              {isKlavis
+              {isKlavis || isLobehubSkill
                 ? t('agentBuilder.installPlugin.connectedAndEnabled')
                 : t('agentBuilder.installPlugin.installedAndEnabled')}
             </span>
             <span style={{ color: 'var(--lobe-text-secondary)', fontSize: 12 }}>
-              {klavisTypeInfo?.label || identifier}
+              {klavisTypeInfo?.label || lobehubSkillProviderInfo?.label || identifier}
             </span>
           </Flexbox>
         </Flexbox>
@@ -96,6 +110,53 @@ const InstallPluginIntervention = memo<BuiltinInterventionProps<InstallPluginPar
               </Flexbox>
               <span style={{ color: 'var(--lobe-text-secondary)', fontSize: 12 }}>
                 {isPendingAuth
+                  ? t('agentBuilder.installPlugin.requiresAuth')
+                  : t('agentBuilder.installPlugin.clickApproveToConnect')}
+              </span>
+            </Flexbox>
+          </Flexbox>
+        </Flexbox>
+      );
+    }
+
+    // Render LobehubSkill provider
+    if (isLobehubSkill) {
+      const icon =
+        typeof lobehubSkillProviderInfo?.icon === 'string'
+          ? lobehubSkillProviderInfo.icon
+          : undefined;
+      const isNotConnected =
+        !lobehubSkillServer || lobehubSkillServer.status !== LobehubSkillStatus.CONNECTED;
+
+      return (
+        <Flexbox
+          gap={12}
+          style={{ background: 'var(--lobe-fill-tertiary)', borderRadius: 8, padding: 16 }}
+        >
+          <Flexbox align="center" gap={12} horizontal>
+            {icon ? (
+              <Image
+                alt={lobehubSkillProviderInfo?.label || identifier}
+                height={40}
+                src={icon}
+                style={{ borderRadius: 8 }}
+                unoptimized
+                width={40}
+              />
+            ) : (
+              <Avatar avatar="🔗" size={40} style={{ borderRadius: 8 }} />
+            )}
+            <Flexbox flex={1} gap={4}>
+              <Flexbox align="center" gap={8} horizontal>
+                <span style={{ fontWeight: 600 }}>
+                  {lobehubSkillProviderInfo?.label || identifier}
+                </span>
+                <span style={{ color: 'var(--lobe-text-tertiary)', fontSize: 12 }}>
+                  LobeHub Skill
+                </span>
+              </Flexbox>
+              <span style={{ color: 'var(--lobe-text-secondary)', fontSize: 12 }}>
+                {isNotConnected
                   ? t('agentBuilder.installPlugin.requiresAuth')
                   : t('agentBuilder.installPlugin.clickApproveToConnect')}
               </span>

--- a/packages/builtin-tool-agent-builder/src/client/Render/InstallPlugin.tsx
+++ b/packages/builtin-tool-agent-builder/src/client/Render/InstallPlugin.tsx
@@ -9,8 +9,16 @@ import type { InstallPluginParams, InstallPluginState } from '../../types';
 
 const InstallPlugin = memo<BuiltinRenderProps<InstallPluginParams, InstallPluginState>>(
   ({ pluginState }) => {
-    const { pluginId, pluginName, installed, awaitingApproval, isKlavis, serverStatus, error } =
-      pluginState || {};
+    const {
+      pluginId,
+      pluginName,
+      installed,
+      awaitingApproval,
+      isKlavis,
+      isLobehubSkill,
+      serverStatus,
+      error,
+    } = pluginState || {};
 
     if (!pluginId) return null;
 
@@ -43,7 +51,7 @@ const InstallPlugin = memo<BuiltinRenderProps<InstallPluginParams, InstallPlugin
         <Flexbox align={'center'} gap={8} horizontal style={{ fontSize: 13 }}>
           <Clock size={14} style={{ color: 'var(--lobe-warning-6)' }} />
           <span style={{ fontWeight: 500 }}>
-            {isKlavis ? (
+            {isKlavis || isLobehubSkill ? (
               <>
                 Waiting for authorization:{' '}
                 <code
@@ -90,7 +98,7 @@ const InstallPlugin = memo<BuiltinRenderProps<InstallPluginParams, InstallPlugin
         <Flexbox align={'center'} gap={8} horizontal style={{ fontSize: 13 }}>
           <CheckCircle size={14} style={{ color: 'var(--lobe-success-6)' }} />
           <span style={{ fontWeight: 500 }}>
-            {isKlavis ? 'Connected and enabled' : 'Installed and enabled'}:{' '}
+            {isKlavis || isLobehubSkill ? 'Connected and enabled' : 'Installed and enabled'}:{' '}
             <code
               style={{
                 background: 'var(--lobe-fill-tertiary)',

--- a/packages/builtin-tool-agent-builder/src/manifest.ts
+++ b/packages/builtin-tool-agent-builder/src/manifest.ts
@@ -27,6 +27,7 @@ export const AgentBuilderManifest: BuiltinToolManifest = {
     {
       description:
         'Search for tools (MCP plugins) in the marketplace. Users can browse and install tools directly from the search results. Use this when users want to find new tools or capabilities.',
+      humanIntervention: 'always',
       name: AgentBuilderApiName.searchMarketTools,
       parameters: {
         properties: {
@@ -55,7 +56,7 @@ export const AgentBuilderManifest: BuiltinToolManifest = {
     // ==================== Write Operations ====================
     {
       description:
-        'Install a plugin for the agent. This tool ALWAYS REQUIRES user approval before installation, even in auto-run mode. For MCP marketplace plugins, it will install and enable the plugin. For Klavis tools that need OAuth, it will initiate the connection flow and wait for user to complete authorization.',
+        'Install a plugin for the agent. This tool ALWAYS REQUIRES user approval before installation, even in auto-run mode. For MCP marketplace plugins, it will install and enable the plugin. For Klavis tools and LobehubSkill providers that need OAuth, it will initiate the connection flow and wait for user to complete authorization.',
       humanIntervention: 'always',
       name: AgentBuilderApiName.installPlugin,
       parameters: {
@@ -67,7 +68,7 @@ export const AgentBuilderManifest: BuiltinToolManifest = {
           },
           source: {
             description:
-              'Plugin source type: "market" for MCP marketplace plugins, "official" for builtin/Klavis tools',
+              'Plugin source type: "market" for MCP marketplace plugins, "official" for builtin/Klavis/LobehubSkill tools',
             enum: ['market', 'official'],
             type: 'string',
           },

--- a/packages/builtin-tool-agent-builder/src/systemRole.ts
+++ b/packages/builtin-tool-agent-builder/src/systemRole.ts
@@ -12,7 +12,7 @@ export const systemPrompt = `You are an Agent Configuration Assistant integrated
 The injected context includes:
 - **agent_meta**: title, description, avatar, backgroundColor, tags
 - **agent_config**: model, provider, plugins, systemRole (preview), and other advanced settings
-- **official_tools**: List of available official tools including built-in tools and LobeHub integrations (Gmail, Google Calendar, Notion, GitHub, etc.) with their enabled/installed status
+- **official_tools**: List of available official tools including built-in tools, Klavis MCP servers, and LobehubSkill providers (Linear, Outlook Calendar, Twitter, etc.) with their enabled/installed status
 
 You should use this context to understand the current state of the agent and available tools before making any modifications.
 </context_awareness>
@@ -24,7 +24,7 @@ You have access to tools that can modify agent configurations:
 - **getAvailableModels**: Get all available AI models and providers that can be used. Optionally filter by provider ID.
 - **searchMarketTools**: Search for tools (MCP plugins) in the marketplace. Shows results with install buttons for users to install directly.
 
-Note: Official tools (built-in tools and LobeHub Mcp integrations) are automatically available in the \`<current_agent_context>\` - no need to search for them.
+Note: Official tools (built-in tools, Klavis MCP servers, and LobehubSkill providers) are automatically available in the \`<current_agent_context>\` - no need to search for them.
 
 **Write Operations:**
 - **updateConfig**: Update agent configuration fields (model, provider, plugins, and advanced settings). Use this for all config changes.
@@ -180,16 +180,16 @@ User: "What tools are available in the marketplace?"
 Action: Use searchMarketTools without query to browse all available tools. Display the list with descriptions and install options.
 
 User: "帮我找一下有什么插件可以用"
-Action: Reference the \`<official_tools>\` from the injected context to show available built-in tools and LobeHub integrations. This allows the user to enable tools directly or connect to services like Gmail, Google Calendar, etc.
+Action: Reference the \`<official_tools>\` from the injected context to show available built-in tools, Klavis MCP servers, and LobehubSkill providers. This allows the user to enable tools directly or connect to services.
 
-User: "I want to connect my Gmail"
-Action: Check the \`<official_tools>\` in the context for Gmail LobeHub integration. If found, use installPlugin with source "official" to connect it.
+User: "I want to connect my Linear"
+Action: Check the \`<official_tools>\` in the context for Linear LobehubSkill provider. If found, use installPlugin with source "official" to connect it.
 
-User: "帮我安装 GitHub 插件"
-Action: Check the \`<official_tools>\` in the context for GitHub integration. If found, use installPlugin with source "official" to install it.
+User: "帮我连接 Twitter"
+Action: Check the \`<official_tools>\` in the context for Twitter (X) LobehubSkill provider. If found, use installPlugin with source "official" to connect it.
 
 User: "What official integrations are available?"
-Action: Reference the \`<official_tools>\` from the injected context to list all available LobeHub integrations like Gmail, Google Calendar, Notion, Slack, GitHub, etc.
+Action: Reference the \`<official_tools>\` from the injected context to list all available integrations including built-in tools, Klavis MCP servers, and LobehubSkill providers (Linear, Outlook Calendar, Twitter, etc.).
 
 User: "帮我设置开场白" / "Set an opening message for this agent"
 Action: Use updateConfig with { config: { openingMessage: "Hello! I'm your AI assistant. How can I help you today?" } }

--- a/packages/builtin-tool-agent-builder/src/types.ts
+++ b/packages/builtin-tool-agent-builder/src/types.ts
@@ -164,7 +164,7 @@ export interface InstallPluginParams {
    */
   identifier: string;
   /**
-   * Plugin source type: 'market' for MCP marketplace, 'official' for builtin/klavis tools
+   * Plugin source type: 'market' for MCP marketplace, 'official' for builtin/klavis/lobehubSkill tools
    */
   source: 'market' | 'official';
 }
@@ -188,6 +188,10 @@ export interface InstallPluginState {
    */
   isKlavis?: boolean;
   /**
+   * Whether the plugin is a LobehubSkill provider that needs OAuth connection
+   */
+  isLobehubSkill?: boolean;
+  /**
    * Klavis OAuth URL if authorization is needed
    */
   oauthUrl?: string;
@@ -204,9 +208,9 @@ export interface InstallPluginState {
    */
   serverName?: string;
   /**
-   * Klavis server status
+   * Server status (for Klavis tools and LobehubSkill providers)
    */
-  serverStatus?: 'connected' | 'pending_auth' | 'error';
+  serverStatus?: 'connected' | 'pending_auth' | 'error' | 'not_connected';
   /**
    * Whether the operation was successful
    */

--- a/packages/context-engine/src/providers/GroupAgentBuilderContextInjector.ts
+++ b/packages/context-engine/src/providers/GroupAgentBuilderContextInjector.ts
@@ -47,8 +47,8 @@ export interface GroupOfficialToolItem {
   installed?: boolean;
   /** Tool display name */
   name: string;
-  /** Tool type: 'builtin' for built-in tools, 'klavis' for LobeHub Mcp servers */
-  type: 'builtin' | 'klavis';
+  /** Tool type: 'builtin' for built-in tools, 'klavis' for LobeHub Mcp servers, 'lobehub-skill' for LobeHub Skill providers */
+  type: 'builtin' | 'klavis' | 'lobehub-skill';
 }
 
 /**
@@ -195,6 +195,7 @@ const defaultFormatGroupContext = (context: GroupAgentBuilderContext): string =>
   if (context.officialTools && context.officialTools.length > 0) {
     const builtinTools = context.officialTools.filter((t) => t.type === 'builtin');
     const klavisTools = context.officialTools.filter((t) => t.type === 'klavis');
+    const lobehubSkillTools = context.officialTools.filter((t) => t.type === 'lobehub-skill');
 
     const toolsSections: string[] = [];
 
@@ -224,6 +225,21 @@ const defaultFormatGroupContext = (context: GroupAgentBuilderContext): string =>
         })
         .join('\n');
       toolsSections.push(`  <klavis_tools>\n${klavisItems}\n  </klavis_tools>`);
+    }
+
+    if (lobehubSkillTools.length > 0) {
+      const lobehubSkillItems = lobehubSkillTools
+        .map((t) => {
+          const attrs = [
+            `id="${t.identifier}"`,
+            `installed="${t.installed ? 'true' : 'false'}"`,
+            `enabled="${t.enabled ? 'true' : 'false'}"`,
+          ].join(' ');
+          const desc = t.description ? ` - ${escapeXml(t.description)}` : '';
+          return `    <tool ${attrs}>${escapeXml(t.name)}${desc}</tool>`;
+        })
+        .join('\n');
+      toolsSections.push(`  <lobehub_skill_tools>\n${lobehubSkillItems}\n  </lobehub_skill_tools>`);
     }
 
     if (toolsSections.length > 0) {

--- a/src/app/[variants]/(main)/agent/profile/features/Header/AgentPublishButton/PublishButton.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/Header/AgentPublishButton/PublishButton.tsx
@@ -1,13 +1,11 @@
-import { ActionIcon } from '@lobehub/ui';
+import { Button } from '@lobehub/ui';
 import { ShapesUploadIcon } from '@lobehub/ui/icons';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
-import { HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { resolveMarketAuthError } from '@/layout/AuthProvider/MarketAuth/errors';
-import { useServerConfigStore } from '@/store/serverConfig';
 
 import ForkConfirmModal from './ForkConfirmModal';
 import type { MarketPublishAction } from './types';
@@ -20,8 +18,6 @@ interface MarketPublishButtonProps {
 
 const PublishButton = memo<MarketPublishButtonProps>(({ action, onPublishSuccess }) => {
   const { t } = useTranslation(['setting', 'marketAuth']);
-
-  const mobile = useServerConfigStore((s) => s.isMobile);
 
   const { isAuthenticated, isLoading, signIn } = useMarketAuth();
   const { checkOwnership, isCheckingOwnership, isPublishing, publish } = useMarketPublish({
@@ -102,13 +98,14 @@ const PublishButton = memo<MarketPublishButtonProps>(({ action, onPublishSuccess
 
   return (
     <>
-      <ActionIcon
+      <Button
         icon={ShapesUploadIcon}
         loading={loading}
         onClick={handleButtonClick}
-        size={HEADER_ICON_SIZE(mobile)}
         title={buttonTitle}
-      />
+      >
+        {t('publishToCommunity')}
+      </Button>
       <ForkConfirmModal
         loading={isPublishing}
         onCancel={handleForkCancel}

--- a/src/app/[variants]/(main)/agent/profile/features/Header/index.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/Header/index.tsx
@@ -5,7 +5,6 @@ import NavHeader from '@/features/NavHeader';
 import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
 
-import AgentPublishButton from './AgentPublishButton';
 import AutoSaveHint from './AutoSaveHint';
 
 const Header = memo(() => {
@@ -16,7 +15,6 @@ const Header = memo(() => {
         <>
           <WideScreenButton />
           <ToggleRightPanelButton icon={BotMessageSquareIcon} showActive={true} />
-          <AgentPublishButton />
         </>
       }
     />

--- a/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -17,6 +17,7 @@ import { useChatStore } from '@/store/chat';
 
 import AgentCronJobs from '../AgentCronJobs';
 import EditorCanvas from '../EditorCanvas';
+import AgentPublishButton from '../Header/AgentPublishButton';
 import AgentHeader from './AgentHeader';
 import AgentTool from './AgentTool';
 
@@ -79,6 +80,7 @@ const ProfileEditor = memo(() => {
           >
             {t('startConversation')}
           </Button>
+          <AgentPublishButton />
           {ENABLE_BUSINESS_FEATURES && (
             <Button icon={Clock} onClick={handleCreateCronJob}>
               {t('agentCronJobs.addJob')}

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -278,6 +278,7 @@ export default {
   'plugin.settings.title': '{{id}} Skill Configuration',
   'plugin.settings.tooltip': 'Skill Configuration',
   'plugin.store': 'Skill Store',
+  'publishToCommunity': 'Publish to Community',
   'settingAgent.avatar.sizeExceeded': 'Image size exceeds 1MB limit, please choose a smaller image',
   'settingAgent.avatar.title': 'Avatar',
   'settingAgent.backgroundColor.title': 'Background Color',

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -1,5 +1,5 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
-import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
+import { KLAVIS_SERVER_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
 import type { OfficialToolItem } from '@lobechat/context-engine';
 import {
   type FetchSSEOptions,
@@ -41,6 +41,7 @@ import { getToolStoreState } from '@/store/tool';
 import {
   builtinToolSelectors,
   klavisStoreSelectors,
+  lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
 import { getUserStoreState, useUserStore } from '@/store/user';
@@ -217,6 +218,28 @@ class ChatService {
             installed: !!server,
             name: klavisType.label,
             type: 'klavis',
+          });
+        }
+      }
+
+      // Get LobehubSkill providers (if enabled)
+      const isLobehubSkillEnabled =
+        typeof window !== 'undefined' &&
+        window.global_serverConfigStore?.getState()?.serverConfig?.enableLobehubSkill;
+
+      if (isLobehubSkillEnabled) {
+        const allLobehubSkillServers = lobehubSkillStoreSelectors.getServers(toolState);
+
+        for (const provider of LOBEHUB_SKILL_PROVIDERS) {
+          const server = allLobehubSkillServers.find((s) => s.identifier === provider.id);
+
+          officialTools.push({
+            description: `LobeHub Skill Provider: ${provider.label}`,
+            enabled: enabledPlugins.includes(provider.id),
+            identifier: provider.id,
+            installed: !!server,
+            name: provider.label,
+            type: 'lobehub-skill',
           });
         }
       }

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -1,7 +1,7 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import { GroupAgentBuilderIdentifier } from '@lobechat/builtin-tool-group-agent-builder';
 import { GTDIdentifier } from '@lobechat/builtin-tool-gtd';
-import { KLAVIS_SERVER_TYPES, isDesktop } from '@lobechat/const';
+import { KLAVIS_SERVER_TYPES, LOBEHUB_SKILL_PROVIDERS, isDesktop } from '@lobechat/const';
 import {
   type AgentBuilderContext,
   type AgentGroupConfig,
@@ -29,7 +29,11 @@ import { getChatGroupStoreState } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
 import { getChatStoreState } from '@/store/chat';
 import { getToolStoreState } from '@/store/tool';
-import { builtinToolSelectors, klavisStoreSelectors } from '@/store/tool/selectors';
+import {
+  builtinToolSelectors,
+  klavisStoreSelectors,
+  lobehubSkillStoreSelectors,
+} from '@/store/tool/selectors';
 
 import { isCanUseVideo, isCanUseVision } from '../helper';
 import {
@@ -213,6 +217,28 @@ export const contextEngineering = async ({
               installed: !!server,
               name: klavisType.label,
               type: 'klavis',
+            });
+          }
+        }
+
+        // Get LobehubSkill providers (if enabled)
+        const isLobehubSkillEnabled =
+          typeof window !== 'undefined' &&
+          window.global_serverConfigStore?.getState()?.serverConfig?.enableLobehubSkill;
+
+        if (isLobehubSkillEnabled) {
+          const allLobehubSkillServers = lobehubSkillStoreSelectors.getServers(toolState);
+
+          for (const provider of LOBEHUB_SKILL_PROVIDERS) {
+            const server = allLobehubSkillServers.find((s) => s.identifier === provider.id);
+
+            officialTools.push({
+              description: `LobeHub Skill Provider: ${provider.label}`,
+              enabled: enabledPlugins.includes(provider.id),
+              identifier: provider.id,
+              installed: !!server,
+              name: provider.label,
+              type: 'lobehub-skill',
             });
           }
         }

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -123,9 +123,19 @@ export const pluginTypes: StateCreator<
       const context = operationId ? { operationId } : undefined;
 
       // Get agent ID, group ID, and topic ID from operation context
-      const agentId = operation?.context?.agentId;
+      let agentId = operation?.context?.agentId;
       let groupId = operation?.context?.groupId;
       const topicId = operation?.context?.topicId;
+
+      // For agent-builder tools, inject activeAgentId from store if not in context
+      // This is needed because AgentBuilderProvider uses a separate scope for messages
+      // but the tools need the correct agentId for execution
+      if (payload.identifier === 'lobe-agent-builder') {
+        const activeAgentId = get().activeAgentId;
+        if (activeAgentId) {
+          agentId = activeAgentId;
+        }
+      }
 
       // For group-agent-builder tools, inject activeGroupId from store if not in context
       // This is needed because AgentBuilderProvider uses a separate scope for messages


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Extend agent tooling to support LobeHub Skill providers alongside existing builtin and Klavis tools, and update the agent profile UI to surface publish-to-community actions more prominently.

New Features:
- Add full-stack support for LobeHub Skill providers as first-class official tools in agent builder, including installation, connection status handling, and context injection for both single and group agents.
- Expose LobeHub Skill providers in the agent profile tooling UI and plugin tags, with dedicated icons, connection state, and integration into existing builtin/Klavis tool lists.
- Require explicit human approval for marketplace tool search and clarify install behavior for MCP marketplace plugins, Klavis servers, and LobeHub Skill providers.
- Move the agent publish-to-community action from the header into the profile editor actions and change it to a labeled button instead of a bare icon.

Enhancements:
- Improve plugin installation UX and messaging to distinguish between installed plugins and connected OAuth-based integrations for Klavis and LobeHub Skill providers.
- Ensure agent-builder tools receive the correct active agent ID when invoked so configuration changes apply to the intended agent.