### PR TITLE
🐛 fix: add end-user info on OpenAI Responses API call

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -907,6 +907,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         store: false,
         stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
+        user: options?.user,
       } as OpenAI.Responses.ResponseCreateParamsStreaming | OpenAI.Responses.ResponseCreateParams;
 
       if (debugParams?.responses?.()) {


### PR DESCRIPTION
#### 💻 Change Type

- [X] 🐛 fix

#### 🔀 Description of Change

The end‑user information was previously included in the chat‑completion API, but it was omitted from the responses API implementation.

This PR add it back.

## Summary by Sourcery

Bug Fixes:
- Include the end-user `user` field in Responses API request parameters when provided in options.