### PR TITLE
🐛 fix(chat): fallback malformed default tool calls to builtin executors

### DIFF
--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -258,6 +258,68 @@ describe('ChatPluginAction', () => {
     });
   });
 
+  describe('internal_invokeDifferentTypePlugin', () => {
+    it('should route default type to builtin executor when builtin executor exists', async () => {
+      const messageId = 'message-id';
+      const payload: ChatToolPayload = {
+        apiName: 'crawlSinglePage',
+        arguments: '{"url":"https://example.com"}',
+        id: 'tool-call-id',
+        identifier: 'lobe-web-browsing',
+        type: 'default',
+      };
+
+      const invokeBuiltinTool = vi.fn().mockResolvedValue(undefined);
+      const invokeDefaultTypePlugin = vi.fn().mockResolvedValue(undefined);
+
+      act(() => {
+        useChatStore.setState({
+          invokeBuiltinTool,
+          invokeDefaultTypePlugin,
+        });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        await result.current.internal_invokeDifferentTypePlugin(messageId, payload);
+      });
+
+      expect(invokeBuiltinTool).toHaveBeenCalledWith(messageId, payload, undefined);
+      expect(invokeDefaultTypePlugin).not.toHaveBeenCalled();
+    });
+
+    it('should keep default routing for non-builtin tools', async () => {
+      const messageId = 'message-id';
+      const payload: ChatToolPayload = {
+        apiName: 'query',
+        arguments: '{}',
+        id: 'tool-call-id',
+        identifier: 'unknown-plugin',
+        type: 'default',
+      };
+
+      const invokeBuiltinTool = vi.fn().mockResolvedValue(undefined);
+      const invokeDefaultTypePlugin = vi.fn().mockResolvedValue(undefined);
+
+      act(() => {
+        useChatStore.setState({
+          invokeBuiltinTool,
+          invokeDefaultTypePlugin,
+        });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        await result.current.internal_invokeDifferentTypePlugin(messageId, payload);
+      });
+
+      expect(invokeBuiltinTool).not.toHaveBeenCalled();
+      expect(invokeDefaultTypePlugin).toHaveBeenCalledWith(messageId, payload);
+    });
+  });
+
   describe('updatePluginState', () => {
     it('should update the plugin state for a message', async () => {
       const messageId = 'message-id';

--- a/src/store/chat/slices/plugin/actions/publicApi.ts
+++ b/src/store/chat/slices/plugin/actions/publicApi.ts
@@ -2,6 +2,7 @@ import { type ChatToolPayload, type RuntimeStepContext, type UIChatMessage } fro
 import i18n from 'i18next';
 
 import { type ChatStore } from '@/store/chat/store';
+import { hasExecutor } from '@/store/tool/slices/builtin/executors';
 import { type StoreSetter } from '@/store/types';
 
 import { type OptimisticUpdateContext } from '../../message/actions/optimisticUpdate';
@@ -91,6 +92,14 @@ export class PluginPublicApiActionImpl {
     payload: ChatToolPayload,
     stepContext?: RuntimeStepContext,
   ): Promise<any> => {
+    // Compatibility fallback:
+    // Some providers may return function names without the `____builtin` suffix,
+    // which gets parsed as type=default. If the identifier/apiName pair matches a
+    // registered builtin executor, route it as builtin to avoid plugin-gateway 404.
+    if (payload.type === 'default' && hasExecutor(payload.identifier, payload.apiName)) {
+      return await this.#get().invokeBuiltinTool(id, payload, stepContext);
+    }
+
     switch (payload.type) {
       case 'standalone': {
         return await this.#get().invokeStandaloneTypePlugin(id, payload);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #12655

#### 🔀 Description of Change

This PR adds a minimal compatibility fallback for malformed tool-call types:

- In `internal_invokeDifferentTypePlugin`, when `payload.type === 'default'`, we now check whether `identifier/apiName` matches a registered builtin executor.
- If matched, route to `invokeBuiltinTool` instead of plugin gateway.

Why:
- Some model outputs occasionally miss the `____builtin` suffix in function names.
- The current parser then falls back to `type=default`, which misroutes builtin calls to `/webapi/plugin/gateway` and causes `PluginMetaNotFound` 404 errors.

Scope:
- Only affects `type=default` calls that can be confidently identified as builtin via executor registry.
- Non-builtin `default` calls keep existing behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added tests in `src/store/chat/slices/plugin/action.test.ts`:
1. `type=default` + builtin identifier/apiName -> routes to `invokeBuiltinTool`
2. `type=default` + non-builtin identifier -> keeps `invokeDefaultTypePlugin` route

Local verification:
- `bunx vitest run --silent='passed-only' 'src/store/chat/slices/plugin/action.test.ts'`
- `bun run type-check`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Builtin tool call may be misrouted to plugin gateway and fail with `PluginMetaNotFound` | Builtin tool call is routed to builtin executor even when parsed type falls back to `default` |

#### 📝 Additional Information

This is intentionally a small, targeted fix to reduce risk and avoid changing tool-name parsing behavior globally.

## Summary by Sourcery

Ensure chat tool invocations with malformed builtin tool-call types are correctly routed to builtin executors instead of plugin gateway when possible.

Bug Fixes:
- Route default-typed tool calls to builtin executors when their identifier and apiName match a registered builtin tool, preventing plugin gateway 404 errors for builtin tools.

Tests:
- Add unit tests covering routing of default-typed tool calls to builtin executors when available and preserving default routing for non-builtin tools.