### PR TITLE
🐛 fix: sloved the old removeSessionTopics not work

### DIFF
--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -76,6 +76,12 @@ export const topicRouter = router({
       return ctx.topicModel.batchDelete(input.ids);
     }),
 
+  batchDeleteByAgentId: topicProcedure
+    .input(z.object({ agentId: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      return ctx.topicModel.batchDeleteByAgentId(input.agentId);
+    }),
+
   batchDeleteBySessionId: topicProcedure
     .input(
       z.object({

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -109,6 +109,10 @@ export class TopicService {
     return lambdaClient.topic.batchDeleteBySessionId.mutate({ id: this.toDbSessionId(sessionId) });
   };
 
+  removeTopicsByAgentId = (agentId: string) => {
+    return lambdaClient.topic.batchDeleteByAgentId.mutate({ agentId });
+  };
+
   batchRemoveTopics = (topics: string[]) => {
     return lambdaClient.topic.batchDelete.mutate({ ids: topics });
   };

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -28,6 +28,7 @@ vi.mock('zustand/traditional');
 vi.mock('@/services/topic', () => ({
   topicService: {
     removeTopics: vi.fn(),
+    removeTopicsByAgentId: vi.fn(),
     removeAllTopic: vi.fn(),
     removeTopic: vi.fn(),
     cloneTopic: vi.fn(),
@@ -570,7 +571,7 @@ describe('topic action', () => {
         await result.current.removeSessionTopics();
       });
 
-      expect(topicService.removeTopics).toHaveBeenCalledWith(activeAgentId);
+      expect(topicService.removeTopicsByAgentId).toHaveBeenCalledWith(activeAgentId);
       expect(refreshTopicSpy).toHaveBeenCalled();
       expect(switchTopicSpy).toHaveBeenCalled();
     });

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -567,7 +567,7 @@ export const chatTopic: StateCreator<
     const { switchTopic, activeAgentId, refreshTopic } = get();
     if (!activeAgentId) return;
 
-    await topicService.removeTopics(activeAgentId);
+    await topicService.removeTopicsByAgentId(activeAgentId);
     await refreshTopic();
 
     // switch to default topic


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix topic deletion to target topics by agent ID instead of relying on the previous session-based removal logic.

Bug Fixes:
- Correct topic removal in the chat store to delete topics by active agent ID.
- Ensure backend topic API supports batch deletion of topics by agent ID to match frontend usage.