### PR TITLE
fix: error message style

### DIFF
--- a/src/components/FileParsingStatus/EmbeddingStatus.tsx
+++ b/src/components/FileParsingStatus/EmbeddingStatus.tsx
@@ -4,27 +4,17 @@ import { BoltIcon, RotateCwIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useIsDark } from '@/hooks/useIsDark';
 import { AsyncTaskStatus, type FileParsingTask } from '@/types/asyncTask';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  errorReasonDark: css`
+  errorReason: css`
     padding: 4px;
     border-radius: 4px;
 
     font-family: monospace;
     font-size: 12px;
 
-    background: color-mix(in srgb, ${cssVar.colorText} 90%, black);
-  `,
-  errorReasonLight: css`
-    padding: 4px;
-    border-radius: 4px;
-
-    font-family: monospace;
-    font-size: 12px;
-
-    background: color-mix(in srgb, ${cssVar.colorText} 90%, white);
+    background: ${cssVar.colorFillTertiary};
   `,
 }));
 
@@ -37,7 +27,6 @@ interface EmbeddingStatusProps extends FileParsingTask {
 const EmbeddingStatus = memo<EmbeddingStatusProps>(
   ({ chunkCount, embeddingStatus, embeddingError, onClick, onErrorClick, className }) => {
     const { t } = useTranslation(['components', 'common']);
-    const isDarkMode = useIsDark();
 
     switch (embeddingStatus) {
       case AsyncTaskStatus.Processing: {
@@ -73,9 +62,7 @@ const EmbeddingStatus = memo<EmbeddingStatusProps>(
               <Flexbox gap={4}>
                 {t('FileParsingStatus.chunks.embeddingStatus.errorResult')}
                 {embeddingError && (
-                  <Flexbox
-                    className={isDarkMode ? styles.errorReasonDark : styles.errorReasonLight}
-                  >
+                  <Flexbox className={styles.errorReason}>
                     [{embeddingError.name}]:{' '}
                     {embeddingError.body && typeof embeddingError.body !== 'string'
                       ? embeddingError.body.detail

--- a/src/components/FileParsingStatus/index.tsx
+++ b/src/components/FileParsingStatus/index.tsx
@@ -5,7 +5,6 @@ import { BoltIcon, Loader2Icon, RotateCwIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useIsDark } from '@/hooks/useIsDark';
 import { AsyncTaskStatus, type FileParsingTask } from '@/types/asyncTask';
 
 import EmbeddingStatus from './EmbeddingStatus';
@@ -18,13 +17,7 @@ const styles = createStaticStyles(({ css }) => ({
     font-family: monospace;
     font-size: 12px;
 
-    background: var(--error-reason-bg, ${cssVar.colorText});
-  `,
-  errorReasonDark: css`
-    --error-reason-bg: color-mix(in srgb, ${cssVar.colorText} 90%, black);
-  `,
-  errorReasonLight: css`
-    --error-reason-bg: color-mix(in srgb, ${cssVar.colorText} 90%, white);
+    background: ${cssVar.colorFillTertiary};
   `,
 }));
 
@@ -53,7 +46,6 @@ const FileParsingStatus = memo<FileParsingStatusProps>(
     hideEmbeddingButton,
   }) => {
     const { t } = useTranslation(['components', 'common']);
-    const isDarkMode = useIsDark();
 
     switch (chunkingStatus) {
       case AsyncTaskStatus.Processing: {
@@ -77,12 +69,7 @@ const FileParsingStatus = memo<FileParsingStatusProps>(
               <Flexbox gap={4}>
                 {t('FileParsingStatus.chunks.status.errorResult')}
                 {chunkingError && (
-                  <Flexbox
-                    className={cx(
-                      styles.errorReason,
-                      isDarkMode ? styles.errorReasonDark : styles.errorReasonLight,
-                    )}
-                  >
+                  <Flexbox className={styles.errorReason}>
                     [{chunkingError.name}]:{' '}
                     {chunkingError.body && typeof chunkingError.body !== 'string'
                       ? chunkingError.body.detail


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Standardize file parsing error message styling and remove theme-dependent variants.

Bug Fixes:
- Fix inconsistent error message background colors between light and dark themes for file parsing and embedding status views.

Enhancements:
- Simplify error message styling by using a single theme token-based background and removing redundant dark/light style branches.