### PR TITLE
🐛 fix: prevent recently viewed items from shrinking

### DIFF
--- a/src/features/Electron/titlebar/RecentlyViewed.tsx
+++ b/src/features/Electron/titlebar/RecentlyViewed.tsx
@@ -34,6 +34,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     cursor: pointer;
 
     overflow: hidden;
+    flex-shrink: 0;
 
     padding-block: 6px;
     padding-inline: 8px;


### PR DESCRIPTION
## Summary
- Add `flex-shrink: 0` to recently viewed items to prevent them from being compressed when container space is limited

## Test Plan
- [x] Verify recently viewed items maintain their size in the titlebar
- [x] Test with multiple items to ensure proper layout

Closes LOBE-4212

## Summary by Sourcery

Bug Fixes:
- Ensure recently viewed titlebar items maintain their intended size by disabling flex shrinking in constrained layouts.