### PR TITLE
🐛 fix(chat): reset activeTopicId when switching agent/group

### DIFF
--- a/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx
@@ -1,4 +1,5 @@
-import { useUnmount } from 'ahooks';
+import { usePrevious, useUnmount } from 'ahooks';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { createStoreUpdater } from 'zustand-utils';
 
@@ -10,6 +11,7 @@ const GroupIdSync = () => {
   const useAgentGroupStoreUpdater = createStoreUpdater(useAgentGroupStore);
   const useChatStoreUpdater = createStoreUpdater(useChatStore);
   const params = useParams<{ gid?: string }>();
+  const prevGroupId = usePrevious(params.gid);
   const router = useQueryRoute();
 
   // Sync groupId to agentGroupStore and chatStore
@@ -18,6 +20,15 @@ const GroupIdSync = () => {
 
   // Inject router to agentGroupStore for navigation
   useAgentGroupStoreUpdater('router', router);
+
+  // Reset activeTopicId when switching to a different group
+  // This prevents messages from being saved to the wrong topic bucket
+  useEffect(() => {
+    // Only reset topic when switching between groups (not on initial mount)
+    if (prevGroupId !== undefined && prevGroupId !== params.gid) {
+      useChatStore.getState().switchTopic(null, { skipRefreshMessage: true });
+    }
+  }, [params.gid, prevGroupId]);
 
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #11395

#### 🔀 Description of Change

When switching agents via dropdown menu, the `activeTopicId` was not being reset, causing messages to be saved to the wrong topic bucket. Users had to click "New Topic" before conversations could be saved properly.

**Root Cause:**
- `AgentIdSync` and `GroupIdSync` components only updated `activeAgentId`/`activeGroupId` when URL params changed
- `activeTopicId` retained the old value from the previous agent/group
- Messages were saved with the new agentId but old topicId, creating a mismatch
- On refresh, messages couldn't be found because they were in the wrong bucket

**Fix:**
- Added `useEffect` hooks to detect agent/group ID changes using `usePrevious`
- When switching (not on initial mount), call `switchTopic(null, { skipRefreshMessage: true })` to synchronously reset `activeTopicId`

#### 🧪 How to Test

1. Open an agent with existing conversations/topics
2. Switch to another agent via the dropdown menu in the sidebar header
3. Send a message immediately without clicking "New Topic"
4. Refresh the page
5. Verify the message is still visible and saved correctly

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Files changed:
- `src/app/[variants]/(main)/agent/_layout/AgentIdSync.tsx`
- `src/app/[variants]/(main)/group/_layout/GroupIdSync.tsx`