### PR TITLE
🐛 fix(e2e): resolve test timeouts and selector mismatches

### DIFF
--- a/e2e/src/steps/agent/message-ops.steps.ts
+++ b/e2e/src/steps/agent/message-ops.steps.ts
@@ -196,10 +196,14 @@ When('用户点击消息的更多操作按钮', async function (this: CustomWorl
   const messageBox = await assistantMessage.boundingBox();
   console.log(`   📍 Message bounding box: y=${messageBox?.y}, height=${messageBox?.height}`);
 
-  // Look for the "more" button by ellipsis icon (lucide-ellipsis or lucide-more-horizontal)
-  // The icon might be `...` which is lucide-ellipsis
+  // Look for the "more" button by lucide icon class names
+  // MoreHorizontal icon has class "lucide-more-horizontal"
+  // Also try "lucide-ellipsis" for compatibility
+  // Use broader selector with lucide class as prefix
   const ellipsisButtons = this.page
-    .locator('svg.lucide-ellipsis, svg.lucide-more-horizontal')
+    .locator(
+      'svg.lucide-more-horizontal, svg.lucide-ellipsis, svg[class*="lucide"][class*="more"], svg[class*="lucide"][class*="ellipsis"]',
+    )
     .locator('..');
   let ellipsisCount = await ellipsisButtons.count();
   console.log(`   📍 Found ${ellipsisCount} buttons with ellipsis/more icon`);

--- a/e2e/src/steps/community/interactions.steps.ts
+++ b/e2e/src/steps/community/interactions.steps.ts
@@ -232,8 +232,12 @@ When('I click on the sort dropdown', async function (this: CustomWorld) {
 When('I select a sort option', async function (this: CustomWorld) {
   await this.page.waitForTimeout(500);
 
-  // Find and click a sort option (assuming dropdown opens a menu)
-  const sortOptions = this.page.locator('[role="option"], [role="menuitem"]');
+  // Find and click a sort option
+  // The sort dropdown uses checkbox menu items, so role is "menuitemcheckbox"
+  // Also support "option" and "menuitem" for compatibility
+  const sortOptions = this.page.locator(
+    '[role="menuitemcheckbox"], [role="option"], [role="menuitem"]',
+  );
 
   // Wait for options to appear
   await sortOptions.first().waitFor({ state: 'visible', timeout: 30_000 });

--- a/e2e/src/steps/home/sidebarAgent.steps.ts
+++ b/e2e/src/steps/home/sidebarAgent.steps.ts
@@ -302,9 +302,15 @@ When('用户在菜单中选择删除', async function (this: CustomWorld) {
 When('用户在弹窗中确认删除', async function (this: CustomWorld) {
   console.log('   📍 Step: 确认删除...');
 
-  const confirmButton = this.page.locator('.ant-modal-confirm-btns button.ant-btn-dangerous');
-  await expect(confirmButton).toBeVisible({ timeout: 5000 });
-  await confirmButton.click();
+  // Try multiple selectors for the confirm button in the modal
+  // Supports both Ant Design v4 and v5 modal structures
+  const confirmButton = this.page.locator(
+    '.ant-modal-confirm-btns button.ant-btn-dangerous, ' +
+      '.ant-modal-footer button.ant-btn-dangerous, ' +
+      '.ant-modal button.ant-btn-dangerous',
+  );
+  await expect(confirmButton.first()).toBeVisible({ timeout: 5000 });
+  await confirmButton.first().click();
   await this.page.waitForTimeout(500);
 
   console.log('   ✅ 已确认删除');

--- a/e2e/src/steps/hooks.ts
+++ b/e2e/src/steps/hooks.ts
@@ -6,8 +6,9 @@ import { startWebServer, stopWebServer } from '../support/webServer';
 import { CustomWorld } from '../support/world';
 
 process.env['E2E'] = '1';
-// Set default timeout for all steps to 10 seconds
-setDefaultTimeout(10_000);
+// Set default timeout for all steps to 30 seconds
+// This allows for network latency, animations, and complex UI operations
+setDefaultTimeout(30_000);
 
 // Store base URL and cached session cookies
 let baseUrl: string;

--- a/e2e/src/steps/page/page-crud.steps.ts
+++ b/e2e/src/steps/page/page-crud.steps.ts
@@ -255,8 +255,8 @@ When('用户右键点击该文稿', async function (this: CustomWorld) {
 When('用户在菜单中选择复制', async function (this: CustomWorld) {
   console.log('   📍 Step: 选择复制选项...');
 
-  // Look for duplicate option (复制 or Duplicate)
-  const duplicateOption = this.page.getByRole('menuitem', { name: /复制|duplicate/i });
+  // Look for duplicate option: "创建副本" (zh-CN), "Duplicate" (en-US), or "复制" (fallback)
+  const duplicateOption = this.page.getByRole('menuitem', { name: /创建副本|duplicate|复制/i });
   await expect(duplicateOption).toBeVisible({ timeout: 5000 });
   await duplicateOption.click();
   await this.page.waitForTimeout(1000);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Related to E2E test failures in CI -->

#### 🔀 Description of Change

This PR fixes multiple E2E test failures caused by timeout and selector issues:

**Root Cause Analysis:**
- Default step timeout was set to 10 seconds, which is insufficient for complex UI operations
- Several selectors did not match the actual DOM elements

**Fixes Applied:**

| File | Issue | Fix |
|------|-------|-----|
| `hooks.ts` | 10s timeout too short | Increased to 30s |
| `page-crud.steps.ts` | Duplicate option text mismatch | Changed regex to match "创建副本" |
| `interactions.steps.ts` | Sort dropdown role mismatch | Added `menuitemcheckbox` role |
| `sidebarAgent.steps.ts` | Delete confirm button selector | Extended for Ant Design compatibility |
| `message-ops.steps.ts` | More actions button selector | Extended lucide icon patterns |

**Affected Tests:**
- `PAGE-RENAME-001/002` - Rename page via context menu
- `PAGE-DUPLICATE-001` - Duplicate page
- `PAGE-DELETE-001` - Delete page
- `AGENT-MSG-003/004` - Delete/collapse message
- `COMMUNITY-INTERACT-005` - Sort models

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

```bash
# Run affected tests
cd e2e
BASE_URL=http://localhost:3006 \
  DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres \
  pnpm exec cucumber-js --config cucumber.config.js --tags "@PAGE-RENAME-001 or @PAGE-DUPLICATE-001 or @PAGE-DELETE-001 or @AGENT-MSG-003 or @AGENT-MSG-004 or @COMMUNITY-INTERACT-005"
```

#### 📝 Additional Information

The 10-second default timeout was the primary cause of all failures. Complex UI operations (involving animations, network requests, and DOM updates) require more time to complete, especially in CI environments.