### PR TITLE
🔨 chore(google): Support External URL file input with SSRF validation to optimize transmission

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -413,7 +413,7 @@
   "upload.preview.prepareTasks": "Preparing chunks...",
   "upload.preview.status.pending": "Preparing to upload...",
   "upload.preview.status.processing": "Processing file...",
-  "upload.validation.videoSizeExceeded": "Video file size must not exceed 20MB. Current file size is {{actualSize}}.",
+  "upload.validation.videoSizeExceeded": "Video file size must not exceed 100MB. Current file size is {{actualSize}}.",
   "viewMode.fullWidth": "Full Width",
   "viewMode.normal": "Standard",
   "viewMode.wideScreen": "Widescreen",

--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -195,6 +195,7 @@
   "providerModels.item.modelConfig.displayName.placeholder": "Please enter the display name of the model, e.g., ChatGPT, GPT-4, etc.",
   "providerModels.item.modelConfig.displayName.title": "Model Display Name",
   "providerModels.item.modelConfig.extendParams.extra": "Choose extended parameters supported by the model. Hover an option to preview controls. Incorrect configs may cause request failures.",
+  "providerModels.item.modelConfig.extendParams.options.codexMaxReasoningEffort.hint": "For GPT-5.1 Codex Max; controls reasoning intensity.",
   "providerModels.item.modelConfig.extendParams.options.disableContextCaching.hint": "For Claude models; can lower cost and speed up responses.",
   "providerModels.item.modelConfig.extendParams.options.enableReasoning.hint": "For Claude, DeepSeek and other reasoning models; unlock deeper thinking.",
   "providerModels.item.modelConfig.extendParams.options.gpt5ReasoningEffort.hint": "For GPT-5 series; controls reasoning intensity.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -413,7 +413,7 @@
   "upload.preview.prepareTasks": "正在准备分块…",
   "upload.preview.status.pending": "准备上传…",
   "upload.preview.status.processing": "文件处理中…",
-  "upload.validation.videoSizeExceeded": "视频文件不能超过 20MB。当前为 {{actualSize}}",
+  "upload.validation.videoSizeExceeded": "视频文件不能超过 100MB。当前为 {{actualSize}}",
   "viewMode.fullWidth": "全宽显示",
   "viewMode.normal": "普通",
   "viewMode.wideScreen": "宽屏",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -195,6 +195,7 @@
   "providerModels.item.modelConfig.displayName.placeholder": "请输入模型的展示名称，例如 ChatGPT、GPT-4 等",
   "providerModels.item.modelConfig.displayName.title": "模型展示名称",
   "providerModels.item.modelConfig.extendParams.extra": "选择模型支持的扩展参数。将鼠标悬停在选项上可预览控制项。配置错误可能导致请求失败。",
+  "providerModels.item.modelConfig.extendParams.options.codexMaxReasoningEffort.hint": "适用于 GPT-5.1 Codex Max；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.disableContextCaching.hint": "适用于 Claude 模型；可降低成本并加快响应速度。",
   "providerModels.item.modelConfig.extendParams.options.enableReasoning.hint": "适用于 Claude、DeepSeek 及其他推理模型；可启用更深层次的思考能力。",
   "providerModels.item.modelConfig.extendParams.options.gpt5ReasoningEffort.hint": "适用于 GPT-5 系列；控制推理强度。",

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -76,6 +76,34 @@ export const openaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'GPT-5.2-Codex is an upgraded GPT-5.2 variant optimized for long-horizon, agentic coding tasks.',
+    displayName: 'GPT-5.2 Codex',
+    id: 'gpt-5.2-codex',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.175, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 14, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-12-18',
+    settings: {
+      extendParams: ['codexMaxReasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       vision: true,
     },
     contextWindowTokens: 128_000,
@@ -93,6 +121,33 @@ export const openaiChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-12-11',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "GPT-5.1 Codex Max: OpenAI's most intelligent coding model, optimized for long-horizon agentic coding tasks, supports reasoning tokens.",
+    displayName: 'GPT-5.1 Codex Max',
+    id: 'gpt-5.1-codex-max',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.125, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-12-04',
+    settings: {
+      extendParams: ['codexMaxReasoningEffort'],
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -269,6 +269,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'gpt5_1ReasoningEffort',
   'gpt5_2ReasoningEffort',
   'gpt5_2ProReasoningEffort',
+  'codexMaxReasoningEffort',
   'textVerbosity',
   'thinking',
   'thinkingBudget',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -241,6 +241,7 @@ export type ExtendParamsType =
   | 'gpt5_1ReasoningEffort'
   | 'gpt5_2ReasoningEffort'
   | 'gpt5_2ProReasoningEffort'
+  | 'codexMaxReasoningEffort'
   | 'textVerbosity'
   | 'thinking'
   | 'thinkingBudget'

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -40,9 +40,11 @@ export const responsesAPIModels = new Set([
   'gpt-5-pro-2025-10-06',
   'gpt-5.1-codex',
   'gpt-5.1-codex-mini',
+  'gpt-5.1-codex-max',
   'gpt-5.2',
   'gpt-5.2-pro-2025-12-11',
   'gpt-5.2-pro',
+  'gpt-5.2-codex',
 ]);
 
 /**

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { Type as SchemaType } from '@google/genai';
 import * as imageToBase64Module from '@lobechat/utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatCompletionTool, OpenAIChatMessage, UserMessageContentPart } from '../../types';
 import { isPublicExternalUrl, parseDataUri, validateExternalUrl } from '../../utils/uriParser';
@@ -27,6 +27,10 @@ vi.mock('../../utils/imageToBase64', () => ({
 
 describe('google contextBuilders', () => {
   describe('buildGooglePart', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('should handle text type messages', async () => {
       const content: UserMessageContentPart = {
         text: 'Hello',

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -85,6 +85,9 @@ export const buildGooglePart = async (
               thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
             };
           }
+          if (validation.isTooLarge) {
+            throw new RangeError(validation.reason || 'External URL file too large');
+          }
           // If validation fails, fall back to base64 conversion
         }
 
@@ -132,6 +135,9 @@ export const buildGooglePart = async (
               },
               thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
             };
+          }
+          if (validation.isTooLarge) {
+            throw new RangeError(validation.reason || 'External URL file too large');
           }
         }
 

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -12,11 +12,11 @@ import { safeParseJSON } from '../../utils/safeParseJSON';
 import { isPublicExternalUrl, parseDataUri, validateExternalUrl } from '../../utils/uriParser';
 
 const GOOGLE_SUPPORTED_IMAGE_TYPES = new Set([
-  'image/jpeg',
-  'image/jpg',
   'image/png',
-  'image/gif',
+  'image/jpeg',
   'image/webp',
+  'image/heic',
+  'image/heif',
 ]);
 
 const isImageTypeSupported = (mimeType: string | null): boolean => {
@@ -118,11 +118,12 @@ export const buildGooglePart = async (
 
         // Fallback: convert URL to base64 (for private/local URLs or failed validation)
         const { base64: urlBase64, mimeType: urlMimeType } = await imageUrlToBase64(url);
+        const resolvedMimeType = urlMimeType || mimeType;
 
-        if (!isImageTypeSupported(mimeType)) return undefined;
+        if (!isImageTypeSupported(resolvedMimeType)) return undefined;
 
         return {
-          inlineData: { data: urlBase64, mimeType: urlMimeType },
+          inlineData: { data: urlBase64, mimeType: resolvedMimeType || 'image/png' },
           thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
         };
       }

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -148,7 +148,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingLevel,
       }) as ThinkingConfig;
 
-      const contents = await buildGoogleMessages(payload.messages);
+      const contents = await buildGoogleMessages(payload.messages, { model });
 
       const controller = new AbortController();
       const originalSignal = options?.signal;
@@ -274,7 +274,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    */
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
     // Convert OpenAI messages to Google format
-    const contents = await buildGoogleMessages(payload.messages);
+    const contents = await buildGoogleMessages(payload.messages, { model: payload.model });
 
     // Handle tools-based structured output
     if (payload.tools && payload.tools.length > 0) {

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -22,3 +22,151 @@ export const parseDataUri = (dataUri: string): UriParserResult => {
     return { base64: null, mimeType: null, type: null };
   }
 };
+
+/**
+ * MIME types supported by Google Gemini External URL feature
+ * @see https://ai.google.dev/gemini-api/docs/file-input-methods#supported-content-types
+ */
+const GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES = new Set([
+  // Text file types
+  'text/html',
+  'text/css',
+  'text/plain',
+  'text/xml',
+  'text/csv',
+  'text/rtf',
+  'text/javascript',
+  // Application file types
+  'application/json',
+  'application/pdf',
+  // Image file types
+  'image/bmp',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+
+/**
+ * Maximum file size limits for Google Gemini file input
+ * @see https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+ *
+ * External URLs: 100MB for all file types
+ * Inline data: 100MB general, 50MB for PDFs
+ */
+const MAX_EXTERNAL_URL_SIZE = 100 * 1024 * 1024; // 100MB for external URLs (all types)
+const MAX_INLINE_DATA_SIZE = 100 * 1024 * 1024; // 100MB for inline data (general)
+const MAX_INLINE_PDF_SIZE = 50 * 1024 * 1024; // 50MB for inline PDFs only
+
+export { MAX_INLINE_DATA_SIZE, MAX_INLINE_PDF_SIZE };
+
+export interface ExternalUrlValidation {
+  /** Content-Length from response headers */
+  contentLength: number;
+  /** Content-Type from response headers */
+  contentType: string;
+  /** Whether the URL is valid for external URL usage */
+  isValid: boolean;
+  /** Reason for invalid URL */
+  reason?: string;
+}
+
+/**
+ * Check if a URL is a public external URL (not localhost, private IP, or local file)
+ */
+export const isPublicExternalUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+
+    // Only allow http and https protocols
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+
+    // Block localhost
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+      return false;
+    }
+
+    // Block private IP ranges
+    // 10.0.0.0/8
+    if (/^10\./.test(hostname)) return false;
+    // 172.16.0.0/12
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(hostname)) return false;
+    // 192.168.0.0/16
+    if (/^192\.168\./.test(hostname)) return false;
+    // 169.254.0.0/16 (link-local)
+    if (/^169\.254\./.test(hostname)) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validate an external URL for Google Gemini file input
+ * Performs a HEAD request to check Content-Length and Content-Type
+ *
+ * @param url - The URL to validate
+ * @returns Validation result with content info
+ */
+export const validateExternalUrl = async (url: string): Promise<ExternalUrlValidation> => {
+  try {
+    // Perform HEAD request to get headers without downloading the file
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': 'LobeChat/1.0 (https://lobehub.com)',
+      },
+      method: 'HEAD',
+    });
+
+    if (!res.ok) {
+      return {
+        contentLength: 0,
+        contentType: '',
+        isValid: false,
+        reason: `HTTP ${res.status}: ${res.statusText}`,
+      };
+    }
+
+    const contentLength = Number.parseInt(res.headers.get('content-length') || '0', 10);
+    const contentType = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+
+    // Check MIME type support
+    if (!GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES.has(contentType)) {
+      return {
+        contentLength,
+        contentType,
+        isValid: false,
+        reason: `Unsupported content type: ${contentType}`,
+      };
+    }
+
+    // Check file size - External URLs support 100MB for all file types
+    // (Unlike inline data where PDFs are limited to 50MB)
+    if (contentLength > MAX_EXTERNAL_URL_SIZE) {
+      return {
+        contentLength,
+        contentType,
+        isValid: false,
+        reason: `File too large: ${contentLength} bytes (max ${MAX_EXTERNAL_URL_SIZE} bytes)`,
+      };
+    }
+
+    return {
+      contentLength,
+      contentType,
+      isValid: true,
+    };
+  } catch (error) {
+    return {
+      contentLength: 0,
+      contentType: '',
+      isValid: false,
+      reason: `Failed to validate URL: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+};

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -67,6 +67,8 @@ export interface ExternalUrlValidation {
   contentLength: number;
   /** Content-Type from response headers */
   contentType: string;
+  /** Whether the URL was rejected due to size limit */
+  isTooLarge?: boolean;
   /** Whether the URL is valid for external URL usage */
   isValid: boolean;
   /** Reason for invalid URL */
@@ -144,6 +146,7 @@ export const validateExternalUrl = async (url: string): Promise<ExternalUrlValid
       return {
         contentLength,
         contentType,
+        isTooLarge: true,
         isValid: false,
         reason: `File too large: ${contentLength} bytes (max ${MAX_EXTERNAL_URL_SIZE} bytes)`,
       };

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -36,7 +36,6 @@ const GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES = new Set([
   'text/plain',
   'text/xml',
   'text/csv',
-  'text/scv',
   'text/rtf',
   'text/javascript',
   // Application file types

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -36,6 +36,7 @@ const GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES = new Set([
   'text/plain',
   'text/xml',
   'text/csv',
+  'text/scv',
   'text/rtf',
   'text/javascript',
   // Application file types
@@ -46,7 +47,6 @@ const GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES = new Set([
   'image/jpeg',
   'image/png',
   'image/webp',
-  'image/gif',
 ]);
 
 /**

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -102,12 +102,19 @@ export const isPublicExternalUrl = (url: string): boolean => {
 export const validateExternalUrl = async (url: string): Promise<ExternalUrlValidation> => {
   try {
     // Perform HEAD request to get headers without downloading the file
-    const res = await ssrfSafeFetch(url, {
-      headers: {
-        'User-Agent': 'LobeChat/1.0 (https://lobehub.com)',
+    const res = await ssrfSafeFetch(
+      url,
+      {
+        headers: {
+          'User-Agent': 'LobeChat/1.0 (https://lobehub.com)',
+        },
+        method: 'HEAD',
       },
-      method: 'HEAD',
-    });
+      {
+        allowIPAddressList: [],
+        allowPrivateIPAddress: false,
+      },
+    );
 
     if (!res.ok) {
       return {

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -36,6 +36,7 @@ export interface LobeAgentChatConfig {
   reasoningEffort?: 'low' | 'medium' | 'high';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   gpt5_1ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  codexMaxReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   gpt5_2ProReasoningEffort?: 'medium' | 'high' | 'xhigh';
   /**
@@ -106,6 +107,7 @@ export const LocalSystemConfigSchema = z.object({
 
 export const AgentChatConfigSchema = z.object({
   autoCreateTopicThreshold: z.number().default(2),
+  codexMaxReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
   compressionModelId: z.string().optional(),
   disableContextCaching: z.boolean().optional(),
   enableAutoCreateTopic: z.boolean().optional(),

--- a/packages/utils/src/client/videoValidation.test.ts
+++ b/packages/utils/src/client/videoValidation.test.ts
@@ -32,22 +32,22 @@ describe('validateVideoFileSize', () => {
   });
 
   it('should return invalid for video files exactly at 20MB limit plus 1 byte', () => {
-    const mockBoundaryFile = new File(['x'.repeat(20 * 1024 * 1024 + 1)], 'boundary.mp4', {
+    const mockBoundaryFile = new File(['x'.repeat(100 * 1024 * 1024 + 1)], 'boundary.mp4', {
       type: 'video/mp4',
     });
     const result = validateVideoFileSize(mockBoundaryFile);
 
     expect(result.isValid).toBe(false);
-    expect(result.actualSize).toBe('20.0 MB');
+    expect(result.actualSize).toBe('100.0 MB');
   });
 
   it('should return valid for video files exactly at 20MB limit', () => {
-    const mockBoundaryFile = new File(['x'.repeat(20 * 1024 * 1024)], 'boundary.mp4', {
+    const mockBoundaryFile = new File(['x'.repeat(100 * 1024 * 1024)], 'boundary.mp4', {
       type: 'video/mp4',
     });
     const result = validateVideoFileSize(mockBoundaryFile);
 
     expect(result.isValid).toBe(true);
-    expect(result.actualSize).toBe('20.0 MB');
+    expect(result.actualSize).toBe('100.0 MB');
   });
 });

--- a/packages/utils/src/client/videoValidation.test.ts
+++ b/packages/utils/src/client/videoValidation.test.ts
@@ -11,7 +11,7 @@ describe('validateVideoFileSize', () => {
     expect(result.actualSize).toBeUndefined();
   });
 
-  it('should return valid for video files under 20MB', () => {
+  it('should return valid for video files under 100MB', () => {
     const mockVideoFile = new File(['x'.repeat(10 * 1024 * 1024)], 'video.mp4', {
       type: 'video/mp4',
     });
@@ -21,17 +21,27 @@ describe('validateVideoFileSize', () => {
     expect(result.actualSize).toBe('10.0 MB');
   });
 
-  it('should return invalid for video files over 20MB', () => {
+  it('should return valid for video files under 100MB (25MB)', () => {
     const mockLargeVideoFile = new File(['x'.repeat(25 * 1024 * 1024)], 'large-video.mp4', {
       type: 'video/mp4',
     });
     const result = validateVideoFileSize(mockLargeVideoFile);
 
-    expect(result.isValid).toBe(false);
+    expect(result.isValid).toBe(true);
     expect(result.actualSize).toBe('25.0 MB');
   });
 
-  it('should return invalid for video files exactly at 20MB limit plus 1 byte', () => {
+  it('should return invalid for video files over 100MB', () => {
+    const mockLargeVideoFile = new File(['x'.repeat(120 * 1024 * 1024)], 'large-video.mp4', {
+      type: 'video/mp4',
+    });
+    const result = validateVideoFileSize(mockLargeVideoFile);
+
+    expect(result.isValid).toBe(false);
+    expect(result.actualSize).toBe('120.0 MB');
+  });
+
+  it('should return invalid for video files exactly at 100MB limit plus 1 byte', () => {
     const mockBoundaryFile = new File(['x'.repeat(100 * 1024 * 1024 + 1)], 'boundary.mp4', {
       type: 'video/mp4',
     });
@@ -41,7 +51,7 @@ describe('validateVideoFileSize', () => {
     expect(result.actualSize).toBe('100.0 MB');
   });
 
-  it('should return valid for video files exactly at 20MB limit', () => {
+  it('should return valid for video files exactly at 100MB limit', () => {
     const mockBoundaryFile = new File(['x'.repeat(100 * 1024 * 1024)], 'boundary.mp4', {
       type: 'video/mp4',
     });

--- a/packages/utils/src/client/videoValidation.ts
+++ b/packages/utils/src/client/videoValidation.ts
@@ -1,6 +1,6 @@
 import { formatSize } from '../format';
 
-const VIDEO_SIZE_LIMIT = 20 * 1024 * 1024; // 20MB in bytes
+const VIDEO_SIZE_LIMIT = 100 * 1024 * 1024; // 100MB in bytes
 
 export interface VideoValidationResult {
   actualSize?: string;

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -5,6 +5,7 @@ import { memo, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import CodexMaxReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/CodexMaxReasoningEffortSlider';
 import GPT5ReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/GPT52ProReasoningEffortSlider';
@@ -58,6 +59,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'gpt5_2ProReasoningEffort',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.codexMaxReasoningEffort.hint',
+    key: 'codexMaxReasoningEffort',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.textVerbosity.hint',
     key: 'textVerbosity',
   },
@@ -94,6 +99,7 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
 // Map variant keys to their base i18n title key (synced with ControlsForm.tsx)
 // This allows reusing existing i18n translations instead of adding new ones
 const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
+  codexMaxReasoningEffort: 'reasoningEffort',
   gpt5ReasoningEffort: 'reasoningEffort',
   gpt5_1ReasoningEffort: 'reasoningEffort',
   gpt5_2ProReasoningEffort: 'reasoningEffort',
@@ -109,6 +115,11 @@ type PreviewMeta = {
 };
 
 const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
+  codexMaxReasoningEffort: {
+    labelSuffix: ' (Codex)',
+    previewWidth: 300,
+    tag: 'reasoning_effort',
+  },
   disableContextCaching: { labelSuffix: ' (Claude)', previewWidth: 400 },
   enableReasoning: { previewWidth: 300, tag: 'thinking.type' },
   gpt5ReasoningEffort: { previewWidth: 300, tag: 'reasoning_effort' },
@@ -211,6 +222,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
   // Preview controls use controlled mode with default values (no store access)
   const previewControls = useMemo<Partial<Record<ExtendParamsType, ReactNode>>>(
     () => ({
+      codexMaxReasoningEffort: <CodexMaxReasoningEffortSlider value="medium" />,
       disableContextCaching: <Switch checked disabled />,
       enableReasoning: <Switch checked disabled />,
       gpt5ReasoningEffort: <GPT5ReasoningEffortSlider value="medium" />,

--- a/src/features/ChatInput/ActionBar/Model/CodexMaxReasoningEffortSlider.tsx
+++ b/src/features/ChatInput/ActionBar/Model/CodexMaxReasoningEffortSlider.tsx
@@ -1,0 +1,15 @@
+import { type CreatedLevelSliderProps, createLevelSliderComponent } from './createLevelSlider';
+
+const CODEX_MAX_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+type CodexMaxReasoningEffort = (typeof CODEX_MAX_REASONING_EFFORT_LEVELS)[number];
+
+export type CodexMaxReasoningEffortSliderProps = CreatedLevelSliderProps<CodexMaxReasoningEffort>;
+
+const CodexMaxReasoningEffortSlider = createLevelSliderComponent<CodexMaxReasoningEffort>({
+  configKey: 'codexMaxReasoningEffort',
+  defaultValue: 'medium',
+  levels: CODEX_MAX_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 200 },
+});
+
+export default CodexMaxReasoningEffortSlider;

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -11,6 +11,7 @@ import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useUpdateAgentConfig } from '../../hooks/useUpdateAgentConfig';
+import CodexMaxReasoningEffortSlider from './CodexMaxReasoningEffortSlider';
 import ContextCachingSwitch from './ContextCachingSwitch';
 import GPT5ReasoningEffortSlider from './GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
@@ -162,6 +163,17 @@ const ControlsForm = memo(() => {
       layout: 'horizontal',
       minWidth: undefined,
       name: 'gpt5_2ProReasoningEffort',
+      style: {
+        paddingBottom: 0,
+      },
+    },
+    {
+      children: <CodexMaxReasoningEffortSlider />,
+      desc: 'reasoning_effort',
+      label: t('extendParams.reasoningEffort.title'),
+      layout: 'horizontal',
+      minWidth: undefined,
+      name: 'codexMaxReasoningEffort',
       style: {
         paddingBottom: 0,
       },

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -451,7 +451,7 @@ export default {
   'upload.preview.status.pending': 'Preparing to upload...',
   'upload.preview.status.processing': 'Processing file...',
   'upload.validation.videoSizeExceeded':
-    'Video file size must not exceed 20MB. Current file size is {{actualSize}}.',
+    'Video file size must not exceed 100MB. Current file size is {{actualSize}}.',
   'viewMode.fullWidth': 'Full Width',
   'viewMode.normal': 'Standard',
   'viewMode.wideScreen': 'Widescreen',

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -222,6 +222,8 @@ export default {
   'providerModels.item.modelConfig.displayName.title': 'Model Display Name',
   'providerModels.item.modelConfig.extendParams.extra':
     'Choose extended parameters supported by the model. Hover an option to preview controls. Incorrect configs may cause request failures.',
+  'providerModels.item.modelConfig.extendParams.options.codexMaxReasoningEffort.hint':
+    'For GPT-5.1 Codex Max; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.disableContextCaching.hint':
     'For Claude models; can lower cost and speed up responses.',
   'providerModels.item.modelConfig.extendParams.options.enableReasoning.hint':

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -106,6 +106,10 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.reasoning_effort = chatConfig.gpt5_2ProReasoningEffort;
   }
 
+  if (modelExtendParams.includes('codexMaxReasoningEffort') && chatConfig.codexMaxReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.codexMaxReasoningEffort;
+  }
+
   // Text verbosity
   if (modelExtendParams.includes('textVerbosity') && chatConfig.textVerbosity) {
     extendParams.verbosity = chatConfig.textVerbosity;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

https://ai.google.dev/gemini-api/docs/file-input-methods#external-urls

添加对 External URL 文件输入方式的支持。非常适配目前使用 s3 的 LobeChat .
向 Gemini 上传图片和 PDF 文件不再需要转成 base64 传输，可减少服务端出口流量。

目前测试仅 Gemini 3 可用，但文档称 Gemini 2.5 也可用，目前添加了模型名限制，后续可再行观察。

----

同时将视频限制提升到 100 MB .

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Support Google Gemini External URL file input with SSRF-safe validation and graceful fallback to inline data.

Enhancements:
- Add SSRF-safe validation utilities for External URL file inputs, including MIME type and size checks aligned with Google Gemini limits.
- Update Google Gemini context builder to prefer External URLs for public image and video URLs, falling back to base64 inline data when validation fails or URLs are non-public.