### PR TITLE
🐛 fix(auth): enable db fallback for secondary-storage sessions

### DIFF
--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -170,6 +170,8 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
         enabled: true,
         maxAge: 10 * 60, // Cache duration in seconds
       },
+      // Keep a DB-backed fallback when Redis secondary storage entries are unexpectedly missing.
+      storeSessionInDatabase: true,
     },
     database: drizzleAdapter(serverDB, {
       provider: 'pg',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #12125

#### 🔀 Description of Change

- Enable `session.storeSessionInDatabase` in Better Auth config when Redis secondary storage is configured.
- Keep a database-backed session fallback so unexpected Redis session-key loss does not immediately force users to sign in again.
- Scope is intentionally minimal and limited to auth session persistence behavior.

#### 🧪 How to Test

1. Deploy with Redis enabled in Docker.
2. Sign in and verify a row exists in `auth_sessions`.
3. Remove Redis session key(s) and call authenticated endpoints; verify session can still be resolved via DB fallback.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

- This change is a defensive fallback and does not alter existing cookie cache settings.
- It reduces logout impact when Redis keys are evicted/removed unexpectedly.
