### PR TITLE
🐛 fix(settings): restore provider_settings feature flag in settings UI

### DIFF
--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -62,7 +62,7 @@ export const useCategory = () => {
   const { t: tAuth } = useTranslation('auth');
   const { t: tSubscription } = useTranslation('subscription');
   const mobile = useServerConfigStore((s) => s.isMobile);
-  const { enableSTT, hideDocs, showAiImage, showApiKeyManage } =
+  const { enableSTT, hideDocs, showAiImage, showApiKeyManage, showProvider } =
     useServerConfigStore(featureFlagsSelectors);
   const [avatar, username] = useUserStore((s) => [
     userProfileSelectors.userAvatar(s),
@@ -170,7 +170,7 @@ export const useCategory = () => {
 
     // AI configuration group - AI-related settings
     const aiConfigItems: CategoryItem[] = [
-      {
+      showProvider && {
         icon: Brain,
         key: SettingsTabs.Provider,
         label: t('tab.provider'),
@@ -248,6 +248,7 @@ export const useCategory = () => {
     mobile,
     showAiImage,
     showApiKeyManage,
+    showProvider,
     avatarUrl,
     username,
   ]);

--- a/src/routes/(mobile)/me/settings/features/useCategory.tsx
+++ b/src/routes/(mobile)/me/settings/features/useCategory.tsx
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom';
 
 import { type CellProps } from '@/components/Cell';
 import { SettingsTabs } from '@/store/global/initialState';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 export const useCategory = () => {
   const navigate = useNavigate();
   const { t } = useTranslation('setting');
+  const { showProvider } = useServerConfigStore(featureFlagsSelectors);
 
   const items: CellProps[] = [
     {
@@ -15,7 +17,7 @@ export const useCategory = () => {
       key: SettingsTabs.Common,
       label: t('tab.common'),
     },
-    {
+    showProvider && {
       icon: Brain,
       key: SettingsTabs.Provider,
       label: t('tab.provider'),


### PR DESCRIPTION
### Bug Description

This PR fixes the regression introduced in #10264, where the `provider_settings` / `showProvider` feature flag was silently decoupled from the settings UI.

**Root cause:** PR #10264 consolidated the legacy `language_model_settings` flag into `provider_settings` and removed the old `showLLM` variable from the Settings page component. However, it never re-wired `showProvider` into the new `useCategory` hooks, which now unconditionally render the Provider tab regardless of the flag value.

**What this PR does:**
- Extracts `showProvider` from `featureFlagsSelectors` in the desktop `useCategory.tsx` hook (`src/routes/(main)/settings/hooks/useCategory.tsx`)
- Conditionally renders `SettingsTabs.Provider` only when `showProvider` is truthy
- Applies the same fix to the mobile `useCategory.tsx` hook (`src/routes/(mobile)/me/settings/features/useCategory.tsx`)
- Adds `showProvider` to the `useMemo` dependency array to ensure reactivity

This restores the intended behavior: when `FEATURE_FLAGS=\"-provider_settings\"` is set, the Provider settings tab is hidden from the sidebar, which is the expected contract for enterprise deployments.

> **Note:** This supersedes the earlier #12635 which incorrectly removed the flag. Thanks to @zhangt2333 for the review feedback pointing out the correct fix direction.

### 📝 Additional Information

Fixes #12579

### ✅ Validations

- [x] Read the [docs](https://lobehub.com/zh/docs).
- [x] Check that there isn't [already an issue](https://github.com/lobehub/lobe-chat/issues) that reports the same bug to avoid creating a duplicate.
- [x] Make sure this is a LobeChat issue and not a third-party library or provider issue.
- [x] Check that this is a concrete bug. For Q&A, please use [GitHub Discussions](https://github.com/lobehub/lobe-chat/discussions) or join our [Discord Server](https://discord.gg/rGHwKq4R).

## Summary by Sourcery

Bug Fixes:
- Gate rendering of the Provider settings tab behind the showProvider feature flag in both desktop and mobile settings categories so it hides correctly when disabled.