### PR TITLE
🐛 fix(ModelSelect): resolve tooltip hover causing popup to close

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "@lobehub/icons": "^4.0.2",
     "@lobehub/market-sdk": "0.29.1",
     "@lobehub/tts": "^4.0.2",
-    "@lobehub/ui": "^4.27.4",
+    "@lobehub/ui": "^4.27.5",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { type ModelAbilities } from 'model-bank';
 import numeral from 'numeral';
-import { CSSProperties, type ComponentProps, type FC, memo } from 'react';
+import { CSSProperties, type FC, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type AiProviderSourceType } from '@/types/aiProvider';
@@ -51,14 +51,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 type TooltipStyles = typeof styles;
 
-const DEFAULT_TOOLTIP_STYLES = {
-  root: { pointerEvents: 'none' },
-} as const satisfies ComponentProps<typeof Tooltip>['styles'];
-
-const FUNCTION_CALL_TOOLTIP_STYLES = {
-  root: { maxWidth: 'unset', pointerEvents: 'none' },
-} as const satisfies ComponentProps<typeof Tooltip>['styles'];
-
 interface ModelInfoTagsProps extends ModelAbilities {
   contextWindowTokens?: number | null;
   directionReverse?: boolean;
@@ -82,11 +74,10 @@ interface FeatureTagItemProps {
   icon: Parameters<typeof Icon>[0]['icon'];
   placement: 'top' | 'right';
   title: string;
-  tooltipStyles?: ComponentProps<typeof Tooltip>['styles'];
 }
 
 const FeatureTagItem = memo<FeatureTagItemProps>(
-  ({ className, color, enabled, icon, placement, title, tooltipStyles }) => {
+  ({ className, color, enabled, icon, placement, title }) => {
     if (!enabled) return null;
 
     const tag = (
@@ -96,7 +87,7 @@ const FeatureTagItem = memo<FeatureTagItemProps>(
     );
 
     return (
-      <Tooltip placement={placement} styles={tooltipStyles ?? DEFAULT_TOOLTIP_STYLES} title={title}>
+      <Tooltip placement={placement} title={title}>
         {tag}
       </Tooltip>
     );
@@ -158,7 +149,6 @@ const FeatureTags = memo<FeatureTagsProps>(
           icon={ToyBrick}
           placement={placement}
           title={t('ModelSelect.featureTag.functionCall')}
-          tooltipStyles={FUNCTION_CALL_TOOLTIP_STYLES}
         />
         <FeatureTagItem
           className={tagClassName}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-4113

#### 🔀 Description of Change

- Upgrade `@lobehub/ui` from `4.27.4` to `4.27.5`
- Remove unused tooltip styles (`DEFAULT_TOOLTIP_STYLES` and `FUNCTION_CALL_STYLES`) in `ModelSelect` component that were causing the popup to close when hovering over tooltips
- Clean up unused `ComponentProps` import

The `pointerEvents: 'none'` style on tooltips was preventing proper interaction. This fix removes the unnecessary style overrides, allowing the default tooltip behavior from `@lobehub/ui` to work correctly.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

**Test steps:**
1. Open model selector dropdown
2. Hover over feature tags (function call, vision, etc.)
3. Verify tooltip appears and popup doesn't close unexpectedly

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This fix addresses the issue where hovering over tooltips in the ModelSelect component would unexpectedly close the dropdown popup.