### PR TITLE
🐛 fix: enable vertical scrolling for topic list on mobile

### DIFF
--- a/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
@@ -12,7 +12,7 @@ const Topic = () => {
         <TopicSearchBar />
         <Flexbox
           height={'100%'}
-          style={{ marginInline: -8, overflow: 'hidden', position: 'relative' }}
+          style={{ marginInline: -8, overflowX: 'hidden', overflowY: 'auto', position: 'relative' }}
           width={'calc(100% + 16px)'}
         >
           <TopicListContent />


### PR DESCRIPTION
## Summary

- Fix topic list not being scrollable on mobile devices by replacing `overflow: 'hidden'` with `overflowX: 'hidden', overflowY: 'auto'` on the topic list Flexbox container
- When topics exceed the viewport height, users can now scroll down to view all topics

Closes #12029

## Test plan

- [ ] Open LobeChat in a mobile browser (or responsive mode)
- [ ] Navigate to the Topic list with enough topics to exceed the viewport height
- [ ] Verify the topic list is now vertically scrollable
- [ ] Verify horizontal overflow is still hidden (no horizontal scroll bar)


## Summary by Sourcery

Bug Fixes:
- Fix mobile topic list not being vertically scrollable when the content exceeds the viewport height.