### PR TITLE
🔨 chore(model-runtime): add onRouteAttempt callback to RouterRuntime

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -61,6 +61,7 @@ type RouterOptions = RouterOptionItem | RouterOptionItem[];
 interface RouterInstance {
   apiType: ApiType;
   baseURLPattern?: RegExp;
+  id?: string;
   models?: string[];
   options: RouterOptions;
   runtime?: RuntimeClass;
@@ -76,6 +77,18 @@ type Routers =
         model?: string;
       },
     ) => RouterInstance[] | Promise<RouterInstance[]>);
+
+export interface RouteAttemptResult {
+  apiType: string;
+  channelId?: string;
+  durationMs: number;
+  error?: unknown;
+  model: string;
+  providerId: string;
+  remark?: string;
+  routerId?: string;
+  success: boolean;
+}
 
 export interface CreateRouterRuntimeOptions<T extends Record<string, any> = any> {
   apiKey?: string;
@@ -123,6 +136,7 @@ export interface CreateRouterRuntimeOptions<T extends Record<string, any> = any>
     | {
         transformModel?: (model: OpenAI.Model) => ChatModelCard;
       };
+  onRouteAttempt?: (result: RouteAttemptResult) => void;
   responses?: {
     handlePayload?: (
       payload: ChatStreamPayload,
@@ -287,6 +301,7 @@ export const createRouterRuntime = ({
 
       for (const [index, optionItem] of routerOptions.entries()) {
         const attempt = index + 1;
+        const startTime = Date.now();
         const {
           channelId,
           id: resolvedApiType,
@@ -309,9 +324,40 @@ export const createRouterRuntime = ({
             );
           }
 
+          try {
+            params.onRouteAttempt?.({
+              apiType: resolvedApiType,
+              channelId,
+              durationMs: Date.now() - startTime,
+              model,
+              providerId: id,
+              remark,
+              routerId: matchedRouter.id,
+              success: true,
+            });
+          } catch (e) {
+            log('onRouteAttempt callback error: %O', e);
+          }
+
           return result;
         } catch (error) {
           lastError = error;
+
+          try {
+            params.onRouteAttempt?.({
+              apiType: resolvedApiType,
+              channelId,
+              durationMs: Date.now() - startTime,
+              error,
+              model,
+              providerId: id,
+              remark,
+              routerId: matchedRouter.id,
+              success: false,
+            });
+          } catch (e) {
+            log('onRouteAttempt callback error: %O', e);
+          }
 
           if (attempt < totalOptions) {
             log(

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -136,7 +136,7 @@ export interface CreateRouterRuntimeOptions<T extends Record<string, any> = any>
     | {
         transformModel?: (model: OpenAI.Model) => ChatModelCard;
       };
-  onRouteAttempt?: (result: RouteAttemptResult) => void;
+  onRouteAttempt?: (result: RouteAttemptResult) => Promise<void>;
   responses?: {
     handlePayload?: (
       payload: ChatStreamPayload,
@@ -324,40 +324,36 @@ export const createRouterRuntime = ({
             );
           }
 
-          try {
-            params.onRouteAttempt?.({
-              apiType: resolvedApiType,
-              channelId,
-              durationMs: Date.now() - startTime,
-              model,
-              providerId: id,
-              remark,
-              routerId: matchedRouter.id,
-              success: true,
-            });
-          } catch (e) {
+          params.onRouteAttempt?.({
+            apiType: resolvedApiType,
+            channelId,
+            durationMs: Date.now() - startTime,
+            model,
+            providerId: id,
+            remark,
+            routerId: matchedRouter.id,
+            success: true,
+          }).catch((e) => {
             log('onRouteAttempt callback error: %O', e);
-          }
+          });
 
           return result;
         } catch (error) {
           lastError = error;
 
-          try {
-            params.onRouteAttempt?.({
-              apiType: resolvedApiType,
-              channelId,
-              durationMs: Date.now() - startTime,
-              error,
-              model,
-              providerId: id,
-              remark,
-              routerId: matchedRouter.id,
-              success: false,
-            });
-          } catch (e) {
+          params.onRouteAttempt?.({
+            apiType: resolvedApiType,
+            channelId,
+            durationMs: Date.now() - startTime,
+            error,
+            model,
+            providerId: id,
+            remark,
+            routerId: matchedRouter.id,
+            success: false,
+          }).catch((e) => {
             log('onRouteAttempt callback error: %O', e);
-          }
+          });
 
           if (attempt < totalOptions) {
             log(

--- a/packages/model-runtime/src/core/RouterRuntime/index.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/index.ts
@@ -6,5 +6,5 @@ export interface RuntimeItem {
   runtime: LobeRuntimeAI;
 }
 
-export type { CreateRouterRuntimeOptions, UniformRuntime } from './createRuntime';
+export type { CreateRouterRuntimeOptions, RouteAttemptResult, UniformRuntime } from './createRuntime';
 export { createRouterRuntime } from './createRuntime';


### PR DESCRIPTION
## Summary
- Add `RouteAttemptResult` interface and optional `onRouteAttempt` callback to `CreateRouterRuntimeOptions`
- The callback fires after each route attempt in `runWithFallback` with timing, channel, model, and error info
- Enables external monitoring of router health (e.g. cloud metrics collection)

## Test plan
- [ ] Verify callback fires on successful route attempts with correct fields
- [ ] Verify callback fires on failed route attempts with error info
- [ ] Verify callback errors are caught and don't affect routing logic
- [ ] Verify no regression when `onRouteAttempt` is not provided

## Summary by Sourcery

Add instrumentation hook to observe router route attempts with timing and outcome metadata.

New Features:
- Introduce RouteAttemptResult interface describing metadata for individual routing attempts.
- Add optional onRouteAttempt callback to router runtime options to receive per-attempt results.

Enhancements:
- Track and report success/failure, timing, and contextual identifiers (router, provider, channel, model) for each route attempt without affecting routing behavior.
- Expose optional router instance id and re-export RouteAttemptResult from the RouterRuntime entrypoint for external consumption.