### PR TITLE
🔧 ci: optimize sync-main-to-canary to merge directly when no conflicts

### DIFF
--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -23,24 +23,39 @@ jobs:
           git config --global user.name 'lobehubbot'
           git config --global user.email 'i@lobehub.com'
 
-      - name: Prepare sync branch
-        id: branch
-        run: |
-          echo "SYNC_BRANCH_MAIN_CANARY=sync/main-to-canary-$(date +'%Y%m%d')" >> $GITHUB_ENV
-
       - name: Sync main to canary
-        if: github.ref == 'refs/heads/main'
         run: |
-          # Sync main to canary
-          git checkout main
-          SYNC_BRANCH_CANARY=${{ env.SYNC_BRANCH_MAIN_CANARY }}
-          git checkout -B $SYNC_BRANCH_CANARY
-          DIFF=$(git diff origin/canary...)
-          if [ -z "$DIFF" ]; then
-            echo "No changes to sync"
-            exit 0
+          git checkout canary
+          git pull origin canary
+
+          # Try merge, detect conflicts
+          if git merge origin/main --no-edit; then
+            # No conflicts, check if there are actual changes
+            if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/canary)" ]; then
+              echo "No changes to sync"
+              exit 0
+            fi
+            echo "Merge succeeded, pushing directly"
+            git push origin canary
+          else
+            echo "Merge conflicts detected, creating PR"
+            git merge --abort
+
+            SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')"
+            git checkout -B "$SYNC_BRANCH" origin/main
+            git push origin "$SYNC_BRANCH" -f
+
+            # Avoid duplicate PR
+            EXISTING_PR=$(gh pr list --base canary --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "PR #$EXISTING_PR already exists"
+            else
+              gh pr create \
+                --base canary \
+                --head "$SYNC_BRANCH" \
+                --title "Sync main branch to canary branch" \
+                --body "Automatic sync from main to canary. Manual conflict resolution required."
+            fi
           fi
-          git push origin $SYNC_BRANCH_CANARY -f
-          gh pr create --base canary --head $SYNC_BRANCH_CANARY --title "Sync main branch to canary branch" --body "Automatic sync" || exit 0
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -24,7 +24,14 @@ jobs:
           git config --global user.email 'i@lobehub.com'
 
       - name: Sync main to canary
+        if: github.ref == 'refs/heads/main'
         run: |
+          # Find existing open sync PR by head branch prefix
+          EXISTING_PR=$(gh pr list --base canary --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("sync/main-to-canary-"))][0] // empty')
+          EXISTING_PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number // empty' 2>/dev/null)
+          EXISTING_BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName // empty' 2>/dev/null)
+
           git checkout canary
           git pull origin canary
 
@@ -36,25 +43,42 @@ jobs:
               exit 0
             fi
             echo "Merge succeeded, pushing directly"
-            git push origin canary
+            if git push origin canary; then
+              # Close stale sync PR if direct push succeeded
+              if [ -n "$EXISTING_PR_NUMBER" ]; then
+                gh pr close "$EXISTING_PR_NUMBER" --comment "Superseded by direct push." --delete-branch || true
+              fi
+              exit 0
+            fi
+
+            # Direct push failed (e.g. non-fast-forward race), fall back to PR
+            echo "Direct push failed, falling back to PR"
+            SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')-${GITHUB_RUN_ID}"
+            git checkout -B "$SYNC_BRANCH"
+            git push origin "$SYNC_BRANCH" -f
+            gh pr create \
+              --base canary \
+              --head "$SYNC_BRANCH" \
+              --title "Sync main branch to canary branch" \
+              --body "Automatic sync from main to canary. Direct push failed, please merge this PR." || true
           else
             echo "Merge conflicts detected, creating PR"
             git merge --abort
 
-            SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')"
-            git checkout -B "$SYNC_BRANCH" origin/canary
-            # Attempt merge main, commit conflict markers if unresolved
-            if ! git merge origin/main --no-edit; then
-              git add -A
-              git commit --no-edit -m "chore: merge main into canary (has conflicts to resolve)"
-            fi
-            git push origin "$SYNC_BRANCH" -f
-
-            # Avoid duplicate PR
-            EXISTING_PR=$(gh pr list --base canary --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number')
-            if [ -n "$EXISTING_PR" ]; then
-              echo "PR #$EXISTING_PR already exists"
+            if [ -n "$EXISTING_PR_NUMBER" ]; then
+              # Existing conflict PR open — notify via comment, don't overwrite manual work
+              gh pr comment "$EXISTING_PR_NUMBER" --body "New commits on \`main\`. Please pull latest \`origin/main\` into this branch to include them."
+              echo "Commented on existing PR #$EXISTING_PR_NUMBER"
             else
+              SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')-${GITHUB_RUN_ID}"
+              git checkout -B "$SYNC_BRANCH" origin/canary
+              # Attempt merge main, commit conflict markers if unresolved
+              if ! git merge origin/main --no-edit; then
+                git add -A
+                git commit --no-edit -m "chore: merge main into canary (has conflicts to resolve)"
+              fi
+              git push origin "$SYNC_BRANCH" -f
+
               printf '%s\n' \
                 'Automatic sync from main to canary. Merge conflicts detected.' \
                 '' \

--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -42,7 +42,12 @@ jobs:
             git merge --abort
 
             SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')"
-            git checkout -B "$SYNC_BRANCH" origin/main
+            git checkout -B "$SYNC_BRANCH" origin/canary
+            # Attempt merge main, commit conflict markers if unresolved
+            if ! git merge origin/main --no-edit; then
+              git add -A
+              git commit --no-edit -m "chore: merge main into canary (has conflicts to resolve)"
+            fi
             git push origin "$SYNC_BRANCH" -f
 
             # Avoid duplicate PR
@@ -50,11 +55,27 @@ jobs:
             if [ -n "$EXISTING_PR" ]; then
               echo "PR #$EXISTING_PR already exists"
             else
+              printf '%s\n' \
+                'Automatic sync from main to canary. Merge conflicts detected.' \
+                '' \
+                '**Resolution steps:**' \
+                '```bash' \
+                'git fetch origin' \
+                "git checkout $SYNC_BRANCH" \
+                'git merge origin/main' \
+                '# Resolve conflicts' \
+                'git add -A && git commit' \
+                'git push' \
+                '```' \
+                '' \
+                '> Do NOT merge canary into a main-based branch — always merge main INTO the canary-based branch to keep a clean commit graph.' \
+                > /tmp/pr-body.md
+
               gh pr create \
                 --base canary \
                 --head "$SYNC_BRANCH" \
                 --title "Sync main branch to canary branch" \
-                --body "Automatic sync from main to canary. Manual conflict resolution required."
+                --body-file /tmp/pr-body.md
             fi
           fi
         env:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,9 @@
+import { fileURLToPath } from 'node:url';
+
 import { eslint } from '@lobehub/lint';
 import { flat as mdxFlat } from 'eslint-plugin-mdx';
+
+const tsconfigRootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export default eslint(
   {
@@ -39,6 +43,13 @@ export default eslint(
     ],
     next: true,
     react: 'next',
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir,
+      },
+    },
   },
   // Global rule overrides
   {


### PR DESCRIPTION
## Summary
- Optimize the main-to-canary sync workflow to directly merge and push when there are no conflicts, avoiding unnecessary PR creation
- When merge conflicts exist, fall back to creating a PR for manual resolution
- Add duplicate PR detection to prevent multiple PRs on the same day

## Test plan
- [ ] Push to main with no conflicts on canary → should auto-merge without PR
- [ ] Push to main with conflicts on canary → should create PR
- [ ] Trigger workflow twice on same day with conflicts → should not create duplicate PRs

## Summary by Sourcery

CI:
- Update the sync-main-to-canary workflow to merge main into canary directly on no-conflict updates, only creating a PR when merge conflicts occur and avoiding duplicate PRs for the same sync date.