### PR TITLE
🐛 fix(model-bank): fix ZenMux model IDs by adding provider prefixes

### DIFF
--- a/packages/model-bank/src/aiModels/zenmux.ts
+++ b/packages/model-bank/src/aiModels/zenmux.ts
@@ -21,7 +21,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
       'GPT-5.2 is a flagship model for coding and agentic workflows with stronger reasoning and long-context performance.',
     displayName: 'GPT-5.2',
     enabled: true,
-    id: 'gpt-5.2',
+    id: 'openai/gpt-5.2',
     maxOutput: 128_000,
     pricing: {
       units: [
@@ -48,7 +48,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     description:
       'GPT-5.2 Pro: a smarter, more precise GPT-5.2 variant (Responses API only), suited for harder problems and longer multi-turn reasoning.',
     displayName: 'GPT-5.2 pro',
-    id: 'gpt-5.2-pro',
+    id: 'openai/gpt-5.2-pro',
     maxOutput: 128_000,
     pricing: {
       units: [
@@ -69,10 +69,10 @@ const zenmuxChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 128_000,
     description:
-      'GPT-5.2 Chat is the ChatGPT variant (chat-latest) for experiencing the newest conversation improvements.',
+      'GPT-5.2 Chat is the ChatGPT variant for experiencing the newest conversation improvements.',
     displayName: 'GPT-5.2 Chat',
     enabled: true,
-    id: 'gpt-5.2-chat-latest',
+    id: 'openai/gpt-5.2-chat',
     maxOutput: 16_384,
     pricing: {
       units: [


### PR DESCRIPTION
#### 💻 Change Type


<!-- For change type, change [ ] to [x]. -->


- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore


#### 🔗 Related Issue


<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->


#### 🔀 Description of Change


Currently, the model IDs defined in the ZenMux configuration (`zenmux.ts`) do not include the required provider prefix.  
For example, model IDs are specified as:


- `gpt-5.2`


instead of the expected fully-qualified format:


- `openai/gpt-5.2`


As a result, the routing layer cannot reliably determine the underlying provider for these models, which may lead to incorrect provider resolution or failed requests.


This PR addresses the issue by:


- Adding the appropriate `provider/` prefix (e.g. `openai/`) to all applicable ZenMux model IDs.
- Cleaning up and normalizing the GPT-5.2 Chat model configuration to ensure consistency with the updated naming scheme.
- Ensuring that ZenMux can correctly route requests based on fully-qualified model identifiers.


#### 🧪 How to Test


- Start the application with the updated ZenMux configuration.
- Verify that model routing correctly resolves the provider for prefixed model IDs (e.g. `openai/gpt-5.2`).
- Send test requests to GPT-5.2 Chat models and confirm that requests are routed to the correct provider without errors.


- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed


#### 📸 Screenshots / Videos


<!-- If this PR includes UI changes, please provide screenshots or videos -->


N/A (no UI changes)


#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update ZenMux chat model identifiers to use fully-qualified provider-prefixed IDs for GPT-5.2 variants and align the GPT-5.2 Chat metadata with the new naming.

Bug Fixes:
- Ensure ZenMux GPT-5.2, GPT-5.2 Pro, and GPT-5.2 Chat models use provider-prefixed IDs so routing can correctly resolve the underlying provider.

Enhancements:
- Simplify the GPT-5.2 Chat model description and normalize its identifier to match the updated naming scheme.