### PR TITLE
✨ feat(vite): add env restart keys plugin for selective .env restart

### DIFF
--- a/plugins/vite/envRestartKeys.ts
+++ b/plugins/vite/envRestartKeys.ts
@@ -1,0 +1,123 @@
+import { existsSync, type FSWatcher, readFileSync, watch } from 'node:fs';
+import path from 'node:path';
+
+import type { Plugin } from 'vite';
+
+/**
+ * Only restart the dev server when whitelisted env keys change,
+ * instead of restarting on every .env file modification.
+ *
+ * Respects Vite's env loading order:
+ *   .env → .env.local → .env.[mode] → .env.[mode].local
+ */
+export function viteEnvRestartKeys(keys: string[]): Plugin {
+  let mode: string;
+  let envDir: string;
+  let prevSnapshot: Record<string, string | undefined>;
+  let dirWatcher: FSWatcher | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function getEnvFileNames(): Set<string> {
+    return new Set(['.env', '.env.local', `.env.${mode}`, `.env.${mode}.local`]);
+  }
+
+  /**
+   * Parse env files directly from disk (bypassing process.env override in loadEnv).
+   * Later files override earlier ones, matching Vite's precedence.
+   */
+  function parseEnvFromDisk(): Record<string, string> {
+    const files = ['.env', '.env.local', `.env.${mode}`, `.env.${mode}.local`].map((f) =>
+      path.join(envDir, f),
+    );
+
+    const result: Record<string, string> = {};
+    for (const file of files) {
+      if (!existsSync(file)) continue;
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eqIdx = trimmed.indexOf('=');
+        if (eqIdx === -1) continue;
+        const key = trimmed.slice(0, eqIdx).trim();
+        let value = trimmed.slice(eqIdx + 1).trim();
+        // strip surrounding quotes
+        if (
+          (value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))
+        ) {
+          value = value.slice(1, -1);
+        }
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  function snapshot(): Record<string, string | undefined> {
+    const env = parseEnvFromDisk();
+    const snap: Record<string, string | undefined> = {};
+    for (const key of keys) {
+      snap[key] = env[key];
+    }
+    return snap;
+  }
+
+  function hasChanges(next: Record<string, string | undefined>): string[] {
+    const changed: string[] = [];
+    for (const key of keys) {
+      if (prevSnapshot[key] !== next[key]) changed.push(key);
+    }
+    return changed;
+  }
+
+  return {
+    name: 'vite-env-restart-keys',
+    apply: 'serve',
+
+    config() {
+      return {
+        server: {
+          watch: {
+            ignored: ['**/.env', '**/.env.*'],
+          },
+        },
+      };
+    },
+
+    configResolved(config) {
+      mode = config.mode;
+      envDir = config.envDir || config.root;
+      prevSnapshot = snapshot();
+    },
+
+    configureServer(server) {
+      dirWatcher?.close();
+
+      const envFileNames = getEnvFileNames();
+
+      dirWatcher = watch(envDir, (_event, filename) => {
+        if (!filename || !envFileNames.has(filename)) return;
+
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          const next = snapshot();
+          const changed = hasChanges(next);
+          prevSnapshot = next;
+          if (changed.length > 0) {
+            server.config.logger.info(
+              `env key changed: ${changed.join(', ')} — restarting server`,
+              { timestamp: true },
+            );
+            server.restart();
+          }
+        }, 100);
+      });
+
+      server.httpServer?.on('close', () => {
+        dirWatcher?.close();
+        dirWatcher = null;
+        if (debounceTimer) clearTimeout(debounceTimer);
+      });
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import type { PluginOption, ViteDevServer } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
+import { viteEnvRestartKeys } from './plugins/vite/envRestartKeys';
 import {
   sharedOptimizeDeps,
   sharedRendererDefine,
@@ -31,6 +32,7 @@ export default defineConfig({
   define: sharedRendererDefine({ isMobile, isElectron: false }),
   optimizeDeps: sharedOptimizeDeps,
   plugins: [
+    viteEnvRestartKeys(['APP_URL']),
     ...sharedRendererPlugins({ platform }),
 
     isDev && {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add a Vite plugin (`viteEnvRestartKeys`) that replaces Vite's default behavior of restarting the dev server on **every** `.env` file change. Instead, it only restarts when specified whitelisted env keys actually change their values.

**How it works:**
- Suppresses Vite's default `.env` file watching via `server.watch.ignored`
- Watches the env directory with `fs.watch` and parses env files directly from disk (bypassing `process.env` contamination in `loadEnv`)
- Respects Vite's env loading order: `.env` → `.env.local` → `.env.[mode]` → `.env.[mode].local`
- Only calls `server.restart()` when a whitelisted key's value differs from the previous snapshot

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Add env keys to the whitelist in `vite.config.ts`: `viteEnvRestartKeys(['APP_URL'])`
2. Run `bun run dev:spa`
3. Modify a non-whitelisted key in `.env` → server should NOT restart
4. Modify `APP_URL` in `.env` → server should restart with log: `env key changed: APP_URL — restarting server`

#### 📝 Additional Information

New file: `plugins/vite/envRestartKeys.ts`

## Summary by Sourcery

Introduce a Vite dev-server plugin to selectively restart on .env changes based on whitelisted environment keys.

New Features:
- Add viteEnvRestartKeys Vite plugin that watches .env files and restarts the dev server only when specified env keys change.

Enhancements:
- Integrate the viteEnvRestartKeys plugin into the Vite config to watch the APP_URL env key during development.