### PR TITLE
fix: Cannot view PDF

### DIFF
--- a/src/app/[variants]/(main)/resource/(home)/index.tsx
+++ b/src/app/[variants]/(main)/resource/(home)/index.tsx
@@ -1,28 +1,20 @@
 'use client';
 
-import { memo, useEffect, useLayoutEffect } from 'react';
+import { memo, useLayoutEffect } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import ResourceManager from '@/features/ResourceManager';
-import { documentSelectors, useFileStore } from '@/store/file';
 import { FilesTabs } from '@/types/files';
 
+import { useInitFileCheck } from '../features/hooks/useInitFileCheck';
 import { useResourceManagerStore } from '../features/store';
 
 const ResourceHomePage = memo(() => {
   const [searchParams] = useSearchParams();
   const location = useLocation();
-  const [setMode, setCurrentViewItemId, setCategory, setLibraryId] = useResourceManagerStore(
-    (s) => [s.setMode, s.setCurrentViewItemId, s.setCategory, s.setLibraryId],
-  );
+  const [setCategory, setLibraryId] = useResourceManagerStore((s) => [s.setCategory, s.setLibraryId]);
 
   const categoryParam = (searchParams.get('category') as FilesTabs) || FilesTabs.All;
-  const fileId = searchParams.get('file');
-
-  // Fetch file or document details to determine correct mode
-  const useFetchKnowledgeItem = useFileStore((s) => s.useFetchKnowledgeItem);
-  const { data: fileData } = useFetchKnowledgeItem(fileId || undefined);
-  const documentData = useFileStore(documentSelectors.getDocumentById(fileId || undefined));
 
   // Clear libraryId when on home route using useLayoutEffect
   // useLayoutEffect runs synchronously before browser paint, ensuring state is cleared
@@ -31,7 +23,8 @@ const ResourceHomePage = memo(() => {
   // When location changes to /resource, clear libraryId
   // Don't clear when location is /library/* (even if this component is still mounted)
   useLayoutEffect(() => {
-    const isOnHomeRoute = location.pathname === '/resource' || !location.pathname.includes('/library/');
+    const isOnHomeRoute =
+      location.pathname === '/resource' || !location.pathname.includes('/library/');
     if (isOnHomeRoute) {
       setLibraryId(undefined);
     }
@@ -40,52 +33,15 @@ const ResourceHomePage = memo(() => {
   // Sync category from URL using useLayoutEffect
   // IMPORTANT: Only sync if we're actually on the home route (not transitioning to library)
   useLayoutEffect(() => {
-    const isOnHomeRoute = location.pathname === '/resource' || !location.pathname.includes('/library/');
+    const isOnHomeRoute =
+      location.pathname === '/resource' || !location.pathname.includes('/library/');
     if (isOnHomeRoute) {
       setCategory(categoryParam);
     }
   }, [categoryParam, setCategory, location.pathname]);
 
   // Sync file view mode from URL
-  useEffect(() => {
-    if (fileId) {
-      setCurrentViewItemId(fileId);
-
-      // Only determine mode when we have file data loaded
-      // This prevents incorrect mode being set while data is loading
-      if (fileData || documentData) {
-        // Check if it's a PDF file - check both file data and document data
-        const isPDF =
-          fileData?.fileType?.toLowerCase() === 'pdf' ||
-          fileData?.fileType?.toLowerCase() === 'application/pdf' ||
-          fileData?.name?.toLowerCase().endsWith('.pdf') ||
-          documentData?.fileType?.toLowerCase() === 'pdf' ||
-          documentData?.fileType?.toLowerCase() === 'application/pdf' ||
-          documentData?.filename?.toLowerCase().endsWith('.pdf');
-
-        // Check if it's a page/document
-        const isPage =
-          !isPDF &&
-          (fileData?.sourceType === 'document' ||
-            fileData?.fileType === 'custom/document' ||
-            !!documentData);
-
-        // Determine mode based on file type
-        if (isPDF) {
-          // PDF files should always use editor mode for PDF viewer
-          setMode('editor');
-        } else if (isPage) {
-          setMode('page');
-        } else {
-          setMode('editor');
-        }
-      }
-    } else {
-      // Reset to explorer mode when no file is selected
-      setMode('explorer');
-      setCurrentViewItemId(undefined);
-    }
-  }, [fileId, fileData, documentData, setCurrentViewItemId, setMode]);
+  useInitFileCheck();
 
   return <ResourceManager />;
 });

--- a/src/app/[variants]/(main)/resource/features/hooks/useInitFileCheck.ts
+++ b/src/app/[variants]/(main)/resource/features/hooks/useInitFileCheck.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { documentSelectors, useFileStore } from '@/store/file';
+
+import { useResourceManagerStore } from '../store';
+
+/**
+ * Used for initial loading only, handle URL like:
+ *
+ * /resource?file=xxxxxx
+ */
+export const useInitFileCheck = () => {
+  const [searchParams] = useSearchParams();
+  const [setMode, setCurrentViewItemId] = useResourceManagerStore((s) => [
+    s.setMode,
+    s.setCurrentViewItemId,
+  ]);
+
+  const fileId = searchParams.get('file');
+
+  const useFetchKnowledgeItem = useFileStore((s) => s.useFetchKnowledgeItem);
+  const { data: fileData } = useFetchKnowledgeItem(fileId || undefined);
+  const documentData = useFileStore(documentSelectors.getDocumentById(fileId || undefined));
+
+  useEffect(() => {
+    if (fileId) {
+      setCurrentViewItemId(fileId);
+
+      if (fileData || documentData) {
+        const isPDF =
+          fileData?.fileType?.toLowerCase() === 'pdf' ||
+          fileData?.fileType?.toLowerCase() === 'application/pdf' ||
+          fileData?.name?.toLowerCase().endsWith('.pdf') ||
+          documentData?.fileType?.toLowerCase() === 'pdf' ||
+          documentData?.fileType?.toLowerCase() === 'application/pdf' ||
+          documentData?.filename?.toLowerCase().endsWith('.pdf') ||
+          documentData?.source?.toLowerCase().endsWith('.pdf');
+
+        const isPage =
+          !isPDF &&
+          (fileData?.sourceType === 'document' ||
+            fileData?.fileType === 'custom/document' ||
+            !!documentData);
+
+        if (isPDF) {
+          setMode('editor');
+        } else if (isPage) {
+          setMode('page');
+        } else {
+          setMode('editor');
+        }
+      }
+    } else {
+      setMode('explorer');
+      setCurrentViewItemId(undefined);
+    }
+  }, [fileId, fileData, documentData]);
+};

--- a/src/app/[variants]/(main)/resource/library/index.tsx
+++ b/src/app/[variants]/(main)/resource/library/index.tsx
@@ -1,32 +1,20 @@
 'use client';
 
-import { memo, useEffect, useLayoutEffect } from 'react';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { memo, useLayoutEffect } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 
 import Container from '@/app/[variants]/(main)/resource/library/features/Container';
 import NProgress from '@/components/NProgress';
 import ResourceManager from '@/features/ResourceManager';
-import { documentSelectors, useFileStore } from '@/store/file';
 
+import { useInitFileCheck } from '../features/hooks/useInitFileCheck';
 import { useKnowledgeBaseItem } from '../features/hooks/useKnowledgeItem';
 import { useResourceManagerStore } from '../features/store';
 
 const MainContent = memo(() => {
   const { id: knowledgeBaseId } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
   const location = useLocation();
-  const [setMode, setCurrentViewItemId, setLibraryId] = useResourceManagerStore((s) => [
-    s.setMode,
-    s.setCurrentViewItemId,
-    s.setLibraryId,
-  ]);
-
-  const fileId = searchParams.get('file');
-
-  // Fetch file or document details to determine correct mode
-  const useFetchKnowledgeItem = useFileStore((s) => s.useFetchKnowledgeItem);
-  const { data: fileData } = useFetchKnowledgeItem(fileId || undefined);
-  const documentData = useFileStore(documentSelectors.getDocumentById(fileId || undefined));
+  const setLibraryId = useResourceManagerStore((s) => s.setLibraryId);
 
   // Load knowledge base data
   useKnowledgeBaseItem(knowledgeBaseId || '');
@@ -43,45 +31,7 @@ const MainContent = memo(() => {
   }, [knowledgeBaseId, setLibraryId, location.pathname]);
 
   // Sync file view mode from URL
-  useEffect(() => {
-    if (fileId) {
-      setCurrentViewItemId(fileId);
-
-      // Only determine mode when we have file data loaded
-      // This prevents incorrect mode being set while data is loading
-      if (fileData || documentData) {
-        // Check if it's a PDF file - check both file data and document data
-        const isPDF =
-          fileData?.fileType?.toLowerCase() === 'pdf' ||
-          fileData?.fileType?.toLowerCase() === 'application/pdf' ||
-          fileData?.name?.toLowerCase().endsWith('.pdf') ||
-          documentData?.fileType?.toLowerCase() === 'pdf' ||
-          documentData?.fileType?.toLowerCase() === 'application/pdf' ||
-          documentData?.filename?.toLowerCase().endsWith('.pdf');
-
-        // Check if it's a page/document
-        const isPage =
-          !isPDF &&
-          (fileData?.sourceType === 'document' ||
-            fileData?.fileType === 'custom/document' ||
-            !!documentData);
-
-        // Determine mode based on file type
-        if (isPDF) {
-          // PDF files should always use editor mode for PDF viewer
-          setMode('editor');
-        } else if (isPage) {
-          setMode('page');
-        } else {
-          setMode('editor');
-        }
-      }
-    } else {
-      // Reset to explorer mode when no file is selected
-      setMode('explorer');
-      setCurrentViewItemId(undefined);
-    }
-  }, [fileId, fileData, documentData, setCurrentViewItemId, setMode]);
+  useInitFileCheck();
 
   return <ResourceManager />;
 });

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -224,6 +224,8 @@ export const fileRouter = router({
       limit: limit + 1,
     });
 
+    console.log('getKnow', knowledgeItems);
+
     // Check if there are more items
     const hasMore = knowledgeItems.length > limit;
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Extract initial file-view routing logic into a shared hook and update resource pages to use it, improving PDF detection and view mode initialization based on URL parameters.

Bug Fixes:
- Ensure PDFs and document pages linked via the file query parameter open in the appropriate viewer mode on initial load.

Enhancements:
- Introduce a reusable useInitFileCheck hook to centralize file-based mode selection for resource and library views.
- Refine PDF detection logic by including additional metadata checks such as document source extension.

Chores:
- Add temporary logging of knowledge item retrievals on the file router for debugging.