### PR TITLE
🐛 fix: fix auto scroll in group

### DIFF
--- a/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
+++ b/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
@@ -40,7 +40,7 @@ const DebugInspector = memo(() => {
       style={{
         background: 'rgba(0,0,0,0.9)',
         borderRadius: 8,
-        bottom: 80,
+        bottom: 135,
         display: 'flex',
         fontFamily: 'monospace',
         fontSize: 11,

--- a/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
+++ b/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
@@ -15,7 +15,7 @@ export const AT_BOTTOM_THRESHOLD = 300;
  * 是否开启调试面板
  * 设为 true 可以显示滚动位置调试信息
  */
-export const OPEN_DEV_INSPECTOR = false;
+export const OPEN_DEV_INSPECTOR = true;
 
 const DebugInspector = memo(() => {
   const atBottom = useConversationStore(virtuaListSelectors.atBottom);

--- a/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
+++ b/src/features/Conversation/ChatList/components/AutoScroll/DebugInspector.tsx
@@ -15,7 +15,7 @@ export const AT_BOTTOM_THRESHOLD = 300;
  * 是否开启调试面板
  * 设为 true 可以显示滚动位置调试信息
  */
-export const OPEN_DEV_INSPECTOR = true;
+export const OPEN_DEV_INSPECTOR = false;
 
 const DebugInspector = memo(() => {
   const atBottom = useConversationStore(virtuaListSelectors.atBottom);

--- a/src/features/Conversation/ChatList/components/AutoScroll/index.tsx
+++ b/src/features/Conversation/ChatList/components/AutoScroll/index.tsx
@@ -8,9 +8,14 @@ import {
   useConversationStore,
   virtuaListSelectors,
 } from '../../../store';
-import BackBottom from '../BackBottom';
-import { AT_BOTTOM_THRESHOLD, OPEN_DEV_INSPECTOR } from './DebugInspector';
 
+/**
+ * AutoScroll component - handles auto-scrolling logic during AI generation.
+ * Should be placed inside the last item of VList so it only triggers when visible.
+ *
+ * This component has no visual output - it only contains the auto-scroll logic.
+ * Debug UI and BackBottom button are rendered separately outside VList.
+ */
 const AutoScroll = memo(() => {
   const atBottom = useConversationStore(virtuaListSelectors.atBottom);
   const isScrolling = useConversationStore(virtuaListSelectors.isScrolling);
@@ -31,59 +36,8 @@ const AutoScroll = memo(() => {
     }
   }, [shouldAutoScroll, scrollToBottom, dbMessages.length, lastMessageContentLength]);
 
-  return (
-    <>
-      {OPEN_DEV_INSPECTOR && (
-        <div
-          style={{
-            bottom: 0,
-            left: 0,
-            pointerEvents: 'none',
-            position: 'absolute',
-            right: 0,
-          }}
-        >
-          {/* Threshold 区域顶部边界线 */}
-          <div
-            style={{
-              background: atBottom ? '#22c55e' : '#ef4444',
-              height: 2,
-              left: 0,
-              opacity: 0.5,
-              position: 'absolute',
-              right: 0,
-              top: -AT_BOTTOM_THRESHOLD,
-            }}
-          />
-
-          {/* Threshold 区域 mask - 显示在指示线上方 */}
-          <div
-            style={{
-              background: atBottom
-                ? 'linear-gradient(to top, rgba(34, 197, 94, 0.15), transparent)'
-                : 'linear-gradient(to top, rgba(239, 68, 68, 0.1), transparent)',
-              height: AT_BOTTOM_THRESHOLD,
-              left: 0,
-              position: 'absolute',
-              right: 0,
-              top: -AT_BOTTOM_THRESHOLD,
-            }}
-          />
-
-          {/* AutoScroll 位置指示线（底部） */}
-          <div
-            style={{
-              background: atBottom ? '#22c55e' : '#ef4444',
-              height: 2,
-              width: '100%',
-            }}
-          />
-        </div>
-      )}
-
-      <BackBottom onScrollToBottom={() => scrollToBottom(true)} visible={!atBottom} />
-    </>
-  );
+  // No visual output - this component only handles auto-scroll logic
+  return null;
 });
 
 AutoScroll.displayName = 'ConversationAutoScroll';

--- a/src/features/Conversation/ChatList/components/AutoScroll/index.tsx
+++ b/src/features/Conversation/ChatList/components/AutoScroll/index.tsx
@@ -32,9 +32,17 @@ const AutoScroll = memo(() => {
   }, [shouldAutoScroll, scrollToBottom, dbMessages.length, lastMessageContentLength]);
 
   return (
-    <div style={{ position: 'relative', width: '100%' }}>
+    <>
       {OPEN_DEV_INSPECTOR && (
-        <>
+        <div
+          style={{
+            bottom: 0,
+            left: 0,
+            pointerEvents: 'none',
+            position: 'absolute',
+            right: 0,
+          }}
+        >
           {/* Threshold 区域顶部边界线 */}
           <div
             style={{
@@ -42,7 +50,6 @@ const AutoScroll = memo(() => {
               height: 2,
               left: 0,
               opacity: 0.5,
-              pointerEvents: 'none',
               position: 'absolute',
               right: 0,
               top: -AT_BOTTOM_THRESHOLD,
@@ -57,7 +64,6 @@ const AutoScroll = memo(() => {
                 : 'linear-gradient(to top, rgba(239, 68, 68, 0.1), transparent)',
               height: AT_BOTTOM_THRESHOLD,
               left: 0,
-              pointerEvents: 'none',
               position: 'absolute',
               right: 0,
               top: -AT_BOTTOM_THRESHOLD,
@@ -69,15 +75,14 @@ const AutoScroll = memo(() => {
             style={{
               background: atBottom ? '#22c55e' : '#ef4444',
               height: 2,
-              position: 'relative',
               width: '100%',
             }}
           />
-        </>
+        </div>
       )}
 
       <BackBottom onScrollToBottom={() => scrollToBottom(true)} visible={!atBottom} />
-    </div>
+    </>
   );
 });
 

--- a/src/features/Conversation/ChatList/components/BackBottom/index.tsx
+++ b/src/features/Conversation/ChatList/components/BackBottom/index.tsx
@@ -4,30 +4,83 @@ import { ArrowDownIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { AT_BOTTOM_THRESHOLD, OPEN_DEV_INSPECTOR } from '../AutoScroll/DebugInspector';
 import { styles } from './style';
 
 export interface BackBottomProps {
+  atBottom: boolean;
   onScrollToBottom: () => void;
   visible: boolean;
 }
 
-const BackBottom = memo<BackBottomProps>(({ visible, onScrollToBottom }) => {
+const BackBottom = memo<BackBottomProps>(({ visible, atBottom, onScrollToBottom }) => {
   const { t } = useTranslation('chat');
 
   return (
-    <ActionIcon
-      className={cx(styles.container, visible && styles.visible)}
-      glass
-      icon={ArrowDownIcon}
-      onClick={onScrollToBottom}
-      size={{
-        blockSize: 36,
-        borderRadius: 36,
-        size: 18,
-      }}
-      title={t('backToBottom')}
-      variant={'outlined'}
-    />
+    <>
+      {/* Debug: 底部指示线 */}
+      {OPEN_DEV_INSPECTOR && (
+        <div
+          style={{
+            bottom: 0,
+            left: 0,
+            pointerEvents: 'none',
+            position: 'absolute',
+            right: 0,
+          }}
+        >
+          {/* Threshold 区域顶部边界线 */}
+          <div
+            style={{
+              background: atBottom ? '#22c55e' : '#ef4444',
+              height: 2,
+              left: 0,
+              opacity: 0.5,
+              position: 'absolute',
+              right: 0,
+              top: -AT_BOTTOM_THRESHOLD,
+            }}
+          />
+
+          {/* Threshold 区域 mask - 显示在指示线上方 */}
+          <div
+            style={{
+              background: atBottom
+                ? 'linear-gradient(to top, rgba(34, 197, 94, 0.15), transparent)'
+                : 'linear-gradient(to top, rgba(239, 68, 68, 0.1), transparent)',
+              height: AT_BOTTOM_THRESHOLD,
+              left: 0,
+              position: 'absolute',
+              right: 0,
+              top: -AT_BOTTOM_THRESHOLD,
+            }}
+          />
+
+          {/* AutoScroll 位置指示线（底部） */}
+          <div
+            style={{
+              background: atBottom ? '#22c55e' : '#ef4444',
+              height: 2,
+              width: '100%',
+            }}
+          />
+        </div>
+      )}
+
+      <ActionIcon
+        className={cx(styles.container, visible && styles.visible)}
+        glass
+        icon={ArrowDownIcon}
+        onClick={onScrollToBottom}
+        size={{
+          blockSize: 36,
+          borderRadius: 36,
+          size: 18,
+        }}
+        title={t('backToBottom')}
+        variant={'outlined'}
+      />
+    </>
   );
 });
 

--- a/src/features/Conversation/ChatList/components/VirtualizedList.tsx
+++ b/src/features/Conversation/ChatList/components/VirtualizedList.tsx
@@ -12,6 +12,7 @@ import DebugInspector, {
   AT_BOTTOM_THRESHOLD,
   OPEN_DEV_INSPECTOR,
 } from './AutoScroll/DebugInspector';
+import BackBottom from './BackBottom';
 
 interface VirtualizedListProps {
   dataSource: string[];
@@ -132,6 +133,9 @@ const VirtualizedList = memo<VirtualizedListProps>(({ dataSource, itemContent })
     }
   }, []);
 
+  const atBottom = useConversationStore(virtuaListSelectors.atBottom);
+  const scrollToBottom = useConversationStore((s) => s.scrollToBottom);
+
   return (
     <div style={{ height: '100%', position: 'relative' }}>
       {/* Debug Inspector - 放在 VList 外面，不会被虚拟列表回收 */}
@@ -146,6 +150,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ dataSource, itemContent })
       >
         {(messageId, index): ReactElement => {
           const isAgentCouncil = messageId.includes('agentCouncil');
+          const isLastItem = index === dataSource.length - 1;
           const content = itemContent(index, messageId);
 
           if (isAgentCouncil) {
@@ -153,6 +158,8 @@ const VirtualizedList = memo<VirtualizedListProps>(({ dataSource, itemContent })
             return (
               <div key={messageId} style={{ position: 'relative', width: '100%' }}>
                 {content}
+                {/* AutoScroll 放在最后一个 Item 里面，这样只有当最后一个 Item 可见时才会触发自动滚动 */}
+                {isLastItem && <AutoScroll />}
               </div>
             );
           }
@@ -160,13 +167,14 @@ const VirtualizedList = memo<VirtualizedListProps>(({ dataSource, itemContent })
           return (
             <WideScreenContainer key={messageId} style={{ position: 'relative' }}>
               {content}
+              {/* AutoScroll 放在最后一个 Item 里面，这样只有当最后一个 Item 可见时才会触发自动滚动 */}
+              {isLastItem && <AutoScroll />}
             </WideScreenContainer>
           );
         }}
       </VList>
-      {/* AutoScroll 放在 VList 外面，不会被虚拟列表回收 */}
-      {/* 这样当用户向上滚动时，BackBottom 按钮仍然可见 */}
-      <AutoScroll />
+      {/* BackBottom 放在 VList 外面，这样无论滚动到哪里都能看到 */}
+      <BackBottom atBottom={atBottom} onScrollToBottom={() => scrollToBottom(true)} visible={!atBottom} />
     </div>
   );
 }, isEqual);

--- a/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.test.ts
+++ b/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.test.ts
@@ -1,0 +1,224 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useScrollToUserMessage } from './useScrollToUserMessage';
+
+describe('useScrollToUserMessage', () => {
+  describe('when user sends a new message', () => {
+    it('should scroll to user message when new message is from user', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 2,
+            isLastMessageFromUser: false,
+          },
+        },
+      );
+
+      // User sends a new message (length increases, last message is from user)
+      rerender({
+        dataSourceLength: 3,
+        isLastMessageFromUser: true,
+      });
+
+      expect(scrollToIndex).toHaveBeenCalledTimes(1);
+      expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'start', smooth: true });
+    });
+
+    it('should scroll to correct index when multiple user messages are sent', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 5,
+            isLastMessageFromUser: false,
+          },
+        },
+      );
+
+      // User sends a new message
+      rerender({
+        dataSourceLength: 6,
+        isLastMessageFromUser: true,
+      });
+
+      // Should scroll to index 4 (dataSourceLength - 2 = 6 - 2 = 4)
+      expect(scrollToIndex).toHaveBeenCalledWith(4, { align: 'start', smooth: true });
+    });
+  });
+
+  describe('when AI/agent responds', () => {
+    it('should NOT scroll when new message is from AI', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 2,
+            isLastMessageFromUser: true,
+          },
+        },
+      );
+
+      // AI responds (length increases, but last message is NOT from user)
+      rerender({
+        dataSourceLength: 3,
+        isLastMessageFromUser: false,
+      });
+
+      expect(scrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it('should NOT scroll when multiple agents respond in group chat', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 3,
+            isLastMessageFromUser: false,
+          },
+        },
+      );
+
+      // First agent responds
+      rerender({
+        dataSourceLength: 4,
+        isLastMessageFromUser: false,
+      });
+
+      expect(scrollToIndex).not.toHaveBeenCalled();
+
+      // Second agent responds
+      rerender({
+        dataSourceLength: 5,
+        isLastMessageFromUser: false,
+      });
+
+      expect(scrollToIndex).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should NOT scroll when length decreases (message deleted)', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 5,
+            isLastMessageFromUser: true,
+          },
+        },
+      );
+
+      // Message deleted (length decreases)
+      rerender({
+        dataSourceLength: 4,
+        isLastMessageFromUser: true,
+      });
+
+      expect(scrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it('should NOT scroll when length stays the same', () => {
+      const scrollToIndex = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 3,
+            isLastMessageFromUser: true,
+          },
+        },
+      );
+
+      // Length stays the same (content update, not new message)
+      rerender({
+        dataSourceLength: 3,
+        isLastMessageFromUser: true,
+      });
+
+      expect(scrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it('should handle null scrollToIndex gracefully', () => {
+      const { rerender } = renderHook(
+        ({ dataSourceLength, isLastMessageFromUser }) =>
+          useScrollToUserMessage({
+            dataSourceLength,
+            isLastMessageFromUser,
+            scrollToIndex: null,
+          }),
+        {
+          initialProps: {
+            dataSourceLength: 2,
+            isLastMessageFromUser: false,
+          },
+        },
+      );
+
+      // Should not throw when scrollToIndex is null
+      expect(() => {
+        rerender({
+          dataSourceLength: 3,
+          isLastMessageFromUser: true,
+        });
+      }).not.toThrow();
+    });
+
+    it('should NOT scroll on initial render', () => {
+      const scrollToIndex = vi.fn();
+
+      renderHook(() =>
+        useScrollToUserMessage({
+          dataSourceLength: 5,
+          isLastMessageFromUser: true,
+          scrollToIndex,
+        }),
+      );
+
+      // Should not scroll on initial render even if last message is from user
+      expect(scrollToIndex).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.ts
+++ b/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.ts
@@ -12,7 +12,9 @@ interface UseScrollToUserMessageOptions {
   /**
    * Function to scroll to a specific index
    */
-  scrollToIndex: ((index: number, options?: { align?: string; smooth?: boolean }) => void) | null;
+  scrollToIndex:
+    | ((index: number, options?: { align?: 'start' | 'center' | 'end'; smooth?: boolean }) => void)
+    | null;
 }
 
 /**

--- a/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.ts
+++ b/src/features/Conversation/ChatList/hooks/useScrollToUserMessage.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+interface UseScrollToUserMessageOptions {
+  /**
+   * Current data source length (number of messages)
+   */
+  dataSourceLength: number;
+  /**
+   * Whether the last message is from the user
+   */
+  isLastMessageFromUser: boolean;
+  /**
+   * Function to scroll to a specific index
+   */
+  scrollToIndex: ((index: number, options?: { align?: string; smooth?: boolean }) => void) | null;
+}
+
+/**
+ * Hook to handle scrolling to user message when user sends a new message.
+ * Only triggers scroll when the new message is from the user, not when AI/agent responds.
+ *
+ * This ensures that in group chat scenarios, when multiple agents are responding,
+ * the view doesn't jump around as each agent starts speaking.
+ */
+export function useScrollToUserMessage({
+  dataSourceLength,
+  isLastMessageFromUser,
+  scrollToIndex,
+}: UseScrollToUserMessageOptions): void {
+  const prevLengthRef = useRef(dataSourceLength);
+
+  useEffect(() => {
+    const hasNewMessage = dataSourceLength > prevLengthRef.current;
+    prevLengthRef.current = dataSourceLength;
+
+    // Only scroll when user sends a new message
+    if (hasNewMessage && isLastMessageFromUser && scrollToIndex) {
+      // Scroll to the second-to-last message (user's message) with the start aligned
+      scrollToIndex(dataSourceLength - 2, { align: 'start', smooth: true });
+    }
+  }, [dataSourceLength, isLastMessageFromUser, scrollToIndex]);
+}

--- a/src/hooks/useAutoScroll.test.ts
+++ b/src/hooks/useAutoScroll.test.ts
@@ -1,0 +1,289 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAutoScroll } from './useAutoScroll';
+
+describe('useAutoScroll', () => {
+  let rafCallbacks: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const flushRAF = () => {
+    const callbacks = [...rafCallbacks];
+    rafCallbacks = [];
+    callbacks.forEach((cb) => cb(performance.now()));
+  };
+
+  const createMockContainer = (scrollTop = 0, scrollHeight = 1000, clientHeight = 400) => {
+    return {
+      clientHeight,
+      scrollHeight,
+      scrollTop,
+    } as HTMLDivElement;
+  };
+
+  describe('when enabled changes from true to false (streaming ends)', () => {
+    it('should maintain scroll position when streaming ends', () => {
+      const { result, rerender } = renderHook(
+        ({ content, enabled }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled }),
+        { initialProps: { content: 'initial', enabled: true } },
+      );
+
+      // Simulate container scrolled to bottom (scrollTop = scrollHeight - clientHeight = 600)
+      const mockContainer = createMockContainer(600, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      // Trigger auto-scroll with content change while streaming
+      rerender({ content: 'updated content', enabled: true });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      // Should scroll to bottom (scrollTop = scrollHeight = 1000)
+      expect(mockContainer.scrollTop).toBe(mockContainer.scrollHeight);
+
+      // Record scroll position before disabling
+      const scrollPositionBeforeDisable = mockContainer.scrollTop;
+
+      // Now simulate streaming end: enabled becomes false
+      // This is where the bug occurs - the hook stops maintaining scroll position
+      rerender({ content: 'final content', enabled: false });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      // BUG TEST: After enabled becomes false, scroll position should be maintained
+      // Currently, the hook doesn't actively preserve position when disabled,
+      // which can cause scroll to reset when DOM changes occur
+      expect(mockContainer.scrollTop).toBe(scrollPositionBeforeDisable);
+    });
+
+    it('should actively restore scroll position when DOM resets it after enabled becomes false', () => {
+      const { result, rerender } = renderHook(
+        ({ content, enabled }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled }),
+        { initialProps: { content: 'initial', enabled: true } },
+      );
+
+      const mockContainer = createMockContainer(600, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      // Auto-scroll to bottom while streaming
+      rerender({ content: 'streaming content...', enabled: true });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      expect(mockContainer.scrollTop).toBe(1000);
+
+      // Record the scroll position at bottom
+      const scrollPositionAtBottom = mockContainer.scrollTop;
+
+      // Streaming ends - enabled becomes false
+      rerender({ content: 'final content', enabled: false });
+
+      // Simulate DOM change that resets scroll position to top
+      // This happens in real browsers when content re-renders
+      mockContainer.scrollTop = 0;
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      // BUG: The hook should restore scroll position when enabled transitions from true to false
+      // Currently it does nothing when enabled=false, so scroll position stays at 0
+      // Expected behavior: hook should detect enabled transition and restore position
+      expect(mockContainer.scrollTop).toBe(scrollPositionAtBottom);
+    });
+
+    it('should preserve scroll position when user has scrolled and streaming ends', () => {
+      const { result, rerender } = renderHook(
+        ({ content, enabled }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled }),
+        { initialProps: { content: 'initial', enabled: true } },
+      );
+
+      // Container at middle position (user scrolled up)
+      const mockContainer = createMockContainer(300, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      // Simulate user scroll (triggers userHasScrolled = true)
+      act(() => {
+        result.current.handleScroll();
+      });
+
+      expect(result.current.userHasScrolled).toBe(true);
+
+      const scrollPositionBeforeDisable = mockContainer.scrollTop;
+
+      // Streaming ends
+      rerender({ content: 'final content', enabled: false });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      // Position should remain unchanged
+      expect(mockContainer.scrollTop).toBe(scrollPositionBeforeDisable);
+    });
+  });
+
+  describe('basic auto-scroll functionality', () => {
+    it('should auto-scroll to bottom when deps change and enabled is true', () => {
+      const { result, rerender } = renderHook(
+        ({ content }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled: true }),
+        { initialProps: { content: 'initial' } },
+      );
+
+      const mockContainer = createMockContainer(0, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      rerender({ content: 'new content' });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      expect(mockContainer.scrollTop).toBe(mockContainer.scrollHeight);
+    });
+
+    it('should not auto-scroll when enabled is false', () => {
+      const { result, rerender } = renderHook(
+        ({ content }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled: false }),
+        { initialProps: { content: 'initial' } },
+      );
+
+      const mockContainer = createMockContainer(100, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+      const initialScrollTop = mockContainer.scrollTop;
+
+      rerender({ content: 'new content' });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      expect(mockContainer.scrollTop).toBe(initialScrollTop);
+    });
+
+    it('should stop auto-scroll when user scrolls away from bottom', () => {
+      const { result, rerender } = renderHook(
+        ({ content }) =>
+          useAutoScroll<HTMLDivElement>({ deps: [content], enabled: true, threshold: 20 }),
+        { initialProps: { content: 'initial' } },
+      );
+
+      // Container NOT at bottom (distance to bottom > threshold)
+      const mockContainer = createMockContainer(100, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      // Simulate user scroll event
+      act(() => {
+        result.current.handleScroll();
+      });
+
+      expect(result.current.userHasScrolled).toBe(true);
+
+      // Content changes but should not auto-scroll due to user scroll lock
+      const scrollTopBeforeUpdate = mockContainer.scrollTop;
+      rerender({ content: 'new content' });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      expect(mockContainer.scrollTop).toBe(scrollTopBeforeUpdate);
+    });
+
+    it('should reset scroll lock when resetScrollLock is called', () => {
+      const { result, rerender } = renderHook(
+        ({ content }) => useAutoScroll<HTMLDivElement>({ deps: [content], enabled: true }),
+        { initialProps: { content: 'initial' } },
+      );
+
+      const mockContainer = createMockContainer(100, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      // User scrolls away
+      act(() => {
+        result.current.handleScroll();
+      });
+
+      expect(result.current.userHasScrolled).toBe(true);
+
+      // Reset scroll lock
+      act(() => {
+        result.current.resetScrollLock();
+      });
+
+      expect(result.current.userHasScrolled).toBe(false);
+
+      // Now auto-scroll should work again
+      rerender({ content: 'new content' });
+
+      act(() => {
+        flushRAF();
+        flushRAF();
+      });
+
+      expect(mockContainer.scrollTop).toBe(mockContainer.scrollHeight);
+    });
+  });
+
+  describe('threshold behavior', () => {
+    it('should not set userHasScrolled when at bottom within threshold', () => {
+      const { result } = renderHook(() =>
+        useAutoScroll<HTMLDivElement>({ deps: [], enabled: true, threshold: 20 }),
+      );
+
+      // Container at bottom (distance = scrollHeight - scrollTop - clientHeight = 1000 - 590 - 400 = 10 < 20)
+      const mockContainer = createMockContainer(590, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      act(() => {
+        result.current.handleScroll();
+      });
+
+      // Should NOT set userHasScrolled because we're within threshold
+      expect(result.current.userHasScrolled).toBe(false);
+    });
+
+    it('should set userHasScrolled when scrolled beyond threshold', () => {
+      const { result } = renderHook(() =>
+        useAutoScroll<HTMLDivElement>({ deps: [], enabled: true, threshold: 20 }),
+      );
+
+      // Container NOT at bottom (distance = 1000 - 500 - 400 = 100 > 20)
+      const mockContainer = createMockContainer(500, 1000, 400);
+      (result.current.ref as { current: HTMLDivElement | null }).current = mockContainer;
+
+      act(() => {
+        result.current.handleScroll();
+      });
+
+      expect(result.current.userHasScrolled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

fix LOBE-3608

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve chat auto-scroll behavior to better handle user messages and virtualized rendering.

Bug Fixes:
- Scroll only to the latest user message when a new user message is sent, avoiding jumps when AI or multiple agents respond.
- Preserve scroll position when auto-scroll is disabled after streaming ends to prevent position resets on DOM re-renders.
- Ensure the AutoScroll/back-to-bottom control is always visible by placing it outside the virtualized list container and adjusting layout and debug overlays.

Enhancements:
- Add a dedicated hook to manage scrolling to the latest user message in conversation views.