### PR TITLE
🐛 fix: the klavis in onboarding connect timeout fixed

### DIFF
--- a/src/app/[variants]/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
@@ -104,7 +104,7 @@ const KlavisToolAuthItem = memo<KlavisToolAuthItemProps>(({ tool, onAuthComplete
         try {
           await refreshKlavisServerTools(identifier);
         } catch (error) {
-          console.error('[Klavis] Failed to check auth status:', error);
+          console.debug('[Klavis] Polling check (expected during auth):', error);
         }
       }, POLL_INTERVAL_MS);
 
@@ -129,7 +129,8 @@ const KlavisToolAuthItem = memo<KlavisToolAuthItemProps>(({ tool, onAuthComplete
               windowCheckIntervalRef.current = null;
             }
             oauthWindowRef.current = null;
-            refreshKlavisServerTools(identifier);
+            // Start polling after window closes
+            startFallbackPolling(identifier);
           }
         } catch {
           if (windowCheckIntervalRef.current) {

--- a/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/app/[variants]/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -120,7 +120,7 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
         try {
           await refreshKlavisServerTools(serverName);
         } catch (error) {
-          console.error('[Klavis] Failed to check auth status:', error);
+          console.debug('[Klavis] Polling check (expected during auth):', error);
         }
       }, POLL_INTERVAL_MS);
 
@@ -145,8 +145,8 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
               windowCheckIntervalRef.current = null;
             }
             oauthWindowRef.current = null;
-            await refreshKlavisServerTools(serverName);
-            setIsWaitingAuth(false);
+            // Start polling after window closes
+            startFallbackPolling(serverName);
           }
         } catch {
           console.log('[Klavis] COOP blocked window.closed access, falling back to polling');

--- a/src/features/ChatInput/ActionBar/Tools/KlavisServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/KlavisServerItem.tsx
@@ -88,7 +88,7 @@ const KlavisServerItem = memo<KlavisServerItemProps>(
           try {
             await refreshKlavisServerTools(serverName);
           } catch (error) {
-            console.error('[Klavis] Failed to check auth status:', error);
+            console.debug('[Klavis] Polling check (expected during auth):', error);
           }
         }, POLL_INTERVAL_MS);
 
@@ -121,8 +121,8 @@ const KlavisServerItem = memo<KlavisServerItemProps>(
               }
               oauthWindowRef.current = null;
 
-              // 窗口关闭后立即检查一次认证状态
-              refreshKlavisServerTools(serverName);
+              // 窗口关闭后开始轮询检查认证状态
+              startFallbackPolling(serverName);
             }
           } catch {
             // COOP 阻止了访问，降级到轮询方案

--- a/src/store/tool/slices/klavisStore/action.ts
+++ b/src/store/tool/slices/klavisStore/action.ts
@@ -210,10 +210,30 @@ export const createKlavisStoreSlice: StateCreator<
         instanceId: server.instanceId,
       });
 
+      // If server returned an auth error (during polling), silently return
+      // This happens when user is still in the process of authorizing
+      if (instanceStatus.error === 'AUTH_ERROR') {
+        set(
+          produce((draft: KlavisStoreState) => {
+            draft.loadingServerIds.delete(identifier);
+          }),
+          false,
+          n('refreshKlavisServerTools/pendingAuth'),
+        );
+        return;
+      }
+
       // If authentication failed, remove server and reset status
       if (!instanceStatus.isAuthenticated) {
         if (!instanceStatus.authNeeded) {
           // If no authentication needed, all is well
+          set(
+            produce((draft: KlavisStoreState) => {
+              draft.loadingServerIds.delete(identifier);
+            }),
+            false,
+            n('refreshKlavisServerTools/noAuthNeeded'),
+          );
           return;
         }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve Klavis server auth polling to avoid timeouts and noisy errors during onboarding and tool authorization flows.

Bug Fixes:
- Handle Klavis getServerInstance authentication failures by returning a structured auth error instead of throwing, preventing spurious 500s during polling.
- Update Klavis store and polling logic to gracefully handle pending-auth states and clear loading flags without treating expected auth errors as failures.
- Adjust OAuth window-close handling to start short-lived polling instead of a single status refresh, reducing onboarding auth timeouts and race conditions.

Enhancements:
- Reduce Klavis auth polling log verbosity by downgrading expected polling errors from error to debug level.