### PR TITLE
💄 style: update batch of model lists (ai360, hunyuan, intern, spark, stepfun, wenxin, seedream)

### DIFF
--- a/packages/model-bank/src/aiModels/ai360.ts
+++ b/packages/model-bank/src/aiModels/ai360.ts
@@ -3,13 +3,52 @@ import type { AIChatModelCard } from '../types/aiModel';
 const ai360ChatModels: AIChatModelCard[] = [
   {
     abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 128_000,
+    description: '360 Zhinao Next-Generation Reasoning Model.',
+    displayName: '360Zhinao3 o1.5',
+    enabled: true,
+    id: '360zhinao3-o1.5',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 128_000,
+    description:
+      '360 Zhinao most powerful reasoning model, featuring the strongest capabilities and supporting both tool calling and advanced reasoning.',
+    displayName: '360Zhinao2 o1.5',
+    id: '360zhinao2-o1.5',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
     },
-    contextWindowTokens: 8000,
+    contextWindowTokens: 128_000,
     description:
       '360zhinao2-o1 builds chain-of-thought via tree search with a reflection mechanism and RL training, enabling self-reflection and self-correction.',
     displayName: '360Zhinao2 o1',
-    enabled: true,
     id: '360zhinao2-o1',
     pricing: {
       currency: 'CNY',
@@ -22,9 +61,56 @@ const ai360ChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 32_000,
+    description: '',
+    displayName: '360Zhinao Pro 32K Thinking Vision',
+    enabled: true,
+    id: '360zhinao-pro-32k-thinking-vision',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 32_000,
+    description: '',
+    displayName: '360Zhinao Turbo',
+    enabled: true,
+    id: '360zhinao-turbo',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 32_000,
+    description: '',
+    displayName: '360Zhinao Turbo Qwen Plus',
+    id: '360zhinao-turbo-qwen-plus',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
     },
-    contextWindowTokens: 8000,
+    contextWindowTokens: 128_000,
     description:
       '360gpt2-o1 builds chain-of-thought via tree search with a reflection mechanism and RL training, enabling self-reflection and self-correction.',
     displayName: '360GPT2 o1',
@@ -43,11 +129,10 @@ const ai360ChatModels: AIChatModelCard[] = [
       functionCall: true,
       search: true,
     },
-    contextWindowTokens: 8000,
+    contextWindowTokens: 32_000,
     description:
       'The flagship 100B-class model in the 360 Zhinao series, suitable for complex tasks across domains.',
     displayName: '360GPT2 Pro',
-    enabled: true,
     id: '360gpt2-pro',
     pricing: {
       currency: 'CNY',
@@ -66,7 +151,7 @@ const ai360ChatModels: AIChatModelCard[] = [
       functionCall: true,
       search: true,
     },
-    contextWindowTokens: 8000,
+    contextWindowTokens: 32_000,
     description:
       'The flagship 100B-class model in the 360 Zhinao series, suitable for complex tasks across domains.',
     displayName: '360GPT Pro',
@@ -84,7 +169,7 @@ const ai360ChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
-    contextWindowTokens: 16_000,
+    contextWindowTokens: 4096,
     description:
       'A translation-specialized model, deeply fine-tuned for leading translation quality.',
     displayName: '360GPT Pro Trans',
@@ -99,11 +184,10 @@ const ai360ChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
-    contextWindowTokens: 7000,
+    contextWindowTokens: 32_000,
     description:
       'A 10B-class model balancing performance and quality, suited for performance/cost-sensitive scenarios.',
     displayName: '360GPT Turbo',
-    enabled: true,
     id: '360gpt-turbo',
     pricing: {
       currency: 'CNY',
@@ -116,9 +200,78 @@ const ai360ChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 65_536,
+    description:
+      'The goal of DeepSeek-V3.2 is to balance reasoning capability with output length, making it suitable for everyday use, such as Q&A scenarios and general-purpose agent tasks. In public reasoning benchmarks, DeepSeek-V3.2 achieves performance on par with GPT-5, just slightly below Gemini-3.0-Pro. Compared to Kimi-K2-Thinking, V3.2 offers significantly shorter outputs, greatly reducing computational cost and user wait times.',
+    displayName: 'DeepSeek V3.2',
+    id: 'deepseek-v3.2',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 4096,
+    description:
+      'DeepSeek V3.2 is a model that strikes a balance between high computational efficiency and excellent reasoning and agent performance.',
+    displayName: 'DeepSeek V3.2 (Paratera)',
+    id: 'paratera/deepseek-v3.2',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 4096,
+    description:
+      'DeepSeek V3.2 is a model that strikes a balance between high computational efficiency and excellent reasoning and agent performance.',
+    displayName: 'DeepSeek V3.2 (SophNet)',
+    id: 'sophnet/deepseek-v3.2',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 65_536,
+    description:
+      'On highly complex tasks, the Speciale model significantly outperforms the standard version, but it consumes considerably more tokens and incurs higher costs. Currently, DeepSeek-V3.2-Speciale is intended for research use only, does not support tool calls, and has not been specifically optimized for everyday conversation or writing tasks.',
+    displayName: 'DeepSeek V3.2 Speciale',
+    id: 'deepseek-v3.2-speciale',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
     },
-    contextWindowTokens: 64_000,
+    contextWindowTokens: 65_536,
     description:
       '360-deployed DeepSeek-R1 uses large-scale RL in post-training to greatly boost reasoning with minimal labels. It matches OpenAI o1 on math, code, and natural language reasoning tasks.',
     displayName: 'DeepSeek R1',
@@ -127,6 +280,83 @@ const ai360ChatModels: AIChatModelCard[] = [
       currency: 'CNY',
       units: [
         { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_000,
+    description: '兼顾生成质量与响应速度，适合作为通用生产级模型',
+    displayName: 'Doubao Seed 2.0 Lite',
+    id: 'volcengine/doubao-seed-2-0-lite',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_000,
+    description: '指向 doubao-seed-2-0-mini 最新版',
+    displayName: 'Doubao Seed 2.0 Mini',
+    id: 'volcengine/doubao-seed-2-0-mini',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_000,
+    description: '指向 doubao-seed-2-0-pro 最新版',
+    displayName: 'Doubao Seed 2.0 Pro',
+    id: 'volcengine/doubao-seed-2-0-pro',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_000,
+    description:
+      'Doubao-Seed-2.0-Code 面向企业级编程需求优化，在 Seed 2.0 优秀的 Agent、VLM 能力基础上，特别增强了代码能力，不仅前端能力表现出众，也对企业常见的多语言编码需求做了特别优化，适合接入各种 AI 编程工具使用。',
+    displayName: 'Doubao Seed 2.0 Code',
+    id: 'volcengine/doubao-seed-2-0-code',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -10,7 +10,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description:
       'DeepSeek V3.2 is DeepSeek’s latest general model with a hybrid reasoning architecture and stronger agent capabilities.',
-    displayName: 'DeepSeek V3.2 Exp',
+    displayName: 'DeepSeek V3.2',
     enabled: true,
     id: 'deepseek-chat',
     maxOutput: 8192,
@@ -33,7 +33,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     contextWindowTokens: 131_072,
     description:
       'DeepSeek V3.2 thinking mode outputs a chain-of-thought before the final answer to improve accuracy.',
-    displayName: 'DeepSeek V3.2 Exp Thinking',
+    displayName: 'DeepSeek V3.2 Thinking',
     enabled: true,
     id: 'deepseek-reasoner',
     maxOutput: 65_536,

--- a/packages/model-bank/src/aiModels/hunyuan.ts
+++ b/packages/model-bank/src/aiModels/hunyuan.ts
@@ -4,6 +4,57 @@ import type { AIChatModelCard } from '../types/aiModel';
 const hunyuanChatModels: AIChatModelCard[] = [
   {
     abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 128_000,
+    description:
+      'Release Features: The model base has been upgraded from TurboS to **Hunyuan 2.0**, resulting in comprehensive capability improvements. It significantly enhances the model’s ability to follow complex instructions, understand multi-turn and long-form text, handle code, operate as an agent, and perform reasoning tasks.',
+    displayName: 'Tencent HY 2.0 Think',
+    enabled: true,
+    id: 'hunyuan-2.0-thinking-20251109',
+    maxOutput: 64_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-09',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      search: true,
+    },
+    contextWindowTokens: 128_000,
+    description:
+      'Release Features: The model base has been upgraded from TurboS to **Hunyuan 2.0**, resulting in comprehensive capability improvements. It significantly enhances instruction-following, multi-turn and long-form text understanding, literary creation, knowledge accuracy, coding, and reasoning abilities.',
+    displayName: 'Tencent HY 2.0 Instruct',
+    enabled: true,
+    id: 'hunyuan-2.0-instruct-20251111',
+    maxOutput: 64_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-11',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
       search: true,
     },
@@ -30,7 +81,6 @@ const hunyuanChatModels: AIChatModelCard[] = [
     description:
       'Significantly improves the slow-thinking model on hard math, complex reasoning, difficult coding, instruction following, and creative writing quality.',
     displayName: 'Hunyuan T1',
-    enabled: true,
     id: 'hunyuan-t1-latest',
     maxOutput: 64_000,
     pricing: {
@@ -41,285 +91,6 @@ const hunyuanChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-08-22',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 92_000,
-    description:
-      'Greatly improves hard math, logic, and coding, boosts output stability, and enhances long-text capability.',
-    displayName: 'Hunyuan T1 20250711',
-    id: 'hunyuan-t1-20250711',
-    maxOutput: 64_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-07-11',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 92_000,
-    description:
-      'Improves creative writing and composition, strengthens frontend coding, math, and logic reasoning, and enhances instruction following.',
-    displayName: 'Hunyuan T1 20250529',
-    id: 'hunyuan-t1-20250529',
-    maxOutput: 64_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-05-29',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 92_000,
-    description:
-      'Improves project-level code generation and writing quality, strengthens multi-turn topic understanding and ToB instruction following, improves word-level understanding, and reduces mixed simplified/traditional and Chinese/English output issues.',
-    displayName: 'Hunyuan T1 20250403',
-    id: 'hunyuan-t1-20250403',
-    maxOutput: 64_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-04-03',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 92_000,
-    description:
-      'Builds balanced arts and STEM capabilities with strong long-text information capture. Supports reasoning answers for math, logic, science, and code problems across difficulty levels.',
-    displayName: 'Hunyuan T1 20250321',
-    id: 'hunyuan-t1-20250321',
-    maxOutput: 64_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-03-21',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 256_000,
-    description:
-      'Upgraded to an MoE architecture with a 256k context window, leading many open models across NLP, code, math, and industry benchmarks.',
-    displayName: 'Hunyuan Lite',
-    enabled: true,
-    id: 'hunyuan-lite',
-    maxOutput: 6000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-10-30',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Uses improved routing to mitigate load balancing and expert collapse. Achieves 99.9% needle-in-a-haystack on long context. MOE-32K offers strong value while handling long inputs.',
-    displayName: 'Hunyuan Standard',
-    id: 'hunyuan-standard',
-    maxOutput: 2000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-02-10',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      search: true,
-    },
-    contextWindowTokens: 256_000,
-    description:
-      'Uses improved routing to mitigate load balancing and expert collapse. Achieves 99.9% needle-in-a-haystack on long context. MOE-256K further expands context length and quality.',
-    displayName: 'Hunyuan Standard 256K',
-    id: 'hunyuan-standard-256K',
-    maxOutput: 6000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-02-10',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Hunyuan-large has ~389B total parameters and ~52B activated, the largest and strongest open MoE model in a Transformer architecture.',
-    displayName: 'Hunyuan Large',
-    enabled: true,
-    id: 'hunyuan-large',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-02-10',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      search: true,
-    },
-    contextWindowTokens: 134_000,
-    description:
-      'Excels at long-document tasks like summarization and QA while also handling general generation. Strong at long-text analysis and generation for complex, detailed content.',
-    displayName: 'Hunyuan Large Longcontext',
-    id: 'hunyuan-large-longcontext',
-    maxOutput: 6000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 18, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-12-18',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'General experience improvements across NLP understanding, writing, chat, QA, translation, and domains; more human-like responses, better clarification on ambiguous intent, improved word parsing, higher creative quality and interactivity, and stronger multi-turn conversations.',
-    displayName: 'Hunyuan Turbo',
-    id: 'hunyuan-turbo-latest',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 9.6, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-01-10',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'This version boosts instruction scaling for better generalization, significantly improves math/code/logic reasoning, enhances word-level understanding, and improves writing quality.',
-    displayName: 'Hunyuan Turbo 20241223',
-    id: 'hunyuan-turbo-20241223',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 9.6, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-01-10',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 134_000,
-    description:
-      'Excels at long-document tasks like summarization and QA while also handling general generation. Strong at long-text analysis and generation for complex, detailed content.',
-    displayName: 'Hunyuan TurboS LongText 128K',
-    id: 'hunyuan-turbos-longtext-128k-20250325',
-    maxOutput: 6000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-03-25',
     settings: {
       searchImpl: 'params',
     },
@@ -351,99 +122,21 @@ const hunyuanChatModels: AIChatModelCard[] = [
     type: 'chat',
   },
   {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 44_000,
+    contextWindowTokens: 256_000,
     description:
-      'Upgraded pretraining data quality and post-training strategy, improving agents, English/low-resource languages, instruction following, code, and STEM capabilities.',
-    displayName: 'Hunyuan TurboS 20250926',
-    id: 'hunyuan-turbos-20250926',
-    maxOutput: 16_000,
+      'Upgraded to an MoE architecture with a 256k context window, leading many open models across NLP, code, math, and industry benchmarks.',
+    displayName: 'Hunyuan Lite',
+    enabled: true,
+    id: 'hunyuan-lite',
+    maxOutput: 6000,
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-26',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 44_000,
-    description:
-      'Upgraded pretraining base with improved writing and reading comprehension, significant gains in code and STEM, and better complex instruction following.',
-    displayName: 'Hunyuan TurboS 20250604',
-    id: 'hunyuan-turbos-20250604',
-    maxOutput: 16_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-06-04',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Upgraded pretraining base to improve instruction understanding and following; alignment boosts math, code, logic, and science; improves writing quality, comprehension, translation accuracy, and knowledge QA; strengthens agent abilities, especially multi-turn understanding.',
-    displayName: 'Hunyuan TurboS 20250416',
-    id: 'hunyuan-turbos-20250416',
-    maxOutput: 8000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-04-16',
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      search: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Unifies math solution style and strengthens multi-turn math QA. Writing style is refined to reduce AI-like tone and add polish.',
-    displayName: 'Hunyuan TurboS 20250313',
-    id: 'hunyuan-turbos-20250313',
-    maxOutput: 8000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-03-13',
-    settings: {
-      searchImpl: 'params',
-    },
+    releasedAt: '2024-10-30',
     type: 'chat',
   },
   {
@@ -452,8 +145,8 @@ const hunyuanChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 24_000,
     description:
-      '基于文本 TurboS 基座生产的图生文快思考模型，相比上一版本在图像基础识别、图像分析推理等维度都有明显的效果提升。',
-    displayName: '混元图生文',
+      'A fast-thinking image-to-text model built on the TurboS text base, showing notable improvements over the previous version in fundamental image recognition and image analysis reasoning.',
+    displayName: 'Hunyuan Vision 1.5 Instruct',
     id: 'hunyuan-vision-1.5-instruct',
     maxOutput: 16_000,
     pricing: {
@@ -464,65 +157,6 @@ const hunyuanChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-12-17',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 36_000,
-    description:
-      'Latest 7B multimodal model with a 32K context window, supporting Chinese/English multimodal chat, object recognition, document table understanding, and multimodal math, outperforming 7B peers on multiple benchmarks.',
-    displayName: 'Hunyuan Lite Vision',
-    id: 'hunyuan-lite-vision',
-    maxOutput: 4000,
-    releasedAt: '2024-12-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 8000,
-    description:
-      'Latest multimodal model with multilingual responses and balanced Chinese/English ability.',
-    displayName: 'Hunyuan Standard Vision',
-    id: 'hunyuan-standard-vision',
-    maxOutput: 2000,
-    releasedAt: '2024-12-31',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 8000,
-    description:
-      'Next-generation vision-language flagship using a new MoE architecture, with broad improvements in recognition, content creation, knowledge QA, and analytical reasoning.',
-    displayName: 'Hunyuan Turbo Vision',
-    id: 'hunyuan-turbo-vision',
-    maxOutput: 2000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 80, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 80, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-11-26',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 16_000,
-    description:
-      'A vision-language model trained from Hunyuan Large for image-text understanding. Supports multi-image + text input at any resolution and improves multilingual visual understanding.',
-    displayName: 'Hunyuan Large Vision',
-    id: 'hunyuan-large-vision',
-    maxOutput: 8000,
-    releasedAt: '2025-05-26',
     type: 'chat',
   },
   {
@@ -546,179 +180,6 @@ const hunyuanChatModels: AIChatModelCard[] = [
     releasedAt: '2025-09-16',
     type: 'chat',
   },
-  {
-    abilities: {
-      reasoning: true,
-      vision: true,
-    },
-    contextWindowTokens: 40_000,
-    description:
-      'Latest t1-vision multimodal deep reasoning model with native long chain-of-thought, significantly improved over the previous default version.',
-    displayName: 'Hunyuan T1 Vision 20250619',
-    id: 'hunyuan-t1-vision-20250619',
-    maxOutput: 16_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-06-19',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Latest TurboS vision-language flagship with major gains on image-text tasks such as entity recognition, knowledge QA, copywriting, and photo-based problem solving.',
-    displayName: 'Hunyuan TurboS Vision 20250619',
-    id: 'hunyuan-turbos-vision-20250619',
-    maxOutput: 16_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-06-19',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'A next-gen vision-language flagship based on the latest TurboS, focused on image-text understanding tasks like entity recognition, knowledge QA, copywriting, and photo-based problem solving.',
-    displayName: 'Hunyuan TurboS Vision',
-    id: 'hunyuan-turbos-vision',
-    maxOutput: 24_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-05-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 32_000,
-    description: 'Latest multimodal model supporting image + text input to generate text.',
-    displayName: 'Hunyuan Vision',
-    id: 'hunyuan-vision',
-    maxOutput: 16_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 18, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 18, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-01-03',
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 8000,
-    description:
-      'Latest code generation model trained with 200B high-quality code and six months of SFT; context expanded to 8K. It ranks top in automated benchmarks for five languages and in human evaluations across ten criteria.',
-    displayName: 'Hunyuan Code',
-    id: 'hunyuan-code',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 3.5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 7, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-11-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 32_000,
-    description:
-      'Latest MoE FunctionCall model trained with high-quality function-call data, featuring a 32K context window and leading benchmark results across dimensions.',
-    displayName: 'Hunyuan FunctionCall',
-    id: 'hunyuan-functioncall',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-04-22',
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_000,
-    description:
-      'Latest roleplay model, officially fine-tuned on roleplay datasets, delivering stronger baseline performance for roleplay scenarios.',
-    displayName: 'Hunyuan Role',
-    id: 'hunyuan-role',
-    maxOutput: 4000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-07-04',
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_000,
-    description:
-      'Latest roleplay model, officially fine-tuned on roleplay datasets, delivering stronger baseline performance for roleplay scenarios.',
-    displayName: 'Hunyuan TurboS Role Plus',
-    id: 'hunyuan-turbos-role-plus',
-    maxOutput: 4000,
-    type: 'chat',
-  },
-  // {
-  //   contextWindowTokens: 8000,
-  //   description:
-  //     'The Hunyuan translation model supports conversational translation; it supports mutual translation among 15 languages, including Chinese, English, Japanese, French, Portuguese, Spanish, Turkish, Russian, Arabic, Korean, Italian, German, Vietnamese, Malay, and Indonesian.',
-  //   displayName: 'Hunyuan Translation Lite',
-  //   id: 'hunyuan-translation-lite',
-  //   maxOutput: 4000,
-  //   pricing: {
-  //     currency: 'CNY',
-  //     input: 1,
-  //     output: 3,
-  //   },
-  //   releasedAt: '2024-11-25',
-  //   type: 'chat',
-  // },
-  // {
-  //   contextWindowTokens: 8000,
-  //   description:
-  //     'Supports mutual translation among 15 languages including Chinese, English, Japanese, French, Portuguese, Spanish, Turkish, Russian, Arabic, Korean, Italian, German, Vietnamese, Malay, and Indonesian. Based on automated COMET evaluation across multi-scenario translation benchmarks, it outperforms similarly sized models on translation between Chinese and other common languages.',
-  //   displayName: 'Hunyuan Translation',
-  //   id: 'hunyuan-translation',
-  //   maxOutput: 4000,
-  //   pricing: {
-  //     currency: 'CNY',
-  //     input: 15,
-  //     output: 45,
-  //   },
-  //   releasedAt: '2024-10-25',
-  //   type: 'chat',
-  // },
 ];
 
 export const allModels = [...hunyuanChatModels];

--- a/packages/model-bank/src/aiModels/internlm.ts
+++ b/packages/model-bank/src/aiModels/internlm.ts
@@ -6,54 +6,84 @@ const internlmChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      vision: true,
     },
-    contextWindowTokens: 32_768,
+    contextWindowTokens: 262_144,
     description:
-      'Our latest model series with excellent reasoning performance, leading open models in its size class. Defaults to the latest InternLM3 series (currently internlm3-8b-instruct).',
-    displayName: 'InternLM3',
-    enabled: true,
-    id: 'internlm3-latest',
+      'By default, it points to our latest released Intern series model, currently set to intern-s1-pro.',
+    displayName: 'Intern',
+    id: 'intern-latest',
     pricing: {
       units: [
         { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
+    releasedAt: '2026-02-04',
     type: 'chat',
   },
   {
     abilities: {
       functionCall: true,
-    },
-    contextWindowTokens: 32_768,
-    description:
-      'Legacy models still maintained with excellent, stable performance after many iterations. Available in 7B and 20B sizes, supporting 1M context and stronger instruction following and tool use. Defaults to the latest InternLM2.5 series (currently internlm2.5-20b-chat).',
-    displayName: 'InternLM2.5',
-    id: 'internlm2.5-latest',
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
+      reasoning: true,
       vision: true,
     },
-    contextWindowTokens: 32_768,
+    contextWindowTokens: 262_144,
     description:
-      'Our latest multimodal model with stronger image-text understanding and long-sequence image comprehension, comparable to top closed models. Defaults to the latest InternVL series (currently internvl3-78b).',
-    displayName: 'InternVL3',
+      'We have launched our most advanced open-source multimodal reasoning model, currently the top-performing open-source multimodal large language model in terms of overall performance.',
+    displayName: 'Intern-S1-Pro',
     enabled: true,
-    id: 'internvl3-latest',
+    id: 'intern-s1-pro',
     pricing: {
       units: [
         { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
+    releasedAt: '2026-02-04',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The open-source multimodal reasoning model not only demonstrates strong general-purpose capabilities but also achieves state-of-the-art performance across a wide range of scientific tasks.',
+    displayName: 'Intern-S1',
+    enabled: true,
+    id: 'intern-s1',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-07-26',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'A lightweight multimodal large model with strong scientific reasoning capabilities.',
+    displayName: 'Intern-S1-Mini',
+    enabled: true,
+    id: 'intern-s1-mini',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-08-20',
     type: 'chat',
   },
   {
@@ -62,15 +92,35 @@ const internlmChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 32_768,
     description:
-      'InternVL2.5 is still maintained with strong, stable performance. Defaults to the latest InternVL2.5 series (currently internvl2.5-78b).',
-    displayName: 'InternVL2.5',
-    id: 'internvl2.5-latest',
+      'By default, it points to the latest model in the InternVL3.5 series, currently set to internvl3.5-241b-a28b.',
+    displayName: 'InternVL3.5',
+    id: 'internvl3.5-latest',
     pricing: {
       units: [
         { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
+    releasedAt: '2025-08-28',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'Our newly released multimodal large model features enhanced image-and-text understanding and long-sequence image comprehension capabilities, achieving performance comparable to leading closed-source models.',
+    displayName: 'InternVL3.5-241B-A28B',
+    enabled: true,
+    id: 'internvl3.5-241b-a28b',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-08-28',
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -194,6 +194,7 @@ const minimaxImageModels: AIImageModelCard[] = [
         default: '1:1',
         enum: ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'],
       },
+      imageUrls: { default: [] },
       prompt: {
         default: '',
       },
@@ -211,8 +212,9 @@ const minimaxImageModels: AIImageModelCard[] = [
     parameters: {
       aspectRatio: {
         default: '1:1',
-        enum: ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'],
+        enum: ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16'],
       },
+      imageUrls: { default: [] },
       prompt: {
         default: '',
       },

--- a/packages/model-bank/src/aiModels/spark.ts
+++ b/packages/model-bank/src/aiModels/spark.ts
@@ -7,12 +7,30 @@ const sparkChatModels: AIChatModelCard[] = [
       reasoning: true,
       search: true,
     },
+    contextWindowTokens: 131_072,
+    description:
+      'X2 Capabilities Overview: 1. Introduces dynamic adjustment of reasoning mode, controlled via the `thinking` field. 2. Expanded context length: 64K input tokens and 128K output tokens. 3. Supports Function Call functionality.',
+    displayName: 'Spark X2',
+    enabled: true,
+    id: 'spark-x',
+    maxOutput: 131_072,
+    settings: {
+      extendParams: ['thinking'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
     contextWindowTokens: 65_535,
     description:
       'X1.5 updates: (1) adds dynamic thinking mode controlled by the `thinking` field; (2) larger context length with 64K input and 64K output; (3) supports FunctionCall.',
     displayName: 'Spark X1.5',
-    enabled: true,
-    id: 'spark-x',
+    id: 'x1',
     maxOutput: 65_535,
     settings: {
       extendParams: ['thinking'],

--- a/packages/model-bank/src/aiModels/stepfun.ts
+++ b/packages/model-bank/src/aiModels/stepfun.ts
@@ -5,6 +5,29 @@ import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
 const stepfunChatModels: AIChatModelCard[] = [
   {
     abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'The flagship language reasoning model from Stepfun. This model delivers top-tier reasoning capabilities along with fast and reliable execution. It can decompose and plan complex tasks, quickly and reliably invoke tools to carry them out, and excel in logical reasoning, mathematics, software engineering, deep research, and other sophisticated tasks. The context length is 256K.',
+    displayName: 'Step 3.5 Flash',
+    enabled: true,
+    id: 'step-3.5-flash',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.7, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
       reasoning: true,
       vision: true,
     },
@@ -17,6 +40,15 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.3, upTo: 0.004 },
+            { rate: 0.8, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
         {
           name: 'textInput',
           strategy: 'tiered',
@@ -54,6 +86,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -75,6 +108,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 20, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -96,6 +130,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 70, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -117,6 +152,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 19, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 95, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 300, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -140,6 +176,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -162,6 +199,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 7.6, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 38, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 120, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -184,6 +222,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 7.6, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 38, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 120, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -207,8 +246,9 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 20, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     settings: {
@@ -229,8 +269,9 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 70, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     settings: {
@@ -251,8 +292,9 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 70, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-01-22',
@@ -271,6 +313,7 @@ const stepfunChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -299,6 +342,10 @@ const stepfunImageModels: AIImageModelCard[] = [
       },
       steps: { default: 50, max: 100, min: 1 },
     },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0, strategy: 'fixed', unit: 'image' }],
+    },
     releasedAt: '2024-08-07',
     type: 'image',
   },
@@ -318,6 +365,10 @@ const stepfunImageModels: AIImageModelCard[] = [
         enum: ['256x256', '512x512', '768x768', '1024x1024', '1280x800', '800x1280'],
       },
       steps: { default: 50, max: 100, min: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.1, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-07-15',
     type: 'image',
@@ -339,6 +390,10 @@ const stepfunImageModels: AIImageModelCard[] = [
         enum: ['512x512', '768x768', '1024x1024'],
       },
       steps: { default: 28, max: 100, min: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-03-04',
     type: 'image',

--- a/packages/model-bank/src/aiModels/taichu.ts
+++ b/packages/model-bank/src/aiModels/taichu.ts
@@ -1,35 +1,25 @@
 import type { AIChatModelCard } from '../types/aiModel';
 
-// https://docs.wair.ac.cn/maas/jiage.html
+// https://cloud.zidongtaichu.com/taichu/maas/#/modellist
 
 const taichuChatModels: AIChatModelCard[] = [
   {
     abilities: {
+      functionCall: true,
       reasoning: true,
+      vision: true,
     },
     contextWindowTokens: 32_768,
     description:
-      'taichu_o1 is a next-gen reasoning model that uses multimodal interaction and reinforcement learning to achieve human-like chain-of-thought, supports complex decision simulation, and exposes reasoning paths while maintaining high-accuracy outputs, suited for strategy analysis and deep thinking.',
-    displayName: 'Taichu O1',
+      'taichu_o1 is a next-generation reasoning large model that achieves human-like chain-of-thought through multimodal interaction and reinforcement learning. It supports complex decision-making simulations and, while maintaining high-precision output, reveals interpretable reasoning pathways. It is well-suited for strategy analysis, deep thinking, and similar scenarios.',
+    displayName: 'Taichu-O1',
     enabled: true,
     id: 'taichu_o1',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 32_768,
-    description:
-      'Trained on massive high-quality data, with stronger text understanding, content creation, and conversational QA.',
-    displayName: 'Taichu 2.0',
-    enabled: true,
-    id: 'taichu_llm',
     pricing: {
       currency: 'CNY',
       units: [
         { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',
@@ -38,17 +28,123 @@ const taichuChatModels: AIChatModelCard[] = [
     abilities: {
       vision: true,
     },
-    contextWindowTokens: 4096,
+    contextWindowTokens: 32_768,
     description:
-      'Combines image understanding, knowledge transfer, and logical attribution, excelling in image-text QA.',
-    displayName: 'Taichu 2.0 VL',
-    enabled: true,
-    id: 'taichu_vl',
+      'The No-Thinking version of the Taichu4.0-VL 2B model features lower memory usage, a lightweight design, fast response speed, and strong multimodal understanding capabilities.',
+    displayName: 'Taichu4.0-VL-2B-NoThinking',
+    id: 'taichu4_vl_2b_nothinking',
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The Thinking version of the Taichu4.0-VL 3B model efficiently performs multimodal understanding and reasoning tasks, with comprehensive upgrades in visual comprehension, visual localization, OCR recognition, and related capabilities.',
+    displayName: 'Taichu4.0-VL-3B-Thinking',
+    id: 'taichu4_vl_3b',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The No-Thinking version of the Taichu4.0-VL 32B model is designed for complex image-and-text understanding and visual knowledge QA scenarios, excelling in image captioning, visual question answering, video comprehension, and visual localization tasks.',
+    displayName: 'Taichu4.0-VL-32B-NoThinking',
+    id: 'taichu4_vl_32b_nothinking',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.7, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 7, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The Thinking version of the Taichu4.0-VL 32B model is suited for complex multimodal understanding and reasoning tasks, demonstrating outstanding performance in multimodal mathematical reasoning, multimodal agent capabilities, and general image and visual comprehension.',
+    displayName: 'Taichu4.0-VL-32B-Thinking',
+    id: 'taichu4_vl_32b',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.7, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 7, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 32_768,
+    description:
+      'The Zidong Taichu large language model is a high-performance text-generation model developed using fully domestic full-stack technologies. Through structured compression of a hundred-billion-parameter base model and task-specific optimization, it significantly enhances complex text comprehension and knowledge reasoning capabilities. It excels in scenarios such as long-document analysis, cross-lingual information extraction, and knowledge-constrained generation.',
+    displayName: 'Taichu-LLM-2B',
+    id: 'taichu_llm_2b',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.9, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 32_768,
+    description:
+      'The Zidong Taichu large language model is a high-performance text-generation model developed using fully domestic full-stack technologies. Through structured compression of a hundred-billion-parameter base model and task-specific optimization, it significantly enhances complex text comprehension and knowledge reasoning capabilities. It excels in scenarios such as long-document analysis, cross-lingual information extraction, and knowledge-constrained generation.',
+    displayName: 'Taichu-LLM-14B',
+    id: 'taichu_llm_14b',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The Zidong Taichu large language model is a high-performance text-generation model developed using fully domestic full-stack technologies. Through structured compression of a hundred-billion-parameter base model and task-specific optimization, it significantly enhances complex text comprehension and knowledge reasoning capabilities. It excels in scenarios such as long-document analysis, cross-lingual information extraction, and knowledge-constrained generation.',
+    displayName: 'Taichu-LLM',
+    id: 'taichu_llm',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1108,6 +1108,48 @@ const doubaoChatModels: AIChatModelCard[] = [
 
 const volcengineImageModels: AIImageModelCard[] = [
   {
+    description:
+      'Doubao-Seedream-5.0-lite is ByteDance’s latest image-generation model. For the first time, it integrates online retrieval capabilities, allowing it to incorporate real-time web information and enhance the timeliness of generated images. The model’s intelligence has also been upgraded, enabling precise interpretation of complex instructions and visual content. Additionally, it offers improved global knowledge coverage, reference consistency, and generation quality in professional scenarios, better meeting enterprise-level visual creation needs.',
+    displayName: 'Seedream 5.0 Lite',
+    enabled: true,
+    id: 'doubao-seedream-5-0-260128',
+    parameters: {
+      height: { default: 2048, max: 16_384, min: 480, step: 1 },
+      imageUrls: { default: [], maxCount: 14, maxFileSize: 10 * 1024 * 1024 },
+      prompt: {
+        default: '',
+      },
+      width: { default: 2048, max: 16_384, min: 480, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Seedream 4.5 is ByteDance’s latest multimodal image model, integrating text-to-image, image-to-image, and batch image generation capabilities, while incorporating commonsense and reasoning abilities. Compared to the previous 4.0 version, it delivers significantly improved generation quality, with better editing consistency and multi-image fusion. It offers more precise control over visual details, producing small text and small faces more naturally, and achieves more harmonious layout and color, enhancing overall aesthetics.',
+    displayName: 'Seedream 4.5',
+    enabled: true,
+    id: 'doubao-seedream-4-5-251128',
+    parameters: {
+      height: { default: 2048, max: 16_384, min: 480, step: 1 },
+      imageUrls: { default: [], maxCount: 14, maxFileSize: 10 * 1024 * 1024 },
+      prompt: {
+        default: '',
+      },
+      width: { default: 2048, max: 16_384, min: 480, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-11-28',
+    type: 'image',
+  },
+  {
     /*
     // TODO: AIImageModelCard does not support config.deploymentName
     config: {
@@ -1120,23 +1162,16 @@ const volcengineImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'doubao-seedream-4-0-250828',
     parameters: {
+      height: { default: 2048, max: 16_384, min: 240, step: 1 },
       imageUrls: { default: [], maxCount: 10, maxFileSize: 10 * 1024 * 1024 },
       prompt: {
         default: '',
       },
-      size: {
-        default: '1024x1024',
-        enum: [
-          '2048x2048',
-          '2304x1728',
-          '1728x2304',
-          '2560x1440',
-          '1440x2560',
-          '2496x1664',
-          '1664x2496',
-          '3024x1296',
-        ],
-      },
+      width: { default: 2048, max: 16_384, min: 240, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-09-09',
     type: 'image',
@@ -1155,23 +1190,16 @@ const volcengineImageModels: AIImageModelCard[] = [
     id: 'doubao-seedream-3-0-t2i-250415',
     parameters: {
       cfg: { default: 2.5, max: 10, min: 1, step: 0.1 },
+      height: { default: 1024, max: 3549, min: 296, step: 1 },
       prompt: {
         default: '',
       },
       seed: { default: null },
-      size: {
-        default: '1024x1024',
-        enum: [
-          '1024x1024',
-          '864x1152',
-          '1152x864',
-          '1280x720',
-          '720x1280',
-          '832x1248',
-          '1248x832',
-          '1512x648',
-        ],
-      },
+      width: { default: 1024, max: 3549, min: 296, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.259, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-04-15',
     type: 'image',

--- a/packages/model-bank/src/aiModels/wenxin.ts
+++ b/packages/model-bank/src/aiModels/wenxin.ts
@@ -96,6 +96,7 @@ const wenxinChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-11-12',
     settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
       searchImpl: 'params',
     },
     type: 'chat',
@@ -187,6 +188,82 @@ const wenxinChatModels: AIChatModelCard[] = [
         { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 3.2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The all-new version of the Wenxin Yiyan large model, with significantly enhanced capabilities in image understanding, creation, translation, and coding. It supports a 32K context length for the first time, with greatly reduced initial token latency.',
+    displayName: 'ERNIE 4.5 Turbo VL 32K',
+    id: 'ernie-4.5-turbo-vl-32k',
+    maxOutput: 12_288,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'The all-new version of the Wenxin Yiyan large model, with significantly enhanced capabilities in image understanding, creation, translation, and coding. It supports a 32K context length for the first time, with greatly reduced initial token latency.',
+    displayName: 'ERNIE 4.5 Turbo VL 32K Preview',
+    id: 'ernie-4.5-turbo-vl-32k-preview',
+    maxOutput: 16_384,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'The all-new version of the Wenxin Yiyan large model, with significantly enhanced capabilities in image understanding, creation, translation, and coding. It supports a 32K context length for the first time, with greatly reduced initial token latency.',
+    displayName: 'ERNIE 4.5 Turbo VL',
+    id: 'ernie-4.5-turbo-vl-latest',
+    maxOutput: 12_288,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      vision: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'The all-new version of the Wenxin Yiyan large model, with significantly enhanced capabilities in image understanding, creation, translation, and coding. It supports a 32K context length for the first time, with greatly reduced initial token latency.',
+    displayName: 'ERNIE 4.5 Turbo VL Preview',
+    id: 'ernie-4.5-turbo-vl-preview',
+    maxOutput: 12_288,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',
@@ -315,6 +392,30 @@ const wenxinChatModels: AIChatModelCard[] = [
       'ERNIE 4.5 21B A3B is an open-source large-parameter model with stronger understanding and generation.',
     displayName: 'ERNIE 4.5 21B A3B',
     id: 'ernie-4.5-21b-a3b',
+    maxOutput: 8192,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'ERNIE-4.5-21B-A3B-Thinking is a text MoE (Mixture-of-Experts) post-trained model with a total of 21B parameters and 3B active parameters, offering significantly enhanced reasoning quality and depth.',
+    displayName: 'ERNIE 4.5 21B A3B Thinking',
+    id: 'ernie-4.5-21b-a3b-thinking',
     maxOutput: 8192,
     pricing: {
       currency: 'CNY',
@@ -544,6 +645,99 @@ const wenxinChatModels: AIChatModelCard[] = [
         { name: 'textInput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
       ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 65_536,
+    description: 'ERNIE X1.1 is a thinking-model preview for evaluation and testing.',
+    displayName: 'ERNIE X1.1',
+    enabled: true,
+    id: 'ernie-x1.1',
+    maxOutput: 65_536,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 65_536,
+    description: 'ERNIE X1.1 Preview is a thinking-model preview for evaluation and testing.',
+    displayName: 'ERNIE X1.1 Preview',
+    id: 'ernie-x1.1-preview',
+    maxOutput: 65_536,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'ERNIE X1 Turbo 32K is a fast thinking model with 32K context for complex reasoning and multi-turn chat.',
+    displayName: 'ERNIE X1 Turbo 32K',
+    id: 'ernie-x1-turbo-32k',
+    maxOutput: 28_160,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 32_768,
+    description:
+      'ERNIE X1 Turbo 32K Preview is a fast thinking model with 32K context for complex reasoning and multi-turn chat.',
+    displayName: 'ERNIE X1 Turbo 32K Preview',
+    id: 'ernie-x1-turbo-32k-preview',
+    maxOutput: 28_160,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    settings: {
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -1066,58 +1260,10 @@ const wenxinChatModels: AIChatModelCard[] = [
       reasoning: true,
       search: true,
     },
-    contextWindowTokens: 65_536,
-    description: 'ERNIE X1.1 Preview is a thinking-model preview for evaluation and testing.',
-    displayName: 'ERNIE X1.1 Preview',
-    enabled: true,
-    id: 'ernie-x1.1-preview',
-    maxOutput: 65_536,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 32_768,
-    description:
-      'ERNIE X1 Turbo 32K is a fast thinking model with 32K context for complex reasoning and multi-turn chat.',
-    displayName: 'ERNIE X1 Turbo 32K',
-    id: 'ernie-x1-turbo-32k',
-    maxOutput: 28_160,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    settings: {
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-    },
     contextWindowTokens: 144_000,
     description:
       'DeepSeek V3.2 Think is a full deep-thinking model with stronger long-chain reasoning.',
     displayName: 'DeepSeek V3.2 Think',
-    enabled: true,
     id: 'deepseek-v3.2-think',
     maxOutput: 32_768,
     pricing: {
@@ -1684,31 +1830,49 @@ const wenxinChatModels: AIChatModelCard[] = [
 const wenxinImageModels: AIImageModelCard[] = [
   {
     description:
+      'musesteamer-air-image is an image-generation model developed by Baidu’s search team to deliver exceptional cost-performance. It can quickly generate clear, action-coherent images based on user prompts, turning user descriptions effortlessly into visuals.',
+    displayName: 'MuseSteamer Air Image',
+    enabled: true,
+    id: 'musesteamer-air-image',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1024x1024',
+        enum: [
+          '1024x1024',
+          '1280x720',
+          '720x1280',
+          '1152x864',
+          '864x1152',
+          '1328x1328',
+          '1664x928',
+          '928x1664',
+          '1472x1104',
+          '1104x1472',
+        ],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.05, strategy: 'fixed', unit: 'image' }],
+    },
+    type: 'image',
+  },
+  {
+    description:
       'ERNIE iRAG is an image retrieval-augmented generation model for image search, image-text retrieval, and content generation.',
     displayName: 'ERNIE iRAG',
     enabled: true,
     id: 'irag-1.0',
     parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
       prompt: {
         default: '',
       },
-      size: {
-        default: '1024x1024',
-        enum: [
-          '768x768',
-          '1024x1024',
-          '1536x1536',
-          '2048x2048',
-          '1024x768',
-          '2048x1536',
-          '768x1024',
-          '1536x2048',
-          '1024x576',
-          '2048x1152',
-          '576x1024',
-          '1152x2048',
-        ],
-      },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -1724,27 +1888,12 @@ const wenxinImageModels: AIImageModelCard[] = [
     enabled: true,
     id: 'ernie-irag-edit',
     parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
       imageUrl: { default: null },
       prompt: {
         default: '',
       },
-      size: {
-        default: '1024x1024',
-        enum: [
-          '768x768',
-          '1024x1024',
-          '1536x1536',
-          '2048x2048',
-          '1024x768',
-          '2048x1536',
-          '768x1024',
-          '1536x2048',
-          '1024x576',
-          '2048x1152',
-          '576x1024',
-          '1152x2048',
-        ],
-      },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
     },
     pricing: {
       currency: 'CNY',
@@ -1755,33 +1904,60 @@ const wenxinImageModels: AIImageModelCard[] = [
   },
   {
     description:
+      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+    displayName: 'Qwen Image',
+    enabled: true,
+    id: 'qwen-image',
+    parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      steps: { default: 25, max: 50, min: 1 },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Qwen Image Edit',
+    enabled: true,
+    id: 'qwen-image-edit',
+    parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      imageUrls: { default: [] },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    type: 'image',
+  },
+  {
+    description:
       'FLUX.1-schnell is a high-performance image generation model for fast multi-style outputs.',
     displayName: 'FLUX.1-schnell',
     enabled: true,
     id: 'flux.1-schnell',
     parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
       prompt: {
         default: '',
       },
       seed: { default: null },
-      size: {
-        default: '1024x1024',
-        enum: [
-          '768x768',
-          '1024x1024',
-          '1536x1536',
-          '2048x2048',
-          '1024x768',
-          '2048x1536',
-          '768x1024',
-          '1536x2048',
-          '1024x576',
-          '2048x1152',
-          '576x1024',
-          '1152x2048',
-        ],
-      },
       steps: { default: 25, max: 50, min: 1 },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
     },
     pricing: {
       currency: 'CNY',

--- a/packages/model-bank/src/modelProviders/taichu.ts
+++ b/packages/model-bank/src/modelProviders/taichu.ts
@@ -1,21 +1,20 @@
 import type { ModelProviderCard } from '@/types/llm';
 
-// ref :https://ai-maas.wair.ac.cn/#/doc
 const Taichu: ModelProviderCard = {
   chatModels: [],
   checkModel: 'taichu_llm',
   description:
     'A next-generation multimodal model from CASIA and the Wuhan Institute of AI, supporting multi-turn QA, writing, image generation, 3D understanding, and signal analysis with stronger cognition and creativity.',
   id: 'taichu',
-  modelsUrl: 'https://ai-maas.wair.ac.cn/#/doc',
+  modelsUrl: 'https://cloud.zidongtaichu.com/taichu/maas/#/modellist',
   name: 'Taichu',
   settings: {
     proxyUrl: {
-      placeholder: 'https://ai-maas.wair.ac.cn/maas/v1',
+      placeholder: 'https://cloud.zidongtaichu.com/maas/v1',
     },
     sdkType: 'openai',
   },
-  url: 'https://ai-maas.wair.ac.cn',
+  url: 'https://cloud.zidongtaichu.com/taichu/maas',
 };
 
 export default Taichu;

--- a/packages/model-runtime/src/providers/minimax/createImage.ts
+++ b/packages/model-runtime/src/providers/minimax/createImage.ts
@@ -34,15 +34,24 @@ export async function createMiniMaxImage(
   try {
     const endpoint = `${baseURL}/image_generation`;
 
+    const requestBody: Record<string, unknown> = {
+      aspect_ratio: params.aspectRatio,
+      model,
+      n: 1,
+      prompt: params.prompt,
+      //prompt_optimizer: true, // 开启 prompt 自动优化
+      ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
+    };
+
+    if (params.imageUrls && params.imageUrls.length > 0) {
+      requestBody.subject_reference = params.imageUrls.map((url) => ({
+        type: 'character',
+        image_file: url,
+      }));
+    }
+
     const response = await fetch(endpoint, {
-      body: JSON.stringify({
-        aspect_ratio: params.aspectRatio,
-        model,
-        n: 1,
-        prompt: params.prompt,
-        //prompt_optimizer: true, // 开启 prompt 自动优化
-        ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
-      }),
+      body: JSON.stringify(requestBody),
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',

--- a/packages/model-runtime/src/providers/spark/index.test.ts
+++ b/packages/model-runtime/src/providers/spark/index.test.ts
@@ -6,7 +6,7 @@ import { testProvider } from '../../providerTestUtils';
 import { LobeSparkAI, params } from './index';
 
 const provider = ModelProvider.Spark;
-const defaultBaseURL = 'https://spark-api-open.xf-yun.com/v1';
+const defaultBaseURL = 'https://spark-api-open.xf-yun.com/v2';
 
 testProvider({
   Runtime: LobeSparkAI,

--- a/packages/model-runtime/src/providers/spark/index.ts
+++ b/packages/model-runtime/src/providers/spark/index.ts
@@ -6,18 +6,18 @@ import { SparkAIStream, transformSparkResponseToStream } from '../../core/stream
 import type { ChatStreamPayload } from '../../types';
 
 const getBaseURLByModel = (model: string): string => {
-  if (model.includes('x1-preview')) {
-    return 'https://spark-api-open-preview.xf-yun.com/v2';
-  }
-  if (model.includes('spark-x')) {
-    return 'https://spark-api-open.xf-yun.com/v2';
+  const v1Regex = /^(?:lite|generalv3|pro-128k|generalv3\.5|max-32k|4\.0Ultra)$/i;
+
+  // Legacy models via v1 endpoint
+  if (v1Regex.test(model)) {
+    return 'https://spark-api-open.xf-yun.com/v1';
   }
 
-  return 'https://spark-api-open.xf-yun.com/v1';
+  return 'https://spark-api-open.xf-yun.com/v2';
 };
 
 export const params = {
-  baseURL: 'https://spark-api-open.xf-yun.com/v1',
+  baseURL: 'https://spark-api-open.xf-yun.com/v2',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload, options) => {
       const { enabledSearch, thinking, tools, ...rest } = payload;

--- a/packages/model-runtime/src/providers/taichu/index.test.ts
+++ b/packages/model-runtime/src/providers/taichu/index.test.ts
@@ -8,7 +8,7 @@ import { testProvider } from '../../providerTestUtils';
 import { LobeTaichuAI } from './index';
 
 const provider = ModelProvider.Taichu;
-const defaultBaseURL = 'https://ai-maas.wair.ac.cn/maas/v1';
+const defaultBaseURL = 'https://cloud.zidongtaichu.com/maas/v1';
 
 testProvider({
   Runtime: LobeTaichuAI,

--- a/packages/model-runtime/src/providers/taichu/index.ts
+++ b/packages/model-runtime/src/providers/taichu/index.ts
@@ -5,7 +5,7 @@ import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactor
 import type { ChatStreamPayload } from '../../types';
 
 export const LobeTaichuAI = createOpenAICompatibleRuntime({
-  baseURL: 'https://ai-maas.wair.ac.cn/maas/v1',
+  baseURL: 'https://cloud.zidongtaichu.com/maas/v1',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload) => {
       const { temperature, top_p, ...rest } = payload;

--- a/packages/model-runtime/src/providers/volcengine/createImage.test.ts
+++ b/packages/model-runtime/src/providers/volcengine/createImage.test.ts
@@ -188,6 +188,70 @@ describe('createVolcengineImage', () => {
         size: '1024x1024',
       });
     });
+
+    it('should convert height and width to size parameter', async () => {
+      const mockResponse = {
+        data: [{ url: 'https://example.com/test.jpg' }],
+      };
+      mockGenerate.mockResolvedValue(mockResponse);
+
+      payload.params = {
+        prompt: 'test prompt',
+        height: 768,
+        width: 1024,
+      };
+
+      await createVolcengineImage(payload, options);
+
+      expect(mockGenerate).toHaveBeenCalledWith({
+        model: 'doubao-seedream-3-0-t2i',
+        watermark: false,
+        prompt: 'test prompt',
+        size: '1024x768',
+      });
+    });
+
+    it('should not convert size when only height is provided', async () => {
+      const mockResponse = {
+        data: [{ url: 'https://example.com/test.jpg' }],
+      };
+      mockGenerate.mockResolvedValue(mockResponse);
+
+      payload.params = {
+        prompt: 'test prompt',
+        height: 1024,
+      };
+
+      await createVolcengineImage(payload, options);
+
+      expect(mockGenerate).toHaveBeenCalledWith({
+        model: 'doubao-seedream-3-0-t2i',
+        watermark: false,
+        prompt: 'test prompt',
+        height: 1024,
+      });
+    });
+
+    it('should not convert size when only width is provided', async () => {
+      const mockResponse = {
+        data: [{ url: 'https://example.com/test.jpg' }],
+      };
+      mockGenerate.mockResolvedValue(mockResponse);
+
+      payload.params = {
+        prompt: 'test prompt',
+        width: 1024,
+      };
+
+      await createVolcengineImage(payload, options);
+
+      expect(mockGenerate).toHaveBeenCalledWith({
+        model: 'doubao-seedream-3-0-t2i',
+        watermark: false,
+        prompt: 'test prompt',
+        width: 1024,
+      });
+    });
   });
 
   describe('image input handling', () => {

--- a/packages/model-runtime/src/providers/volcengine/createImage.ts
+++ b/packages/model-runtime/src/providers/volcengine/createImage.ts
@@ -39,6 +39,16 @@ export async function createVolcengineImage(
     ]),
   );
 
+  // Convert height and weight/width to size parameter
+  const imgHeight = userInput.height;
+  const imgWidth = userInput.width;
+
+  if (imgHeight !== undefined && imgWidth !== undefined) {
+    userInput.size = `${imgWidth}x${imgHeight}`;
+    delete userInput.height;
+    delete userInput.width;
+  }
+
   // Volcengine supports direct URL or base64, no need to convert to File objects
   // Check if there is image input
   const hasImageInput =

--- a/packages/model-runtime/src/providers/wenxin/createImage.test.ts
+++ b/packages/model-runtime/src/providers/wenxin/createImage.test.ts
@@ -1,0 +1,910 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateImagePayload } from '../../types/image';
+import { createWenxinImage } from './createImage';
+
+// Mock the console.error to avoid polluting test output
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const mockOptions: CreateImageOptions = {
+  apiKey: 'test-api-key',
+  baseURL: 'https://qianfan.baidubce.com/v2',
+  provider: 'wenxin',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createWenxinImage', () => {
+  describe('Success scenarios for musesteamer models', () => {
+    it('should successfully generate image with basic prompt', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/test-image.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-test123',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: '画一个西瓜',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/musesteamer/images/generations');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: '画一个西瓜',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle custom size', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/custom-size.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-custom456',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Abstract digital art',
+          size: '1280x720',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Abstract digital art',
+        size: '1280x720',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle seed value correctly', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/seeded-image.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-seeded',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Reproducible image with seed',
+          seed: 42949672,
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Reproducible image with seed',
+        seed: 42949672,
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle seed value of 0 correctly', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/zero-seed.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-zero-seed',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Image with seed 0',
+          seed: 0,
+        },
+      };
+
+      await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Image with seed 0',
+        seed: 0,
+      });
+    });
+
+    it('should handle multiple generated images and return first one', async () => {
+      const mockImageUrls = [
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/image-1.jpeg',
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/image-2.jpeg',
+      ];
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-multiple',
+          created: 1764665123,
+          data: [{ url: mockImageUrls[0] }, { url: mockImageUrls[1] }],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Multiple images test',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrls[0],
+      });
+    });
+
+    it('should handle both size and seed', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/combined.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-combined',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Combined parameters test',
+          size: '1024x1024',
+          seed: 12345,
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Combined parameters test',
+        size: '1024x1024',
+        seed: 12345,
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should support other musesteamer models using startsWith', async () => {
+      const mockImageUrl = 'https://qianfan.baidubce.com/musesteamer-pro-image/images/test.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-musesteamer-pro',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-pro-image',
+        params: {
+          prompt: 'Test with pro model',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/musesteamer/images/generations');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-pro-image',
+        prompt: 'Test with pro model',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle custom width and height', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/custom-dims.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-custom-dims',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Abstract digital art',
+          width: 1280,
+          height: 720,
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Abstract digital art',
+        size: '1280x720',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should prefer width and height over size when both are provided', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/precedence.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-precedence',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Precedence test',
+          width: 1024,
+          height: 1024,
+          size: '1280x720',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'Precedence test',
+        size: '1024x1024',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle width, height, and seed together', async () => {
+      const mockImageUrl =
+        'https://qianfan.baidubce.com/musesteamer-air-image/images/all-params.jpeg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-all-params',
+          created: 1764665123,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'All parameters test',
+          width: 1024,
+          height: 768,
+          seed: 42,
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'musesteamer-air-image',
+        prompt: 'All parameters test',
+        size: '1024x768',
+        seed: 42,
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+  });
+
+  describe('Success scenarios for qwen-image', () => {
+    it('should successfully generate image with qwen-image model', async () => {
+      const mockImageUrl = 'https://qianfan-img-gen.bj.bcebos.com/qwen-image/test-image.png';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-p5vuu9vgsn',
+          created: 1735264326,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image',
+        params: {
+          prompt: '画一只小狗',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/generations');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'qwen-image',
+        prompt: '画一只小狗',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle qwen-image with size and seed', async () => {
+      const mockImageUrl = 'https://qianfan-img-gen.bj.bcebos.com/qwen-image/test-image-2.png';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-qwen-custom',
+          created: 1735264326,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image',
+        params: {
+          prompt: 'A beautiful sunset',
+          size: '1024x768',
+          seed: 42,
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'qwen-image',
+        prompt: 'A beautiful sunset',
+        size: '1024x768',
+        seed: 42,
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+  });
+
+  describe('Success scenarios for qwen-image-edit', () => {
+    it('should successfully edit image with qwen-image-edit model when imageUrl exists', async () => {
+      const mockImageUrl = 'https://qianfan-img-gen.bj.bcebos.com/qwen-image-edit/edited-image.png';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-qwen-edit',
+          created: 1735264326,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image-edit',
+        params: {
+          prompt: 'Add a red car',
+          imageUrl: 'https://example.com/source-image.jpg',
+          size: '1024x1024',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/edits');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'qwen-image-edit',
+        prompt: 'Add a red car',
+        image: 'https://example.com/source-image.jpg',
+        size: '1024x1024',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should use generations endpoint for qwen-image-edit when imageUrl is not present', async () => {
+      const mockImageUrl =
+        'https://qianfan-img-gen.bj.bcebos.com/qwen-image-edit/generated-image.png';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-qwen-gen',
+          created: 1735264326,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image-edit',
+        params: {
+          prompt: 'Generate an image',
+          size: '1024x1024',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/generations');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'qwen-image-edit',
+        prompt: 'Generate an image',
+        size: '1024x1024',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should use imageUrls array when imageUrls exists', async () => {
+      const mockImageUrl =
+        'https://qianfan-img-gen.bj.bcebos.com/qwen-image-edit/edited-image-2.png';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-qwen-edit-urls',
+          created: 1735264326,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image-edit',
+        params: {
+          prompt: 'Edit this image',
+          imageUrls: [
+            'https://example.com/source-image.jpg',
+            'https://example.com/second-image.jpg',
+          ],
+          size: '1024x1024',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/edits');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'qwen-image-edit',
+        prompt: 'Edit this image',
+        image: ['https://example.com/source-image.jpg', 'https://example.com/second-image.jpg'],
+        size: '1024x1024',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+  });
+
+  describe('Success scenarios for ernie-irag-edit', () => {
+    it('should use edits endpoint for ernie-irag-edit when imageUrl exists', async () => {
+      const mockImageUrl = 'https://qianfan-model.bj.bcebos.com/ernie-irag-edit/edited-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-iwjxy4gpyc',
+          created: 1744787581,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'ernie-irag-edit',
+        params: {
+          prompt: '',
+          imageUrl: 'https://sdc-def.example.com/image.jpg',
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/edits');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'ernie-irag-edit',
+        prompt: '',
+        image: 'https://sdc-def.example.com/image.jpg',
+        feature: 'variation',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should use edits endpoint for ernie-irag-edit when imageUrls exists', async () => {
+      const mockImageUrl = 'https://qianfan-model.bj.bcebos.com/ernie-irag-edit/edited-image-2.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-irag-edit-urls',
+          created: 1744787581,
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'ernie-irag-edit',
+        params: {
+          prompt: '',
+          imageUrls: ['https://example.com/image.jpg', 'https://example.com/second.jpg'],
+        },
+      };
+
+      const result = await createWenxinImage(payload, mockOptions);
+
+      const fetchCall = (fetch as any).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://qianfan.baidubce.com/v2/images/edits');
+      const requestBody = JSON.parse(fetchCall[1].body);
+      expect(requestBody).toEqual({
+        model: 'ernie-irag-edit',
+        prompt: '',
+        image: ['https://example.com/image.jpg', 'https://example.com/second.jpg'],
+        feature: 'variation',
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+  });
+
+  describe('Error scenarios', () => {
+    it('should handle HTTP error responses', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({
+          error: 'Invalid prompt format',
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Invalid prompt',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle non-JSON error responses', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: async () => {
+          throw new Error('Failed to parse JSON');
+        },
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image',
+        params: {
+          prompt: 'Test prompt',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle empty data array', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-empty',
+          created: 1764665123,
+          data: [],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Empty result test',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle missing data field', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-no-data',
+          created: 1764665123,
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image',
+        params: {
+          prompt: 'Missing data test',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle null/empty image URL', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'as-empty-url',
+          created: 1764665123,
+          data: [
+            {
+              url: '',
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'ernie-irag-edit',
+        params: {
+          prompt: '',
+          imageUrl: 'https://example.com/image.jpg',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle network errors', async () => {
+      global.fetch = vi.fn().mockRejectedValueOnce(new Error('Network connection failed'));
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'Network error test',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle unauthorized access', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({
+          error: 'Invalid API key',
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image',
+        params: {
+          prompt: 'Unauthorized test',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+
+    it('should handle malformed JSON response', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Unexpected token in JSON');
+        },
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'musesteamer-air-image',
+        params: {
+          prompt: 'JSON error test',
+        },
+      };
+
+      await expect(createWenxinImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'wenxin',
+        }),
+      );
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/wenxin/createImage.ts
+++ b/packages/model-runtime/src/providers/wenxin/createImage.ts
@@ -1,0 +1,112 @@
+import createDebug from 'debug';
+
+import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import { AgentRuntimeError } from '../../utils/createError';
+
+const log = createDebug('lobe-image:wenxin');
+
+interface WenxinImageResponse {
+  created: number;
+  data: {
+    url: string;
+  }[];
+  id: string;
+}
+
+/**
+ * Create image using Wenxin API
+ * Supports multiple models with different endpoints:
+ * - musesteamer-air-image: /v2/musesteamer/images/generations
+ * - Other models (with image): /v2/images/edits
+ * - Other models (without image): /v2/images/generations
+ */
+export async function createWenxinImage(
+  payload: CreateImagePayload,
+  options: CreateImageOptions,
+): Promise<CreateImageResponse> {
+  const { apiKey, baseURL, provider } = options;
+  const { model, params } = payload;
+
+  try {
+    let endpoint: string;
+
+    const images =
+      params.imageUrls && params.imageUrls.length > 0 ? params.imageUrls : params.imageUrl;
+
+    if (model.startsWith('musesteamer')) {
+      endpoint = `${baseURL}/musesteamer/images/generations`;
+    } else {
+      if (images) {
+        endpoint = `${baseURL}/images/edits`;
+      } else {
+        endpoint = `${baseURL}/images/generations`;
+      }
+    }
+
+    const requestBody: Record<string, any> = {
+      model,
+      prompt: params.prompt,
+      ...(images !== undefined && { image: images }),
+      ...(params.seed !== undefined && { seed: params.seed }),
+      ...(params.width !== undefined && params.height !== undefined
+        ? { size: `${params.width}x${params.height}` }
+        : params.size !== undefined
+          ? { size: params.size }
+          : {}),
+      ...(params.steps !== undefined && { steps: params.steps }),
+      ...(model === 'ernie-irag-edit' && { feature: 'variation' }),
+    };
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify(requestBody),
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    if (!response.ok) {
+      let errorData;
+      try {
+        errorData = await response.json();
+      } catch {}
+
+      const errorMessage =
+        typeof errorData?.error === 'string'
+          ? errorData.error
+          : JSON.stringify(errorData?.error || errorData);
+
+      throw new Error(
+        `Wenxin API error (${response.status}): ${errorMessage || response.statusText}`,
+      );
+    }
+
+    const data: WenxinImageResponse = await response.json();
+
+    log('Image generation response: %O', data);
+
+    if (!data.data || data.data.length === 0) {
+      throw new Error('No images generated in response');
+    }
+
+    const resultImageUrl = data.data[0].url;
+
+    if (!resultImageUrl) {
+      throw new Error('No valid image URL in response');
+    }
+
+    log('Image generated successfully: %s', resultImageUrl);
+
+    return { imageUrl: resultImageUrl };
+  } catch (error) {
+    log('Error in createWenxinImage: %O', error);
+
+    throw AgentRuntimeError.createImage({
+      error: error as any,
+      errorType: 'ProviderBizError',
+      provider,
+    });
+  }
+}

--- a/packages/model-runtime/src/providers/wenxin/index.ts
+++ b/packages/model-runtime/src/providers/wenxin/index.ts
@@ -3,6 +3,7 @@ import { ModelProvider } from 'model-bank';
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { processMultiProviderModelList } from '../../utils/modelParse';
+import { createWenxinImage } from './createImage';
 
 export interface WenxinModelCard {
   id: string;
@@ -33,6 +34,7 @@ export const params = {
       } as any;
     },
   },
+  createImage: createWenxinImage,
   debug: {
     chatCompletion: () => process.env.DEBUG_WENXIN_CHAT_COMPLETION === '1',
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 更新 360智脑，腾讯混元，书生，讯飞星火，Stepfun，文心一言，豆包Seedream，Taichu模型列表
2. Spark 默认 baseUrl 更换为 v2 版本，兼容 v1 老版本（新模型均走 v2）
3. Hunyuan 移除大量无效模型，修正 `hunyuan-vision-1.5-instruct` 错误的 desc 和显示名
4. Wenxin 生图模型增加 `qwen-iamge` `qwen-image-edit` `musesteamer-air-image` 蒸汽机模型
5. Doubao Seedream 生图模型增加 `doubao-seedream-4-5-251128` `doubao-seedream-5-0-260128` 支持自由分辨率选择
6. Taichu 修正 BaseURL 错误
7. Minimax 为 `image-01` `image-01-live` 增加图生图功能（仅支持人物主体参考，用于图生图）

---

|模型||
|-|-|
|`qwen-image`|<img width="571" height="549" alt="image" src="https://github.com/user-attachments/assets/e4f87562-e9ac-4871-94ec-b2970361d266" />|
|`qwen-image-edit`|<img width="514" height="552" alt="image" src="https://github.com/user-attachments/assets/49eed8fa-11fd-4dde-9bd2-a10f3d43df1b" />|
|`musesteamer-air-image`|<img width="916" height="721" alt="image" src="https://github.com/user-attachments/assets/bc3b9181-c0f4-41ae-a1bd-ff41aaf8edb3" />|
|`doubao-seedream-4-5-251128`|<img width="857" height="716" alt="image" src="https://github.com/user-attachments/assets/dce5f151-6c14-4922-85da-404908e50ddd" />|
|`image-01-live`|<img width="1519" height="721" alt="image" src="https://github.com/user-attachments/assets/8a8f0e9f-e012-4d09-9d22-38827ab1929e" />|
|`image-01`|<img width="1081" height="916" alt="image" src="https://github.com/user-attachments/assets/b84e7182-afc3-4e7a-920f-e85fce0fdc76" />|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update multiple provider model catalogs and Spark runtime configuration to reflect the latest upstream offerings and endpoints.

New Features:
- Add new Hunyuan 2.0 thinking and instruct chat models and promote key existing models while pruning obsolete entries.
- Extend Wenxin catalog with new ERNIE 4.5 Turbo VL variants, ERNIE 4.5 21B A3B Thinking, ERNIE X1.1/X1 Turbo 32K variants, and Qwen image generation/editing models.
- Add new 360 Zhinao reasoning, turbo, DeepSeek V3.2, and Doubao Seed 2.0 family models to the 360 provider catalog.
- Refresh InternLM catalog around the new Intern-S1 series and InternVL3.5 models with updated default aliases.
- Introduce Stepfun Step 3.5 Flash model, cache-read pricing units for existing tiers, and pricing for image models.
- Add Spark X2 model and remap existing Spark X1.5 model id.

Enhancements:
- Adjust context window sizes, abilities, and enablement flags across several providers to align with current upstream capabilities.
- Switch Spark provider default base URL to v2 and route only legacy models through the v1 endpoint.