### PR TITLE
🔨 chore(analytics): add Product Hunt campaign tracking events

### DIFF
--- a/packages/const/src/analytics.ts
+++ b/packages/const/src/analytics.ts
@@ -1,3 +1,3 @@
 import { isDesktop } from './version';
 
-export const BUSINESS_LINE = isDesktop ? 'lobe-chat-desktop' : 'lobe-chat';
+export const BUSINESS_LINE = isDesktop ? 'lobehub-desktop' : 'lobehub';

--- a/src/components/HighlightNotification/index.tsx
+++ b/src/components/HighlightNotification/index.tsx
@@ -12,6 +12,7 @@ export interface HighlightNotificationProps {
   actionLabel?: ReactNode;
   description?: ReactNode;
   image?: string;
+  onActionClick?: () => void;
   onClose?: () => void;
   open?: boolean;
   title?: ReactNode;
@@ -62,7 +63,7 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const HighlightNotification = memo<HighlightNotificationProps>(
-  ({ open, onClose, image, title, description, actionLabel, actionHref }) => {
+  ({ open, onClose, onActionClick, image, title, description, actionLabel, actionHref }) => {
     if (!open) return null;
 
     return (
@@ -77,6 +78,7 @@ const HighlightNotification = memo<HighlightNotificationProps>(
               <Link
                 className={styles.action}
                 href={actionHref || '/'}
+                onClick={onActionClick}
                 rel="noopener noreferrer"
                 target="_blank"
               >


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-4140

#### 🔀 Description of Change

- Add analytics tracking for Product Hunt notification card events:
  - `product_hunt_card_viewed` (with trigger: auto/menu_click)
  - `product_hunt_card_closed`
  - `product_hunt_action_clicked`
- Rename business line from `lobe-chat` to `lobehub` for consistent branding
- Add `onActionClick` callback prop to `HighlightNotification` component
- Wrap all tracking calls with try-catch to ensure no impact on business logic

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Modify `startTime` in Footer to current date to enable Product Hunt card
2. Check browser console / PostHog for tracking events
3. Verify card open/close/action click all fire correct events
4. Verify card functionality works even if analytics fails

#### 📸 Screenshots / Videos

<img width="1064" height="1494" alt="image" src="https://github.com/user-attachments/assets/ad8cfafa-59f0-48ea-b6e8-9d66e0be9565" />
<img width="2284" height="246" alt="image" src="https://github.com/user-attachments/assets/240e5538-bee9-4e09-8384-4d283a0bd2d7" />
<img width="1916" height="1538" alt="image" src="https://github.com/user-attachments/assets/d8d2a8bc-53b2-4516-8ea2-667cbd57872d" />


#### 📝 Additional Information

- All tracking is wrapped in try-catch to ensure analytics failures never affect the Product Hunt card functionality
- Uses optional chaining `analytics?.track()` for additional safety
- Business logic always executes before tracking calls