### PR TITLE
💄 style(model-runtime): add Claude Opus 4.6 support for Bedrock runtime

### DIFF
--- a/packages/model-bank/src/aiModels/bedrock.ts
+++ b/packages/model-bank/src/aiModels/bedrock.ts
@@ -5,12 +5,47 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
     description:
-      'Claude Opus 4.5 is Anthropic’s flagship model, combining exceptional intelligence and scalable performance for complex tasks requiring the highest-quality responses and reasoning.',
+      "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
+    displayName: 'Claude Opus 4.6',
+    enabled: true,
+    id: 'us.anthropic.claude-opus-4-6-v1',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 10, '5m': 6.25 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-05',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'effort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "Claude Opus 4.5 is Anthropic's flagship model, combining exceptional intelligence and scalable performance for complex tasks requiring the highest-quality responses and reasoning.",
     displayName: 'Claude Opus 4.5',
     enabled: true,
     id: 'global.anthropic.claude-opus-4-5-20251101-v1:0',
@@ -32,11 +67,12 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
-    description: 'Claude Sonnet 4.5 is Anthropic’s most intelligent model to date.',
+    description: "Claude Sonnet 4.5 is Anthropic's most intelligent model to date.",
     displayName: 'Claude Sonnet 4.5',
     enabled: true,
     id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
@@ -57,12 +93,13 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
     description:
-      'Claude Haiku 4.5 is Anthropic’s fastest and most intelligent Haiku model, with lightning speed and extended thinking.',
+      "Claude Haiku 4.5 is Anthropic's fastest and most intelligent Haiku model, with lightning speed and extended thinking.",
     displayName: 'Claude Haiku 4.5',
     enabled: true,
     id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
@@ -104,12 +141,13 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
     description:
-      'Claude 3.7 Sonnet is Anthropic’s fastest next-gen model. Compared to Claude 3 Haiku, it improves across skills and surpasses the previous flagship Claude 3 Opus on many intelligence benchmarks.',
+      "Claude 3.7 Sonnet is Anthropic's fastest next-gen model. Compared to Claude 3 Haiku, it improves across skills and surpasses the previous flagship Claude 3 Opus on many intelligence benchmarks.",
     displayName: 'Claude 3.7 Sonnet',
     id: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
     maxOutput: 64_000,

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -96,6 +96,34 @@ export const anthropicChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
+    displayName: 'Claude Opus 4.6',
+    enabled: true,
+    id: 'claude-opus-4-6',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 6.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-05',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'effort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       structuredOutput: true,
       vision: true,
     },

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -19,4 +19,4 @@ const LobeHub: ModelProviderCard = {
 
 export default LobeHub;
 
-export const planCardModels = ['gpt-4o-mini', 'deepseek-reasoner', 'claude-3-5-sonnet-latest'];
+export const planCardModels = ['claude-sonnet-4-5-20250929', 'gemini-3-pro-preview', 'gpt-5.2', 'deepseek-chat'];

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -172,7 +172,7 @@ export const buildDefaultAnthropicPayload = async (
             ),
             type: 'enabled',
           }
-        : { type: 'adaptive' as any };
+        : { type: 'adaptive' };
 
     return {
       max_tokens: resolvedMaxTokens,

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -166,9 +166,10 @@ export const buildDefaultAnthropicPayload = async (
     const resolvedThinking: Anthropic.MessageCreateParams['thinking'] =
       thinking.type === 'enabled'
         ? {
-            budget_tokens: thinking?.budget_tokens
-              ? Math.min(thinking.budget_tokens, resolvedMaxTokens - 1)
-              : 1024,
+            budget_tokens: Math.min(
+              thinking?.budget_tokens || 1024,
+              resolvedMaxTokens - 1,
+            ),
             type: 'enabled',
           }
         : { type: 'adaptive' as any };

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -754,7 +754,7 @@ describe('LobeAnthropicAI', () => {
           ],
           model: 'claude-3-haiku-20240307',
           system: undefined,
-          thinking: { type: 'enabled', budget_tokens: 1024 },
+          thinking: { type: 'enabled', budget_tokens: 999 },
           tools: undefined,
         });
       });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related to #12139

#### 🔀 Description of Change

Sync Claude Opus 4.6 support to Bedrock runtime, following the pattern established in #12139 for the Anthropic direct API.

**Model Bank:**
- Add Opus 4.6 to Bedrock model bank (`us.anthropic.claude-opus-4-6-v1`) and LobeHub hosted model bank (`claude-opus-4-6`)
- Configure adaptive thinking and effort as `extendParams`
- Add missing `search: true` ability to Opus 4.5, Sonnet 4.5, Haiku 4.5, and 3.7 Sonnet in Bedrock
- Fix single-quote string escaping issues in Bedrock model descriptions

**Bedrock Runtime:**
- Support adaptive thinking (`thinking.type: 'adaptive'`) alongside existing `enabled` mode
- Support `output_config.effort` parameter for adaptive thinking
- Strip assistant turn prefill for Opus 4.6 (not supported by the model)
- Pass `anthropicBase` to `resolveCacheTTL` instead of full payload for type safety

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified Bedrock model ID `us.anthropic.claude-opus-4-6-v1` works via direct API call. Verified adaptive thinking with effort parameter works on Anthropic official API.

#### 📝 Additional Information

The Bedrock model ID format for Opus 4.6 differs from previous models - it does NOT use the `:0` suffix. `us.anthropic.claude-opus-4-6-v1` is the correct format (tested and confirmed).

## Summary by Sourcery

Add Claude Opus 4.6 support to the Bedrock runtime and model bank, including adaptive thinking and effort parameters, while updating related Bedrock model metadata.

New Features:
- Expose Claude Opus 4.6 as a chat model in both the Bedrock and LobeHub Anthropic model banks with pricing, limits, and extended settings for adaptive thinking and effort.
- Enable adaptive thinking mode with optional effort configuration in the Bedrock runtime alongside the existing thinking mode.

Enhancements:
- Prevent assistant-turn prefill for Claude Opus 4.6 in Bedrock since the model does not support it.
- Pass a simplified Anthropics base payload to cache TTL resolution for improved type safety.
- Add search capability flags to several existing Anthropic Bedrock models and correct string escaping in their descriptions.