### PR TITLE
🐛 fix(builtin-tool-memory): update identity tool should have type for enum

### DIFF
--- a/packages/builtin-tool-memory/src/manifest.ts
+++ b/packages/builtin-tool-memory/src/manifest.ts
@@ -558,6 +558,7 @@ export const MemoryManifest: BuiltinToolManifest = {
               memoryType: {
                 description: 'Memory type, use null for omitting the field',
                 enum: [...MEMORY_TYPES, null],
+                type: ['string', 'null'],
               },
               summary: {
                 description:


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Add an explicit union type for the memoryType enum in the builtin tool memory manifest so enum values and null are correctly typed.