### PR TITLE
🐛 fix: preserve structured errors in agent runtime stream path

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -9,7 +9,14 @@ import {
 import { ToolNameResolver } from '@lobechat/context-engine';
 import { parse } from '@lobechat/conversation-flow';
 import { consumeStreamUntilDone } from '@lobechat/model-runtime';
-import { type ChatToolPayload, type MessageToolCall, type UIChatMessage } from '@lobechat/types';
+import {
+  AgentRuntimeErrorType,
+  ChatErrorType,
+  type ChatMessageError,
+  type ChatToolPayload,
+  type MessageToolCall,
+  type UIChatMessage,
+} from '@lobechat/types';
 import { serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
 
@@ -29,6 +36,56 @@ const timing = debug('lobe-server:agent-runtime:timing');
 const TOOL_PRICING: Record<string, number> = {
   'lobe-web-browsing/craw': 0,
   'lobe-web-browsing/search': 0,
+};
+
+const formatRuntimeError = (error: unknown): ChatMessageError => {
+  // Handle ChatCompletionErrorPayload format
+  // e.g., { errorType: 'InvalidProviderAPIKey', error: { ... }, provider: 'openai' }
+  if (error && typeof error === 'object' && 'errorType' in error) {
+    const payload = error as {
+      error?: unknown;
+      errorType: ChatMessageError['type'];
+      message?: string;
+    };
+
+    return {
+      body: payload.error || error,
+      message: payload.message || String(payload.errorType),
+      type: payload.errorType,
+    };
+  }
+
+  // Handle ChatMessageError format
+  // e.g., { type: 'ProviderBizError', message: '...', body: {...} }
+  if (error && typeof error === 'object' && 'type' in error && 'message' in error) {
+    const payload = error as {
+      body?: unknown;
+      message: string;
+      type: ChatMessageError['type'];
+    };
+
+    return {
+      body: payload.body,
+      message: payload.message,
+      type: payload.type,
+    };
+  }
+
+  // Handle standard Error objects
+  if (error instanceof Error) {
+    return {
+      body: { name: error.name },
+      message: error.message,
+      type: ChatErrorType.InternalServerError,
+    };
+  }
+
+  // Fallback for unknown error types
+  return {
+    body: error,
+    message: String(error),
+    type: AgentRuntimeErrorType.AgentRuntimeError,
+  };
 };
 
 export interface RuntimeExecutorContext {
@@ -519,10 +576,14 @@ export const createRuntimeExecutors = (
         },
       };
     } catch (error) {
-      // Publish error event
+      const formattedError = formatRuntimeError(error);
+
+      // Publish structured error event
       await streamManager.publishStreamEvent(operationId, {
         data: {
-          error: (error as Error).message,
+          error: formattedError,
+          errorType: formattedError.type,
+          message: formattedError.message,
           phase: 'llm_execution',
         },
         stepIndex,

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -56,17 +56,24 @@ const formatRuntimeError = (error: unknown): ChatMessageError => {
   }
 
   // Handle ChatMessageError format
-  // e.g., { type: 'ProviderBizError', message: '...', body: {...} }
-  if (error && typeof error === 'object' && 'type' in error && 'message' in error) {
+  // e.g., { type: 'ProviderBizError', message?: '...', body?: {...} }
+  if (error && typeof error === 'object' && 'type' in error) {
     const payload = error as {
       body?: unknown;
-      message: string;
+      message?: string;
       type: ChatMessageError['type'];
     };
 
+    const body = payload.body ?? error;
+    const bodyMessage =
+      body && typeof body === 'object' && 'message' in body
+        ? (body as { message?: unknown }).message
+        : undefined;
+
     return {
-      body: payload.body,
-      message: payload.message,
+      body,
+      message:
+        payload.message ?? (typeof bodyMessage === 'string' ? bodyMessage : String(payload.type)),
       type: payload.type,
     };
   }

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -367,13 +367,10 @@ export const createRuntimeExecutors = (
       // Consume stream to ensure all callbacks complete execution
       await consumeStreamUntilDone(response);
 
-      // If a stream error was captured via onError callback, throw to propagate the error
+      // If a stream error was captured via onError callback, throw original payload
+      // to preserve structured fields (type/errorType/body/provider) for downstream handling.
       if (streamError) {
-        const errorMessage =
-          typeof streamError.message === 'string'
-            ? streamError.message
-            : JSON.stringify(streamError);
-        throw new Error(`LLM stream error: ${errorMessage}`);
+        throw streamError;
       }
 
       await flushTextBuffer();

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1972,7 +1972,13 @@ describe('RuntimeExecutors', () => {
         expect.objectContaining({
           type: 'error',
           data: expect.objectContaining({
-            error: '401 Unauthorized',
+            error: expect.objectContaining({
+              body: expect.objectContaining({ name: 'Error' }),
+              message: '401 Unauthorized',
+              type: 500,
+            }),
+            errorType: 500,
+            message: '401 Unauthorized',
             phase: 'llm_execution',
           }),
         }),

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1930,7 +1930,11 @@ describe('RuntimeExecutors', () => {
         type: 'call_llm' as const,
       };
 
-      await expect(executors.call_llm!(instruction, state)).rejects.toThrow(/LLM stream error/);
+      await expect(executors.call_llm!(instruction, state)).rejects.toMatchObject({
+        body: { message: 'rate limit exceeded' },
+        message: 'rate limit exceeded',
+        type: 'ProviderBizError',
+      });
 
       // Error event should be published to stream manager
       expect(mockStreamManager.publishStreamEvent).toHaveBeenCalledWith(

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1945,6 +1945,65 @@ describe('RuntimeExecutors', () => {
       );
     });
 
+    it('should preserve type-only ChatMessageError payload for llm_execution events', async () => {
+      const { consumeStreamUntilDone: realConsume } =
+        await import('../../../../../packages/model-runtime/src/utils/consumeStream');
+      const { createCallbacksTransformer } =
+        await import('../../../../../packages/model-runtime/src/core/streams/protocol');
+
+      vi.mocked(consumeStreamUntilDone).mockImplementation(realConsume);
+
+      const errorPayload = {
+        body: { message: 'chunk parse failed' },
+        type: 'StreamChunkError',
+      };
+
+      const mockChat = vi.fn().mockImplementation(async (_payload: any, options: any) => {
+        const callbacks = options?.callback;
+        const sseLines = ['event: error\n', `data: ${JSON.stringify(errorPayload)}\n\n`];
+        const source = new ReadableStream<string>({
+          start(controller) {
+            for (const line of sseLines) controller.enqueue(line);
+            controller.close();
+          },
+        });
+        return new Response(source.pipeThrough(createCallbacksTransformer(callbacks)));
+      });
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue({ chat: mockChat } as any);
+
+      const executors = createRuntimeExecutors(ctx);
+      const state = createMockState();
+      const instruction = {
+        payload: {
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'gpt-4',
+          parentMessageId: 'parent-msg-123',
+          provider: 'openai',
+          tools: [],
+        },
+        type: 'call_llm' as const,
+      };
+
+      await expect(executors.call_llm!(instruction, state)).rejects.toEqual(errorPayload);
+
+      expect(mockStreamManager.publishStreamEvent).toHaveBeenCalledWith(
+        'op-123',
+        expect.objectContaining({
+          type: 'error',
+          data: expect.objectContaining({
+            error: expect.objectContaining({
+              body: expect.objectContaining({ message: 'chunk parse failed' }),
+              message: 'chunk parse failed',
+              type: 'StreamChunkError',
+            }),
+            errorType: 'StreamChunkError',
+            message: 'chunk parse failed',
+            phase: 'llm_execution',
+          }),
+        }),
+      );
+    });
+
     it('should throw and not produce llm_result when modelRuntime.chat rejects', async () => {
       // When chat() throws (pre-stream error like auth failure), it SHOULD propagate
       const mockChat = vi.fn().mockRejectedValue(new Error('401 Unauthorized'));

--- a/src/server/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.test.ts
@@ -495,6 +495,49 @@ describe('AgentRuntimeService', () => {
       );
     });
 
+    it('should preserve type-only ChatMessageError in step_execution error handling', async () => {
+      const llmError = {
+        body: { message: 'chunk parse failed' },
+        type: 'StreamChunkError',
+      };
+      const mockRuntime = { step: vi.fn().mockRejectedValue(llmError) };
+      vi.spyOn(service as any, 'createAgentRuntime').mockReturnValue({ runtime: mockRuntime });
+
+      await expect(service.executeStep(mockParams)).rejects.toEqual(llmError);
+
+      expect(mockStreamManager.publishStreamEvent).toHaveBeenCalledWith('test-operation-1', {
+        type: 'error',
+        stepIndex: 1,
+        data: {
+          stepIndex: 1,
+          phase: 'step_execution',
+          message: 'chunk parse failed',
+          errorType: 'StreamChunkError',
+          error: {
+            body: {
+              message: 'chunk parse failed',
+            },
+            message: 'chunk parse failed',
+            type: 'StreamChunkError',
+          },
+        },
+      });
+
+      expect(mockCoordinator.saveAgentState).toHaveBeenCalledWith(
+        'test-operation-1',
+        expect.objectContaining({
+          error: expect.objectContaining({
+            body: {
+              message: 'chunk parse failed',
+            },
+            message: 'chunk parse failed',
+            type: 'StreamChunkError',
+          }),
+          status: 'error',
+        }),
+      );
+    });
+
     it('should save error state to coordinator for later retrieval (inMemory mode fix)', async () => {
       const error = new Error('Test error for inMemory mode');
       const mockRuntime = { step: vi.fn().mockRejectedValue(error) };

--- a/src/server/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.test.ts
@@ -418,7 +418,15 @@ describe('AgentRuntimeService', () => {
         data: {
           stepIndex: 1,
           phase: 'step_execution',
-          error: 'Runtime error',
+          message: 'Runtime error',
+          errorType: 500,
+          error: {
+            body: {
+              name: 'Error',
+            },
+            message: 'Runtime error',
+            type: 500,
+          },
         },
       });
     });

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -62,17 +62,24 @@ function formatErrorForState(error: unknown): ChatMessageError {
   }
 
   // Handle ChatMessageError format
-  // e.g., { type: 'ProviderBizError', message: '...', body: {...} }
-  if (error && typeof error === 'object' && 'type' in error && 'message' in error) {
+  // e.g., { type: 'ProviderBizError', message?: '...', body?: {...} }
+  if (error && typeof error === 'object' && 'type' in error) {
     const payload = error as {
       body?: unknown;
-      message: string;
+      message?: string;
       type: ChatMessageError['type'];
     };
 
+    const body = payload.body ?? error;
+    const bodyMessage =
+      body && typeof body === 'object' && 'message' in body
+        ? (body as { message?: unknown }).message
+        : undefined;
+
     return {
-      body: payload.body,
-      message: payload.message,
+      body,
+      message:
+        payload.message ?? (typeof bodyMessage === 'string' ? bodyMessage : String(payload.type)),
       type: payload.type,
     };
   }

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -61,6 +61,22 @@ function formatErrorForState(error: unknown): ChatMessageError {
     };
   }
 
+  // Handle ChatMessageError format
+  // e.g., { type: 'ProviderBizError', message: '...', body: {...} }
+  if (error && typeof error === 'object' && 'type' in error && 'message' in error) {
+    const payload = error as {
+      body?: unknown;
+      message: string;
+      type: ChatMessageError['type'];
+    };
+
+    return {
+      body: payload.body,
+      message: payload.message,
+      type: payload.type,
+    };
+  }
+
   // Handle standard Error objects
   if (error instanceof Error) {
     return {
@@ -882,10 +898,14 @@ export class AgentRuntimeService {
     } catch (error) {
       log('Step %d failed for operation %s: %O', stepIndex, operationId, error);
 
-      // Publish error event
+      const formattedError = formatErrorForState(error);
+
+      // Publish structured error event
       await this.streamManager.publishStreamEvent(operationId, {
         data: {
-          error: (error as Error).message,
+          error: formattedError,
+          errorType: formattedError.type,
+          message: formattedError.message,
           phase: 'step_execution',
           stepIndex,
         },
@@ -897,7 +917,7 @@ export class AgentRuntimeService {
       const errorState = await this.coordinator.loadAgentState(operationId);
       const finalStateWithError = {
         ...errorState!,
-        error: formatErrorForState(error),
+        error: formattedError,
         status: 'error' as const,
       };
 

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -1,5 +1,5 @@
 import { isDesktop } from '@lobechat/const';
-import { type ChatToolPayload } from '@lobechat/types';
+import { type ChatMessageError, type ChatToolPayload } from '@lobechat/types';
 import debug from 'debug';
 import i18n from 'i18next';
 
@@ -48,14 +48,28 @@ export class AgentActionImpl {
     this.#get().cancelOperation(messageOpId, 'Cleanup requested');
   };
 
-  internal_handleAgentError = (assistantId: string, errorMessage: string): void => {
+  internal_handleAgentError = (
+    assistantId: string,
+    errorMessage: string,
+    error?: ChatMessageError,
+  ): void => {
     log(`Agent error for ${assistantId}: ${errorMessage}`);
+
+    const normalizedError: ChatMessageError = error
+      ? {
+          ...error,
+          message: error.message || errorMessage,
+        }
+      : ({
+          message: errorMessage,
+          type: 'UnknownError' as any,
+        } as ChatMessageError);
 
     // Find operation by messageId (assistantId) and fail it
     const messageOpId = this.#get().messageOperationMap[assistantId];
     if (messageOpId) {
       this.#get().failOperation(messageOpId, {
-        message: errorMessage,
+        message: normalizedError.message || errorMessage,
         type: 'AgentExecutionError',
       });
     }
@@ -65,10 +79,7 @@ export class AgentActionImpl {
       id: assistantId,
       type: 'updateMessage',
       value: {
-        error: {
-          message: errorMessage,
-          type: 'UnknownError' as any,
-        },
+        error: normalizedError,
       },
     });
 
@@ -320,10 +331,23 @@ export class AgentActionImpl {
       case 'error': {
         const { error, message, phase } = event.data || {};
         log(`Error in ${phase} for ${assistantId}:`, error);
-        this.#get().internal_handleAgentError(
-          assistantId,
-          message || error || 'Unknown agent error',
-        );
+
+        const structuredError =
+          error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          'type' in error &&
+          typeof (error as any).message === 'string'
+            ? (error as ChatMessageError)
+            : undefined;
+
+        const errorMessage =
+          message ||
+          structuredError?.message ||
+          (typeof error === 'string' ? error : undefined) ||
+          'Unknown agent error';
+
+        this.#get().internal_handleAgentError(assistantId, errorMessage, structuredError);
         break;
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #12660

#### 🔀 Description of Change

This PR fixes structured error propagation on the AgentRuntime server execution path (tool success + continuation LLM failure scenario), and keeps UI-facing stream error payloads structured.

1. **Preserve original stream error payload** in `RuntimeExecutors.call_llm`
   - stop wrapping stream errors into plain `Error(message)`
   - throw original `streamError` object so `type/errorType/body/provider` is retained

2. **Publish structured step error events** in `AgentRuntimeService.executeStep`
   - `type: 'error'` events now include:
     - `error` (full `ChatMessageError`)
     - `errorType`
     - `message`
   - improve `formatErrorForState` to also accept `ChatMessageError` shape directly

3. **Keep frontend message error type** in aiAgent stream handling
   - `runAgent` no longer forces `UnknownError` when structured error is available
   - use structured `ChatMessageError` from stream event for message update

4. **Publish structured `llm_execution` stream errors in RuntimeExecutors**
   - align `llm_execution` payload shape with `step_execution` payload shape
   - include `error` + `errorType` + `message` to avoid losing provider error type on early stream error handling

This addresses the mismatch where runtime failures were parsed but eventually downgraded to generic errors on the aiAgent path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts'
bunx vitest run --silent='passed-only' 'src/server/services/agentRuntime/AgentRuntimeService.test.ts'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

Per request, this PR intentionally **does not** add provider-specific `1302 -> QuotaLimitReached` mapping yet.
