### PR TITLE
🐛 fix: prevent useActionSWR from auto-fetching on mount

### DIFF
--- a/src/features/OllamaModelDownloader/index.tsx
+++ b/src/features/OllamaModelDownloader/index.tsx
@@ -41,10 +41,10 @@ const OllamaModelDownloader = memo<OllamaModelDownloaderProps>(
       isValidating: isDownloading,
       error,
     } = useActionSWR(
-      [modelToPull],
-      async ([model]) => {
+      ['ollama.downloadModel', modelToPull],
+      async () => {
         await modelsService.downloadModel(
-          { model, provider: 'ollama' },
+          { model: modelToPull, provider: 'ollama' },
           { onProgress: handleProgress },
         );
 

--- a/src/libs/swr/index.ts
+++ b/src/libs/swr/index.ts
@@ -1,5 +1,5 @@
 import useSWR, { type SWRHook } from 'swr';
-
+import useSWRMutation from 'swr/mutation';
 
 /**
  * This type of request method is relatively flexible data, which will be triggered on the first time
@@ -63,20 +63,18 @@ export const useOnlyFetchOnceSWR: SWRHook = (key, fetch, config) =>
   });
 
 /**
- * 这一类请求方法用于做操作触发，必须使用 mutute 来触发请求操作，好处是自带了 loading / error 状态。
- * 可以很简单地完成 loading / error 态的交互处理，同时，相同 swr key 的请求会自动共享 loading态（例如新建助理按钮和右上角的 + 号）
+ * 这一类请求方法用于做操作触发，必须使用 mutate 来触发请求操作，好处是自带了 loading / error 状态。
+ * 可以很简单地完成 loading / error 态的交互处理，同时，相同 swr key 的请求会自动共享 loading 态（例如新建助理按钮和右上角的 + 号）
  * 非常适用于新建等操作。
+ *
+ * 使用 useSWRMutation 而非 useSWR，因为 useSWR 即使设置了 revalidateOnMount: false，
+ * 在缓存为空时仍会自动调用 fetcher。而 useSWRMutation 只会在手动调用 trigger 时执行。
  */
-// @ts-ignore
-export const useActionSWR: SWRHook = (key, fetch, config) =>
-  useSWR(key, fetch, {
-    refreshWhenHidden: false,
-    refreshWhenOffline: false,
-    revalidateOnFocus: false,
-    revalidateOnMount: false,
-    revalidateOnReconnect: false,
-    ...config,
-  });
+export const useActionSWR = <T>(key: string | any[], fetcher: () => Promise<T>, config?: any) => {
+  const { trigger, isMutating, ...rest } = useSWRMutation(key, fetcher, config);
+  // Return with legacy property names for backward compatibility
+  return { ...rest, isValidating: isMutating, mutate: trigger };
+};
 
 export interface SWRRefreshParams<T, A = (...args: any[]) => any> {
   action: A;


### PR DESCRIPTION
## Summary

- Changed `useActionSWR` to use `useSWRMutation` instead of `useSWR`
- This prevents unintended auto-fetching when cache is empty (even with `revalidateOnMount: false`)
- Fixed a bug where switching topics would trigger automatic agent creation

## Root Cause

`useSWR` auto-fetches when cache is empty, regardless of `revalidateOnMount: false`. When switching topics, the message list temporarily becomes empty, causing `AgentWelcome` to render. The `AddButton` in `AgentWelcome` used `useActionSWR` which would auto-fetch and create a new agent, then navigate to its profile page.

## Solution

Changed `useActionSWR` to use `useSWRMutation` which only executes the fetcher when `trigger()` (renamed to `mutate()` for backward compatibility) is manually called.

## Related Issues

Fixes #11489

## Test Plan

- [ ] Refresh page on `/agent/:aid` route
- [ ] Click a topic in the sidebar
- [ ] Verify no automatic navigation to a new agent's profile page occurs

## Summary by Sourcery

Switch useActionSWR to useSWRMutation to prevent unintended auto-fetching and align callers with the new mutation-based behavior.

Bug Fixes:
- Prevent automatic execution of useActionSWR requests when the cache is empty, avoiding unintended side effects such as auto-creating agents on mount.

Enhancements:
- Refine useActionSWR to expose a mutation-style API built on useSWRMutation while preserving legacy field names for backward compatibility.
- Adjust Ollama model download logic to use a more explicit SWR mutation key and fetcher signature aligned with the new useActionSWR implementation.