### PR TITLE
🐛 fix(context-engine): allow tool type recovery from manifest when models strip suffixes

### DIFF
--- a/packages/context-engine/src/engine/tools/ToolNameResolver.ts
+++ b/packages/context-engine/src/engine/tools/ToolNameResolver.ts
@@ -86,7 +86,7 @@ export class ToolNameResolver {
           id: toolCall.id,
           identifier,
           thoughtSignature: toolCall.thoughtSignature,
-          type: (type ?? 'default') as any,
+          type: (type ?? manifests[identifier]?.type ?? 'default') as any,
         };
 
         // Step 2: Resolve hashed apiName if needed

--- a/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/ToolNameResolver.test.ts
@@ -259,6 +259,32 @@ describe('ToolNameResolver', () => {
       expect(result[0].identifier).toBe('plugin1');
       expect(result[1].identifier).toBe('plugin2');
     });
+
+    it('should recover tool type from manifest if model strips the suffix (e.g. GLM-4)', () => {
+      const toolCalls = [
+        {
+          function: { arguments: '{}', name: 'lobe-notebook____createDocument' },
+          id: 'call_1',
+          type: 'function',
+        },
+      ];
+
+      const manifests = {
+        'lobe-notebook': {
+          api: [{ description: '', name: 'createDocument', parameters: {} }],
+          identifier: 'lobe-notebook',
+          meta: {},
+          type: 'builtin' as const,
+        },
+      };
+
+      const result = resolver.resolve(toolCalls, manifests);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].identifier).toBe('lobe-notebook');
+      expect(result[0].apiName).toBe('createDocument');
+      expect(result[0].type).toBe('builtin'); // Recovered from manifest!
+    });
   });
 
   describe('resolve - hashed apiName', () => {


### PR DESCRIPTION
### 🐛 Bug Description

Models from Zhipu AI (like GLM-4) incorrectly strip the tool type suffix (e.g., `____builtin` or `____standalone`) from the tool name when returning function calls. This violates the OpenAI specification and causes `ToolNameResolver` in `@lobechat/context-engine` to misidentify the tool type as `default`, breaking all builtin tools (Notebook, GTD, Web Browsing) for GLM users.

This PR adds a robust recovery mechanism to `ToolNameResolver.resolve()`. If the LLM strips the suffix and the parsed `type` is missing, it will now fallback to looking up the exact plugin's type from the injected `manifests` map (`manifests[identifier]?.type`). A regression test has been added to ensure models that strip suffixes are handled correctly.

### 📝 Additional Information

Fixes #12557

### ✅ Validations

- [x] Read the [docs](https://lobehub.com/zh/docs).
- [x] Check that there isn't [already an issue](https://github.com/lobehub/lobe-chat/issues) that reports the same bug to avoid creating a duplicate.
- [x] Make sure this is a LobeChat issue and not a third-party library or provider issue.
- [x] Check that this is a concrete bug. For Q&A, please use [GitHub Discussions](https://github.com/lobehub/lobe-chat/discussions) or join our [Discord Server](https://discord.gg/rGHwKq4R).