### PR TITLE
chore: revert to back to header mode

### DIFF
--- a/src/app/[variants]/(main)/home/features/InputArea/ModeHeader.tsx
+++ b/src/app/[variants]/(main)/home/features/InputArea/ModeHeader.tsx
@@ -1,7 +1,7 @@
-import { ActionIcon, Block, Text } from '@lobehub/ui';
+import { ActionIcon, Block, Flexbox, Text } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { BotIcon, FilePenIcon, PenLineIcon, X } from 'lucide-react';
+import { BotIcon, FilePenIcon, ImageIcon, PenLineIcon, X } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -22,6 +22,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const modeConfig = {
   agent: { icon: BotIcon, titleKey: 'starter.createAgent' },
   group: { icon: GroupBotSquareIcon, titleKey: 'starter.createGroup' },
+  image: { icon: ImageIcon, titleKey: 'starter.image' },
   research: { icon: FilePenIcon, titleKey: 'starter.deepResearch' },
   write: { icon: PenLineIcon, titleKey: 'starter.write' },
 } as const;
@@ -40,27 +41,29 @@ const ModeHeader = memo(() => {
   const Icon = config.icon;
 
   return (
-    <Block
-      align="center"
-      className={styles.container}
-      gap={8}
-      horizontal
-      padding={4}
-      variant={'filled'}
-    >
-      <Icon color={cssVar.colorTextDescription} size={16} />
-      <Text fontSize={12} type={'secondary'}>
-        {t(config.titleKey)}
-      </Text>
-      <ActionIcon
-        icon={X}
-        onClick={clearInputMode}
-        size="small"
-        style={{
-          borderRadius: 16,
-        }}
-      />
-    </Block>
+    <Flexbox align={'flex-start'} padding={4}>
+      <Block
+        align="center"
+        className={styles.container}
+        gap={8}
+        horizontal
+        padding={4}
+        variant={'filled'}
+      >
+        <Icon color={cssVar.colorTextDescription} size={16} />
+        <Text fontSize={12} type={'secondary'}>
+          {t(config.titleKey)}
+        </Text>
+        <ActionIcon
+          icon={X}
+          onClick={clearInputMode}
+          size="small"
+          style={{
+            borderRadius: 16,
+          }}
+        />
+      </Block>
+    </Flexbox>
   );
 });
 

--- a/src/app/[variants]/(main)/home/features/InputArea/index.tsx
+++ b/src/app/[variants]/(main)/home/features/InputArea/index.tsx
@@ -68,9 +68,8 @@ const InputArea = () => {
             }}
           >
             <DesktopChatInput
-              actionBarRightContent={inputActiveMode ? <ModeHeader /> : undefined}
-              autoCollapse={false}
               dropdownPlacement="bottomLeft"
+              extenHeaderContent={inputActiveMode ? <ModeHeader /> : undefined}
               inputContainerProps={inputContainerProps}
             />
           </ChatInputProvider>

--- a/src/features/ChatInput/ActionBar/index.tsx
+++ b/src/features/ChatInput/ActionBar/index.tsx
@@ -41,11 +41,10 @@ const mapActionsToItems = (keys: ActionKeys[]): ChatInputActionsProps['items'] =
   });
 
 export interface ActionToolbarProps {
-  autoCollapse?: boolean;
   dropdownPlacement?: DropdownPlacement;
 }
 
-const ActionToolbar = memo<ActionToolbarProps>(({ autoCollapse = true, dropdownPlacement }) => {
+const ActionToolbar = memo<ActionToolbarProps>(({ dropdownPlacement }) => {
   const [expandInputActionbar, toggleExpandInputActionbar] = useGlobalStore((s) => [
     systemStatusSelectors.expandInputActionbar(s),
     s.toggleExpandInputActionbar,
@@ -65,10 +64,9 @@ const ActionToolbar = memo<ActionToolbarProps>(({ autoCollapse = true, dropdownP
   return (
     <ActionBarContext.Provider value={contextValue}>
       <ChatInputActions
-        autoCollapse={autoCollapse}
         collapseOffset={mobile ? 48 : 80}
-        defaultGroupCollapse={autoCollapse}
-        groupCollapse={autoCollapse ? !expandInputActionbar : false}
+        defaultGroupCollapse={true}
+        groupCollapse={!expandInputActionbar}
         items={items}
         onGroupCollapseChange={(v) => {
           toggleExpandInputActionbar(!v);

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -50,19 +50,13 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 interface DesktopChatInputProps extends ActionToolbarProps {
-  actionBarRightContent?: ReactNode;
+  extenHeaderContent?: ReactNode;
   inputContainerProps?: ChatInputProps;
   showFootnote?: boolean;
 }
 
 const DesktopChatInput = memo<DesktopChatInputProps>(
-  ({
-    showFootnote,
-    inputContainerProps,
-    actionBarRightContent,
-    autoCollapse,
-    dropdownPlacement,
-  }) => {
+  ({ showFootnote, inputContainerProps, extenHeaderContent, dropdownPlacement }) => {
     const { t } = useTranslation('chat');
     const [chatInputHeight, updateSystemStatus] = useGlobalStore((s) => [
       systemStatusSelectors.chatInputHeight(s),
@@ -99,12 +93,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
           defaultHeight={chatInputHeight || 32}
           footer={
             <ChatInputActionBar
-              left={
-                <Flexbox align="center" gap={8} horizontal>
-                  <ActionBar autoCollapse={autoCollapse} dropdownPlacement={dropdownPlacement} />
-                  {actionBarRightContent}
-                </Flexbox>
-              }
+              left={<ActionBar dropdownPlacement={dropdownPlacement} />}
               right={<SendArea />}
               style={{ paddingRight: 8 }}
             />
@@ -112,6 +101,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
           fullscreen={expand}
           header={
             <Flexbox gap={0}>
+              {extenHeaderContent}
               {showTypoBar && <TypoBar />}
               {contextContainerNode}
             </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Revert the chat input UI back to a header-based mode layout and simplify the action bar collapsing behavior.

Enhancements:
- Add support for an image mode entry in the input mode header configuration.
- Adjust the desktop chat input to render optional extended header content instead of embedding mode controls in the action bar area.
- Simplify the chat input action bar by removing the configurable auto-collapse behavior and always controlling collapse from global state.