### PR TITLE
🔨 chore(home): type mismatch for `SessionGroup`

### DIFF
--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -22,7 +22,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
+const GroupItem = memo<Omit<SessionGroupItem, 'createdAt' | 'updatedAt'>>(({ id, name }) => {
   const { t } = useTranslation('chat');
   const { message, modal } = App.useApp();
 

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useHomeStore } from '@/store/home';
 import { homeAgentListSelectors } from '@/store/home/selectors';
-import { type SessionGroupItem } from '@/types/session';
 
 import GroupItem from './GroupItem';
 
@@ -52,10 +51,10 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
       <Flexbox>
         <SortableList
           items={sessionGroupItems}
-          onChange={(items: SessionGroupItem[]) => {
+          onChange={(items) => {
             updateGroupSort(items);
           }}
-          renderItem={(item: SessionGroupItem) => (
+          renderItem={(item) => (
             <SortableList.Item
               align={'center'}
               className={styles.container}

--- a/src/store/home/slices/sidebarUI/action.ts
+++ b/src/store/home/slices/sidebarUI/action.ts
@@ -65,7 +65,7 @@ export interface SidebarUIAction {
   /**
    * Update group sort order
    */
-  updateGroupSort: (items: SessionGroupItem[]) => Promise<void>;
+  updateGroupSort: (items: Omit<SessionGroupItem, 'createdAt' | 'updatedAt'>[]) => Promise<void>;
 
   // ========== UI State Actions ==========
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align SessionGroup-related types in the home sidebar configuration modal and actions to resolve type mismatches and restrict props to the fields actually used.

Enhancements:
- Relax callback parameter typing in the ConfigGroupModal sortable list to rely on inferred types.
- Narrow GroupItem props to a subset of SessionGroupItem fields used by the component.
- Tighten the updateGroupSort action signature to accept SessionGroup items without timestamp fields.

Chores:
- Clean up SessionGroup type usage in home sidebar UI components and store actions to keep them consistent.