### PR TITLE
🐛 fix(editor): prevent crash when toggling enableInputMarkdown setting

### DIFF
--- a/src/features/ChatInput/ChatInputProvider.tsx
+++ b/src/features/ChatInput/ChatInputProvider.tsx
@@ -1,5 +1,8 @@
 import { useEditor } from '@lobehub/editor/react';
-import { type ReactNode, memo, useRef } from 'react';
+import { type MutableRefObject, type ReactNode, memo, useRef } from 'react';
+
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 
 import StoreUpdater, { type StoreUpdaterProps } from './StoreUpdater';
 import { Provider, createStore } from './store';
@@ -8,10 +11,16 @@ interface ChatInputProviderProps extends StoreUpdaterProps {
   children: ReactNode;
 }
 
-export const ChatInputProvider = memo<ChatInputProviderProps>(
+interface ChatInputProviderInnerProps extends StoreUpdaterProps {
+  children: ReactNode;
+  contentRef: MutableRefObject<string>;
+}
+
+const ChatInputProviderInner = memo<ChatInputProviderInnerProps>(
   ({
     agentId,
     children,
+    contentRef,
     leftActions,
     rightActions,
     mobile,
@@ -31,6 +40,7 @@ export const ChatInputProvider = memo<ChatInputProviderProps>(
         createStore={() =>
           createStore({
             allowExpand,
+            contentRef,
             editor,
             leftActions,
             mentionItems,
@@ -60,3 +70,13 @@ export const ChatInputProvider = memo<ChatInputProviderProps>(
     );
   },
 );
+
+export const ChatInputProvider = (props: ChatInputProviderProps) => {
+  const enableRichRender = useUserStore(labPreferSelectors.enableInputMarkdown);
+  // Ref to persist content across re-mounts when enableRichRender changes
+  const contentRef = useRef<string>('');
+
+  return (
+    <ChatInputProviderInner contentRef={contentRef} key={`editor-${enableRichRender}`} {...props} />
+  );
+};

--- a/src/features/ChatInput/store/initialState.ts
+++ b/src/features/ChatInput/store/initialState.ts
@@ -1,6 +1,7 @@
 import { type IEditor, type SlashOptions } from '@lobehub/editor';
 import type { ChatInputProps } from '@lobehub/editor/react';
 import type { MenuProps } from '@lobehub/ui';
+import type { MutableRefObject } from 'react';
 
 import { type ActionKeys } from '@/features/ChatInput';
 
@@ -39,6 +40,7 @@ export interface PublicState {
 }
 
 export interface State extends PublicState {
+  contentRef?: MutableRefObject<string>;
   editor?: IEditor;
   isContentEmpty: boolean;
   markdownContent: string;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-2663

#### 🔀 Description of Change

Fix "Node TableNode has not been registered" error that occurred when switching the `enableInputMarkdown` setting from disabled to enabled.

**Root Cause:**
Lexical editor nodes must be registered at editor creation time. When `enableRichRender` was toggled from `false` to `true`, plugins (like `ReactTablePlugin`) tried to register nodes (like `TableNode`) on an already-created editor instance, causing the crash.

**Solution:**
Use key-based re-mounting with content preservation via ref:
- Outer component holds `contentRef` to persist content across re-mounts
- Inner component re-mounts when `enableRichRender` changes (via React key)
- Content is restored from ref on editor initialization

**Files Changed:**
- `ChatInputProvider.tsx` - Split into outer/inner components with ref-based content preservation
- `InputEditor/index.tsx` - Save content to ref on change, restore on init
- `store/initialState.ts` - Add `contentRef` type
- `CronJobContentEditor.tsx` - Same pattern for cron job editor

#### 🧪 How to Test

1. Go to Settings > Labs
2. Find "Enable Input Markdown" toggle
3. Toggle it off, type some text in chat input
4. Toggle it back on
5. Verify: No crash, and text content is preserved

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

This fix ensures seamless switching between plain text and rich markdown editing modes without data loss or crashes.