### PR TITLE
🐛 fix: fixed the agent group builder tools excaution edge case crash

### DIFF
--- a/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
+++ b/packages/builtin-tool-group-agent-builder/src/client/Inspector/BatchCreateAgents/index.tsx
@@ -81,7 +81,7 @@ export const BatchCreateAgentsInspector = memo<
       {displayInfo && (
         <>
           <div className={styles.avatarGroup}>
-            {displayInfo.displayAgents.map((agent, index) => (
+            {displayInfo.displayAgents?.map((agent, index) => (
               <Avatar
                 avatar={agent.avatar}
                 key={index}

--- a/src/features/Conversation/Messages/AgentCouncil/components/CouncilList.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/CouncilList.tsx
@@ -62,7 +62,7 @@ const CouncilList = memo<CouncilListProps>(({ members, displayMode, activeTab })
               minWidth: MIN_WIDTH * members.length + 32 + 32 * (members.length - 1),
             }}
           >
-            {members.map((member, idx) => {
+            {members?.map((member, idx) => {
               if (!member) return null;
               return (
                 <Fragment key={member.id}>
@@ -77,7 +77,7 @@ const CouncilList = memo<CouncilListProps>(({ members, displayMode, activeTab })
                   >
                     <CouncilMember index={idx} item={member} />
                   </Flexbox>
-                  {idx < members.length - 1 && (
+                  {idx < members?.length - 1 && (
                     <Divider
                       dashed
                       orientation={'vertical'}


### PR DESCRIPTION
#### 💻 Change Type

fix: LOBE-3482

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Handle optional council member and agent lists to prevent runtime crashes when these arrays are undefined.

Bug Fixes:
- Guard council member rendering and divider logic against undefined member arrays in the conversation council list.
- Guard batch agent avatar rendering against undefined display agent arrays in the agent builder inspector.