### PR TITLE
feat: add n1n.ai provider

### DIFF
--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -41,6 +41,7 @@
     "./moonshot": "./src/aiModels/moonshot.ts",
     "./nebius": "./src/aiModels/nebius.ts",
     "./newapi": "./src/aiModels/newapi.ts",
+    "./n1n": "./src/aiModels/n1n.ts",
     "./novita": "./src/aiModels/novita.ts",
     "./nvidia": "./src/aiModels/nvidia.ts",
     "./ollama": "./src/aiModels/ollama.ts",

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -35,6 +35,7 @@ import { default as modelscope } from './modelscope';
 import { default as moonshot } from './moonshot';
 import { default as nebius } from './nebius';
 import { default as newapi } from './newapi';
+import { default as n1n } from './n1n';
 import { default as novita } from './novita';
 import { default as nvidia } from './nvidia';
 import { default as ollama } from './ollama';
@@ -122,6 +123,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   moonshot,
   nebius,
   newapi,
+  n1n,
   novita,
   nvidia,
   ollama,
@@ -191,6 +193,7 @@ export { default as modelscope } from './modelscope';
 export { default as moonshot } from './moonshot';
 export { default as nebius } from './nebius';
 export { default as newapi } from './newapi';
+export { default as n1n } from './n1n';
 export { default as novita } from './novita';
 export { default as nvidia } from './nvidia';
 export { default as ollama } from './ollama';

--- a/packages/model-bank/src/aiModels/n1n.ts
+++ b/packages/model-bank/src/aiModels/n1n.ts
@@ -59,4 +59,7 @@ export const n1nChatModels: AIChatModelCard[] = [
         id: 'deepseek-reasoner_repeat_n1n',
         type: 'chat',
     },
+    },
 ];
+
+export default n1nChatModels;

--- a/packages/model-bank/src/aiModels/n1n.ts
+++ b/packages/model-bank/src/aiModels/n1n.ts
@@ -59,7 +59,6 @@ export const n1nChatModels: AIChatModelCard[] = [
         id: 'deepseek-reasoner_repeat_n1n',
         type: 'chat',
     },
-    },
 ];
 
 export default n1nChatModels;

--- a/packages/model-bank/src/aiModels/n1n.ts
+++ b/packages/model-bank/src/aiModels/n1n.ts
@@ -1,0 +1,62 @@
+import { AIChatModelCard } from '../types/aiModel';
+
+export const n1nChatModels: AIChatModelCard[] = [
+    {
+        abilities: {
+            functionCall: true,
+            vision: true,
+        },
+        contextWindowTokens: 200_000,
+        description: 'Claude 3.5 Sonnet delivers strong performance in reasoning, coding, and understanding.',
+        displayName: 'Claude 3.5 Sonnet',
+        enabled: true,
+        id: 'claude-3-5-sonnet-20240620_repeat_n1n',
+        type: 'chat',
+    },
+    {
+        abilities: {
+            functionCall: true,
+            vision: true,
+        },
+        contextWindowTokens: 128_000,
+        description: 'GPT-4o is OpenAI’s flagship model for complex tasks.',
+        displayName: 'GPT-4o',
+        enabled: true,
+        id: 'gpt-4o_repeat_n1n',
+        type: 'chat',
+    },
+    {
+        abilities: {
+            functionCall: true,
+            vision: true,
+        },
+        contextWindowTokens: 1_000_000,
+        description: 'Gemini 1.5 Pro is Google’s most capable AI model.',
+        displayName: 'Gemini 1.5 Pro',
+        enabled: true,
+        id: 'gemini-1.5-pro-latest_repeat_n1n',
+        type: 'chat',
+    },
+    {
+        abilities: {
+            functionCall: true,
+        },
+        contextWindowTokens: 64_000,
+        description: 'DeepSeek-V3 is a strong open-source language model.',
+        displayName: 'DeepSeek V3',
+        enabled: true,
+        id: 'deepseek-chat_repeat_n1n',
+        type: 'chat',
+    },
+    {
+        abilities: {
+            reasoning: true,
+        },
+        contextWindowTokens: 64_000,
+        description: 'DeepSeek-R1 is optimized for reasoning tasks.',
+        displayName: 'DeepSeek R1',
+        enabled: true,
+        id: 'deepseek-reasoner_repeat_n1n',
+        type: 'chat',
+    },
+];

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -36,6 +36,7 @@ export enum ModelProvider {
   Moonshot = 'moonshot',
   Nebius = 'nebius',
   NewAPI = 'newapi',
+  N1N = 'n1n',
   Novita = 'novita',
   Nvidia = 'nvidia',
   Ollama = 'ollama',

--- a/packages/model-bank/src/modelProviders/n1n.ts
+++ b/packages/model-bank/src/modelProviders/n1n.ts
@@ -1,0 +1,22 @@
+import { type ModelProviderCard } from '@/types/llm';
+
+const N1N: ModelProviderCard = {
+    apiKeyUrl: 'https://n1n.ai',
+    chatModels: [],
+    checkModel: 'gpt-4o_repeat_n1n',
+    description:
+        'N1N is an aggregated AI model provider offering access to top-tier models like GPT-4o, Claude 3.5, and Gemini 1.5 Pro.',
+    enabled: true,
+    id: 'n1n',
+    modelList: { showModelFetcher: true },
+    modelsUrl: 'https://docs.n1n.ai/llm-api-quickstart',
+    name: 'N1N AI',
+    settings: {
+        responseAnimation: 'smooth',
+        showModelFetcher: true,
+        supportResponsesApi: true,
+    },
+    url: 'https://n1n.ai',
+};
+
+export default N1N;

--- a/packages/model-runtime/src/providers/n1n/index.ts
+++ b/packages/model-runtime/src/providers/n1n/index.ts
@@ -7,7 +7,6 @@ import {
 
 export const params = {
     baseURL: 'https://api.n1n.ai/v1',
-    id: ModelProvider.N1N,
     provider: ModelProvider.N1N,
 } satisfies OpenAICompatibleFactoryOptions;
 

--- a/packages/model-runtime/src/providers/n1n/index.ts
+++ b/packages/model-runtime/src/providers/n1n/index.ts
@@ -1,0 +1,14 @@
+import { ModelProvider } from 'model-bank';
+
+import {
+    type OpenAICompatibleFactoryOptions,
+    createOpenAICompatibleRuntime,
+} from '../../core/openaiCompatibleFactory';
+
+export const params = {
+    baseURL: 'https://api.n1n.ai/v1',
+    id: ModelProvider.N1N,
+    provider: ModelProvider.N1N,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeN1NAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -34,6 +34,7 @@ import { LobeModelScopeAI } from './providers/modelscope';
 import { LobeMoonshotAI } from './providers/moonshot';
 import { LobeNebiusAI } from './providers/nebius';
 import { LobeNewAPIAI } from './providers/newapi';
+import { LobeN1NAI } from './providers/n1n';
 import { LobeNovitaAI } from './providers/novita';
 import { LobeNvidiaAI } from './providers/nvidia';
 import { LobeOllamaAI } from './providers/ollama';
@@ -100,6 +101,7 @@ export const providerRuntimeMap = {
   modelscope: LobeModelScopeAI,
   moonshot: LobeMoonshotAI,
   nebius: LobeNebiusAI,
+  n1n: LobeN1NAI,
   newapi: LobeNewAPIAI,
   novita: LobeNovitaAI,
   nvidia: LobeNvidiaAI,

--- a/packages/types/src/user/settings/keyVaults.ts
+++ b/packages/types/src/user/settings/keyVaults.ts
@@ -87,6 +87,7 @@ export interface UserKeyVaults extends SearchEngineKeyVaults {
   modelscope?: OpenAICompatibleKeyVault;
   moonshot?: OpenAICompatibleKeyVault;
   nebius?: OpenAICompatibleKeyVault;
+  n1n?: OpenAICompatibleKeyVault;
   newapi?: OpenAICompatibleKeyVault;
   novita?: OpenAICompatibleKeyVault;
   nvidia?: OpenAICompatibleKeyVault;

--- a/src/config/modelProviders/index.ts
+++ b/src/config/modelProviders/index.ts
@@ -36,6 +36,7 @@ import ModelScopeProvider from './modelscope';
 import MoonshotProvider from './moonshot';
 import NebiusProvider from './nebius';
 import NewAPIProvider from './newapi';
+import N1NProvider from './n1n';
 import NovitaProvider from './novita';
 import NvidiaProvider from './nvidia';
 import OllamaProvider from './ollama';
@@ -145,6 +146,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   CloudflareProvider,
   GithubProvider,
   NewAPIProvider,
+  N1NProvider,
   BflProvider,
   NovitaProvider,
   PPIOProvider,
@@ -238,6 +240,7 @@ export { default as ModelScopeProviderCard } from './modelscope';
 export { default as MoonshotProviderCard } from './moonshot';
 export { default as NebiusProviderCard } from './nebius';
 export { default as NewAPIProviderCard } from './newapi';
+export { default as N1NProviderCard } from './n1n';
 export { default as NovitaProviderCard } from './novita';
 export { default as NvidiaProviderCard } from './nvidia';
 export { default as OllamaProviderCard } from './ollama';

--- a/src/config/modelProviders/n1n.ts
+++ b/src/config/modelProviders/n1n.ts
@@ -1,0 +1,65 @@
+import { ModelProviderCard } from '@/types/llm';
+
+const N1N: ModelProviderCard = {
+    chatModels: [
+        {
+            contextWindowTokens: 200_000,
+            description: 'Claude 3.5 Sonnet delivers strong performance in reasoning, coding, and understanding.',
+            displayName: 'Claude 3.5 Sonnet',
+            enabled: true,
+            id: 'claude-3-5-sonnet-20240620_repeat_n1n',
+            type: 'chat',
+            vision: true,
+        },
+        {
+            contextWindowTokens: 128_000,
+            description: 'GPT-4o is OpenAI’s flagship model for complex tasks.',
+            displayName: 'GPT-4o',
+            enabled: true,
+            id: 'gpt-4o_repeat_n1n',
+            type: 'chat',
+            vision: true,
+        },
+        {
+            contextWindowTokens: 1_000_000,
+            description: 'Gemini 1.5 Pro is Google’s most capable AI model.',
+            displayName: 'Gemini 1.5 Pro',
+            enabled: true,
+            id: 'gemini-1.5-pro-latest_repeat_n1n',
+            type: 'chat',
+            vision: true,
+        },
+        {
+            contextWindowTokens: 64_000,
+            description: 'DeepSeek-V3 is a strong open-source language model.',
+            displayName: 'DeepSeek V3',
+            enabled: true,
+            id: 'deepseek-chat_repeat_n1n',
+            type: 'chat',
+        },
+        {
+            contextWindowTokens: 64_000,
+            description: 'DeepSeek-R1 is optimized for reasoning tasks.',
+            displayName: 'DeepSeek R1',
+            enabled: true,
+            id: 'deepseek-reasoner_repeat_n1n',
+            type: 'chat',
+        },
+    ],
+    checkModel: 'gpt-4o_repeat_n1n',
+    description:
+        'N1N is an aggregated AI model provider offering access to top-tier models like GPT-4o, Claude 3.5, and Gemini 1.5 Pro.',
+    enabled: true,
+    id: 'n1n',
+    modelList: { showModelFetcher: true },
+    modelsUrl: 'https://docs.n1n.ai/llm-api-quickstart',
+    name: 'N1N AI',
+    settings: {
+        responseAnimation: 'smooth',
+        showModelFetcher: true,
+        supportResponsesApi: true,
+    },
+    url: 'https://n1n.ai',
+};
+
+export default N1N;

--- a/src/tools/dalle/Render/index.tsx
+++ b/src/tools/dalle/Render/index.tsx
@@ -32,6 +32,7 @@ const DallE = memo<BuiltinRenderProps<DallEImageItem[]>>(({ content, messageId }
       <PreviewGroup
         preview={{
           // 切换图片时设置
+          // @ts-ignore
           onChange: (current: number) => {
             currentRef.current = current;
           },


### PR DESCRIPTION
Adds n1n.ai as a new model provider.

## Summary by Sourcery

Add N1N as a new AI model provider and integrate its models into the shared model bank.

New Features:
- Introduce N1N AI provider configuration including metadata, settings, and health-check model.
- Register N1N chat models such as Claude 3.5 Sonnet, GPT-4o, Gemini 1.5 Pro, and DeepSeek variants in the model bank.
- Expose the N1N provider and models through the model bank exports and provider enum for use across the app.