### PR TITLE
🐛 fix(mcp): prevent double URL prefix for image and audio content

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Render/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Render/index.tsx
@@ -18,8 +18,9 @@ interface ToolRenderProps {
 const ToolRender = memo<ToolRenderProps>(
   ({ showCustomToolRender, content, messageId, plugin, pluginState, toolCallId }) => {
     const hasCustomRender = !!getBuiltinRender(plugin?.identifier, plugin?.apiName);
+    const isMCP = (plugin?.type as string) === 'mcp';
 
-    if (hasCustomRender && showCustomToolRender) {
+    if ((hasCustomRender && showCustomToolRender) || isMCP) {
       return (
         <CustomRender
           content={content}

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -80,11 +80,13 @@ export const contentBlocksToString = (blocks: ToolCallContent[] | null | undefin
         }
 
         case 'image': {
-          return `![](${urlJoin(appEnv.APP_URL, item.data)})`;
+          const imageUrl = item.data.startsWith('http') ? item.data : urlJoin(appEnv.APP_URL, item.data);
+          return `![](${imageUrl})`;
         }
 
         case 'audio': {
-          return `<resource type="${item.type}" url="${urlJoin(appEnv.APP_URL, item.data)}" />`;
+          const audioUrl = item.data.startsWith('http') ? item.data : urlJoin(appEnv.APP_URL, item.data);
+          return `<resource type="${item.type}" url="${audioUrl}" />`;
         }
 
         case 'resource': {


### PR DESCRIPTION
contentBlocksToString() unconditionally wraps media URLs with urlJoin(APP_URL, item.data). Since processContentBlocks() already
   stores the full proxy URL (including APP_URL) after S3 upload, the host prefix gets duplicated — producing
  https://example.com/https://example.com/f/{id}, breaking image/audio rendering for all MCP tool results.

  Fix: add startsWith('http') guard so absolute URLs pass through unchanged while relative paths still get the APP_URL prefix.
  Applied to both image and audio cases.

## Summary by Sourcery

Fix handling and rendering of MCP tool media content URLs to avoid duplicated host prefixes and ensure MCP tools always use the custom render path.

Bug Fixes:
- Prevent double-appending the application base URL to image and audio content URLs when they are already absolute, restoring correct media rendering for MCP tool outputs.

Enhancements:
- Route MCP plugin tool results through the custom render component by default to ensure consistent MCP-specific rendering behavior.