### PR TITLE
🐛 fix(input): revert #11755 to fix chat input unfocus

### DIFF
--- a/src/features/ChatInput/ChatInputProvider.tsx
+++ b/src/features/ChatInput/ChatInputProvider.tsx
@@ -1,8 +1,5 @@
 import { useEditor } from '@lobehub/editor/react';
-import { type MutableRefObject, type ReactNode, memo, useRef } from 'react';
-
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
+import { type ReactNode, memo, useRef } from 'react';
 
 import StoreUpdater, { type StoreUpdaterProps } from './StoreUpdater';
 import { Provider, createStore } from './store';
@@ -11,16 +8,10 @@ interface ChatInputProviderProps extends StoreUpdaterProps {
   children: ReactNode;
 }
 
-interface ChatInputProviderInnerProps extends StoreUpdaterProps {
-  children: ReactNode;
-  contentRef: MutableRefObject<string>;
-}
-
-const ChatInputProviderInner = memo<ChatInputProviderInnerProps>(
+export const ChatInputProvider = memo<ChatInputProviderProps>(
   ({
     agentId,
     children,
-    contentRef,
     leftActions,
     rightActions,
     mobile,
@@ -40,7 +31,6 @@ const ChatInputProviderInner = memo<ChatInputProviderInnerProps>(
         createStore={() =>
           createStore({
             allowExpand,
-            contentRef,
             editor,
             leftActions,
             mentionItems,
@@ -70,13 +60,3 @@ const ChatInputProviderInner = memo<ChatInputProviderInnerProps>(
     );
   },
 );
-
-export const ChatInputProvider = (props: ChatInputProviderProps) => {
-  const enableRichRender = useUserStore(labPreferSelectors.enableInputMarkdown);
-  // Ref to persist content across re-mounts when enableRichRender changes
-  const contentRef = useRef<string>('');
-
-  return (
-    <ChatInputProviderInner contentRef={contentRef} key={`editor-${enableRichRender}`} {...props} />
-  );
-};

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -37,7 +37,7 @@ const className = cx(css`
 `);
 
 const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
-  const [editor, slashMenuRef, send, updateMarkdownContent, expand, mentionItems, contentRef] =
+  const [editor, slashMenuRef, send, updateMarkdownContent, expand, mentionItems] =
     useChatInputStore((s) => [
       s.editor,
       s.slashMenuRef,
@@ -45,7 +45,6 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       s.updateMarkdownContent,
       s.expand,
       s.mentionItems,
-      s.contentRef,
     ]);
 
   const storeApi = useStoreApi();
@@ -152,11 +151,7 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       onBlur={() => {
         disableScope(HotkeyEnum.AddUserMessage);
       }}
-      onChange={(e) => {
-        // Save content to parent ref for restoration when enableRichRender changes
-        if (contentRef) {
-          contentRef.current = e.getDocument('markdown') as unknown as string;
-        }
+      onChange={() => {
         updateMarkdownContent();
       }}
       onCompositionEnd={() => {
@@ -182,13 +177,7 @@ const InputEditor = memo<{ defaultRows?: number }>(({ defaultRows = 2 }) => {
       onFocus={() => {
         enableScope(HotkeyEnum.AddUserMessage);
       }}
-      onInit={(editor) => {
-        storeApi.setState({ editor });
-        // Restore content from parent ref when editor re-initializes
-        if (contentRef?.current) {
-          editor.setDocument('markdown', contentRef.current);
-        }
-      }}
+      onInit={(editor) => storeApi.setState({ editor })}
       onPressEnter={({ event: e }) => {
         if (e.shiftKey || isChineseInput.current) return;
         // when user like alt + enter to add ai message

--- a/src/features/ChatInput/store/initialState.ts
+++ b/src/features/ChatInput/store/initialState.ts
@@ -1,7 +1,6 @@
 import { type IEditor, type SlashOptions } from '@lobehub/editor';
 import type { ChatInputProps } from '@lobehub/editor/react';
 import type { MenuProps } from '@lobehub/ui';
-import type { MutableRefObject } from 'react';
 
 import { type ActionKeys } from '@/features/ChatInput';
 
@@ -40,7 +39,6 @@ export interface PublicState {
 }
 
 export interface State extends PublicState {
-  contentRef?: MutableRefObject<string>;
   editor?: IEditor;
   isContentEmpty: boolean;
   markdownContent: string;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

@Innei  #11755 PR 导致输入文本后就直接失焦，我先回滚了。然后你需要针对这个场景补一个 E2E 用例确保不会有 regression
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Revert prior changes that persisted editor content across rich text toggle for cron job content and chat input, restoring simpler editor initialization behavior without shared content refs.

Enhancements:
- Simplify cron job content editor by initializing document content directly on editor readiness instead of using an external ref for persistence.
- Simplify chat input provider and editor state by removing the shared contentRef mechanism from the store and components.