### PR TITLE
🐛 fix(topic): correct topic item href route for agent and group pages

### DIFF
--- a/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -3,7 +3,6 @@ import { cssVar } from 'antd-style';
 import { MessageSquareDashed, Star } from 'lucide-react';
 import { Suspense, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import urlJoin from 'url-join';
 
 import { isDesktop } from '@/const/version';
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -33,7 +32,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId }) =>
   // Construct href for cmd+click support
   const href = useMemo(() => {
     if (!activeAgentId || !id) return undefined;
-    return urlJoin('/chat', `?agent=${activeAgentId}&topic=${id}`);
+    return `/agent/${activeAgentId}?topic=${id}`;
   }, [activeAgentId, id]);
 
   const [editing, isLoading] = useChatStore((s) => [

--- a/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/app/[variants]/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -3,7 +3,6 @@ import { cssVar } from 'antd-style';
 import { MessageSquareDashed, Star } from 'lucide-react';
 import { Suspense, memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import urlJoin from 'url-join';
 
 import { isDesktop } from '@/const/version';
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -35,7 +34,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId }) =>
   // Construct href for cmd+click support
   const href = useMemo(() => {
     if (!activeGroupId || !id) return undefined;
-    return urlJoin('/group', activeGroupId, `?topic=${id}`);
+    return `/group/${activeGroupId}?topic=${id}`;
   }, [activeGroupId, id]);
 
   const [editing, isLoading] = useChatStore((s) => [


### PR DESCRIPTION
## Summary

resolve LOBE-3602

- Fix agent topic item href from `/chat?agent=xxx&topic=xxx` to `/agent/xxx?topic=xxx`
- Fix group topic href to use direct template literal instead of urlJoin
- Remove unused urlJoin import

## Test plan

- [ ] Verify cmd+click on topic items in agent page navigates to correct URL
- [ ] Verify cmd+click on topic items in group page navigates to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)