### PR TITLE
✨ style(model-bank): add Kimi K2.5 to LobeHub provider

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/moonshot.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/moonshot.ts
@@ -4,6 +4,35 @@ export const moonshotChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Kimi K2.5 is Kimi\'s most versatile model to date, featuring a native multimodal architecture that supports both vision and text inputs, "thinking" and "non-thinking" modes, and both conversational and agent tasks.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'kimi-k2.5',
+    maxOutput: 32_768,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-01-27',
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       search: true,
     },
     contextWindowTokens: 131_072,


### PR DESCRIPTION
## Summary
- Add Kimi K2.5 model to LobeHub provider with multimodal capabilities
- Supports vision, reasoning, function calling, structured output, and search
- Context window: 262K tokens, max output: 32K tokens

## Pricing (USD)
- Input: $0.60 / 1M tokens
- Input (cache read): $0.10 / 1M tokens  
- Output: $3.00 / 1M tokens

## Test plan
- [ ] Verify model appears in LobeHub provider model list
- [ ] Test vision capability with image input
- [ ] Test reasoning mode toggle

## Summary by Sourcery

Add the Kimi K2.5 multimodal chat model to the LobeHub Moonshot provider with configured capabilities and pricing.

New Features:
- Introduce the Kimi K2.5 chat model with multimodal, reasoning, function-calling, search, and structured output support in the LobeHub provider.

Enhancements:
- Configure context window, max output, pricing, and reasoning/search settings for the new Kimi K2.5 model entry.