### PR TITLE
🐛 fix: fix Topic component causing stack overflow and freezing the app

### DIFF
--- a/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
@@ -1,20 +1,24 @@
-import { Flexbox } from '@lobehub/ui';
-
-import TopicSearchBar from '@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicSearchBar';
-
-import TopicModal from './features/TopicModal';
+import { Flexbox } from "@lobehub/ui";
+import TopicListContent from "@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent";
+import TopicSearchBar from "@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicSearchBar";
+import TopicModal from "./features/TopicModal";
 
 const Topic = () => {
   return (
     <TopicModal>
-      <Flexbox gap={8} height={'100%'} padding={'8px 8px 0'} style={{ overflow: 'hidden' }}>
+      <Flexbox
+        gap={8}
+        height={"100%"}
+        padding={"8px 8px 0"}
+        style={{ overflow: "hidden" }}
+      >
         <TopicSearchBar />
         <Flexbox
-          height={'100%'}
-          style={{ marginInline: -8, overflow: 'hidden', position: 'relative' }}
-          width={'calc(100% + 16px)'}
+          height={"100%"}
+          style={{ marginInline: -8, overflow: "hidden", position: "relative" }}
+          width={"calc(100% + 16px)"}
         >
-          <Topic />
+          <TopicListContent />
         </Flexbox>
       </Flexbox>
     </TopicModal>

--- a/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
@@ -1,22 +1,19 @@
-import { Flexbox } from "@lobehub/ui";
-import TopicListContent from "@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent";
-import TopicSearchBar from "@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicSearchBar";
-import TopicModal from "./features/TopicModal";
+import { Flexbox } from '@lobehub/ui';
+
+import TopicListContent from '@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicListContent';
+import TopicSearchBar from '@/app/[variants]/(main)/agent/_layout/Sidebar/Topic/TopicSearchBar';
+
+import TopicModal from './features/TopicModal';
 
 const Topic = () => {
   return (
     <TopicModal>
-      <Flexbox
-        gap={8}
-        height={"100%"}
-        padding={"8px 8px 0"}
-        style={{ overflow: "hidden" }}
-      >
+      <Flexbox gap={8} height={'100%'} padding={'8px 8px 0'} style={{ overflow: 'hidden' }}>
         <TopicSearchBar />
         <Flexbox
-          height={"100%"}
-          style={{ marginInline: -8, overflow: "hidden", position: "relative" }}
-          width={"calc(100% + 16px)"}
+          height={'100%'}
+          style={{ marginInline: -8, overflow: 'hidden', position: 'relative' }}
+          width={'calc(100% + 16px)'}
         >
           <TopicListContent />
         </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #11284, Fixes #11355, Fixes #11132, Fixes #11546

#### 🔀 Description of Change

Infinite recursion bug in the Topic component that caused the app to freeze on mobile devices when clicking the chat header.

Topic component was rendering itself (<Topic />) inside its own return statement, creating an infinite loop that caused a stack overflow.

Fixed by Replacing the recursive <Topic /> call with the correct <TopicListContent /> component.

#### 🧪 How to Test

Tried on mobile PWA and mobile browser.

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

This was a bug that only manifested on mobile and PWA when the topic modal was triggered. The infinite recursion caused the JavaScript call stack to overflow, freezing the entire application and requiring a page reload.

No breaking changes or migrations needed.

## Summary by Sourcery

Bug Fixes:
- Resolve an infinite recursion in the mobile Topic component by rendering the topic list content instead of the Topic component itself within the modal.