### PR TITLE
💄 style: center active model on open in model switch panel

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/VirtualItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/VirtualItemRenderer.tsx
@@ -106,6 +106,7 @@ export const VirtualItemRenderer = memo<VirtualItemRendererProps>(
           <Block
             className={styles.menuItem}
             clickable
+            data-model-key={key}
             key={key}
             onClick={async () => {
               onModelChange(item.model.id, item.provider.id);
@@ -132,6 +133,7 @@ export const VirtualItemRenderer = memo<VirtualItemRendererProps>(
           <Block
             className={styles.menuItem}
             clickable
+            data-model-key={key}
             key={key}
             onClick={async () => {
               onModelChange(item.data.model.id, singleProvider.id);
@@ -150,11 +152,15 @@ export const VirtualItemRenderer = memo<VirtualItemRendererProps>(
           (p) => menuKey(p.id, item.data.model.id) === activeKey,
         );
         const isActive = !!activeProvider;
+        const activeModelKey = activeProvider
+          ? menuKey(activeProvider.id, item.data.model.id)
+          : undefined;
 
         return (
           <Block
             className={styles.menuItem}
             clickable
+            data-model-key={activeModelKey}
             key={item.data.displayName}
             variant={isActive ? 'filled' : 'borderless'}
           >


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

优化聊天页模型切换面板展开时的定位与渲染，选中的模型（正在使用的模型）初始即居中显示，免去寻找。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Center the currently active model in the model switch panel when it opens and adjust list virtualization around the active item.

New Features:
- Automatically center the selected model within the model switch panel on open for easier discovery.

Enhancements:
- Refine list virtualization to compute a render window around the active item with dynamic padding instead of a fixed initial slice.
- Add stable data attributes to model items to support locating and centering the active model in the list.