### PR TITLE
✨ feat(model-runtime): pass userId in RouteAttemptResult callback

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -4,35 +4,34 @@
 import type { GoogleGenAIOptions } from '@google/genai';
 import type { ChatModelCard } from '@lobechat/types';
 import debug from 'debug';
-import OpenAI, { ClientOptions } from 'openai';
-import { Stream } from 'openai/streaming';
+import type { ClientOptions } from 'openai';
+import type OpenAI from 'openai';
+import type { Stream } from 'openai/streaming';
 
 import { LobeOpenAI } from '../../providers/openai';
 import { LobeVertexAI } from '../../providers/vertexai';
-import {
+import type {
+  ChatCompletionErrorPayload,
+  ChatMethodOptions,
+  ChatStreamCallbacks,
+  ChatStreamPayload,
   CreateImagePayload,
   CreateImageResponse,
   CreateVideoPayload,
   CreateVideoResponse,
+  EmbeddingsOptions,
+  EmbeddingsPayload,
   GenerateObjectOptions,
   GenerateObjectPayload,
   HandleCreateVideoWebhookPayload,
   HandleCreateVideoWebhookResult,
   ILobeAgentRuntimeErrorType,
-} from '../../types';
-import {
-  type ChatCompletionErrorPayload,
-  ChatMethodOptions,
-  ChatStreamCallbacks,
-  ChatStreamPayload,
-  EmbeddingsOptions,
-  EmbeddingsPayload,
   TextToSpeechPayload,
 } from '../../types';
 import { postProcessModelList } from '../../utils/postProcessModelList';
 import { safeParseJSON } from '../../utils/safeParseJSON';
-import { LobeRuntimeAI } from '../BaseAI';
-import {
+import type { LobeRuntimeAI } from '../BaseAI';
+import type {
   CreateImageOptions,
   CreateVideoOptions,
   CustomClientOptions,
@@ -96,6 +95,7 @@ export interface RouteAttemptResult {
   remark?: string;
   routerId?: string;
   success: boolean;
+  userId?: string;
 }
 
 export interface CreateRouterRuntimeOptions<T extends Record<string, any> = any> {
@@ -350,6 +350,7 @@ export const createRouterRuntime = ({
               remark,
               routerId: matchedRouter.id,
               success: true,
+              userId: this._options.userId,
             })
             .catch((e) => {
               log('onRouteAttempt callback error: %O', e);
@@ -370,6 +371,7 @@ export const createRouterRuntime = ({
               remark,
               routerId: matchedRouter.id,
               success: false,
+              userId: this._options.userId,
             })
             .catch((e) => {
               log('onRouteAttempt callback error: %O', e);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Add `userId` field to `RouteAttemptResult` interface and pass `this._options.userId` in both success and failure paths of `runWithFallback`. This enables downstream `onRouteAttempt` callbacks to associate route attempts with specific users for per-user analytics and monitoring.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

## Summary by Sourcery

New Features:
- Include an optional userId field on RouteAttemptResult and propagate the configured user ID to onRouteAttempt callbacks for both successful and failed route attempts.