### PR TITLE
🐛 fix(mcp): fix content rendering for MCP tool results

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Render/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Render/index.tsx
@@ -18,8 +18,9 @@ interface ToolRenderProps {
 const ToolRender = memo<ToolRenderProps>(
   ({ showCustomToolRender, content, messageId, plugin, pluginState, toolCallId }) => {
     const hasCustomRender = !!getBuiltinRender(plugin?.identifier, plugin?.apiName);
+    const isMCP = (plugin?.type as string) === 'mcp';
 
-    if (hasCustomRender && showCustomToolRender) {
+    if ((hasCustomRender && showCustomToolRender) || isMCP) {
       return (
         <CustomRender
           content={content}

--- a/src/features/PluginsUI/Render/MCPType/index.tsx
+++ b/src/features/PluginsUI/Render/MCPType/index.tsx
@@ -23,7 +23,7 @@ export interface MCPTypeProps {
 }
 
 const MCPType = memo<MCPTypeProps>(({ pluginState, arguments: args }) => {
-  if (!pluginState) return;
+  if (!pluginState?.content || !Array.isArray(pluginState.content)) return;
 
   const { content } = pluginState;
 

--- a/src/server/services/mcp/contentProcessor.test.ts
+++ b/src/server/services/mcp/contentProcessor.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock appEnv before importing
+vi.mock('@/envs/app', () => ({
+  appEnv: { APP_URL: 'https://my-app.example.com' },
+}));
+
+import { contentBlocksToString } from './contentProcessor';
+
+describe('contentBlocksToString', () => {
+  it('should return empty string for null/undefined', () => {
+    expect(contentBlocksToString(null)).toBe('');
+    expect(contentBlocksToString(undefined)).toBe('');
+  });
+
+  it('should return empty string for empty array', () => {
+    expect(contentBlocksToString([])).toBe('');
+  });
+
+  it('should extract text from text blocks', () => {
+    const result = contentBlocksToString([{ type: 'text', text: 'Hello world' }]);
+    expect(result).toBe('Hello world');
+  });
+
+  it('should join multiple text blocks with double newline', () => {
+    const result = contentBlocksToString([
+      { type: 'text', text: 'First' },
+      { type: 'text', text: 'Second' },
+    ]);
+    expect(result).toBe('First\n\nSecond');
+  });
+
+  // --- URL resolution tests (Sourcery AI review fix) ---
+
+  it('should NOT double-prefix absolute http URLs for images', () => {
+    const result = contentBlocksToString([
+      { type: 'image', data: 'https://cdn.example.com/img.png', mimeType: 'image/png' },
+    ]);
+    expect(result).toBe('![](https://cdn.example.com/img.png)');
+    expect(result).not.toContain('https://my-app.example.com/https://');
+  });
+
+  it('should NOT double-prefix absolute http URLs for audio', () => {
+    const result = contentBlocksToString([
+      { type: 'audio', data: 'https://cdn.example.com/audio.mp3', mimeType: 'audio/mp3' },
+    ]);
+    expect(result).toContain('url="https://cdn.example.com/audio.mp3"');
+    expect(result).not.toContain('https://my-app.example.com/https://');
+  });
+
+  it('should prefix relative paths with APP_URL for images', () => {
+    const result = contentBlocksToString([
+      { type: 'image', data: '/f/abc123.png', mimeType: 'image/png' },
+    ]);
+    expect(result).toBe('![](https://my-app.example.com/f/abc123.png)');
+  });
+
+  it('should prefix relative paths with APP_URL for audio', () => {
+    const result = contentBlocksToString([
+      { type: 'audio', data: '/f/audio123.mp3', mimeType: 'audio/mp3' },
+    ]);
+    expect(result).toContain('url="https://my-app.example.com/f/audio123.mp3"');
+  });
+
+  it('should NOT treat paths starting with "http" (no "://") as absolute URLs', () => {
+    // Edge case from Sourcery review: "http-assets/foo.png" should be treated as relative
+    const result = contentBlocksToString([
+      { type: 'image', data: 'http-assets/foo.png', mimeType: 'image/png' },
+    ]);
+    expect(result).toBe('![](https://my-app.example.com/http-assets/foo.png)');
+  });
+
+  it('should handle mixed content blocks', () => {
+    const result = contentBlocksToString([
+      { type: 'text', text: 'Generated image:' },
+      { type: 'image', data: 'https://cdn.example.com/result.jpg', mimeType: 'image/jpeg' },
+    ]);
+    expect(result).toBe('Generated image:\n\n![](https://cdn.example.com/result.jpg)');
+  });
+
+  it('should skip unknown block types', () => {
+    const result = contentBlocksToString([
+      { type: 'text', text: 'Hello' },
+      { type: 'unknown_type' } as any,
+    ]);
+    expect(result).toBe('Hello');
+  });
+
+  it('should handle resource blocks', () => {
+    const resource = { uri: 'file:///tmp/data.json', text: '{}' };
+    const result = contentBlocksToString([
+      { type: 'resource', resource } as any,
+    ]);
+    expect(result).toContain('resource');
+    expect(result).toContain(JSON.stringify(resource));
+  });
+});

--- a/src/server/services/mcp/contentProcessor.ts
+++ b/src/server/services/mcp/contentProcessor.ts
@@ -64,6 +64,12 @@ export const processContentBlocks = async (
 };
 
 /**
+ * Resolve a media URL: return as-is if already absolute, otherwise join with APP_URL.
+ */
+const resolveMediaUrl = (data: string): string =>
+  /^https?:\/\//.test(data) ? data : urlJoin(appEnv.APP_URL, data);
+
+/**
  * Convert content blocks to string
  * - text: Extract text field
  * - image/audio: Extract data field (usually the proxy URL after upload)
@@ -80,11 +86,11 @@ export const contentBlocksToString = (blocks: ToolCallContent[] | null | undefin
         }
 
         case 'image': {
-          return `![](${urlJoin(appEnv.APP_URL, item.data)})`;
+          return `![](${resolveMediaUrl(item.data)})`;
         }
 
         case 'audio': {
-          return `<resource type="${item.type}" url="${urlJoin(appEnv.APP_URL, item.data)}" />`;
+          return `<resource type="${item.type}" url="${resolveMediaUrl(item.data)}" />`;
         }
 
         case 'resource': {


### PR DESCRIPTION
## Summary

  Fixes MCP tool results displaying as raw JSON instead of rendered inline content (images, formatted text).

  **Root cause:** Two independent issues working together:
  1. `contentBlocksToString()` double-prefixes absolute URLs — `processContentBlocks()` stores full proxy URLs (e.g.,
  `https://app.com/f/abc.png`), then `contentBlocksToString()` redundantly applies `urlJoin(APP_URL, data)`, creating malformed
  `https://app.com/https://app.com/f/abc.png`
  2. MCP tool results always fall through to `FallbackArgumentRender` (raw JSON) because `getBuiltinRender()` returns `undefined`
   for MCP identifiers

  ## Changes

  - **`contentProcessor.ts`**: Extract `resolveMediaUrl()` helper using `/^https?:\/\//` regex to correctly distinguish absolute
  URLs from relative paths (e.g., `http-assets/foo.png` is relative, not absolute)
  - **`Render/index.tsx`**: Route `type='mcp'` tools to `CustomRender` → `PluginRender` → `MCPType` for proper inline rendering
  of images and formatted text
  - **`MCPType/index.tsx`**: Add `Array.isArray(pluginState.content)` guard to prevent render-time crash when `pluginState` has
  unexpected shape
  - **`contentProcessor.test.ts`**: Add unit tests covering absolute/relative URL resolution, edge cases, and mixed content
  blocks

  ## How it was tested

  - Verified MCP image generation tool renders images inline instead of showing base64 JSON
  - Verified non-MCP builtin tools (Knowledge Base, Web Browsing, etc.) are unaffected
  - Unit tests pass covering: null/undefined input, absolute URLs (no double-prefix), relative paths (correctly prefixed),
  `http-assets/` edge case, mixed content, resource blocks

  ## Test plan

  - [ ] MCP tool returning `ImageContent` renders inline image (not raw JSON)
  - [ ] MCP tool returning `TextContent` renders as formatted Markdown
  - [ ] Non-MCP builtin tools still render with their custom renderers
  - [ ] FallbackArgumentRender still works for market plugins (type='default')
  - [ ] Absolute proxy URLs are not double-prefixed
  - [ ] Relative paths are correctly joined with APP_URL
  - [ ] Unit tests pass: `vitest run contentProcessor.test.ts`

## Summary by Sourcery

Fix MCP tool result rendering and URL handling so media content displays correctly instead of raw JSON.

Bug Fixes:
- Prevent double-prefixing of absolute media URLs when converting MCP content blocks to strings.
- Ensure MCP tools use the custom render pipeline so their results render inline instead of falling back to raw JSON.
- Avoid crashes in MCP plugin rendering when plugin state content is missing or not an array.

Tests:
- Add unit tests for MCP content URL resolution across absolute URLs, relative paths, and mixed content blocks.