### PR TITLE
🐛 fix(memory-user-memory): should fallback to server configured provider & model

### DIFF
--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -1660,6 +1660,7 @@ export class MemoryExtractionExecutor {
         config,
       ]),
     );
+
     const providerModels = runtimeState.enabledAiModels.reduce<Record<string, Set<string>>>(
       (acc, model) => {
         const providerId = normalizeProvider(model.providerId);
@@ -1692,15 +1693,23 @@ export class MemoryExtractionExecutor {
       for (const providerId of providerOrder) {
         const models = providerModels[providerId];
         if (!models) continue;
-
         if (models.has(modelId)) return providerId;
 
         const preferredMatch = candidateModels.find((preferredModel) => models.has(preferredModel));
         if (preferredMatch) return providerId;
       }
+      if (fallbackProvider) {
+        console.warn(
+          `[memory-extraction] no enabled provider found for ${label || 'model'} "${modelId}"`,
+          `(preferred ${preferredProviders}), falling back to server-configured provider "${fallbackProvider}".`,
+        );
+
+        return normalizeProvider(fallbackProvider);
+      }
 
       throw new Error(
-        `Unable to resolve provider for ${label || 'model'} "${modelId}". Check preferred providers/models configuration.`,
+        `Unable to resolve provider for ${label || 'model'} "${modelId}". ` +
+          `Check preferred providers/models configuration.`,
       );
     };
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Add fallback to the server-configured provider when resolving a provider for a memory extraction model fails due to no enabled providers matching.