### PR TITLE
🐛 fix(desktop): prevent duplicate IPC handler registration from dynamic imports

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -18,6 +18,14 @@ export default defineConfig({
       rollupOptions: {
         // Native modules must be externalized to work correctly
         external: getExternalDependencies(),
+        output: {
+          // Prevent debug package from being bundled into index.js to avoid side-effect pollution
+          manualChunks(id) {
+            if (id.includes('node_modules/debug')) {
+              return 'vendor-debug';
+            }
+          },
+        },
       },
       sourcemap: isDev ? 'inline' : false,
     },
@@ -25,7 +33,6 @@ export default defineConfig({
       'process.env.UPDATE_CHANNEL': JSON.stringify(process.env.UPDATE_CHANNEL),
       'process.env.UPDATE_SERVER_URL': JSON.stringify(process.env.UPDATE_SERVER_URL),
     },
-
     resolve: {
       alias: {
         '@': resolve(__dirname, 'src/main'),

--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -24,6 +24,7 @@ function getTargetPlatform() {
   return process.env.npm_config_platform || os.platform();
 }
 const isDarwin = getTargetPlatform() === 'darwin';
+
 /**
  * List of native modules that need special handling
  * Only add the top-level native modules here - dependencies are resolved automatically
@@ -53,20 +54,30 @@ function resolveDependencies(
     return visited;
   }
 
+  // Always add the module name first (important for workspace dependencies
+  // that may not be in local node_modules but are declared in nativeModules)
+  visited.add(moduleName);
+
   const packageJsonPath = path.join(nodeModulesPath, moduleName, 'package.json');
 
-  // Check if module exists
+  // If module doesn't exist locally, still keep it in visited but skip dependency resolution
   if (!fs.existsSync(packageJsonPath)) {
     return visited;
   }
 
-  visited.add(moduleName);
-
   try {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     const dependencies = packageJson.dependencies || {};
+    const optionalDependencies = packageJson.optionalDependencies || {};
 
+    // Resolve regular dependencies
     for (const dep of Object.keys(dependencies)) {
+      resolveDependencies(dep, visited, nodeModulesPath);
+    }
+
+    // Also resolve optional dependencies (important for native modules like @napi-rs/canvas
+    // which have platform-specific binaries in optional deps)
+    for (const dep of Object.keys(optionalDependencies)) {
       resolveDependencies(dep, visited, nodeModulesPath);
     }
   } catch {
@@ -115,4 +126,80 @@ export function getAsarUnpackPatterns() {
  */
 export function getExternalDependencies() {
   return getAllDependencies();
+}
+
+/**
+ * Copy native modules to destination, resolving symlinks
+ * This is used in afterPack hook to handle pnpm symlinks correctly
+ * @param {string} destNodeModules - Destination node_modules path
+ */
+export async function copyNativeModules(destNodeModules) {
+  const fsPromises = await import('node:fs/promises');
+  const deps = getAllDependencies();
+  const sourceNodeModules = path.join(__dirname, 'node_modules');
+
+  console.log(`📦 Copying ${deps.length} native modules to unpacked directory...`);
+
+  for (const dep of deps) {
+    const sourcePath = path.join(sourceNodeModules, dep);
+    const destPath = path.join(destNodeModules, dep);
+
+    try {
+      // Check if source exists (might be a symlink)
+      const stat = await fsPromises.lstat(sourcePath);
+
+      if (stat.isSymbolicLink()) {
+        // Resolve the symlink to get the real path
+        const realPath = await fsPromises.realpath(sourcePath);
+        console.log(`  📎 ${dep} (symlink -> ${path.relative(sourceNodeModules, realPath)})`);
+
+        // Create destination directory
+        await fsPromises.mkdir(path.dirname(destPath), { recursive: true });
+
+        // Copy the actual directory content (not the symlink)
+        await copyDir(realPath, destPath);
+      } else if (stat.isDirectory()) {
+        console.log(`  📁 ${dep}`);
+        await fsPromises.mkdir(path.dirname(destPath), { recursive: true });
+        await copyDir(sourcePath, destPath);
+      }
+    } catch (err) {
+      // Module might not exist (optional dependency for different platform)
+      console.log(`  ⏭️  ${dep} (skipped: ${err.code || err.message})`);
+    }
+  }
+
+  console.log(`✅ Native modules copied successfully`);
+}
+
+/**
+ * Recursively copy a directory
+ * @param {string} src - Source directory
+ * @param {string} dest - Destination directory
+ */
+async function copyDir(src, dest) {
+  const fsPromises = await import('node:fs/promises');
+
+  await fsPromises.mkdir(dest, { recursive: true });
+  const entries = await fsPromises.readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else if (entry.isSymbolicLink()) {
+      // For symlinks within the module, resolve and copy the actual file
+      const realPath = await fsPromises.realpath(srcPath);
+      const realStat = await fsPromises.stat(realPath);
+      if (realStat.isDirectory()) {
+        await copyDir(realPath, destPath);
+      } else {
+        await fsPromises.copyFile(realPath, destPath);
+      }
+    } else {
+      await fsPromises.copyFile(srcPath, destPath);
+    }
+  }
 }

--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -33,8 +33,8 @@ const isDarwin = getTargetPlatform() === 'darwin';
 export const nativeModules = [
   // macOS-only native modules
   ...(isDarwin ? ['node-mac-permissions'] : []),
+  '@napi-rs/canvas',
   // Add more native modules here as needed
-  // e.g., 'better-sqlite3', 'sharp', etc.
 ];
 
 /**

--- a/packages/file-loaders/package.json
+++ b/packages/file-loaders/package.json
@@ -33,10 +33,10 @@
     "pdfjs-dist": "5.4.530",
     "word-extractor": "^1.0.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "yauzl": "^3.2.0"
+    "yauzl": "^3.2.0",
+    "@napi-rs/canvas": "^0.1.70"
   },
   "devDependencies": {
-    "@napi-rs/canvas": "^0.1.70",
     "@types/concat-stream": "^2.0.3",
     "@types/yauzl": "^2.10.3",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- Fix duplicate `__ELECTRON_LOG__` IPC handler registration caused by Rollup bundling `debug` package into `index.js`
- When dynamic imports in `@lobechat/file-loaders` loaded, they would `require("./index.js")` to get shared `debug` dependency, re-executing side-effect code including electron-log's IPC handler registration
- Add `manualChunks` config to isolate `debug` package into separate chunk (`vendor-debug.js`)
- Add `@napi-rs/canvas` to native modules list for proper externalization

## Root Cause
Rollup's default code-splitting strategy merges shared dependencies into the entry chunk (`index.js`). When dynamic import chunks need these shared deps, they `require` the entry chunk, causing side-effects (like IPC handler registration) to execute again in CJS format.

## Test plan
- [x] Run desktop app in dev mode
- [x] Trigger file reading via IPC (e.g., open a local file)
- [x] Verify no "Attempted to register a second handler for '__ELECTRON_LOG__'" error appears

## Summary by Sourcery

Adjust desktop Electron bundling to avoid duplicate IPC handler side effects and ensure native dependencies are properly externalized.

Build:
- Configure Rollup manualChunks in the Electron Vite config to isolate the debug package into a separate vendor chunk and prevent it from being bundled into the main entry file.

Deployment:
- Add @napi-rs/canvas to the native modules configuration so it is treated as an external native dependency during packaging.