### PR TITLE
fix(docker): hoist @napi-rs/canvas for PDF parsing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -18,3 +18,4 @@ public-hoist-pattern[]=*stylelint*
 
 public-hoist-pattern[]=@auth/core
 public-hoist-pattern[]=pdfjs-dist
+public-hoist-pattern[]=@napi-rs/canvas-*


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

Fixes #12396

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Docker 部署时上传 PDF 文件报错 `DOMMatrix is not defined`,原因是pnpm的隔离导致`@napi-rs/canvas-linux-x64-gnu` 等平台特定包未被提升到顶层 `node_modules/`，Next.js `outputFileTracing` 无法打包。在 `.npmrc` 中添加 `public-hoist-pattern[]=@napi-rs/canvas-*` 解决。同时 `node:24-slim` 基础镜像缺少 `libfontconfig.so`，`@napi-rs/canvas` 原生绑定 dlopen 失败。在 Dockerfile 中安装`libfontconfig1` 解决。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix PDF upload failures in Docker deployments by ensuring required native canvas dependencies are available at runtime and during bundling.

Bug Fixes:
- Resolve PDF parsing errors in Docker by installing libfontconfig1 so @napi-rs/canvas native bindings can load correctly.

Build:
- Adjust npm hoisting configuration so @napi-rs/canvas platform-specific packages are available for Next.js output file tracing in container builds.