### PR TITLE
fix(editor): editor layout add `min-width: 0`

### DIFF
--- a/src/app/[variants]/(main)/agent/profile/index.tsx
+++ b/src/app/[variants]/(main)/agent/profile/index.tsx
@@ -8,6 +8,7 @@ import AgentBuilder from '@/features/AgentBuilder';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { StyleSheet } from '@/utils/styles';
 
 import Header from './features/Header';
 import ProfileEditor from './features/ProfileEditor';
@@ -15,13 +16,25 @@ import ProfileHydration from './features/ProfileHydration';
 import ProfileProvider from './features/ProfileProvider';
 import { useProfileStore } from './features/store';
 
+const styles = StyleSheet.create({
+  contentWrapper: {
+    cursor: 'text',
+    display: 'flex',
+    overflowY: 'auto',
+    position: 'relative',
+  },
+  profileArea: {
+    minWidth: 0,
+  },
+});
+
 const ProfileArea = memo(() => {
   const editor = useProfileStore((s) => s.editor);
   const isAgentConfigLoading = useAgentStore(agentSelectors.isAgentConfigLoading);
 
   return (
     <>
-      <Flexbox flex={1} height={'100%'}>
+      <Flexbox flex={1} height={'100%'} style={styles.profileArea}>
         {isAgentConfigLoading ? (
           <Loading debugId="ProfileArea" />
         ) : (
@@ -33,7 +46,7 @@ const ProfileArea = memo(() => {
               onClick={() => {
                 editor?.focus();
               }}
-              style={{ cursor: 'text', display: 'flex', overflowY: 'auto', position: 'relative' }}
+              style={styles.contentWrapper}
               width={'100%'}
             >
               <WideScreenContainer>

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -15,6 +15,7 @@ import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useDocumentStore } from '@/store/document';
 import { editorSelectors } from '@/store/document/slices/editor';
 import { usePageStore } from '@/store/page';
+import { StyleSheet } from '@/utils/styles';
 
 import Copilot from './Copilot';
 import EditorCanvas from './EditorCanvas';
@@ -24,6 +25,22 @@ import { PageEditorProvider } from './PageEditorProvider';
 import PageTitle from './PageTitle';
 import TitleSection from './TitleSection';
 import { usePageEditorStore } from './store';
+
+const styles = StyleSheet.create({
+  contentWrapper: {
+    display: 'flex',
+    overflowY: 'auto',
+    position: 'relative',
+  },
+  editorContainer: {
+    minWidth: 0,
+    position: 'relative',
+  },
+  editorContent: {
+    overflowY: 'auto',
+    position: 'relative',
+  },
+});
 
 interface PageEditorProps {
   emoji?: string;
@@ -77,16 +94,11 @@ const PageEditorCanvas = memo(() => {
         style={{ backgroundColor: cssVar.colorBgContainer }}
         width={'100%'}
       >
-        <Flexbox flex={1} height={'100%'} style={{ position: 'relative' }}>
+        <Flexbox flex={1} height={'100%'} style={styles.editorContainer}>
           <Header />
-          <Flexbox
-            height={'100%'}
-            horizontal
-            style={{ display: 'flex', overflowY: 'auto', position: 'relative' }}
-            width={'100%'}
-          >
+          <Flexbox height={'100%'} horizontal style={styles.contentWrapper} width={'100%'}>
             <WideScreenContainer onClick={() => editor?.focus()} wrapperStyle={{ cursor: 'text' }}>
-              <Flexbox flex={1} style={{ overflowY: 'auto', position: 'relative' }}>
+              <Flexbox flex={1} style={styles.editorContent}>
                 <TitleSection />
                 <EditorCanvas />
               </Flexbox>

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,0 +1,10 @@
+import type { CSSProperties } from 'react';
+
+export const StyleSheet = {
+  compose: (...styles: Array<CSSProperties | undefined | null | false>): CSSProperties => {
+    return Object.assign({}, ...styles.filter(Boolean));
+  },
+  create: (styles: Record<string, CSSProperties>) => {
+    return styles;
+  },
+};


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue


resolves LOBE-3845

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure editor-related layouts shrink correctly within flex containers by introducing shared style helpers and applying min-width constraints.

Bug Fixes:
- Prevent the page editor and agent profile editor areas from overflowing or mis-sizing by adding min-width: 0 within their flex layouts.

Enhancements:
- Introduce a reusable StyleSheet utility for composing and creating typed React style objects and apply it to consolidate inline editor layout styles.