### PR TITLE
✨ feat(redis): add pipeline support to Redis abstraction layer

### DIFF
--- a/src/libs/redis/redis.test.ts
+++ b/src/libs/redis/redis.test.ts
@@ -206,6 +206,20 @@ describe('mocked', () => {
     await provider.disconnect();
   });
 
+  it('pipeline set converts SetOptions to ioredis token args', async () => {
+    const { mocks, provider } = await createMockedProvider();
+    const pipeMock = mocks.pipeline();
+
+    pipeMock.exec.mockResolvedValue([[null, 'OK']]);
+
+    const pipe = provider.pipeline();
+    pipe.set('key', 'value', { ex: 60, nx: true });
+    await pipe.exec();
+
+    expect(pipeMock.set).toHaveBeenCalledWith('key', 'value', 'EX', 60, 'NX');
+    await provider.disconnect();
+  });
+
   it('supports buffer keys for hashes and strings', async () => {
     const { mocks, provider } = await createMockedProvider();
 

--- a/src/libs/redis/redis.test.ts
+++ b/src/libs/redis/redis.test.ts
@@ -23,6 +23,32 @@ const buildRedisConfig = (): RedisConfig | null => {
 const loadRedisProvider = async () => (await import('./redis')).IoRedisRedisProvider;
 
 const createMockedProvider = async () => {
+  const createPipelineMock = () => {
+    const pipeMocks = {
+      incr: vi.fn(),
+      expire: vi.fn(),
+      get: vi.fn(),
+      set: vi.fn(),
+      setex: vi.fn(),
+      del: vi.fn(),
+      decr: vi.fn(),
+      hget: vi.fn(),
+      hset: vi.fn(),
+      hdel: vi.fn(),
+      hgetall: vi.fn(),
+      exec: vi.fn().mockResolvedValue([]),
+    };
+    // Make each command return the pipeline itself for chaining
+    for (const key of Object.keys(pipeMocks) as (keyof typeof pipeMocks)[]) {
+      if (key !== 'exec') {
+        pipeMocks[key].mockReturnValue(pipeMocks);
+      }
+    }
+    return pipeMocks;
+  };
+
+  const pipelineMocks = createPipelineMock();
+
   const mocks = {
     connect: vi.fn().mockResolvedValue(undefined),
     ping: vi.fn().mockResolvedValue('PONG'),
@@ -43,6 +69,7 @@ const createMockedProvider = async () => {
     hdel: vi.fn().mockResolvedValue(1),
     hgetall: vi.fn().mockResolvedValue({ a: '1' }),
     eval: vi.fn().mockResolvedValue(null),
+    pipeline: vi.fn().mockReturnValue(pipelineMocks),
   };
 
   vi.resetModules();
@@ -71,6 +98,7 @@ const createMockedProvider = async () => {
       hdel = mocks.hdel;
       hgetall = mocks.hgetall;
       eval = mocks.eval;
+      pipeline = mocks.pipeline;
     }
 
     return { default: FakeRedis };
@@ -151,6 +179,30 @@ describe('mocked', () => {
 
     expect(mocks.eval).toHaveBeenCalledWith('return redis.call("GET", KEYS[1])', 1, 'my-key');
     expect(result).toBe(1);
+    await provider.disconnect();
+  });
+
+  it('pipeline chains commands and executes in one round-trip', async () => {
+    const { mocks, provider } = await createMockedProvider();
+    const pipeMock = mocks.pipeline();
+
+    pipeMock.exec.mockResolvedValue([
+      [null, 2],
+      [null, 1],
+      [null, 3],
+      [null, 1],
+    ]);
+
+    const pipe = provider.pipeline();
+    pipe.incr('key1').expire('key1', 100).incr('key2').expire('key2', 200);
+    const results = await pipe.exec();
+
+    expect(mocks.pipeline).toHaveBeenCalled();
+    expect(pipeMock.incr).toHaveBeenCalledWith('key1');
+    expect(pipeMock.expire).toHaveBeenCalledWith('key1', 100);
+    expect(pipeMock.incr).toHaveBeenCalledWith('key2');
+    expect(pipeMock.expire).toHaveBeenCalledWith('key2', 200);
+    expect(results).toHaveLength(4);
     await provider.disconnect();
   });
 

--- a/src/libs/redis/redis.ts
+++ b/src/libs/redis/redis.ts
@@ -119,6 +119,25 @@ export class IoRedisRedisProvider implements BaseRedisProvider {
   }
 
   pipeline(): RedisPipeline {
-    return this.ensureClient().pipeline() as RedisPipeline;
+    const raw = this.ensureClient().pipeline();
+    const pipe: RedisPipeline = {
+      decr: (key) => (raw.decr(key), pipe),
+      del: (...keys) => (raw.del(...keys), pipe),
+      exec: () => raw.exec() as Promise<[Error | null, unknown][] | null>,
+      expire: (key, seconds) => (raw.expire(key, seconds), pipe),
+      get: (key) => (raw.get(key), pipe),
+      hdel: (key, ...fields) => (raw.hdel(key, ...fields), pipe),
+      hget: (key, field) => (raw.hget(key, field), pipe),
+      hgetall: (key) => (raw.hgetall(key), pipe),
+      hset: (key, field, value) => (raw.hset(key, field, value), pipe),
+      incr: (key) => (raw.incr(key), pipe),
+      set: (key, value, options?) => {
+        const args = buildIORedisSetArgs(options);
+        (raw.set as any)(key, value, ...args);
+        return pipe;
+      },
+      setex: (key, seconds, value) => (raw.setex(key, seconds, value), pipe),
+    };
+    return pipe;
   }
 }

--- a/src/libs/redis/redis.ts
+++ b/src/libs/redis/redis.ts
@@ -6,6 +6,7 @@ import {
   type RedisConfig,
   type RedisKey,
   type RedisMSetArgument,
+  type RedisPipeline,
   type RedisSetResult,
   type RedisValue,
   type SetOptions,
@@ -117,4 +118,7 @@ export class IoRedisRedisProvider implements BaseRedisProvider {
     return this.ensureClient().eval(script, numkeys, ...args) as Promise<T>;
   }
 
+  pipeline(): RedisPipeline {
+    return this.ensureClient().pipeline() as unknown as RedisPipeline;
+  }
 }

--- a/src/libs/redis/redis.ts
+++ b/src/libs/redis/redis.ts
@@ -119,6 +119,6 @@ export class IoRedisRedisProvider implements BaseRedisProvider {
   }
 
   pipeline(): RedisPipeline {
-    return this.ensureClient().pipeline() as unknown as RedisPipeline;
+    return this.ensureClient().pipeline() as RedisPipeline;
   }
 }

--- a/src/libs/redis/types.ts
+++ b/src/libs/redis/types.ts
@@ -39,7 +39,7 @@ export interface RedisPipeline {
   hgetall: (key: RedisKey) => RedisPipeline;
   hset: (key: RedisKey, field: RedisKey, value: RedisValue) => RedisPipeline;
   incr: (key: RedisKey) => RedisPipeline;
-  set: (key: RedisKey, value: RedisValue, ...args: any[]) => RedisPipeline;
+  set: (key: RedisKey, value: RedisValue, options?: SetOptions) => RedisPipeline;
   setex: (key: RedisKey, seconds: number, value: RedisValue) => RedisPipeline;
 }
 

--- a/src/libs/redis/types.ts
+++ b/src/libs/redis/types.ts
@@ -25,6 +25,24 @@ export interface SetOptions {
 export type RedisSetResult = 'OK' | null | string;
 export type RedisMSetArgument = Record<string, RedisValue> | Map<RedisKey, RedisValue>;
 
+/**
+ * Chainable pipeline builder. Commands are buffered and sent in a single round-trip on exec().
+ */
+export interface RedisPipeline {
+  decr: (key: RedisKey) => RedisPipeline;
+  del: (...keys: RedisKey[]) => RedisPipeline;
+  exec: () => Promise<[error: Error | null, result: unknown][]>;
+  expire: (key: RedisKey, seconds: number) => RedisPipeline;
+  get: (key: RedisKey) => RedisPipeline;
+  hdel: (key: RedisKey, ...fields: RedisKey[]) => RedisPipeline;
+  hget: (key: RedisKey, field: RedisKey) => RedisPipeline;
+  hgetall: (key: RedisKey) => RedisPipeline;
+  hset: (key: RedisKey, field: RedisKey, value: RedisValue) => RedisPipeline;
+  incr: (key: RedisKey) => RedisPipeline;
+  set: (key: RedisKey, value: RedisValue, ...args: any[]) => RedisPipeline;
+  setex: (key: RedisKey, seconds: number, value: RedisValue) => RedisPipeline;
+}
+
 export interface RedisClient {
   decr: (key: RedisKey) => Promise<number>;
   del: (...keys: RedisKey[]) => Promise<number>;
@@ -39,6 +57,7 @@ export interface RedisClient {
   incr: (key: RedisKey) => Promise<number>;
   mget: (...keys: RedisKey[]) => Promise<(string | null)[]>;
   mset: (values: RedisMSetArgument) => Promise<'OK'>;
+  pipeline: () => RedisPipeline;
   set: (key: RedisKey, value: RedisValue, options?: SetOptions) => Promise<RedisSetResult>;
   setex: (key: RedisKey, seconds: number, value: RedisValue) => Promise<'OK'>;
   ttl: (key: RedisKey) => Promise<number>;

--- a/src/libs/redis/types.ts
+++ b/src/libs/redis/types.ts
@@ -31,7 +31,7 @@ export type RedisMSetArgument = Record<string, RedisValue> | Map<RedisKey, Redis
 export interface RedisPipeline {
   decr: (key: RedisKey) => RedisPipeline;
   del: (...keys: RedisKey[]) => RedisPipeline;
-  exec: () => Promise<[error: Error | null, result: unknown][]>;
+  exec: () => Promise<[error: Error | null, result: unknown][] | null>;
   expire: (key: RedisKey, seconds: number) => RedisPipeline;
   get: (key: RedisKey) => RedisPipeline;
   hdel: (key: RedisKey, ...fields: RedisKey[]) => RedisPipeline;


### PR DESCRIPTION
## Summary
- Add `RedisPipeline` interface and `pipeline()` method to `BaseRedisProvider` / `IoRedisRedisProvider`, enabling batched Redis commands in a single round-trip
- Fix `exec()` return type to `Promise<... | null>` to match ioredis `ChainableCommander`
- Replace unsafe `as unknown as RedisPipeline` cast with safe `as RedisPipeline`
- Add pipeline test coverage with mock verification of chain + exec behavior

## Changes
- `src/libs/redis/types.ts`: Add `RedisPipeline` interface and `pipeline()` to `RedisClient`
- `src/libs/redis/redis.ts`: Implement `pipeline()` method in `IoRedisRedisProvider`
- `src/libs/redis/redis.test.ts`: Add pipeline mock and test case

## Test plan
- [x] Pipeline mock test passes: verifies chainable commands and exec
- [x] Integrated test suite still passes
- [x] Verified with real Redis (Docker) that pipeline incr/expire works correctly