### PR TITLE
🐛 fix(ci): use `pull_request_target` to support fork PR secrets

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main


### PR DESCRIPTION
### 问题

Auto Tag Release workflow 在 fork PR 被 merge 后执行失败：

```
##[error]Input required and not supplied: token
```

**根因**：`pull_request` 事件对于来自 fork 的 PR，GitHub 不允许访问目标仓库的 secrets，导致 `secrets.GH_TOKEN` 为空。

### 修复

将触发事件从 `pull_request` 改为 `pull_request_target`。

`pull_request_target` 在目标仓库（base repo）的上下文中运行，可以正常访问 secrets。同时使用的是 base branch 上的 workflow 文件，不会被 fork PR 篡改，安全性无影响。

### 关联

- 失败的 run: https://github.com/lobehub/lobehub/actions/runs/22036486861

## Summary by Sourcery

CI:
- Change the auto-tag release workflow event from pull_request to pull_request_target so CI can access repository secrets when forked PRs are merged.