### PR TITLE
🔧 fix: update PR build workflows to trigger on release branches

### DIFF
--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -20,8 +20,8 @@ env:
 jobs:
   test:
     name: Code quality check
-    # 添加 PR label 触发条件，只有添加了 trigger:build-desktop 标签的 PR 才会触发构建
-    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-desktop')
+    # 添加 PR label 或 release/* 分支触发：有 trigger:build-desktop 标签或 PR 源分支为 release/* 时触发
+    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-desktop') || startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest # 只在 ubuntu 上运行一次检查
     steps:
       - name: Checkout base
@@ -49,7 +49,7 @@ jobs:
   version:
     name: Determine version
     # 与 test job 相同的触发条件
-    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-desktop')
+    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-desktop') || startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     outputs:
       # 输出版本信息，供后续 job 使用

--- a/.github/workflows/pr-build-docker.yml
+++ b/.github/workflows/pr-build-docker.yml
@@ -21,8 +21,8 @@ env:
 jobs:
   build:
     name: Build ${{ matrix.platform }} Docker Image
-    # 添加 PR label 触发条件,只有添加了 trigger:build-docker 标签的 PR 才会触发构建
-    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-docker')
+    # 添加 PR label 或 release/* 分支触发：有 trigger:build-docker 标签或 PR 源分支为 release/* 时触发
+    if: contains(github.event.pull_request.labels.*.name, 'trigger:build-docker') || startsWith(github.event.pull_request.head.ref, 'release/')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary by Sourcery

Update PR build workflows to also run for release branches in addition to label-triggered runs.

CI:
- Adjust PR desktop build workflow conditions to trigger when the PR has the trigger label or originates from a release/* branch.
- Adjust PR Docker build workflow conditions to trigger when the PR has the trigger label or originates from a release/* branch.