### PR TITLE
🐛 fix: improve GitHub Copilot auth retry logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,18 +131,18 @@
       "prettier --write --no-error-on-unmatched-pattern"
     ],
     "*.{mjs,cjs}": [
-      "prettier --write",
-      "eslint --fix"
+      "eslint --fix",
+      "prettier --write"
     ],
     "*.{js,jsx}": [
-      "prettier --write",
+      "eslint --fix",
       "stylelint --fix",
-      "eslint --fix"
+      "prettier --write"
     ],
     "*.{ts,tsx}": [
-      "prettier --parser=typescript --write",
       "stylelint --fix",
-      "eslint --fix"
+      "eslint --fix",
+      "prettier --parser=typescript --write"
     ]
   },
   "overrides": {

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -237,8 +237,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
       } catch (error: any) {
         const status = error?.status ?? error?.error?.status ?? error?.response?.status;
 
-        // 401: Refresh token once
-        if (status === 401 && !hasRefreshedAuth) {
+        // 401: Refresh token once (only if we have an exchange credential to fall back to)
+        if (status === 401 && !hasRefreshedAuth && this.githubToken) {
           hasRefreshedAuth = true;
           this.cachedBearerToken = undefined;
           tokenManager.invalidate(this.githubToken);

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -1,11 +1,11 @@
-import type { ChatModelCard } from '@lobechat/types';
+import  { type ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import OpenAI from 'openai';
 
-import type { LobeRuntimeAI } from '../../core/BaseAI';
+import  { type LobeRuntimeAI } from '../../core/BaseAI';
 import { pruneReasoningPayload } from '../../core/contextBuilders/openai';
 import { OpenAIStream } from '../../core/streams';
-import type { ChatMethodOptions, ChatStreamPayload } from '../../types';
+import  { type ChatMethodOptions, type ChatStreamPayload } from '../../types';
 import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
 import { StreamingResponse } from '../../utils/response';
@@ -14,7 +14,6 @@ const COPILOT_BASE_URL = 'https://api.githubcopilot.com';
 const TOKEN_EXCHANGE_URL = 'https://api.github.com/copilot_internal/v2/token';
 
 const MAX_TOTAL_ATTEMPTS = 5;
-const MAX_AUTH_REFRESH = 1;
 const MAX_RATE_LIMIT_RETRIES = 3;
 
 interface CachedToken {
@@ -227,7 +226,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
 
   private async executeWithRetry<T>(fn: () => Promise<T>): Promise<T> {
     let totalAttempts = 0;
-    let authRefreshAttempts = 0;
+    let hasRefreshedAuth = false;
     let rateLimitAttempts = 0;
 
     while (totalAttempts < MAX_TOTAL_ATTEMPTS) {
@@ -239,8 +238,9 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
         const status = error?.status ?? error?.error?.status ?? error?.response?.status;
 
         // 401: Refresh token once
-        if (status === 401 && authRefreshAttempts < MAX_AUTH_REFRESH) {
-          authRefreshAttempts++;
+        if (status === 401 && !hasRefreshedAuth) {
+          hasRefreshedAuth = true;
+          this.cachedBearerToken = undefined;
           tokenManager.invalidate(this.githubToken);
           continue;
         }

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -1,11 +1,11 @@
-import  { type ChatModelCard } from '@lobechat/types';
+import { type ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import OpenAI from 'openai';
 
-import  { type LobeRuntimeAI } from '../../core/BaseAI';
+import { type LobeRuntimeAI } from '../../core/BaseAI';
 import { pruneReasoningPayload } from '../../core/contextBuilders/openai';
 import { OpenAIStream } from '../../core/streams';
-import  { type ChatMethodOptions, type ChatStreamPayload } from '../../types';
+import { type ChatMethodOptions, type ChatStreamPayload } from '../../types';
 import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
 import { StreamingResponse } from '../../utils/response';


### PR DESCRIPTION
## Summary

- Simplify auth refresh tracking from counter (`MAX_AUTH_REFRESH`) to boolean flag (`hasRefreshedAuth`)
- Clear cached bearer token (`this.cachedBearerToken = undefined`) on 401 to ensure fresh token exchange
- Remove unused `MAX_AUTH_REFRESH` constant

## Test plan

- [x] Verify GitHub Copilot provider handles 401 responses correctly with token refresh
- [x] Confirm rate limit retry logic remains unaffected

## Summary by Sourcery

Improve GitHub Copilot provider authentication retry behavior when handling unauthorized responses.

Bug Fixes:
- Ensure a fresh bearer token is fetched by clearing the cached token on 401 responses before retrying authentication.

Enhancements:
- Simplify authentication refresh tracking by replacing the max refresh counter with a boolean flag indicating whether auth has been refreshed once.