### PR TITLE
🐛 fix(tool-ui): fix icon margin and text overflow in FilePathDisplay

### DIFF
--- a/packages/builtin-tool-local-system/src/client/Inspector/ListLocalFiles/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Inspector/ListLocalFiles/index.tsx
@@ -2,7 +2,7 @@
 
 import type { ListLocalFileParams } from '@lobechat/electron-client-ipc';
 import type { BuiltinInspectorProps } from '@lobechat/types';
-import { Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import { cssVar, cx } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -43,7 +43,9 @@ export const ListLocalFilesInspector = memo<
   return (
     <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
       <span>{t('builtins.lobe-local-system.apiName.listLocalFiles')}: </span>
-      <FilePathDisplay isDirectory filePath={path} />
+      <Flexbox allowShrink horizontal align={'center'} justify={'center'}>
+        <FilePathDisplay isDirectory filePath={path} />
+      </Flexbox>
       {!isLoading &&
         pluginState?.listResults &&
         (hasResults ? (

--- a/packages/builtin-tool-local-system/src/client/components/FilePathDisplay.tsx
+++ b/packages/builtin-tool-local-system/src/client/components/FilePathDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MaterialFileTypeIcon } from '@lobehub/ui';
+import { MaterialFileTypeIcon, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import path from 'path-browserify-esm';
 import { memo, useMemo } from 'react';
@@ -11,7 +11,10 @@ const styles = createStaticStyles(({ css }) => ({
     margin-inline-end: 4px;
   `,
   text: css`
+    overflow: hidden;
     color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
   `,
 }));
 
@@ -42,13 +45,23 @@ export const FilePathDisplay = memo<FilePathDisplayProps>(({ filePath, isDirecto
       {name && (
         <MaterialFileTypeIcon
           className={styles.icon}
+          fallbackUnknownType={false}
           filename={name}
           size={16}
           type={isDirectory ? 'folder' : 'file'}
           variant={'raw'}
         />
       )}
-      {displayPath && <span className={styles.text}>{displayPath}</span>}
+      {displayPath && (
+        <Text
+          className={styles.text}
+          ellipsis={{
+            tooltipWhenOverflow: true,
+          }}
+        >
+          {displayPath}
+        </Text>
+      )}
     </>
   );
 });

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -48,8 +48,6 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
     justify-content: center;
 
-    border-radius: ${cssVar.borderRadiusLG};
-
     background: ${cssVar.colorBgMask};
 
     transition: all 0.2s ease-in-out;

--- a/src/styles/text.ts
+++ b/src/styles/text.ts
@@ -19,12 +19,14 @@ export const oneLineEllipsis = lineEllipsis(1);
 export const inspectorTextStyles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
+    display: flex;
+    align-items: center;
+
+    min-width: 0;
 
     color: ${cssVar.colorTextSecondary};
     text-overflow: ellipsis;
+    white-space: nowrap;
   `,
 }));
 


### PR DESCRIPTION
## Summary

- Fix missing icon margin in FilePathDisplay component
- Add text overflow ellipsis with tooltip for long file paths
- Switch inspector text styles from `-webkit-box` to flexbox for proper alignment

Fixes LOBE-2541

## Summary by Sourcery

Improve file path display and inspector text layout to handle long paths and align content correctly.

Bug Fixes:
- Prevent file type icons in FilePathDisplay from missing horizontal spacing and showing incorrect fallback icons.
- Ensure long file paths in FilePathDisplay are truncated with ellipsis and surfaced via tooltip instead of overflowing their container.
- Fix inspector text layout so content stays on a single line, truncates with ellipsis, and aligns vertically within flex containers.

Enhancements:
- Wrap the FilePathDisplay component in a flexible container within the ListLocalFiles inspector to allow proper shrinking and alignment of the path text.