### PR TITLE
✨ feat(nvidia): add new models and simplify payload handling for NVIDIA NIM

### DIFF
--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -1,6 +1,6 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 
-import type { AiFullModelCard, LobeDefaultAiModelListItem } from '../types/aiModel';
+import { type AiFullModelCard, type LobeDefaultAiModelListItem } from '../types/aiModel';
 import { default as ai21 } from './ai21';
 import { default as ai302 } from './ai302';
 import { default as ai360 } from './ai360';

--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -1,10 +1,9 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import { type AIChatModelCard } from '../types/aiModel';
 
 const nvidiaChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      reasoning: true,
     },
     contextWindowTokens: 128_000,
     description:
@@ -13,6 +12,87 @@ const nvidiaChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'minimaxai/minimax-m2',
     maxOutput: 16_384,
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.1 is a compact, fast, cost-effective MoE model built for top-tier coding and agent performance.',
+    displayName: 'MiniMax-M2.1',
+    enabled: true,
+    id: 'minimaxai/minimax-m2.1',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'DeepSeek V3.2 is a next-gen reasoning model with stronger complex reasoning and chain-of-thought capabilities.',
+    displayName: 'DeepSeek V3.2',
+    enabled: true,
+    id: 'deepseek-ai/deepseek-v3.2',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'GLM-4.7 is Zhipu latest flagship model, enhanced for Agentic Coding scenarios with improved coding capabilities.',
+    displayName: 'GLM-4.7',
+    enabled: true,
+    id: 'z-ai/glm4.7',
+    maxOutput: 131_072,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "GLM-5 is Zhipu AI's new flagship foundation model for agent engineering, achieving open-source SOTA performance in coding and agent capabilities. It matches Claude Opus 4.5 in performance.",
+    displayName: 'GLM-5',
+    enabled: true,
+    id: 'z-ai/glm5',
+    maxOutput: 131_072,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Kimi K2.5 is the most intelligent Kimi model to date, featuring native multimodal architecture.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'moonshotai/kimi-k2.5',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -4,6 +4,7 @@ const nvidiaChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
     },
     contextWindowTokens: 128_000,
     description:
@@ -17,6 +18,7 @@ const nvidiaChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
     },
     contextWindowTokens: 204_800,
     description:

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { ModelParamsSchema } from '../standard-parameters';
+import { type ModelParamsSchema } from '../standard-parameters';
 
 export type ModelPriceCurrency = 'CNY' | 'USD';
 

--- a/packages/model-runtime/src/providers/nvidia/index.test.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.test.ts
@@ -53,7 +53,7 @@ describe('LobeNvidiaAI - custom features', () => {
       });
     });
 
-    it('should add chat_template_kwargs with thinking undefined for thinking models without thinking type', () => {
+    it('should not add chat_template_kwargs when thinking type is not set', () => {
       const payload = {
         model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
@@ -65,15 +65,13 @@ describe('LobeNvidiaAI - custom features', () => {
       expect(result).toEqual({
         model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: undefined },
       });
     });
 
-    it('should not add chat_template_kwargs for non-thinking models', () => {
+    it('should not add chat_template_kwargs when thinking param is not provided', () => {
       const payload = {
         model: 'meta/llama-3.1-8b-instruct',
         messages: [{ role: 'user', content: 'test' }],
-        thinking: { type: 'enabled' as const },
       };
 
       const result = params.chatCompletion!.handlePayload!(payload as any);
@@ -81,6 +79,22 @@ describe('LobeNvidiaAI - custom features', () => {
       expect(result).toEqual({
         model: 'meta/llama-3.1-8b-instruct',
         messages: [{ role: 'user', content: 'test' }],
+      });
+    });
+
+    it('should add chat_template_kwargs for glm-5', () => {
+      const payload = {
+        model: 'z-ai/glm5',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result).toEqual({
+        model: 'z-ai/glm5',
+        messages: [{ role: 'user', content: 'test' }],
+        chat_template_kwargs: { thinking: true },
       });
     });
 
@@ -95,8 +109,107 @@ describe('LobeNvidiaAI - custom features', () => {
       expect(result).toEqual({
         model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: undefined },
       });
+    });
+
+    it('should add chat_template_kwargs for deepseek-v3.2', () => {
+      const payload = {
+        model: 'deepseek-ai/deepseek-v3.2',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result).toEqual({
+        model: 'deepseek-ai/deepseek-v3.2',
+        messages: [{ role: 'user', content: 'test' }],
+        chat_template_kwargs: { thinking: true },
+      });
+    });
+
+    it('should add chat_template_kwargs for glm-4.7', () => {
+      const payload = {
+        model: 'z-ai/glm4.7',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result).toEqual({
+        model: 'z-ai/glm4.7',
+        messages: [{ role: 'user', content: 'test' }],
+        chat_template_kwargs: { thinking: true },
+      });
+    });
+
+    it('should add chat_template_kwargs for kimi-k2.5', () => {
+      const payload = {
+        model: 'moonshotai/kimi-k2.5',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result).toEqual({
+        model: 'moonshotai/kimi-k2.5',
+        messages: [{ role: 'user', content: 'test' }],
+        chat_template_kwargs: { thinking: true },
+      });
+    });
+
+    it('should convert reasoning to reasoning_content for minimax-m2.1 (interleaved thinking)', () => {
+      const payload = {
+        model: 'minimaxai/minimax-m2.1',
+        messages: [
+          { role: 'user', content: 'test' },
+          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+        ],
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'test' },
+        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
+      ]);
+    });
+
+    it('should convert reasoning to reasoning_content for minimax-m2 (interleaved thinking)', () => {
+      const payload = {
+        model: 'minimaxai/minimax-m2',
+        messages: [
+          { role: 'user', content: 'test' },
+          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+        ],
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'test' },
+        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
+      ]);
+    });
+
+    it('should not convert reasoning for non-interleaved-thinking models', () => {
+      const payload = {
+        model: 'meta/llama-3.1-8b-instruct',
+        messages: [
+          { role: 'user', content: 'test' },
+          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+        ],
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      // reasoning field should remain unchanged for non-interleaved-thinking models
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'test' },
+        { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+      ]);
     });
 
     it('should preserve other payload properties', () => {

--- a/packages/model-runtime/src/providers/nvidia/index.test.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.test.ts
@@ -21,7 +21,8 @@ testProvider({
 
 describe('LobeNvidiaAI - custom features', () => {
   describe('handlePayload', () => {
-    it('should add chat_template_kwargs with thinking enabled for thinking models', () => {
+    // thinking parameter conversion
+    it('should add chat_template_kwargs with thinking: true when thinking.type is enabled', () => {
       const payload = {
         model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
@@ -37,9 +38,9 @@ describe('LobeNvidiaAI - custom features', () => {
       });
     });
 
-    it('should add chat_template_kwargs with thinking disabled for thinking models', () => {
+    it('should add chat_template_kwargs with thinking: false when thinking.type is disabled', () => {
       const payload = {
-        model: 'deepseek-ai/deepseek-v3.1-terminus',
+        model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
         thinking: { type: 'disabled' as const },
       };
@@ -47,7 +48,7 @@ describe('LobeNvidiaAI - custom features', () => {
       const result = params.chatCompletion!.handlePayload!(payload as any);
 
       expect(result).toEqual({
-        model: 'deepseek-ai/deepseek-v3.1-terminus',
+        model: 'deepseek-ai/deepseek-v3.1',
         messages: [{ role: 'user', content: 'test' }],
         chat_template_kwargs: { thinking: false },
       });
@@ -82,119 +83,8 @@ describe('LobeNvidiaAI - custom features', () => {
       });
     });
 
-    it('should add chat_template_kwargs for glm-5', () => {
-      const payload = {
-        model: 'z-ai/glm5',
-        messages: [{ role: 'user', content: 'test' }],
-        thinking: { type: 'enabled' as const },
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result).toEqual({
-        model: 'z-ai/glm5',
-        messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: true },
-      });
-    });
-
-    it('should handle payload without thinking parameter', () => {
-      const payload = {
-        model: 'deepseek-ai/deepseek-v3.1',
-        messages: [{ role: 'user', content: 'test' }],
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result).toEqual({
-        model: 'deepseek-ai/deepseek-v3.1',
-        messages: [{ role: 'user', content: 'test' }],
-      });
-    });
-
-    it('should add chat_template_kwargs for deepseek-v3.2', () => {
-      const payload = {
-        model: 'deepseek-ai/deepseek-v3.2',
-        messages: [{ role: 'user', content: 'test' }],
-        thinking: { type: 'enabled' as const },
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result).toEqual({
-        model: 'deepseek-ai/deepseek-v3.2',
-        messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: true },
-      });
-    });
-
-    it('should add chat_template_kwargs for glm-4.7', () => {
-      const payload = {
-        model: 'z-ai/glm4.7',
-        messages: [{ role: 'user', content: 'test' }],
-        thinking: { type: 'enabled' as const },
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result).toEqual({
-        model: 'z-ai/glm4.7',
-        messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: true },
-      });
-    });
-
-    it('should add chat_template_kwargs for kimi-k2.5', () => {
-      const payload = {
-        model: 'moonshotai/kimi-k2.5',
-        messages: [{ role: 'user', content: 'test' }],
-        thinking: { type: 'enabled' as const },
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result).toEqual({
-        model: 'moonshotai/kimi-k2.5',
-        messages: [{ role: 'user', content: 'test' }],
-        chat_template_kwargs: { thinking: true },
-      });
-    });
-
-    it('should convert reasoning to reasoning_content for minimax-m2.1 (interleaved thinking)', () => {
-      const payload = {
-        model: 'minimaxai/minimax-m2.1',
-        messages: [
-          { role: 'user', content: 'test' },
-          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
-        ],
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result.messages).toEqual([
-        { role: 'user', content: 'test' },
-        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
-      ]);
-    });
-
-    it('should convert reasoning to reasoning_content for minimax-m2 (interleaved thinking)', () => {
-      const payload = {
-        model: 'minimaxai/minimax-m2',
-        messages: [
-          { role: 'user', content: 'test' },
-          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
-        ],
-      };
-
-      const result = params.chatCompletion!.handlePayload!(payload as any);
-
-      expect(result.messages).toEqual([
-        { role: 'user', content: 'test' },
-        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
-      ]);
-    });
-
-    it('should not convert reasoning for non-interleaved-thinking models', () => {
+    // reasoning -> reasoning_content conversion
+    it('should convert reasoning to reasoning_content for all NVIDIA models', () => {
       const payload = {
         model: 'meta/llama-3.1-8b-instruct',
         messages: [
@@ -205,11 +95,29 @@ describe('LobeNvidiaAI - custom features', () => {
 
       const result = params.chatCompletion!.handlePayload!(payload as any);
 
-      // reasoning field should remain unchanged for non-interleaved-thinking models
       expect(result.messages).toEqual([
         { role: 'user', content: 'test' },
-        { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
       ]);
+    });
+
+    it('should convert reasoning to reasoning_content combined with thinking param', () => {
+      const payload = {
+        model: 'z-ai/glm5',
+        messages: [
+          { role: 'user', content: 'test' },
+          { role: 'assistant', reasoning: { content: 'thinking process' }, content: 'response' },
+        ],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'test' },
+        { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
+      ]);
+      expect(result.chat_template_kwargs).toEqual({ thinking: true });
     });
 
     it('should preserve other payload properties', () => {

--- a/packages/model-runtime/src/providers/nvidia/index.test.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.test.ts
@@ -83,6 +83,45 @@ describe('LobeNvidiaAI - custom features', () => {
       });
     });
 
+    it('should use enable_thinking and clear_thinking for GLM models when enabled', () => {
+      const payload = {
+        model: 'z-ai/glm5',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.chat_template_kwargs).toEqual({ enable_thinking: true, clear_thinking: false });
+    });
+
+    it('should use enable_thinking and clear_thinking for GLM models when disabled', () => {
+      const payload = {
+        model: 'z-ai/glm5',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'disabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.chat_template_kwargs).toEqual({
+        enable_thinking: false,
+        clear_thinking: false,
+      });
+    });
+
+    it('should use thinking for non-GLM models', () => {
+      const payload = {
+        model: 'deepseek-ai/deepseek-v3.2',
+        messages: [{ role: 'user', content: 'test' }],
+        thinking: { type: 'enabled' as const },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.chat_template_kwargs).toEqual({ thinking: true });
+    });
+
     // reasoning -> reasoning_content conversion
     it('should convert reasoning to reasoning_content for all NVIDIA models', () => {
       const payload = {
@@ -117,7 +156,8 @@ describe('LobeNvidiaAI - custom features', () => {
         { role: 'user', content: 'test' },
         { role: 'assistant', content: 'response', reasoning_content: 'thinking process' },
       ]);
-      expect(result.chat_template_kwargs).toEqual({ thinking: true });
+      // GLM models use enable_thinking + clear_thinking
+      expect(result.chat_template_kwargs).toEqual({ enable_thinking: true, clear_thinking: false });
     });
 
     it('should preserve other payload properties', () => {

--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -4,18 +4,6 @@ import { type OpenAICompatibleFactoryOptions } from '../../core/openaiCompatible
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { processMultiProviderModelList } from '../../utils/modelParse';
 
-// Models that support interleaved thinking format (reasoning -> reasoning_content)
-const INTERLEAVED_THINKING_MODELS = new Set([
-  'deepseek-ai/deepseek-v3.1',
-  'deepseek-ai/deepseek-v3.1-terminus',
-  'deepseek-ai/deepseek-v3.2',
-  'z-ai/glm4.7',
-  'z-ai/glm5',
-  'moonshotai/kimi-k2.5',
-  'minimaxai/minimax-m2',
-  'minimaxai/minimax-m2.1',
-]);
-
 export interface NvidiaModelCard {
   id: string;
 }
@@ -26,30 +14,28 @@ export const params = {
     handlePayload: (payload) => {
       const { model, thinking, messages, ...rest } = payload;
 
+      // Convert reasoning to reasoning_content for NVIDIA API format
+      // NVIDIA NIM requires reasoning_content instead of reasoning for all models
+      const processedMessages = messages?.map((message: any) => {
+        if (message.role === 'assistant' && message.reasoning?.content) {
+          const { reasoning, ...restMessage } = message;
+          return {
+            ...restMessage,
+            reasoning_content: reasoning.content,
+          };
+        }
+        return message;
+      });
+
       // Convert thinking.type to boolean for API
       const thinkingFlag =
         thinking?.type === 'enabled' ? true : thinking?.type === 'disabled' ? false : undefined;
 
-      // Process interleaved thinking - convert reasoning to reasoning_content
-      // Only for models that support interleaved thinking format
-      const processedMessages = INTERLEAVED_THINKING_MODELS.has(model)
-        ? messages?.map((message: any) => {
-            if (message.role === 'assistant' && message.reasoning?.content) {
-              const { reasoning, ...restMessage } = message;
-              return {
-                ...restMessage,
-                reasoning_content: reasoning.content,
-              };
-            }
-            return message;
-          })
-        : messages;
-
       return {
         ...rest,
         model,
-        ...(processedMessages ? { messages: processedMessages } : {}),
-        // Send chat_template_kwargs based on thinking parameter
+        messages: processedMessages,
+        // Send chat_template_kwargs when thinking is explicitly set
         ...(thinkingFlag !== undefined
           ? {
               chat_template_kwargs: { thinking: thinkingFlag },

--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -1,12 +1,19 @@
 import { ModelProvider } from 'model-bank';
 
-import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { type OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { processMultiProviderModelList } from '../../utils/modelParse';
 
-const THINKING_MODELS = new Set([
+// Models that support interleaved thinking format (reasoning -> reasoning_content)
+const INTERLEAVED_THINKING_MODELS = new Set([
   'deepseek-ai/deepseek-v3.1',
   'deepseek-ai/deepseek-v3.1-terminus',
+  'deepseek-ai/deepseek-v3.2',
+  'z-ai/glm4.7',
+  'z-ai/glm5',
+  'moonshotai/kimi-k2.5',
+  'minimaxai/minimax-m2',
+  'minimaxai/minimax-m2.1',
 ]);
 
 export interface NvidiaModelCard {
@@ -17,15 +24,33 @@ export const params = {
   baseURL: 'https://integrate.api.nvidia.com/v1',
   chatCompletion: {
     handlePayload: (payload) => {
-      const { model, thinking, ...rest } = payload;
+      const { model, thinking, messages, ...rest } = payload;
 
+      // Convert thinking.type to boolean for API
       const thinkingFlag =
         thinking?.type === 'enabled' ? true : thinking?.type === 'disabled' ? false : undefined;
+
+      // Process interleaved thinking - convert reasoning to reasoning_content
+      // Only for models that support interleaved thinking format
+      const processedMessages = INTERLEAVED_THINKING_MODELS.has(model)
+        ? messages?.map((message: any) => {
+            if (message.role === 'assistant' && message.reasoning?.content) {
+              const { reasoning, ...restMessage } = message;
+              return {
+                ...restMessage,
+                reasoning_content: reasoning.content,
+              };
+            }
+            return message;
+          })
+        : messages;
 
       return {
         ...rest,
         model,
-        ...(THINKING_MODELS.has(model)
+        ...(processedMessages ? { messages: processedMessages } : {}),
+        // Send chat_template_kwargs based on thinking parameter
+        ...(thinkingFlag !== undefined
           ? {
               chat_template_kwargs: { thinking: thinkingFlag },
             }

--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -4,6 +4,10 @@ import { type OpenAICompatibleFactoryOptions } from '../../core/openaiCompatible
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { processMultiProviderModelList } from '../../utils/modelParse';
 
+// Models that support preserved thinking (enable_thinking + clear_thinking parameters)
+// Ref: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking
+const supportPreservedThinkingModels = new Set(['z-ai/glm4.7', 'z-ai/glm5']);
+
 export interface NvidiaModelCard {
   id: string;
 }
@@ -31,15 +35,30 @@ export const params = {
       const thinkingFlag =
         thinking?.type === 'enabled' ? true : thinking?.type === 'disabled' ? false : undefined;
 
+      // Check if model uses preserved thinking (enable_thinking + clear_thinking)
+      const usePreservedThinking = model && supportPreservedThinkingModels.has(model);
+
+      const chatTemplateKwargs: Record<string, any> = {};
+
+      if (thinkingFlag !== undefined) {
+        if (usePreservedThinking) {
+          // Models with preserved thinking: use enable_thinking + clear_thinking
+          // set clear_thinking to false to preserve reasoning content across turns
+          chatTemplateKwargs.enable_thinking = thinkingFlag;
+          chatTemplateKwargs.clear_thinking = false;
+        } else {
+          // Other models: use thinking parameter
+          chatTemplateKwargs.thinking = thinkingFlag;
+        }
+      }
+
       return {
         ...rest,
         model,
         messages: processedMessages,
         // Send chat_template_kwargs when thinking is explicitly set
-        ...(thinkingFlag !== undefined
-          ? {
-              chat_template_kwargs: { thinking: thinkingFlag },
-            }
+        ...(Object.keys(chatTemplateKwargs).length > 0
+          ? { chat_template_kwargs: chatTemplateKwargs }
           : {}),
       } as any;
     },


### PR DESCRIPTION
Add new models to NVIDIA NIM provider and simplify payload handling logic.

   **New Models:**
   - MiniMax-M2.1, DeepSeek V3.2, GLM-4.7, GLM-5, Kimi K2.5

   **Payload Handling:**
   - Remove redundant model list filtering
   - Convert `reasoning` to `reasoning_content` (NVIDIA NIM API format requirement)
   - Convert `thinking.type` to `chat_template_kwargs.thinking` (API parameter format)
