### PR TITLE
 🐛 fix: Fix context builder for OpenAI

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -273,7 +273,7 @@ describe('convertOpenAIResponseInputs', () => {
 
     expect(result).toEqual([
       {
-        arguments: 'test_function',
+        arguments: '{"key": "value"}',
         call_id: 'call_123',
         name: 'test_function',
         type: 'function_call',
@@ -362,7 +362,7 @@ describe('convertOpenAIResponseInputs', () => {
     expect(result).toEqual([
       { role: 'user', content: 'I need help with a function' },
       {
-        arguments: 'get_data',
+        arguments: '{}',
         call_id: 'call_456',
         name: 'get_data',
         type: 'function_call',

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -89,7 +89,7 @@ export const convertOpenAIResponseInputs = async (
       if (message.role === 'assistant' && message.tool_calls && message.tool_calls?.length > 0) {
         message.tool_calls?.forEach((tool) => {
           input.push({
-            arguments: tool.function.name,
+            arguments: tool.function.arguments,
             call_id: tool.id,
             name: tool.function.name,
             type: 'function_call',


### PR DESCRIPTION
#### 💻 Change Type
- [x] 🐛 fix

#### 🔀 Description of Change

Fix a typo preventing local OpenAI models to be used.

In OpenAI’s Responses API context builder, the `function_call` `arguments` parameter has been incorrectly set to the function name. This issue is preventing the local model from operating correctly.

## Summary by Sourcery

Fix OpenAI Responses API context builder to correctly propagate tool call arguments instead of the function name.

Bug Fixes:
- Ensure function call context entries use the tool call arguments field rather than the function name, enabling proper use of local OpenAI models.

Tests:
- Update OpenAI context builder tests to assert that function call arguments are correctly passed through.