### PR TITLE
🐛 fix: make /api/version publicly accessible

### DIFF
--- a/src/app/(backend)/api/version/route.ts
+++ b/src/app/(backend)/api/version/route.ts
@@ -6,8 +6,27 @@ export interface VersionResponseData {
   version: string;
 }
 
+// Allow public access to version endpoint
+export const dynamic = 'force-dynamic';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
 export async function GET() {
-  return NextResponse.json({
-    version: pkg.version,
-  } satisfies VersionResponseData);
+  return NextResponse.json(
+    {
+      version: pkg.version,
+    } satisfies VersionResponseData,
+    { headers: corsHeaders },
+  );
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: corsHeaders,
+    status: 204,
+  });
 }


### PR DESCRIPTION
Move /api/version endpoint from the (backend) route group to src/app/api/version to make it publicly accessible without authentication.

This change is based on the dev branch.