### PR TITLE
🐛 fix: resolve server version check issue for desktop app

### DIFF
--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ProductLogo } from '@/components/Branding';
 import { CHANGELOG_URL, MANUAL_UPGRADE_URL, OFFICIAL_SITE } from '@/const/url';
-import { CURRENT_VERSION, isDesktop } from '@/const/version';
+import { CURRENT_VERSION } from '@/const/version';
 import { useNewVersion } from '@/features/User/UserPanel/useNewVersion';
 import { useGlobalStore } from '@/store/global';
 
@@ -25,7 +25,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
   ]);
   const { t } = useTranslation('common');
 
-  useCheckServerVersion(isDesktop);
+  useCheckServerVersion();
 
   const showServerVersion = serverVersion && serverVersion !== CURRENT_VERSION;
 

--- a/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -5,7 +5,6 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createStoreUpdater } from 'zustand-utils';
 
-import { isDesktop } from '@/const/version';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useAgentStore } from '@/store/agent';
 import { useAiInfraStore } from '@/store/aiInfra';
@@ -44,7 +43,7 @@ const StoreInitialization = memo(() => {
   useInitSystemStatus();
 
   // check server version in desktop app
-  useCheckServerVersion(isDesktop);
+  useCheckServerVersion();
 
   // fetch server config
   const useFetchServerConfig = useServerConfigStore((s) => s.useInitServerConfig);


### PR DESCRIPTION
## Summary

- Fix version check to only run for self-hosted remote server mode (not cloud mode)
- Get remote server URL from electron store for proper origin detection
- Remove unnecessary `isDesktop` parameter from `useCheckServerVersion` hook

## Test Plan

- [x] Verify version check works correctly in desktop app with self-hosted remote server
- [x] Verify version check is skipped in cloud storage mode
- [x] Verify version check is skipped in web app