### PR TITLE
✨ feat(model-runtime): add optionIndex to RouteAttemptResult

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -91,6 +91,7 @@ export interface RouteAttemptResult {
   durationMs: number;
   error?: unknown;
   model: string;
+  optionIndex: number;
   providerId: string;
   remark?: string;
   routerId?: string;
@@ -346,6 +347,7 @@ export const createRouterRuntime = ({
               channelId,
               durationMs: Date.now() - startTime,
               model,
+              optionIndex: index,
               providerId: id,
               remark,
               routerId: matchedRouter.id,
@@ -367,6 +369,7 @@ export const createRouterRuntime = ({
               durationMs: Date.now() - startTime,
               error,
               model,
+              optionIndex: index,
               providerId: id,
               remark,
               routerId: matchedRouter.id,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add `optionIndex` field to `RouteAttemptResult` interface and pass the option array index in `onRouteAttempt` callback.

This enables downstream consumers (e.g. cloud alerting) to distinguish primary channels (`optionIndex === 0`) from fallback channels, allowing smarter alert filtering.

#### 🧪 How to Test

- [x] No tests needed

## Summary by Sourcery

New Features:
- Include the option index in RouteAttemptResult and propagate it through onRouteAttempt callbacks so consumers can distinguish primary from fallback channels.