### PR TITLE
update flow

### DIFF
--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -399,8 +399,20 @@ jobs:
             fi
           done
 
-          # 2. 上传 manifest 到根目录 (electron-updater 需要)
-          # 上传 stable*.yml (stable channel) 和 latest*.yml (fallback)
+          # 2. 创建 stable*.yml (从 latest*.yml 复制)
+          # electron-updater 在 channel=stable 时会找 stable-mac.yml
+          echo ""
+          echo "📋 Creating stable*.yml files from latest*.yml..."
+          for yml in release/latest*.yml; do
+            if [ -f "$yml" ]; then
+              stable_name=$(basename "$yml" | sed 's/latest/stable/')
+              cp "$yml" "release/$stable_name"
+              echo "   📄 Created $stable_name from $(basename $yml)"
+            fi
+          done
+
+          # 3. 上传 manifest 到根目录 (electron-updater 需要)
+          # stable*.yml 用于 stable channel，latest*.yml 用于 GitHub fallback
           echo ""
           echo "📋 Uploading manifest files to s3://$S3_BUCKET/stable/"
           for yml in release/stable*.yml release/latest*.yml; do

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -421,16 +421,15 @@ jobs:
           if [ -f "$RENDERER_TAR" ]; then
             RENDERER_SHA512=$(shasum -a 512 "$RENDERER_TAR" | awk '{print $1}' | xxd -r -p | base64)
             RENDERER_SIZE=$(stat -f%z "$RENDERER_TAR" 2>/dev/null || stat -c%s "$RENDERER_TAR")
-            cat > "release/stable-renderer.yml" << EOF
-version: $VERSION
-files:
-  - url: $VERSION/lobehub-renderer.tar.gz
-    sha512: $RENDERER_SHA512
-    size: $RENDERER_SIZE
-path: $VERSION/lobehub-renderer.tar.gz
-sha512: $RENDERER_SHA512
-releaseDate: '$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'
-EOF
+            RELEASE_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+            echo "version: $VERSION" > "release/stable-renderer.yml"
+            echo "files:" >> "release/stable-renderer.yml"
+            echo "  - url: $VERSION/lobehub-renderer.tar.gz" >> "release/stable-renderer.yml"
+            echo "    sha512: $RENDERER_SHA512" >> "release/stable-renderer.yml"
+            echo "    size: $RENDERER_SIZE" >> "release/stable-renderer.yml"
+            echo "path: $VERSION/lobehub-renderer.tar.gz" >> "release/stable-renderer.yml"
+            echo "sha512: $RENDERER_SHA512" >> "release/stable-renderer.yml"
+            echo "releaseDate: '$RELEASE_DATE'" >> "release/stable-renderer.yml"
             echo "   📄 Created stable-renderer.yml with SHA512 checksum"
           else
             echo "   ⚠️ Renderer tar not found, skipping manifest creation"

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -435,15 +435,18 @@ jobs:
             echo "   ⚠️ Renderer tar not found, skipping manifest creation"
           fi
 
-          # 4. 上传 manifest 到根目录 (electron-updater 需要)
-          # stable*.yml 用于 stable channel，latest*.yml 用于 GitHub fallback
+          # 4. 上传 manifest 到根目录和版本目录
+          # 根目录: electron-updater 需要，会被每次发版覆盖
+          # 版本目录: 作为存档保留
           echo ""
-          echo "📋 Uploading manifest files to s3://$S3_BUCKET/stable/"
+          echo "📋 Uploading manifest files..."
           for yml in release/stable*.yml release/latest*.yml; do
             if [ -f "$yml" ]; then
               filename=$(basename "$yml")
-              echo "   ↗️ $filename"
+              echo "   ↗️ $filename -> s3://$S3_BUCKET/stable/$filename"
               aws s3 cp "$yml" "s3://$S3_BUCKET/stable/$filename" $ENDPOINT_ARG
+              echo "   ↗️ $filename -> s3://$S3_BUCKET/stable/$VERSION/$filename (archive)"
+              aws s3 cp "$yml" "s3://$S3_BUCKET/stable/$VERSION/$filename" $ENDPOINT_ARG
             fi
           done
 

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -414,7 +414,29 @@ jobs:
             fi
           done
 
-          # 3. 上传 manifest 到根目录 (electron-updater 需要)
+          # 3. 创建 renderer manifest (用于验证 renderer tar 完整性)
+          echo ""
+          echo "📋 Creating renderer manifest..."
+          RENDERER_TAR="release/lobehub-renderer.tar.gz"
+          if [ -f "$RENDERER_TAR" ]; then
+            RENDERER_SHA512=$(shasum -a 512 "$RENDERER_TAR" | awk '{print $1}' | xxd -r -p | base64)
+            RENDERER_SIZE=$(stat -f%z "$RENDERER_TAR" 2>/dev/null || stat -c%s "$RENDERER_TAR")
+            cat > "release/stable-renderer.yml" << EOF
+version: $VERSION
+files:
+  - url: $VERSION/lobehub-renderer.tar.gz
+    sha512: $RENDERER_SHA512
+    size: $RENDERER_SIZE
+path: $VERSION/lobehub-renderer.tar.gz
+sha512: $RENDERER_SHA512
+releaseDate: '$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'
+EOF
+            echo "   📄 Created stable-renderer.yml with SHA512 checksum"
+          else
+            echo "   ⚠️ Renderer tar not found, skipping manifest creation"
+          fi
+
+          # 4. 上传 manifest 到根目录 (electron-updater 需要)
           # stable*.yml 用于 stable channel，latest*.yml 用于 GitHub fallback
           echo ""
           echo "📋 Uploading manifest files to s3://$S3_BUCKET/stable/"

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -399,15 +399,18 @@ jobs:
             fi
           done
 
-          # 2. 创建 stable*.yml (从 latest*.yml 复制)
+          # 2. 创建 stable*.yml (从 latest*.yml 复制，并修改 URL 加上版本目录前缀)
           # electron-updater 在 channel=stable 时会找 stable-mac.yml
+          # S3 目录结构: stable/{version}/xxx.dmg，所以 URL 需要加上 {version}/ 前缀
           echo ""
           echo "📋 Creating stable*.yml files from latest*.yml..."
           for yml in release/latest*.yml; do
             if [ -f "$yml" ]; then
               stable_name=$(basename "$yml" | sed 's/latest/stable/')
-              cp "$yml" "release/$stable_name"
-              echo "   📄 Created $stable_name from $(basename $yml)"
+              # 复制并修改 URL: 给所有 url 字段加上版本目录前缀
+              # url: xxx.dmg -> url: {VERSION}/xxx.dmg
+              sed "s|url: |url: $VERSION/|g" "$yml" > "release/$stable_name"
+              echo "   📄 Created $stable_name from $(basename $yml) with URL prefix: $VERSION/"
             fi
           done
 

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -90,41 +90,10 @@ jobs:
           fi
 
   # ============================================
-  # 代码质量检查
-  # ============================================
-  test:
-    name: Code quality check
-    needs: [check-stable]
-    if: needs.check-stable.outputs.is_stable == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout base
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          package-manager-cache: false
-
-      - name: Install bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install deps
-        run: bun i
-
-      - name: Lint
-        run: bun run lint
-
-  # ============================================
   # 多平台构建
   # ============================================
   build:
-    needs: [check-stable, test]
+    needs: [check-stable]
     if: needs.check-stable.outputs.is_stable == 'true'
     name: Build Desktop App
     runs-on: ${{ matrix.os }}
@@ -181,7 +150,9 @@ jobs:
       # Linux 构建
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: npm run desktop:build
+        run: |
+          npm run desktop:build
+          tar -czf apps/desktop/release/lobehub-renderer.tar.gz -C out .
         env:
           UPDATE_CHANNEL: stable
           UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -112,6 +112,8 @@ jobs:
     if: needs.check-stable.outputs.is_stable == 'true'
     name: Configure Build Matrix
     runs-on: ubuntu-latest
+    permissions:
+      administration: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -311,6 +311,7 @@ jobs:
           # 手动触发时创建为 draft
           draft: ${{ github.event_name == 'workflow_dispatch' }}
           files: |
+            release/stable*
             release/latest*
             release/*.dmg*
             release/*.zip*
@@ -329,9 +330,10 @@ jobs:
   # S3 目录结构:
   #   s3://bucket/
   #     stable/
-  #       latest-mac.yml      ← electron-updater 检查更新
-  #       latest.yml          ← Windows
-  #       latest-linux.yml    ← Linux
+  #       stable-mac.yml      ← electron-updater 检查更新 (stable channel)
+  #       stable.yml          ← Windows (stable channel)
+  #       stable-linux.yml    ← Linux (stable channel)
+  #       latest-mac.yml      ← fallback for GitHub provider
   #       {version}/          ← 版本目录
   #         *.dmg, *.zip, *.exe, ...
   # ============================================
@@ -398,9 +400,10 @@ jobs:
           done
 
           # 2. 上传 manifest 到根目录 (electron-updater 需要)
+          # 上传 stable*.yml (stable channel) 和 latest*.yml (fallback)
           echo ""
           echo "📋 Uploading manifest files to s3://$S3_BUCKET/stable/"
-          for yml in release/latest*.yml; do
+          for yml in release/stable*.yml release/latest*.yml; do
             if [ -f "$yml" ]; then
               filename=$(basename "$yml")
               echo "   ↗️ $filename"

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: boolean
         default: true
+      use_self_hosted_mac:
+        description: 'Use self-hosted macOS ARM64 runner'
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -112,31 +117,9 @@ jobs:
     if: needs.check-stable.outputs.is_stable == 'true'
     name: Configure Build Matrix
     runs-on: ubuntu-latest
-    permissions:
-      administration: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Check Self-Hosted Runner
-        id: check-runner
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Checking self-hosted runner status..."
-          # 尝试获取 Runner 列表，如果失败(如权限不足)则忽略错误，此时 runners 为空，后续逻辑会自动 fallback
-          runners=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/actions/runners 2>/dev/null || true)
-          
-          # 检查是否存在状态为 online 且包含指定标签的 Runner
-          online_runner=$(echo "$runners" | jq -r '.runners[] | select(.status == "online") | select(.labels | map(.name) | contains(["self-hosted", "macOS", "ARM64"])) | .id' 2>/dev/null | head -n 1)
-          
-          if [ -n "$online_runner" ]; then
-            echo "✅ Found online self-hosted runner (ID: $online_runner)"
-            echo "use_self_hosted=true" >> $GITHUB_ENV
-          else
-            echo "⚠️ No online self-hosted runner found (or API access denied). Falling back to GitHub-hosted runner."
-            echo "use_self_hosted=false" >> $GITHUB_ENV
-          fi
-
       - name: Generate Matrix
         id: set-matrix
         run: |
@@ -154,8 +137,9 @@ jobs:
           fi
 
           # macOS (ARM64)
+          # Release 事件默认使用 self-hosted，手动触发时根据 input 决定
           if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_mac }}" == "true" ]]; then
-            if [ "$use_self_hosted" == "true" ]; then
+            if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.use_self_hosted_mac }}" == "true" ]]; then
                echo "Using Self-Hosted Runner for macOS ARM64"
                arm_entry='{"os": ["self-hosted", "macOS", "ARM64"], "name": "macos-arm64"}'
             else

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -29,6 +29,21 @@ on:
         description: 'Version to build (e.g., 2.0.0)'
         required: true
         type: string
+      build_mac:
+        description: 'Build macOS (ARM64)'
+        required: false
+        type: boolean
+        default: true
+      build_windows:
+        description: 'Build Windows'
+        required: false
+        type: boolean
+        default: true
+      build_linux:
+        description: 'Build Linux'
+        required: false
+        type: boolean
+        default: true
       skip_s3_upload:
         description: 'Skip S3 upload (for testing)'
         required: false
@@ -90,16 +105,78 @@ jobs:
           fi
 
   # ============================================
+  # 配置构建矩阵 (检查自托管 Runner)
+  # ============================================
+  configure-build:
+    needs: [check-stable]
+    if: needs.check-stable.outputs.is_stable == 'true'
+    name: Configure Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Check Self-Hosted Runner
+        id: check-runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking self-hosted runner status..."
+          # 尝试获取 Runner 列表，如果失败(如权限不足)则忽略错误，此时 runners 为空，后续逻辑会自动 fallback
+          runners=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/actions/runners 2>/dev/null || true)
+          
+          # 检查是否存在状态为 online 且包含指定标签的 Runner
+          online_runner=$(echo "$runners" | jq -r '.runners[] | select(.status == "online") | select(.labels | map(.name) | contains(["self-hosted", "macOS", "ARM64"])) | .id' 2>/dev/null | head -n 1)
+          
+          if [ -n "$online_runner" ]; then
+            echo "✅ Found online self-hosted runner (ID: $online_runner)"
+            echo "use_self_hosted=true" >> $GITHUB_ENV
+          else
+            echo "⚠️ No online self-hosted runner found (or API access denied). Falling back to GitHub-hosted runner."
+            echo "use_self_hosted=false" >> $GITHUB_ENV
+          fi
+
+      - name: Generate Matrix
+        id: set-matrix
+        run: |
+          # 基础矩阵
+          static_matrix='[]'
+
+          # Windows
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_windows }}" == "true" ]]; then
+            static_matrix=$(echo "$static_matrix" | jq '. + [{"os": "windows-2025", "name": "windows-2025"}]')
+          fi
+          
+          # Linux
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_linux }}" == "true" ]]; then
+            static_matrix=$(echo "$static_matrix" | jq '. + [{"os": "ubuntu-latest", "name": "ubuntu-latest"}]')
+          fi
+
+          # macOS (ARM64)
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_mac }}" == "true" ]]; then
+            if [ "$use_self_hosted" == "true" ]; then
+               echo "Using Self-Hosted Runner for macOS ARM64"
+               arm_entry='{"os": ["self-hosted", "macOS", "ARM64"], "name": "macos-arm64"}'
+            else
+               echo "Using GitHub-Hosted Runner for macOS ARM64"
+               arm_entry='{"os": "macos-14", "name": "macos-arm64"}'
+            fi
+            static_matrix=$(echo "$static_matrix" | jq --argjson entry "$arm_entry" '. + [$entry]')
+          fi
+          
+          # 输出
+          echo "matrix={\"include\":$static_matrix}" >> $GITHUB_OUTPUT
+
+  # ============================================
   # 多平台构建
   # ============================================
   build:
-    needs: [check-stable]
+    needs: [check-stable, configure-build]
     if: needs.check-stable.outputs.is_stable == 'true'
     name: Build Desktop App
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [macos-latest, macos-15-intel, windows-2025, ubuntu-latest]
+      fail-fast: false
+      matrix: ${{ fromJson(needs.configure-build.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -165,7 +242,7 @@ jobs:
       - name: Upload artifacts
         uses: ./.github/actions/desktop-upload-artifacts
         with:
-          artifact-name: release-${{ matrix.os }}
+          artifact-name: release-${{ matrix.name }}
 
   # ============================================
   # 合并 macOS 多架构文件
@@ -292,15 +369,11 @@ jobs:
           echo ""
           echo "📋 Version: ${{ needs.check-stable.outputs.version }}"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.UPDATE_S3_REGION || 'us-east-1' }}
-
       - name: Upload to S3
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.UPDATE_S3_REGION || 'us-east-1' }}
           S3_BUCKET: ${{ secrets.UPDATE_S3_BUCKET }}
           S3_ENDPOINT: ${{ secrets.UPDATE_S3_ENDPOINT }}
           VERSION: ${{ needs.check-stable.outputs.version }}

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -143,12 +143,12 @@ jobs:
 
           # Windows
           if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_windows }}" == "true" ]]; then
-            static_matrix=$(echo "$static_matrix" | jq '. + [{"os": "windows-2025", "name": "windows-2025"}]')
+            static_matrix=$(echo "$static_matrix" | jq -c '. + [{"os": "windows-2025", "name": "windows-2025"}]')
           fi
-          
+
           # Linux
           if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_linux }}" == "true" ]]; then
-            static_matrix=$(echo "$static_matrix" | jq '. + [{"os": "ubuntu-latest", "name": "ubuntu-latest"}]')
+            static_matrix=$(echo "$static_matrix" | jq -c '. + [{"os": "ubuntu-latest", "name": "ubuntu-latest"}]')
           fi
 
           # macOS (ARM64)
@@ -160,9 +160,9 @@ jobs:
                echo "Using GitHub-Hosted Runner for macOS ARM64"
                arm_entry='{"os": "macos-14", "name": "macos-arm64"}'
             fi
-            static_matrix=$(echo "$static_matrix" | jq --argjson entry "$arm_entry" '. + [$entry]')
+            static_matrix=$(echo "$static_matrix" | jq -c --argjson entry "$arm_entry" '. + [$entry]')
           fi
-          
+
           # 输出
           echo "matrix={\"include\":$static_matrix}" >> $GITHUB_OUTPUT
 

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -159,6 +159,10 @@ const config = {
   // Native modules must be unpacked from asar to work correctly
   asarUnpack: getAsarUnpackPatterns(),
 
+  // Set channel for stable builds to generate stable-mac.yml instead of latest-mac.yml
+  // This ensures electron-updater looks for the correct manifest file
+  channel: isStable ? 'stable' : undefined,
+
   detectUpdateChannel: true,
 
   directories: {

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -159,10 +159,6 @@ const config = {
   // Native modules must be unpacked from asar to work correctly
   asarUnpack: getAsarUnpackPatterns(),
 
-  // Set channel for stable builds to generate stable-mac.yml instead of latest-mac.yml
-  // This ensures electron-updater looks for the correct manifest file
-  channel: isStable ? 'stable' : undefined,
-
   detectUpdateChannel: true,
 
   directories: {

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -21,12 +21,11 @@ export default defineConfig({
       },
       sourcemap: isDev ? 'inline' : false,
     },
-    // 这里是关键：在构建时进行文本替换
+
     define: {
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      'process.env.OFFICIAL_CLOUD_SERVER': JSON.stringify(process.env.OFFICIAL_CLOUD_SERVER),
       'process.env.UPDATE_CHANNEL': JSON.stringify(process.env.UPDATE_CHANNEL),
-      // Custom update server URL (for stable channel)
+
       'process.env.UPDATE_SERVER_URL': JSON.stringify(process.env.UPDATE_SERVER_URL),
     },
 

--- a/apps/desktop/scripts/update-test/dev-app-update.local.yml
+++ b/apps/desktop/scripts/update-test/dev-app-update.local.yml
@@ -13,5 +13,6 @@ provider: generic
 url: http://localhost:8787/stable
 updaterCacheDirName: lobehub-desktop-local-test
 
-# 重要：不要设置 channel，否则会找 {channel}-mac.yml 而不是 latest-mac.yml
-# 默认 channel 是 "latest"，会找 latest-mac.yml
+# 设置 channel 为 stable 以匹配生产环境行为
+# stable channel 会找 stable-mac.yml
+channel: stable

--- a/apps/desktop/scripts/update-test/generate-manifest.sh
+++ b/apps/desktop/scripts/update-test/generate-manifest.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # ============================================
-# 生成更新 manifest 文件 (latest-mac.yml 等)
+# 生成更新 manifest 文件 ({channel}-mac.yml)
 #
 # 目录结构:
 #   server/
 #     {channel}/
-#       latest-mac.yml
+#       {channel}-mac.yml  (e.g., stable-mac.yml)
 #       {version}/
 #         xxx.dmg
 #         xxx.zip
@@ -48,7 +48,7 @@ show_help() {
     echo "生成的目录结构:"
     echo "  server/"
     echo "    {channel}/"
-    echo "      latest-mac.yml"
+    echo "      {channel}-mac.yml  (e.g., stable-mac.yml)"
     echo "      {version}/"
     echo "        xxx.dmg"
     echo "        xxx.zip"
@@ -202,9 +202,10 @@ if [ -z "$RELEASE_NOTES" ]; then
 - 本地测试环境配置"
 fi
 
-# 生成 latest-mac.yml
+# 生成 {channel}-mac.yml (e.g., stable-mac.yml)
+MANIFEST_FILE="$CHANNEL-mac.yml"
 echo ""
-echo "📝 生成 $CHANNEL/latest-mac.yml..."
+echo "📝 生成 $CHANNEL/$MANIFEST_FILE..."
 
 DMG_SHA512=""
 DMG_SIZE="0"
@@ -223,14 +224,14 @@ if [ -n "$ZIP_FILE" ] && [ -f "$VERSION_DIR/$ZIP_FILE" ]; then
     ZIP_SIZE=$(get_file_size "$VERSION_DIR/$ZIP_FILE")
 fi
 
-# 写入 latest-mac.yml (放在渠道目录下)
-cat > "$CHANNEL_DIR/latest-mac.yml" << EOF
+# 写入 manifest 文件 (放在渠道目录下)
+cat > "$CHANNEL_DIR/$MANIFEST_FILE" << EOF
 version: $VERSION
 files:
 EOF
 
 if [ -n "$DMG_FILE" ]; then
-cat >> "$CHANNEL_DIR/latest-mac.yml" << EOF
+cat >> "$CHANNEL_DIR/$MANIFEST_FILE" << EOF
   - url: $VERSION/$DMG_FILE
     sha512: ${DMG_SHA512:-placeholder}
     size: $DMG_SIZE
@@ -238,14 +239,14 @@ EOF
 fi
 
 if [ -n "$ZIP_FILE" ]; then
-cat >> "$CHANNEL_DIR/latest-mac.yml" << EOF
+cat >> "$CHANNEL_DIR/$MANIFEST_FILE" << EOF
   - url: $VERSION/$ZIP_FILE
     sha512: ${ZIP_SHA512:-placeholder}
     size: $ZIP_SIZE
 EOF
 fi
 
-cat >> "$CHANNEL_DIR/latest-mac.yml" << EOF
+cat >> "$CHANNEL_DIR/$MANIFEST_FILE" << EOF
 path: $VERSION/${DMG_FILE:-LobeHub-$VERSION-arm64.dmg}
 sha512: ${DMG_SHA512:-placeholder}
 releaseDate: '$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'
@@ -253,13 +254,13 @@ releaseNotes: |
 $(echo "$RELEASE_NOTES" | sed 's/^/  /')
 EOF
 
-echo "✅ 已生成 $CHANNEL_DIR/latest-mac.yml"
+echo "✅ 已生成 $CHANNEL_DIR/$MANIFEST_FILE"
 
 # 显示生成的文件内容
 echo ""
 echo "📋 文件内容:"
 echo "----------------------------------------"
-cat "$CHANNEL_DIR/latest-mac.yml"
+cat "$CHANNEL_DIR/$MANIFEST_FILE"
 echo "----------------------------------------"
 
 # 显示目录结构

--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -26,6 +26,7 @@ export class UpdaterManager {
   private downloading: boolean = false;
   private updateAvailable: boolean = false;
   private isManualCheck: boolean = false;
+  private usingFallbackProvider: boolean = false;
 
   constructor(app: AppCore) {
     this.app = app;
@@ -313,13 +314,13 @@ export class UpdaterManager {
 
   /**
    * Configure update provider based on channel
-   * - Stable channel + UPDATE_SERVER_URL: Use generic HTTP provider
+   * - Stable channel + UPDATE_SERVER_URL: Use generic HTTP provider (S3) as primary
    * - Other channels (beta/nightly): Use GitHub provider
    */
   private configureUpdateProvider() {
-    if (isStableChannel && UPDATE_SERVER_URL) {
-      // Stable channel uses custom update server (generic HTTP)
-      logger.info(`Configuring generic provider for stable channel`);
+    if (isStableChannel && UPDATE_SERVER_URL && !this.usingFallbackProvider) {
+      // Stable channel uses custom update server (generic HTTP) as primary
+      logger.info(`Configuring generic provider for stable channel (primary)`);
       logger.info(`Update server URL: ${UPDATE_SERVER_URL}`);
 
       autoUpdater.setFeedURL({
@@ -328,7 +329,8 @@ export class UpdaterManager {
       });
     } else {
       // Beta/nightly channels use GitHub, or fallback to GitHub if UPDATE_SERVER_URL not configured
-      logger.info(`Configuring GitHub provider for ${channel} channel`);
+      const reason = this.usingFallbackProvider ? '(fallback from S3)' : '';
+      logger.info(`Configuring GitHub provider for ${channel} channel ${reason}`);
 
       autoUpdater.setFeedURL({
         owner: githubConfig.owner,
@@ -339,6 +341,41 @@ export class UpdaterManager {
       logger.info(`GitHub update URL configured: ${githubConfig.owner}/${githubConfig.repo}`);
     }
   }
+
+  /**
+   * Switch to fallback provider (GitHub) and retry update check
+   * Called when primary provider (S3) fails
+   */
+  private switchToFallbackAndRetry = async () => {
+    // Only fallback if we're on stable channel with S3 configured and haven't already fallen back
+    if (!isStableChannel || !UPDATE_SERVER_URL || this.usingFallbackProvider) {
+      return false;
+    }
+
+    logger.info('Primary update server (S3) failed, switching to GitHub fallback...');
+    this.usingFallbackProvider = true;
+    this.configureUpdateProvider();
+
+    // Retry update check with fallback provider
+    try {
+      await autoUpdater.checkForUpdates();
+      return true;
+    } catch (error) {
+      logger.error('Fallback provider (GitHub) also failed:', error);
+      return false;
+    }
+  };
+
+  /**
+   * Reset to primary provider for next update check
+   */
+  private resetToPrimaryProvider = () => {
+    if (this.usingFallbackProvider) {
+      logger.info('Resetting to primary update provider (S3)');
+      this.usingFallbackProvider = false;
+      this.configureUpdateProvider();
+    }
+  };
 
   private registerEvents() {
     logger.debug('Registering updater events');
@@ -351,6 +388,9 @@ export class UpdaterManager {
       logger.info(`Update available: ${info.version}`);
       this.updateAvailable = true;
 
+      // Reset to primary provider for next check cycle
+      this.resetToPrimaryProvider();
+
       if (this.isManualCheck) {
         this.mainWindow.broadcast('manualUpdateAvailable', info);
       } else {
@@ -362,13 +402,27 @@ export class UpdaterManager {
 
     autoUpdater.on('update-not-available', (info) => {
       logger.info(`Update not available. Current: ${info.version}`);
+
+      // Reset to primary provider for next check cycle
+      this.resetToPrimaryProvider();
+
       if (this.isManualCheck) {
         this.mainWindow.broadcast('manualUpdateNotAvailable', info);
       }
     });
 
-    autoUpdater.on('error', (err) => {
+    autoUpdater.on('error', async (err) => {
       logger.error('Error in auto-updater:', err);
+
+      // Try fallback to GitHub if S3 failed
+      if (!this.usingFallbackProvider && isStableChannel && UPDATE_SERVER_URL) {
+        logger.info('Attempting fallback to GitHub provider...');
+        const fallbackSucceeded = await this.switchToFallbackAndRetry();
+        if (fallbackSucceeded) {
+          return; // Fallback initiated, don't report error yet
+        }
+      }
+
       if (this.isManualCheck) {
         this.mainWindow.broadcast('updateError', err.message);
       }

--- a/apps/desktop/src/main/env.ts
+++ b/apps/desktop/src/main/env.ts
@@ -84,11 +84,12 @@ export const getDesktopEnv = memoize(() =>
       OFFICIAL_CLOUD_SERVER: z.string().optional().default('https://app.lobehub.com'),
 
       // updater
-      UPDATE_CHANNEL: z.string().optional(),
+      // process.env.xxx will replace in build stage
+      UPDATE_CHANNEL: z.string().optional().default(process.env.UPDATE_CHANNEL),
 
       // Custom update server URL (for stable channel)
       // e.g., https://releases.lobehub.com/stable or https://your-bucket.s3.amazonaws.com/releases
-      UPDATE_SERVER_URL: z.string().optional(),
+      UPDATE_SERVER_URL: z.string().optional().default(process.env.UPDATE_SERVER_URL),
     },
   }),
 );


### PR DESCRIPTION
## Summary by Sourcery

Update the desktop stable release workflow and updater behavior to support configurable build targets, stable-channel manifests, and a fallback from S3 to GitHub for updates.

New Features:
- Allow selectively building macOS, Windows, and Linux artifacts via workflow inputs and a dynamically generated build matrix.
- Add support for stable-channel update manifests (stable-*.yml) including a renderer manifest to verify frontend bundle integrity.
- Introduce automatic fallback from the S3-based generic update provider to GitHub releases when update checks fail on the stable channel.

Enhancements:
- Package Linux desktop build output into a tarball artifact for distribution.
- Upload both stable and versioned update manifests to S3 to preserve historical records of releases.
- Adjust macOS release file merging logic to prioritize stable-channel manifests when available.
- Align local update-test tooling and configuration with the new stable-channel manifest naming and behavior.
- Default desktop environment configuration for UPDATE_CHANNEL and UPDATE_SERVER_URL to build-time environment variables in production builds.

CI:
- Refactor the desktop stable release workflow to configure a build matrix via a dedicated job, support optional self-hosted macOS runners, and improve artifact naming.
- Inline AWS credentials via environment variables in the upload step instead of using a separate credentials action.

Tests:
- Update local update-test manifest generation and dev configuration to produce channel-specific manifests consistent with production behavior.