### PR TITLE
💄 style: get user timezone when open

### DIFF
--- a/packages/types/src/user/settings/general.ts
+++ b/packages/types/src/user/settings/general.ts
@@ -23,5 +23,6 @@ export interface UserGeneralConfig {
   primaryColor?: PrimaryColors;
   responseLanguage?: string;
   telemetry: boolean;
+  timezone?: string;
   transitionMode?: ResponseAnimationStyle;
 }

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -241,11 +241,7 @@ export function defineConfig() {
     return response;
   };
 
-  logDefault('Middleware configuration: %O', {
-    enableOIDC: authEnv.ENABLE_OIDC,
-  });
+  logDefault('Middleware configuration: %O', { enableOIDC: authEnv.ENABLE_OIDC });
 
-  return {
-    middleware: betterAuthMiddleware,
-  };
+  return { middleware: betterAuthMiddleware };
 }

--- a/src/server/services/bot/replyTemplate.ts
+++ b/src/server/services/bot/replyTemplate.ts
@@ -139,9 +139,7 @@ function renderInlineStats(params: {
 
 // ==================== 1. Start ====================
 
-export function renderStart(content?: string): string {
-  return getExtremeAck(content);
-}
+export const renderStart = getExtremeAck;
 
 // ==================== 2. LLM Generating ====================
 

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -78,7 +78,7 @@ describe('createCommonSlice', () => {
           telemetry: true,
         },
         settings: {
-          general: { fontSize: 14 },
+          general: { fontSize: 14, timezone: 'America/New_York' },
         },
         email: 'test@example.com',
       };
@@ -194,7 +194,10 @@ describe('createCommonSlice', () => {
         expect(result.current.isUserStateInit).toBeTruthy();
         // 验证状态未被错误更新
         expect(result.current.user?.avatar).toEqual('abc');
-        expect(result.current.settings).toEqual({});
+        // When settings is null, auto-detect timezone will set it
+        expect(result.current.settings).toEqual({
+          general: { timezone: expect.any(String) },
+        });
       });
     });
 

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -149,6 +149,18 @@ export class CommonActionImpl {
               false,
               n('initUserState'),
             );
+
+            // Auto-detect and sync browser timezone on first load
+            const currentTimezone = data.settings?.general?.timezone;
+            if (!currentTimezone && typeof Intl !== 'undefined') {
+              const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+              if (detectedTimezone) {
+                this.#get()
+                  .updateGeneralConfig({ timezone: detectedTimezone })
+                  .catch(() => {});
+              }
+            }
+
             //analytics
             const analytics = getSingletonAnalyticsOptional();
             analytics?.identify(data.userId || '', {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

close LOBE-5375
<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Detect and propagate the user’s timezone from client settings into bot conversations, aligning AgentBridgeService and routing with per-user context.

New Features:
- Automatically detect the browser timezone on first load and store it in the user’s general settings.

Enhancements:
- Bind AgentBridgeService instances to a specific database and user, and lazily load/cache the user’s timezone from settings for use in bot replies.
- Pass the resolved timezone into bot progress/start messages and simplify the reply template entry point.
- Update BotMessageRouter to construct per-user AgentBridgeService instances with the correct database context.