### PR TITLE
Feature flags: hide homepage features if feature flag is disabled

### DIFF
--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useInitBuiltinAgent } from '@/hooks/useInitBuiltinAgent';
 import { type StarterMode } from '@/store/home';
 import { useHomeStore } from '@/store/home';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
@@ -48,6 +49,7 @@ interface StarterItem {
 
 const StarterList = memo(() => {
   const { t } = useTranslation('home');
+  const { showAiImage } = useServerConfigStore(featureFlagsSelectors);
 
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.agentBuilder);
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.groupAgentBuilder);
@@ -60,41 +62,48 @@ const StarterList = memo(() => {
   ]);
 
   const items: StarterItem[] = useMemo(
-    () => [
-      {
-        icon: BotIcon,
-        key: 'agent',
-        titleKey: 'starter.createAgent',
-      },
-      {
-        icon: GroupBotSquareIcon,
-        key: 'group',
-        titleKey: 'starter.createGroup',
-      },
-      {
-        icon: PenLineIcon,
-        key: 'write',
-        titleKey: 'starter.write',
-      },
-      {
-        icon: NanoBanana.Color,
-        key: 'image',
-        titleKey: 'starter.nanoBanana2',
-      },
-      // {
-      //   hot: true,
-      //   icon: VideoIcon,
-      //   key: 'video',
-      //   titleKey: 'starter.seedance',
-      // },
-      // {
-      //   disabled: true,
-      //   icon: MicroscopeIcon,
-      //   key: 'research',
-      //   titleKey: 'starter.deepResearch',
-      // },
-    ],
-    [],
+    () => {
+      const items: StarterItem[] = [
+        {
+          icon: BotIcon,
+          key: 'agent',
+          titleKey: 'starter.createAgent',
+        },
+        {
+          icon: GroupBotSquareIcon,
+          key: 'group',
+          titleKey: 'starter.createGroup',
+        },
+        {
+          icon: PenLineIcon,
+          key: 'write',
+          titleKey: 'starter.write',
+        },
+        // {
+        //   hot: true,
+        //   icon: VideoIcon,
+        //   key: 'video',
+        //   titleKey: 'starter.seedance',
+        // },
+        // {
+        //   disabled: true,
+        //   icon: MicroscopeIcon,
+        //   key: 'research',
+        //   titleKey: 'starter.deepResearch',
+        // },
+      ];
+
+      if (showAiImage) {
+        items.push({
+          icon: NanoBanana.Color,
+          key: 'image',
+          titleKey: 'starter.nanoBanana2',
+        });
+      }
+
+      return items;
+    },
+    [showAiImage],
   );
 
   const handleClick = useCallback(

--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -9,7 +9,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { useHomeStore } from '@/store/home';
-import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
+import { featureFlagsSelectors, serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 import CommunityRecommend from '../CommunityRecommend';
 import SuggestQuestions from '../SuggestQuestions';
@@ -23,6 +23,7 @@ const leftActions: ActionKeys[] = ['model', 'search', 'memory', 'fileUpload', 't
 const InputArea = () => {
   const { loading, send, inboxAgentId } = useSend();
   const inputActiveMode = useHomeStore((s) => s.inputActiveMode);
+  const { showMarket } = useServerConfigStore(featureFlagsSelectors);
   const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
   const isKlavisEnabled = useServerConfigStore(serverConfigSelectors.enableKlavis);
   const showSkillBanner = isLobehubSkillEnabled || isKlavisEnabled;
@@ -135,7 +136,7 @@ const InputArea = () => {
           >
             <Flexbox gap={24}>
               <SuggestQuestions mode={inputActiveMode} />
-              <CommunityRecommend mode={inputActiveMode} />
+              {showMarket && <CommunityRecommend mode={inputActiveMode} />}
             </Flexbox>
           </motion.div>
         )}

--- a/src/routes/(main)/home/features/index.tsx
+++ b/src/routes/(main)/home/features/index.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useHomeStore } from '@/store/home';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
@@ -18,6 +19,7 @@ import WelcomeText from './WelcomeText';
 const Home = memo(() => {
   const { i18n } = useTranslation();
   const isLogin = useUserStore(authSelectors.isLogin);
+  const { showMarket } = useServerConfigStore(featureFlagsSelectors);
   const inputActiveMode = useHomeStore((s) => s.inputActiveMode);
 
   // Hide other modules when a starter mode is active
@@ -38,7 +40,7 @@ const Home = memo(() => {
             <RecentPage />
           </>
         )}
-        <CommunityAgents />
+        {showMarket && <CommunityAgents />}
         {/*<FeaturedPlugins />*/}
         {isLogin && <RecentResource />}
       </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #12688

#### 🔀 Description of Change

`<CommunityAgents />` now only renders when `showMarket` is `true`. When the `market` flag is off, the community agents section is completely removed from the homepage.

The "Nano Banana" image pill is now conditionally included in the items array based on `showAiImage`. When `ai_image` is off, the pill doesn't render and users can't navigate to `/image`.

`<CommunityRecommend />` (the contextual agent/group recommendations that appear when a starter mode is active) is also gated behind `showMarket`.

#### 🧪 How to Test

Add the features flags and navigate to the homepage.

#### 📝 Additional Information

The routes are still being rendered and are accessible via direct URL. The features flags should disallow complete access to them. 

If you want I can include something for it but for this PR I feel it's too much.

## Summary by Sourcery

Gate homepage market- and image-related UI elements behind server-configured feature flags so they no longer appear when disabled.

Bug Fixes:
- Prevent the Nano Banana image starter pill from rendering when the AI image feature flag is disabled, blocking navigation to the image page from the homepage.
- Hide the Community Agents section on the homepage when the market feature flag is disabled.
- Hide contextual CommunityRecommend suggestions when the market feature flag is disabled.