### PR TITLE
📝 docs(auth): add email_not_found FAQ and webhook configuration

### DIFF
--- a/docs/self-hosting/advanced/auth/nextauth-to-betterauth.mdx
+++ b/docs/self-hosting/advanced/auth/nextauth-to-betterauth.mdx
@@ -327,6 +327,32 @@ After migration, if you encounter login issues, try clearing your browser's site
 
 This error occurs because the database schema is outdated. Run `pnpm db:migrate` to update the database structure before running the migration script.
 
+### email\_not\_found error
+
+If you see a redirect to `signin?callbackUrl=...&error=email_not_found`, it means LobeChat cannot get the user's email.
+
+<Callout type={'warning'}>
+  **Important**: Better Auth currently **requires user email** for authentication. All SSO providers must be configured to return email information, otherwise users cannot log in.
+</Callout>
+
+Common causes:
+
+**Cause 1: SSO connection not requesting email permission**
+
+When configuring SSO connections (e.g., GitHub in Auth0), make sure to enable **Email Address** permission in the Attributes section. LobeChat requires user email for authentication.
+
+**Cause 2: User email not configured in identity provider**
+
+For identity providers like Casdoor or Logto, users may not have an email configured.
+
+Solution:
+
+1. First configure the Webhook in LobeChat to sync user data from the identity provider:
+   - [Casdoor Webhook Configuration](/docs/self-hosting/advanced/auth/providers/casdoor)
+   - [Logto Webhook Configuration](/docs/self-hosting/advanced/auth/providers/logto)
+2. Then configure the user's email in the identity provider's admin console
+3. The user data will be synced to LobeChat via Webhook, and the user can then log in
+
 ## Related Reading
 
 <Cards>

--- a/docs/self-hosting/advanced/auth/nextauth-to-betterauth.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/nextauth-to-betterauth.zh-CN.mdx
@@ -322,6 +322,32 @@ npx tsx scripts/nextauth-to-betterauth/verify.ts
 
 这是因为数据库 schema 未更新。请先运行 `pnpm db:migrate` 更新数据库结构，然后再执行迁移脚本。
 
+### email\_not\_found 错误
+
+如果登录时跳转到 `signin?callbackUrl=...&error=email_not_found`，说明 LobeChat 无法获取用户邮箱。
+
+<Callout type={'warning'}>
+  **重要提示**：Better Auth 目前**强依赖用户邮箱**进行身份认证。所有 SSO 提供商必须配置为返回邮箱信息，否则用户无法登录。
+</Callout>
+
+常见原因：
+
+**原因 1：SSO 连接未请求邮箱权限**
+
+配置 SSO 连接时（如 Auth0 中的 GitHub 连接），务必在 **Attributes** 部分勾选 **Email Address** 权限。LobeChat 需要用户邮箱进行身份认证。
+
+**原因 2：用户在身份提供商中未配置邮箱**
+
+对于 Casdoor、Logto 等身份提供商，用户可能没有配置邮箱。
+
+解决方案：
+
+1. 先在 LobeChat 中配置身份提供商的 Webhook 以同步用户数据：
+   - [Casdoor Webhook 配置](/zh/docs/self-hosting/advanced/auth/providers/casdoor)
+   - [Logto Webhook 配置](/zh/docs/self-hosting/advanced/auth/providers/logto)
+2. 然后在身份提供商的管理后台为用户配置邮箱
+3. 用户数据通过 Webhook 同步到 LobeChat 后即可正常登录
+
 ## 相关阅读
 
 <Cards>

--- a/docs/self-hosting/advanced/auth/providers/casdoor.mdx
+++ b/docs/self-hosting/advanced/auth/providers/casdoor.mdx
@@ -39,17 +39,34 @@ tags:
 
   When deploying LobeChat, you need to configure the following environment variables:
 
-  | Environment Variable             | Type     | Description                                                                   |
-  | -------------------------------- | -------- | ----------------------------------------------------------------------------- |
-  | `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32` |
-  | `AUTH_SSO_PROVIDERS`             | Required | SSO provider for LobeChat. Use `casdoor` for Casdoor                          |
-  | `AUTH_CASDOOR_ID`                | Required | Client ID from Casdoor application                                            |
-  | `AUTH_CASDOOR_SECRET`            | Required | Client Secret from Casdoor application                                        |
-  | `AUTH_CASDOOR_ISSUER`            | Required | Casdoor server URL (e.g., `https://your-casdoor-domain`)                      |
+  | Environment Variable     | Type     | Description                                                                   |
+  | ------------------------ | -------- | ----------------------------------------------------------------------------- |
+  | `AUTH_SECRET`            | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32` |
+  | `AUTH_SSO_PROVIDERS`     | Required | SSO provider for LobeChat. Use `casdoor` for Casdoor                          |
+  | `AUTH_CASDOOR_ID`        | Required | Client ID from Casdoor application                                            |
+  | `AUTH_CASDOOR_SECRET`    | Required | Client Secret from Casdoor application                                        |
+  | `AUTH_CASDOOR_ISSUER`    | Required | Casdoor server URL (e.g., `https://your-casdoor-domain`)                      |
+  | `CASDOOR_WEBHOOK_SECRET` | Optional | Secret key for validating Webhook requests from Casdoor                       |
 
   <Callout type={'tip'}>
     Go to [📘 Environment Variables](/docs/self-hosting/environment-variables/auth#casdoor) for detailed information on these variables.
   </Callout>
+
+  ### Configure Webhook (Optional)
+
+  > Available in Casdoor `>=1.843.0`.
+
+  Configure Casdoor Webhook to sync user data updates to LobeChat.
+
+  1. Go to **Admin Tools** -> **Webhooks** and create a Webhook
+  2. Fill in the following fields:
+     - URL: `https://your-domain.com/api/webhooks/casdoor`
+     - Method: `POST`
+     - Content Type: `application/json`
+     - Headers: `casdoor-secret`: `your-webhook-secret`
+     - Events: `update-user`
+  3. Generate a secret at [generate-secret.vercel.app/10](https://generate-secret.vercel.app/10)
+  4. Set the secret in the `CASDOOR_WEBHOOK_SECRET` environment variable
 </Steps>
 
 <Callout type={'info'}>

--- a/docs/self-hosting/advanced/auth/providers/casdoor.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/providers/casdoor.zh-CN.mdx
@@ -37,17 +37,34 @@ tags:
 
   在部署 LobeChat 时，你需要配置以下环境变量：
 
-  | 环境变量                             | 类型 | 描述                                                |
-  | -------------------------------- | -- | ------------------------------------------------- |
-  | `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`    |
-  | `AUTH_SSO_PROVIDERS`             | 必选 | SSO 提供商。使用 Casdoor 请填写 `casdoor`                  |
-  | `AUTH_CASDOOR_ID`                | 必选 | Casdoor 应用的 Client ID                             |
-  | `AUTH_CASDOOR_SECRET`            | 必选 | Casdoor 应用的 Client Secret                         |
-  | `AUTH_CASDOOR_ISSUER`            | 必选 | Casdoor 服务器 URL（例如 `https://your-casdoor-domain`） |
+  | 环境变量                     | 类型 | 描述                                                |
+  | ------------------------ | -- | ------------------------------------------------- |
+  | `AUTH_SECRET`            | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`    |
+  | `AUTH_SSO_PROVIDERS`     | 必选 | SSO 提供商。使用 Casdoor 请填写 `casdoor`                  |
+  | `AUTH_CASDOOR_ID`        | 必选 | Casdoor 应用的 Client ID                             |
+  | `AUTH_CASDOOR_SECRET`    | 必选 | Casdoor 应用的 Client Secret                         |
+  | `AUTH_CASDOOR_ISSUER`    | 必选 | Casdoor 服务器 URL（例如 `https://your-casdoor-domain`） |
+  | `CASDOOR_WEBHOOK_SECRET` | 可选 | 用于验证 Casdoor 发送的 Webhook 请求是否合法的密钥                |
 
   <Callout type={'tip'}>
     前往 [📘 环境变量](/zh/docs/self-hosting/environment-variables/auth#casdoor) 可查阅相关变量详情。
   </Callout>
+
+  ### 配置 Webhook（可选）
+
+  > 在 Casdoor `>=1.843.0` 上可用。
+
+  配置 Casdoor 的 Webhook 以便在用户信息更新时同步到 LobeChat。
+
+  1. 前往 `管理工具` -> `Webhooks`，创建一个 Webhook
+  2. 填写以下字段：
+     - 链接：`https://your-domain.com/api/webhooks/casdoor`
+     - 方法：`POST`
+     - 内容类型：`application/json`
+     - 协议头：`casdoor-secret`: `你的Webhook密钥`
+     - 事件：`update-user`
+  3. 密钥可前往 [generate-secret.vercel.app/10](https://generate-secret.vercel.app/10) 生成
+  4. 将密钥填写到环境变量 `CASDOOR_WEBHOOK_SECRET`
 </Steps>
 
 <Callout type={'info'}>部署成功后，用户将可以通过 Casdoor 身份认证并使用 LobeChat。</Callout>

--- a/docs/self-hosting/advanced/auth/providers/logto.mdx
+++ b/docs/self-hosting/advanced/auth/providers/logto.mdx
@@ -41,17 +41,30 @@ tags:
 
   When deploying LobeChat, you need to configure the following environment variables:
 
-  | Environment Variable             | Type     | Description                                                                   |
-  | -------------------------------- | -------- | ----------------------------------------------------------------------------- |
-  | `AUTH_SECRET`                    | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32` |
-  | `AUTH_SSO_PROVIDERS`             | Required | SSO provider for LobeChat. Use `logto` for Logto                              |
-  | `AUTH_LOGTO_ID`                  | Required | App ID from Logto application                                                 |
-  | `AUTH_LOGTO_SECRET`              | Required | App Secret from Logto application                                             |
-  | `AUTH_LOGTO_ISSUER`              | Required | Logto issuer URL (e.g., `https://your-tenant.logto.app/oidc`)                 |
+  | Environment Variable        | Type     | Description                                                                   |
+  | --------------------------- | -------- | ----------------------------------------------------------------------------- |
+  | `AUTH_SECRET`               | Required | Key used to encrypt session tokens. Generate using: `openssl rand -base64 32` |
+  | `AUTH_SSO_PROVIDERS`        | Required | SSO provider for LobeChat. Use `logto` for Logto                              |
+  | `AUTH_LOGTO_ID`             | Required | App ID from Logto application                                                 |
+  | `AUTH_LOGTO_SECRET`         | Required | App Secret from Logto application                                             |
+  | `AUTH_LOGTO_ISSUER`         | Required | Logto issuer URL (e.g., `https://your-tenant.logto.app/oidc`)                 |
+  | `LOGTO_WEBHOOK_SIGNING_KEY` | Optional | Secret key for validating Webhook requests from Logto                         |
 
   <Callout type={'tip'}>
     Go to [📘 Environment Variables](/docs/self-hosting/environment-variables/auth#logto) for detailed information on these variables.
   </Callout>
+
+  ### Configure Webhook (Optional)
+
+  Configure Logto Webhook to sync user data updates to LobeChat.
+
+  1. Go to **Webhooks** in Logto Console and create a Webhook
+  2. Fill in the following fields:
+     - Endpoint URL: `https://your-domain.com/api/webhooks/logto`
+     - Events:
+       - `User.Data.Updated`: Sync user profile updates
+       - `User.SuspensionStatus.Updated`: Sync user suspension status
+  3. After creation, copy the `Signing Key` and set it in the `LOGTO_WEBHOOK_SIGNING_KEY` environment variable
 </Steps>
 
 <Callout type={'info'}>

--- a/docs/self-hosting/advanced/auth/providers/logto.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/providers/logto.zh-CN.mdx
@@ -39,17 +39,30 @@ tags:
 
   在部署 LobeChat 时，你需要配置以下环境变量：
 
-  | 环境变量                             | 类型 | 描述                                                        |
-  | -------------------------------- | -- | --------------------------------------------------------- |
-  | `AUTH_SECRET`                    | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`            |
-  | `AUTH_SSO_PROVIDERS`             | 必选 | SSO 提供商。使用 Logto 请填写 `logto`                              |
-  | `AUTH_LOGTO_ID`                  | 必选 | Logto 应用的 App ID                                          |
-  | `AUTH_LOGTO_SECRET`              | 必选 | Logto 应用的 App Secret                                      |
-  | `AUTH_LOGTO_ISSUER`              | 必选 | Logto Issuer URL（例如 `https://your-tenant.logto.app/oidc`） |
+  | 环境变量                        | 类型 | 描述                                                        |
+  | --------------------------- | -- | --------------------------------------------------------- |
+  | `AUTH_SECRET`               | 必选 | 用于加密会话令牌的密钥。使用以下命令生成：`openssl rand -base64 32`            |
+  | `AUTH_SSO_PROVIDERS`        | 必选 | SSO 提供商。使用 Logto 请填写 `logto`                              |
+  | `AUTH_LOGTO_ID`             | 必选 | Logto 应用的 App ID                                          |
+  | `AUTH_LOGTO_SECRET`         | 必选 | Logto 应用的 App Secret                                      |
+  | `AUTH_LOGTO_ISSUER`         | 必选 | Logto Issuer URL（例如 `https://your-tenant.logto.app/oidc`） |
+  | `LOGTO_WEBHOOK_SIGNING_KEY` | 可选 | 用于验证 Logto 发送的 Webhook 请求是否合法的密钥                          |
 
   <Callout type={'tip'}>
     前往 [📘 环境变量](/zh/docs/self-hosting/environment-variables/auth#logto) 可查阅相关变量详情。
   </Callout>
+
+  ### 配置 Webhook（可选）
+
+  配置 Logto 的 Webhook，以便在用户信息更新时 LobeChat 可以接收到通知并同步数据。
+
+  1. 前往 Logto 控制台的 `Webhooks`，创建一个 Webhook
+  2. 填写以下字段：
+     - 端点 URL：`https://your-domain.com/api/webhooks/logto`
+     - 事件：
+       - `User.Data.Updated`：同步用户资料信息的更新
+       - `User.SuspensionStatus.Updated`：同步用户暂停状态
+  3. 创建后，复制 `签名密钥` 填写到环境变量 `LOGTO_WEBHOOK_SIGNING_KEY`
 </Steps>
 
 <Callout type={'info'}>部署成功后，用户将可以通过 Logto 身份认证并使用 LobeChat。</Callout>


### PR DESCRIPTION
## Summary

- Add `email_not_found` troubleshooting FAQ to NextAuth migration docs (zh-CN & en)
- Emphasize Better Auth requires user email for authentication
- Add `CASDOOR_WEBHOOK_SECRET` env var and webhook setup guide to Casdoor provider docs
- Add `LOGTO_WEBHOOK_SIGNING_KEY` env var and webhook setup guide to Logto provider docs

## Test plan

- [ ] Verify documentation renders correctly on docs site
- [ ] Check all internal links are working