### PR TITLE
🐛 fix(user): add length validation for username and fullName

### DIFF
--- a/locales/zh-CN/auth.json
+++ b/locales/zh-CN/auth.json
@@ -196,6 +196,7 @@
   "profile.usernamePlaceholder": "字母、数字或下划线",
   "profile.usernameRequired": "用户名不能为空",
   "profile.usernameRule": "仅支持字母、数字或下划线",
+  "profile.usernameTooLong": "用户名不能超过 64 个字符",
   "profile.usernameUpdateFailed": "更新失败，请稍后重试",
   "signin.subtitle": "登录或注册你的 {{appName}} 账号",
   "signin.title": "同 Agent 团队一起无限进步",

--- a/src/locales/default/auth.ts
+++ b/src/locales/default/auth.ts
@@ -206,6 +206,7 @@ export default {
   'profile.usernamePlaceholder': 'Enter a username with letters, numbers, or underscores',
   'profile.usernameRequired': 'Username cannot be empty',
   'profile.usernameRule': 'Username can only contain letters, numbers, or underscores',
+  'profile.usernameTooLong': 'Username cannot exceed 64 characters',
   'profile.usernameUpdateFailed': 'Failed to update username, please try again later',
   'signin.subtitle': 'Sign up or log in to your {{appName}} account',
   'signin.title': 'Agent teammates that grow with you',

--- a/src/routes/(main)/settings/profile/features/FullNameRow.tsx
+++ b/src/routes/(main)/settings/profile/features/FullNameRow.tsx
@@ -63,6 +63,8 @@ const FullNameRow = ({ mobile }: FullNameRowProps) => {
         {!mobile && <Text strong>{t('profile.fullNameInputHint')}</Text>}
         <Input
           autoFocus
+          showCount
+          maxLength={64}
           placeholder={t('profile.fullName')}
           value={editValue}
           onChange={(e) => setEditValue(e.target.value)}

--- a/src/routes/(main)/settings/profile/features/UsernameRow.tsx
+++ b/src/routes/(main)/settings/profile/features/UsernameRow.tsx
@@ -41,6 +41,7 @@ const UsernameRow = ({ mobile }: UsernameRowProps) => {
   const validateUsername = (value: string): string => {
     const trimmed = value.trim();
     if (!trimmed) return t('profile.usernameRequired');
+    if (trimmed.length > 64) return t('profile.usernameTooLong');
     if (!usernameRegex.test(trimmed)) return t('profile.usernameRule');
     return '';
   };
@@ -99,6 +100,8 @@ const UsernameRow = ({ mobile }: UsernameRowProps) => {
         {!mobile && <Text strong>{t('profile.usernameInputHint')}</Text>}
         <Input
           autoFocus
+          showCount
+          maxLength={64}
           placeholder={t('profile.usernamePlaceholder')}
           status={error ? 'error' : undefined}
           value={editValue}

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -30,6 +30,7 @@ const usernameSchema = z
   .string()
   .trim()
   .min(1, { message: 'USERNAME_REQUIRED' })
+  .max(64, { message: 'USERNAME_TOO_LONG' })
   .regex(/^\w+$/, { message: 'USERNAME_INVALID' });
 
 const userProcedure = authedProcedure.use(serverDatabase).use(async ({ ctx, next }) => {
@@ -174,9 +175,11 @@ export const userRouter = router({
     return ctx.userModel.updateUser({ avatar: input });
   }),
 
-  updateFullName: userProcedure.input(z.string()).mutation(async ({ ctx, input }) => {
-    return ctx.userModel.updateUser({ fullName: input });
-  }),
+  updateFullName: userProcedure
+    .input(z.string().trim().max(64))
+    .mutation(async ({ ctx, input }) => {
+      return ctx.userModel.updateUser({ fullName: input });
+    }),
 
   updateGuide: userProcedure.input(UserGuideSchema).mutation(async ({ ctx, input }) => {
     return ctx.userModel.updateGuide(input);

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -176,7 +176,7 @@ export const userRouter = router({
   }),
 
   updateFullName: userProcedure
-    .input(z.string().trim().max(64))
+    .input(z.string().trim().max(64, { message: 'FULLNAME_TOO_LONG' }))
     .mutation(async ({ ctx, input }) => {
       return ctx.userModel.updateUser({ fullName: input });
     }),
@@ -217,14 +217,12 @@ export const userRouter = router({
   }),
 
   updateUsername: userProcedure.input(usernameSchema).mutation(async ({ ctx, input }) => {
-    const username = input.trim();
-
-    const existedUser = await UserModel.findByUsername(ctx.serverDB, username);
+    const existedUser = await UserModel.findByUsername(ctx.serverDB, input);
     if (existedUser && existedUser.id !== ctx.userId) {
       throw new TRPCError({ code: 'CONFLICT', message: 'USERNAME_TAKEN' });
     }
 
-    return ctx.userModel.updateUser({ username });
+    return ctx.userModel.updateUser({ username: input });
   }),
 });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Backend `username` and `fullName` fields had no max length validation, allowing arbitrarily long values via direct API calls that bypass frontend validation.

**Changes:**
- Add `.max(64)` to `usernameSchema` in the backend TRPC router
- Add `.trim().max(64)` to `updateFullName` input schema
- Add `maxLength={64}` and `showCount` to `UsernameRow` and `FullNameRow` Input components
- Add client-side length validation in `UsernameRow.validateUsername`
- Add `usernameTooLong` i18n translations (en-US + zh-CN)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Go to Settings → Profile
2. Try editing username — should show character count and cap at 64
3. Try editing full name — should show character count and cap at 64
4. Direct API call with >64 char username should return validation error

#### 📝 Additional Information

N/A