### PR TITLE
✨ feat: add new NVIDIA models and tweak the behavior of the enable thinking

### DIFF
--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -101,6 +101,88 @@ const nvidiaChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.1 is a compact, fast, cost-effective MoE model built for top-tier coding and agent performance.',
+    displayName: 'MiniMax-M2.1',
+    enabled: true,
+    id: 'minimaxai/minimax-m2.1',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'DeepSeek V3.2 is a next-gen reasoning model with stronger complex reasoning and chain-of-thought capabilities.',
+    displayName: 'DeepSeek V3.2',
+    enabled: true,
+    id: 'deepseek-ai/deepseek-v3.2',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'GLM-4.7 is Zhipu latest flagship model, enhanced for Agentic Coding scenarios with improved coding capabilities.',
+    displayName: 'GLM-4.7',
+    enabled: true,
+    id: 'z-ai/glm4.7',
+    maxOutput: 131_072,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      "GLM-5 is Zhipu AI's new flagship foundation model for agent engineering, achieving open-source SOTA performance in coding and agent capabilities. It matches Claude Opus 4.5 in performance.",
+    displayName: 'GLM-5',
+    enabled: true,
+    id: 'z-ai/glm5',
+    maxOutput: 131_072,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Kimi K2.5 is the most intelligent Kimi model to date, featuring native multimodal architecture.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'moonshotai/kimi-k2.5',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
     contextWindowTokens: 131_072,
     description:
       'DeepSeek V3.1 is a next-gen reasoning model with stronger complex reasoning and chain-of-thought for deep analysis tasks.',
@@ -272,6 +354,38 @@ const nvidiaChatModels: AIChatModelCard[] = [
       'An advanced LLM for code generation, reasoning, and repair across mainstream programming languages.',
     displayName: 'Qwen2.5 Coder 32B Instruct',
     id: 'qwen/qwen2.5-coder-32b-instruct',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.5 is the latest large language model from MiniMax, featuring a Mixture-of-Experts (MoE) architecture with 229 billion total parameters. It achieves industry-leading performance in programming, agent tool calling, search tasks, and office scenarios.',
+    displayName: 'MiniMax-M2.5',
+    enabled: true,
+    id: 'minimaxai/minimax-m2.5',
+    maxOutput: 131_072,
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_010_000,
+    description:
+      'Supports text, image, and video inputs. For text-only tasks, its performance is comparable to Qwen3 Max, offering higher efficiency and lower cost. In multimodal capabilities, it delivers significant improvements over the Qwen3 VL series.',
+    displayName: 'Qwen3.5-397B-A17B',
+    enabled: true,
+    id: 'qwen/qwen3.5-397b-a17b',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+    },
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -375,6 +375,7 @@ const nvidiaChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       vision: true,
+      video: true,
     },
     contextWindowTokens: 1_010_000,
     description:
@@ -384,7 +385,7 @@ const nvidiaChatModels: AIChatModelCard[] = [
     id: 'qwen/qwen3.5-397b-a17b',
     maxOutput: 65_536,
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['enableReasoning'],
     },
     type: 'chat',
   },

--- a/packages/model-runtime/src/providers/nvidia/index.test.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.test.ts
@@ -83,7 +83,7 @@ describe('LobeNvidiaAI - custom features', () => {
       });
     });
 
-    it('should use enable_thinking and clear_thinking for GLM models when enabled', () => {
+    it('should use enable_thinking and clear_thinking for GLM models', () => {
       const payload = {
         model: 'z-ai/glm5',
         messages: [{ role: 'user', content: 'test' }],

--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -8,6 +8,10 @@ import { processMultiProviderModelList } from '../../utils/modelParse';
 // Ref: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking
 const supportPreservedThinkingModels = new Set(['z-ai/glm4.7', 'z-ai/glm5']);
 
+// Models that use enable_thinking parameter (without clear_thinking)
+// Ref: NVIDIA NIM
+const enableThinkingModels = new Set(['qwen/qwen3.5-397b-a17b']);
+
 export interface NvidiaModelCard {
   id: string;
 }
@@ -35,8 +39,13 @@ export const params = {
       const thinkingFlag =
         thinking?.type === 'enabled' ? true : thinking?.type === 'disabled' ? false : undefined;
 
+      // Get thinking budget tokens (reasoningBudgetToken)
+      const thinkingBudget = thinking?.budget_tokens;
+
       // Check if model uses preserved thinking (enable_thinking + clear_thinking)
       const usePreservedThinking = model && supportPreservedThinkingModels.has(model);
+      // Check if model uses enable_thinking parameter
+      const useEnableThinking = model && enableThinkingModels.has(model);
 
       const chatTemplateKwargs: Record<string, any> = {};
 
@@ -46,10 +55,20 @@ export const params = {
           // set clear_thinking to false to preserve reasoning content across turns
           chatTemplateKwargs.enable_thinking = thinkingFlag;
           chatTemplateKwargs.clear_thinking = false;
+        } else if (useEnableThinking) {
+          // Models using enable_thinking: use enable_thinking + thinking_budget
+          chatTemplateKwargs.enable_thinking = thinkingFlag;
+          if (thinkingBudget !== undefined) {
+            chatTemplateKwargs.thinking_budget = thinkingBudget;
+          }
         } else {
           // Other models: use thinking parameter
           chatTemplateKwargs.thinking = thinkingFlag;
         }
+      } else if (useEnableThinking && thinkingBudget !== undefined) {
+        // Handle case where only thinkingBudget is set without thinking type
+        chatTemplateKwargs.enable_thinking = false;
+        chatTemplateKwargs.thinking_budget = thinkingBudget;
       }
 
       return {

--- a/packages/model-runtime/src/providers/nvidia/index.ts
+++ b/packages/model-runtime/src/providers/nvidia/index.ts
@@ -39,12 +39,9 @@ export const params = {
       const thinkingFlag =
         thinking?.type === 'enabled' ? true : thinking?.type === 'disabled' ? false : undefined;
 
-      // Get thinking budget tokens (reasoningBudgetToken)
-      const thinkingBudget = thinking?.budget_tokens;
-
       // Check if model uses preserved thinking (enable_thinking + clear_thinking)
       const usePreservedThinking = model && supportPreservedThinkingModels.has(model);
-      // Check if model uses enable_thinking parameter
+      // Check if model uses enable_thinking parameter (without clear_thinking)
       const useEnableThinking = model && enableThinkingModels.has(model);
 
       const chatTemplateKwargs: Record<string, any> = {};
@@ -56,19 +53,12 @@ export const params = {
           chatTemplateKwargs.enable_thinking = thinkingFlag;
           chatTemplateKwargs.clear_thinking = false;
         } else if (useEnableThinking) {
-          // Models using enable_thinking: use enable_thinking + thinking_budget
+          // Models using enable_thinking: use enable_thinking only
           chatTemplateKwargs.enable_thinking = thinkingFlag;
-          if (thinkingBudget !== undefined) {
-            chatTemplateKwargs.thinking_budget = thinkingBudget;
-          }
         } else {
           // Other models: use thinking parameter
           chatTemplateKwargs.thinking = thinkingFlag;
         }
-      } else if (useEnableThinking && thinkingBudget !== undefined) {
-        // Handle case where only thinkingBudget is set without thinking type
-        chatTemplateKwargs.enable_thinking = false;
-        chatTemplateKwargs.thinking_budget = thinkingBudget;
       }
 
       return {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

**Add 7 new NVIDIA NIM models:**
   - MiniMax-M2.1 / MiniMax-M2.5 - MoE models for coding and agent performance
   - DeepSeek V3.2 - Next-gen reasoning model with chain-of-thought capabilities
   - GLM-4.7 / GLM-5 - Zhipu AI flagship models, optimized for Agentic Coding
   - Kimi K2.5 - Moonshot AI's latest model with native multimodal support
   - Qwen3.5-397B-A17B - Alibaba's multimodal model supporting text/image/video input

   **Tweak the behavior of enable thinking:**
   Implemented different thinking parameter formats for different model types:
   - GLM models (`z-ai/glm4.7`, `z-ai/glm5`): use `enable_thinking + clear_thinking` (Preserved Thinking)
   - Qwen models (`qwen/qwen3.5-397b-a17b`): use `enable_thinking + thinking_budget`
   - Other models: use standard `thinking` parameter

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add new NVIDIA NIM chat models with reasoning capabilities and refine thinking-parameter handling for specific model families.

New Features:
- Register multiple new NVIDIA NIM chat models, including MiniMax-M2.1/M2.5, DeepSeek V3.2, GLM-4.7/GLM-5, Kimi K2.5, and Qwen3.5-397B-A17B with appropriate capabilities and metadata.

Enhancements:
- Adjust NVIDIA provider thinking controls to support preserved thinking for GLM models, enable_thinking plus budget for Qwen3.5-397B-A17B, and fall back to the generic thinking parameter for other models.
- Handle thinking budget-only requests for enable_thinking models by mapping them to the correct NVIDIA parameters.
- Update provider tests to reflect the generalized GLM preserved-thinking behavior.