### PR TITLE
🐛 fix: show fallback title for custom assistant in chat messages

### DIFF
--- a/src/features/Conversation/ChatItem/components/Title.tsx
+++ b/src/features/Conversation/ChatItem/components/Title.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@lobehub/ui';
 import dayjs from 'dayjs';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { type ChatItemProps } from '../type';
 
@@ -12,11 +13,14 @@ export interface TitleProps {
 }
 
 const Title = memo<TitleProps>(({ showTitle, time, avatar, titleAddon }) => {
+  const { t } = useTranslation('chat');
+  const title = avatar.title || t('untitledAgent');
+
   return (
     <>
-      {showTitle && avatar.title && (
+      {showTitle && (
         <Text fontSize={14} weight={500}>
-          {avatar.title}
+          {title}
         </Text>
       )}
       {showTitle ? titleAddon : undefined}


### PR DESCRIPTION
### 🐛 Bug Fix

When a custom assistant's `avatar.title` is empty or null, the bot title in chat messages was not displayed.

### Changes

- Added fallback to display `Untitled Agent` when `avatar.title` is empty in the `Title` component

### Related Issue

Closes LOBE-2232