### PR TITLE
🐛 fix(builtin-tool-memory): missing activities for topK parameter

### DIFF
--- a/packages/builtin-tool-memory/package.json
+++ b/packages/builtin-tool-memory/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*",
+    "@types/json-schema": "^7.0.15",
     "promptfoo": "^0.120.17"
   },
   "peerDependencies": {

--- a/packages/builtin-tool-memory/src/manifest.ts
+++ b/packages/builtin-tool-memory/src/manifest.ts
@@ -8,6 +8,7 @@ import {
   MERGE_STRATEGIES,
   RELATIONSHIPS,
 } from '@lobechat/types';
+import { JSONSchema7 } from 'json-schema'
 
 import { systemPrompt } from './systemRole';
 import { MemoryApiName } from './types';
@@ -26,7 +27,9 @@ export const MemoryManifest: BuiltinToolManifest = {
           query: { type: 'string' },
           topK: {
             additionalProperties: false,
+            description: "Limits on number of memories to return per layer, default to search 3 activities, 0 contexts, 0 experiences, and 0 preferences if not specified.",
             properties: {
+              activities: { minimum: 0, type: 'integer' },
               contexts: { minimum: 0, type: 'integer' },
               experiences: { minimum: 0, type: 'integer' },
               preferences: { minimum: 0, type: 'integer' },
@@ -37,7 +40,7 @@ export const MemoryManifest: BuiltinToolManifest = {
         },
         required: ['query', 'topK'],
         type: 'object',
-      },
+      } satisfies JSONSchema7,
     },
     {
       description:


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix the builtin memory tool manifest schema for the topK parameter and align types with JSON Schema.

Bug Fixes:
- Add the missing activities limit to the topK configuration so memory queries can constrain returned activities correctly.

Enhancements:
- Document the default topK behavior in the schema description and assert the manifest object satisfies the JSONSchema7 type.

Build:
- Add @types/json-schema as a dev dependency for typed JSON Schema support in the builtin memory package.