### PR TITLE
✨ feat(moonshot): add kimi-k2 thinking models and update model bank

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -72,66 +72,6 @@ export const googleChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
-      "Gemini 3 Pro is Google's most powerful agent and vibe-coding model, delivering richer visuals and deeper interaction on top of state-of-the-art reasoning.",
-    displayName: 'Gemini 3 Pro Preview',
-    enabled: true,
-    id: 'gemini-3-pro-preview',
-    maxOutput: 65_536,
-    pricing: {
-      units: [
-        {
-          name: 'textInput_cacheRead',
-          strategy: 'tiered',
-          tiers: [
-            { rate: 0.2, upTo: 200_000 },
-            { rate: 0.4, upTo: 'infinity' },
-          ],
-          unit: 'millionTokens',
-        },
-        {
-          name: 'textInput',
-          strategy: 'tiered',
-          tiers: [
-            { rate: 2, upTo: 200_000 },
-            { rate: 4, upTo: 'infinity' },
-          ],
-          unit: 'millionTokens',
-        },
-        {
-          name: 'textOutput',
-          strategy: 'tiered',
-          tiers: [
-            { rate: 12, upTo: 200_000 },
-            { rate: 18, upTo: 'infinity' },
-          ],
-          unit: 'millionTokens',
-        },
-        {
-          lookup: { prices: { '1h': 4.5 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    releasedAt: '2025-11-18',
-    settings: {
-      extendParams: ['thinkingLevel2', 'urlContext'],
-      searchImpl: 'params',
-      searchProvider: 'google',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      video: true,
-      vision: true,
-    },
-    contextWindowTokens: 1_048_576 + 65_536,
-    description:
       "Gemini 3 Flash Preview is Google's latest best-value model, improving on Gemini 2.5 Flash.",
     displayName: 'Gemini 3 Flash Preview',
     enabled: true,
@@ -315,13 +255,14 @@ export const googleChatModels: AIChatModelCard[] = [
       imageOutput: true,
       vision: true,
     },
-    contextWindowTokens: 32_768 + 32_768,
+    contextWindowTokens: 65_536 + 32_768,
     description:
       "Nano Banana is Google's newest, fastest, and most efficient native multimodal model, enabling conversational image generation and editing.",
     displayName: 'Nano Banana',
-    id: 'gemini-2.5-flash-image-preview',
+    id: 'gemini-2.5-flash-image',
     maxOutput: 32_768,
     pricing: {
+      approximatePricePerImage: 0.039,
       units: [
         { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'imageInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
@@ -330,28 +271,9 @@ export const googleChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-08-26',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      imageOutput: true,
-      vision: true,
+    settings: {
+      extendParams: ['imageAspectRatio'],
     },
-    contextWindowTokens: 32_768,
-    description: 'Gemini 2.0 Flash experimental model with image generation support.',
-    displayName: 'Gemini 2.0 Flash (Image Generation) Experimental',
-    id: 'gemini-2.0-flash-exp-image-generation',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'imageInput', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'audioInput', rate: 0.7, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-03-14',
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/lobehub/chat/moonshot.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/moonshot.ts
@@ -35,12 +35,12 @@ export const moonshotChatModels: AIChatModelCard[] = [
       functionCall: true,
       search: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 262_144,
     description:
-      'kimi-k2 is an MoE foundation model with strong coding and agent capabilities (1T total params, 32B active), outperforming other mainstream open models across reasoning, programming, math, and agent benchmarks.',
+      'kimi-k2 is an MoE foundation model with strong coding and agent capabilities (1T total params, 32B active). Based on kimi-k2-0711-preview, with enhanced agentic coding abilities and better context understanding.',
     displayName: 'Kimi K2',
     enabled: true,
-    id: 'kimi-k2-0711-preview',
+    id: 'kimi-k2-0905-preview',
     pricing: {
       units: [
         { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
@@ -48,7 +48,81 @@ export const moonshotChatModels: AIChatModelCard[] = [
         { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-07-11',
+    releasedAt: '2025-09-05',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      search: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'High-speed version of kimi-k2, always aligned with the latest kimi-k2. Same model parameters, output speed up to 60–100 tokens/sec.',
+    displayName: 'Kimi K2 Turbo',
+    enabled: true,
+    id: 'kimi-k2-turbo-preview',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'K2 thinking model with general agentic and reasoning capabilities, specializing in deep reasoning tasks via multi-step tool use.',
+    displayName: 'Kimi K2 Thinking',
+    enabled: true,
+    id: 'kimi-k2-thinking',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-06',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses.',
+    displayName: 'Kimi K2 Thinking Turbo',
+    enabled: true,
+    id: 'kimi-k2-thinking-turbo',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-06',
     settings: {
       searchImpl: 'params',
     },

--- a/packages/model-bank/src/aiModels/lobehub/image.ts
+++ b/packages/model-bank/src/aiModels/lobehub/image.ts
@@ -49,7 +49,7 @@ export const lobehubImageModels: AIImageModelCard[] = [
     description:
       "Nano Banana is Google's newest, fastest, and most efficient native multimodal model, enabling conversational image generation and editing.",
     displayName: 'Nano Banana',
-    id: 'gemini-2.5-flash-image-preview:image',
+    id: 'gemini-2.5-flash-image:image',
     parameters: nanoBananaParameters,
     pricing: {
       approximatePricePerImage: 0.039,

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -249,6 +249,65 @@ describe('LobeMoonshotOpenAI', () => {
       });
     });
 
+    describe('kimi-k2-thinking native thinking models', () => {
+      it('should always enable thinking for kimi-k2-thinking', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking',
+          temperature: 0.5,
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({ type: 'enabled' });
+        expect(payload.temperature).toBe(1);
+        expect(payload.top_p).toBe(0.95);
+        expect(payload.frequency_penalty).toBe(0);
+        expect(payload.presence_penalty).toBe(0);
+      });
+
+      it('should always enable thinking for kimi-k2-thinking-turbo', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking-turbo',
+          temperature: 0.5,
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({ type: 'enabled' });
+        expect(payload.temperature).toBe(1);
+      });
+
+      it('should ignore thinking disabled for native thinking models', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking',
+          thinking: { budget_tokens: 0, type: 'disabled' },
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({ type: 'enabled' });
+        expect(payload.temperature).toBe(1);
+      });
+
+      it('should force reasoning_content on assistant messages', async () => {
+        await instance.chat({
+          messages: [
+            { content: 'Hello', role: 'user' },
+            { content: 'Response', role: 'assistant' },
+            { content: 'Follow-up', role: 'user' },
+          ],
+          model: 'kimi-k2-thinking',
+        });
+
+        const payload = getLastRequestPayload();
+        const assistantMessage = payload.messages.find(
+          (message: any) => message.role === 'assistant',
+        );
+
+        expect(assistantMessage?.reasoning_content).toBe('');
+      });
+    });
+
     describe('interleaved thinking', () => {
       it('should convert reasoning to reasoning_content for assistant messages', async () => {
         await instance.chat({
@@ -421,6 +480,75 @@ describe('LobeMoonshotAnthropicAI', () => {
         const payload = getLastRequestPayload();
 
         expect(payload.thinking).toBeUndefined();
+      });
+    });
+
+    describe('kimi-k2-thinking native thinking models', () => {
+      it('should always enable thinking for kimi-k2-thinking', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking',
+          temperature: 0.5,
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({
+          budget_tokens: 1024,
+          type: 'enabled',
+        });
+        expect(payload.temperature).toBe(1);
+        expect(payload.top_p).toBe(0.95);
+      });
+
+      it('should always enable thinking for kimi-k2-thinking-turbo', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking-turbo',
+          temperature: 0.5,
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({
+          budget_tokens: 1024,
+          type: 'enabled',
+        });
+        expect(payload.temperature).toBe(1);
+      });
+
+      it('should ignore thinking disabled for native thinking models', async () => {
+        await instance.chat({
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'kimi-k2-thinking',
+          thinking: { budget_tokens: 0, type: 'disabled' },
+        });
+
+        const payload = getLastRequestPayload();
+        expect(payload.thinking).toEqual({
+          budget_tokens: 1024,
+          type: 'enabled',
+        });
+        expect(payload.temperature).toBe(1);
+      });
+
+      it('should force thinking block on assistant messages', async () => {
+        await instance.chat({
+          messages: [
+            { content: 'Hello', role: 'user' },
+            { content: 'Response', role: 'assistant' },
+            { content: 'Follow-up', role: 'user' },
+          ],
+          model: 'kimi-k2-thinking',
+        });
+
+        const payload = getLastRequestPayload();
+        const assistantMessage = payload.messages.find(
+          (message: any) => message.role === 'assistant',
+        );
+
+        expect(assistantMessage?.content).toEqual([
+          { type: 'thinking', thinking: ' ' },
+          { type: 'text', text: 'Response' },
+        ]);
       });
     });
 

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -27,6 +27,7 @@ const DEFAULT_MOONSHOT_ANTHROPIC_BASE_URL = 'https://api.moonshot.ai/anthropic';
 // Shared constants and helpers
 const MOONSHOT_SEARCH_TOOL = { function: { name: '$web_search' }, type: 'builtin_function' } as any;
 const isKimiK25Model = (model: string) => model === 'kimi-k2.5';
+const isKimiNativeThinkingModel = (model: string) => model.startsWith('kimi-k2-thinking');
 const isEmptyContent = (content: any) =>
   content === '' || content === null || content === undefined;
 const hasValidReasoning = (reasoning: any) => reasoning?.content && !reasoning?.signature;
@@ -116,7 +117,8 @@ const buildMoonshotAnthropicPayload = async (
     8192;
 
   const isK25 = isKimiK25Model(payload.model);
-  const isThinkingEnabled = isK25 && payload.thinking?.type !== 'disabled';
+  const isNativeThinking = isKimiNativeThinkingModel(payload.model);
+  const isThinkingEnabled = isNativeThinking || (isK25 && payload.thinking?.type !== 'disabled');
 
   const basePayload = await buildDefaultAnthropicPayload({
     ...payload,
@@ -128,15 +130,15 @@ const buildMoonshotAnthropicPayload = async (
   const tools = appendSearchTool(basePayload.tools, payload.enabledSearch);
   const basePayloadWithSearch = { ...basePayload, tools };
 
-  if (!isK25) return basePayloadWithSearch;
+  if (!isK25 && !isNativeThinking) return basePayloadWithSearch;
 
   const resolvedThinkingBudget = payload.thinking?.budget_tokens
     ? Math.min(payload.thinking.budget_tokens, resolvedMaxTokens - 1)
     : 1024;
   const thinkingParam =
-    payload.thinking?.type === 'disabled'
-      ? ({ type: 'disabled' } as const)
-      : ({ budget_tokens: resolvedThinkingBudget, type: 'enabled' } as const);
+    isNativeThinking || payload.thinking?.type !== 'disabled'
+      ? ({ budget_tokens: resolvedThinkingBudget, type: 'enabled' } as const)
+      : ({ type: 'disabled' } as const);
 
   return {
     ...basePayloadWithSearch,
@@ -154,12 +156,16 @@ const buildMoonshotOpenAIPayload = (
   const { enabledSearch, messages, model, temperature, thinking, tools, ...rest } = payload;
 
   const isK25 = isKimiK25Model(model);
-  const isThinkingEnabled = isK25 && thinking?.type !== 'disabled';
+  const isNativeThinking = isKimiNativeThinkingModel(model);
+  const isThinkingEnabled = isNativeThinking || (isK25 && thinking?.type !== 'disabled');
   const normalizedMessages = normalizeMessagesForOpenAI(messages, isThinkingEnabled);
   const moonshotTools = appendSearchTool(tools, enabledSearch);
 
-  if (isK25) {
-    const thinkingParam = isThinkingEnabled ? { type: 'enabled' } : { type: 'disabled' };
+  if (isK25 || isNativeThinking) {
+    const thinkingParam =
+      isNativeThinking || thinking?.type !== 'disabled'
+        ? { type: 'enabled' }
+        : { type: 'disabled' };
 
     return {
       ...rest,

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { ModelProvider } from 'model-bank';
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { testProvider } from '../../providerTestUtils';
@@ -22,6 +23,7 @@ describe('LobeXAI - custom features', () => {
     vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
       new ReadableStream() as any,
     );
+    vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(new ReadableStream() as any);
   });
 
   describe('isGrokReasoningModel', () => {
@@ -44,7 +46,7 @@ describe('LobeXAI - custom features', () => {
         temperature: 0.7,
       });
 
-      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      const calledPayload = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
       expect(calledPayload.frequency_penalty).toBeUndefined();
       expect(calledPayload.presence_penalty).toBeUndefined();
       expect(calledPayload.model).toBe('grok-4');
@@ -59,41 +61,60 @@ describe('LobeXAI - custom features', () => {
         temperature: 0.7,
       });
 
-      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      const calledPayload = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
       expect(calledPayload.frequency_penalty).toBe(0.5);
       expect(calledPayload.presence_penalty).toBe(0.3);
     });
 
-    it('should add search_parameters when enabledSearch is true', async () => {
-      process.env.XAI_MAX_SEARCH_RESULTS = '10';
-      process.env.XAI_SAFE_SEARCH = '1';
-
+    it('should use responses API when enabledSearch is true', async () => {
       await instance.chat({
         messages: [{ content: 'Hello', role: 'user' }],
         model: 'grok-2',
         enabledSearch: true,
       });
 
-      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
-      expect(calledPayload.search_parameters).toBeDefined();
-      expect(calledPayload.search_parameters.max_search_results).toBe(10);
-      expect(calledPayload.search_parameters.mode).toBe('auto');
-      expect(calledPayload.search_parameters.return_citations).toBe(true);
-      expect(calledPayload.search_parameters.sources).toHaveLength(3);
-
-      delete process.env.XAI_MAX_SEARCH_RESULTS;
-      delete process.env.XAI_SAFE_SEARCH;
+      expect(instance['client'].responses.create).toHaveBeenCalled();
+      expect(instance['client'].chat.completions.create).not.toHaveBeenCalled();
     });
 
-    it('should not add search_parameters when enabledSearch is false', async () => {
+    it('should not use responses API when enabledSearch is false', async () => {
       await instance.chat({
         messages: [{ content: 'Hello', role: 'user' }],
         model: 'grok-2',
         enabledSearch: false,
       });
 
-      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
-      expect(calledPayload.search_parameters).toBeUndefined();
+      expect(instance['client'].chat.completions.create).toHaveBeenCalled();
+      expect(instance['client'].responses.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('responses.handlePayload', () => {
+    it('should add web_search and x_search tools when enabledSearch is true', async () => {
+      await instance.chat({
+        enabledSearch: true,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-2',
+        tools: [{ function: { description: 'test', name: 'test' }, type: 'function' as const }],
+      });
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.tools).toEqual([
+        { description: 'test', name: 'test', type: 'function' },
+        { type: 'web_search' },
+        { type: 'x_search' },
+      ]);
+    });
+
+    it('should add web_search and x_search without existing tools', async () => {
+      await instance.chat({
+        enabledSearch: true,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-2',
+      });
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.tools).toEqual([{ type: 'web_search' }, { type: 'x_search' }]);
     });
   });
 

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -1,6 +1,7 @@
 import { ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import type { ChatStreamPayload } from '../../types';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
 import { createXAIImage } from './createImage';
 
@@ -20,41 +21,22 @@ export const LobeXAI = createOpenAICompatibleRuntime({
     handlePayload: (payload) => {
       const { enabledSearch, frequency_penalty, model, presence_penalty, ...rest } = payload;
 
+      if (enabledSearch) {
+        return { ...rest, apiMode: 'responses', enabledSearch, model } as ChatStreamPayload;
+      }
+
       return {
         ...rest,
         frequency_penalty: isGrokReasoningModel(model) ? undefined : frequency_penalty,
         model,
         presence_penalty: isGrokReasoningModel(model) ? undefined : presence_penalty,
         stream: true,
-        ...(enabledSearch && {
-          search_parameters: {
-            max_search_results: Math.min(
-              Math.max(parseInt(process.env.XAI_MAX_SEARCH_RESULTS ?? '15', 10), 1),
-              30,
-            ),
-            mode: 'auto',
-            return_citations: true,
-            sources: [
-              {
-                safe_search: process.env.XAI_SAFE_SEARCH === '1',
-                type: 'news',
-              },
-              /*
-              { type: 'rss' },
-              */
-              {
-                safe_search: process.env.XAI_SAFE_SEARCH === '1',
-                type: 'web',
-              },
-              { type: 'x' },
-            ],
-          },
-        }),
       } as any;
     },
   },
   debug: {
     chatCompletion: () => process.env.DEBUG_XAI_CHAT_COMPLETION === '1',
+    responses: () => process.env.DEBUG_XAI_RESPONSES === '1',
   },
   models: async ({ client }) => {
     const modelsPage = (await client.models.list()) as any;
@@ -63,4 +45,19 @@ export const LobeXAI = createOpenAICompatibleRuntime({
     return processModelList(modelList, MODEL_LIST_CONFIGS.xai, 'xai');
   },
   provider: ModelProvider.XAI,
+  responses: {
+    handlePayload: (payload) => {
+      const { enabledSearch, tools, ...rest } = payload;
+
+      const xaiTools = enabledSearch
+        ? [...(tools || []), { type: 'web_search' }, { type: 'x_search' }]
+        : tools;
+
+      return {
+        ...rest,
+        stream: payload.stream ?? true,
+        tools: xaiTools,
+      } as any;
+    },
+  },
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ✅ test
- [x] 🔨 chore

#### 🔀 Description of Change

**Google model bank cleanup:**
- Remove `gemini-3-pro-preview` (shutdown Mar 9, 2026)
- Remove `gemini-2.0-flash-exp-image-generation` (already shut down)
- Replace `gemini-2.5-flash-image-preview` with stable `gemini-2.5-flash-image`

**Moonshot model updates:**
- Upgrade `kimi-k2-0711-preview` to `kimi-k2-0905-preview` (256k context)
- Add `kimi-k2-turbo-preview`, `kimi-k2-thinking`, `kimi-k2-thinking-turbo`

**Moonshot thinking fix:**
- Fix `kimi-k2-thinking` and `kimi-k2-thinking-turbo` not outputting reasoning content
- Add `isKimiNativeThinkingModel` helper to detect native thinking models
- Ensure thinking params are always sent for native thinking models in both OpenAI and Anthropic payload builders (previously only `kimi-k2.5` was handled)

**XAI fix:**
- Migrate from deprecated Live Search API to Responses API

#### 🧪 How to Test

- [x] Added/updated tests

New test cases cover both OpenAI and Anthropic format paths for kimi-k2-thinking models:
- Always-enabled thinking mode
- Ignoring disabled thinking flag
- Forced reasoning_content / thinking blocks on assistant messages