### PR TITLE
🔨 chore(community): all category of agent list result in empty result

### DIFF
--- a/src/server/services/discover/index.ts
+++ b/src/server/services/discover/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@lobechat/const';
 import {
   type AgentStatus,
+  AssistantCategory,
   type AssistantListResponse,
   type AssistantMarketSource,
   type AssistantQueryParams,
@@ -672,6 +673,9 @@ export class DiscoverService {
       ownerId,
       includeAgentGroup,
     } = rest;
+    const shouldOmitCategory = [AssistantCategory.All, AssistantCategory.Discover].includes(
+      category as AssistantCategory,
+    );
 
     try {
       const normalizedLocale = normalizeLocale(locale);
@@ -705,7 +709,7 @@ export class DiscoverService {
       }
 
       const data = await this.market.agents.getAgentList({
-        category,
+        category: shouldOmitCategory ? undefined : category,
         haveSkills,
         // includeAgentGroup may not be in SDK type definition yet, using 'as any'
         includeAgentGroup,
@@ -827,14 +831,14 @@ export class DiscoverService {
     log('getMcpList: params=%O', params);
     const { category, locale, sort } = params;
     const normalizedLocale = normalizeLocale(locale);
-    const isDiscoverCategory = category === McpCategory.Discover;
+    const shouldOmitCategory = [McpCategory.All, McpCategory.Discover].includes(category as McpCategory)
 
     const result = await this.market.plugins.getPluginList(
       {
         ...params,
-        category: isDiscoverCategory ? undefined : category,
+        category: shouldOmitCategory ? undefined : category,
         locale: normalizedLocale,
-        sort: isDiscoverCategory ? McpSorts.Recommended : sort,
+        sort: shouldOmitCategory ? McpSorts.Recommended : sort,
       },
       {
         next: {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust discover service filtering so that "All" and "Discover" categories no longer pass a category filter that results in empty agent and plugin lists, and ensure recommended sorting is applied for these categories in MCP plugin discovery.

Bug Fixes:
- Fix agent list queries so selecting the "All" or "Discover" category no longer yields empty results by omitting the category filter in these cases.
- Fix MCP plugin list queries so "All" and "Discover" categories use no category filter and default to recommended sorting instead of returning empty results.