### PR TITLE
🐛 fix: filter stdio MCP tools on web environment

### DIFF
--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -1,5 +1,5 @@
 import { type LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createAgentToolsEngine, createToolsEngine, getEnabledTools } from './index';
 
@@ -63,9 +63,13 @@ vi.mock('@/store/tool', () => ({
   }),
 }));
 
+let mockGetInstalledPluginById: (id: string) => () => any = () => () => undefined;
+let mockInstalledPluginManifestList: () => LobeChatPluginManifest[] = () => [];
+
 vi.mock('@/store/tool/selectors', () => ({
   pluginSelectors: {
-    installedPluginManifestList: () => [],
+    getInstalledPluginById: (id: string) => mockGetInstalledPluginById(id),
+    installedPluginManifestList: () => mockInstalledPluginManifestList(),
   },
   klavisStoreSelectors: {
     klavisAsLobeTools: () => [],
@@ -86,6 +90,11 @@ vi.mock('@/helpers/getSearchConfig', () => ({
 }));
 
 describe('toolEngineering', () => {
+  afterEach(() => {
+    mockGetInstalledPluginById = () => () => undefined;
+    mockInstalledPluginManifestList = () => [];
+  });
+
   describe('createToolsEngine', () => {
     it('should generate tools array for enabled plugins', () => {
       const toolsEngine = createToolsEngine();
@@ -171,6 +180,68 @@ describe('toolEngineering', () => {
 
       expect(result.enabledToolIds).toEqual(['search', 'lobe-web-browsing']);
       expect(result.enabledToolIds).toHaveLength(2);
+    });
+  });
+
+  describe('stdio MCP filtering on web', () => {
+    const stdioMcpManifest = {
+      api: [
+        {
+          description: 'Run stdio tool',
+          name: 'run',
+          parameters: { properties: {}, required: [], type: 'object' },
+        },
+      ],
+      identifier: 'stdio-mcp-plugin',
+      meta: { title: 'Stdio MCP', avatar: '🔧' },
+      type: 'default',
+    } as unknown as LobeChatPluginManifest;
+
+    const httpMcpManifest = {
+      api: [
+        {
+          description: 'Run http tool',
+          name: 'run',
+          parameters: { properties: {}, required: [], type: 'object' },
+        },
+      ],
+      identifier: 'http-mcp-plugin',
+      meta: { title: 'HTTP MCP', avatar: '🌐' },
+      type: 'default',
+    } as unknown as LobeChatPluginManifest;
+
+    it('should filter stdio MCP tools in non-desktop environment', () => {
+      mockInstalledPluginManifestList = () => [stdioMcpManifest];
+      mockGetInstalledPluginById = (id: string) => () =>
+        id === 'stdio-mcp-plugin'
+          ? { customParams: { mcp: { type: 'stdio' } }, identifier: id }
+          : undefined;
+
+      const toolsEngine = createAgentToolsEngine({ model: 'gpt-4', provider: 'openai' });
+      const result = toolsEngine.generateToolsDetailed({
+        toolIds: ['stdio-mcp-plugin'],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain('stdio-mcp-plugin');
+    });
+
+    it('should NOT filter http MCP tools in non-desktop environment', () => {
+      mockInstalledPluginManifestList = () => [httpMcpManifest];
+      mockGetInstalledPluginById = (id: string) => () =>
+        id === 'http-mcp-plugin'
+          ? { customParams: { mcp: { type: 'http' } }, identifier: id }
+          : undefined;
+
+      const toolsEngine = createAgentToolsEngine({ model: 'gpt-4', provider: 'openai' });
+      const result = toolsEngine.generateToolsDetailed({
+        toolIds: ['http-mcp-plugin'],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain('http-mcp-plugin');
     });
   });
 

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -3,6 +3,7 @@
  */
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
+import { isDesktop } from '@lobechat/const';
 import { type PluginEnableChecker } from '@lobechat/context-engine';
 import { ToolsEngine } from '@lobechat/context-engine';
 import { type ChatCompletionTool, type WorkingModel } from '@lobechat/types';
@@ -88,6 +89,16 @@ export const createAgentToolsEngine = (workingModel: WorkingModel) =>
       if (!shouldEnableTool(pluginId)) {
         return false;
       }
+
+      // Filter stdio MCP tools in non-desktop environments
+      // stdio transport requires Electron IPC and cannot work on web
+      if (!isDesktop) {
+        const plugin = pluginSelectors.getInstalledPluginById(pluginId)(getToolStoreState());
+        if (plugin?.customParams?.mcp?.type === 'stdio') {
+          return false;
+        }
+      }
+
       // For WebBrowsingManifest, apply search logic
       if (pluginId === WebBrowsingManifest.identifier) {
         const searchConfig = getSearchConfig(workingModel.model, workingModel.provider);

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -345,9 +345,11 @@ export function defineConfig(config: CustomNextConfig) {
     // when external packages in dev mode with turbopack, this config will lead to bundle error
     // @napi-rs/canvas is a native module that can't be bundled by Turbopack
     // pdfjs-dist uses @napi-rs/canvas for DOMMatrix polyfill in Node.js environment
-    serverExternalPackages: config.serverExternalPackages
-      ? config.serverExternalPackages
-      : ['pdfkit', '@napi-rs/canvas', 'pdfjs-dist'],
+    serverExternalPackages: config.serverExternalPackages ?? [
+      'pdfkit',
+      '@napi-rs/canvas',
+      'pdfjs-dist',
+    ],
 
     transpilePackages: ['mermaid', 'better-auth-harmony'],
     turbopack: {

--- a/src/store/tool/slices/plugin/selectors.ts
+++ b/src/store/tool/slices/plugin/selectors.ts
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import { type LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 import { uniq } from 'es-toolkit/compat';
 
@@ -56,6 +57,8 @@ const installedPluginMetaList = (s: ToolStoreState) =>
   installedPlugins(s)
     // Filter out Klavis plugins (they have their own display location)
     .filter((p) => !p.customParams?.klavis)
+    // Filter out stdio MCP plugins on non-desktop (stdio requires Electron IPC)
+    .filter((p) => isDesktop || p.customParams?.mcp?.type !== 'stdio')
     .map<InstallPluginMeta>((p) => ({
       author: p.manifest?.author,
       createdAt: p.manifest?.createdAt || (p.manifest as any)?.createAt,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes issue where stdio-based MCP tools (desktop-only) were being injected into agent conversations on web platforms, causing runtime errors due to cloud sync.

#### 🔀 Description of Change

Prevents stdio MCP tools from being injected into agent conversations on web. Added environment-aware filtering in `createAgentToolsEngine` enableChecker — on non-desktop environments, checks `customParams.mcp.type` and disables `stdio` tools since they require Electron IPC.

#### 🧪 How to Test

- [x] Added/updated tests

Two new test cases:
1. stdio MCP tools are filtered out on web environment
2. http MCP tools are NOT filtered on web environment

## Summary by Sourcery

Filter desktop-only stdio MCP tools from agent tool injection on web platforms to avoid runtime issues.

Bug Fixes:
- Prevent stdio-based MCP tools from being enabled in non-desktop environments where Electron IPC is unavailable.

Tests:
- Add tests verifying stdio MCP tools are excluded and HTTP MCP tools remain available in non-desktop environments.