### PR TITLE
🔧 chore: upgrade macOS ARM64 runner from macos-14 to macos-15

### DIFF
--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -148,7 +148,7 @@ jobs:
           # 使用 GitHub Hosted Runner
           if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_mac }}" == "true" ]]; then
             echo "Using GitHub-Hosted Runner for macOS ARM64"
-            arm_entry='{"os": "macos-14", "name": "macos-arm64"}'
+            arm_entry='{"os": "macos-15", "name": "macos-arm64"}'
             static_matrix=$(echo "$static_matrix" | jq -c --argjson entry "$arm_entry" '. + [$entry]')
           fi
 


### PR DESCRIPTION
## Summary
- Upgrade macOS ARM64 GitHub-hosted runner from `macos-14` to `macos-15` in the desktop stable release workflow

## Test plan
- [ ] Verify workflow runs successfully on macos-15 runner
- [ ] Confirm desktop build artifacts are generated correctly

## Summary by Sourcery

CI:
- Switch the macOS ARM64 GitHub-hosted runner in the desktop stable release workflow from macos-14 to macos-15.