### PR TITLE
🐛 fix(copilot): pass correct scope when creating new session in PageEditor

### DIFF
--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -189,7 +189,7 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
           <div className={cx(styles.fadeContainer, isHovered ? styles.fadeIn : styles.fadeOut)}>
             <ActionIcon
               icon={PlusIcon}
-              onClick={() => switchTopic()}
+              onClick={() => switchTopic(null, { scope: 'page' })}
               size={DESKTOP_HEADER_ICON_SIZE}
               title={t('actions.addNewTopic')}
             />

--- a/src/styles/antdOverride.ts
+++ b/src/styles/antdOverride.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import { type Theme, css } from 'antd-style';
 import { rgba } from 'polished';
 
@@ -16,4 +17,12 @@ export default ({ token }: { prefixCls: string; token: Theme }) => css`
     background: ${rgba(token.colorBgLayout, 0.5)} !important;
     backdrop-filter: blur(2px);
   }
+
+  ${isDesktop &&
+  css`
+    .${token.prefixCls}-modal-mask.${token.prefixCls}-modal-mask-blur {
+      background: ${rgba(token.colorBgLayout, 0.8)} !important;
+      backdrop-filter: none !important;
+    }
+  `}
 `;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

fix LOBE-3378

#### 🔀 Description of Change

Fixed an issue where clicking the "New Topic" button in PageEditor Copilot panel would not create a new session.

**Root Cause:** The `switchTopic()` function was being called without a `scope` parameter. It defaulted to `'main'` scope, while `PageAgentProvider` uses `'page'` scope for message management. This scope mismatch caused the session data to be cleared in the wrong scope, preventing new session creation.

**Fix:** Pass `scope: 'page'` when calling `switchTopic()` in the Copilot toolbar.

#### 🧪 How to Test

1. Open any page in PageEditor
2. Open the Copilot panel
3. Send some messages to start a conversation
4. Click the "+" button to create a new topic/session
5. Verify a new session is created and the previous messages are cleared

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Single line change in `src/features/PageEditor/Copilot/Toolbar.tsx`:
```diff
- onClick={() => switchTopic()}
+ onClick={() => switchTopic(null, { scope: 'page' })}
```

## Summary by Sourcery

Align Copilot new-topic behavior and desktop modal styling with the Page Editor experience.

Bug Fixes:
- Ensure creating a new Copilot topic in the Page Editor uses the correct 'page' scope so a new session is actually created and previous messages are cleared.

Enhancements:
- Adjust desktop modal blur styling so blurred modal masks use a more opaque background with no backdrop blur.