### PR TITLE
🐛 fix: use env vars in release workflow to prevent shell injection

### DIFF
--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -84,11 +84,16 @@ jobs:
     steps:
       - name: Check release info
         id: check
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           # 判断触发方式
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             # 手动触发: 使用输入的版本号
-            version="${{ inputs.version }}"
+            version="$INPUT_VERSION"
             version="${version#v}"
             echo "is_manual=true" >> $GITHUB_OUTPUT
             echo "version=${version}" >> $GITHUB_OUTPUT
@@ -96,14 +101,13 @@ jobs:
             echo "🔧 Manual trigger: version=${version}"
           else
             # Release 触发: 从 tag 提取版本号
-            version="${{ github.event.release.tag_name }}"
+            version="$RELEASE_TAG"
             version="${version#v}"
             echo "is_manual=false" >> $GITHUB_OUTPUT
             echo "version=${version}" >> $GITHUB_OUTPUT
-            release_body="${{ github.event.release.body }}"
             {
               echo "release_notes<<EOF"
-              printf '%s\n' "$release_body"
+              printf '%s\n' "$RELEASE_BODY"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

- Fix `main: command not found` error in `release-desktop-stable.yml` caused by backticks in release body being interpreted as shell command substitution
- Refactor inline `${{ }}` expressions to step-level `env` variables (`RELEASE_TAG`, `RELEASE_BODY`, `EVENT_NAME`, `INPUT_VERSION`) to safely handle arbitrary release body content

## Root Cause

`github.event.release.body` was directly interpolated into a double-quoted bash string. When the release body contained backtick-wrapped text (e.g. `` `main` ``), bash interpreted them as command substitution, executing `main` as a command.

## Fix

Pass GitHub context values through step `env` mappings instead of inline interpolation. GitHub Actions `env` mappings don't go through shell parsing, safely handling any content including backticks, quotes, and special characters.

## Test plan

- [ ] Trigger a release with backtick-containing body — no shell errors
- [ ] Verify `release_notes` output contains full release body
- [ ] Manual `workflow_dispatch` trigger still works correctly

## Summary by Sourcery

Prevent shell injection and parsing errors in the desktop release workflow by routing GitHub context values through step-level environment variables instead of inline interpolation.

Bug Fixes:
- Fix failure in the desktop stable release workflow when release bodies contain backticks or other shell-sensitive characters.

Enhancements:
- Refactor release-desktop-stable workflow to use step-level environment variables for event name, tag, version, and release body before shell execution.