### PR TITLE
🐛 fix(ci): improve release workflows for prereleases

### DIFF
--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -341,7 +341,7 @@ jobs:
             release/*.rpm*
             release/*.tar.gz*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   # ============================================
   # 清理旧的 Canary Releases (保留最近 7 个)

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -44,7 +44,8 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.prerelease }}
 
       - name: Docker login
         uses: docker/login-action@v3
@@ -109,7 +110,8 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.prerelease }}
 
       - name: Docker login
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   release:
     name: Release
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

- **release-desktop-canary**: Use `GH_TOKEN` instead of `GITHUB_TOKEN` for release artifact upload
- **release-docker**: Fix Docker tagging — `latest` only for stable releases; tag prerelease versions with their tag name
- **release.yml**: Skip release job when ref contains `-` (prerelease tags like `v1.0.0-beta`)

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed (CI workflow changes)

#### 📝 Additional Information

CI workflow improvements for prerelease handling.

Made with [Cursor](https://cursor.com)