### PR TITLE
🐛 fix(desktop): resolve onboarding navigation issues after logout

### DIFF
--- a/scripts/generate-oidc-jwk.mjs
+++ b/scripts/generate-oidc-jwk.mjs
@@ -21,7 +21,9 @@ async function generateJwks() {
     console.error('正在生成 RSA 密钥对...');
 
     // 生成 RS256 密钥对
-    const { privateKey } = await generateKeyPair('RS256');
+    const { privateKey } = await generateKeyPair('RS256', {
+      extractable: true,
+    });
 
     // 导出为 JWK 格式
     const jwk = await exportJWK(privateKey);

--- a/src/app/[variants]/(desktop)/desktop-onboarding/navigation.ts
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/navigation.ts
@@ -1,0 +1,11 @@
+import { DesktopOnboardingScreen } from './types';
+
+const DESKTOP_ONBOARDING_ROUTE = '/desktop-onboarding';
+export const getDesktopOnboardingPath = (screen?: DesktopOnboardingScreen) => {
+  if (!screen) return DESKTOP_ONBOARDING_ROUTE;
+  return `${DESKTOP_ONBOARDING_ROUTE}?screen=${encodeURIComponent(screen)}`;
+};
+
+export const navigateToDesktopOnboarding = (screen?: DesktopOnboardingScreen) => {
+  location.href = getDesktopOnboardingPath(screen);
+};

--- a/src/app/[variants]/(desktop)/desktop-onboarding/storage.ts
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/storage.ts
@@ -1,5 +1,7 @@
+import { DesktopOnboardingScreen, isDesktopOnboardingScreen } from './types';
+
 export const DESKTOP_ONBOARDING_STORAGE_KEY = 'lobechat:desktop:onboarding:completed:v1';
-export const DESKTOP_ONBOARDING_STEP_KEY = 'lobechat:desktop:onboarding:step:v1';
+export const DESKTOP_ONBOARDING_SCREEN_KEY = 'lobechat:desktop:onboarding:screen:v1';
 
 export const getDesktopOnboardingCompleted = () => {
   if (typeof window === 'undefined') return true;
@@ -35,33 +37,29 @@ export const clearDesktopOnboardingCompleted = () => {
 };
 
 /**
- * Get the persisted onboarding step (for restoring after app restart)
+ * Get the persisted onboarding screen (for restoring after app restart)
  */
-export const getDesktopOnboardingStep = (): number | null => {
+export const getDesktopOnboardingScreen = () => {
   if (typeof window === 'undefined') return null;
 
   try {
-    const step = window.localStorage.getItem(DESKTOP_ONBOARDING_STEP_KEY);
-    if (step) {
-      const parsedStep = Number.parseInt(step, 10);
-      if (parsedStep >= 1 && parsedStep <= 4) {
-        return parsedStep;
-      }
-    }
-    return null;
+    const screen = window.localStorage.getItem(DESKTOP_ONBOARDING_SCREEN_KEY);
+    if (!screen) return null;
+    if (!isDesktopOnboardingScreen(screen)) return null;
+    return screen;
   } catch {
     return null;
   }
 };
 
 /**
- * Persist the current onboarding step
+ * Persist the current onboarding screen
  */
-export const setDesktopOnboardingStep = (step: number) => {
+export const setDesktopOnboardingScreen = (screen: DesktopOnboardingScreen) => {
   if (typeof window === 'undefined') return false;
 
   try {
-    window.localStorage.setItem(DESKTOP_ONBOARDING_STEP_KEY, step.toString());
+    window.localStorage.setItem(DESKTOP_ONBOARDING_SCREEN_KEY, screen);
     return true;
   } catch {
     return false;
@@ -69,13 +67,13 @@ export const setDesktopOnboardingStep = (step: number) => {
 };
 
 /**
- * Clear the persisted onboarding step (called when onboarding completes)
+ * Clear the persisted onboarding screen (called when onboarding completes)
  */
-export const clearDesktopOnboardingStep = () => {
+export const clearDesktopOnboardingScreen = () => {
   if (typeof window === 'undefined') return false;
 
   try {
-    window.localStorage.removeItem(DESKTOP_ONBOARDING_STEP_KEY);
+    window.localStorage.removeItem(DESKTOP_ONBOARDING_SCREEN_KEY);
     return true;
   } catch {
     return false;

--- a/src/app/[variants]/(desktop)/desktop-onboarding/types.ts
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/types.ts
@@ -1,0 +1,37 @@
+export enum DesktopOnboardingScreen {
+  DataMode = 'data-mode',
+  Login = 'login',
+  Permissions = 'permissions',
+  Welcome = 'welcome',
+}
+
+export const isDesktopOnboardingScreen = (value: unknown): value is DesktopOnboardingScreen => {
+  if (typeof value !== 'string') return false;
+  return (Object.values(DesktopOnboardingScreen) as string[]).includes(value);
+};
+
+export const desktopOnboardingLegacyStepToScreen = (
+  step: number,
+): DesktopOnboardingScreen | null => {
+  switch (step) {
+    case 1: {
+      return DesktopOnboardingScreen.Welcome;
+    }
+    case 2: {
+      return DesktopOnboardingScreen.Permissions;
+    }
+    case 3: {
+      return DesktopOnboardingScreen.DataMode;
+    }
+    case 4: {
+      return DesktopOnboardingScreen.Login;
+    }
+    // Legacy hash routing used `#5` in some places. Treat it as "login".
+    case 5: {
+      return DesktopOnboardingScreen.Login;
+    }
+    default: {
+      return null;
+    }
+  }
+};

--- a/src/app/[variants]/(desktop)/desktop-onboarding/types.ts
+++ b/src/app/[variants]/(desktop)/desktop-onboarding/types.ts
@@ -9,29 +9,3 @@ export const isDesktopOnboardingScreen = (value: unknown): value is DesktopOnboa
   if (typeof value !== 'string') return false;
   return (Object.values(DesktopOnboardingScreen) as string[]).includes(value);
 };
-
-export const desktopOnboardingLegacyStepToScreen = (
-  step: number,
-): DesktopOnboardingScreen | null => {
-  switch (step) {
-    case 1: {
-      return DesktopOnboardingScreen.Welcome;
-    }
-    case 2: {
-      return DesktopOnboardingScreen.Permissions;
-    }
-    case 3: {
-      return DesktopOnboardingScreen.DataMode;
-    }
-    case 4: {
-      return DesktopOnboardingScreen.Login;
-    }
-    // Legacy hash routing used `#5` in some places. Treat it as "login".
-    case 5: {
-      return DesktopOnboardingScreen.Login;
-    }
-    default: {
-      return null;
-    }
-  }
-};

--- a/src/features/User/UserPanel/PanelContent.tsx
+++ b/src/features/User/UserPanel/PanelContent.tsx
@@ -1,15 +1,17 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { Flexbox } from '@lobehub/ui';
-import { useRouter } from '@/libs/next/navigation';
 import { memo } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
+import { navigateToDesktopOnboarding } from '@/app/[variants]/(desktop)/desktop-onboarding/navigation';
 import { clearDesktopOnboardingCompleted } from '@/app/[variants]/(desktop)/desktop-onboarding/storage';
+import { DesktopOnboardingScreen } from '@/app/[variants]/(desktop)/desktop-onboarding/types';
 import BusinessPanelContent from '@/business/client/features/User/BusinessPanelContent';
 import BrandWatermark from '@/components/BrandWatermark';
 import Menu from '@/components/Menu';
 import { isDesktop } from '@/const/version';
 import { enableBetterAuth, enableNextAuth } from '@/envs/auth';
+import { useRouter } from '@/libs/next/navigation';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
@@ -21,7 +23,7 @@ import { useMenu } from './useMenu';
 
 const PanelContent = memo<{ closePopover: () => void }>(({ closePopover }) => {
   const router = useRouter();
-  const navigate = useNavigate();
+
   const isLoginWithAuth = useUserStore(authSelectors.isLoginWithAuth);
   const [openSignIn, signOut] = useUserStore((s) => [s.openLogin, s.logout]);
   const { mainItems, logoutItems } = useMenu();
@@ -35,17 +37,15 @@ const PanelContent = memo<{ closePopover: () => void }>(({ closePopover }) => {
     if (isDesktop) {
       closePopover();
 
-      // Desktop: clear OIDC tokens (electron main) + re-enter desktop onboarding at Screen5.
       try {
         const { remoteServerService } = await import('@/services/electron/remoteServer');
         await remoteServerService.clearRemoteServerConfig();
-      } catch {
-        // Ignore: even if IPC is unavailable, still proceed to onboarding.
+        clearDesktopOnboardingCompleted();
+        signOut();
+        navigateToDesktopOnboarding(DesktopOnboardingScreen.Login);
+      } catch (error) {
+        console.error(error);
       }
-
-      clearDesktopOnboardingCompleted();
-      signOut();
-      navigate('/desktop-onboarding#5', { replace: true });
       return;
     }
 

--- a/src/features/User/UserPanel/PanelContent.tsx
+++ b/src/features/User/UserPanel/PanelContent.tsx
@@ -40,11 +40,12 @@ const PanelContent = memo<{ closePopover: () => void }>(({ closePopover }) => {
       try {
         const { remoteServerService } = await import('@/services/electron/remoteServer');
         await remoteServerService.clearRemoteServerConfig();
+      } catch (error) {
+        console.error(error);
+      } finally {
         clearDesktopOnboardingCompleted();
         signOut();
         navigateToDesktopOnboarding(DesktopOnboardingScreen.Login);
-      } catch (error) {
-        console.error(error);
       }
       return;
     }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

解决登出后 onboarding 跳转问题

#### 🔀 Description of Change

This PR fixes the desktop onboarding navigation issues that occurred after user logout. The main changes include:

- **Refactored step-based navigation to screen-based navigation system**: Replaced numeric step identifiers with a type-safe `DesktopOnboardingScreen` enum for better maintainability and clarity
- **Improved screen persistence and URL synchronization**: Fixed issues where the onboarding screen state wasn't properly persisted or synchronized with the URL
- **Enhanced platform-specific screen resolution**: Better handling of macOS-specific permissions screen, with proper fallback for other platforms
- **Extracted navigation logic**: Created reusable utility functions for navigation and screen type checking

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Start the desktop app and complete onboarding
2. Log out from the app
3. Verify that the app correctly navigates to the appropriate onboarding screen
4. Test navigation between screens using both UI buttons and URL parameters

#### 📸 Screenshots / Videos

N/A - Logic changes only

#### 📝 Additional Information

This change improves the robustness of the onboarding flow by using explicit screen identifiers instead of numeric steps, making the code more maintainable and less prone to navigation bugs.