### PR TITLE
fix(userMemories,database): should not fail if extra structure mismatch

### DIFF
--- a/packages/database/src/models/userMemory/__tests__/model.test.ts
+++ b/packages/database/src/models/userMemory/__tests__/model.test.ts
@@ -1463,6 +1463,23 @@ describe('UserMemoryModel', () => {
         type: UserMemoryContextObjectType.Person,
       });
     });
+
+    it('should not throw on non-JSON extra and preserve raw text', () => {
+      const result = UserMemoryModel.parseAssociatedObjects([
+        {
+          name: 'Policy Doc',
+          type: UserMemoryContextObjectType.Other,
+          extra: 'plain text metadata note',
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        extra: { raw: 'plain text metadata note' },
+        name: 'Policy Doc',
+        type: UserMemoryContextObjectType.Other,
+      });
+    });
   });
 
   describe('parseAssociatedSubjects - valid schema', () => {
@@ -1480,6 +1497,22 @@ describe('UserMemoryModel', () => {
       expect(result[0]).toMatchObject({
         name: 'TestSubject',
         extra: { role: 'admin' },
+      });
+    });
+
+    it('should not throw on plain text subject extra', () => {
+      const result = UserMemoryModel.parseAssociatedSubjects([
+        {
+          name: 'Runtime Agent',
+          type: 'person',
+          extra: 'subject plain text metadata',
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        extra: { raw: 'subject plain text metadata' },
+        name: 'Runtime Agent',
       });
     });
   });

--- a/packages/database/src/models/userMemory/model.ts
+++ b/packages/database/src/models/userMemory/model.ts
@@ -89,6 +89,23 @@ const coerceDate = (input: unknown): Date | null => {
   return null;
 };
 
+const parseAssociationExtra = (
+  value: string | null | undefined,
+): Record<string, unknown> | null => {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+
+    return { value: parsed };
+  } catch {
+    return { raw: value };
+  }
+};
+
 export interface BaseCreateUserMemoryParams {
   capturedAt?: Date;
   details: string;
@@ -372,8 +389,9 @@ export class UserMemoryModel {
     value.forEach((item) => {
       const parsed = AssociatedObjectSchema.safeParse(item);
       if (parsed.success) {
-        const extra = JSON.parse(parsed.data.extra || '{}');
-        parsed.data.extra = extra;
+        const extra = parseAssociationExtra(parsed.data.extra);
+        if (extra) parsed.data.extra = extra as any;
+        else delete (parsed.data as any).extra;
         associations.push(parsed.data);
         return;
       }
@@ -399,8 +417,9 @@ export class UserMemoryModel {
     value.forEach((item) => {
       const parsed = AssociatedObjectSchema.safeParse(item);
       if (parsed.success) {
-        const extra = JSON.parse(parsed.data.extra || '{}');
-        parsed.data.extra = extra;
+        const extra = parseAssociationExtra(parsed.data.extra);
+        if (extra) parsed.data.extra = extra as any;
+        else delete (parsed.data as any).extra;
         associations.push(parsed.data);
         return;
       }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Handle non-JSON association extras in user memories without throwing and normalize them into structured metadata.

Bug Fixes:
- Prevent user memory association parsing from throwing when `extra` contains non-JSON text.

Enhancements:
- Normalize association `extra` fields by parsing JSON when possible and preserving non-JSON values as raw metadata objects.
- Extend user memory model tests to cover plain-text `extra` handling for associated objects and subjects.