### PR TITLE
🐛 fix: fix topic messages display error when switch topic quickly

### DIFF
--- a/src/app/[variants]/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -48,8 +48,8 @@ const Conversation = memo(() => {
       context={context}
       hasInitMessages={!!messages}
       messages={messages}
-      onMessagesChange={(messages) => {
-        replaceMessages(messages, { context });
+      onMessagesChange={(messages, ctx) => {
+        replaceMessages(messages, { context: ctx });
       }}
       operationState={operationState}
     >

--- a/src/app/[variants]/(main)/group/features/Conversation/ConversationArea.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/ConversationArea.tsx
@@ -58,8 +58,8 @@ const Conversation = memo<ConversationAreaProps>(({ mobile = false }) => {
       hasInitMessages={!!messages}
       // hooks={groupHooks}
       messages={messages}
-      onMessagesChange={(messages) => {
-        replaceMessages(messages, { context });
+      onMessagesChange={(messages, ctx) => {
+        replaceMessages(messages, { context: ctx });
       }}
       operationState={operationState}
     >

--- a/src/app/[variants]/(main)/group/profile/features/AgentBuilder/AgentBuilderProvider.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/AgentBuilder/AgentBuilderProvider.tsx
@@ -47,8 +47,8 @@ const AgentBuilderProvider = memo<AgentBuilderProviderProps>(({ agentId, childre
       context={context}
       hasInitMessages={!!messages}
       messages={messages}
-      onMessagesChange={(msgs) => {
-        replaceMessages(msgs, { context });
+      onMessagesChange={(msgs, ctx) => {
+        replaceMessages(msgs, { context: ctx });
       }}
       operationState={operationState}
     >

--- a/src/app/[variants]/share/t/[id]/SharedMessageList.tsx
+++ b/src/app/[variants]/share/t/[id]/SharedMessageList.tsx
@@ -40,8 +40,8 @@ const SharedMessageList = memo<SharedMessageListProps>(({ agentId, groupId, shar
       context={context}
       hasInitMessages={!!messages}
       messages={messages}
-      onMessagesChange={(messages) => {
-        replaceMessages(messages, { context });
+      onMessagesChange={(messages, ctx) => {
+        replaceMessages(messages, { context: ctx });
       }}
     >
       <Flexbox flex={1}>

--- a/src/features/AgentBuilder/AgentBuilderProvider.tsx
+++ b/src/features/AgentBuilder/AgentBuilderProvider.tsx
@@ -46,8 +46,8 @@ const AgentBuilderProvider = memo<AgentBuilderProviderProps>(({ agentId, childre
       context={context}
       hasInitMessages={!!messages}
       messages={messages}
-      onMessagesChange={(msgs) => {
-        replaceMessages(msgs, { context });
+      onMessagesChange={(msgs, ctx) => {
+        replaceMessages(msgs, { context: ctx });
       }}
       operationState={operationState}
     >

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -42,8 +42,9 @@ export interface ConversationProviderProps {
    * Use this to sync messages back to external state (e.g., ChatStore)
    *
    * @param messages - The updated messages array
+   * @param context - The context that this data belongs to (prevents race conditions)
    */
-  onMessagesChange?: (messages: UIChatMessage[]) => void;
+  onMessagesChange?: (messages: UIChatMessage[], context: ConversationContext) => void;
   /**
    * External operation state (from ChatStore)
    *

--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -30,7 +30,7 @@ export interface StoreUpdaterProps {
   /**
    * Callback when messages are fetched or changed internally
    */
-  onMessagesChange?: (messages: UIChatMessage[]) => void;
+  onMessagesChange?: (messages: UIChatMessage[], context: ConversationContext) => void;
   /**
    * External operation state (from ChatStore)
    */

--- a/src/features/Conversation/store/initialState.ts
+++ b/src/features/Conversation/store/initialState.ts
@@ -33,8 +33,10 @@ export interface State extends DataState, InputState, MessageStateState, VirtuaL
 
   /**
    * Callback when messages are fetched or changed internally
+   * @param messages - The updated messages array
+   * @param context - The context that this data belongs to (prevents race conditions)
    */
-  onMessagesChange?: (messages: UIChatMessage[]) => void;
+  onMessagesChange?: (messages: UIChatMessage[], context: ConversationContext) => void;
 
   /**
    * External operation state (from ChatStore)

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -74,7 +74,7 @@ export const dataSlice: StateCreator<
     });
 
     // Sync changes to external store (ChatStore)
-    get().onMessagesChange?.(newDbMessages);
+    get().onMessagesChange?.(newDbMessages, get().context);
   },
 
   replaceMessages: (messages) => {
@@ -84,7 +84,7 @@ export const dataSlice: StateCreator<
     set({ dbMessages: messages, displayMessages: flatList }, false, 'replaceMessages');
 
     // Sync changes to external store (ChatStore)
-    get().onMessagesChange?.(messages);
+    get().onMessagesChange?.(messages, get().context);
   },
 
   switchMessageBranch: async (messageId, branchIndex) => {
@@ -106,7 +106,6 @@ export const dataSlice: StateCreator<
     // Also skip fetch when topicId is null (new conversation state) - there's no server data,
     // only local optimistic updates. Fetching would return empty array and overwrite local data.
     const shouldFetch = !skipFetch && !!context.agentId && !!context.topicId;
-
     return useClientDataSWRWithSync<UIChatMessage[]>(
       shouldFetch ? ['CONVERSATION_FETCH_MESSAGES', context] : null,
 
@@ -116,6 +115,7 @@ export const dataSlice: StateCreator<
       {
         onData: (data) => {
           if (!data) return;
+          if (!context.topicId) return;
 
           // Parse messages using conversation-flow
           const { flatList } = parse(data);
@@ -126,8 +126,9 @@ export const dataSlice: StateCreator<
             messagesInit: true,
           });
 
-          // Call onMessagesChange callback if provided
-          get().onMessagesChange?.(data);
+          // Call onMessagesChange callback with the request context (not current context)
+          // This ensures data is stored to the correct topic even if user switched topics
+          get().onMessagesChange?.(data, context);
         },
       },
     );

--- a/src/features/PageEditor/PageAgentProvider.tsx
+++ b/src/features/PageEditor/PageAgentProvider.tsx
@@ -49,8 +49,8 @@ const PageAgentProvider = memo<PageAgentProviderProps>(({ pageAgentId, children 
       context={context}
       hasInitMessages={!!messages}
       messages={messages}
-      onMessagesChange={(msgs) => {
-        replaceMessages(msgs, { context });
+      onMessagesChange={(msgs, ctx) => {
+        replaceMessages(msgs, { context: ctx });
       }}
       operationState={operationState}
     >

--- a/src/features/Portal/Thread/Chat/index.tsx
+++ b/src/features/Portal/Thread/Chat/index.tsx
@@ -204,8 +204,8 @@ const ThreadChat = memo(() => {
       hasInitMessages={!!messages}
       hooks={hooks}
       messages={messages}
-      onMessagesChange={(msgs) => {
-        replaceMessages(msgs, { context });
+      onMessagesChange={(msgs, ctx) => {
+        replaceMessages(msgs, { context: ctx });
       }}
       operationState={operationState}
       skipFetch={isCreatingNewThread}

--- a/src/store/page/slices/crud/action.ts
+++ b/src/store/page/slices/crud/action.ts
@@ -47,10 +47,6 @@ export interface CrudAction {
    * Duplicate an existing page
    */
   duplicatePage: (pageId: string) => Promise<{ [key: string]: any; id: string }>;
-  /**
-   * Fetch full page detail by ID and update documents array
-   */
-  fetchPageDetail: (pageId: string) => Promise<void>;
   navigateToPage: (pageId: string | null) => void;
   /**
    * Remove a page (deletes from documents table)
@@ -238,50 +234,6 @@ export const createCrudSlice: StateCreator<
     get().internal_dispatchDocuments({ document: editorPage, type: 'addDocument' });
 
     return newPage;
-  },
-
-  fetchPageDetail: async (pageId) => {
-    try {
-      const document = await documentService.getDocumentById(pageId);
-
-      if (!document) {
-        console.warn(`[fetchPageDetail] Page not found: ${pageId}`);
-        return;
-      }
-
-      const fullPage: LobeDocument = {
-        content: document.content || null,
-        createdAt: document.createdAt ? new Date(document.createdAt) : new Date(),
-        editorData:
-          typeof document.editorData === 'string'
-            ? JSON.parse(document.editorData)
-            : document.editorData || null,
-        fileType: document.fileType,
-        filename: document.title || document.filename || 'Untitled',
-        id: document.id,
-        metadata: document.metadata || {},
-        source: 'document',
-        sourceType: DocumentSourceType.EDITOR,
-        title: document.title || '',
-        totalCharCount: document.content?.length || 0,
-        totalLineCount: 0,
-        updatedAt: document.updatedAt ? new Date(document.updatedAt) : new Date(),
-      };
-
-      // Update document via internal dispatch
-      const { documents } = get();
-      if (documents?.some((doc) => doc.id === pageId)) {
-        get().internal_dispatchDocuments({
-          document: fullPage,
-          id: pageId,
-          type: 'updateDocument',
-        });
-      } else {
-        get().internal_dispatchDocuments({ document: fullPage, type: 'addDocument' });
-      }
-    } catch (error) {
-      console.error('[fetchPageDetail] Failed to fetch page:', error);
-    }
   },
 
   navigateToPage: (pageId) => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure conversation message updates are associated with the correct context to avoid race conditions when switching topics.

Bug Fixes:
- Pass conversation context along with messages to onMessagesChange callbacks throughout the conversation flow so updates are applied to the correct topic even after switching.
- Guard message fetch handling to ignore responses when no topicId is present, preventing stale or mismatched topic data from overwriting current state.
- Remove the unused fetchPageDetail action from the CRUD page slice to avoid dead code and potential confusion.