### PR TITLE
🐛 fix: fix switch skill in home input

### DIFF
--- a/src/app/[variants]/(main)/home/_layout/HomeAgentIdSync.tsx
+++ b/src/app/[variants]/(main)/home/_layout/HomeAgentIdSync.tsx
@@ -1,0 +1,23 @@
+import { useUnmount } from 'ahooks';
+import { createStoreUpdater } from 'zustand-utils';
+
+import { useAgentStore } from '@/store/agent';
+import { builtinAgentSelectors } from '@/store/agent/selectors';
+
+const HomeAgentIdSync = () => {
+  const useAgentStoreUpdater = createStoreUpdater(useAgentStore);
+
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+
+  // Sync inbox agent id to activeAgentId when on home page
+  useAgentStoreUpdater('activeAgentId', inboxAgentId);
+
+  // Clear activeAgentId when unmounting (leaving home page)
+  useUnmount(() => {
+    useAgentStore.setState({ activeAgentId: undefined });
+  });
+
+  return null;
+};
+
+export default HomeAgentIdSync;

--- a/src/app/[variants]/(main)/home/_layout/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/index.tsx
@@ -6,6 +6,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useIsDark } from '@/hooks/useIsDark';
 import { useHomeStore } from '@/store/home';
 
+import HomeAgentIdSync from './HomeAgentIdSync';
 import RecentHydration from './RecentHydration';
 import Sidebar from './Sidebar';
 import { styles } from './style';
@@ -56,6 +57,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
           {content}
         </Flexbox>
 
+        <HomeAgentIdSync />
         <RecentHydration />
       </Flexbox>
     </Activity>

--- a/src/store/agent/slices/plugin/action.ts
+++ b/src/store/agent/slices/plugin/action.ts
@@ -26,6 +26,7 @@ export const createPluginSlice: StateCreator<
   togglePlugin: async (id, open) => {
     const originConfig = agentSelectors.currentAgentConfig(get());
 
+    console.log('originConfig:', originConfig);
     const config = produce(originConfig, (draft) => {
       draft.plugins = produce(draft.plugins || [], (plugins) => {
         const index = plugins.indexOf(id);

--- a/src/store/agent/slices/plugin/action.ts
+++ b/src/store/agent/slices/plugin/action.ts
@@ -26,7 +26,6 @@ export const createPluginSlice: StateCreator<
   togglePlugin: async (id, open) => {
     const originConfig = agentSelectors.currentAgentConfig(get());
 
-    console.log('originConfig:', originConfig);
     const config = produce(originConfig, (draft) => {
       draft.plugins = produce(draft.plugins || [], (plugins) => {
         const index = plugins.indexOf(id);

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -315,11 +315,10 @@ export const createLobehubSkillStoreSlice: StateCreator<
         const response = await toolsClient.market.connectListConnections.query();
 
         // Debug logging
-        console.log('[useFetchLobehubSkillConnections] raw response:', response);
 
         return response.connections.map((conn: any) => {
           // Debug logging for each connection
-          console.log('[useFetchLobehubSkillConnections] connection:', conn);
+
           // Get provider config from local definition for correct display name
           const providerConfig = getLobehubSkillProviderById(conn.providerId);
           return {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Synchronize the home page’s active agent with the inbox agent to fix skill switching behavior on the home screen.

New Features:
- Add a HomeAgentIdSync helper component to keep the home page’s active agent ID aligned with the inbox agent ID and clear it when leaving the page.

Bug Fixes:
- Ensure the correct active agent is selected on the home page so switching skills works as expected.

Enhancements:
- Clean up verbose logging in the lobehub skill connections fetch and add targeted debug logging in the plugin slice for agent config inspection.