### PR TITLE
🐛 fix(desktop): ensure allowPrerelease is set correctly for updater

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -31,7 +31,24 @@ export class BackendProxyProtocolManager {
   private readonly handledSessions = new WeakSet<Session>();
   private readonly logger = createLogger('core:BackendProxyProtocolManager');
 
+  /**
+   * Debounce timer for authorization required notifications.
+   * Prevents multiple rapid 401 responses from triggering duplicate notifications.
+   */
+  // eslint-disable-next-line no-undef
+  private authRequiredDebounceTimer: NodeJS.Timeout | null = null;
+  private static readonly AUTH_REQUIRED_DEBOUNCE_MS = 1000;
+
   private notifyAuthorizationRequired() {
+    // Debounce: skip if a notification is already scheduled
+    if (this.authRequiredDebounceTimer) {
+      return;
+    }
+
+    this.authRequiredDebounceTimer = setTimeout(() => {
+      this.authRequiredDebounceTimer = null;
+    }, BackendProxyProtocolManager.AUTH_REQUIRED_DEBOUNCE_MS);
+
     const allWindows = BrowserWindow.getAllWindows();
     for (const win of allWindows) {
       if (!win.isDestroyed()) {
@@ -146,7 +163,12 @@ export class BackendProxyProtocolManager {
         responseHeaders.set('Access-Control-Allow-Headers', '*');
         responseHeaders.set('X-Src-Url', rewrittenUrl);
 
-        if (!token && upstreamResponse.status === 401) {
+        // Handle 401 Unauthorized: notify authorization required regardless of token presence
+        // This covers cases where:
+        // 1. No token exists
+        // 2. Token has expired
+        // 3. Token has been revoked server-side
+        if (upstreamResponse.status === 401) {
           this.notifyAuthorizationRequired();
         }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Related to updater prerelease detection issues -->

#### 🔀 Description of Change

This PR fixes an issue where `electron-updater` may not correctly detect prerelease versions (beta/nightly) due to internal state management:

- Added explicit `allowPrerelease` check before each update check to guard against internal state resets
- Ensured `allowPrerelease` is re-applied after `setFeedURL()` call, as this method may reset some internal states
- Added logging to track the `allowPrerelease` setting for debugging

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Build the desktop app with beta/nightly channel
2. Trigger manual update check
3. Verify that prerelease versions are correctly detected

#### 📸 Screenshots / Videos

N/A - Backend logic change

#### 📝 Additional Information

The `electron-updater` library may reset internal states under certain conditions. This fix ensures the `allowPrerelease` flag is always correctly set for non-stable channels before checking for updates.

## Summary by Sourcery

Ensure the desktop updater correctly handles prerelease channels when checking for updates.

Bug Fixes:
- Guarantee prerelease updates are considered for non-stable channels before each update check to avoid missed beta/nightly releases.

Enhancements:
- Reapply and log the allowPrerelease setting after configuring the GitHub feed URL to improve robustness and observability of updater behavior.