### PR TITLE
🐛 fix: remove isDesktop guard from client fetch switch visibility

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
-import { AES_GCM_URL, BASE_PROVIDER_DOC_URL, FORM_STYLE, isDesktop } from '@lobechat/const';
+import { AES_GCM_URL, BASE_PROVIDER_DOC_URL, FORM_STYLE } from '@lobechat/const';
 import { ProviderCombine } from '@lobehub/icons';
 import { type FormGroupItemType, type FormItemProps } from '@lobehub/ui';
 import {
@@ -357,14 +357,12 @@ const ProviderConfig = memo<ProviderConfigProps>(
 
     /*
      * Conditions to show Client Fetch Switch
-     * 0. is not desktop app
      * 1. provider is not disabled browser request
      * 2. provider show browser request by default
      * 3. Provider allow to edit endpoint and the value of endpoint is not empty
      * 4. There is an apikey provided by user
      */
     const showClientFetch =
-      !isDesktop &&
       !disableBrowserRequest &&
       (defaultShowBrowserRequest ||
         (showEndpoint && isProviderEndpointNotEmpty) ||


### PR DESCRIPTION
## Summary
- Remove `!isDesktop` condition from `showClientFetch` in ProviderConfig, allowing desktop app users to see and toggle the "Fetch on Client" switch
- Server-side default values (lmstudio/ollama `fetchOnClient: false` on desktop) remain unchanged — only UI visibility is affected

## Test plan
- [x] Verify "Fetch on Client" switch appears in desktop app provider settings when conditions are met
- [x] Verify toggling the switch correctly updates provider config
- [x] Verify web app behavior is unchanged

## Summary by Sourcery

Bug Fixes:
- Ensure desktop app users can see and toggle the "Fetch on Client" switch under the same conditions as web users.