### PR TITLE
🐛 fix: update the agentbuilder tools not always use humanIntervention

### DIFF
--- a/packages/builtin-tool-agent-builder/src/manifest.ts
+++ b/packages/builtin-tool-agent-builder/src/manifest.ts
@@ -27,7 +27,6 @@ export const AgentBuilderManifest: BuiltinToolManifest = {
     {
       description:
         'Search for tools (MCP plugins) in the marketplace. Users can browse and install tools directly from the search results. Use this when users want to find new tools or capabilities.',
-      humanIntervention: 'always',
       name: AgentBuilderApiName.searchMarketTools,
       parameters: {
         properties: {
@@ -57,7 +56,6 @@ export const AgentBuilderManifest: BuiltinToolManifest = {
     {
       description:
         'Install a plugin for the agent. This tool ALWAYS REQUIRES user approval before installation, even in auto-run mode. For MCP marketplace plugins, it will install and enable the plugin. For Klavis tools and LobehubSkill providers that need OAuth, it will initiate the connection flow and wait for user to complete authorization.',
-      humanIntervention: 'always',
       name: AgentBuilderApiName.installPlugin,
       parameters: {
         properties: {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

fix LOBE-3605
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Allow marketplace tool search and plugin installation tools to run without being hard-coded as always requiring human intervention in the manifest.