### PR TITLE
🐛 fix: use custom avatar for group chat in sidebar

### DIFF
--- a/packages/database/src/repositories/home/index.ts
+++ b/packages/database/src/repositories/home/index.ts
@@ -59,6 +59,8 @@ export class HomeRepository {
     // 2. Query all chatGroups (group chats)
     const chatGroupList = await this.db
       .select({
+        avatar: chatGroups.avatar,
+        backgroundColor: chatGroups.backgroundColor,
         description: chatGroups.description,
         groupId: chatGroups.groupId,
         id: chatGroups.id,
@@ -102,6 +104,8 @@ export class HomeRepository {
       updatedAt: Date;
     }>,
     chatGroupItems: Array<{
+      avatar: string | null;
+      backgroundColor: string | null;
       description: string | null;
       groupId: string | null;
       id: string;
@@ -132,7 +136,9 @@ export class HomeRepository {
         updatedAt: a.updatedAt,
       })),
       ...chatGroupItems.map((g) => ({
-        avatar: memberAvatarsMap.get(g.id) ?? null,
+        // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
+        avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
+        backgroundColor: g.avatar ? g.backgroundColor : null,
         description: g.description,
         groupId: g.groupId,
         id: g.id,
@@ -214,6 +220,8 @@ export class HomeRepository {
     // 2. Search chat groups by title or description
     const chatGroupResults = await this.db
       .select({
+        avatar: chatGroups.avatar,
+        backgroundColor: chatGroups.backgroundColor,
         description: chatGroups.description,
         id: chatGroups.id,
         pinned: chatGroups.pinned,
@@ -250,7 +258,8 @@ export class HomeRepository {
       ),
       ...chatGroupResults.map((g) =>
         cleanObject({
-          avatar: memberAvatarsMap.get(g.id),
+          avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
+          backgroundColor: g.avatar ? g.backgroundColor : null,
           description: g.description,
           id: g.id,
           pinned: g.pinned ?? false,

--- a/packages/types/src/home.ts
+++ b/packages/types/src/home.ts
@@ -17,11 +17,15 @@ export interface GroupMemberAvatar {
 export interface SidebarAgentItem {
   /**
    * Avatar can be:
-   * - string: single avatar for agents
-   * - GroupMemberAvatar[]: array of member avatars for groups
+   * - string: single avatar for agents or custom group avatar
+   * - GroupMemberAvatar[]: array of member avatars for groups (when no custom avatar)
    * - null: no avatar
    */
   avatar?: GroupMemberAvatar[] | string | null;
+  /**
+   * Background color for the avatar (used for custom group avatars)
+   */
+  backgroundColor?: string | null;
   description?: string | null;
   id: string;
   pinned: boolean;

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
@@ -7,7 +7,7 @@ import { type CSSProperties, type DragEvent, memo, useCallback, useMemo } from '
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
-import GroupAvatar from '@/features/GroupAvatar';
+import AgentGroupAvatar from '@/features/AgentGroupAvatar';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useGlobalStore } from '@/store/global';
 import { useHomeStore } from '@/store/home';
@@ -23,7 +23,7 @@ interface GroupItemProps {
 }
 
 const GroupItem = memo<GroupItemProps>(({ item, style, className }) => {
-  const { id, avatar, title, pinned } = item;
+  const { id, avatar, backgroundColor, title, pinned } = item;
   const { t } = useTranslation('chat');
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
@@ -82,8 +82,21 @@ const GroupItem = memo<GroupItemProps>(({ item, style, className }) => {
     if (isUpdating) {
       return <Icon color={cssVar.colorTextDescription} icon={Loader2} size={18} spin />;
     }
-    return <GroupAvatar avatars={(avatar as any) || []} size={22} />;
-  }, [isUpdating, avatar]);
+
+    // If avatar is a string, it's a custom group avatar
+    const customAvatar = typeof avatar === 'string' ? avatar : undefined;
+    // If avatar is an array, it's member avatars for composition
+    const memberAvatars = Array.isArray(avatar) ? avatar : [];
+
+    return (
+      <AgentGroupAvatar
+        avatar={customAvatar}
+        backgroundColor={backgroundColor || undefined}
+        memberAvatars={memberAvatars}
+        size={22}
+      />
+    );
+  }, [isUpdating, avatar, backgroundColor]);
 
   const dropdownMenu = useGroupDropdownMenu({
     id,


### PR DESCRIPTION
## Summary

Fixes [LOBE-4883](https://linear.app/lobehub/issue/LOBE-4883)

When a group chat has a custom avatar set, the sidebar was always showing the member composition avatar instead of the custom one. Entering the group detail page would display the correct avatar.

### Root Cause

1. **Data layer**: `HomeRepository` did not query `chatGroups.avatar` and `chatGroups.backgroundColor`, so the sidebar data always fell back to member avatar composition.
2. **Render layer**: `AgentGroupItem` used `GroupAvatar` (member composition) directly, without checking for a custom avatar like the detail page does via `AgentGroupAvatar`.

### Changes

| File | Change |
|---|---|
| `packages/types/src/home.ts` | Added `backgroundColor` field to `SidebarAgentItem` |
| `packages/database/src/repositories/home/index.ts` | Query `chatGroups.avatar` / `chatGroups.backgroundColor`; prioritize custom avatar over member composition in both `getSidebarAgentList` and `searchAgents` |
| `src/.../AgentGroupItem/index.tsx` | Replaced `GroupAvatar` with `AgentGroupAvatar` for proper custom vs composition avatar detection |

### Related

- Context conversation: https://app.lobehub.com/share/t/9ALXWDCG
