### PR TITLE
🔧 chore: use pnpm for Vercel install command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "buildCommand": "bun run build:vercel",
-  "installCommand": "npx bun@1.2.23 install"
+  "installCommand": "npx pnpm@10.26.2 install"
 }


### PR DESCRIPTION
## Summary
- Switch Vercel install command from `bun` to `pnpm` for better compatibility

## Changes
- Update `installCommand` in `vercel.json` from `npx bun@1.2.23 install` to `npx pnpm@10.26.2 install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update Vercel configuration to run `npx pnpm@10.26.2 install` as the install command during builds.