### PR TITLE
✨ feat(google): Support direct PDF file transfer for Gemini

### DIFF
--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -1,5 +1,5 @@
 import { filesPrompts } from '@lobechat/prompts';
-import { MessageContentPart } from '@lobechat/types';
+import { ChatFileItem, MessageContentPart } from '@lobechat/types';
 import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
 import { parseDataUri } from '@lobechat/utils/uriParser';
 import { isDesktopLocalStaticServerUrl } from '@lobechat/utils/url';
@@ -48,10 +48,10 @@ export interface MessageContentConfig {
 }
 
 export interface UserMessageContentPart {
-  googleThoughtSignature?: string;
   file_url?: {
     url: string;
   };
+  googleThoughtSignature?: string;
   image_url?: {
     detail?: string;
     url: string;
@@ -163,16 +163,16 @@ export class MessageContentProcessor extends BaseProcessor {
     let textContent = message.content || '';
 
     const isGoogleProvider = this.config.provider === 'google';
-    const fileList = message.fileList || [];
+    const fileList: ChatFileItem[] = message.fileList || [];
     const googlePdfFiles = isGoogleProvider
       ? fileList.filter((file) => {
-        const fileType = file.fileType?.toLowerCase();
-        return (
-          fileType === 'application/pdf' &&
-          file.size <= MAX_GOOGLE_EXTERNAL_PDF_SIZE &&
-          isHttpUrl(file.url)
-        );
-      })
+          const fileType = file.fileType?.toLowerCase();
+          return (
+            fileType === 'application/pdf' &&
+            file.size <= MAX_GOOGLE_EXTERNAL_PDF_SIZE &&
+            isHttpUrl(file.url)
+          );
+        })
       : [];
 
     const fileListForPrompt = isGoogleProvider

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -2,7 +2,7 @@ import { filesPrompts } from '@lobechat/prompts';
 import { ChatFileItem, MessageContentPart } from '@lobechat/types';
 import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
 import { parseDataUri } from '@lobechat/utils/uriParser';
-import { isDesktopLocalStaticServerUrl } from '@lobechat/utils/url';
+import { isDesktopLocalStaticServerUrl, isLocalOrPrivateUrl } from '@lobechat/utils/url';
 import debug from 'debug';
 
 import { BaseProcessor } from '../base/BaseProcessor';
@@ -170,7 +170,8 @@ export class MessageContentProcessor extends BaseProcessor {
           return (
             fileType === 'application/pdf' &&
             file.size <= MAX_GOOGLE_EXTERNAL_PDF_SIZE &&
-            isHttpUrl(file.url)
+            isHttpUrl(file.url) &&
+            !isLocalOrPrivateUrl(file.url)
           );
         })
       : [];

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -49,6 +49,9 @@ export interface MessageContentConfig {
 
 export interface UserMessageContentPart {
   googleThoughtSignature?: string;
+  file_url?: {
+    url: string;
+  };
   image_url?: {
     detail?: string;
     url: string;
@@ -56,11 +59,22 @@ export interface UserMessageContentPart {
   signature?: string;
   text?: string;
   thinking?: string;
-  type: 'text' | 'image_url' | 'thinking' | 'video_url';
+  type: 'text' | 'image_url' | 'thinking' | 'video_url' | 'file_url';
   video_url?: {
     url: string;
   };
 }
+
+const MAX_GOOGLE_EXTERNAL_PDF_SIZE = 100 * 1024 * 1024;
+
+const isHttpUrl = (url: string) => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Message Content Processor
@@ -148,11 +162,30 @@ export class MessageContentProcessor extends BaseProcessor {
     // Add text content
     let textContent = message.content || '';
 
+    const isGoogleProvider = this.config.provider === 'google';
+    const fileList = message.fileList || [];
+    const googlePdfFiles = isGoogleProvider
+      ? fileList.filter((file) => {
+        const fileType = file.fileType?.toLowerCase();
+        return (
+          fileType === 'application/pdf' &&
+          file.size <= MAX_GOOGLE_EXTERNAL_PDF_SIZE &&
+          isHttpUrl(file.url)
+        );
+      })
+      : [];
+
+    const fileListForPrompt = isGoogleProvider
+      ? fileList.filter((file) => !googlePdfFiles.includes(file))
+      : fileList;
+
+    let filesContext = '';
+
     // Add file context (if file context is enabled and has files, images or videos)
     if ((hasFiles || hasImages || hasVideos) && this.config.fileContext?.enabled) {
-      const filesContext = filesPrompts({
+      filesContext = filesPrompts({
         addUrl: this.config.fileContext.includeFileUrl ?? true,
-        fileList: message.fileList,
+        fileList: fileListForPrompt,
         imageList: message.imageList || [],
         videoList: message.videoList || [],
       });
@@ -170,6 +203,15 @@ export class MessageContentProcessor extends BaseProcessor {
       });
     }
 
+    if (googlePdfFiles.length > 0) {
+      googlePdfFiles.forEach((file) => {
+        contentParts.push({
+          file_url: { url: file.url },
+          type: 'file_url',
+        });
+      });
+    }
+
     // Process image content
     if (hasImages && this.config.isCanUseVision?.(this.config.model, this.config.provider)) {
       const imageContentParts = await this.processImageList(message.imageList || []);
@@ -183,7 +225,7 @@ export class MessageContentProcessor extends BaseProcessor {
     }
 
     // Explicitly return fields, keeping only necessary message fields
-    const hasFileContext = (hasFiles || hasImages || hasVideos) && this.config.fileContext?.enabled;
+    const hasFileContext = !!filesContext;
     const hasVisionContent =
       hasImages && this.config.isCanUseVision?.(this.config.model, this.config.provider);
     const hasVideoContent =
@@ -420,6 +462,9 @@ export class MessageContentProcessor extends BaseProcessor {
       }
       case 'video_url': {
         return !!(part.video_url && part.video_url.url);
+      }
+      case 'file_url': {
+        return !!(part.file_url && part.file_url.url);
       }
       default: {
         return false;

--- a/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
+++ b/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
@@ -366,6 +366,44 @@ describe('MessageContentProcessor', () => {
       expect(content[0].type).toBe('text');
       expect(content[0].text).toContain('SYSTEM CONTEXT');
     });
+
+    it('should keep file context for google pdf with private http url', async () => {
+      mockIsCanUseVision.mockReturnValue(false);
+
+      const processor = new MessageContentProcessor({
+        model: 'gemini-3-flash-preview',
+        provider: 'google',
+        isCanUseVision: mockIsCanUseVision,
+        fileContext: { enabled: true, includeFileUrl: true },
+      });
+
+      const messages: UIChatMessage[] = [
+        {
+          id: 'test',
+          role: 'user',
+          content: 'Hello',
+          fileList: [
+            {
+              id: 'file1',
+              name: 'local.pdf',
+              fileType: 'application/pdf',
+              size: 1024,
+              url: 'http://127.0.0.1:8080/local.pdf',
+            },
+          ],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+
+      const result = await processor.process(createContext(messages));
+
+      expect(Array.isArray(result.messages[0].content)).toBe(true);
+      const content = result.messages[0].content as any[];
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe('text');
+      expect(content[0].text).toContain('SYSTEM CONTEXT');
+    });
   });
 
   describe('Reasoning/thinking content', () => {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -148,7 +148,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingLevel,
       }) as ThinkingConfig;
 
-      const contents = await buildGoogleMessages(payload.messages);
+      const contents = await buildGoogleMessages(payload.messages, { model });
 
       const controller = new AbortController();
       const originalSignal = options?.signal;
@@ -168,9 +168,9 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         imageConfig:
           modelsWithModalities.has(model) && imageAspectRatio
             ? {
-                aspectRatio: imageAspectRatio,
-                imageSize: imageResolution,
-              }
+              aspectRatio: imageAspectRatio,
+              imageSize: imageResolution,
+            }
             : undefined,
         maxOutputTokens: payload.max_tokens,
         responseModalities: modelsWithModalities.has(model) ? ['Text', 'Image'] : undefined,
@@ -274,7 +274,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    */
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
     // Convert OpenAI messages to Google format
-    const contents = await buildGoogleMessages(payload.messages);
+    const contents = await buildGoogleMessages(payload.messages, { model: payload.model });
 
     // Handle tools-based structured output
     if (payload.tools && payload.tools.length > 0) {

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -7,13 +7,13 @@ export type LLMRoleType = 'user' | 'system' | 'assistant' | 'function' | 'tool';
 export type ChatResponseFormat =
   | { type: 'json_object' }
   | {
-      json_schema: {
-        name: string;
-        schema: Record<string, any>;
-        strict?: boolean;
-      };
-      type: 'json_schema';
+    json_schema: {
+      name: string;
+      schema: Record<string, any>;
+      strict?: boolean;
     };
+    type: 'json_schema';
+  };
 
 interface UserMessageContentPartThinking {
   signature: string;
@@ -33,6 +33,13 @@ interface UserMessageContentPartImage {
   type: 'image_url';
 }
 
+interface UserMessageContentPartFile {
+  file_url: {
+    url: string;
+  };
+  type: 'file_url';
+}
+
 interface UserMessageContentPartVideo {
   type: 'video_url';
   video_url: { url: string };
@@ -41,6 +48,7 @@ interface UserMessageContentPartVideo {
 export type UserMessageContentPart =
   | UserMessageContentPartText
   | UserMessageContentPartImage
+  | UserMessageContentPartFile
   | UserMessageContentPartVideo
   | UserMessageContentPartThinking;
 

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -1,3 +1,5 @@
+import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
+
 interface UriParserResult {
   base64: string | null;
   mimeType: string | null;
@@ -20,5 +22,147 @@ export const parseDataUri = (dataUri: string): UriParserResult => {
   } catch {
     // Neither a Data URI nor a valid URL
     return { base64: null, mimeType: null, type: null };
+  }
+};
+
+/**
+ * MIME types supported by Google Gemini External URL feature
+ * @see https://ai.google.dev/gemini-api/docs/file-input-methods#supported-content-types
+ */
+const GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES = new Set([
+  // Text file types
+  'text/html',
+  'text/css',
+  'text/plain',
+  'text/xml',
+  'text/csv',
+  'text/rtf',
+  'text/javascript',
+  // Application file types
+  'application/json',
+  'application/pdf',
+  // Image file types
+  'image/bmp',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+
+/**
+ * Maximum file size limits for Google Gemini file input
+ * @see https://ai.google.dev/gemini-api/docs/file-input-methods#method-comparison
+ *
+ * External URLs: 100MB for all file types
+ * Inline data: 100MB general, 50MB for PDFs
+ */
+const MAX_EXTERNAL_URL_SIZE = 100 * 1024 * 1024; // 100MB for external URLs (all types)
+const MAX_INLINE_DATA_SIZE = 100 * 1024 * 1024; // 100MB for inline data (general)
+const MAX_INLINE_PDF_SIZE = 50 * 1024 * 1024; // 50MB for inline PDFs only
+
+export { MAX_INLINE_DATA_SIZE, MAX_INLINE_PDF_SIZE };
+
+export interface ExternalUrlValidation {
+  /** Content-Length from response headers */
+  contentLength: number;
+  /** Content-Type from response headers */
+  contentType: string;
+  /** Whether the URL was rejected due to size limit */
+  isTooLarge?: boolean;
+  /** Whether the URL is valid for external URL usage */
+  isValid: boolean;
+  /** Reason for invalid URL */
+  reason?: string;
+}
+
+/**
+ * Check if a URL is an external HTTP(S) URL
+ * SSRF protection is enforced by ssrfSafeFetch during validation
+ */
+export const isPublicExternalUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+
+    // Only allow http and https protocols
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validate an external URL for Google Gemini file input
+ * Performs a HEAD request to check Content-Length and Content-Type
+ *
+ * @param url - The URL to validate
+ * @returns Validation result with content info
+ */
+export const validateExternalUrl = async (url: string): Promise<ExternalUrlValidation> => {
+  try {
+    // Perform HEAD request to get headers without downloading the file
+    const res = await ssrfSafeFetch(
+      url,
+      {
+        headers: {
+          'User-Agent': 'LobeChat/1.0 (https://lobehub.com)',
+        },
+        method: 'HEAD',
+      },
+      {
+        allowIPAddressList: [],
+        allowPrivateIPAddress: false,
+      },
+    );
+
+    if (!res.ok) {
+      return {
+        contentLength: 0,
+        contentType: '',
+        isValid: false,
+        reason: `HTTP ${res.status}: ${res.statusText}`,
+      };
+    }
+
+    const contentLength = Number.parseInt(res.headers.get('content-length') || '0', 10);
+    const contentType = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+
+    // Check MIME type support
+    if (!GOOGLE_EXTERNAL_URL_SUPPORTED_TYPES.has(contentType)) {
+      return {
+        contentLength,
+        contentType,
+        isValid: false,
+        reason: `Unsupported content type: ${contentType}`,
+      };
+    }
+
+    // Check file size - External URLs support 100MB for all file types
+    // (Unlike inline data where PDFs are limited to 50MB)
+    if (contentLength > MAX_EXTERNAL_URL_SIZE) {
+      return {
+        contentLength,
+        contentType,
+        isTooLarge: true,
+        isValid: false,
+        reason: `File too large: ${contentLength} bytes (max ${MAX_EXTERNAL_URL_SIZE} bytes)`,
+      };
+    }
+
+    return {
+      contentLength,
+      contentType,
+      isValid: true,
+    };
+  } catch (error) {
+    return {
+      contentLength: 0,
+      contentType: '',
+      isValid: false,
+      reason: `Failed to validate URL: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 };

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -5,22 +5,22 @@ import { OpenAIFunctionCall } from './functionCall';
 export type ChatResponseFormat =
   | { type: 'json_object' }
   | {
-      json_schema: {
-        /**
-         * Schema identifier required by OpenAI.
-         */
-        name: string;
-        /**
-         * JSON schema definition used for validation.
-         */
-        schema: Record<string, any>;
-        /**
-         * Enforce strict schema validation when true.
-         */
-        strict?: boolean;
-      };
-      type: 'json_schema';
+    json_schema: {
+      /**
+       * Schema identifier required by OpenAI.
+       */
+      name: string;
+      /**
+       * JSON schema definition used for validation.
+       */
+      schema: Record<string, any>;
+      /**
+       * Enforce strict schema validation when true.
+       */
+      strict?: boolean;
     };
+    type: 'json_schema';
+  };
 
 interface UserMessageContentPartText {
   text: string;
@@ -34,7 +34,17 @@ interface UserMessageContentPartImage {
   type: 'image_url';
 }
 
-export type UserMessageContentPart = UserMessageContentPartText | UserMessageContentPartImage;
+interface UserMessageContentPartFile {
+  file_url: {
+    url: string;
+  };
+  type: 'file_url';
+}
+
+export type UserMessageContentPart =
+  | UserMessageContentPartText
+  | UserMessageContentPartImage
+  | UserMessageContentPartFile;
 
 export interface OpenAIChatMessage {
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

- close #5347

#### 🔀 Description of Change

目前将 PDF 传递给 Gemini 会解析文本并传递，本 pr 将 PDF 用类似图片文件形式直传 Gemini，以充分利用 Gemini 原生文件处理能力。

- 请先合并： #11507

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Support direct PDF file transfer to Google Gemini using external URLs or inline data, with model-aware routing and validation, while extending message content handling and tests to cover the new file_url flow.

New Features:
- Support file_url content parts for Google chats to send PDF files directly to Gemini via external URLs or inline data, depending on model capabilities and file properties.

Enhancements:
- Add external URL validation and size limits for Gemini-compatible file types using SSRF-safe HEAD requests.
- Prefer Gemini external URL fileData usage for public image and (future) video URLs when supported by the model, falling back to inline base64 when needed.
- Propagate model information into Google message builders so they can choose between external URLs and inline data appropriately.
- Adjust message content processing to exclude eligible Google PDF URLs from in-text file context while still attaching them as structured file_url parts.

Tests:
- Add unit tests for MessageContentProcessor to verify Google PDF handling for HTTP(S) vs non-HTTP URLs and file_url generation.
- Add unit tests for Google context builders to cover file_url handling, external URL behavior, and the new model-dependent logic.