### PR TITLE
🐛 fix(AgentSetting): center Empty component in opening questions

### DIFF
--- a/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
+++ b/src/features/AgentSetting/AgentOpening/OpeningQuestions.tsx
@@ -14,7 +14,7 @@ import { selectors } from '../store/selectors';
 const styles = createStaticStyles(({ css, cssVar }) => ({
   empty: css`
     margin-block: 24px;
-    margin-inline: 0;
+    margin-inline: auto;
   `,
   questionItemContainer: css`
     padding-block: 8px;


### PR DESCRIPTION
## Summary
- Fix Empty component not horizontally centered in opening questions section
- Change `margin-inline: 0` to `margin-inline: auto`

## Test plan
- [ ] Open agent settings > opening questions
- [ ] Verify Empty component is centered when no questions exist

## Summary by Sourcery

Bug Fixes:
- Fix misaligned Empty component in the opening questions section by updating its horizontal margin styling.