### PR TITLE
🐛 fix(home): use correct CreateGroupModal for session group creation

### DIFF
--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/ModalProvider.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/ModalProvider.tsx
@@ -5,8 +5,8 @@ import { type ReactNode, createContext, memo, useContext, useMemo, useState } fr
 import { ChatGroupWizard } from '@/components/ChatGroupWizard';
 import { MemberSelectionModal } from '@/components/MemberSelectionModal';
 
-import CreateGroupModal from '../../CreateGroupModal';
 import ConfigGroupModal from './Modals/ConfigGroupModal';
+import CreateGroupModal from './Modals/CreateGroupModal';
 
 interface AgentModalContextValue {
   closeAllModals: () => void;

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -288,6 +288,7 @@ export const ModelItemRender = memo<ModelItemRenderProps>(
           <Text
             ellipsis={{
               tooltip: displayNameOrId,
+              tooltipWhenOverflow: true,
             }}
             style={mobile ? { maxWidth: '60vw' } : { minWidth: 0, overflow: 'hidden' }}
           >

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -288,7 +288,6 @@ export const ModelItemRender = memo<ModelItemRenderProps>(
           <Text
             ellipsis={{
               tooltip: displayNameOrId,
-              tooltipWhenOverflow: true,
             }}
             style={mobile ? { maxWidth: '60vw' } : { minWidth: 0, overflow: 'hidden' }}
           >


### PR DESCRIPTION
## Summary

- Fix "Add New Group" menu item opening wrong modal
- Use simple session group creation modal instead of complex agent selection modal

## Problem

When clicking "Add New Group" in the agent dropdown menu, it was incorrectly opening the complex `CreateGroupModal` (from `home/_layout/CreateGroupModal`) which requires selecting agents. This is meant for a different use case.

## Solution

Changed the import in `ModalProvider.tsx` to use the correct `CreateGroupModal` from `./Modals/CreateGroupModal` which is a simple modal that only requires entering a group name to create an agent folder (session group).

## Changes

- `ModalProvider.tsx`: Fixed import path for `CreateGroupModal`
- `ModelSelect/index.tsx`: Fixed unrelated type error (removed deprecated `tooltipWhenOverflow` prop)

## Test plan

- [x] Type check passes
- [ ] Manual test: Click "Add New Group" in agent menu, verify simple name input modal appears

## Related Issues

Closes: LOBE-4192

🤖 Generated with [Claude Code](https://claude.com/claude-code)