### PR TITLE
✨ feat: add CAMB AI as TTS provider

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -574,6 +574,8 @@
   "settingSystemTools.tools.grep.desc": "GNU grep - standard text search tool",
   "settingSystemTools.tools.mdfind.desc": "macOS Spotlight search (fast indexed search)",
   "settingSystemTools.tools.rg.desc": "ripgrep - extremely fast text search tool",
+  "settingTTS.cambai.title": "CAMB AI",
+  "settingTTS.cambai.ttsModel": "CAMB AI Text-to-Speech Model",
   "settingTTS.openai.sttModel": "OpenAI Speech-to-Text Model",
   "settingTTS.openai.title": "OpenAI",
   "settingTTS.openai.ttsModel": "OpenAI Text-to-Speech Model",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -574,6 +574,8 @@
   "settingSystemTools.tools.grep.desc": "GNU grep - 标准文本搜索工具",
   "settingSystemTools.tools.mdfind.desc": "macOS 聚焦搜索（快速索引搜索）",
   "settingSystemTools.tools.rg.desc": "ripgrep - 极快的文本搜索工具",
+  "settingTTS.cambai.title": "CAMB AI",
+  "settingTTS.cambai.ttsModel": "CAMB AI 语音合成模型",
   "settingTTS.openai.sttModel": "OpenAI 语音识别模型",
   "settingTTS.openai.title": "OpenAI",
   "settingTTS.openai.ttsModel": "OpenAI 语音合成模型",

--- a/packages/const/src/fetch.ts
+++ b/packages/const/src/fetch.ts
@@ -6,6 +6,8 @@ export const USE_AZURE_OPENAI = 'X-use-azure-openai';
 
 export const AZURE_OPENAI_API_VERSION = 'X-azure-openai-api-version';
 
+export const CAMBAI_API_KEY_HEADER_KEY = 'X-cambai-api-key';
+
 export const OAUTH_AUTHORIZED = 'X-oauth-authorized';
 
 /**

--- a/packages/const/src/settings/tts.ts
+++ b/packages/const/src/settings/tts.ts
@@ -1,6 +1,9 @@
 import type { UserTTSConfig } from '@lobechat/types';
 
 export const DEFAULT_TTS_CONFIG: UserTTSConfig = {
+  cambAI: {
+    ttsModel: 'mars-flash',
+  },
   openAI: {
     sttModel: 'whisper-1',
     ttsModel: 'tts-1',

--- a/packages/types/src/agent/tts.ts
+++ b/packages/types/src/agent/tts.ts
@@ -1,10 +1,11 @@
-export type TTSServer = 'openai' | 'edge' | 'microsoft';
+export type TTSServer = 'openai' | 'edge' | 'microsoft' | 'cambai';
 
 export interface LobeAgentTTSConfig {
   showAllLocaleVoice?: boolean;
   sttLocale: 'auto' | string;
   ttsService: TTSServer;
   voice: {
+    cambai?: string;
     edge?: string;
     microsoft?: string;
     openai: string;

--- a/packages/types/src/user/settings/tts.ts
+++ b/packages/types/src/user/settings/tts.ts
@@ -1,6 +1,9 @@
 export type STTServer = 'openai' | 'browser';
 
 export interface UserTTSConfig {
+  cambAI: {
+    ttsModel: 'mars-flash' | 'mars-pro';
+  };
   openAI: {
     sttModel: 'whisper-1';
     ttsModel: 'gpt-4o-mini-tts' | 'tts-1' | 'tts-1-hd';

--- a/src/app/(backend)/webapi/tts/cambai/route.ts
+++ b/src/app/(backend)/webapi/tts/cambai/route.ts
@@ -1,0 +1,41 @@
+import { CAMBAI_API_KEY_HEADER_KEY } from '@/const/fetch';
+
+const CAMBAI_TTS_URL = 'https://client.camb.ai/apis/tts-stream';
+
+export const POST = async (req: Request) => {
+  const apiKey = req.headers.get(CAMBAI_API_KEY_HEADER_KEY);
+
+  if (!apiKey) {
+    return new Response(JSON.stringify({ message: 'CAMB AI API key is required' }), {
+      headers: { 'content-type': 'application/json' },
+      status: 401,
+    });
+  }
+
+  const payload = await req.json();
+
+  const response = await fetch(CAMBAI_TTS_URL, {
+    body: JSON.stringify(payload),
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[webapi/tts/cambai] TTS request failed:', errorText);
+    return new Response(JSON.stringify({ error: errorText }), {
+      headers: { 'content-type': 'application/json' },
+      status: response.status,
+    });
+  }
+
+  return new Response(response.body, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': response.headers.get('Content-Type') || 'audio/mpeg',
+    },
+  });
+};

--- a/src/app/(backend)/webapi/voices/cambai/route.ts
+++ b/src/app/(backend)/webapi/voices/cambai/route.ts
@@ -1,0 +1,38 @@
+import { CAMBAI_API_KEY_HEADER_KEY } from '@/const/fetch';
+
+const CAMBAI_VOICES_URL = 'https://client.camb.ai/apis/list-voices';
+
+export const GET = async (req: Request) => {
+  const apiKey = req.headers.get(CAMBAI_API_KEY_HEADER_KEY);
+
+  if (!apiKey) {
+    return new Response(JSON.stringify({ message: 'CAMB AI API key is required' }), {
+      headers: { 'content-type': 'application/json' },
+      status: 401,
+    });
+  }
+
+  const response = await fetch(CAMBAI_VOICES_URL, {
+    headers: {
+      'x-api-key': apiKey,
+    },
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[webapi/voices/cambai] Voice list request failed:', errorText);
+    return new Response(JSON.stringify({ error: errorText }), {
+      headers: { 'content-type': 'application/json' },
+      status: response.status,
+    });
+  }
+
+  const data = await response.json();
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'Cache-Control': 'max-age=3600',
+      'content-type': 'application/json;charset=UTF-8',
+    },
+  });
+};

--- a/src/app/(backend)/webapi/voices/cambai/route.ts
+++ b/src/app/(backend)/webapi/voices/cambai/route.ts
@@ -32,6 +32,7 @@ export const GET = async (req: Request) => {
   return new Response(JSON.stringify(data), {
     headers: {
       'Cache-Control': 'max-age=3600',
+      'Vary': CAMBAI_API_KEY_HEADER_KEY,
       'content-type': 'application/json;charset=UTF-8',
     },
   });

--- a/src/app/[variants]/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/app/[variants]/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -4,7 +4,13 @@ import { Avatar, Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { BrainIcon, MessageSquareHeartIcon, MessagesSquareIcon, UserIcon } from 'lucide-react';
+import {
+  BrainIcon,
+  MessageSquareHeartIcon,
+  MessagesSquareIcon,
+  Mic2Icon,
+  UserIcon,
+} from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -62,6 +68,11 @@ const Content = memo(() => {
           icon: <Icon icon={BrainIcon} />,
           key: ChatSettingsTabs.Modal,
           label: t('agentTab.modal'),
+        },
+        {
+          icon: <Icon icon={Mic2Icon} />,
+          key: ChatSettingsTabs.TTS,
+          label: t('agentTab.tts'),
         },
       ].filter(Boolean) as ItemType[],
     [t, isInbox],

--- a/src/app/[variants]/(main)/settings/tts/features/CambAI.tsx
+++ b/src/app/[variants]/(main)/settings/tts/features/CambAI.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { type FormGroupItemType } from '@lobehub/ui';
+import { Form, Icon, Select, Skeleton } from '@lobehub/ui';
+import isEqual from 'fast-deep-equal';
+import { Loader2Icon } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { FORM_STYLE } from '@/const/layoutTokens';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
+
+import { cambaiTTSModelOptions } from './const';
+
+const CambAI = memo(() => {
+  const { t } = useTranslation('setting');
+  const [form] = Form.useForm();
+  const { tts } = useUserStore(settingsSelectors.currentSettings, isEqual);
+  const [setSettings, isUserStateInit] = useUserStore((s) => [s.setSettings, s.isUserStateInit]);
+  const [loading, setLoading] = useState(false);
+
+  if (!isUserStateInit) return <Skeleton active paragraph={{ rows: 5 }} title={false} />;
+
+  const cambai: FormGroupItemType = {
+    children: [
+      {
+        children: <Select options={cambaiTTSModelOptions} />,
+        label: t('settingTTS.cambai.ttsModel'),
+        name: ['cambAI', 'ttsModel'],
+      },
+    ],
+    extra: loading && <Icon spin icon={Loader2Icon} size={16} style={{ opacity: 0.5 }} />,
+    title: t('settingTTS.cambai.title'),
+  };
+
+  return (
+    <Form
+      collapsible={false}
+      form={form}
+      initialValues={tts}
+      items={[cambai]}
+      itemsType={'group'}
+      variant={'filled'}
+      onValuesChange={async (values) => {
+        setLoading(true);
+        await setSettings({
+          tts: values,
+        });
+        setLoading(false);
+      }}
+      {...FORM_STYLE}
+    />
+  );
+});
+
+export default CambAI;

--- a/src/app/[variants]/(main)/settings/tts/features/const.tsx
+++ b/src/app/[variants]/(main)/settings/tts/features/const.tsx
@@ -25,6 +25,17 @@ export const opeanaiSTTOptions: SelectProps['options'] = [
   },
 ];
 
+export const cambaiTTSModelOptions: SelectProps['options'] = [
+  {
+    label: 'MARS Flash',
+    value: 'mars-flash',
+  },
+  {
+    label: 'MARS Pro',
+    value: 'mars-pro',
+  },
+];
+
 export const sttOptions: SelectProps['options'] = [
   {
     label: 'OpenAI',

--- a/src/app/[variants]/(main)/settings/tts/index.tsx
+++ b/src/app/[variants]/(main)/settings/tts/index.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import SettingHeader from '@/app/[variants]/(main)/settings/features/SettingHeader';
 
+import CambAI from './features/CambAI';
 import OpenAI from './features/OpenAI';
 import STT from './features/STT';
 
@@ -12,6 +13,7 @@ const Page = () => {
       <SettingHeader title={t('tab.tts')} />
       <STT />
       <OpenAI />
+      <CambAI />
     </>
   );
 };

--- a/src/features/AgentSetting/AgentSettingsContent.tsx
+++ b/src/features/AgentSetting/AgentSettingsContent.tsx
@@ -9,6 +9,7 @@ import AgentChat from './AgentChat';
 import AgentMeta from './AgentMeta';
 import AgentModal from './AgentModal';
 import AgentOpening from './AgentOpening';
+import AgentTTS from './AgentTTS';
 
 export interface AgentSettingsContentProps {
   loadingSkeleton: ReactNode;
@@ -26,6 +27,7 @@ const AgentSettingsContent = memo<AgentSettingsContentProps>(({ tab, loadingSkel
       {tab === ChatSettingsTabs.Opening && <AgentOpening />}
       {tab === ChatSettingsTabs.Chat && <AgentChat />}
       {tab === ChatSettingsTabs.Modal && <AgentModal />}
+      {tab === ChatSettingsTabs.TTS && <AgentTTS />}
     </>
   );
 });

--- a/src/features/AgentSetting/AgentTTS/index.tsx
+++ b/src/features/AgentSetting/AgentTTS/index.tsx
@@ -3,7 +3,7 @@
 import { VoiceList } from '@lobehub/tts';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form, Select } from '@lobehub/ui';
-import { Switch } from 'antd';
+import { Form as AntdForm, Input, Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { Mic } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -23,12 +23,15 @@ const { openaiVoiceOptions, localeOptions } = VoiceList;
 const AgentTTS = memo(() => {
   const { t } = useTranslation('setting');
   const [form] = Form.useForm();
+  const ttsService = AntdForm.useWatch([TTS_SETTING_KEY, 'ttsService'], form);
   const voiceList = useGlobalStore((s) => {
     const locale = globalGeneralSelectors.currentLanguage(s);
     return (all?: boolean) => new VoiceList(all ? undefined : locale);
   });
   const config = useStore(selectors.currentTtsConfig, isEqual);
   const updateConfig = useStore((s) => s.setAgentConfig);
+
+  const activeService = ttsService ?? config.ttsService;
 
   const { edgeVoiceOptions, microsoftVoiceOptions } = useMemo(
     () => voiceList(config.showAllLocaleVoice),
@@ -46,7 +49,7 @@ const AgentTTS = memo(() => {
       {
         children: <Switch />,
         desc: t('settingTTS.showAllLocaleVoice.desc'),
-        hidden: config.ttsService === 'openai',
+        hidden: activeService === 'openai' || activeService === 'cambai',
         label: t('settingTTS.showAllLocaleVoice.title'),
         layout: 'horizontal',
         minWidth: undefined,
@@ -56,7 +59,7 @@ const AgentTTS = memo(() => {
       {
         children: <SelectWithTTSPreview options={openaiVoiceOptions} server={'openai'} />,
         desc: t('settingTTS.voice.desc'),
-        hidden: config.ttsService !== 'openai',
+        hidden: activeService !== 'openai',
         label: t('settingTTS.voice.title'),
         name: [TTS_SETTING_KEY, 'voice', 'openai'],
       },
@@ -64,7 +67,7 @@ const AgentTTS = memo(() => {
         children: <SelectWithTTSPreview options={edgeVoiceOptions} server={'edge'} />,
         desc: t('settingTTS.voice.desc'),
         divider: false,
-        hidden: config.ttsService !== 'edge',
+        hidden: activeService !== 'edge',
         label: t('settingTTS.voice.title'),
         name: [TTS_SETTING_KEY, 'voice', 'edge'],
       },
@@ -72,9 +75,17 @@ const AgentTTS = memo(() => {
         children: <SelectWithTTSPreview options={microsoftVoiceOptions} server={'microsoft'} />,
         desc: t('settingTTS.voice.desc'),
         divider: false,
-        hidden: config.ttsService !== 'microsoft',
+        hidden: activeService !== 'microsoft',
         label: t('settingTTS.voice.title'),
         name: [TTS_SETTING_KEY, 'voice', 'microsoft'],
+      },
+      {
+        children: <Input placeholder={'147320'} />,
+        desc: t('settingTTS.voice.desc'),
+        divider: false,
+        hidden: activeService !== 'cambai',
+        label: t('settingTTS.voice.title'),
+        name: [TTS_SETTING_KEY, 'voice', 'cambai'],
       },
       {
         children: (

--- a/src/features/AgentSetting/AgentTTS/options.tsx
+++ b/src/features/AgentSetting/AgentTTS/options.tsx
@@ -16,4 +16,8 @@ export const ttsOptions: SelectProps['options'] = [
     label: <LabelRenderer Icon={Azure.Avatar} label={'Microsoft Speech'} />,
     value: 'microsoft',
   },
+  {
+    label: 'CAMB AI',
+    value: 'cambai',
+  },
 ];

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -1,14 +1,14 @@
 import { type UIChatMessage } from '@lobechat/types';
-import { ActionIconGroup, Flexbox, createRawModal } from '@lobehub/ui';
 import type { ActionIconGroupEvent, ActionIconGroupItemType } from '@lobehub/ui';
+import { ActionIconGroup, createRawModal, Flexbox } from '@lobehub/ui';
 import { memo, useCallback, useMemo } from 'react';
 
 import { ReactionPicker } from '../../../components/Reaction';
 import ShareMessageModal, { type ShareModalProps } from '../../../components/ShareMessageModal';
 import {
-  Provider,
   createStore,
   messageStateSelectors,
+  Provider,
   useConversationStore,
   useConversationStoreApi,
 } from '../../../store';
@@ -128,8 +128,8 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
       const base =
         actionsConfig?.bar ??
         (hasTools
-          ? [defaultActions.delAndRegenerate, defaultActions.copy]
-          : [defaultActions.edit, defaultActions.copy]);
+          ? [defaultActions.delAndRegenerate, defaultActions.copy, defaultActions.tts]
+          : [defaultActions.edit, defaultActions.copy, defaultActions.tts]);
       return [...base, ...extraBarItems];
     }, [
       actionsConfig?.bar,
@@ -137,6 +137,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
       defaultActions.delAndRegenerate,
       defaultActions.copy,
       defaultActions.edit,
+      defaultActions.tts,
       extraBarItems,
     ]);
 
@@ -211,7 +212,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
     if (error) return <ErrorActionsBar actions={defaultActions} onActionClick={handleAction} />;
 
     return (
-      <Flexbox align={'center'} gap={8} horizontal>
+      <Flexbox horizontal align={'center'} gap={8}>
         <ReactionPicker messageId={id} />
         <ActionIconGroup items={items} menu={menu} onActionClick={handleAction} />
       </Flexbox>

--- a/src/hooks/useCambAITTS.ts
+++ b/src/hooks/useCambAITTS.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface CambAITTSOptions {
+  api?: {
+    headers?: HeadersInit;
+    serviceUrl?: string;
+  };
+  onError?: (err: Error) => void;
+  onErrorRetry?: (err: Error) => void;
+  onFinish?: (arrayBuffers: ArrayBuffer[]) => void;
+  onSuccess?: () => void;
+  options?: {
+    language?: string;
+    model?: string;
+    voice?: string;
+  };
+}
+
+export const useCambAITTS = (content: string, options?: CambAITTSOptions) => {
+  const [isGlobalLoading, setIsGlobalLoading] = useState(false);
+  const [audio, setAudio] = useState<HTMLAudioElement>();
+  const [response, setResponse] = useState<Response>();
+  const [text, setText] = useState(content);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const audioUrlRef = useRef<string | null>(null);
+
+  // Cleanup on unmount: abort fetch, revoke URLs
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+      }
+    };
+  }, []);
+
+  const stop = useCallback(() => {
+    abortControllerRef.current?.abort();
+    if (audio) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+    setIsGlobalLoading(false);
+  }, [audio]);
+
+  const start = useCallback(async () => {
+    if (!content) return;
+
+    setIsGlobalLoading(true);
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    try {
+      const serviceUrl = options?.api?.serviceUrl || '/webapi/tts/cambai';
+      const res = await fetch(serviceUrl, {
+        body: JSON.stringify({
+          language: (options?.options?.language || 'en-US').toLowerCase().replace('_', '-'),
+          speech_model: options?.options?.model || 'mars-flash',
+          text: content,
+          voice_id: Number(options?.options?.voice) || 147_320,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...options?.api?.headers,
+        },
+        method: 'POST',
+        signal: controller.signal,
+      });
+
+      setResponse(res);
+
+      if (!res.ok) {
+        options?.onError?.(new Error(`TTS request failed: ${res.status}`));
+        setIsGlobalLoading(false);
+        return;
+      }
+
+      const arrayBuffer = await res.arrayBuffer();
+      const blob = new Blob([arrayBuffer], { type: 'audio/mpeg' });
+      const url = URL.createObjectURL(blob);
+
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+      }
+      audioUrlRef.current = url;
+
+      const audioElement = new Audio(url);
+      setAudio(audioElement);
+
+      // Use { once: true } to auto-remove listener after firing
+      audioElement.addEventListener(
+        'ended',
+        () => {
+          setIsGlobalLoading(false);
+        },
+        { once: true },
+      );
+
+      try {
+        await audioElement.play();
+      } catch (playError) {
+        setIsGlobalLoading(false);
+        options?.onError?.(new Error('Audio playback failed. Check browser autoplay settings.'));
+        return;
+      }
+
+      options?.onFinish?.([arrayBuffer]);
+      options?.onSuccess?.();
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') {
+        setIsGlobalLoading(false);
+        return;
+      }
+      options?.onError?.(error as Error);
+      setIsGlobalLoading(false);
+    }
+  }, [content, options]);
+
+  return { audio, isGlobalLoading, response, setText, start, stop };
+};

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -9,7 +9,9 @@ import { useEdgeSpeech, useMicrosoftSpeech, useOpenAITTS } from '@lobehub/tts/re
 import isEqual from 'fast-deep-equal';
 
 import { useBusinessTTSProvider } from '@/business/client/hooks/useBusinessTTSProvider';
+import { useCambAITTS } from '@/hooks/useCambAITTS';
 import { createHeaderWithOpenAI } from '@/services/_header';
+import { createHeaderWithCambAI } from '@/services/_headerCambai';
 import { API_ENDPOINTS } from '@/services/_url';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -31,7 +33,7 @@ export const useTTS = (content: string, config?: TTSConfig) => {
   const lang = useGlobalStore(globalGeneralSelectors.currentLanguage);
   const voice = useAgentStore(agentSelectors.currentAgentTTSVoice(lang));
   const businessTTSProvider = useBusinessTTSProvider();
-  let useSelectedTTS;
+  let useSelectedTTS: any;
   let options: any = {};
   switch (config?.server || ttsAgentSettings.ttsService) {
     case 'openai': {
@@ -75,12 +77,27 @@ export const useTTS = (content: string, config?: TTSConfig) => {
       } as MicrosoftSpeechOptions;
       break;
     }
+    case 'cambai': {
+      useSelectedTTS = useCambAITTS;
+      options = {
+        api: {
+          headers: createHeaderWithCambAI(),
+          serviceUrl: API_ENDPOINTS.tts('cambai'),
+        },
+        options: {
+          language: lang,
+          model: ttsSettings.cambAI?.ttsModel || 'mars-flash',
+          voice: config?.voice || voice,
+        },
+      };
+      break;
+    }
   }
 
   return useSelectedTTS(content, {
     ...config,
     ...options,
-    onFinish: (arraybuffers) => {
+    onFinish: (arraybuffers: ArrayBuffer[]) => {
       config?.onUpload?.(options.voice || 'alloy', arraybuffers);
     },
   });

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -648,6 +648,8 @@ export default {
   'settingSystemTools.tools.grep.desc': 'GNU grep - standard text search tool',
   'settingSystemTools.tools.mdfind.desc': 'macOS Spotlight search (fast indexed search)',
   'settingSystemTools.tools.rg.desc': 'ripgrep - extremely fast text search tool',
+  'settingTTS.cambai.title': 'CAMB AI',
+  'settingTTS.cambai.ttsModel': 'CAMB AI Text-to-Speech Model',
   'settingTTS.openai.sttModel': 'OpenAI Speech-to-Text Model',
   'settingTTS.openai.title': 'OpenAI',
   'settingTTS.openai.ttsModel': 'OpenAI Text-to-Speech Model',

--- a/src/services/_headerCambai.ts
+++ b/src/services/_headerCambai.ts
@@ -1,0 +1,12 @@
+import { CAMBAI_API_KEY_HEADER_KEY } from '@/const/fetch';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+export const createHeaderWithCambAI = (header?: HeadersInit): HeadersInit => {
+  const keyVaults: Record<string, any> =
+    aiProviderSelectors.providerKeyVaults('cambai')(useAiInfraStore.getState()) || {};
+
+  return {
+    ...header,
+    [CAMBAI_API_KEY_HEADER_KEY]: keyVaults.apiKey || process.env.NEXT_PUBLIC_CAMBAI_API_KEY || '',
+  };
+};

--- a/src/services/_headerCambai.ts
+++ b/src/services/_headerCambai.ts
@@ -7,6 +7,6 @@ export const createHeaderWithCambAI = (header?: HeadersInit): HeadersInit => {
 
   return {
     ...header,
-    [CAMBAI_API_KEY_HEADER_KEY]: keyVaults.apiKey || process.env.NEXT_PUBLIC_CAMBAI_API_KEY || '',
+    [CAMBAI_API_KEY_HEADER_KEY]: keyVaults.apiKey || '',
   };
 };

--- a/src/services/_url.ts
+++ b/src/services/_url.ts
@@ -23,11 +23,13 @@ export const API_ENDPOINTS = {
 
   // STT
   stt: withElectronProtocolIfElectron('/webapi/stt/openai'),
-
   // TTS
   tts: (provider: string) => withElectronProtocolIfElectron(`/webapi/tts/${provider}`),
   edge: withElectronProtocolIfElectron('/webapi/tts/edge'),
   microsoft: withElectronProtocolIfElectron('/webapi/tts/microsoft'),
+
+  // Voices
+  voicesCambai: withElectronProtocolIfElectron('/webapi/voices/cambai'),
 };
 
 export const MARKET_OIDC_ENDPOINTS = {

--- a/src/store/agent/selectors/selectors.ts
+++ b/src/store/agent/selectors/selectors.ts
@@ -161,6 +161,10 @@ const currentAgentTTSVoice =
         currentVoice = voice.microsoft || (voiceList.microsoftVoiceOptions?.[0].value as string);
         break;
       }
+      case 'cambai': {
+        currentVoice = voice.cambai || '147320';
+        break;
+      }
     }
     return currentVoice || 'alloy';
   };


### PR DESCRIPTION
## Summary
- Adds CAMB AI as a new TTS provider alongside OpenAI, Edge Speech, and Microsoft Speech
- Supports MARS Flash and MARS Pro speech models
- Per-agent voice ID configuration via Voice Service settings tab
- TTS proxy route and voice list proxy with API key header forwarding
- Play button on message action bar for quick TTS playback

## Changes
- **New files:** TTS proxy route, voices proxy route, `useCambAITTS` hook, CAMB AI settings component, header helper
- **Modified:** Agent settings (Voice Service tab), TTS hook integration, agent voice selector, i18n keys, type definitions