### PR TITLE
🐛 fix(model-runtime): ensure reasoning_content for deepseek-reasoner tool calls

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -104,6 +104,75 @@ describe('LobeDeepSeekAI - custom features', () => {
 
       expect(result.stream).toBe(false);
     });
+
+    it('should add empty reasoning_content for assistant messages in deepseek-reasoner', () => {
+      const payload = {
+        messages: [
+          { role: 'user', content: 'Search weather' },
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: {
+                  name: 'search',
+                  arguments: '{"q":"weather"}',
+                },
+              },
+            ],
+          },
+          { role: 'tool', content: '{"result":"sunny"}', tool_call_id: 'call_1' },
+        ],
+        model: 'deepseek-reasoner',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'Search weather' },
+        {
+          role: 'assistant',
+          content: '',
+          reasoning_content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: {
+                name: 'search',
+                arguments: '{"q":"weather"}',
+              },
+            },
+          ],
+        },
+        { role: 'tool', content: '{"result":"sunny"}', tool_call_id: 'call_1' },
+      ]);
+    });
+
+    it('should preserve existing reasoning_content for deepseek-reasoner assistant messages', () => {
+      const payload = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Previous answer',
+            reasoning_content: 'existing reasoning',
+          },
+        ],
+        model: 'deepseek-reasoner',
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.messages).toEqual([
+        {
+          role: 'assistant',
+          content: 'Previous answer',
+          reasoning_content: 'existing reasoning',
+        },
+      ]);
+    });
   });
 
   describe('Debug Configuration', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #11924

#### 🔀 Description of Change

This PR fixes DeepSeek reasoner tool-calling compatibility by ensuring assistant history messages always include `reasoning_content`.

Key updates:
- Update DeepSeek `chatCompletion.handlePayload` to normalize historical reasoning fields without mutating source messages.
- For `deepseek-reasoner`, always add `reasoning_content` to assistant messages (`''` fallback when missing).
- Preserve existing `reasoning_content` when already provided.
- Add regression tests for assistant tool-calls history and existing reasoning preservation.

This prevents errors like:
`Missing 'reasoning_content' field in the assistant message at message index ...`

#### 🧪 How to Test

- Run:
  - `bunx vitest run --silent='passed-only' 'src/providers/deepseek/index.test.ts'`
- Validate scenarios:
  - `deepseek-reasoner` with assistant tool-calls history and missing reasoning should send `reasoning_content: ''`.
  - Existing `reasoning_content` remains unchanged.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This is a runtime compatibility fix focused on DeepSeek reasoner multi-turn/tool-calls requests.

## Summary by Sourcery

Ensure DeepSeek chat payloads consistently include reasoning content for assistant history messages, especially for the deepseek-reasoner model.

Bug Fixes:
- Fix missing reasoning_content in deepseek-reasoner assistant history messages that caused tool-call errors.

Tests:
- Add regression tests verifying empty reasoning_content is injected for deepseek-reasoner assistant tool-call messages and existing reasoning_content is preserved.