### PR TITLE
:bug: fix: should not pass `input_image` in message content when has no `image_url`

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -397,6 +397,52 @@ describe('convertOpenAIResponseInputs', () => {
       { content: '杭州天气如何', role: 'user' },
     ]);
   });
+
+  it('should handle opeanai and claude mixed message', async () => {
+    const messages: OpenAIChatMessage[] = [
+      {
+        content: 'system prompts',
+        role: 'system',
+      },
+      {
+        content: '你是谁',
+        role: 'user',
+      },
+      {
+        content: [
+          {
+            signature: 'E',
+            thinking: 'thoughts',
+            type: 'thinking',
+          },
+          {
+            text: '我是 Claude',
+            type: 'text',
+          },
+        ],
+        role: 'assistant',
+        reasoning: {
+          content: 'The user is asking',
+          duration: 110,
+          // @ts-expect-error: ignore
+          signature: 'E',
+        },
+      },
+    ];
+    const result = await convertOpenAIResponseInputs(messages);
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer' },
+      { content: '你是谁', role: 'user' },
+      {
+        summary: [{ text: 'The user is asking', type: 'summary_text' }],
+        type: 'reasoning',
+      },
+      {
+        content: [{ text: '我是 Claude', type: 'input_text' }],
+        role: 'assistant',
+      },
+    ]);
+  });
 });
 
 describe('convertImageUrlToFile', () => {

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -399,6 +399,7 @@ describe('convertOpenAIResponseInputs', () => {
   });
 
   it('should handle opeanai and claude mixed message', async () => {
+    // See: https://github.com/lobehub/lobehub/pull/12017
     const messages: OpenAIChatMessage[] = [
       {
         content: 'system prompts',

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -438,7 +438,7 @@ describe('convertOpenAIResponseInputs', () => {
         type: 'reasoning',
       },
       {
-        content: [{ text: '我是 Claude', type: 'input_text' }],
+        content: [{ text: '我是 Claude', type: 'output_text' }],
         role: 'assistant',
       },
     ]);

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -398,7 +398,7 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
-  it('should handle opeanai and claude mixed message', async () => {
+  it('should handle openai and claude mixed message', async () => {
     // See: https://github.com/lobehub/lobehub/pull/12017
     const messages: OpenAIChatMessage[] = [
       {

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -123,6 +123,11 @@ export const convertOpenAIResponseInputs = async (
           : await Promise.all(
               (message.content || []).map(async (c) => {
                 if (c.type === 'text') {
+                  // if assistant message, set type to output_text
+                  // https://platform.openai.com/docs/guides/text
+                  if (message.role === 'assistant') {
+                    return { ...c, type: 'output_text' };
+                  }
                   return { ...c, type: 'input_text' };
                 }
                 const image = await convertMessageContent(c as OpenAI.ChatCompletionContentPart);

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -146,7 +146,7 @@ export const convertOpenAIResponseInputs = async (
         content:
           typeof processedContent === 'string'
             ? processedContent
-            : processedContent.filter(Boolean),
+            : processedContent.filter((m) => m !== undefined),
       } as OpenAI.Responses.ResponseInputItem;
 
       // remove reasoning field from the message item

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -116,27 +116,32 @@ export const convertOpenAIResponseInputs = async (
 
       // default item
       // also need handle image
+
+      const processedContent =
+        typeof message.content === 'string'
+          ? message.content
+          : await Promise.all(
+              (message.content || []).map(async (c) => {
+                if (c.type === 'text') {
+                  return { ...c, type: 'input_text' };
+                }
+                const image = await convertMessageContent(c as OpenAI.ChatCompletionContentPart);
+                if (!(image as OpenAI.ChatCompletionContentPartImage).image_url?.url) {
+                  return undefined;
+                }
+                return {
+                  image_url: (image as OpenAI.ChatCompletionContentPartImage).image_url?.url,
+                  type: 'input_image',
+                };
+              }),
+            );
+
       const item = {
         ...message,
         content:
-          typeof message.content === 'string'
-            ? message.content
-            : await Promise.all(
-                (message.content || []).map(async (c) => {
-                  if (c.type === 'text') {
-                    return { ...c, type: 'input_text' };
-                  }
-
-                  const image = await convertMessageContent(
-                    c as OpenAI.ChatCompletionContentPart,
-                    options,
-                  );
-                  return {
-                    image_url: (image as OpenAI.ChatCompletionContentPartImage).image_url?.url,
-                    type: 'input_image',
-                  };
-                }),
-              ),
+          typeof processedContent === 'string'
+            ? processedContent
+            : processedContent.filter(Boolean),
       } as OpenAI.Responses.ResponseInputItem;
 
       // remove reasoning field from the message item


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close #9501

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

1. 开启 Claude 的 reasoning 模式，发送一条信息
2. 转为使用 GPT，效果见下面动图

#### 🔀 Description of Change

- `packages/model-runtime/src/core/contextBuilders/openai.test.ts`: 补充一个从 claude 转到 gpt 的真实 message 测试
- `packages/model-runtime/src/core/contextBuilders/openai.ts`: 
  - 如果不是图片，即没有 image_url ，返回 undefined，并在实际填充前过滤
  - 如果 message role 为 assistant ，那入参应该为 `output_test` ，ref: [openai | doc](https://platform.openai.com/docs/guides/text?api-mode=responses)

修复完成后，从使用 Claude 转到 GPT 时，能够顺利聊天，同时含 reasoning 的 message content 能够正常 pass （如修复后动图 gpt 说自己不是 claude）

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ![image-url-b4](https://github.com/user-attachments/assets/ce0e0019-fe08-4514-b015-8de7fd95e71a)  | ![image-url-af](https://github.com/user-attachments/assets/e98c4d0e-c288-4e97-b936-20fa5b47cc81) |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

一个含 Claude Reasonig 信息的原文
```json
[
    {
        "content": "For latex wrapper, use `$` instead of `\\(` or `\\)`, use `$$` instead of `\\[` or `\\]`\n",
        "role": "system"
    },
    {
        "content": "你好",
        "role": "user"
    },
    {
        "content": "你好！我能帮你做什么？如果你愿意，可以直接说下你的目标或贴出材料/题目。",
        "role": "assistant"
    },
    {
        "content": "你是谁",
        "role": "user"
    },
    {
        "content": [
            {
                "signature": "ErgCCkgICxABGAIqQPxGYDlZGfdh4hTw7BRGrv/DeUtjI6mDpeFA0klVArBAh1jYCc+pv76+ED8MSkRn5c88WDN90W/mGNTxj98QH90SDNRnBTc4cM3fhbHcphoMOwPECxfTv0eqHdORIjCq/xvEhtxFs0mXY/GyZIpT3jngBrTAdOk55UjFtvjMUdABbuO4m1RlusIlTckbPMwqnQG8oBJr2IxjjNVKjR1BdnKGGUIirhqAvIUuASPQT7RWPSyXtj39xJK9X8dn07cRKiBft7DzybKs+g/KxZby6Uw0nG97vNVaPNjKCPZXrhGF1kKLkAdBfMJqlJkiHKd68q9zydYPStkqYgBbEoDxJFVfwTGUCT7IoU+4phMdE6m7Zxuvz5x3QZEQRq6AjOW4PaZmBOD95wV9+IK/B+TmGAE=",
                "thinking": "The user is asking \"你是谁\" which means \"Who are you?\" in Chinese. I should introduce myself as Claude, an AI assistant made by Anthropic.",
                "type": "thinking"
            },
            {
                "text": "我是 Claude，由 Anthropic 公司开发的 AI 助手。\n\n我可以帮你：\n- 解答问题\n- 分析和讨论各种话题\n- 协助写作、编程、数学等任务\n- 提供信息和建议\n\n有什么我可以帮到你的吗？",
                "type": "text"
            }
        ],
        "role": "assistant",
        "reasoning": {
            "content": "The user is asking \"你是谁\" which means \"Who are you?\" in Chinese. I should introduce myself as Claude, an AI assistant made by Anthropic.",
            "duration": 110,
            "signature": "ErgCCkgICxABGAIqQPxGYDlZGfdh4hTw7BRGrv/DeUtjI6mDpeFA0klVArBAh1jYCc+pv76+ED8MSkRn5c88WDN90W/mGNTxj98QH90SDNRnBTc4cM3fhbHcphoMOwPECxfTv0eqHdORIjCq/xvEhtxFs0mXY/GyZIpT3jngBrTAdOk55UjFtvjMUdABbuO4m1RlusIlTckbPMwqnQG8oBJr2IxjjNVKjR1BdnKGGUIirhqAvIUuASPQT7RWPSyXtj39xJK9X8dn07cRKiBft7DzybKs+g/KxZby6Uw0nG97vNVaPNjKCPZXrhGF1kKLkAdBfMJqlJkiHKd68q9zydYPStkqYgBbEoDxJFVfwTGUCT7IoU+4phMdE6m7Zxuvz5x3QZEQRq6AjOW4PaZmBOD95wV9+IK/B+TmGAE="
        }
    },
    {
        "content": "你能干什么",
        "role": "user"
    }
]
```

## Summary by Sourcery

Handle mixed Claude reasoning and OpenAI messages without emitting invalid image inputs.

Bug Fixes:
- Avoid generating `input_image` content parts when no valid `image_url` is present in the OpenAI message content.

Tests:
- Add coverage for converting mixed OpenAI and Claude reasoning messages to ensure correct summary and assistant content extraction.