### PR TITLE
🔨 chore: Prefer to use `VERCEL_URL` rather than `VERCEL_BRANCH_URL`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const isVercel = !!process.env.VERCEL_ENV;
 const nextConfig = defineConfig({
   experimental: {
     webpackBuildWorker: true,
-    webpackMemoryOptimizations: true,
+    webpackMemoryOptimizations: false,
   },
   // Vercel serverless optimization: exclude musl binaries
   // Vercel uses Amazon Linux (glibc), not Alpine Linux (musl)

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const isVercel = !!process.env.VERCEL_ENV;
 const nextConfig = defineConfig({
   experimental: {
     webpackBuildWorker: true,
-    webpackMemoryOptimizations: false,
+    webpackMemoryOptimizations: true,
   },
   // Vercel serverless optimization: exclude musl binaries
   // Vercel uses Amazon Linux (glibc), not Alpine Linux (musl)

--- a/src/envs/__tests__/app.test.ts
+++ b/src/envs/__tests__/app.test.ts
@@ -117,7 +117,7 @@ describe('APP_URL fallback', () => {
       expect(config.APP_URL).toBe('https://lobechat.vercel.app');
     });
 
-    it('should use VERCEL_BRANCH_URL in preview environment', async () => {
+    it('should use VERCEL_URL in preview environment', async () => {
       process.env.VERCEL = '1';
       process.env.VERCEL_ENV = 'preview';
       process.env.VERCEL_BRANCH_URL = 'lobechat-git-feature-org.vercel.app';
@@ -125,41 +125,35 @@ describe('APP_URL fallback', () => {
 
       const { getAppConfig } = await import('../app');
       const config = getAppConfig();
-      expect(config.APP_URL).toBe('https://lobechat-git-feature-org.vercel.app');
+      expect(config.APP_URL).toBe('https://lobechat-abc123.vercel.app');
     });
 
-    it('should fallback to VERCEL_URL when VERCEL_BRANCH_URL is not set', async () => {
+    it('should fallback to VERCEL_BRANCH_URL when VERCEL_URL is not set', async () => {
       process.env.VERCEL = '1';
       process.env.VERCEL_ENV = 'preview';
-      process.env.VERCEL_URL = 'lobechat-abc123.vercel.app';
+      process.env.VERCEL_BRANCH_URL = 'lobechat-git-feature-org.vercel.app';
 
       const { getAppConfig } = await import('../app');
       const config = getAppConfig();
-      expect(config.APP_URL).toBe('https://lobechat-abc123.vercel.app');
+      expect(config.APP_URL).toBe('https://lobechat-git-feature-org.vercel.app');
     });
   });
 
   describe('local environment', () => {
     it('should use localhost:3010 in development', async () => {
-      
       vi.stubEnv('NODE_ENV', 'development');
 
       const { getAppConfig } = await import('../app');
       const config = getAppConfig();
       expect(config.APP_URL).toBe('http://localhost:3010');
-
-      
     });
 
     it('should use localhost:3210 in non-development', async () => {
-      
       vi.stubEnv('NODE_ENV', 'test');
 
       const { getAppConfig } = await import('../app');
       const config = getAppConfig();
       expect(config.APP_URL).toBe('http://localhost:3210');
-
-      
     });
   });
 });

--- a/src/envs/app.ts
+++ b/src/envs/app.ts
@@ -6,16 +6,16 @@ const isInVercel = process.env.VERCEL === '1';
 
 // Vercel URL fallback order (by stability):
 // 1. VERCEL_PROJECT_PRODUCTION_URL - project level, most stable
-// 2. VERCEL_BRANCH_URL - branch level, stable across deployments on same branch
-// 3. VERCEL_URL - deployment level, changes every deployment
+// 2. VERCEL_URL - deployment level, changes every deployment
+// 3. VERCEL_BRANCH_URL - branch level, stable across deployments on same branch
 const getVercelUrl = () => {
   if (process.env.VERCEL_ENV === 'production' && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
   }
-  if (process.env.VERCEL_BRANCH_URL) {
-    return `https://${process.env.VERCEL_BRANCH_URL}`;
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
   }
-  return `https://${process.env.VERCEL_URL}`;
+  return `https://${process.env.VERCEL_BRANCH_URL}`;
 };
 
 const APP_URL = process.env.APP_URL

--- a/src/libs/better-auth/utils/config.ts
+++ b/src/libs/better-auth/utils/config.ts
@@ -50,8 +50,8 @@ export const getTrustedOrigins = (enabledSSOProviders: string[]) => {
 
   const defaults = [
     normalizeOrigin(appEnv.APP_URL),
-    normalizeOrigin(process.env.VERCEL_BRANCH_URL),
     normalizeOrigin(process.env.VERCEL_URL),
+    normalizeOrigin(process.env.VERCEL_BRANCH_URL),
     MOBILE_APP_SCHEME,
     // Add expo URL in development
     ...(isDev ? [EXPO_DEV_SCHEME] : []),


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

目前项目已统一使用 BetterAuth，对于不同开发分支需要提供不同的 `APP_URL`，若优先使用 `VERCEL_BRANCH_URL` 会产生诸多不便，Vercel 默认为每个部署提供的地址也是 `VERCEL_URL` 。


---

~~此外为加快部署，是否能考虑为项目添加 `pnpm-lock.yaml` ？~~

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Prefer VERCEL_URL over VERCEL_BRANCH_URL when deriving the application URL in Vercel environments and align auth configuration accordingly.

Enhancements:
- Adjust APP_URL resolution to prioritize VERCEL_URL with VERCEL_BRANCH_URL as a fallback in preview environments.
- Update BetterAuth trusted origin configuration to include VERCEL_URL before VERCEL_BRANCH_URL for consistency with APP_URL resolution.

Tests:
- Update APP_URL fallback tests to reflect the new Vercel URL precedence and expected values in preview environments.