### PR TITLE
🐛 fix: message pollution

### DIFF
--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -11,6 +11,7 @@ import { mutate, useClientDataSWR } from '@/libs/swr';
 import { chatGroupService } from '@/services/chatGroup';
 import { sessionService } from '@/services/session';
 import { getChatGroupStoreState } from '@/store/agentGroup';
+import { useChatStore } from '@/store/chat';
 import { type SessionStore } from '@/store/session';
 import { getUserStoreState, useUserStore } from '@/store/user';
 import { settingsSelectors, userProfileSelectors } from '@/store/user/selectors';
@@ -214,6 +215,9 @@ export const createSessionSlice: StateCreator<
 
   switchSession: (sessionId) => {
     if (get().activeAgentId === sessionId) return;
+
+    // Synchronously clear active topic to prevent message pollution when switching sessions
+    useChatStore.getState().switchTopic(null, { skipRefreshMessage: true });
 
     set({ activeAgentId: sessionId }, false, n(`activeSession/${sessionId}`));
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

fix: clear active topic synchronously when switching sessions
- Add useChatStore.switchTopic(null) call in switchSession action to prevent message pollution from race conditions
- Add unit tests for switchSession verifying topic clearing behavior
- Setup default mock for useChatStore in beforeEach to fix test failures

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure session switching also resets the active chat topic to avoid cross-session message leakage.

Bug Fixes:
- Clear the active chat topic when switching sessions so messages are not sent to a previous session's topic.

Tests:
- Add a unit test verifying that switching sessions updates the active session and clears the active topic in the chat store.

## Summary by Sourcery

Ensure switching chat sessions also clears the active topic to prevent cross-session message leakage.

Bug Fixes:
- Clear the active chat topic synchronously when switching sessions to avoid messages being associated with the wrong session.

Tests:
- Add unit tests covering switchSession behavior, including topic clearing and no-op when switching to the same session.
- Introduce default mocking for the chat store in session action tests to stabilize and standardize test behavior.