### PR TITLE
fix(electron): adjust nodrag region in navigation bar

### DIFF
--- a/src/features/Electron/titlebar/NavigationBar.tsx
+++ b/src/features/Electron/titlebar/NavigationBar.tsx
@@ -53,13 +53,12 @@ const NavigationBar = memo(() => {
   return (
     <Flexbox
       align="center"
-      className={electronStylish.nodrag}
       data-width={leftPanelWidth}
       horizontal
       justify="end"
       style={{ width: `${leftPanelWidth - 12}px` }}
     >
-      <Flexbox align="center" gap={2} horizontal>
+      <Flexbox align="center" className={electronStylish.nodrag} gap={2} horizontal>
         <ActionIcon disabled={!canGoBack} icon={ArrowLeft} onClick={goBack} size="small" />
         <ActionIcon disabled={!canGoForward} icon={ArrowRight} onClick={goForward} size="small" />
         <Popover


### PR DESCRIPTION
Moves the nodrag class to the button container to improve window dragging behavior.

## Summary by Sourcery

Bug Fixes:
- Fix window drag region in the Electron navigation bar by moving the non-draggable area to only cover the navigation button group.