### PR TITLE
👷 ci: add docs revalidation workflow and migration improvements

### DIFF
--- a/.claude/prompts/migration-support.md
+++ b/.claude/prompts/migration-support.md
@@ -2,6 +2,14 @@
 
 You are a support assistant for LobeChat authentication migration issues. Your job is to help users who are migrating from NextAuth or Clerk to Better Auth.
 
+**IMPORTANT**: The official documentation website is `https://lobehub.com`. When providing documentation links, always use `https://lobehub.com/docs/...` format. Never use `lobechat.com` - that domain is incorrect.
+
+Examples of correct documentation URLs:
+- `https://lobehub.com/docs/self-hosting/advanced/auth/nextauth-to-betterauth`
+- `https://lobehub.com/docs/self-hosting/advanced/auth/clerk-to-betterauth`
+- `https://lobehub.com/docs/self-hosting/advanced/auth`
+- `https://lobehub.com/docs/self-hosting/advanced/auth/providers/casdoor`
+
 ## Target Issues
 
 This workflow only handles comments on these specific migration feedback issues:
@@ -9,29 +17,7 @@ This workflow only handles comments on these specific migration feedback issues:
 - \#11757 - NextAuth to Better Auth migration
 - \#11707 - Clerk to Better Auth migration
 
-## Step 1: Read the Latest Documentation
-
-Before responding to any user, you MUST first read the latest migration documentation:
-
-For NextAuth migration (issue #11757):
-
-```bash
-cat docs/self-hosting/advanced/auth/nextauth-to-betterauth.mdx
-```
-
-For Clerk migration (issue #11707):
-
-```bash
-cat docs/self-hosting/advanced/auth/clerk-to-betterauth.mdx
-```
-
-Also read the main auth documentation:
-
-```bash
-cat docs/self-hosting/advanced/auth.mdx
-```
-
-## Step 2: Check for Sensitive Information Leaks
+## Step 1: Check for Sensitive Information Leaks
 
 Before processing, scan the user's comment for potential secrets or sensitive data:
 
@@ -57,7 +43,7 @@ I will not process this request until the sensitive information is removed.
 
 Do NOT process the rest of the comment if secrets are detected.
 
-## Step 3: Handle Success Feedback
+## Step 2: Handle Success Feedback
 
 If the user's comment indicates their issue is resolved or deployment succeeded (e.g., "solved", "fixed", "working now", "thanks", "problem resolved", "successfully deployed"):
 
@@ -69,7 +55,7 @@ echo "HIDE_COMMENT=true" >> /tmp/claude-output
 
 2. Do NOT post any reply - just create the marker file and stop processing.
 
-## Step 4: Check Required Information
+## Step 3: Check Required Information
 
 Read the issue description to see what information users should provide:
 
@@ -79,9 +65,9 @@ gh issue view [ISSUE_NUMBER] --json body -q '.body'
 
 Check the "How to Reporting Issues" section in the issue description for required information. If the user's comment is missing any required items, politely ask them to provide it.
 
-## Step 5: Common Issues and Solutions
+## Step 4: Common Issues and Solutions
 
-You already read the full documentation in Step 1. Look for the "Troubleshooting" or "FAQ" section in those docs and match the user's issue against documented solutions. If a solution exists, provide it with a link to the documentation.
+Look for the "Troubleshooting" or "FAQ" section in the migration docs and match the user's issue against documented solutions. If a solution exists, provide it with a link to the documentation.
 
 ## Response Guidelines
 

--- a/.claude/prompts/team-assignment.md
+++ b/.claude/prompts/team-assignment.md
@@ -10,7 +10,6 @@
 - **@nekomeowww**: Memory, backend, deployment, DevOps
 - **@sudongyuer**: Mobile app (React Native)
 - **@sxjeru**: Model providers and configuration
-- **@cy948**: (inactive)
 - **@rdmclin2**: Team workspace
 - **@tcmonster**: Subscription, refund, recharge, business cooperation
 

--- a/.claude/prompts/team-assignment.md
+++ b/.claude/prompts/team-assignment.md
@@ -3,15 +3,16 @@
 ## Quick Reference by Name
 
 - **@arvinxx**: Last resort only, mention for priority:high issues, tool calling , mcp
-- **@canisminor1990**: Design, UI components, editor
-- **@tjx666**: Image/video generation, vision, cloud, documentation, TTS
+- **@canisminor1990**: Design, UI components, editor, markdown rendering
+- **@tjx666**: Image/video generation, vision, cloud version, documentation, TTS, auth, login/register
 - **@ONLY-yours**: Performance, streaming, settings, general bugs, web platform, marketplace
 - **@RiverTwilight**: Knowledge base, files (KB-related), group chat
 - **@nekomeowww**: Memory, backend, deployment, DevOps
 - **@sudongyuer**: Mobile app (React Native)
 - **@sxjeru**: Model providers and configuration
-- **@cy948**: Auth Modules
+- **@cy948**: (inactive)
 - **@rdmclin2**: Team workspace
+- **@tcmonster**: Subscription, refund, recharge, business cooperation
 
 Quick reference for assigning issues based on labels.
 
@@ -41,7 +42,10 @@ Quick reference for assigning issues based on labels.
 | `feature:knowledge-base` | @RiverTwilight  | Knowledge base and RAG                                                  |
 | `feature:files`          | @RiverTwilight  | File upload/management (when KB-related)<br>@ONLY-yours (general files) |
 | `feature:editor`         | @canisminor1990 | Lobe Editor                                                             |
-| `feature:auth`           | @cy948          | Authentication/authorization                                            |
+| `feature:markdown`       | @canisminor1990 | Markdown rendering                                                      |
+| `feature:auth`           | @tjx666         | Authentication/authorization                                            |
+| `feature:login`          | @tjx666         | Login issues                                                            |
+| `feature:register`       | @tjx666         | Registration issues                                                     |
 | `feature:api`            | @nekomeowww     | Backend API                                                             |
 | `feature:streaming`      | @arvinxx        | Streaming response                                                      |
 | `feature:settings`       | @ONLY-yours     | Settings and configuration                                              |
@@ -57,6 +61,10 @@ Quick reference for assigning issues based on labels.
 | `feature:group-chat`     | @RiverTwilight  | Group chat functionality                                                |
 | `feature:memory`         | @nekomeowww     | Memory feature                                                          |
 | `feature:team-workspace` | @rdmclin2       | Team workspace application                                              |
+| `feature:subscription`   | @tcmonster      | Subscription and billing                                                |
+| `feature:refund`         | @tcmonster      | Refund requests                                                         |
+| `feature:recharge`       | @tcmonster      | Recharge and payment                                                    |
+| `feature:business`       | @tcmonster      | Business cooperation and partnership                                    |
 
 ### Deployment Labels (deployment:\*)
 
@@ -79,7 +87,7 @@ Quick reference for assigning issues based on labels.
 | Label              | Owner                | Notes                        |
 | ------------------ | -------------------- | ---------------------------- |
 | 💄 Design          | @canisminor1990      | Design and styling           |
-| 📝 Documentation   | @tjx666              | Documentation                |
+| 📝 Documentation   | @canisminor1990 / @tjx666 | Official docs website issues |
 | ⚡️ Performance     | @ONLY-yours          | Performance optimization     |
 | 🐛 Bug             | (depends on feature) | Assign based on other labels |
 | 🌠 Feature Request | (depends on feature) | Assign based on other labels |

--- a/.github/workflows/claude-migration-support.yml
+++ b/.github/workflows/claude-migration-support.yml
@@ -1,5 +1,4 @@
 name: Claude Migration Support
-description: Automatically respond to migration feedback issues using Claude Code
 
 on:
   issue_comment:
@@ -76,6 +75,7 @@ jobs:
 
             3. Read additional reference files:
             - Main auth documentation: `cat docs/self-hosting/advanced/auth.mdx`
+            - Migration internals: `cat docs/self-hosting/advanced/auth/migration-internals.mdx`
             - Deprecated env vars checker: `cat scripts/_shared/checkDeprecatedAuth.js`
 
             4. Analyze the user's comment and determine:

--- a/.github/workflows/revalidate-docs.yml
+++ b/.github/workflows/revalidate-docs.yml
@@ -1,0 +1,25 @@
+name: Revalidate Docs
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - 'docs/**'
+
+jobs:
+  revalidate:
+    name: Revalidate Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs revalidation
+        run: |
+          response=$(curl "${{ secrets.DOCS_REVALIDATE_URL }}" --silent --show-error)
+          echo "Response: $response"
+          if [ "$response" != '{"success":true}' ]; then
+            echo "Error: Unexpected response"
+            exit 1
+          fi

--- a/docs/self-hosting/advanced/auth/nextauth-to-betterauth.mdx
+++ b/docs/self-hosting/advanced/auth/nextauth-to-betterauth.mdx
@@ -91,6 +91,12 @@ Better Auth supports additional features with these new environment variables:
 
 For small self-hosted deployments, the simplest approach is to let users re-login with their SSO accounts.
 
+<Callout type={'tip'}>
+  **Casdoor Users**: If you use Casdoor as your identity provider, please read
+  the [email\_not\_found Error](#email_not_found-error) section first to
+  understand email configuration requirements.
+</Callout>
+
 <Callout type={'warning'}>
   **Limitation**: This method loses SSO connection data. Use [Full Migration](#full-migration) to preserve SSO connections.
 

--- a/docs/self-hosting/advanced/auth/nextauth-to-betterauth.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/nextauth-to-betterauth.zh-CN.mdx
@@ -87,6 +87,11 @@ Better Auth 支持更多功能，以下是新增的环境变量：
 
 对于小型自托管部署，最简单的方法是让用户使用 SSO 账户重新登录。
 
+<Callout type={'tip'}>
+  **Casdoor 用户注意**：如果你使用 Casdoor 作为身份提供商，请先阅读
+  [email\_not\_found 错误](#email_not_found-错误) 部分，了解邮箱配置要求。
+</Callout>
+
 <Callout type={'warning'}>
   **限制**：此方法会丢失 SSO 连接数据。如需保留 SSO 连接，请使用 [完整迁移](#完整迁移)。
 

--- a/scripts/_shared/checkDeprecatedAuth.js
+++ b/scripts/_shared/checkDeprecatedAuth.js
@@ -135,6 +135,32 @@ const DEPRECATED_CHECKS = [
     name: 'APP_URL Trailing Slash',
   },
   {
+    docUrl: `${MIGRATION_DOC_BASE}/providers/casdoor`,
+    getVars: () => {
+      const providers = process.env['AUTH_SSO_PROVIDERS'] || '';
+      if (providers.includes('casdoor') && !process.env['CASDOOR_WEBHOOK_SECRET']) {
+        return ['CASDOOR_WEBHOOK_SECRET'];
+      }
+      return [];
+    },
+    message:
+      'Casdoor webhook is required for syncing user data (email, avatar, etc.) to LobeChat. Without it, users without email configured in Casdoor cannot login. Please configure CASDOOR_WEBHOOK_SECRET following the documentation.',
+    name: 'Casdoor Webhook',
+  },
+  {
+    docUrl: `${MIGRATION_DOC_BASE}/providers/logto`,
+    getVars: () => {
+      const providers = process.env['AUTH_SSO_PROVIDERS'] || '';
+      if (providers.includes('logto') && !process.env['LOGTO_WEBHOOK_SIGNING_KEY']) {
+        return ['LOGTO_WEBHOOK_SIGNING_KEY'];
+      }
+      return [];
+    },
+    message:
+      'Logto webhook is required for syncing user data (email, avatar, etc.) to LobeChat. Without it, users without email configured in Logto cannot login. Please configure LOGTO_WEBHOOK_SIGNING_KEY following the documentation.',
+    name: 'Logto Webhook',
+  },
+  {
     docUrl: `${MIGRATION_DOC_BASE}/nextauth-to-betterauth`,
     formatVar: (envVar) => {
       const mapping = {


### PR DESCRIPTION
## Summary
- Add workflow to trigger docs revalidation on push to main/next when docs/ changes
- Fix claude-migration-support workflow (remove invalid description, add migration-internals doc)
- Add Casdoor tip in migration docs for email configuration
- Add env checks for CASDOOR_WEBHOOK_SECRET and LOGTO_WEBHOOK_SIGNING_KEY

## Test plan
- [ ] Verify revalidate-docs workflow triggers on docs/ changes
- [ ] Verify claude-migration-support workflow runs correctly
- [ ] Verify env checks work for Casdoor/Logto webhook secrets