### PR TITLE
🐛 fix(mcp): fix installation check hanging issue in desktop app

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
       },
       sourcemap: isDev ? 'inline' : false,
     },
-
     define: {
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
       'process.env.UPDATE_CHANNEL': JSON.stringify(process.env.UPDATE_CHANNEL),

--- a/src/features/MCP/MCPInstallProgress/InstallError/ErrorDetails.tsx
+++ b/src/features/MCP/MCPInstallProgress/InstallError/ErrorDetails.tsx
@@ -1,8 +1,7 @@
-import { Button, Flexbox, Highlighter, Icon, Tag } from '@lobehub/ui';
+import { Flexbox, Highlighter, Tag } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import * as motion from 'motion/react-m';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type MCPErrorInfoMetadata } from '@/types/plugins';
@@ -12,94 +11,73 @@ const ErrorDetails = memo<{
   errorMessage?: string;
 }>(({ errorInfo, errorMessage }) => {
   const { t } = useTranslation('plugin');
-  const [expanded, setExpanded] = useState(false);
 
   return (
     <Flexbox gap={8}>
-      <Button
-        color={'default'}
-        icon={<Icon icon={expanded ? ChevronDown : ChevronRight} />}
-        onClick={() => setExpanded(!expanded)}
-        size="small"
-        style={{
-          fontSize: '12px',
-          padding: '0 4px',
-        }}
-        variant="filled"
+      <motion.div
+        animate={{ height: 'auto', opacity: 1 }}
+        initial={{ height: 0, opacity: 0 }}
+        style={{ overflow: 'hidden' }}
       >
-        {expanded
-          ? t('mcpInstall.errorDetails.hideDetails')
-          : t('mcpInstall.errorDetails.showDetails')}
-      </Button>
-
-      {expanded && (
-        <motion.div
-          animate={{ height: 'auto', opacity: 1 }}
-          initial={{ height: 0, opacity: 0 }}
-          style={{ overflow: 'hidden' }}
+        <Flexbox
+          gap={8}
+          style={{
+            backgroundColor: cssVar.colorFillQuaternary,
+            borderRadius: 8,
+            fontFamily: 'monospace',
+            fontSize: '11px',
+            padding: '8px 12px',
+          }}
         >
-          <Flexbox
-            gap={8}
-            style={{
-              backgroundColor: cssVar.colorFillQuaternary,
-              borderRadius: 8,
-              fontFamily: 'monospace',
-              fontSize: '11px',
-              padding: '8px 12px',
-            }}
-          >
-            {errorInfo.params && (
-              <Flexbox gap={4}>
-                <div>
-                  <Tag color="blue" variant={'filled'}>
-                    {t('mcpInstall.errorDetails.connectionParams')}
-                  </Tag>
-                </div>
-                <div style={{ marginTop: 4, wordBreak: 'break-all' }}>
-                  {errorInfo.params.command && (
-                    <div>
-                      {t('mcpInstall.errorDetails.command')}: {errorInfo.params.command}
-                    </div>
-                  )}
-                  {errorInfo.params.args && (
-                    <div>
-                      {t('mcpInstall.errorDetails.args')}: {errorInfo.params.args.join(' ')}
-                    </div>
-                  )}
-                </div>
-              </Flexbox>
-            )}
-
-            {errorInfo.errorLog && (
-              <Flexbox gap={4}>
-                <div>
-                  <Tag color="red" variant={'filled'}>
-                    {t('mcpInstall.errorDetails.errorOutput')}
-                  </Tag>
-                </div>
-                <Highlighter
-                  language={'log'}
-                  style={{
-                    maxHeight: 200,
-                    overflow: 'auto',
-                  }}
-                >
-                  {errorInfo.errorLog}
-                </Highlighter>
-              </Flexbox>
-            )}
-
-            {errorInfo.originalError && errorInfo.originalError !== errorMessage && (
+          {errorInfo.params && (
+            <Flexbox gap={4}>
               <div>
-                <Tag color="orange">{t('mcpInstall.errorDetails.originalError')}</Tag>
-                <div style={{ marginTop: 4, wordBreak: 'break-all' }}>
-                  {errorInfo.originalError}
-                </div>
+                <Tag color="blue" variant={'filled'}>
+                  {t('mcpInstall.errorDetails.connectionParams')}
+                </Tag>
               </div>
-            )}
-          </Flexbox>
-        </motion.div>
-      )}
+              <div style={{ marginTop: 4, wordBreak: 'break-all' }}>
+                {errorInfo.params.command && (
+                  <div>
+                    {t('mcpInstall.errorDetails.command')}: {errorInfo.params.command}
+                  </div>
+                )}
+                {errorInfo.params.args && (
+                  <div>
+                    {t('mcpInstall.errorDetails.args')}: {errorInfo.params.args.join(' ')}
+                  </div>
+                )}
+              </div>
+            </Flexbox>
+          )}
+
+          {errorInfo.errorLog && (
+            <Flexbox gap={4}>
+              <div>
+                <Tag color="red" variant={'filled'}>
+                  {t('mcpInstall.errorDetails.errorOutput')}
+                </Tag>
+              </div>
+              <Highlighter
+                language={'log'}
+                style={{
+                  maxHeight: 200,
+                  overflow: 'auto',
+                }}
+              >
+                {errorInfo.errorLog}
+              </Highlighter>
+            </Flexbox>
+          )}
+
+          {errorInfo.originalError && errorInfo.originalError !== errorMessage && (
+            <div>
+              <Tag color="orange">{t('mcpInstall.errorDetails.originalError')}</Tag>
+              <div style={{ marginTop: 4, wordBreak: 'break-all' }}>{errorInfo.originalError}</div>
+            </div>
+          )}
+        </Flexbox>
+      </motion.div>
     </Flexbox>
   );
 });

--- a/src/libs/mcp/types.ts
+++ b/src/libs/mcp/types.ts
@@ -240,3 +240,34 @@ export function createMCPError(
 
   return error;
 }
+
+/**
+ * STDIO Process Output separator used in enhanced error messages
+ */
+const STDIO_OUTPUT_SEPARATOR = '--- STDIO Process Output ---';
+
+/**
+ * Parse error message to extract STDIO process output logs
+ * The enhanced error format from desktop is:
+ * "Original message\n\n--- STDIO Process Output ---\nlogs..."
+ */
+export interface ParsedStdioError {
+  errorLog?: string;
+  originalMessage: string;
+}
+
+export function parseStdioErrorMessage(errorMessage: string): ParsedStdioError {
+  const separatorIndex = errorMessage.indexOf(STDIO_OUTPUT_SEPARATOR);
+
+  if (separatorIndex === -1) {
+    return { originalMessage: errorMessage };
+  }
+
+  const originalMessage = errorMessage.slice(0, separatorIndex).trim();
+  const errorLog = errorMessage.slice(separatorIndex + STDIO_OUTPUT_SEPARATOR.length).trim();
+
+  return {
+    errorLog: errorLog || undefined,
+    originalMessage: originalMessage || errorMessage,
+  };
+}

--- a/src/store/tool/slices/mcpStore/action.ts
+++ b/src/store/tool/slices/mcpStore/action.ts
@@ -303,8 +303,6 @@ export const createMCPPluginStoreSlice: StateCreator<
         // Check if cloudEndPoint is available: web + stdio type + haveCloudEndpoint exists
         const hasCloudEndpoint = !isDesktop && stdioOption && haveCloudEndpoint;
 
-        console.log('hasCloudEndpoint', hasCloudEndpoint);
-
         let shouldUseHttpDeployment = !!httpOption && (!hasNonHttpDeployment || !isDesktop);
 
         if (hasCloudEndpoint) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Resolves Linear LOBE-2986
Fix Discord: https://discord.com/channels/1127171173982154893/1460839821244239935

#### 🔀 Description of Change

**Problem:** MCP plugin installation was hanging at "Checking installation environment" step.

**Root Cause:** The `checkPackageInstalled` function was using `npx -y <package> --version` to verify package availability. This caused two issues:
1. `npx -y` downloads the package if not cached, which shouldn't happen during "check" phase
2. MCP servers don't always support `--version` flag - they may start as long-running processes instead

**Solution:** 
- Removed the problematic `npx -y` check from `checkPackageInstalled`
- Now only checks global npm list (`npm list -g`)
- For npm packages, pre-installation is not required - `npx` handles on-demand download during actual MCP connection

#### 🧪 How to Test

1. Open LobeChat Desktop app
2. Go to Plugin Store → MCP section
3. Try to install any MCP plugin (e.g., @21st-dev/magic)
4. Verify that "Checking installation environment" step completes quickly without hanging

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

This change also includes enhanced error handling and logging for MCP connections from the previous commit.

## Summary by Sourcery

Fix MCP plugin installation environment checks in the desktop app and improve MCP connection error reporting and diagnostics.

Bug Fixes:
- Prevent MCP plugin installation checks from hanging by relying only on global npm list instead of executing packages via npx.
- Ensure MCP stdio clients are always disconnected safely even when client creation or operations fail.
- Avoid accessing undefined best installation result data when determining MCP install checks.

Enhancements:
- Capture and surface MCP stdio process stderr logs through a custom MCPConnectionError for clearer failure diagnostics.
- Expose parsed MCP stdio error logs and connection parameters in store state and UI, including the MCP manifest test flow, to aid debugging.
- Simplify MCP install error details UI by always showing structured error information with animated expansion.
- Improve system dependency checks by allowing explicit checkCommand overrides and minor build config cleanup.