### PR TITLE
🐛 fix: use oauth2.link for generic OIDC provider account linking

### DIFF
--- a/src/app/[variants]/(main)/settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/app/[variants]/(main)/settings/profile/features/SSOProvidersList/index.tsx
@@ -34,8 +34,11 @@ export const SSOProvidersList = memo(() => {
   }, [providers]);
 
   // Get available providers for linking (filter out already linked)
+  // Normalize provider IDs when comparing to handle aliases (e.g. microsoft-entra-id → microsoft)
   const availableProviders = useMemo(() => {
-    return (oAuthSSOProviders || []).filter((provider) => !linkedProviderIds.has(provider));
+    return (oAuthSSOProviders || []).filter(
+      (provider) => !linkedProviderIds.has(normalizeProviderId(provider)),
+    );
   }, [oAuthSSOProviders, linkedProviderIds]);
 
   const handleUnlinkSSO = async (provider: string) => {

--- a/src/libs/better-auth/auth-client.ts
+++ b/src/libs/better-auth/auth-client.ts
@@ -10,6 +10,7 @@ import type { auth } from '@/auth';
 
 export const {
   linkSocial,
+  oauth2,
   accountInfo,
   listAccounts,
   requestPasswordReset,


### PR DESCRIPTION
## Summary
- Use `oauth2.link` API from genericOAuth plugin instead of `linkSocial` for generic OIDC providers
- `linkSocial` only works with built-in providers (google, github, etc)

Closes #11987

## Summary by Sourcery

Update SSO provider linking to use the appropriate auth client APIs for built-in and generic OIDC providers.

Bug Fixes:
- Fix account linking for generic OIDC providers by using the oauth2.link API instead of linkSocial.

Enhancements:
- Normalize provider IDs and route built-in providers through linkSocial while delegating generic providers to oauth2.link in the SSO linking flow.