### PR TITLE
🐛 fix(model-runtime): filter unsupported image types (SVG) before sending to vision models

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -125,6 +125,44 @@ describe('anthropicHelpers', () => {
 
       await expect(buildAnthropicBlock(content)).rejects.toThrow('Invalid image URL: invalid-url');
     });
+
+    it('should return undefined for unsupported SVG image (base64)', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: 'image/svg+xml',
+        base64: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==',
+        type: 'base64',
+      });
+
+      const content = {
+        type: 'image_url',
+        image_url: {
+          url: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==',
+        },
+      } as const;
+
+      const result = await buildAnthropicBlock(content);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for unsupported SVG image (URL)', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: null,
+        base64: null,
+        type: 'url',
+      });
+      vi.mocked(imageUrlToBase64).mockResolvedValueOnce({
+        base64: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==',
+        mimeType: 'image/svg+xml',
+      });
+
+      const content = {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/image.svg' },
+      } as const;
+
+      const result = await buildAnthropicBlock(content);
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('buildAnthropicMessage', () => {

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -149,6 +149,48 @@ describe('google contextBuilders', () => {
         thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
       });
     });
+
+    it('should return undefined for unsupported SVG image (base64)', async () => {
+      const svgBase64 =
+        'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==';
+
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        base64: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==',
+        mimeType: 'image/svg+xml',
+        type: 'base64',
+      });
+
+      const content: UserMessageContentPart = {
+        image_url: { url: svgBase64 },
+        type: 'image_url',
+      };
+
+      const result = await buildGooglePart(content);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for unsupported SVG image (URL)', async () => {
+      const svgUrl = 'https://example.com/image.svg';
+
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        base64: null,
+        mimeType: null,
+        type: 'url',
+      });
+
+      vi.spyOn(imageToBase64Module, 'imageUrlToBase64').mockResolvedValueOnce({
+        base64: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==',
+        mimeType: 'image/svg+xml',
+      });
+
+      const content: UserMessageContentPart = {
+        image_url: { url: svgUrl },
+        type: 'image_url',
+      };
+
+      const result = await buildGooglePart(content);
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('buildGoogleMessage', () => {

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -11,6 +11,19 @@ import { ChatCompletionTool, OpenAIChatMessage, UserMessageContentPart } from '.
 import { safeParseJSON } from '../../utils/safeParseJSON';
 import { parseDataUri } from '../../utils/uriParser';
 
+const GOOGLE_SUPPORTED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+const isImageTypeSupported = (mimeType: string | null): boolean => {
+  if (!mimeType) return true;
+  return GOOGLE_SUPPORTED_IMAGE_TYPES.has(mimeType.toLowerCase());
+};
+
 /**
  * Magic thoughtSignature
  * @see https://ai.google.dev/gemini-api/docs/thought-signatures#model-behavior:~:text=context_engineering_is_the_way_to_go
@@ -43,6 +56,8 @@ export const buildGooglePart = async (
           throw new TypeError("Image URL doesn't contain base64 data");
         }
 
+        if (!isImageTypeSupported(mimeType)) return undefined;
+
         return {
           inlineData: { data: base64, mimeType: mimeType || 'image/png' },
           thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
@@ -51,6 +66,8 @@ export const buildGooglePart = async (
 
       if (type === 'url') {
         const { base64, mimeType } = await imageUrlToBase64(content.image_url.url);
+
+        if (!isImageTypeSupported(mimeType)) return undefined;
 
         return {
           inlineData: { data: base64, mimeType },


### PR DESCRIPTION
## Summary

- Filter out unsupported image formats (like SVG) in model-runtime before sending to vision models
- Add supported image types validation in Anthropic and Google context builders
- Return `undefined` for unsupported formats, which gets filtered out by existing `filter(Boolean)` logic

## Problem

Vision models like Claude and Gemini don't support SVG images (`image/svg+xml`). Previously, SVG images were converted to base64 and passed through unchanged, causing runtime errors when the model API rejected the unsupported format.

## Solution

Added MIME type validation at the context builder level:

**Supported formats:**
- `image/jpeg`
- `image/jpg`
- `image/png`
- `image/gif`
- `image/webp`

**Unsupported formats (filtered out):**
- `image/svg+xml`
- Any other non-standard image formats

## Changes

- `packages/model-runtime/src/core/contextBuilders/anthropic.ts`: Add image type validation
- `packages/model-runtime/src/core/contextBuilders/google.ts`: Add image type validation
- `packages/model-runtime/src/core/contextBuilders/anthropic.test.ts`: Add 2 test cases
- `packages/model-runtime/src/core/contextBuilders/google.test.ts`: Add 2 test cases

## Test plan

- [x] Added test for SVG base64 image filtering (Anthropic)
- [x] Added test for SVG URL image filtering (Anthropic)
- [x] Added test for SVG base64 image filtering (Google)
- [x] Added test for SVG URL image filtering (Google)
- [x] All 60 context builder tests pass
- [x] Type check passes

## Related Issues

Closes: LOBE-4125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Filter unsupported image formats from vision model context builders to avoid runtime errors when sending images to Anthropic and Google models.

Bug Fixes:
- Skip building context blocks/parts for unsupported image MIME types (such as SVG) in Anthropic and Google context builders, returning undefined so they are filtered out before reaching the model APIs.

Tests:
- Add Anthropic and Google context builder tests to assert SVG images (base64 and URL) are treated as unsupported and omitted from the built context.