### PR TITLE
🐛 fix: surface streaming errors during mid-stream pulls

### DIFF
--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -151,9 +151,19 @@ export function readableFromAsyncIterable<T>(iterable: AsyncIterable<T>) {
     },
 
     async pull(controller) {
-      const { done, value } = await it.next();
-      if (done) controller.close();
-      else controller.enqueue(value);
+      try {
+        const { done, value } = await it.next();
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch (e) {
+        const error = e as Error;
+
+        controller.enqueue(
+          (ERROR_CHUNK_PREFIX +
+            JSON.stringify({ message: error.message, name: error.name, stack: error.stack })) as T,
+        );
+        controller.close();
+      }
     },
   });
 }
@@ -171,9 +181,19 @@ export const convertIterableToStream = <T>(stream: AsyncIterable<T>) => {
       await it.return?.(reason);
     },
     async pull(controller) {
-      const { done, value } = await it.next();
-      if (done) controller.close();
-      else controller.enqueue(value);
+      try {
+        const { done, value } = await it.next();
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch (e) {
+        const error = e as Error;
+
+        controller.enqueue(
+          (ERROR_CHUNK_PREFIX +
+            JSON.stringify({ message: error.message, name: error.name, stack: error.stack })) as T,
+        );
+        controller.close();
+      }
     },
 
     async start(controller) {


### PR DESCRIPTION
### Motivation

- Streaming iterators could throw after the first yielded value and those errors were not being surfaced to the SSE pipeline, causing silent server-side failures instead of visible error events in the frontend.
- Ensure mid-stream provider errors (e.g. rate limits) are converted into structured SSE error chunks so the client can render them like other streaming errors.

### Description

- Added error handling in `convertIterableToStream` (and the lower-level readable helper) to catch exceptions from subsequent `next()` calls and enqueue an error chunk prefixed with `ERROR_CHUNK_PREFIX` so downstream transformers can surface it as an SSE error event (file: `packages/model-runtime/src/core/streams/protocol.ts`).
- Added a unit test that yields a value then throws from an async generator and verifies the pipeline produces an error chunk with `FIRST_CHUNK_ERROR_KEY` set and the original error message (file: `packages/model-runtime/src/core/streams/protocol.test.ts`).
- Updated imports in the test to include `convertIterableToStream` and `FIRST_CHUNK_ERROR_KEY` and to pipe the readable through `createFirstErrorHandleTransformer` to assert behavior.

### Testing

- Added a unit test `convertIterableToStream should surface errors from subsequent pulls as error chunks` in `packages/model-runtime/src/core/streams/protocol.test.ts` which asserts the mid-stream error is emitted as an error chunk; the test is included in the repo.
- Attempted to run the file-level tests with `bunx vitest run --silent='passed-only' 'src/core/streams/protocol.test.ts'` under `packages/model-runtime`, but the run failed due to registry access when resolving `vitest` (HTTP 403), so automated test execution could not complete in this environment.
- Test files and transformers were updated and committed; the new test should pass in CI or a developer environment with access to the package registry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739cc14810832ab56a5c847dfa2eda)

## Summary by Sourcery

Surface mid-stream errors from async iterables as structured error chunks in the streaming pipeline and verify the behavior with a new unit test.

Bug Fixes:
- Convert exceptions thrown during async iterable pulls into error chunks prefixed with the streaming error marker so they propagate through the SSE pipeline instead of failing silently.

Tests:
- Add a unit test ensuring convertIterableToStream emits a first-chunk error object when an async generator throws after yielding an initial value.