### PR TITLE
🐛 fix: when use trpc client should include the credentials cookies

### DIFF
--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -77,15 +77,22 @@ const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
 const linkOptions = {
   // eslint-disable-next-line no-undef
   fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Ensure credentials are included to send cookies (like mp_token)
+    // eslint-disable-next-line no-undef
+    const fetchOptions: RequestInit = {
+      ...init,
+      credentials: 'include',
+    };
+
     if (isDesktop) {
       // eslint-disable-next-line no-undef
-      const res = await fetch(input as string, init as RequestInit);
+      const res = await fetch(input as string, fetchOptions);
 
       if (res) return res;
     }
 
     // eslint-disable-next-line no-undef
-    return await fetch(input, init as RequestInit);
+    return await fetch(input, fetchOptions);
   },
   headers: async () => {
     // dynamic import to avoid circular dependency


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Fix TRPC lambda client so that fetch requests include credentials, allowing cookies such as authentication tokens to be sent correctly.