### PR TITLE
♻️ refactor(ModelSelect): migrate from antd Select to LobeSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "@lobehub/icons": "^4.0.2",
     "@lobehub/market-sdk": "0.29.1",
     "@lobehub/tts": "^4.0.2",
-    "@lobehub/ui": "^4.28.0",
+    "@lobehub/ui": "^4.29.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -56,6 +56,7 @@ const ProfileEditor = memo(() => {
           style={{ marginBottom: 12 }}
         >
           <ModelSelect
+            initialWidth
             onChange={updateConfig}
             value={{
               model: config.model,

--- a/src/app/[variants]/(main)/group/profile/features/MemberProfile/index.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/MemberProfile/index.tsx
@@ -114,6 +114,7 @@ const MemberProfile = memo(() => {
           style={{ marginBottom: 12 }}
         >
           <ModelSelect
+            initialWidth
             onChange={updateAgentConfig}
             value={{
               model: config?.model,

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -6,15 +6,9 @@ import { ModelItemRender, ProviderItemRender } from '@/components/ModelSelect';
 import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
-const prefixCls = 'ant';
-
 const styles = createStaticStyles(({ css }) => ({
   popup: css`
-    width: 360px;
-
-    &.${prefixCls}-select-dropdown .${prefixCls}-select-item-option-grouped {
-      padding-inline-start: 12px;
-    }
+    width: max(360px, var(--anchor-width));
   `,
 }));
 
@@ -26,14 +20,26 @@ interface ModelOption {
 
 interface ModelSelectProps extends Pick<LobeSelectProps, 'loading' | 'size' | 'style' | 'variant'> {
   defaultValue?: { model: string; provider?: string };
+  initialWidth?: boolean;
   onChange?: (props: { model: string; provider: string }) => void;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
   showAbility?: boolean;
+
   value?: { model: string; provider?: string };
 }
 
 const ModelSelect = memo<ModelSelectProps>(
-  ({ value, onChange, showAbility = true, requiredAbilities, loading, size, style, variant }) => {
+  ({
+    value,
+    onChange,
+    initialWidth = false,
+    showAbility = true,
+    requiredAbilities,
+    loading,
+    size,
+    style,
+    variant,
+  }) => {
     const enabledList = useEnabledChatModels();
 
     const options = useMemo<LobeSelectProps['options']>(() => {
@@ -85,6 +91,7 @@ const ModelSelect = memo<ModelSelectProps>(
           defaultValue={`${value?.provider}/${value?.model}`}
           loading={loading}
           onChange={(value, option) => {
+            if (!value) return;
             const model = (value as string).split('/').slice(1).join('/');
             onChange?.({ model, provider: (option as unknown as ModelOption).provider });
           }}
@@ -94,11 +101,12 @@ const ModelSelect = memo<ModelSelectProps>(
           size={size}
           style={{
             minWidth: 200,
-            width: 'initial',
+            width: initialWidth ? 'initial' : undefined,
             ...style,
           }}
           value={`${value?.provider}/${value?.model}`}
           variant={variant}
+          virtual
         />
       </TooltipGroup>
     );

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -12,7 +12,12 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
+type ModelAbilities = EnabledProviderWithModels['children'][number]['abilities'];
+
 interface ModelOption {
+  abilities?: ModelAbilities;
+  displayName?: string;
+  id: string;
   label: ReactNode;
   provider: string;
   value: string;
@@ -95,9 +100,21 @@ const ModelSelect = memo<ModelSelectProps>(
             const model = (value as string).split('/').slice(1).join('/');
             onChange?.({ model, provider: (option as unknown as ModelOption).provider });
           }}
+          optionRender={(option) => {
+            const data = option as unknown as ModelOption;
+            return (
+              <ModelItemRender
+                displayName={data.displayName}
+                id={data.id}
+                showInfoTag
+                {...data.abilities}
+              />
+            );
+          }}
           options={options}
           popupClassName={styles.popup}
           popupMatchSelectWidth={false}
+          selectedIndicatorVariant="bold"
           size={size}
           style={{
             minWidth: 200,

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,8 +1,8 @@
-import { Select, type SelectProps, TooltipGroup } from '@lobehub/ui';
+import { LobeSelect, type LobeSelectProps, TooltipGroup } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo, useMemo } from 'react';
+import { type ReactNode, memo, useMemo } from 'react';
 
-import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
+import { ModelItemRender, ProviderItemRender } from '@/components/ModelSelect';
 import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
@@ -10,26 +10,21 @@ const prefixCls = 'ant';
 
 const styles = createStaticStyles(({ css }) => ({
   popup: css`
+    width: 360px;
+
     &.${prefixCls}-select-dropdown .${prefixCls}-select-item-option-grouped {
       padding-inline-start: 12px;
-    }
-  `,
-  select: css`
-    .${prefixCls}-select-selection-item {
-      .${TAG_CLASSNAME} {
-        display: none;
-      }
     }
   `,
 }));
 
 interface ModelOption {
-  label: any;
+  label: ReactNode;
   provider: string;
   value: string;
 }
 
-interface ModelSelectProps extends Pick<SelectProps, 'loading' | 'size' | 'style' | 'variant'> {
+interface ModelSelectProps extends Pick<LobeSelectProps, 'loading' | 'size' | 'style' | 'variant'> {
   defaultValue?: { model: string; provider?: string };
   onChange?: (props: { model: string; provider: string }) => void;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
@@ -41,7 +36,7 @@ const ModelSelect = memo<ModelSelectProps>(
   ({ value, onChange, showAbility = true, requiredAbilities, loading, size, style, variant }) => {
     const enabledList = useEnabledChatModels();
 
-    const options = useMemo<SelectProps['options']>(() => {
+    const options = useMemo<LobeSelectProps['options']>(() => {
       const getChatModels = (provider: EnabledProviderWithModels) => {
         const models =
           requiredAbilities && requiredAbilities.length > 0
@@ -81,30 +76,25 @@ const ModelSelect = memo<ModelSelectProps>(
             options: opts,
           };
         })
-        .filter(Boolean) as SelectProps['options'];
+        .filter(Boolean) as LobeSelectProps['options'];
     }, [enabledList, requiredAbilities, showAbility]);
 
     return (
       <TooltipGroup>
-        <Select
-          className={styles.select}
-          classNames={{
-            popup: { root: styles.popup },
-          }}
+        <LobeSelect
           defaultValue={`${value?.provider}/${value?.model}`}
           loading={loading}
           onChange={(value, option) => {
-            const model = value.split('/').slice(1).join('/');
+            const model = (value as string).split('/').slice(1).join('/');
             onChange?.({ model, provider: (option as unknown as ModelOption).provider });
           }}
-          optionRender={(option) => (
-            <ModelItemRender {...option.data} {...option.data.abilities} showInfoTag />
-          )}
           options={options}
+          popupClassName={styles.popup}
           popupMatchSelectWidth={false}
           size={size}
           style={{
             minWidth: 200,
+            width: 'initial',
             ...style,
           }}
           value={`${value?.provider}/${value?.model}`}


### PR DESCRIPTION
## Summary
- Migrate ModelSelect component from antd `Select` to `@lobehub/ui` `LobeSelect`
- Fix popover z-index issues by using LobeSelect's proper z-index handling
- Set fixed popup width to 360px for better UX

## Changes
- Replace `Select` with `LobeSelect` from `@lobehub/ui`
- Simplify styles by using `popupClassName` instead of `classNames`
- Remove unused `TAG_CLASSNAME` import and select styles

## Test plan
- [x] Verify ModelSelect dropdown appears with correct z-index
- [x] Confirm popup width is 360px
- [x] Test model selection functionality works correctly

fix LOBE-4210

## Summary by Sourcery

Refactor the ModelSelect component to use the shared LobeSelect dropdown with improved popup behavior and layout.

New Features:
- Use LobeSelect from @lobehub/ui for the model selection dropdown instead of the antd Select component.

Enhancements:
- Standardize ModelSelect option typing against LobeSelectProps and ReactNode labels.
- Adjust the dropdown popup styling to enforce a 360px width and avoid width inheritance issues from the trigger input.