### PR TITLE
🔨 chore(home): fix the session group type with shared base type

### DIFF
--- a/packages/types/src/session/sessionGroup.ts
+++ b/packages/types/src/session/sessionGroup.ts
@@ -7,12 +7,15 @@ export enum SessionDefaultGroup {
   Pinned = 'pinned',
 }
 
-export interface SessionGroupItem {
+export interface SessionGroupItem extends SessionGroupItemBase {
   createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SessionGroupItemBase {
   id: string;
   name: string;
   sort?: number | null;
-  updatedAt: Date;
 }
 
 export type SessionGroups = SessionGroupItem[];

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -6,7 +6,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useHomeStore } from '@/store/home';
-import { type SessionGroupItem } from '@/types/session';
+import type { SessionGroupItemBase } from '@/types/session';
 
 const styles = createStaticStyles(({ css }) => ({
   content: css`
@@ -22,7 +22,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const GroupItem = memo<Omit<SessionGroupItem, 'createdAt' | 'updatedAt'>>(({ id, name }) => {
+const GroupItem = memo<SessionGroupItemBase>(({ id, name }) => {
   const { t } = useTranslation('chat');
   const { message, modal } = App.useApp();
 

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
@@ -10,6 +10,7 @@ import { useHomeStore } from '@/store/home';
 import { homeAgentListSelectors } from '@/store/home/selectors';
 
 import GroupItem from './GroupItem';
+import { SessionGroupItemBase } from '@/types/session';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
@@ -51,10 +52,10 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
       <Flexbox>
         <SortableList
           items={sessionGroupItems}
-          onChange={(items) => {
+          onChange={(items: SessionGroupItemBase[]) => {
             updateGroupSort(items);
           }}
-          renderItem={(item) => (
+          renderItem={(item: SessionGroupItemBase) => (
             <SortableList.Item
               align={'center'}
               className={styles.container}

--- a/src/store/home/slices/sidebarUI/action.ts
+++ b/src/store/home/slices/sidebarUI/action.ts
@@ -9,7 +9,7 @@ import { homeService } from '@/services/home';
 import { sessionService } from '@/services/session';
 import { getAgentStoreState } from '@/store/agent';
 import type { HomeStore } from '@/store/home/store';
-import { type SessionGroupItem } from '@/types/session';
+import type { SessionGroupItemBase } from '@/types/session';
 import { setNamespace } from '@/utils/storeDebug';
 
 const n = setNamespace('sidebarUI');
@@ -65,7 +65,7 @@ export interface SidebarUIAction {
   /**
    * Update group sort order
    */
-  updateGroupSort: (items: Omit<SessionGroupItem, 'createdAt' | 'updatedAt'>[]) => Promise<void>;
+  updateGroupSort: (items: SessionGroupItemBase[]) => Promise<void>;
 
   // ========== UI State Actions ==========
   /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Extract a shared base type for session group items and update home sidebar group configuration to use it where only common fields are required.

Enhancements:
- Introduce a SessionGroupItemBase type shared across session group usages and refine SessionGroupItem to extend it with timestamp fields.
- Align home UI components and sidebar actions for session group configuration to use the shared base type for sorting and rendering.