### PR TITLE
🐛 fix(model-runtime): filter null values from enum for Gemini compatibility

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1154,6 +1154,79 @@ describe('google contextBuilders', () => {
         type: 'string',
       });
     });
+
+    it('should filter null values from enum arrays for Google compatibility', () => {
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'A tool with enum containing null',
+          name: 'enumTool',
+          parameters: {
+            properties: {
+              memoryType: {
+                enum: ['short_term', 'long_term', null, 'working'],
+                type: 'string',
+              },
+              nested: {
+                properties: {
+                  status: {
+                    enum: [null, 'active', 'inactive', null],
+                    type: 'string',
+                  },
+                },
+                type: 'object',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool);
+
+      // null values should be filtered from enum arrays
+      expect(result.parameters?.properties).toEqual({
+        memoryType: {
+          enum: ['short_term', 'long_term', 'working'],
+          type: 'string',
+        },
+        nested: {
+          properties: {
+            status: {
+              enum: ['active', 'inactive'],
+              type: 'string',
+            },
+          },
+          type: 'object',
+        },
+      });
+    });
+
+    it('should handle enum with only null values', () => {
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'A tool with enum containing only null',
+          name: 'nullEnumTool',
+          parameters: {
+            properties: {
+              value: {
+                enum: [null],
+                type: 'string',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool);
+
+      // When enum only contains null, the enum property should be removed
+      expect(result.parameters?.properties?.value).toEqual({
+        type: 'string',
+      });
+    });
   });
 
   describe('buildGoogleTools', () => {

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -248,6 +248,16 @@ const sanitizeSchemaForGoogle = (schema: Record<string, any>): Record<string, an
       continue;
     }
 
+    // Filter null values from enum arrays (Google doesn't support null in enum)
+    if (key === 'enum' && Array.isArray(value)) {
+      const filteredEnum = value.filter((item) => item !== null);
+      // Only set enum if there are remaining values after filtering
+      if (filteredEnum.length > 0) {
+        result[key] = filteredEnum;
+      }
+      continue;
+    }
+
     // Recursively process nested objects
     if (value && typeof value === 'object') {
       result[key] = sanitizeSchemaForGoogle(value);


### PR DESCRIPTION
## Summary

- Gemini API 的 enum 不支持 null 值，会导致报错：`GenerateContentRequest.tools[0].function_declarations[29].parameters.properties[set].properties[memoryType].enum[10]: cannot be empty`
- 在 `sanitizeSchemaForGoogle` 函数中添加过滤 enum 数组中 null 值的逻辑
- 添加了相关测试用例

## Test plan

- [x] 运行 `bunx vitest run` 测试 google context builder - 36 个测试全部通过
- [ ] 使用包含 null enum 的工具调用 Gemini API 验证不再报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Google context builder sanitizes tool parameter schemas for Gemini enum compatibility by stripping unsupported null enum values.

Bug Fixes:
- Filter null values from enum arrays in sanitized tool parameter schemas to avoid Gemini API errors when enums include null.
- Remove enum definitions when all enum entries are null to produce valid schemas for Gemini.

Tests:
- Add unit tests covering enum arrays with mixed values including null and enums containing only null values to verify Google schema sanitization.