### PR TITLE
🐛 fix: slove the descktop use offical endpoint mcp not use stdio

### DIFF
--- a/src/store/tool/slices/mcpStore/action.ts
+++ b/src/store/tool/slices/mcpStore/action.ts
@@ -293,17 +293,14 @@ export const createMCPPluginStoreSlice: StateCreator<
             (!option?.connection?.type && !option?.connection?.url),
         );
 
-        const hasNonHttpDeployment = deploymentOptions.some((option) => {
-          const type = option?.connection?.type;
-          if (!type && option?.connection?.url) return false;
+        // Check if cloudEndPoint is available: stdio type + haveCloudEndpoint exists
+        // Both desktop and web should use cloud endpoint if available
+        const hasCloudEndpoint = stdioOption && haveCloudEndpoint;
 
-          return type && type !== 'http';
-        });
-
-        // Check if cloudEndPoint is available: web + stdio type + haveCloudEndpoint exists
-        const hasCloudEndpoint = !isDesktop && stdioOption && haveCloudEndpoint;
-
-        let shouldUseHttpDeployment = !!httpOption && (!hasNonHttpDeployment || !isDesktop);
+        // Prioritize endpoint (http/cloud) over stdio in all environments
+        // Desktop: endpoint > stdio
+        // Web: endpoint only (stdio not supported)
+        let shouldUseHttpDeployment = !!httpOption;
 
         if (hasCloudEndpoint) {
           // Use cloudEndPoint, create cloud type connection
@@ -664,10 +661,10 @@ export const createMCPPluginStoreSlice: StateCreator<
             errorLog,
             params: connection
               ? {
-                  args: connection.args,
-                  command: connection.command,
-                  type: connection.type,
-                }
+                args: connection.args,
+                command: connection.command,
+                type: connection.type,
+              }
               : undefined,
             step: 'installation_error',
             timestamp: Date.now(),


### PR DESCRIPTION
#### 💻 Change Type

fixed: LOBE-4175

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust MCP deployment selection to consistently prioritize HTTP/cloud endpoints over stdio across desktop and web environments.

Bug Fixes:
- Ensure desktop uses cloud endpoints when available instead of falling back to stdio-only connections.
- Align endpoint selection logic so both desktop and web prioritize HTTP/cloud deployments over stdio where possible.

Enhancements:
- Clean up error logging parameter formatting for MCP connection installation failures.