### PR TITLE
🐛 fix: resolve addNewTopic button stuck in loading state

### DIFF
--- a/src/app/[variants]/(main)/agent/_layout/Sidebar/Header/Nav.tsx
+++ b/src/app/[variants]/(main)/agent/_layout/Sidebar/Header/Nav.tsx
@@ -33,14 +33,11 @@ const Nav = memo(() => {
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
 
-  // 使用 useSWRMutation 代替 useActionSWR，因为它是专为 action 设计的
-  // isMutating 初始值为 false，只有 trigger 被调用后才会变成 true
   const { trigger, isMutating } = useSWRMutation('openNewTopicOrSaveTopic', () =>
     openNewTopicOrSaveTopic(),
   );
 
   const handleNewTopic = () => {
-    // If in agent sub-route, navigate back to agent chat first
     if (isProfileActive && agentId) {
       router.push(urlJoin('/agent', agentId));
     }

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -157,10 +157,11 @@ export const chatTopic: StateCreator<
     const { switchTopic, saveToTopic, refreshMessages, activeTopicId } = get();
     const hasTopic = !!activeTopicId;
 
-    if (hasTopic) switchTopic(null);
-    else {
+    if (hasTopic) {
+      await switchTopic(null);
+    } else {
       await saveToTopic();
-      refreshMessages();
+      await refreshMessages();
     }
   },
 


### PR DESCRIPTION
## Summary

- Replace `useActionSWR` with `useSWRMutation` for topic action button
- `useActionSWR`'s `isValidating` could initialize as `true` due to SWR cache residual state
- `useSWRMutation`'s `isMutating` only becomes `true` after `trigger()` is called, which is the correct behavior for action buttons
- Also fix missing `await` for `switchTopic` and `refreshMessages` calls in `openNewTopicOrSaveTopic`

## Root Cause

When using `useActionSWR` (which wraps `useSWR`), the `isValidating` state could be `true` on initial mount if there was a previous request in the SWR cache that didn't complete properly. This caused the "Add New Topic" button to be stuck in loading state even though no request was actually in progress.

## Solution

Use `useSWRMutation` instead, which is specifically designed for mutation/action scenarios:
- `isMutating` is guaranteed to be `false` on initial mount
- Only becomes `true` after `trigger()` is explicitly called
- Cleaner semantics for action-based operations

## Test plan

- [x] Navigate to agent chat page
- [x] Verify "Add New Topic" button is not in loading state on page load
- [x] Click the button and verify loading state appears during operation
- [x] Verify loading state clears after operation completes

## Summary by Sourcery

Fix topic creation button loading behavior and ensure topic switching and message refresh actions complete correctly.

Bug Fixes:
- Prevent the Add New Topic button from getting stuck in a loading state by using a mutation-based hook for the action trigger.
- Ensure topic switching and message refresh operations complete by awaiting their asynchronous calls in openNewTopicOrSaveTopic.