### PR TITLE
💄 style: support Cmd+Click to open sidebar nav in new tab

### DIFF
--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlMultiPages/index.tsx
@@ -41,7 +41,9 @@ export const CrawlMultiPagesInspector = memo<BuiltinInspectorProps<CrawlMultiPag
       <div
         className={cx(inspectorTextStyles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
       >
-        <span>{t('builtins.lobe-web-browsing.apiName.crawlMultiPages')}: </span>
+        <span>
+          {t('builtins.lobe-web-browsing.apiName.crawlMultiPages')}:{'\u00A0'}
+        </span>
         {displayText && <span className={highlightTextStyles.gold}>{displayText}</span>}
       </div>
     );

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/CrawlSinglePage/index.tsx
@@ -29,7 +29,9 @@ export const CrawlSinglePageInspector = memo<BuiltinInspectorProps<CrawlSinglePa
       <div
         className={cx(inspectorTextStyles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
       >
-        <span>{t('builtins.lobe-web-browsing.apiName.crawlSinglePage')}: </span>
+        <span>
+          {t('builtins.lobe-web-browsing.apiName.crawlSinglePage')}:{'\u00A0'}
+        </span>
         {url && <span className={highlightTextStyles.gold}>{url}</span>}
       </div>
     );

--- a/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Inspector/Search/index.tsx
@@ -31,7 +31,9 @@ export const SearchInspector = memo<BuiltinInspectorProps<SearchQuery, UniformSe
           (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
         )}
       >
-        <span>{t('builtins.lobe-web-browsing.apiName.search')}: </span>
+        <span>
+          {t('builtins.lobe-web-browsing.apiName.search')}:{'\u00A0'}
+        </span>
         {query && <span className={highlightTextStyles.primary}>{query}</span>}
         {!isLoading &&
           !isArgumentsStreaming &&

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
@@ -100,6 +100,10 @@ const Tool = memo<GroupToolProps>(
       if (isAlwaysExpand && expand === false) {
         return;
       }
+      // When collapsing, also turn off debug mode so the accordion can actually collapse
+      if (expand === false) {
+        setShowDebug(false);
+      }
       setShowToolRender(!!expand);
     };
 

--- a/src/features/NavPanel/SideBarHeaderLayout.tsx
+++ b/src/features/NavPanel/SideBarHeaderLayout.tsx
@@ -11,6 +11,7 @@ import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import { isDesktop } from '@/const/version';
+import { isModifierClick } from '@/utils/navigation';
 
 import BackButton from './components/BackButton';
 import ToggleLeftPanelButton from './ToggleLeftPanelButton';
@@ -103,6 +104,7 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
           ].map((item) => ({
             ...item,
             onClick: (event) => {
+              if (isModifierClick(event)) return;
               const href = item.href;
               if (href) {
                 event.preventDefault();

--- a/src/features/NavPanel/components/BackNav.tsx
+++ b/src/features/NavPanel/components/BackNav.tsx
@@ -1,12 +1,13 @@
 import { ActionIcon, Button, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ChevronLeftIcon } from 'lucide-react';
-import { type PropsWithChildren } from 'react';
+import { type MouseEvent, type PropsWithChildren, type ReactNode, useCallback } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { isModifierClick } from '@/utils/navigation';
 
 import ToggleLeftPanelButton from '../ToggleLeftPanelButton';
 
@@ -23,33 +24,41 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const BackNav = memo<PropsWithChildren>(({ children }) => {
+const BackLink = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (isModifierClick(e)) return;
+      e.preventDefault();
+      navigate('/');
+    },
+    [navigate],
+  );
+
+  return (
+    <Link to="/" onClick={handleClick}>
+      {children}
+    </Link>
+  );
+};
+
+const BackNav = memo<PropsWithChildren>(({ children }) => {
   const { t } = useTranslation('common');
-  let leftContent;
-  if (!children) {
-    leftContent = (
-      <Button
-        className={styles.button}
-        icon={ChevronLeftIcon}
-        type={'text'}
-        onClick={() => navigate('/')}
-      >
+  const leftContent = children ? (
+    <Flexbox horizontal align={'center'} gap={4}>
+      <BackLink>
+        <ActionIcon icon={ChevronLeftIcon} size={DESKTOP_HEADER_ICON_SIZE} />
+      </BackLink>
+      {children}
+    </Flexbox>
+  ) : (
+    <BackLink>
+      <Button className={styles.button} icon={ChevronLeftIcon} type={'text'}>
         {t('back')}
       </Button>
-    );
-  } else {
-    leftContent = (
-      <Flexbox horizontal align={'center'} gap={4}>
-        <ActionIcon
-          icon={ChevronLeftIcon}
-          size={DESKTOP_HEADER_ICON_SIZE}
-          onClick={() => navigate('/')}
-        />
-        {children}
-      </Flexbox>
-    );
-  }
+    </BackLink>
+  );
+
   return (
     <Flexbox horizontal align={'center'} gap={4} justify={'space-between'} padding={8}>
       {leftContent}

--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -7,6 +7,7 @@ import { type ReactNode } from 'react';
 import { memo } from 'react';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
+import { isModifierClick } from '@/utils/navigation';
 
 const ACTION_CLASS_NAME = 'nav-item-actions';
 
@@ -104,7 +105,7 @@ const NavItem = memo<NavItemProps>(
           if (disabled || loading) return;
           // Prevent default link behavior for normal clicks (let onClick handle it)
           // But allow cmd+click to open in new tab
-          if (href && !e.metaKey && !e.ctrlKey) {
+          if (href && !isModifierClick(e)) {
             e.preventDefault();
           }
           onClick?.(e);

--- a/src/routes/(main)/community/_layout/Sidebar/Header/Nav.tsx
+++ b/src/routes/(main)/community/_layout/Sidebar/Header/Nav.tsx
@@ -11,6 +11,7 @@ import { type NavItemProps } from '@/features/NavPanel/components/NavItem';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { usePathname } from '@/libs/router/navigation';
 import { DiscoverTab } from '@/types/discover';
+import { isModifierClick } from '@/utils/navigation';
 
 interface Item {
   icon: NavItemProps['icon'];
@@ -86,6 +87,7 @@ const Nav = memo(() => {
             key={item.key}
             to={item.url}
             onClick={(e) => {
+              if (isModifierClick(e)) return;
               e.preventDefault();
               item?.onClick?.();
               if (item.url) {

--- a/src/routes/(main)/eval/_layout/Sidebar/Body/BenchmarkList.tsx
+++ b/src/routes/(main)/eval/_layout/Sidebar/Body/BenchmarkList.tsx
@@ -21,6 +21,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useEvalStore } from '@/store/eval';
+import { isModifierClick } from '@/utils/navigation';
 
 const SYSTEM_ICONS = [
   LoaderPinwheel,
@@ -79,6 +80,7 @@ const BenchmarkList = memo<BenchmarkListProps>(({ activeKey, itemKey }) => {
               key={b.id}
               to={`/eval/bench/${b.id}`}
               onClick={(e) => {
+                if (isModifierClick(e)) return;
                 e.preventDefault();
                 navigate(`/eval/bench/${b.id}`);
               }}

--- a/src/routes/(main)/home/_layout/Body/BottomMenu/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/BottomMenu/index.tsx
@@ -7,6 +7,7 @@ import { getRouteById } from '@/config/routes';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useActiveTabKey } from '@/hooks/useActiveTabKey';
 import { SidebarTabKey } from '@/store/global/initialState';
+import { isModifierClick } from '@/utils/navigation';
 
 interface Item {
   icon: any;
@@ -59,6 +60,7 @@ const BottomMenu = memo(() => {
           key={item.key}
           to={item.url}
           onClick={(e) => {
+            if (isModifierClick(e)) return;
             e.preventDefault();
             navigate(item.url);
           }}

--- a/src/routes/(main)/home/_layout/Header/components/Nav.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/Nav.tsx
@@ -17,6 +17,7 @@ import {
   serverConfigSelectors,
   useServerConfigStore,
 } from '@/store/serverConfig';
+import { isModifierClick } from '@/utils/navigation';
 
 interface Item {
   hidden?: boolean | undefined;
@@ -111,6 +112,7 @@ const Nav = memo(() => {
             key={item.key}
             to={item.url}
             onClick={(e) => {
+              if (isModifierClick(e)) return;
               e.preventDefault();
               item?.onClick?.();
               if (item.url) {

--- a/src/routes/(main)/memory/_layout/Sidebar/Header/Nav.tsx
+++ b/src/routes/(main)/memory/_layout/Sidebar/Header/Nav.tsx
@@ -18,6 +18,7 @@ import { type NavItemProps } from '@/features/NavPanel/components/NavItem';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { usePathname } from '@/libs/router/navigation';
 import { useGlobalStore } from '@/store/global';
+import { isModifierClick } from '@/utils/navigation';
 
 interface Item {
   icon: NavItemProps['icon'];
@@ -117,6 +118,7 @@ const Nav = memo(() => {
             key={item.key}
             to={item.url}
             onClick={(e) => {
+              if (isModifierClick(e)) return;
               e.preventDefault();
               item?.onClick?.();
               if (item.url) {

--- a/src/routes/(main)/settings/_layout/Body/index.tsx
+++ b/src/routes/(main)/settings/_layout/Body/index.tsx
@@ -2,10 +2,11 @@
 
 import { Accordion, AccordionItem, Flexbox, Text } from '@lobehub/ui';
 import { memo, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { SettingsTabs } from '@/store/global/initialState';
+import { isModifierClick } from '@/utils/navigation';
 
 import { SettingsGroupKey, useCategory } from '../../hooks/useCategory';
 
@@ -24,12 +25,8 @@ const Body = memo(() => {
     return SettingsTabs.Profile;
   }, [location.pathname]);
 
-  const handleTabClick = (tab: SettingsTabs) => {
-    if (tab === SettingsTabs.Provider) {
-      navigate('/settings/provider/all');
-    } else {
-      navigate(`/settings/${tab}`);
-    }
+  const getTabUrl = (tab: SettingsTabs) => {
+    return tab === SettingsTabs.Provider ? '/settings/provider/all' : `/settings/${tab}`;
   };
 
   return (
@@ -57,15 +54,22 @@ const Body = memo(() => {
             }
           >
             <Flexbox gap={1} paddingBlock={1}>
-              {group.items.map((item) => (
-                <NavItem
-                  active={activeTab === item.key}
-                  icon={item.icon}
-                  key={item.key}
-                  title={item.label}
-                  onClick={() => handleTabClick(item.key)}
-                />
-              ))}
+              {group.items.map((item) => {
+                const url = getTabUrl(item.key);
+                return (
+                  <Link
+                    key={item.key}
+                    to={url}
+                    onClick={(e) => {
+                      if (isModifierClick(e)) return;
+                      e.preventDefault();
+                      navigate(url);
+                    }}
+                  >
+                    <NavItem active={activeTab === item.key} icon={item.icon} title={item.label} />
+                  </Link>
+                );
+              })}
             </Flexbox>
           </AccordionItem>
         ))}

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,11 @@
+import { isDesktop } from '@/const/version';
+
+/**
+ * Check if user is performing a modifier click (Cmd+Click on Mac, Ctrl+Click on other OS)
+ * to open link in new tab. Always returns false on desktop (Electron) since
+ * there's no browser tab concept.
+ */
+export const isModifierClick = (e: { ctrlKey: boolean; metaKey: boolean }): boolean => {
+  if (isDesktop) return false;
+  return e.metaKey || e.ctrlKey;
+};


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-3124

#### 🔀 Description of Change

**1. Cmd+Click support for sidebar navigation (LOBE-3124)**

Sidebar nav items and back buttons used `onClick + navigate()` with unconditional `e.preventDefault()`, which blocked Cmd+Click (or Ctrl+Click) from opening links in new browser tabs.

- Added `isModifierClick` utility (`src/utils/navigation.ts`) that checks for Cmd/Ctrl modifier keys, returning `false` on Desktop (Electron) since there's no browser tab concept
- Updated all sidebar `<Link onClick>` handlers to skip `preventDefault()` when modifier click is detected
- Wrapped `BackNav` buttons in `<Link>` elements to provide native `<a>` href for new-tab support
- Wrapped Settings sidebar `NavItem` in `<Link>` for consistent behavior
- Unified `NavItem` internal modifier check to use `isModifierClick`

Files changed: `SideBarHeaderLayout.tsx`, `BackNav.tsx`, `NavItem.tsx`, home Nav, BottomMenu, community Nav, memory Nav, BenchmarkList, settings Body

**2. Tool inspector UI fixes**

- Fixed tool accordion not collapsible when debug mode is active
- Used non-breaking space in tool inspector text to prevent layout shifts

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

**Cmd+Click test:**
- Web: Cmd+Click (Mac) / Ctrl+Click (Windows) any sidebar nav item → should open in new browser tab
- Web: Normal click → should still do SPA navigation (no page refresh)
- Web: Cmd+Click breadcrumb links → should open in new tab
- Web: Cmd+Click back button → should open in new tab
- Desktop: Cmd+Click behavior unchanged (same as normal click)

#### 📝 Additional Information

Desktop (Electron) is excluded from modifier click detection since there's no browser tab concept. `isModifierClick` always returns `false` when `isDesktop` is `true`.