### PR TITLE
🐛 fix(copilot): history popover not refreshing when agentId changes

### DIFF
--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon, Block, Flexbox, Popover } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { ChevronsUpDownIcon, Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
-import { Suspense, memo, useMemo, useState } from 'react';
+import { Suspense, memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AgentAvatar from '@/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentItem/Avatar';
@@ -164,6 +164,15 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
   const setActiveAgentId = useAgentStore((s) => s.setActiveAgentId);
   const [topicPopoverOpen, setTopicPopoverOpen] = useState(false);
 
+  const handleAgentChange = useCallback(
+    (id: string) => {
+      setActiveAgentId(id);
+      // Sync chatStore's activeAgentId to ensure topic selectors work correctly
+      useChatStore.setState({ activeAgentId: id });
+    },
+    [setActiveAgentId],
+  );
+
   // Fetch topics for the agent builder
   useChatStore((s) => s.useFetchTopics)(true, { agentId });
 
@@ -181,7 +190,7 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
     <NavHeader
       left={
         <Flexbox align="center" gap={8} horizontal>
-          <AgentSelector agentId={agentId} onAgentChange={setActiveAgentId} />
+          <AgentSelector agentId={agentId} onAgentChange={handleAgentChange} />
         </Flexbox>
       }
       right={

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -184,7 +184,9 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
 
   const [toggleRightPanel] = useGlobalStore((s) => [s.toggleRightPanel]);
 
-  const hideHistory = !topics || topics.length === 0;
+  // topics === undefined means still loading, topics.length === 0 means confirmed empty
+  const isLoadingTopics = topics === undefined;
+  const hideHistory = !isLoadingTopics && topics.length === 0;
 
   return (
     <NavHeader
@@ -227,7 +229,7 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
                   </Flexbox>
                 }
                 onOpenChange={setTopicPopoverOpen}
-                open={topicPopoverOpen}
+                open={isLoadingTopics ? false : topicPopoverOpen}
                 placement="bottomRight"
                 styles={{
                   content: {
@@ -237,7 +239,12 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
                 }}
                 trigger="click"
               >
-                <ActionIcon icon={Clock3Icon} size={DESKTOP_HEADER_ICON_SIZE} />
+                <ActionIcon
+                  disabled={isLoadingTopics}
+                  icon={Clock3Icon}
+                  loading={isLoadingTopics}
+                  size={DESKTOP_HEADER_ICON_SIZE}
+                />
               </Popover>
             )}
           </div>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

Fixes LOBE-3910

#### 🔀 Description of Change

**Bug Fix: History not refreshing when switching agent**

The codebase has two separate stores that both maintain an `activeAgentId`:
- `useAgentStore.activeAgentId` - updated when user switches agent
- `useChatStore.activeAgentId` - used by topic selectors

When switching agents via `AgentSelector`, only `agentStore.activeAgentId` was being updated, while `chatStore.activeAgentId` remained stale.

**Solution:** Added `handleAgentChange` callback that syncs both stores when switching agents.

---

**UX Improvement: Loading state for history button**

Previously, the history button would immediately disappear when switching agents (because topics data was undefined during loading), causing a jarring UI experience.

**Solution:**
- Show loading/disabled state while topics are being fetched (`topics === undefined`)
- Only hide the button when confirmed there are no topics (`topics.length === 0`)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Open the Copilot panel
2. Switch between different agents using the agent selector
3. Verify that:
   - The history button shows loading state briefly during switch
   - History popover correctly shows topics for the selected agent
   - Button only hides when agent truly has no topics