### PR TITLE
🐛 fix slove the pwa not open provider & agents in settings

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -544,6 +544,7 @@
   "systemAgent.translation.title": "Message Translation Agent",
   "tab.about": "About",
   "tab.agent": "Agent Service",
+  "tab.all": "All",
   "tab.apikey": "API Key Management",
   "tab.chatAppearance": "Chat Appearance",
   "tab.common": "Appearance",

--- a/locales/zh-CN/auth.json
+++ b/locales/zh-CN/auth.json
@@ -221,6 +221,7 @@
   "stats.updatedAt": "更新至",
   "stats.welcome": "{{username}}，这是你与 {{appName}} 一起记录协作的第 <span>{{days}}</span> 天",
   "stats.words": "累计字数",
+  "tab.all": "全部",
   "tab.apikey": "API Key",
   "tab.profile": "账号",
   "tab.security": "安全",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -544,6 +544,7 @@
   "systemAgent.translation.title": "消息内容翻译助理",
   "tab.about": "关于",
   "tab.agent": "助理服务",
+  "tab.all": "全部",
   "tab.apikey": "API Key 管理",
   "tab.chatAppearance": "聊天外观",
   "tab.common": "外观",

--- a/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
+++ b/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
@@ -174,6 +174,35 @@ export const mobileRoutes: RouteConfig[] = [
             element: dynamicElement(() => import('../settings'), 'Mobile > Settings'),
             index: true,
           },
+          // Provider routes with nested structure
+          {
+            children: [
+              {
+                element: redirectElement('/settings/provider/all'),
+                index: true,
+              },
+              {
+                element: dynamicElement(
+                  () => import('../../(main)/settings/provider').then((m) => m.ProviderDetailPage),
+                  'Mobile > Settings > Provider > Detail',
+                ),
+                path: ':providerId',
+              },
+            ],
+            element: dynamicElement(
+              () => import('../../(main)/settings/provider').then((m) => m.ProviderLayout),
+              'Mobile > Settings > Provider > Layout',
+            ),
+            path: 'provider',
+          },
+          // Other settings tabs (common, agent, memory, tts, about, etc.)
+          {
+            element: dynamicElement(
+              () => import('../../(main)/settings'),
+              'Mobile > Settings > Tab',
+            ),
+            path: ':tab',
+          },
         ],
         element: <MobileSettingsLayout />,
         errorElement: <ErrorBoundary resetPath="/settings" />,

--- a/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
+++ b/src/app/[variants]/(mobile)/router/mobileRouter.config.tsx
@@ -7,6 +7,7 @@ import MobileChatLayout from '@/app/[variants]/(mobile)/chat/_layout';
 import MobileMeHomeLayout from '@/app/[variants]/(mobile)/me/(home)/layout';
 import MobileMeProfileLayout from '@/app/[variants]/(mobile)/me/profile/layout';
 import MobileMeSettingsLayout from '@/app/[variants]/(mobile)/me/settings/layout';
+import MobileSettingsProviderLayout from '@/app/[variants]/(mobile)/settings/provider/_layout';
 import {
   BusinessMobileRoutesWithMainLayout,
   BusinessMobileRoutesWithoutMainLayout,
@@ -189,10 +190,7 @@ export const mobileRoutes: RouteConfig[] = [
                 path: ':providerId',
               },
             ],
-            element: dynamicElement(
-              () => import('../../(main)/settings/provider').then((m) => m.ProviderLayout),
-              'Mobile > Settings > Provider > Layout',
-            ),
+            element: <MobileSettingsProviderLayout />,
             path: 'provider',
           },
           // Other settings tabs (common, agent, memory, tts, about, etc.)

--- a/src/app/[variants]/(mobile)/settings/_layout/Header.tsx
+++ b/src/app/[variants]/(mobile)/settings/_layout/Header.tsx
@@ -4,10 +4,9 @@ import { Flexbox } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { enableAuth } from '@/envs/auth';
-import { useQueryState } from '@/hooks/useQueryParam';
 import { useShowMobileWorkspace } from '@/hooks/useShowMobileWorkspace';
 import { type SettingsTabs } from '@/store/global/initialState';
 import { useSessionStore } from '@/store/session';
@@ -17,26 +16,16 @@ const Header = memo(() => {
   const { t } = useTranslation('setting');
   const showMobileWorkspace = useShowMobileWorkspace();
   const navigate = useNavigate();
-  const [activeSettingsKey, setActiveSettingsKey] = useQueryState('active');
-  const [providerName, setProviderName] = useQueryState('provider');
+  const params = useParams<{ providerId?: string, tab?: string; }>();
 
   const isSessionActive = useSessionStore((s) => !!s.activeId);
-  const isProvider = providerName ? true : false;
+  const isProvider = params.providerId && params.providerId !== 'all';
 
   const handleBackClick = () => {
-    console.log(
-      'gobackclick',
-      isSessionActive,
-      showMobileWorkspace,
-      activeSettingsKey,
-      providerName,
-    );
     if (isSessionActive && showMobileWorkspace) {
       navigate('/agent');
-    } else if (activeSettingsKey === 'provider' && providerName) {
-      setProviderName(null);
-      setActiveSettingsKey('provider');
-      navigate(-1);
+    } else if (isProvider) {
+      navigate('/settings/provider/all');
     } else {
       navigate(enableAuth ? '/me/settings' : '/me');
     }
@@ -49,7 +38,9 @@ const Header = memo(() => {
           title={
             <Flexbox align={'center'} gap={8} horizontal>
               <span style={{ lineHeight: 1.2 }}>
-                {isProvider ? providerName : t(`tab.${activeSettingsKey as SettingsTabs}` as any)}
+                {isProvider
+                  ? params.providerId
+                  : t(`tab.${(params.tab || 'all') as SettingsTabs}` as any)}
               </span>
             </Flexbox>
           }

--- a/src/app/[variants]/(mobile)/settings/_layout/index.tsx
+++ b/src/app/[variants]/(mobile)/settings/_layout/index.tsx
@@ -3,7 +3,10 @@
 import { memo } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import MobileContentLayout from '@/components/server/MobileNavLayout';
+
 import SettingsContextProvider from '../../../(main)/settings/_layout/ContextProvider';
+import Header from './Header';
 
 const MobileSettingsWrapper = memo(() => {
   return (
@@ -13,7 +16,9 @@ const MobileSettingsWrapper = memo(() => {
         showOpenAIProxyUrl: true,
       }}
     >
-      <Outlet />
+      <MobileContentLayout header={<Header />}>
+        <Outlet />
+      </MobileContentLayout>
     </SettingsContextProvider>
   );
 });

--- a/src/app/[variants]/(mobile)/settings/provider/_layout/index.tsx
+++ b/src/app/[variants]/(mobile)/settings/provider/_layout/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+
+import ProviderMenu from '../../../../(main)/settings/provider/ProviderMenu';
+
+const Layout = () => {
+  const params = useParams<{ providerId: string }>();
+  const navigate = useNavigate();
+
+  const handleProviderSelect = (providerKey: string) => {
+    navigate(`/settings/provider/${providerKey}`);
+  };
+
+  return params.providerId === 'all' ? (
+    <ProviderMenu mobile={true} onProviderSelect={handleProviderSelect} />
+  ) : (
+    <Outlet />
+  );
+};
+
+export default Layout;

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -622,6 +622,7 @@ export default {
   'systemAgent.translation.title': 'Message Translation Agent',
   'tab.about': 'About',
   'tab.agent': 'Agent Service',
+  'tab.all': 'All',
   'tab.apikey': 'API Key Management',
   'tab.chatAppearance': 'Chat Appearance',
   'tab.common': 'Appearance',


### PR DESCRIPTION
#### 💻 Change Type

fixed LOBE-2513

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix mobile settings routing so provider details and other settings tabs are accessible in the PWA.

Bug Fixes:
- Add nested provider layout and detail routes under mobile settings to correctly open provider pages.
- Add generic tab route under mobile settings to restore navigation to other settings sections (e.g. agents, memory, tts, about).