### PR TITLE
🔨 chore(memory-user-memory): support effort & tool permission for configuring memory

### DIFF
--- a/packages/builtin-tool-memory/src/executor/index.ts
+++ b/packages/builtin-tool-memory/src/executor/index.ts
@@ -1,18 +1,20 @@
-import type {
-  ActivityMemoryItemSchema,
-  AddIdentityActionSchema,
-  ContextMemoryItemSchema,
-  ExperienceMemoryItemSchema,
-  PreferenceMemoryItemSchema,
-  RemoveIdentityActionSchema,
-  UpdateIdentityActionSchema,
+import  {
+  type ActivityMemoryItemSchema,
+  type AddIdentityActionSchema,
+  type ContextMemoryItemSchema,
+  type ExperienceMemoryItemSchema,
+  type PreferenceMemoryItemSchema,
+  type RemoveIdentityActionSchema,
+  type UpdateIdentityActionSchema,
 } from '@lobechat/memory-user-memory/schemas';
 import { formatMemorySearchResults } from '@lobechat/prompts';
-import type { BuiltinToolResult, SearchMemoryParams } from '@lobechat/types';
+import  { type BuiltinToolContext, type BuiltinToolResult, type SearchMemoryParams } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
-import type { z } from 'zod';
+import  { type z } from 'zod';
 
 import { userMemoryService } from '@/services/userMemory';
+import { getAgentStoreState } from '@/store/agent';
+import { agentChatConfigSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 
 import { MemoryIdentifier } from '../manifest';
 import { MemoryApiName } from '../types';
@@ -25,6 +27,23 @@ import { MemoryApiName } from '../types';
 class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
   readonly identifier = MemoryIdentifier;
   protected readonly apiEnum = MemoryApiName;
+
+  private resolveToolPermission = (agentId?: string): 'read-only' | 'read-write' => {
+    const state = getAgentStoreState();
+    if (!state) return 'read-write';
+
+    const chatConfig = agentId
+      ? chatConfigByIdSelectors.getChatConfigById(agentId)(state)
+      : agentChatConfigSelectors.currentChatConfig(state);
+
+    return chatConfig?.memory?.toolPermission === 'read-only' ? 'read-only' : 'read-write';
+  };
+
+  private ensureWritable = (agentId?: string) => {
+    if (this.resolveToolPermission(agentId) === 'read-only') {
+      throw new Error('Memory tool is in read-only mode for this chat');
+    }
+  };
 
   // ==================== Search API ====================
 
@@ -61,8 +80,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   addContextMemory = async (
     params: z.infer<typeof ContextMemoryItemSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.addContextMemory(params);
 
       if (!result.success) {
@@ -99,8 +120,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   addActivityMemory = async (
     params: z.infer<typeof ActivityMemoryItemSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.addActivityMemory(params);
 
       if (!result.success) {
@@ -138,8 +161,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   addExperienceMemory = async (
     params: z.infer<typeof ExperienceMemoryItemSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.addExperienceMemory(params);
 
       if (!result.success) {
@@ -177,8 +202,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   addIdentityMemory = async (
     params: z.infer<typeof AddIdentityActionSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.addIdentityMemory(params);
 
       if (!result.success) {
@@ -215,8 +242,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   addPreferenceMemory = async (
     params: z.infer<typeof PreferenceMemoryItemSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.addPreferenceMemory(params);
 
       if (!result.success) {
@@ -255,8 +284,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   updateIdentityMemory = async (
     params: z.infer<typeof UpdateIdentityActionSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.updateIdentityMemory(params);
 
       if (!result.success) {
@@ -293,8 +324,10 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
    */
   removeIdentityMemory = async (
     params: z.infer<typeof RemoveIdentityActionSchema>,
+    ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
     try {
+      this.ensureWritable(ctx?.agentId);
       const result = await userMemoryService.removeIdentityMemory(params);
 
       if (!result.success) {

--- a/packages/builtin-tool-memory/src/executor/index.ts
+++ b/packages/builtin-tool-memory/src/executor/index.ts
@@ -45,14 +45,31 @@ class MemoryExecutor extends BaseExecutor<typeof MemoryApiName> {
     }
   };
 
+  private resolveMemoryEffort = (agentId?: string): 'high' | 'low' | 'medium' | undefined => {
+    const state = getAgentStoreState();
+    if (!state) return undefined;
+
+    const chatConfig = agentId
+      ? chatConfigByIdSelectors.getChatConfigById(agentId)(state)
+      : agentChatConfigSelectors.currentChatConfig(state);
+
+    return chatConfig?.memory?.effort;
+  };
+
   // ==================== Search API ====================
 
   /**
    * Search user memories based on query
    */
-  searchUserMemory = async (params: SearchMemoryParams): Promise<BuiltinToolResult> => {
+  searchUserMemory = async (
+    params: SearchMemoryParams,
+    ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
     try {
-      const result = await userMemoryService.searchMemory(params);
+      const result = await userMemoryService.searchMemory({
+        ...params,
+        effort: this.resolveMemoryEffort(ctx?.agentId),
+      });
 
       return {
         content: formatMemorySearchResults({ query: params.query, results: result }),

--- a/packages/builtin-tool-memory/src/systemRole.ts
+++ b/packages/builtin-tool-memory/src/systemRole.ts
@@ -4,7 +4,14 @@ export const systemPrompt = `You have a LobeHub Memory Tool. This tool is to rec
 Current user: {{username}}
 Session date: {{date}}
 Conversation language: {{language}}
+Memory effort level: {{memory_effort}}
 </session_context>
+
+<memory_effort_policy>
+- **low**: Prefer fewer memory operations. Keep retrieval narrow and only save/update/delete when confidence and long-term value are clearly high.
+- **medium**: Balanced behavior. Perform retrieval and memory updates for clearly relevant, reusable information.
+- **high**: Be proactive. Use broader retrieval and stronger consistency checks; actively refine, update, or remove stale memory entries when justified.
+</memory_effort_policy>
 
 <core_responsibilities>
 1. Inspect every turn for information that belongs to the five memory layers (identity, context, preference, experience, activity). When information is relevant and clear, err on the side of allowing extraction so specialised aggregators can refine it.

--- a/packages/const/src/settings/memory.ts
+++ b/packages/const/src/settings/memory.ts
@@ -1,5 +1,6 @@
-import type { UserMemorySettings } from '@lobechat/types';
+import  { type UserMemorySettings } from '@lobechat/types';
 
 export const DEFAULT_MEMORY_SETTINGS: UserMemorySettings = {
   enabled: true,
+  effort: 'medium',
 };

--- a/packages/const/src/userMemory.ts
+++ b/packages/const/src/userMemory.ts
@@ -8,6 +8,13 @@ export const DEFAULT_SEARCH_USER_MEMORY_TOP_K = {
   experiences: 0,
   preferences: 3,
 };
+
+export const MEMORY_SEARCH_TOP_K_LIMITS = {
+  high: { activities: 6, contexts: 4, experiences: 4, preferences: 6 },
+  low: { activities: 2, contexts: 0, experiences: 0, preferences: 2 },
+  medium: { ...DEFAULT_SEARCH_USER_MEMORY_TOP_K },
+} as const;
+
 export interface UserMemoryConfigItem {
   model: string;
   provider: string;

--- a/packages/context-engine/src/providers/UserMemoryInjector.ts
+++ b/packages/context-engine/src/providers/UserMemoryInjector.ts
@@ -1,15 +1,20 @@
-import type { UserMemoryData } from '@lobechat/prompts';
+import  { type UserMemoryData } from '@lobechat/prompts';
 import { promptUserMemory } from '@lobechat/prompts';
 import debug from 'debug';
 
 import { BaseFirstUserContentProvider } from '../base/BaseFirstUserContentProvider';
-import type { PipelineContext, ProcessorOptions } from '../types';
+import  { type PipelineContext, type ProcessorOptions } from '../types';
 
 const log = debug('context-engine:provider:UserMemoryInjector');
 
 export interface UserMemoryInjectorConfig {
   /** User memories data */
   memories?: UserMemoryData;
+}
+
+export interface MemoryContext {
+  /** Effective memory effort for the current request */
+  effort?: 'high' | 'low' | 'medium';
 }
 
 /**

--- a/packages/context-engine/src/providers/index.ts
+++ b/packages/context-engine/src/providers/index.ts
@@ -36,4 +36,4 @@ export type { PageEditorContextInjectorConfig } from './PageEditorContextInjecto
 export type { PageSelectionsInjectorConfig } from './PageSelectionsInjector';
 export type { SystemRoleInjectorConfig } from './SystemRoleInjector';
 export type { ToolSystemRoleConfig } from './ToolSystemRole';
-export type { UserMemoryInjectorConfig } from './UserMemoryInjector';
+export type { MemoryContext, UserMemoryInjectorConfig } from './UserMemoryInjector';

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -1,55 +1,80 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import { z } from 'zod';
 
-import { SearchMode } from '../search';
-import { LocalSystemConfig } from './agentConfig';
+import { type SearchMode } from '../search';
+import  { type UserMemoryEffort } from '../user/settings/memory';
+import { type LocalSystemConfig } from './agentConfig';
 
 export interface WorkingModel {
   model: string;
   provider: string;
 }
 
-export interface LobeAgentChatConfig {
-  /**
-   * Local System configuration (desktop only)
-   */
-  localSystem?: LocalSystemConfig;
-  enableAutoCreateTopic?: boolean;
+export interface AgentMemoryChatConfig {
+  memory?: {
+    effort?: UserMemoryEffort;
+    toolPermission?: 'read-only' | 'read-write';
+  };
+}
+
+export interface LobeAgentChatConfig extends AgentMemoryChatConfig {
   autoCreateTopicThreshold: number;
+  /**
+   * Model ID to use for generating compression summaries
+   */
+  compressionModelId?: string;
+  /**
+   * Disable context caching
+   */
+  disableContextCaching?: boolean;
 
-  enableMaxTokens?: boolean;
+  effort?: 'low' | 'medium' | 'high' | 'max';
 
   /**
-   * Whether to enable streaming output
+   * Whether to enable adaptive thinking (Claude Opus 4.6)
    */
-  enableStreaming?: boolean;
+  enableAdaptiveThinking?: boolean;
 
+  enableAutoCreateTopic?: boolean;
+  /**
+   * Whether to auto-scroll during AI streaming output
+   * undefined = use global setting
+   */
+  enableAutoScrollOnStreaming?: boolean;
+  /**
+   * Enable history message compression threshold
+   * @deprecated Use enableContextCompression instead
+   */
+  enableCompressHistory?: boolean;
+  /**
+   * Enable context compression
+   * When enabled, old messages will be compressed into summaries when token threshold is reached
+   */
+  enableContextCompression?: boolean;
+  /**
+   * Enable historical message count
+   */
+  enableHistoryCount?: boolean;
+  enableMaxTokens?: boolean;
   /**
    * Whether to enable reasoning
    */
   enableReasoning?: boolean;
   /**
-   * Whether to enable adaptive thinking (Claude Opus 4.6)
-   */
-  enableAdaptiveThinking?: boolean;
-  /**
    * Custom reasoning effort level
    */
   enableReasoningEffort?: boolean;
-  effort?: 'low' | 'medium' | 'high' | 'max';
-  reasoningBudgetToken?: number;
-  reasoningEffort?: 'low' | 'medium' | 'high';
-  gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
-  gpt5_1ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
-  gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
-  gpt5_2ProReasoningEffort?: 'medium' | 'high' | 'xhigh';
   /**
-   * Output text verbosity control
+   * Whether to enable streaming output
    */
-  textVerbosity?: 'low' | 'medium' | 'high';
-  thinking?: 'disabled' | 'auto' | 'enabled';
-  thinkingLevel?: 'minimal' | 'low' | 'medium' | 'high';
-  thinkingBudget?: number;
+  enableStreaming?: boolean;
+  gpt5_1ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  gpt5_2ProReasoningEffort?: 'medium' | 'high' | 'xhigh';
+  gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+  gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
+  /**
+   * Number of historical messages
+   */
+  historyCount?: number;
   /**
    * Image aspect ratio for image generation models
    */
@@ -58,41 +83,25 @@ export interface LobeAgentChatConfig {
    * Image resolution for image generation models
    */
   imageResolution?: '1K' | '2K' | '4K';
-  /**
-   * Disable context caching
-   */
-  disableContextCaching?: boolean;
-  /**
-   * Number of historical messages
-   */
-  historyCount?: number;
-  /**
-   * Enable historical message count
-   */
-  enableHistoryCount?: boolean;
-  /**
-   * Enable history message compression threshold
-   * @deprecated Use enableContextCompression instead
-   */
-  enableCompressHistory?: boolean;
-
-  /**
-   * Enable context compression
-   * When enabled, old messages will be compressed into summaries when token threshold is reached
-   */
-  enableContextCompression?: boolean;
-  /**
-   * Model ID to use for generating compression summaries
-   */
-  compressionModelId?: string;
-
   inputTemplate?: string;
+  /**
+   * Local System configuration (desktop only)
+   */
+  localSystem?: LocalSystemConfig;
+  reasoningBudgetToken?: number;
+  reasoningEffort?: 'low' | 'medium' | 'high';
 
-  searchMode?: SearchMode;
   searchFCModel?: WorkingModel;
-  urlContext?: boolean;
-  useModelBuiltinSearch?: boolean;
+  searchMode?: SearchMode;
 
+  /**
+   * Output text verbosity control
+   */
+  textVerbosity?: 'low' | 'medium' | 'high';
+
+  thinking?: 'disabled' | 'auto' | 'enabled';
+  thinkingBudget?: number;
+  thinkingLevel?: 'minimal' | 'low' | 'medium' | 'high';
   /**
    * Maximum length for tool execution result content (in characters)
    * This prevents context overflow when sending tool results back to LLM
@@ -100,13 +109,10 @@ export interface LobeAgentChatConfig {
    */
   toolResultMaxLength?: number;
 
-  /**
-   * Whether to auto-scroll during AI streaming output
-   * undefined = use global setting
-   */
-  enableAutoScrollOnStreaming?: boolean;
+  urlContext?: boolean;
+
+  useModelBuiltinSearch?: boolean;
 }
-/* eslint-enable */
 
 /**
  * Zod schema for LocalSystemConfig
@@ -115,43 +121,54 @@ export const LocalSystemConfigSchema = z.object({
   workingDirectory: z.string().optional(),
 });
 
-export const AgentChatConfigSchema = z.object({
-  autoCreateTopicThreshold: z.number().default(2),
-  compressionModelId: z.string().optional(),
-  disableContextCaching: z.boolean().optional(),
-  effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
-  enableAdaptiveThinking: z.boolean().optional(),
-  enableAutoCreateTopic: z.boolean().optional(),
-  enableAutoScrollOnStreaming: z.boolean().optional(),
-  enableCompressHistory: z.boolean().optional(),
-  enableContextCompression: z.boolean().optional(),
-  enableHistoryCount: z.boolean().optional(),
-  enableMaxTokens: z.boolean().optional(),
-  enableReasoning: z.boolean().optional(),
-  enableReasoningEffort: z.boolean().optional(),
-  enableStreaming: z.boolean().optional(),
-  gpt5ReasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
-  gpt5_1ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
-  gpt5_2ProReasoningEffort: z.enum(['medium', 'high', 'xhigh']).optional(),
-  gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
-  historyCount: z.number().optional(),
-  imageAspectRatio: z.string().optional(),
-  imageResolution: z.enum(['1K', '2K', '4K']).optional(),
-  localSystem: LocalSystemConfigSchema.optional(),
-  reasoningBudgetToken: z.number().optional(),
-  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
-  searchFCModel: z
+export const MemoryChatConfigSchema = z.object({
+  memory: z
     .object({
-      model: z.string(),
-      provider: z.string(),
+      effort: z.enum(['low', 'medium', 'high']).optional(),
+      toolPermission: z.enum(['read-only', 'read-write']).optional(),
     })
     .optional(),
-  searchMode: z.enum(['off', 'on', 'auto']).optional(),
-  textVerbosity: z.enum(['low', 'medium', 'high']).optional(),
-  thinking: z.enum(['disabled', 'auto', 'enabled']).optional(),
-  thinkingBudget: z.number().optional(),
-  thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
-  toolResultMaxLength: z.number().default(6000),
-  urlContext: z.boolean().optional(),
-  useModelBuiltinSearch: z.boolean().optional(),
 });
+
+export const AgentChatConfigSchema = z
+  .object({
+    autoCreateTopicThreshold: z.number().default(2),
+    compressionModelId: z.string().optional(),
+    disableContextCaching: z.boolean().optional(),
+    effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
+    enableAdaptiveThinking: z.boolean().optional(),
+    enableAutoCreateTopic: z.boolean().optional(),
+    enableAutoScrollOnStreaming: z.boolean().optional(),
+    enableCompressHistory: z.boolean().optional(),
+    enableContextCompression: z.boolean().optional(),
+    enableHistoryCount: z.boolean().optional(),
+    enableMaxTokens: z.boolean().optional(),
+    enableReasoning: z.boolean().optional(),
+    enableReasoningEffort: z.boolean().optional(),
+    enableStreaming: z.boolean().optional(),
+    gpt5ReasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+    gpt5_1ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
+    gpt5_2ProReasoningEffort: z.enum(['medium', 'high', 'xhigh']).optional(),
+    gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
+    historyCount: z.number().optional(),
+    imageAspectRatio: z.string().optional(),
+    imageResolution: z.enum(['1K', '2K', '4K']).optional(),
+    localSystem: LocalSystemConfigSchema.optional(),
+    reasoningBudgetToken: z.number().optional(),
+    reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+    searchFCModel: z
+      .object({
+        model: z.string(),
+        provider: z.string(),
+      })
+      .optional(),
+    searchMode: z.enum(['off', 'on', 'auto']).optional(),
+    textVerbosity: z.enum(['low', 'medium', 'high']).optional(),
+    thinking: z.enum(['disabled', 'auto', 'enabled']).optional(),
+    thinkingBudget: z.number().optional(),
+    thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+    toolResultMaxLength: z.number().default(6000),
+    urlContext: z.boolean().optional(),
+    useModelBuiltinSearch: z.boolean().optional(),
+  })
+  .merge(MemoryChatConfigSchema);

--- a/packages/types/src/asyncTask.ts
+++ b/packages/types/src/asyncTask.ts
@@ -20,7 +20,7 @@ export enum AsyncTaskErrorType {
    * Free plan users are not allowed to use this feature
    */
   FreePlanLimit = 'FreePlanLimit',
-  // eslint-disable-next-line typescript-sort-keys/string-enum
+
   InvalidProviderAPIKey = 'InvalidProviderAPIKey',
   /* ↑ cloud slot ↑ */
 

--- a/packages/types/src/user/settings/memory.ts
+++ b/packages/types/src/user/settings/memory.ts
@@ -1,3 +1,6 @@
+export type UserMemoryEffort = 'high' | 'low' | 'medium';
+
 export interface UserMemorySettings {
+  effort?: UserMemoryEffort;
   enabled?: boolean;
 }

--- a/packages/types/src/userMemory/tools.ts
+++ b/packages/types/src/userMemory/tools.ts
@@ -8,6 +8,7 @@ import type {
 } from './layers';
 
 export const searchMemorySchema = z.object({
+  effort: z.enum(['low', 'medium', 'high']).optional(),
   query: z.string(),
   /**
    * Optional limits for each memory layer. If omitted, server defaults are used.

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -115,7 +115,7 @@ describe('memoryRouter.reEmbedMemories', () => {
       userMemoriesActivities: {
         findMany: vi.fn().mockResolvedValue(activitiesRows),
       },
-    }) as const;
+    });
 
     vi.mocked(getServerDB).mockResolvedValue(dbStub as any);
 

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -37,6 +37,14 @@ vi.mock('@/database/models/userMemory', async (importOriginal) => {
 
 const embeddingsMock = vi.fn();
 const mockCtx = { authorizationHeader: 'Bearer mock-token', userId: 'test-user' };
+const makeServerDBMock = (query: Record<string, any> = {}) => ({
+  query: {
+    userSettings: {
+      findFirst: vi.fn().mockResolvedValue({ memory: null }),
+    },
+    ...query,
+  },
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -88,28 +96,26 @@ describe('memoryRouter.reEmbedMemories', () => {
       { feedback: 'feedback text', id: 'activity-1', narrative: 'narrative text' },
     ];
 
-    const dbStub = {
-      query: {
-        userMemories: {
-          findMany: vi.fn().mockResolvedValue(userMemoriesRows),
-        },
-        userMemoriesContexts: {
-          findMany: vi.fn().mockResolvedValue(contextsRows),
-        },
-        userMemoriesExperiences: {
-          findMany: vi.fn().mockResolvedValue(experiencesRows),
-        },
-        userMemoriesIdentities: {
-          findMany: vi.fn().mockResolvedValue(identitiesRows),
-        },
-        userMemoriesPreferences: {
-          findMany: vi.fn().mockResolvedValue(preferencesRows),
-        },
-        userMemoriesActivities: {
-          findMany: vi.fn().mockResolvedValue(activitiesRows),
-        },
+    const dbStub = makeServerDBMock({
+      userMemories: {
+        findMany: vi.fn().mockResolvedValue(userMemoriesRows),
       },
-    } as const;
+      userMemoriesContexts: {
+        findMany: vi.fn().mockResolvedValue(contextsRows),
+      },
+      userMemoriesExperiences: {
+        findMany: vi.fn().mockResolvedValue(experiencesRows),
+      },
+      userMemoriesIdentities: {
+        findMany: vi.fn().mockResolvedValue(identitiesRows),
+      },
+      userMemoriesPreferences: {
+        findMany: vi.fn().mockResolvedValue(preferencesRows),
+      },
+      userMemoriesActivities: {
+        findMany: vi.fn().mockResolvedValue(activitiesRows),
+      },
+    }) as const;
 
     vi.mocked(getServerDB).mockResolvedValue(dbStub as any);
 
@@ -169,9 +175,7 @@ describe('userMemories.queryMemories', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
@@ -217,9 +221,7 @@ describe('userMemories.queryMemories', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
@@ -242,9 +244,7 @@ describe('userMemories.getMemoryDetail', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
@@ -270,9 +270,7 @@ describe('userMemories.getMemoryDetail', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
@@ -350,9 +348,7 @@ describe('userMemories.retrieveMemory', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 
@@ -365,7 +361,7 @@ describe('userMemories.retrieveMemory', () => {
     expect(searchWithEmbedding.mock.calls[0][0]).toBeTypeOf('object');
     expect(searchWithEmbedding.mock.calls[0][0]).toStrictEqual({
       embedding: [1],
-      limits: { activities: 1, contexts: 1, experiences: 1, preferences: 1 },
+      limits: { activities: 1, contexts: 0, experiences: 0, preferences: 1 },
     });
 
     expect(result.contexts[0]).toMatchObject({
@@ -398,9 +394,7 @@ describe('userMemories.toolAddActivityMemory', () => {
         }) as any,
     );
 
-    vi.mocked(getServerDB).mockResolvedValue({
-      query: {},
-    } as any);
+    vi.mocked(getServerDB).mockResolvedValue(makeServerDBMock() as any);
 
     const caller = userMemoriesRouter.createCaller(mockCtx as any);
 

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_SEARCH_USER_MEMORY_TOP_K,
   DEFAULT_USER_MEMORY_EMBEDDING_DIMENSIONS,
   DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM,
+  MEMORY_SEARCH_TOP_K_LIMITS,
 } from '@lobechat/const';
 import { type LobeChatDatabase } from '@lobechat/database';
 import {
@@ -39,6 +40,7 @@ import {
   userMemoriesExperiences,
   userMemoriesIdentities,
   userMemoriesPreferences,
+  userSettings,
 } from '@/database/schemas';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
@@ -54,6 +56,7 @@ const EMPTY_SEARCH_RESULT: SearchMemoryResult = {
 
 type MemorySearchContext = {
   memoryModel: UserMemoryModel;
+  memoryEffort: MemoryEffort;
   serverDB: LobeChatDatabase;
   userId: string;
 };
@@ -134,6 +137,27 @@ const mapMemorySearchResult = (layeredResults: MemorySearchResult): SearchMemory
   } satisfies SearchMemoryResult;
 };
 
+type MemoryEffort = 'high' | 'low' | 'medium';
+
+const normalizeMemoryEffort = (value: unknown): MemoryEffort => {
+  if (value === 'low' || value === 'medium' || value === 'high') return value;
+  return 'medium';
+};
+
+const applySearchLimitsByEffort = (
+  effort: MemoryEffort,
+  requested: { activities: number; contexts: number; experiences: number; preferences: number },
+) => {
+  const limit = MEMORY_SEARCH_TOP_K_LIMITS[effort];
+
+  return {
+    activities: Math.min(requested.activities, limit.activities),
+    contexts: Math.min(requested.contexts, limit.contexts),
+    experiences: Math.min(requested.experiences, limit.experiences),
+    preferences: Math.min(requested.preferences, limit.preferences),
+  };
+};
+
 const searchUserMemories = async (
   ctx: MemorySearchContext,
   input: z.infer<typeof searchMemorySchema>,
@@ -156,9 +180,11 @@ const searchUserMemories = async (
     preferences: input.topK?.preferences ?? DEFAULT_SEARCH_USER_MEMORY_TOP_K.preferences,
   };
 
+  const effortConstrainedLimits = applySearchLimitsByEffort(ctx.memoryEffort, limits);
+
   const layeredResults = await ctx.memoryModel.searchWithEmbedding({
     embedding: queryEmbeddings?.[0],
-    limits,
+    limits: effortConstrainedLimits,
   });
 
   return mapMemorySearchResult(layeredResults);
@@ -233,12 +259,23 @@ const normalizeEmbeddable = (value?: string | null): string | undefined => {
 
 const memoryProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
+  const userSettingsRow = await ctx.serverDB.query.userSettings.findFirst({
+    columns: { memory: true },
+    where: eq(userSettings.id, ctx.userId),
+  });
+  const memoryConfig =
+    typeof userSettingsRow?.memory === 'object' && userSettingsRow?.memory !== null
+      ? (userSettingsRow.memory as { effort?: unknown })
+      : undefined;
+  const memoryEffort = normalizeMemoryEffort(memoryConfig?.effort);
+
   return opts.next({
     ctx: {
       activityModel: new UserMemoryActivityModel(ctx.serverDB, ctx.userId),
       experienceModel: new UserMemoryExperienceModel(ctx.serverDB, ctx.userId),
       identityModel: new UserMemoryIdentityModel(ctx.serverDB, ctx.userId),
       memoryModel: new UserMemoryModel(ctx.serverDB, ctx.userId),
+      memoryEffort,
     },
   });
 });

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -173,14 +173,17 @@ const searchUserMemories = async (
     model: embeddingModel,
   });
 
-  const limits = {
-    activities: input.topK?.activities ?? DEFAULT_SEARCH_USER_MEMORY_TOP_K.activities,
-    contexts: input.topK?.contexts ?? DEFAULT_SEARCH_USER_MEMORY_TOP_K.contexts,
-    experiences: input.topK?.experiences ?? DEFAULT_SEARCH_USER_MEMORY_TOP_K.experiences,
-    preferences: input.topK?.preferences ?? DEFAULT_SEARCH_USER_MEMORY_TOP_K.preferences,
+  const effectiveEffort = normalizeMemoryEffort(input.effort ?? ctx.memoryEffort);
+  const effortDefaults = MEMORY_SEARCH_TOP_K_LIMITS[effectiveEffort];
+
+  const requestedLimits = {
+    activities: input.topK?.activities ?? effortDefaults.activities,
+    contexts: input.topK?.contexts ?? effortDefaults.contexts,
+    experiences: input.topK?.experiences ?? effortDefaults.experiences,
+    preferences: input.topK?.preferences ?? effortDefaults.preferences,
   };
 
-  const effortConstrainedLimits = applySearchLimitsByEffort(ctx.memoryEffort, limits);
+  const effortConstrainedLimits = applySearchLimitsByEffort(effectiveEffort, requestedLimits);
 
   const layeredResults = await ctx.memoryModel.searchWithEmbedding({
     embedding: queryEmbeddings?.[0],

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -957,14 +957,17 @@ export const userMemoriesRouter = router({
       }
     }),
 
-  searchMemory: memoryProcedure.input(searchMemorySchema).query(async ({ input, ctx }) => {
-    try {
-      return await searchUserMemories(ctx, input);
-    } catch (error) {
-      console.error('Failed to retrieve memories:', error);
-      return EMPTY_SEARCH_RESULT;
+  searchMemory: memoryProcedure
+    .input(searchMemorySchema)
+    .query(async ({ input, ctx }) => {
+      try {
+        return await searchUserMemories(ctx, input);
+      } catch (error) {
+        console.error('Failed to retrieve memories:', error);
+        return EMPTY_SEARCH_RESULT;
+      }
     }
-  }),
+  ),
 
   toolAddActivityMemory: memoryProcedure
     .input(ActivityMemoryItemSchema)

--- a/src/server/routers/lambda/userMemory.ts
+++ b/src/server/routers/lambda/userMemory.ts
@@ -6,29 +6,27 @@ import {
   CreateUserMemoryIdentitySchema,
   MemorySourceType,
   UpdateUserMemoryIdentitySchema,
-  UserMemoryExtractionMetadata,
+  type UserMemoryExtractionMetadata,
 } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { AsyncTaskModel, initUserMemoryExtractionMetadata } from '@/database/models/asyncTask';
 import { TopicModel } from '@/database/models/topic';
-import { UserMemoryModel } from '@/database/models/userMemory';
-import {
-  UserMemoryActivityModel,
+import {   UserMemoryActivityModel,
   UserMemoryContextModel,
   UserMemoryExperienceModel,
   UserMemoryIdentityModel,
-  UserMemoryPreferenceModel,
-} from '@/database/models/userMemory/index';
+UserMemoryModel,
+  UserMemoryPreferenceModel } from '@/database/models/userMemory';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { appEnv } from '@/envs/app';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 import {
-  MemoryExtractionWorkflowService,
   buildWorkflowPayloadInput,
+  MemoryExtractionWorkflowService,
   normalizeMemoryExtractionPayload,
 } from '@/server/services/memory/userMemory/extract';
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -142,6 +142,9 @@ class ChatService {
     // =================== 1.1 process user memories =================== //
 
     const enableUserMemories = settingsSelectors.memoryEnabled(getUserStoreState());
+    const userMemorySettings = settingsSelectors.currentMemorySettings(getUserStoreState());
+    const effectiveMemoryEffort =
+      chatConfig.memory?.effort ?? userMemorySettings.effort ?? 'medium';
 
     // =================== 1.2 build agent builder context =================== //
 
@@ -254,6 +257,9 @@ class ChatService {
       systemRole: agentConfig.systemRole,
       tools: enabledToolIds,
       topicId,
+      memoryContext: {
+        effort: effectiveMemoryEffort,
+      },
     });
 
     // ============  3. process extend params   ============ //

--- a/src/store/user/slices/settings/action.ts
+++ b/src/store/user/slices/settings/action.ts
@@ -88,14 +88,17 @@ export class UserSettingsActionImpl {
     if (isEqual(prevSetting, nextSettings)) return;
 
     const diffs = difference(nextSettings, defaultSettings);
+    const isEmptyObjectDiff = (value: unknown): boolean =>
+      !!value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value as object).length === 0;
 
     // When user resets a field to default value, we need to explicitly include it in diffs
     // to override the previously saved non-default value in the backend
     const changedFields = difference(nextSettings, prevSetting);
     for (const key of Object.keys(changedFields)) {
       // Only handle fields that were previously set by user (exist in prevSetting)
-      if (key in prevSetting && !(key in diffs)) {
-        (diffs as any)[key] = (nextSettings as any)[key];
+      const keyDiff = (diffs as any)[key];
+      if (key in prevSetting && (!(key in diffs) || isEmptyObjectDiff(keyDiff))) {
+        (diffs as any)[key] = (changedFields as any)[key];
       }
     }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add configurable memory effort and tool permissions to chat and user memory flows, wiring them through settings, context engineering, and the builtin memory tool.

Enhancements:
- Introduce shared agent memory chat config and schema to support per-chat memory effort and permissions.
- Propagate user memory effort from user settings and chat config into memory searching, constraining search limits based on effort levels.
- Expose memory context (including effort) to the context engine and builtin memory tool system prompt for more adaptive memory behavior.
- Make the builtin memory tool respect a per-chat read-only/read-write permission when performing write operations.
- Extend default user memory settings to include a medium effort level and define centralized search limit presets by effort tier.