### PR TITLE
🐛 fix: correct desktop download URL path

### DIFF
--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -66,6 +66,6 @@ export const CHANGELOG_URL = urlJoin(OFFICIAL_SITE, 'changelog/versions');
 
 export const DOWNLOAD_URL = {
   android: 'https://play.google.com/store/apps/details?id=com.lobehub.app',
-  default: urlJoin(OFFICIAL_SITE, '/download'),
+  default: urlJoin(OFFICIAL_SITE, '/downloads'),
   ios: 'https://testflight.apple.com/join/2ZbjX4Qp',
 } as const;


### PR DESCRIPTION
## Summary
- Fixed the download URL path from `/download` to `/downloads` to match the actual official site path

## Test plan
- [ ] Verify the download button on desktop client navigates to the correct URL

## Summary by Sourcery

Bug Fixes:
- Correct the desktop download URL path from /download to /downloads to match the official site.