### PR TITLE
🔨 chore(model-runtime): add User-Agent header for Anthropic API calls

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import Anthropic from '@anthropic-ai/sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createDefaultAnthropicClient } from './index';
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const MockAnthropic = vi.fn();
+  return { default: MockAnthropic };
+});
+
+vi.mock('@lobechat/const', () => ({
+  CURRENT_VERSION: '1.0.0-test',
+}));
+
+const MockedAnthropic = vi.mocked(Anthropic);
+
+describe('createDefaultAnthropicClient', () => {
+  it('should include User-Agent header with current version', () => {
+    MockedAnthropic.mockClear();
+
+    createDefaultAnthropicClient({ apiKey: 'test-key' });
+
+    expect(MockedAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: expect.objectContaining({
+          'User-Agent': 'lobehub/1.0.0-test',
+        }),
+      }),
+    );
+  });
+
+  it('should preserve caller-provided default headers alongside User-Agent', () => {
+    MockedAnthropic.mockClear();
+
+    createDefaultAnthropicClient({
+      apiKey: 'test-key',
+      defaultHeaders: { 'X-Custom': 'value' },
+    });
+
+    const passedOptions = MockedAnthropic.mock.calls[0][0] as any;
+
+    expect(passedOptions.defaultHeaders).toMatchObject({
+      'User-Agent': 'lobehub/1.0.0-test',
+      'X-Custom': 'value',
+    });
+  });
+});

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -1,5 +1,6 @@
 import Anthropic, { ClientOptions } from '@anthropic-ai/sdk';
 import type { Stream } from '@anthropic-ai/sdk/streaming';
+import { CURRENT_VERSION } from '@lobechat/const';
 import type { ChatModelCard } from '@lobechat/types';
 import debug from 'debug';
 
@@ -166,10 +167,7 @@ export const buildDefaultAnthropicPayload = async (
     const resolvedThinking: Anthropic.MessageCreateParams['thinking'] =
       thinking.type === 'enabled'
         ? {
-            budget_tokens: Math.min(
-              thinking?.budget_tokens || 1024,
-              resolvedMaxTokens - 1,
-            ),
+            budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
             type: 'enabled',
           }
         : { type: 'adaptive' };
@@ -227,6 +225,7 @@ export const createDefaultAnthropicClient = <T extends Record<string, any> = any
 ) => {
   const betaHeaders = process.env.ANTHROPIC_BETA_HEADERS;
   const defaultHeaders = {
+    'User-Agent': `lobehub/${CURRENT_VERSION}`,
     ...options.defaultHeaders,
     ...(betaHeaders ? { 'anthropic-beta': betaHeaders } : {}),
   };


### PR DESCRIPTION
#### 💻 Change Type

- [X] ✨ feat

#### 🔀 Description of Change

Adds a user-agent header for Anthropic API calls, so that can better aggregate and recognize traffic from successful open-source libraries

#### 🧪 How to Test

- [X] Added/updated tests

## Summary by Sourcery

Add a User-Agent header identifying the library version to all Anthropic API client calls and verify its presence via unit tests.

New Features:
- Include a lobe-chat versioned User-Agent header in the default headers for Anthropic-compatible clients.

Tests:
- Add unit tests to ensure the User-Agent header is set with the current version and coexists with caller-provided default headers.