### PR TITLE
🐛 fix: stabilize single-message screenshot share rendering

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,6 @@
 import { type AnchorHTMLAttributes } from 'react';
 import React, { memo } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useInRouterContext } from 'react-router-dom';
 
 interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   children?: React.ReactNode | undefined;
@@ -13,10 +13,21 @@ interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  * - Internal routes → React Router Link
  */
 const Link = memo<LinkProps>(({ href, children, ...props }) => {
+  const inRouterContext = useInRouterContext();
+
   // External links use native <a> tag
   if (href?.startsWith('http://') || href?.startsWith('https://')) {
     return (
       <a href={href} rel="noreferrer" {...props}>
+        {children}
+      </a>
+    );
+  }
+
+  // Fallback to native <a> when used outside React Router (e.g., raw modal portals)
+  if (!inRouterContext) {
+    return (
+      <a href={href || '/'} {...props}>
         {children}
       </a>
     );

--- a/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
+++ b/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
@@ -4,17 +4,18 @@ import { ModelTag } from '@lobehub/icons';
 import { Avatar, Flexbox } from '@lobehub/ui';
 import { ChatHeaderTitle } from '@lobehub/ui/chat';
 import { cx } from 'antd-style';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
 
 import { ProductLogo } from '@/components/Branding';
-import { ChatItem } from '@/features/Conversation/ChatItem';
+import { ConversationProvider, MessageItem } from '@/features/Conversation';
 import PluginTag from '@/features/PluginTag';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { useAgentMeta, useIsBuiltinAgent } from '../../../hooks';
-import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
+import { useConversationStore } from '../../../store';
 import { styles as containerStyles } from '../style';
 import { styles } from './style';
 import { type FieldType } from './type';
@@ -34,14 +35,16 @@ const Preview = memo<PreviewProps>(
 
     const agentMeta = useAgentMeta(message.agentId);
     const isBuiltinAgent = useIsBuiltinAgent();
-
-    // Process message content for proper rendering
-    const processedContent = normalizeThinkTags(processWithArtifact(message.content));
+    const context = useConversationStore((s) => s.context);
 
     const { t } = useTranslation('chat');
 
     const displayTitle = agentMeta.title || title;
     const displayDesc = isBuiltinAgent ? t('inbox.desc') : agentMeta.description;
+    const previewContext = useMemo(
+      () => ({ ...context, agentId: message.agentId || context.agentId }),
+      [context, message.agentId],
+    );
 
     return (
       <div className={containerStyles.preview}>
@@ -76,15 +79,22 @@ const Preview = memo<PreviewProps>(
               style={{ paddingTop: 24, position: 'relative' }}
               width={'100%'}
             >
-              <ChatItem
-                id={message.id}
-                message={processedContent}
-                avatar={{
-                  avatar: agentMeta.avatar,
-                  backgroundColor: agentMeta.backgroundColor,
-                  title: displayTitle,
-                }}
-              />
+              <MemoryRouter>
+                <ConversationProvider
+                  context={previewContext}
+                  hasInitMessages={true}
+                  messages={[message]}
+                  skipFetch={true}
+                >
+                  <Flexbox
+                    height={'100%'}
+                    style={{ padding: 24, pointerEvents: 'none', position: 'relative' }}
+                    width={'100%'}
+                  >
+                    <MessageItem id={message.id} index={0} />
+                  </Flexbox>
+                </ConversationProvider>
+              </MemoryRouter>
             </Flexbox>
             {withFooter ? (
               <Flexbox align={'center'} className={styles.footer} gap={4}>


### PR DESCRIPTION
#### 💻 Change Type
  <!-- For change type, change [ ] to [x]. -->

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue
  <!-- Link to the issue that is fixed by this PR -->
  Fixed #11681

  #### 🔀 Description of Change
  <!-- Thank you for your Pull Request. Please provide a description above. -->

  This PR fixes multiple regressions in single-message screenshot sharing:

  1. Markdown formatting mismatch
      - Single-message screenshot now reuses the same conversation message rendering path as topic screenshot, instead of rendering raw/plain content.
      - This keeps markdown/tool-related UI behavior consistent with normal chat rendering.
contexts.
  2. Tool-call message support in screenshot preview
      - Tool-call messages no longer render as empty/incorrect content in single-message screenshot mode.
      - Tool-related message blocks now follow standard MessageItem rendering.

  #### 🧪 How to Test
  <!-- Please describe how you tested your changes -->
  <!-- For AI features, please include test prompts or scenarios -->

  - Open a chat with:
      1. a normal assistant markdown message (headings/list/code block),
      2. an assistant message with tool calls,
      3. (optional) a message that can trigger provider error UI.
  - For each target message:
      - Open single-message share modal → Screenshot tab.
      - Verify preview renders correctly and does not crash.
      - Verify Copy and Download both work.
  - Regression check:
      - Share whole topic screenshot still behaves as before.
  - [x] Tested locally
  - [ ] Added/updated tests
  - [x] No tests needed

  #### 📸 Screenshots / Videos
  <!-- If this PR includes UI changes, please provide screenshots or videos -->
<img width="1800" height="1030" alt="image" src="https://github.com/user-attachments/assets/ebbc1193-315c-4f62-9eb5-fa892494a576" />


  #### 📝 Additional Information
  <!-- Add any other context about the Pull Request here. -->

  - Scope is limited to share preview rendering path; no backend/data schema changes.
  - No breaking API changes.
  - Risk is low and concentrated in share modal preview behavior.

## Summary by Sourcery

Stabilize single-message screenshot preview rendering by reusing the standard conversation message pipeline and ensuring it works correctly within routing context constraints.

Bug Fixes:
- Fix single-message share preview to render messages using the same MessageItem-based conversation pipeline as regular chat and topic screenshots, preserving markdown and tool-call behavior.
- Prevent router-related errors in shared content by falling back to native anchor links when no React Router context is available.