### PR TITLE
♻️ chore(docker-compose): refactor docker compose

### DIFF
--- a/docker-compose/deploy/.env.example
+++ b/docker-compose/deploy/.env.example
@@ -1,0 +1,36 @@
+# Proxy, if you need it
+# HTTP_PROXY=http://localhost:7890
+# HTTPS_PROXY=http://localhost:7890
+
+
+# Other environment variables, as needed. You can refer to the environment variables configuration for the client version, making sure not to have ACCESS_CODE.
+# OPENAI_API_KEY=sk-xxxx
+# OPENAI_PROXY_URL=https://api.openai.com/v1
+# OPENAI_MODEL_LIST=...
+
+
+# ===========================
+# ====== Preset config ====== 
+# ===========================
+# if no special requirements, no need to change
+LOBE_PORT=3210
+RUSTFS_PORT=9000
+APP_URL=http://localhost:3210
+# INTERNAL_APP_URL is optional, used for server-to-server calls
+# to bypass CDN/proxy. If not set, defaults to APP_URL.
+# Example: INTERNAL_APP_URL=http://localhost:3210
+
+# Postgres related, which are the necessary environment variables for DB
+LOBE_DB_NAME=lobechat
+POSTGRES_PASSWORD=uWNZugjBqixf8dxC
+
+# RUSTFS S3 configuration
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_SECRET_KEY=YOUR_RUSTFS_PASSWORD
+
+# Configure the bucket information of RUSTFS
+S3_PUBLIC_DOMAIN=http://localhost:9000
+S3_ENDPOINT=http://localhost:9000
+RUSTFS_LOBE_BUCKET=lobe
+
+JWKS_KEY={"keys":[{"d":"PVoFyqyrGstB8wU52S7gqqQQdZLtin_thcEM0nrNtqp9U-NlKLlhgEcWp5t89ycgvhsAzmrRbezGj4JBTr3jn7eWdwQpPJNYiipnsgeJn0pwsB0H2dMqtavxinoPVXkMTOuGHMTFhhyguFBw2JbIL0PTQUcUlXjv40OoJpYHZeggSxgfV-TuxjwW8Ll4-n84M5IOi6A53RvioE-Hm1iyIc2XLBCfyOu-SbAQYi8HzrA64kCxobAB0peLQMiAzfZmwPKiGOhnhKrAlYmG02qFnbUYiJu_-AXwsAyGv9S9i6dwK7QXaGGWYyis8LlPpd_JmPrBnrWomwDlI045NUMWZQ","dp":"OSXI2NBBZl2r0Dpf4-1z44A_jC5lOyXtJhXQYnSXy5eIuxTJcEtkUYagGEwnREO4Q3t-4J-lT_6Y71M1ZlgKG1upwfw1O4aE3vGpHOik9iZYYCjA8fe5uBfOpX1ELmOtHNoHRhMtyjuPxSFXLlSp3bgcF1f3F40ClukdvXCx0Mc","dq":"m6hNdfj-F8E_7nUlX2nG95OffkFrhHTo67ML9aPgpvFwBlzg-hk5LwtxMfUzngqWF78TMl0JDm7vS1bz0xlWqXqu8pFPoTUnUoWgYfvuyHLBwR5TgccQkfoKbkSMzYNy8VJPXZeyIjVXsW98tZvj-NZF-M9Pke_EWJm-jjXCu_8","e":"AQAB","kty":"RSA","n":"piffosMS0HOSgsSr_zQkXYaQt1kOCD73VR0b2XJD6UdQCKPbnBOzTIuA_xowX61QVsl5pCZLTw8ERC3r2Nlxj5Rp_H6RuOT7ioUqlbnxSGnfuAn8dFupY3A-sf9HVDOvtJdlS-nO9yA4wWU-A50zZ1Mf0pPZlUZE6dUQfsJFi5yXaNAybyk3U4VpMO_SXAilWEHVhiO0F0ccpJMCkT47AeXmYH9MlWwIGcay0UiAsdrs8J-q1arZ7Mbq0oxHmUXJG0vwRvAL8KnCEi8cJ3e2kKCRcr-BQCujsHUyUl6f_ATwSVuTHdAR1IzIcW37v27h3WQK_v0ffQM1NstamDX5vQ","p":"4myVm2M5cZGvVXsOmWUTUG87VC1GlQcL5tmMNSGSpQCL8yWZ1vANkmCxSMptrKB4dU9DAB3On6_oMhW1pJ3uYNGSW49BcmJoLkiWKeg5zWFnKPQNuThQmY1sCCubtKhBQgaYUr7TVzN9smrDV3zCu9MlRl-XPwnEmWaDII3g-f8","q":"u9v4IOEsb4l2Y3eWKE2bwJh5fJRR4vivaYA7U-1-OpvDwB3A48Rey9IL1ucXqE5G1Du8BtijPm5oSAar5uzrjtg1bZ9gevif6DnBGaIRE7LnSrUsTPfZwzntJ1rTaGiVe_pAdnTKXXaH6DxygXxH4wvGgA44V3TTfBXQUcjzdEM","qi":"lDBnSPKkRnYqQvbqVD1LxzqBPEeqEA3GyCqMj6fIZNgoEaBSLi0TSsUyGZ5mahX3KO35vKAZa5jvGjhvUGUiXycq8KvRZdeGK45vJdwZT2TiXiDwo9IQgJcbFMpxaB9DhjX2x0yqxgUY5ca75jLqbMuKBKBN0PVqIr9jlHkR8_s","use":"sig","kid":"6823046760c5d460","alg":"RS256"}]}

--- a/docker-compose/deploy/.env.example
+++ b/docker-compose/deploy/.env.example
@@ -3,14 +3,8 @@
 # HTTPS_PROXY=http://localhost:7890
 
 
-# Other environment variables, as needed. You can refer to the environment variables configuration for the client version, making sure not to have ACCESS_CODE.
-# OPENAI_API_KEY=sk-xxxx
-# OPENAI_PROXY_URL=https://api.openai.com/v1
-# OPENAI_MODEL_LIST=...
-
-
 # ===========================
-# ====== Preset config ====== 
+# ====== Preset config ======
 # ===========================
 # if no special requirements, no need to change
 LOBE_PORT=3210

--- a/docker-compose/deploy/.env.example
+++ b/docker-compose/deploy/.env.example
@@ -2,6 +2,11 @@
 # HTTP_PROXY=http://localhost:7890
 # HTTPS_PROXY=http://localhost:7890
 
+# Allowed email addresses for login, separated by commas
+# When set, only emails in the list can log in, other users cannot log in
+# Leave empty to allow all users to register
+# AUTH_ALLOWED_EMAILS=user1@example.com,user2@example.com
+
 
 # ===========================
 # ====== Preset config ======

--- a/docker-compose/deploy/.env.zh-CN.example
+++ b/docker-compose/deploy/.env.zh-CN.example
@@ -1,0 +1,33 @@
+# Proxy，如果你需要的话（比如你使用 GitHub 作为鉴权服务提供商）
+# HTTP_PROXY=http://localhost:7890
+# HTTPS_PROXY=http://localhost:7890
+
+
+# 其他环境变量，视需求而定，可以参照客户端版本的环境变量配置，注意不要有 ACCESS_CODE
+# OPENAI_API_KEY=sk-xxxx
+# OPENAI_PROXY_URL=https://api.openai.com/v1
+# OPENAI_MODEL_LIST=...
+
+
+# ===================
+# ===== 预设配置 =====
+# ===================
+# 如没有特殊需要不用更改
+LOBE_PORT=3210
+RUSTFS_PORT=9000
+APP_URL=http://localhost:3210
+
+# Postgres 相关，也即 DB 必须的环境变量
+LOBE_DB_NAME=lobechat
+POSTGRES_PASSWORD=uWNZugjBqixf8dxC
+
+# RustFS S3 配置
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_SECRET_KEY=YOUR_RUSTFS_PASSWORD
+
+# 在下方配置 rustfs 中添加的桶
+S3_PUBLIC_DOMAIN=http://localhost:9000
+S3_ENDPOINT=http://localhost:9000
+RUSTFS_LOBE_BUCKET=lobe
+
+JWKS_KEY={"keys":[{"d":"PVoFyqyrGstB8wU52S7gqqQQdZLtin_thcEM0nrNtqp9U-NlKLlhgEcWp5t89ycgvhsAzmrRbezGj4JBTr3jn7eWdwQpPJNYiipnsgeJn0pwsB0H2dMqtavxinoPVXkMTOuGHMTFhhyguFBw2JbIL0PTQUcUlXjv40OoJpYHZeggSxgfV-TuxjwW8Ll4-n84M5IOi6A53RvioE-Hm1iyIc2XLBCfyOu-SbAQYi8HzrA64kCxobAB0peLQMiAzfZmwPKiGOhnhKrAlYmG02qFnbUYiJu_-AXwsAyGv9S9i6dwK7QXaGGWYyis8LlPpd_JmPrBnrWomwDlI045NUMWZQ","dp":"OSXI2NBBZl2r0Dpf4-1z44A_jC5lOyXtJhXQYnSXy5eIuxTJcEtkUYagGEwnREO4Q3t-4J-lT_6Y71M1ZlgKG1upwfw1O4aE3vGpHOik9iZYYCjA8fe5uBfOpX1ELmOtHNoHRhMtyjuPxSFXLlSp3bgcF1f3F40ClukdvXCx0Mc","dq":"m6hNdfj-F8E_7nUlX2nG95OffkFrhHTo67ML9aPgpvFwBlzg-hk5LwtxMfUzngqWF78TMl0JDm7vS1bz0xlWqXqu8pFPoTUnUoWgYfvuyHLBwR5TgccQkfoKbkSMzYNy8VJPXZeyIjVXsW98tZvj-NZF-M9Pke_EWJm-jjXCu_8","e":"AQAB","kty":"RSA","n":"piffosMS0HOSgsSr_zQkXYaQt1kOCD73VR0b2XJD6UdQCKPbnBOzTIuA_xowX61QVsl5pCZLTw8ERC3r2Nlxj5Rp_H6RuOT7ioUqlbnxSGnfuAn8dFupY3A-sf9HVDOvtJdlS-nO9yA4wWU-A50zZ1Mf0pPZlUZE6dUQfsJFi5yXaNAybyk3U4VpMO_SXAilWEHVhiO0F0ccpJMCkT47AeXmYH9MlWwIGcay0UiAsdrs8J-q1arZ7Mbq0oxHmUXJG0vwRvAL8KnCEi8cJ3e2kKCRcr-BQCujsHUyUl6f_ATwSVuTHdAR1IzIcW37v27h3WQK_v0ffQM1NstamDX5vQ","p":"4myVm2M5cZGvVXsOmWUTUG87VC1GlQcL5tmMNSGSpQCL8yWZ1vANkmCxSMptrKB4dU9DAB3On6_oMhW1pJ3uYNGSW49BcmJoLkiWKeg5zWFnKPQNuThQmY1sCCubtKhBQgaYUr7TVzN9smrDV3zCu9MlRl-XPwnEmWaDII3g-f8","q":"u9v4IOEsb4l2Y3eWKE2bwJh5fJRR4vivaYA7U-1-OpvDwB3A48Rey9IL1ucXqE5G1Du8BtijPm5oSAar5uzrjtg1bZ9gevif6DnBGaIRE7LnSrUsTPfZwzntJ1rTaGiVe_pAdnTKXXaH6DxygXxH4wvGgA44V3TTfBXQUcjzdEM","qi":"lDBnSPKkRnYqQvbqVD1LxzqBPEeqEA3GyCqMj6fIZNgoEaBSLi0TSsUyGZ5mahX3KO35vKAZa5jvGjhvUGUiXycq8KvRZdeGK45vJdwZT2TiXiDwo9IQgJcbFMpxaB9DhjX2x0yqxgUY5ca75jLqbMuKBKBN0PVqIr9jlHkR8_s","use":"sig","kid":"6823046760c5d460","alg":"RS256"}]}

--- a/docker-compose/deploy/.env.zh-CN.example
+++ b/docker-compose/deploy/.env.zh-CN.example
@@ -2,6 +2,10 @@
 # HTTP_PROXY=http://localhost:7890
 # HTTPS_PROXY=http://localhost:7890
 
+# 允许登录的邮箱地址，用英文逗号分隔
+# 设置后只有列表中的邮箱可以登录，其他用户可以注册但无法登录
+# 留空则允许所有用户注册登录
+# AUTH_ALLOWED_EMAILS=user1@example.com,user2@example.com
 
 # ===================
 # ===== 预设配置 =====

--- a/docker-compose/deploy/.env.zh-CN.example
+++ b/docker-compose/deploy/.env.zh-CN.example
@@ -3,12 +3,6 @@
 # HTTPS_PROXY=http://localhost:7890
 
 
-# 其他环境变量，视需求而定，可以参照客户端版本的环境变量配置，注意不要有 ACCESS_CODE
-# OPENAI_API_KEY=sk-xxxx
-# OPENAI_PROXY_URL=https://api.openai.com/v1
-# OPENAI_MODEL_LIST=...
-
-
 # ===================
 # ===== 预设配置 =====
 # ===================
@@ -18,7 +12,7 @@ RUSTFS_PORT=9000
 APP_URL=http://localhost:3210
 
 # Postgres 相关，也即 DB 必须的环境变量
-LOBE_DB_NAME=lobechat
+LOBE_DB_NAME=lobehub
 POSTGRES_PASSWORD=uWNZugjBqixf8dxC
 
 # RustFS S3 配置

--- a/docker-compose/deploy/bucket.config.json
+++ b/docker-compose/deploy/bucket.config.json
@@ -1,0 +1,18 @@
+{
+  "ID": "",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["*"]
+      },
+      "Action": ["s3:GetObject"],
+      "NotAction": [],
+      "Resource": ["arn:aws:s3:::lobe/*"],
+      "NotResource": [],
+      "Condition": {}
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/docker-compose/deploy/docker-compose.yml
+++ b/docker-compose/deploy/docker-compose.yml
@@ -1,0 +1,148 @@
+name: lobehub
+services:
+  network-service:
+    image: alpine
+    container_name: lobe-network
+    restart: always
+    ports:
+      - '${RUSTFS_PORT}:9000' # RustFS API
+      - '9001:9001' # RustFS Console
+      - '${LOBE_PORT}:3210' # LobeChat
+    command: tail -f /dev/null
+    networks:
+      - lobe-network
+
+  postgresql:
+    image: paradedb/paradedb:latest
+    container_name: lobe-postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - './data:/var/lib/postgresql/data'
+    environment:
+      - 'POSTGRES_DB=${LOBE_DB_NAME}'
+      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: always
+    networks:
+      - lobe-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: lobe-redis
+    ports:
+      - '6379:6379'
+    command: redis-server --save 60 1000 --appendonly yes
+    volumes:
+      - 'redis_data:/data'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: always
+    networks:
+      - lobe-network
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: lobe-rustfs
+    network_mode: 'service:network-service'
+    environment:
+      - RUSTFS_CONSOLE_ENABLE=true
+      - RUSTFS_ACCESS_KEY=${RUSTFS_ACCESS_KEY}
+      - RUSTFS_SECRET_KEY=${RUSTFS_SECRET_KEY}
+    volumes:
+      - rustfs-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9000/health >/dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    command: ["--access-key","${RUSTFS_ACCESS_KEY}","--secret-key","${RUSTFS_SECRET_KEY}","/data"]
+
+  rustfs-init:
+    image: minio/mc:latest
+    container_name: lobe-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    volumes:
+      - ./bucket.config.json:/bucket.config.json:ro
+    entrypoint: /bin/sh
+    command: -c '
+        set -eux;
+        echo "S3_ACCESS_KEY=${RUSTFS_ACCESS_KEY}, S3_SECRET_KEY=${RUSTFS_SECRET_KEY}";
+        mc --version;
+        mc alias set rustfs "http://network-service:9000" "${RUSTFS_ACCESS_KEY}" "${RUSTFS_SECRET_KEY}";
+        mc ls rustfs || true;
+        mc mb "rustfs/lobe" --ignore-existing;
+        mc admin info rustfs || true;
+        mc anonymous set-json "/bucket.config.json" "rustfs/lobe";
+      '
+    restart: "no"
+    networks:
+      - lobe-network
+
+  searxng:
+    image: searxng/searxng
+    container_name: lobe-searxng
+    volumes:
+      - './searxng-settings.yml:/etc/searxng/settings.yml'
+    environment:
+      - 'SEARXNG_SETTINGS_FILE=/etc/searxng/settings.yml'
+    restart: always
+    networks:
+      - lobe-network
+    env_file:
+      - .env
+
+  lobe:
+    image: lobehub/lobehub
+    container_name: lobehub
+    network_mode: 'service:network-service'
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      network-service:
+        condition: service_started
+      rustfs:
+        condition: service_healthy
+      rustfs-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    environment:
+      - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
+      - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
+      - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
+      - 'S3_BUCKET=${RUSTFS_LOBE_BUCKET}'
+      - 'S3_ENABLE_PATH_STYLE=1'
+      - 'S3_ACCESS_KEY=${RUSTFS_ACCESS_KEY}'
+      - 'S3_ACCESS_KEY_ID=${RUSTFS_ACCESS_KEY}'
+      - 'S3_SECRET_ACCESS_KEY=${RUSTFS_SECRET_KEY}'
+      - 'LLM_VISION_IMAGE_USE_BASE64=1'
+      - 'S3_SET_ACL=0'
+      - 'SEARXNG_URL=http://searxng:8080'
+      - 'REDIS_URL=redis://redis:6379'
+      - 'REDIS_PREFIX=lobechat'
+      - 'REDIS_TLS=0'
+    env_file:
+      - .env
+    restart: always
+
+volumes:
+  data:
+    driver: local
+  redis_data:
+    driver: local
+  rustfs-data:
+    driver: local
+
+networks:
+  lobe-network:
+    driver: bridge

--- a/docker-compose/deploy/docker-compose.yml
+++ b/docker-compose/deploy/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - lobe-network
 
   postgresql:
-    image: paradedb/paradedb:latest
+    image: paradedb/paradedb:latest-pg17
     container_name: lobe-postgres
     ports:
       - '5432:5432'

--- a/docker-compose/deploy/searxng-settings.yml
+++ b/docker-compose/deploy/searxng-settings.yml
@@ -1,0 +1,2582 @@
+general:
+  # Debug mode, only for development. Is overwritten by ${SEARXNG_DEBUG}
+  debug: false
+  # displayed name
+  instance_name: "searxng"
+  # For example: https://example.com/privacy
+  privacypolicy_url: false
+  # use true to use your own donation page written in searx/info/en/donate.md
+  # use false to disable the donation link
+  donation_url: false
+  # mailto:contact@example.com
+  contact_url: false
+  # record stats
+  enable_metrics: true
+  # expose stats in open metrics format at /metrics
+  # leave empty to disable (no password set)
+  # open_metrics: <password>
+  open_metrics: ''
+
+brand:
+  new_issue_url: https://github.com/searxng/searxng/issues/new
+  docs_url: https://docs.searxng.org/
+  public_instances: https://searx.space
+  wiki_url: https://github.com/searxng/searxng/wiki
+  issue_url: https://github.com/searxng/searxng/issues
+  # custom:
+  #   maintainer: "Jon Doe"
+  #   # Custom entries in the footer: [title]: [link]
+  #   links:
+  #     Uptime: https://uptime.searxng.org/history/darmarit-org
+  #     About: "https://searxng.org"
+
+search:
+  # Filter results. 0: None, 1: Moderate, 2: Strict
+  safe_search: 0
+  # Existing autocomplete backends: "baidu", "brave", "dbpedia", "duckduckgo", "google", "yandex",
+  # "mwmbl", "seznam", "stract", "swisscows", "qwant", "wikipedia" -
+  # leave blank to turn it off by default.
+  autocomplete: ""
+  # minimun characters to type before autocompleter starts
+  autocomplete_min: 4
+  # backend for the favicon near URL in search results.
+  # Available resolvers: "allesedv", "duckduckgo", "google", "yandex" - leave blank to turn it off by default.
+  favicon_resolver: ""
+  # Default search language - leave blank to detect from browser information or
+  # use codes from 'languages.py'
+  default_lang: "auto"
+  # max_page: 0  # if engine supports paging, 0 means unlimited numbers of pages
+  # Available languages
+  # languages:
+  #   - all
+  #   - en
+  #   - en-US
+  #   - de
+  #   - it-IT
+  #   - fr
+  #   - fr-BE
+  # ban time in seconds after engine errors
+  ban_time_on_fail: 5
+  # max ban time in seconds after engine errors
+  max_ban_time_on_fail: 120
+  suspended_times:
+    # Engine suspension time after error (in seconds; set to 0 to disable)
+    # For error "Access denied" and "HTTP error [402, 403]"
+    SearxEngineAccessDenied: 86400
+    # For error "CAPTCHA"
+    SearxEngineCaptcha: 86400
+    # For error "Too many request" and "HTTP error 429"
+    SearxEngineTooManyRequests: 3600
+    # Cloudflare CAPTCHA
+    cf_SearxEngineCaptcha: 1296000
+    cf_SearxEngineAccessDenied: 86400
+    # ReCAPTCHA
+    recaptcha_SearxEngineCaptcha: 604800
+
+  # remove format to deny access, use lower case.
+  # formats: [html, csv, json, rss]
+  formats:
+    - html
+    - json
+server:
+  # Is overwritten by ${SEARXNG_PORT} and ${SEARXNG_BIND_ADDRESS}
+  port: 8888
+  bind_address: "127.0.0.1"
+  # public URL of the instance, to ensure correct inbound links. Is overwritten
+  # by ${SEARXNG_URL}.
+  base_url: /  # "http://example.com/location"
+  # rate limit the number of request on the instance, block some bots.
+  # Is overwritten by ${SEARXNG_LIMITER}
+  limiter: false
+  # enable features designed only for public instances.
+  # Is overwritten by ${SEARXNG_PUBLIC_INSTANCE}
+  public_instance: false
+
+  # If your instance owns a /etc/searxng/settings.yml file, then set the following
+  # values there.
+
+  secret_key: "779c5b69fe650f147be9012abca6b44a8697acdb2817b46353f4779bb07d81d1"  # Is overwritten by ${SEARXNG_SECRET}
+  # Proxy image results through SearXNG. Is overwritten by ${SEARXNG_IMAGE_PROXY}
+  image_proxy: false
+  # 1.0 and 1.1 are supported
+  http_protocol_version: "1.0"
+  # POST queries are more secure as they don't show up in history but may cause
+  # problems when using Firefox containers
+  method: "POST"
+  default_http_headers:
+    X-Content-Type-Options: nosniff
+    X-Download-Options: noopen
+    X-Robots-Tag: noindex, nofollow
+    Referrer-Policy: no-referrer
+
+redis:
+  # URL to connect redis database. Is overwritten by ${SEARXNG_REDIS_URL}.
+  # https://docs.searxng.org/admin/settings/settings_redis.html#settings-redis
+  url: false
+
+ui:
+  # Custom static path - leave it blank if you didn't change
+  static_path: ""
+  # Is overwritten by ${SEARXNG_STATIC_USE_HASH}.
+  static_use_hash: false
+  # Custom templates path - leave it blank if you didn't change
+  templates_path: ""
+  # query_in_title: When true, the result page's titles contains the query
+  # it decreases the privacy, since the browser can records the page titles.
+  query_in_title: false
+  # infinite_scroll: When true, automatically loads the next page when scrolling to bottom of the current page.
+  infinite_scroll: false
+  # ui theme
+  default_theme: simple
+  # center the results ?
+  center_alignment: false
+  # URL prefix of the internet archive, don't forget trailing slash (if needed).
+  # cache_url: "https://webcache.googleusercontent.com/search?q=cache:"
+  # Default interface locale - leave blank to detect from browser information or
+  # use codes from the 'locales' config section
+  default_locale: ""
+  # Open result links in a new tab by default
+  # results_on_new_tab: false
+  theme_args:
+    # style of simple theme: auto, light, dark
+    simple_style: auto
+  # Perform search immediately if a category selected.
+  # Disable to select multiple categories at once and start the search manually.
+  search_on_category_select: true
+  # Hotkeys: default or vim
+  hotkeys: default
+  # URL formatting: pretty, full or host
+  url_formatting: pretty
+
+# Lock arbitrary settings on the preferences page.
+#
+# preferences:
+#   lock:
+#     - categories
+#     - language
+#     - autocomplete
+#     - favicon
+#     - safesearch
+#     - method
+#     - doi_resolver
+#     - locale
+#     - theme
+#     - results_on_new_tab
+#     - infinite_scroll
+#     - search_on_category_select
+#     - method
+#     - image_proxy
+#     - query_in_title
+
+# searx supports result proxification using an external service:
+# https://github.com/asciimoo/morty uncomment below section if you have running
+# morty proxy the key is base64 encoded (keep the !!binary notation)
+# Note: since commit af77ec3, morty accepts a base64 encoded key.
+#
+# result_proxy:
+#   url: http://127.0.0.1:3000/
+#   # the key is a base64 encoded string, the YAML !!binary prefix is optional
+#   key: !!binary "your_morty_proxy_key"
+#   # [true|false] enable the "proxy" button next to each result
+#   proxify_results: true
+
+# communication with search engines
+#
+outgoing:
+  # default timeout in seconds, can be override by engine
+  request_timeout: 3.0
+  # the maximum timeout in seconds
+  # max_request_timeout: 10.0
+  # suffix of searx_useragent, could contain information like an email address
+  # to the administrator
+  useragent_suffix: ""
+  # The maximum number of concurrent connections that may be established.
+  pool_connections: 100
+  # Allow the connection pool to maintain keep-alive connections below this
+  # point.
+  pool_maxsize: 20
+  # See https://www.python-httpx.org/http2/
+  enable_http2: true
+  # uncomment below section if you want to use a custom server certificate
+  # see https://www.python-httpx.org/advanced/#changing-the-verification-defaults
+  # and https://www.python-httpx.org/compatibility/#ssl-configuration
+  #  verify: ~/.mitmproxy/mitmproxy-ca-cert.cer
+  #
+  # uncomment below section if you want to use a proxyq see: SOCKS proxies
+  #   https://2.python-requests.org/en/latest/user/advanced/#proxies
+  # are also supported: see
+  #   https://2.python-requests.org/en/latest/user/advanced/#socks
+  #
+  #  proxies:
+  #    all://:
+  #      - http://proxy1:8080
+  #      - http://proxy2:8080
+  #
+  #  using_tor_proxy: true
+  #
+  # Extra seconds to add in order to account for the time taken by the proxy
+  #
+  #  extra_proxy_timeout: 10
+  #
+  # uncomment below section only if you have more than one network interface
+  # which can be the source of outgoing search requests
+  #
+  #  source_ips:
+  #    - 1.1.1.1
+  #    - 1.1.1.2
+  #    - fe80::/126
+
+# External plugin configuration, for more details see
+#   https://docs.searxng.org/admin/settings/settings_plugins.html
+#
+# plugins:
+#   - mypackage.mymodule.MyPlugin
+#   - mypackage.mymodule.MyOtherPlugin
+#   - ...
+
+# Comment or un-comment plugin to activate / deactivate by default.
+#   https://docs.searxng.org/admin/settings/settings_plugins.html
+#
+# enabled_plugins:
+#   # these plugins are enabled if nothing is configured ..
+#   - 'Basic Calculator'
+#   - 'Hash plugin'
+#   - 'Self Information'
+#   - 'Tracker URL remover'
+#   - 'Unit converter plugin'
+#   - 'Ahmia blacklist'  # activation depends on outgoing.using_tor_proxy
+#   # these plugins are disabled if nothing is configured ..
+#   - 'Hostnames plugin'  # see 'hostnames' configuration below
+#   - 'Open Access DOI rewrite'
+#   - 'Tor check plugin'
+
+# Configuration of the "Hostnames plugin":
+#
+# hostnames:
+#   replace:
+#     '(.*\.)?youtube\.com$': 'invidious.example.com'
+#     '(.*\.)?youtu\.be$': 'invidious.example.com'
+#     '(.*\.)?reddit\.com$': 'teddit.example.com'
+#     '(.*\.)?redd\.it$': 'teddit.example.com'
+#     '(www\.)?twitter\.com$': 'nitter.example.com'
+#   remove:
+#     - '(.*\.)?facebook.com$'
+#   low_priority:
+#     - '(.*\.)?google(\..*)?$'
+#   high_priority:
+#     - '(.*\.)?wikipedia.org$'
+#
+# Alternatively you can use external files for configuring the "Hostnames plugin":
+#
+# hostnames:
+#  replace: 'rewrite-hosts.yml'
+#
+# Content of 'rewrite-hosts.yml' (place the file in the same directory as 'settings.yml'):
+# '(.*\.)?youtube\.com$': 'invidious.example.com'
+# '(.*\.)?youtu\.be$': 'invidious.example.com'
+#
+
+checker:
+  # disable checker when in debug mode
+  off_when_debug: true
+
+  # use "scheduling: false" to disable scheduling
+  # scheduling: interval or int
+
+  # to activate the scheduler:
+  # * uncomment "scheduling" section
+  # * add "cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1"
+  #   to your uwsgi.ini
+
+  # scheduling:
+  #   start_after: [300, 1800]  # delay to start the first run of the checker
+  #   every: [86400, 90000]     # how often the checker runs
+
+  # additional tests: only for the YAML anchors (see the engines section)
+  #
+  additional_tests:
+    rosebud: &test_rosebud
+      matrix:
+        query: rosebud
+        lang: en
+      result_container:
+        - not_empty
+        - ['one_title_contains', 'citizen kane']
+      test:
+        - unique_results
+
+    android: &test_android
+      matrix:
+        query: ['android']
+        lang: ['en', 'de', 'fr', 'zh-CN']
+      result_container:
+        - not_empty
+        - ['one_title_contains', 'google']
+      test:
+        - unique_results
+
+  # tests: only for the YAML anchors (see the engines section)
+  tests:
+    infobox: &tests_infobox
+      infobox:
+        matrix:
+          query: ["linux", "new york", "bbc"]
+        result_container:
+          - has_infobox
+
+categories_as_tabs:
+  general:
+  images:
+  videos:
+  news:
+  map:
+  music:
+  it:
+  science:
+  files:
+  social media:
+
+engines:
+  - name: 9gag
+    engine: 9gag
+    shortcut: 9g
+    disabled: true
+
+  - name: adobe stock
+    engine: adobe_stock
+    shortcut: asi
+    categories: ["images"]
+    # https://docs.searxng.org/dev/engines/online/adobe_stock.html
+    adobe_order: relevance
+    adobe_content_types: ["photo", "illustration", "zip_vector", "template", "3d", "image"]
+    timeout: 6
+    disabled: true
+
+  - name: adobe stock video
+    engine: adobe_stock
+    shortcut: asv
+    network: adobe stock
+    categories: ["videos"]
+    adobe_order: relevance
+    adobe_content_types: ["video"]
+    timeout: 6
+    disabled: true
+
+  - name: adobe stock audio
+    engine: adobe_stock
+    shortcut: asa
+    network: adobe stock
+    categories: ["music"]
+    adobe_order: relevance
+    adobe_content_types: ["audio"]
+    timeout: 6
+    disabled: true
+
+  - name: alexandria
+    engine: json_engine
+    shortcut: alx
+    categories: general
+    paging: true
+    search_url: https://api.alexandria.org/?a=1&q={query}&p={pageno}
+    results_query: results
+    title_query: title
+    url_query: url
+    content_query: snippet
+    timeout: 1.5
+    disabled: true
+    about:
+      website: https://alexandria.org/
+      official_api_documentation: https://github.com/alexandria-org/alexandria-api/raw/master/README.md
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
+  # - name: astrophysics data system
+  #   engine: astrophysics_data_system
+  #   sort: asc
+  #   weight: 5
+  #   categories: [science]
+  #   api_key: your-new-key
+  #   shortcut: ads
+
+  - name: alpine linux packages
+    engine: alpinelinux
+    disabled: true
+    shortcut: alp
+
+  - name: annas archive
+    engine: annas_archive
+    disabled: true
+    shortcut: aa
+
+  # - name: annas articles
+  #   engine: annas_archive
+  #   shortcut: aaa
+  #   # https://docs.searxng.org/dev/engines/online/annas_archive.html
+  #   aa_content: 'magazine' # book_fiction, book_unknown, book_nonfiction, book_comic
+  #   aa_ext: 'pdf'  # pdf, epub, ..
+  #   aa_sort: oldest'  # newest, oldest, largest, smallest
+
+  - name: apk mirror
+    engine: apkmirror
+    timeout: 4.0
+    shortcut: apkm
+    disabled: true
+
+  - name: apple app store
+    engine: apple_app_store
+    shortcut: aps
+    disabled: true
+
+  # Requires Tor
+  - name: ahmia
+    engine: ahmia
+    categories: onions
+    enable_http: true
+    shortcut: ah
+
+  - name: anaconda
+    engine: xpath
+    paging: true
+    first_page_num: 0
+    search_url: https://anaconda.org/search?q={query}&page={pageno}
+    results_xpath: //tbody/tr
+    url_xpath: ./td/h5/a[last()]/@href
+    title_xpath: ./td/h5
+    content_xpath: ./td[h5]/text()
+    categories: it
+    timeout: 6.0
+    shortcut: conda
+    disabled: true
+
+  - name: arch linux wiki
+    engine: archlinux
+    shortcut: al
+
+  - name: nixos wiki
+    engine: mediawiki
+    shortcut: nixw
+    base_url: https://wiki.nixos.org/
+    search_type: text
+    disabled: true
+    categories: [it, software wikis]
+
+  - name: artic
+    engine: artic
+    shortcut: arc
+    timeout: 4.0
+
+  - name: arxiv
+    engine: arxiv
+    shortcut: arx
+    timeout: 4.0
+
+  - name: ask
+    engine: ask
+    shortcut: ask
+    disabled: true
+
+  # tmp suspended:  dh key too small
+  # - name: base
+  #   engine: base
+  #   shortcut: bs
+
+  - name: bandcamp
+    engine: bandcamp
+    shortcut: bc
+    categories: music
+
+  - name: wikipedia
+    engine: wikipedia
+    shortcut: wp
+    # add "list" to the array to get results in the results list
+    display_type: ["infobox"]
+    categories: [general]
+
+  - name: bilibili
+    engine: bilibili
+    shortcut: bil
+    disabled: true
+
+  - name: bing
+    engine: bing
+    shortcut: bi
+    disabled: true
+
+  - name: bing images
+    engine: bing_images
+    shortcut: bii
+
+  - name: bing news
+    engine: bing_news
+    shortcut: bin
+
+  - name: bing videos
+    engine: bing_videos
+    shortcut: biv
+
+  - name: bitbucket
+    engine: xpath
+    paging: true
+    search_url: https://bitbucket.org/repo/all/{pageno}?name={query}
+    url_xpath: //article[@class="repo-summary"]//a[@class="repo-link"]/@href
+    title_xpath: //article[@class="repo-summary"]//a[@class="repo-link"]
+    content_xpath: //article[@class="repo-summary"]/p
+    categories: [it, repos]
+    timeout: 4.0
+    disabled: true
+    shortcut: bb
+    about:
+      website: https://bitbucket.org/
+      wikidata_id: Q2493781
+      official_api_documentation: https://developer.atlassian.com/bitbucket
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: bpb
+    engine: bpb
+    shortcut: bpb
+    disabled: true
+
+  - name: btdigg
+    engine: btdigg
+    shortcut: bt
+    disabled: true
+
+  - name: openverse
+    engine: openverse
+    categories: images
+    shortcut: opv
+
+  - name: media.ccc.de
+    engine: ccc_media
+    shortcut: c3tv
+    # We don't set language: de here because media.ccc.de is not just
+    # for a German audience. It contains many English videos and many
+    # German videos have English subtitles.
+    disabled: true
+
+  - name: chefkoch
+    engine: chefkoch
+    shortcut: chef
+    # to show premium or plus results too:
+    # skip_premium: false
+
+  - name: cloudflareai
+    engine: cloudflareai
+    shortcut: cfai
+    # get api token and accont id from https://developers.cloudflare.com/workers-ai/get-started/rest-api/
+    cf_account_id: 'your_cf_accout_id'
+    cf_ai_api: 'your_cf_api'
+    # create your ai gateway by https://developers.cloudflare.com/ai-gateway/get-started/creating-gateway/
+    cf_ai_gateway: 'your_cf_ai_gateway_name'
+    # find the model name from https://developers.cloudflare.com/workers-ai/models/#text-generation
+    cf_ai_model: 'ai_model_name'
+    # custom your preferences
+    # cf_ai_model_display_name: 'Cloudflare AI'
+    # cf_ai_model_assistant: 'prompts_for_assistant_role'
+    # cf_ai_model_system: 'prompts_for_system_role'
+    timeout: 30
+    disabled: true
+
+  # - name: core.ac.uk
+  #   engine: core
+  #   categories: science
+  #   shortcut: cor
+  #   # get your API key from: https://core.ac.uk/api-keys/register/
+  #   api_key: 'unset'
+
+  - name: cppreference
+    engine: cppreference
+    shortcut: cpp
+    paging: false
+    disabled: true
+
+  - name: crossref
+    engine: crossref
+    shortcut: cr
+    timeout: 30
+    disabled: true
+
+  - name: crowdview
+    engine: json_engine
+    shortcut: cv
+    categories: general
+    paging: false
+    search_url: https://crowdview-next-js.onrender.com/api/search-v3?query={query}
+    results_query: results
+    url_query: link
+    title_query: title
+    content_query: snippet
+    title_html_to_text: true
+    content_html_to_text: true
+    disabled: true
+    about:
+      website: https://crowdview.ai/
+
+  - name: yep
+    engine: yep
+    shortcut: yep
+    categories: general
+    search_type: web
+    timeout: 5
+    disabled: true
+
+  - name: yep images
+    engine: yep
+    shortcut: yepi
+    categories: images
+    search_type: images
+    disabled: true
+
+  - name: yep news
+    engine: yep
+    shortcut: yepn
+    categories: news
+    search_type: news
+    disabled: true
+
+  - name: curlie
+    engine: xpath
+    shortcut: cl
+    categories: general
+    disabled: true
+    paging: true
+    lang_all: ''
+    search_url: https://curlie.org/search?q={query}&lang={lang}&start={pageno}&stime=92452189
+    page_size: 20
+    results_xpath: //div[@id="site-list-content"]/div[@class="site-item"]
+    url_xpath: ./div[@class="title-and-desc"]/a/@href
+    title_xpath: ./div[@class="title-and-desc"]/a/div
+    content_xpath: ./div[@class="title-and-desc"]/div[@class="site-descr"]
+    about:
+      website: https://curlie.org/
+      wikidata_id: Q60715723
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: currency
+    engine: currency_convert
+    categories: general
+    shortcut: cc
+
+  - name: deezer
+    engine: deezer
+    shortcut: dz
+    disabled: true
+
+  - name: destatis
+    engine: destatis
+    shortcut: destat
+    disabled: true
+
+  - name: deviantart
+    engine: deviantart
+    shortcut: da
+    timeout: 3.0
+
+  - name: ddg definitions
+    engine: duckduckgo_definitions
+    shortcut: ddd
+    weight: 2
+    disabled: true
+    tests: *tests_infobox
+
+  # cloudflare protected
+  # - name: digbt
+  #   engine: digbt
+  #   shortcut: dbt
+  #   timeout: 6.0
+  #   disabled: true
+
+  - name: docker hub
+    engine: docker_hub
+    shortcut: dh
+    categories: [it, packages]
+
+  - name: encyclosearch
+    engine: json_engine
+    shortcut: es
+    categories: general
+    paging: true
+    search_url: https://encyclosearch.org/encyclosphere/search?q={query}&page={pageno}&resultsPerPage=15
+    results_query: Results
+    url_query: SourceURL
+    title_query: Title
+    content_query: Description
+    disabled: true
+    about:
+      website: https://encyclosearch.org
+      official_api_documentation: https://encyclosearch.org/docs/#/rest-api
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
+  - name: erowid
+    engine: xpath
+    paging: true
+    first_page_num: 0
+    page_size: 30
+    search_url: https://www.erowid.org/search.php?q={query}&s={pageno}
+    url_xpath: //dl[@class="results-list"]/dt[@class="result-title"]/a/@href
+    title_xpath: //dl[@class="results-list"]/dt[@class="result-title"]/a/text()
+    content_xpath: //dl[@class="results-list"]/dd[@class="result-details"]
+    categories: []
+    shortcut: ew
+    disabled: true
+    about:
+      website: https://www.erowid.org/
+      wikidata_id: Q1430691
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  # - name: elasticsearch
+  #   shortcut: es
+  #   engine: elasticsearch
+  #   base_url: http://localhost:9200
+  #   username: elastic
+  #   password: changeme
+  #   index: my-index
+  #   # available options: match, simple_query_string, term, terms, custom
+  #   query_type: match
+  #   # if query_type is set to custom, provide your query here
+  #   #custom_query_json: {"query":{"match_all": {}}}
+  #   #show_metadata: false
+  #   disabled: true
+
+  - name: wikidata
+    engine: wikidata
+    shortcut: wd
+    timeout: 3.0
+    weight: 2
+    # add "list" to the array to get results in the results list
+    display_type: ["infobox"]
+    tests: *tests_infobox
+    categories: [general]
+
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+
+  - name: duckduckgo images
+    engine: duckduckgo_extra
+    categories: [images, web]
+    ddg_category: images
+    shortcut: ddi
+    disabled: true
+
+  - name: duckduckgo videos
+    engine: duckduckgo_extra
+    categories: [videos, web]
+    ddg_category: videos
+    shortcut: ddv
+    disabled: true
+
+  - name: duckduckgo news
+    engine: duckduckgo_extra
+    categories: [news, web]
+    ddg_category: news
+    shortcut: ddn
+    disabled: true
+
+  - name: duckduckgo weather
+    engine: duckduckgo_weather
+    shortcut: ddw
+    disabled: true
+
+  - name: apple maps
+    engine: apple_maps
+    shortcut: apm
+    disabled: true
+    timeout: 5.0
+
+  - name: emojipedia
+    engine: emojipedia
+    timeout: 4.0
+    shortcut: em
+    disabled: true
+
+  - name: tineye
+    engine: tineye
+    shortcut: tin
+    timeout: 9.0
+    disabled: true
+
+  - name: etymonline
+    engine: xpath
+    paging: true
+    search_url: https://etymonline.com/search?page={pageno}&q={query}
+    url_xpath: //a[contains(@class, "word__name--")]/@href
+    title_xpath: //a[contains(@class, "word__name--")]
+    content_xpath: //section[contains(@class, "word__defination")]
+    first_page_num: 1
+    shortcut: et
+    categories: [dictionaries]
+    about:
+      website: https://www.etymonline.com/
+      wikidata_id: Q1188617
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  # - name: ebay
+  #   engine: ebay
+  #   shortcut: eb
+  #   base_url: 'https://www.ebay.com'
+  #   disabled: true
+  #   timeout: 5
+
+  - name: 1x
+    engine: www1x
+    shortcut: 1x
+    timeout: 3.0
+    disabled: true
+
+  - name: fdroid
+    engine: fdroid
+    shortcut: fd
+    disabled: true
+
+  - name: findthatmeme
+    engine: findthatmeme
+    shortcut: ftm
+    disabled: true
+
+  - name: flickr
+    categories: images
+    shortcut: fl
+    # You can use the engine using the official stable API, but you need an API
+    # key, see: https://www.flickr.com/services/apps/create/
+    # engine: flickr
+    # api_key: 'apikey' # required!
+    # Or you can use the html non-stable engine, activated by default
+    engine: flickr_noapi
+
+  - name: free software directory
+    engine: mediawiki
+    shortcut: fsd
+    categories: [it, software wikis]
+    base_url: https://directory.fsf.org/
+    search_type: title
+    timeout: 5.0
+    disabled: true
+    about:
+      website: https://directory.fsf.org/
+      wikidata_id: Q2470288
+
+  # - name: freesound
+  #   engine: freesound
+  #   shortcut: fnd
+  #   disabled: true
+  #   timeout: 15.0
+  # API key required, see: https://freesound.org/docs/api/overview.html
+  #   api_key: MyAPIkey
+
+  - name: frinkiac
+    engine: frinkiac
+    shortcut: frk
+    disabled: true
+
+  - name: fyyd
+    engine: fyyd
+    shortcut: fy
+    timeout: 8.0
+    disabled: true
+
+  - name: geizhals
+    engine: geizhals
+    shortcut: geiz
+    disabled: true
+
+  - name: genius
+    engine: genius
+    shortcut: gen
+
+  - name: gentoo
+    engine: mediawiki
+    shortcut: ge
+    categories: ["it", "software wikis"]
+    base_url: "https://wiki.gentoo.org/"
+    api_path: "api.php"
+    search_type: text
+    timeout: 10
+
+  - name: gitlab
+    engine: gitlab
+    base_url: https://gitlab.com
+    shortcut: gl
+    disabled: true
+    about:
+      website: https://gitlab.com/
+      wikidata_id: Q16639197
+
+  # - name: gnome
+  #   engine: gitlab
+  #   base_url: https://gitlab.gnome.org
+  #   shortcut: gn
+  #   about:
+  #     website: https://gitlab.gnome.org
+  #     wikidata_id: Q44316
+
+  - name: github
+    engine: github
+    shortcut: gh
+
+  - name: codeberg
+    # https://docs.searxng.org/dev/engines/online/gitea.html
+    engine: gitea
+    base_url: https://codeberg.org
+    shortcut: cb
+    disabled: true
+
+  - name: gitea.com
+    engine: gitea
+    base_url: https://gitea.com
+    shortcut: gitea
+    disabled: true
+
+  - name: goodreads
+    engine: goodreads
+    shortcut: good
+    timeout: 4.0
+    disabled: true
+
+  - name: google
+    engine: google
+    shortcut: go
+    # additional_tests:
+    #   android: *test_android
+
+  - name: google images
+    engine: google_images
+    shortcut: goi
+    # additional_tests:
+    #   android: *test_android
+    #   dali:
+    #     matrix:
+    #       query: ['Dali Christ']
+    #       lang: ['en', 'de', 'fr', 'zh-CN']
+    #     result_container:
+    #       - ['one_title_contains', 'Salvador']
+
+  - name: google news
+    engine: google_news
+    shortcut: gon
+    # additional_tests:
+    #   android: *test_android
+
+  - name: google videos
+    engine: google_videos
+    shortcut: gov
+    # additional_tests:
+    #   android: *test_android
+
+  - name: google scholar
+    engine: google_scholar
+    shortcut: gos
+
+  - name: google play apps
+    engine: google_play
+    categories: [files, apps]
+    shortcut: gpa
+    play_categ: apps
+    disabled: true
+
+  - name: google play movies
+    engine: google_play
+    categories: videos
+    shortcut: gpm
+    play_categ: movies
+    disabled: true
+
+  - name: material icons
+    engine: material_icons
+    categories: images
+    shortcut: mi
+    disabled: true
+
+  - name: habrahabr
+    engine: xpath
+    paging: true
+    search_url: https://habr.com/en/search/page{pageno}/?q={query}
+    results_xpath: //article[contains(@class, "tm-articles-list__item")]
+    url_xpath: .//a[@class="tm-title__link"]/@href
+    title_xpath: .//a[@class="tm-title__link"]
+    content_xpath: .//div[contains(@class, "article-formatted-body")]
+    categories: it
+    timeout: 4.0
+    disabled: true
+    shortcut: habr
+    about:
+      website: https://habr.com/
+      wikidata_id: Q4494434
+      official_api_documentation: https://habr.com/en/docs/help/api/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: hackernews
+    engine: hackernews
+    shortcut: hn
+    disabled: true
+
+  - name: hex
+    engine: hex
+    shortcut: hex
+    disabled: true
+    # Valid values: name inserted_at updated_at total_downloads recent_downloads
+    sort_criteria: "recent_downloads"
+    page_size: 10
+
+  - name: crates.io
+    engine: crates
+    shortcut: crates
+    disabled: true
+    timeout: 6.0
+
+  - name: hoogle
+    engine: xpath
+    search_url: https://hoogle.haskell.org/?hoogle={query}
+    results_xpath: '//div[@class="result"]'
+    title_xpath: './/div[@class="ans"]//a'
+    url_xpath: './/div[@class="ans"]//a/@href'
+    content_xpath: './/div[@class="from"]'
+    page_size: 20
+    categories: [it, packages]
+    shortcut: ho
+    about:
+      website: https://hoogle.haskell.org/
+      wikidata_id: Q34010
+      official_api_documentation: https://hackage.haskell.org/api
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
+  - name: imdb
+    engine: imdb
+    shortcut: imdb
+    timeout: 6.0
+    disabled: true
+
+  - name: imgur
+    engine: imgur
+    shortcut: img
+    disabled: true
+
+  - name: ina
+    engine: ina
+    shortcut: in
+    timeout: 6.0
+    disabled: true
+
+  - name: invidious
+    engine: invidious
+    # Instanes will be selected randomly, see https://api.invidious.io/ for
+    # instances that are stable (good uptime) and close to you.
+    base_url:
+      - https://invidious.adminforge.de
+      - https://inv.nadeko.net
+    shortcut: iv
+    timeout: 3.0
+    disabled: true
+
+  - name: ipernity
+    engine: ipernity
+    shortcut: ip
+    disabled: true
+
+  - name: jisho
+    engine: jisho
+    shortcut: js
+    timeout: 3.0
+    disabled: true
+
+  - name: kickass
+    engine: kickass
+    base_url:
+      - https://kickasstorrents.to
+      - https://kickasstorrents.cr
+      - https://kickasstorrent.cr
+      - https://kickass.sx
+      - https://kat.am
+    shortcut: kc
+    timeout: 4.0
+
+  - name: lemmy communities
+    engine: lemmy
+    lemmy_type: Communities
+    shortcut: leco
+
+  - name: lemmy users
+    engine: lemmy
+    network: lemmy communities
+    lemmy_type: Users
+    shortcut: leus
+
+  - name: lemmy posts
+    engine: lemmy
+    network: lemmy communities
+    lemmy_type: Posts
+    shortcut: lepo
+
+  - name: lemmy comments
+    engine: lemmy
+    network: lemmy communities
+    lemmy_type: Comments
+    shortcut: lecom
+
+  - name: library genesis
+    engine: xpath
+    # search_url: https://libgen.is/search.php?req={query}
+    search_url: https://libgen.rs/search.php?req={query}
+    url_xpath: //a[contains(@href,"book/index.php?md5")]/@href
+    title_xpath: //a[contains(@href,"book/")]/text()[1]
+    content_xpath: //td/a[1][contains(@href,"=author")]/text()
+    categories: files
+    timeout: 7.0
+    disabled: true
+    shortcut: lg
+    about:
+      website: https://libgen.fun/
+      wikidata_id: Q22017206
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: z-library
+    engine: zlibrary
+    shortcut: zlib
+    categories: files
+    timeout: 7.0
+
+  - name: library of congress
+    engine: loc
+    shortcut: loc
+    categories: images
+
+  - name: libretranslate
+    engine: libretranslate
+    # https://github.com/LibreTranslate/LibreTranslate?tab=readme-ov-file#mirrors
+    base_url:
+      - https://libretranslate.com/translate
+    # api_key: abc123
+    shortcut: lt
+    disabled: true
+
+  - name: lingva
+    engine: lingva
+    shortcut: lv
+    # set lingva instance in url, by default it will use the official instance
+    # url: https://lingva.thedaviddelta.com
+
+  - name: lobste.rs
+    engine: xpath
+    search_url: https://lobste.rs/search?q={query}&what=stories&order=relevance
+    results_xpath: //li[contains(@class, "story")]
+    url_xpath: .//a[@class="u-url"]/@href
+    title_xpath: .//a[@class="u-url"]
+    content_xpath: .//a[@class="domain"]
+    categories: it
+    shortcut: lo
+    timeout: 5.0
+    disabled: true
+    about:
+      website: https://lobste.rs/
+      wikidata_id: Q60762874
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: mastodon users
+    engine: mastodon
+    mastodon_type: accounts
+    base_url: https://mastodon.social
+    shortcut: mau
+
+  - name: mastodon hashtags
+    engine: mastodon
+    mastodon_type: hashtags
+    base_url: https://mastodon.social
+    shortcut: mah
+
+  # - name: matrixrooms
+  #   engine: mrs
+  #   # https://docs.searxng.org/dev/engines/online/mrs.html
+  #   # base_url: https://mrs-api-host
+  #   shortcut: mtrx
+  #   disabled: true
+
+  - name: mdn
+    shortcut: mdn
+    engine: json_engine
+    categories: [it]
+    paging: true
+    search_url: https://developer.mozilla.org/api/v1/search?q={query}&page={pageno}
+    results_query: documents
+    url_query: mdn_url
+    url_prefix: https://developer.mozilla.org
+    title_query: title
+    content_query: summary
+    about:
+      website: https://developer.mozilla.org
+      wikidata_id: Q3273508
+      official_api_documentation: null
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
+  - name: metacpan
+    engine: metacpan
+    shortcut: cpan
+    disabled: true
+    number_of_results: 20
+
+  # - name: meilisearch
+  #   engine: meilisearch
+  #   shortcut: mes
+  #   enable_http: true
+  #   base_url: http://localhost:7700
+  #   index: my-index
+
+  - name: mixcloud
+    engine: mixcloud
+    shortcut: mc
+
+  # MongoDB engine
+  # Required dependency: pymongo
+  # - name: mymongo
+  #   engine: mongodb
+  #   shortcut: md
+  #   exact_match_only: false
+  #   host: '127.0.0.1'
+  #   port: 27017
+  #   enable_http: true
+  #   results_per_page: 20
+  #   database: 'business'
+  #   collection: 'reviews'  # name of the db collection
+  #   key: 'name'  # key in the collection to search for
+
+  - name: mozhi
+    engine: mozhi
+    base_url:
+      - https://mozhi.aryak.me
+      - https://translate.bus-hit.me
+      - https://nyc1.mz.ggtyler.dev
+    # mozhi_engine: google - see https://mozhi.aryak.me for supported engines
+    timeout: 4.0
+    shortcut: mz
+    disabled: true
+
+  - name: mwmbl
+    engine: mwmbl
+    # api_url: https://api.mwmbl.org
+    shortcut: mwm
+    disabled: true
+
+  - name: npm
+    engine: npm
+    shortcut: npm
+    timeout: 5.0
+    disabled: true
+
+  - name: nyaa
+    engine: nyaa
+    shortcut: nt
+    disabled: true
+
+  - name: mankier
+    engine: json_engine
+    search_url: https://www.mankier.com/api/v2/mans/?q={query}
+    results_query: results
+    url_query: url
+    title_query: name
+    content_query: description
+    categories: it
+    shortcut: man
+    about:
+      website: https://www.mankier.com/
+      official_api_documentation: https://www.mankier.com/api
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
+  # read https://docs.searxng.org/dev/engines/online/mullvad_leta.html
+  # - name: mullvadleta
+  #   engine: mullvad_leta
+  #   leta_engine: google # choose one of the following: google, brave
+  #   use_cache: true  # Only 100 non-cache searches per day, suggested only for private instances
+  #   search_url: https://leta.mullvad.net
+  #   categories: [general, web]
+  #   shortcut: ml
+
+  - name: odysee
+    engine: odysee
+    shortcut: od
+    disabled: true
+
+  - name: openairedatasets
+    engine: json_engine
+    paging: true
+    search_url: https://api.openaire.eu/search/datasets?format=json&page={pageno}&size=10&title={query}
+    results_query: response/results/result
+    url_query: metadata/oaf:entity/oaf:result/children/instance/webresource/url/$
+    title_query: metadata/oaf:entity/oaf:result/title/$
+    content_query: metadata/oaf:entity/oaf:result/description/$
+    content_html_to_text: true
+    categories: "science"
+    shortcut: oad
+    timeout: 5.0
+    about:
+      website: https://www.openaire.eu/
+      wikidata_id: Q25106053
+      official_api_documentation: https://api.openaire.eu/
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
+  - name: openairepublications
+    engine: json_engine
+    paging: true
+    search_url: https://api.openaire.eu/search/publications?format=json&page={pageno}&size=10&title={query}
+    results_query: response/results/result
+    url_query: metadata/oaf:entity/oaf:result/children/instance/webresource/url/$
+    title_query: metadata/oaf:entity/oaf:result/title/$
+    content_query: metadata/oaf:entity/oaf:result/description/$
+    content_html_to_text: true
+    categories: science
+    shortcut: oap
+    timeout: 5.0
+    about:
+      website: https://www.openaire.eu/
+      wikidata_id: Q25106053
+      official_api_documentation: https://api.openaire.eu/
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
+  - name: openlibrary
+    engine: openlibrary
+    shortcut: ol
+    timeout: 5
+    disabled: true
+
+  - name: openmeteo
+    engine: open_meteo
+    shortcut: om
+    disabled: true
+
+  # - name: opensemanticsearch
+  #   engine: opensemantic
+  #   shortcut: oss
+  #   base_url: 'http://localhost:8983/solr/opensemanticsearch/'
+
+  - name: openstreetmap
+    engine: openstreetmap
+    shortcut: osm
+
+  - name: openrepos
+    engine: xpath
+    paging: true
+    search_url: https://openrepos.net/search/node/{query}?page={pageno}
+    url_xpath: //li[@class="search-result"]//h3[@class="title"]/a/@href
+    title_xpath: //li[@class="search-result"]//h3[@class="title"]/a
+    content_xpath: //li[@class="search-result"]//div[@class="search-snippet-info"]//p[@class="search-snippet"]
+    categories: files
+    timeout: 4.0
+    disabled: true
+    shortcut: or
+    about:
+      website: https://openrepos.net/
+      wikidata_id:
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: packagist
+    engine: json_engine
+    paging: true
+    search_url: https://packagist.org/search.json?q={query}&page={pageno}
+    results_query: results
+    url_query: url
+    title_query: name
+    content_query: description
+    categories: [it, packages]
+    disabled: true
+    timeout: 5.0
+    shortcut: pack
+    about:
+      website: https://packagist.org
+      wikidata_id: Q108311377
+      official_api_documentation: https://packagist.org/apidoc
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
+  - name: pdbe
+    engine: pdbe
+    shortcut: pdb
+    # Hide obsolete PDB entries.  Default is not to hide obsolete structures
+    #  hide_obsolete: false
+
+  - name: photon
+    engine: photon
+    shortcut: ph
+
+  - name: pinterest
+    engine: pinterest
+    shortcut: pin
+
+  - name: piped
+    engine: piped
+    shortcut: ppd
+    categories: videos
+    piped_filter: videos
+    timeout: 3.0
+
+    # URL to use as link and for embeds
+    frontend_url: https://srv.piped.video
+    # Instance will be selected randomly, for more see https://piped-instances.kavin.rocks/
+    backend_url:
+      - https://pipedapi.adminforge.de
+      - https://pipedapi.nosebs.ru
+      - https://pipedapi.ducks.party
+      - https://pipedapi.reallyaweso.me
+      - https://api.piped.private.coffee
+      - https://pipedapi.darkness.services
+
+  - name: piped.music
+    engine: piped
+    network: piped
+    shortcut: ppdm
+    categories: music
+    piped_filter: music_songs
+    timeout: 3.0
+
+  - name: piratebay
+    engine: piratebay
+    shortcut: tpb
+    # You may need to change this URL to a proxy if piratebay is blocked in your
+    # country
+    url: https://thepiratebay.org/
+    timeout: 3.0
+
+  - name: pixiv
+    shortcut: pv
+    engine: pixiv
+    disabled: true
+    inactive: true
+    pixiv_image_proxies:
+      - https://pximg.example.org
+      # A proxy is required to load the images. Hosting an image proxy server
+      # for Pixiv:
+      #    --> https://pixivfe.pages.dev/hosting-image-proxy-server/
+      # Proxies from public instances.  Ask the public instances owners if they
+      # agree to receive traffic from SearXNG!
+      #    --> https://codeberg.org/VnPower/PixivFE#instances
+      #    --> https://github.com/searxng/searxng/pull/3192#issuecomment-1941095047
+      # image proxy of https://pixiv.cat
+      # - https://i.pixiv.cat
+      # image proxy of https://www.pixiv.pics
+      # - https://pximg.cocomi.eu.org
+      # image proxy of https://pixivfe.exozy.me
+      # - https://pximg.exozy.me
+      # image proxy of https://pixivfe.ducks.party
+      # - https://pixiv.ducks.party
+      # image proxy of https://pixiv.perennialte.ch
+      # - https://pximg.perennialte.ch
+
+  - name: podcastindex
+    engine: podcastindex
+    shortcut: podcast
+
+  # Required dependency: psychopg2
+  #  - name: postgresql
+  #    engine: postgresql
+  #    database: postgres
+  #    username: postgres
+  #    password: postgres
+  #    limit: 10
+  #    query_str: 'SELECT * from my_table WHERE my_column = %(query)s'
+  #    shortcut : psql
+
+  - name: presearch
+    engine: presearch
+    search_type: search
+    categories: [general, web]
+    shortcut: ps
+    timeout: 4.0
+    disabled: true
+
+  - name: presearch images
+    engine: presearch
+    network: presearch
+    search_type: images
+    categories: [images, web]
+    timeout: 4.0
+    shortcut: psimg
+    disabled: true
+
+  - name: presearch videos
+    engine: presearch
+    network: presearch
+    search_type: videos
+    categories: [general, web]
+    timeout: 4.0
+    shortcut: psvid
+    disabled: true
+
+  - name: presearch news
+    engine: presearch
+    network: presearch
+    search_type: news
+    categories: [news, web]
+    timeout: 4.0
+    shortcut: psnews
+    disabled: true
+
+  - name: pub.dev
+    engine: xpath
+    shortcut: pd
+    search_url: https://pub.dev/packages?q={query}&page={pageno}
+    paging: true
+    results_xpath: //div[contains(@class,"packages-item")]
+    url_xpath: ./div/h3/a/@href
+    title_xpath: ./div/h3/a
+    content_xpath: ./div/div/div[contains(@class,"packages-description")]/span
+    categories: [packages, it]
+    timeout: 3.0
+    disabled: true
+    first_page_num: 1
+    about:
+      website: https://pub.dev/
+      official_api_documentation: https://pub.dev/help/api
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: public domain image archive
+    engine: public_domain_image_archive
+    shortcut: pdia
+
+  - name: pubmed
+    engine: pubmed
+    shortcut: pub
+    timeout: 3.0
+
+  - name: pypi
+    shortcut: pypi
+    engine: pypi
+
+  - name: qwant
+    qwant_categ: web
+    engine: qwant
+    shortcut: qw
+    categories: [general, web]
+    additional_tests:
+      rosebud: *test_rosebud
+
+  - name: qwant news
+    qwant_categ: news
+    engine: qwant
+    shortcut: qwn
+    categories: news
+    network: qwant
+
+  - name: qwant images
+    qwant_categ: images
+    engine: qwant
+    shortcut: qwi
+    categories: [images, web]
+    network: qwant
+
+  - name: qwant videos
+    qwant_categ: videos
+    engine: qwant
+    shortcut: qwv
+    categories: [videos, web]
+    network: qwant
+
+  # - name: library
+  #   engine: recoll
+  #   shortcut: lib
+  #   base_url: 'https://recoll.example.org/'
+  #   search_dir: ''
+  #   mount_prefix: /export
+  #   dl_prefix: 'https://download.example.org'
+  #   timeout: 30.0
+  #   categories: files
+  #   disabled: true
+
+  # - name: recoll library reference
+  #   engine: recoll
+  #   base_url: 'https://recoll.example.org/'
+  #   search_dir: reference
+  #   mount_prefix: /export
+  #   dl_prefix: 'https://download.example.org'
+  #   shortcut: libr
+  #   timeout: 30.0
+  #   categories: files
+  #   disabled: true
+
+  - name: radio browser
+    engine: radio_browser
+    shortcut: rb
+
+  - name: reddit
+    engine: reddit
+    shortcut: re
+    page_size: 25
+    disabled: true
+
+  - name: right dao
+    engine: xpath
+    paging: true
+    page_size: 12
+    search_url: https://rightdao.com/search?q={query}&start={pageno}
+    results_xpath: //div[contains(@class, "description")]
+    url_xpath: ../div[contains(@class, "title")]/a/@href
+    title_xpath: ../div[contains(@class, "title")]
+    content_xpath: .
+    categories: general
+    shortcut: rd
+    disabled: true
+    about:
+      website: https://rightdao.com/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: rottentomatoes
+    engine: rottentomatoes
+    shortcut: rt
+    disabled: true
+
+  # Required dependency: redis
+  # - name: myredis
+  #   shortcut : rds
+  #   engine: redis_server
+  #   exact_match_only: false
+  #   host: '127.0.0.1'
+  #   port: 6379
+  #   enable_http: true
+  #   password: ''
+  #   db: 0
+
+  # tmp suspended: bad certificate
+  #  - name: scanr structures
+  #    shortcut: scs
+  #    engine: scanr_structures
+  #    disabled: true
+
+  - name: searchmysite
+    engine: xpath
+    shortcut: sms
+    categories: general
+    paging: true
+    search_url: https://searchmysite.net/search/?q={query}&page={pageno}
+    results_xpath: //div[contains(@class,'search-result')]
+    url_xpath: .//a[contains(@class,'result-link')]/@href
+    title_xpath: .//span[contains(@class,'result-title-txt')]/text()
+    content_xpath: ./p[@id='result-hightlight']
+    disabled: true
+    about:
+      website: https://searchmysite.net
+
+  - name: sepiasearch
+    engine: sepiasearch
+    shortcut: sep
+
+  - name: soundcloud
+    engine: soundcloud
+    shortcut: sc
+
+  - name: stackoverflow
+    engine: stackexchange
+    shortcut: st
+    api_site: 'stackoverflow'
+    categories: [it, q&a]
+
+  - name: askubuntu
+    engine: stackexchange
+    shortcut: ubuntu
+    api_site: 'askubuntu'
+    categories: [it, q&a]
+
+  - name: superuser
+    engine: stackexchange
+    shortcut: su
+    api_site: 'superuser'
+    categories: [it, q&a]
+
+  - name: discuss.python
+    engine: discourse
+    shortcut: dpy
+    base_url: 'https://discuss.python.org'
+    categories: [it, q&a]
+    disabled: true
+
+  - name: caddy.community
+    engine: discourse
+    shortcut: caddy
+    base_url: 'https://caddy.community'
+    categories: [it, q&a]
+    disabled: true
+
+  - name: pi-hole.community
+    engine: discourse
+    shortcut: pi
+    categories: [it, q&a]
+    base_url: 'https://discourse.pi-hole.net'
+    disabled: true
+
+  - name: searchcode code
+    engine: searchcode_code
+    shortcut: scc
+    disabled: true
+
+  # - name: searx
+  #   engine: searx_engine
+  #   shortcut: se
+  #   instance_urls :
+  #       - http://127.0.0.1:8888/
+  #       - ...
+  #   disabled: true
+
+  - name: semantic scholar
+    engine: semantic_scholar
+    disabled: true
+    shortcut: se
+
+  # Spotify needs API credentials
+  # - name: spotify
+  #   engine: spotify
+  #   shortcut: stf
+  #   api_client_id: *******
+  #   api_client_secret: *******
+
+  # - name: solr
+  #   engine: solr
+  #   shortcut: slr
+  #   base_url: http://localhost:8983
+  #   collection: collection_name
+  #   sort: '' # sorting: asc or desc
+  #   field_list: '' # comma separated list of field names to display on the UI
+  #   default_fields: '' # default field to query
+  #   query_fields: '' # query fields
+  #   enable_http: true
+
+  # - name: springer nature
+  #   engine: springer
+  #   # get your API key from: https://dev.springernature.com/signup
+  #   # working API key, for test & debug: "a69685087d07eca9f13db62f65b8f601"
+  #   api_key: 'unset'
+  #   shortcut: springer
+  #   timeout: 15.0
+
+  - name: startpage
+    engine: startpage
+    shortcut: sp
+    startpage_categ: web
+    categories: [general, web]
+    additional_tests:
+      rosebud: *test_rosebud
+
+  - name: startpage news
+    engine: startpage
+    startpage_categ: news
+    categories: [news, web]
+    shortcut: spn
+
+  - name: startpage images
+    engine: startpage
+    startpage_categ: images
+    categories: [images, web]
+    shortcut: spi
+
+  - name: tokyotoshokan
+    engine: tokyotoshokan
+    shortcut: tt
+    timeout: 6.0
+    disabled: true
+
+  - name: solidtorrents
+    engine: solidtorrents
+    shortcut: solid
+    timeout: 4.0
+    base_url:
+      - https://solidtorrents.to
+      - https://bitsearch.to
+
+  # For this demo of the sqlite engine download:
+  #   https://liste.mediathekview.de/filmliste-v2.db.bz2
+  # and unpack into searx/data/filmliste-v2.db
+  # Query to test: "!demo concert"
+  #
+  # - name: demo
+  #   engine: sqlite
+  #   shortcut: demo
+  #   categories: general
+  #   result_template: default.html
+  #   database: searx/data/filmliste-v2.db
+  #   query_str:  >-
+  #     SELECT title || ' (' || time(duration, 'unixepoch') || ')' AS title,
+  #            COALESCE( NULLIF(url_video_hd,''), NULLIF(url_video_sd,''), url_video) AS url,
+  #            description AS content
+  #       FROM film
+  #      WHERE title LIKE :wildcard OR description LIKE :wildcard
+  #      ORDER BY duration DESC
+
+  - name: tagesschau
+    engine: tagesschau
+    # when set to false, display URLs from Tagesschau, and not the actual source
+    # (e.g. NDR, WDR, SWR, HR, ...)
+    use_source_url: true
+    shortcut: ts
+    disabled: true
+
+  - name: tmdb
+    engine: xpath
+    paging: true
+    categories: movies
+    search_url: https://www.themoviedb.org/search?page={pageno}&query={query}
+    results_xpath: //div[contains(@class,"movie") or contains(@class,"tv")]//div[contains(@class,"card")]
+    url_xpath: .//div[contains(@class,"poster")]/a/@href
+    thumbnail_xpath: .//img/@src
+    title_xpath: .//div[contains(@class,"title")]//h2
+    content_xpath: .//div[contains(@class,"overview")]
+    shortcut: tm
+    disabled: true
+
+  # Requires Tor
+  - name: torch
+    engine: xpath
+    paging: true
+    search_url:
+      http://xmh57jrknzkhv6y3ls3ubitzfqnkrwxhopf5aygthi7d6rplyvk3noyd.onion/cgi-bin/omega/omega?P={query}&DEFAULTOP=and
+    results_xpath: //table//tr
+    url_xpath: ./td[2]/a
+    title_xpath: ./td[2]/b
+    content_xpath: ./td[2]/small
+    categories: onions
+    enable_http: true
+    shortcut: tch
+
+  # torznab engine lets you query any torznab compatible indexer.  Using this
+  # engine in combination with Jackett opens the possibility to query a lot of
+  # public and private indexers directly from SearXNG. More details at:
+  # https://docs.searxng.org/dev/engines/online/torznab.html
+  #
+  # - name: Torznab EZTV
+  #   engine: torznab
+  #   shortcut: eztv
+  #   base_url: http://localhost:9117/api/v2.0/indexers/eztv/results/torznab
+  #   enable_http: true  # if using localhost
+  #   api_key: xxxxxxxxxxxxxxx
+  #   show_magnet_links: true
+  #   show_torrent_files: false
+  #   # https://github.com/Jackett/Jackett/wiki/Jackett-Categories
+  #   torznab_categories:  # optional
+  #     - 2000
+  #     - 5000
+
+  # tmp suspended - too slow, too many errors
+  #  - name: urbandictionary
+  #    engine      : xpath
+  #    search_url  : https://www.urbandictionary.com/define.php?term={query}
+  #    url_xpath   : //*[@class="word"]/@href
+  #    title_xpath : //*[@class="def-header"]
+  #    content_xpath: //*[@class="meaning"]
+  #    shortcut: ud
+
+  - name: unsplash
+    engine: unsplash
+    shortcut: us
+
+  - name: yandex
+    engine: yandex
+    categories: general
+    search_type: web
+    shortcut: yd
+    disabled: true
+    inactive: true
+
+  - name: yandex images
+    engine: yandex
+    categories: images
+    search_type: images
+    shortcut: ydi
+    disabled: true
+    inactive: true
+
+  - name: yandex music
+    engine: yandex_music
+    shortcut: ydm
+    disabled: true
+    # https://yandex.com/support/music/access.html
+    inactive: true
+
+  - name: yahoo
+    engine: yahoo
+    shortcut: yh
+    disabled: true
+
+  - name: yahoo news
+    engine: yahoo_news
+    shortcut: yhn
+
+  - name: youtube
+    shortcut: yt
+    # You can use the engine using the official stable API, but you need an API
+    # key See: https://console.developers.google.com/project
+    #
+    # engine: youtube_api
+    # api_key: 'apikey' # required!
+    #
+    # Or you can use the html non-stable engine, activated by default
+    engine: youtube_noapi
+
+  - name: dailymotion
+    engine: dailymotion
+    shortcut: dm
+
+  - name: vimeo
+    engine: vimeo
+    shortcut: vm
+
+  - name: wiby
+    engine: json_engine
+    paging: true
+    search_url: https://wiby.me/json/?q={query}&p={pageno}
+    url_query: URL
+    title_query: Title
+    content_query: Snippet
+    categories: [general, web]
+    shortcut: wib
+    disabled: true
+    about:
+      website: https://wiby.me/
+
+  - name: wikibooks
+    engine: mediawiki
+    weight: 0.5
+    shortcut: wb
+    categories: [general, wikimedia]
+    base_url: "https://{language}.wikibooks.org/"
+    search_type: text
+    disabled: true
+    about:
+      website: https://www.wikibooks.org/
+      wikidata_id: Q367
+
+  - name: wikinews
+    engine: mediawiki
+    shortcut: wn
+    categories: [news, wikimedia]
+    base_url: "https://{language}.wikinews.org/"
+    search_type: text
+    srsort: create_timestamp_desc
+    about:
+      website: https://www.wikinews.org/
+      wikidata_id: Q964
+
+  - name: wikiquote
+    engine: mediawiki
+    weight: 0.5
+    shortcut: wq
+    categories: [general, wikimedia]
+    base_url: "https://{language}.wikiquote.org/"
+    search_type: text
+    disabled: true
+    additional_tests:
+      rosebud: *test_rosebud
+    about:
+      website: https://www.wikiquote.org/
+      wikidata_id: Q369
+
+  - name: wikisource
+    engine: mediawiki
+    weight: 0.5
+    shortcut: ws
+    categories: [general, wikimedia]
+    base_url: "https://{language}.wikisource.org/"
+    search_type: text
+    disabled: true
+    about:
+      website: https://www.wikisource.org/
+      wikidata_id: Q263
+
+  - name: wikispecies
+    engine: mediawiki
+    shortcut: wsp
+    categories: [general, science, wikimedia]
+    base_url: "https://species.wikimedia.org/"
+    search_type: text
+    disabled: true
+    about:
+      website: https://species.wikimedia.org/
+      wikidata_id: Q13679
+    tests:
+      wikispecies:
+        matrix:
+          query: "Campbell, L.I. et al. 2011: MicroRNAs"
+          lang: en
+        result_container:
+          - not_empty
+          - ['one_title_contains', 'Tardigrada']
+        test:
+          - unique_results
+
+  - name: wiktionary
+    engine: mediawiki
+    shortcut: wt
+    categories: [dictionaries, wikimedia]
+    base_url: "https://{language}.wiktionary.org/"
+    search_type: text
+    about:
+      website: https://www.wiktionary.org/
+      wikidata_id: Q151
+
+  - name: wikiversity
+    engine: mediawiki
+    weight: 0.5
+    shortcut: wv
+    categories: [general, wikimedia]
+    base_url: "https://{language}.wikiversity.org/"
+    search_type: text
+    disabled: true
+    about:
+      website: https://www.wikiversity.org/
+      wikidata_id: Q370
+
+  - name: wikivoyage
+    engine: mediawiki
+    weight: 0.5
+    shortcut: wy
+    categories: [general, wikimedia]
+    base_url: "https://{language}.wikivoyage.org/"
+    search_type: text
+    disabled: true
+    about:
+      website: https://www.wikivoyage.org/
+      wikidata_id: Q373
+
+  - name: wikicommons.images
+    engine: wikicommons
+    shortcut: wc
+    categories: images
+    search_type: images
+    number_of_results: 10
+
+  - name: wikicommons.videos
+    engine: wikicommons
+    shortcut: wcv
+    categories: videos
+    search_type: videos
+    number_of_results: 10
+
+  - name: wikicommons.audio
+    engine: wikicommons
+    shortcut: wca
+    categories: music
+    search_type: audio
+    number_of_results: 10
+
+  - name: wikicommons.files
+    engine: wikicommons
+    shortcut: wcf
+    categories: files
+    search_type: files
+    number_of_results: 10
+
+  - name: wolframalpha
+    shortcut: wa
+    # You can use the engine using the official stable API, but you need an API
+    # key.  See: https://products.wolframalpha.com/api/
+    #
+    # engine: wolframalpha_api
+    # api_key: ''
+    #
+    # Or you can use the html non-stable engine, activated by default
+    engine: wolframalpha_noapi
+    timeout: 6.0
+    categories: general
+    disabled: true
+
+  - name: dictzone
+    engine: dictzone
+    shortcut: dc
+
+  - name: mymemory translated
+    engine: translated
+    shortcut: tl
+    timeout: 5.0
+    # You can use without an API key, but you are limited to 1000 words/day
+    # See: https://mymemory.translated.net/doc/usagelimits.php
+    # api_key: ''
+
+  # Required dependency: mysql-connector-python
+  #  - name: mysql
+  #    engine: mysql_server
+  #    database: mydatabase
+  #    username: user
+  #    password: pass
+  #    limit: 10
+  #    query_str: 'SELECT * from mytable WHERE fieldname=%(query)s'
+  #    shortcut: mysql
+
+  # Required dependency: mariadb
+  #  - name: mariadb
+  #    engine: mariadb_server
+  #    database: mydatabase
+  #    username: user
+  #    password: pass
+  #    limit: 10
+  #    query_str: 'SELECT * from mytable WHERE fieldname=%(query)s'
+  #    shortcut: mdb
+
+  - name: 1337x
+    engine: 1337x
+    shortcut: 1337x
+    disabled: true
+
+  - name: duden
+    engine: duden
+    shortcut: du
+    disabled: true
+
+  - name: seznam
+    shortcut: szn
+    engine: seznam
+    disabled: true
+
+  # - name: deepl
+  #   engine: deepl
+  #   shortcut: dpl
+  #   # You can use the engine using the official stable API, but you need an API key
+  #   # See: https://www.deepl.com/pro-api?cta=header-pro-api
+  #   api_key: ''  # required!
+  #   timeout: 5.0
+  #   disabled: true
+
+  - name: mojeek
+    shortcut: mjk
+    engine: mojeek
+    categories: [general, web]
+    disabled: true
+
+  - name: mojeek images
+    shortcut: mjkimg
+    engine: mojeek
+    categories: [images, web]
+    search_type: images
+    paging: false
+    disabled: true
+
+  - name: mojeek news
+    shortcut: mjknews
+    engine: mojeek
+    categories: [news, web]
+    search_type: news
+    paging: false
+    disabled: true
+
+  - name: moviepilot
+    engine: moviepilot
+    shortcut: mp
+    disabled: true
+
+  - name: naver
+    shortcut: nvr
+    categories: [general, web]
+    engine: xpath
+    paging: true
+    search_url: https://search.naver.com/search.naver?where=webkr&sm=osp_hty&ie=UTF-8&query={query}&start={pageno}
+    url_xpath: //a[@class="link_tit"]/@href
+    title_xpath: //a[@class="link_tit"]
+    content_xpath: //div[@class="total_dsc_wrap"]/a
+    first_page_num: 1
+    page_size: 10
+    disabled: true
+    about:
+      website: https://www.naver.com/
+      wikidata_id: Q485639
+      official_api_documentation: https://developers.naver.com/docs/nmt/examples/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+      language: ko
+
+  - name: rubygems
+    shortcut: rbg
+    engine: xpath
+    paging: true
+    search_url: https://rubygems.org/search?page={pageno}&query={query}
+    results_xpath: /html/body/main/div/a[@class="gems__gem"]
+    url_xpath: ./@href
+    title_xpath: ./span/h2
+    content_xpath: ./span/p
+    suggestion_xpath: /html/body/main/div/div[@class="search__suggestions"]/p/a
+    first_page_num: 1
+    categories: [it, packages]
+    disabled: true
+    about:
+      website: https://rubygems.org/
+      wikidata_id: Q1853420
+      official_api_documentation: https://guides.rubygems.org/rubygems-org-api/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: peertube
+    engine: peertube
+    shortcut: ptb
+    paging: true
+    # alternatives see: https://instances.joinpeertube.org/instances
+    # base_url: https://tube.4aem.com
+    categories: videos
+    disabled: true
+    timeout: 6.0
+
+  - name: mediathekviewweb
+    engine: mediathekviewweb
+    shortcut: mvw
+    disabled: true
+
+  - name: yacy
+    # https://docs.searxng.org/dev/engines/online/yacy.html
+    engine: yacy
+    categories: general
+    search_type: text
+    base_url:
+      - https://yacy.searchlab.eu
+      # see https://github.com/searxng/searxng/pull/3631#issuecomment-2240903027
+      # - https://search.kyun.li
+      # - https://yacy.securecomcorp.eu
+      # - https://yacy.myserv.ca
+      # - https://yacy.nsupdate.info
+      # - https://yacy.electroncash.de
+    shortcut: ya
+    disabled: true
+    # if you aren't using HTTPS for your local yacy instance disable https
+    # enable_http: false
+    search_mode: 'global'
+    # timeout can be reduced in 'local' search mode
+    timeout: 5.0
+
+  - name: yacy images
+    engine: yacy
+    network: yacy
+    categories: images
+    search_type: image
+    shortcut: yai
+    disabled: true
+    # timeout can be reduced in 'local' search mode
+    timeout: 5.0
+
+  - name: rumble
+    engine: rumble
+    shortcut: ru
+    base_url: https://rumble.com/
+    paging: true
+    categories: videos
+    disabled: true
+
+  - name: livespace
+    engine: livespace
+    shortcut: ls
+    categories: videos
+    disabled: true
+    timeout: 5.0
+
+  - name: wordnik
+    engine: wordnik
+    shortcut: def
+    categories: [dictionaries]
+    timeout: 5.0
+
+  - name: woxikon.de synonyme
+    engine: xpath
+    shortcut: woxi
+    categories: [dictionaries]
+    timeout: 5.0
+    disabled: true
+    search_url: https://synonyme.woxikon.de/synonyme/{query}.php
+    url_xpath: //div[@class="upper-synonyms"]/a/@href
+    content_xpath: //div[@class="synonyms-list-group"]
+    title_xpath: //div[@class="upper-synonyms"]/a
+    no_result_for_http_status: [404]
+    about:
+      website: https://www.woxikon.de/
+      wikidata_id:  # No Wikidata ID
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+      language: de
+
+  - name: seekr news
+    engine: seekr
+    shortcut: senews
+    categories: news
+    seekr_category: news
+    disabled: true
+
+  - name: seekr images
+    engine: seekr
+    network: seekr news
+    shortcut: seimg
+    categories: images
+    seekr_category: images
+    disabled: true
+
+  - name: seekr videos
+    engine: seekr
+    network: seekr news
+    shortcut: sevid
+    categories: videos
+    seekr_category: videos
+    disabled: true
+
+  - name: stract
+    engine: stract
+    shortcut: str
+    disabled: true
+
+  - name: svgrepo
+    engine: svgrepo
+    shortcut: svg
+    timeout: 10.0
+    disabled: true
+
+  - name: tootfinder
+    engine: tootfinder
+    shortcut: toot
+
+  - name: voidlinux
+    engine: voidlinux
+    shortcut: void
+    disabled: true
+
+  - name: wallhaven
+    engine: wallhaven
+    # api_key: abcdefghijklmnopqrstuvwxyz
+    shortcut: wh
+
+    # wikimini: online encyclopedia for children
+    # The fulltext and title parameter is necessary for Wikimini because
+    # sometimes it will not show the results and redirect instead
+  - name: wikimini
+    engine: xpath
+    shortcut: wkmn
+    search_url: https://fr.wikimini.org/w/index.php?search={query}&title=Sp%C3%A9cial%3ASearch&fulltext=Search
+    url_xpath: //li/div[@class="mw-search-result-heading"]/a/@href
+    title_xpath: //li//div[@class="mw-search-result-heading"]/a
+    content_xpath: //li/div[@class="searchresult"]
+    categories: general
+    disabled: true
+    about:
+      website: https://wikimini.org/
+      wikidata_id: Q3568032
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+      language: fr
+
+  - name: wttr.in
+    engine: wttr
+    shortcut: wttr
+    timeout: 9.0
+
+  - name: yummly
+    engine: yummly
+    shortcut: yum
+    disabled: true
+
+  - name: brave
+    engine: brave
+    shortcut: br
+    time_range_support: true
+    paging: true
+    categories: [general, web]
+    brave_category: search
+    # brave_spellcheck: true
+
+  - name: brave.images
+    engine: brave
+    network: brave
+    shortcut: brimg
+    categories: [images, web]
+    brave_category: images
+
+  - name: brave.videos
+    engine: brave
+    network: brave
+    shortcut: brvid
+    categories: [videos, web]
+    brave_category: videos
+
+  - name: brave.news
+    engine: brave
+    network: brave
+    shortcut: brnews
+    categories: news
+    brave_category: news
+
+  # - name: brave.goggles
+  #   engine: brave
+  #   network: brave
+  #   shortcut: brgog
+  #   time_range_support: true
+  #   paging: true
+  #   categories: [general, web]
+  #   brave_category: goggles
+  #   Goggles: # required! This should be a URL ending in .goggle
+
+  - name: lib.rs
+    shortcut: lrs
+    engine: lib_rs
+    disabled: true
+
+  - name: sourcehut
+    shortcut: srht
+    engine: xpath
+    paging: true
+    search_url: https://sr.ht/projects?page={pageno}&search={query}
+    results_xpath: (//div[@class="event-list"])[1]/div[@class="event"]
+    url_xpath: ./h4/a[2]/@href
+    title_xpath: ./h4/a[2]
+    content_xpath: ./p
+    first_page_num: 1
+    categories: [it, repos]
+    disabled: true
+    about:
+      website: https://sr.ht
+      wikidata_id: Q78514485
+      official_api_documentation: https://man.sr.ht/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+  - name: goo
+    shortcut: goo
+    engine: xpath
+    paging: true
+    search_url: https://search.goo.ne.jp/web.jsp?MT={query}&FR={pageno}0
+    url_xpath: //div[@class="result"]/p[@class='title fsL1']/a/@href
+    title_xpath: //div[@class="result"]/p[@class='title fsL1']/a
+    content_xpath: //p[contains(@class,'url fsM')]/following-sibling::p
+    first_page_num: 0
+    categories: [general, web]
+    disabled: true
+    timeout: 4.0
+    about:
+      website: https://search.goo.ne.jp
+      wikidata_id: Q249044
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+      language: ja
+
+  - name: bt4g
+    engine: bt4g
+    shortcut: bt4g
+
+  - name: pkg.go.dev
+    engine: pkg_go_dev
+    shortcut: pgo
+    disabled: true
+
+# Doku engine lets you access to any Doku wiki instance:
+# A public one or a privete/corporate one.
+#  - name: ubuntuwiki
+#    engine: doku
+#    shortcut: uw
+#    base_url: 'https://doc.ubuntu-fr.org'
+
+# Be careful when enabling this engine if you are
+# running a public instance. Do not expose any sensitive
+# information. You can restrict access by configuring a list
+# of access tokens under tokens.
+#  - name: git grep
+#    engine: command
+#    command: ['git', 'grep', '{{QUERY}}']
+#    shortcut: gg
+#    tokens: []
+#    disabled: true
+#    delimiter:
+#        chars: ':'
+#        keys: ['filepath', 'code']
+
+# Be careful when enabling this engine if you are
+# running a public instance. Do not expose any sensitive
+# information. You can restrict access by configuring a list
+# of access tokens under tokens.
+#  - name: locate
+#    engine: command
+#    command: ['locate', '{{QUERY}}']
+#    shortcut: loc
+#    tokens: []
+#    disabled: true
+#    delimiter:
+#        chars: ' '
+#        keys: ['line']
+
+# Be careful when enabling this engine if you are
+# running a public instance. Do not expose any sensitive
+# information. You can restrict access by configuring a list
+# of access tokens under tokens.
+#  - name: find
+#    engine: command
+#    command: ['find', '.', '-name', '{{QUERY}}']
+#    query_type: path
+#    shortcut: fnd
+#    tokens: []
+#    disabled: true
+#    delimiter:
+#        chars: ' '
+#        keys: ['line']
+
+# Be careful when enabling this engine if you are
+# running a public instance. Do not expose any sensitive
+# information. You can restrict access by configuring a list
+# of access tokens under tokens.
+#  - name: pattern search in files
+#    engine: command
+#    command: ['fgrep', '{{QUERY}}']
+#    shortcut: fgr
+#    tokens: []
+#    disabled: true
+#    delimiter:
+#        chars: ' '
+#        keys: ['line']
+
+# Be careful when enabling this engine if you are
+# running a public instance. Do not expose any sensitive
+# information. You can restrict access by configuring a list
+# of access tokens under tokens.
+#  - name: regex search in files
+#    engine: command
+#    command: ['grep', '{{QUERY}}']
+#    shortcut: gr
+#    tokens: []
+#    disabled: true
+#    delimiter:
+#        chars: ' '
+#        keys: ['line']
+
+doi_resolvers:
+  oadoi.org: 'https://oadoi.org/'
+  doi.org: 'https://doi.org/'
+  doai.io: 'https://dissem.in/'
+  sci-hub.se: 'https://sci-hub.se/'
+  sci-hub.st: 'https://sci-hub.st/'
+  sci-hub.ru: 'https://sci-hub.ru/'
+
+default_doi_resolver: 'oadoi.org'

--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -263,10 +263,10 @@ show_message() {
         tips_allow_ports)
             case $LANGUAGE in
                 zh_CN)
-                    echo "请确保服务器以下端口未被占用且能被访问：3210, 9000, 9001, 8000"
+                    echo "请确保服务器以下端口未被占用且能被访问：3210, 9000, 9001"
                 ;;
                 *)
-                    echo "Please make sure the following ports on the server are not occupied and can be accessed: 3210, 9000, 9001, 8000"
+                    echo "Please make sure the following ports on the server are not occupied and can be accessed: 3210, 9000, 9001"
                 ;;
             esac
         ;;
@@ -315,12 +315,10 @@ show_message() {
         tips_init_database_failed)
             case $LANGUAGE in
                 zh_CN)
-                    echo "无法初始化数据库，为了避免你的数据重复初始化，请在首次成功启动时运行以下指令清空 Casdoor 初始配置文件："
-                    echo "echo '{}' > init_data.json"
+                    echo "无法初始化数据库"
                 ;;
                 *)
-                    echo "Failed to initialize the database. To avoid your data being initialized repeatedly, run the following command to unmount the initial configuration file of Casdoor when you first start successfully:"
-                    echo "echo '{}' > init_data.json"
+                    echo "Failed to initialize the database."
                 ;;
             esac
         ;;
@@ -338,7 +336,7 @@ show_message() {
             case $LANGUAGE in
                 zh_CN)
                     echo "请选择部署模式："
-                    echo "(0) 域名模式（访问时无需指明端口），需要使用反向代理服务 LobeHub, RustFS, Casdoor ，并分别分配一个域名；"
+                    echo "(0) 域名模式（访问时无需指明端口），需要使用反向代理服务 LobeHub, RustFS，并分别分配一个域名；"
                     echo "(1) 端口模式（访问时需要指明端口，如使用IP访问，或域名+端口访问），需要放开指定端口；"
                     echo "(2) 本地模式（仅供本地测试使用）"
                     echo "如果你对这些内容疑惑，可以先选择使用本地模式进行部署，稍后根据文档指引再进行修改。"
@@ -346,7 +344,7 @@ show_message() {
                 ;;
                 *)
                     echo "Please select the deployment mode:"
-                    echo "(0) Domain mode (no need to specify the port when accessing), you need to use the reverse proxy service LobeHub, RustFS, Casdoor, and assign a domain name respectively;"
+                    echo "(0) Domain mode (no need to specify the port when accessing), you need to use the reverse proxy service LobeHub, RustFS, and assign a domain name respectively;"
                     echo "(1) Port mode (need to specify the port when accessing, such as using IP access, or domain name + port access), you need to open the specified port;"
                     echo "(2) Local mode (for local testing only)"
                     echo "If you are confused about these contents, you can choose to deploy in local mode first, and then modify according to the document guide later."
@@ -469,10 +467,9 @@ ask() {
 # == Variables ==
 # ===============
 # File list
-SUB_DIR="docker-compose/local"
+SUB_DIR="docker-compose/deploy"
 FILES=(
     "$SUB_DIR/docker-compose.yml"
-    "$SUB_DIR/init_data.json"
     "$SUB_DIR/searxng-settings.yml"
     "$SUB_DIR/bucket.config.json"
 )
@@ -481,10 +478,7 @@ ENV_EXAMPLES=(
     "$SUB_DIR/.env.example"
 )
 # Default values
-CASDOOR_PASSWORD="pswd123"
-CASDOOR_SECRET="CASDOOR_SECRET"
 RUSTFS_SECRET_KEY="YOUR_RUSTFS_PASSWORD"
-CASDOOR_HOST="localhost:8000"
 RUSTFS_HOST="localhost:9000"
 PROTOCOL="http"
 
@@ -514,9 +508,8 @@ section_download_files(){
     fi
     
     download_file "$SOURCE_URL/${FILES[0]}" "docker-compose.yml"
-    download_file "$SOURCE_URL/${FILES[1]}" "init_data.json"
-    download_file "$SOURCE_URL/${FILES[2]}" "searxng-settings.yml"
-    download_file "$SOURCE_URL/${FILES[3]}" "bucket.config.json"
+    download_file "$SOURCE_URL/${FILES[1]}" "searxng-settings.yml"
+    download_file "$SOURCE_URL/${FILES[2]}" "bucket.config.json"
     # Download .env.example with the specified language
     if [ "$LANGUAGE" = "zh_CN" ]; then
         download_file "$SOURCE_URL/${ENV_EXAMPLES[0]}" ".env"
@@ -576,15 +569,10 @@ section_configurate_host() {
             echo "LobeHub" $(show_message "ask_domain" "example.com")
             ask "(example.com)"
             LOBE_HOST="$ask_result"
-            # If user use domain mode, ask for the domain of RustFS and Casdoor
+            # If user use domain mode, ask for the domain of RustFS
             echo "RustFS S3 API" $(show_message "ask_domain" "s3.example.com")
             ask "(s3.example.com)"
             RUSTFS_HOST="$ask_result"
-            echo "Casdoor API" $(show_message "ask_domain" "auth.example.com")
-            ask "(auth.example.com)"
-            CASDOOR_HOST="$ask_result"
-            # Setup callback url for Casdoor
-            sed "${SED_INPLACE_ARGS[@]}" "s/"example.com"/${LOBE_HOST}/" init_data.json
         ;;
         1)
             DEPLOY_MODE="ip"
@@ -595,21 +583,15 @@ section_configurate_host() {
             # If user use ip mode, append the port to the host
             LOBE_HOST="${HOST}:3210"
             RUSTFS_HOST="${HOST}:9000"
-            CASDOOR_HOST="${HOST}:8000"
-            # Setup callback url for Casdoor
-            sed "${SED_INPLACE_ARGS[@]}" "s/"localhost:3210"/${LOBE_HOST}/" init_data.json
         ;;
         *)
             echo "Invalid deploy mode: $ask_result"
             exit 1
         ;;
     esac
-    
+
     # lobe host
     sed "${SED_INPLACE_ARGS[@]}" "s#^APP_URL=.*#APP_URL=$PROTOCOL://$LOBE_HOST#" .env
-    # auth related
-    sed "${SED_INPLACE_ARGS[@]}" "s#^AUTH_CASDOOR_ISSUER=.*#AUTH_CASDOOR_ISSUER=$PROTOCOL://$CASDOOR_HOST#" .env
-    sed "${SED_INPLACE_ARGS[@]}" "s#^origin=.*#origin=$PROTOCOL://$CASDOOR_HOST#" .env
     # s3 related
     sed "${SED_INPLACE_ARGS[@]}" "s#^S3_PUBLIC_DOMAIN=.*#S3_PUBLIC_DOMAIN=$PROTOCOL://$RUSTFS_HOST#" .env
     sed "${SED_INPLACE_ARGS[@]}" "s#^S3_ENDPOINT=.*#S3_ENDPOINT=$PROTOCOL://$RUSTFS_HOST#" .env
@@ -664,37 +646,7 @@ section_regenerate_secrets() {
         exit 1
     fi
     echo $(show_message "security_secrect_regenerate")
-    
-    # Generate CASDOOR_SECRET
-    CASDOOR_SECRET=$(generate_key 32)
-    if [ $? -ne 0 ]; then
-        echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_SECRET"
-    else
-        # Search and replace the value of CASDOOR_SECRET in .env
-        sed "${SED_INPLACE_ARGS[@]}" "s#^AUTH_CASDOOR_SECRET=.*#AUTH_CASDOOR_SECRET=${CASDOOR_SECRET}#" .env
-        if [ $? -ne 0 ]; then
-            echo $(show_message "security_secrect_regenerate_failed") "AUTH_CASDOOR_SECRET in \`.env\`"
-        fi
-        # replace `clientSecrect` in init_data.json
-        sed "${SED_INPLACE_ARGS[@]}" "s#dbf205949d704de81b0b5b3603174e23fbecc354#${CASDOOR_SECRET}#" init_data.json
-        if [ $? -ne 0 ]; then
-            echo $(show_message "security_secrect_regenerate_failed") "AUTH_CASDOOR_SECRET in \`init_data.json\`"
-        fi
-    fi
-    
-    # Generate Casdoor User
-    CASDOOR_USER="admin"
-    CASDOOR_PASSWORD=$(generate_key 10)
-    if [ $? -ne 0 ]; then
-        echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_PASSWORD"
-        CASDOOR_PASSWORD="pswd123"
-    else
-        # replace `password` in init_data.json
-        sed "${SED_INPLACE_ARGS[@]}" "s/"pswd123"/${CASDOOR_PASSWORD}/" init_data.json
-        if [ $? -ne 0 ]; then
-            echo $(show_message "security_secrect_regenerate_failed") "CASDOOR_PASSWORD in \`init_data.json\`"
-        fi
-    fi
+
     # Generate RUSTFS S3 User Password
     RUSTFS_SECRET_KEY=$(generate_key 8)
     if [ $? -ne 0 ]; then
@@ -735,13 +687,10 @@ section_init_database() {
     fi
 
     docker compose pull
-    docker compose up --detach postgresql casdoor
+    docker compose up --detach postgresql
     # hopefully enough time for even the slower systems
 	sleep 15
 	docker compose stop
-
-    # Init finished, remove init mount
-    echo '{}' > init_data.json
 }
 
 show_message "ask_init_database"
@@ -759,16 +708,14 @@ fi
 section_display_configurated_report() {
     # Display configuration reports
     echo $(show_message "security_secrect_regenerate_report")
-    
-    echo -e "LobeHub: \n  - URL: $PROTOCOL://$LOBE_HOST \n  - Username: user \n  - Password: ${CASDOOR_PASSWORD} "
-    echo -e "Casdoor: \n  - URL: $PROTOCOL://$CASDOOR_HOST \n  - Username: admin \n  - Password: ${CASDOOR_PASSWORD}\n"
+
+    echo -e "LobeHub: \n  - URL: $PROTOCOL://$LOBE_HOST"
     echo -e "RustFS: \n  - URL: $PROTOCOL://$RUSTFS_HOST \n  - Username: admin\n  - Password: ${RUSTFS_SECRET_KEY}\n"
-    
+
     # if user run in domain mode, diplay reverse proxy configuration
     if [[ "$DEPLOY_MODE" == "domain" ]]; then
         echo $(show_message "tips_add_reverse_proxy")
         printf "\n%s\t->\t%s\n" "$LOBE_HOST" "127.0.0.1:3210"
-        printf "%s\t->\t%s\n" "$CASDOOR_HOST" "127.0.0.1:8000"
         printf "%s\t->\t%s\n" "$RUSTFS_HOST" "127.0.0.1:9000"
     fi
 

--- a/docker-compose/setup.sh
+++ b/docker-compose/setup.sh
@@ -406,31 +406,33 @@ download_file() {
 }
 
 print_centered() {
-    # Define colors
-    declare -A colors
-    colors=(
-        [black]="\e[30m"
-        [red]="\e[31m"
-        [green]="\e[32m"
-        [yellow]="\e[33m"
-        [blue]="\e[34m"
-        [magenta]="\e[35m"
-        [cyan]="\e[36m"
-        [white]="\e[37m"
-        [reset]="\e[0m"
-    )
     local text="$1"                                   # Get input texts
     local color="${2:-reset}"                         # Get color, default to reset
     local term_width=$(tput cols)                     # Get terminal width
     local text_length=${#text}                        # Get text length
     local padding=$(((term_width - text_length) / 2)) # Get padding
-    # Check if the color is valid
-    if [[ -z "${colors[$color]}" ]]; then
-        echo "Invalid color specified. Available colors: ${!colors[@]}"
-        return 1
-    fi
+
+    # Get color code (compatible with bash 3.x)
+    local color_code=""
+    local reset_code="\e[0m"
+    case "$color" in
+        black)   color_code="\e[30m" ;;
+        red)     color_code="\e[31m" ;;
+        green)   color_code="\e[32m" ;;
+        yellow)  color_code="\e[33m" ;;
+        blue)    color_code="\e[34m" ;;
+        magenta) color_code="\e[35m" ;;
+        cyan)    color_code="\e[36m" ;;
+        white)   color_code="\e[37m" ;;
+        reset)   color_code="\e[0m" ;;
+        *)
+            echo "Invalid color specified. Available colors: black red green yellow blue magenta cyan white reset"
+            return 1
+        ;;
+    esac
+
     # Print the text with padding
-    printf "%*s${colors[$color]}%s${colors[reset]}\n" $padding "" "$text"
+    printf "%*s${color_code}%s${reset_code}\n" $padding "" "$text"
 }
 
 # Usage:

--- a/docs/self-hosting/advanced/auth/providers/casdoor.mdx
+++ b/docs/self-hosting/advanced/auth/providers/casdoor.mdx
@@ -81,6 +81,116 @@ tags:
   After successful deployment, users will be able to authenticate with Casdoor and use LobeChat.
 </Callout>
 
+## Docker Compose Deployment with Casdoor
+
+If you're deploying LobeHub using Docker Compose, refer to the following configuration to integrate Casdoor as an authentication service.
+
+### Reverse Proxy Configuration
+
+In domain mode, you need to configure a reverse proxy to ensure Casdoor is accessible:
+
+| Domain             | Proxy Port | Description     |
+| ------------------ | ---------- | --------------- |
+| `auth.example.com` | `8000`     | Casdoor service |
+
+<Callout type="important">
+  If you're using panel software like [aaPanel](https://www.bt.cn/) for reverse proxy configuration,
+  ensure it does not intercept requests to the `.well-known` path to facilitate the proper functioning of Casdoor's OAuth2 configuration.
+  Below is a whitelist configuration for the Nginx server block concerning paths for Casdoor reverse proxy:
+
+  ```nginx
+  location /.well-known/openid-configuration {
+    proxy_pass http://localhost:8000;  # Forward to localhost:8000
+    proxy_set_header Host $host;  # Keep the original host header
+    proxy_set_header X-Real-IP $remote_addr;  # Keep the client's real IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # Keep the forwarded IP
+    proxy_set_header X-Forwarded-Proto $scheme;  # Keep the request protocol
+  }
+  ```
+
+  ⚠️ Please do not enable any form of caching in the reverse proxy settings of such panel software to avoid affecting the normal operation of the service.
+  See [https://github.com/lobehub/lobe-chat/discussions/5986](https://github.com/lobehub/lobe-chat/discussions/5986)
+</Callout>
+
+### Required Configuration
+
+1. LobeHub needs to communicate with Casdoor, so you need to configure Casdoor's Issuer:
+
+```env
+AUTH_CASDOOR_ISSUER=https://auth.example.com
+```
+
+This configuration affects LobeHub's login authentication service. Ensure the Casdoor service URL is correct.
+
+2. Allow callback URL in Casdoor to point to LobeHub:
+
+In Casdoor's Web panel under `Authentication -> Applications` -> `<Application ID, default is app-built-in>` -> `Redirect URLs`, add:
+
+```
+https://lobe.example.com/api/auth/callback/casdoor
+```
+
+3. Casdoor needs Origin information in environment variables:
+
+```env
+origin=https://auth.example.com
+```
+
+### Troubleshooting
+
+#### Cannot Login Properly
+
+Check container logs for the following errors:
+
+```sh
+docker logs -f lobehub
+```
+
+**r3: "response" is not a conform Authorization Server Metadata response**
+
+```log
+lobehub      | [auth][error] r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
+```
+
+Cause: This issue is typically caused by improper reverse proxy configuration. Ensure your reverse proxy doesn't intercept Casdoor's OAuth2 configuration requests.
+
+Solution:
+
+- Refer to the reverse proxy configuration notes above.
+
+- Direct troubleshooting: Access `https://auth.example.com/.well-known/openid-configuration`:
+  - If non-JSON data is returned, your reverse proxy configuration is incorrect.
+  - If the returned JSON's `"issuer": "URL"` field doesn't match `https://auth.example.com`, your environment variable configuration is incorrect.
+
+**TypeError: fetch failed**
+
+```log
+lobehub      | [auth][error] TypeError: fetch failed
+```
+
+Cause: LobeHub cannot access the authentication service.
+
+Solution:
+
+- Check if your authentication service is running properly and if LobeHub's network can reach it.
+
+- Direct troubleshooting: Use `curl` in the LobeHub container terminal to access `https://auth.example.com/.well-known/openid-configuration`. If JSON data is returned, your authentication service is working correctly.
+
+#### OAuth Token Exchange Failures with Reverse Proxy
+
+If OAuth authentication fails during the token exchange phase when using Docker behind a reverse proxy, this is typically caused by the default `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` setting.
+
+**Solution**: Set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` in your `.env` file and restart Docker containers:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+### Docker Compose Configuration Files
+
+Casdoor Docker Compose configuration files can be found in the [docker-compose/local/casdoor](https://github.com/lobehub/lobe-chat/tree/main/docker-compose/local/casdoor) directory.
+
 ## Related Resources
 
 - [Casdoor Documentation](https://casdoor.org/docs/overview)

--- a/docs/self-hosting/advanced/auth/providers/casdoor.zh-CN.mdx
+++ b/docs/self-hosting/advanced/auth/providers/casdoor.zh-CN.mdx
@@ -77,6 +77,171 @@ tags:
 
 <Callout type={'info'}>部署成功后，用户将可以通过 Casdoor 身份认证并使用 LobeChat。</Callout>
 
+## Docker Compose 部署 Casdoor
+
+如果你使用 Docker Compose 部署 LobeHub，可以参考以下配置来集成 Casdoor 作为鉴权服务。
+
+### 反向代理配置
+
+在域名模式中，你需要完成反向代理配置，并确保局域网 / 公网能访问到 Casdoor 服务：
+
+| 域名                 | 反代端口   | 说明         |
+| ------------------ | ------ | ---------- |
+| `auth.example.com` | `8000` | Casdoor 服务 |
+
+<Callout type="important">
+  如果你使用如 [宝塔面板](https://www.bt.cn/) 等面板软件进行反向代理配置，
+  你需要确保其对 `.well-known` 路径的请求不进行拦截，以确保 Casdoor 的 OAuth2 配置能够正常工作。
+  这里提供一份针对 Casdoor 服务的 Nginx server 块的路径白名单配置：
+
+  ```nginx
+  location /.well-known/openid-configuration {
+    proxy_pass http://localhost:8000;  # 转发到 localhost:8000
+    proxy_set_header Host $host;  # 保留原始主机头
+    proxy_set_header X-Real-IP $remote_addr;  # 保留客户端真实IP
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # 保留转发的IP
+    proxy_set_header X-Forwarded-Proto $scheme;  # 保留请求协议
+  }
+  ```
+
+  ⚠️ 请不要在此类面板软件的反向代理设置中开启任何形式的缓存，以免影响服务的正常运行。
+  详情请见 [https://github.com/lobehub/lobe-chat/discussions/5986](https://github.com/lobehub/lobe-chat/discussions/5986)
+</Callout>
+
+### 必要配置
+
+1. LobeHub 需要与 Casdoor 通讯，因此你需要配置 Casdoor 的 Issuer：
+
+```env
+AUTH_CASDOOR_ISSUER=https://auth.example.com
+```
+
+该配置会影响 LobeHub 的登录鉴权服务，你需要确保 Casdoor 服务的地址正确。
+
+2. 在 Casdoor 中允许回调地址为 LobeHub 的地址：
+
+请在 Casdoor 的 Web 面板的 `身份认证 -> 应用` -> `<应用ID，默认为 app-built-in>` -> `重定向URL` 中添加一行：
+
+```
+https://lobe.example.com/api/auth/callback/casdoor
+```
+
+3. Casdoor 需要在环境变量中提供访问的 Origin 信息：
+
+```env
+origin=https://auth.example.com
+```
+
+### 使用 MinIO 存储 Casdoor 头像
+
+允许用户在 Casdoor 中更换头像：
+
+1. 你需要首先在 `buckets` 中创建一个名为 `casdoor` 的桶，选择自定义策略，复制并粘贴如下内容：
+
+   ```json
+   {
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "AWS": ["*"]
+         },
+         "Action": ["s3:GetBucketLocation"],
+         "Resource": ["arn:aws:s3:::casdoor"]
+       },
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "AWS": ["*"]
+         },
+         "Action": ["s3:ListBucket"],
+         "Resource": ["arn:aws:s3:::casdoor"],
+         "Condition": {
+           "StringEquals": {
+             "s3:prefix": ["files/*"]
+           }
+         }
+       },
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "AWS": ["*"]
+         },
+         "Action": ["s3:PutObject", "s3:DeleteObject", "s3:GetObject"],
+         "Resource": ["arn:aws:s3:::casdoor/**"]
+       }
+     ],
+     "Version": "2012-10-17"
+   }
+   ```
+
+2. 创建一个新的访问密钥，将生成的 `Access Key` 和 `Secret Key` 存储之
+
+3. 在 Casdoor 的 `身份认证 -> 提供商` 中关联 MinIO S3 服务，以下是一个示例配置：
+
+   ![casdoor](/blog/assets18bb134dbc5792d6a624199cca8bf7d3.webp)
+
+   其中，客户端 ID、客户端密钥为上一步创建的访问密钥中的 `Access Key` 和 `Secret Key`，`192.168.31.251` 应当被替换为 `your_server_ip`。
+
+4. 在 Casdoor 的 `身份认证 -> 应用` 中，对 `app-built-in` 应用添加提供商，选择 `minio`，保存并退出
+
+5. 你可以在 Casdoor 的 `身份认证 -> 资源` 中，尝试上传文件以测试配置是否正确
+
+### 常见问题
+
+#### 无法正常登陆
+
+请根据容器日志检查是否存在以下错误：
+
+```sh
+docker logs -f lobe-chat
+```
+
+**r3: "response" is not a conform Authorization Server Metadata response**
+
+```log
+lobe-chat      | [auth][error] r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
+```
+
+成因：该问题一般是由于你的反向代理配置不正确导致的，你需要确保你的反向代理配置不会拦截 Casdoor 的 OAuth2 配置请求。
+
+解决方案：
+
+- 请参考上方的反向代理配置注意事项。
+
+- 一个直接的排查方式，你可以直接访问 `https://auth.example.com/.well-known/openid-configuration`，如果：
+  - 返回了非 JSON 格式的数据，则说明你的反向代理配置错误。
+  - 如果返回的 JSON 格式数据中的 `"issuer": "URL"` 字段不是你配置的 `https://auth.example.com`，则说明你的环境变量配置错误。
+
+**TypeError: fetch failed**
+
+```log
+lobe-chat      | [auth][error] TypeError: fetch failed
+```
+
+成因：LobeHub 无法访问鉴权服务。
+
+解决方案：
+
+- 请检查你的鉴权服务是否正常运行，以及 LobeHub 所在的网络是否能够访问到鉴权服务。
+
+- 一个直接的排查方式，你可以在 LobeHub 容器的终端中，使用 `curl` 命令访问你的鉴权服务 `https://auth.example.com/.well-known/openid-configuration`，如果返回了 JSON 格式的数据，则说明你的鉴权服务正常运行。
+
+#### 反向代理下 OAuth 令牌交换失败
+
+如果在反向代理后使用 Docker 时 OAuth 认证在令牌交换阶段失败，这通常是由默认的 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` 设置引起的，该设置会将 URL 重写为 `127.0.0.1:3210`。
+
+**解决方案**: 在 `.env` 文件中设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` 并重启 Docker 容器：
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+### Docker Compose 配置文件
+
+Casdoor 的 Docker Compose 配置文件可以在 [docker-compose/local/casdoor](https://github.com/lobehub/lobe-chat/tree/main/docker-compose/local/casdoor) 目录中找到。
+
 ## 相关资源
 
 - [Casdoor 文档](https://casdoor.org/docs/overview)

--- a/docs/self-hosting/platform/docker-compose.mdx
+++ b/docs/self-hosting/platform/docker-compose.mdx
@@ -31,7 +31,7 @@ tags:
 
   - The one-click startup script is only for initial deployment; for subsequent deployments, please refer to the [Custom Deployment](#custom-deployment) section.
 
-  - Port occupation check: Ensure that ports `3210`, `8000`, `9000`, and `9001` are available.
+  - Port occupation check: Ensure that ports `3210`, `9000`, and `9001` are available.
 </Callout>
 
 Execute the following commands to set up the deployment environment; the directory `lobehub` will be used to store your configuration files and subsequent database files.
@@ -67,24 +67,13 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Check Configuration Generation Report
 
-  After the script finishes running, you need to check the configuration generation report, which includes the accounts and initial login passwords for the Casdoor administrator and user.
-
-  <Callout type="warning">
-    Please log in to LobeHub using the user account; the administrator account is only for managing
-    Casdoor.
-  </Callout>
+  After the script finishes running, check the configuration generation report which includes service URLs and passwords.
 
   ```log
   The results of the secure key generation are as follows:
   LobeHub:
     - URL: http://localhost:3210
-    - Username: user
-    - Password: c66f8c
-  Casdoor:
-    - URL: http://localhost:8000
-    - Username: admin
-    - Password: c66f8c
-  Minio:
+  RustFS:
     - URL: http://localhost:9000
     - Username: admin
     - Password: 8c82ea41
@@ -99,7 +88,7 @@ The script supports the following deployment modes; please choose the appropriat
   ### Check Logs
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   If you see the following logs in the container, it means the startup was successful:
@@ -108,7 +97,7 @@ The script supports the following deployment modes; please choose the appropriat
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        http://localhost:3210
     - Network:      http://0.0.0.0:3210
 
@@ -118,7 +107,7 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Access Application
 
-  Visit your LobeHub service at [http://localhost:3210](http://localhost:3210). The account credentials for the application can be found in the report from step `2`.
+  Visit your LobeHub service at [http://localhost:3210](http://localhost:3210).
 </Steps>
 
 ### Port Mode
@@ -133,24 +122,13 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Check Configuration Generation Report
 
-  After the script finishes running, please check the configuration generation report for the Casdoor administrator account, user account, and their initial login passwords.
-
-  <Callout type="warning">
-    Please log in to LobeHub using the user account; the administrator account is only for managing
-    Casdoor.
-  </Callout>
+  After the script finishes running, check the configuration generation report which includes service URLs and passwords.
 
   ```log
   The results of the secure key generation are as follows:
   LobeHub:
     - URL: http://your_server_ip:3210
-    - Username: user
-    - Password: 837e26
-  Casdoor:
-    - URL: http://your_server_ip:8000
-    - Username: admin
-    - Password: 837e26
-  Minio:
+  RustFS:
     - URL: http://your_server_ip:9000
     - Username: admin
     - Password: dbac8440
@@ -165,7 +143,7 @@ The script supports the following deployment modes; please choose the appropriat
   ### Check Logs
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   If you see the following logs in the container, it means the startup was successful:
@@ -174,7 +152,7 @@ The script supports the following deployment modes; please choose the appropriat
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        http://your_server_ip:3210
     - Network:      http://0.0.0.0:3210
    ✓ Starting...
@@ -183,14 +161,7 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Access Application
 
-  You can access your LobeHub service at `http://your_server_ip:3210`. The account credentials for the application can be found in the report from step `2`.
-
-  <Callout type="warning">
-    If your service can accessed via the public network,
-    we strongly recommend disabling the registration,
-    refer to the [documentation](https://lobehub.com/docs/self-hosting/advanced/auth/providers/casdoor)
-    for more information.
-  </Callout>
+  You can access your LobeHub service at `http://your_server_ip:3210`.
 </Steps>
 
 ### Domain Mode
@@ -200,40 +171,18 @@ The script supports the following deployment modes; please choose the appropriat
 
   In domain mode, you need to complete the reverse proxy configuration and ensure that the LAN/public can access the following services. Please use a reverse proxy to map the following service ports to the domain names:
 
-  | Domain                 | Proxy Port | Required |
-  | ---------------------- | ---------- | -------- |
-  | `lobe.example.com`     | `3210`     | Yes      |
-  | `auth.example.com`     | `8000`     | Yes      |
-  | `minio.example.com`    | `9000`     | Yes      |
-  | `minio-ui.example.com` | `9001`     |          |
-
-  <Callout type="important">
-    If you are using panel software like [aaPanel](https://www.bt.cn/) for reverse proxy configuration,
-    ensure it does not intercept requests to the `.well-known` path to facilitate the proper functioning of Casdoor's OAuth2 configuration.
-    Below is a whitelist configuration for the Nginx server block concerning paths for Casdoor reverse proxy:
-
-    ```nginx
-    location /.well-known/openid-configuration {
-    proxy_pass http://localhost:8000;  # Forward to localhost:8000
-    proxy_set_header Host $host;  # Keep the original host header
-    proxy_set_header X-Real-IP $remote_addr;  # Keep the client's real IP
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # Keep the forwarded IP
-    proxy_set_header X-Forwarded-Proto $scheme;  # Keep the request protocol
-    }
-    ```
-
-    ⚠️ If you are using such panel software,
-    please do not enable any form of caching in the reverse proxy settings of such panel software to avoid affecting the normal operation of the service.
-    Read more at [https://github.com/lobehub/lobe-chat/discussions/5986](https://github.com/lobehub/lobe-chat/discussions/5986)
-  </Callout>
+  | Domain              | Proxy Port | Required |
+  | ------------------- | ---------- | -------- |
+  | `lobe.example.com`  | `3210`     | Yes      |
+  | `s3.example.com`    | `9000`     | Yes      |
+  | `s3-ui.example.com` | `9001`     |          |
 
   ### Complete Remaining Configuration in Interactive Script
 
   In domain mode, you need to complete the following configurations based on script prompts:
 
   - Domain setup for the LobeHub service: `lobe.example.com`
-  - Domain setup for the Minio service: `minio.example.com`
-  - Domain setup for the Casdoor service: `auth.example.com`
+  - Domain setup for the S3 service: `s3.example.com`
   - Choose the access protocol: `http` or `https`
   - Regenerate secure keys: We highly recommend regenerating the secure keys; if you lack the key generation library required by the script, we suggest referring to the [Custom Deployment](#custom-deployment) section for key modifications.
 
@@ -249,25 +198,14 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Check Configuration Generation Report
 
-  After the script finishes running, you need to check the configuration generation report, which includes the initial login password for the Casdoor administrator.
-
-  <Callout type="warning">
-    Please log in to LobeHub using the user account; the administrator account is only for managing
-    Casdoor.
-  </Callout>
+  After the script finishes running, check the configuration generation report which includes service URLs and passwords.
 
   ```log
   The results of the secure key generation are as follows:
   LobeHub:
     - URL: https://lobe.example.com
-    - Username: user
-    - Password: 837e26
-  Casdoor:
-    - URL: https://auth.example.com
-    - Username: admin
-    - Password: 837e26
-  Minio:
-    - URL: https://minio.example.com
+  RustFS:
+    - URL: https://s3.example.com
     - Username: admin
     - Password: dbac8440
   ```
@@ -281,7 +219,7 @@ The script supports the following deployment modes; please choose the appropriat
   ### Check Logs
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   If you see the following logs in the container, it indicates a successful startup:
@@ -290,7 +228,7 @@ The script supports the following deployment modes; please choose the appropriat
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        https://localhost:3210
     - Network:      http://0.0.0.0:3210
     ✓ Starting...
@@ -299,23 +237,16 @@ The script supports the following deployment modes; please choose the appropriat
 
   ### Access Application
 
-  You can access your LobeHub service via `https://lobe.example.com`. The account credentials for the application can be found in the report from step `3`.
-
-  <Callout type="warning">
-    If your service can accessed via the public network,
-    we strongly recommend disabling the registration,
-    refer to the [documentation](https://lobehub.com/docs/self-hosting/advanced/auth/providers/casdoor)
-    for more information.
-  </Callout>
+  You can access your LobeHub service via `https://lobe.example.com`.
 </Steps>
 
 ## Custom Deployment
 
-This section mainly introduces the configurations that need to be modified to customize the deployment of the LobeHub service in different network environments. Before starting, you can download the [Docker Compose configuration file](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/docker-compose.yml) and the [environment variable configuration file](https://raw.githubusercontent.com/lobehub/lobe-chat/refs/heads/main/docker-compose/local/.env.example).
+This section mainly introduces the configurations that need to be modified to customize the deployment of the LobeHub service in different network environments. Before starting, you can download the [Docker Compose configuration file](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/docker-compose.yml) and the [environment variable configuration file](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/.env.example).
 
 ```sh
-curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/docker-compose.yml
-curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/.env.example
+curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/.env.example
 mv .env.example .env
 ```
 
@@ -326,16 +257,15 @@ mv .env.example .env
 
 ### Prerequisites
 
-Generally, to fully run the LobeHub database version, you will need at least the following four services:
+Generally, to fully run the LobeHub database version, you will need at least the following three services:
 
 - The LobeHub database version itself
 - PostgreSQL database with PGVector plugin
 - Object storage service that supports S3 protocol
-- An SSO authentication service supported by LobeHub
 
 These services can be combined through self-hosting or online cloud services to meet various deployment needs. In this article, we provide a Docker Compose configuration entirely based on open-source self-hosted services, which can be used directly to start the LobeHub database version or modified to suit your requirements.
 
-We use [MinIO](https://github.com/minio/minio) as the local S3 object storage service and [Casdoor](https://github.com/casdoor/casdoor) as the local authentication service by default.
+We use [RustFS](https://github.com/rustfs/rustfs) as the local S3 object storage service by default. To configure SSO authentication services, please refer to the [Authentication Services](/docs/self-hosting/advanced/auth) documentation.
 
 <Callout type="warning">
   If your network topology is complex, please make sure these services can communicate properly
@@ -346,40 +276,16 @@ We use [MinIO](https://github.com/minio/minio) as the local S3 object storage se
 
 Now, we will introduce the necessary configurations for running these services:
 
-1. Casdoor
+1. S3 Object Storage
 
-- LobeHub requires communication with Casdoor, so you need to configure Casdoor's Issuer.
-
-```env
-AUTH_CASDOOR_ISSUER=https://auth.example.com
-```
-
-This configuration will affect LobeHub's login authentication service, and you need to ensure that the URL of the Casdoor service is correct. You can find common manifestations and solutions for errors in this configuration in the [FAQ](#faq).
-
-- Additionally, you need to allow the callback URL in Casdoor to point to the LobeHub address:
-
-Please add a line in the `Authentication -> Application` -> `<Application ID, default is app-built-in>` -> `Redirect URI` in Casdoor's web panel:
-
-```
-https://auth.example.com/api/auth/callback/casdoor
-```
-
-- Casdoor needs to provide the Origin information for access in the environment variables:
+LobeHub needs to provide a public access URL for object files for the LLM service provider, so you need to configure the S3 Endpoint:
 
 ```env
-origin=https://auth.example.com
+S3_PUBLIC_DOMAIN=https://s3.example.com
+S3_ENDPOINT=https://s3.example.com
 ```
 
-2. MinIO
-
-- LobeHub needs to provide a public access URL for object files for the LLM service provider, hence you need to configure MinIO's Endpoint.
-
-```env
-S3_PUBLIC_DOMAIN=https://minio.example.com
-S3_ENDPOINT=https://minio.example.com
-```
-
-3. PostgreSQL
+2. PostgreSQL
 
 This configuration is found in the `docker-compose.yml` file, and you will need to configure the database name and password:
 
@@ -392,220 +298,16 @@ services:
 
 ## FAQ
 
-#### Unable to Log In Properly
+#### Database Migration Issues
 
-Check for the following errors based on the container logs:
-
-```sh
-docker logs -f lobe-chat
-```
-
-- r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
-
-```log
-lobe-chat      | [auth][error] r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
-```
-
-Cause: This issue is typically caused by improper reverse proxy configuration; you need to ensure your reverse proxy configuration does not intercept the Casdoor OAuth2 configuration requests.
-
-Solutions:
-
-- Please refer to the reverse proxy configuration notes in the [Domain Mode](#domain-mode) section.
-
-- A direct troubleshooting method is to access `https://auth.example.com/.well-known/openid-configuration` directly; if:
-
-  - Non-JSON format data is returned, it indicates your reverse proxy configuration is incorrect.
-  - If the returned JSON format data contains an `"issuer": "URL"` field that does not match your configured `https://auth.example.com`, it indicates your environment variable configuration is incorrect.
-
-- TypeError: fetch failed
-
-```log
-lobe-chat      | [auth][error] TypeError: fetch failed
-```
-
-Cause: LobeHub cannot access the authentication service.
-
-Solutions:
-
-- Check whether your authentication service is running properly and whether LobeHub's network can reach the authentication service.
-
-- A straightforward troubleshooting method is to use the `curl` command in the LobeHub container terminal to access your authentication service at `https://auth.example.com/.well-known/openid-configuration`. If JSON format data is returned, it indicates your authentication service is functioning correctly.
-
-#### OAuth Token Exchange Failures with Reverse Proxy
-
-If OAuth authentication fails during the token exchange phase when using Docker behind a reverse proxy, this is typically caused by the default `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` setting which rewrites URLs to `127.0.0.1:3210`.
-
-**Solution**: Set `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` in your `.env` file and restart Docker containers:
-
-```bash
-docker compose down
-docker compose up -d
-```
-
-````markdown
-## Extended Configuration
-
-To enhance your LobeHub service, you can perform the following extended configurations according to your needs.
-
-### Use MinIO to Store Casdoor Avatars
-
-Allow users to change their avatars in Casdoor.
-
-1. First, create a bucket named `casdoor` in `buckets`, select a custom policy, and copy and paste the content below (if you modify the bucket name, please find and replace accordingly).
-
-   ```json
-   {
-     "Statement": [
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:GetBucketLocation"],
-         "Resource": ["arn:aws:s3:::casdoor"]
-       },
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:ListBucket"],
-         "Resource": ["arn:aws:s3:::casdoor"],
-         "Condition": {
-           "StringEquals": {
-             "s3:prefix": ["files/*"]
-           }
-         }
-       },
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:PutObject", "s3:DeleteObject", "s3:GetObject"],
-         "Resource": ["arn:aws:s3:::casdoor/**"]
-       }
-     ],
-     "Version": "2012-10-17"
-   }
-   ```
-````
-
-2. Create a new access key and store the generated `Access Key` and `Secret Key`.
-
-3. In Casdoor's `Authentication -> Providers`, associate the MinIO S3 service. Below is an example configuration:
-
-   ![casdoor](/blog/assets18bb134dbc5792d6a624199cca8bf7d3.webp)
-
-   Here, the client ID and client secret correspond to the `Access Key` and `Secret Key` from the previous step; replace `192.168.31.251` with `your_server_ip`.
-
-4. In Casdoor's `Authentication -> Apps`, add a provider to the `app-built-in` application, select `minio`, and save and exit.
-
-5. You can attempt to upload a file in Casdoor's `Authentication -> Resources` to test if the configuration is correct.
-
-### Migrating from `logto` to `Casdoor` in Production Deployment
-
-This is applicable for users who have been using `logto` as their login and authentication service in a production environment.
-
-<Callout type="info">
-  Due to significant instability when using [Logto](https://logto.io/) as a login and authentication
-  service, the following tutorial is based on deploying with an IP mode, implementing a domain
-  release solution using Casdoor as the authentication service provider. The remainder of this
-  article will illustrate using this as an example. If you are using other login authentication
-  services like Logto, the process should be similar, but be aware that port configurations may
-  differ among different services.
-</Callout>
-
-In the following, it is assumed that in addition to the above services, you are also running an **Nginx** layer for reverse proxy and SSL configuration.
-
-The domain and corresponding service port descriptions are as follows:
-
-- `lobe.example.com`: This is your LobeHub service domain, which needs to reverse proxy to the LobeHub service port, default is `3210`.
-- `auth.example.com`: This is your Logto UI domain, which needs to reverse proxy to the Logto WebUI service port, default is `8000`.
-- `minio.example.com`: This is your MinIO API domain, which needs to reverse proxy to the MinIO API service port, default is `9000`.
-- `minio-ui.example.com`: Optional, this is your MinIO UI domain, which needs to reverse proxy to the MinIO WebUI service port, default is `9001`.
-
-#### Configuration File
+You can check the logs using the following command:
 
 ```sh
-bash <(curl -fsSL https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/setup.sh) -f -l zh_CN
-docker compose up -d
-```
-
-Make sure to save the newly generated password at this time!
-
-After running, you will get three files:
-
-- init\_data.json
-- docker-compose.yml
-- .env
-
-Next, modify the configuration files to achieve domain release.
-
-1. Modify the `docker-compose.yml` file.
-
-   1. Change the `MINIO_API_CORS_ALLOW_ORIGIN` field of `minio`.
-
-   ```yaml
-   'MINIO_API_CORS_ALLOW_ORIGIN=https://lobe.example.com'
-   ```
-
-   2. Modify the `origin` field of `casdoor`.
-
-   ```yaml
-   origin: 'https://auth.example.com'
-   ```
-
-   3. Modify the `environment` field of `lobe`.
-
-   ```yaml
-   # - 'APP_URL=http://localhost:3210'
-   - 'APP_URL=https://lobe.example.com'
-
-   - 'AUTH_SSO_PROVIDERS=casdoor'
-   - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
-   - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
-   # - 'AUTH_URL=http://localhost:${LOBE_PORT}/api/auth'
-   - 'AUTH_URL=https://lobe.example.com/api/auth'
-
-   # - 'AUTH_CASDOOR_ISSUER=http://localhost:${CASDOOR_PORT}'
-   - 'AUTH_CASDOOR_ISSUER=https://auth.example.com'
-
-   - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
-   # - 'S3_ENDPOINT=http://localhost:${MINIO_PORT}'
-   - 'S3_ENDPOINT=https://minio.example.com'
-
-   - 'S3_BUCKET=${MINIO_LOBE_BUCKET}'
-   # - 'S3_PUBLIC_DOMAIN=http://localhost:${MINIO_PORT}'
-   - 'S3_PUBLIC_DOMAIN=https://minio.example.com'
-
-   - 'S3_ENABLE_PATH_STYLE=1'
-   - 'LLM_VISION_IMAGE_USE_BASE64=1'
-   ```
-
-2. Modify the `.env` file.
-
-<Callout type="info">For security reasons, modify the ROOT USER field in the `.env` file.</Callout>
-
-```sh
-# MinIO S3 configuration
-MINIO_ROOT_USER=XXXX
-MINIO_ROOT_PASSWORD=XXXX
-```
-
-#### Postgres Database Configuration
-
-You can check the logs with the following command:
-
-```sh
-docker logs -f lobe-chat
+docker logs -f lobehub
 ```
 
 <Callout type="tip">
-  In our official Docker images, automatic migration of the database schema is performed before
-  starting the images. Our official images guarantee the stability of "empty database -> complete
-  tables" for automatic table creation. Therefore, we recommend your database instance use an empty
-  table instance to avoid the trouble of manually maintaining table structure or migrations.
+  In our official Docker images, database schema migration is automatically performed before starting. Our official images guarantee the stability of "empty database -> complete tables" for automatic table creation. Therefore, we recommend your database instance use an empty table instance to avoid the trouble of manually maintaining table structure or migrations.
 </Callout>
 
 If you encounter issues during table creation, you can try the following command to forcibly remove the database container and restart:
@@ -616,71 +318,10 @@ sudo rm -rf ./data   # Remove mounted database data
 docker compose up -d # Restart
 ```
 
-#### Login Authentication Service Configuration
-
-You first need to access the WebUI for configuration:
-
-- If you have set up the reverse proxy as mentioned before, open `https://auth.example.com`
-- Otherwise, after port mapping, open `http://localhost:8000`
-
-Log in to the admin account:
-
-- The default username is admin.
-- The default password is the random password generated when downloading the config file. If forgotten, you can find it in the `init_data.json` file.
-
-After logging in, perform the following actions:
-
-1. In `User Management -> Organizations`, add a new organization with the name and display name `Lobe Users`. Keep the rest as default.
-2. In `Authentication -> Apps`, add a new application.
-
-- Name and display name should be `LobeHub`.
-- Organization should be `Lobe Users`.
-- Add a line in Redirect URLs as `https://lobe.example.com/api/auth/callback/casdoor`.
-- Disable all login methods except password.
-- Fill in the client ID and client secret in the `.env` file under `AUTH_CASDOOR_ID` and `AUTH_CASDOOR_SECRET`.
-- (Optional) Design the appearance of the login and registration pages by mimicking the `built-in` application configuration.
-- Save and exit.
+#### Using `INTERNAL_APP_URL` for Internal Server Communication
 
 <Callout type="info">
-  Following the steps above ensures that not all users are administrators by default, leading to an
-  unsafe situation.
-</Callout>
-
-#### S3 Object Storage Service Configuration
-
-This article uses MinIO as an example to explain the configuration process. If you are using another S3 service provider, please refer to their documentation for configuration.
-
-<Callout type="warning">
-  Please remember to configure the corresponding S3 service provider's CORS settings to ensure that LobeHub can access the S3 service correctly.
-
-  In this document, you need to allow cross-origin requests from `https://lobe.example.com`. This can either be configured in MinIO WebUI under `Configuration - API - Cors Allow Origin`, or in the Docker Compose configuration under `minio - environment - MINIO_API_CORS_ALLOW_ORIGIN`.
-
-  If you use the second method (which is also the default), you will no longer be able to configure it in the MinIO WebUI.
-</Callout>
-
-You first need to access the WebUI for configuration:
-
-- If you have set up the reverse proxy as mentioned before, open `https://minio-ui.example.com`
-- Otherwise, after port mapping, open `http://localhost:9001`
-
-1. Enter the `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` you set in the login interface, then click login.
-
-2. In the left panel under User / Access Keys, click `Create New Access Key`, no additional modifications needed, and fill the generated `Access Key` and `Secret Key` into your `.env` file under `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY`.
-
-<Image alt="Create MinIO Access Key" src="/blog/assetsfa2c650be15522ac2fd71a3e434a1b2e.webp" />
-
-3. Restart the LobeHub service:
-
-   ```sh
-   docker compose up -d
-   ```
-
-At this point, you have successfully deployed the LobeHub database version, and you can access your LobeHub service at `https://lobe.example.com`.
-
-#### Configuring Internal Server Communication with `INTERNAL_APP_URL`
-
-<Callout type="info">
-  If you are deploying LobeHub behind a CDN (like Cloudflare) or reverse proxy, you may want to configure internal server-to-server communication to bypass the CDN/proxy layer for better performance.
+  If you're deploying LobeHub behind a CDN (like Cloudflare) or reverse proxy, you may want to configure internal server-to-server communication to bypass the CDN/proxy layer for better performance.
 </Callout>
 
 You can configure the `INTERNAL_APP_URL` environment variable:
@@ -708,168 +349,9 @@ If `INTERNAL_APP_URL` is not set, it defaults to `APP_URL`.
   For Docker Compose deployments with `network_mode: 'service:network-service'`, use `http://localhost:3210` as the `INTERNAL_APP_URL`.
 </Callout>
 
-#### Configuration Files
+## Configuring Authentication
 
-For convenience, here is a summary of example configuration files required for the production deployment using the Casdoor authentication scheme:
-
-- `.env`
-
-```sh
-# Proxy, if you need it
-# HTTP_PROXY=http://localhost:7890
-# HTTPS_PROXY=http://localhost:7890
-
-# Other environment variables, as needed. You can refer to the environment variables configuration for the client version.
-# OPENAI_API_KEY=sk-xxxx
-# OPENAI_PROXY_URL=https://api.openai.com/v1
-# OPENAI_MODEL_LIST=...
-
-# ===========================
-# ====== Preset config ======
-# ===========================
-# if no special requirements, no need to change
-LOBE_PORT=3210
-CASDOOR_PORT=8000
-MINIO_PORT=9000
-
-# Postgres related, which are the necessary environment variables for DB
-LOBE_DB_NAME=LobeHub
-POSTGRES_PASSWORD=uWNZugjBqixf8dxC
-
-# Casdoor secret
-AUTH_CASDOOR_ID=943e627d79d5dd8a22a1
-AUTH_CASDOOR_SECRET=6ec24ac304e92e160ef0d0656ecd86de8cb563f1
-
-# MinIO S3 configuration
-MINIO_ROOT_USER=Joe
-MINIO_ROOT_PASSWORD=Crj1570768
-
-# Configure the bucket information of MinIO
-MINIO_LOBE_BUCKET=lobe
-S3_ACCESS_KEY_ID=dB6Uq9CYZPdWSZouPyEd
-S3_SECRET_ACCESS_KEY=aPBW8CVULkh8bw1GatlT0GjLihcXHLNwRml4pieS
-```
-
-- `docker-compose.yml`
-
-```yaml
-name: lobehub
-services:
-  network-service:
-    image: alpine
-    container_name: lobe-network
-    ports:
-      - '${MINIO_PORT}:${MINIO_PORT}' # MinIO API
-      - '9001:9001' # MinIO Console
-      - '${CASDOOR_PORT}:${CASDOOR_PORT}' # Casdoor
-      - '${LOBE_PORT}:3210' # LobeHub
-    command: tail -f /dev/null
-    networks:
-      - lobe-network
-
-  postgresql:
-    image: pgvector/pgvector:pg17
-    container_name: lobe-postgres
-    ports:
-      - '5432:5432'
-    volumes:
-      - './data:/var/lib/postgresql/data'
-    environment:
-      - 'POSTGRES_DB=${LOBE_DB_NAME}'
-      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    restart: always
-    networks:
-      - lobe-network
-
-  minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
-    container_name: lobe-minio
-    network_mode: 'service:network-service'
-    volumes:
-      - './s3_data:/etc/minio/data'
-    environment:
-      - 'MINIO_ROOT_USER=${MINIO_ROOT_USER}'
-      - 'MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}'
-      # - 'MINIO_API_CORS_ALLOW_ORIGIN=http://localhost:${LOBE_PORT}'
-      - 'MINIO_API_CORS_ALLOW_ORIGIN=https://lobe.example.com'
-    restart: always
-    command: >
-      server /etc/minio/data --address ":${MINIO_PORT}" --console-address ":9001"
-
-  casdoor:
-    image: casbin/casdoor
-    container_name: lobe-casdoor
-    entrypoint: /bin/sh -c './server --createDatabase=true'
-    network_mode: 'service:network-service'
-    depends_on:
-      postgresql:
-        condition: service_healthy
-    environment:
-      RUNNING_IN_DOCKER: 'true'
-      driverName: 'postgres'
-      dataSourceName: 'user=postgres password=${POSTGRES_PASSWORD} host=postgresql port=5432 sslmode=disable dbname=casdoor'
-      # origin: 'http://localhost:${CASDOOR_PORT}'
-      origin: 'https://auth.example.com'
-      runmode: 'dev'
-    volumes:
-      - ./init_data.json:/init_data.json
-
-  lobe:
-    image: lobehub/lobehub
-    container_name: lobehub
-    network_mode: 'service:network-service'
-    depends_on:
-      postgresql:
-        condition: service_healthy
-      network-service:
-        condition: service_started
-      minio:
-        condition: service_started
-      casdoor:
-        condition: service_started
-
-    environment:
-      # - 'APP_URL=http://localhost:3210'
-      - 'APP_URL=https://lobe.example.com'
-
-      - 'AUTH_SSO_PROVIDERS=casdoor'
-      - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
-      - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
-      # - 'AUTH_URL=http://localhost:${LOBE_PORT}/api/auth'
-      - 'AUTH_URL=https://lobe.example.com/api/auth'
-
-      # - 'AUTH_CASDOOR_ISSUER=http://localhost:${CASDOOR_PORT}'
-      - 'AUTH_CASDOOR_ISSUER=https://auth.example.com'
-
-      - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
-      # - 'S3_ENDPOINT=http://localhost:${MINIO_PORT}'
-      - 'S3_ENDPOINT=https://minio.example.com'
-
-      - 'S3_BUCKET=${MINIO_LOBE_BUCKET}'
-      # - 'S3_PUBLIC_DOMAIN=http://localhost:${MINIO_PORT}'
-      - 'S3_PUBLIC_DOMAIN=https://minio.example.com'
-
-      - 'S3_ENABLE_PATH_STYLE=1'
-      - 'LLM_VISION_IMAGE_USE_BASE64=1'
-    env_file:
-      - .env
-    restart: always
-
-volumes:
-  data:
-    driver: local
-  s3_data:
-    driver: local
-
-networks:
-  lobe-network:
-    driver: bridge
-```
+To configure SSO authentication services (such as Casdoor, Logto, etc.), please refer to the [Authentication Services](/docs/self-hosting/advanced/auth) documentation.
 
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub
 [docker-pulls-shield]: https://img.shields.io/docker/pulls/lobehub/lobehub?color=45cc11&labelColor=black&style=flat-square

--- a/docs/self-hosting/platform/docker-compose.mdx
+++ b/docs/self-hosting/platform/docker-compose.mdx
@@ -34,10 +34,10 @@ tags:
   - Port occupation check: Ensure that ports `3210`, `8000`, `9000`, and `9001` are available.
 </Callout>
 
-Execute the following commands to set up the deployment environment; the directory `lobe-chat-db` will be used to store your configuration files and subsequent database files.
+Execute the following commands to set up the deployment environment; the directory `lobehub` will be used to store your configuration files and subsequent database files.
 
 ```sh
-mkdir lobe-chat-db && cd lobe-chat-db
+mkdir lobehub && cd lobehub
 ```
 
 Fetch and execute the deployment script:

--- a/docs/self-hosting/platform/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/platform/docker-compose.zh-CN.mdx
@@ -32,10 +32,10 @@ tags:
   - 端口占用检查：确保 `3210`、`8000`、`9000`、`9001` 端口可用
 </Callout>
 
-执行以下命令初始化部署环境，目录 `lobe-chat-db` 将用于存放你的配置文件和后续的数据库文件。
+执行以下命令初始化部署环境，目录 `lobehub` 将用于存放你的配置文件和后续的数据库文件。
 
 ```sh
-mkdir lobe-chat-db && cd lobe-chat-db
+mkdir lobehub && cd lobehub
 ```
 
 获取并执行部署脚本：

--- a/docs/self-hosting/platform/docker-compose.zh-CN.mdx
+++ b/docs/self-hosting/platform/docker-compose.zh-CN.mdx
@@ -29,7 +29,7 @@ tags:
 
   - 一键启动脚本为首次部署专用，非首次部署请参考 [自定义部署](#自定义部署) 章节
 
-  - 端口占用检查：确保 `3210`、`8000`、`9000`、`9001` 端口可用
+  - 端口占用检查：确保 `3210`、`9000`、`9001` 端口可用
 </Callout>
 
 执行以下命令初始化部署环境，目录 `lobehub` 将用于存放你的配置文件和后续的数据库文件。
@@ -64,21 +64,13 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 查看配置生成报告
 
-  你需要在脚本运行结束后查看配置生成报告，包括 Casdoor 管理员的帐号、用户账号和它们的初始登录密码。
-
-  <Callout type="warning">请使用用户账号登录 LobeHub，管理员账号仅用于管理 Casdoor。</Callout>
+  你需要在脚本运行结束后查看配置生成报告，包括各服务的访问地址和密码。
 
   ```log
   安全密钥生成结果如下：
   LobeHub:
     - URL: http://localhost:3210
-    - Username: user
-    - Password: c66f8c
-  Casdoor:
-    - URL: http://localhost:8000
-    - Username: admin
-    - Password: c66f8c
-  Minio:
+  RustFS:
     - URL: http://localhost:9000
     - Username: admin
     - Password: 8c82ea41
@@ -93,7 +85,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   ### 检查日志
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   如果你在容器中看到了以下日志，则说明已经启动成功：
@@ -102,7 +94,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        http://localhost:3210
     - Network:      http://0.0.0.0:3210
 
@@ -112,7 +104,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 访问应用
 
-  通过 [http://localhost:3210](http://localhost:3210) 访问你的 LobeHub 服务。应用的账号密码在步骤`2`的报告中。
+  通过 [http://localhost:3210](http://localhost:3210) 访问你的 LobeHub 服务。
 </Steps>
 
 ### 端口模式
@@ -127,21 +119,13 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 查看配置生成报告
 
-  你需要在脚本运行结束后查看配置生成报告，包括 Casdoor 管理员的帐号、用户账号和它们的初始登录密码。
-
-  <Callout type="warning">请使用用户账号登录 LobeHub，管理员账号仅用于管理 Casdoor。</Callout>
+  你需要在脚本运行结束后查看配置生成报告，包括各服务的访问地址和密码。
 
   ```log
   安全密钥生成结果如下：
   LobeHub:
     - URL: http://your_server_ip:3210
-    - Username: user
-    - Password: 837e26
-  Casdoor:
-    - URL: http://your_server_ip:8000
-    - Username: admin
-    - Password: 837e26
-  Minio:
+  RustFS:
     - URL: http://your_server_ip:9000
     - Username: admin
     - Password: dbac8440
@@ -156,7 +140,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   ### 检查日志
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   如果你在容器中看到了以下日志，则说明已经启动成功：
@@ -165,7 +149,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        http://your_server_ip:3210
     - Network:      http://0.0.0.0:3210
    ✓ Starting...
@@ -174,11 +158,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 访问应用
 
-  你可以通过 `http://your_server_ip:3210` 访问你的 LobeHub 服务。应用的账号密码在步骤`2`的报告中。
-
-  <Callout type="warning">
-    请注意，如果你的服务能够被公网访问，我们强烈建议你参考 [文档](https://lobehub.com/zh/docs/self-hosting/advanced/auth/providers/casdoor) 关闭注册功能。
-  </Callout>
+  你可以通过 `http://your_server_ip:3210` 访问你的 LobeHub 服务。
 </Steps>
 
 ### 域名模式
@@ -188,39 +168,18 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   在域名模式中，你需要完成反向代理配置，并确保局域网 / 公网能访问到以下服务。请使用反向代理将以下服务端口映射到域名：
 
-  | 域名                     | 反代端口   | 是否必选 |
-  | ---------------------- | ------ | ---- |
-  | `lobe.example.com`     | `3210` | 必选   |
-  | `auth.example.com`     | `8000` | 必选   |
-  | `minio.example.com`    | `9000` | 必选   |
-  | `minio-ui.example.com` | `9001` |      |
-
-  <Callout type="important">
-    如果你使用如 [宝塔面板](https://www.bt.cn/) 等面板软件进行反向代理配置，
-    你需要确保其对 `.well-known` 路径的请求不进行拦截，以确保 Casdoor 的 OAuth2 配置能够正常工作。
-    这里提供一份针对 Casdoor 服务的 Nginx server 块的路径白名单配置：
-
-    ```nginx
-    location /.well-known/openid-configuration {
-      proxy_pass http://localhost:8000;  # 转发到 localhost:8000
-      proxy_set_header Host $host;  # 保留原始主机头
-      proxy_set_header X-Real-IP $remote_addr;  # 保留客户端真实IP
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # 保留转发的IP
-      proxy_set_header X-Forwarded-Proto $scheme;  # 保留请求协议
-    }
-    ```
-
-    ⚠️ 请不要在此类面板软件的反向代理设置中开启任何形式的缓存，以免影响服务的正常运行。
-    详情请见 [https://github.com/lobehub/lobe-chat/discussions/5986](https://github.com/lobehub/lobe-chat/discussions/5986)
-  </Callout>
+  | 域名                  | 反代端口   | 是否必选 |
+  | ------------------- | ------ | ---- |
+  | `lobe.example.com`  | `3210` | 必选   |
+  | `s3.example.com`    | `9000` | 必选   |
+  | `s3-ui.example.com` | `9001` |      |
 
   ### 在交互式脚本中完成剩余配置
 
   在域名模式中，你需要根据脚本提示完成：
 
   - LobeHub 服务的域名设置：`lobe.example.com`
-  - Minio 服务的域名设置：`minio.example.com`
-  - Casdoor 服务的域名设置：`auth.example.com`
+  - S3 服务的域名设置：`s3.example.com`
   - 选择访问协议：`http` 或 `https`
   - 安全密钥重新生成：我们强烈建议你重新生成安全密钥，如果你缺少脚本所需的密钥生成库，我们建议你参考 [自定义部署](#自定义部署) 章节对密钥进行修改。
 
@@ -236,22 +195,14 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 查看配置生成报告
 
-  你需要在脚本运行结束后查看配置生成报告，包括 Casdoor 管理员的初始登录密码。
-
-  <Callout type="warning">请使用用户账号登录 LobeHub，管理员账号仅用于管理 Casdoor。</Callout>
+  你需要在脚本运行结束后查看配置生成报告，包括各服务的访问地址和密码。
 
   ```log
   安全密钥生成结果如下：
   LobeHub:
     - URL: https://lobe.example.com
-    - Username: user
-    - Password: 837e26
-  Casdoor:
-    - URL: https://auth.example.com
-    - Username: admin
-    - Password: 837e26
-  Minio:
-    - URL: https://minio.example.com
+  RustFS:
+    - URL: https://s3.example.com
     - Username: admin
     - Password: dbac8440
   ```
@@ -265,7 +216,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   ### 检查日志
 
   ```sh
-  docker logs -f lobe-chat
+  docker logs -f lobehub
   ```
 
   如果你在容器中看到了以下日志，则说明已经启动成功：
@@ -274,7 +225,7 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
   [Database] Start to migration...
   ✅ database migration pass.
   -------------------------------------
-    ▲ Next.js 14.x.x
+    ▲ Next.js 16.x.x
     - Local:        https://localhost:3210
     - Network:      http://0.0.0.0:3210
     ✓ Starting...
@@ -283,20 +234,16 @@ bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
 
   ### 访问应用
 
-  你可以通过 `https://lobe.example.com` 访问你的 LobeHub 服务。应用的账号密码在步骤`3`的报告中。
-
-  <Callout type="warning">
-    请注意，如果你的服务能够被公网访问，我们强烈建议你参考 [文档](https://lobehub.com/zh/docs/self-hosting/advanced/auth/providers/casdoor) 关闭注册功能。
-  </Callout>
+  你可以通过 `https://lobe.example.com` 访问你的 LobeHub 服务。
 </Steps>
 
 ## 自定义部署
 
-该章节主要为你介绍在不同的网络环境下自定义部署 LobeHub 服务必须要修改的配置。在开始前，你可以先下载 [Docker Compose 配置文件](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/docker-compose.yml) 以及 [环境变量配置文件](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/.env.zh-CN.example)。
+该章节主要为你介绍在不同的网络环境下自定义部署 LobeHub 服务必须要修改的配置。在开始前，你可以先下载 [Docker Compose 配置文件](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/docker-compose.yml) 以及 [环境变量配置文件](https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/.env.zh-CN.example)。
 
 ```sh
-curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/docker-compose.yml
-curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/local/.env.zh-CN.example
+curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lobehub/lobe-chat/HEAD/docker-compose/deploy/.env.zh-CN.example
 mv .env.zh-CN.example .env
 ```
 
@@ -307,16 +254,15 @@ mv .env.zh-CN.example .env
 
 ### 预备知识
 
-一般来讲，想要完整的运行 LobeHub 数据库版本，你需要至少拥有如下四个服务
+一般来讲，想要完整的运行 LobeHub 数据库版本，你需要至少拥有如下三个服务：
 
 - LobeHub 数据库版本自身
 - 带有 PGVector 插件的 PostgreSQL 数据库
 - 支持 S3 协议的对象存储服务
-- 受 LobeHub 支持的 SSO 登录鉴权服务
 
 这些服务可以通过自建或者在线云服务组合搭配，以满足不同层次的部署需求。本文中，我们提供了完全基于开源自建服务的 Docker Compose 配置，你可以直接使用这份配置文件来启动 LobeHub 数据库版本，也可以对之进行修改以适应你的需求。
 
-我们默认使用 [MinIO](https://github.com/minio/minio) 作为本地 S3 对象存储服务，使用 [Casdoor](https://github.com/casdoor/casdoor) 作为本地鉴权服务。
+我们默认使用 [RustFS](https://github.com/rustfs/rustfs) 作为本地 S3 对象存储服务。如需配置 SSO 登录鉴权服务，请参考 [身份验证服务](/zh/docs/self-hosting/advanced/auth) 文档。
 
 <Callout type="warning">
   如果你的网络拓扑较为复杂，请先确保在你的网络环境中这些服务能够正常通讯。
@@ -326,40 +272,16 @@ mv .env.zh-CN.example .env
 
 以下我们将介绍运行这些服务的必要配置：
 
-1. Casdoor
+1. S3 对象存储
 
-- LobeHub 需要与 Casdoor 通讯，因此你需要配置 Casdoor 的 Issuer 。
-
-```env
-AUTH_CASDOOR_ISSUER=https://auth.example.com
-```
-
-该配置会影响 LobeHub 的登录鉴权服务，你需要确保 Casdoor 服务的地址正确。你可以在 [常见问题](#常见问题) 中找到该配置错误的常见现象及解决方案。
-
-- 同时，你也需要在 Casdoor 中允许回调地址为 LobeHub 的地址：
-
-请在 Casdoor 的 Web 面板的 `身份认证 -> 应用` -> `<应用ID，默认为 app-built-in>` -> `重定向URL` 中添加一行：
-
-```
-https://auth.example.com/api/auth/callback/casdoor
-```
-
-- Casdoor 需要在环境变量中提供访问的 Origin 信息：
+LobeHub 需要为 LLM 服务提供商提供文件对象的公网访问地址，因此你需要配置 S3 的 Endpoint：
 
 ```env
-origin=https://auth.example.com
+S3_PUBLIC_DOMAIN=https://s3.example.com
+S3_ENDPOINT=https://s3.example.com
 ```
 
-2. MinIO
-
-- LobeHub 需要为 LLM 服务提供商提供文件对象的公网访问地址，因此你需要配置 MinIO 的 Endpoint 。
-
-```env
-S3_PUBLIC_DOMAIN=https://minio.example.com
-S3_ENDPOINT=https://minio.example.com
-```
-
-3. PostgreSQL
+2. PostgreSQL
 
 该配置位于 `docker-compose.yml` 文件中，你需要配置数据库的名称和密码：
 
@@ -372,216 +294,16 @@ services:
 
 ## 常见问题
 
-#### 无法正常登陆
-
-请根据容器日志检查是否存在以下错误
-
-```sh
-docker logs -f lobe-chat
-```
-
-- r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
-
-```log
-lobe-chat      | [auth][error] r3: "response" is not a conform Authorization Server Metadata response (unexpected HTTP status code)
-```
-
-成因：该问题一般是由于你的反向代理配置不正确导致的，你需要确保你的反向代理配置不会拦截 Casdoor 的 OAuth2 配置请求。
-
-解决方案：
-
-- 请参考 [域名模式](#域名模式) 章节中的反向代理配置注意事项。
-
-- 一个直接的排查方式，你可以直接访问 `https://auth.example.com/.well-known/openid-configuration`，如果
-
-  - 返回了非 JSON 格式的数据，则说明你的反向代理配置错误。
-  - 如果返回的 JSON 格式数据中的 `"issuer": "URL"` 字段不是你配置的 `https://auth.example.com`，则说明你的环境变量配置错误。
-
-- TypeError: fetch failed
-
-```log
-lobe-chat      | [auth][error] TypeError: fetch failed
-```
-
-成因：LobeHub 无法访问鉴权服务。
-
-解决方案：
-
-- 请检查你的鉴权服务是否正常运行，以及 LobeHub 所在的网络是否能够访问到鉴权服务。
-
-- 一个直接的排查方式，你可以在 LobeHub 容器的终端中，使用 `curl` 命令访问你的鉴权服务 `https://auth.example.com/.well-known/openid-configuration`，如果返回了 JSON 格式的数据，则说明你的鉴权服务正常运行。
-
-#### 反向代理下 OAuth 令牌交换失败
-
-如果在反向代理后使用 Docker 时 OAuth 认证在令牌交换阶段失败，这通常是由默认的 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=1` 设置引起的，该设置会将 URL 重写为 `127.0.0.1:3210`。
-
-**解决方案**: 在 `.env` 文件中设置 `MIDDLEWARE_REWRITE_THROUGH_LOCAL=0` 并重启 Docker 容器：
-
-```bash
-docker compose down
-docker compose up -d
-```
-
-## 拓展配置
-
-为了完善你的 LobeHub 服务，你可以根据你的需求进行以下拓展配置。
-
-### 使用 MinIO 存储 Casdoor 头像
-
-允许用户在 Casdoor 中更换头像
-
-1. 你需要首先在 `buckets` 中创建一个名为 `casdoor` 的桶，选择自定义策略，复制并粘贴如下内容（如果你修改了桶名，请自行查找替换）
-
-   ```json
-   {
-     "Statement": [
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:GetBucketLocation"],
-         "Resource": ["arn:aws:s3:::casdoor"]
-       },
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:ListBucket"],
-         "Resource": ["arn:aws:s3:::casdoor"],
-         "Condition": {
-           "StringEquals": {
-             "s3:prefix": ["files/*"]
-           }
-         }
-       },
-       {
-         "Effect": "Allow",
-         "Principal": {
-           "AWS": ["*"]
-         },
-         "Action": ["s3:PutObject", "s3:DeleteObject", "s3:GetObject"],
-         "Resource": ["arn:aws:s3:::casdoor/**"]
-       }
-     ],
-     "Version": "2012-10-17"
-   }
-   ```
-
-2. 创建一个新的访问密钥，将生成的 `Access Key` 和 `Secret Key` 存储之
-
-3. 在 Casdoor 的 `身份认证 -> 提供商` 中关联 MinIO S3 服务，以下是一个示例配置：
-
-   ![casdoor](/blog/assets18bb134dbc5792d6a624199cca8bf7d3.webp)
-
-   其中，客户端 ID、客户端密钥为上一步创建的访问密钥中的 `Access Key` 和 `Secret Key`，`192.168.31.251` 应当被替换为 `your_server_ip`。
-
-4. 在 Casdoor 的 `身份认证 -> 应用` 中，对 `app-built-in` 应用添加提供商，选择 `minio`，保存并退出
-
-5. 你可以在 Casdoor 的 `身份认证 -> 资源` 中，尝试上传文件以测试配置是否正确
-
-### 生产部署下从 `logto` 迁移至 `Casdoor`
-
-适用于已经在生产环境下使用 `logto` 作为登录鉴权服务的用户
-
-<Callout type="info">
-  由于使用[Logto](https://logto.io/) 作为登录鉴权服务存在比较大的不稳定性。 因此，下文基于发布到 IP
-  模式的教程，实现了使用 Casdoor 作为鉴权服务提供商的域名发布方案。
-  本文剩余部分也将以其为例进行说明。如果你使用其他诸如 Logto
-  等其他登录鉴权服务，流程应当相近，但请注意不同的登录鉴权服务的端口配置可能有所差异。
-</Callout>
-
-在下文中，我们假设在上述服务之外，你还运行了一层 **Nginx** 来进行反向代理、配置 SSL。
-
-域名和配套服务端口说明如下：
-
-- `lobe.example.com`：为你的 LobeHub 服务端域名，需要反向代理到 LobeHub 服务端口，默认为 `3210`
-- `auth.example.com`：为你的 Logto UI 域名，需要反向代理到 Logto WebUI 服务端口，默认为 `8000`
-- `minio.example.com`：为你的 MinIO API 域名，需要反向代理到 MinIO API 服务端口，默认为 `9000`
-- `minio-ui.example.com`：可选，为你的 MinIO UI 域名，需要反向代理到 MinIO WebUI 服务端口，默认为 `9001`
-
-#### 配置文件
-
-```sh
-bash <(curl -fsSL https://lobe.li/setup.sh) -l zh_CN
-docker compose up -d
-```
-
-注意保存此时生成的新密码！
-
-运行后会获得三个文件
-
-- init\_data.json
-- docker-compose.yml
-- .env
-
-接下来，修改配置文件以实现域名发布
-
-1. 修改 `docker-compose.yml` 文件
-
-   1. 修改 `minio`的`MINIO_API_CORS_ALLOW_ORIGIN`字段。
-
-   ```yaml
-   'MINIO_API_CORS_ALLOW_ORIGIN=https://lobe.example.com'
-   ```
-
-   2. 修改`casdoor`的`origin`字段。
-
-   ```yaml
-   origin: 'https://auth.example.com'
-   ```
-
-   3. 修改`lobe`的`environment`字段。
-
-   ```yaml
-   # - 'APP_URL=http://localhost:3210'
-   - 'APP_URL=https://lobe.example.com'
-
-   - 'AUTH_SSO_PROVIDERS=casdoor'
-   - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
-   - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
-   # - 'AUTH_URL=http://localhost:${LOBE_PORT}/api/auth'
-   - 'AUTH_URL=https://lobe.example.com/api/auth'
-
-   # - 'AUTH_CASDOOR_ISSUER=http://localhost:${CASDOOR_PORT}'
-   - 'AUTH_CASDOOR_ISSUER=https://auth.example.com'
-
-   - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
-   # - 'S3_ENDPOINT=http://localhost:${MINIO_PORT}'
-   - 'S3_ENDPOINT=https://minio.example.com'
-
-   - 'S3_BUCKET=${MINIO_LOBE_BUCKET}'
-   # - 'S3_PUBLIC_DOMAIN=http://localhost:${MINIO_PORT}'
-   - 'S3_PUBLIC_DOMAIN=https://minio.example.com'
-
-   - 'S3_ENABLE_PATH_STYLE=1'
-   - 'LLM_VISION_IMAGE_USE_BASE64=1'
-   ```
-
-2. 修改 `.env` 文件
-
-<Callout type="info">为了安全起见，修改 `.env` 文件中的 ROOT USER 的字段</Callout>
-
-```sh
-# MinIO S3 configuration
-MINIO_ROOT_USER=XXXX
-MINIO_ROOT_PASSWORD=XXXX
-```
-
-#### Postgres 数据库配置
+#### 数据库迁移问题
 
 你可以使用下述指令检查日志：
 
 ```sh
-docker logs -f lobe-chat
+docker logs -f lobehub
 ```
 
 <Callout type="tip">
-  在我们官方的 Docker 镜像中，会在启动镜像前自动执行数据库 schema 的 migration
-  ，我们的官方镜像承诺「空数据库 ->
-  完整表」这一段自动建表的稳定性。因此我们建议你的数据库实例使用一个空表实例，进而省去手动维护表结构或者
-  migration 的麻烦。
+  在我们官方的 Docker 镜像中，会在启动镜像前自动执行数据库 schema 的 migration，我们的官方镜像承诺「空数据库 -> 完整表」这一段自动建表的稳定性。因此我们建议你的数据库实例使用一个空表实例，进而省去手动维护表结构或者 migration 的麻烦。
 </Callout>
 
 如果你在建表的时候出现了问题，你可以尝试使用如下命令强制移除数据库容器并重新启动：
@@ -591,66 +313,6 @@ docker compose down  # 停止服务
 sudo rm -rf ./data   # 移除挂载的数据库数据
 docker compose up -d # 重新启动
 ```
-
-#### 登录鉴权服务配置
-
-你需要首先访问 WebUI 来进行配置：
-
-- 如果你按照前文配置了反向代理，打开 `https://auth.example.com`
-- 否则，请在进行端口映射后，打开 `http://localhost:8000`
-
-登录管理员账户
-
-- 默认用户名为 admin
-- 默认密码为 下载配置文件时生成的随机密码。如忘记可到 `init_data.json` 文件中找回
-
-登入后执行如下操作
-
-1. 在 `用户管理 -> 组织` 中，添加一个新的组织。名称与显示名称为 `Lobe Users`。其余保持默认即可。
-2. 在 `身份认证 -> 应用` 中，添加一个新的应用。
-
-- 名称与显示名称为 `LobeHub`。
-- 组织为 `Lobe Users`。
-- 重定向 URLS 中添加一行 为 `https://lobe.example.com/api/auth/callback/casdoor`。
-- 关闭除密码外的登录方式 。
-- 将客户端 ID 和客户端密钥分别填入 `.env`中的 `AUTH_CASDOOR_ID` 和 `AUTH_CASDOOR_SECRET` 中。
-- (可选) 仿照`built-in`应用的配置，来设计登录和注册的页面外观。
-- 保存并退出。
-
-<Callout type="info">
-  通过上述步骤，可以避免默认情况下所有用户均为管理员导致的不安全的情况。
-</Callout>
-
-#### S3 对象存储服务配置
-
-本文以 MinIO 为例，解释配置过程，如果你使用的是其他 S3 服务商，请参照其文档进行配置。
-
-<Callout type="warning">
-  请记得注意配置对应 S3 服务商的 CORS 跨域配置，以确保 LobeHub 能够正常访问 S3 服务。
-
-  在本文中，你需要允许 `https://lobe.example.com` 的跨域请求。这既可以在 MinIO WebUI 的 `Configuration - API - Cors Allow Origin` 中配置，也可以在 Docker Compose 中的 `minio - environment - MINIO_API_CORS_ALLOW_ORIGIN` 中配置。
-
-  如果你使用第二种方法（这也是默认的方法）进行配置，你将无法再在 MinIO WebUI 中配置。
-</Callout>
-
-你需要首先访问 WebUI 来进行配置：
-
-- 如果你按照前文配置了反向代理，打开 `https://minio-ui.example.com`
-- 否则，请在进行端口映射后，打开 `http://localhost:9001`
-
-1. 在登录界面输入你设置的 `MINIO_ROOT_USER` 和 `MINIO_ROOT_PASSWORD`，然后点击登录
-
-2. 在左侧面板 User / Access Keys 处，点击 `Create New Access Key`，无需额外修改，将生成的 `Access Key` 和 `Secret Key` 填入你的 `.env` 文件中的 `S3_ACCESS_KEY_ID` 和 `S3_SECRET_ACCESS_KEY` 中
-
-<Image alt="创建 MinIO 访问密钥" src="/blog/assetsfa2c650be15522ac2fd71a3e434a1b2e.webp" />
-
-3. 重启 LobeHub 服务：
-
-   ```sh
-   docker compose up -d
-   ```
-
-至此，你已经成功部署了 LobeHub 数据库版本，你可以通过 `https://lobe.example.com` 访问你的 LobeHub 服务。
 
 #### 使用 `INTERNAL_APP_URL` 配置内部服务器通信
 
@@ -683,168 +345,9 @@ environment:
   对于使用 `network_mode: 'service:network-service'` 的 Docker Compose 部署，请使用 `http://localhost:3210` 作为 `INTERNAL_APP_URL`。
 </Callout>
 
-#### 配置文件
+## 配置身份验证
 
-为方便一键复制，在此汇总基于 casdoor 鉴权方案的域名方式下生产部署配置服务端数据库所需要的示例配置文件。
-
-- `.env`
-
-```sh
-# Proxy, if you need it
-# HTTP_PROXY=http://localhost:7890
-# HTTPS_PROXY=http://localhost:7890
-
-# Other environment variables, as needed. You can refer to the environment variables configuration for the client version.
-# OPENAI_API_KEY=sk-xxxx
-# OPENAI_PROXY_URL=https://api.openai.com/v1
-# OPENAI_MODEL_LIST=...
-
-# ===========================
-# ====== Preset config ======
-# ===========================
-# if no special requirements, no need to change
-LOBE_PORT=3210
-CASDOOR_PORT=8000
-MINIO_PORT=9000
-
-# Postgres related, which are the necessary environment variables for DB
-LOBE_DB_NAME=LobeHub
-POSTGRES_PASSWORD=uWNZugjBqixf8dxC
-
-# Casdoor secret
-AUTH_CASDOOR_ID=943e627d79d5dd8a22a1
-AUTH_CASDOOR_SECRET=6ec24ac304e92e160ef0d0656ecd86de8cb563f1
-
-# MinIO S3 configuration
-MINIO_ROOT_USER=Joe
-MINIO_ROOT_PASSWORD=Crj1570768
-
-# Configure the bucket information of MinIO
-MINIO_LOBE_BUCKET=lobe
-S3_ACCESS_KEY_ID=dB6Uq9CYZPdWSZouPyEd
-S3_SECRET_ACCESS_KEY=aPBW8CVULkh8bw1GatlT0GjLihcXHLNwRml4pieS
-```
-
-- `docker-compose.yml`
-
-```yaml
-name: lobehub
-services:
-  network-service:
-    image: alpine
-    container_name: lobe-network
-    ports:
-      - '${MINIO_PORT}:${MINIO_PORT}' # MinIO API
-      - '9001:9001' # MinIO Console
-      - '${CASDOOR_PORT}:${CASDOOR_PORT}' # Casdoor
-      - '${LOBE_PORT}:3210' # LobeHub
-    command: tail -f /dev/null
-    networks:
-      - lobe-network
-
-  postgresql:
-    image: pgvector/pgvector:pg17
-    container_name: lobe-postgres
-    ports:
-      - '5432:5432'
-    volumes:
-      - './data:/var/lib/postgresql/data'
-    environment:
-      - 'POSTGRES_DB=${LOBE_DB_NAME}'
-      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    restart: always
-    networks:
-      - lobe-network
-
-  minio:
-    image: minio/minio
-    container_name: lobe-minio
-    network_mode: 'service:network-service'
-    volumes:
-      - './s3_data:/etc/minio/data'
-    environment:
-      - 'MINIO_ROOT_USER=${MINIO_ROOT_USER}'
-      - 'MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}'
-      # - 'MINIO_API_CORS_ALLOW_ORIGIN=http://localhost:${LOBE_PORT}'
-      - 'MINIO_API_CORS_ALLOW_ORIGIN=https://lobe.example.com'
-    restart: always
-    command: >
-      server /etc/minio/data --address ":${MINIO_PORT}" --console-address ":9001"
-
-  casdoor:
-    image: casbin/casdoor
-    container_name: lobe-casdoor
-    entrypoint: /bin/sh -c './server --createDatabase=true'
-    network_mode: 'service:network-service'
-    depends_on:
-      postgresql:
-        condition: service_healthy
-    environment:
-      RUNNING_IN_DOCKER: 'true'
-      driverName: 'postgres'
-      dataSourceName: 'user=postgres password=${POSTGRES_PASSWORD} host=postgresql port=5432 sslmode=disable dbname=casdoor'
-      # origin: 'http://localhost:${CASDOOR_PORT}'
-      origin: 'https://auth.example.com'
-      runmode: 'dev'
-    volumes:
-      - ./init_data.json:/init_data.json
-
-  lobe:
-    image: lobehub/lobehub
-    container_name: lobehub
-    network_mode: 'service:network-service'
-    depends_on:
-      postgresql:
-        condition: service_healthy
-      network-service:
-        condition: service_started
-      minio:
-        condition: service_started
-      casdoor:
-        condition: service_started
-
-    environment:
-      # - 'APP_URL=http://localhost:3210'
-      - 'APP_URL=https://lobe.example.com'
-
-      - 'AUTH_SSO_PROVIDERS=casdoor'
-      - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
-      - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
-      # - 'AUTH_URL=http://localhost:${LOBE_PORT}/api/auth'
-      - 'AUTH_URL=https://lobe.example.com/api/auth'
-
-      # - 'AUTH_CASDOOR_ISSUER=http://localhost:${CASDOOR_PORT}'
-      - 'AUTH_CASDOOR_ISSUER=https://auth.example.com'
-
-      - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
-      # - 'S3_ENDPOINT=http://localhost:${MINIO_PORT}'
-      - 'S3_ENDPOINT=https://minio.example.com'
-
-      - 'S3_BUCKET=${MINIO_LOBE_BUCKET}'
-      # - 'S3_PUBLIC_DOMAIN=http://localhost:${MINIO_PORT}'
-      - 'S3_PUBLIC_DOMAIN=https://minio.example.com'
-
-      - 'S3_ENABLE_PATH_STYLE=1'
-      - 'LLM_VISION_IMAGE_USE_BASE64=1'
-    env_file:
-      - .env
-    restart: always
-
-volumes:
-  data:
-    driver: local
-  s3_data:
-    driver: local
-
-networks:
-  lobe-network:
-    driver: bridge
-```
+如需配置 SSO 登录鉴权服务（如 Casdoor、Logto 等），请参考 [身份验证服务](/zh/docs/self-hosting/advanced/auth) 文档。
 
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub
 [docker-pulls-shield]: https://img.shields.io/docker/pulls/lobehub/lobehub?color=45cc11&labelColor=black&style=flat-square

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -31,9 +31,14 @@ const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
     return <ContentLoading id={id} />;
   }
 
+  const isSingleLine = (message || '').split('\n').length <= 2;
+
   return (
     content && (
-      <MarkdownMessage {...markdownProps} className={cx(hasTools && styles.pWithTool)}>
+      <MarkdownMessage
+        {...markdownProps}
+        className={cx(hasTools && isSingleLine && styles.pWithTool)}
+      >
         {message}
       </MarkdownMessage>
     )


### PR DESCRIPTION
## Summary

- 新建 `docker-compose/deploy` 目录，包含最小化部署配置
- 仅保留核心服务：postgresql、redis、rustfs、searxng、lobe
- 移除 Casdoor 认证服务相关配置
- 移除可观测性服务（Grafana/Prometheus/Tempo/otel-collector）
- 使用 `paradedb/paradedb:latest` 镜像（支持 pgvector + pg_search）
- 更新 `setup.sh` 指向新的 deploy 目录
- 清理 `.env` 示例文件中的 Casdoor 相关配置

## One-Click Test Script

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/lobehub/lobehub/chore/refactor-one-click-scripts/docker-compose/setup.sh) -l zh_CN --url https://raw.githubusercontent.com/lobehub/lobehub/chore/refactor-one-click-scripts
```

## Test plan

- [ ] 使用一键脚本测试部署流程
- [ ] 验证 PostgreSQL (paradedb) 正常启动
- [ ] 验证 RustFS 正常初始化
- [ ] 验证 LobeChat 服务正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a streamlined docker-compose deploy configuration using ParadeDB-based PostgreSQL, Redis, RustFS, SearXNG, and LobeChat, and update the one-click setup script to target this new deploy stack while removing legacy Casdoor integration.

Enhancements:
- Add a new minimal docker-compose deploy stack with PostgreSQL (ParadeDB), Redis, RustFS, SearXNG, and LobeChat plus associated SearXNG settings and S3 bucket policy config.
- Refine the docker-compose setup script to use the new deploy directory, drop Casdoor-related initialization and configuration, and simplify required port and host setup messaging.
- Adjust message rendering so the tool-aware paragraph styling is applied only for single-line assistant messages with tools, improving layout in multi-line cases.

Chores:
- Add localized example environment files for the new deploy configuration.