### PR TITLE
🐛 fix(community): should be able to switch category with All and Discover

### DIFF
--- a/src/app/[variants]/(main)/community/(list)/agent/features/Category/index.tsx
+++ b/src/app/[variants]/(main)/community/(list)/agent/features/Category/index.tsx
@@ -17,7 +17,7 @@ import { useCategory } from './useCategory';
 const Category = memo(() => {
   const useAssistantCategories = useDiscoverStore((s) => s.useAssistantCategories);
   const {
-    category = 'all',
+    category = AssistantCategory.Discover,
     q,
     source,
   } = useQuery() as { category?: AssistantCategory; q?: string; source?: string };
@@ -29,7 +29,7 @@ const Category = memo(() => {
     qs.stringifyUrl(
       {
         query: {
-          category: [AssistantCategory.All, AssistantCategory.Discover].includes(key) ? null : key,
+          category: key === AssistantCategory.Discover ? null : key,
           q,
           sort: key === AssistantCategory.Discover ? AssistantSorts.Recommended : null,
         },

--- a/src/app/[variants]/(main)/community/(list)/mcp/features/Category/index.tsx
+++ b/src/app/[variants]/(main)/community/(list)/mcp/features/Category/index.tsx
@@ -16,7 +16,10 @@ import CategoryMenu from '../../../../components/CategoryMenu';
 
 const Category = memo(() => {
   const useMcpCategories = useDiscoverStore((s) => s.useMcpCategories);
-  const { category = McpCategory.Discover, q } = useQuery() as { category?: McpCategory; q?: string };
+  const { category = McpCategory.Discover, q } = useQuery() as {
+    category?: McpCategory;
+    q?: string;
+  };
   const { data: items = [] } = useMcpCategories({ q });
   const navigate = useNavigate();
   const cates = useCategory();
@@ -25,7 +28,7 @@ const Category = memo(() => {
     qs.stringifyUrl(
       {
         query: {
-          category: [McpCategory.All, McpCategory.Discover].includes(key) ? null : key,
+          category: key === McpCategory.Discover ? null : key,
           q,
           sort: key === McpCategory.Discover ? McpSorts.Recommended : null,
         },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix category selection behavior in community lists so Discover acts as the default category and URL query parameters are set consistently when switching categories.

Bug Fixes:
- Ensure MCP community list clears the category query only when Discover is selected, allowing proper switching between All and other categories.
- Set Discover as the default agent category and align category query handling so Discover uses recommended sorting and does not persist as an explicit category in the URL.