### PR TITLE
💄 style: fix minimax m2.5 model name error `MiniMax-M2.5-Lightning` -> `MiniMax-M2.5-highspeed`

### DIFF
--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -31,9 +31,9 @@ const minimaxChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 204_800,
-    description: 'M2.5 Lightning: Same performance, faster and more agile (approx. 100 tps).',
-    displayName: 'MiniMax M2.5 Lightning',
-    id: 'MiniMax-M2.5-Lightning',
+    description: 'M2.5 Highspeed: Same performance, faster and more agile (approx. 100 tps).',
+    displayName: 'MiniMax M2.5 Highspeed',
+    id: 'MiniMax-M2.5-highspeed',
     maxOutput: 131_072,
     pricing: {
       currency: 'CNY',
@@ -78,8 +78,8 @@ const minimaxChatModels: AIChatModelCard[] = [
     contextWindowTokens: 204_800,
     description:
       'Powerful multilingual programming capabilities, comprehensively upgraded programming experience. Faster and more efficient.',
-    displayName: 'MiniMax M2.1 Lightning',
-    id: 'MiniMax-M2.1-Lightning',
+    displayName: 'MiniMax M2.1 Highspeed',
+    id: 'MiniMax-M2.1-highspeed',
     maxOutput: 131_072,
     pricing: {
       currency: 'CNY',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 修正 Minimax 2.5 模型名称错误 `MiniMax-M2.5-Lightning` -> `MiniMax-M2.5-highspeed`

<img width="758" height="435" alt="image" src="https://github.com/user-attachments/assets/731b7302-f2db-4a6a-a11a-bbc93c578ca6" />

https://platform.minimaxi.com/docs/api-reference/text-openai-api#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A8%A1%E5%9E%8B

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Correct MiniMax chat model metadata to use the proper Highspeed variants instead of the outdated Lightning ones.

Bug Fixes:
- Fix incorrect MiniMax M2.5 model identifier and display metadata to match the official MiniMax-M2.5-highspeed model.
- Fix incorrect MiniMax M2.1 model identifier and display metadata to match the official MiniMax-M2.1-highspeed model.