### PR TITLE
🐛 fix(resource): fix batch deletion logic

### DIFF
--- a/src/store/file/slices/resource/action.ts
+++ b/src/store/file/slices/resource/action.ts
@@ -230,12 +230,15 @@ export class ResourceActionImpl {
     if (ids.length === 0) return;
 
     // 1. Read sourceType from resourceMap for each ID (client-side, no API call)
-    const { resourceMap, resourceList } = this.#get();
+    const { resourceMap, resourceList, fileList } = this.#get();
+
+    const fileListMap = new Map(fileList.map((f) => [f.id, f]));
+
     const fileIds: string[] = [];
     const documentIds: string[] = [];
 
     for (const id of ids) {
-      const resource = resourceMap.get(id);
+      const resource = resourceMap.get(id) ?? fileListMap.get(id);
       if (resource?.sourceType === 'document') {
         documentIds.push(id);
       } else {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

Fall back to fileList when resourceMap misses an id so batch select-all deletion works correctly
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->
Self-hosted docker, upload files in resources and pages, select all to delete.
<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Ensure batch delete correctly classifies resources as documents or files by falling back to the full file list when a resource ID is missing from the resource map.