### PR TITLE
🐛 fix: skill detail page icon problem 

### DIFF
--- a/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -3,7 +3,7 @@
 import { type KlavisServerType } from '@lobechat/const';
 import { Avatar, DropdownMenu, Flexbox, Icon, Button as LobeButton } from '@lobehub/ui';
 import { App, Button } from 'antd';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { cssVar } from 'antd-style';
 import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -14,17 +14,10 @@ import { type KlavisServer, KlavisServerStatus } from '@/store/tool/slices/klavi
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
-import { sharedStyles } from './style';
+import { styles } from './style';
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
-
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  pending: css`
-    font-size: 14px;
-    color: ${cssVar.colorWarning};
-  `,
-}));
 
 interface KlavisSkillItemProps {
   server?: KlavisServer;
@@ -193,7 +186,7 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
   const renderStatus = () => {
     if (!server) {
       return (
-        <span className={sharedStyles.disconnected}>
+        <span className={styles.disconnected}>
           {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
         </span>
       );
@@ -201,17 +194,17 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
 
     switch (server.status) {
       case KlavisServerStatus.CONNECTED: {
-        return <span className={sharedStyles.connected}>{t('tools.klavis.connected')}</span>;
+        return <span className={styles.connected}>{t('tools.klavis.connected')}</span>;
       }
       case KlavisServerStatus.PENDING_AUTH: {
         return <span className={styles.pending}>{t('tools.klavis.authRequired')}</span>;
       }
       case KlavisServerStatus.ERROR: {
-        return <span className={sharedStyles.error}>{t('tools.klavis.error')}</span>;
+        return <span className={styles.error}>{t('tools.klavis.error')}</span>;
       }
       default: {
         return (
-          <span className={sharedStyles.disconnected}>
+          <span className={styles.disconnected}>
             {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
@@ -278,7 +271,7 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
   return (
     <Flexbox
       align="center"
-      className={sharedStyles.container}
+      className={styles.container}
       gap={16}
       horizontal
       justify="space-between"
@@ -297,9 +290,9 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
           }
           style={{ cursor: 'pointer' }}
         >
-          <div className={sharedStyles.icon}>{renderIcon()}</div>
+          <div className={styles.icon}>{renderIcon()}</div>
           <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-            <span className={sharedStyles.title}>{serverType.label}</span>
+            <span className={styles.title}>{serverType.label}</span>
             {!isConnected && renderStatus()}
           </Flexbox>
         </Flexbox>

--- a/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -284,21 +284,24 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
       justify="space-between"
     >
       <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-        <div className={sharedStyles.icon}>{renderIcon()}</div>
-        <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-          <span
-            className={sharedStyles.title}
-            onClick={() =>
-              createIntegrationDetailModal({
-                identifier: serverType.identifier,
-                serverName: serverType.serverName,
-                type: 'klavis',
-              })
-            }
-          >
-            {serverType.label}
-          </span>
-          {!isConnected && renderStatus()}
+        <Flexbox
+          align="center"
+          gap={16}
+          horizontal
+          onClick={() =>
+            createIntegrationDetailModal({
+              identifier: serverType.identifier,
+              serverName: serverType.serverName,
+              type: 'klavis',
+            })
+          }
+          style={{ cursor: 'pointer' }}
+        >
+          <div className={sharedStyles.icon}>{renderIcon()}</div>
+          <Flexbox gap={4} style={{ overflow: 'hidden' }}>
+            <span className={sharedStyles.title}>{serverType.label}</span>
+            {!isConnected && renderStatus()}
+          </Flexbox>
         </Flexbox>
       </Flexbox>
       <Flexbox align="center" gap={12} horizontal>

--- a/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -14,51 +14,15 @@ import { type KlavisServer, KlavisServerStatus } from '@/store/tool/slices/klavi
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
+import { sharedStyles } from './style';
+
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  connected: css`
-    font-size: 14px;
-    color: ${cssVar.colorSuccess};
-  `,
-  container: css`
-    padding-block: 12px;
-    padding-inline: 0;
-  `,
-  disconnected: css`
-    font-size: 14px;
-    color: ${cssVar.colorTextTertiary};
-  `,
-  error: css`
-    font-size: 14px;
-    color: ${cssVar.colorError};
-  `,
-  icon: css`
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-
-    width: 48px;
-    height: 48px;
-    border-radius: 12px;
-
-    background: ${cssVar.colorFillTertiary};
-  `,
   pending: css`
     font-size: 14px;
     color: ${cssVar.colorWarning};
-  `,
-  title: css`
-    cursor: pointer;
-    font-size: 15px;
-    font-weight: 500;
-    color: ${cssVar.colorText};
-
-    &:hover {
-      color: ${cssVar.colorPrimary};
-    }
   `,
 }));
 
@@ -229,7 +193,7 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
   const renderStatus = () => {
     if (!server) {
       return (
-        <span className={styles.disconnected}>
+        <span className={sharedStyles.disconnected}>
           {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
         </span>
       );
@@ -237,17 +201,17 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
 
     switch (server.status) {
       case KlavisServerStatus.CONNECTED: {
-        return <span className={styles.connected}>{t('tools.klavis.connected')}</span>;
+        return <span className={sharedStyles.connected}>{t('tools.klavis.connected')}</span>;
       }
       case KlavisServerStatus.PENDING_AUTH: {
         return <span className={styles.pending}>{t('tools.klavis.authRequired')}</span>;
       }
       case KlavisServerStatus.ERROR: {
-        return <span className={styles.error}>{t('tools.klavis.error')}</span>;
+        return <span className={sharedStyles.error}>{t('tools.klavis.error')}</span>;
       }
       default: {
         return (
-          <span className={styles.disconnected}>
+          <span className={sharedStyles.disconnected}>
             {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
@@ -314,16 +278,16 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
   return (
     <Flexbox
       align="center"
-      className={styles.container}
+      className={sharedStyles.container}
       gap={16}
       horizontal
       justify="space-between"
     >
       <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-        <div className={styles.icon}>{renderIcon()}</div>
+        <div className={sharedStyles.icon}>{renderIcon()}</div>
         <Flexbox gap={4} style={{ overflow: 'hidden' }}>
           <span
-            className={styles.title}
+            className={sharedStyles.title}
             onClick={() =>
               createIntegrationDetailModal({
                 identifier: serverType.identifier,

--- a/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -15,53 +15,17 @@ import {
   LobehubSkillStatus,
 } from '@/store/tool/slices/lobehubSkillStore/types';
 
+import { sharedStyles } from './style';
+
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  connected: css`
-    font-size: 14px;
-    color: ${cssVar.colorSuccess};
-  `,
-  container: css`
-    padding-block: 12px;
-    padding-inline: 0;
-  `,
-  disconnected: css`
-    font-size: 14px;
-    color: ${cssVar.colorTextTertiary};
-  `,
   disconnectedIcon: css`
     opacity: 0.5;
   `,
   disconnectedTitle: css`
     color: ${cssVar.colorTextTertiary};
-  `,
-  error: css`
-    font-size: 14px;
-    color: ${cssVar.colorError};
-  `,
-  icon: css`
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-
-    width: 48px;
-    height: 48px;
-    border-radius: 12px;
-
-    background: ${cssVar.colorFillTertiary};
-  `,
-  title: css`
-    cursor: pointer;
-    font-size: 15px;
-    font-weight: 500;
-    color: ${cssVar.colorText};
-
-    &:hover {
-      color: ${cssVar.colorPrimary};
-    }
   `,
 }));
 
@@ -234,7 +198,7 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
   const renderStatus = () => {
     if (!server) {
       return (
-        <span className={styles.disconnected}>
+        <span className={sharedStyles.disconnected}>
           {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
         </span>
       );
@@ -243,17 +207,17 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
     switch (server.status) {
       case LobehubSkillStatus.CONNECTED: {
         return (
-          <span className={styles.connected}>
+          <span className={sharedStyles.connected}>
             {t('tools.lobehubSkill.connected', { defaultValue: 'Connected' })}
           </span>
         );
       }
       case LobehubSkillStatus.ERROR: {
-        return <span className={styles.error}>{t('tools.lobehubSkill.error')}</span>;
+        return <span className={sharedStyles.error}>{t('tools.lobehubSkill.error')}</span>;
       }
       default: {
         return (
-          <span className={styles.disconnected}>
+          <span className={sharedStyles.disconnected}>
             {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
@@ -300,18 +264,18 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
   return (
     <Flexbox
       align="center"
-      className={styles.container}
+      className={sharedStyles.container}
       gap={16}
       horizontal
       justify="space-between"
     >
       <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-        <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
+        <div className={`${sharedStyles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
           {renderIcon()}
         </div>
         <Flexbox gap={4} style={{ overflow: 'hidden' }}>
           <span
-            className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}
+            className={`${sharedStyles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}
             onClick={() =>
               createIntegrationDetailModal({
                 identifier: provider.id,

--- a/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -3,7 +3,7 @@
 import { type LobehubSkillProviderType } from '@lobechat/const';
 import { Avatar, DropdownMenu, Flexbox, Icon, Button as LobeButton } from '@lobehub/ui';
 import { App, Button } from 'antd';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { cssVar } from 'antd-style';
 import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,19 +15,10 @@ import {
   LobehubSkillStatus,
 } from '@/store/tool/slices/lobehubSkillStore/types';
 
-import { sharedStyles } from './style';
+import { styles } from './style';
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
-
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  disconnectedIcon: css`
-    opacity: 0.5;
-  `,
-  disconnectedTitle: css`
-    color: ${cssVar.colorTextTertiary};
-  `,
-}));
 
 interface LobehubSkillItemProps {
   provider: LobehubSkillProviderType;
@@ -198,7 +189,7 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
   const renderStatus = () => {
     if (!server) {
       return (
-        <span className={sharedStyles.disconnected}>
+        <span className={styles.disconnected}>
           {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
         </span>
       );
@@ -207,17 +198,17 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
     switch (server.status) {
       case LobehubSkillStatus.CONNECTED: {
         return (
-          <span className={sharedStyles.connected}>
+          <span className={styles.connected}>
             {t('tools.lobehubSkill.connected', { defaultValue: 'Connected' })}
           </span>
         );
       }
       case LobehubSkillStatus.ERROR: {
-        return <span className={sharedStyles.error}>{t('tools.lobehubSkill.error')}</span>;
+        return <span className={styles.error}>{t('tools.lobehubSkill.error')}</span>;
       }
       default: {
         return (
-          <span className={sharedStyles.disconnected}>
+          <span className={styles.disconnected}>
             {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
@@ -264,7 +255,7 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
   return (
     <Flexbox
       align="center"
-      className={sharedStyles.container}
+      className={styles.container}
       gap={16}
       horizontal
       justify="space-between"
@@ -282,13 +273,11 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
           }
           style={{ cursor: 'pointer' }}
         >
-          <div className={`${sharedStyles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
+          <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
             {renderIcon()}
           </div>
           <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-            <span
-              className={`${sharedStyles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}
-            >
+            <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
               {provider.label}
             </span>
             {!isConnected && renderStatus()}

--- a/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -270,22 +270,29 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
       justify="space-between"
     >
       <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-        <div className={`${sharedStyles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
-          {renderIcon()}
-        </div>
-        <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-          <span
-            className={`${sharedStyles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}
-            onClick={() =>
-              createIntegrationDetailModal({
-                identifier: provider.id,
-                type: 'lobehub',
-              })
-            }
-          >
-            {provider.label}
-          </span>
-          {!isConnected && renderStatus()}
+        <Flexbox
+          align="center"
+          gap={16}
+          horizontal
+          onClick={() =>
+            createIntegrationDetailModal({
+              identifier: provider.id,
+              type: 'lobehub',
+            })
+          }
+          style={{ cursor: 'pointer' }}
+        >
+          <div className={`${sharedStyles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
+            {renderIcon()}
+          </div>
+          <Flexbox gap={4} style={{ overflow: 'hidden' }}>
+            <span
+              className={`${sharedStyles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}
+            >
+              {provider.label}
+            </span>
+            {!isConnected && renderStatus()}
+          </Flexbox>
         </Flexbox>
       </Flexbox>
       <Flexbox align="center" gap={12} horizontal>

--- a/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
@@ -14,7 +14,7 @@ import { pluginSelectors } from '@/store/tool/selectors';
 import { type LobeToolType } from '@/types/tool/tool';
 
 import Actions from './Actions';
-import { sharedStyles } from './style';
+import { styles } from './style';
 
 interface McpSkillItemProps {
   author?: string;
@@ -39,7 +39,7 @@ const McpSkillItem = memo<McpSkillItemProps>(
       <>
         <Flexbox
           align="center"
-          className={sharedStyles.container}
+          className={styles.container}
           gap={16}
           horizontal
           justify="space-between"
@@ -52,10 +52,10 @@ const McpSkillItem = memo<McpSkillItemProps>(
               onClick={() => setDetailOpen(true)}
               style={{ cursor: 'pointer' }}
             >
-              <div className={sharedStyles.icon}>
+              <div className={styles.icon}>
                 <PluginAvatar avatar={avatar} size={32} />
               </div>
-              <span className={sharedStyles.title}>{title}</span>
+              <span className={styles.title}>{title}</span>
             </Flexbox>
             <PluginTag author={author} isMCP={isMCP} type={type} />
           </Flexbox>

--- a/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Flexbox, Modal, Block } from '@lobehub/ui';
-import { createStaticStyles } from 'antd-style';
+import { Flexbox, Modal } from '@lobehub/ui';
 import { Suspense, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -15,35 +14,7 @@ import { pluginSelectors } from '@/store/tool/selectors';
 import { type LobeToolType } from '@/types/tool/tool';
 
 import Actions from './Actions';
-
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  container: css`
-    padding-block: 12px;
-    padding-inline: 0;
-  `,
-  icon: css`
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-
-    width: 40px;
-    height: 40px;
-    border-radius: 12px;
-
-    background: ${cssVar.colorFillTertiary};
-  `,
-  title: css`
-    cursor: pointer;
-    font-size: 15px;
-    font-weight: 500;
-    color: ${cssVar.colorText};
-
-    &:hover {
-      color: ${cssVar.colorPrimary};
-    }
-  `,
-}));
+import { sharedStyles } from './style';
 
 interface McpSkillItemProps {
   author?: string;
@@ -68,17 +39,17 @@ const McpSkillItem = memo<McpSkillItemProps>(
       <>
         <Flexbox
           align="center"
-          className={styles.container}
+          className={sharedStyles.container}
           gap={16}
           horizontal
           justify="space-between"
         >
-          <Flexbox align="center" gap={12} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-            <Block className={styles.icon} variant={'outlined'}>
+          <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
+            <div className={sharedStyles.icon}>
               <PluginAvatar avatar={avatar} size={32} />
-            </Block>
+            </div>
             <Flexbox align="center" gap={8} horizontal style={{ overflow: 'hidden' }}>
-              <span className={styles.title} onClick={() => setDetailOpen(true)}>
+              <span className={sharedStyles.title} onClick={() => setDetailOpen(true)}>
                 {title}
               </span>
               <PluginTag author={author} isMCP={isMCP} type={type} />

--- a/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/McpSkillItem.tsx
@@ -45,15 +45,19 @@ const McpSkillItem = memo<McpSkillItemProps>(
           justify="space-between"
         >
           <Flexbox align="center" gap={16} horizontal style={{ flex: 1, overflow: 'hidden' }}>
-            <div className={sharedStyles.icon}>
-              <PluginAvatar avatar={avatar} size={32} />
-            </div>
-            <Flexbox align="center" gap={8} horizontal style={{ overflow: 'hidden' }}>
-              <span className={sharedStyles.title} onClick={() => setDetailOpen(true)}>
-                {title}
-              </span>
-              <PluginTag author={author} isMCP={isMCP} type={type} />
+            <Flexbox
+              align="center"
+              gap={16}
+              horizontal
+              onClick={() => setDetailOpen(true)}
+              style={{ cursor: 'pointer' }}
+            >
+              <div className={sharedStyles.icon}>
+                <PluginAvatar avatar={avatar} size={32} />
+              </div>
+              <span className={sharedStyles.title}>{title}</span>
             </Flexbox>
+            <PluginTag author={author} isMCP={isMCP} type={type} />
           </Flexbox>
           <Actions identifier={identifier} isMCP={isMCP} type={type} />
         </Flexbox>

--- a/src/app/[variants]/(main)/settings/skill/features/style.ts
+++ b/src/app/[variants]/(main)/settings/skill/features/style.ts
@@ -1,0 +1,42 @@
+import { createStaticStyles } from 'antd-style';
+
+export const sharedStyles = createStaticStyles(({ css, cssVar }) => ({
+  connected: css`
+    font-size: 14px;
+    color: ${cssVar.colorSuccess};
+  `,
+  container: css`
+    padding-block: 12px;
+    padding-inline: 0;
+  `,
+  disconnected: css`
+    font-size: 14px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  error: css`
+    font-size: 14px;
+    color: ${cssVar.colorError};
+  `,
+  icon: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  title: css`
+    cursor: pointer;
+    font-size: 15px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+
+    &:hover {
+      color: ${cssVar.colorPrimary};
+    }
+  `,
+}));

--- a/src/app/[variants]/(main)/settings/skill/features/style.ts
+++ b/src/app/[variants]/(main)/settings/skill/features/style.ts
@@ -1,6 +1,6 @@
 import { createStaticStyles } from 'antd-style';
 
-export const sharedStyles = createStaticStyles(({ css, cssVar }) => ({
+export const styles = createStaticStyles(({ css, cssVar }) => ({
   connected: css`
     font-size: 14px;
     color: ${cssVar.colorSuccess};
@@ -11,6 +11,12 @@ export const sharedStyles = createStaticStyles(({ css, cssVar }) => ({
   `,
   disconnected: css`
     font-size: 14px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  disconnectedIcon: css`
+    opacity: 0.5;
+  `,
+  disconnectedTitle: css`
     color: ${cssVar.colorTextTertiary};
   `,
   error: css`
@@ -28,6 +34,10 @@ export const sharedStyles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: 12px;
 
     background: ${cssVar.colorFillTertiary};
+  `,
+  pending: css`
+    font-size: 14px;
+    color: ${cssVar.colorWarning};
   `,
   title: css`
     cursor: pointer;

--- a/src/features/ChatInput/ActionBar/Tools/KlavisSkillIcon.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/KlavisSkillIcon.tsx
@@ -1,0 +1,29 @@
+import { type KlavisServerType } from '@lobechat/const';
+import { Icon } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { memo } from 'react';
+
+export const SKILL_ICON_SIZE = 20;
+
+/**
+ * Klavis 服务器图标组件
+ */
+const KlavisSkillIcon = memo<Pick<KlavisServerType, 'icon' | 'label'> & { size: number }>(
+  ({ icon, label, size = SKILL_ICON_SIZE }) => {
+    if (typeof icon === 'string') {
+      return (
+        <img
+          alt={label}
+          src={icon}
+          style={{ maxHeight: size, maxWidth: size, objectFit: 'contain' }}
+        />
+      );
+    }
+
+    return <Icon fill={cssVar.colorText} icon={icon} size={size} />;
+  },
+);
+
+KlavisSkillIcon.displayName = 'KlavisSkillIcon';
+
+export default KlavisSkillIcon;

--- a/src/features/ChatInput/ActionBar/Tools/LobehubSkillIcon.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/LobehubSkillIcon.tsx
@@ -1,0 +1,29 @@
+import { type LobehubSkillProviderType } from '@lobechat/const';
+import { Icon } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { memo } from 'react';
+
+export const SKILL_ICON_SIZE = 20;
+
+/**
+ * LobeHub Skill Provider 图标组件
+ */
+const LobehubSkillIcon = memo<Pick<LobehubSkillProviderType, 'icon' | 'label'> & { size: number }>(
+  ({ icon, label, size = SKILL_ICON_SIZE }) => {
+    if (typeof icon === 'string') {
+      return (
+        <img
+          alt={label}
+          src={icon}
+          style={{ maxHeight: size, maxWidth: size, objectFit: 'contain' }}
+        />
+      );
+    }
+
+    return <Icon fill={cssVar.colorText} icon={icon} size={size} />;
+  },
+);
+
+LobehubSkillIcon.displayName = 'LobehubSkillIcon';
+
+export default LobehubSkillIcon;

--- a/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
@@ -38,10 +38,6 @@ export const toolsListStyles = createStaticStyles(({ css }) => ({
 
     width: 24px;
     height: 24px;
-
-    .ant-avatar {
-      margin-inline-end: 0;
-    }
   `,
 }));
 

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1,16 +1,13 @@
 import {
   KLAVIS_SERVER_TYPES,
-  type KlavisServerType,
   LOBEHUB_SKILL_PROVIDERS,
-  type LobehubSkillProviderType,
   RECOMMENDED_SKILLS,
   RecommendedSkillType,
 } from '@lobechat/const';
 import { Avatar, Icon, type ItemType } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ToyBrick } from 'lucide-react';
-import { memo, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PluginAvatar from '@/components/Plugins/PluginAvatar';
@@ -29,54 +26,12 @@ import {
 
 import { useAgentId } from '../../hooks/useAgentId';
 import KlavisServerItem from './KlavisServerItem';
+import KlavisSkillIcon from './KlavisSkillIcon';
+import LobehubSkillIcon from './LobehubSkillIcon';
 import LobehubSkillServerItem from './LobehubSkillServerItem';
 import ToolItem from './ToolItem';
 
 const SKILL_ICON_SIZE = 20;
-
-/**
- * Klavis 服务器图标组件
- */
-const KlavisIcon = memo<Pick<KlavisServerType, 'icon' | 'label'>>(({ icon, label }) => {
-  if (typeof icon === 'string') {
-    return (
-      <Avatar
-        alt={label}
-        avatar={icon}
-        shape={'square'}
-        size={SKILL_ICON_SIZE}
-        style={{ flex: 'none' }}
-      />
-    );
-  }
-
-  return <Icon fill={cssVar.colorText} icon={icon} size={SKILL_ICON_SIZE} />;
-});
-
-KlavisIcon.displayName = 'KlavisIcon';
-
-/**
- * LobeHub Skill Provider 图标组件
- */
-const LobehubSkillIcon = memo<Pick<LobehubSkillProviderType, 'icon' | 'label'>>(
-  ({ icon, label }) => {
-    if (typeof icon === 'string') {
-      return (
-        <Avatar
-          alt={label}
-          avatar={icon}
-          shape={'square'}
-          size={SKILL_ICON_SIZE}
-          style={{ flex: 'none' }}
-        />
-      );
-    }
-
-    return <Icon fill={cssVar.colorText} icon={icon} size={SKILL_ICON_SIZE} />;
-  },
-);
-
-LobehubSkillIcon.displayName = 'LobehubSkillIcon';
 
 export const useControls = ({ setUpdating }: { setUpdating: (updating: boolean) => void }) => {
   const { t } = useTranslation('setting');
@@ -172,7 +127,7 @@ export const useControls = ({ setUpdating }: { setUpdating: (updating: boolean) 
             (type) =>
               installedKlavisIds.has(type.identifier) || recommendedKlavisIds.has(type.identifier),
           ).map((type) => ({
-            icon: <KlavisIcon icon={type.icon} label={type.label} />,
+            icon: <KlavisSkillIcon icon={type.icon} label={type.label} size={SKILL_ICON_SIZE} />,
             key: type.identifier,
             label: (
               <KlavisServerItem
@@ -195,7 +150,13 @@ export const useControls = ({ setUpdating }: { setUpdating: (updating: boolean) 
             (provider) =>
               installedLobehubIds.has(provider.id) || recommendedLobehubIds.has(provider.id),
           ).map((provider) => ({
-            icon: <LobehubSkillIcon icon={provider.icon} label={provider.label} />,
+            icon: (
+              <LobehubSkillIcon
+                icon={provider.icon}
+                label={provider.label}
+                size={SKILL_ICON_SIZE}
+              />
+            ),
             key: provider.id, // 使用 provider.id 作为 key，与 pluginId 保持一致
             label: <LobehubSkillServerItem label={provider.label} provider={provider.id} />,
           }))

--- a/src/features/IntegrationDetailModal/IntegrationDetailContent.tsx
+++ b/src/features/IntegrationDetailModal/IntegrationDetailContent.tsx
@@ -6,7 +6,7 @@ import {
   getKlavisServerByServerIdentifier,
   getLobehubSkillProviderById,
 } from '@lobechat/const';
-import { Flexbox, Icon, Image, Tag, Text, Typography, useModalContext } from '@lobehub/ui';
+import { Avatar, Flexbox, Icon, Tag, Text, Typography, useModalContext } from '@lobehub/ui';
 import { Button, Divider } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { Klavis } from 'klavis';
@@ -19,6 +19,8 @@ import { useToolStore } from '@/store/tool';
 import { klavisStoreSelectors, lobehubSkillStoreSelectors } from '@/store/tool/selectors';
 import { KlavisServerStatus } from '@/store/tool/slices/klavisStore';
 import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
+
+const ICON_SIZE = 56;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   authorLink: css`
@@ -59,11 +61,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     justify-content: center;
 
-    width: 56px;
-    height: 56px;
-    border-radius: 12px;
-
-    background: ${cssVar.colorBgContainer};
+    width: ${ICON_SIZE}px;
+    height: ${ICON_SIZE}px;
   `,
   introduction: css`
     font-size: 14px;
@@ -185,9 +184,9 @@ export const IntegrationDetailContent = ({
 
   const renderIcon = () => {
     if (typeof icon === 'string') {
-      return <Image alt={label} height={36} src={icon} width={36} />;
+      return <Avatar avatar={icon} shape={'square'} size={ICON_SIZE} />;
     }
-    return <Icon fill={cssVar.colorText} icon={icon} size={36} />;
+    return <Icon fill={cssVar.colorText} icon={icon} size={ICON_SIZE} />;
   };
 
   const handleAuthorClick = () => {
@@ -229,7 +228,11 @@ export const IntegrationDetailContent = ({
         style={{ flexWrap: 'nowrap' }}
       >
         <Flexbox align="center" gap={16} horizontal>
-          <div className={styles.icon}>{renderIcon()}</div>
+          {typeof icon === 'string' ? (
+            renderIcon()
+          ) : (
+            <div className={styles.icon}>{renderIcon()}</div>
+          )}
           <Flexbox gap={4}>
             <span className={styles.title}>{label}</span>
             <Text style={{ fontSize: 14 }} type="secondary">

--- a/src/features/IntegrationDetailModal/IntegrationDetailContent.tsx
+++ b/src/features/IntegrationDetailModal/IntegrationDetailContent.tsx
@@ -6,7 +6,7 @@ import {
   getKlavisServerByServerIdentifier,
   getLobehubSkillProviderById,
 } from '@lobechat/const';
-import { Avatar, Flexbox, Icon, Tag, Text, Typography, useModalContext } from '@lobehub/ui';
+import { Flexbox, Icon, Tag, Text, Typography, useModalContext } from '@lobehub/ui';
 import { Button, Divider } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { Klavis } from 'klavis';
@@ -184,7 +184,13 @@ export const IntegrationDetailContent = ({
 
   const renderIcon = () => {
     if (typeof icon === 'string') {
-      return <Avatar avatar={icon} shape={'square'} size={ICON_SIZE} />;
+      return (
+        <img
+          alt={label}
+          src={icon}
+          style={{ maxHeight: ICON_SIZE, maxWidth: ICON_SIZE, objectFit: 'contain' }}
+        />
+      );
     }
     return <Icon fill={cssVar.colorText} icon={icon} size={ICON_SIZE} />;
   };
@@ -228,11 +234,7 @@ export const IntegrationDetailContent = ({
         style={{ flexWrap: 'nowrap' }}
       >
         <Flexbox align="center" gap={16} horizontal>
-          {typeof icon === 'string' ? (
-            renderIcon()
-          ) : (
-            <div className={styles.icon}>{renderIcon()}</div>
-          )}
+          <div className={styles.icon}>{renderIcon()}</div>
           <Flexbox gap={4}>
             <span className={styles.title}>{label}</span>
             <Text style={{ fontSize: 14 }} type="secondary">

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -316,9 +316,8 @@ const AgentTool = memo<AgentToolProps>(
           icon: (
             <Avatar
               avatar={item.meta.avatar}
-              shape={'square'}
               size={SKILL_ICON_SIZE}
-              style={{ flex: 'none' }}
+              style={{ marginInlineEnd: 0 }}
             />
           ),
           key: item.identifier,
@@ -351,7 +350,11 @@ const AgentTool = memo<AgentToolProps>(
     const mapPluginToItem = useCallback(
       (item: (typeof installedPluginList)[0]) => ({
         icon: item?.avatar ? (
-          <PluginAvatar avatar={item.avatar} size={SKILL_ICON_SIZE} />
+          <PluginAvatar
+            avatar={item.avatar}
+            size={SKILL_ICON_SIZE}
+            style={{ marginInlineEnd: 0 }}
+          />
         ) : (
           <Icon icon={ToyBrick} size={SKILL_ICON_SIZE} />
         ),
@@ -435,9 +438,8 @@ const AgentTool = memo<AgentToolProps>(
           icon: (
             <Avatar
               avatar={item.meta.avatar}
-              shape={'square'}
               size={SKILL_ICON_SIZE}
-              style={{ flex: 'none' }}
+              style={{ marginInlineEnd: 0 }}
             />
           ),
           key: item.identifier,

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -48,12 +48,10 @@ const SKILL_ICON_SIZE = 20;
 const KlavisIcon = memo<Pick<KlavisServerType, 'icon' | 'label'>>(({ icon, label }) => {
   if (typeof icon === 'string') {
     return (
-      <Avatar
+      <img
         alt={label}
-        avatar={icon}
-        shape={'square'}
-        size={SKILL_ICON_SIZE}
-        style={{ flex: 'none' }}
+        src={icon}
+        style={{ maxHeight: SKILL_ICON_SIZE, maxWidth: SKILL_ICON_SIZE, objectFit: 'contain' }}
       />
     );
   }
@@ -68,12 +66,10 @@ const LobehubSkillIcon = memo<Pick<LobehubSkillProviderType, 'icon' | 'label'>>(
   ({ icon, label }) => {
     if (typeof icon === 'string') {
       return (
-        <Avatar
+        <img
           alt={label}
-          avatar={icon}
-          shape={'square'}
-          size={SKILL_ICON_SIZE}
-          style={{ flex: 'none' }}
+          src={icon}
+          style={{ maxHeight: SKILL_ICON_SIZE, maxWidth: SKILL_ICON_SIZE, objectFit: 'contain' }}
         />
       );
     }

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  KLAVIS_SERVER_TYPES,
-  type KlavisServerType,
-  LOBEHUB_SKILL_PROVIDERS,
-  type LobehubSkillProviderType,
-} from '@lobechat/const';
+import { KLAVIS_SERVER_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
 import { Avatar, Button, Flexbox, Icon, type ItemType } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
@@ -15,6 +10,10 @@ import { useTranslation } from 'react-i18next';
 
 import PluginAvatar from '@/components/Plugins/PluginAvatar';
 import KlavisServerItem from '@/features/ChatInput/ActionBar/Tools/KlavisServerItem';
+import KlavisSkillIcon, {
+  SKILL_ICON_SIZE,
+} from '@/features/ChatInput/ActionBar/Tools/KlavisSkillIcon';
+import LobehubSkillIcon from '@/features/ChatInput/ActionBar/Tools/LobehubSkillIcon';
 import LobehubSkillServerItem from '@/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem';
 import ToolItem from '@/features/ChatInput/ActionBar/Tools/ToolItem';
 import ActionDropdown from '@/features/ChatInput/ActionBar/components/ActionDropdown';
@@ -39,44 +38,6 @@ import PopoverContent from './PopoverContent';
 const WEB_BROWSING_IDENTIFIER = 'lobe-web-browsing';
 
 type TabType = 'all' | 'installed';
-
-const SKILL_ICON_SIZE = 20;
-
-/**
- * Klavis 服务器图标组件
- */
-const KlavisIcon = memo<Pick<KlavisServerType, 'icon' | 'label'>>(({ icon, label }) => {
-  if (typeof icon === 'string') {
-    return (
-      <img
-        alt={label}
-        src={icon}
-        style={{ maxHeight: SKILL_ICON_SIZE, maxWidth: SKILL_ICON_SIZE, objectFit: 'contain' }}
-      />
-    );
-  }
-
-  return <Icon fill={cssVar.colorText} icon={icon} size={SKILL_ICON_SIZE} />;
-});
-
-/**
- * LobeHub Skill Provider 图标组件
- */
-const LobehubSkillIcon = memo<Pick<LobehubSkillProviderType, 'icon' | 'label'>>(
-  ({ icon, label }) => {
-    if (typeof icon === 'string') {
-      return (
-        <img
-          alt={label}
-          src={icon}
-          style={{ maxHeight: SKILL_ICON_SIZE, maxWidth: SKILL_ICON_SIZE, objectFit: 'contain' }}
-        />
-      );
-    }
-
-    return <Icon fill={cssVar.colorText} icon={icon} size={SKILL_ICON_SIZE} />;
-  },
-);
 
 export interface AgentToolProps {
   /**
@@ -263,7 +224,7 @@ const AgentTool = memo<AgentToolProps>(
       () =>
         isKlavisEnabledInEnv
           ? KLAVIS_SERVER_TYPES.map((type) => ({
-              icon: <KlavisIcon icon={type.icon} label={type.label} />,
+              icon: <KlavisSkillIcon icon={type.icon} label={type.label} size={SKILL_ICON_SIZE} />,
               key: type.identifier,
               label: (
                 <KlavisServerItem
@@ -283,7 +244,13 @@ const AgentTool = memo<AgentToolProps>(
       () =>
         isLobehubSkillEnabled
           ? LOBEHUB_SKILL_PROVIDERS.map((provider) => ({
-              icon: <LobehubSkillIcon icon={provider.icon} label={provider.label} />,
+              icon: (
+                <LobehubSkillIcon
+                  icon={provider.icon}
+                  label={provider.label}
+                  size={SKILL_ICON_SIZE}
+                />
+              ),
               key: provider.id, // 使用 provider.id 作为 key，与 pluginId 保持一致
               label: <LobehubSkillServerItem label={provider.label} provider={provider.id} />,
             }))


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Unify skill item styling and icon rendering across settings, chat tools, and integration detail views while making skill list rows open their detail modals when clicking the icon area.

Enhancements:
- Extract shared skill item styles into a reusable style module and apply it to Lobehub, Klavis, and MCP skill components.
- Refine click targets so clicking skill icons/rows opens the integration or skill detail views, improving usability on the skill detail page.
- Standardize skill provider and server icons to use img/Icon components with consistent sizing and spacing in the profile editor, chat tools list, and integration detail modal.
- Centralize Klavis and Lobehub skill icon components for reuse in the chat input tools and profile editor.