### PR TITLE
🔨 chore(userMemories): @upstash/workflow workflow id will drift, fallback to chat-topic group serveMany

### DIFF
--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/[...any]/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/[...any]/route.ts
@@ -3,7 +3,7 @@ import { serveMany } from '@upstash/workflow/dist/nextjs';
 
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 
-import { processTopicWorkflow } from '../workflows/topic';
+import { processTopicWorkflow } from '../process-topic/workflows/topic';
 
 const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic/workflows/topic.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic/workflows/topic.ts
@@ -174,4 +174,4 @@ export const processTopicWorkflow = createWorkflow<MemoryExtractionPayloadInput,
   },
 );
 
-processTopicWorkflow.workflowId = 'process-topic/process-topic';
+processTopicWorkflow.workflowId = 'process-topic';

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
@@ -46,11 +46,6 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(
         });
 
         try {
-          console.log('[chat-topic][batch] Starting batch topic processing workflow', {
-            topicIds: payload.topicIds,
-            userIds: payload.userIds,
-          });
-
           if (!payload.userIds.length) {
             span.setStatus({ code: SpanStatusCode.OK });
 
@@ -83,6 +78,7 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(
           // Delegate per-topic extraction to dedicated workflow for better isolation
           await Promise.all(
             payload.topicIds.map(async (topicId, index) => {
+              console.log(processTopicWorkflow.workflowId);
               await context.invoke(
                 `memory:user-memory:extract:users:${userId}:topics:${topicId}:invoke:${index}`,
                 {
@@ -112,10 +108,6 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(
               );
             }),
           );
-
-          console.log('[chat-topic][batch] Batch topic processing workflow completed', {
-            processedTopics: payload.topicIds.length,
-          });
 
           // Trigger user persona update after topic processing using the workflow client.
           await context.run(`memory:user-memory:users:${userId}`, async () => {

--- a/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
+++ b/src/app/(backend)/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics/route.ts
@@ -78,7 +78,6 @@ export const { POST } = serve<MemoryExtractionPayloadInput>(
           // Delegate per-topic extraction to dedicated workflow for better isolation
           await Promise.all(
             payload.topicIds.map(async (topicId, index) => {
-              console.log(processTopicWorkflow.workflowId);
               await context.invoke(
                 `memory:user-memory:extract:users:${userId}:topics:${topicId}:invoke:${index}`,
                 {

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -2177,9 +2177,6 @@ export class MemoryExtractionExecutor {
 
 const WORKFLOW_PATHS = {
   personaUpdate: '/api/workflows/memory-user-memory/pipelines/persona/update-writing',
-  // process-topic is exposed via serveMany under a catch-all route, so it requires the extra slug
-  // segment to reach the actual workflow handler.
-  topic: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic/process-topic',
   topicBatch: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics',
   userTopics: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics',
   users: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-users',
@@ -2263,28 +2260,6 @@ export class MemoryExtractionWorkflowService {
         //
         // Currently, CEPA (context, experience, preference, activity) + identity = 5 layers.
         // and since identity requires sequential processing, we set parallelism to 5.
-        parallelism: 5,
-      },
-      headers: options?.extraHeaders,
-      url,
-    });
-  }
-
-  static triggerProcessTopic(
-    userId: string,
-    topicId: string,
-    payload: MemoryExtractionPayloadInput,
-    options?: { extraHeaders?: Record<string, string> },
-  ) {
-    if (!payload.baseUrl) {
-      throw new Error('Missing baseUrl for workflow trigger');
-    }
-
-    const url = getWorkflowUrl(WORKFLOW_PATHS.topic, payload.baseUrl);
-    return this.getClient().trigger({
-      body: { ...payload, topicIds: [topicId], userId, userIds: [userId] },
-      flowControl: {
-        key: `memory-user-memory.pipelines.chat-topic.process-topic.user.${userId}.topic.${topicId}`,
         parallelism: 5,
       },
       headers: options?.extraHeaders,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align chat-topic user memory workflows with the updated Upstash workflow routing and identifiers to ensure consistent topic processing behavior.

Enhancements:
- Adjust process-topic workflow export path to use the generic chat-topic catch-all serveMany endpoint.
- Simplify and standardize the processTopic workflowId to 'process-topic' for stable identification across workflows.
- Remove noisy batch-level logging in the chat-topic batch processing route while adding a targeted log for the per-topic workflow identifier.