### PR TITLE
🐛 fix(desktop): stub better-auth client for Electron renderer

### DIFF
--- a/apps/desktop/resources/error.html
+++ b/apps/desktop/resources/error.html
@@ -5,10 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LobeHub - 连接错误</title>
     <style>
-      body {
+      .drag-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 32px;
         -webkit-app-region: drag;
+      }
+
+      body {
         margin: 0;
-        padding: 0;
+        padding: 32px 0 0;
         height: 100vh;
         display: flex;
         justify-content: center;
@@ -72,7 +80,6 @@
       }
 
       .retry-button {
-        -webkit-app-region: no-drag;
         padding: 0.75rem 1.5rem;
         background-color: #f5f5f5;
         color: #1f1f1f;
@@ -89,6 +96,7 @@
     </style>
   </head>
   <body>
+    <div class="drag-bar"></div>
     <div class="container">
       <div class="error-icon">⚠️</div>
       <h1 class="error-title">Connection Error</h1>

--- a/apps/desktop/resources/splash.html
+++ b/apps/desktop/resources/splash.html
@@ -5,10 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LobeHub</title>
     <style>
-      body {
+      .drag-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 48px;
         -webkit-app-region: drag;
+      }
+
+      body {
         margin: 0;
-        padding: 0;
+        padding: 48px 0 0;
         height: 100vh;
         display: flex;
         justify-content: center;
@@ -70,6 +78,7 @@
     </style>
   </head>
   <body>
+    <div class="drag-bar"></div>
     <div class="container">
       <svg
         class="lobe-brand-loading"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "desktop:package:local:reuse": "npm run package:local:reuse --prefix=./apps/desktop",
     "dev": "tsx scripts/devStartupSequence.mts",
     "dev:bun": "bun --bun next dev -p 3010",
+    "dev:desktop": "cd apps/desktop && pnpm run dev",
     "dev:docker": "docker compose -f docker-compose/dev/docker-compose.yml up -d --wait postgresql redis rustfs searxng",
     "dev:docker:down": "docker compose -f docker-compose/dev/docker-compose.yml down",
     "dev:docker:reset": "docker compose -f docker-compose/dev/docker-compose.yml down -v && rm -rf docker-compose/dev/data && npm run dev:docker && pnpm db:migrate",

--- a/src/libs/better-auth/auth-client.desktop.ts
+++ b/src/libs/better-auth/auth-client.desktop.ts
@@ -1,19 +1,57 @@
-const noop = (() => {}) as any;
+import {
+  adminClient,
+  genericOAuthClient,
+  inferAdditionalFields,
+  magicLinkClient,
+} from 'better-auth/client/plugins';
+import { createAuthClient } from 'better-auth/react';
 
-export const changeEmail = noop;
-export const linkSocial = noop;
-export const oauth2 = noop;
-export const accountInfo = noop;
-export const listAccounts = noop;
-export const requestPasswordReset = noop;
-export const resetPassword = noop;
-export const sendVerificationEmail = noop;
-export const signIn = noop;
-export const signOut = noop;
-export const signUp = noop;
-export const unlinkAccount = noop;
-export const useSession = () => ({
-  data: null,
-  error: null,
-  isPending: false,
-});
+import { type auth } from '@/auth';
+import { electronSyncSelectors } from '@/store/electron/selectors/sync';
+import { getElectronStoreState } from '@/store/electron/store';
+
+let _client: any = null;
+
+function getClient() {
+  if (!_client) {
+    const baseURL = electronSyncSelectors.remoteServerUrl(getElectronStoreState());
+
+    _client = createAuthClient({
+      baseURL,
+      plugins: [
+        adminClient(),
+        inferAdditionalFields<typeof auth>(),
+        genericOAuthClient(),
+        magicLinkClient(),
+      ],
+    });
+  }
+  return _client;
+}
+
+function lazyProp(key: string): any {
+  return new Proxy(Object.create(null), {
+    apply(_t, thisArg, args) {
+      return Reflect.apply(getClient()[key], thisArg, args);
+    },
+    get(_t, prop, receiver) {
+      const target = getClient()[key];
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+export const changeEmail = lazyProp('changeEmail');
+export const linkSocial = lazyProp('linkSocial');
+export const oauth2 = lazyProp('oauth2');
+export const accountInfo = lazyProp('accountInfo');
+export const listAccounts = lazyProp('listAccounts');
+export const requestPasswordReset = lazyProp('requestPasswordReset');
+export const resetPassword = lazyProp('resetPassword');
+export const sendVerificationEmail = lazyProp('sendVerificationEmail');
+export const signIn = lazyProp('signIn');
+export const signOut = lazyProp('signOut');
+export const signUp = lazyProp('signUp');
+export const unlinkAccount = lazyProp('unlinkAccount');
+export const useSession = lazyProp('useSession');

--- a/src/libs/better-auth/auth-client.desktop.ts
+++ b/src/libs/better-auth/auth-client.desktop.ts
@@ -1,0 +1,19 @@
+const noop = (() => {}) as any;
+
+export const changeEmail = noop;
+export const linkSocial = noop;
+export const oauth2 = noop;
+export const accountInfo = noop;
+export const listAccounts = noop;
+export const requestPasswordReset = noop;
+export const resetPassword = noop;
+export const sendVerificationEmail = noop;
+export const signIn = noop;
+export const signOut = noop;
+export const signUp = noop;
+export const unlinkAccount = noop;
+export const useSession = () => ({
+  data: null,
+  error: null,
+  isPending: false,
+});

--- a/src/libs/better-auth/auth-client.desktop.ts
+++ b/src/libs/better-auth/auth-client.desktop.ts
@@ -30,7 +30,8 @@ function getClient() {
 }
 
 function lazyProp(key: string): any {
-  return new Proxy(Object.create(null), {
+  // Target must be a function for the Proxy apply trap to work
+  return new Proxy(function () {}, {
     apply(_t, thisArg, args) {
       return Reflect.apply(getClient()[key], thisArg, args);
     },

--- a/src/routes/(main)/settings/profile/index.tsx
+++ b/src/routes/(main)/settings/profile/index.tsx
@@ -131,7 +131,7 @@ const ProfileSetting = ({ mobile }: ProfileSettingProps) => {
           )}
 
           {/* SSO Providers Row */}
-          {isLogin && (
+          {isLogin && !isDesktop && (
             <>
               <Divider style={{ margin: 0 }} />
               <ProfileRow label={t('profile.sso.providers')} mobile={mobile}>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The Electron desktop renderer was stuck on the loading screen because `better-auth/react` crashed during module evaluation — it relies on server-side APIs unavailable in the Electron context.

**Changes:**
- Add `auth-client.desktop.ts` noop stub so the `vitePlatformResolve` plugin resolves it instead of the real `better-auth` client in desktop builds
- Fix drag-bar regions in `splash.html` and `error.html` (separate `drag-bar` div instead of body-level `-webkit-app-region: drag`)
- Add `dev:desktop` convenience script in root `package.json`

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Build the desktop renderer: `cd apps/desktop && pnpm run build`
2. Launch the Electron app
3. Verify the app no longer hangs on the loading screen and React mounts successfully

#### 📝 Additional Information

The `vitePlatformResolve` Vite plugin automatically resolves `.desktop.ts` variants when building for the `desktop` platform, so any import of `@/libs/better-auth/auth-client` in the desktop build will pick up the stub instead of the real implementation.

## Summary by Sourcery

Stub out the Better Auth client for the Electron desktop renderer and adjust desktop UX assets and scripts to avoid renderer crashes and improve window drag behavior.

Bug Fixes:
- Provide a desktop-specific no-op Better Auth client so the Electron renderer no longer crashes or hangs on the loading screen when auth is imported.
- Fix drag regions in the desktop splash and error windows by using a dedicated draggable bar instead of making the entire body draggable.

Chores:
- Add a root-level dev:desktop script to simplify running the desktop app in development mode.