### PR TITLE
🐛 fix: add the execAgents with execScript & exportFiles

### DIFF
--- a/packages/builtin-tool-skills/src/index.ts
+++ b/packages/builtin-tool-skills/src/index.ts
@@ -1,6 +1,7 @@
 export { SkillsManifest } from './manifest';
 export { systemPrompt } from './systemRole';
 export {
+  type CommandResult,
   type ReadReferenceParams,
   type RunSkillParams,
   SkillsApiName,

--- a/src/server/services/toolExecution/serverRuntimes/skills.ts
+++ b/src/server/services/toolExecution/serverRuntimes/skills.ts
@@ -1,31 +1,56 @@
 import { builtinSkills } from '@lobechat/builtin-skills';
-import { SkillsIdentifier } from '@lobechat/builtin-tool-skills';
+import { SkillsIdentifier, type CommandResult } from '@lobechat/builtin-tool-skills';
 import {
+  type ExportFileResult,
   type SkillImportServiceResult,
   type SkillRuntimeService,
   SkillsExecutionRuntime,
 } from '@lobechat/builtin-tool-skills/executionRuntime';
+import type { CodeInterpreterToolName } from '@lobehub/market-sdk';
 import type { SkillItem, SkillListItem, SkillResourceContent } from '@lobechat/types';
+import debug from 'debug';
+import { sha256 } from 'js-sha256';
 
 import { AgentSkillModel } from '@/database/models/agentSkill';
+import { FileModel } from '@/database/models/file';
+import { FileS3 } from '@/server/modules/S3';
+import { FileService } from '@/server/services/file';
+import { MarketService } from '@/server/services/market';
 import { SkillImporter } from '@/server/services/skill/importer';
 import { SkillResourceService } from '@/server/services/skill/resource';
 
 import { type ServerRuntimeRegistration } from './types';
 
+const log = debug('lobe-server:skills-runtime');
+
 class SkillServerRuntimeService implements SkillRuntimeService {
   private importer: SkillImporter;
   private resourceService: SkillResourceService;
   private skillModel: AgentSkillModel;
+  private marketService: MarketService;
+  private fileService: FileService;
+  private fileModel: FileModel;
+  private topicId?: string;
+  private userId: string;
 
   constructor(options: {
+    fileModel: FileModel;
+    fileService: FileService;
     importer: SkillImporter;
+    marketService: MarketService;
     resourceService: SkillResourceService;
     skillModel: AgentSkillModel;
+    topicId?: string;
+    userId: string;
   }) {
     this.skillModel = options.skillModel;
     this.resourceService = options.resourceService;
     this.importer = options.importer;
+    this.marketService = options.marketService;
+    this.fileService = options.fileService;
+    this.fileModel = options.fileModel;
+    this.topicId = options.topicId;
+    this.userId = options.userId;
   }
 
   findAll = (): Promise<{ data: SkillListItem[]; total: number }> => {
@@ -61,11 +86,186 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     if (!skill.resources) throw new Error(`Skill has no resources: ${id}`);
     return this.resourceService.readResource(skill.resources, path);
   };
+
+  execScript = async (
+    command: string,
+    options: {
+      config?: { description?: string; id?: string; name?: string };
+      description: string;
+      runInClient?: boolean;
+    },
+  ): Promise<CommandResult> => {
+    const { config, description } = options;
+
+    if (!this.topicId) {
+      throw new Error('topicId is required for execScript');
+    }
+
+    try {
+      // Look up skill zipUrl if config is provided (same logic as market.ts)
+      let enhancedParams: any = {
+        command,
+        config,
+        description,
+      };
+
+      if (config?.name) {
+        const skill = await this.skillModel.findByName(config.name);
+
+        // If skill not found, return error with available skills
+        if (!skill) {
+          const allSkills = await this.skillModel.findAll();
+          const availableSkills = allSkills.data.map((s) => s.name).join(', ');
+
+          const errorMessage = availableSkills
+            ? `Skill "${config.name}" not found. Available skills: ${availableSkills}`
+            : `Skill "${config.name}" not found. No skills available. Please import a skill first.`;
+
+          log('Skill not found: %s. Available skills: %s', config.name, availableSkills);
+
+          return {
+            exitCode: 1,
+            output: '',
+            stderr: errorMessage,
+            success: false,
+          };
+        }
+
+        if (skill.zipFileHash) {
+          // Get S3 key from globalFiles
+          const fileInfo = await this.fileModel.checkHash(skill.zipFileHash);
+
+          if (fileInfo.isExist && fileInfo.url) {
+            // Convert S3 key to full URL
+            const fullUrl = await this.fileService.getFullFileUrl(fileInfo.url);
+            if (fullUrl) {
+              enhancedParams.zipUrl = fullUrl;
+              log('Added zipUrl to execScript params for skill %s: %s', skill.name, fullUrl);
+            }
+          }
+        }
+      }
+
+      // Call market-sdk's runBuildInTool
+      const market = this.marketService.market;
+      const response = await market.plugins.runBuildInTool(
+        'execScript' as CodeInterpreterToolName,
+        enhancedParams,
+        { topicId: this.topicId, userId: this.userId },
+      );
+
+      log('execScript response: %O', response);
+
+      if (!response.success) {
+        return {
+          exitCode: 1,
+          output: '',
+          stderr: response.error?.message || 'Command execution failed',
+          success: false,
+        };
+      }
+
+      const result = response.data?.result || {};
+
+      return {
+        exitCode: result.exitCode ?? (response.success ? 0 : 1),
+        output: result.stdout || result.output || '',
+        stderr: result.stderr || '',
+        success: response.success && (result.exitCode === 0 || result.exitCode === undefined),
+      };
+    } catch (error) {
+      log('Error executing script: %O', error);
+      return {
+        exitCode: 1,
+        output: '',
+        stderr: (error as Error).message || 'Command execution failed',
+        success: false,
+      };
+    }
+  };
+
+  exportFile = async (path: string, filename: string): Promise<ExportFileResult> => {
+    if (!this.topicId) {
+      throw new Error('topicId is required for exportFile');
+    }
+
+    try {
+      const s3 = new FileS3();
+
+      // Use date-based sharding (same as market.ts)
+      const today = new Date().toISOString().split('T')[0];
+      const key = `code-interpreter-exports/${today}/${this.topicId}/${filename}`;
+
+      // Step 1: Generate pre-signed upload URL
+      const uploadUrl = await s3.createPreSignedUrl(key);
+      log('Generated upload URL for key: %s', key);
+
+      // Step 2: Call sandbox's exportFile tool with the upload URL
+      const market = this.marketService.market;
+      const response = await market.plugins.runBuildInTool(
+        'exportFile' as CodeInterpreterToolName,
+        { path, uploadUrl },
+        { topicId: this.topicId, userId: this.userId },
+      );
+
+      log('Sandbox exportFile response: %O', response);
+
+      if (!response.success) {
+        return {
+          filename,
+          success: false,
+        };
+      }
+
+      const result = response.data?.result;
+      const uploadSuccess = result?.success !== false;
+
+      if (!uploadSuccess) {
+        return {
+          filename,
+          success: false,
+        };
+      }
+
+      // Step 3: Get file metadata from S3
+      const metadata = await s3.getFileMetadata(key);
+      const fileSize = metadata.contentLength;
+      const mimeType = metadata.contentType || result?.mimeType || 'application/octet-stream';
+
+      // Step 4: Create persistent file record
+      const fileHash = sha256(key + Date.now().toString());
+
+      const { fileId, url } = await this.fileService.createFileRecord({
+        fileHash,
+        fileType: mimeType,
+        name: filename,
+        size: fileSize,
+        url: key, // Store S3 key
+      });
+
+      log('Created file record: fileId=%s, url=%s', fileId, url);
+
+      return {
+        fileId,
+        filename,
+        mimeType,
+        size: fileSize,
+        success: true,
+        url, // This is the permanent /f:id URL
+      };
+    } catch (error) {
+      log('Error exporting file: %O', error);
+      return {
+        filename,
+        success: false,
+      };
+    }
+  };
 }
 
 /**
  * Skills Server Runtime
- * Per-request runtime (needs serverDB, userId)
+ * Per-request runtime (needs serverDB, userId, topicId)
  */
 export const skillsRuntime: ServerRuntimeRegistration = {
   factory: (context) => {
@@ -79,8 +279,20 @@ export const skillsRuntime: ServerRuntimeRegistration = {
     const skillModel = new AgentSkillModel(context.serverDB, context.userId);
     const resourceService = new SkillResourceService(context.serverDB, context.userId);
     const importer = new SkillImporter(context.serverDB, context.userId);
+    const marketService = new MarketService({ userInfo: { userId: context.userId } });
+    const fileService = new FileService(context.serverDB, context.userId);
+    const fileModel = new FileModel(context.serverDB, context.userId);
 
-    const service = new SkillServerRuntimeService({ importer, resourceService, skillModel });
+    const service = new SkillServerRuntimeService({
+      fileModel,
+      fileService,
+      importer,
+      marketService,
+      resourceService,
+      skillModel,
+      topicId: context.topicId,
+      userId: context.userId,
+    });
 
     return new SkillsExecutionRuntime({ builtinSkills, service });
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Integrate execScript and exportFile capabilities into the skills server runtime so built-in tools can execute code and export files within a topic-scoped context.

New Features:
- Add execScript support in the skills runtime, delegating code execution to the market service with optional skill-based zipUrl resolution.
- Add exportFile support in the skills runtime, exporting sandbox files to S3 and persisting them as file records accessible via permanent URLs.

Bug Fixes:
- Align execScript skill lookup and error handling in the market router with the skills runtime, returning a structured error when the requested skill is missing.

Enhancements:
- Extend the skills server runtime factory to inject market, file, and context metadata dependencies required by the new execution and export features.
- Expose the CommandResult type from the builtin-tool-skills package for consumers of the new execScript API.