### PR TITLE
🐛 fix: correct import path for defaultSecurityBlacklist test

### DIFF
--- a/packages/agent-runtime/src/core/__tests__/defaultSecurityBlacklist.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/defaultSecurityBlacklist.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_SECURITY_BLACKLIST } from '../../audit/defaultSecurityBlacklist';
 import { InterventionChecker } from '../InterventionChecker';
-import { DEFAULT_SECURITY_BLACKLIST } from '../defaultSecurityBlacklist';
 
 describe('DEFAULT_SECURITY_BLACKLIST', () => {
   describe('File System Dangers', () => {


### PR DESCRIPTION
## Summary
- Fix broken import path in `defaultSecurityBlacklist.test.ts` that was lost during rebase conflict resolution
- The module was moved from `core/` to `audit/` in a prior refactor, but the test import wasn't updated

## Test plan
- [x] TypeScript type-check passes with zero errors for the affected file
- [x] ESLint import sorting fixed

## Summary by Sourcery

Fix a broken test import for the default security blacklist module after it was moved to a new location.

Bug Fixes:
- Correct the import path in the defaultSecurityBlacklist test to point to the moved module.

Tests:
- Update the defaultSecurityBlacklist test file so it correctly imports the audited module and passes linting/type checks.