### PR TITLE
🐛 fix: resolve tooltip z-index stacking context in ModelSwitchPanel

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/index.tsx
+++ b/src/features/ModelSwitchPanel/components/List/index.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, TooltipGroup } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
 import { type FC, type ReactNode } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -88,15 +88,13 @@ export const List: FC<ListProps> = ({
         height: listHeight,
       }}
     >
-      <TooltipGroup>
-        <Virtuoso
-          isScrolling={handleScrollingStateChange}
-          itemContent={itemContent}
-          overscan={200}
-          style={{ height: listHeight }}
-          totalCount={listItems.length}
-        />
-      </TooltipGroup>
+      <Virtuoso
+        isScrolling={handleScrollingStateChange}
+        itemContent={itemContent}
+        overscan={200}
+        style={{ height: listHeight }}
+        totalCount={listItems.length}
+      />
     </Flexbox>
   );
 };

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuPositioner,
   DropdownMenuRoot,
   DropdownMenuTrigger,
+  TooltipGroup,
 } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 
@@ -35,22 +36,24 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
     );
 
     return (
-      <DropdownMenuRoot open={isOpen} onOpenChange={handleOpenChange}>
-        <DropdownMenuTrigger openOnHover={openOnHover}>{children}</DropdownMenuTrigger>
-        <DropdownMenuPortal>
-          <DropdownMenuPositioner hoverTrigger={openOnHover} placement={placement}>
-            <DropdownMenuPopup className={styles.container}>
-              <PanelContent
-                extraControls={extraControls}
-                model={modelProp}
-                provider={providerProp}
-                onModelChange={onModelChange}
-                onOpenChange={handleOpenChange}
-              />
-            </DropdownMenuPopup>
-          </DropdownMenuPositioner>
-        </DropdownMenuPortal>
-      </DropdownMenuRoot>
+      <TooltipGroup>
+        <DropdownMenuRoot open={isOpen} onOpenChange={handleOpenChange}>
+          <DropdownMenuTrigger openOnHover={openOnHover}>{children}</DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner hoverTrigger={openOnHover} placement={placement}>
+              <DropdownMenuPopup className={styles.container}>
+                <PanelContent
+                  extraControls={extraControls}
+                  model={modelProp}
+                  provider={providerProp}
+                  onModelChange={onModelChange}
+                  onOpenChange={handleOpenChange}
+                />
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenuRoot>
+      </TooltipGroup>
     );
   },
 );


### PR DESCRIPTION
## Summary
- Move `TooltipGroup` from inside `List` (wrapping `Virtuoso`) to the `ModelSwitchPanel` root level
- Fixes tooltip z-index stacking context issue where tooltips were rendered behind the dropdown panel

## Test plan
- [x] Open model switch panel and hover over model items to verify tooltips display correctly above the panel
- [x] Verify tooltip grouping behavior (delay sharing) still works as expected

## Summary by Sourcery

Wrap the model switch dropdown in a top-level tooltip group to correct tooltip stacking behavior.

Bug Fixes:
- Ensure model item tooltips render above the model switch dropdown panel by moving the tooltip grouping context to the panel root.

Enhancements:
- Maintain shared tooltip delay behavior for all tooltips within the model switch panel by centralizing the tooltip group at the panel level.