### PR TITLE
ci: add workflows permission to sync-main-to-canary

### DIFF
--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   sync-branches:


### PR DESCRIPTION
### Problem

The `sync-main-to-canary` workflow fails when merge conflicts involve `.github/workflows/` files. GitHub rejects the branch push with:

> refusing to allow a GitHub App to create or update workflow `.github/workflows/auto-tag-release.yml` without `workflows` permission

See: https://github.com/lobehub/lobehub/actions/runs/22016240178/job/63618336709

### Root Cause

The workflow only declares `contents: write` and `pull-requests: write` permissions. When the sync branch contains changes to workflow files (e.g. due to merge conflicts), GitHub requires the additional `workflows: write` permission.

### Fix

Add `workflows: write` to the workflow permissions block.

## Summary by Sourcery

CI:
- Add workflows: write permission to the sync-main-to-canary GitHub Actions workflow to allow updates to workflow files during branch syncs.