### PR TITLE
feat: add Avian as a new AI model provider

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -5,6 +5,7 @@
   "aihubmix.description": "AiHubMix provides access to multiple AI models through a unified API.",
   "akashchat.description": "Akash is a permissionless cloud resource marketplace with competitive pricing compared to traditional cloud providers.",
   "anthropic.description": "Anthropic builds advanced language models like Claude 3.5 Sonnet, Claude 3 Sonnet, Claude 3 Opus, and Claude 3 Haiku, balancing intelligence, speed, and cost for workloads from enterprise to rapid-response use cases.",
+  "avian.description": "Avian is an AI inference platform providing access to frontier open-source models including DeepSeek, Kimi, GLM, and MiniMax with an OpenAI-compatible API, high performance, and competitive pricing.",
   "azure.description": "Azure offers advanced AI models, including GPT-3.5 and GPT-4 series, for diverse data types and complex tasks with a focus on safe, reliable, and sustainable AI.",
   "azureai.description": "Azure provides advanced AI models, including GPT-3.5 and GPT-4 series, for diverse data types and complex tasks with a focus on safe, reliable, and sustainable AI.",
   "baichuan.description": "Baichuan AI focuses on foundation models with strong performance on Chinese knowledge, long-context processing, and creative generation. Its models (Baichuan 4, Baichuan 3 Turbo, Baichuan 3 Turbo 128k) are optimized for different scenarios and offer strong value.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -5,6 +5,7 @@
   "aihubmix.description": "AiHubMix 通过统一 API 提供多种 AI 模型的访问能力。",
   "akashchat.description": "Akash 是一个无需许可的云资源市场，与传统云提供商相比，其定价具有竞争力。",
   "anthropic.description": "Anthropic 构建了先进的语言模型，如 Claude 3.5 Sonnet、Claude 3 Sonnet、Claude 3 Opus 和 Claude 3 Haiku，兼顾智能、速度与成本，适用于企业级到快速响应等多种场景。",
+  "avian.description": "Avian 是一个 AI 推理平台，通过兼容 OpenAI 的 API 提供前沿开源模型，包括 DeepSeek、Kimi、GLM 和 MiniMax，具有高性能和有竞争力的定价。",
   "azure.description": "Azure 提供先进的 AI 模型，包括 GPT-3.5 和 GPT-4 系列，支持多种数据类型和复杂任务，注重安全、可靠与可持续的 AI 实践。",
   "azureai.description": "Azure 提供先进的 AI 模型，包括 GPT-3.5 和 GPT-4 系列，支持多种数据类型和复杂任务，注重安全、可靠与可持续的 AI 实践。",
   "baichuan.description": "百川智能专注于基础模型研发，具备强大的中文知识理解、长文本处理与创意生成能力。其模型（如百川4、百川3 Turbo、百川3 Turbo 128k）针对不同场景优化，性价比高。",

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -12,6 +12,7 @@
     "./aihubmix": "./src/aiModels/aihubmix.ts",
     "./akashchat": "./src/aiModels/akashchat.ts",
     "./anthropic": "./src/aiModels/anthropic.ts",
+    "./avian": "./src/aiModels/avian.ts",
     "./azureai": "./src/aiModels/azureai.ts",
     "./azure": "./src/aiModels/azure.ts",
     "./baichuan": "./src/aiModels/baichuan.ts",

--- a/packages/model-bank/src/aiModels/avian.ts
+++ b/packages/model-bank/src/aiModels/avian.ts
@@ -1,0 +1,88 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+const avianChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 163_840,
+    description:
+      'DeepSeek V3.2 is a powerful MoE model with strong reasoning and coding capabilities.',
+    displayName: 'DeepSeek V3.2',
+    enabled: true,
+    id: 'deepseek/deepseek-v3.2',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.26, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.38, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'Kimi K2.5 is a versatile multimodal model supporting vision and text inputs, thinking and non-thinking modes, and both conversational and agent tasks.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'moonshotai/kimi-k2.5',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.45, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'GLM-5 is a next-generation foundation model from Zhipu AI with strong reasoning and instruction-following capabilities.',
+    displayName: 'GLM-5',
+    enabled: true,
+    id: 'z-ai/glm-5',
+    maxOutput: 16_384,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.55, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'MiniMax M2.5 is a high-performance model with a 1M token context window and strong general-purpose language understanding.',
+    displayName: 'MiniMax M2.5',
+    enabled: true,
+    id: 'minimax/minimax-m2.5',
+    maxOutput: 1_000_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.1, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+];
+
+export const allModels = [...avianChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -7,6 +7,7 @@ import { default as ai360 } from './ai360';
 import { default as aihubmix } from './aihubmix';
 import { default as akashchat } from './akashchat';
 import { default as anthropic } from './anthropic';
+import { default as avian } from './avian';
 import { default as azure } from './azure';
 import { default as azureai } from './azureai';
 import { default as baichuan } from './baichuan';
@@ -100,6 +101,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   aihubmix,
   akashchat,
   anthropic,
+  avian,
   azure,
   azureai,
   baichuan,
@@ -174,6 +176,7 @@ export { default as ai360 } from './ai360';
 export { default as aihubmix } from './aihubmix';
 export { default as akashchat } from './akashchat';
 export { default as anthropic } from './anthropic';
+export { default as avian } from './avian';
 export { default as azure } from './azure';
 export { default as azureai } from './azureai';
 export { default as baichuan } from './baichuan';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -5,6 +5,7 @@ export enum ModelProvider {
   AiHubMix = 'aihubmix',
   AkashChat = 'akashchat',
   Anthropic = 'anthropic',
+  Avian = 'avian',
   Azure = 'azure',
   AzureAI = 'azureai',
   Baichuan = 'baichuan',

--- a/packages/model-bank/src/modelProviders/avian.ts
+++ b/packages/model-bank/src/modelProviders/avian.ts
@@ -1,0 +1,19 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+const Avian: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'deepseek/deepseek-v3.2',
+  description:
+    'Avian is an AI inference platform providing access to frontier open-source models with high performance and competitive pricing.',
+  id: 'avian',
+  name: 'Avian',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.avian.io/v1',
+    },
+    sdkType: 'openai',
+  },
+  url: 'https://avian.io',
+};
+
+export default Avian;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -8,6 +8,7 @@ import Ai360Provider from './ai360';
 import AiHubMixProvider from './aihubmix';
 import AkashChatProvider from './akashchat';
 import AnthropicProvider from './anthropic';
+import AvianProvider from './avian';
 import AzureProvider from './azure';
 import AzureAIProvider from './azureai';
 import BaichuanProvider from './baichuan';
@@ -203,6 +204,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   CerebrasProvider,
   ZenMuxProvider,
   StraicoProvider,
+  AvianProvider,
   XiaomiMiMoProvider,
 ];
 
@@ -221,6 +223,7 @@ export { default as Ai360ProviderCard } from './ai360';
 export { default as AiHubMixProviderCard } from './aihubmix';
 export { default as AkashChatProviderCard } from './akashchat';
 export { default as AnthropicProviderCard } from './anthropic';
+export { default as AvianProviderCard } from './avian';
 export { default as AzureProviderCard } from './azure';
 export { default as AzureAIProviderCard } from './azureai';
 export { default as BaichuanProviderCard } from './baichuan';

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -8,6 +8,7 @@ export * from './core/usageConverters';
 export * from './helpers';
 export { LobeAkashChatAI } from './providers/akashchat';
 export { LobeAnthropicAI } from './providers/anthropic';
+export { LobeAvianAI } from './providers/avian';
 export { LobeAzureAI } from './providers/azureai';
 export { LobeAzureOpenAI } from './providers/azureOpenai';
 export { LobeBedrockAI } from './providers/bedrock';

--- a/packages/model-runtime/src/providers/avian/index.ts
+++ b/packages/model-runtime/src/providers/avian/index.ts
@@ -1,0 +1,11 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const LobeAvianAI = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.avian.io/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_AVIAN_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Avian,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -4,6 +4,7 @@ import { LobeAi360AI } from './providers/ai360';
 import { LobeAiHubMixAI } from './providers/aihubmix';
 import { LobeAkashChatAI } from './providers/akashchat';
 import { LobeAnthropicAI } from './providers/anthropic';
+import { LobeAvianAI } from './providers/avian';
 import { LobeAzureAI } from './providers/azureai';
 import { LobeAzureOpenAI } from './providers/azureOpenai';
 import { LobeBaichuanAI } from './providers/baichuan';
@@ -77,6 +78,7 @@ export const providerRuntimeMap = {
   aihubmix: LobeAiHubMixAI,
   akashchat: LobeAkashChatAI,
   anthropic: LobeAnthropicAI,
+  avian: LobeAvianAI,
   azure: LobeAzureOpenAI,
   azureai: LobeAzureAI,
   baichuan: LobeBaichuanAI,

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -39,6 +39,9 @@ export const getLLMConfig = () => {
       ENABLED_ANTHROPIC: z.boolean(),
       ANTHROPIC_API_KEY: z.string().optional(),
 
+      ENABLED_AVIAN: z.boolean(),
+      AVIAN_API_KEY: z.string().optional(),
+
       ENABLED_MINIMAX: z.boolean(),
       MINIMAX_API_KEY: z.string().optional(),
 
@@ -257,6 +260,9 @@ export const getLLMConfig = () => {
 
       ENABLED_ANTHROPIC: process.env.ENABLED_ANTHROPIC !== '0',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+
+      ENABLED_AVIAN: !!process.env.AVIAN_API_KEY,
+      AVIAN_API_KEY: process.env.AVIAN_API_KEY,
 
       ENABLED_MINIMAX: !!process.env.MINIMAX_API_KEY,
       MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,


### PR DESCRIPTION
## Summary

Add [Avian](https://avian.io) as a new built-in AI model provider. Avian is an inference platform that provides access to frontier open-source models through an OpenAI-compatible API with competitive pricing.

**Models included:**
| Model | Context | Max Output | Input $/M | Output $/M | Capabilities |
|-------|---------|------------|-----------|------------|--------------|
| DeepSeek V3.2 | 164K | 65K | $0.26 | $0.38 | Chat, Function Calling, Reasoning |
| Kimi K2.5 | 131K | 8K | $0.45 | $2.20 | Chat, Function Calling, Reasoning, Vision |
| GLM-5 | 131K | 16K | $0.30 | $2.55 | Chat, Function Calling, Reasoning |
| MiniMax M2.5 | 1M | 1M | $0.30 | $1.10 | Chat, Function Calling |

## Changes

- `packages/model-bank/src/const/modelProvider.ts` — Add `Avian` to `ModelProvider` enum
- `packages/model-bank/src/aiModels/avian.ts` — Define 4 chat models with pricing
- `packages/model-bank/src/aiModels/index.ts` — Register avian models
- `packages/model-bank/src/modelProviders/avian.ts` — Provider card configuration
- `packages/model-bank/src/modelProviders/index.ts` — Register provider card
- `packages/model-bank/package.json` — Add `avian` export
- `packages/model-runtime/src/providers/avian/index.ts` — OpenAI-compatible runtime
- `packages/model-runtime/src/runtimeMap.ts` — Register runtime
- `packages/model-runtime/src/index.ts` — Export `LobeAvianAI`
- `src/envs/llm.ts` — Add `ENABLED_AVIAN` and `AVIAN_API_KEY` env vars
- `locales/en-US/providers.json` — English description
- `locales/zh-CN/providers.json` — Chinese description

## Notes

- Follows the same pattern as other OpenAI-compatible providers (e.g., Straico, ZenMux)
- No custom runtime logic needed — standard `createOpenAICompatibleRuntime` factory
- API base URL: `https://api.avian.io/v1`
- Auth: Bearer token via `AVIAN_API_KEY` environment variable

## Summary by Sourcery

Add Avian as a new OpenAI-compatible AI model provider and wire it into the model bank, runtime, and configuration system.

New Features:
- Introduce Avian chat models, including DeepSeek V3.2, Kimi K2.5, GLM-5, and MiniMax M2.5, with defined capabilities and pricing.
- Add an Avian model provider card with OpenAI-compatible settings and default API endpoint.
- Expose a new LobeAvianAI runtime mapped to the Avian provider for chat completions.

Enhancements:
- Extend the global model provider enum, default provider list, and default model list to include Avian.
- Export Avian models and provider card from the model-bank package and Avian runtime from the model-runtime package.
- Add configuration and env support for enabling Avian via ENABLED_AVIAN and AVIAN_API_KEY, defaulting enablement to presence of the API key.

Documentation:
- Add English and Chinese localized descriptions for the Avian provider.