### PR TITLE
🐛 fix: add api/version and api/desktop to public routes

### DIFF
--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -163,6 +163,8 @@ export function defineConfig() {
     '/api/workflows(.*)',
     '/api/agent(.*)',
     '/api/dev(.*)',
+    '/api/version',
+    '/api/desktop/(.*)',
     '/webapi(.*)',
     '/trpc(.*)',
     // better auth
@@ -180,6 +182,7 @@ export function defineConfig() {
     '/market-auth-callback',
     // public share pages
     '/share(.*)',
+    // version
   ]);
 
   const betterAuthMiddleware = async (req: NextRequest) => {

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -163,10 +163,11 @@ export function defineConfig() {
     '/api/workflows(.*)',
     '/api/agent(.*)',
     '/api/dev(.*)',
-    '/api/version',
-    '/api/desktop/(.*)',
     '/webapi(.*)',
     '/trpc(.*)',
+    // version
+    '/api/version',
+    '/api/desktop/(.*)',
     // better auth
     '/signin',
     '/signup',
@@ -182,7 +183,7 @@ export function defineConfig() {
     '/market-auth-callback',
     // public share pages
     '/share(.*)',
-    // version
+ 
   ]);
 
   const betterAuthMiddleware = async (req: NextRequest) => {


### PR DESCRIPTION
## Summary
- Add `/api/version` and `/api/desktop/(.*)` to the public route matcher so these endpoints are accessible without authentication

## Test plan
- [x] Verify `/api/version` returns version info without auth
- [x] Verify `/api/desktop/*` endpoints are accessible without auth
- [x] Verify other protected routes still require authentication

## Summary by Sourcery

Allow specific API routes to bypass authentication by marking them as public in the proxy configuration.

New Features:
- Expose /api/version as a public endpoint accessible without authentication.
- Expose /api/desktop/* endpoints as public routes accessible without authentication.