### PR TITLE
🔨 chore: add /chat redirect to homepage

### DIFF
--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -308,6 +308,11 @@ export function defineConfig(config: CustomNextConfig) {
         permanent: false,
         source: '/repos',
       },
+      {
+        destination: '/',
+        permanent: true,
+        source: '/chat',
+      },
       ...(config.redirects ?? []),
     ],
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

This PR adds support for the legacy `/chat` route by redirecting it to the homepage (`/`).

#### 🔀 Description of Change

Added a permanent HTTP 301 redirect from `/chat` to `/` in the Next.js configuration file. This ensures backward compatibility for any existing links or bookmarks pointing to the old `/chat` path.

#### 🧪 How to Test

- [x] No tests needed

The redirect is configured at the Next.js level and will be validated by the build process.

#### 📝 Additional Information

This is a simple configuration change that adds a redirect rule for a legacy route path. The change is non-breaking and improves user experience by handling old URLs gracefully.

## Summary by Sourcery

Enhancements:
- Configure a permanent 301 redirect from /chat to / to preserve compatibility with legacy URLs.