### PR TITLE
🐛 fix(resource): fix batch deletion logic and prevent unintended original resource loss

### DIFF
--- a/packages/database/src/repositories/knowledge/index.ts
+++ b/packages/database/src/repositories/knowledge/index.ts
@@ -176,7 +176,7 @@ export class KnowledgeRepo {
         'file' as source_type
       FROM ${files} f
       LEFT JOIN ${documents} d
-        ON f.id = d.file_id
+        ON f.id = d.file_id AND d.source_type = 'file'
       WHERE f.user_id = ${this.userId}
         AND NOT EXISTS (
           SELECT 1 FROM ${knowledgeBaseFiles}
@@ -387,7 +387,7 @@ export class KnowledgeRepo {
           ON f.id = kbf.file_id
           AND kbf.knowledge_base_id = ${knowledgeBaseId}
         LEFT JOIN ${documents} d
-          ON f.id = d.file_id
+          ON f.id = d.file_id AND d.source_type = 'file'
         WHERE ${sql.join(kbWhereConditions, sql` AND `)}
       `;
     }
@@ -422,7 +422,7 @@ export class KnowledgeRepo {
         'file' as source_type
       FROM ${files} f
       LEFT JOIN ${documents} d
-        ON f.id = d.file_id
+        ON f.id = d.file_id AND d.source_type = 'file'
       WHERE ${sql.join(whereConditions, sql` AND `)}
     `;
   }

--- a/src/server/services/document/index.ts
+++ b/src/server/services/document/index.ts
@@ -172,7 +172,10 @@ export class DocumentService {
     }
 
     // Delete the associated file record if it exists
-    if (document.fileId) {
+    // Skip cascade deletion when sourceType === 'file': those fileIds point to the
+    // user's original upload (e.g. a Demo PDF), which must NOT be removed when only
+    // the derived document entry is deleted.
+    if (document.fileId && document.sourceType !== 'file') {
       await this.fileModel.delete(document.fileId);
     }
 

--- a/src/store/file/slices/resource/action.ts
+++ b/src/store/file/slices/resource/action.ts
@@ -230,12 +230,17 @@ export class ResourceActionImpl {
     if (ids.length === 0) return;
 
     // 1. Read sourceType from resourceMap for each ID (client-side, no API call)
-    const { resourceMap, resourceList } = this.#get();
+    const { resourceMap, resourceList, fileList } = this.#get();
+
+    // Build a Map from fileList once (O(n)) so the per-id fallback lookup is O(1)
+    // rather than O(n) via Array.find, keeping the overall loop O(n) instead of O(n²).
+    const fileListMap = new Map(fileList.map((f) => [f.id, f]));
+
     const fileIds: string[] = [];
     const documentIds: string[] = [];
 
     for (const id of ids) {
-      const resource = resourceMap.get(id);
+      const resource = resourceMap.get(id) ?? fileListMap.get(id);
       if (resource?.sourceType === 'document') {
         documentIds.push(id);
       } else {


### PR DESCRIPTION
- Fall back to fileList when resourceMap misses an id so batch select-all deletion works correctly
- Guard file cascading deletion to only trigger when document.sourceType === 'api'
- Change parseDocument() sourceType from 'file' to 'editor' to distinguish from raw user uploads
- Add source_type filter to knowledge repo JOIN to prevent duplicate file rows

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->
https://github.com/lobehub/lobehub/issues/12448

And issue associated with https://github.com/lobehub/lobehub/pull/12530:unintended original resource loss
Pages->upload file(PDF)-> Resource -> delete page will affect pdf file 
<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Fix resource deletion behavior to prevent unintended file loss and ensure correct batch deletion handling.

Bug Fixes:
- Prevent associated files from being deleted when removing non-API documents.
- Correct batch resource deletion to resolve resources missing from the in-memory map.
- Avoid duplicate file rows in knowledge queries by filtering joined documents on file source type.

Enhancements:
- Differentiate editor-generated documents from raw file uploads by using a distinct source type in document parsing.