### PR TITLE
🐛 fix: fix parallel tools calling race issue

### DIFF
--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -731,6 +731,14 @@ export const streamingExecutor: StateCreator<
         result.newState.status,
       );
 
+      // After parallel tool batch completes, refresh messages to ensure all tool results are synced
+      // This fixes the race condition where each tool's replaceMessages may overwrite others
+      // REMEMBER: There is no test for it (too hard to add), if you want to change it , ask @arvinxx first
+      if (result.nextContext?.phase === 'tools_batch_result') {
+        log('[internal_execAgentRuntime] Tools batch completed, refreshing messages to sync state');
+        await get().refreshMessages(context);
+      }
+
       // Handle completion and error events
       for (const event of result.events) {
         switch (event.type) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close https://github.com/lobehub/lobe-chat/issues/11454 

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Clarify client vs server execution for GTD async tasks and fix a race condition when handling results from parallel tool executions.

Bug Fixes:
- Ensure chat message state stays consistent after parallel tool batches complete by refreshing messages once the batch finishes.

Enhancements:
- Document when to use the runInClient flag for async tasks and add runInClient configuration to the GTD tool manifest for single and parallel tasks.