### PR TITLE
🐛 fix: allow user-edited systemRole to take effect for inbox agent

### DIFF
--- a/src/services/chat/mecha/agentConfigResolver.test.ts
+++ b/src/services/chat/mecha/agentConfigResolver.test.ts
@@ -470,6 +470,64 @@ describe('resolveAgentConfig', () => {
         expect(result.plugins).toContain('user-plugin');
       });
 
+      it('should use user-edited systemRole over builtin template', () => {
+        const userSystemRole = 'You are a translation assistant';
+        vi.spyOn(agentSelectors.agentSelectors, 'getAgentConfigById').mockReturnValue(
+          () =>
+            ({
+              ...mockAgentConfig,
+              systemRole: userSystemRole,
+            }) as any,
+        );
+
+        vi.spyOn(builtinAgents, 'getAgentRuntimeConfig').mockReturnValue({
+          plugins: [],
+          systemRole: 'Inbox builtin system role template',
+        });
+
+        const result = resolveAgentConfig({ agentId: 'inbox-agent' });
+
+        expect(result.agentConfig.systemRole).toBe(userSystemRole);
+      });
+
+      it('should fallback to builtin template when user systemRole is empty', () => {
+        vi.spyOn(agentSelectors.agentSelectors, 'getAgentConfigById').mockReturnValue(
+          () =>
+            ({
+              ...mockAgentConfig,
+              systemRole: '',
+            }) as any,
+        );
+
+        vi.spyOn(builtinAgents, 'getAgentRuntimeConfig').mockReturnValue({
+          plugins: [],
+          systemRole: 'Inbox builtin system role template',
+        });
+
+        const result = resolveAgentConfig({ agentId: 'inbox-agent' });
+
+        expect(result.agentConfig.systemRole).toBe('Inbox builtin system role template');
+      });
+
+      it('should fallback to builtin template when user systemRole is undefined', () => {
+        vi.spyOn(agentSelectors.agentSelectors, 'getAgentConfigById').mockReturnValue(
+          () =>
+            ({
+              ...mockAgentConfig,
+              systemRole: undefined,
+            }) as any,
+        );
+
+        vi.spyOn(builtinAgents, 'getAgentRuntimeConfig').mockReturnValue({
+          plugins: [],
+          systemRole: 'Inbox builtin system role template',
+        });
+
+        const result = resolveAgentConfig({ agentId: 'inbox-agent' });
+
+        expect(result.agentConfig.systemRole).toBe('Inbox builtin system role template');
+      });
+
       it('should use basePlugins from agentConfig when ctx.plugins is not provided', () => {
         // This test verifies the fix for the issue where INBOX agent lost user-configured plugins
         // when resolveAgentConfig was called without the plugins parameter.

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -186,10 +186,10 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       ctx.groupId,
       group
         ? {
-          groupId: group.id,
-          supervisorAgentId: group.supervisorAgentId,
-          title: group.title,
-        }
+            groupId: group.id,
+            supervisorAgentId: group.supervisorAgentId,
+            title: group.title,
+          }
         : null,
       agentId,
     );
@@ -292,11 +292,11 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       ctx.groupId,
       group
         ? {
-          agentsCount: group.agents?.length,
-          groupId: group.id,
-          supervisorAgentId: group.supervisorAgentId,
-          title: group.title,
-        }
+            agentsCount: group.agents?.length,
+            groupId: group.id,
+            supervisorAgentId: group.supervisorAgentId,
+            title: group.title,
+          }
         : null,
     );
 
@@ -337,7 +337,13 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
   });
 
   // Merge runtime systemRole into agent config
-  let resolvedSystemRole = runtimeConfig?.systemRole ?? agentConfig.systemRole;
+  // For inbox agent: user-edited systemRole takes priority, builtin template as fallback
+  // For other builtin agents (group-supervisor, agent-builder, etc.): runtime systemRole is
+  // the core instruction and should not be overridden by user profile systemRole
+  let resolvedSystemRole =
+    slug === BUILTIN_AGENT_SLUGS.inbox
+      ? agentConfig.systemRole || runtimeConfig?.systemRole || ''
+      : (runtimeConfig?.systemRole ?? agentConfig.systemRole);
 
   // Merge plugins: runtime plugins take priority, fallback to base plugins
   let finalPlugins =


### PR DESCRIPTION
The inbox agent's systemRole was always overridden by the hardcoded builtin template via `runtimeConfig?.systemRole ?? agentConfig.systemRole`, making user edits in the agent profile have no effect.

Now for inbox agent, user-edited systemRole takes priority. When the user clears it (empty string), it falls back to the builtin template as default. Other builtin agents (group-supervisor, agent-builder, etc.) are unaffected.

#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

In `src/services/chat/mecha/agentConfigResolver.ts`, the systemRole merge logic for builtin agents was:

```typescript
let resolvedSystemRole = runtimeConfig?.systemRole ?? agentConfig.systemRole;
```

Since `runtimeConfig.systemRole` for inbox always returns a non-empty hardcoded template from `packages/builtin-agents/src/agents/inbox/systemRole.ts`, the `??` operator never falls through to `agentConfig.systemRole` (the user-edited value from the database).

**Fix**: For inbox agent only, reverse the priority using `||`:

```typescript
let resolvedSystemRole =
  slug === BUILTIN_AGENT_SLUGS.inbox
    ? agentConfig.systemRole || runtimeConfig?.systemRole || ''
    : (runtimeConfig?.systemRole ?? agentConfig.systemRole);
```

- **User set a custom systemRole** → use the user's value
- **User cleared systemRole (empty string)** → fall back to the builtin template

Other builtin agents retain the original `??` behavior since their runtime systemRole is the core instruction (e.g., group-supervisor embeds user systemRole as context within its template).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

1. Open the inbox agent (Lobe AI) profile settings
2. Edit the system prompt and save
3. Send a message — the custom system prompt should now take effect
4. Clear the system prompt — it should fall back to the default builtin template

3 new test cases added covering user-edited priority, empty fallback, and undefined fallback. All 64 tests pass.

#### 📝 Additional Information

No breaking changes. Only the inbox agent behavior is affected; all other builtin agents (group-supervisor, agent-builder, page-agent) retain their existing systemRole merge logic.

## Summary by Sourcery

Adjust system role resolution for the inbox agent so user-configured prompts correctly override the builtin template while preserving existing behavior for other builtin agents.

Bug Fixes:
- Ensure the inbox agent uses the user-edited systemRole when set, falling back to the builtin template only when the user value is empty or undefined.

Tests:
- Add unit tests covering inbox agent systemRole precedence and fallback behavior to the builtin template.