### PR TITLE
✨ feat(desktop): add manual update check entry in About page

### DIFF
--- a/apps/desktop/src/main/controllers/UpdaterCtr.ts
+++ b/apps/desktop/src/main/controllers/UpdaterCtr.ts
@@ -12,7 +12,7 @@ export default class UpdaterCtr extends ControllerModule {
   @IpcMethod()
   async checkForUpdates() {
     logger.info('Check for updates requested');
-    await this.app.updaterManager.checkForUpdates();
+    await this.app.updaterManager.checkForUpdates({ manual: true });
   }
 
   /**

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -29,6 +29,7 @@
   "branchingRequiresSavedTopic": "Current topic is not saved, please save it first to use subtopic feature",
   "cancel": "Cancel",
   "changelog": "Changelog",
+  "checkForUpdates": "Check for Updates",
   "clientDB.autoInit.title": "Initializing PGlite Database",
   "clientDB.error.desc": "PGlite failed to initialize. Retry first. If it helps, open Self-serve fixes and follow the steps. Still stuck after a few tries? Use Report issue to send us the error details.",
   "clientDB.error.detail": "Error reason: [{{type}}] {{message}}. Details are as follows:",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -29,6 +29,7 @@
   "branchingRequiresSavedTopic": "当前话题未保存。保存后即可使用子话题",
   "cancel": "取消",
   "changelog": "更新日志",
+  "checkForUpdates": "检查更新",
   "clientDB.autoInit.title": "初始化 PGlite 数据库",
   "clientDB.error.desc": "PGlite 数据库初始化遇到了问题。你可以先点右侧「重试」；如果方便，也可以打开「自助解决」按提示处理。多次重试仍不行：欢迎通过「反馈问题」把错误信息发给我们，我们会尽快排查。",
   "clientDB.error.detail": "原因：[{{type}}] {{message}}，明细如下：",

--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -73,7 +73,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
           <Button block={mobile}>{t('changelog')}</Button>
         </a>
         {isDesktop && !hasNewVersion && (
-          <Button block={mobile} onClick={() => void autoUpdateService.checkUpdate(); }>
+          <Button block={mobile} onClick={() => void autoUpdateService.checkUpdate()}>
             {t('checkForUpdates')}
           </Button>
         )}

--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -73,7 +73,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
           <Button block={mobile}>{t('changelog')}</Button>
         </a>
         {isDesktop && !hasNewVersion && (
-          <Button block={mobile} onClick={() => void autoUpdateService.checkUpdate()}>
+          <Button block={mobile} onClick={() => void autoUpdateService.checkUpdate(); }>
             {t('checkForUpdates')}
           </Button>
         )}

--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -32,10 +32,6 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
   const showServerVersion = serverVersion && serverVersion !== CURRENT_VERSION;
   const isDesktop = useMemo(() => !!getElectronIpc(), []);
 
-  const handleCheckForUpdates = () => {
-    autoUpdateService.checkUpdate();
-  };
-
   return (
     <Flexbox
       align={mobile ? 'stretch' : 'center'}
@@ -77,7 +73,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
           <Button block={mobile}>{t('changelog')}</Button>
         </a>
         {isDesktop && !hasNewVersion && (
-          <Button block={mobile} onClick={handleCheckForUpdates}>
+          <Button block={mobile} onClick={() => void autoUpdateService.checkUpdate()}>
             {t('checkForUpdates')}
           </Button>
         )}

--- a/src/app/[variants]/(main)/settings/about/features/Version.tsx
+++ b/src/app/[variants]/(main)/settings/about/features/Version.tsx
@@ -1,13 +1,15 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
+import { getElectronIpc } from '@lobechat/electron-client-ipc';
 import { Block, Button, Flexbox, Tag } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ProductLogo } from '@/components/Branding';
 import { CHANGELOG_URL, MANUAL_UPGRADE_URL, OFFICIAL_SITE } from '@/const/url';
 import { CURRENT_VERSION } from '@/const/version';
 import { useNewVersion } from '@/features/User/UserPanel/useNewVersion';
+import { autoUpdateService } from '@/services/electron/autoUpdate';
 import { useGlobalStore } from '@/store/global';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -28,6 +30,11 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
   useCheckServerVersion();
 
   const showServerVersion = serverVersion && serverVersion !== CURRENT_VERSION;
+  const isDesktop = useMemo(() => !!getElectronIpc(), []);
+
+  const handleCheckForUpdates = () => {
+    autoUpdateService.checkUpdate();
+  };
 
   return (
     <Flexbox
@@ -69,7 +76,12 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
         <a href={CHANGELOG_URL} rel="noreferrer" style={{ flex: 1 }} target="_blank">
           <Button block={mobile}>{t('changelog')}</Button>
         </a>
-        {hasNewVersion && (
+        {isDesktop && !hasNewVersion && (
+          <Button block={mobile} onClick={handleCheckForUpdates}>
+            {t('checkForUpdates')}
+          </Button>
+        )}
+        {hasNewVersion && !isDesktop && (
           <a href={MANUAL_UPGRADE_URL} rel="noreferrer" style={{ flex: 1 }} target="_blank">
             <Button block={mobile} type={'primary'}>
               {t('upgradeVersion.action')}

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -34,6 +34,7 @@ export default {
     'Current topic is not saved, please save it first to use subtopic feature',
   'cancel': 'Cancel',
   'changelog': 'Changelog',
+  'checkForUpdates': 'Check for Updates',
   'clientDB.autoInit.title': 'Initializing PGlite Database',
   'clientDB.error.desc':
     'PGlite failed to initialize. Retry first. If it helps, open Self-serve fixes and follow the steps. Still stuck after a few tries? Use Report issue to send us the error details.',


### PR DESCRIPTION
## Summary
Add a 'Check for Updates' button to the About page that allows desktop users to manually trigger update checks without relying on automatic schedules. The button appears only on desktop and is hidden when a new version is already detected.

## Changes
- Add `checkForUpdates` i18n translations (en-US, zh-CN)
- Modify UpdaterCtr to pass `manual: true` flag for update checks
- Add check update button to Version component with desktop-only visibility

## Test Plan
- [ ] Tested on desktop (macOS/Windows/Linux)
- [ ] Verify button appears only on desktop and when no new version is available
- [ ] Check update flow works correctly when clicking the button

## Summary by Sourcery

Add a desktop-only manual update check entry to the About page and ensure manual checks are flagged appropriately in the desktop updater controller.

New Features:
- Add a Check for Updates button to the About page that is only shown on desktop when no new version is currently available.

Enhancements:
- Flag desktop update checks initiated via IPC as manual in the updater controller.
- Extend common i18n resources with a checkForUpdates string key for supported locales.