### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/auto-i18n.yml
+++ b/.github/workflows/auto-i18n.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_TOKEN }}
           add-paths: |

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -319,7 +319,7 @@ jobs:
 
       - name: Create Temporary Release for PR
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: PR Build v${{ needs.version.outputs.version }}
           tag_name: v${{ needs.version.outputs.version }}

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -234,7 +234,7 @@ jobs:
 
       # 将构建产物上传到现有 release (现在包含合并后的 latest-mac.yml)
       - name: Upload to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -316,7 +316,7 @@ jobs:
         run: ls -R release
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           # 手动触发时使用输入的版本号创建 tag
           tag_name: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', needs.check-stable.outputs.version) || github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,8 +189,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install deps
         run: pnpm install


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peter-evans/create-pull-request` | [`v7`](https://github.com/peter-evans/create-pull-request/releases/tag/v7) | [`v8`](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | [Release](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | auto-i18n.yml |
| `pnpm/action-setup` | [`v2`](https://github.com/pnpm/action-setup/releases/tag/v2) | [`v4`](https://github.com/pnpm/action-setup/releases/tag/v4) | [Release](https://github.com/pnpm/action-setup/releases/tag/v4) | test.yml |
| `softprops/action-gh-release` | [`v1`](https://github.com/softprops/action-gh-release/releases/tag/v1) | [`v2`](https://github.com/softprops/action-gh-release/releases/tag/v2) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | pr-build-desktop.yml, release-desktop-beta.yml, release-desktop-stable.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.

## Summary by Sourcery

Upgrade GitHub Actions versions used in CI workflows to their latest major releases for improved security and reliability.

CI:
- Bump peter-evans/create-pull-request from v7 to v8 in the auto-i18n workflow.
- Bump softprops/action-gh-release from v1 to v2 in PR and desktop release workflows.
- Bump pnpm/action-setup from v2 to v4 in the test workflow.