### PR TITLE
feat(provider): add ModelsLab chat provider

### DIFF
--- a/packages/model-bank/src/aiModels/modelslab.ts
+++ b/packages/model-bank/src/aiModels/modelslab.ts
@@ -1,0 +1,5 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+const modelsLabChatModels: AIChatModelCard[] = [];
+
+export { modelsLabChatModels };

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -33,6 +33,7 @@ export enum ModelProvider {
   LobeHub = 'lobehub',
   Minimax = 'minimax',
   Mistral = 'mistral',
+  ModelsLab = 'modelslab',
   ModelScope = 'modelscope',
   Moonshot = 'moonshot',
   Nebius = 'nebius',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -36,6 +36,7 @@ import LMStudioProvider from './lmstudio';
 import LobeHubProvider from './lobehub';
 import MinimaxProvider from './minimax';
 import MistralProvider from './mistral';
+import ModelsLabProvider from './modelslab';
 import ModelScopeProvider from './modelscope';
 import MoonshotProvider from './moonshot';
 import NebiusProvider from './nebius';
@@ -164,6 +165,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   GroqProvider,
   PerplexityProvider,
   MistralProvider,
+  ModelsLabProvider,
   ModelScopeProvider,
   Ai21Provider,
   UpstageProvider,
@@ -231,6 +233,7 @@ export { default as CometAPIProviderCard } from './cometapi';
 export { default as ComfyUIProviderCard } from './comfyui';
 export { default as DeepSeekProviderCard } from './deepseek';
 export { default as FalProviderCard } from './fal';
+export { default as ModelsLabProviderCard } from './modelslab';
 export { default as FireworksAIProviderCard } from './fireworksai';
 export { default as GiteeAIProviderCard } from './giteeai';
 export { default as GithubProviderCard } from './github';

--- a/packages/model-bank/src/modelProviders/modelslab.ts
+++ b/packages/model-bank/src/modelProviders/modelslab.ts
@@ -1,0 +1,22 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+/**
+ * @see https://docs.modelslab.com
+ */
+const ModelsLab: ModelProviderCard = {
+  apiKeyUrl: 'https://modelslab.com/account/api-key',
+  chatModels: [],
+  checkModel: 'meta-llama/Meta-Llama-3-8B-Instruct',
+  description:
+    'ModelsLab is a developer-first AI API platform for text-to-image, video, voice, and uncensored chat generation.',
+  id: 'modelslab',
+  modelsUrl: 'https://docs.modelslab.com',
+  name: 'ModelsLab',
+  settings: {
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://modelslab.com',
+};
+
+export default ModelsLab;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -21,6 +21,7 @@ export { LobeGroq } from './providers/groq';
 export { LobeHubAI } from './providers/lobehub';
 export { LobeMinimaxAI } from './providers/minimax';
 export { LobeMistralAI } from './providers/mistral';
+export { LobeModelsLabAI } from './providers/modelslab';
 export { LobeMoonshotAI } from './providers/moonshot';
 export { LobeNebiusAI } from './providers/nebius';
 export { LobeNewAPIAI } from './providers/newapi';

--- a/packages/model-runtime/src/providers/modelslab/index.test.ts
+++ b/packages/model-runtime/src/providers/modelslab/index.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { describe, expect, it } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeModelsLabAI, params } from './index';
+
+const provider = ModelProvider.ModelsLab;
+const defaultBaseURL = 'https://modelslab.com/api/uncensored-chat/v1';
+
+testProvider({
+  Runtime: LobeModelsLabAI,
+  bizErrorType: 'ProviderBizError',
+  chatDebugEnv: 'DEBUG_MODELSLAB_CHAT_COMPLETION',
+  chatModel: 'meta-llama/Meta-Llama-3-8B-Instruct',
+  defaultBaseURL,
+  invalidErrorType: 'InvalidProviderAPIKey',
+  provider,
+  test: {
+    skipAPICall: true,
+    skipErrorHandle: true,
+  },
+});
+
+describe('LobeModelsLabAI', () => {
+  describe('params export', () => {
+    it('should export params object', () => {
+      expect(params).toBeDefined();
+      expect(params.provider).toBe(ModelProvider.ModelsLab);
+      expect(params.baseURL).toBe('https://modelslab.com/api/uncensored-chat/v1');
+    });
+
+    it('should have debug configuration', () => {
+      expect(params.debug).toBeDefined();
+      expect(params.debug.chatCompletion).toBeDefined();
+      expect(typeof params.debug.chatCompletion).toBe('function');
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/modelslab/index.ts
+++ b/packages/model-runtime/src/providers/modelslab/index.ts
@@ -1,0 +1,14 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const params = {
+  baseURL: 'https://modelslab.com/api/uncensored-chat/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_MODELSLAB_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.ModelsLab,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeModelsLabAI = createOpenAICompatibleRuntime(params);


### PR DESCRIPTION
## Summary

Adds **ModelsLab** as an OpenAI-compatible chat provider, following the existing AkashChat/AiHubMix patterns.

[ModelsLab](https://modelslab.com) is an AI generation API platform providing text-to-image, video, voice, and **uncensored chat** via an OpenAI-compatible endpoint.

## Files Changed

| File | Change |
|------|--------|
| `packages/model-bank/src/const/modelProvider.ts` | Add `ModelProvider.ModelsLab = 'modelslab'` |
| `packages/model-bank/src/modelProviders/modelslab.ts` | Provider card |
| `packages/model-bank/src/aiModels/modelslab.ts` | Model list (uses model fetcher) |
| `packages/model-bank/src/modelProviders/index.ts` | Register provider |
| `packages/model-runtime/src/providers/modelslab/index.ts` | OpenAI-compatible runtime |
| `packages/model-runtime/src/providers/modelslab/index.test.ts` | Tests |
| `packages/model-runtime/src/index.ts` | Export LobeModelsLabAI |

## API Details

- **Endpoint**: `https://modelslab.com/api/uncensored-chat/v1`
- **Auth**: `Authorization: Bearer YOUR_API_KEY` (standard OpenAI format)
- **Docs**: https://docs.modelslab.com
- **API Key**: https://modelslab.com/account/api-key
- **SDK Type**: `openai` (fully compatible)
- **Model Fetcher**: enabled (fetches available models dynamically)

## Checklist

- [x] Follows AkashChat/AiHubMix provider pattern exactly
- [x] `ModelProvider.ModelsLab` added to enum
- [x] 7 files total (same as other providers)
- [x] Tests included with `testProvider`
- [x] `showModelFetcher: true` (dynamic model list)
- [x] No breaking changes

## Summary by Sourcery

Add ModelsLab as an OpenAI-compatible chat provider across model-bank and model-runtime.

New Features:
- Introduce a ModelsLab model provider card and dynamic model list configuration in model-bank.
- Expose a LobeModelsLabAI OpenAI-compatible runtime client for the ModelsLab chat endpoint.

Tests:
- Add unit tests validating the ModelsLab runtime configuration and exported params.