### PR TITLE
🔨 chore: fix oidc-provider issue in turbopack

### DIFF
--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -81,8 +81,6 @@ export function defineConfig(config: CustomNextConfig) {
       // refs: https://github.com/lobehub/lobe-chat/pull/7430
       serverMinification: false,
       webVitalsAttribution: ['CLS', 'LCP'],
-      webpackBuildWorker: true,
-      webpackMemoryOptimizations: true,
       ...config.experimental,
     },
     async headers() {
@@ -358,8 +356,8 @@ export function defineConfig(config: CustomNextConfig) {
       'pdfkit',
       '@napi-rs/canvas',
       'pdfjs-dist',
-
       'ajv',
+      'oidc-provider',
     ],
 
     transpilePackages: ['mermaid', 'better-auth-harmony'],


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

https://github.com/lobehub/lobehub/pull/7430

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

Turbopack 不支持 `serverMinification` 参数，需换用成 serverExternalPackages 来解决

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update Next.js configuration to address a Turbopack compatibility issue with oidc-provider and clean up experimental webpack settings.

Enhancements:
- Remove deprecated or unnecessary experimental webpack configuration flags from the Next.js setup.
- Ensure oidc-provider is included in the list of server-side external packages for proper Turbopack handling.

Chores:
- Tidy Next.js experimental configuration related to webpack build workers and memory optimizations.