### PR TITLE
🐛 fix: fix group broadcast trigger tool use

### DIFF
--- a/packages/agent-runtime/src/groupOrchestration/GroupOrchestrationSupervisor.ts
+++ b/packages/agent-runtime/src/groupOrchestration/GroupOrchestrationSupervisor.ts
@@ -76,6 +76,8 @@ export class GroupOrchestrationSupervisor implements IGroupOrchestrationSupervis
             return {
               payload: {
                 agentIds: params.agentIds as string[],
+                // Broadcast agents should not call tools by default
+                disableTools: true,
                 instruction: params.instruction as string | undefined,
                 toolMessageId: params.toolMessageId as string,
               },

--- a/packages/agent-runtime/src/groupOrchestration/__tests__/GroupOrchestrationSupervisor.test.ts
+++ b/packages/agent-runtime/src/groupOrchestration/__tests__/GroupOrchestrationSupervisor.test.ts
@@ -96,7 +96,7 @@ describe('GroupOrchestrationSupervisor', () => {
       });
     });
 
-    it('should return parallel_call_agents instruction for broadcast decision', async () => {
+    it('should return parallel_call_agents instruction for broadcast decision with disableTools: true', async () => {
       const supervisor = new GroupOrchestrationSupervisor(defaultConfig);
       const state = createMockState();
 
@@ -119,6 +119,8 @@ describe('GroupOrchestrationSupervisor', () => {
         type: 'parallel_call_agents',
         payload: {
           agentIds: ['agent-1', 'agent-2'],
+          // Broadcast agents should have tools disabled by default
+          disableTools: true,
           instruction: 'Discuss',
           toolMessageId: 'tool-msg-1',
         },

--- a/packages/agent-runtime/src/groupOrchestration/types.ts
+++ b/packages/agent-runtime/src/groupOrchestration/types.ts
@@ -32,6 +32,11 @@ export interface SupervisorInstructionCallAgent {
 export interface SupervisorInstructionParallelCallAgents {
   payload: {
     agentIds: string[];
+    /**
+     * Whether to disable tools for broadcast agents
+     * When true, agents will respond without calling any tools
+     */
+    disableTools?: boolean;
     instruction?: string;
     /**
      * The tool message ID that triggered the broadcast

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -51,6 +51,12 @@ export interface AgentConfigResolverContext {
   /** Agent ID to resolve config for */
   agentId: string;
 
+  /**
+   * Whether to disable all tools for this agent execution.
+   * When true, returns empty plugins array (used for broadcast scenarios).
+   */
+  disableTools?: boolean;
+
   // Builtin agent specific context
   /** Document content for page-agent */
   documentContent?: string;
@@ -112,13 +118,27 @@ export interface ResolvedAgentConfig {
  * For regular agents, this simply returns the config from the store.
  */
 export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAgentConfig => {
-  const { agentId, model, documentContent, plugins, targetAgentConfig, isSubTask } = ctx;
+  const { agentId, model, documentContent, plugins, targetAgentConfig, isSubTask, disableTools } =
+    ctx;
 
-  log('resolveAgentConfig called with agentId: %s, scope: %s, isSubTask: %s', agentId, ctx.scope, isSubTask);
+  log(
+    'resolveAgentConfig called with agentId: %s, scope: %s, isSubTask: %s, disableTools: %s',
+    agentId,
+    ctx.scope,
+    isSubTask,
+    disableTools,
+  );
 
-  // Helper to filter out lobe-gtd in sub-task context to prevent nested sub-task creation
-  const applySubTaskFilter = (pluginIds: string[]) =>
-    isSubTask ? pluginIds.filter((id) => id !== 'lobe-gtd') : pluginIds;
+  // Helper to apply plugin filters:
+  // 1. If disableTools is true, return empty array (for broadcast scenarios)
+  // 2. If isSubTask is true, filter out lobe-gtd to prevent nested sub-task creation
+  const applyPluginFilters = (pluginIds: string[]) => {
+    if (disableTools) {
+      log('disableTools is true, returning empty plugins');
+      return [];
+    }
+    return isSubTask ? pluginIds.filter((id) => id !== 'lobe-gtd') : pluginIds;
+  };
 
   const agentStoreState = getAgentStoreState();
 
@@ -209,7 +229,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
         agentConfig: finalAgentConfig,
         chatConfig: finalChatConfig,
         isBuiltinAgent: false,
-        plugins: applySubTaskFilter(pageAgentPlugins),
+        plugins: applyPluginFilters(pageAgentPlugins),
       };
     }
 
@@ -218,7 +238,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       agentConfig: finalAgentConfig,
       chatConfig: finalChatConfig,
       isBuiltinAgent: false,
-      plugins: applySubTaskFilter(finalPlugins),
+      plugins: applyPluginFilters(finalPlugins),
     };
   }
 
@@ -339,7 +359,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
     agentConfig: finalAgentConfig,
     chatConfig: resolvedChatConfig,
     isBuiltinAgent: true,
-    plugins: applySubTaskFilter(finalPlugins),
+    plugins: applyPluginFilters(finalPlugins),
     slug,
   };
 };

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -633,6 +633,7 @@ export const streamingExecutor: StateCreator<
       messages,
       parentMessageId: params.parentMessageId,
       agentId,
+      disableTools,
       topicId,
       threadId: threadId ?? undefined,
       initialState: params.initialState,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Propagate a new disableTools flag through agent runtime and group orchestration so broadcasted agent calls run without tools by default, and add tests to validate tool disabling behavior.

New Features:
- Add a disableTools option to agent runtime execution and group orchestration parallel calls to control whether tools can be used.

Bug Fixes:
- Ensure group broadcast agents run with tools disabled by default to avoid unintended tool usage during parallel calls.

Enhancements:
- Guard tool manifest generation in the streaming executor when tools are disabled, and improve logging of broadcast calls with the disableTools flag.
- Refine async task status handling switch formatting for better readability.

Tests:
- Add unit tests for internal_createAgentState behavior when tools are disabled and for supervisor broadcast instructions including disableTools in parallel agent calls.