### PR TITLE
🔇 chore: remove debug console.log statements

### DIFF
--- a/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -63,7 +63,6 @@ const AgentHeader = memo(() => {
       setUploading(true);
       try {
         const result = await uploadWithProgress({ file });
-        console.log('result', result);
         if (result?.url) {
           updateMeta({ avatar: result.url });
         }

--- a/src/app/[variants]/(main)/community/(detail)/agent/features/Details/Overview/index.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/agent/features/Details/Overview/index.tsx
@@ -30,9 +30,7 @@ const Overview = memo(() => {
     backgroundColor,
     config,
   } = useDetailContext();
-  console.log('examples', examples);
 
-  console.log('summary', summary);
   const data: any = [
     {
       content: config?.openingMessage,

--- a/src/app/[variants]/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
@@ -90,9 +90,7 @@ const AddAgent = memo<{ mobile?: boolean }>(({ mobile }) => {
       });
     }
 
-    if (shouldNavigate) {
-      console.log(shouldNavigate);
-    }
+    void shouldNavigate;
 
     return result;
   };

--- a/src/app/[variants]/(main)/community/(detail)/user/features/FollowStats.tsx
+++ b/src/app/[variants]/(main)/community/(detail)/user/features/FollowStats.tsx
@@ -10,8 +10,6 @@ const FollowStats = memo(() => {
   const { t } = useTranslation('discover');
   const { user } = useUserDetailContext();
 
-  console.log(user);
-
   const followingCount = user.followingCount ?? 0;
   const followersCount = user.followersCount ?? 0;
 

--- a/src/app/[variants]/(main)/community/(list)/features/SortButton/index.tsx
+++ b/src/app/[variants]/(main)/community/(list)/features/SortButton/index.tsx
@@ -188,7 +188,7 @@ const SortButton = memo(() => {
     // If "My Own" is selected, add ownerId to query
     if (config === AssistantSorts.MyOwn) {
       const userInfo = getCurrentUserInfo();
-      console.log('userInfo', userInfo);
+
       if (userInfo?.accountId) {
         query.ownerId = userInfo.accountId;
       }

--- a/src/app/[variants]/(main)/community/features/UserAvatar/index.tsx
+++ b/src/app/[variants]/(main)/community/features/UserAvatar/index.tsx
@@ -53,8 +53,6 @@ const UserAvatar = memo(() => {
   // 检查是否需要完善资料
   const needsProfileSetup = checkNeedsProfileSetup(enableMarketTrustedClient, userProfile);
 
-  console.log('needsProfileSetup', needsProfileSetup);
-
   const handleSignIn = useCallback(async () => {
     setLoading(true);
     try {

--- a/src/app/[variants]/(main)/group/profile/features/Header/AgentPublishButton/PublishResultModal.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/Header/AgentPublishButton/PublishResultModal.tsx
@@ -19,7 +19,6 @@ const PublishResultModal = memo<PublishResultModalProps>(({ identifier, onCancel
 
   const handleGoToMarket = () => {
     if (identifier) {
-      console.log('identifier', identifier);
       navigate(`/community/group_agent/${identifier}`);
     }
     onCancel();

--- a/src/app/[variants]/(main)/group/profile/features/MemberProfile/AgentHeader.tsx
+++ b/src/app/[variants]/(main)/group/profile/features/MemberProfile/AgentHeader.tsx
@@ -75,7 +75,6 @@ const AgentHeader = memo<AgentHeaderProps>(({ readOnly }) => {
       setUploading(true);
       try {
         const result = await uploadWithProgress({ file });
-        console.log('result', result);
         if (result?.url) {
           optimisticUpdateAgentMeta(agentId, { avatar: result.url });
         }

--- a/src/app/[variants]/(main)/settings/hotkey/features/Desktop.tsx
+++ b/src/app/[variants]/(main)/settings/hotkey/features/Desktop.tsx
@@ -41,7 +41,6 @@ const HotkeySetting = memo(() => {
           setLoading(true);
           try {
             const result = await updateDesktopHotkey(item.id, value);
-            console.log(result);
             if (result.success) {
               message.success(t('hotkey.updateSuccess', { ns: 'setting' }));
             } else {

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
@@ -17,7 +17,7 @@ const SearchResult = memo(() => {
   const batchToggleAiModels = useAiInfraStore((s) => s.batchToggleAiModels);
 
   const filteredModels = useAiInfraStore(aiModelSelectors.filteredAiProviderModelList, isEqual);
-  console.log('filteredModels:', filteredModels);
+
   const [batchLoading, setBatchLoading] = useState(false);
 
   const isEmpty = filteredModels.length === 0;

--- a/src/app/[variants]/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
+++ b/src/app/[variants]/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
@@ -77,8 +77,6 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy }) => {
     [data, groupBy],
   );
 
-  console.log('ModelTable', groupBy, formattedData);
-
   return isLoading ? (
     <Skeleton active paragraph={{ rows: 8 }} title={false} />
   ) : (

--- a/src/features/ChatInput/Desktop/ContextContainer/ContextList.tsx
+++ b/src/features/ChatInput/Desktop/ContextContainer/ContextList.tsx
@@ -30,7 +30,7 @@ const ContextList = memo(() => {
   const rawSelectionList = useFileStore(fileChatSelectors.chatContextSelections);
   const showSelectionList = useFileStore(fileChatSelectors.chatContextSelectionHasItem);
   const clearChatContextSelections = useFileStore((s) => s.clearChatContextSelections);
-  console.log(rawSelectionList);
+
   // Clear selections only when agentId changes (not on initial mount)
   useEffect(() => {
     if (prevAgentIdRef.current !== undefined && prevAgentIdRef.current !== agentId) {

--- a/src/features/ChatInput/Mobile/FilePreview/FileItem/index.tsx
+++ b/src/features/ChatInput/Mobile/FilePreview/FileItem/index.tsx
@@ -20,8 +20,6 @@ const FileItem = memo<FileItemProps>((props) => {
   const { file, id, previewUrl, status } = props;
   const [removeFile] = useFileStore((s) => [s.removeChatUploadFile]);
 
-  console.log('file', file);
-
   if (file.type.startsWith('image')) {
     return (
       <Image

--- a/src/features/DevPanel/features/Table/TableCell.tsx
+++ b/src/features/DevPanel/features/Table/TableCell.tsx
@@ -8,7 +8,7 @@ interface TableCellProps {
   rowIndex: number;
 }
 
-const TableCell = ({ dataItem, column, rowIndex }: TableCellProps) => {
+const TableCell = ({ dataItem, column }: TableCellProps) => {
   const data = get(dataItem, column);
   const content = useMemo(() => {
     if (isDate(data)) return dayjs(data).format('YYYY-MM-DD HH:mm:ss');
@@ -29,7 +29,7 @@ const TableCell = ({ dataItem, column, rowIndex }: TableCellProps) => {
   }, [data]);
 
   return (
-    <td key={column} onDoubleClick={() => console.log('Edit cell:', rowIndex, column)}>
+    <td key={column}>
       {/* 不能使用 antd 的 Text， 会有大量的重渲染导致滚动极其卡顿 */}
       {content}
     </td>

--- a/src/features/Portal/Plugins/Body/index.tsx
+++ b/src/features/Portal/Plugins/Body/index.tsx
@@ -10,7 +10,6 @@ import ToolRender from './ToolRender';
 const ToolUI = () => {
   const messageId = useChatStore(chatPortalSelectors.toolMessageId);
   const message = useChatStore(dbMessageSelectors.getDbMessageById(messageId || ''), isEqual);
-  console.log(messageId, message);
   // make sure the message and id is valid
   if (!messageId || !message) return;
 

--- a/src/features/ProtocolUrlHandler/InstallPlugin/CustomPluginInstallModal.tsx
+++ b/src/features/ProtocolUrlHandler/InstallPlugin/CustomPluginInstallModal.tsx
@@ -79,7 +79,6 @@ const CustomPluginInstallModal = memo<CustomPluginInstallModalProps>(
             description: schema.description,
           },
         };
-        console.log('testParams:', testParams);
 
         const testResult = await testMcpConnection(testParams);
 

--- a/src/libs/trpc/middleware/userAuth.ts
+++ b/src/libs/trpc/middleware/userAuth.ts
@@ -7,7 +7,6 @@ export const userAuth = trpc.middleware(async (opts) => {
 
   // `ctx.user` is nullable
   if (!ctx.userId) {
-    console.log('better auth: no session found in context');
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
 

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -224,8 +224,6 @@ export const fileRouter = router({
       limit: limit + 1,
     });
 
-    console.log('getKnow', knowledgeItems);
-
     // Check if there are more items
     const hasMore = knowledgeItems.length > limit;
 

--- a/src/services/import/index.ts
+++ b/src/services/import/index.ts
@@ -4,7 +4,7 @@ import { lambdaClient } from '@/libs/trpc/client';
 import { uploadService } from '@/services/upload';
 import { useUserStore } from '@/store/user';
 import { type ImportPgDataStructure } from '@/types/export';
-import { type ImporterEntryData, ImportStage, type OnImportCallbacks } from '@/types/importer';
+import { ImportStage, type ImporterEntryData, type OnImportCallbacks } from '@/types/importer';
 import { type UserSettings } from '@/types/user/settings';
 import { uuid } from '@/utils/uuid';
 
@@ -113,7 +113,6 @@ class ImportService {
         pathname: `import_config/${filename}`,
       });
       pathname = result.data.path;
-      console.log(pathname);
     } catch {
       throw new Error('Upload Error');
     }

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -323,7 +323,7 @@ export const pluginTypes: StateCreator<
 
       if (!!result) data = result;
     } catch (error) {
-      console.log(error);
+      console.error(error);
       const err = error as Error;
 
       // ignore the aborted request error
@@ -459,7 +459,7 @@ export const pluginTypes: StateCreator<
         await messageService.updateMessage(id, { traceId: res.traceId });
       }
     } catch (error) {
-      console.log(error);
+      console.error(error);
       const err = error as Error;
 
       // ignore the aborted request error

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -169,7 +169,7 @@ export const createFileSlice: StateCreator<
       if (isChunkingUnsupported(file.type)) return;
 
       const data = await ragService.parseFileContent(fileResult.id);
-      console.log(data);
+      console.log('parseFileContent data:', data);
     });
 
     await Promise.all(pools);


### PR DESCRIPTION
## Summary
- Remove debug `console.log` statements from 21 files across the codebase
- Clean up unused variables using `void` statements
- Remove unused `rowIndex` parameter from `TableCell` component

## Changes
This is a cleanup PR that removes leftover debug logging statements that were committed during development:
- Community features (UserAvatar, FollowStats, SortButton, AddAgent, Overview)
- Agent/Group profile components (AgentHeader, PublishResultModal)
- Settings components (Desktop hotkey, SearchResult, ModelTable)
- Chat input components (ContextList, FileItem)
- DevPanel TableCell
- Portal Plugins Body
- Services and store actions

## Test Plan
- [x] No functional changes, only removal of debug statements
- [x] Pre-commit hooks passed (type-check, lint, prettier)