### PR TITLE
🐛fix: update search settings for models

### DIFF
--- a/packages/database/src/repositories/aiInfra/index.test.ts
+++ b/packages/database/src/repositories/aiInfra/index.test.ts
@@ -874,6 +874,32 @@ describe('AiInfraRepos', () => {
       // 无 settings
       expect(merged?.settings).toBeUndefined();
     });
+
+    it('should inject default settings for a builtin model with search enabled but no settings, when no user model exists', async () => {
+      const mockProviders = [
+        { enabled: true, id: 'qwen', name: 'Qwen', source: 'builtin' as const },
+      ];
+
+      // 后端内置模型：开启了 search，但没有 settings 字段
+      const builtinModel = {
+        id: 'qwen-plus',
+        enabled: true,
+        type: 'chat' as const,
+        abilities: { search: true },
+      };
+
+      vi.spyOn(repo.aiModelModel, 'getAllModels').mockResolvedValue([]);
+      vi.spyOn(repo, 'getAiProviderList').mockResolvedValue(mockProviders);
+      vi.spyOn(repo as any, 'fetchBuiltinModels').mockResolvedValue([builtinModel]);
+
+      const result = await repo.getEnabledModels();
+
+      const model = result.find((m) => m.id === 'qwen-plus');
+      expect(model).toBeDefined();
+      expect(model?.abilities?.search).toBe(true);
+
+      expect(model?.settings).toEqual({ searchImpl: 'params' });
+    });
   });
 
   describe('getAiProviderModelList', () => {

--- a/packages/database/src/repositories/aiInfra/index.test.ts
+++ b/packages/database/src/repositories/aiInfra/index.test.ts
@@ -874,32 +874,6 @@ describe('AiInfraRepos', () => {
       // 无 settings
       expect(merged?.settings).toBeUndefined();
     });
-
-    it('should inject default settings for a builtin model with search enabled but no settings, when no user model exists', async () => {
-      const mockProviders = [
-        { enabled: true, id: 'qwen', name: 'Qwen', source: 'builtin' as const },
-      ];
-
-      // 后端内置模型：开启了 search，但没有 settings 字段
-      const builtinModel = {
-        id: 'qwen-plus',
-        enabled: true,
-        type: 'chat' as const,
-        abilities: { search: true },
-      };
-
-      vi.spyOn(repo.aiModelModel, 'getAllModels').mockResolvedValue([]);
-      vi.spyOn(repo, 'getAiProviderList').mockResolvedValue(mockProviders);
-      vi.spyOn(repo as any, 'fetchBuiltinModels').mockResolvedValue([builtinModel]);
-
-      const result = await repo.getEnabledModels();
-
-      const model = result.find((m) => m.id === 'qwen-plus');
-      expect(model).toBeDefined();
-      expect(model?.abilities?.search).toBe(true);
-
-      expect(model?.settings).toEqual({ searchImpl: 'params' });
-    });
   });
 
   describe('getAiProviderModelList', () => {

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -44,6 +44,7 @@ const PROVIDER_SEARCH_DEFAULTS: Record<
   // perplexity: defaults to internal
   perplexity: { searchImpl: 'internal' },
   qwen: { searchImpl: 'params' },
+  search1api: { searchImpl: 'internal' },
   spark: { searchImpl: 'params' }, // Some models (like max-32k) will prioritize built-in if marked as internal
   stepfun: { searchImpl: 'params' },
   vertexai: { searchImpl: 'params', searchProvider: 'google' },

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -206,32 +206,32 @@ export class AiInfraRepos {
             const user = allModels.find((m) => m.id === item.id && m.providerId === provider.id);
 
             // User hasn't modified local model
-            const baseModel = !user
-              ? {
-                  ...item,
-                  abilities: item.abilities || {},
-                  providerId: provider.id,
-                }
-              : {
-                  ...item,
-                  abilities: !isEmpty(user.abilities) ? user.abilities : item.abilities || {},
-                  config: !isEmpty(user.config) ? user.config : item.config,
-                  contextWindowTokens:
-                    typeof user.contextWindowTokens === 'number'
-                      ? user.contextWindowTokens
-                      : item.contextWindowTokens,
-                  displayName: user?.displayName || item.displayName,
-                  enabled: typeof user.enabled === 'boolean' ? user.enabled : item.enabled,
-                  id: item.id,
-                  providerId: provider.id,
-                  settings: isEmpty(user.settings)
-                    ? item.settings
-                    : merge(item.settings || {}, user.settings || {}),
-                sort: user.sort || undefined,
-                  type: user.type || item.type,
-                };
+            if (!user)
+              return {
+                ...item,
+                abilities: item.abilities || {},
+                providerId: provider.id,
+              };
 
-            return injectSearchSettings(provider.id, baseModel); // Always check and inject search settings for the final model object
+            const mergedModel = {
+              ...item,
+              abilities: !isEmpty(user.abilities) ? user.abilities : item.abilities || {},
+              config: !isEmpty(user.config) ? user.config : item.config,
+              contextWindowTokens:
+                typeof user.contextWindowTokens === 'number'
+                  ? user.contextWindowTokens
+                  : item.contextWindowTokens,
+              displayName: user?.displayName || item.displayName,
+              enabled: typeof user.enabled === 'boolean' ? user.enabled : item.enabled,
+              id: item.id,
+              providerId: provider.id,
+              settings: isEmpty(user.settings)
+                ? item.settings
+                : merge(item.settings || {}, user.settings || {}),
+              sort: user.sort || undefined,
+              type: user.type || item.type,
+            };
+            return injectSearchSettings(provider.id, mergedModel); // User modified local model, check search settings
           })
           .filter((item) => (filterEnabled ? item.enabled : true));
       },

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -205,32 +205,32 @@ export class AiInfraRepos {
             const user = allModels.find((m) => m.id === item.id && m.providerId === provider.id);
 
             // User hasn't modified local model
-            if (!user)
-              return {
-                ...item,
-                abilities: item.abilities || {},
-                providerId: provider.id,
-              };
+            const baseModel = !user
+              ? {
+                  ...item,
+                  abilities: item.abilities || {},
+                  providerId: provider.id,
+                }
+              : {
+                  ...item,
+                  abilities: !isEmpty(user.abilities) ? user.abilities : item.abilities || {},
+                  config: !isEmpty(user.config) ? user.config : item.config,
+                  contextWindowTokens:
+                    typeof user.contextWindowTokens === 'number'
+                      ? user.contextWindowTokens
+                      : item.contextWindowTokens,
+                  displayName: user?.displayName || item.displayName,
+                  enabled: typeof user.enabled === 'boolean' ? user.enabled : item.enabled,
+                  id: item.id,
+                  providerId: provider.id,
+                  settings: isEmpty(user.settings)
+                    ? item.settings
+                    : merge(item.settings || {}, user.settings || {}),
+                sort: user.sort || undefined,
+                  type: user.type || item.type,
+                };
 
-            const mergedModel = {
-              ...item,
-              abilities: !isEmpty(user.abilities) ? user.abilities : item.abilities || {},
-              config: !isEmpty(user.config) ? user.config : item.config,
-              contextWindowTokens:
-                typeof user.contextWindowTokens === 'number'
-                  ? user.contextWindowTokens
-                  : item.contextWindowTokens,
-              displayName: user?.displayName || item.displayName,
-              enabled: typeof user.enabled === 'boolean' ? user.enabled : item.enabled,
-              id: item.id,
-              providerId: provider.id,
-              settings: isEmpty(user.settings)
-                ? item.settings
-                : merge(item.settings || {}, user.settings || {}),
-              sort: user.sort || undefined,
-              type: user.type || item.type,
-            };
-            return injectSearchSettings(provider.id, mergedModel); // User modified local model, check search settings
+            return injectSearchSettings(provider.id, baseModel); // Always check and inject search settings for the final model object
           })
           .filter((item) => (filterEnabled ? item.enabled : true));
       },

--- a/packages/model-bank/src/aiModels/qiniu.ts
+++ b/packages/model-bank/src/aiModels/qiniu.ts
@@ -106,6 +106,7 @@ const qiniuChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
     },
     contextWindowTokens: 131_072,
     description:

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -222,7 +222,8 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -246,7 +247,8 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     settings: {
-      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -2601,6 +2603,9 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-05-28',
+    settings: {
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {
@@ -2623,6 +2628,9 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-01-27',
+    settings: {
+      searchImpl: 'params',
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -222,7 +222,7 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     settings: {
-      extendParams: ['enableReasoning'],
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
       searchImpl: 'params',
     },
     type: 'chat',
@@ -247,7 +247,7 @@ const qwenChatModels: AIChatModelCard[] = [
       ],
     },
     settings: {
-      extendParams: ['enableReasoning'],
+      extendParams: ['enableReasoning', 'reasoningBudgetToken'],
       searchImpl: 'params',
     },
     type: 'chat',
@@ -2604,6 +2604,7 @@ const qwenChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2025-05-28',
     settings: {
+      extendParams: ['reasoningBudgetToken'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/search1api.ts
+++ b/packages/model-bank/src/aiModels/search1api.ts
@@ -13,6 +13,9 @@ const search1apiChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'deepseek-r1-70b-online',
     maxOutput: 16_384,
+    settings: {
+      searchImpl: 'internal',
+    },
     type: 'chat',
   },
   {
@@ -27,6 +30,9 @@ const search1apiChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'deepseek-r1-online',
     maxOutput: 8192,
+    settings: {
+      searchImpl: 'internal',
+    },
     type: 'chat',
   },
   {
@@ -41,6 +47,9 @@ const search1apiChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'deepseek-r1-70b-fast-online',
     maxOutput: 16_384,
+    settings: {
+      searchImpl: 'internal',
+    },
     type: 'chat',
   },
   {
@@ -55,6 +64,9 @@ const search1apiChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'deepseek-r1-fast-online',
     maxOutput: 16_384,
+    settings: {
+      searchImpl: 'internal',
+    },
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/zenmux.ts
+++ b/packages/model-bank/src/aiModels/zenmux.ts
@@ -111,6 +111,7 @@ const zenmuxChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 1_050_000,

--- a/packages/model-runtime/src/providers/qwen/index.ts
+++ b/packages/model-runtime/src/providers/qwen/index.ts
@@ -45,7 +45,7 @@ export const LobeQwenAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        ...(model.includes('-thinking')
+        ...(['-thinking', 'deepseek-r1'].some((keyword) => model.toLowerCase().includes(keyword))
           ? {
               enable_thinking: true,
               thinking_budget:


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

历史pr #10683

修正一些模型的参数
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Align search configuration and reasoning enablement across search1api, Qwen, Qiniu, and Zenmux chat models.

New Features:
- Expose search capability for selected Qiniu and Zenmux chat models.

Bug Fixes:
- Ensure search1api and Qwen models consistently use the correct search implementation strategy.
- Automatically enable Qwen-style thinking parameters for DeepSeek R1 models via the provider runtime.
- Add provider-level default search settings for the search1api provider.