### PR TITLE
✨ feat(business-model-runtime): add router metrics service stub

### DIFF
--- a/packages/business/model-runtime/src/index.ts
+++ b/packages/business/model-runtime/src/index.ts
@@ -1,1 +1,2 @@
+export * from './router-metrics';
 export * from './router-runtime-options';

--- a/packages/business/model-runtime/src/router-metrics.ts
+++ b/packages/business/model-runtime/src/router-metrics.ts
@@ -1,0 +1,53 @@
+export interface RouteAttemptInput {
+  apiType: string;
+  channelId?: string;
+  durationMs: number;
+  error?: unknown;
+  model: string;
+  providerId: string;
+  remark?: string;
+  routerId?: string;
+  success: boolean;
+}
+
+export interface ChannelStats {
+  errorRate: number;
+  errors: number;
+  recentMinuteErrors: number;
+  total: number;
+}
+
+export class RouterMetricsService {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async recordAttempt(_result: RouteAttemptInput): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getChannelStats(_routerId: string, _channelId: string): Promise<ChannelStats> {
+    return { errorRate: 0, errors: 0, recentMinuteErrors: 0, total: 0 };
+  }
+
+  async getAllChannelIds(): Promise<Array<{ channelId: string; routerId: string }>> {
+    return [];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async tryAcquireAlertLock(_routerId: string, _channelId: string): Promise<boolean> {
+    return false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getModelStats(_modelId: string): Promise<ChannelStats> {
+    return { errorRate: 0, errors: 0, recentMinuteErrors: 0, total: 0 };
+  }
+
+  async getAllModelIds(): Promise<string[]> {
+    return [];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async tryAcquireModelAlertLock(_modelId: string): Promise<boolean> {
+    return false;
+  }
+}
+
+export const routerMetricsService = new RouterMetricsService();

--- a/packages/business/model-runtime/src/router-runtime-options.ts
+++ b/packages/business/model-runtime/src/router-runtime-options.ts
@@ -1,3 +1,6 @@
+import type { RouteAttemptInput } from './router-metrics';
+import { routerMetricsService } from './router-metrics';
+
 interface RouterInstance {
   apiType: string;
   models?: string[];
@@ -16,11 +19,16 @@ interface RouterInstance {
 
 interface LobehubRouterRuntimeOptions {
   id: string;
+  onRouteAttempt?: (result: RouteAttemptInput) => void;
   routers: (options: any, runtimeContext: { model?: string }) => Promise<RouterInstance[]>;
 }
 
 export const lobehubRouterRuntimeOptions: LobehubRouterRuntimeOptions = {
   id: 'lobehub',
+
+  onRouteAttempt: (result) => {
+    routerMetricsService.recordAttempt(result).catch(console.error);
+  },
 
   // eslint-disable-next-line unused-imports/no-unused-vars, @typescript-eslint/no-unused-vars
   routers: async (options, { model: _model }) => {


### PR DESCRIPTION
## Summary
- Add `RouterMetricsService` stub with no-op implementations for the open-source package
- Export `RouteAttemptInput`, `ChannelStats` interfaces and `routerMetricsService` singleton
- Methods: `recordAttempt`, `getChannelStats`, `getAllChannelIds`, `tryAcquireAlertLock`, `getModelStats`, `getAllModelIds`, `tryAcquireModelAlertLock`
- Cloud repo overrides this with actual Redis-backed implementation via pnpm overrides

## Test plan
- [ ] Verify open-source `@lobechat/business-model-runtime` exports compile without errors
- [ ] Verify cloud override still takes precedence via pnpm overrides

## Summary by Sourcery

Introduce a stubbed router metrics service to the business model runtime and expose its interfaces and singleton for open-source usage.

New Features:
- Add a RouterMetricsService class with no-op implementations for recording route attempts and retrieving channel and model statistics.
- Export RouteAttemptInput and ChannelStats interfaces along with a routerMetricsService singleton from the model runtime package.