### PR TITLE
🔨 chore(memory-user-memory): should not append date & time

### DIFF
--- a/packages/memory-user-memory/src/prompts/layers/activity.ts
+++ b/packages/memory-user-memory/src/prompts/layers/activity.ts
@@ -46,6 +46,7 @@ export const activityPrompt = [
   '## Memory Formatting Guidelines',
   '',
   '> ALL MEMORY ITEMS MUST BE SELF-CONTAINED',
+  '- Do not append date or time information to the `title`; keep timing in temporal fields or narrative instead.',
   '- Use concrete names/entities—avoid pronouns.',
   '- Preserve the original language from user input—do not translate.',
   '- Include relevant details, participants, places, timing if present, and outcomes.',

--- a/packages/memory-user-memory/src/prompts/layers/context.ts
+++ b/packages/memory-user-memory/src/prompts/layers/context.ts
@@ -58,6 +58,7 @@ export const contextPrompt = [
   '## Memory Formatting Guidelines',
   '',
   '> CRITICAL REQUIREMENT: ALL MEMORY ITEMS MUST BE SELF-CONTAINED',
+  '- Do not append date or time information to the `title`; keep any timing details within the body fields instead.',
   '',
   'Every memory item you create must be standalone and understandable without',
   'extra context:',

--- a/packages/memory-user-memory/src/prompts/layers/experience.ts
+++ b/packages/memory-user-memory/src/prompts/layers/experience.ts
@@ -55,6 +55,7 @@ export const experiencePrompt = [
   '## Memory Formatting Guidelines',
   '',
   '> CRITICAL REQUIREMENT: ALL MEMORY ITEMS MUST BE SELF-CONTAINED',
+  '- Do not append date or time information to the `title`; keep timing in temporal fields or narrative instead.',
   '',
   'Every memory item you create must be standalone and understandable without',
   'extra context:',

--- a/packages/memory-user-memory/src/prompts/layers/identity.ts
+++ b/packages/memory-user-memory/src/prompts/layers/identity.ts
@@ -112,6 +112,7 @@ export const identityPrompt = [
   '## Memory Formatting Guidelines',
   '',
   '> CRITICAL REQUIREMENT: ALL MEMORY ITEMS MUST BE SELF-CONTAINED',
+  '- Do not append date or time information to the `title`; keep timing in temporal fields or narrative instead.',
   '',
   'Every memory item you create must be standalone and understandable without',
   'extra context:',

--- a/packages/memory-user-memory/src/prompts/layers/preference.ts
+++ b/packages/memory-user-memory/src/prompts/layers/preference.ts
@@ -64,6 +64,7 @@ export const preferencePrompt = [
   '## Memory Formatting Guidelines',
   '',
   '> CRITICAL REQUIREMENT: ALL MEMORY ITEMS MUST BE SELF-CONTAINED',
+  '- Do not append date or time information to the `title`; keep timing in temporal fields or narrative instead.',
   '',
   'Every memory item you create must be standalone and understandable without',
   'extra context:',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Documentation:
- Document that memory item titles must not include date or time information, directing temporal details to dedicated fields or narrative instead.