### PR TITLE
🐛 fix(model-runtime): fix moonshot interleaved thinking and circular dependency

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/apiTypes.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/apiTypes.ts
@@ -1,0 +1,18 @@
+import type { LobeRuntimeAI } from '../BaseAI';
+
+export type ApiType =
+  | 'anthropic'
+  | 'azure'
+  | 'bedrock'
+  | 'cloudflare'
+  | 'deepseek'
+  | 'fal'
+  | 'google'
+  | 'minimax'
+  | 'moonshot'
+  | 'openai'
+  | 'qwen'
+  | 'vertexai'
+  | 'xai';
+
+export type RuntimeClass = new (options?: any) => LobeRuntimeAI;

--- a/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
@@ -6,10 +6,12 @@ import { LobeDeepSeekAI } from '../../providers/deepseek';
 import { LobeFalAI } from '../../providers/fal';
 import { LobeGoogleAI } from '../../providers/google';
 import { LobeMinimaxAI } from '../../providers/minimax';
+import { LobeMoonshotAI } from '../../providers/moonshot';
 import { LobeOpenAI } from '../../providers/openai';
 import { LobeQwenAI } from '../../providers/qwen';
 import { LobeVertexAI } from '../../providers/vertexai';
 import { LobeXAI } from '../../providers/xai';
+import type { ApiType, RuntimeClass } from './apiTypes';
 
 export const baseRuntimeMap = {
   anthropic: LobeAnthropicAI,
@@ -20,8 +22,9 @@ export const baseRuntimeMap = {
   fal: LobeFalAI,
   google: LobeGoogleAI,
   minimax: LobeMinimaxAI,
+  moonshot: LobeMoonshotAI,
   openai: LobeOpenAI,
   qwen: LobeQwenAI,
   vertexai: LobeVertexAI,
   xai: LobeXAI,
-};
+} satisfies Record<ApiType, RuntimeClass>;

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -21,23 +21,31 @@ export interface MoonshotModelCard {
 const DEFAULT_MOONSHOT_BASE_URL = 'https://api.moonshot.ai/v1';
 const DEFAULT_MOONSHOT_ANTHROPIC_BASE_URL = 'https://api.moonshot.ai/anthropic';
 
+// Shared constants and helpers
+const MOONSHOT_SEARCH_TOOL = { function: { name: '$web_search' }, type: 'builtin_function' } as any;
+const isKimiK25Model = (model: string) => model === 'kimi-k2.5';
+const isEmptyContent = (content: any) =>
+  content === '' || content === null || content === undefined;
+const hasValidReasoning = (reasoning: any) => reasoning?.content && !reasoning?.signature;
+
+const getK25Params = (isThinkingEnabled: boolean) => ({
+  temperature: isThinkingEnabled ? 1 : 0.6,
+  top_p: 0.95,
+});
+
+const appendSearchTool = <T>(tools: T[] | undefined, enabledSearch?: boolean): T[] | undefined => {
+  if (!enabledSearch) return tools;
+  return tools?.length ? [...tools, MOONSHOT_SEARCH_TOOL] : [MOONSHOT_SEARCH_TOOL];
+};
+
+// Anthropic format helpers
 const buildThinkingBlock = (reasoning: any) =>
-  reasoning?.content && !reasoning?.signature
-    ? { thinking: reasoning.content, type: 'thinking' as const }
-    : null;
+  hasValidReasoning(reasoning) ? { thinking: reasoning.content, type: 'thinking' as const } : null;
 
 const toContentArray = (content: any) =>
   Array.isArray(content) ? content : [{ text: content, type: 'text' as const }];
 
-const isEmptyContent = (content: any) =>
-  content === '' || content === null || content === undefined;
-
-/**
- * Normalize assistant messages:
- * - Add space placeholder for empty content (#8418)
- * - Convert reasoning to thinking block for interleaved thinking
- */
-const normalizeMoonshotMessages = (messages: ChatStreamPayload['messages']) =>
+const normalizeMessagesForAnthropic = (messages: ChatStreamPayload['messages']) =>
   messages.map((message: any) => {
     if (message.role !== 'assistant') return message;
 
@@ -50,26 +58,22 @@ const normalizeMoonshotMessages = (messages: ChatStreamPayload['messages']) =>
     }
 
     if (!thinkingBlock) return rest;
-
     return { ...rest, content: [thinkingBlock, ...toContentArray(message.content)] };
   });
 
-/**
- * Append Moonshot web search tool for builtin search capability
- */
-const appendMoonshotSearchTool = (
-  tools: Anthropic.MessageCreateParams['tools'] | undefined,
-  enabledSearch?: boolean,
-) => {
-  if (!enabledSearch) return tools;
+// OpenAI format helpers
+const normalizeMessagesForOpenAI = (messages: ChatStreamPayload['messages']) =>
+  messages.map((message: any) => {
+    if (message.role !== 'assistant') return message;
 
-  const moonshotSearchTool = {
-    function: { name: '$web_search' },
-    type: 'builtin_function',
-  } as any;
+    const { reasoning, ...rest } = message;
+    const normalized = isEmptyContent(message.content) ? { ...rest, content: ' ' } : rest;
 
-  return tools?.length ? [...tools, moonshotSearchTool] : [moonshotSearchTool];
-};
+    if (hasValidReasoning(reasoning)) {
+      return { ...normalized, reasoning_content: reasoning.content };
+    }
+    return normalized;
+  });
 
 /**
  * Build Moonshot Anthropic format payload with special handling for kimi-k2.5 thinking
@@ -77,7 +81,6 @@ const appendMoonshotSearchTool = (
 const buildMoonshotAnthropicPayload = async (
   payload: ChatStreamPayload,
 ): Promise<Anthropic.MessageCreateParams> => {
-  const normalizedMessages = normalizeMoonshotMessages(payload.messages);
   const resolvedMaxTokens =
     payload.max_tokens ??
     (await getModelPropertyWithFallback<number | undefined>(
@@ -91,14 +94,13 @@ const buildMoonshotAnthropicPayload = async (
     ...payload,
     enabledSearch: false,
     max_tokens: resolvedMaxTokens,
-    messages: normalizedMessages,
+    messages: normalizeMessagesForAnthropic(payload.messages),
   });
 
-  const tools = appendMoonshotSearchTool(basePayload.tools, payload.enabledSearch);
+  const tools = appendSearchTool(basePayload.tools, payload.enabledSearch);
   const basePayloadWithSearch = { ...basePayload, tools };
 
-  const isK25Model = payload.model === 'kimi-k2.5';
-  if (!isK25Model) return basePayloadWithSearch;
+  if (!isKimiK25Model(payload.model)) return basePayloadWithSearch;
 
   const resolvedThinkingBudget = payload.thinking?.budget_tokens
     ? Math.min(payload.thinking.budget_tokens, resolvedMaxTokens - 1)
@@ -107,13 +109,11 @@ const buildMoonshotAnthropicPayload = async (
     payload.thinking?.type === 'disabled'
       ? ({ type: 'disabled' } as const)
       : ({ budget_tokens: resolvedThinkingBudget, type: 'enabled' } as const);
-  const isThinkingEnabled = thinkingParam.type === 'enabled';
 
   return {
     ...basePayloadWithSearch,
-    temperature: isThinkingEnabled ? 1 : 0.6,
+    ...getK25Params(thinkingParam.type === 'enabled'),
     thinking: thinkingParam,
-    top_p: 0.95,
   };
 };
 
@@ -125,71 +125,33 @@ const buildMoonshotOpenAIPayload = (
 ): OpenAI.ChatCompletionCreateParamsStreaming => {
   const { enabledSearch, messages, model, temperature, thinking, tools, ...rest } = payload;
 
-  // Normalize messages: handle empty assistant messages and interleaved thinking
-  const normalizedMessages = messages.map((message: any) => {
-    let normalizedMessage = message;
+  const normalizedMessages = normalizeMessagesForOpenAI(messages);
+  const moonshotTools = appendSearchTool(tools, enabledSearch);
 
-    // Add a space for empty assistant messages (#8418)
-    if (
-      message.role === 'assistant' &&
-      (message.content === '' || message.content === null || message.content === undefined)
-    ) {
-      normalizedMessage = { ...normalizedMessage, content: ' ' };
-    }
-
-    // Interleaved thinking: convert reasoning to reasoning_content
-    if (message.role === 'assistant' && message.reasoning) {
-      const { reasoning, ...messageWithoutReasoning } = normalizedMessage;
-      return {
-        ...messageWithoutReasoning,
-        ...(!reasoning.signature && reasoning.content
-          ? { reasoning_content: reasoning.content }
-          : {}),
-      };
-    }
-    return normalizedMessage;
-  });
-
-  const moonshotTools = enabledSearch
-    ? [
-        ...(tools || []),
-        {
-          function: { name: '$web_search' },
-          type: 'builtin_function',
-        },
-      ]
-    : tools;
-
-  const isK25Model = model === 'kimi-k2.5';
-
-  if (isK25Model) {
+  if (isKimiK25Model(model)) {
     const thinkingParam =
       thinking?.type === 'disabled' ? { type: 'disabled' } : { type: 'enabled' };
-    const isThinkingEnabled = thinkingParam.type === 'enabled';
 
     return {
       ...rest,
+      ...getK25Params(thinkingParam.type === 'enabled'),
       frequency_penalty: 0,
       messages: normalizedMessages,
       model,
       presence_penalty: 0,
       stream: payload.stream ?? true,
-      temperature: isThinkingEnabled ? 1 : 0.6,
       thinking: thinkingParam,
       tools: moonshotTools?.length ? moonshotTools : undefined,
-      top_p: 0.95,
     } as any;
   }
-
-  // Moonshot temperature is normalized by dividing by 2
-  const normalizedTemperature = temperature !== undefined ? temperature / 2 : undefined;
 
   return {
     ...rest,
     messages: normalizedMessages,
     model,
     stream: payload.stream ?? true,
-    temperature: normalizedTemperature,
+    // Moonshot temperature is normalized by dividing by 2
+    temperature: temperature !== undefined ? temperature / 2 : undefined,
     tools: moonshotTools?.length ? moonshotTools : undefined,
   } as OpenAI.ChatCompletionCreateParamsStreaming;
 };

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -21,16 +21,37 @@ export interface MoonshotModelCard {
 const DEFAULT_MOONSHOT_BASE_URL = 'https://api.moonshot.ai/v1';
 const DEFAULT_MOONSHOT_ANTHROPIC_BASE_URL = 'https://api.moonshot.ai/anthropic';
 
+const buildThinkingBlock = (reasoning: any) =>
+  reasoning?.content && !reasoning?.signature
+    ? { thinking: reasoning.content, type: 'thinking' as const }
+    : null;
+
+const toContentArray = (content: any) =>
+  Array.isArray(content) ? content : [{ text: content, type: 'text' as const }];
+
+const isEmptyContent = (content: any) =>
+  content === '' || content === null || content === undefined;
+
 /**
- * Normalize empty assistant messages by adding a space placeholder (#8418)
+ * Normalize assistant messages:
+ * - Add space placeholder for empty content (#8418)
+ * - Convert reasoning to thinking block for interleaved thinking
  */
 const normalizeMoonshotMessages = (messages: ChatStreamPayload['messages']) =>
-  messages.map((message) => {
+  messages.map((message: any) => {
     if (message.role !== 'assistant') return message;
-    if (message.content !== '' && message.content !== null && message.content !== undefined)
-      return message;
 
-    return { ...message, content: [{ text: ' ', type: 'text' as const }] };
+    const { reasoning, ...rest } = message;
+    const thinkingBlock = buildThinkingBlock(reasoning);
+
+    if (isEmptyContent(message.content)) {
+      const placeholder = { text: ' ', type: 'text' as const };
+      return { ...rest, content: thinkingBlock ? [thinkingBlock] : [placeholder] };
+    }
+
+    if (!thinkingBlock) return rest;
+
+    return { ...rest, content: [thinkingBlock, ...toContentArray(message.content)] };
   });
 
 /**

--- a/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
+++ b/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
@@ -14,7 +14,7 @@ import { selectors } from '../store/selectors';
 const styles = createStaticStyles(({ css, cssVar }) => ({
   empty: css`
     margin-block: 24px;
-    margin-inline: 0;
+    margin-inline: auto;
   `,
   questionItemContainer: css`
     padding-block: 8px;


### PR DESCRIPTION
## Summary
- Add `apiTypes.ts` to break circular dependency between `createRuntime.ts` and `baseRuntimeMap.ts`
- Use dynamic import for `baseRuntimeMap` in `createRuntime.ts` to resolve module initialization order
- Add `moonshot` to `baseRuntimeMap` for RouterRuntime support
- Convert `reasoning` to thinking block in `normalizeMoonshotMessages` for Anthropic format interleaved thinking
- Add tests for interleaved thinking scenarios

## Test plan
- [ ] Run moonshot tests: `bunx vitest run --silent='passed-only' packages/model-runtime/src/providers/moonshot/index.test.ts`
- [ ] Verify kimi-k2.5 with interleaved thinking works correctly via Anthropic format API

## Summary by Sourcery

Fix Moonshot provider interleaved thinking handling and extend router runtime provider support while resolving a circular dependency.

New Features:
- Support Moonshot as a router runtime provider via the base runtime map.

Bug Fixes:
- Normalize Moonshot assistant messages to correctly represent interleaved thinking by converting reasoning into thinking blocks and handling empty content placeholders.
- Resolve a circular dependency between router runtime creation and base runtime map by introducing shared API type definitions and using dynamic imports.

Enhancements:
- Type the router runtime API map using a central ApiType and RuntimeClass definition and update runtime creation to be asynchronous where needed.

Tests:
- Add Moonshot interleaved thinking test cases covering reasoning-only, combined reasoning and content, signed reasoning, and tool call scenarios.