### PR TITLE
🐛 fix(topic): use responseLanguage for topic/thread title summarization

### DIFF
--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -79,6 +79,9 @@ vi.mock('@/store/user/selectors', () => ({
   systemAgentSelectors: {
     thread: vi.fn(() => ({})),
   },
+  userGeneralSettingsSelectors: {
+    responseLanguage: vi.fn(() => undefined),
+  },
   userProfileSelectors: {
     userAvatar: vi.fn(() => 'avatar-url'),
   },

--- a/src/store/chat/slices/thread/action.ts
+++ b/src/store/chat/slices/thread/action.ts
@@ -18,7 +18,7 @@ import { type ChatStore } from '@/store/chat/store';
 import { globalHelpers } from '@/store/global/helpers';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
-import { systemAgentSelectors } from '@/store/user/selectors';
+import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
 
@@ -202,7 +202,14 @@ export class ChatThreadActionImpl {
 
         internal_updateThreadTitleInSummary(threadId, output);
       },
-      params: merge(threadConfig, chainSummaryTitle(messages, globalHelpers.getCurrentLanguage())),
+      params: merge(
+        threadConfig,
+        chainSummaryTitle(
+          messages,
+          userGeneralSettingsSelectors.responseLanguage(useUserStore.getState()) ||
+            globalHelpers.getCurrentLanguage(),
+        ),
+      ),
     });
   };
 

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -20,7 +20,7 @@ import { useGlobalStore } from '@/store/global';
 import { globalHelpers } from '@/store/global/helpers';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
-import { systemAgentSelectors } from '@/store/user/selectors';
+import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { type ChatTopic, type CreateTopicParams } from '@/types/topic';
 import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
@@ -221,7 +221,14 @@ export class ChatTopicActionImpl {
 
         internal_updateTopicTitleInSummary(topicId, output);
       },
-      params: merge(topicConfig, chainSummaryTitle(messages, globalHelpers.getCurrentLanguage())),
+      params: merge(
+        topicConfig,
+        chainSummaryTitle(
+          messages,
+          userGeneralSettingsSelectors.responseLanguage(useUserStore.getState()) ||
+            globalHelpers.getCurrentLanguage(),
+        ),
+      ),
       trace: this.#get().getCurrentTracePayload({
         traceName: TraceNameMap.SummaryTopicTitle,
         topicId,

--- a/src/store/image/slices/generationTopic/action.test.ts
+++ b/src/store/image/slices/generationTopic/action.test.ts
@@ -47,6 +47,9 @@ vi.mock('@/store/user/selectors', () => ({
       provider: 'openai',
     }),
   },
+  userGeneralSettingsSelectors: {
+    responseLanguage: vi.fn(() => undefined),
+  },
 }));
 
 beforeEach(() => {

--- a/src/store/image/slices/generationTopic/action.ts
+++ b/src/store/image/slices/generationTopic/action.ts
@@ -10,7 +10,7 @@ import { generationTopicService } from '@/services/generationTopic';
 import { globalHelpers } from '@/store/global/helpers';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
-import { systemAgentSelectors } from '@/store/user/selectors';
+import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { type ImageGenerationTopic } from '@/types/generation';
 import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
@@ -108,7 +108,12 @@ export class GenerationTopicActionImpl {
     await chatService.fetchPresetTaskResult({
       params: merge(
         generationTopicAgentConfig,
-        chainSummaryGenerationTitle(prompts, 'image', globalHelpers.getCurrentLanguage()),
+        chainSummaryGenerationTitle(
+          prompts,
+          'image',
+          userGeneralSettingsSelectors.responseLanguage(useUserStore.getState()) ||
+            globalHelpers.getCurrentLanguage(),
+        ),
       ),
       onError: async () => {
         const fallbackTitle = generateFallbackTitle();

--- a/src/store/user/slices/settings/selectors/general.ts
+++ b/src/store/user/slices/settings/selectors/general.ts
@@ -17,6 +17,7 @@ const contextMenuMode = (s: UserStore) => {
   if (config !== undefined) return config;
   return isDesktop ? 'default' : 'disabled';
 };
+const responseLanguage = (s: UserStore) => generalConfig(s).responseLanguage;
 const telemetry = (s: UserStore) => generalConfig(s).telemetry;
 const enableAutoScrollOnStreaming = (s: UserStore) =>
   generalConfig(s).enableAutoScrollOnStreaming ?? true;
@@ -31,6 +32,7 @@ export const userGeneralSettingsSelectors = {
   mermaidTheme,
   neutralColor,
   primaryColor,
+  responseLanguage,
   telemetry,
   transitionMode,
 };

--- a/src/store/video/slices/generationTopic/action.ts
+++ b/src/store/video/slices/generationTopic/action.ts
@@ -10,7 +10,7 @@ import { chatService } from '@/services/chat';
 import { generationTopicService } from '@/services/generationTopic';
 import { globalHelpers } from '@/store/global/helpers';
 import { useUserStore } from '@/store/user';
-import { systemAgentSelectors } from '@/store/user/selectors';
+import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 import { type ImageGenerationTopic } from '@/types/generation';
 import { merge } from '@/utils/merge';
 import { setNamespace } from '@/utils/storeDebug';
@@ -252,7 +252,12 @@ export const createGenerationTopicSlice: StateCreator<
       },
       params: merge(
         generationTopicAgentConfig,
-        chainSummaryGenerationTitle(prompts, 'video', globalHelpers.getCurrentLanguage()),
+        chainSummaryGenerationTitle(
+          prompts,
+          'video',
+          userGeneralSettingsSelectors.responseLanguage(useUserStore.getState()) ||
+            globalHelpers.getCurrentLanguage(),
+        ),
       ),
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Topic and thread title summarization was always using the UI language (`getCurrentLanguage()`) instead of the user's configured AI response language (`responseLanguage`). This caused titles to be generated in the UI language even when the user explicitly set a different response language.

**Changes:**
- Added `responseLanguage` selector to `userGeneralSettingsSelectors`
- Updated 4 call sites (topic, thread, image generation topic, video generation topic) to prioritize `responseLanguage` with fallback to UI language

**Logic:** `responseLanguage || getCurrentLanguage()` — uses the user's configured AI response language if set, otherwise falls back to UI language.

#### 🧪 How to Test

1. Set a `responseLanguage` different from UI language (e.g., UI in English, response language in Chinese)
2. Create a new chat conversation and send a few messages
3. Verify the auto-generated topic title uses the response language, not the UI language
4. Also test thread title summarization and image/video generation topic titles

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Summary by Sourcery

Use the configured AI response language for automatically generated topic, thread, and media generation titles, falling back to the UI language when not set.

Bug Fixes:
- Ensure topic and thread title summarization respects the user-configured AI response language instead of always using the UI language.
- Align image and video generation topic titles with the user-configured AI response language, with fallback to UI language.