### PR TITLE
👷 chore: enable consistent-type-imports ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,12 @@ export default eslint(
       'react/no-unknown-property': 0,
       'regexp/match-any': 0,
       'unicorn/better-regex': 0,
+      '@typescript-eslint/consistent-type-imports': [
+        2,
+        {
+          fixStyle: 'separate-type-imports',
+        },
+      ],
     },
   },
   // MDX files

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -3,6 +3,7 @@ import { ChatErrorType } from '@lobechat/types';
 import { getXorPayload } from '@lobechat/utils/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as EnvsAuthModule from '@/envs/auth';
 import { createErrorResponse } from '@/utils/errorResponse';
 
 import { type RequestHandler } from './index';
@@ -22,7 +23,7 @@ vi.mock('@lobechat/utils/server', () => ({
 }));
 
 vi.mock('@/envs/auth', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/envs/auth')>();
+  const actual = await importOriginal<typeof EnvsAuthModule>();
   return {
     ...actual,
   };

--- a/src/app/(backend)/webapi/chat/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.test.ts
@@ -5,6 +5,7 @@ import { ChatErrorType } from '@lobechat/types';
 import { getXorPayload } from '@lobechat/utils/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as EnvsAuthModule from '@/envs/auth';
 import { LOBE_CHAT_AUTH_HEADER, OAUTH_AUTHORIZED } from '@/envs/auth';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 
@@ -24,7 +25,7 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
 }));
 
 vi.mock('@/envs/auth', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/envs/auth')>();
+  const actual = await importOriginal<typeof EnvsAuthModule>();
   return {
     ...actual,
   };

--- a/src/app/(backend)/webapi/models/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/models/[provider]/route.test.ts
@@ -5,6 +5,7 @@ import { ChatErrorType } from '@lobechat/types';
 import { getXorPayload } from '@lobechat/utils/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as EnvsAuthModule from '@/envs/auth';
 import { LOBE_CHAT_AUTH_HEADER } from '@/envs/auth';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 
@@ -19,7 +20,7 @@ vi.mock('@lobechat/utils/server', () => ({
 }));
 
 vi.mock('@/envs/auth', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/envs/auth')>();
+  const actual = await importOriginal<typeof EnvsAuthModule>();
   return {
     ...actual,
   };

--- a/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
+++ b/src/app/[variants]/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/index.tsx
@@ -8,9 +8,9 @@ import { useTranslation } from 'react-i18next';
 
 import { useHomeStore } from '@/store/home';
 import { homeAgentListSelectors } from '@/store/home/selectors';
+import type { SessionGroupItemBase } from '@/types/session';
 
 import GroupItem from './GroupItem';
-import { SessionGroupItemBase } from '@/types/session';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
@@ -44,29 +44,29 @@ const ConfigGroupModal = memo<ModalProps>(({ open, onCancel }) => {
     <Modal
       allowFullscreen
       footer={null}
-      onCancel={onCancel}
       open={open}
       title={t('sessionGroup.config')}
       width={400}
+      onCancel={onCancel}
     >
       <Flexbox>
         <SortableList
           items={sessionGroupItems}
-          onChange={(items: SessionGroupItemBase[]) => {
-            updateGroupSort(items);
-          }}
           renderItem={(item: SessionGroupItemBase) => (
             <SortableList.Item
+              horizontal
               align={'center'}
               className={styles.container}
               gap={4}
-              horizontal
               id={item.id}
               justify={'space-between'}
             >
               <GroupItem {...item} />
             </SortableList.Item>
           )}
+          onChange={(items: SessionGroupItemBase[]) => {
+            updateGroupSort(items);
+          }}
         />
         <Button
           block

--- a/src/app/[variants]/(mobile)/me/(home)/__tests__/useCategory.test.tsx
+++ b/src/app/[variants]/(mobile)/me/(home)/__tests__/useCategory.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import type * as ConstVersionModule from '@/const/version';
 import { ServerConfigStoreProvider } from '@/store/serverConfig/Provider';
 import { useUserStore } from '@/store/user';
 
@@ -24,7 +25,7 @@ vi.mock('react-i18next', () => ({
 
 // Mock version constants
 vi.mock('@/const/version', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/const/version')>();
+  const actual = await importOriginal<typeof ConstVersionModule>();
   return {
     ...actual,
     isServerMode: false,

--- a/src/components/DragUpload/useDragUpload.test.tsx
+++ b/src/components/DragUpload/useDragUpload.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import type * as AntdModule from 'antd';
 import { App } from 'antd';
 import { type Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,7 +14,7 @@ import { getContainer, useDragUpload } from './useDragUpload';
 vi.mock('@/hooks/useModelSupportVision');
 vi.mock('@/store/agent');
 vi.mock('antd', async () => {
-  const actual = await vi.importActual<typeof import('antd')>('antd');
+  const actual = await vi.importActual<typeof AntdModule>('antd');
   const mockWarning = vi.fn();
 
   return {

--- a/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
+++ b/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
@@ -1,3 +1,4 @@
+import type * as AntdStyleModule from 'antd-style';
 import { ModelProvider } from 'model-bank';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -19,7 +20,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('antd-style', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('antd-style')>();
+  const actual = await importOriginal<typeof AntdStyleModule>();
 
   return {
     ...actual,

--- a/src/features/Conversation/hooks/useAgentMeta.test.ts
+++ b/src/features/Conversation/hooks/useAgentMeta.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { useAgentStore } from '@/store/agent';
 
+import type * as ConversationStoreModule from '../store';
 import { useConversationStore } from '../store';
 import { useAgentMeta, useIsBuiltinAgent } from './useAgentMeta';
 
@@ -10,7 +11,7 @@ vi.mock('zustand/traditional');
 
 // Mock the ConversationStore
 vi.mock('../store', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../store')>();
+  const actual = await importOriginal<typeof ConversationStoreModule>();
   return {
     ...actual,
     useConversationStore: vi.fn(),

--- a/src/hooks/useUserAvatar.test.ts
+++ b/src/hooks/useUserAvatar.test.ts
@@ -1,3 +1,4 @@
+import type * as LobechatConstModule from '@lobechat/const';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,7 +13,7 @@ vi.mock('zustand/traditional');
 let mockIsDesktop = false;
 
 vi.mock('@lobechat/const', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@lobechat/const')>();
+  const actual = await importOriginal<typeof LobechatConstModule>();
   return {
     ...actual,
     get isDesktop() {

--- a/src/libs/observability/traceparent.test.ts
+++ b/src/libs/observability/traceparent.test.ts
@@ -1,7 +1,7 @@
+import type * as OtelApiModule from '@lobechat/observability-otel/api';
 import { type Mock } from 'vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// eslint-disable-next-line import/first
 import { getActiveTraceId, injectSpanTraceHeaders } from './traceparent';
 
 vi.mock('@lobechat/observability-otel/api', () => {
@@ -30,9 +30,7 @@ const mockSpan = (traceId: string, spanId: string) =>
 const headersWith = (...args: ConstructorParameters<typeof Headers>) => new Headers(...args);
 
 describe('injectSpanTraceHeaders', () => {
-  const api = vi.importMock<typeof import('@lobechat/observability-otel/api')>(
-    '@lobechat/observability-otel/api',
-  );
+  const api = vi.importMock<typeof OtelApiModule>('@lobechat/observability-otel/api');
 
   afterEach(() => {
     vi.resetAllMocks();
@@ -76,9 +74,7 @@ describe('injectSpanTraceHeaders', () => {
 });
 
 describe('getActiveTraceId', () => {
-  const api = vi.importMock<typeof import('@lobechat/observability-otel/api')>(
-    '@lobechat/observability-otel/api',
-  );
+  const api = vi.importMock<typeof OtelApiModule>('@lobechat/observability-otel/api');
 
   afterEach(() => {
     vi.resetAllMocks();

--- a/src/libs/trpc/middleware/openTelemetry.test.ts
+++ b/src/libs/trpc/middleware/openTelemetry.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as TraceparentModule from '@/libs/observability/traceparent';
 import { injectSpanTraceHeaders } from '@/libs/observability/traceparent';
 
-// eslint-disable-next-line import/first
 import { openTelemetry } from './openTelemetry';
 
 const spanContext = {
@@ -55,7 +55,7 @@ vi.mock('../lambda/init', () => {
 });
 
 vi.mock('@/libs/observability/traceparent', async () => {
-  const actual = await vi.importActual<typeof import('@/libs/observability/traceparent')>(
+  const actual = await vi.importActual<typeof TraceparentModule>(
     '@/libs/observability/traceparent',
   );
   return {

--- a/src/server/globalConfig/genServerAiProviderConfig.test.ts
+++ b/src/server/globalConfig/genServerAiProviderConfig.test.ts
@@ -1,10 +1,11 @@
+import type * as ModelBankModule from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { genServerAiProvidersConfig } from './genServerAiProviderConfig';
 
 // Mock dependencies using importOriginal to preserve real provider data
 vi.mock('model-bank', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('model-bank')>();
+  const actual = await importOriginal<typeof ModelBankModule>();
   return {
     ...actual,
     // Keep the original exports but we can override specific ones if needed

--- a/src/server/routers/lambda/__tests__/aiAgent.test.ts
+++ b/src/server/routers/lambda/__tests__/aiAgent.test.ts
@@ -3,6 +3,7 @@ import { type LobeChatDatabase } from '@lobechat/database';
 import { agents, agentsToSessions, sessions, threads, topics } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { eq } from 'drizzle-orm';
+import type * as ModelBankModule from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { aiAgentRouter } from '../aiAgent';
@@ -47,7 +48,7 @@ vi.mock('@/server/services/aiChat', () => ({
 
 // Mock model-bank with dynamic import to preserve other exports
 vi.mock('model-bank', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('model-bank')>();
+  const actual = await importOriginal<typeof ModelBankModule>();
   return {
     ...actual,
     LOBE_DEFAULT_MODEL_LIST: [

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -3,6 +3,7 @@ import { LayersEnum, TypesEnum } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getServerDB } from '@/database/core/db-adaptor';
+import type * as UserMemoryModule from '@/database/models/userMemory';
 import { UserMemoryModel } from '@/database/models/userMemory';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 
@@ -23,7 +24,7 @@ vi.mock('@/server/modules/ModelRuntime', () => ({
 }));
 
 vi.mock('@/database/models/userMemory', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/database/models/userMemory')>();
+  const actual = await importOriginal<typeof UserMemoryModule>();
   const mockUserMemoryModel: any = vi.fn();
   mockUserMemoryModel.parseDateFromString = actual.UserMemoryModel.parseDateFromString;
   mockUserMemoryModel.parseAssociatedLocations = actual.UserMemoryModel.parseAssociatedLocations;
@@ -32,7 +33,7 @@ vi.mock('@/database/models/userMemory', async (importOriginal) => {
   return {
     ...actual,
     UserMemoryModel: mockUserMemoryModel,
-  } satisfies typeof import('@/database/models/userMemory');
+  } satisfies typeof UserMemoryModule;
 });
 
 const embeddingsMock = vi.fn();

--- a/src/server/services/agent/index.test.ts
+++ b/src/server/services/agent/index.test.ts
@@ -5,7 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentModel } from '@/database/models/agent';
 import { SessionModel } from '@/database/models/session';
 import { UserModel } from '@/database/models/user';
-import { initializeRedisWithPrefix, isRedisEnabled,RedisKeys } from '@/libs/redis';
+import type * as RedisModule from '@/libs/redis';
+import { initializeRedisWithPrefix, isRedisEnabled, RedisKeys } from '@/libs/redis';
 import { parseAgentConfig } from '@/server/globalConfig/parseDefaultAgent';
 
 import { AgentService } from './index';
@@ -40,7 +41,7 @@ vi.mock('@/envs/redis', () => ({
 }));
 
 vi.mock('@/libs/redis', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/libs/redis')>();
+  const original = await importOriginal<typeof RedisModule>();
   return {
     ...original,
     initializeRedisWithPrefix: vi.fn(),
@@ -360,7 +361,9 @@ describe('AgentService', () => {
       (AgentModel as any).mockImplementation(() => mockAgentModel);
       (parseAgentConfig as any).mockReturnValue({});
       // Use mockResolvedValueOnce to avoid affecting subsequent tests
-      mockUserModel.getUserSettingsDefaultAgentConfig.mockResolvedValueOnce({ config: userDefaultConfig });
+      mockUserModel.getUserSettingsDefaultAgentConfig.mockResolvedValueOnce({
+        config: userDefaultConfig,
+      });
 
       const newService = new AgentService(mockDb, mockUserId);
       const result = await newService.getAgentConfig('agent-1');
@@ -542,7 +545,9 @@ describe('AgentService', () => {
         (AgentModel as any).mockImplementation(() => mockAgentModel);
         (parseAgentConfig as any).mockReturnValue({});
         vi.mocked(isRedisEnabled).mockReturnValue(true);
-        vi.mocked(initializeRedisWithPrefix).mockRejectedValue(new Error('Redis connection failed'));
+        vi.mocked(initializeRedisWithPrefix).mockRejectedValue(
+          new Error('Redis connection failed'),
+        );
 
         const newService = new AgentService(mockDb, mockUserId);
         const result = await newService.getAgentConfigById('agent-1');

--- a/src/server/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment node
  */
+import type * as ModelBankModule from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentRuntimeService } from './AgentRuntimeService';
@@ -120,7 +121,7 @@ vi.mock('@/server/modules/Mecha', () => ({
 
 // Mock model-bank
 vi.mock('model-bank', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('model-bank')>();
+  const actual = await importOriginal<typeof ModelBankModule>();
   return {
     ...actual,
     LOBE_DEFAULT_MODEL_LIST: [

--- a/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -1,3 +1,4 @@
+import type * as ModelBankModule from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiAgentService } from '../index';
@@ -114,7 +115,7 @@ vi.mock('@/server/modules/Mecha', () => ({
 
 // Mock model-bank
 vi.mock('model-bank', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('model-bank')>();
+  const actual = await importOriginal<typeof ModelBankModule>();
   return {
     ...actual,
     LOBE_DEFAULT_MODEL_LIST: [

--- a/src/server/services/memory/userMemory/persona/__tests__/service.test.ts
+++ b/src/server/services/memory/userMemory/persona/__tests__/service.test.ts
@@ -5,6 +5,7 @@ import { getTestDB } from '@lobechat/database/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
+import type * as AiInfraReposModule from '@/database/repositories/aiInfra';
 
 import { UserPersonaService } from '../service';
 
@@ -18,7 +19,7 @@ const aiInfraMocks = vi.hoisted(() => ({
 vi.mock('@/database/repositories/aiInfra', () => {
   const AiInfraRepos = vi.fn().mockImplementation(() => ({
     getAiProviderRuntimeState: aiInfraMocks.getAiProviderRuntimeState,
-  })) as unknown as typeof import('@/database/repositories/aiInfra').AiInfraRepos;
+  })) as unknown as typeof AiInfraReposModule.AiInfraRepos;
 
   (AiInfraRepos as any).tryMatchingModelFrom = aiInfraMocks.tryMatchingModelFrom;
   (AiInfraRepos as any).tryMatchingProviderFrom = aiInfraMocks.tryMatchingProviderFrom;

--- a/src/store/agentGroup/slices/curd.test.ts
+++ b/src/store/agentGroup/slices/curd.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_CHAT_GROUP_CHAT_CONFIG } from '@/const/settings';
+import type * as SwrModule from '@/libs/swr';
 import { mutate } from '@/libs/swr';
 import { chatGroupService } from '@/services/chatGroup';
 
@@ -16,7 +17,7 @@ vi.mock('@/services/chatGroup', () => ({
 }));
 
 vi.mock('@/libs/swr', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/libs/swr')>();
+  const actual = await importOriginal<typeof SwrModule>();
   return { ...actual, mutate: vi.fn().mockResolvedValue(undefined) };
 });
 

--- a/src/store/agentGroup/slices/member.test.ts
+++ b/src/store/agentGroup/slices/member.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as SwrModule from '@/libs/swr';
 import { mutate } from '@/libs/swr';
 import { chatGroupService } from '@/services/chatGroup';
 
@@ -16,7 +17,7 @@ vi.mock('@/services/chatGroup', () => ({
 }));
 
 vi.mock('@/libs/swr', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/libs/swr')>();
+  const actual = await importOriginal<typeof SwrModule>();
   return { ...actual, mutate: vi.fn().mockResolvedValue(undefined) };
 });
 

--- a/src/store/aiInfra/slices/aiModel/action.test.ts
+++ b/src/store/aiInfra/slices/aiModel/action.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { type AiProviderModelListItem } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as SwrModule from '@/libs/swr';
 import { mutate } from '@/libs/swr';
 import { aiModelService } from '@/services/aiModel';
 import { withSWR } from '~test-utils';
@@ -11,7 +12,7 @@ import { useAiInfraStore as useStore } from '../../store';
 vi.mock('zustand/traditional');
 
 vi.mock('@/libs/swr', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/libs/swr')>();
+  const actual = await importOriginal<typeof SwrModule>();
   return {
     ...actual,
     mutate: vi.fn(),

--- a/src/store/image/slices/generationBatch/action.test.ts
+++ b/src/store/image/slices/generationBatch/action.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as SwrModule from '@/libs/swr';
 import { mutate } from '@/libs/swr';
 import { generationService } from '@/services/generation';
 import { generationBatchService } from '@/services/generationBatch';
@@ -26,7 +27,7 @@ vi.mock('@/services/generationBatch', () => ({
 }));
 
 vi.mock('@/libs/swr', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/libs/swr')>();
+  const actual = await importOriginal<typeof SwrModule>();
   return {
     ...actual,
     mutate: vi.fn(),

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -13,7 +13,7 @@ import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/exe
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
 
-import type { IBuiltinToolExecutor } from '../types';
+import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
 import { notebookExecutor } from './lobe-notebook';
 import { pageAgentExecutor } from './lobe-page-agent';
 import { webBrowsing } from './lobe-web-browsing';
@@ -80,8 +80,8 @@ export const invokeExecutor = async (
   identifier: string,
   apiName: string,
   params: any,
-  ctx: import('../types').BuiltinToolContext,
-): Promise<import('../types').BuiltinToolResult> => {
+  ctx: BuiltinToolContext,
+): Promise<BuiltinToolResult> => {
   const executor = executorRegistry.get(identifier);
 
   if (!executor) {

--- a/src/store/tool/slices/lobehubSkillStore/action.test.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.test.ts
@@ -1,3 +1,4 @@
+import type * as LobechatConstModule from '@lobechat/const';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -13,7 +14,7 @@ beforeEach(() => {
 });
 
 vi.mock('@lobechat/const', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@lobechat/const')>();
+  const actual = await importOriginal<typeof LobechatConstModule>();
   return {
     ...actual,
     getLobehubSkillProviderById: vi.fn((id: string) => ({

--- a/src/store/tool/slices/mcpStore/action.test.ts
+++ b/src/store/tool/slices/mcpStore/action.test.ts
@@ -1,3 +1,4 @@
+import type * as LobechatConstModule from '@lobechat/const';
 import { type LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';
 import { type PluginItem } from '@lobehub/market-sdk';
 import { act, renderHook, waitFor } from '@testing-library/react';
@@ -59,7 +60,7 @@ const bootstrapToolStoreWithDesktop = async (isDesktopEnv: boolean) => {
   process.env.NEXT_PUBLIC_IS_DESKTOP_APP = isDesktopEnv ? '1' : '0';
 
   vi.doMock('@lobechat/const', async () => {
-    const actual = await vi.importActual<typeof import('@lobechat/const')>('@lobechat/const');
+    const actual = await vi.importActual<typeof LobechatConstModule>('@lobechat/const');
     return {
       ...actual,
       isDesktop: isDesktopEnv,


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/consistent-type-imports` ESLint rule with `fixStyle: 'separate-type-imports'` to enforce consistent usage of type imports across the codebase
- Fix all 28 existing violations by replacing inline `typeof import('...')` type annotations with top-level `import type * as Module` declarations
- Convert `import { Type }` to `import type { Type }` where imports are only used as types

## Test plan
- [x] `eslint --no-fix` reports 0 `consistent-type-imports` violations
- [x] All modified files pass TypeScript type check (no TS errors)

## Summary by Sourcery

Enforce consistent TypeScript type import style across the codebase and update existing usages to comply with the new linting rule.

Enhancements:
- Enable the @typescript-eslint/consistent-type-imports ESLint rule configured to use separate type-only imports.
- Refine various modules to distinguish value imports from type-only imports, improving clarity and tree-shaking behavior.

Tests:
- Update Vitest and other test files to use module-level type imports instead of inline typeof import(...) annotations, aligning them with the new linting policy.