### PR TITLE
✨ feat: add Gemini 3.1 Pro Preview model support

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -118,6 +118,67 @@ const googleChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities and adds medium thinking level support.',
+    displayName: 'Gemini 3.1 Pro Preview',
+    enabled: true,
+    id: 'gemini-3.1-pro-preview',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 200_000 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 12, upTo: 200_000 },
+            { rate: 18, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-19',
+    settings: {
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },

--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -6,6 +6,67 @@ export const googleChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities (ARC-AGI-2 77.1%) and adds medium thinking level support.',
+    displayName: 'Gemini 3.1 Pro Preview',
+    enabled: true,
+    id: 'gemini-3.1-pro-preview',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 200_000 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 12, upTo: 200_000 },
+            { rate: 18, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-19',
+    settings: {
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -8,6 +8,67 @@ const vertexaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities and adds medium thinking level support.',
+    displayName: 'Gemini 3.1 Pro Preview',
+    enabled: true,
+    id: 'gemini-3.1-pro-preview',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 200_000 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 12, upTo: 200_000 },
+            { rate: 18, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-19',
+    settings: {
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -19,4 +19,4 @@ const LobeHub: ModelProviderCard = {
 
 export default LobeHub;
 
-export const planCardModels = ['claude-sonnet-4-5-20250929', 'gemini-3-pro-preview', 'gpt-5.2', 'deepseek-chat'];
+export const planCardModels = ['claude-sonnet-4-5-20250929', 'gemini-3.1-pro-preview', 'gpt-5.2', 'deepseek-chat'];

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -255,6 +255,7 @@ export type ExtendParamsType =
   | 'thinkingBudget'
   | 'thinkingLevel'
   | 'thinkingLevel2'
+  | 'thinkingLevel3'
   | 'imageAspectRatio'
   | 'imageResolution'
   | 'urlContext';
@@ -284,6 +285,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'thinkingBudget',
   'thinkingLevel',
   'thinkingLevel2',
+  'thinkingLevel3',
   'imageAspectRatio',
   'imageResolution',
   'urlContext',

--- a/packages/model-runtime/src/providers/google/thinkingResolver.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.ts
@@ -19,7 +19,7 @@ export type GoogleThinkingModelCategory = 'pro' | 'flash' | 'flashLite' | 'robot
 /**
  * Thinking level for Gemini 3.0+ models
  */
-export type GoogleThinkingLevel = 'low' | 'high';
+export type GoogleThinkingLevel = 'low' | 'medium' | 'high';
 
 /**
  * Options for resolving Google thinking configuration

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -150,7 +150,7 @@ export interface ChatStreamPayload {
   /**
    * Thinking level for Gemini models (e.g., gemini-3.0-pro)
    */
-  thinkingLevel?: 'low' | 'high';
+  thinkingLevel?: 'low' | 'medium' | 'high';
   tool_choice?: string;
   tools?: ChatCompletionTool[];
   /**

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -102,6 +102,8 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig {
   thinking?: 'disabled' | 'auto' | 'enabled';
   thinkingBudget?: number;
   thinkingLevel?: 'minimal' | 'low' | 'medium' | 'high';
+  thinkingLevel2?: 'low' | 'high';
+  thinkingLevel3?: 'low' | 'medium' | 'high';
   /**
    * Maximum length for tool execution result content (in characters)
    * This prevents context overflow when sending tool results back to LLM
@@ -167,6 +169,8 @@ export const AgentChatConfigSchema = z
     thinking: z.enum(['disabled', 'auto', 'enabled']).optional(),
     thinkingBudget: z.number().optional(),
     thinkingLevel: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+    thinkingLevel2: z.enum(['low', 'high']).optional(),
+    thinkingLevel3: z.enum(['low', 'medium', 'high']).optional(),
     toolResultMaxLength: z.number().default(6000),
     urlContext: z.boolean().optional(),
     useModelBuiltinSearch: z.boolean().optional(),

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -17,6 +17,7 @@ import ReasoningTokenSlider from '@/features/ChatInput/ActionBar/Model/Reasoning
 import TextVerbositySlider from '@/features/ChatInput/ActionBar/Model/TextVerbositySlider';
 import ThinkingBudgetSlider from '@/features/ChatInput/ActionBar/Model/ThinkingBudgetSlider';
 import ThinkingLevel2Slider from '@/features/ChatInput/ActionBar/Model/ThinkingLevel2Slider';
+import ThinkingLevel3Slider from '@/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider';
 import ThinkingLevelSlider from '@/features/ChatInput/ActionBar/Model/ThinkingLevelSlider';
 import ThinkingSlider from '@/features/ChatInput/ActionBar/Model/ThinkingSlider';
 
@@ -87,6 +88,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'thinkingLevel2',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.thinkingLevel3.hint',
+    key: 'thinkingLevel3',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.urlContext.hint',
     key: 'urlContext',
   },
@@ -108,6 +113,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   gpt5_2ProReasoningEffort: 'reasoningEffort',
   gpt5_2ReasoningEffort: 'reasoningEffort',
   thinkingLevel2: 'thinkingLevel',
+  thinkingLevel3: 'thinkingLevel',
 };
 
 type PreviewMeta = {
@@ -143,6 +149,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 500, tag: 'thinkingBudget' },
   thinkingLevel: { labelSuffix: ' (Gemini 3)', previewWidth: 280, tag: 'thinkingLevel' },
   thinkingLevel2: { labelSuffix: ' (Gemini 3)', previewWidth: 200, tag: 'thinkingLevel' },
+  thinkingLevel3: { labelSuffix: ' (Gemini 3.1)', previewWidth: 230, tag: 'thinkingLevel' },
   urlContext: { labelSuffix: ' (Gemini)', previewWidth: 400, tag: 'urlContext' },
 };
 
@@ -243,6 +250,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       thinkingBudget: <ThinkingBudgetSlider defaultValue={2 * 1024} />,
       thinkingLevel: <ThinkingLevelSlider value="high" />,
       thinkingLevel2: <ThinkingLevel2Slider value="high" />,
+      thinkingLevel3: <ThinkingLevel3Slider value="high" />,
       urlContext: <Switch checked disabled />,
     }),
     [],

--- a/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ControlsForm.tsx
@@ -24,6 +24,7 @@ import ReasoningTokenSlider from './ReasoningTokenSlider';
 import TextVerbositySlider from './TextVerbositySlider';
 import ThinkingBudgetSlider from './ThinkingBudgetSlider';
 import ThinkingLevel2Slider from './ThinkingLevel2Slider';
+import ThinkingLevel3Slider from './ThinkingLevel3Slider';
 import ThinkingLevelSlider from './ThinkingLevelSlider';
 import ThinkingSlider from './ThinkingSlider';
 
@@ -264,6 +265,17 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
       layout: 'horizontal',
       minWidth: undefined,
       name: 'thinkingLevel2',
+      style: {
+        paddingBottom: 0,
+      },
+      desc: 'thinkingLevel',
+    },
+    {
+      children: <ThinkingLevel3Slider />,
+      label: t('extendParams.thinkingLevel.title'),
+      layout: 'horizontal',
+      minWidth: undefined,
+      name: 'thinkingLevel3',
       style: {
         paddingBottom: 0,
       },

--- a/src/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider.tsx
@@ -1,0 +1,16 @@
+import { type CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+const THINKING_LEVELS_3 = ['low', 'medium', 'high'] as const;
+type ThinkingLevel3 = (typeof THINKING_LEVELS_3)[number];
+
+export type ThinkingLevel3SliderProps = CreatedLevelSliderProps<ThinkingLevel3>;
+
+const ThinkingLevel3Slider = createLevelSliderComponent<ThinkingLevel3>({
+  configKey: 'thinkingLevel',
+  defaultValue: 'high',
+  levels: THINKING_LEVELS_3,
+  style: { minWidth: 160 },
+});
+
+export default ThinkingLevel3Slider;

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -279,6 +279,8 @@ export default {
     'For Gemini 3 Flash Preview models; controls thinking depth.',
   'providerModels.item.modelConfig.extendParams.options.thinkingLevel2.hint':
     'For Gemini 3 Pro Preview models; controls thinking depth.',
+  'providerModels.item.modelConfig.extendParams.options.thinkingLevel3.hint':
+    'For Gemini 3.1 Pro Preview models; controls thinking depth with low/medium/high levels.',
   'providerModels.item.modelConfig.extendParams.options.urlContext.hint':
     'For Gemini series; supports providing URL context.',
   'providerModels.item.modelConfig.extendParams.placeholder':

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -484,6 +484,96 @@ describe('resolveModelExtendParams', () => {
         expect(result.thinkingLevel).toBeUndefined();
       });
     });
+
+    describe('thinkingLevel2 param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel2',
+        ]);
+      });
+
+      it('should set thinkingLevel from thinkingLevel2 config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel2: 'low',
+          } as any,
+          model: 'gemini-3-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('low');
+      });
+
+      it('should not set thinkingLevel when thinkingLevel2 is not configured', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'gemini-3-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBeUndefined();
+      });
+
+      it('should not read from thinkingLevel config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'high',
+          } as any,
+          model: 'gemini-3-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBeUndefined();
+      });
+    });
+
+    describe('thinkingLevel3 param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel3',
+        ]);
+      });
+
+      it('should set thinkingLevel from thinkingLevel3 config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel3: 'medium',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('medium');
+      });
+
+      it('should not set thinkingLevel when thinkingLevel3 is not configured', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBeUndefined();
+      });
+
+      it('should not read from thinkingLevel config key', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'high',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBeUndefined();
+      });
+    });
   });
 
   describe('URL context', () => {

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -136,6 +136,14 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingLevel = chatConfig.thinkingLevel;
   }
 
+  if (modelExtendParams.includes('thinkingLevel2') && chatConfig.thinkingLevel2) {
+    extendParams.thinkingLevel = chatConfig.thinkingLevel2;
+  }
+
+  if (modelExtendParams.includes('thinkingLevel3') && chatConfig.thinkingLevel3) {
+    extendParams.thinkingLevel = chatConfig.thinkingLevel3;
+  }
+
   // URL context
   if (modelExtendParams.includes('urlContext') && chatConfig.urlContext) {
     extendParams.urlContext = chatConfig.urlContext;


### PR DESCRIPTION
## Summary
- Add `gemini-3.1-pro-preview` model definition to Google, Vertex AI, and LobeHub cloud providers with tiered pricing matching Gemini 3 Pro
- Introduce `thinkingLevel3` extend param type supporting `low`/`medium`/`high` thinking levels, with new `ThinkingLevel3Slider` UI component
- Fix a bug where `thinkingLevel2` and `thinkingLevel3` slider values were not passed to the API (form field name/config key mismatch)
- Expand `GoogleThinkingLevel` and `ChatStreamPayload.thinkingLevel` types to include `medium`
- Update `planCardModels` from `gemini-3-pro-preview` to `gemini-3.1-pro-preview`

## Changes
- `packages/model-bank/` — model definitions, `thinkingLevel3` in `ExtendParamsType`
- `packages/model-runtime/` — `GoogleThinkingLevel` and `ChatStreamPayload` type expansion
- `packages/types/` — `thinkingLevel2`/`thinkingLevel3` fields in `LobeAgentChatConfig`
- `src/features/ChatInput/` — `ThinkingLevel3Slider.tsx`, `ControlsForm.tsx` registration
- `src/services/chat/mecha/modelParamsResolver.ts` — read correct config keys per variant
- `src/services/chat/mecha/modelParamsResolver.test.ts` — 6 new test cases for thinkingLevel2/3

## Test plan
- [x] Unit tests pass (58/58 in modelParamsResolver.test.ts)
- [ ] Verify `gemini-3.1-pro-preview` appears in model selector for Google, Vertex AI, LobeHub
- [ ] Verify ThinkingLevel3Slider renders with low/medium/high
- [ ] Verify setting slider to `medium` sends `thinkingLevel: "medium"` in API request
- [ ] Verify `thinkingResolver` regex matches `gemini-3.1-pro-preview`

## Summary by Sourcery

Add support for the Gemini 3.1 Pro Preview model with a new three-level thinking control and ensure its config values are correctly wired through to the Google runtime.

New Features:
- Introduce the gemini-3.1-pro-preview chat model for Google, Vertex AI, and LobeHub providers with pricing metadata and extend params configured.
- Add a ThinkingLevel3Slider UI control and extend-params wiring for configuring low/medium/high thinking levels on supported models.

Bug Fixes:
- Ensure thinkingLevel2 and thinkingLevel3 configuration values are correctly read from chat config and forwarded as thinkingLevel in model extend params, avoiding incorrect use of the generic thinkingLevel key.

Enhancements:
- Extend Google thinking level and ChatStreamPayload types to support a medium thinking level for Gemini models.
- Expose thinkingLevel2 and thinkingLevel3 fields in the agent chat config schema for typed configuration of Gemini 3 and 3.1 thinking controls.
- Update LobeHub plan card models to highlight gemini-3.1-pro-preview in the featured model list.
- Improve provider model config UI to support selecting thinkingLevel3 with appropriate labels, previews, and hints for Gemini 3.1.

Tests:
- Add unit coverage for resolving thinkingLevel from thinkingLevel2 and thinkingLevel3 config keys for Gemini 3 Pro and 3.1 Pro Preview models.