### PR TITLE
 🐛 fix: slove the agent group editor not focus in editdata area

### DIFF
--- a/src/app/[variants]/(main)/group/profile/features/GroupProfile/index.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/GroupProfile/index.tsx
@@ -3,7 +3,7 @@
 import { Button, Flexbox } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { PlayIcon } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
@@ -42,6 +42,15 @@ const GroupProfile = memo(() => {
   const onContentChange = useCallback(() => {
     handleContentChange(saveContent);
   }, [handleContentChange, saveContent]);
+
+  // Stabilize editorData object reference to prevent unnecessary re-renders
+  const editorData = useMemo(
+    () => ({
+      content: currentGroup?.content ?? undefined,
+      editorData: currentGroup?.editorData,
+    }),
+    [currentGroup?.content, currentGroup?.editorData],
+  );
 
   return (
     <>
@@ -83,11 +92,8 @@ const GroupProfile = memo(() => {
       {/* Group Content Editor */}
       <EditorCanvas
         editor={editor}
-        editorData={{
-          content: currentGroup?.content ?? undefined,
-          editorData: currentGroup?.editorData,
-        }}
-        key={groupId}
+        editorData={editorData}
+        entityId={groupId}
         onContentChange={onContentChange}
         placeholder={t('group.profile.contentPlaceholder', { ns: 'chat' })}
       />

--- a/src/app/[variants]/(main)/group/profile/features/MemberProfile/index.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/MemberProfile/index.tsx
@@ -34,8 +34,8 @@ const MemberProfile = memo(() => {
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
   const groupId = useAgentGroupStore(agentGroupSelectors.activeGroupId);
-  const currentGroup = useAgentGroupStore(agentGroupSelectors.currentGroup);
-  const currentGroupAgents = useAgentGroupStore(agentGroupSelectors.currentGroupAgents);
+  const currentGroup = useAgentGroupStore(agentGroupSelectors.currentGroup, isEqual);
+  const currentGroupAgents = useAgentGroupStore(agentGroupSelectors.currentGroupAgents, isEqual);
   const router = useQueryRoute();
 
   // Check if the current agent is the supervisor
@@ -46,6 +46,15 @@ const MemberProfile = memo(() => {
     const agent = currentGroupAgents.find((a) => a.id === agentId);
     return agent ? !agent.isSupervisor && !agent.virtual : false;
   }, [currentGroupAgents, agentId]);
+
+  // Stabilize editorData object reference to prevent unnecessary re-renders
+  const editorData = useMemo(
+    () => ({
+      content: config?.systemRole,
+      editorData: config?.editorData,
+    }),
+    [config?.systemRole, config?.editorData],
+  );
 
   // Wrap updateAgentConfigById for saving editor content
   const updateContent = useCallback(
@@ -136,11 +145,8 @@ const MemberProfile = memo(() => {
       {/* Main Content: Prompt Editor */}
       <EditorCanvas
         editor={editor}
-        editorData={{
-          content: config?.systemRole,
-          editorData: config?.editorData,
-        }}
-        key={agentId}
+        editorData={editorData}
+        entityId={agentId}
         onContentChange={onContentChange}
         placeholder={
           isSupervisor

--- a/src/features/EditorCanvas/EditorCanvas.tsx
+++ b/src/features/EditorCanvas/EditorCanvas.tsx
@@ -39,6 +39,14 @@ export interface EditorCanvasProps {
   };
 
   /**
+   * Entity ID (e.g., agentId, groupId) to track which entity is being edited.
+   * When entityId changes, editor content will be reloaded.
+   * When entityId stays the same, editorData changes won't trigger reload.
+   * This prevents focus loss during auto-save and optimistic updates.
+   */
+  entityId?: string;
+
+  /**
    * Extra plugins to prepend to BASE_PLUGINS (e.g., ReactLiteXmlPlugin)
    */
   extraPlugins?: EditorPlugins;
@@ -113,7 +121,7 @@ export interface EditorCanvasWithEditorProps extends EditorCanvasProps {
  * - AutoSave hint display (documentId mode)
  */
 export const EditorCanvas = memo<EditorCanvasWithEditorProps>(
-  ({ editor, documentId, editorData, ...props }) => {
+  ({ editor, documentId, editorData, entityId, ...props }) => {
     // documentId mode - fetch and render with loading/error states
     if (documentId) {
       return (
@@ -127,7 +135,7 @@ export const EditorCanvas = memo<EditorCanvasWithEditorProps>(
     if (editorData) {
       return (
         <EditorErrorBoundary>
-          <EditorDataMode editor={editor} editorData={editorData} {...props} />
+          <EditorDataMode editor={editor} editorData={editorData} entityId={entityId} {...props} />
         </EditorErrorBoundary>
       );
     }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve editor behavior for agent and group profiles to prevent focus loss when auto-saving and switching entities.

Bug Fixes:
- Prevent the agent and group profile editors from losing focus or reloading content unnecessarily during auto-save and optimistic updates by reloading only when the edited entity changes.
- Avoid overwriting newer agent data in the agent store with older server data by merging group agent details based on updatedAt timestamps.

Enhancements:
- Track an entityId in EditorCanvas and EditorDataMode so content reloads only when switching entities, not on every editorData change.
- Stabilize group and member profile editor data and group store selectors with memoization and equality checks to reduce unnecessary re-renders.