### PR TITLE
fix: add defensive array check in favoriteTopic to prevent TypeError

### DIFF
--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -302,12 +302,12 @@ export const chatTopic: StateCreator<
     await mutate(
       ['cronTopicsWithJobInfo', activeAgentId],
       (groups?: CronTopicsGroupWithJobInfo[]) => {
-        if (!groups) return groups;
+        if (!Array.isArray(groups)) return groups;
 
         let updated = false;
         const next = groups.map((group) => {
           let groupUpdated = false;
-          const topics = group.topics.map((topic) => {
+          const topics = (group.topics || []).map((topic) => {
             if (topic.id !== id) return topic;
             if (topic.favorite === favorite) return topic;
             groupUpdated = true;


### PR DESCRIPTION
## Summary
- Fix `TypeError: h.map is not a function` crash in favoriteTopic
- Use `Array.isArray()` for strict type checking instead of falsy check
- Add fallback empty array for `group.topics` to handle undefined values

## Problem
When favoriting/unfavoriting a topic on a group topic page, the app crashes with `TypeError: h.map is not a function`. The root cause is that the `favoriteTopic` method's SWR mutate callback checks `if (!groups) return groups` which only catches `null` and `undefined`. When SWR cache contains malformed data (e.g., an object or string instead of an array), the `.map()` call fails.

## Solution
Two changes in `src/store/chat/slices/topic/action.ts`:
1. Changed `if (!groups) return groups` to `if (!Array.isArray(groups)) return groups` for strict array type validation
2. Added fallback `(group.topics || []).map(...)` to prevent undefined errors on `group.topics`

## Test plan
- [ ] Navigate to a group topic page
- [ ] Click favorite/unfavorite on a topic
- [ ] Verify no TypeError is thrown
- [ ] Verify the favorite state toggles correctly

Fixes #12072

## Summary by Sourcery

Prevent crashes in the favorite topic mutation by validating cached group data and safely handling missing topic lists.

Bug Fixes:
- Guard favorite topic SWR mutation against non-array cached group data to avoid TypeError when mapping.
- Provide a safe fallback for missing group topic arrays during favorite toggling to prevent runtime errors.