### PR TITLE
💄 style: add emoji reaction feature for messages

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -165,6 +165,7 @@
   "messageAction.delAndRegenerate": "Delete and Regenerate",
   "messageAction.deleteDisabledByThreads": "This message has a subtopic and can’t be deleted",
   "messageAction.expand": "Expand Message",
+  "messageAction.reaction": "Add Reaction",
   "messageAction.regenerate": "Regenerate",
   "messages.dm.sentTo": "Visible only to {{name}}",
   "messages.dm.title": "DM",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -165,6 +165,7 @@
   "messageAction.delAndRegenerate": "删除并重新生成",
   "messageAction.deleteDisabledByThreads": "该消息有子话题，无法删除",
   "messageAction.expand": "展开消息",
+  "messageAction.reaction": "添加表情",
   "messageAction.regenerate": "重新生成",
   "messages.dm.sentTo": "仅对 {{name}} 可见",
   "messages.dm.title": "私信",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
     "@codesandbox/sandpack-react": "^2.20.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "@emotion/react": "^11.14.0",
     "@fal-ai/client": "^1.8.4",
     "@formkit/auto-animate": "^0.9.0",

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -14,6 +14,7 @@ import {
   MessageCleanupProcessor,
   MessageContentProcessor,
   PlaceholderVariablesProcessor,
+  ReactionFeedbackProcessor,
   SupervisorRoleRestoreProcessor,
   TaskMessageProcessor,
   TasksFlattenProcessor,
@@ -299,6 +300,8 @@ export class MessagesEngine {
       // =============================================
       // Phase 5: Content Processing
       // =============================================
+      // 22. Reaction feedback injection (append user reaction feedback to assistant messages)
+      new ReactionFeedbackProcessor({ enabled: true }),
 
       // 22. Message content processing (image encoding, etc.)
       new MessageContentProcessor({

--- a/packages/context-engine/src/engine/messages/types.ts
+++ b/packages/context-engine/src/engine/messages/types.ts
@@ -218,6 +218,10 @@ export interface MessagesEngineParams {
   groupAgentBuilderContext?: GroupAgentBuilderContext;
   /** GTD (Getting Things Done) configuration */
   gtd?: GTDConfig;
+  /** Reaction feedback configuration */
+  reactionFeedback?: {
+    enabled?: boolean;
+  };
   /** User memory configuration */
   userMemory?: UserMemoryConfig;
 

--- a/packages/context-engine/src/processors/ReactionFeedback.ts
+++ b/packages/context-engine/src/processors/ReactionFeedback.ts
@@ -1,0 +1,100 @@
+import type { EmojiReaction } from '@lobechat/types';
+import debug from 'debug';
+
+import { BaseProcessor } from '../base/BaseProcessor';
+import type { PipelineContext, ProcessorOptions } from '../types';
+
+const log = debug('context-engine:processor:ReactionFeedbackProcessor');
+
+export interface ReactionFeedbackConfig {
+  /** Whether to enable reaction feedback injection */
+  enabled?: boolean;
+}
+
+/**
+ * Reaction Feedback Processor
+ * Converts emoji reactions to feedback text and injects into assistant messages
+ */
+export class ReactionFeedbackProcessor extends BaseProcessor {
+  readonly name = 'ReactionFeedbackProcessor';
+
+  constructor(
+    private config: ReactionFeedbackConfig = {},
+    options: ProcessorOptions = {},
+  ) {
+    super(options);
+  }
+
+  protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
+    if (!this.config.enabled) {
+      return this.markAsExecuted(context);
+    }
+
+    const clonedContext = this.cloneContext(context);
+    let processedCount = 0;
+
+    for (let i = 0; i < clonedContext.messages.length; i++) {
+      const message = clonedContext.messages[i];
+
+      // Only process assistant messages with reactions
+      if (message.role === 'assistant' && message.metadata?.reactions) {
+        const reactions = message.metadata.reactions as Record<string, EmojiReaction>;
+        const feedbackText = this.convertReactionsToFeedback(reactions);
+
+        if (feedbackText) {
+          const originalContent = message.content;
+
+          // Only append feedback to string content
+          if (typeof originalContent === 'string') {
+            clonedContext.messages[i] = {
+              ...message,
+              content: `${originalContent}\n\n[User Feedback: ${feedbackText}]`,
+            };
+            processedCount++;
+            log(`Injected feedback for message ${message.id}: ${feedbackText}`);
+          }
+        }
+      }
+    }
+
+    clonedContext.metadata.reactionFeedbackProcessed = processedCount;
+    log(`Reaction feedback processing completed, processed ${processedCount} messages`);
+
+    return this.markAsExecuted(clonedContext);
+  }
+
+  /**
+   * Convert reactions object to human-readable feedback text
+   */
+  private convertReactionsToFeedback(reactions: Record<string, EmojiReaction>): string {
+    const feedbackParts: string[] = [];
+
+    for (const [emoji] of Object.entries(reactions)) {
+      const sentiment = this.getEmojiSentiment(emoji);
+      if (sentiment) {
+        feedbackParts.push(sentiment);
+      }
+    }
+
+    return feedbackParts.join(', ');
+  }
+
+  /**
+   * Map emoji to sentiment description
+   */
+  private getEmojiSentiment(emoji: string): string | null {
+    const sentimentMap: Record<string, string> = {
+      '❤️': 'loved this response',
+      '🎉': 'user found this excellent',
+      '👀': 'user wants to look into this more',
+      '👍': 'positive - user found this helpful',
+      '👎': 'negative - user found this unhelpful',
+      '😄': 'user found this amusing',
+      '😢': 'user found this sad or disappointing',
+      '🚀': 'user found this impressive',
+      '🤔': 'user wants more clarification',
+    };
+
+    return sentimentMap[emoji] || `reacted with ${emoji}`;
+  }
+}

--- a/packages/context-engine/src/processors/ReactionFeedback.ts
+++ b/packages/context-engine/src/processors/ReactionFeedback.ts
@@ -38,7 +38,7 @@ export class ReactionFeedbackProcessor extends BaseProcessor {
 
       // Only process assistant messages with reactions
       if (message.role === 'assistant' && message.metadata?.reactions) {
-        const reactions = message.metadata.reactions as Record<string, EmojiReaction>;
+        const reactions = message.metadata.reactions as EmojiReaction[];
         const feedbackText = this.convertReactionsToFeedback(reactions);
 
         if (feedbackText) {
@@ -64,13 +64,13 @@ export class ReactionFeedbackProcessor extends BaseProcessor {
   }
 
   /**
-   * Convert reactions object to human-readable feedback text
+   * Convert reactions array to human-readable feedback text
    */
-  private convertReactionsToFeedback(reactions: Record<string, EmojiReaction>): string {
+  private convertReactionsToFeedback(reactions: EmojiReaction[]): string {
     const feedbackParts: string[] = [];
 
-    for (const [emoji] of Object.entries(reactions)) {
-      const sentiment = this.getEmojiSentiment(emoji);
+    for (const reaction of reactions) {
+      const sentiment = this.getEmojiSentiment(reaction.emoji);
       if (sentiment) {
         feedbackParts.push(sentiment);
       }

--- a/packages/context-engine/src/processors/__tests__/ReactionFeedback.test.ts
+++ b/packages/context-engine/src/processors/__tests__/ReactionFeedback.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+
+import { ReactionFeedbackProcessor } from '../ReactionFeedback';
+
+const createContext = (messages: any[]) => ({
+  initialState: {
+    messages: [],
+    model: 'gpt-4',
+    provider: 'openai',
+    systemRole: '',
+    tools: [],
+  },
+  isAborted: false,
+  messages,
+  metadata: {
+    maxTokens: 4096,
+    model: 'gpt-4',
+  },
+});
+
+const createMessage = (
+  id: string,
+  role: string,
+  content: string | any[],
+  reactions?: { count: number; emoji: string; users: string[] }[],
+) => ({
+  content,
+  createdAt: Date.now(),
+  id,
+  role,
+  updatedAt: Date.now(),
+  ...(reactions ? { metadata: { reactions } } : {}),
+});
+
+describe('ReactionFeedbackProcessor', () => {
+  it('should skip processing when disabled', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: false });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'Hello', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('2', 'user', 'Thanks'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[0].content).toBe('Hello');
+    expect(result.messages[1].content).toBe('Thanks');
+    expect(result.metadata.reactionFeedbackProcessed).toBeUndefined();
+  });
+
+  it('should inject feedback emoji into the next user message', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'user', 'Hi'),
+      createMessage('2', 'assistant', 'Hello!', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('3', 'user', 'Tell me more'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[0].content).toBe('Hi');
+    expect(result.messages[1].content).toBe('Hello!');
+    expect(result.messages[2].content).toBe('[User Feedback Emoji: 👍]\n\nTell me more');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(1);
+  });
+
+  it('should handle multiple reactions on one assistant message', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'Great answer', [
+        { count: 1, emoji: '👍', users: ['user1'] },
+        { count: 1, emoji: '🚀', users: ['user1'] },
+      ]),
+      createMessage('2', 'user', 'Continue'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[1].content).toBe('[User Feedback Emoji: 👍 🚀]\n\nContinue');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(2);
+  });
+
+  it('should accumulate emojis from multiple assistant messages into one user message', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'First response', [
+        { count: 1, emoji: '👍', users: ['user1'] },
+      ]),
+      createMessage('2', 'assistant', 'Second response', [
+        { count: 1, emoji: '👎', users: ['user1'] },
+      ]),
+      createMessage('3', 'user', 'Next question'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[2].content).toBe('[User Feedback Emoji: 👍 👎]\n\nNext question');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(2);
+  });
+
+  it('should not modify assistant messages', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'Response with reaction', [
+        { count: 1, emoji: '❤️', users: ['user1'] },
+      ]),
+      createMessage('2', 'user', 'Follow up'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[0].content).toBe('Response with reaction');
+  });
+
+  it('should skip assistant messages without reactions', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'No reactions here'),
+      createMessage('2', 'user', 'Reply'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[1].content).toBe('Reply');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(0);
+  });
+
+  it('should discard pending feedback when no following user message exists', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'user', 'Question'),
+      createMessage('2', 'assistant', 'Answer', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[0].content).toBe('Question');
+    expect(result.messages[1].content).toBe('Answer');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(0);
+  });
+
+  it('should skip non-string user message content', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'Response', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('2', 'user', [{ text: 'array content', type: 'text' }]),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[1].content).toEqual([{ text: 'array content', type: 'text' }]);
+    expect(result.metadata.reactionFeedbackProcessed).toBe(0);
+  });
+
+  it('should reset pending emojis after injection', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'assistant', 'First', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('2', 'user', 'Second question'),
+      createMessage('3', 'assistant', 'Third'),
+      createMessage('4', 'user', 'Fourth question'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[1].content).toBe('[User Feedback Emoji: 👍]\n\nSecond question');
+    expect(result.messages[3].content).toBe('Fourth question');
+  });
+
+  it('should handle mixed conversation with multiple feedback injection points', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const context = createContext([
+      createMessage('1', 'user', 'Q1'),
+      createMessage('2', 'assistant', 'A1', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('3', 'user', 'Q2'),
+      createMessage('4', 'assistant', 'A2', [{ count: 1, emoji: '👎', users: ['user1'] }]),
+      createMessage('5', 'user', 'Q3'),
+    ]);
+
+    const result = await processor.process(context);
+
+    expect(result.messages[0].content).toBe('Q1');
+    expect(result.messages[2].content).toBe('[User Feedback Emoji: 👍]\n\nQ2');
+    expect(result.messages[4].content).toBe('[User Feedback Emoji: 👎]\n\nQ3');
+    expect(result.metadata.reactionFeedbackProcessed).toBe(2);
+  });
+
+  it('should not mutate the original context', async () => {
+    const processor = new ReactionFeedbackProcessor({ enabled: true });
+
+    const originalMessages = [
+      createMessage('1', 'assistant', 'Response', [{ count: 1, emoji: '👍', users: ['user1'] }]),
+      createMessage('2', 'user', 'Follow up'),
+    ];
+    const context = createContext(originalMessages);
+
+    await processor.process(context);
+
+    expect(context.messages[1].content).toBe('Follow up');
+  });
+});

--- a/packages/context-engine/src/processors/index.ts
+++ b/packages/context-engine/src/processors/index.ts
@@ -20,6 +20,7 @@ export {
 } from './PlaceholderVariables';
 export { SupervisorRoleRestoreProcessor } from './SupervisorRoleRestore';
 export { TaskMessageProcessor } from './TaskMessage';
+export { ReactionFeedbackProcessor } from './ReactionFeedback';
 export { TasksFlattenProcessor } from './TasksFlatten';
 export { ToolCallProcessor } from './ToolCall';
 export { ToolMessageReorder } from './ToolMessageReorder';
@@ -34,5 +35,6 @@ export type {
   PlaceholderValueMap,
   PlaceholderVariablesConfig,
 } from './PlaceholderVariables';
+export type { ReactionFeedbackConfig } from './ReactionFeedback';
 export type { TaskMessageConfig } from './TaskMessage';
 export type { ToolCallConfig } from './ToolCall';

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -77,12 +77,25 @@ export const ModelPerformanceSchema = z.object({
   latency: z.number().optional(),
 });
 
+// ============ Emoji Reaction ============ //
+
+export interface EmojiReaction {
+  count: number;
+  users: string[];
+}
+
+export const EmojiReactionSchema = z.object({
+  count: z.number(),
+  users: z.array(z.string()),
+});
+
 export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSchema).extend({
   collapsed: z.boolean().optional(),
   inspectExpanded: z.boolean().optional(),
   isMultimodal: z.boolean().optional(),
   isSupervisor: z.boolean().optional(),
   pageSelections: z.array(PageSelectionSchema).optional(),
+  reactions: z.record(z.string(), EmojiReactionSchema).optional(),
 });
 
 export interface ModelUsage extends ModelTokensUsage {
@@ -155,4 +168,9 @@ export interface MessageMetadata extends ModelUsage, ModelPerformance {
    * Used for Ask AI functionality to persist selection context
    */
   pageSelections?: PageSelection[];
+  /**
+   * Emoji reactions on this message
+   * Key is the emoji character (e.g., "👍", "❤️")
+   */
+  reactions?: Record<string, EmojiReaction>;
 }

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -80,11 +80,13 @@ export const ModelPerformanceSchema = z.object({
 // ============ Emoji Reaction ============ //
 
 export interface EmojiReaction {
+  emoji: string;
   count: number;
   users: string[];
 }
 
 export const EmojiReactionSchema = z.object({
+  emoji: z.string(),
   count: z.number(),
   users: z.array(z.string()),
 });
@@ -95,7 +97,7 @@ export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSche
   isMultimodal: z.boolean().optional(),
   isSupervisor: z.boolean().optional(),
   pageSelections: z.array(PageSelectionSchema).optional(),
-  reactions: z.record(z.string(), EmojiReactionSchema).optional(),
+  reactions: z.array(EmojiReactionSchema).optional(),
 });
 
 export interface ModelUsage extends ModelTokensUsage {
@@ -170,7 +172,6 @@ export interface MessageMetadata extends ModelUsage, ModelPerformance {
   pageSelections?: PageSelection[];
   /**
    * Emoji reactions on this message
-   * Key is the emoji character (e.g., "👍", "❤️")
    */
-  reactions?: Record<string, EmojiReaction>;
+  reactions?: EmojiReaction[];
 }

--- a/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/agent/features/Conversation/MainChatInput/index.tsx
@@ -40,6 +40,7 @@ const MainChatInput = memo(() => {
       }}
       rightActions={rightActions}
       sendMenu={{ items: sendMenuItems }}
+      skipScrollMarginWithList
     />
   );
 });

--- a/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
+++ b/src/app/[variants]/(main)/group/features/Conversation/MainChatInput/index.tsx
@@ -40,6 +40,7 @@ const MainChatInput = memo(() => {
       }}
       rightActions={rightActions}
       sendMenu={{ items: sendMenuItems }}
+      skipScrollMarginWithList
     />
   );
 });

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -43,6 +43,10 @@ export interface ChatInputProps {
    * Send menu configuration (for send options like Enter/Cmd+Enter, Add AI/User message)
    */
   sendMenu?: MenuProps;
+  /**
+   * 与 ChatList 共同挨在一起的时候，将一点间距去掉
+   */
+  skipScrollMarginWithList?: boolean;
 }
 
 /**
@@ -60,6 +64,7 @@ const ChatInput = memo<ChatInputProps>(
     sendMenu,
     sendButtonProps: customSendButtonProps,
     onEditorReady,
+    skipScrollMarginWithList,
   }) => {
     const { t } = useTranslation('chat');
 
@@ -132,7 +137,7 @@ const ChatInput = memo<ChatInputProps>(
     };
 
     const defaultContent = (
-      <WideScreenContainer>
+      <WideScreenContainer style={skipScrollMarginWithList ? { marginTop: -12 } : undefined}>
         {sendMessageErrorMsg && (
           <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
             <Alert

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -1,8 +1,9 @@
 import { type UIChatMessage } from '@lobechat/types';
-import { ActionIconGroup, createRawModal } from '@lobehub/ui';
+import { ActionIconGroup, Flexbox, createRawModal } from '@lobehub/ui';
 import type { ActionIconGroupEvent, ActionIconGroupItemType } from '@lobehub/ui';
 import { memo, useCallback, useMemo } from 'react';
 
+import { ReactionPicker } from '../../../components/Reaction';
 import ShareMessageModal, { type ShareModalProps } from '../../../components/ShareMessageModal';
 import {
   Provider,
@@ -68,6 +69,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
   ({ actionsConfig, id, data, index }) => {
     const { error, tools } = data;
     const store = useConversationStoreApi();
+    const addReaction = useConversationStore((s) => s.addReaction);
 
     const handleOpenShareModal = useCallback(() => {
       createRawModal(
@@ -209,7 +211,12 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
 
     if (error) return <ErrorActionsBar actions={defaultActions} onActionClick={handleAction} />;
 
-    return <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />;
+    return (
+      <Flexbox align={'center'} gap={8} horizontal>
+        <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+        <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
+      </Flexbox>
+    );
   },
 );
 

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -69,7 +69,6 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
   ({ actionsConfig, id, data, index }) => {
     const { error, tools } = data;
     const store = useConversationStoreApi();
-    const addReaction = useConversationStore((s) => s.addReaction);
 
     const handleOpenShareModal = useCallback(() => {
       createRawModal(
@@ -213,7 +212,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
 
     return (
       <Flexbox align={'center'} gap={8} horizontal>
-        <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+        <ReactionPicker messageId={id} />
         <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
       </Flexbox>
     );

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -1,9 +1,13 @@
 import { LOADING_FLAT } from '@lobechat/const';
 import { type UIChatMessage } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
+
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
 
 import { messageStateSelectors, useConversationStore } from '../../../store';
+import { ReactionDisplay } from '../../../components/Reaction';
 import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessage';
 import DisplayContent from '../../components/DisplayContent';
 import FileChunks from '../../components/FileChunks';
@@ -19,6 +23,9 @@ const MessageContent = memo<UIChatMessage>(
     const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
     const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
     const isReasoning = useConversationStore(messageStateSelectors.isMessageInReasoning(id));
+    const addReaction = useConversationStore((s) => s.addReaction);
+    const removeReaction = useConversationStore((s) => s.removeReaction);
+    const userId = useUserStore(userProfileSelectors.userId)!;
 
     const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && !!tools;
 
@@ -32,6 +39,28 @@ const MessageContent = memo<UIChatMessage>(
       (!props.reasoning && isReasoning);
 
     const showFileChunks = !!chunksList && chunksList.length > 0;
+
+    const reactions = metadata?.reactions || [];
+
+    const handleReactionClick = useCallback(
+      (emoji: string) => {
+        const existing = reactions.find((r) => r.emoji === emoji);
+        if (existing && existing.users.includes(userId)) {
+          removeReaction(id, emoji);
+        } else {
+          addReaction(id, emoji);
+        }
+      },
+      [id, reactions, addReaction, removeReaction],
+    );
+
+    const isActive = useCallback(
+      (emoji: string) => {
+        const reaction = reactions.find((r) => r.emoji === emoji);
+        return !!reaction && reaction.users.includes(userId);
+      },
+      [reactions],
+    );
 
     if (isCollapsed) return <CollapsedMessage content={content} id={id} />;
 
@@ -52,6 +81,14 @@ const MessageContent = memo<UIChatMessage>(
           tempDisplayContent={metadata?.tempDisplayContent}
         />
         {showImageItems && <ImageFileListViewer items={imageList} />}
+        {reactions.length > 0 && (
+          <ReactionDisplay
+            isActive={isActive}
+            onAdd={(emoji) => addReaction(id, emoji)}
+            onReactionClick={handleReactionClick}
+            reactions={reactions}
+          />
+        )}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -6,8 +6,8 @@ import { memo, useCallback } from 'react';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
-import { messageStateSelectors, useConversationStore } from '../../../store';
 import { ReactionDisplay } from '../../../components/Reaction';
+import { messageStateSelectors, useConversationStore } from '../../../store';
 import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessage';
 import DisplayContent from '../../components/DisplayContent';
 import FileChunks from '../../components/FileChunks';
@@ -84,7 +84,7 @@ const MessageContent = memo<UIChatMessage>(
         {reactions.length > 0 && (
           <ReactionDisplay
             isActive={isActive}
-            onAdd={(emoji) => addReaction(id, emoji)}
+            messageId={id}
             onReactionClick={handleReactionClick}
             reactions={reactions}
           />

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -71,7 +71,6 @@ interface GroupActionsProps {
 const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, contentBlock }) => {
   const { tools } = data;
   const store = useConversationStoreApi();
-  const addReaction = useConversationStore((s) => s.addReaction);
   const handleOpenShareModal = useCallback(() => {
     createRawModal(
       (props: ShareModalProps) => (
@@ -166,7 +165,7 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
 
   return (
     <Flexbox align={'center'} gap={8} horizontal>
-      <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+      <ReactionPicker messageId={id} />
       <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
     </Flexbox>
   );

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -1,8 +1,9 @@
 import { type AssistantContentBlock, type UIChatMessage } from '@lobechat/types';
-import { ActionIconGroup, createRawModal } from '@lobehub/ui';
+import { ActionIconGroup, Flexbox, createRawModal } from '@lobehub/ui';
 import type { ActionIconGroupEvent, ActionIconGroupItemType } from '@lobehub/ui';
 import { memo, useCallback, useMemo } from 'react';
 
+import { ReactionPicker } from '../../../components/Reaction';
 import ShareMessageModal, { type ShareModalProps } from '../../../components/ShareMessageModal';
 import {
   Provider,
@@ -70,6 +71,7 @@ interface GroupActionsProps {
 const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, contentBlock }) => {
   const { tools } = data;
   const store = useConversationStoreApi();
+  const addReaction = useConversationStore((s) => s.addReaction);
   const handleOpenShareModal = useCallback(() => {
     createRawModal(
       (props: ShareModalProps) => (
@@ -162,7 +164,12 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
     [allActions],
   );
 
-  return <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />;
+  return (
+    <Flexbox align={'center'} gap={8} horizontal>
+      <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+      <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
+    </Flexbox>
+  );
 });
 
 WithContentId.displayName = 'GroupActionsWithContentId';

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -4,8 +4,6 @@ import type { AssistantContentBlock, EmojiReaction } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 import { type MouseEventHandler, Suspense, memo, useCallback, useMemo } from 'react';
 
-import { ReactionDisplay } from '../../components/Reaction';
-
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
 import { ChatItem } from '@/features/Conversation/ChatItem';
 import { useNewScreen } from '@/features/Conversation/Messages/components/useNewScreen';
@@ -17,6 +15,7 @@ import { useGlobalStore } from '@/store/global';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
+import { ReactionDisplay } from '../../components/Reaction';
 import { useAgentMeta } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
 import {
@@ -176,7 +175,7 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing, isLat
       {reactions.length > 0 && (
         <ReactionDisplay
           isActive={isReactionActive}
-          onAdd={(emoji) => addReaction(id, emoji)}
+          messageId={id}
           onReactionClick={handleReactionClick}
           reactions={reactions}
         />

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import type { AssistantContentBlock } from '@lobechat/types';
+import type { AssistantContentBlock, EmojiReaction } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 import { type MouseEventHandler, Suspense, memo, useCallback, useMemo } from 'react';
+
+import { ReactionDisplay } from '../../components/Reaction';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
 import { ChatItem } from '@/features/Conversation/ChatItem';
@@ -12,6 +14,8 @@ import dynamic from '@/libs/next/dynamic';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
 
 import { useAgentMeta } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
@@ -45,7 +49,8 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing, isLat
   // Get message and actionsConfig from ConversationStore
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual)!;
 
-  const { agentId, usage, createdAt, children, performance, model, provider, branch } = item;
+  const { agentId, usage, createdAt, children, performance, model, provider, branch, metadata } =
+    item;
   const avatar = useAgentMeta(agentId);
 
   // Collect fileList from all children blocks
@@ -74,6 +79,31 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing, isLat
     isLatestItem,
     messageId: id,
   });
+
+  const addReaction = useConversationStore((s) => s.addReaction);
+  const removeReaction = useConversationStore((s) => s.removeReaction);
+  const userId = useUserStore(userProfileSelectors.userId)!;
+  const reactions: EmojiReaction[] = metadata?.reactions || [];
+
+  const handleReactionClick = useCallback(
+    (emoji: string) => {
+      const existing = reactions.find((r) => r.emoji === emoji);
+      if (existing && existing.users.includes(userId)) {
+        removeReaction(id, emoji);
+      } else {
+        addReaction(id, emoji);
+      }
+    },
+    [id, reactions, addReaction, removeReaction],
+  );
+
+  const isReactionActive = useCallback(
+    (emoji: string) => {
+      const reaction = reactions.find((r) => r.emoji === emoji);
+      return !!reaction && reaction.users.includes(userId);
+    },
+    [reactions],
+  );
 
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
   const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
@@ -142,6 +172,14 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing, isLat
       )}
       {model && (
         <Usage model={model} performance={performance} provider={provider!} usage={usage} />
+      )}
+      {reactions.length > 0 && (
+        <ReactionDisplay
+          isActive={isReactionActive}
+          onAdd={(emoji) => addReaction(id, emoji)}
+          onReactionClick={handleReactionClick}
+          reactions={reactions}
+        />
       )}
       <Suspense fallback={null}>
         {editing && contentId && <EditState content={lastAssistantMsg?.content} id={contentId} />}

--- a/src/features/Conversation/Messages/Supervisor/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Supervisor/Actions/index.tsx
@@ -1,8 +1,9 @@
 import { type AssistantContentBlock, type UIChatMessage } from '@lobechat/types';
-import { ActionIconGroup, createRawModal } from '@lobehub/ui';
+import { ActionIconGroup, Flexbox, createRawModal } from '@lobehub/ui';
 import type { ActionIconGroupEvent, ActionIconGroupItemType } from '@lobehub/ui';
 import { memo, useCallback, useMemo } from 'react';
 
+import { ReactionPicker } from '../../../components/Reaction';
 import ShareMessageModal, { type ShareModalProps } from '../../../components/ShareMessageModal';
 import {
   Provider,
@@ -69,6 +70,7 @@ interface GroupActionsProps {
  */
 const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, contentBlock }) => {
   const store = useConversationStoreApi();
+  const addReaction = useConversationStore((s) => s.addReaction);
   const handleOpenShareModal = useCallback(() => {
     createRawModal(
       (props: ShareModalProps) => (
@@ -154,7 +156,12 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
     [allActions],
   );
 
-  return <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />;
+  return (
+    <Flexbox align={'center'} gap={8} horizontal>
+      <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+      <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
+    </Flexbox>
+  );
 });
 
 WithContentId.displayName = 'GroupActionsWithContentId';

--- a/src/features/Conversation/Messages/Supervisor/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Supervisor/Actions/index.tsx
@@ -70,7 +70,6 @@ interface GroupActionsProps {
  */
 const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, contentBlock }) => {
   const store = useConversationStoreApi();
-  const addReaction = useConversationStore((s) => s.addReaction);
   const handleOpenShareModal = useCallback(() => {
     createRawModal(
       (props: ShareModalProps) => (
@@ -158,7 +157,7 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
 
   return (
     <Flexbox align={'center'} gap={8} horizontal>
-      <ReactionPicker onSelect={(emoji) => addReaction(id, emoji)} />
+      <ReactionPicker messageId={id} />
       <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
     </Flexbox>
   );

--- a/src/features/Conversation/Messages/Supervisor/index.tsx
+++ b/src/features/Conversation/Messages/Supervisor/index.tsx
@@ -6,8 +6,6 @@ import isEqual from 'fast-deep-equal';
 import { type MouseEventHandler, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ReactionDisplay } from '../../components/Reaction';
-
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
 import AgentGroupAvatar from '@/features/AgentGroupAvatar';
 import { ChatItem } from '@/features/Conversation/ChatItem';
@@ -17,6 +15,7 @@ import { agentGroupSelectors } from '@/store/agentGroup/selectors';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
+import { ReactionDisplay } from '../../components/Reaction';
 import { useAgentMeta } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
 import {
@@ -155,7 +154,7 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing, isLat
       {reactions.length > 0 && (
         <ReactionDisplay
           isActive={isReactionActive}
-          onAdd={(emoji) => addReaction(id, emoji)}
+          messageId={id}
           onReactionClick={handleReactionClick}
           reactions={reactions}
         />

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { EmojiReaction } from '@lobechat/types';
+import { createStyles } from 'antd-style';
+import { memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+const useStyles = createStyles(({ css, token }) => ({
+  active: css`
+    border: 1px solid ${token.colorPrimary};
+    background: ${token.colorPrimaryBg};
+  `,
+  container: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-block-start: 8px;
+  `,
+  count: css`
+    font-size: 12px;
+    color: ${token.colorTextSecondary};
+  `,
+  reactionTag: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+
+    padding-block: 2px;
+    padding-inline: 8px;
+    border: 1px solid transparent;
+    border-radius: ${token.borderRadius}px;
+
+    font-size: 14px;
+
+    background: ${token.colorFillSecondary};
+
+    transition: all 0.2s;
+
+    &:hover {
+      background: ${token.colorFillTertiary};
+    }
+  `,
+}));
+
+interface ReactionDisplayProps {
+  /**
+   * Whether the current user has reacted (used for single-user mode)
+   */
+  isActive?: (emoji: string) => boolean;
+  /**
+   * Callback when a reaction is clicked
+   */
+  onReactionClick?: (emoji: string) => void;
+  /**
+   * The reactions to display
+   */
+  reactions: Record<string, EmojiReaction>;
+}
+
+const ReactionDisplay = memo<ReactionDisplayProps>(({ reactions, onReactionClick, isActive }) => {
+  const { styles, cx } = useStyles();
+
+  const reactionEntries = Object.entries(reactions);
+
+  if (reactionEntries.length === 0) return null;
+
+  return (
+    <Flexbox className={styles.container} horizontal>
+      {reactionEntries.map(([emoji, data]) => (
+        <div
+          className={cx(styles.reactionTag, isActive?.(emoji) && styles.active)}
+          key={emoji}
+          onClick={() => onReactionClick?.(emoji)}
+        >
+          <span>{emoji}</span>
+          {data.count > 1 && <span className={styles.count}>{data.count}</span>}
+        </div>
+      ))}
+    </Flexbox>
+  );
+});
+
+ReactionDisplay.displayName = 'ReactionDisplay';
+
+export default ReactionDisplay;

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import type { EmojiReaction } from '@lobechat/types';
+import { Flexbox } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 const useStyles = createStyles(({ css, token }) => ({
   active: css`
@@ -56,26 +56,24 @@ interface ReactionDisplayProps {
   /**
    * The reactions to display
    */
-  reactions: Record<string, EmojiReaction>;
+  reactions: EmojiReaction[];
 }
 
 const ReactionDisplay = memo<ReactionDisplayProps>(({ reactions, onReactionClick, isActive }) => {
   const { styles, cx } = useStyles();
 
-  const reactionEntries = Object.entries(reactions);
-
-  if (reactionEntries.length === 0) return null;
+  if (reactions.length === 0) return null;
 
   return (
     <Flexbox className={styles.container} horizontal>
-      {reactionEntries.map(([emoji, data]) => (
+      {reactions.map((reaction) => (
         <div
-          className={cx(styles.reactionTag, isActive?.(emoji) && styles.active)}
-          key={emoji}
-          onClick={() => onReactionClick?.(emoji)}
+          className={cx(styles.reactionTag, isActive?.(reaction.emoji) && styles.active)}
+          key={reaction.emoji}
+          onClick={() => onReactionClick?.(reaction.emoji)}
         >
-          <span>{emoji}</span>
-          {data.count > 1 && <span className={styles.count}>{data.count}</span>}
+          <span>{reaction.emoji}</span>
+          {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
         </div>
       ))}
     </Flexbox>

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -51,9 +51,9 @@ interface ReactionDisplayProps {
    */
   isActive?: (emoji: string) => boolean;
   /**
-   * Callback when an emoji is added via the inline picker
+   * The message ID for adding reactions via the inline picker
    */
-  onAdd?: (emoji: string) => void;
+  messageId?: string;
   /**
    * Callback when a reaction is clicked
    */
@@ -65,7 +65,7 @@ interface ReactionDisplayProps {
 }
 
 const ReactionDisplay = memo<ReactionDisplayProps>(
-  ({ reactions, onReactionClick, onAdd, isActive }) => {
+  ({ reactions, onReactionClick, messageId, isActive }) => {
     const { styles, cx } = useStyles();
 
     if (reactions.length === 0) return null;
@@ -82,7 +82,7 @@ const ReactionDisplay = memo<ReactionDisplayProps>(
             {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
           </div>
         ))}
-        {onAdd && <ReactionPicker onSelect={onAdd} />}
+        {messageId && <ReactionPicker messageId={messageId} />}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -5,10 +5,11 @@ import { Flexbox } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { memo } from 'react';
 
+import ReactionPicker from './ReactionPicker';
+
 const useStyles = createStyles(({ css, token }) => ({
   active: css`
-    border: 1px solid ${token.colorPrimary};
-    background: ${token.colorPrimaryBg};
+    background: ${token.colorFillTertiary};
   `,
   container: css`
     display: flex;
@@ -27,12 +28,13 @@ const useStyles = createStyles(({ css, token }) => ({
     gap: 4px;
     align-items: center;
 
-    padding-block: 2px;
-    padding-inline: 8px;
-    border: 1px solid transparent;
-    border-radius: ${token.borderRadius}px;
+    height: 28px;
+    padding-block: 0;
+    padding-inline: 10px;
+    border-radius: 14px;
 
     font-size: 14px;
+    line-height: 1;
 
     background: ${token.colorFillSecondary};
 
@@ -50,6 +52,10 @@ interface ReactionDisplayProps {
    */
   isActive?: (emoji: string) => boolean;
   /**
+   * Callback when an emoji is added via the inline picker
+   */
+  onAdd?: (emoji: string) => void;
+  /**
    * Callback when a reaction is clicked
    */
   onReactionClick?: (emoji: string) => void;
@@ -59,26 +65,29 @@ interface ReactionDisplayProps {
   reactions: EmojiReaction[];
 }
 
-const ReactionDisplay = memo<ReactionDisplayProps>(({ reactions, onReactionClick, isActive }) => {
-  const { styles, cx } = useStyles();
+const ReactionDisplay = memo<ReactionDisplayProps>(
+  ({ reactions, onReactionClick, onAdd, isActive }) => {
+    const { styles, cx } = useStyles();
 
-  if (reactions.length === 0) return null;
+    if (reactions.length === 0) return null;
 
-  return (
-    <Flexbox className={styles.container} horizontal>
-      {reactions.map((reaction) => (
-        <div
-          className={cx(styles.reactionTag, isActive?.(reaction.emoji) && styles.active)}
-          key={reaction.emoji}
-          onClick={() => onReactionClick?.(reaction.emoji)}
-        >
-          <span>{reaction.emoji}</span>
-          {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
-        </div>
-      ))}
-    </Flexbox>
-  );
-});
+    return (
+      <Flexbox align={'center'} className={styles.container} horizontal>
+        {reactions.map((reaction) => (
+          <div
+            className={cx(styles.reactionTag, isActive?.(reaction.emoji) && styles.active)}
+            key={reaction.emoji}
+            onClick={() => onReactionClick?.(reaction.emoji)}
+          >
+            <span>{reaction.emoji}</span>
+            {reaction.count > 1 && <span className={styles.count}>{reaction.count}</span>}
+          </div>
+        ))}
+        {onAdd && <ReactionPicker onSelect={onAdd} />}
+      </Flexbox>
+    );
+  },
+);
 
 ReactionDisplay.displayName = 'ReactionDisplay';
 

--- a/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionDisplay.tsx
@@ -15,7 +15,6 @@ const useStyles = createStyles(({ css, token }) => ({
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
-    margin-block-start: 8px;
   `,
   count: css`
     font-size: 12px;

--- a/src/features/Conversation/components/Reaction/ReactionPicker.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionPicker.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { ActionIcon, Tooltip } from '@lobehub/ui';
+import { Popover } from 'antd';
+import { createStyles } from 'antd-style';
+import { SmilePlus } from 'lucide-react';
+import { type FC, type ReactNode, memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+const QUICK_REACTIONS = ['👍', '👎', '❤️', '😄', '🎉', '😢', '🤔', '🚀'];
+
+const useStyles = createStyles(({ css, token }) => ({
+  emojiButton: css`
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 32px;
+    height: 32px;
+    border-radius: ${token.borderRadius}px;
+
+    font-size: 18px;
+
+    transition: all 0.2s;
+
+    &:hover {
+      transform: scale(1.1);
+      background: ${token.colorFillSecondary};
+    }
+  `,
+  pickerContainer: css`
+    padding: 8px;
+  `,
+}));
+
+interface ReactionPickerProps {
+  /**
+   * Callback when an emoji is selected
+   */
+  onSelect: (emoji: string) => void;
+  /**
+   * Custom trigger element
+   */
+  trigger?: ReactNode;
+}
+
+const ReactionPicker: FC<ReactionPickerProps> = memo(({ onSelect, trigger }) => {
+  const { styles } = useStyles();
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (emoji: string) => {
+    onSelect(emoji);
+    setOpen(false);
+  };
+
+  const content = (
+    <Flexbox className={styles.pickerContainer} gap={4} horizontal wrap="wrap">
+      {QUICK_REACTIONS.map((emoji) => (
+        <div className={styles.emojiButton} key={emoji} onClick={() => handleSelect(emoji)}>
+          {emoji}
+        </div>
+      ))}
+    </Flexbox>
+  );
+
+  return (
+    <Popover
+      arrow={false}
+      content={content}
+      onOpenChange={setOpen}
+      open={open}
+      placement="top"
+      trigger="click"
+    >
+      {trigger || (
+        <Tooltip title={t('messageAction.reaction')}>
+          <ActionIcon icon={SmilePlus} size="small" />
+        </Tooltip>
+      )}
+    </Popover>
+  );
+});
+
+ReactionPicker.displayName = 'ReactionPicker';
+
+export default ReactionPicker;

--- a/src/features/Conversation/components/Reaction/ReactionPicker.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionPicker.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { ActionIcon, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Tooltip } from '@lobehub/ui';
 import { Popover } from 'antd';
 import { createStyles } from 'antd-style';
 import { SmilePlus } from 'lucide-react';
 import { type FC, type ReactNode, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Flexbox } from 'react-layout-kit';
 
 const QUICK_REACTIONS = ['👍', '👎', '❤️', '😄', '🎉', '😢', '🤔', '🚀'];
 

--- a/src/features/Conversation/components/Reaction/ReactionPicker.tsx
+++ b/src/features/Conversation/components/Reaction/ReactionPicker.tsx
@@ -12,6 +12,8 @@ import { useTranslation } from 'react-i18next';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 
+import { useConversationStore } from '../../store';
+
 const QUICK_REACTIONS = ['👍', '👎', '❤️', '😄', '😂', '😅', '🎉', '😢', '🤔', '🚀'];
 
 const useStyles = createStyles(({ css, token }) => ({
@@ -61,20 +63,21 @@ const useStyles = createStyles(({ css, token }) => ({
 }));
 
 interface ReactionPickerProps {
-  onSelect: (emoji: string) => void;
+  messageId: string;
   trigger?: ReactNode;
 }
 
-const ReactionPicker: FC<ReactionPickerProps> = memo(({ onSelect, trigger }) => {
+const ReactionPicker: FC<ReactionPickerProps> = memo(({ messageId, trigger }) => {
   const { styles } = useStyles();
   const { t } = useTranslation('chat');
   const theme = useTheme();
   const locale = useGlobalStore(globalGeneralSelectors.currentLanguage);
+  const addReaction = useConversationStore((s) => s.addReaction);
   const [open, setOpen] = useState(false);
   const [showFullPicker, setShowFullPicker] = useState(false);
 
   const handleSelect = (emoji: string) => {
-    onSelect(emoji);
+    addReaction(messageId, emoji);
     setOpen(false);
     setShowFullPicker(false);
   };

--- a/src/features/Conversation/components/Reaction/index.ts
+++ b/src/features/Conversation/components/Reaction/index.ts
@@ -1,0 +1,2 @@
+export { default as ReactionDisplay } from './ReactionDisplay';
+export { default as ReactionPicker } from './ReactionPicker';

--- a/src/features/Conversation/store/slices/message/action/crud.ts
+++ b/src/features/Conversation/store/slices/message/action/crud.ts
@@ -8,7 +8,7 @@ import {
   type ChatToolPayloadWithResult,
   type ChatVideoItem,
   type CreateMessageParams,
-  type EmojiReaction,
+
   type GroundingSearch,
   type MessageMetadata,
   type MessagePluginItem,
@@ -31,12 +31,6 @@ import { dataSelectors } from '../../data/selectors';
  * with optimistic updates (update UI first, then persist to database)
  */
 export interface MessageCRUDAction {
-  // ===== Reaction ===== //
-  /**
-   * Add an emoji reaction to a message
-   */
-  addReaction: (messageId: string, emoji: string) => Promise<void>;
-
   // ===== Update Tools ===== //
   /**
    * Add a tool to an assistant message
@@ -92,11 +86,6 @@ export interface MessageCRUDAction {
    * Delete a tool message and remove the tool from its parent assistant message
    */
   deleteToolMessage: (id: string) => Promise<void>;
-
-  /**
-   * Remove an emoji reaction from a message
-   */
-  removeReaction: (messageId: string, emoji: string) => Promise<void>;
 
   /**
    * Remove a tool from an assistant message
@@ -181,29 +170,6 @@ export const messageCRUDSlice: StateCreator<
   [],
   MessageCRUDAction
 > = (set, get) => ({
-  // ===== Reaction ===== //
-  addReaction: async (messageId, emoji) => {
-    const { updateMessageMetadata } = get();
-    const message = dataSelectors.getDisplayMessageById(messageId)(get());
-
-    const currentReactions = message?.metadata?.reactions || [];
-    const existingIndex = currentReactions.findIndex((r: EmojiReaction) => r.emoji === emoji);
-
-    let newReactions: EmojiReaction[];
-
-    if (existingIndex >= 0) {
-      // Update existing reaction
-      newReactions = currentReactions.map((r: EmojiReaction, i: number) =>
-        i === existingIndex ? { ...r, count: r.count + 1, users: [...r.users, 'user'] } : r,
-      );
-    } else {
-      // Add new reaction
-      newReactions = [...currentReactions, { count: 1, emoji, users: ['user'] }];
-    }
-
-    await updateMessageMetadata(messageId, { reactions: newReactions });
-  },
-
   // ===== Update Tools ===== //
   addToolToMessage: async (messageId, tool) => {
     const { internal_dispatchMessage, replaceMessages, context } = get();
@@ -402,31 +368,6 @@ export const messageCRUDSlice: StateCreator<
     if (result?.success && result.messages) {
       replaceMessages(result.messages);
     }
-  },
-
-  removeReaction: async (messageId, emoji) => {
-    const { updateMessageMetadata } = get();
-    const message = dataSelectors.getDisplayMessageById(messageId)(get());
-
-    const currentReactions = message?.metadata?.reactions || [];
-    const existingIndex = currentReactions.findIndex((r: EmojiReaction) => r.emoji === emoji);
-
-    if (existingIndex < 0) return;
-
-    const emojiReaction = currentReactions[existingIndex];
-    let newReactions: EmojiReaction[];
-
-    if (emojiReaction.count <= 1) {
-      // Remove the reaction entirely
-      newReactions = currentReactions.filter((_: EmojiReaction, i: number) => i !== existingIndex);
-    } else {
-      // Decrease count
-      newReactions = currentReactions.map((r: EmojiReaction, i: number) =>
-        i === existingIndex ? { ...r, count: r.count - 1, users: r.users.slice(0, -1) } : r,
-      );
-    }
-
-    await updateMessageMetadata(messageId, { reactions: newReactions });
   },
 
   removeToolFromMessage: async (messageId, toolCallId) => {

--- a/src/features/Conversation/store/slices/message/action/index.ts
+++ b/src/features/Conversation/store/slices/message/action/index.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 
 import type { Store as ConversationStore } from '../../../action';
 import { type MessageCRUDAction, messageCRUDSlice } from './crud';
+import { type MessageReactionAction, messageReactionSlice } from './reaction';
 import { sendMessage } from './sendMessage';
 import { type MessageStateAction, messageStateSlice } from './state';
 
@@ -10,10 +11,11 @@ import { type MessageStateAction, messageStateSlice } from './state';
  *
  * Handles all message operations:
  * - CRUD (create, read, update, delete)
+ * - Reaction (add, remove emoji reactions)
  * - State management (loading, collapsed, editing)
  * - Sending messages
  */
-export interface MessageAction extends MessageCRUDAction, MessageStateAction {
+export interface MessageAction extends MessageCRUDAction, MessageReactionAction, MessageStateAction {
   /**
    * Add an AI message (convenience method)
    */
@@ -38,6 +40,9 @@ export const messageSlice: StateCreator<
 > = (set, get, ...rest) => ({
   // Spread CRUD actions
   ...messageCRUDSlice(set, get, ...rest),
+
+  // Spread reaction actions
+  ...messageReactionSlice(set, get, ...rest),
 
   // Spread state actions
   ...messageStateSlice(set, get, ...rest),

--- a/src/features/Conversation/store/slices/message/action/reaction.ts
+++ b/src/features/Conversation/store/slices/message/action/reaction.ts
@@ -1,0 +1,80 @@
+import type { EmojiReaction } from '@lobechat/types';
+import type { StateCreator } from 'zustand';
+
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
+import type { Store as ConversationStore } from '../../../action';
+import { dataSelectors } from '../../data/selectors';
+
+export interface MessageReactionAction {
+  /**
+   * Add an emoji reaction to a message
+   */
+  addReaction: (messageId: string, emoji: string) => Promise<void>;
+
+  /**
+   * Remove an emoji reaction from a message
+   */
+  removeReaction: (messageId: string, emoji: string) => Promise<void>;
+}
+
+export const messageReactionSlice: StateCreator<
+  ConversationStore,
+  [['zustand/devtools', never]],
+  [],
+  MessageReactionAction
+> = (set, get) => ({
+  addReaction: async (messageId, emoji) => {
+    const { updateMessageMetadata } = get();
+    const message = dataSelectors.getDisplayMessageById(messageId)(get());
+    const userId = userProfileSelectors.userId(useUserStore.getState())!;
+
+    const currentReactions = message?.metadata?.reactions || [];
+    const existingIndex = currentReactions.findIndex((r: EmojiReaction) => r.emoji === emoji);
+
+    let newReactions: EmojiReaction[];
+
+    if (existingIndex >= 0) {
+      newReactions = currentReactions.map((r: EmojiReaction, i: number) =>
+        i === existingIndex ? { ...r, count: r.count + 1, users: [...r.users, userId] } : r,
+      );
+    } else {
+      newReactions = [...currentReactions, { count: 1, emoji, users: [userId] }];
+    }
+
+    await updateMessageMetadata(messageId, { reactions: newReactions });
+  },
+
+  removeReaction: async (messageId, emoji) => {
+    const { updateMessageMetadata } = get();
+    const message = dataSelectors.getDisplayMessageById(messageId)(get());
+    const userId = userProfileSelectors.userId(useUserStore.getState())!;
+
+    const currentReactions = message?.metadata?.reactions || [];
+    const existingIndex = currentReactions.findIndex((r: EmojiReaction) => r.emoji === emoji);
+
+    if (existingIndex < 0) return;
+
+    const emojiReaction = currentReactions[existingIndex];
+    let newReactions: EmojiReaction[];
+
+    if (emojiReaction.count <= 1) {
+      newReactions = currentReactions.filter((_: EmojiReaction, i: number) => i !== existingIndex);
+    } else {
+      const userIndex = emojiReaction.users.lastIndexOf(userId);
+      const newUsers =
+        userIndex >= 0
+          ? [
+              ...emojiReaction.users.slice(0, userIndex),
+              ...emojiReaction.users.slice(userIndex + 1),
+            ]
+          : emojiReaction.users.slice(0, -1);
+      newReactions = currentReactions.map((r: EmojiReaction, i: number) =>
+        i === existingIndex ? { ...r, count: r.count - 1, users: newUsers } : r,
+      );
+    }
+
+    await updateMessageMetadata(messageId, { reactions: newReactions });
+  },
+});

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -190,6 +190,7 @@ export default {
   'messageAction.delAndRegenerate': 'Delete and Regenerate',
   'messageAction.deleteDisabledByThreads': 'This message has a subtopic and can’t be deleted',
   'messageAction.expand': 'Expand Message',
+  'messageAction.reaction': 'Add Reaction',
   'messageAction.regenerate': 'Regenerate',
   'messages.dm.sentTo': 'Visible only to {{name}}',
   'messages.dm.title': 'DM',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

close LOBE-3100
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Introduce emoji reactions for chat messages and propagate reaction feedback into the context engine for assistant responses.

New Features:
- Add emoji reaction metadata to messages, including counts and per-emoji user lists.
- Expose addReaction and removeReaction actions on the message store slice to update message metadata reactions.
- Add ReactionPicker and ReactionDisplay UI components to let users add and view emoji reactions on messages.
- Introduce a ReactionFeedbackProcessor in the context engine to convert emoji reactions into textual feedback appended to assistant messages.

Enhancements:
- Extend localization with a new message action label for adding reactions.
- Export the ReactionFeedback processor and its config from the context engine processors index for pipeline integration.