### PR TITLE
📝 docs: update expired Discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ This project is [LobeHub Community License](./LICENSE) licensed.
 [deploy-on-sealos-link]: https://template.usw.sealos.io/deploy?templateName=lobe-chat-db
 [deploy-on-zeabur-button-image]: https://zeabur.com/button.svg
 [deploy-on-zeabur-link]: https://zeabur.com/templates/VZGGTI
-[discord-link]: https://discord.gg/AYFPHvv2jT
+[discord-link]: https://discord.gg/lobehub
 [discord-shield]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
 [discord-shield-badge]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -854,7 +854,7 @@ This project is [LobeHub Community License](./LICENSE) licensed.
 [deploy-on-sealos-link]: https://template.hzh.sealos.run/deploy?templateName=lobe-chat-db
 [deploy-on-zeabur-button-image]: https://zeabur.com/button.svg
 [deploy-on-zeabur-link]: https://zeabur.com/templates/VZGGTI
-[discord-link]: https://discord.gg/AYFPHvv2jT
+[discord-link]: https://discord.gg/lobehub
 [discord-shield]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
 [discord-shield-badge]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -18,7 +18,7 @@ export const BRANDING_URL = {
 };
 
 export const SOCIAL_URL = {
-  discord: 'https://discord.gg/AYFPHvv2jT',
+  discord: 'https://discord.gg/lobehub',
   github: 'https://github.com/lobehub',
   medium: 'https://medium.com/@lobehub',
   x: 'https://x.com/lobehub',

--- a/packages/web-crawler/src/utils/html/terms.html
+++ b/packages/web-crawler/src/utils/html/terms.html
@@ -1079,7 +1079,7 @@
                         ></path></svg
                     ></span>
                   </div> </a
-                ><a target="_blank" href="https://discord.gg/AYFPHvv2jT">
+                ><a target="_blank" href="https://discord.gg/lobehub">
                   <div
                     style="border-radius: 5px; height: 36px; width: 36px"
                     aria-describedby=":R1orniiqdfb:"


### PR DESCRIPTION
### 📝 Description

Updates the expired Discord invitation link across all files in the repository.

**Fixes #10580**

### 🔗 Changes

| File | Change |
|------|--------|
| `README.md` | Updated Discord link |
| `README.zh-CN.md` | Updated Discord link |
| `packages/business/const/src/branding.ts` | Updated Discord link |
| `packages/web-crawler/src/utils/html/terms.html` | Updated Discord link |

### 🔄 Before / After

- **Before**: `https://discord.gg/AYFPHvv2jT` (expired)
- **After**: `https://discord.gg/lobehub` (active community server)

### ✅ Checklist

- [x] Searched codebase for all occurrences of the old link
- [x] Verified the new link is the official LobeHub Discord server
- [x] No code logic changes — documentation only

## Summary by Sourcery

Update Discord community invitation URL across documentation and app surfaces to point to the active server.

Enhancements:
- Update the Discord social/branding URL used in the application to the new community server link.
- Refresh the Discord link in the web crawler terms HTML so it directs users to the active server.

Documentation:
- Replace the expired Discord invite link with the new community server link in English and Chinese READMEs.