### PR TITLE
🐛 fix(community): agent discover list should not be empty

### DIFF
--- a/src/app/[variants]/(main)/community/(list)/agent/features/Category/index.tsx
+++ b/src/app/[variants]/(main)/community/(list)/agent/features/Category/index.tsx
@@ -9,7 +9,7 @@ import { SCROLL_PARENT_ID } from '@/app/[variants]/(main)/community/features/con
 import { withSuspense } from '@/components/withSuspense';
 import { useQuery } from '@/hooks/useQuery';
 import { useDiscoverStore } from '@/store/discover';
-import { AssistantCategory } from '@/types/discover';
+import { AssistantCategory, AssistantSorts } from '@/types/discover';
 
 import CategoryMenu from '../../../../components/CategoryMenu';
 import { useCategory } from './useCategory';
@@ -28,7 +28,11 @@ const Category = memo(() => {
   const genUrl = (key: AssistantCategory) =>
     qs.stringifyUrl(
       {
-        query: { category: key === AssistantCategory.All ? null : key, q, source },
+        query: {
+          category: [AssistantCategory.All, AssistantCategory.Discover].includes(key) ? null : key,
+          q,
+          sort: key === AssistantCategory.Discover ? AssistantSorts.Recommended : null,
+        },
         url: '/community/agent',
       },
       { skipNull: true },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure the agent Discover list is populated by clearing the category filter and applying the recommended sort when Discover is selected.