### PR TITLE
✨ feat(model-bank): lobehub provider add Claude Sonnet 4.6 support

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -9,6 +9,33 @@ export const anthropicChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 200_000,
+    description: "Claude Sonnet 4.6 is Anthropic's best combination of speed and intelligence.",
+    displayName: 'Claude Sonnet 4.6',
+    enabled: true,
+    id: 'claude-sonnet-4-6',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 3.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-18',
+    settings: {
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'effort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
     description: "Claude Sonnet 4.5 is Anthropic's most intelligent model to date.",
     displayName: 'Claude Sonnet 4.5',
     enabled: true,

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -1,10 +1,10 @@
-import Anthropic, { ClientOptions } from '@anthropic-ai/sdk';
+import Anthropic, { type ClientOptions } from '@anthropic-ai/sdk';
 import type { Stream } from '@anthropic-ai/sdk/streaming';
 import type { ChatModelCard } from '@lobechat/types';
 import debug from 'debug';
 
 import { hasTemperatureTopPConflict } from '../../const/models';
-import {
+import type {
   ChatCompletionErrorPayload,
   ChatMethodOptions,
   ChatStreamCallbacks,
@@ -12,14 +12,15 @@ import {
   GenerateObjectOptions,
   GenerateObjectPayload,
 } from '../../types';
-import { AgentRuntimeErrorType, ILobeAgentRuntimeErrorType } from '../../types/error';
+import type { ILobeAgentRuntimeErrorType } from '../../types/error';
+import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
 import { debugStream } from '../../utils/debugStream';
 import { desensitizeUrl } from '../../utils/desensitizeUrl';
 import { getModelPricing } from '../../utils/getModelPricing';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
 import { StreamingResponse } from '../../utils/response';
-import { LobeRuntimeAI } from '../BaseAI';
+import type { LobeRuntimeAI } from '../BaseAI';
 import {
   buildAnthropicMessages,
   buildAnthropicTools,
@@ -148,8 +149,8 @@ export const buildDefaultAnthropicPayload = async (
 
   const postMessages = await buildAnthropicMessages(userMessages, { enabledContextCaching });
 
-  // Claude Opus 4.6 does not support assistant turn prefill
-  if (model.includes('opus-4-6') && postMessages.at(-1)?.role === 'assistant') {
+  // Claude 4.6 models do not support assistant turn prefill
+  if (model.includes('-4-6') && postMessages.at(-1)?.role === 'assistant') {
     postMessages.pop();
   }
 
@@ -166,10 +167,7 @@ export const buildDefaultAnthropicPayload = async (
     const resolvedThinking: Anthropic.MessageCreateParams['thinking'] =
       thinking.type === 'enabled'
         ? {
-            budget_tokens: Math.min(
-              thinking?.budget_tokens || 1024,
-              resolvedMaxTokens - 1,
-            ),
+            budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
             type: 'enabled',
           }
         : { type: 'adaptive' };
@@ -431,7 +429,9 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
         const finalPayload = { ...postPayload, stream: shouldStream };
 
         if (debugParams?.chatCompletion?.()) {
+          // eslint-disable-next-line no-console
           console.log('[requestPayload]');
+          // eslint-disable-next-line no-console
           console.log(JSON.stringify(finalPayload), '\n');
         }
 


### PR DESCRIPTION
## Summary
- Add Claude Sonnet 4.6 model card to lobehub provider with adaptive thinking and effort support
- Extend assistant turn prefill restriction from Opus 4.6 only to all 4.6 models (anthropicCompatibleFactory and bedrock provider)

## Test plan
- [ ] Verify Sonnet 4.6 appears in model list with correct pricing and settings
- [ ] Verify assistant turn prefill is correctly disabled for Sonnet 4.6
- [ ] Verify adaptive thinking and effort params work with Sonnet 4.6

## Summary by Sourcery

Add support for Claude Sonnet 4.6 and align Anthropic-compatible runtimes with the capabilities and constraints of all Claude 4.6 models.

New Features:
- Register Claude Sonnet 4.6 as a lobehub Anthropic chat model with pricing, context window, and extended settings for context caching, adaptive thinking, and effort controls.

Enhancements:
- Extend the assistant turn prefill restriction to all Claude 4.6 models in both the Bedrock provider and Anthropic-compatible factory.
- Simplify Bedrock client initialization and Anthropic thinking budget handling, and improve request payload debug logging.