### PR TITLE
ci: fix sync workflow by using PAT for checkout

### DIFF
--- a/.github/workflows/sync-main-to-canary.yaml
+++ b/.github/workflows/sync-main-to-canary.yaml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   sync-branches:
@@ -18,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
### Problem

The previous fix (`workflows: write`) is **invalid** — `workflows` is not a valid permission scope in GitHub Actions workflow syntax, causing the workflow file to fail validation:

> `(Line: 11, Col: 3): Unexpected value 'workflows'`

The root issue is that `GITHUB_TOKEN` **cannot** push changes to `.github/workflows/` files regardless of permissions — this is a GitHub security restriction.

### Fix

1. **Revert** the invalid `workflows: write` permission
2. **Add `token: ${{ secrets.GH_TOKEN }}`** to the `actions/checkout` step — this configures git credentials with the PAT (which has the `workflow` scope), allowing `git push` to push branches containing workflow file changes

The workflow already uses `secrets.GH_TOKEN` for `gh` CLI operations, but the checkout step was using the default `GITHUB_TOKEN` for git credentials. This mismatch caused the push rejection when merge conflicts involved workflow files.

### Ref
- Failed run: https://github.com/lobehub/lobehub/actions/runs/22016240178/job/63618336709

## Summary by Sourcery

Fix the sync-main-to-canary workflow so it can push changes to workflow files using a personal access token instead of the default GITHUB_TOKEN.

CI:
- Remove the invalid `workflows: write` permission from the sync-main-to-canary workflow.
- Configure the checkout step in the sync-main-to-canary workflow to use `secrets.GH_TOKEN` for git operations.