### PR TITLE
✨ feat: support agent group unpublish agents

### DIFF
--- a/src/app/[variants]/(main)/community/(detail)/user/features/DetailProvider.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/DetailProvider.tsx
@@ -19,7 +19,11 @@ export interface UserDetailContextConfig {
   isOwner: boolean;
   mobile?: boolean;
   onEditProfile?: (onSuccess?: (profile: MarketUserProfile) => void) => void;
-  onStatusChange?: (identifier: string, action: 'publish' | 'unpublish' | 'deprecate') => void;
+  onStatusChange?: (
+    identifier: string,
+    action: 'publish' | 'unpublish' | 'deprecate',
+    type?: 'agent' | 'group',
+  ) => void;
   totalInstalls: number;
   user: DiscoverUserInfo;
 }

--- a/src/app/[variants]/(main)/community/(detail)/user/features/UserAgentCard.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/UserAgentCard.tsx
@@ -78,6 +78,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
     `,
     moreButton: css`
       position: absolute;
+      z-index: 10;
       inset-block-start: 12px;
       inset-inline-end: 12px;
 
@@ -259,14 +260,13 @@ const UserAgentCard = memo<UserAgentCardProps>(
         width={'100%'}
       >
         {isOwner && (
-          <DropdownMenu items={menuItems}>
-            <div
-              className={cx('more-button', styles.moreButton)}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Icon icon={MoreVerticalIcon} size={16} style={{ cursor: 'pointer' }} />
-            </div>
-          </DropdownMenu>
+          <div onClick={(e) => e.stopPropagation()}>
+            <DropdownMenu items={menuItems as any}>
+              <div className={cx('more-button', styles.moreButton)}>
+                <Icon icon={MoreVerticalIcon} size={16} style={{ cursor: 'pointer' }} />
+              </div>
+            </DropdownMenu>
+          </div>
         )}
         <Flexbox
           align={'flex-start'}

--- a/src/app/[variants]/(main)/community/(detail)/user/features/useUserDetail.ts
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/useUserDetail.ts
@@ -6,8 +6,10 @@ import { useTranslation } from 'react-i18next';
 
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { marketApiService } from '@/services/marketApi';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 export type AgentStatusAction = 'publish' | 'unpublish' | 'deprecate';
+export type EntityType = 'agent' | 'group';
 
 interface UseUserDetailOptions {
   onMutate?: () => void;
@@ -17,43 +19,67 @@ export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
   const { t } = useTranslation('setting');
   const { message, modal } = App.useApp();
   const { session } = useMarketAuth();
+  const enableMarketTrustedClient = useServerConfigStore(
+    serverConfigSelectors.enableMarketTrustedClient,
+  );
 
   const handleStatusChange = useCallback(
-    async (identifier: string, action: AgentStatusAction) => {
-      if (!session?.accessToken) {
+    async (identifier: string, action: AgentStatusAction, type: EntityType = 'agent') => {
+      if (!enableMarketTrustedClient && !session?.accessToken) {
         message.error(t('myAgents.errors.notAuthenticated'));
         return;
       }
 
-      const messageKey = `agent-status-${action}`;
+      const messageKey = `${type}-status-${action}`;
       const loadingText = t(`myAgents.actions.${action}Loading` as any);
       const successText = t(`myAgents.actions.${action}Success` as any);
       const errorText = t(`myAgents.actions.${action}Error` as any);
 
-      async function executeStatusChange(identifier: string, action: AgentStatusAction) {
+      async function executeStatusChange(
+        identifier: string,
+        action: AgentStatusAction,
+        type: EntityType,
+      ) {
         try {
           message.loading({ content: loadingText, key: messageKey });
           marketApiService.setAccessToken(session!.accessToken);
 
-          switch (action) {
-            case 'publish': {
-              await marketApiService.publishAgent(identifier);
-              break;
+          if (type === 'group') {
+            switch (action) {
+              case 'publish': {
+                await marketApiService.publishAgentGroup(identifier);
+                break;
+              }
+              case 'unpublish': {
+                await marketApiService.unpublishAgentGroup(identifier);
+                break;
+              }
+              case 'deprecate': {
+                await marketApiService.deprecateAgentGroup(identifier);
+                break;
+              }
             }
-            case 'unpublish': {
-              await marketApiService.unpublishAgent(identifier);
-              break;
-            }
-            case 'deprecate': {
-              await marketApiService.deprecateAgent(identifier);
-              break;
+          } else {
+            switch (action) {
+              case 'publish': {
+                await marketApiService.publishAgent(identifier);
+                break;
+              }
+              case 'unpublish': {
+                await marketApiService.unpublishAgent(identifier);
+                break;
+              }
+              case 'deprecate': {
+                await marketApiService.deprecateAgent(identifier);
+                break;
+              }
             }
           }
 
           message.success({ content: successText, key: messageKey });
           onMutate?.();
         } catch (error) {
-          console.error(`[useUserDetail] ${action} agent error:`, error);
+          console.error(`[useUserDetail] ${action} ${type} error:`, error);
           message.error({
             content: `${errorText}: ${error instanceof Error ? error.message : 'Unknown error'}`,
             key: messageKey,
@@ -61,7 +87,6 @@ export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
         }
       }
 
-      // For deprecate action, show confirmation dialog first
       if (action === 'deprecate') {
         modal.confirm({
           cancelText: t('myAgents.actions.cancel'),
@@ -69,16 +94,16 @@ export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
           okButtonProps: { danger: true },
           okText: t('myAgents.actions.confirmDeprecate'),
           onOk: async () => {
-            await executeStatusChange(identifier, action);
+            await executeStatusChange(identifier, action, type);
           },
           title: t('myAgents.actions.deprecateConfirmTitle'),
         });
         return;
       }
 
-      await executeStatusChange(identifier, action);
+      await executeStatusChange(identifier, action, type);
     },
-    [session?.accessToken, message, modal, t, onMutate],
+    [enableMarketTrustedClient, session?.accessToken, message, modal, t, onMutate],
   );
 
   return {

--- a/src/server/routers/lambda/market/agentGroup.ts
+++ b/src/server/routers/lambda/market/agentGroup.ts
@@ -202,6 +202,66 @@ export const agentGroupRouter = router({
 
   
   /**
+   * Deprecate agent group
+   * POST /market/agent-group/:identifier/deprecate
+   */
+deprecateAgentGroup: agentGroupProcedure
+    .input(z.object({ identifier: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      log('deprecateAgentGroup input: %O', input);
+
+      try {
+        const deprecateUrl = `${MARKET_BASE_URL}/api/v1/agent-groups/${input.identifier}/deprecate`;
+
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+
+        const userInfo = ctx.marketUserInfo as TrustedClientUserInfo | undefined;
+        const accessToken = (ctx as { marketOidcAccessToken?: string }).marketOidcAccessToken;
+
+        if (userInfo) {
+          const trustedClientToken = generateTrustedClientToken(userInfo);
+          if (trustedClientToken) {
+            headers['x-lobe-trust-token'] = trustedClientToken;
+          }
+        }
+
+        if (!headers['x-lobe-trust-token'] && accessToken) {
+          headers['Authorization'] = `Bearer ${accessToken}`;
+        }
+
+        const response = await fetch(deprecateUrl, {
+          headers,
+          method: 'POST',
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          log(
+            'Deprecate agent group failed: %s %s - %s',
+            response.status,
+            response.statusText,
+            errorText,
+          );
+          throw new Error(`Failed to deprecate agent group: ${response.statusText}`);
+        }
+
+        log('Deprecate agent group success');
+        return { success: true };
+      } catch (error) {
+        log('Error deprecating agent group: %O', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to deprecate agent group',
+        });
+      }
+    }),
+
+  
+  
+/**
    * Fork an agent group
    * POST /market/agent-group/:identifier/fork
    */
@@ -340,7 +400,6 @@ getAgentGroupForkSource: agentGroupProcedure
 
   
   
-
 /**
    * Get all forks of an agent group
    * GET /market/agent-group/:identifier/forks
@@ -395,6 +454,66 @@ getAgentGroupForks: agentGroupProcedure
           cause: error,
           code: 'INTERNAL_SERVER_ERROR',
           message: error instanceof Error ? error.message : 'Failed to get agent group forks',
+        });
+      }
+    }),
+
+  
+  
+/**
+   * Publish agent group
+   * POST /market/agent-group/:identifier/publish
+   */
+publishAgentGroup: agentGroupProcedure
+    .input(z.object({ identifier: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      log('publishAgentGroup input: %O', input);
+
+      try {
+        const publishUrl = `${MARKET_BASE_URL}/api/v1/agent-groups/${input.identifier}/publish`;
+
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+
+        const userInfo = ctx.marketUserInfo as TrustedClientUserInfo | undefined;
+        const accessToken = (ctx as { marketOidcAccessToken?: string }).marketOidcAccessToken;
+
+        if (userInfo) {
+          const trustedClientToken = generateTrustedClientToken(userInfo);
+          if (trustedClientToken) {
+            headers['x-lobe-trust-token'] = trustedClientToken;
+          }
+        }
+
+        if (!headers['x-lobe-trust-token'] && accessToken) {
+          headers['Authorization'] = `Bearer ${accessToken}`;
+        }
+
+        const response = await fetch(publishUrl, {
+          headers,
+          method: 'POST',
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          log(
+            'Publish agent group failed: %s %s - %s',
+            response.status,
+            response.statusText,
+            errorText,
+          );
+          throw new Error(`Failed to publish agent group: ${response.statusText}`);
+        }
+
+        log('Publish agent group success');
+        return { success: true };
+      } catch (error) {
+        log('Error publishing agent group: %O', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to publish agent group',
         });
       }
     }),
@@ -491,6 +610,65 @@ publishOrCreate: agentGroupProcedure
           cause: error,
           code: 'INTERNAL_SERVER_ERROR',
           message: error instanceof Error ? error.message : 'Failed to publish group',
+        });
+      }
+    }),
+
+  
+  /**
+   * Unpublish agent group
+   * POST /market/agent-group/:identifier/unpublish
+   */
+unpublishAgentGroup: agentGroupProcedure
+    .input(z.object({ identifier: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      log('unpublishAgentGroup input: %O', input);
+
+      try {
+        const unpublishUrl = `${MARKET_BASE_URL}/api/v1/agent-groups/${input.identifier}/unpublish`;
+
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+
+        const userInfo = ctx.marketUserInfo as TrustedClientUserInfo | undefined;
+        const accessToken = (ctx as { marketOidcAccessToken?: string }).marketOidcAccessToken;
+
+        if (userInfo) {
+          const trustedClientToken = generateTrustedClientToken(userInfo);
+          if (trustedClientToken) {
+            headers['x-lobe-trust-token'] = trustedClientToken;
+          }
+        }
+
+        if (!headers['x-lobe-trust-token'] && accessToken) {
+          headers['Authorization'] = `Bearer ${accessToken}`;
+        }
+
+        const response = await fetch(unpublishUrl, {
+          headers,
+          method: 'POST',
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          log(
+            'Unpublish agent group failed: %s %s - %s',
+            response.status,
+            response.statusText,
+            errorText,
+          );
+          throw new Error(`Failed to unpublish agent group: ${response.statusText}`);
+        }
+
+        log('Unpublish agent group success');
+        return { success: true };
+      } catch (error) {
+        log('Error unpublishing agent group: %O', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to unpublish agent group',
         });
       }
     }),

--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -1761,6 +1761,7 @@ export class DiscoverService {
         knowledgeCount: agent.knowledgeCount || 0,
         pluginCount: agent.pluginCount || 0,
         schemaVersion: 1,
+        status: agent.status,
         tags: agent.tags || [],
         title: agent.name || agent.identifier,
         tokenUsage: agent.tokenUsage || 0,
@@ -1780,6 +1781,7 @@ export class DiscoverService {
         isOfficial: group.isOfficial || false,
         memberCount: 0, // Will be populated from memberAgents in detail view
         schemaVersion: 1,
+        status: group.status,
         tags: group.tags || [],
         title: group.name || group.identifier,
         updatedAt: group.updatedAt,
@@ -1802,6 +1804,7 @@ export class DiscoverService {
           knowledgeCount: agent.knowledgeCount || 0,
           pluginCount: agent.pluginCount || 0,
           schemaVersion: 1,
+          status: agent.status,
           tags: agent.tags || [],
           title: agent.name || agent.identifier,
           tokenUsage: agent.tokenUsage || 0,
@@ -1824,6 +1827,7 @@ export class DiscoverService {
         isOfficial: group.isOfficial || false,
         memberCount: 0, // Will be populated from memberAgents in detail view
         schemaVersion: 1,
+        status: group.status,
         tags: group.tags || [],
         title: group.name || group.identifier,
         updatedAt: group.updatedAt,

--- a/src/services/marketApi.ts
+++ b/src/services/marketApi.ts
@@ -146,6 +146,20 @@ export class MarketApiService {
     return lambdaClient.market.agent.getAgentForkSource.query({ identifier });
   }
 
+  // ==================== Agent Group Status Management ====================
+
+  async publishAgentGroup(identifier: string): Promise<void> {
+    await lambdaClient.market.agentGroup.publishAgentGroup.mutate({ identifier });
+  }
+
+  async unpublishAgentGroup(identifier: string): Promise<void> {
+    await lambdaClient.market.agentGroup.unpublishAgentGroup.mutate({ identifier });
+  }
+
+  async deprecateAgentGroup(identifier: string): Promise<void> {
+    await lambdaClient.market.agentGroup.deprecateAgentGroup.mutate({ identifier });
+  }
+
   // ==================== Fork Agent Group API ====================
 
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add server and client support for managing agent group publication status in the marketplace, including publish, unpublish, and deprecate actions.

New Features:
- Expose new lambda router endpoints to publish, unpublish, and deprecate agent groups via the marketplace API.
- Add market API client methods and user detail hooks to change status for both individual agents and agent groups.
- Enhance the user group card UI with owner-only actions menu and status badges for group publication state.

Enhancements:
- Update trusted-client / access-token handling for status changes to support environments with or without market trusted client configuration.
- Align the agent card actions dropdown behavior with the new group card dropdown interaction.