### PR TITLE
🐛 fix: fix share single message

### DIFF
--- a/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
+++ b/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
@@ -14,6 +14,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { useAgentMeta, useIsBuiltinAgent } from '../../../hooks';
+import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
 import { styles as containerStyles } from '../style';
 import { styles } from './style';
 import { type FieldType } from './type';
@@ -33,6 +34,9 @@ const Preview = memo<PreviewProps>(
 
     const agentMeta = useAgentMeta(message.agentId);
     const isBuiltinAgent = useIsBuiltinAgent();
+
+    // Process message content for proper rendering
+    const processedContent = normalizeThinkTags(processWithArtifact(message.content));
 
     const { t } = useTranslation('chat');
 
@@ -79,6 +83,7 @@ const Preview = memo<PreviewProps>(
                   title: displayTitle,
                 }}
                 id={message.id}
+                message={processedContent}
               />
             </Flexbox>
             {withFooter ? (

--- a/src/features/Conversation/store/slices/input/action.ts
+++ b/src/features/Conversation/store/slices/input/action.ts
@@ -1,5 +1,7 @@
 import type { StateCreator } from 'zustand';
 
+import { useChatStore } from '@/store/chat';
+
 import type { State } from '../../initialState';
 
 export interface InputAction {
@@ -22,10 +24,14 @@ export interface InputAction {
 export const inputSlice: StateCreator<State & InputAction, [], [], InputAction> = (set) => ({
   cleanupInput: () => {
     set({ editor: null, inputMessage: '' });
+    // Also clear ChatStore's mainInputEditor
+    useChatStore.setState({ mainInputEditor: null });
   },
 
   setEditor: (editor) => {
     set({ editor });
+    // Sync to ChatStore's mainInputEditor for error recovery in sendMessage
+    useChatStore.setState({ mainInputEditor: editor });
   },
 
   updateInputMessage: (message) => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

close LOBE-2484
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix single-message sharing by synchronizing input editor state with the chat store and normalizing shared message content for correct preview rendering.

Bug Fixes:
- Clear and synchronize the main input editor state in both the input slice and chat store during editor updates and cleanup.
- Normalize and preprocess shared message content before rendering image previews to ensure single messages display correctly.