### PR TITLE
♻️ refactor(config): remove dead `provider_settings` feature flag

### DIFF
--- a/src/config/featureFlags/schema.test.ts
+++ b/src/config/featureFlags/schema.test.ts
@@ -5,7 +5,6 @@ import { evaluateFeatureFlag, FeatureFlagsSchema, mapFeatureFlagsEnvToState } fr
 describe('FeatureFlagsSchema', () => {
   it('should validate correct feature flags with boolean values', () => {
     const result = FeatureFlagsSchema.safeParse({
-      provider_settings: false,
       openai_api_key: true,
       openai_proxy_url: false,
       create_session: true,
@@ -98,7 +97,6 @@ describe('evaluateFeatureFlag', () => {
 describe('mapFeatureFlagsEnvToState', () => {
   it('should correctly map boolean feature flags to state', () => {
     const config = {
-      provider_settings: true,
       openai_api_key: true,
       openai_proxy_url: false,
       edit_agent: false,
@@ -120,7 +118,6 @@ describe('mapFeatureFlagsEnvToState', () => {
 
     expect(mappedState).toMatchObject({
       isAgentEditable: false,
-      showProvider: true,
       showOpenAIApiKey: true,
       showOpenAIProxyUrl: false,
       showApiKeyManage: false,

--- a/src/config/featureFlags/schema.ts
+++ b/src/config/featureFlags/schema.ts
@@ -7,8 +7,6 @@ export const FeatureFlagsSchema = z.object({
   check_updates: FeatureFlagValue.optional(),
 
   // settings
-  provider_settings: FeatureFlagValue.optional(),
-
   openai_api_key: FeatureFlagValue.optional(),
   openai_proxy_url: FeatureFlagValue.optional(),
 
@@ -58,8 +56,6 @@ export const evaluateFeatureFlag = (
 };
 
 export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
-  provider_settings: true,
-
   openai_api_key: true,
   openai_proxy_url: true,
 
@@ -91,7 +87,6 @@ export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
 export const mapFeatureFlagsEnvToState = (config: IFeatureFlags, userId?: string) => {
   return {
     isAgentEditable: evaluateFeatureFlag(config.edit_agent, userId),
-    showProvider: evaluateFeatureFlag(config.provider_settings, userId),
 
     showOpenAIApiKey: evaluateFeatureFlag(config.openai_api_key, userId),
     showOpenAIProxyUrl: evaluateFeatureFlag(config.openai_proxy_url, userId),

--- a/src/store/serverConfig/selectors.test.ts
+++ b/src/store/serverConfig/selectors.test.ts
@@ -11,7 +11,6 @@ describe('featureFlagsSelectors', () => {
       featureFlags: {
         ...mapFeatureFlagsEnvToState(DEFAULT_FEATURE_FLAGS),
         isAgentEditable: false,
-        showProvider: true,
         showMarket: true,
         showAiImage: true,
       },
@@ -20,7 +19,6 @@ describe('featureFlagsSelectors', () => {
     const result = featureFlagsSelectors(store.getState());
 
     expect(result.isAgentEditable).toBe(false);
-    expect(result.showProvider).toBe(true);
     expect(result.showMarket).toBe(true);
     expect(result.showAiImage).toBe(true);
   });


### PR DESCRIPTION
### 🐛 Bug Description

The `provider_settings` feature flag and its mapped `showProvider` state are no longer consumed anywhere in the codebase since PR #10264. However, they remained in the schema and state mappings, creating dead code that could cause confusion.

This PR cleans up the technical debt by completely removing `provider_settings` and `showProvider` from the configuration schema and related tests.

### 📝 Additional Information

Fixes #12579

### ✅ Validations

- [x] Read the [docs](https://lobehub.com/zh/docs).
- [x] Check that there isn't [already an issue](https://github.com/lobehub/lobe-chat/issues) that reports the same bug to avoid creating a duplicate.
- [x] Make sure this is a LobeChat issue and not a third-party library or provider issue.
- [x] Check that this is a concrete bug. For Q&A, please use [GitHub Discussions](https://github.com/lobehub/lobe-chat/discussions) or join our [Discord Server](https://discord.gg/rGHwKq4R).