### PR TITLE
♻️ chore(ci): remove unnecessary fetch-depth: 0 from workflows

### DIFF
--- a/.github/workflows/claude-auto-e2e-testing.yml
+++ b/.github/workflows/claude-auto-e2e-testing.yml
@@ -21,7 +21,7 @@ env:
   DATABASE_DRIVER: node
   KEY_VAULTS_SECRET: LA7n9k3JdEcbSgml2sxfw+4TV1AzaaFU5+R176aQz4s=
   AUTH_SECRET: e2e-test-secret-key-for-better-auth-32chars!
-  AUTH_EMAIL_VERIFICATION: "0"
+  AUTH_EMAIL_VERIFICATION: '0'
   S3_ACCESS_KEY_ID: e2e-mock-access-key
   S3_SECRET_ACCESS_KEY: e2e-mock-secret-key
   S3_BUCKET: e2e-mock-bucket
@@ -43,14 +43,13 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
         ports:
           - 5432:5432
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -67,7 +66,7 @@ jobs:
       - name: Build application
         run: bun run build
         env:
-          SKIP_LINT: "1"
+          SKIP_LINT: '1'
 
       - name: Configure Git
         run: |
@@ -85,7 +84,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          allowed_non_write_users: "*"
+          allowed_non_write_users: '*'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"

--- a/.github/workflows/claude-auto-testing.yml
+++ b/.github/workflows/claude-auto-testing.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Copy security prompt
         run: |

--- a/.github/workflows/claude-translate-comments.yml
+++ b/.github/workflows/claude-translate-comments.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Configure Git
         run: |

--- a/.github/workflows/claude-translator.yml
+++ b/.github/workflows/claude-translator.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Copy security prompt
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Copy security prompt
         run: |

--- a/.github/workflows/manual-build-desktop.yml
+++ b/.github/workflows/manual-build-desktop.yml
@@ -51,8 +51,6 @@ jobs:
       version: ${{ steps.set_version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -103,8 +101,6 @@ jobs:
         os: [macos-latest, macos-15-intel]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -181,8 +177,6 @@ jobs:
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup
@@ -227,8 +221,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node & Bun
         uses: ./.github/actions/setup-node-bun
@@ -56,8 +54,6 @@ jobs:
       version: ${{ steps.set_version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -96,8 +92,6 @@ jobs:
         os: [macos-latest, macos-15-intel, windows-2025, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -286,8 +280,6 @@ jobs:
       artifact_path: ${{ steps.set_path.outputs.path }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       # 下载合并后的构建产物
       - name: Download merged artifacts

--- a/.github/workflows/pr-build-docker.yml
+++ b/.github/workflows/pr-build-docker.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Checkout PR branch
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -107,8 +105,6 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Download digests
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -61,8 +61,6 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -91,8 +89,6 @@ jobs:
         os: [macos-latest, macos-15-intel, windows-2025, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          fetch-tags: true
 
       - name: Check commit message prefix
         id: check
@@ -133,8 +132,6 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -167,8 +164,6 @@ jobs:
         os: [macos-15, macos-15-intel, windows-2025, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup

--- a/.github/workflows/release-desktop-nightly.yml
+++ b/.github/workflows/release-desktop-nightly.yml
@@ -48,7 +48,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          fetch-tags: true
 
       - name: Check for code changes since last nightly
         id: changes
@@ -128,8 +127,6 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -162,8 +159,6 @@ jobs:
         os: [macos-15, macos-15-intel, windows-2025, ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup

--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -176,8 +176,6 @@ jobs:
       matrix: ${{ fromJson(needs.configure-build.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/desktop-build-setup

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   release:
     types: [published]
 
@@ -33,8 +33,6 @@ jobs:
 
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -93,8 +91,6 @@ jobs:
     steps:
       - name: Checkout base
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Download digests
         uses: actions/download-artifact@v7

--- a/.github/workflows/verify-desktop-patch.yml
+++ b/.github/workflows/verify-desktop-patch.yml
@@ -23,7 +23,7 @@ on:
       - 'src/components/mdx/**'
       - 'src/features/DevPanel/**'
       - 'src/server/translation.ts'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node & Bun
         uses: ./.github/actions/setup-node-bun


### PR DESCRIPTION
## Summary
- Removed 18 unnecessary `fetch-depth: 0` from workflow checkout steps that only perform build/lint/test (no git history operations)
- Retained 4 necessary `fetch-depth: 0` in jobs that require full git history (tag operations, branch sync)
- Removed redundant `fetch-tags: true` where `fetch-depth: 0` already fetches all tags
- Fixed pre-existing `yml/no-empty-mapping-value` lint errors in `release-docker.yml` and `verify-desktop-patch.yml`

## Test plan
- [ ] Verify CI workflows still pass (build, lint, test jobs)
- [ ] Verify release workflows that need tags still work correctly (nightly, canary calculate-version)

## Summary by Sourcery

Simplify GitHub Actions workflows by removing unnecessary full-history checkouts and addressing minor YAML lint issues.

Build:
- Remove redundant checkout fetch-depth configuration from desktop and Docker build workflows that do not require full git history.

CI:
- Clean up various Claude-related and verification workflows by dropping unnecessary checkout fetch-depth overrides.
- Ensure release workflows rely on minimal checkout configuration while preserving jobs that still require full history and tags.
- Fix YAML lint issues in release and verification workflows by explicitly specifying empty workflow_dispatch mappings and normalizing quoting.