### PR TITLE
🐛 fix: slove the execAgent task run error & parse crash problem

### DIFF
--- a/packages/builtin-tool-group-management/src/systemRole.ts
+++ b/packages/builtin-tool-group-management/src/systemRole.ts
@@ -324,6 +324,19 @@ Action:
 - executeAgentTask: \`agentId\`, \`title\` (brief UI label), \`task\` (detailed instructions with expected deliverables), \`timeout\` (optional, default 30min)
 - executeAgentTasks: \`tasks\` (array of {agentId, title, task, timeout?}), \`skipCallSupervisor\` (optional)
 
+**⚠️ CRITICAL: JSON Array Format for executeAgentTasks**
+The \`tasks\` parameter MUST be a proper JSON array, NOT a stringified JSON string.
+
+✅ Correct format:
+\`\`\`json
+{"tasks": [{"agentId": "xxx", "title": "...", "instruction": "..."}]}
+\`\`\`
+
+❌ Wrong format (DO NOT stringify the array):
+\`\`\`json
+{"tasks": "[{\\"agentId\\": \\"xxx\\", ...}]"}
+\`\`\`
+
 **Flow Control:**
 - vote: \`question\`, \`options\` (array of {id, label, description}), \`voterAgentIds\` (optional), \`requireReasoning\` (default true)
 </tool_usage_guidelines>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Handle flexible task input formats for executeAgentTasks and clarify expected JSON array format in system role guidelines.

Bug Fixes:
- Gracefully handle executeAgentTasks inputs where tasks are returned as stringified JSON instead of an array to prevent runtime errors when computing agent IDs.

Documentation:
- Document the required JSON array format for the executeAgentTasks tasks parameter and explicitly warn against passing a stringified JSON array.