### PR TITLE
💄 style: add Gemini 3.1 Pro Preview model

### DIFF
--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -232,6 +232,7 @@
   "providerModels.item.modelConfig.extendParams.options.thinkingBudget.hint": "For Gemini series; controls thinking budget.",
   "providerModels.item.modelConfig.extendParams.options.thinkingLevel.hint": "For Gemini 3 Flash Preview models; controls thinking depth.",
   "providerModels.item.modelConfig.extendParams.options.thinkingLevel2.hint": "For Gemini 3 Pro Preview models; controls thinking depth.",
+  "providerModels.item.modelConfig.extendParams.options.thinkingLevel3.hint": "For Gemini 3.1 Pro Preview models; controls thinking depth.",
   "providerModels.item.modelConfig.extendParams.options.urlContext.hint": "For Gemini series; supports providing URL context.",
   "providerModels.item.modelConfig.extendParams.placeholder": "Select extended parameters to enable",
   "providerModels.item.modelConfig.extendParams.previewFallback": "Preview unavailable",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -232,6 +232,7 @@
   "providerModels.item.modelConfig.extendParams.options.thinkingBudget.hint": "适用于 Gemini 系列；控制思考预算。",
   "providerModels.item.modelConfig.extendParams.options.thinkingLevel.hint": "适用于 Gemini 3 Flash 预览模型；控制思考深度。",
   "providerModels.item.modelConfig.extendParams.options.thinkingLevel2.hint": "适用于 Gemini 3 Pro 预览模型；控制思考深度。",
+  "providerModels.item.modelConfig.extendParams.options.thinkingLevel3.hint": "适用于 Gemini 3.1 Pro 预览模型；控制思考深度。",
   "providerModels.item.modelConfig.extendParams.options.urlContext.hint": "适用于 Gemini 系列；支持提供 URL 上下文。",
   "providerModels.item.modelConfig.extendParams.placeholder": "选择要启用的扩展参数",
   "providerModels.item.modelConfig.extendParams.previewFallback": "无法预览",

--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import { type AIChatModelCard } from '../types/aiModel';
 
 const aihubmixModels: AIChatModelCard[] = [
   {
@@ -1125,6 +1125,67 @@ const aihubmixModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      'Gemini 3.1 Pro Preview provides better thinking, improved token efficiency, and a reliable experience optimized for software engineering behavior.',
+    displayName: 'Gemini 3.1 Pro Preview',
+    enabled: true,
+    id: 'gemini-3.1-pro-preview',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 200_000 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 200_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 12, upTo: 200_000 },
+            { rate: 18, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-19',
+    settings: {
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },
@@ -1132,7 +1193,6 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro is Google’s most intelligent model with SOTA reasoning and multimodal understanding, plus strong agent and vibe-coding capabilities.',
     displayName: 'Gemini 3 Pro Preview',
-    enabled: true,
     id: 'gemini-3-pro-preview',
     maxOutput: 65_536,
     pricing: {

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard } from '../types/aiModel';
+import { type AIChatModelCard } from '../types/aiModel';
 
 const anthropicChatModels: AIChatModelCard[] = [
   {
@@ -230,69 +230,6 @@ const anthropicChatModels: AIChatModelCard[] = [
     settings: {
       extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
       searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      'Claude 3.7 Sonnet is Anthropic’s most intelligent model and the first hybrid reasoning model on the market. It can produce near-instant responses or extended step-by-step reasoning that users can see. Sonnet is especially strong at coding, data science, vision, and agent tasks.',
-    displayName: 'Claude 3.7 Sonnet',
-    id: 'claude-3-7-sonnet-20250219',
-    maxOutput: 64_000,
-    pricing: {
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    releasedAt: '2025-02-24',
-    settings: {
-      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      'Claude 3.5 Haiku is Anthropic’s fastest next-gen model. Compared to Claude 3 Haiku, it improves across skills and surpasses the previous largest model Claude 3 Opus on many intelligence benchmarks.',
-    displayName: 'Claude 3.5 Haiku',
-    id: 'claude-3-5-haiku-20241022',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1.6, '5m': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    releasedAt: '2024-11-05',
-    settings: {
-      extendParams: ['disableContextCaching'],
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -493,34 +493,6 @@ const googleChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      video: true,
-      vision: true,
-    },
-    contextWindowTokens: 1_048_576 + 65_536,
-    description: 'Preview release (Septempber 25th, 2025) of Gemini 2.5 Flash',
-    displayName: 'Gemini 2.5 Flash Preview Sep 2025',
-    id: 'gemini-2.5-flash-preview-09-2025',
-    maxOutput: 65_536,
-    pricing: {
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-09-25',
-    settings: {
-      extendParams: ['thinkingBudget', 'urlContext'],
-      searchImpl: 'params',
-      searchProvider: 'google',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
       imageOutput: true,
       vision: true,
     },
@@ -1018,30 +990,6 @@ const googleImageModels: AIImageModelCard[] = [
     parameters: imagenGenParameters,
     pricing: {
       units: [{ name: 'imageGeneration', rate: 0.02, strategy: 'fixed', unit: 'image' }],
-    },
-  },
-  {
-    displayName: 'Imagen 4 Preview 06-06',
-    id: 'imagen-4.0-generate-preview-06-06',
-    type: 'image',
-    description: 'Imagen fourth-generation text-to-image model family.',
-    organization: 'Deepmind',
-    releasedAt: '2025-06-06',
-    parameters: imagenGenParameters,
-    pricing: {
-      units: [{ name: 'imageGeneration', rate: 0.04, strategy: 'fixed', unit: 'image' }],
-    },
-  },
-  {
-    displayName: 'Imagen 4 Ultra Preview 06-06',
-    id: 'imagen-4.0-ultra-generate-preview-06-06',
-    type: 'image',
-    description: 'Imagen fourth-generation text-to-image Ultra variant.',
-    organization: 'Deepmind',
-    releasedAt: '2025-06-11',
-    parameters: imagenGenParameters,
-    pricing: {
-      units: [{ name: 'imageGeneration', rate: 0.06, strategy: 'fixed', unit: 'image' }],
     },
   },
 ];

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -1,5 +1,5 @@
-import type { ModelParamsSchema } from '../standard-parameters';
-import type { AIChatModelCard, AIImageModelCard } from '../types';
+import { type ModelParamsSchema } from '../standard-parameters';
+import { type AIChatModelCard, type AIImageModelCard } from '../types';
 
 /**
  * gemini implicit caching not extra cost
@@ -186,7 +186,6 @@ const googleChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro is Google’s most powerful agent and vibe-coding model, delivering richer visuals and deeper interaction on top of state-of-the-art reasoning.',
     displayName: 'Gemini 3 Pro Preview',
-    enabled: true,
     id: 'gemini-3-pro-preview',
     maxOutput: 65_536,
     pricing: {
@@ -945,7 +944,6 @@ export const nanoBananaProParameters: ModelParamsSchema = {
   },
 };
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 const googleImageModels: AIImageModelCard[] = [
   {
     displayName: 'Nano Banana Pro',
@@ -1047,8 +1045,6 @@ const googleImageModels: AIImageModelCard[] = [
     },
   },
 ];
-/* eslint-enable sort-keys-fix/sort-keys-fix */
-
 export const allModels = [...googleChatModels, ...googleImageModels];
 
 export default allModels;

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard } from '../../../types/aiModel';
+import { type AIChatModelCard } from '../../../types/aiModel';
 
 export const anthropicChatModels: AIChatModelCard[] = [
   {
@@ -82,37 +82,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-05-23',
-    settings: {
-      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      "Claude Sonnet 3.7 is Anthropic's most intelligent model and the first hybrid reasoning model on the market, supporting near-instant responses or extended thinking with fine-grained control.",
-    displayName: 'Claude Sonnet 3.7',
-    id: 'claude-3-7-sonnet-20250219',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
     settings: {
       extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
     },
@@ -275,36 +244,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
     releasedAt: '2025-10-16',
     settings: {
       extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      "Claude 3.5 Haiku is Anthropic's fastest next-gen model, improving across skills and surpassing the previous flagship Claude 3 Opus on many benchmarks.",
-    displayName: 'Claude 3.5 Haiku',
-    id: 'claude-3-5-haiku-20241022',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1.6, '5m': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    releasedAt: '2024-11-05',
-    settings: {
-      extendParams: ['disableContextCaching'],
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -96,6 +96,37 @@ export const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 200_000,
     description:
+      "Claude Sonnet 3.7 is Anthropic's most intelligent model and the first hybrid reasoning model on the market, supporting near-instant responses or extended thinking with fine-grained control.",
+    displayName: 'Claude Sonnet 3.7',
+    id: 'claude-3-7-sonnet-20250219',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    settings: {
+      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',
     enabled: true,
@@ -244,6 +275,36 @@ export const anthropicChatModels: AIChatModelCard[] = [
     releasedAt: '2025-10-16',
     settings: {
       extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      vision: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "Claude 3.5 Haiku is Anthropic's fastest next-gen model, improving across skills and surpassing the previous flagship Claude 3 Opus on many benchmarks.",
+    displayName: 'Claude 3.5 Haiku',
+    id: 'claude-3-5-haiku-20241022',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 1.6, '5m': 1 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2024-11-05',
+    settings: {
+      extendParams: ['disableContextCaching'],
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -1,11 +1,11 @@
-import type { ModelParamsSchema } from '../standard-parameters';
-import type {
-  AIChatModelCard,
-  AIEmbeddingModelCard,
-  AIImageModelCard,
-  AIRealtimeModelCard,
-  AISTTModelCard,
-  AITTSModelCard,
+import { type ModelParamsSchema } from '../standard-parameters';
+import {
+  type AIChatModelCard,
+  type AIEmbeddingModelCard,
+  type AIImageModelCard,
+  type AIRealtimeModelCard,
+  type AISTTModelCard,
+  type AITTSModelCard,
 } from '../types/aiModel';
 
 export const gptImage1ParamsSchema: ModelParamsSchema = {
@@ -836,24 +836,6 @@ export const openaiChatModels: AIChatModelCard[] = [
       searchImpl: 'params',
     },
     */
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 128_000,
-    description:
-      'ChatGPT-4o is a dynamic model updated in real time, combining strong understanding and generation for large-scale use cases like customer support, education, and technical support.',
-    displayName: 'ChatGPT-4o',
-    id: 'chatgpt-4o-latest',
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-08-14',
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -258,6 +258,51 @@ const qwenChatModels: AIChatModelCard[] = [
     contextWindowTokens: 202_752,
     description:
       'The GLM series is a hybrid reasoning model from Zhipu AI built for agents, with thinking and non-thinking modes.',
+    displayName: 'GLM-5',
+    id: 'glm-5',
+    maxOutput: 16_384,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 4,
+              '[0.032, infinity]': 6,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 18,
+              '[0.032, infinity]': 22,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 202_752,
+    description:
+      'The GLM series is a hybrid reasoning model from Zhipu AI built for agents, with thinking and non-thinking modes.',
     displayName: 'GLM-4.6',
     id: 'glm-4.6',
     maxOutput: 16_384,

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -435,6 +435,53 @@ const qwenChatModels: AIChatModelCard[] = [
       functionCall: true,
     },
     config: {
+      deploymentName: 'qwen3-coder-next',
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Next‑gen Qwen coder optimized for complex multi-file code generation, debugging, and high‑throughput agent workflows. Designed for strong tool integration and improved reasoning performance.',
+    displayName: 'Qwen3 Coder Next',
+    id: 'qwen3-coder-next',
+    maxOutput: 65_536,
+    organization: 'Qwen',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 1,
+              '[0.032, 0.128]': 1.5,
+              '[0.128, infinity]': 2.5,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.032]': 4,
+              '[0.032, 0.128]': 6,
+              '[0.128, infinity]': 10,
+            },
+            pricingParams: ['textInputRange'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    config: {
       deploymentName: 'qwen3-coder-plus', // Supports context caching
     },
     contextWindowTokens: 1_000_000,

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -1,4 +1,4 @@
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
 import { imagenGenParameters, nanoBananaParameters } from './google';
 
 // ref: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
@@ -76,7 +76,6 @@ const vertexaiChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro is Google’s most powerful agent and vibe-coding model, delivering richer visuals and deeper interaction on top of state-of-the-art reasoning.',
     displayName: 'Gemini 3 Pro Preview',
-    enabled: true,
     id: 'gemini-3-pro-preview',
     maxOutput: 65_536,
     pricing: {
@@ -466,7 +465,6 @@ const vertexaiChatModels: AIChatModelCard[] = [
   },
 ];
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 const vertexaiImageModels: AIImageModelCard[] = [
   {
     displayName: 'Nano Banana',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { ModelParamsSchema, VideoModelParamsSchema } from '../standard-parameters';
+import { type ModelParamsSchema, type VideoModelParamsSchema } from '../standard-parameters';
 
 export type ModelPriceCurrency = 'CNY' | 'USD';
 

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -14,7 +14,7 @@ const bizErrorType = 'ProviderBizError';
 const invalidErrorType = 'InvalidProviderAPIKey';
 
 // Mock the console.error to avoid polluting test output
-vi.spyOn(console, 'error').mockImplementation(() => { });
+vi.spyOn(console, 'error').mockImplementation(() => {});
 
 let instance: InstanceType<typeof LobeAnthropicAI>;
 
@@ -124,7 +124,7 @@ describe('LobeAnthropicAI', () => {
           { content: 'You are an awesome greeter', role: 'system' },
           { content: 'Hello', role: 'user' },
         ],
-        model: 'claude-3-7-sonnet-20250219',
+        model: 'claude-sonnet-4-5-20250929',
         temperature: 0,
       });
 
@@ -138,7 +138,7 @@ describe('LobeAnthropicAI', () => {
               role: 'user',
             },
           ],
-          model: 'claude-3-7-sonnet-20250219',
+          model: 'claude-sonnet-4-5-20250929',
           stream: true,
           system: [
             {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -1,25 +1,25 @@
-import type {
-  GenerateContentConfig,
-  HttpOptions,
-  ThinkingConfig,
-  Tool as GoogleFunctionCallTool,
+import {
+  type GenerateContentConfig,
+  type HttpOptions,
+  type ThinkingConfig,
+  type Tool as GoogleFunctionCallTool,
 } from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
 import debug from 'debug';
 
-import type { LobeRuntimeAI } from '../../core/BaseAI';
+import { type LobeRuntimeAI } from '../../core/BaseAI';
 import { buildGoogleMessages, buildGoogleTools } from '../../core/contextBuilders/google';
 import { GoogleGenerativeAIStream, VertexAIStream } from '../../core/streams';
 import { LOBE_ERROR_KEY } from '../../core/streams/google';
-import type {
-  ChatCompletionTool,
-  ChatMethodOptions,
-  ChatStreamPayload,
-  GenerateObjectOptions,
-  GenerateObjectPayload,
+import {
+  type ChatCompletionTool,
+  type ChatMethodOptions,
+  type ChatStreamPayload,
+  type GenerateObjectOptions,
+  type GenerateObjectPayload,
 } from '../../types';
 import { AgentRuntimeErrorType } from '../../types/error';
-import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import { type CreateImagePayload, type CreateImageResponse } from '../../types/image';
 import { AgentRuntimeError } from '../../utils/createError';
 import { debugStream } from '../../utils/debugStream';
 import { getModelPricing } from '../../utils/getModelPricing';
@@ -130,7 +130,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
       : undefined;
 
     this.apiKey = apiKey;
-    this.client = client ? client : new GoogleGenAI({ apiKey, httpOptions });
+    this.client = client ?? new GoogleGenAI({ apiKey, httpOptions });
     this.baseURL = client ? undefined : baseURL || DEFAULT_BASE_URL;
     this.isVertexAi = isVertexAi || false;
 
@@ -214,8 +214,8 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         : 'DEBUG_GOOGLE_CHAT_COMPLETION';
 
       if (process.env[key] === '1') {
-        console.log('[requestPayload]');
-        console.log(JSON.stringify(finalPayload), '\n');
+        log('[requestPayload]');
+        log(JSON.stringify(finalPayload), '\n');
       }
 
       const geminiStreamResponse = await this.client.models.generateContentStream(finalPayload);

--- a/packages/model-runtime/src/providers/google/thinkingResolver.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix*/
 /**
  * Google Gemini Thinking Resolver
  *
@@ -19,7 +18,7 @@ export type GoogleThinkingModelCategory = 'pro' | 'flash' | 'flashLite' | 'robot
 /**
  * Thinking level for Gemini 3.0+ models
  */
-export type GoogleThinkingLevel = 'low' | 'medium' | 'high';
+export type GoogleThinkingLevel = 'minimal' | 'low' | 'medium' | 'high';
 
 /**
  * Options for resolving Google thinking configuration

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -147,9 +147,9 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   textVerbosity: { labelSuffix: '', previewWidth: 250, tag: 'text_verbosity' },
   thinking: { labelSuffix: ' (Doubao)', previewWidth: 300, tag: 'thinking.type' },
   thinkingBudget: { labelSuffix: ' (Gemini)', previewWidth: 500, tag: 'thinkingBudget' },
-  thinkingLevel: { labelSuffix: ' (Gemini 3)', previewWidth: 280, tag: 'thinkingLevel' },
-  thinkingLevel2: { labelSuffix: ' (Gemini 3)', previewWidth: 200, tag: 'thinkingLevel' },
-  thinkingLevel3: { labelSuffix: ' (Gemini 3.1)', previewWidth: 230, tag: 'thinkingLevel' },
+  thinkingLevel: { labelSuffix: ' (3 Flash)', previewWidth: 280, tag: 'thinkingLevel' },
+  thinkingLevel2: { labelSuffix: ' (3 Pro)', previewWidth: 200, tag: 'thinkingLevel' },
+  thinkingLevel3: { labelSuffix: ' (Gemini 3.1)', previewWidth: 200, tag: 'thinkingLevel' },
   urlContext: { labelSuffix: ' (Gemini)', previewWidth: 400, tag: 'urlContext' },
 };
 
@@ -256,35 +256,6 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
     [],
   );
 
-  const descOverrides: Partial<Record<ExtendParamsType, ReactNode>> = {
-    disableContextCaching: (() => {
-      const original = tChat('extendParams.disableContextCaching.desc', { defaultValue: '' });
-
-      const sanitized = original.replace(/（<\d>.*?<\/\d>）/u, '');
-
-      return (
-        sanitized || (
-          <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
-            单条对话生成成本最高可降低 90%，响应速度提升 4 倍。开启后将自动禁用历史消息数限制
-          </Trans>
-        )
-      );
-    })(),
-    enableReasoning: (() => {
-      const original = tChat('extendParams.enableReasoning.desc', { defaultValue: '' });
-
-      const sanitized = original.replace(/（<\d>.*?<\/\d>）/u, '');
-
-      return (
-        sanitized || (
-          <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
-            基于 Claude Thinking 机制限制，开启后将自动禁用历史消息数限制
-          </Trans>
-        )
-      );
-    })(),
-  };
-
   const previewFallback = String(
     t('providerModels.item.modelConfig.extendParams.previewFallback', {
       defaultValue: 'Preview unavailable',
@@ -292,6 +263,35 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
   );
 
   const definitions = useMemo<ExtendParamsDefinition[]>(() => {
+    const descOverrides: Partial<Record<ExtendParamsType, ReactNode>> = {
+      disableContextCaching: (() => {
+        const original = tChat('extendParams.disableContextCaching.desc', { defaultValue: '' });
+
+        const sanitized = original.replace(/（<\d>.*?<\/\d>）/u, '');
+
+        return (
+          sanitized || (
+            <Trans i18nKey={'extendParams.disableContextCaching.desc'} ns={'chat'}>
+              单条对话生成成本最高可降低 90%，响应速度提升 4 倍。开启后将自动禁用历史消息数限制
+            </Trans>
+          )
+        );
+      })(),
+      enableReasoning: (() => {
+        const original = tChat('extendParams.enableReasoning.desc', { defaultValue: '' });
+
+        const sanitized = original.replace(/（<\d>.*?<\/\d>）/u, '');
+
+        return (
+          sanitized || (
+            <Trans i18nKey={'extendParams.enableReasoning.desc'} ns={'chat'}>
+              基于 Claude Thinking 机制限制，开启后将自动禁用历史消息数限制
+            </Trans>
+          )
+        );
+      })(),
+    };
+
     return EXTEND_PARAMS_OPTIONS.map((item) => {
       const descKey = `extendParams.${item.key}.desc`;
       const rawDesc = tChat(descKey as any, { defaultValue: '' });
@@ -305,11 +305,10 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
         tChat(`extendParams.${titleKey}.title` as any, { defaultValue: item.key }),
       );
 
-      const label = meta?.labelOverride
-        ? meta.labelOverride
-        : meta?.labelSuffix
-          ? `${baseLabel}${meta.labelSuffix}`
-          : baseLabel;
+      const label =
+        meta?.labelOverride ||
+        (meta?.labelSuffix && `${baseLabel}${meta.labelSuffix}`) ||
+        baseLabel;
 
       return {
         desc,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

https://ai.google.dev/gemini-api/docs/gemini-3

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add support for the Gemini 3.1 Pro Preview model and its new thinking level controls across providers and UI.

New Features:
- Introduce a Gemini 3.1 Pro Preview chat model for Google, Vertex AI, and AIHubMix providers with pricing, capabilities, and extended parameters.
- Add a third thinking level control (thinkingLevel3) with a dedicated slider component and wiring into extended parameter selection and chat controls.
- Extend Google thinking level configuration to support a wider range of thinking granularities.

Enhancements:
- Adjust existing thinking level labels to distinguish Gemini 3 Flash, 3 Pro, and 3.1 models in the model config UI.
- Refine logging in the Google runtime provider to use the shared logger utility instead of console output.
- Standardize type import style across several model definition files and simplify label composition logic in the extend-params UI.