### PR TITLE
🐛 fix(docker): add librt.so.1 to fix PDF parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -e && \
     cp /etc/proxychains4.conf /distroless/etc/proxychains4.conf && \
     cp /usr/lib/$(arch)-linux-gnu/libstdc++.so.6 /distroless/lib/libstdc++.so.6 && \
     cp /usr/lib/$(arch)-linux-gnu/libgcc_s.so.1 /distroless/lib/libgcc_s.so.1 && \
+    cp /usr/lib/$(arch)-linux-gnu/librt.so.1 /distroless/lib/librt.so.1 && \
     cp /usr/local/bin/node /distroless/bin/node && \
     cp /etc/ssl/certs/ca-certificates.crt /distroless/etc/ssl/certs/ca-certificates.crt && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes https://github.com/lobehub/lobehub/issues/12038 and https://github.com/lobehub/lobehub/issues/9021

#### 🔀 Description of Change

在 Dockerfile 的 `base` 阶段添加 `librt.so.1` 库文件，修复 `@napi-rs/canvas` 无法加载导致 PDF 解析失败的问题。

仅添加一行：
```dockerfile
cp /usr/lib/$(arch)-linux-gnu/librt.so.1 /distroless/lib/librt.so.1 && \
```

#### 🧪 How to Test

1. 构建 Docker 镜像
2. 上传 PDF 文件进行解析
3. 确认不再出现 DOMMatrix is not defined 错误

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
根本原因：PR #11686 添加了 @napi-rs/canvas 依赖用于 pdfjs-dist v5.x，但 Dockerfile 未同步更新以包含所需的 librt.so.1 库。
