### PR TITLE
🐛 fix(memory): add 'experience' to memory types enum to prevent zod crash

### DIFF
--- a/packages/memory-user-memory/src/schemas/common.ts
+++ b/packages/memory-user-memory/src/schemas/common.ts
@@ -26,6 +26,7 @@ export const MEMORY_TYPES = [
   'context',
   'activity',
   'event',
+  'experience',
   'location',
   'people',
   'topic',

--- a/packages/types/src/userMemory/shared.ts
+++ b/packages/types/src/userMemory/shared.ts
@@ -58,6 +58,7 @@ export enum TypesEnum {
   Activity = 'activity',
   Context = 'context',
   Event = 'event',
+  Experience = 'experience',
   Fact = 'fact',
   Location = 'location',
   Other = 'other',


### PR DESCRIPTION
### 🐛 Bug Description

When models call the `toolAddExperienceMemory` tool, they actively pass `memoryType: "experience"`. However, `"experience"` was missing from the `TypesEnum` in `packages/types/src/userMemory/shared.ts`, causing a Zod `invalid_enum_value` validation crash during the tool payload parsing.

This PR adds `Experience = 'experience'` to `TypesEnum` and the `MEMORY_TYPES` array, aligning the schema with the actual tool inputs.

### 📝 Additional Information

Fixes #12608

### ✅ Validations

- [x] Read the [docs](https://lobehub.com/zh/docs).
- [x] Check that there isn't [already an issue](https://github.com/lobehub/lobe-chat/issues) that reports the same bug to avoid creating a duplicate.
- [x] Make sure this is a LobeChat issue and not a third-party library or provider issue.
- [x] Check that this is a concrete bug. For Q&A, please use [GitHub Discussions](https://github.com/lobehub/lobe-chat/discussions) or join our [Discord Server](https://discord.gg/rGHwKq4R).