### PR TITLE
🐛 fix: fixed compressed group message & open the switch config to control compression config enabled

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -446,6 +446,8 @@
   "settingImage.defaultCount.desc": "Set the default number of images generated when creating a new task in the image generation panel.",
   "settingImage.defaultCount.label": "Default Image Count",
   "settingImage.defaultCount.title": "AI Art",
+  "settingModel.enableContextCompression.desc": "Automatically compress historical messages into summaries when conversation exceeds 64,000 tokens, saving 60-80% token usage",
+  "settingModel.enableContextCompression.title": "Enable Auto Context Compression",
   "settingModel.enableMaxTokens.title": "Enable Max Tokens Limit",
   "settingModel.enableReasoningEffort.title": "Enable Reasoning Effort Adjustment",
   "settingModel.frequencyPenalty.desc": "The higher the value, the more diverse and rich the vocabulary; the lower the value, the simpler and more straightforward the language.",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -446,6 +446,8 @@
   "settingImage.defaultCount.desc": "设置图像生成面板在创建新任务时的默认图片数量。",
   "settingImage.defaultCount.label": "默认图片数量",
   "settingImage.defaultCount.title": "AI 绘画设置",
+  "settingModel.enableContextCompression.desc": "当对话消息超过 64,000 tokens 时，自动将历史消息压缩为摘要，节省 60-80% 的 token 用量",
+  "settingModel.enableContextCompression.title": "开启自动上下文压缩",
   "settingModel.enableMaxTokens.title": "开启单次回复限制",
   "settingModel.enableReasoningEffort.title": "开启推理强度调整",
   "settingModel.frequencyPenalty.desc": "值越大，用词越丰富多样；值越低，用词更朴实简单",

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
     "remove-markdown": "^0.6.3",
-    "resend": "^6.8.0",
+    "resend": "6.8.0",
     "resolve-accept-language": "^3.1.15",
     "rtl-detect": "^1.1.2",
     "semver": "^7.7.3",

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -283,21 +283,25 @@ export class GeneralChatAgent implements Agent {
     switch (context.phase) {
       case 'init':
       case 'user_input': {
-        // Check if context compression is needed before calling LLM
-        const compressionCheck = shouldCompress(state.messages, {
-          maxWindowToken: this.config.compressionConfig?.maxWindowToken,
-        });
+        // Check if context compression is enabled and needed before calling LLM
+        const compressionEnabled = this.config.compressionConfig?.enabled ?? true; // Default to enabled
 
-        if (compressionCheck.needsCompression) {
-          // Context exceeds threshold, compress ALL messages into a single summary
-          return {
-            payload: {
-              currentTokenCount: compressionCheck.currentTokenCount,
-              existingSummary: this.findExistingSummary(state.messages),
-              messages: state.messages,
-            },
-            type: 'compress_context',
-          } as AgentInstructionCompressContext;
+        if (compressionEnabled) {
+          const compressionCheck = shouldCompress(state.messages, {
+            maxWindowToken: this.config.compressionConfig?.maxWindowToken,
+          });
+
+          if (compressionCheck.needsCompression) {
+            // Context exceeds threshold, compress ALL messages into a single summary
+            return {
+              payload: {
+                currentTokenCount: compressionCheck.currentTokenCount,
+                existingSummary: this.findExistingSummary(state.messages),
+                messages: state.messages,
+              },
+              type: 'compress_context',
+            } as AgentInstructionCompressContext;
+          }
         }
 
         // User input received, call LLM to generate response

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -69,16 +69,15 @@ export interface GeneralAgentConfig {
   };
   /**
    * Context compression configuration
-   * Note: Compression checking is always enabled to prevent context overflow.
-   * When triggered, ALL messages are compressed into a single MessageGroup summary.
+   * When enabled and triggered, ALL messages are compressed into a single MessageGroup summary.
    */
   compressionConfig?: {
+    /** Whether context compression is enabled (default: true) */
+    enabled?: boolean;
     /** Model's max context window token count (default: 128k) */
     maxWindowToken?: number;
   };
   modelRuntimeConfig?: {
-    model: string;
-    provider: string;
     /**
      * Compression model configuration
      * Used for context compression tasks
@@ -87,6 +86,8 @@ export interface GeneralAgentConfig {
       model: string;
       provider: string;
     };
+    model: string;
+    provider: string;
   };
   operationId: string;
   userId?: string;

--- a/src/features/ChatInput/ActionBar/Params/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/Params/Controls.tsx
@@ -320,7 +320,23 @@ const Controls = memo<ControlsProps>(({ setUpdating }) => {
       : []),
   ];
 
-  const allItems = [...baseItems, ...maxTokensItems];
+  // Context Compression items
+  const contextCompressionItems: FormItemProps[] = [
+    {
+      children: <Switch />,
+      label: (
+        <Flexbox align={'center'} className={styles.label} gap={8} horizontal>
+          {t('settingModel.enableContextCompression.title')}
+          <InfoTooltip title={t('settingModel.enableContextCompression.desc')} />
+        </Flexbox>
+      ),
+      name: ['chatConfig', 'enableContextCompression'],
+      tag: 'compression',
+      valuePropName: 'checked',
+    },
+  ];
+
+  const allItems = [...baseItems, ...maxTokensItems, ...contextCompressionItems];
 
   return (
     <Form

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -97,14 +97,10 @@ const ModelSelect = memo<ModelSelectProps>(
         .filter(Boolean) as LobeSelectProps['options'];
     }, [enabledList, requiredAbilities, showAbility]);
 
-    // Memoize the value string to prevent creating new references on every render
-    const selectValue = useMemo(() => {
-      return value?.provider && value?.model ? `${value.provider}/${value.model}` : undefined;
-    }, [value?.provider, value?.model]);
-
     return (
       <TooltipGroup>
         <LobeSelect
+          defaultValue={`${value?.provider}/${value?.model}`}
           loading={loading}
           onChange={(value, option) => {
             if (!value) return;
@@ -132,7 +128,7 @@ const ModelSelect = memo<ModelSelectProps>(
             width: initialWidth ? 'initial' : undefined,
             ...style,
           }}
-          value={selectValue}
+          value={`${value?.provider}/${value?.model}`}
           variant={variant}
           virtual
         />

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -97,10 +97,14 @@ const ModelSelect = memo<ModelSelectProps>(
         .filter(Boolean) as LobeSelectProps['options'];
     }, [enabledList, requiredAbilities, showAbility]);
 
+    // Memoize the value string to prevent creating new references on every render
+    const selectValue = useMemo(() => {
+      return value?.provider && value?.model ? `${value.provider}/${value.model}` : undefined;
+    }, [value?.provider, value?.model]);
+
     return (
       <TooltipGroup>
         <LobeSelect
-          defaultValue={`${value?.provider}/${value?.model}`}
           loading={loading}
           onChange={(value, option) => {
             if (!value) return;
@@ -128,7 +132,7 @@ const ModelSelect = memo<ModelSelectProps>(
             width: initialWidth ? 'initial' : undefined,
             ...style,
           }}
-          value={`${value?.provider}/${value?.model}`}
+          value={selectValue}
           variant={variant}
           virtual
         />

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -501,6 +501,9 @@ export default {
     'Set the default number of images generated when creating a new task in the image generation panel.',
   'settingImage.defaultCount.label': 'Default Image Count',
   'settingImage.defaultCount.title': 'AI Art',
+  'settingModel.enableContextCompression.desc':
+    'Automatically compress historical messages into summaries when conversation exceeds 64,000 tokens, saving 60-80% token usage',
+  'settingModel.enableContextCompression.title': 'Enable Auto Context Compression',
   'settingModel.enableMaxTokens.title': 'Enable Max Tokens Limit',
   'settingModel.enableReasoningEffort.title': 'Enable Reasoning Effort Adjustment',
   'settingModel.frequencyPenalty.desc':

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -126,8 +126,7 @@ export class AgentRuntimeService {
    */
   private stepCallbacks: Map<string, StepLifecycleCallbacks> = new Map();
   private get baseURL() {
-    const baseUrl =
-      process.env.AGENT_RUNTIME_BASE_URL || appEnv.APP_URL || 'http://localhost:3010';
+    const baseUrl = process.env.AGENT_RUNTIME_BASE_URL || appEnv.APP_URL || 'http://localhost:3010';
 
     return urlJoin(baseUrl, '/api/agent');
   }
@@ -840,6 +839,9 @@ export class AgentRuntimeService {
     // Create Durable Agent instance
     const agent = new GeneralChatAgent({
       agentConfig: metadata?.agentConfig,
+      compressionConfig: {
+        enabled: metadata?.agentConfig?.chatConfig?.enableContextCompression ?? true,
+      },
       modelRuntimeConfig: metadata?.modelRuntimeConfig,
       operationId,
       userId: metadata?.userId,

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -702,6 +702,9 @@ export const streamingExecutor: StateCreator<
 
     const agent = new GeneralChatAgent({
       agentConfig: { maxSteps: 1000 },
+      compressionConfig: {
+        enabled: agentConfigData.chatConfig?.enableContextCompression ?? true, // Default to enabled
+      },
       operationId: `${messageKey}/${params.parentMessageId}`,
       modelRuntimeConfig,
     });

--- a/src/store/chat/slices/message/selectors/displayMessage.test.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.test.ts
@@ -833,5 +833,26 @@ describe('displayMessageSelectors', () => {
       const result = displayMessageSelectors.findLastMessageId('msg-1')(state as ChatStore);
       expect(result).toBe('tool-result-id');
     });
+
+    it('should return lastMessageId for compressedGroup instead of group id', () => {
+      const compressedGroupMessage = {
+        id: 'mg_123456',
+        role: 'compressedGroup',
+        content: 'Compressed summary',
+        lastMessageId: 'msg-999',
+        compressedMessages: [],
+        pinnedMessages: [],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [compressedGroupMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId('mg_123456')(state as ChatStore);
+      expect(result).toBe('msg-999');
+    });
   });
 });

--- a/src/store/chat/slices/message/selectors/displayMessage.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.ts
@@ -247,7 +247,7 @@ const findLastBlockId = (block: AssistantContentBlock | undefined): string | und
 
 /**
  * Recursively finds the last message ID in a message tree
- * Priority: children > tools > self
+ * Priority: children > tools > compressedGroup.lastMessageId > self
  */
 const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | undefined => {
   if (!node) return undefined;
@@ -264,7 +264,12 @@ const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | u
     return lastTool?.result_msg_id;
   }
 
-  // Priority 3: Return self ID
+  // Priority 3: For compressedGroup, return lastMessageId instead of group ID
+  if (node.role === 'compressedGroup' && 'lastMessageId' in node) {
+    return (node as any).lastMessageId;
+  }
+
+  // Priority 4: Return self ID
   return node.id;
 };
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Make context compression behavior configurable and fix handling of compressed group messages when determining the last message ID.

New Features:
- Add a user-facing switch to enable or disable automatic context compression per chat configuration.

Bug Fixes:
- Ensure compressed group messages return their underlying last message ID instead of the group ID when resolving the last message.

Enhancements:
- Introduce an optional context compression enable flag in the general agent configuration and thread it through agent runtime creation.
- Update locale strings to document and describe the context compression setting in the model settings UI.

Tests:
- Add a selector test case verifying last message resolution for compressed group messages.