### PR TITLE
fix: allow vertical scrolling in mobile topic list

### DIFF
--- a/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/Topic/index.tsx
@@ -12,7 +12,7 @@ const Topic = () => {
         <TopicSearchBar />
         <Flexbox
           height={'100%'}
-          style={{ marginInline: -8, overflow: 'hidden', position: 'relative' }}
+          style={{ marginInline: -8, overflowX: 'hidden', overflowY: 'auto', position: 'relative' }}
           width={'calc(100% + 16px)'}
         >
           <TopicListContent />


### PR DESCRIPTION
## Summary
- Fix mobile topic list not being scrollable when topics exceed viewport height
- Changed `overflow: 'hidden'` to `overflowX: 'hidden', overflowY: 'auto'` in the mobile Topic container

## Problem
In the mobile view, the Topic list container uses `overflow: hidden`, which prevents vertical scrolling. When the list of topics exceeds the viewport height, users are unable to scroll down to view older topics.

## Solution
Updated the Flexbox container style in `src/app/[variants]/(mobile)/chat/features/Topic/index.tsx` to explicitly allow vertical scrolling (`overflowY: 'auto'`) while keeping horizontal overflow hidden (`overflowX: 'hidden'`).

## Test plan
- [ ] Open LobeChat on a mobile browser or in responsive/mobile view
- [ ] Create enough topics to exceed the viewport height
- [ ] Verify the topic list is now scrollable vertically
- [ ] Verify horizontal overflow remains hidden

Fixes #12029

## Summary by Sourcery

Bug Fixes:
- Fix mobile topic list not being scrollable when topics exceed the viewport height on small screens.