### PR TITLE
💄 style: support more Qwen i2i & t2i models

### DIFF
--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2491,6 +2491,30 @@ const qwenImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   {
+    description: 'Wanxiang 2.5 I2I Preview supports single-image editing and multi-image fusion.',
+    displayName: 'Wanxiang2.5 I2I Preview',
+    enabled: true,
+    id: 'wan2.5-i2i-preview',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1280, min: 768, step: 1 },
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1280, min: 768, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-09-23',
+    type: 'image',
+  },
+  {
     description:
       'Wanxiang 2.5 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints.',
     displayName: 'Wanxiang2.5 T2I Preview',

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -1130,8 +1130,8 @@ const qwenChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      search: true,
       reasoning: true,
+      search: true,
     },
     contextWindowTokens: 262_144,
     description:
@@ -2353,6 +2353,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
     displayName: 'Qwen Image Edit',
+    enabled: true,
     id: 'qwen-image-edit',
     organization: 'Qwen',
     parameters: {
@@ -2423,6 +2424,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
     displayName: 'Qwen Image',
+    enabled: true,
     id: 'qwen-image',
     organization: 'Qwen',
     parameters: {
@@ -2557,6 +2559,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Wanxiang 2.2 Plus is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
     displayName: 'Wanxiang2.2 T2I Plus',
+    enabled: true,
     id: 'wan2.2-t2i-plus',
     organization: 'Qwen',
     parameters: {
@@ -2661,6 +2664,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1 [schnell] is the most advanced open-source few-step model, surpassing similar competitors and even strong non-distilled models like Midjourney v6.0 and DALL-E 3 (HD). It is finely tuned to preserve pretraining diversity, significantly improving visual quality, instruction following, size/aspect variation, font handling, and output diversity.',
     displayName: 'FLUX.1 [schnell]',
+    enabled: true,
     id: 'flux-schnell',
     organization: 'Qwen',
     parameters: {
@@ -2685,6 +2689,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1 [dev] is an open-weights distilled model for non-commercial use. It keeps near-pro image quality and instruction following while running more efficiently, using resources better than same-size standard models.',
     displayName: 'FLUX.1 [dev]',
+    enabled: true,
     id: 'flux-dev',
     organization: 'Qwen',
     parameters: {
@@ -2709,6 +2714,7 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1-merged combines the deep features explored in "DEV" with the high-speed advantages of "Schnell", extending performance limits and broadening applications.',
     displayName: 'FLUX.1-merged',
+    enabled: true,
     id: 'flux-merged',
     organization: 'Qwen',
     parameters: {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2289,12 +2289,12 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'z-image-turbo',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1536, max: 2048, min: 512, step: 1 },
+      height: { default: 1536, max: 4096, min: 256, step: 1 },
       prompt: {
         default: '',
       },
       seed: { default: null },
-      width: { default: 1024, max: 2048, min: 512, step: 1 },
+      width: { default: 1024, max: 4096, min: 256, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2311,6 +2311,7 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'qwen-image-edit-max',
     organization: 'Qwen',
     parameters: {
+      height: { default: 1536, max: 2048, min: 512, step: 1 },
       imageUrls: {
         default: [],
       },
@@ -2318,6 +2319,7 @@ const qwenImageModels: AIImageModelCard[] = [
         default: '',
       },
       seed: { default: null },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2334,6 +2336,7 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'qwen-image-edit-plus',
     organization: 'Qwen',
     parameters: {
+      height: { default: 1536, max: 2048, min: 512, step: 1 },
       imageUrls: {
         default: [],
       },
@@ -2341,6 +2344,7 @@ const qwenImageModels: AIImageModelCard[] = [
         default: '',
       },
       seed: { default: null },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2451,7 +2455,7 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'wan2.6-image',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1280, max: 1280, min: 768, step: 1 },
+      height: { default: 1280, max: 2880, min: 640, step: 1 },
       imageUrls: {
         default: [],
       },
@@ -2459,7 +2463,7 @@ const qwenImageModels: AIImageModelCard[] = [
         default: '',
       },
       seed: { default: null },
-      width: { default: 1280, max: 1280, min: 768, step: 1 },
+      width: { default: 1280, max: 2880, min: 640, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2476,12 +2480,12 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'wan2.6-t2i',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      height: { default: 1280, max: 2880, min: 640, step: 1 },
       prompt: {
         default: '',
       },
       seed: { default: null },
-      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+      width: { default: 1280, max: 2880, min: 640, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2496,7 +2500,7 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'wan2.5-i2i-preview',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1280, max: 1280, min: 768, step: 1 },
+      height: { default: 1280, max: 2560, min: 384, step: 1 },
       imageUrls: {
         default: [],
       },
@@ -2504,7 +2508,7 @@ const qwenImageModels: AIImageModelCard[] = [
         default: '',
       },
       seed: { default: null },
-      width: { default: 1280, max: 1280, min: 768, step: 1 },
+      width: { default: 1280, max: 2560, min: 384, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -2520,12 +2524,12 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'wan2.5-t2i-preview',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      height: { default: 1280, max: 2880, min: 640, step: 1 },
       prompt: {
         default: '',
       },
       seed: { default: null },
-      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+      width: { default: 1280, max: 2880, min: 640, step: 1 },
     },
     pricing: {
       currency: 'CNY',

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2284,6 +2284,74 @@ const qwenImageModels: AIImageModelCard[] = [
   {
     description:
       'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Z-Image Turbo',
+    enabled: true,
+    id: 'z-image-turbo',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-16',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Qwen Image Edit Max',
+    enabled: true,
+    id: 'qwen-image-edit-max',
+    organization: 'Qwen',
+    parameters: {
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-16',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Qwen Image Edit Plus',
+    enabled: true,
+    id: 'qwen-image-edit-plus',
+    organization: 'Qwen',
+    parameters: {
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-10-30',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
     displayName: 'Qwen Image Edit',
     enabled: true,
     id: 'qwen-image-edit',
@@ -2302,6 +2370,54 @@ const qwenImageModels: AIImageModelCard[] = [
       units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-09-18',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+    displayName: 'Qwen Image Max',
+    enabled: true,
+    id: 'qwen-image-max',
+    organization: 'Qwen',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1664x928',
+        enum: ['1664x928', '1472x1140', '1328x1328', '1140x1472', '928x1664'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-12-30',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+    displayName: 'Qwen Image Plus',
+    enabled: true,
+    id: 'qwen-image-plus',
+    organization: 'Qwen',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1664x928',
+        enum: ['1664x928', '1472x1140', '1328x1328', '1140x1472', '928x1664'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-09',
     type: 'image',
   },
   {
@@ -2326,6 +2442,72 @@ const qwenImageModels: AIImageModelCard[] = [
       units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-08-13',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.6 Image',
+    enabled: true,
+    id: 'wan2.6-image',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1280, min: 768, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1280, min: 768, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.6 T2I',
+    enabled: true,
+    id: 'wan2.6-t2i',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.5 T2I Preview',
+    enabled: true,
+    id: 'wan2.5-t2i-preview',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
     type: 'image',
   },
   {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2311,8 +2311,8 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'qwen-image-edit-max',
     organization: 'Qwen',
     parameters: {
-      imageUrl: {
-        default: '',
+      imageUrls: {
+        default: [],
       },
       prompt: {
         default: '',
@@ -2334,8 +2334,8 @@ const qwenImageModels: AIImageModelCard[] = [
     id: 'qwen-image-edit-plus',
     organization: 'Qwen',
     parameters: {
-      imageUrl: {
-        default: '',
+      imageUrls: {
+        default: [],
       },
       prompt: {
         default: '',
@@ -2452,8 +2452,8 @@ const qwenImageModels: AIImageModelCard[] = [
     organization: 'Qwen',
     parameters: {
       height: { default: 1280, max: 1280, min: 768, step: 1 },
-      imageUrl: {
-        default: '',
+      imageUrls: {
+        default: [],
       },
       prompt: {
         default: '',
@@ -2497,8 +2497,8 @@ const qwenImageModels: AIImageModelCard[] = [
     organization: 'Qwen',
     parameters: {
       height: { default: 1280, max: 1280, min: 768, step: 1 },
-      imageUrl: {
-        default: '',
+      imageUrls: {
+        default: [],
       },
       prompt: {
         default: '',

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2353,7 +2353,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
     displayName: 'Qwen Image Edit',
-    enabled: true,
     id: 'qwen-image-edit',
     organization: 'Qwen',
     parameters: {
@@ -2424,7 +2423,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
     displayName: 'Qwen Image',
-    enabled: true,
     id: 'qwen-image',
     organization: 'Qwen',
     parameters: {
@@ -2493,7 +2491,6 @@ const qwenImageModels: AIImageModelCard[] = [
   {
     description: 'Wanxiang 2.5 I2I Preview supports single-image editing and multi-image fusion.',
     displayName: 'Wanxiang2.5 I2I Preview',
-    enabled: true,
     id: 'wan2.5-i2i-preview',
     organization: 'Qwen',
     parameters: {
@@ -2518,7 +2515,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Wanxiang 2.5 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints.',
     displayName: 'Wanxiang2.5 T2I Preview',
-    enabled: true,
     id: 'wan2.5-t2i-preview',
     organization: 'Qwen',
     parameters: {
@@ -2540,7 +2536,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Wanxiang 2.2 Flash is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
     displayName: 'Wanxiang2.2 T2I Flash',
-    enabled: true,
     id: 'wan2.2-t2i-flash',
     organization: 'Qwen',
     parameters: {
@@ -2562,7 +2557,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'Wanxiang 2.2 Plus is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
     displayName: 'Wanxiang2.2 T2I Plus',
-    enabled: true,
     id: 'wan2.2-t2i-plus',
     organization: 'Qwen',
     parameters: {
@@ -2667,7 +2661,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1 [schnell] is the most advanced open-source few-step model, surpassing similar competitors and even strong non-distilled models like Midjourney v6.0 and DALL-E 3 (HD). It is finely tuned to preserve pretraining diversity, significantly improving visual quality, instruction following, size/aspect variation, font handling, and output diversity.',
     displayName: 'FLUX.1 [schnell]',
-    enabled: true,
     id: 'flux-schnell',
     organization: 'Qwen',
     parameters: {
@@ -2692,7 +2685,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1 [dev] is an open-weights distilled model for non-commercial use. It keeps near-pro image quality and instruction following while running more efficiently, using resources better than same-size standard models.',
     displayName: 'FLUX.1 [dev]',
-    enabled: true,
     id: 'flux-dev',
     organization: 'Qwen',
     parameters: {
@@ -2717,7 +2709,6 @@ const qwenImageModels: AIImageModelCard[] = [
     description:
       'FLUX.1-merged combines the deep features explored in "DEV" with the high-speed advantages of "Schnell", extending performance limits and broadening applications.',
     displayName: 'FLUX.1-merged',
-    enabled: true,
     id: 'flux-merged',
     organization: 'Qwen',
     parameters: {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2283,13 +2283,13 @@ const qwenChatModels: AIChatModelCard[] = [
 const qwenImageModels: AIImageModelCard[] = [
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Z-Image is a lightweight text-to-image generation model that can rapidly produce images, supports both Chinese and English text rendering, and flexibly adapts to multiple resolutions and aspect ratios.',
     displayName: 'Z-Image Turbo',
     enabled: true,
     id: 'z-image-turbo',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      height: { default: 1536, max: 2048, min: 512, step: 1 },
       prompt: {
         default: '',
       },
@@ -2298,14 +2298,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.1, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-16',
+    releasedAt: '2025-12-19',
     type: 'image',
   },
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Qwen Image Editing Model supports multi-image input and multi-image output, enabling precise in-image text editing, object addition, removal, or relocation, subject action modification, image style transfer, and enhanced visual detail.',
     displayName: 'Qwen Image Edit Max',
     enabled: true,
     id: 'qwen-image-edit-max',
@@ -2321,14 +2321,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.5, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-16',
+    releasedAt: '2026-01-17',
     type: 'image',
   },
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Qwen Image Editing Model supports multi-image input and multi-image output, enabling precise in-image text editing, object addition, removal, or relocation, subject action modification, image style transfer, and enhanced visual detail.',
     displayName: 'Qwen Image Edit Plus',
     enabled: true,
     id: 'qwen-image-edit-plus',
@@ -2344,9 +2344,9 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-10-30',
+    releasedAt: '2025-12-23',
     type: 'image',
   },
   {
@@ -2374,7 +2374,7 @@ const qwenImageModels: AIImageModelCard[] = [
   },
   {
     description:
-      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+      'Qwen Image Generation Model (Max series) delivers enhanced realism and visual naturalness compared with the Plus series, effectively reducing AI-generated artifacts, and demonstrating outstanding performance in human appearance, texture details, and text rendering.',
     displayName: 'Qwen Image Max',
     enabled: true,
     id: 'qwen-image-max',
@@ -2391,14 +2391,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.5, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-12-30',
+    releasedAt: '2025-12-31',
     type: 'image',
   },
   {
     description:
-      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+      'It supports a wide range of artistic styles and is particularly proficient at rendering complex text within images, enabling integrated image–text layout design.',
     displayName: 'Qwen Image Plus',
     enabled: true,
     id: 'qwen-image-plus',
@@ -2415,9 +2415,9 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-09',
+    releasedAt: '2026-01-12',
     type: 'image',
   },
   {
@@ -2445,14 +2445,16 @@ const qwenImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   {
-    description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    description: 'Wanxiang 2.6 Image supports image editing and mixed image–text layout output.',
     displayName: 'Wanxiang2.6 Image',
     enabled: true,
     id: 'wan2.6-image',
     organization: 'Qwen',
     parameters: {
       height: { default: 1280, max: 1280, min: 768, step: 1 },
+      imageUrl: {
+        default: '',
+      },
       prompt: {
         default: '',
       },
@@ -2461,14 +2463,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-07-28',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.6 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints (same as Wanxiang 2.5).',
     displayName: 'Wanxiang2.6 T2I',
     enabled: true,
     id: 'wan2.6-t2i',
@@ -2483,14 +2485,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-07-28',
+    releasedAt: '2025-12-16',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.5 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints.',
     displayName: 'Wanxiang2.5 T2I Preview',
     enabled: true,
     id: 'wan2.5-t2i-preview',
@@ -2505,14 +2507,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-07-28',
+    releasedAt: '2025-09-23',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.2 Flash is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
     displayName: 'Wanxiang2.2 T2I Flash',
     enabled: true,
     id: 'wan2.2-t2i-flash',
@@ -2534,7 +2536,7 @@ const qwenImageModels: AIImageModelCard[] = [
   },
   {
     description:
-      'Wanxiang 2.2 Pro is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
+      'Wanxiang 2.2 Plus is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
     displayName: 'Wanxiang2.2 T2I Plus',
     enabled: true,
     id: 'wan2.2-t2i-plus',

--- a/packages/model-runtime/src/providers/qwen/createImage.test.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.test.ts
@@ -658,23 +658,6 @@ describe('createQwenImage', () => {
       });
     });
 
-    it('should throw error when imageUrl is missing for qwen-image-edit', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          // imageUrl is missing
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
-      );
-    });
-
     it('should handle qwen-image-edit API errors', async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: false,
@@ -787,23 +770,6 @@ describe('createQwenImage', () => {
       expect(body.input.messages[0].content[0].image).toBe('https://example.com/first-image.jpg');
     });
 
-    it('should throw error when imageUrls is empty array', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          imageUrls: [], // Empty array
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
-      );
-    });
-
     it('should prioritize imageUrl over imageUrls when both are provided', async () => {
       const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/priority-test.jpg';
 
@@ -843,23 +809,6 @@ describe('createQwenImage', () => {
       // Should use imageUrl, not imageUrls
       expect(body.input.messages[0].content[0].image).toBe(
         'https://example.com/priority-image.jpg',
-      );
-    });
-
-    it('should throw error when neither imageUrl nor imageUrls are provided', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          // Neither imageUrl nor imageUrls provided
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
       );
     });
   });

--- a/packages/model-runtime/src/providers/qwen/createImage.test.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
-import type { CreateImagePayload } from '../../types/image';
+import { type CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import { type CreateImagePayload } from '../../types/image';
 import { createQwenImage } from './createImage';
 
 // Mock the console.error to avoid polluting test output
@@ -23,6 +23,109 @@ afterEach(() => {
 });
 
 describe('createQwenImage', () => {
+  describe('Base URL handling', () => {
+    it('should use intl baseURL when provided', async () => {
+      const mockTaskId = 'task-123456';
+      const mockImageUrl = 'https://example.com/test-image.jpg';
+      const intlBaseUrl = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+
+      // Mock fetch for task creation and immediate success
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: { task_id: mockTaskId },
+            request_id: 'req-123',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: {
+              task_id: mockTaskId,
+              task_status: 'SUCCEEDED',
+              results: [{ url: mockImageUrl }],
+            },
+            request_id: 'req-124',
+          }),
+        });
+
+      const payload: CreateImagePayload = {
+        model: 'wanx-v1',
+        params: {
+          prompt: 'Test image',
+        },
+      };
+
+      const optionsWithCustomUrl: CreateImageOptions = {
+        apiKey: 'test-api-key',
+        provider: 'qwen',
+        baseURL: intlBaseUrl,
+      };
+
+      const result = await createQwenImage(payload, optionsWithCustomUrl);
+
+      // Verify the custom base URL is used (without /compatible-mode/v1)
+      expect(fetch).toHaveBeenCalledWith(
+        'https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis',
+        expect.any(Object),
+      );
+
+      // Verify the task status query also uses the custom base URL
+      expect(fetch).toHaveBeenCalledWith(
+        'https://dashscope-intl.aliyuncs.com/api/v1/tasks/task-123456',
+        expect.any(Object),
+      );
+
+      expect(result).toEqual({ imageUrl: mockImageUrl });
+    });
+
+    it('should use default baseURL when not provided', async () => {
+      const mockTaskId = 'task-123456';
+      const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/test-image.jpg';
+
+      // Mock fetch for task creation and immediate success
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: { task_id: mockTaskId },
+            request_id: 'req-123',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: {
+              task_id: mockTaskId,
+              task_status: 'SUCCEEDED',
+              results: [{ url: mockImageUrl }],
+            },
+            request_id: 'req-124',
+          }),
+        });
+
+      const payload: CreateImagePayload = {
+        model: 'wanx-v1',
+        params: {
+          prompt: 'Test image',
+        },
+      };
+
+      const result = await createQwenImage(payload, mockOptions);
+
+      // Verify the default base URL is used
+      expect(fetch).toHaveBeenCalledWith(
+        'https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis',
+        expect.any(Object),
+      );
+
+      expect(result).toEqual({ imageUrl: mockImageUrl });
+    });
+  });
+
   describe('Success scenarios', () => {
     it('should successfully generate image with immediate success', async () => {
       const mockTaskId = 'task-123456';

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -144,14 +144,12 @@ async function createMultimodalGeneration(
   const endpoint = `https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`;
   log('Creating image with model: %s, endpoint: %s', model, endpoint);
 
-  const content: Array<{ image: string } | { text: string }> = [{ text: params.prompt }];
+  const content: Array<{ image: string | string[] } | { text: string }> = [{ text: params.prompt }];
 
   if (params.imageUrl) {
     content.unshift({ image: params.imageUrl });
-    log('Using imageUrl for image-to-image generation');
   } else if (params.imageUrls && params.imageUrls.length > 0) {
-    content.unshift({ image: params.imageUrls[0] });
-    log('Using first imageUrls for image-to-image generation');
+    content.unshift({ image: params.imageUrls });
   }
 
   const response = await fetch(endpoint, {

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -1,8 +1,8 @@
 import createDebug from 'debug';
 
-import { type CreateImageOptions } from '../../core/openaiCompatibleFactory';
-import { type CreateImagePayload, type CreateImageResponse } from '../../types/image';
-import { type TaskResult } from '../../utils/asyncifyPolling';
+import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import type { TaskResult } from '../../utils/asyncifyPolling';
 import { asyncifyPolling } from '../../utils/asyncifyPolling';
 import { AgentRuntimeError } from '../../utils/createError';
 

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -116,7 +116,7 @@ async function createQwenImageTask(
       // Failed to parse JSON error response
     }
     throw new Error(
-      `Failed to create ${endpoint} task (${response.status}): ${errorData?.message || response.statusText}`,
+      `Failed to create ${endpoint} task for model ${model} (${response.status}): ${errorData?.message || response.statusText}`,
     );
   }
 
@@ -179,24 +179,24 @@ async function createMultimodalGeneration(
       // Failed to parse JSON error response
     }
     throw new Error(
-      `Failed to create image (${response.status}): ${errorData?.message || response.statusText}`,
+      `Failed to create image for model ${model} (${response.status}): ${errorData?.message || response.statusText}`,
     );
   }
 
   const data: QwenMultimodalGenerationResponse = await response.json();
 
   if (!data.output.choices || data.output.choices.length === 0) {
-    throw new Error('No image choices returned from API');
+    throw new Error(`No image choices returned from API for model ${model}`);
   }
 
   const choice = data.output.choices[0];
   if (!choice.message.content || choice.message.content.length === 0) {
-    throw new Error('No image content returned from API');
+    throw new Error(`No image content returned from API for model ${model}`);
   }
 
   const imageContent = choice.message.content.find((content) => 'image' in content);
   if (!imageContent) {
-    throw new Error('No image found in response content');
+    throw new Error(`No image found in response content for model ${model}`);
   }
 
   const resultImageUrl = imageContent.image;
@@ -227,7 +227,7 @@ async function queryTaskStatus(taskId: string, apiKey: string): Promise<QwenImag
       // Failed to parse JSON error response
     }
     throw new Error(
-      `Failed to query task status (${response.status}): ${errorData?.message || response.statusText}`,
+      `Failed to query task status for ${taskId} (${response.status}): ${errorData?.message || response.statusText}`,
     );
   }
 
@@ -276,9 +276,10 @@ export async function createQwenImage(
           }
 
           if (taskStatus.output.task_status === 'FAILED') {
-            const errorMessage = taskStatus.output.error_message || 'Image generation task failed';
+            const errorMessage =
+              taskStatus.output.error_message || 'Task failed without error message';
             return {
-              error: new Error(`Qwen image generation failed: ${errorMessage}`),
+              error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
               status: 'failed',
             };
           }
@@ -322,9 +323,10 @@ export async function createQwenImage(
           }
 
           if (taskStatus.output.task_status === 'FAILED') {
-            const errorMessage = taskStatus.output.error_message || 'Image generation task failed';
+            const errorMessage =
+              taskStatus.output.error_message || 'Task failed without error message';
             return {
-              error: new Error(`Qwen image generation failed: ${errorMessage}`),
+              error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
               status: 'failed',
             };
           }

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -16,9 +16,9 @@ const text2ImageModels = [
   /^flux-/,
 ];
 
-const image2ImageModels = [/^wan2\.(2|5)-i2i-$/];
+const image2ImageModels = [/^wan2\.(2|5)-i2i-/];
 
-const imageRequiredModels = [/^qwen-image-edit/, /^wan2\.(2|5)-i2i-$/, /^wan2\.6-image/];
+const imageRequiredModels = [/^qwen-image-edit/, /^wan2\.(2|5)-i2i-/, /^wan2\.6-image/];
 
 // Helper function to check if model matches any pattern in the array
 function matchesModel(model: string, patterns: Array<string | RegExp>): boolean {
@@ -163,7 +163,7 @@ async function createMultimodalGeneration(
     content.unshift({ image: params.imageUrl });
   } else if (params.imageUrls && params.imageUrls.length > 0) {
     // Add each image as a separate object in the content array
-    for (const imageUrl of params.imageUrls.reverse()) {
+    for (const imageUrl of params.imageUrls) {
       content.unshift({ image: imageUrl });
     }
   }
@@ -274,7 +274,7 @@ export async function createQwenImage(
   // Check if URL has /compatible-mode/v1 suffix and remove it
   const suffixIndex = baseURL ? baseURL.indexOf('/compatible-mode/v1') : -1;
   const dashscopeURL: string =
-    suffixIndex > -1 ? baseURL!.slice(0, suffixIndex) : 'https://dashscope.aliyuncs.com';
+    suffixIndex > -1 ? baseURL!.slice(0, suffixIndex) : baseURL || 'https://dashscope.aliyuncs.com';
   log('Using dashscopeURL: %s', dashscopeURL);
 
   try {

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -25,7 +25,7 @@ const text2ImageModels = new Set([
   'flux-merged',
 ]);
 
-const image2ImageModels = new Set(['wan2.5-i2i-preview', 'wanx2.1-imageedit']);
+const image2ImageModels = new Set(['wan2.5-i2i-preview']);
 
 interface QwenImageTaskResponse {
   output: {
@@ -249,10 +249,7 @@ export async function createQwenImage(
   const { model } = payload;
 
   try {
-    const isImage2ImageModel = image2ImageModels.has(model);
-    const isText2ImageModel = text2ImageModels.has(model);
-
-    if (isImage2ImageModel) {
+    if (image2ImageModels.has(model)) {
       log('Using image2image API for model: %s', model);
 
       const taskId = await createQwenImageTask(payload, apiKey, 'image2image');
@@ -298,7 +295,7 @@ export async function createQwenImage(
       return result;
     }
 
-    if (isText2ImageModel) {
+    if (text2ImageModels.has(model)) {
       log('Using text2image API for model: %s', model);
 
       const taskId = await createQwenImageTask(payload, apiKey, 'text2image');


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #10346

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 更新的文生图，图生图模型列表，`z-image` `wan2.5` `wan2.6` `qwen-image-plus/max` `qwen-image-edit-plus/max`
2. 新增 `image2image` endpoint，为老版本图生图模型进行兼容
3. 默认使用 `multimodal-generation` endpoint（新模型目前调研下来都是用这个了，同时支持图生图和文生图）
4. 支持多区域 Dashscope URL，跟随 baseUrl 参数，自动切分 `/compatible-mode/v1` 默认北京区域
    北京 https://dashscope.aliyuncs.com
    新加坡 https://dashscope-intl.aliyuncs.com
    弗吉尼亚 https://dashscope-us.aliyuncs.com

|Endpoint||
|-|-|
|`multimodal-generation`|<img width="826" height="547" alt="image" src="https://github.com/user-attachments/assets/38206851-94bc-48cc-8a57-24ed7155782f" /><img width="521" height="383" alt="image" src="https://github.com/user-attachments/assets/40fe0ed0-35fd-443d-868f-3ae2c27352f9" /><img width="681" height="557" alt="image" src="https://github.com/user-attachments/assets/8101b0f1-81c8-4892-a6e2-b51b5b0e0235" />|
|`text2image`|<img width="600" height="564" alt="image" src="https://github.com/user-attachments/assets/39e82a4f-5305-4f30-ae4d-e5339f401e6d" />|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

ref: https://help.aliyun.com/zh/model-studio/newly-released-models
ref: https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=2987148

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Extend Qwen image generation support to cover new text-to-image and image-to-image models while routing legacy models via dedicated text2image/image2image endpoints and defaulting other models to the multimodal-generation API.

New Features:
- Add model metadata and configuration for new Qwen image models including Z-Image Turbo, Qwen Image Edit Max/Plus, Qwen Image Max/Plus, and Wanxiang 2.5/2.6 variants.
- Introduce explicit handling of legacy text-to-image and image-to-image Qwen models via separate async text2image and image2image endpoints.

Enhancements:
- Update the Qwen image creation flow to prefer the multimodal-generation endpoint for newer models and improve error messaging and logging across image workflows.
- Reformat select Qwen chat model descriptions for consistency without changing behavior.

Tests:
- Adjust Qwen image creation tests to align with the new multimodal-generation behavior and removed strict input validation on qwen-image-edit-specific image URL requirements.