### PR TITLE
Fixed PWA settings not appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,6 +459,27 @@
     "registry": "https://registry.npmjs.org"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@lobehub/editor",
+      "@playwright/browser-chromium",
+      "@scarf/scarf",
+      "@swc/core",
+      "@tree-sitter-grammars/tree-sitter-yaml",
+      "@vercel/speed-insights",
+      "better-sqlite3",
+      "core-js",
+      "core-js-pure",
+      "electron",
+      "es5-ext",
+      "esbuild",
+      "onnxruntime-node",
+      "promptfoo",
+      "protobufjs",
+      "sharp",
+      "tree-sitter",
+      "tree-sitter-json",
+      "unrs-resolver"
+    ],
     "overrides": {
       "@lobehub/ui": "4.33.4",
       "better-auth": "1.4.6",

--- a/src/app/[variants]/(mobile)/chat/features/ChatHeader/index.tsx
+++ b/src/app/[variants]/(mobile)/chat/features/ChatHeader/index.tsx
@@ -1,17 +1,32 @@
 'use client';
 
+import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
+import { Settings } from 'lucide-react';
 import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import ShareButton from '@/app/[variants]/(main)/agent/features/Conversation/Header/ShareButton';
+import { MOBILE_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import { INBOX_SESSION_ID } from '@/const/session';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
+import { useAgentStore } from '@/store/agent';
 
 import ChatHeaderTitle from './ChatHeaderTitle';
 
 const MobileHeader = memo(() => {
   const router = useQueryRoute();
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const { t } = useTranslation('common');
+
+  const handleOpenSettings = () => {
+    if (activeAgentId) {
+      navigate(`/agent/${activeAgentId}/settings`);
+    }
+  };
 
   return (
     <ChatHeader
@@ -19,7 +34,17 @@ const MobileHeader = memo(() => {
       onBackClick={() =>
         router.push('/agent', { query: { session: INBOX_SESSION_ID }, replace: true })
       }
-      right={<ShareButton mobile open={open} setOpen={setOpen} />}
+      right={
+        <Flexbox gap={4} horizontal>
+          <ActionIcon
+            icon={Settings}
+            onClick={handleOpenSettings}
+            size={MOBILE_HEADER_ICON_SIZE}
+            title={t('setting')}
+          />
+          <ShareButton mobile open={open} setOpen={setOpen} />
+        </Flexbox>
+      }
       showBackButton
       style={{ width: '100%' }}
     />

--- a/src/features/AgentSetting/AgentSettingsContent.tsx
+++ b/src/features/AgentSetting/AgentSettingsContent.tsx
@@ -5,8 +5,11 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { ChatSettingsTabs } from '@/store/global/initialState';
 
 import AgentChat from './AgentChat';
+import AgentMeta from './AgentMeta';
 import AgentModal from './AgentModal';
 import AgentOpening from './AgentOpening';
+import AgentPrompt from './AgentPrompt';
+import AgentTTS from './AgentTTS';
 
 export interface AgentSettingsContentProps {
   loadingSkeleton: ReactNode;
@@ -20,9 +23,12 @@ const AgentSettingsContent = memo<AgentSettingsContentProps>(({ tab, loadingSkel
 
   return (
     <>
+      {tab === ChatSettingsTabs.Meta && <AgentMeta />}
+      {tab === ChatSettingsTabs.Prompt && <AgentPrompt />}
       {tab === ChatSettingsTabs.Opening && <AgentOpening />}
       {tab === ChatSettingsTabs.Chat && <AgentChat />}
       {tab === ChatSettingsTabs.Modal && <AgentModal />}
+      {tab === ChatSettingsTabs.TTS && <AgentTTS />}
     </>
   );
 });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

-Added Settings icon button to the right side of the mobile chat header  to access chat model settings (agent profile) on mobile/PWA                            

- Added missing tab content for Meta, Prompt, and TTS tabs that were not rendering on mobile/PWA.
                                                                                                               
- Navigation Fix: Used activeAgentId from agent store instead of session store activeId to correctly navigate to settings page with proper agent ID

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally                                                                                              
                                                                       
  1. Open the app on mobile browser or PWA                                                                              
  2. Navigate to a chat/agent conversation                                                                            
  3. Click the Settings icon (gear) in the top right header                                                     
  4. Verify the settings page opens with all tabs working (Agent Info, Prompt, Opening, Chat, Model, TTS)       
                                                   

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

![Alt text](https://s4.ezgif.com/tmp/ezgif-4e8c8857e0d25923.gif)

#### 📝 Additional Information
Files changed:                                                                                                
  - src/app/[variants]/(mobile)/chat/features/ChatHeader/index.tsx - Added Settings button                      
  - src/features/AgentSetting/AgentSettingsContent.tsx - Added missing tab content

## Summary by Sourcery

Fix mobile/PWA agent settings visibility and navigation while tightening PNPM’s built-dependencies configuration.

Bug Fixes:
- Ensure the mobile chat header provides access to the agent settings page using the correct active agent ID.
- Render the Meta, Prompt, and TTS tabs in the agent settings view so their content appears on mobile/PWA.

Enhancements:
- Add a settings icon button to the mobile chat header alongside the share button for quicker access to agent settings.

Build:
- Restrict PNPM to only build a defined set of heavy dependencies via the onlyBuiltDependencies configuration.