### PR TITLE
✨ feat: support image upload in editor with desktop file picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@lobehub/chat-plugin-sdk": "^1.32.4",
     "@lobehub/chat-plugins-gateway": "^1.9.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^3.14.0",
+    "@lobehub/editor": "^3.16.1",
     "@lobehub/icons": "^4.1.0",
     "@lobehub/market-sdk": "0.29.2",
     "@lobehub/tts": "^4.0.2",

--- a/packages/electron-client-ipc/src/types/localSystem.ts
+++ b/packages/electron-client-ipc/src/types/localSystem.ts
@@ -273,6 +273,48 @@ export interface EditLocalFileResult {
   success: boolean;
 }
 
+// Open Dialog types
+export interface ShowOpenDialogParams {
+  /**
+   * File type filters
+   */
+  filters?: { extensions: string[]; name: string }[];
+  /**
+   * Allow selecting multiple files
+   */
+  multiple?: boolean;
+  /**
+   * Dialog title
+   */
+  title?: string;
+}
+
+export interface ShowOpenDialogResult {
+  /**
+   * Whether the dialog was cancelled
+   */
+  canceled: boolean;
+  /**
+   * The selected file paths (empty if cancelled)
+   */
+  filePaths: string[];
+}
+
+// Pick File (dialog + read in one IPC call)
+export interface PickFileParams {
+  filters?: { extensions: string[]; name: string }[];
+  title?: string;
+}
+
+export interface PickFileResult {
+  canceled: boolean;
+  file?: {
+    data: Uint8Array;
+    mimeType: string;
+    name: string;
+  };
+}
+
 // Save Dialog types
 export interface ShowSaveDialogParams {
   /**

--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { IEditor } from '@lobehub/editor';
+import { isDesktop } from '@lobechat/const';
+import { type IEditor } from '@lobehub/editor';
 import {
   ReactCodemirrorPlugin,
   ReactCodePlugin,
@@ -14,16 +15,21 @@ import {
   ReactToolbarPlugin,
 } from '@lobehub/editor';
 import { Editor, useEditorState } from '@lobehub/editor/react';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { EditorCanvasProps } from './EditorCanvas';
+import { type EditorCanvasProps } from './EditorCanvas';
 import InlineToolbar from './InlineToolbar';
+import { useImageUpload } from './useImageUpload';
+
+const IMAGE_FILTERS = [
+  { extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif'], name: 'Images' },
+];
 
 /**
- * Base plugins for the editor (without toolbar)
+ * Base plugins for the editor (without image and toolbar, which need dynamic config)
  */
-const BASE_PLUGINS = [
+const STATIC_PLUGINS = [
   ReactLiteXmlPlugin,
   ReactListPlugin,
   ReactCodePlugin,
@@ -32,9 +38,6 @@ const BASE_PLUGINS = [
   ReactLinkPlugin,
   ReactTablePlugin,
   ReactMathPlugin,
-  Editor.withProps(ReactImagePlugin, {
-    defaultBlockImage: true,
-  }),
 ];
 
 export interface InternalEditorProps extends EditorCanvasProps {
@@ -62,6 +65,19 @@ const InternalEditor = memo<InternalEditorProps>(
   }) => {
     const { t } = useTranslation('file');
     const editorState = useEditorState(editor);
+    const handleImageUpload = useImageUpload();
+
+    const handlePickFile = useCallback(async (): Promise<File | null> => {
+      if (!isDesktop) return null;
+      const { ensureElectronIpc } = await import('@/utils/electron/ipc');
+      const ipc = ensureElectronIpc();
+      const result = await (ipc as any).localSystem.handlePickFile({
+        filters: IMAGE_FILTERS,
+      });
+      if (result.canceled || !result.file) return null;
+      const { data, mimeType, name } = result.file;
+      return new File([data], name, { type: mimeType });
+    }, []);
 
     const finalPlaceholder = placeholder || t('pageEditor.editorPlaceholder');
 
@@ -70,8 +86,16 @@ const InternalEditor = memo<InternalEditorProps>(
       // If custom plugins provided, use them directly
       if (customPlugins) return customPlugins;
 
+      const imagePlugin = Editor.withProps(ReactImagePlugin, {
+        defaultBlockImage: true,
+        handleUpload: handleImageUpload,
+        onPickFile: isDesktop ? handlePickFile : undefined,
+      });
+
       // Build base plugins with optional extra plugins prepended
-      const basePlugins = extraPlugins ? [...extraPlugins, ...BASE_PLUGINS] : BASE_PLUGINS;
+      const basePlugins = extraPlugins
+        ? [...extraPlugins, ...STATIC_PLUGINS, imagePlugin]
+        : [...STATIC_PLUGINS, imagePlugin];
 
       // Add toolbar if enabled
       if (floatingToolbar) {
@@ -91,7 +115,16 @@ const InternalEditor = memo<InternalEditorProps>(
       }
 
       return basePlugins;
-    }, [customPlugins, editor, editorState, extraPlugins, floatingToolbar, toolbarExtraItems]);
+    }, [
+      customPlugins,
+      editor,
+      editorState,
+      extraPlugins,
+      floatingToolbar,
+      handleImageUpload,
+      handlePickFile,
+      toolbarExtraItems,
+    ]);
 
     useEffect(() => {
       // for easier debug, mount editor instance to window

--- a/src/features/EditorCanvas/index.ts
+++ b/src/features/EditorCanvas/index.ts
@@ -7,3 +7,4 @@ export {
 } from './EditorCanvas';
 export { EditorErrorBoundary } from './ErrorBoundary';
 export { default as InlineToolbar, type InlineToolbarProps } from './InlineToolbar';
+export { useImageUpload } from './useImageUpload';

--- a/src/features/EditorCanvas/useImageUpload.ts
+++ b/src/features/EditorCanvas/useImageUpload.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+import { useFileStore } from '@/store/file';
+
+/**
+ * Shared hook for editor image upload.
+ * Returns a handler compatible with ReactImagePlugin's `handleUpload` signature.
+ */
+export const useImageUpload = () => {
+  const uploadWithProgress = useFileStore((s) => s.uploadWithProgress);
+
+  return useCallback(
+    async (file: File): Promise<{ url: string }> => {
+      try {
+        const result = await uploadWithProgress({
+          file,
+          skipCheckFileType: false,
+          source: 'page-editor',
+        });
+        if (!result) throw new Error('Upload returned empty result');
+        return { url: result.url };
+      } catch (error) {
+        throw new Error('Image upload failed', { cause: error });
+      }
+    },
+    [uploadWithProgress],
+  );
+};

--- a/src/features/PageEditor/EditorCanvas/index.tsx
+++ b/src/features/PageEditor/EditorCanvas/index.tsx
@@ -21,7 +21,7 @@ const EditorCanvas = memo<EditorCanvasProps>(({ placeholder, style }) => {
   const editor = usePageEditorStore((s) => s.editor);
   const documentId = usePageEditorStore((s) => s.documentId);
 
-  const slashItems = useSlashItems(editor);
+  const slashItems = useSlashItems();
   const askCopilotItem = useAskCopilotItem(editor);
 
   return (


### PR DESCRIPTION
## Summary
- Add `handleShowOpenDialog` and `handlePickFile` IPC methods for Electron desktop file picker
- Create `useImageUpload` hook for editor image upload with progress tracking
- Refactor `ReactImagePlugin` config to support `handleUpload` and `onPickFile` callbacks
- Simplify slash command image insertion by delegating upload logic to the plugin layer
- Upgrade `@lobehub/editor` to `^3.16.1`

Fixes LOBE-2295

## Test plan
- [x] Verify image upload works in web editor via slash command and toolbar
- [x] Verify desktop app file picker dialog opens correctly for image selection
- [x] Verify uploaded images display correctly with progress indication
- [x] Verify drag-and-drop image upload still works
- [x] Verify empty images in documents can be replaced