### PR TITLE
🔧 ci(release): improve stable/beta release detection logic

### DIFF
--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -4,7 +4,7 @@ name: Release Desktop Beta
 # Beta/Nightly 频道发版工作流
 # ============================================
 # 触发条件: 发布包含 pre-release 标识的 release
-# 如: v2.0.0-beta.1, v2.0.0-alpha.1, v2.0.0-rc.1, v2.0.0-nightly.xxx
+# 如: v2.0.0-beta.1, v2.0.0-alpha.1, v2.0.0-rc.1, v2.0.0-nightly.xxx, v2.0.0-next.292
 #
 # 注意: Stable 版本 (如 v2.0.0) 由 release-desktop-stable.yml 处理
 # ============================================
@@ -24,10 +24,10 @@ env:
 
 jobs:
   # ============================================
-  # 检查是否为 Beta/Nightly 版本 (排除 Stable)
+  # 检查是否为 Beta/Nightly/Next 版本 (排除 Stable)
   # ============================================
   check-beta:
-    name: Check if Beta/Nightly Release
+    name: Check if Beta/Nightly/Next Release
     runs-on: ubuntu-latest
     outputs:
       is_beta: ${{ steps.check.outputs.is_beta }}
@@ -40,10 +40,10 @@ jobs:
           version="${version#v}"
           echo "version=${version}" >> $GITHUB_OUTPUT
 
-          # Beta/Nightly 版本包含 beta/alpha/rc/nightly
-          if [[ "$version" == *"beta"* ]] || [[ "$version" == *"alpha"* ]] || [[ "$version" == *"rc"* ]] || [[ "$version" == *"nightly"* ]]; then
+          # Beta/Nightly/Next 版本包含 beta/alpha/rc/nightly/next
+          if [[ "$version" == *"beta"* ]] || [[ "$version" == *"alpha"* ]] || [[ "$version" == *"rc"* ]] || [[ "$version" == *"nightly"* ]] || [[ "$version" == *"next"* ]]; then
             echo "is_beta=true" >> $GITHUB_OUTPUT
-            echo "✅ Beta/Nightly release detected: $version"
+            echo "✅ Beta/Nightly/Next release detected: $version"
           else
             echo "is_beta=false" >> $GITHUB_OUTPUT
             echo "⏭️ Skipping: $version is a stable release (handled by release-desktop-stable.yml)"

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -3,10 +3,10 @@ name: Release Desktop Stable
 # ============================================
 # Stable 频道发版工作流
 # ============================================
-# 触发条件: 发布不含 pre-release 标识的 release (如 v2.0.0)
+# 触发条件: 发布不含 pre-release 后缀的 release (如 v2.0.0)
 #
 # 与 Beta 的区别:
-#   1. 仅响应 stable 版本 tag (不含 beta/alpha/rc/nightly)
+#   1. 仅响应 stable 版本 tag (不含任何 '-' 后缀)
 #   2. 使用 STABLE 专用的 Umami 配置
 #   3. 额外上传到 S3 更新服务器
 #   4. 构建时注入 UPDATE_SERVER_URL 让客户端从 S3 检查更新
@@ -84,8 +84,8 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # 手动触发: 使用输入的版本号
             version="${{ inputs.version }}"
+            version="${version#v}"
             echo "is_manual=true" >> $GITHUB_OUTPUT
-            echo "is_stable=true" >> $GITHUB_OUTPUT
             echo "version=${version}" >> $GITHUB_OUTPUT
             echo "release_notes=" >> $GITHUB_OUTPUT
             echo "🔧 Manual trigger: version=${version}"
@@ -101,15 +101,15 @@ jobs:
               printf '%s\n' "$release_body"
               echo "EOF"
             } >> $GITHUB_OUTPUT
+          fi
 
-            # 检查是否为 stable 版本 (不含 beta/alpha/rc/nightly)
-            if [[ "$version" == *"beta"* ]] || [[ "$version" == *"alpha"* ]] || [[ "$version" == *"rc"* ]] || [[ "$version" == *"nightly"* ]]; then
-              echo "is_stable=false" >> $GITHUB_OUTPUT
-              echo "⏭️ Skipping: $version is not a stable release"
-            else
-              echo "is_stable=true" >> $GITHUB_OUTPUT
-              echo "✅ Stable release detected: $version"
-            fi
+          # 检查是否为 stable 版本 (不含任何 '-' 后缀)
+          if [[ "$version" == *"-"* ]]; then
+            echo "is_stable=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Skipping: $version is not a stable release"
+          else
+            echo "is_stable=true" >> $GITHUB_OUTPUT
+            echo "✅ Stable release detected: $version"
           fi
 
   # ============================================


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Improve the release workflow detection logic for stable and beta channels:

**release-desktop-beta.yml:**
- Add `next` version support alongside beta/alpha/rc/nightly
- Update workflow naming and comments to reflect the addition

**release-desktop-stable.yml:**
- Simplify stable version detection by checking for `-` suffix instead of enumerating specific prerelease identifiers (beta/alpha/rc/nightly)
- This approach is more robust as any version with a `-` suffix (like `-next.292`) will be correctly identified as non-stable
- Fix the manual trigger flow to properly strip the `v` prefix before the stable check

#### 🧪 How to Test

- [x] No tests needed

This change affects CI workflows only. The logic can be verified by:
1. Creating a release with `next` version (e.g., `v2.0.0-next.292`) - should trigger beta workflow
2. Creating a stable release (e.g., `v2.1.0`) - should trigger stable workflow

#### 📝 Additional Information

The previous approach of explicitly listing prerelease identifiers was brittle - if a new identifier type was introduced (like `next`), it would incorrectly be processed as stable. The new `-` suffix check is more future-proof.

## Summary by Sourcery

Improve CI release workflows to more robustly distinguish stable releases from pre-release channels and add support for "next" versions in the beta workflow.

CI:
- Update stable desktop release workflow to treat any version with a '-' suffix as non-stable and correctly handle manually provided versions without the 'v' prefix.
- Extend beta desktop release workflow to recognize 'next' prerelease tags alongside existing beta/alpha/rc/nightly variants.