### PR TITLE
🐛 fix: hotfix v2.1.29

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -41,19 +41,28 @@ jobs:
             echo "⏭️ Not a release PR"
           fi
 
-      - name: Detect hotfix PR (branch prefix)
+      - name: Detect hotfix PR (branch prefix + commit prefix gate)
         id: hotfix
         if: steps.release.outputs.should_tag != 'true'
         run: |
           HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Head ref: $HEAD_REF"
+          echo "PR Title: $PR_TITLE"
 
-          if [[ "$HEAD_REF" == hotfix/* ]]; then
-            echo "should_tag=true" >> $GITHUB_OUTPUT
-            echo "✅ Detected hotfix PR"
-          else
+          if [[ "$HEAD_REF" != hotfix/* ]]; then
             echo "should_tag=false" >> $GITHUB_OUTPUT
             echo "⏭️ Not a hotfix PR"
+            exit 0
+          fi
+
+          # Gate: PR title must match style/feat/fix/refactor prefix (with optional gitmoji)
+          if echo "$PR_TITLE" | grep -qiE '^(💄\s*)?style(\(.+\))?:|^(✨\s*)?feat(\(.+\))?:|^(🐛\s*)?fix(\(.+\))?:|^(♻️\s*)?refactor(\(.+\))?:'; then
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+            echo "✅ Detected hotfix PR with valid commit prefix"
+          else
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Hotfix PR but title does not match style/feat/fix/refactor prefix, skipping tag"
           fi
 
       - name: Prepare main branch

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -41,7 +41,7 @@ jobs:
             echo "⏭️ Not a release PR"
           fi
 
-      - name: Detect hotfix PR (branch prefix + commit prefix gate)
+      - name: Detect hotfix PR (branch first, title fallback)
         id: hotfix
         if: steps.release.outputs.should_tag != 'true'
         run: |
@@ -50,19 +50,20 @@ jobs:
           echo "Head ref: $HEAD_REF"
           echo "PR Title: $PR_TITLE"
 
-          if [[ "$HEAD_REF" != hotfix/* ]]; then
-            echo "should_tag=false" >> $GITHUB_OUTPUT
-            echo "⏭️ Not a hotfix PR"
+          # Priority 1: hotfix/* branch always counts as hotfix, ignore PR title gate.
+          if [[ "$HEAD_REF" == hotfix/* ]]; then
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+            echo "✅ Detected hotfix PR from hotfix/* branch (title gate bypassed)"
             exit 0
           fi
 
-          # Gate: PR title must match style/feat/fix/refactor prefix (with optional gitmoji)
-          if echo "$PR_TITLE" | grep -qiE '^(💄\s*)?style(\(.+\))?:|^(✨\s*)?feat(\(.+\))?:|^(🐛\s*)?fix(\(.+\))?:|^(♻️\s*)?refactor(\(.+\))?:'; then
+          # Priority 2: fallback to PR title prefix gate (legacy behavior).
+          if echo "$PR_TITLE" | grep -qiE '^(💄[[:space:]]*)?style(\(.+\))?:|^(✨[[:space:]]*)?feat(\(.+\))?:|^(🐛[[:space:]]*)?fix(\(.+\))?:|^(♻️[[:space:]]*)?refactor(\(.+\))?:|^((🐛|🩹)[[:space:]]*)?hotfix(\(.+\))?:'; then
             echo "should_tag=true" >> $GITHUB_OUTPUT
-            echo "✅ Detected hotfix PR with valid commit prefix"
+            echo "✅ Detected hotfix PR from title prefix gate"
           else
             echo "should_tag=false" >> $GITHUB_OUTPUT
-            echo "⏭️ Hotfix PR but title does not match style/feat/fix/refactor prefix, skipping tag"
+            echo "⏭️ Not a hotfix PR (neither hotfix/* branch nor style/feat/fix/refactor/hotfix title prefix)"
           fi
 
       - name: Prepare main branch

--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -23,24 +23,84 @@ jobs:
           git config --global user.name 'lobehubbot'
           git config --global user.email 'i@lobehub.com'
 
-      - name: Prepare sync branch
-        id: branch
-        run: |
-          echo "SYNC_BRANCH_MAIN_CANARY=sync/main-to-canary-$(date +'%Y%m%d')" >> $GITHUB_ENV
-
       - name: Sync main to canary
         if: github.ref == 'refs/heads/main'
         run: |
-          # Sync main to canary
-          git checkout main
-          SYNC_BRANCH_CANARY=${{ env.SYNC_BRANCH_MAIN_CANARY }}
-          git checkout -B $SYNC_BRANCH_CANARY
-          DIFF=$(git diff origin/canary...)
-          if [ -z "$DIFF" ]; then
-            echo "No changes to sync"
-            exit 0
+          # Find existing open sync PR by head branch prefix
+          EXISTING_PR=$(gh pr list --base canary --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("sync/main-to-canary-"))][0] // empty')
+          EXISTING_PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number // empty' 2>/dev/null)
+          EXISTING_BRANCH=$(echo "$EXISTING_PR" | jq -r '.headRefName // empty' 2>/dev/null)
+
+          git checkout canary
+          git pull origin canary
+
+          # Try merge, detect conflicts
+          if git merge origin/main --no-edit; then
+            # No conflicts, check if there are actual changes
+            if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/canary)" ]; then
+              echo "No changes to sync"
+              exit 0
+            fi
+            echo "Merge succeeded, pushing directly"
+            if git push origin canary; then
+              # Close stale sync PR if direct push succeeded
+              if [ -n "$EXISTING_PR_NUMBER" ]; then
+                gh pr close "$EXISTING_PR_NUMBER" --comment "Superseded by direct push." --delete-branch || true
+              fi
+              exit 0
+            fi
+
+            # Direct push failed (e.g. non-fast-forward race), fall back to PR
+            echo "Direct push failed, falling back to PR"
+            SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')-${GITHUB_RUN_ID}"
+            git checkout -B "$SYNC_BRANCH"
+            git push origin "$SYNC_BRANCH" -f
+            gh pr create \
+              --base canary \
+              --head "$SYNC_BRANCH" \
+              --title "Sync main branch to canary branch" \
+              --body "Automatic sync from main to canary. Direct push failed, please merge this PR." || true
+          else
+            echo "Merge conflicts detected, creating PR"
+            git merge --abort
+
+            if [ -n "$EXISTING_PR_NUMBER" ]; then
+              # Existing conflict PR open — notify via comment, don't overwrite manual work
+              gh pr comment "$EXISTING_PR_NUMBER" --body "New commits on \`main\`. Please pull latest \`origin/main\` into this branch to include them."
+              echo "Commented on existing PR #$EXISTING_PR_NUMBER"
+            else
+              SYNC_BRANCH="sync/main-to-canary-$(date +'%Y%m%d')-${GITHUB_RUN_ID}"
+              git checkout -B "$SYNC_BRANCH" origin/canary
+              # Attempt merge main, commit conflict markers if unresolved
+              if ! git merge origin/main --no-edit; then
+                git add -A
+                git commit --no-edit -m "chore: merge main into canary (has conflicts to resolve)"
+              fi
+              git push origin "$SYNC_BRANCH" -f
+
+              printf '%s\n' \
+                'Automatic sync from main to canary. Merge conflicts detected.' \
+                '' \
+                '**Resolution steps:**' \
+                '```bash' \
+                'git fetch origin' \
+                "git checkout $SYNC_BRANCH" \
+                'git merge origin/main' \
+                '# Resolve conflicts' \
+                'git add -A && git commit' \
+                'git push' \
+                '```' \
+                '' \
+                '> Do NOT merge canary into a main-based branch — always merge main INTO the canary-based branch to keep a clean commit graph.' \
+                > /tmp/pr-body.md
+
+              gh pr create \
+                --base canary \
+                --head "$SYNC_BRANCH" \
+                --title "Sync main branch to canary branch" \
+                --body-file /tmp/pr-body.md
+            fi
           fi
-          git push origin $SYNC_BRANCH_CANARY -f
-          gh pr create --base canary --head $SYNC_BRANCH_CANARY --title "Sync main branch to canary branch" --body "Automatic sync" || exit 0
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "@lobehub/icons": "^4.1.0",
     "@lobehub/market-sdk": "0.29.2",
     "@lobehub/tts": "^4.0.2",
-    "@lobehub/ui": "^4.36.2",
+    "@lobehub/ui": "^4.36.3",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",


### PR DESCRIPTION
## 🩹 Hotfix v2.1.29

This PR starts a hotfix release from `main`.

### Release Process
1. ✅ Hotfix branch created from main
2. ✅ Pushed to remote
3. 🔄 Waiting for PR review and merge
4. ⏳ Auto tag + GitHub Release will be created after merge

---
Created by hotfix script

## Summary by Sourcery

Improve main-to-canary sync workflow robustness and tighten hotfix auto-tagging criteria for release automation.

Enhancements:
- Make the main-to-canary sync workflow attempt direct merges to canary, falling back to PR creation only when necessary or when conflicts occur, and handle existing sync PRs more gracefully.
- Refine hotfix detection in the auto-tag workflow by requiring both a hotfix branch prefix and a valid conventional commit-style PR title prefix before tagging.
- Update the @lobehub/ui dependency to the latest patch version.

Build:
- Adjust release auto-tag workflow logic to gate hotfix tagging by both branch naming and PR title format.

CI:
- Enhance GitHub Actions workflow for syncing main to canary with conflict handling, direct-push optimization, and automated PR management.