### PR TITLE
🐛 fix: internlm provider base url and homepage

### DIFF
--- a/docs/usage/providers/internlm.mdx
+++ b/docs/usage/providers/internlm.mdx
@@ -14,7 +14,7 @@ tags:
 
 <Image cover src={'https://github.com/user-attachments/assets/be7dcd49-0165-4f7b-bf90-0739cc9dd212'} />
 
-[InternLM](https://platform.sensenova.cn/home) is a large pre-trained language model jointly launched by the Shanghai Artificial Intelligence Laboratory and Shusheng Group. This model focuses on natural language processing, aimed at understanding and generating human language, boasting powerful semantic comprehension and text generation capabilities.
+[InternLM](https://internlm.intern-ai.org.cn/) is a large pre-trained language model jointly launched by the Shanghai Artificial Intelligence Laboratory and Shusheng Group. This model focuses on natural language processing, aimed at understanding and generating human language, boasting powerful semantic comprehension and text generation capabilities.
 
 This article will guide you on how to use InternLM in LobeChat.
 
@@ -39,7 +39,7 @@ This article will guide you on how to use InternLM in LobeChat.
 
   <Image alt={'Enter API Key'} inStep src={'https://github.com/user-attachments/assets/8ec7656e-1e3d-41e0-95a0-f6883135c2fc'} />
 
-  - Enter the obtained `AccessKey ID` and `AccessKey Secret`
+  - Enter the obtained API Key
   - Choose a InternLM model for your AI assistant to start a conversation
 
   <Image alt={'Select InternLM Model and Start Conversation'} inStep src={'https://github.com/user-attachments/assets/76ad163e-ee19-4f95-a712-85bea764d3ec'} />

--- a/docs/usage/providers/internlm.zh-CN.mdx
+++ b/docs/usage/providers/internlm.zh-CN.mdx
@@ -12,7 +12,7 @@ tags:
 
 <Image cover src={'https://github.com/user-attachments/assets/be7dcd49-0165-4f7b-bf90-0739cc9dd212'} />
 
-[书生浦语（InternLM）](https://platform.sensenova.cn/home) 是由上海人工智能实验室与书生集团联合推出的一款大型预训练语言模型。该模型专注于自然语言处理，旨在理解和生成自然语言，具备强大的语义理解和文本生成能力。
+[书生浦语（InternLM）](https://internlm.intern-ai.org.cn/) 是由上海人工智能实验室与书生集团联合推出的一款大型预训练语言模型。该模型专注于自然语言处理，旨在理解和生成自然语言，具备强大的语义理解和文本生成能力。
 
 本文将指导你如何在 LobeChat 中使用书生浦语。
 
@@ -32,11 +32,11 @@ tags:
   ### 步骤二：在 LobeChat 中配置书生浦语
 
   - 访问 LobeChat 的`设置`界面
-  - 在`AI 服务商`下找到 `书生浦语` 的设置项
+  - 在`AI 服务商`下找到 `书生` 的设置项
 
   <Image alt={'填入 API 密钥'} inStep src={'https://github.com/user-attachments/assets/8ec7656e-1e3d-41e0-95a0-f6883135c2fc'} />
 
-  - 填入获得的 `AccessKey ID` 和 `AccessKey Secret`
+  - 填入获得的 API Key
   - 为你的 AI 助手选择一个书生浦语的模型即可开始对话
 
   <Image alt={'选择书生浦语模型并开始对话'} inStep src={'https://github.com/user-attachments/assets/76ad163e-ee19-4f95-a712-85bea764d3ec'} />

--- a/packages/model-bank/src/modelProviders/internlm.ts
+++ b/packages/model-bank/src/modelProviders/internlm.ts
@@ -14,7 +14,7 @@ const InternLM: ModelProviderCard = {
   settings: {
     disableBrowserRequest: true,
     proxyUrl: {
-      placeholder: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+      placeholder: 'https://chat.intern-ai.org.cn/api/v1',
     },
     sdkType: 'openai',
     showModelFetcher: true,

--- a/packages/model-runtime/src/providers/internlm/index.test.ts
+++ b/packages/model-runtime/src/providers/internlm/index.test.ts
@@ -9,7 +9,7 @@ import { LobeInternLMAI, params } from './index';
 testProvider({
   Runtime: LobeInternLMAI,
   provider: ModelProvider.InternLM,
-  defaultBaseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+  defaultBaseURL: 'https://chat.intern-ai.org.cn/api/v1',
   chatDebugEnv: 'DEBUG_INTERNLM_CHAT_COMPLETION',
   chatModel: 'internlm2_5-7b-chat',
   test: {
@@ -30,7 +30,7 @@ describe('LobeInternLMAI - custom features', () => {
 
   describe('params object', () => {
     it('should export params with correct baseURL', () => {
-      expect(params.baseURL).toBe('https://internlm-chat.intern-ai.org.cn/puyu/api/v1');
+      expect(params.baseURL).toBe('https://chat.intern-ai.org.cn/api/v1');
     });
 
     it('should have correct provider', () => {
@@ -116,7 +116,7 @@ describe('LobeInternLMAI - custom features', () => {
   describe('models', () => {
     it('should fetch and process models', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -137,7 +137,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should detect function call capability from model name', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -156,7 +156,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should detect vision capability from model name', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -175,7 +175,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should handle case-insensitive keyword matching', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -194,7 +194,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should merge with known model data from model-bank', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -215,7 +215,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should handle models not in model-bank', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -238,7 +238,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should set enabled flag from known model', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -255,7 +255,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should inherit abilities from known model', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -291,7 +291,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should handle empty model list', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -306,7 +306,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should filter out null/undefined models', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -322,7 +322,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should set contextWindowTokens from known model', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -340,7 +340,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should set displayName from known model', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({
@@ -358,7 +358,7 @@ describe('LobeInternLMAI - custom features', () => {
 
     it('should combine keyword detection with known model abilities', async () => {
       const mockClient = {
-        baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+        baseURL: 'https://chat.intern-ai.org.cn/api/v1',
         apiKey: 'test',
         models: {
           list: vi.fn().mockResolvedValue({

--- a/packages/model-runtime/src/providers/internlm/index.ts
+++ b/packages/model-runtime/src/providers/internlm/index.ts
@@ -11,7 +11,7 @@ export interface InternLMModelCard {
 }
 
 export const params = {
-  baseURL: 'https://internlm-chat.intern-ai.org.cn/puyu/api/v1',
+  baseURL: 'https://chat.intern-ai.org.cn/api/v1',
   chatCompletion: {
     handlePayload: (payload) => {
       return {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

api url capture from https://internlm.intern-ai.org.cn/api/document?lang=zh

<img width="540" height="222" alt="image" src="https://github.com/user-attachments/assets/8378b187-a420-43d2-bf65-9e968442230e" />


<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update InternLM provider configuration and documentation to use the current API base URL and homepage.

Bug Fixes:
- Correct InternLM default API base URL and related test expectations to the current chat.intern-ai.org.cn endpoint.

Enhancements:
- Align InternLM model provider proxy placeholder with the updated API base URL.

Documentation:
- Update InternLM provider docs (Chinese and English) with the new official homepage URL and revise instructions to reference a single API Key instead of AccessKey ID/Secret.