### PR TITLE
🐛 fix: remove ChatInput store dependency from ModelSwitchPanel ControlsForm

### DIFF
--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -5,8 +5,6 @@ import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
-import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
@@ -38,8 +36,8 @@ interface ControlsFormProps {
 
 const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: providerProp }) => {
   const { t } = useTranslation('chat');
-  const agentId = useAgentId();
-  const { updateAgentChatConfig } = useUpdateAgentConfig();
+  const agentId = useAgentStore((s) => s.activeAgentId) || '';
+  const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
   const [agentModel, agentProvider] = useAgentStore((s) => [
     agentByIdSelectors.getAgentModelById(agentId)(s),
     agentByIdSelectors.getAgentModelProviderById(agentId)(s),
@@ -355,7 +353,7 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
           .filter(Boolean) as FormItemProps[]
       }
       onValuesChange={async (_, values) => {
-        await updateAgentChatConfig(values);
+        await updateAgentChatConfigById(agentId, values);
       }}
     />
   );

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select.tsx
@@ -1,8 +1,6 @@
 import { Select } from 'antd';
 import { memo, useMemo } from 'react';
 
-import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
-import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 
@@ -59,14 +57,14 @@ const ImageAspectRatio2SelectInner = memo<{
 // Store-connected component - uses agent store hooks
 const ImageAspectRatio2SelectWithStore = memo<{ defaultValue: AspectRatio2 }>(
   ({ defaultValue }) => {
-    const agentId = useAgentId();
-    const { updateAgentChatConfig } = useUpdateAgentConfig();
+    const agentId = useAgentStore((s) => s.activeAgentId) || '';
+    const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
     const config = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
 
     const storeValue = (config.imageAspectRatio2 as AspectRatio2) || defaultValue;
 
     const handleChange = (ratio: AspectRatio2) => {
-      updateAgentChatConfig({ imageAspectRatio2: ratio });
+      updateAgentChatConfigById(agentId, { imageAspectRatio2: ratio });
     };
 
     return <ImageAspectRatio2SelectInner value={storeValue} onChange={handleChange} />;

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatioSelect.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatioSelect.tsx
@@ -1,8 +1,6 @@
 import { Select } from 'antd';
 import { memo, useMemo } from 'react';
 
-import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
-import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 
@@ -54,14 +52,14 @@ const ImageAspectRatioSelectInner = memo<{
 
 // Store-connected component - uses agent store hooks
 const ImageAspectRatioSelectWithStore = memo<{ defaultValue: AspectRatio }>(({ defaultValue }) => {
-  const agentId = useAgentId();
-  const { updateAgentChatConfig } = useUpdateAgentConfig();
+  const agentId = useAgentStore((s) => s.activeAgentId) || '';
+  const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
   const config = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
 
   const storeValue = (config.imageAspectRatio as AspectRatio) || defaultValue;
 
   const handleChange = (ratio: AspectRatio) => {
-    updateAgentChatConfig({ imageAspectRatio: ratio });
+    updateAgentChatConfigById(agentId, { imageAspectRatio: ratio });
   };
 
   return <ImageAspectRatioSelectInner value={storeValue} onChange={handleChange} />;

--- a/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/createLevelSlider.tsx
@@ -5,8 +5,6 @@ import { type SliderSingleProps } from 'antd/es/slider';
 import { type CSSProperties } from 'react';
 import { memo } from 'react';
 
-import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
-import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 
@@ -67,14 +65,14 @@ export function createLevelSliderComponent<T extends string>(config: LevelSlider
 
   // Store-connected component - uses agent store hooks
   const LevelSliderWithStore = memo<{ defaultValue: T }>(({ defaultValue: dv }) => {
-    const agentId = useAgentId();
-    const { updateAgentChatConfig } = useUpdateAgentConfig();
+    const agentId = useAgentStore((s) => s.activeAgentId) || '';
+    const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
     const agentConfig = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
 
     const storeValue = (agentConfig[configKey] as T) || dv;
 
     const handleChange = (newValue: T) => {
-      updateAgentChatConfig({ [configKey]: newValue });
+      updateAgentChatConfigById(agentId, { [configKey]: newValue });
     };
 
     return <LevelSliderInner defaultValue={dv} value={storeValue} onChange={handleChange} />;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

#### 🔀 Description of Change

`ControlsForm` and its child components (`createLevelSlider`, `ImageAspectRatioSelect`, `ImageAspectRatio2Select`) used `useAgentId()` which internally calls `useChatInputStore()`. This requires a `ChatInputProvider` ancestor in the React tree.

However, `ModelSwitchPanel` renders its dropdown content via `DropdownMenuPortal` (React portal to `document.body`), which is completely outside the `ChatInputProvider` tree (only wraps `MainChatInput`). When scrolling the model list, hovering over models with `extendParams` triggers `ModelDetailPanel` → `ControlsForm` to mount, and `useChatInputStore()` throws:

```
Error: Seems like you have not used zustand provider as an ancestor.
```

**Fix:** Replace `useAgentId()` / `useUpdateAgentConfig()` (which depend on `ChatInputProvider`) with direct `activeAgentId` access from the global agent store. Since `ModelSwitchPanel` always operates on the active agent, this is the correct behavior.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open any agent chat page
2. Click the model ID tag in the header
3. Scroll the model dropdown list
4. Verify no crash occurs