### PR TITLE
🐛 fix(changelog): normalize versionRange to valid semver

### DIFF
--- a/docs/changelog/index.json
+++ b/docs/changelog/index.json
@@ -6,7 +6,7 @@
       "image": "/blog/assets7f3b38c1d76cceb91edb29d6b1eb60db.webp",
       "id": "2025-12-20-mcp",
       "date": "2025-12-20",
-      "versionRange": ["1.142.8", "1.143"]
+      "versionRange": ["1.142.8", "1.143.0"]
     },
     {
       "image": "/blog/assets3a7f0b29839603336e39e923b423409b.webp",


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

点击左下角的 `?` 打开更新日志，更新日志无法加载，原因是有个版本号没有符合semver标准导致报错：
```bash
ff66713d94b3783a.js:2 Error getting changelog lists: TypeError: Invalid version. Must be a string. Got type "undefined".
    at new u (15e8da76c04deac3.js:1:16936)
    at t.exports (15e8da76c04deac3.js:1:22299)
    at t.exports [as lt] (15e8da76c04deac3.js:1:22942)
    at C.formatVersionRange (ff66713d94b3783a.js:2:3293)
    at ff66713d94b3783a.js:2:3072
    at Array.map (<anonymous>)
    at C.mergeChangelogs (ff66713d94b3783a.js:2:2992)
    at C.getChangelogIndex (ff66713d94b3783a.js:2:1560)
```

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
|   <img width="1742" height="558" alt="image" src="https://github.com/user-attachments/assets/39895f11-8712-41c5-a3f0-80cfbede56f7" /> | <img width="1746" height="1648" alt="image" src="https://github.com/user-attachments/assets/29b48057-ef5e-41c3-937e-1e20dec61705" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Fix changelog loading errors caused by invalid or undefined version ranges in the changelog index metadata.