### PR TITLE
🐛 fix: hide LocalFile actions in topic share page

### DIFF
--- a/src/features/Conversation/Markdown/plugins/LocalFile/Render/index.tsx
+++ b/src/features/Conversation/Markdown/plugins/LocalFile/Render/index.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 
 import { LocalFile } from '@/features/LocalFile';
 
+import { useConversationStore } from '../../../../store';
 import { type MarkdownElementProps } from '../../type';
 
 interface LocalFileProps {
@@ -14,6 +15,7 @@ interface LocalFileProps {
 const Render = memo<MarkdownElementProps<LocalFileProps>>(({ node }) => {
   // Extract properties from node.properties
   const { name, path, isDirectory } = node?.properties || {};
+  const isSharePage = useConversationStore((s) => !!s.context.topicShareId);
 
   if (!name || !path) {
     // If required properties are missing, render an error or null
@@ -24,7 +26,7 @@ const Render = memo<MarkdownElementProps<LocalFileProps>>(({ node }) => {
   // isDirectory may be true (from plugin) or undefined; ensure it is a boolean
   const isDir = isDirectory === true;
 
-  return <LocalFile isDirectory={isDir} name={name} path={path} />;
+  return <LocalFile isDirectory={isDir} name={name} path={path} readonly={isSharePage} />;
 }, isEqual);
 
 export default Render;

--- a/src/features/LocalFile/LocalFile.tsx
+++ b/src/features/LocalFile/LocalFile.tsx
@@ -38,9 +38,14 @@ interface LocalFileProps {
   isDirectory?: boolean;
   name: string;
   path?: string;
+  /**
+   * When true, disable interactive actions (Open / Show in Folder).
+   * Used in share pages where local file operations are not available.
+   */
+  readonly?: boolean;
 }
 
-export const LocalFile = ({ name, path, isDirectory = false }: LocalFileProps) => {
+export const LocalFile = ({ name, path, isDirectory = false, readonly = false }: LocalFileProps) => {
   const { t } = useTranslation('components');
 
   const handleOpenFile = () => {
@@ -69,8 +74,8 @@ export const LocalFile = ({ name, path, isDirectory = false }: LocalFileProps) =
     </Flexbox>
   );
 
-  // Directory: no popover, just click to open
-  if (isDirectory) {
+  // Directory or readonly mode (e.g. share page): no popover, just display
+  if (isDirectory || readonly) {
     return fileContent;
   }
 


### PR DESCRIPTION
## Bug Description

In topic share pages, the `LocalFile` markdown component was showing **Open** and **Show in Folder** action buttons on hover. These are desktop-only local file operations that are not available (and meaningless) to share page viewers.

https://app.lobehub.com/share/t/qsnBkhxz

## Changes

### `src/features/LocalFile/LocalFile.tsx`
- Added `readonly` prop (default `false`) to `LocalFile` component
- When `readonly=true`, skip `Popover` rendering — only display the file name and icon without any action buttons

### `src/features/Conversation/Markdown/plugins/LocalFile/Render/index.tsx`
- Read `context.topicShareId` from `useConversationStore` to detect share page context
- Pass `readonly={isSharePage}` to the `LocalFile` component

## Summary
- Minimal 2-file change, no breaking changes
- `LocalFile` gains a reusable `readonly` prop that can be leveraged in other read-only contexts in the future

## Summary by Sourcery

Make LocalFile markdown elements non-interactive on topic share pages where local file operations are unavailable.

New Features:
- Add a reusable readonly mode to the LocalFile component to disable interactive actions in read-only contexts such as share pages.

Bug Fixes:
- Prevent LocalFile markdown elements on topic share pages from exposing Open and Show in Folder actions that are not supported for shared viewers.