### PR TITLE
ci: declare explicit read-only GITHUB_TOKEN permission for lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 0 * * *' # every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lighthouse-badger-advanced:
     name: ${{ matrix.NAME }}


### PR DESCRIPTION
## Summary\n- add explicit `permissions: contents: read` to `.github/workflows/lighthouse.yml`\n\n## Why\nThis workflow currently relies on implicit default token scopes. Explicitly declaring read-only access improves security posture and keeps permission intent clear, while preserving the existing dedicated secret-token flow for write operations.\n\n## Notes\n- configuration-only change; no audit logic changed\n

## Summary by Sourcery

CI:
- Add explicit read-only contents permission to the Lighthouse workflow GITHUB_TOKEN configuration.