### PR TITLE
🐛 fix: add cron pages enables change should reload the state

### DIFF
--- a/src/app/[variants]/(main)/agent/cron/[cronId]/features/CronJobHeader.tsx
+++ b/src/app/[variants]/(main)/agent/cron/[cronId]/features/CronJobHeader.tsx
@@ -6,13 +6,14 @@ import { useTranslation } from 'react-i18next';
 interface CronJobHeaderProps {
   enabled?: boolean;
   isNewJob?: boolean;
+  isTogglingEnabled?: boolean;
   name: string;
   onNameChange: (name: string) => void;
   onToggleEnabled?: (enabled: boolean) => void;
 }
 
 const CronJobHeader = memo<CronJobHeaderProps>(
-  ({ enabled, isNewJob, name, onNameChange, onToggleEnabled }) => {
+  ({ enabled, isNewJob, isTogglingEnabled, name, onNameChange, onToggleEnabled }) => {
     const { t } = useTranslation(['setting', 'common']);
 
     return (
@@ -34,7 +35,11 @@ const CronJobHeader = memo<CronJobHeaderProps>(
         {!isNewJob && (
           <Flexbox align="center" gap={12} horizontal>
             {/* Enable/Disable Switch */}
-            <Switch checked={enabled ?? false} onChange={onToggleEnabled} />
+            <Switch
+              checked={enabled ?? false}
+              loading={isTogglingEnabled}
+              onChange={onToggleEnabled}
+            />
           </Flexbox>
         )}
       </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

fix: LOBE-4208

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure cron job enable/disable actions immediately reflect in UI state and refresh related cron topic data.

Bug Fixes:
- Fix cron job enable/disable toggle so that changing the enabled state updates the cron job record and refreshes related cron topics.

Enhancements:
- Add a loading state to the cron job enabled switch to indicate when the enabled status is being updated.