### PR TITLE
🐛 fix: update message regeneration logic

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/useAssistantActions.ts
+++ b/src/features/Conversation/Messages/Assistant/Actions/useAssistantActions.ts
@@ -137,8 +137,9 @@ export const useAssistantActions = ({
       regenerate: {
         disabled: isRegenerating,
         handleClick: () => {
-          regenerateAssistantMessage(id);
-          if (data.error) deleteMessage(id);
+          if (data.error) return delAndRegenerateMessage(id);
+
+          return regenerateAssistantMessage(id);
         },
         icon: RotateCcw,
         key: 'regenerate',

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
@@ -148,8 +148,8 @@ export const useGroupActions = ({
       regenerate: {
         disabled: isRegenerating,
         handleClick: () => {
-          regenerateAssistantMessage(id);
-          if (data.error) deleteMessage(id);
+          if (data.error) return delAndRegenerateMessage(id);
+          return regenerateAssistantMessage(id);
         },
         icon: RotateCcw,
         key: 'regenerate',

--- a/src/features/Conversation/Messages/Supervisor/Actions/useGroupActions.ts
+++ b/src/features/Conversation/Messages/Supervisor/Actions/useGroupActions.ts
@@ -123,8 +123,8 @@ export const useGroupActions = ({
       regenerate: {
         disabled: isRegenerating,
         handleClick: () => {
-          regenerateAssistantMessage(id);
-          if (data.error) deleteMessage(id);
+          if (data.error) return delAndRegenerateMessage(id);
+          return regenerateAssistantMessage(id);
         },
         icon: RotateCcw,
         key: 'regenerate',

--- a/src/features/Conversation/Messages/Task/Actions/useAssistantActions.ts
+++ b/src/features/Conversation/Messages/Task/Actions/useAssistantActions.ts
@@ -115,8 +115,8 @@ export const useAssistantActions = ({
       regenerate: {
         disabled: isRegenerating,
         handleClick: () => {
-          regenerateAssistantMessage(id);
-          if (data.error) deleteMessage(id);
+          if (data.error) return delAndRegenerateMessage(id);
+          return regenerateAssistantMessage(id);
         },
         icon: RotateCcw,
         key: 'regenerate',

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -246,12 +246,16 @@ export const useChatItemContextMenu = ({
           if (inPortalThread) {
             resendThreadMessage(id);
           } else if (role === 'assistant') {
+            if (item.error) {
+              delAndRegenerateMessage(id);
+              break;
+            }
+
             regenerateAssistantMessage(id);
           } else {
             regenerateUserMessage(id);
           }
 
-          if (item.error) deleteMessage(id);
           break;
         }
         case 'delAndRegenerate': {

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -244,6 +244,10 @@ export const useChatItemContextMenu = ({
         }
         case 'regenerate': {
           if (inPortalThread) {
+            if (item.error) {
+              delAndResendThreadMessage(id);
+              break;
+            }
             resendThreadMessage(id);
           } else if (role === 'assistant') {
             if (item.error) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore


#### 🔀 Description of Change

The error response message block includes a "retry" button. Clicking this button triggers a retry, but the regenerated content does not appear.

This is due to tRPC request batching: when clicking the retry button on an error message block, both `regenerate` and `delete` operations are triggered concurrently. Since tRPC's `httpBatchLink` automatically batches multiple mutations sent within a short time window into a single HTTP request, these two operations get merged and executed together, causing the `activeBranchIndex` metadata to be set at an incorrect timing and resulting in the regenerated content not being displayed correctly.

Fix: Use the existing correct-implemented `delAndRegenerateMessage` function for all retry scenarios.


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Summary by Sourcery

Standardize assistant message retry behavior so error retries use the combined delete-and-regenerate flow to ensure regenerated content appears correctly.

Bug Fixes:
- Fix assistant message retry from context menu so errored messages use a single delete-and-regenerate operation instead of separate delete and regenerate mutations.
- Fix assistant and group message regenerate buttons to use the delete-and-regenerate flow when retrying errored messages, preventing tRPC batched mutation conflicts.