### PR TITLE
💄 style: add new MiniMax-M2.5 model

### DIFF
--- a/packages/model-bank/src/aiModels/infiniai.ts
+++ b/packages/model-bank/src/aiModels/infiniai.ts
@@ -1,8 +1,50 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import  { type AIChatModelCard } from '../types/aiModel';
 
 // https://cloud.infini-ai.com/genstudio/model
 
 const infiniaiChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 198_000,
+    description:
+      'A strong reasoning and agentic model from Z.ai with 744B total parameters (40B active), built for complex systems engineering and long-horizon tasks.',
+    displayName: 'GLM-5',
+    enabled: true,
+    id: 'glm-5',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 22, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-13',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.5 is a state-of-the-art large language model designed for real-world productivity and coding tasks.',
+    displayName: 'MiniMax M2.5',
+    enabled: true,
+    id: 'minimax-m2.5',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-13',
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,

--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -1,4 +1,4 @@
-import  { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 
 const minimaxChatModels: AIChatModelCard[] = [
   {

--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import  { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 
 const minimaxChatModels: AIChatModelCard[] = [
   {
@@ -8,9 +8,54 @@ const minimaxChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 204_800,
     description:
+      'Top-tier performance and ultimate cost-effectiveness, easily handling complex tasks (approx. 60 tps).',
+    displayName: 'MiniMax M2.5',
+    enabled: true,
+    id: 'MiniMax-M2.5',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-12',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description: 'M2.5 Lightning: Same performance, faster and more agile (approx. 100 tps).',
+    displayName: 'MiniMax M2.5 Lightning',
+    id: 'MiniMax-M2.5-Lightning',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-12',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
       'Powerful multilingual programming capabilities, comprehensively upgraded programming experience',
     displayName: 'MiniMax M2.1',
-    enabled: true,
     id: 'MiniMax-M2.1',
     maxOutput: 131_072,
     pricing: {

--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -1,6 +1,18 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import { type AIChatModelCard } from '../types/aiModel';
 
 const nvidiaChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'A strong reasoning and agentic model from Z.ai with 744B total parameters (40B active), built for complex systems engineering and long-horizon tasks.',
+    displayName: 'GLM-5',
+    id: 'z-ai/glm5',
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,
@@ -10,7 +22,6 @@ const nvidiaChatModels: AIChatModelCard[] = [
     description:
       'MiniMax-M2 is a compact, fast, cost-effective MoE model (230B total, 10B active) built for top-tier coding and agent performance while retaining strong general intelligence. It excels at multi-file edits, code-run-fix loops, test validation, and complex toolchains.',
     displayName: 'MiniMax-M2',
-    enabled: true,
     id: 'minimaxai/minimax-m2',
     maxOutput: 16_384,
     type: 'chat',
@@ -24,7 +35,6 @@ const nvidiaChatModels: AIChatModelCard[] = [
     description:
       'DeepSeek V3.1 is a next-gen reasoning model with stronger complex reasoning and chain-of-thought for deep analysis tasks.',
     displayName: 'DeepSeek V3.1 Terminus',
-    enabled: true,
     id: 'deepseek-ai/deepseek-v3.1-terminus',
     maxOutput: 16_384,
     settings: {

--- a/packages/model-bank/src/aiModels/ollamacloud.ts
+++ b/packages/model-bank/src/aiModels/ollamacloud.ts
@@ -1,6 +1,32 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import  { type AIChatModelCard } from '../types/aiModel';
 
 const ollamaCloudModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.5 is a state-of-the-art large language model designed for real-world productivity and coding tasks.',
+    displayName: 'MiniMax M2.5',
+    enabled: true,
+    id: 'minimax-m2.5',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'A strong reasoning and agentic model from Z.ai with 744B total parameters (40B active), built for complex systems engineering and long-horizon tasks.',
+    displayName: 'GLM-5',
+    enabled: true,
+    id: 'glm-5',
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,
@@ -46,20 +72,6 @@ const ollamaCloudModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576,
     description:
-      'Gemini 3 Pro is Google’s most intelligent model, with state-of-the-art reasoning, multimodal understanding, and strong agent and vibe-coding capabilities.',
-    displayName: 'Gemini 3 Pro Preview',
-    id: 'gemini-3-pro-preview',
-    releasedAt: '2025-11-20',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      vision: true,
-    },
-    contextWindowTokens: 1_048_576,
-    description:
       'Gemini 3 Flash is the smartest model built for speed, combining cutting-edge intelligence with excellent search grounding.',
     displayName: 'Gemini 3 Flash Preview',
     id: 'gemini-3-flash-preview',
@@ -73,7 +85,6 @@ const ollamaCloudModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 204_800,
     displayName: 'MiniMax M2.1',
-    enabled: true,
     id: 'minimax-m2.1',
     type: 'chat',
   },
@@ -98,7 +109,6 @@ const ollamaCloudModels: AIChatModelCard[] = [
     description:
       "GLM-4.7 is Zhipu's latest flagship model, enhanced for Agentic Coding scenarios with improved coding capabilities, long-term task planning, and tool collaboration. It achieves leading performance among open-source models on multiple public benchmarks. General capabilities are improved with more concise and natural responses and more immersive writing. For complex agent tasks, instruction following during tool calls is stronger, and the frontend aesthetics and long-term task completion efficiency of Artifacts and Agentic Coding are further enhanced.",
     displayName: 'GLM-4.7',
-    enabled: true,
     id: 'glm-4.7',
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 
 // https://help.aliyun.com/zh/model-studio/models?spm=a2c4g.11186623
 

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -1,7 +1,64 @@
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import  { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 
 // https://siliconflow.cn/zh-cn/models
 const siliconcloudChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 198_000,
+    description:
+      'GLM-5 是智谱推出的新一代大语言模型，专注于复杂系统工程和长周期 Agent 任务。模型参数扩展至 744B 参数（40B 激活），并集成了 DeepSeek Sparse Attention。',
+    displayName: 'GLM-5 (Pro)',
+    id: 'Pro/zai-org/glm-5',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 1,
+              '[0.032, infinity]': 1.5,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput_cacheRead',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 4,
+              '[0.032, infinity]': 6,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 18,
+              '[0.032, infinity]': 22,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-12',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,
@@ -21,6 +78,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2026-01-27',
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
     type: 'chat',
   },
   {
@@ -59,6 +119,9 @@ const siliconcloudChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-12-23',
+    settings: {
+      extendParams: ['reasoningBudgetToken'],
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1,8 +1,246 @@
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 
 // https://www.volcengine.com/docs/82379/1330310
 
 const doubaoChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    config: {
+      deploymentName: 'doubao-seed-2-0-pro-260215',
+    },
+    contextWindowTokens: 256_000,
+    description:
+      "Doubao-Seed-2.0-pro is ByteDance's flagship Agent general model, with all-around leaps in complex task planning and execution capabilities.",
+    displayName: 'Doubao Seed 2.0 Pro',
+    enabled: true,
+    id: 'doubao-seed-2.0-pro',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 3.2,
+              '[0.032, 0.128]': 4.8,
+              '[0.128, 0.256]': 9.6,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 16,
+              '[0.032, 0.128]': 24,
+              '[0.128, 0.256]': 48,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.64, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 0.017 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    settings: {
+      extendParams: ['gpt5ReasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    config: {
+      deploymentName: 'doubao-seed-2-0-lite-260215',
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Doubao-Seed-2.0-lite is a new multimodal deep-reasoning model that delivers better value and a strong choice for common tasks, with a context window up to 256k.',
+    displayName: 'Doubao Seed 2.0 Lite',
+    enabled: true,
+    id: 'doubao-seed-2.0-lite',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 0.6,
+              '[0.032, 0.128]': 0.9,
+              '[0.128, 0.256]': 1.8,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 3.6,
+              '[0.032, 0.128]': 5.4,
+              '[0.128, 0.256]': 10.8,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.12, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 0.017 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    settings: {
+      extendParams: ['gpt5ReasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    config: {
+      deploymentName: 'doubao-seed-2-0-mini-260215',
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Doubao-Seed-2.0-mini is a lightweight model with fast response and high performance, suitable for small tasks and high-concurrency scenarios.',
+    displayName: 'Doubao Seed 2.0 Mini',
+    id: 'doubao-seed-2.0-mini',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 0.2,
+              '[0.032, 0.128]': 0.4,
+              '[0.128, 0.256]': 0.8,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 2,
+              '[0.032, 0.128]': 4,
+              '[0.128, 0.256]': 8,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.04, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 0.017 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    settings: {
+      extendParams: ['gpt5ReasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    config: {
+      deploymentName: 'doubao-seed-2-0-code-preview-260215',
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Doubao-Seed-2.0-code is deeply optimized for agentic coding, supports multimodal inputs and a 256k context window, fitting coding, vision understanding, and agent workflows.',
+    displayName: 'Doubao Seed 2.0 Code',
+    id: 'doubao-seed-2.0-code',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 3.2,
+              '[0.032, 0.128]': 4.8,
+              '[0.128, 0.256]': 9.6,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 16,
+              '[0.032, 0.128]': 24,
+              '[0.128, 0.256]': 48,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        { name: 'textInput_cacheRead', rate: 0.64, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 0.017 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    settings: {
+      extendParams: ['gpt5ReasoningEffort'],
+    },
+    type: 'chat',
+  },
   {
     abilities: {
       functionCall: true,
@@ -16,7 +254,6 @@ const doubaoChatModels: AIChatModelCard[] = [
     description:
       'Doubao-Seed-1.8 has stronger multimodal understanding and Agent capabilities, supports text/image/video input and context caching, and can deliver excellent performance in complex tasks.',
     displayName: 'Doubao Seed 1.8',
-    enabled: true,
     id: 'doubao-seed-1.8',
     maxOutput: 64_000,
     pricing: {
@@ -198,7 +435,6 @@ const doubaoChatModels: AIChatModelCard[] = [
     description:
       'DeepSeek-V3.2 is the first hybrid reasoning model from DeepSeek that integrates thinking into tool usage. It uses efficient architecture to save computation, large-scale reinforcement learning to enhance capabilities, and large-scale synthetic task data to strengthen generalization. The combination of these three achieves performance comparable to GPT-5-High, with significantly reduced output length, notably decreasing computational overhead and user wait times.',
     displayName: 'DeepSeek V3.2',
-    enabled: true,
     id: 'deepseek-v3.2',
     maxOutput: 32_768,
     pricing: {
@@ -507,7 +743,6 @@ const doubaoChatModels: AIChatModelCard[] = [
     description:
       'Doubao-Seed-1.6-flash is an ultra-fast multimodal deep-reasoning model with TPOT as low as 10ms. It supports both text and vision, surpasses the previous lite model in text understanding, and matches competing pro models in vision. It supports a 256k context window and up to 16k output tokens.',
     displayName: 'Doubao Seed 1.6 Flash',
-    enabled: true,
     id: 'doubao-seed-1.6-flash',
     maxOutput: 32_000,
     pricing: {

--- a/packages/model-bank/src/modelProviders/minimax.ts
+++ b/packages/model-bank/src/modelProviders/minimax.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderCard } from '@/types/llm';
+import { type ModelProviderCard } from '@/types/llm';
 
 // ref: https://platform.minimaxi.com/document/Models
 const Minimax: ModelProviderCard = {
@@ -19,6 +19,7 @@ const Minimax: ModelProviderCard = {
       text: 'smooth',
     },
     sdkType: 'openai',
+    showModelFetcher: false,
   },
   url: 'https://www.minimaxi.com',
 };

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -1,7 +1,7 @@
-import type { ChatModelCard } from '@lobechat/types';
-import type { AIBaseModelCard, AiModelSettings, ExtendParamsType } from 'model-bank';
+import  { type ChatModelCard } from '@lobechat/types';
+import  { type AIBaseModelCard, type AiModelSettings, type ExtendParamsType } from 'model-bank';
 
-import type { ModelProviderKey } from '../types';
+import  { type ModelProviderKey } from '../types';
 
 export interface ModelProcessorConfig {
   excludeKeywords?: readonly string[]; // Do not add tags to models that match
@@ -31,7 +31,7 @@ export const MODEL_LIST_CONFIGS = {
   },
   deepseek: {
     functionCallKeywords: ['v3', 'r1', 'deepseek-chat'],
-    reasoningKeywords: ['r1', 'deepseek-reasoner', 'v3.1', 'v3.2'],
+    reasoningKeywords: ['r1', 'deepseek-reasoner', 'v3.'],
     visionKeywords: ['ocr'],
   },
   google: {
@@ -65,14 +65,14 @@ export const MODEL_LIST_CONFIGS = {
   },
   moonshot: {
     functionCallKeywords: ['moonshot', 'kimi'],
-    reasoningKeywords: ['thinking'],
-    visionKeywords: ['vision', 'kimi-latest', 'kimi-thinking-preview'],
+    reasoningKeywords: ['thinking', 'k2.5'],
+    visionKeywords: ['vision', 'kimi-latest', 'kimi-thinking-preview', 'k2.5'],
   },
   openai: {
     excludeKeywords: ['audio'],
-    functionCallKeywords: ['4o', '4.1', 'o3', 'o4', 'oss'],
-    reasoningKeywords: ['o1', 'o3', 'o4', 'oss'],
-    visionKeywords: ['4o', '4.1', 'o4'],
+    functionCallKeywords: ['4o', '4.1', 'o3', 'o4', 'oss', '-5'],
+    reasoningKeywords: ['o1', 'o3', 'o4', 'oss', '-5'],
+    visionKeywords: ['4o', '4.1', 'o4', '-5'],
   },
   qwen: {
     functionCallKeywords: [
@@ -85,7 +85,7 @@ export const MODEL_LIST_CONFIGS = {
       'qwen2.5',
       'qwen3',
     ],
-    reasoningKeywords: ['qvq', 'qwq', 'qwen3', '!-instruct-', '!-coder-', '!-max-'],
+    reasoningKeywords: ['qvq', 'qwq', 'qwen3', '!-instruct-', '!-coder-'],
     visionKeywords: ['qvq', '-vl', '-omni'],
   },
   replicate: {
@@ -106,7 +106,7 @@ export const MODEL_LIST_CONFIGS = {
     visionKeywords: ['v0'],
   },
   volcengine: {
-    functionCallKeywords: ['1.5', '1-5', '1.6', '1-6'],
+    functionCallKeywords: ['seed'],
     reasoningKeywords: ['thinking', 'seed', 'ui-tars'],
     visionKeywords: ['vision', '-m', 'seed', 'ui-tars'],
   },
@@ -130,8 +130,8 @@ export const MODEL_LIST_CONFIGS = {
     visionKeywords: ['vision'],
   },
   zhipu: {
-    functionCallKeywords: ['glm-4', 'glm-z1'],
-    reasoningKeywords: ['glm-zero', 'glm-z1', 'glm-4.'],
+    functionCallKeywords: ['glm-4', 'glm-z1', 'glm-5'],
+    reasoningKeywords: ['glm-zero', 'glm-z1', 'glm-4.', 'glm-5'],
     visionKeywords: ['re:glm-4(\\.\\d)?v'],
   },
 } as const;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close #12315

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

https://minimaxi.com/news/minimax-m25

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add new MiniMax-M2.5 and GLM-5 reasoning models across multiple providers and update model parsing metadata to recognize new reasoning/function-calling capabilities.

New Features:
- Register MiniMax M2.5 and MiniMax M2.5 Lightning chat models for the native MiniMax provider with pricing and limits.
- Expose MiniMax M2.5 and GLM-5 chat models via Infini AI and Ollama Cloud providers.
- Introduce GLM-5 Pro chat model configuration for the SiliconCloud provider.

Enhancements:
- Annotate existing SiliconCloud chat models with extended reasoning-related settings.
- Adjust model parsing keyword rules to better classify reasoning, function-calling, and vision capabilities for DeepSeek, Moonshot, OpenAI, Qwen, Volcengine, and Zhipu models.
- Standardize type-only imports for several AI model and runtime modules.

Chores:
- Remove the deprecated Gemini 3 Pro Preview model from the Ollama Cloud model list and clean up enabled flags on some existing models.