### PR TITLE
🐛 fix(docker): Fix the issue of missing `@napi-rs/canvas` platform native binding package in standalone build

### DIFF
--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -42,6 +42,7 @@ export function defineConfig(config: CustomNextConfig) {
               // `@napi-rs/canvas` is loaded via dynamic `require()` (see packages/file-loaders),
               // which may not be picked up by Next.js output tracing.
               'node_modules/@napi-rs/canvas/**/*',
+              'node_modules/@napi-rs/canvas-*/**/*',
               // pnpm real package locations (including platform-specific bindings with `.node`)
               'node_modules/.pnpm/@napi-rs+canvas*/**/*',
               'node_modules/.pnpm/@napi-rs+canvas-*/**/*',


### PR DESCRIPTION
…standalone output

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

Fixed https://github.com/lobehub/lobehub/issues/12354, https://github.com/lobehub/lobehub/issues/12314

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Docker部署时解析PDF会报DOMMatrix is not defined，排查下来发现是standalone输出缺少@napi-rs/canvas
的平台特定原生绑定包@napi-rs/canvas-linux-x64-gnu。

现有的outputFileTracingIncludes只匹配了node_modules/@napi-rs/canvas/**/*，但运行时实际会需要@napi-rs/canvas-linux-x64-gnu这样的包，这些包名带有平台后缀，不在原来的 glob 范围内。

改动很小，就是加了一行node_modules/@napi-rs/canvas-*/**/* 把这些平台包也包含进去。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure @napi-rs/canvas platform-specific native binding packages are bundled into standalone Docker builds to prevent runtime errors when parsing PDFs.