### PR TITLE
♻️ chore: remove electron-liquid-glass and restore macOS vibrancy reapply

### DIFF
--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -33,7 +33,7 @@ const isDarwin = getTargetPlatform() === 'darwin';
  */
 export const nativeModules = [
   // macOS-only native modules
-  ...(isDarwin ? ['node-mac-permissions', 'electron-liquid-glass'] : []),
+  ...(isDarwin ? ['node-mac-permissions'] : []),
   '@napi-rs/canvas',
   // Add more native modules here as needed
 ];

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.70",
-    "electron-liquid-glass": "^1.1.1",
     "electron-updater": "^6.6.2",
     "electron-window-state": "^5.0.3",
     "fetch-socks": "^1.3.2",

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -154,7 +154,7 @@ export default class Browser {
   private setupWindow(browserWindow: BrowserWindow): void {
     logger.debug(`[${this.identifier}] BrowserWindow instance created.`);
 
-    // Setup theme management (includes liquid glass lifecycle on macOS Tahoe)
+    // Setup theme management
     this.themeManager.attach(browserWindow);
 
     // Setup network interceptors

--- a/apps/desktop/src/main/core/browser/WindowThemeManager.ts
+++ b/apps/desktop/src/main/core/browser/WindowThemeManager.ts
@@ -4,7 +4,7 @@ import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { type BrowserWindow, type BrowserWindowConstructorOptions, nativeTheme } from 'electron';
 
 import { buildDir } from '@/const/dir';
-import { isDev, isMac, isMacTahoe, isWindows } from '@/const/env';
+import { isDev, isMac, isWindows } from '@/const/env';
 import { createLogger } from '@/utils/logger';
 
 import {
@@ -28,18 +28,6 @@ interface WindowsThemeConfig {
   titleBarStyle: 'hidden';
 }
 
-// Lazy-load liquid glass only on macOS Tahoe to avoid import errors on other platforms.
-// Dynamic require is intentional: native .node addons cannot be loaded via
-// async import() and must be synchronously required at module init time.
-let liquidGlass: typeof import('electron-liquid-glass').default | undefined;
-if (isMacTahoe) {
-  try {
-    liquidGlass = require('electron-liquid-glass');
-  } catch {
-    // Native module not available (e.g. wrong architecture or missing binary)
-  }
-}
-
 /**
  * Manages window theme configuration and visual effects
  */
@@ -48,7 +36,6 @@ export class WindowThemeManager {
   private browserWindow?: BrowserWindow;
   private listenerSetup = false;
   private boundHandleThemeChange: () => void;
-  private liquidGlassViewId?: number;
 
   constructor(identifier: string) {
     this.identifier = identifier;
@@ -68,20 +55,12 @@ export class WindowThemeManager {
 
   /**
    * Attach to a browser window and setup theme handling.
-   * Owns the full visual effect lifecycle including liquid glass on macOS Tahoe.
+   * Owns the full visual effect lifecycle.
    */
   attach(browserWindow: BrowserWindow): void {
     this.browserWindow = browserWindow;
     this.setupThemeListener();
     this.applyVisualEffects();
-
-    // Liquid glass must be applied after window content loads (native view needs
-    // a rendered surface). The effect persists across subsequent in-window navigations.
-    if (this.useLiquidGlass) {
-      browserWindow.webContents.once('did-finish-load', () => {
-        this.applyLiquidGlass();
-      });
-    }
   }
 
   /**
@@ -93,7 +72,6 @@ export class WindowThemeManager {
       this.listenerSetup = false;
       logger.debug(`[${this.identifier}] Theme listener cleaned up.`);
     }
-    this.liquidGlassViewId = undefined;
     this.browserWindow = undefined;
   }
 
@@ -107,13 +85,6 @@ export class WindowThemeManager {
   }
 
   /**
-   * Whether liquid glass is available and should be used
-   */
-  get useLiquidGlass(): boolean {
-    return isMacTahoe && !!liquidGlass;
-  }
-
-  /**
    * Get platform-specific theme configuration for window creation
    */
   getPlatformConfig(): Partial<BrowserWindowConstructorOptions> {
@@ -124,14 +95,6 @@ export class WindowThemeManager {
       // Calculate traffic light position to center vertically in title bar
       // Traffic light buttons are approximately 12px tall
       const trafficLightY = Math.round((TITLE_BAR_HEIGHT - 12) / 2);
-
-      if (this.useLiquidGlass) {
-        // Liquid glass requires transparent window and must NOT use vibrancy — they conflict.
-        return {
-          trafficLightPosition: { x: 12, y: trafficLightY },
-          transparent: true,
-        };
-      }
 
       return {
         trafficLightPosition: { x: 12, y: trafficLightY },
@@ -231,42 +194,12 @@ export class WindowThemeManager {
   }
 
   /**
-   * Apply macOS visual effects.
-   * - Tahoe+: liquid glass auto-adapts to dark mode; ensure it's applied if not yet.
-   * - Pre-Tahoe: vibrancy is managed natively by Electron, no runtime action needed.
+   * Reapply macOS visual effects at runtime.
+   * This keeps vibrancy consistent after theme source updates.
    */
   private applyMacVisualEffects(): void {
     if (!this.browserWindow) return;
 
-    if (this.useLiquidGlass) {
-      // Attempt apply if not yet done (e.g. initial load failed, or window recreated)
-      this.applyLiquidGlass();
-    }
-  }
-
-  // ==================== Liquid Glass ====================
-
-  /**
-   * Apply liquid glass native view to the window.
-   * Idempotent — guards against double-application via `liquidGlassViewId`.
-   */
-  applyLiquidGlass(): void {
-    if (!this.useLiquidGlass || !liquidGlass) return;
-    if (!this.browserWindow || this.browserWindow.isDestroyed()) return;
-    if (this.liquidGlassViewId !== undefined) return;
-
-    try {
-      // Ensure traffic light buttons remain visible with transparent window
-      this.browserWindow.setWindowButtonVisibility(true);
-
-      const handle = this.browserWindow.getNativeWindowHandle();
-
-      this.liquidGlassViewId = liquidGlass.addView(handle);
-      liquidGlass.unstable_setVariant(this.liquidGlassViewId, 15);
-
-      logger.info(`[${this.identifier}] Liquid glass applied (viewId: ${this.liquidGlassViewId})`);
-    } catch (error) {
-      logger.error(`[${this.identifier}] Failed to apply liquid glass:`, error);
-    }
+    this.browserWindow.setVibrancy('sidebar');
   }
 }


### PR DESCRIPTION
## Summary
- Remove `electron-liquid-glass` dependency and all related logic from desktop app
- Restore `applyMacVisualEffects()` to reapply vibrancy at runtime on theme change
- Clean up `WindowThemeManager`, `native-deps.config.mjs`, and `package.json`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Remove the electron-liquid-glass integration and rely on Electron’s built-in macOS vibrancy handling for window theming.

Bug Fixes:
- Restore runtime reapplication of macOS vibrancy when the theme changes.

Enhancements:
- Simplify WindowThemeManager by removing liquid glass handling and centralizing vibrancy reapplication.
- Update Browser window setup comments to reflect the simplified theme management lifecycle.

Build:
- Update native-deps configuration to drop the electron-liquid-glass native module.
- Remove electron-liquid-glass from desktop app dependencies.