### PR TITLE
🔨 chore(userMemories): can render persona even without roles

### DIFF
--- a/src/app/[variants]/(main)/memory/(home)/index.tsx
+++ b/src/app/[variants]/(main)/memory/(home)/index.tsx
@@ -2,6 +2,8 @@ import { Flexbox } from '@lobehub/ui';
 // import { PencilLineIcon } from 'lucide-react';
 import { type FC } from 'react';
 
+import MemoryAnalysis from '@/app/[variants]/(main)/memory/features/MemoryAnalysis';
+import MemoryEmpty from '@/app/[variants]/(main)/memory/features/MemoryEmpty';
 import { SCROLL_PARENT_ID } from '@/app/[variants]/(main)/memory/features/TimeLineView/useScrollParent';
 import Loading from '@/components/Loading/BrandTextLoading';
 import NavHeader from '@/features/NavHeader';
@@ -9,27 +11,21 @@ import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
 import { useUserMemoryStore } from '@/store/userMemory';
 
-import MemoryAnalysis from '@/app/[variants]/(main)/memory/features/MemoryAnalysis';
-import MemoryEmpty from '@/app/[variants]/(main)/memory/features/MemoryEmpty';
 import Persona from './features/Persona';
 import PersonaHeader from './features/Persona/PersonaHeader';
 import RoleTagCloud from './features/RoleTagCloud';
 
 const Home: FC = () => {
   const useFetchTags = useUserMemoryStore((s) => s.useFetchTags);
+  const useFetchPersona = useUserMemoryStore((s) => s.useFetchPersona);
   const roles = useUserMemoryStore((s) => s.roles);
-  const { isLoading } = useFetchTags();
+  const persona = useUserMemoryStore((s) => s.persona);
+
+  const { isLoading: isTagsLoading } = useFetchTags();
+  const { isLoading: isPersonaLoading } = useFetchPersona();
   // const { EditorModalElement, openEditor } = usePersonaEditor();
 
-  if (isLoading) return <Loading debugId={'Home'} />;
-
-  if (!roles || roles.length === 0) {
-    return (
-      <MemoryEmpty>
-        <MemoryAnalysis />
-      </MemoryEmpty>
-    );
-  }
+  if (isTagsLoading || isPersonaLoading) return <Loading debugId={'Home'} />;
 
   return (
     <Flexbox flex={1} height={'100%'}>
@@ -52,9 +48,19 @@ const Home: FC = () => {
         width={'100%'}
       >
         <WideScreenContainer gap={32} paddingBlock={48}>
-          <PersonaHeader />
-          <RoleTagCloud tags={roles} />
-          <Persona />
+          {roles?.length > 0 && <RoleTagCloud tags={roles} />}
+          {persona ? (
+            <>
+              <PersonaHeader />
+              <Persona />
+            </>
+          ) : (
+            !roles?.length && (
+              <MemoryEmpty>
+                <MemoryAnalysis />
+              </MemoryEmpty>
+            )
+          )}
         </WideScreenContainer>
       </Flexbox>
       {/* {EditorModalElement} */}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust home memory view to handle persona loading separately from role tags and display persona when available even without roles.

New Features:
- Allow rendering of the persona section even when no role tags are present, as long as persona data exists.

Bug Fixes:
- Prevent the home memory view from showing the empty state when persona data exists but there are no role tags by gating the empty state on both missing roles and persona.

Enhancements:
- Introduce combined loading handling for tags and persona data before rendering the memory home view layout.