### PR TITLE
🐛 fix: add missing description parameter docs in Notebook system prompt

### DIFF
--- a/packages/builtin-tool-notebook/src/systemRole.ts
+++ b/packages/builtin-tool-notebook/src/systemRole.ts
@@ -10,6 +10,26 @@ export const systemPrompt = `You have access to the Notebook tool for creating a
 Note: The list of existing documents is automatically provided in the context, so you don't need to query for it.
 </tool_overview>
 
+<api_parameters>
+**createDocument** - All three parameters are required:
+- title (required): A descriptive title for the document
+- description (required): A brief summary of the document (1-2 sentences), shown in document lists
+- content (required): The document content in Markdown format
+- type (optional): "markdown" (default), "note", "report", or "article"
+
+**updateDocument**:
+- id (required): The document ID to update
+- title (optional): New title
+- content (optional): New content
+- append (optional): If true, append to existing content instead of replacing
+
+**getDocument**:
+- id (required): The document ID to retrieve
+
+**deleteDocument**:
+- id (required): The document ID to delete
+</api_parameters>
+
 <when_to_use>
 **Save to Notebook when**:
 - User explicitly asks to "save", "write down", or "document" something


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 Bug 修复 | Bug Fix

### 🔀 变更说明 | Description of Change

https://app.lobehub.com/share/t/y6ih1qCf

The `createDocument` API requires a `description` parameter (as defined in `manifest.ts`), but the system prompt in `systemRole.ts` didn't mention it. This caused models (especially Gemini) to omit the description field when calling `createDocument`, resulting in validation errors:

```json
{
  "code": "invalid_type",
  "expected": "string",
  "received": "undefined",
  "path": ["description"],
  "message": "Required"
}
```

### 📝 补充信息 | Additional Information

Added `<api_parameters>` section to the system prompt to clearly document all required and optional parameters for each Notebook API:

- **createDocument**: title (required), description (required), content (required), type (optional)
- **updateDocument**: id (required), title/content/append (optional)
- **getDocument**: id (required)
- **deleteDocument**: id (required)

closes #11391

## Summary by Sourcery

Clarify and document the Notebook tool API parameters in the system prompt to ensure models correctly include required fields when calling Notebook APIs.

Bug Fixes:
- Ensure the Notebook system prompt documents the required description field for createDocument to prevent validation errors from missing parameters.

Enhancements:
- Document parameter requirements and options for all Notebook APIs (createDocument, updateDocument, getDocument, deleteDocument) in the system prompt for more reliable tool usage.