### PR TITLE
✨ feat(cloud): add Seedream 5 Lite model

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/image.ts
+++ b/packages/model-bank/src/aiModels/lobehub/image.ts
@@ -158,6 +158,37 @@ export const lobehubImageModels: AIImageModelCard[] = [
   },
   {
     description:
+      'ByteDance-Seedream-5.0-lite by BytePlus features web-retrieval-augmented generation for real-time information, enhanced complex prompt interpretation, and improved reference consistency for professional visual creation.',
+    displayName: 'Seedream 5 Lite',
+    enabled: true,
+    id: 'seedream-5-0-260128',
+    parameters: {
+      imageUrls: { default: [], maxCount: 14, maxFileSize: 10 * 1024 * 1024 },
+      prompt: { default: '' },
+      seed: { default: null },
+      size: {
+        default: '2048x2048',
+        enum: [
+          '2048x2048',
+          '2560x1440',
+          '1440x2560',
+          '3072x2048',
+          '2048x3072',
+          '2560x2048',
+          '2048x2560',
+          '3072x1920',
+          '1920x3072',
+        ],
+      },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.035, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-02-24',
+    type: 'image',
+  },
+  {
+    description:
       'Seedream 4.5, built by ByteDance Seed team, supports multi-image editing and composition. Features enhanced subject consistency, precise instruction following, spatial logic understanding, aesthetic expression, poster layout and logo design with high-precision text-image rendering.',
     displayName: 'Seedream 4.5',
     enabled: true,

--- a/packages/model-runtime/src/providers/volcengine/createImage.test.ts
+++ b/packages/model-runtime/src/providers/volcengine/createImage.test.ts
@@ -189,6 +189,29 @@ describe('createVolcengineImage', () => {
       });
     });
 
+    it('should strip height and width when size is provided', async () => {
+      const mockResponse = {
+        data: [{ url: 'https://example.com/test.jpg' }],
+      };
+      mockGenerate.mockResolvedValue(mockResponse);
+
+      payload.params = {
+        prompt: 'test prompt',
+        size: '2048x2048',
+        height: 1024,
+        width: 1024,
+      };
+
+      await createVolcengineImage(payload, options);
+
+      expect(mockGenerate).toHaveBeenCalledWith({
+        model: 'doubao-seedream-3-0-t2i',
+        watermark: false,
+        prompt: 'test prompt',
+        size: '2048x2048',
+      });
+    });
+
     it('should convert height and width to size parameter', async () => {
       const mockResponse = {
         data: [{ url: 'https://example.com/test.jpg' }],
@@ -352,6 +375,23 @@ describe('createVolcengineImage', () => {
       expect(OpenAI.default).toHaveBeenCalledWith({
         apiKey: 'test-api-key',
         baseURL: 'https://custom-endpoint.com/api/v1',
+      });
+    });
+
+    it('should use BytePlus baseURL for international endpoint', async () => {
+      const mockResponse = {
+        data: [{ url: 'https://example.com/test.jpg' }],
+      };
+      mockGenerate.mockResolvedValue(mockResponse);
+
+      options.baseURL = 'https://ark.ap-southeast.bytepluses.com/api/v3';
+
+      await createVolcengineImage(payload, options);
+
+      const OpenAI = await import('openai');
+      expect(OpenAI.default).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+        baseURL: 'https://ark.ap-southeast.bytepluses.com/api/v3',
       });
     });
 

--- a/packages/model-runtime/src/providers/volcengine/createImage.ts
+++ b/packages/model-runtime/src/providers/volcengine/createImage.ts
@@ -42,6 +42,8 @@ export async function createVolcengineImage(
   // Handle size parameter: use directly if provided, otherwise convert from height/width
   if (userInput.size) {
     log('Using direct size parameter: %s', userInput.size);
+    delete userInput.height;
+    delete userInput.width;
   } else {
     const imgHeight = userInput.height;
     const imgWidth = userInput.width;

--- a/packages/model-runtime/src/providers/volcengine/createImage.ts
+++ b/packages/model-runtime/src/providers/volcengine/createImage.ts
@@ -39,14 +39,18 @@ export async function createVolcengineImage(
     ]),
   );
 
-  // Convert height and weight/width to size parameter
-  const imgHeight = userInput.height;
-  const imgWidth = userInput.width;
+  // Handle size parameter: use directly if provided, otherwise convert from height/width
+  if (userInput.size) {
+    log('Using direct size parameter: %s', userInput.size);
+  } else {
+    const imgHeight = userInput.height;
+    const imgWidth = userInput.width;
 
-  if (imgHeight !== undefined && imgWidth !== undefined) {
-    userInput.size = `${imgWidth}x${imgHeight}`;
-    delete userInput.height;
-    delete userInput.width;
+    if (imgHeight !== undefined && imgWidth !== undefined) {
+      userInput.size = `${imgWidth}x${imgHeight}`;
+      delete userInput.height;
+      delete userInput.width;
+    }
   }
 
   // Volcengine supports direct URL or base64, no need to convert to File objects

--- a/src/business/server/image-generation/chargeAfterGenerate.ts
+++ b/src/business/server/image-generation/chargeAfterGenerate.ts
@@ -1,6 +1,7 @@
 import { type ModelUsage } from '@/types/index';
 
 interface ChargeParams {
+  latency?: number;
   metadata: {
     asyncTaskId: string;
     generationBatchId: string;

--- a/src/business/server/image-generation/chargeAfterGenerate.ts
+++ b/src/business/server/image-generation/chargeAfterGenerate.ts
@@ -1,13 +1,13 @@
-import { type ModelUsage } from '@/types/index';
+import { type ModelPerformance, type ModelUsage } from '@/types/index';
 
 interface ChargeParams {
-  latency?: number;
   metadata: {
     asyncTaskId: string;
     generationBatchId: string;
     modelId: string;
     topicId?: string;
   };
+  metrics?: ModelPerformance;
   modelUsage?: ModelUsage;
   provider: string;
   userId: string;

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -344,7 +344,7 @@ export const imageRouter = router({
 
           if (ENABLE_BUSINESS_FEATURES) {
             await chargeAfterGenerate({
-              latency: duration,
+              metrics: { latency: duration },
               metadata: {
                 asyncTaskId: taskId,
                 generationBatchId,

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -265,20 +265,6 @@ export const imageRouter = router({
 
           const { modelUsage } = response;
 
-          if (ENABLE_BUSINESS_FEATURES) {
-            await chargeAfterGenerate({
-              metadata: {
-                asyncTaskId: taskId,
-                generationBatchId,
-                modelId: model,
-                topicId: generationTopicId,
-              },
-              modelUsage,
-              provider,
-              userId: ctx.userId,
-            });
-          }
-
           // Check if operation has been cancelled
           checkAbortSignal(signal);
 
@@ -348,10 +334,28 @@ export const imageRouter = router({
             },
           );
 
-          log('Updating task status to Success: %s', taskId);
+          const duration = Date.now() - generationBatch.createdAt.getTime();
+
+          log('Updating task status to Success: %s, duration: %dms', taskId, duration);
           await ctx.asyncTaskModel.update(taskId, {
+            duration,
             status: AsyncTaskStatus.Success,
           });
+
+          if (ENABLE_BUSINESS_FEATURES) {
+            await chargeAfterGenerate({
+              latency: duration,
+              metadata: {
+                asyncTaskId: taskId,
+                generationBatchId,
+                modelId: model,
+                topicId: generationTopicId,
+              },
+              modelUsage,
+              provider,
+              userId: ctx.userId,
+            });
+          }
 
           log('Async image generation completed successfully: %s', taskId);
           return { success: true };


### PR DESCRIPTION
## Summary
- Add ByteDance Seedream 5 Lite image generation model with preset size options
- Update Volcengine `createImage` to support direct `size` parameter alongside existing `height`/`width` conversion

## Test plan
- [ ] Verify Seedream 5 Lite model appears in model list
- [ ] Test image generation with different size presets (e.g. 2048x2048, 2560x1440)
- [ ] Verify existing models using height/width parameters still work correctly

## Summary by Sourcery

Add a new ByteDance Seedream 5 Lite image generation model and extend Volcengine image creation to accept a direct size parameter.

New Features:
- Introduce the ByteDance Seedream 5 Lite image generation model with preset resolution options and pricing metadata in the model bank.

Enhancements:
- Allow Volcengine image creation to use a direct size parameter when provided, while still supporting automatic conversion from height and width inputs.