### PR TITLE
🐛 fix: add the Agent Meta info back into agent advance model

### DIFF
--- a/src/app/[variants]/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -4,7 +4,7 @@ import { Avatar, Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { BrainIcon, MessageSquareHeartIcon, MessagesSquareIcon } from 'lucide-react';
+import { BrainIcon, MessageSquareHeartIcon, MessagesSquareIcon, UserIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -24,7 +24,7 @@ const Content = memo(() => {
   ]);
   const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
   const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
-  const [tab, setTab] = useState(isInbox ? ChatSettingsTabs.Modal : ChatSettingsTabs.Opening);
+  const [tab, setTab] = useState(isInbox ? ChatSettingsTabs.Modal : ChatSettingsTabs.Meta);
 
   const updateAgentConfig = async (config: any) => {
     if (!agentId) return;
@@ -39,6 +39,13 @@ const Content = memo(() => {
   const menuItems: ItemType[] = useMemo(
     () =>
       [
+        !isInbox
+          ? {
+              icon: <Icon icon={UserIcon} />,
+              key: ChatSettingsTabs.Meta,
+              label: t('agentTab.meta'),
+            }
+          : null,
         !isInbox
           ? {
               icon: <Icon icon={MessageSquareHeartIcon} />,

--- a/src/features/AgentSetting/AgentSettingsContent.tsx
+++ b/src/features/AgentSetting/AgentSettingsContent.tsx
@@ -6,6 +6,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { ChatSettingsTabs } from '@/store/global/initialState';
 
 import AgentChat from './AgentChat';
+import AgentMeta from './AgentMeta';
 import AgentModal from './AgentModal';
 import AgentOpening from './AgentOpening';
 
@@ -21,6 +22,7 @@ const AgentSettingsContent = memo<AgentSettingsContentProps>(({ tab, loadingSkel
 
   return (
     <>
+      {tab === ChatSettingsTabs.Meta && <AgentMeta />}
       {tab === ChatSettingsTabs.Opening && <AgentOpening />}
       {tab === ChatSettingsTabs.Chat && <AgentChat />}
       {tab === ChatSettingsTabs.Modal && <AgentModal />}


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Restore the agent metadata tab in the agent settings flow for non-inbox agents and make it the default tab when opening settings.

Bug Fixes:
- Reintroduce the Agent Meta tab in the agent settings menu for non-inbox agents so its content is accessible again.
- Ensure the Agent Meta component renders when the Meta tab is selected in agent settings.