### PR TITLE
🐛 fix(mcp): fix double APP_URL prefix in image/audio content URLs

### DIFF
--- a/src/server/services/mcp/contentProcessor.test.ts
+++ b/src/server/services/mcp/contentProcessor.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ToolCallContent } from '@/libs/mcp';
+
+import { contentBlocksToString, processContentBlocks } from './contentProcessor';
+
+describe('contentProcessor', () => {
+  describe('contentBlocksToString', () => {
+    it('should return empty string for null input', () => {
+      expect(contentBlocksToString(null)).toBe('');
+    });
+
+    it('should return empty string for undefined input', () => {
+      expect(contentBlocksToString(undefined)).toBe('');
+    });
+
+    it('should return empty string for empty array', () => {
+      expect(contentBlocksToString([])).toBe('');
+    });
+
+    it('should convert text content to string', () => {
+      const blocks: ToolCallContent[] = [{ type: 'text', text: 'hello world' }];
+      expect(contentBlocksToString(blocks)).toBe('hello world');
+    });
+
+    it('should convert image content with full URL without double prefix', () => {
+      const blocks: ToolCallContent[] = [
+        {
+          type: 'image',
+          data: 'https://example.com/f/abc-123',
+          mimeType: 'image/png',
+        },
+      ];
+      const result = contentBlocksToString(blocks);
+      expect(result).toBe('![](https://example.com/f/abc-123)');
+      // Ensure no double URL prefix
+      expect(result).not.toContain('https://example.com/https://example.com');
+    });
+
+    it('should convert audio content with full URL without double prefix', () => {
+      const blocks: ToolCallContent[] = [
+        {
+          type: 'audio',
+          data: 'https://example.com/f/audio-123',
+          mimeType: 'audio/mp3',
+        },
+      ];
+      const result = contentBlocksToString(blocks);
+      expect(result).toBe('<resource type="audio" url="https://example.com/f/audio-123" />');
+      expect(result).not.toContain('https://example.com/https://example.com');
+    });
+
+    it('should join multiple content blocks with double newlines', () => {
+      const blocks: ToolCallContent[] = [
+        { type: 'text', text: 'Description:' },
+        { type: 'image', data: 'https://example.com/f/img-1', mimeType: 'image/png' },
+        { type: 'text', text: 'End.' },
+      ];
+      const result = contentBlocksToString(blocks);
+      expect(result).toBe('Description:\n\n![](https://example.com/f/img-1)\n\nEnd.');
+    });
+
+    it('should handle resource content', () => {
+      const blocks: ToolCallContent[] = [
+        {
+          type: 'resource',
+          resource: { uri: 'file:///test.txt', text: 'content', mimeType: 'text/plain' },
+        } as ToolCallContent,
+      ];
+      const result = contentBlocksToString(blocks);
+      expect(result).toContain('<resource type="resource">');
+    });
+
+    it('should skip unknown content types', () => {
+      const blocks = [{ type: 'unknown', data: 'test' }] as unknown as ToolCallContent[];
+      expect(contentBlocksToString(blocks)).toBe('');
+    });
+  });
+
+  describe('processContentBlocks', () => {
+    const mockFileService = {
+      uploadBase64: vi.fn(),
+    } as any;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should upload image and replace base64 data with URL', async () => {
+      mockFileService.uploadBase64.mockResolvedValue({
+        url: 'https://example.com/f/uploaded-img',
+        fileId: 'file-1',
+        key: 'mcp/images/2025-01-01/abc.png',
+      });
+
+      const blocks: ToolCallContent[] = [
+        {
+          type: 'image',
+          data: 'iVBORw0KGgoAAAANSUhEUg==',
+          mimeType: 'image/png',
+        },
+      ];
+
+      const result = await processContentBlocks(blocks, mockFileService);
+
+      expect(result[0].type).toBe('image');
+      expect((result[0] as any).data).toBe('https://example.com/f/uploaded-img');
+      expect(mockFileService.uploadBase64).toHaveBeenCalledWith(
+        'iVBORw0KGgoAAAANSUhEUg==',
+        expect.stringContaining('mcp/images/'),
+      );
+    });
+
+    it('should upload audio and replace base64 data with URL', async () => {
+      mockFileService.uploadBase64.mockResolvedValue({
+        url: 'https://example.com/f/uploaded-audio',
+        fileId: 'file-2',
+        key: 'mcp/audio/2025-01-01/abc.mp3',
+      });
+
+      const blocks: ToolCallContent[] = [
+        {
+          type: 'audio',
+          data: 'base64audiodata==',
+          mimeType: 'audio/mp3',
+        },
+      ];
+
+      const result = await processContentBlocks(blocks, mockFileService);
+
+      expect(result[0].type).toBe('audio');
+      expect((result[0] as any).data).toBe('https://example.com/f/uploaded-audio');
+    });
+
+    it('should pass through text content unchanged', async () => {
+      const blocks: ToolCallContent[] = [{ type: 'text', text: 'hello' }];
+      const result = await processContentBlocks(blocks, mockFileService);
+      expect(result[0]).toEqual({ type: 'text', text: 'hello' });
+    });
+
+    it('should produce correct string when combined with contentBlocksToString', async () => {
+      mockFileService.uploadBase64.mockResolvedValue({
+        url: 'https://myapp.com/f/img-uuid',
+        fileId: 'file-3',
+        key: 'mcp/images/2025-01-01/xyz.png',
+      });
+
+      const blocks: ToolCallContent[] = [
+        { type: 'text', text: 'Here is the screenshot:' },
+        { type: 'image', data: 'base64data==', mimeType: 'image/png' },
+      ];
+
+      const processed = await processContentBlocks(blocks, mockFileService);
+      const str = contentBlocksToString(processed);
+
+      expect(str).toBe('Here is the screenshot:\n\n![](https://myapp.com/f/img-uuid)');
+      // The critical assertion: no double URL prefix
+      expect(str).not.toContain('https://myapp.com/https://myapp.com');
+    });
+  });
+});

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -1,8 +1,6 @@
 import debug from 'debug';
 import pMap from 'p-map';
-import urlJoin from 'url-join';
 
-import { appEnv } from '@/envs/app';
 import { fileEnv } from '@/envs/file';
 import { type AudioContent, type ImageContent, type ToolCallContent } from '@/libs/mcp';
 import { type FileService } from '@/server/services/file';
@@ -80,11 +78,11 @@ export const contentBlocksToString = (blocks: ToolCallContent[] | null | undefin
         }
 
         case 'image': {
-          return `![](${urlJoin(appEnv.APP_URL, item.data)})`;
+          return `![](${item.data})`;
         }
 
         case 'audio': {
-          return `<resource type="${item.type}" url="${urlJoin(appEnv.APP_URL, item.data)}" />`;
+          return `<resource type="${item.type}" url="${item.data}" />`;
         }
 
         case 'resource': {


### PR DESCRIPTION
contentBlocksToString() was prepending APP_URL via urlJoin() to item.data, but item.data already contained the full URL after processContentBlocks() uploaded to S3. This caused URLs like: https://example.com/https://example.com/f/uuid

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes https://github.com/lobehub/lobehub/issues/12397

#### 🔀 Description of Change

  `contentBlocksToString()` in `src/server/services/mcp/contentProcessor.ts` used `urlJoin(appEnv.APP_URL, item.data)` to construct image/audio URLs. However, `item.data` is already a
  full URL (e.g. `https://example.com/f/uuid`) set by `processContentBlocks()` after uploading to S3 via `fileService.uploadBase64()`. This resulted in double-prefixed URLs like
  `https://example.com/https://example.com/f/uuid`.

  The fix removes the redundant `urlJoin(appEnv.APP_URL, ...)` wrapping and uses `item.data` directly. Also added unit tests for `contentBlocksToString()` and `processContentBlocks()`
  (13 test cases).

before:
<img width="1566" height="488" alt="image" src="https://github.com/user-attachments/assets/5df665dc-b563-4bee-94c2-0d4d30e5ff5a" />

after:
<img width="1274" height="614" alt="image" src="https://github.com/user-attachments/assets/e45e5d8e-cd63-4193-9da3-2a0ecfc90bb8" />

  #### 🧪 How to Test

  - [ ] Tested locally
  - [x] Added/updated tests
  - [ ] No tests needed

  1. Configure an MCP server that returns `ImageContent` (e.g. a screenshot tool)
  2. Call the MCP tool in a conversation
  3. Verify the image URL in the tool result message is correct (single `APP_URL` prefix, not doubled)

  #### 📸 Screenshots / Videos

  N/A - No UI changes, backend URL construction fix only.

  #### 📝 Additional Information

  The bug only manifests when `APP_URL` is configured to a non-empty value (e.g. `https://lobe.example.com`). When `APP_URL` is empty, the double join coincidentally produces a correct
   relative path, which is likely why it wasn't caught earlier.

## Summary by Sourcery

Fix construction of MCP image and audio content URLs and add regression tests for content block processing.

Bug Fixes:
- Use the already-absolute URL stored in content blocks for image and audio content instead of prefixing APP_URL again, preventing double-prefixed URLs.

Tests:
- Add unit tests for processContentBlocks and contentBlocksToString to cover image and audio URL handling and prevent regressions.