### PR TITLE
✨ feat: redesign Copilot ChatInput with compact action bar layout

### DIFF
--- a/src/features/ChatInput/ActionBar/components/Action.tsx
+++ b/src/features/ChatInput/ActionBar/components/Action.tsx
@@ -43,7 +43,7 @@ const Action = memo<ActionProps>(
       value: open,
     });
     const mobile = useServerConfigStore((s) => s.isMobile);
-    const { dropdownPlacement } = useActionBarContext();
+    const { actionSize, dropdownPlacement } = useActionBarContext();
     const iconNode = (
       <ActionIcon
         disabled={disabled}
@@ -60,10 +60,12 @@ const Action = memo<ActionProps>(
           setShow(true);
         }}
         {...rest}
-        size={{
-          blockSize: 36,
-          size: 20,
-        }}
+        size={
+          actionSize ?? {
+            blockSize: 36,
+            size: 20,
+          }
+        }
       />
     );
 

--- a/src/features/ChatInput/ActionBar/context.ts
+++ b/src/features/ChatInput/ActionBar/context.ts
@@ -8,6 +8,7 @@ import { createContext, useContext } from 'react';
 type DropdownPlacement = 'bottom' | 'bottomLeft' | 'bottomRight' | 'top' | 'topLeft' | 'topRight';
 
 export interface ActionBarContextValue {
+  actionSize?: { blockSize: number; size: number };
   borderRadius?: number;
   dropdownPlacement?: DropdownPlacement;
 }

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -55,6 +55,7 @@ const styles = createStaticStyles(({ css }) => ({
 interface DesktopChatInputProps extends ActionToolbarProps {
   extentHeaderContent?: ReactNode;
   inputContainerProps?: ChatInputProps;
+  sendAreaPrefix?: ReactNode;
   showFootnote?: boolean;
 }
 
@@ -66,6 +67,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
     borderRadius,
     extraActionItems,
     dropdownPlacement,
+    sendAreaPrefix,
   }) => {
     const { t } = useTranslation('chat');
     const [chatInputHeight, updateSystemStatus] = useGlobalStore((s) => [
@@ -108,7 +110,6 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
           slashMenuRef={slashMenuRef}
           footer={
             <ChatInputActionBar
-              right={<SendArea />}
               style={{ paddingRight: 8 }}
               left={
                 <ActionBar
@@ -116,6 +117,16 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
                   dropdownPlacement={dropdownPlacement}
                   extraActionItems={extraActionItems}
                 />
+              }
+              right={
+                sendAreaPrefix ? (
+                  <Flexbox horizontal align={'center'} gap={6}>
+                    {sendAreaPrefix}
+                    <SendArea />
+                  </Flexbox>
+                ) : (
+                  <SendArea />
+                )
               }
             />
           }

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -53,8 +53,10 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 interface DesktopChatInputProps extends ActionToolbarProps {
+  actionBarStyle?: React.CSSProperties;
   extentHeaderContent?: ReactNode;
   inputContainerProps?: ChatInputProps;
+  leftContent?: ReactNode;
   sendAreaPrefix?: ReactNode;
   showFootnote?: boolean;
 }
@@ -64,9 +66,11 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
     showFootnote,
     inputContainerProps,
     extentHeaderContent,
+    actionBarStyle,
     borderRadius,
     extraActionItems,
     dropdownPlacement,
+    leftContent,
     sendAreaPrefix,
   }) => {
     const { t } = useTranslation('chat');
@@ -110,13 +114,15 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
           slashMenuRef={slashMenuRef}
           footer={
             <ChatInputActionBar
-              style={{ paddingRight: 8 }}
+              style={actionBarStyle ?? { paddingRight: 8 }}
               left={
-                <ActionBar
-                  borderRadius={borderRadius}
-                  dropdownPlacement={dropdownPlacement}
-                  extraActionItems={extraActionItems}
-                />
+                leftContent ?? (
+                  <ActionBar
+                    borderRadius={borderRadius}
+                    dropdownPlacement={dropdownPlacement}
+                    extraActionItems={extraActionItems}
+                  />
+                )
               }
               right={
                 sendAreaPrefix ? (

--- a/src/features/ChatInput/SendArea/SendButton.tsx
+++ b/src/features/ChatInput/SendArea/SendButton.tsx
@@ -7,6 +7,7 @@ import { selectors, useChatInputStore } from '../store';
 const SendButton = memo(() => {
   const sendMenu = useChatInputStore((s) => s.sendMenu);
   const shape = useChatInputStore((s) => s.sendButtonProps?.shape);
+  const size = useChatInputStore((s) => s.sendButtonProps?.size);
   const { generating, disabled } = useChatInputStore(selectors.sendButtonProps, isEqual);
   const [send, handleStop] = useChatInputStore((s) => [s.handleSendButton, s.handleStop]);
 
@@ -17,6 +18,7 @@ const SendButton = memo(() => {
       menu={sendMenu as any}
       placement={'topRight'}
       shape={shape}
+      size={size}
       trigger={['hover']}
       onClick={() => send()}
       onStop={() => handleStop()}

--- a/src/features/ChatInput/store/initialState.ts
+++ b/src/features/ChatInput/store/initialState.ts
@@ -15,6 +15,7 @@ export interface SendButtonProps {
   generating: boolean;
   onStop: (params: { editor: IEditor }) => void;
   shape?: 'round' | 'default';
+  size?: number;
 }
 
 export const initialSendButtonState: SendButtonProps = {

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { type SlashOptions } from '@lobehub/editor';
+import { type ChatInputActionsProps } from '@lobehub/editor/react';
 import { type MenuProps } from '@lobehub/ui';
 import { Alert, Flexbox } from '@lobehub/ui';
 import { type ReactNode } from 'react';
@@ -21,10 +22,18 @@ import { messageStateSelectors, useConversationStore } from '../store';
 
 export interface ChatInputProps {
   /**
+   * Whether to allow fullscreen expand button
+   */
+  allowExpand?: boolean;
+  /**
    * Custom children to render instead of default Desktop component.
    * Use this to add custom UI like error alerts, MessageFromUrl, etc.
    */
   children?: ReactNode;
+  /**
+   * Extra action items to append to the ActionBar
+   */
+  extraActionItems?: ChatInputActionsProps['items'];
   /**
    * Left action buttons configuration
    */
@@ -41,6 +50,10 @@ export interface ChatInputProps {
    * Right action buttons configuration
    */
   rightActions?: ActionKeys[];
+  /**
+   * Custom content to render before the SendArea (right side of action bar)
+   */
+  sendAreaPrefix?: ReactNode;
   /**
    * Custom send button props override
    */
@@ -63,11 +76,14 @@ export interface ChatInputProps {
  */
 const ChatInput = memo<ChatInputProps>(
   ({
+    allowExpand,
     leftActions = [],
     rightActions = [],
     children,
+    extraActionItems,
     mentionItems,
     sendMenu,
+    sendAreaPrefix,
     sendButtonProps: customSendButtonProps,
     onEditorReady,
     skipScrollMarginWithList,
@@ -154,13 +170,14 @@ const ChatInput = memo<ChatInputProps>(
             />
           </Flexbox>
         )}
-        <DesktopChatInput borderRadius={12} />
+        <DesktopChatInput borderRadius={12} extraActionItems={extraActionItems} sendAreaPrefix={sendAreaPrefix} />
       </WideScreenContainer>
     );
 
     return (
       <ChatInputProvider
         agentId={agentId}
+        allowExpand={allowExpand}
         leftActions={leftActions}
         mentionItems={mentionItems}
         rightActions={rightActions}

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -22,6 +22,10 @@ import { messageStateSelectors, useConversationStore } from '../store';
 
 export interface ChatInputProps {
   /**
+   * Custom style for the action bar container
+   */
+  actionBarStyle?: React.CSSProperties;
+  /**
    * Whether to allow fullscreen expand button
    */
   allowExpand?: boolean;
@@ -38,6 +42,10 @@ export interface ChatInputProps {
    * Left action buttons configuration
    */
   leftActions?: ActionKeys[];
+  /**
+   * Custom left content to replace the default ActionBar entirely
+   */
+  leftContent?: ReactNode;
   /**
    * Mention items for @ mentions (for group chat)
    */
@@ -76,8 +84,10 @@ export interface ChatInputProps {
  */
 const ChatInput = memo<ChatInputProps>(
   ({
+    actionBarStyle,
     allowExpand,
     leftActions = [],
+    leftContent,
     rightActions = [],
     children,
     extraActionItems,
@@ -170,7 +180,13 @@ const ChatInput = memo<ChatInputProps>(
             />
           </Flexbox>
         )}
-        <DesktopChatInput borderRadius={12} extraActionItems={extraActionItems} sendAreaPrefix={sendAreaPrefix} />
+        <DesktopChatInput
+          actionBarStyle={actionBarStyle}
+          borderRadius={12}
+          extraActionItems={extraActionItems}
+          leftContent={leftContent}
+          sendAreaPrefix={sendAreaPrefix}
+        />
       </WideScreenContainer>
     );
 

--- a/src/features/DevPanel/features/FloatPanel.tsx
+++ b/src/features/DevPanel/features/FloatPanel.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { BRANDING_NAME } from '@lobechat/business-const';
-import { ActionIcon, Flexbox, FluentEmoji, Icon, SideNav } from '@lobehub/ui';
-import { FloatButton } from 'antd';
+import { ActionIcon, Flexbox, FluentEmoji, SideNav } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { BugIcon, BugOff, XIcon } from 'lucide-react';
-import { type ReactNode } from 'react';
-import { memo, useEffect, useState } from 'react';
+import { XIcon } from 'lucide-react';
+import { memo, type ReactNode, useEffect, useState } from 'react';
 import { Rnd } from 'react-rnd';
 
 import { isDesktop } from '@/const/version';
@@ -14,7 +12,6 @@ import { usePathname } from '@/libs/next/navigation';
 
 // 定义样式
 const styles = createStaticStyles(({ css }) => {
-  const prefixCls = 'ant';
   return {
     collapsed: css`
       pointer-events: none;
@@ -26,23 +23,22 @@ const styles = createStaticStyles(({ css }) => {
       transform: scale(1);
       opacity: 1;
     `,
-    floatButton: css`
-      inset-block-end: 16px;
-      inset-inline-end: 16px;
+    debugButton: css`
+      cursor: default;
+      user-select: none;
 
-      width: 36px;
-      height: 36px;
-      border: 1px solid ${cssVar.colorBorderSecondary};
+      position: fixed;
+      inset-block-end: 9px;
+      inset-inline-end: 9px;
 
-      font-size: 20px;
-      .${prefixCls}-float-btn-body {
-        background: ${cssVar.colorBgLayout};
+      padding-block: 1px;
+      padding-inline: 8px;
+      border-radius: 12px;
 
-        &:hover {
-          width: auto;
-          background: ${cssVar.colorBgElevated};
-        }
-      }
+      font-size: 8px;
+      color: ${cssVar.colorBgContainer};
+
+      background-color: ${cssVar.colorText};
     `,
     header: css`
       cursor: move;
@@ -114,9 +110,8 @@ const CollapsibleFloatPanel = memo<CollapsibleFloatPanelProps>(({ items }) => {
       {
         // desktop devtools 下隐藏
         pathname !== '/desktop/devtools' && isDesktop && (
-          <FloatButton
-            className={styles.floatButton}
-            icon={<Icon icon={isExpanded ? BugOff : BugIcon} />}
+          <div
+            className={styles.debugButton}
             onClick={async () => {
               if (isDesktop) {
                 const { electronDevtoolsService } = await import('@/services/electron/devtools');
@@ -127,7 +122,9 @@ const CollapsibleFloatPanel = memo<CollapsibleFloatPanelProps>(({ items }) => {
               }
               setIsExpanded(!isExpanded);
             }}
-          />
+          >
+            DEV
+          </div>
         )
       }
       {isExpanded && (

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -37,7 +37,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
       <DropdownMenuRoot open={isOpen} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger openOnHover={openOnHover}>{children}</DropdownMenuTrigger>
         <DropdownMenuPortal>
-          <DropdownMenuPositioner hoverTrigger placement={placement}>
+          <DropdownMenuPositioner hoverTrigger={openOnHover} placement={placement}>
             <DropdownMenuPopup className={styles.container}>
               <PanelContent
                 model={modelProp}

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -20,6 +20,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
     open,
     placement = 'topLeft',
     provider: providerProp,
+    openOnHover = true,
   }) => {
     const [internalOpen, setInternalOpen] = useState(false);
     const isOpen = open ?? internalOpen;
@@ -34,7 +35,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
 
     return (
       <DropdownMenuRoot open={isOpen} onOpenChange={handleOpenChange}>
-        <DropdownMenuTrigger openOnHover>{children}</DropdownMenuTrigger>
+        <DropdownMenuTrigger openOnHover={openOnHover}>{children}</DropdownMenuTrigger>
         <DropdownMenuPortal>
           <DropdownMenuPositioner hoverTrigger placement={placement}>
             <DropdownMenuPopup className={styles.container}>

--- a/src/features/ModelSwitchPanel/types.ts
+++ b/src/features/ModelSwitchPanel/types.ts
@@ -58,6 +58,10 @@ export interface ModelSwitchPanelProps {
   onOpenChange?: (open: boolean) => void;
   open?: boolean;
   /**
+   * Whether to open the panel on hover. Defaults to true.
+   */
+  openOnHover?: boolean;
+  /**
    * Dropdown placement. Defaults to 'topLeft'.
    */
   placement?: DropdownPlacement;

--- a/src/features/NavHeader/index.tsx
+++ b/src/features/NavHeader/index.tsx
@@ -29,6 +29,7 @@ const NavHeader = memo<NavHeaderProps>(
 
     return (
       <Flexbox
+        allowShrink
         horizontal
         align={'center'}
         flex={'none'}
@@ -40,7 +41,14 @@ const NavHeader = memo<NavHeaderProps>(
         {...rest}
       >
         <TooltipGroup>
-          <Flexbox horizontal align={'center'} gap={2} justify={'flex-start'} style={styles?.left}>
+          <Flexbox
+            allowShrink
+            horizontal
+            align={'center'}
+            gap={2}
+            justify={'flex-start'}
+            style={styles?.left}
+          >
             {showTogglePanelButton && !expand && <ToggleLeftPanelButton />}
             {left}
           </Flexbox>

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
@@ -20,7 +20,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   container: css`
     cursor: pointer;
-    border-radius: 24px;
+    border-radius: 12px;
     background: ${cssVar.colorFillTertiary};
 
     :hover {
@@ -122,7 +122,7 @@ const AgentSelectorAction = memo<AgentSelectorActionProps>(({ agentId, onAgentCh
       }}
       onOpenChange={setOpen}
     >
-      <Center horizontal className={cx(styles.container)} height={36} paddingInline={8}>
+      <Center horizontal className={cx(styles.container)} height={28} paddingInline={6}>
         <Flexbox horizontal align={'center'} gap={4}>
           <AgentAvatar
             avatar={typeof activeAgent?.avatar === 'string' ? activeAgent.avatar : undefined}

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
@@ -1,0 +1,139 @@
+import { Center, Flexbox, Popover } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { ChevronsUpDownIcon } from 'lucide-react';
+import { memo, Suspense, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import AgentAvatar from '@/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentItem/Avatar';
+import { AgentModalProvider } from '@/app/[variants]/(main)/home/_layout/Body/Agent/ModalProvider';
+import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { useFetchAgentList } from '@/hooks/useFetchAgentList';
+import { useAgentStore } from '@/store/agent';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
+
+import AgentItem from './AgentItem';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chevron: css`
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  container: css`
+    cursor: pointer;
+    border-radius: 24px;
+    background: ${cssVar.colorFillTertiary};
+
+    :hover {
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+}));
+
+interface AgentSelectorActionProps {
+  agentId: string;
+  onAgentChange: (id: string) => void;
+}
+
+const AgentSelectorAction = memo<AgentSelectorActionProps>(({ agentId, onAgentChange }) => {
+  const { t } = useTranslation(['chat', 'common']);
+  const [open, setOpen] = useState(false);
+
+  const agents = useHomeStore(homeAgentListSelectors.allAgents);
+  const isAgentListInit = useHomeStore(homeAgentListSelectors.isAgentListInit);
+  const pageAgentId = useAgentStore((s) => s.builtinAgentIdMap['page-agent']);
+  const pageAgentData = useAgentStore((s) => s.agentMap[pageAgentId || '']);
+
+  useFetchAgentList();
+
+  const agentsWithBuiltin = useMemo(() => {
+    const hasPageAgent = agents.some((agent) => agent.id === pageAgentId);
+
+    if (pageAgentId && !hasPageAgent) {
+      return [
+        {
+          avatar: pageAgentData?.avatar || null,
+          description: pageAgentData?.description || null,
+          id: pageAgentId,
+          pinned: false,
+          title: t('builtinCopilot', { defaultValue: 'Built-in Copilot', ns: 'chat' }),
+          type: 'agent' as const,
+          updatedAt: new Date(),
+        },
+        ...agents,
+      ];
+    }
+
+    return agents;
+  }, [agents, pageAgentId, pageAgentData, t]);
+
+  const activeAgent = useMemo(
+    () => agentsWithBuiltin.find((agent) => agent.id === agentId),
+    [agentId, agentsWithBuiltin],
+  );
+
+  const handleAgentChange = useCallback(
+    (id: string) => {
+      onAgentChange(id);
+    },
+    [onAgentChange],
+  );
+
+  const renderAgents = (
+    <Flexbox
+      gap={4}
+      padding={8}
+      style={{
+        maxHeight: '50vh',
+        overflowY: 'auto',
+        width: '100%',
+      }}
+    >
+      {agentsWithBuiltin.map((agent) => (
+        <AgentItem
+          active={agent.id === agentId}
+          agentId={agent.id}
+          agentTitle={agent.title || t('untitledAgent', { ns: 'chat' })}
+          avatar={agent.avatar}
+          key={agent.id}
+          onAgentChange={handleAgentChange}
+          onClose={() => setOpen(false)}
+        />
+      ))}
+    </Flexbox>
+  );
+
+  return (
+    <Popover
+      open={open}
+      placement="topLeft"
+      trigger="click"
+      content={
+        <Suspense fallback={<SkeletonList rows={6} />}>
+          <AgentModalProvider>
+            {isAgentListInit ? renderAgents : <SkeletonList rows={6} />}
+          </AgentModalProvider>
+        </Suspense>
+      }
+      styles={{
+        content: {
+          padding: 0,
+          width: 240,
+        },
+      }}
+      onOpenChange={setOpen}
+    >
+      <Center horizontal className={cx(styles.container)} height={36} paddingInline={8}>
+        <Flexbox horizontal align={'center'} gap={4}>
+          <AgentAvatar
+            avatar={typeof activeAgent?.avatar === 'string' ? activeAgent.avatar : undefined}
+          />
+          <ChevronsUpDownIcon className={styles.chevron} size={14} />
+        </Flexbox>
+      </Center>
+    </Popover>
+  );
+});
+
+AgentSelectorAction.displayName = 'AgentSelectorAction';
+
+export default AgentSelectorAction;

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
@@ -20,7 +20,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   container: css`
     cursor: pointer;
+
     border-radius: 12px;
+    border-start-start-radius: 8px;
+    border-end-start-radius: 8px;
+
     background: ${cssVar.colorFillTertiary};
 
     :hover {
@@ -55,7 +59,7 @@ const AgentSelectorAction = memo<AgentSelectorActionProps>(({ agentId, onAgentCh
           description: pageAgentData?.description || null,
           id: pageAgentId,
           pinned: false,
-          title: t('builtinCopilot', { defaultValue: 'Built-in Copilot', ns: 'chat' }),
+          title: t('builtinCopilot'),
           type: 'agent' as const,
           updatedAt: new Date(),
         },

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -1,9 +1,9 @@
-import { type ChatInputActionsProps } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
 import { memo, useCallback, useEffect, useMemo } from 'react';
 
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { actionMap } from '@/features/ChatInput/ActionBar/config';
+import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
 import { ChatInput, ChatList } from '@/features/Conversation';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -17,6 +17,11 @@ import Welcome from './Welcome';
 const Search = actionMap['search'];
 
 const EMPTY_LEFT_ACTIONS: [] = [];
+
+const COMPACT_ACTION_SIZE = { blockSize: 28, size: 16 };
+const COMPACT_CONTEXT_VALUE = { actionSize: COMPACT_ACTION_SIZE };
+const COMPACT_ACTION_BAR_STYLE = { paddingLeft: 8, paddingRight: 4 };
+const COMPACT_SEND_BUTTON_PROPS = { size: 28 };
 
 interface ConversationProps {
   agentId: string;
@@ -52,17 +57,15 @@ const Conversation = memo<ConversationProps>(({ agentId }) => {
     [setActiveAgentId],
   );
 
-  const copilotItems: ChatInputActionsProps['items'] = useMemo(
-    () => [
-      {
-        alwaysDisplay: true,
-        children: (
+  const leftContent = useMemo(
+    () => (
+      <ActionBarContext value={COMPACT_CONTEXT_VALUE}>
+        <Flexbox horizontal align={'center'} gap={2}>
           <AgentSelectorAction agentId={currentAgentId} onAgentChange={handleAgentChange} />
-        ),
-        key: 'agent-selector',
-      },
-      { children: <Search />, key: 'search' },
-    ],
+          <Search />
+        </Flexbox>
+      </ActionBarContext>
+    ),
     [currentAgentId, handleAgentChange],
   );
 
@@ -82,10 +85,12 @@ const Conversation = memo<ConversationProps>(({ agentId }) => {
           <ChatList welcome={<Welcome />} />
         </Flexbox>
         <ChatInput
+          actionBarStyle={COMPACT_ACTION_BAR_STYLE}
           allowExpand={false}
-          extraActionItems={copilotItems}
           leftActions={EMPTY_LEFT_ACTIONS}
+          leftContent={leftContent}
           sendAreaPrefix={modelSelector}
+          sendButtonProps={COMPACT_SEND_BUTTON_PROPS}
         />
       </Flexbox>
     </DragUploadZone>

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -1,21 +1,26 @@
+import { type ChatInputActionsProps } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
-import { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
 import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
-import { type ActionKeys } from '@/features/ChatInput';
+import { actionMap } from '@/features/ChatInput/ActionBar/config';
 import { ChatInput, ChatList } from '@/features/Conversation';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 
+import AgentSelectorAction from './AgentSelector/AgentSelectorAction';
+import CopilotModelSelector from './CopilotModelSelector';
 import CopilotToolbar from './Toolbar';
 import Welcome from './Welcome';
 
+const Search = actionMap['search'];
+
+const EMPTY_LEFT_ACTIONS: [] = [];
+
 interface ConversationProps {
-  // Default agent id
   agentId: string;
 }
-const actions: ActionKeys[] = ['model', 'search'];
 
 const Conversation = memo<ConversationProps>(({ agentId }) => {
   const [activeAgentId, setActiveAgentId, useFetchAgentConfig] = useAgentStore((s) => [
@@ -23,43 +28,65 @@ const Conversation = memo<ConversationProps>(({ agentId }) => {
     s.setActiveAgentId,
     s.useFetchAgentConfig,
   ]);
-  const [isHovered, setIsHovered] = useState(false);
 
   useEffect(() => {
     setActiveAgentId(agentId);
-    // Also set the chat store's activeAgentId so topic selectors can work correctly
     useChatStore.setState({ activeAgentId: agentId });
   }, [agentId, setActiveAgentId]);
 
   const currentAgentId = activeAgentId || agentId;
 
-  // Fetch agent config when activeAgentId changes to ensure it's loaded in the store
-  // This is needed when user switches to a different agent
   useFetchAgentConfig(true, currentAgentId);
 
-  // Get agent's model info for vision support check
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(currentAgentId)(s));
   const provider = useAgentStore((s) =>
     agentByIdSelectors.getAgentModelProviderById(currentAgentId)(s),
   );
   const { handleUploadFiles } = useUploadFiles({ model, provider });
 
+  const handleAgentChange = useCallback(
+    (id: string) => {
+      setActiveAgentId(id);
+      useChatStore.setState({ activeAgentId: id });
+    },
+    [setActiveAgentId],
+  );
+
+  const copilotItems: ChatInputActionsProps['items'] = useMemo(
+    () => [
+      {
+        alwaysDisplay: true,
+        children: (
+          <AgentSelectorAction agentId={currentAgentId} onAgentChange={handleAgentChange} />
+        ),
+        key: 'agent-selector',
+      },
+      { children: <Search />, key: 'search' },
+    ],
+    [currentAgentId, handleAgentChange],
+  );
+
+  const modelSelector = useMemo(
+    () => <CopilotModelSelector agentId={currentAgentId} />,
+    [currentAgentId],
+  );
+
   return (
     <DragUploadZone
       style={{ flex: 1, height: '100%', minWidth: 300 }}
       onUploadFiles={handleUploadFiles}
     >
-      <Flexbox
-        flex={1}
-        height={'100%'}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <CopilotToolbar agentId={currentAgentId} isHovered={isHovered} />
+      <Flexbox flex={1} height={'100%'}>
+        <CopilotToolbar agentId={currentAgentId} />
         <Flexbox flex={1} style={{ overflow: 'hidden' }}>
           <ChatList welcome={<Welcome />} />
         </Flexbox>
-        <ChatInput leftActions={actions} />
+        <ChatInput
+          allowExpand={false}
+          extraActionItems={copilotItems}
+          leftActions={EMPTY_LEFT_ACTIONS}
+          sendAreaPrefix={modelSelector}
+        />
       </Flexbox>
     </DragUploadZone>
   );

--- a/src/features/PageEditor/Copilot/Conversation.tsx
+++ b/src/features/PageEditor/Copilot/Conversation.tsx
@@ -20,7 +20,7 @@ const EMPTY_LEFT_ACTIONS: [] = [];
 
 const COMPACT_ACTION_SIZE = { blockSize: 28, size: 16 };
 const COMPACT_CONTEXT_VALUE = { actionSize: COMPACT_ACTION_SIZE };
-const COMPACT_ACTION_BAR_STYLE = { paddingLeft: 8, paddingRight: 4 };
+const COMPACT_ACTION_BAR_STYLE = { paddingLeft: 4, paddingRight: 4 };
 const COMPACT_SEND_BUTTON_PROPS = { size: 28 };
 
 interface ConversationProps {

--- a/src/features/PageEditor/Copilot/CopilotModelSelector.tsx
+++ b/src/features/PageEditor/Copilot/CopilotModelSelector.tsx
@@ -1,10 +1,9 @@
-import { Center, Flexbox } from '@lobehub/ui';
+import { ActionIcon, Center, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ChevronDownIcon, Settings2Icon } from 'lucide-react';
-import { memo, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
+import { memo, useCallback, useState } from 'react';
 
-import Action from '@/features/ChatInput/ActionBar/components/Action';
+import ActionPopover from '@/features/ChatInput/ActionBar/components/ActionPopover';
 import ControlsForm from '@/features/ChatInput/ActionBar/Model/ControlsForm';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import { useAgentStore } from '@/store/agent';
@@ -28,7 +27,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   trigger: css`
     cursor: pointer;
-    border-radius: 8px;
+    border-radius: 6px;
 
     :hover {
       background: ${cssVar.colorFillTertiary};
@@ -41,7 +40,7 @@ interface CopilotModelSelectorProps {
 }
 
 const CopilotModelSelector = memo<CopilotModelSelectorProps>(({ agentId }) => {
-  const { t } = useTranslation('chat');
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const [model, provider, updateAgentConfigById] = useAgentStore((s) => [
     agentByIdSelectors.getAgentModelById(agentId)(s),
@@ -65,8 +64,13 @@ const CopilotModelSelector = memo<CopilotModelSelectorProps>(({ agentId }) => {
 
   return (
     <Flexbox horizontal align={'center'}>
-      <ModelSwitchPanel model={model} provider={provider} onModelChange={handleModelChange}>
-        <Center horizontal className={styles.trigger} height={36} paddingInline={8}>
+      <ModelSwitchPanel
+        model={model}
+        openOnHover={false}
+        provider={provider}
+        onModelChange={handleModelChange}
+      >
+        <Center horizontal className={styles.trigger} height={28} paddingInline={6}>
           <Flexbox horizontal align={'center'} gap={2}>
             <span className={styles.name}>{displayName}</span>
             <ChevronDownIcon className={styles.chevron} size={12} />
@@ -74,17 +78,20 @@ const CopilotModelSelector = memo<CopilotModelSelectorProps>(({ agentId }) => {
         </Center>
       </ModelSwitchPanel>
       {isModelHasExtendParams && (
-        <Action
-          icon={Settings2Icon}
-          showTooltip={false}
-          style={{ borderRadius: 8 }}
-          title={t('extendParams.title')}
-          popover={{
-            content: <ControlsForm />,
-            minWidth: 350,
-            placement: 'topRight',
-          }}
-        />
+        <ActionPopover
+          content={<ControlsForm />}
+          minWidth={350}
+          open={settingsOpen}
+          placement={'topRight'}
+          trigger={'click'}
+          onOpenChange={setSettingsOpen}
+        >
+          <ActionIcon
+            icon={Settings2Icon}
+            size={{ blockSize: 28, size: 16 }}
+            onClick={() => setSettingsOpen(true)}
+          />
+        </ActionPopover>
       )}
     </Flexbox>
   );

--- a/src/features/PageEditor/Copilot/CopilotModelSelector.tsx
+++ b/src/features/PageEditor/Copilot/CopilotModelSelector.tsx
@@ -1,0 +1,95 @@
+import { Center, Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { ChevronDownIcon, Settings2Icon } from 'lucide-react';
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Action from '@/features/ChatInput/ActionBar/components/Action';
+import ControlsForm from '@/features/ChatInput/ActionBar/Model/ControlsForm';
+import ModelSwitchPanel from '@/features/ModelSwitchPanel';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chevron: css`
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  name: css`
+    overflow: hidden;
+
+    max-width: 120px;
+
+    font-size: 12px;
+    line-height: 1;
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  trigger: css`
+    cursor: pointer;
+    border-radius: 8px;
+
+    :hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+}));
+
+interface CopilotModelSelectorProps {
+  agentId: string;
+}
+
+const CopilotModelSelector = memo<CopilotModelSelectorProps>(({ agentId }) => {
+  const { t } = useTranslation('chat');
+
+  const [model, provider, updateAgentConfigById] = useAgentStore((s) => [
+    agentByIdSelectors.getAgentModelById(agentId)(s),
+    agentByIdSelectors.getAgentModelProviderById(agentId)(s),
+    s.updateAgentConfigById,
+  ]);
+
+  const enabledModel = useAiInfraStore(aiModelSelectors.getEnabledModelById(model, provider));
+  const isModelHasExtendParams = useAiInfraStore(
+    aiModelSelectors.isModelHasExtendParams(model, provider),
+  );
+
+  const displayName = enabledModel?.displayName || model;
+
+  const handleModelChange = useCallback(
+    async (params: { model: string; provider: string }) => {
+      await updateAgentConfigById(agentId, params);
+    },
+    [agentId, updateAgentConfigById],
+  );
+
+  return (
+    <Flexbox horizontal align={'center'}>
+      <ModelSwitchPanel model={model} provider={provider} onModelChange={handleModelChange}>
+        <Center horizontal className={styles.trigger} height={36} paddingInline={8}>
+          <Flexbox horizontal align={'center'} gap={2}>
+            <span className={styles.name}>{displayName}</span>
+            <ChevronDownIcon className={styles.chevron} size={12} />
+          </Flexbox>
+        </Center>
+      </ModelSwitchPanel>
+      {isModelHasExtendParams && (
+        <Action
+          icon={Settings2Icon}
+          showTooltip={false}
+          style={{ borderRadius: 8 }}
+          title={t('extendParams.title')}
+          popover={{
+            content: <ControlsForm />,
+            minWidth: 350,
+            placement: 'topRight',
+          }}
+        />
+      )}
+    </Flexbox>
+  );
+});
+
+CopilotModelSelector.displayName = 'CopilotModelSelector';
+
+export default CopilotModelSelector;

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -1,179 +1,24 @@
-import { ActionIcon, Block, Flexbox, Popover } from '@lobehub/ui';
-import { createStaticStyles, cx } from 'antd-style';
-import { ChevronsUpDownIcon, Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
-import { memo, Suspense, useCallback, useMemo, useState } from 'react';
+import { ActionIcon, Flexbox, Popover, Text } from '@lobehub/ui';
+import { Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import AgentAvatar from '@/app/[variants]/(main)/home/_layout/Body/Agent/List/AgentItem/Avatar';
-import { AgentModalProvider } from '@/app/[variants]/(main)/home/_layout/Body/Agent/ModalProvider';
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import NavHeader from '@/features/NavHeader';
-import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchAgentList } from '@/hooks/useFetchAgentList';
-import { useAgentStore } from '@/store/agent';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/slices/topic/selectors';
 import { useGlobalStore } from '@/store/global';
-import { useHomeStore } from '@/store/home';
-import { homeAgentListSelectors } from '@/store/home/selectors';
 
-import AgentItem from './AgentSelector/AgentItem';
 import TopicItem from './TopicSelector/TopicItem';
-
-const styles = createStaticStyles(({ css }) => ({
-  fadeContainer: css`
-    display: flex;
-    gap: 0;
-    align-items: center;
-    transition: opacity 0.2s ease-in-out;
-  `,
-  fadeIn: css`
-    opacity: 1;
-  `,
-  fadeOut: css`
-    pointer-events: none;
-    opacity: 0;
-  `,
-}));
-
-interface AgentSelectorProps {
-  agentId: string;
-  onAgentChange: (id: string) => void;
-}
-
-const AgentSelector = memo<AgentSelectorProps>(({ agentId, onAgentChange }) => {
-  const { t } = useTranslation(['chat', 'common']);
-  const [open, setOpen] = useState(false);
-
-  const agents = useHomeStore(homeAgentListSelectors.allAgents);
-  const isAgentListInit = useHomeStore(homeAgentListSelectors.isAgentListInit);
-  const pageAgentId = useAgentStore((s) => s.builtinAgentIdMap['page-agent']);
-  const pageAgentData = useAgentStore((s) => s.agentMap[pageAgentId || '']);
-
-  useFetchAgentList();
-
-  // Always include the Built-in Copilot (page agent) in the agent list
-  const agentsWithBuiltin = useMemo(() => {
-    // Check if page agent is already in the list
-    const hasPageAgent = agents.some((agent) => agent.id === pageAgentId);
-
-    // If page agent exists and is not in the list, add it at the beginning
-    if (pageAgentId && !hasPageAgent) {
-      return [
-        {
-          avatar: pageAgentData?.avatar || null,
-          description: pageAgentData?.description || null,
-          id: pageAgentId,
-          pinned: false,
-          title: t('builtinCopilot', { defaultValue: 'Built-in Copilot', ns: 'chat' }),
-          type: 'agent' as const,
-          updatedAt: new Date(),
-        },
-        ...agents,
-      ];
-    }
-
-    return agents;
-  }, [agents, pageAgentId, pageAgentData, t]);
-
-  const activeAgent = useMemo(
-    () => agentsWithBuiltin.find((agent) => agent.id === agentId),
-    [agentId, agentsWithBuiltin],
-  );
-
-  const renderAgents = (
-    <Flexbox
-      gap={4}
-      padding={8}
-      style={{
-        maxHeight: '50vh',
-        overflowY: 'auto',
-        width: '100%',
-      }}
-    >
-      {agentsWithBuiltin.map((agent) => (
-        <AgentItem
-          active={agent.id === agentId}
-          agentId={agent.id}
-          agentTitle={agent.title || t('untitledAgent', { ns: 'chat' })}
-          avatar={agent.avatar}
-          key={agent.id}
-          onAgentChange={onAgentChange}
-          onClose={() => setOpen(false)}
-        />
-      ))}
-    </Flexbox>
-  );
-
-  return (
-    <Popover
-      open={open}
-      placement="bottomLeft"
-      trigger="click"
-      content={
-        <Suspense fallback={<SkeletonList rows={6} />}>
-          <AgentModalProvider>
-            {isAgentListInit ? renderAgents : <SkeletonList rows={6} />}
-          </AgentModalProvider>
-        </Suspense>
-      }
-      styles={{
-        content: {
-          padding: 0,
-          width: 240,
-        },
-      }}
-      onOpenChange={setOpen}
-    >
-      <Block
-        clickable
-        horizontal
-        align={'center'}
-        gap={4}
-        padding={2}
-        variant={'borderless'}
-        style={{
-          minWidth: 32,
-        }}
-      >
-        <AgentAvatar
-          avatar={typeof activeAgent?.avatar === 'string' ? activeAgent.avatar : undefined}
-        />
-        <ActionIcon
-          icon={ChevronsUpDownIcon}
-          size={{
-            blockSize: 28,
-            size: 16,
-          }}
-          style={{
-            width: 24,
-          }}
-        />
-      </Block>
-    </Popover>
-  );
-});
 
 interface CopilotToolbarProps {
   agentId: string;
-  isHovered: boolean;
 }
 
-const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
+const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId }) => {
   const { t } = useTranslation('topic');
-  const setActiveAgentId = useAgentStore((s) => s.setActiveAgentId);
   const [topicPopoverOpen, setTopicPopoverOpen] = useState(false);
 
-  const handleAgentChange = useCallback(
-    (id: string) => {
-      setActiveAgentId(id);
-      // Sync chatStore's activeAgentId to ensure topic selectors work correctly
-      useChatStore.setState({ activeAgentId: id });
-    },
-    [setActiveAgentId],
-  );
-
-  // Fetch topics for the agent builder
   useChatStore((s) => s.useFetchTopics)(true, { agentId });
 
   const [activeTopicId, switchTopic, topics] = useChatStore((s) => [
@@ -182,73 +27,74 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
     topicSelectors.currentTopics(s),
   ]);
 
+  const currentTopic = useChatStore(topicSelectors.currentActiveTopic);
+
   const [toggleRightPanel] = useGlobalStore((s) => [s.toggleRightPanel]);
 
-  // topics === undefined means still loading, topics.length === 0 means confirmed empty
   const isLoadingTopics = topics === undefined;
   const hideHistory = !isLoadingTopics && topics.length === 0;
+
+  const topicTitle = currentTopic?.title || t('title');
 
   return (
     <NavHeader
       showTogglePanelButton={false}
       left={
-        <Flexbox horizontal align="center" gap={8}>
-          <AgentSelector agentId={agentId} onAgentChange={handleAgentChange} />
-        </Flexbox>
+        <Text ellipsis style={{ fontSize: 13, fontWeight: 500, maxWidth: 200 }} type={'secondary'}>
+          {topicTitle}
+        </Text>
       }
       right={
         <>
-          <div className={cx(styles.fadeContainer, isHovered ? styles.fadeIn : styles.fadeOut)}>
-            <ActionIcon
-              icon={PlusIcon}
-              size={DESKTOP_HEADER_ICON_SIZE}
-              title={t('actions.addNewTopic')}
-              onClick={() => switchTopic(null, { scope: 'page' })}
-            />
-            {!hideHistory && (
-              <Popover
-                open={isLoadingTopics ? false : topicPopoverOpen}
-                placement="bottomRight"
-                trigger="click"
-                content={
-                  <Flexbox
-                    gap={4}
-                    padding={8}
-                    style={{
-                      maxHeight: '50vh',
-                      overflowY: 'auto',
-                      width: '100%',
-                    }}
-                  >
-                    {(topics || []).map((topic) => (
-                      <TopicItem
-                        active={topic.id === activeTopicId}
-                        key={topic.id}
-                        topicId={topic.id}
-                        topicTitle={topic.title}
-                        onClose={() => setTopicPopoverOpen(false)}
-                        onTopicChange={(id) => switchTopic(id)}
-                      />
-                    ))}
-                  </Flexbox>
-                }
-                styles={{
-                  content: {
-                    padding: 0,
-                    width: 240,
-                  },
-                }}
-                onOpenChange={setTopicPopoverOpen}
-              >
-                <ActionIcon
-                  disabled={isLoadingTopics}
-                  icon={Clock3Icon}
-                  loading={isLoadingTopics}
-                  size={DESKTOP_HEADER_ICON_SIZE}
-                />
-              </Popover>
-            )}
-          </div>
+          <ActionIcon
+            icon={PlusIcon}
+            size={DESKTOP_HEADER_ICON_SIZE}
+            title={t('actions.addNewTopic')}
+            onClick={() => switchTopic(null, { scope: 'page' })}
+          />
+          {!hideHistory && (
+            <Popover
+              open={isLoadingTopics ? false : topicPopoverOpen}
+              placement="bottomRight"
+              trigger="click"
+              content={
+                <Flexbox
+                  gap={4}
+                  padding={8}
+                  style={{
+                    maxHeight: '50vh',
+                    overflowY: 'auto',
+                    width: '100%',
+                  }}
+                >
+                  {(topics || []).map((topic) => (
+                    <TopicItem
+                      active={topic.id === activeTopicId}
+                      key={topic.id}
+                      topicId={topic.id}
+                      topicTitle={topic.title}
+                      onClose={() => setTopicPopoverOpen(false)}
+                      onTopicChange={(id) => switchTopic(id)}
+                    />
+                  ))}
+                </Flexbox>
+              }
+              styles={{
+                content: {
+                  padding: 0,
+                  width: 240,
+                },
+              }}
+              onOpenChange={setTopicPopoverOpen}
+            >
+              <ActionIcon
+                disabled={isLoadingTopics}
+                icon={Clock3Icon}
+                loading={isLoadingTopics}
+                size={DESKTOP_HEADER_ICON_SIZE}
+              />
+            </Popover>
+          )}
           <ActionIcon
             icon={PanelRightCloseIcon}
             size={DESKTOP_HEADER_ICON_SIZE}
@@ -260,6 +106,6 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId, isHovered }) => {
   );
 });
 
-CopilotToolbar.displayName = 'TopicSelector';
+CopilotToolbar.displayName = 'CopilotToolbar';
 
 export default CopilotToolbar;

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -40,7 +40,13 @@ const CopilotToolbar = memo<CopilotToolbarProps>(({ agentId }) => {
     <NavHeader
       showTogglePanelButton={false}
       left={
-        <Text ellipsis style={{ fontSize: 13, fontWeight: 500, maxWidth: 200 }} type={'secondary'}>
+        <Text
+          style={{ fontSize: 13, fontWeight: 500, marginLeft: 8 }}
+          type={'secondary'}
+          ellipsis={{
+            tooltipWhenOverflow: true,
+          }}
+        >
           {topicTitle}
         </Text>
       }


### PR DESCRIPTION
## Summary

- Redesign Copilot ChatInput action bar with compact 28px height layout
- Left side: Agent Selector (12px radius) + Search action
- Right side: Text-based Model Selector (e.g. "Claude Sonnet 4.5") + Settings icon + compact Send button
- Add `leftContent`, `sendAreaPrefix`, `actionBarStyle` props to `ChatInput` / `DesktopChatInput` for per-consumer customization
- Extend `ActionBarContext` with `actionSize` so Action components adapt to compact mode
- Add `size` to `SendButtonProps` for flexible send button sizing
- Add `openOnHover` prop to `ModelSwitchPanel`

![CleanShot 2026-02-12 at 14 39 35@2x](https://github.com/user-attachments/assets/dfc9d3bd-042c-4d41-affe-d1b235aff644)
