### PR TITLE
🐛 fix: prevent scroll anchoring during streaming

### DIFF
--- a/src/features/Conversation/ChatList/components/VirtualizedList.tsx
+++ b/src/features/Conversation/ChatList/components/VirtualizedList.tsx
@@ -145,7 +145,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ dataSource, itemContent })
         onScroll={handleScroll}
         onScrollEnd={handleScrollEnd}
         ref={virtuaRef}
-        style={{ height: '100%', paddingBottom: 24 }}
+        style={{ height: '100%', overflowAnchor: 'none', paddingBottom: 24 }}
       >
         {(messageId, index): ReactElement => {
           const isAgentCouncil = messageId.includes('agentCouncil');


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

Disable scroll anchoring on the conversation virtual list so streaming updates don't shift the viewport.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Disable scroll anchoring on the virtualized conversation list container to keep the viewport stable while messages stream in.