### PR TITLE
🐛 fix: add await to handleResponseAPIMode to ensure proper error handling

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -367,7 +367,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             } as OpenAI.ChatCompletionCreateParamsStreaming);
 
         if ((postPayload as any).apiMode === 'responses') {
-          return this.handleResponseAPIMode(processedPayload, options);
+          return await this.handleResponseAPIMode(processedPayload, options);
         }
 
         const computedBaseURL =
@@ -452,7 +452,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           log('sending chat completion request with %d messages', messages.length);
 
           if (debugParams?.chatCompletion?.()) {
+            // eslint-disable-next-line no-console
             console.log('[requestPayload]');
+            // eslint-disable-next-line no-console
             console.log(JSON.stringify(finalPayload), '\n');
           }
 
@@ -564,7 +566,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       const log = debug(`${this.logPrefix}:models`);
       log('fetching available models');
 
-      let resultModels: ChatModelCard[] = [];
+      let resultModels: ChatModelCard[];
       if (typeof models === 'function') {
         log('using custom models function');
         resultModels = await models({ client: this.client });
@@ -957,7 +959,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       } as OpenAI.Responses.ResponseCreateParamsStreaming | OpenAI.Responses.ResponseCreateParams;
 
       if (debugParams?.responses?.()) {
+        // eslint-disable-next-line no-console
         console.log('[requestPayload]');
+        // eslint-disable-next-line no-console
         console.log(JSON.stringify(postPayload), '\n');
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

#### 🔀 Description of Change

In `openaiCompatibleFactory`, `handleResponseAPIMode` is called with `return` but without `await` inside a `try/catch` block. This causes async rejections from the Responses API path to bypass the `catch` block's `handleError()`, resulting in raw errors propagating to the route handler and defaulting to HTTP 500 instead of proper error codes (e.g., 471 for `ProviderBizError`).

The fix adds `await` so that promise rejections are properly caught and mapped through `handleError()`.

Also fixes pre-existing lint issues in the same file (`no-console`, `no-useless-assignment`).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed