### PR TITLE
fix: add TTS and Translate actions to assistant messages with tool calls

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -119,6 +119,8 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
     defaultActions.copy,
     collapseAction,
     defaultActions.divider,
+    defaultActions.tts,
+    defaultActions.translate,
     defaultActions.share,
     defaultActions.divider,
     defaultActions.regenerate,

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
@@ -8,6 +8,7 @@ import {
   ListChevronsDownUp,
   ListChevronsUpDown,
   ListRestart,
+  Play,
   RotateCcw,
   Share2,
   StepForward,
@@ -38,6 +39,7 @@ export interface GroupActions {
   regenerate: ActionItem;
   share: ActionItem;
   translate: ActionItem;
+  tts: ActionItem;
 }
 
 interface UseGroupActionsParams {
@@ -71,6 +73,7 @@ export const useGroupActions = ({
     deleteMessage,
     regenerateAssistantMessage,
     translateMessage,
+    ttsMessage,
     delAndRegenerateMessage,
     continueGenerationMessage,
   ] = useConversationStore((s) => [
@@ -79,6 +82,7 @@ export const useGroupActions = ({
     s.deleteMessage,
     s.regenerateAssistantMessage,
     s.translateMessage,
+    s.ttsMessage,
     s.delAndRegenerateMessage,
     s.continueGenerationMessage,
   ]);
@@ -172,6 +176,12 @@ export const useGroupActions = ({
         key: 'translate',
         label: t('translate.action', { ns: 'chat' }),
       },
+      tts: {
+        handleClick: () => ttsMessage(id),
+        icon: Play,
+        key: 'tts',
+        label: t('tts.action', { ns: 'chat' }),
+      },
     }),
     [
       id,
@@ -185,6 +195,7 @@ export const useGroupActions = ({
       deleteMessage,
       regenerateAssistantMessage,
       translateMessage,
+      ttsMessage,
       delAndRegenerateMessage,
       toggleMessageCollapsed,
       continueGenerationMessage,


### PR DESCRIPTION
## Summary

Fixes #12173

Added TTS (Text-to-Speech) and Translate actions to the dropdown menu for assistant messages that include tool calls (`assistantGroup` message type).

## Problem

When an AI model responds with tool calls, the message is rendered as an `assistantGroup` type. The action dropdown menu for these messages was **missing TTS and Translate options** entirely.

For regular assistant messages (without tool calls), both TTS and Translate appear correctly in the dropdown. However, when the same model produces a response with tool calls, only Edit, Copy, Collapse Message, Share, Regenerate, and Delete were shown.

## Root Cause

The `GroupActionsBar` component (and `useGroupActions` hook) **explicitly excluded** `tts` and `translate` actions from the menu, unlike the regular `AssistantActionsBar`.

## Solution

### Files Changed

1. **`src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts`**
   - Added `Play` icon import
   - Added `tts: ActionItem` to `GroupActions` interface
   - Added `ttsMessage` to store actions destructuring
   - Implemented `tts` action with proper handler and icon
   - Added `ttsMessage` to dependencies array

2. **`src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx`**
   - Added `defaultActions.tts` and `defaultActions.translate` to `menuItems` array

### Before
```typescript
const menuItems = actionsConfig?.menu ?? [
  defaultActions.edit,
  defaultActions.copy,
  collapseAction,
  defaultActions.divider,
  defaultActions.share,
  // ❌ Missing TTS and Translate
  defaultActions.divider,
  defaultActions.regenerate,
  defaultActions.del,
];
```

### After
```typescript
const menuItems = actionsConfig?.menu ?? [
  defaultActions.edit,
  defaultActions.copy,
  collapseAction,
  defaultActions.divider,
  defaultActions.tts,
  defaultActions.translate,
  defaultActions.share,
  defaultActions.divider,
  defaultActions.regenerate,
  defaultActions.del,
];
```

## Testing

- Verified type-check passes: `bun run type-check`
- Implementation follows the same pattern as `AssistantActionsBar`

## Test Plan

- [ ] Start a conversation with any AI model that supports tool calling (e.g., GPT-4o, Claude)
- [ ] Enable at least one plugin/tool for the agent
- [ ] Send a prompt that triggers a tool call (e.g., web search)
- [ ] Wait for model to complete the tool call and generate response
- [ ] Click the `⋯` (more actions) dropdown on the assistant's response
- [ ] Verify TTS and Translate actions are now present in the menu
- [ ] Test TTS functionality works correctly
- [ ] Test Translate functionality works correctly

## Summary by Sourcery

Add missing text-to-speech and translate actions to assistant messages that include tool calls.

Bug Fixes:
- Expose TTS and Translate actions in the actions menu for assistantGroup messages so they match regular assistant messages.

Enhancements:
- Wire assistantGroup actions into the conversation store for TTS handling and localize the new TTS action label.