### PR TITLE
🔨 chore: remove dead eslint disable comments for deleted rules

### DIFF
--- a/.agents/skills/db-migrations/SKILL.md
+++ b/.agents/skills/db-migrations/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: db-migrations
+description: Database migration guide. Use when generating migrations, writing migration SQL, or modifying database schemas. Triggers on migration generation, schema changes, or idempotent SQL questions.
+---
+
 # Database Migrations Guide
 
 ## Step 1: Generate Migrations
@@ -77,4 +82,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS "users_email_unique" ON "users" USING btree ("
 -- ❌ Bad
 DROP TABLE "old_table";
 CREATE INDEX "users_email_idx" ON "users" ("email");
+```
+
+## Step 4: Regenerate Client After SQL Edits
+
+After modifying the generated SQL (e.g., adding `IF NOT EXISTS`), regenerate the client:
+
+```bash
+bun run db:generate:client
 ```

--- a/.agents/skills/drizzle/SKILL.md
+++ b/.agents/skills/drizzle/SKILL.md
@@ -202,39 +202,4 @@ return { ...dataset, testCases };
 
 ## Database Migrations
 
-See `references/db-migrations.md` for detailed migration guide.
-
-```bash
-# Generate migrations
-bun run db:generate
-
-# After modifying SQL (e.g., adding IF NOT EXISTS)
-bun run db:generate:client
-```
-
-### Migration Best Practices
-
-All migration SQL must be **idempotent** (safe to re-run):
-
-```sql
--- ✅ Tables: IF NOT EXISTS
-CREATE TABLE IF NOT EXISTS "agent_eval_runs" (...);
-
--- ✅ Columns: IF NOT EXISTS / IF EXISTS
-ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "avatar" text;
-ALTER TABLE "users" DROP COLUMN IF EXISTS "old_field";
-
--- ✅ Foreign keys: DROP IF EXISTS + ADD (no IF NOT EXISTS for constraints)
-ALTER TABLE "t" DROP CONSTRAINT IF EXISTS "t_fk";
-ALTER TABLE "t" ADD CONSTRAINT "t_fk" FOREIGN KEY ("col") REFERENCES "ref"("id") ON DELETE cascade;
-
--- ✅ Indexes: IF NOT EXISTS
-CREATE INDEX IF NOT EXISTS "users_email_idx" ON "users" ("email");
-
--- ❌ Non-idempotent (will fail on re-run)
-CREATE TABLE "agent_eval_runs" (...);
-ALTER TABLE "users" ADD COLUMN "avatar" text;
-ALTER TABLE "t" ADD CONSTRAINT "t_fk" FOREIGN KEY ...;
-```
-
-Rename migration files meaningfully: `0046_meaningless.sql` → `0046_user_add_avatar.sql`
+See the `db-migrations` skill for the detailed migration guide.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,17 +6,9 @@
   },
   "editor.formatOnSave": true,
   // don't show errors, but fix when save and git pre commit
-  "eslint.rules.customizations": [
-    // { "rule": "import/order", "severity": "off" },
-    // { "rule": "prettier/prettier", "severity": "off" },
-    // { "rule": "react/jsx-sort-props", "severity": "off" },
-    // { "rule": "sort-keys-fix/sort-keys-fix", "severity": "off" },
-    // { "rule": "simple-import-sort/exports", "severity": "off" },
-    // { "rule": "typescript-sort-keys/interface", "severity": "off" }
-  ],
+  "eslint.rules.customizations": [],
   "eslint.validate": [
-    // vscode eslint not 插件兼容性有问题
-    // "json",
+    "json",
     "javascript",
     "javascriptreact",
     "typescript",

--- a/packages/builtin-tool-agent-management/src/manifest.ts
+++ b/packages/builtin-tool-agent-management/src/manifest.ts
@@ -4,7 +4,6 @@ import { systemPrompt } from './systemRole';
 import { AgentManagementApiName, AgentManagementIdentifier } from './types';
 
 export const AgentManagementManifest: BuiltinToolManifest = {
-  /* eslint-disable sort-keys-fix/sort-keys-fix */
   api: [
     // ==================== Agent CRUD ====================
     {

--- a/packages/builtin-tool-group-agent-builder/src/manifest.ts
+++ b/packages/builtin-tool-group-agent-builder/src/manifest.ts
@@ -92,7 +92,6 @@ export const GroupAgentBuilderManifest: BuiltinToolManifest = {
             description: 'Array of agent definitions to create',
             items: {
               properties: {
-                /* eslint-disable sort-keys-fix/sort-keys-fix */
                 avatar: {
                   description: "An emoji or image URL for the agent's avatar (optional).",
                   type: 'string',
@@ -116,7 +115,6 @@ export const GroupAgentBuilderManifest: BuiltinToolManifest = {
                   items: { type: 'string' },
                   type: 'array',
                 },
-                /* eslint-enable sort-keys-fix/sort-keys-fix */
               },
               required: ['avatar', 'title', 'description', 'systemRole'],
               type: 'object',

--- a/packages/builtin-tool-group-management/src/manifest.ts
+++ b/packages/builtin-tool-group-management/src/manifest.ts
@@ -7,7 +7,6 @@ import { GroupManagementApiName } from './types';
 export const GroupManagementIdentifier = 'lobe-group-management';
 
 export const GroupManagementManifest: BuiltinToolManifest = {
-  /* eslint-disable sort-keys-fix/sort-keys-fix */
   api: [
     // ==================== Communication Coordination ====================
     {

--- a/packages/builtin-tool-group-management/src/types.ts
+++ b/packages/builtin-tool-group-management/src/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 
 /**
  * API names for Group Management tool

--- a/packages/builtin-tool-gtd/src/client/components/SortableTodoList/store/actions.ts
+++ b/packages/builtin-tool-gtd/src/client/components/SortableTodoList/store/actions.ts
@@ -64,7 +64,6 @@ export const createActions = (
     ...initialState,
     items: defaultItems.map((item) => ({ ...item, id: generateId() })),
 
-    /* eslint-disable sort-keys-fix/sort-keys-fix */
     addItem: () => {
       const { items, newItemText } = get();
       if (!newItemText.trim()) return;

--- a/packages/builtin-tool-page-agent/src/manifest.ts
+++ b/packages/builtin-tool-page-agent/src/manifest.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import type { BuiltinToolManifest } from '@lobechat/types';
 
 import { systemPrompt } from './systemRole';

--- a/packages/builtin-tool-page-agent/src/types.ts
+++ b/packages/builtin-tool-page-agent/src/types.ts
@@ -3,7 +3,6 @@
  */
 export const PageAgentIdentifier = 'lobe-page-agent';
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 export const DocumentApiName = {
   // Initialize
   initPage: 'initPage',
@@ -20,7 +19,6 @@ export const DocumentApiName = {
   // Text Operations
   replaceText: 'replaceText',
 };
-/* eslint-enable sort-keys-fix/sort-keys-fix */
 
 // ============ State Types for Renders ============
 

--- a/packages/business/const/src/bedrock-model-mapping.ts
+++ b/packages/business/const/src/bedrock-model-mapping.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 
 export const cloudModelIdMapping: Record<string, string> = {
   // 'claude-sonnet-4-5-20250929': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',

--- a/packages/database/src/schemas/agentCronJob.ts
+++ b/packages/database/src/schemas/agentCronJob.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import type { ExecutionConditions } from '@lobechat/types';
 import { boolean, index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 

--- a/packages/database/src/schemas/agentSkill.ts
+++ b/packages/database/src/schemas/agentSkill.ts
@@ -1,5 +1,4 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
-import { SkillManifest, SkillResourceMeta } from '@lobechat/types';
+import type { SkillManifest, SkillResourceMeta } from '@lobechat/types';
 import { relations } from 'drizzle-orm';
 import { index, jsonb, pgTable, text, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
 

--- a/packages/database/src/schemas/aiInfra.ts
+++ b/packages/database/src/schemas/aiInfra.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import type { AiProviderConfig, AiProviderSettings } from '@lobechat/types';
 import {
   boolean,

--- a/packages/database/src/schemas/apiKey.ts
+++ b/packages/database/src/schemas/apiKey.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { boolean, index, pgTable, text, varchar } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
 

--- a/packages/database/src/schemas/asyncTask.ts
+++ b/packages/database/src/schemas/asyncTask.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { index, integer, jsonb, pgTable, text, uuid } from 'drizzle-orm/pg-core';
 
 import { timestamps } from './_helpers';

--- a/packages/database/src/schemas/chatGroup.ts
+++ b/packages/database/src/schemas/chatGroup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import {
   boolean,
   index,

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { isNotNull } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import {

--- a/packages/database/src/schemas/generation.ts
+++ b/packages/database/src/schemas/generation.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import type { GenerationAsset } from '@lobechat/types';
 import { index, integer, jsonb, pgTable, text, uuid, varchar } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';

--- a/packages/database/src/schemas/message.ts
+++ b/packages/database/src/schemas/message.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import type { GroundingSearch, ModelReasoning, ToolIntervention } from '@lobechat/types';
 import {
   boolean,

--- a/packages/database/src/schemas/oidc.ts
+++ b/packages/database/src/schemas/oidc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { boolean, index, jsonb, pgTable, primaryKey, text, varchar } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 

--- a/packages/database/src/schemas/rag.ts
+++ b/packages/database/src/schemas/rag.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import {
   index,
   integer,

--- a/packages/database/src/schemas/ragEvals.ts
+++ b/packages/database/src/schemas/ragEvals.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { DEFAULT_MODEL } from '@lobechat/const';
 import { EvalEvaluationStatus } from '@lobechat/types';
 import { index, integer, jsonb, pgTable, text, uuid } from 'drizzle-orm/pg-core';

--- a/packages/database/src/schemas/rbac.ts
+++ b/packages/database/src/schemas/rbac.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { boolean, index, jsonb, pgTable, primaryKey, text, timestamp } from 'drizzle-orm/pg-core';
 
 import { createNanoId } from '../utils/idGenerator';

--- a/packages/database/src/schemas/session.ts
+++ b/packages/database/src/schemas/session.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { boolean, index, integer, pgTable, text, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
 

--- a/packages/database/src/schemas/user.ts
+++ b/packages/database/src/schemas/user.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { DEFAULT_PREFERENCE } from '@lobechat/const';
 import type { CustomPluginParams, UserOnboarding } from '@lobechat/types';
 import type { LobeChatPluginManifest } from '@lobehub/chat-plugin-sdk';

--- a/packages/database/src/schemas/userMemories/index.ts
+++ b/packages/database/src/schemas/userMemories/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { bigint, index, jsonb, numeric, pgTable, real, text, vector } from 'drizzle-orm/pg-core';
 
 import { idGenerator } from '../../utils/idGenerator';

--- a/packages/database/src/schemas/userMemories/persona.ts
+++ b/packages/database/src/schemas/userMemories/persona.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix  */
 import { index, integer, jsonb, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
 
 import { createNanoId } from '../../utils/idGenerator';

--- a/packages/database/vitest.config.mts
+++ b/packages/database/vitest.config.mts
@@ -8,7 +8,6 @@ export default defineConfig({
   },
   test: {
     alias: {
-      /* eslint-disable sort-keys-fix/sort-keys-fix */
       '@/const': resolve(__dirname, '../const/src'),
       '@/utils/errorResponse': resolve(__dirname, '../../src/utils/errorResponse'),
       '@/utils': resolve(__dirname, '../utils/src'),
@@ -16,7 +15,7 @@ export default defineConfig({
       '@/libs/model-runtime': resolve(__dirname, '../model-runtime/src'),
       '@/types': resolve(__dirname, '../types/src'),
       '@': resolve(__dirname, '../../src'),
-      /* eslint-enable */
+
     },
     environment: 'happy-dom',
     exclude: [

--- a/packages/database/vitest.config.server.mts
+++ b/packages/database/vitest.config.server.mts
@@ -4,7 +4,6 @@ import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     alias: {
-      /* eslint-disable sort-keys-fix/sort-keys-fix */
       '@/const': resolve(__dirname, '../const/src'),
       '@/utils/errorResponse': resolve(__dirname, '../../src/utils/errorResponse'),
       '@/utils': resolve(__dirname, '../utils/src'),
@@ -12,7 +11,7 @@ export default defineConfig({
       '@/libs/model-runtime': resolve(__dirname, '../model-runtime/src'),
       '@/types': resolve(__dirname, '../types/src'),
       '@': resolve(__dirname, '../../src'),
-      /* eslint-enable */
+
     },
     coverage: {
       all: false,

--- a/packages/edge-config/src/types.ts
+++ b/packages/edge-config/src/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import type { BusinessEdgeConfigData } from '@lobechat/business-config/server';
 
 /**

--- a/packages/model-bank/src/standard-parameters/index.ts
+++ b/packages/model-bank/src/standard-parameters/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import type { Simplify } from 'type-fest';
 import { z } from 'zod';
 

--- a/packages/model-bank/src/standard-parameters/video.ts
+++ b/packages/model-bank/src/standard-parameters/video.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import type { Simplify } from 'type-fest';
 import { z } from 'zod';
 

--- a/packages/model-runtime/src/core/BaseAI.ts
+++ b/packages/model-runtime/src/core/BaseAI.ts
@@ -21,7 +21,6 @@ import type {
   TextToSpeechPayload,
 } from '../types';
 
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 export interface LobeRuntimeAI {
   baseURL?: string;
   chat?: (payload: ChatStreamPayload, options?: ChatMethodOptions) => Promise<Response>;

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -553,7 +553,6 @@ const transformOpenAIStream = (
 
     const err = e as Error;
 
-    /* eslint-disable sort-keys-fix/sort-keys-fix */
     const errorData = {
       body: {
         message:

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -179,7 +179,6 @@ const transformOpenAIStream = (
 
     const err = e as Error;
 
-    /* eslint-disable sort-keys-fix/sort-keys-fix */
     const errorData = {
       body: {
         message:

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import { CREDITS_PER_DOLLAR, USD_TO_CNY } from '@lobechat/const/currency';
 import type { ModelTokensUsage } from '@lobechat/types';
 import debug from 'debug';

--- a/packages/model-runtime/src/providers/github/index.ts
+++ b/packages/model-runtime/src/providers/github/index.ts
@@ -25,7 +25,6 @@ export interface GithubModelCard {
   version: string;
 }
 
-/* eslint-enable typescript-sort-keys/interface */
 
 export const params = {
   baseURL: 'https://models.github.ai/inference',

--- a/packages/model-runtime/src/providers/togetherai/type.ts
+++ b/packages/model-runtime/src/providers/togetherai/type.ts
@@ -50,7 +50,6 @@ interface Depth {
 }
 
 export interface TogetherAIModel {
-  // eslint-disable-next-line typescript-sort-keys/interface
   access: string;
   config: Config;
   context_length: number;

--- a/packages/model-runtime/src/types/error.ts
+++ b/packages/model-runtime/src/types/error.ts
@@ -3,7 +3,6 @@ import { AgentRuntimeErrorType } from '@lobechat/types';
 
 export const AGENT_RUNTIME_ERROR_SET = new Set<string>(Object.values(AgentRuntimeErrorType));
 
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 export const StandardErrorType = {
   // ******* Client Error ******* //
   BadRequest: 400,

--- a/packages/model-runtime/src/types/image.ts
+++ b/packages/model-runtime/src/types/image.ts
@@ -1,4 +1,3 @@
-/* eslint-disable typescript-sort-keys/interface */
 import type { ModelUsage } from '@lobechat/types';
 import type { RuntimeImageGenParams } from 'model-bank';
 

--- a/packages/model-runtime/src/types/video.ts
+++ b/packages/model-runtime/src/types/video.ts
@@ -1,4 +1,3 @@
-/* eslint-disable typescript-sort-keys/interface */
 import { RuntimeVideoGenParams } from 'model-bank';
 
 export type CreateVideoPayload = {

--- a/packages/observability-otel/src/node.ts
+++ b/packages/observability-otel/src/node.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix, typescript-sort-keys/interface */
 import { env } from 'node:process';
 
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 // ******* Runtime Biz Error ******* //
 export const AgentRuntimeErrorType = {
   AgentRuntimeError: 'AgentRuntimeError', // Agent Runtime module runtime error

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,4 +1,3 @@
-/* eslint-disable typescript-sort-keys/interface */
 export interface ClientSecretPayload {
   /**
    * Represents the user's API key

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -75,7 +75,6 @@ export interface MessageMapContext {
   topicId?: string | null;
 }
 
-/* eslint-disable typescript-sort-keys/interface */
 /**
  * Context for identifying a conversation or message list
  * This is the standard type for all conversation-related context passing

--- a/packages/types/src/fetch.ts
+++ b/packages/types/src/fetch.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import type { ILobeAgentRuntimeErrorType } from './agentRuntime';
 
 export const ChatErrorType = {

--- a/packages/types/src/message/common/messageGroup.ts
+++ b/packages/types/src/message/common/messageGroup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 
 /**
  * Message group type

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 import { z } from 'zod';
 
 import { PageSelection, PageSelectionSchema } from './pageSelection';

--- a/packages/types/src/message/common/pageSelection.ts
+++ b/packages/types/src/message/common/pageSelection.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 import { z } from 'zod';
 
 /**

--- a/packages/types/src/message/db/item.ts
+++ b/packages/types/src/message/db/item.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 import type { GroundingSearch } from '../../search';
 import type { MessageMetadata, ModelReasoning, ToolIntervention } from '../common';
 

--- a/packages/types/src/message/db/params.ts
+++ b/packages/types/src/message/db/params.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix */
 import { z } from 'zod';
 
 import type { GroundingSearch } from '../../search';

--- a/packages/types/src/message/ui/params.ts
+++ b/packages/types/src/message/ui/params.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
 import { z } from 'zod';
 
 import type { ConversationContext } from '../../conversation';

--- a/packages/types/src/tool/plugin.ts
+++ b/packages/types/src/tool/plugin.ts
@@ -26,7 +26,6 @@ export interface CustomPluginParams {
     serverUrl: string;
   };
 
-  /* eslint-disable sort-keys-fix/sort-keys-fix , typescript-sort-keys/interface */
   manifestMode?: 'local' | 'url';
   manifestUrl?: string;
   /**

--- a/packages/utils/vitest.config.mts
+++ b/packages/utils/vitest.config.mts
@@ -4,11 +4,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     alias: {
-      /* eslint-disable sort-keys-fix/sort-keys-fix */
       '@/const': resolve(__dirname, '../const/src'),
       '@/utils': resolve(__dirname, './src'),
       '@': resolve(__dirname, '../../src'),
-      /* eslint-enable */
+
     },
     coverage: {
       all: false,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -58,7 +58,7 @@ export default defineConfig({
       '@': resolve(__dirname, './src'),
       '~test-utils': resolve(__dirname, './tests/utils.tsx'),
       'lru_map': resolve(__dirname, './tests/mocks/lru_map'),
-      /* eslint-enable */
+
     },
     coverage: {
       all: false,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔀 Description of Change

Remove all `eslint-disable` / `eslint-enable` comments for rules that have been deleted from the ESLint config:

- `sort-keys-fix/sort-keys-fix`
- `typescript-sort-keys/interface`

Also clean up stale commented-out rule customizations in `.vscode/settings.json` and orphaned `/* eslint-enable */` comments.

54 files changed, 69 lines removed.

#### 🧪 How to Test

- [x] No tests needed