### PR TITLE
  💄 style(cloud): remove deprecated chatgpt-4o-latest

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
@@ -258,24 +258,6 @@ export const openaiChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 128_000,
-    description:
-      'ChatGPT-4o is a dynamic model updated in real time. It combines strong understanding and generation for large-scale use cases like customer support, education, and technical support.',
-    displayName: 'ChatGPT-4o',
-    id: 'chatgpt-4o-latest',
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-08-14',
-    type: 'chat',
-  },
-  {
-    abilities: {
       functionCall: true,
       vision: true,
     },


### PR DESCRIPTION
## Summary
- Remove the `chatgpt-4o-latest` model card from LobeHub OpenAI chat models

## Summary by Sourcery

Enhancements:
- Simplify the OpenAI chat model catalog by dropping support for the `chatgpt-4o-latest` entry.