### PR TITLE
fix: DEFAULT_AGENT_CONFIG meta keys (avatar, displayName) placed in wrong bucket

### DIFF
--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -64,6 +64,12 @@ The `DEFAULT_AGENT_CONFIG` is used to configure the default settings for the Lob
 | Special Characters      | `inputTemplate="Hello; I am a bot;"`                                                                                     | Set the input template to `Hello; I am a bot;`.                                                                    |
 | Error Handling          | `model=gpt-4;maxToken`                                                                                                   | Ignore invalid entry `maxToken` and only parse `model=gpt-4`.                                                      |
 | Value Override          | `model=gpt-4;model=gpt-4-1106-preview`                                                                                   | If a key is repeated, use the value that appears last; in this case, the value of `model` is `gpt-4-1106-preview`. |
+| Display Name            | `displayName=My Assistant`                                                                                               | Set the agent's display name shown in the sidebar and chat header.                                                 |
+| Avatar                  | `avatar=https://example.com/avatar.png`                                                                                  | Set the agent's avatar to a custom image URL or emoji.                                                             |
+| Description             | `description=A helpful coding assistant`                                                                                 | Set the agent's description.                                                                                       |
+| Background Color        | `backgroundColor=#4a90d9`                                                                                                | Set the agent's background color (used when no avatar is set).                                                     |
+| Tags                    | `tags=coding,writing`                                                                                                    | Set the agent's tags.                                                                                              |
+| Full Example            | `model=gpt-4;provider=openai;displayName=My Bot;avatar=🤖;systemRole=You are helpful`                                   | Set model, provider, display name, avatar, and system role together.                                               |
 
 Further reading:
 

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -61,6 +61,12 @@ LobeHub 在部署时提供了一些额外的配置项，你可以使用环境变
 | 特殊字符  | `inputTemplate="Hello; I am a bot;"`                                                                                    | 设置输入模板为 `Hello; I am a bot;`。                         |
 | 错误处理  | `model=gpt-4;maxToken`                                                                                                  | 忽略无效条目 `maxToken`，仅解析出 `model=gpt-4`。                 |
 | 值覆盖   | `model=gpt-4;model=gpt-4-1106-preview`                                                                                  | 如果键重复，使用最后一次出现的值，此处 `model` 的值为 `gpt-4-1106-preview`。 |
+| 显示名称 | `displayName=My Assistant`                                                                                               | 设置助理在侧边栏和聊天头部显示的名称。                                   |
+| 头像   | `avatar=https://example.com/avatar.png`                                                                                  | 设置助理的头像为自定义图片 URL 或 emoji。                             |
+| 描述   | `description=A helpful coding assistant`                                                                                 | 设置助理的描述。                                              |
+| 背景颜色 | `backgroundColor=#4a90d9`                                                                                                | 设置助理的背景颜色（未设置头像时使用）。                                  |
+| 标签   | `tags=coding,writing`                                                                                                    | 设置助理的标签。                                              |
+| 完整示例 | `model=gpt-4;provider=openai;displayName=My Bot;avatar=🤖;systemRole=You are helpful`                                   | 同时设置模型、服务商、显示名称、头像和系统角色。                              |
 
 相关阅读：
 

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -14,7 +14,7 @@ import { type GlobalServerConfig } from '@/types/serverConfig';
 import { cleanObject } from '@/utils/object';
 
 import { genServerAiProvidersConfig } from './genServerAiProviderConfig';
-import { parseAgentConfig } from './parseDefaultAgent';
+import { parseAgentConfig, parseDefaultAgentSettings } from './parseDefaultAgent';
 import { parseFilesConfig } from './parseFilesConfig';
 import { getPublicMemoryExtractionConfig } from './parseMemoryExtractionConfig';
 
@@ -71,9 +71,7 @@ export const getServerGlobalConfig = async () => {
         withDeploymentName: true,
       },
     }),
-    defaultAgent: {
-      config: parseAgentConfig(DEFAULT_AGENT_CONFIG),
-    },
+    defaultAgent: parseDefaultAgentSettings(DEFAULT_AGENT_CONFIG),
     disableEmailPassword: authEnv.AUTH_DISABLE_EMAIL_PASSWORD,
     enableBusinessFeatures: ENABLE_BUSINESS_FEATURES,
     enableEmailVerification: authEnv.AUTH_EMAIL_VERIFICATION,
@@ -104,6 +102,8 @@ export const getServerGlobalConfig = async () => {
 export const getServerDefaultAgentConfig = () => {
   const { DEFAULT_AGENT_CONFIG } = getAppConfig();
 
+  // Only return the config portion (not meta) for server-side agent config merging.
+  // Meta keys (avatar, displayName, etc.) are handled separately via getServerGlobalConfig().
   return parseAgentConfig(DEFAULT_AGENT_CONFIG) || {};
 };
 

--- a/src/server/globalConfig/parseDefaultAgent.test.ts
+++ b/src/server/globalConfig/parseDefaultAgent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseAgentConfig } from './parseDefaultAgent';
+import { parseAgentConfig, parseDefaultAgentSettings } from './parseDefaultAgent';
 
 describe('parseAgentConfig', () => {
   describe('single functional feature', () => {
@@ -191,5 +191,87 @@ describe('parseAgentConfig', () => {
     const envStr = 'model=';
     const expected = { model: undefined }; // 或 { model: '' }，取决于应用逻辑
     expect(parseAgentConfig(envStr)).toEqual(expected);
+  });
+});
+
+describe('parseDefaultAgentSettings', () => {
+  it('should put model and provider into config', () => {
+    const result = parseDefaultAgentSettings('model=gpt-4;provider=openai');
+
+    expect(result).toEqual({
+      config: { model: 'gpt-4', provider: 'openai' },
+    });
+  });
+
+  it('should put avatar and description into meta', () => {
+    const result = parseDefaultAgentSettings('avatar=https://example.com/avatar.png;description=A helpful bot');
+
+    expect(result).toEqual({
+      meta: { avatar: 'https://example.com/avatar.png', description: 'A helpful bot' },
+    });
+  });
+
+  it('should map displayName to meta.title', () => {
+    const result = parseDefaultAgentSettings('displayName=My Assistant');
+
+    expect(result).toEqual({
+      meta: { title: 'My Assistant' },
+    });
+  });
+
+  it('should put title directly into meta', () => {
+    const result = parseDefaultAgentSettings('title=My Assistant');
+
+    expect(result).toEqual({
+      meta: { title: 'My Assistant' },
+    });
+  });
+
+  it('should split a full config with both config and meta keys', () => {
+    const envStr =
+      'model=gemini-2.5-flash;provider=openai;displayName=Significa Assistant;avatar=https://cdn.significa.co/logo.png;systemRole=You are helpful';
+
+    const result = parseDefaultAgentSettings(envStr);
+
+    expect(result).toEqual({
+      config: {
+        model: 'gemini-2.5-flash',
+        provider: 'openai',
+        systemRole: 'You are helpful',
+      },
+      meta: {
+        avatar: 'https://cdn.significa.co/logo.png',
+        title: 'Significa Assistant',
+      },
+    });
+  });
+
+  it('should handle backgroundColor and tags as meta keys', () => {
+    const result = parseDefaultAgentSettings('model=gpt-4;backgroundColor=#ff0000;tags=coding,writing');
+
+    expect(result).toEqual({
+      config: { model: 'gpt-4' },
+      meta: { backgroundColor: '#ff0000', tags: ['coding', 'writing'] },
+    });
+  });
+
+  it('should return undefined for empty string', () => {
+    expect(parseDefaultAgentSettings('')).toBeUndefined();
+  });
+
+  it('should omit config key when only meta keys are present', () => {
+    const result = parseDefaultAgentSettings('displayName=Bot;avatar=https://example.com/a.png');
+
+    expect(result).toEqual({
+      meta: { avatar: 'https://example.com/a.png', title: 'Bot' },
+    });
+  });
+
+  it('should omit meta key when only config keys are present', () => {
+    const result = parseDefaultAgentSettings('model=gpt-4;params.max_tokens=300');
+
+    expect(result).toEqual({
+      config: { model: 'gpt-4', params: { max_tokens: 300 } },
+    });
   });
 });

--- a/src/server/globalConfig/parseDefaultAgent.test.ts
+++ b/src/server/globalConfig/parseDefaultAgent.test.ts
@@ -274,4 +274,36 @@ describe('parseDefaultAgentSettings', () => {
       config: { model: 'gpt-4', params: { max_tokens: 300 } },
     });
   });
+
+  it('should let later displayName override earlier title', () => {
+    const result = parseDefaultAgentSettings('title=First;displayName=Second');
+
+    expect(result).toEqual({
+      meta: { title: 'Second' },
+    });
+  });
+
+  it('should let later title override earlier displayName', () => {
+    const result = parseDefaultAgentSettings('displayName=First;title=Second');
+
+    expect(result).toEqual({
+      meta: { title: 'Second' },
+    });
+  });
+
+  it('should use last value when displayName appears multiple times with title in between', () => {
+    const result = parseDefaultAgentSettings('displayName=A;title=B;displayName=C');
+
+    expect(result).toEqual({
+      meta: { title: 'C' },
+    });
+  });
+
+  it('should use last value when title appears after repeated displayName', () => {
+    const result = parseDefaultAgentSettings('displayName=A;displayName=B;title=C');
+
+    expect(result).toEqual({
+      meta: { title: 'C' },
+    });
+  });
 });

--- a/src/server/globalConfig/parseDefaultAgent.ts
+++ b/src/server/globalConfig/parseDefaultAgent.ts
@@ -79,18 +79,29 @@ export const parseAgentConfig = (envStr: string) => {
  * Parse DEFAULT_AGENT_CONFIG env string and split the result into { config, meta }
  * so that meta keys (avatar, displayName, description, etc.) end up in the right bucket.
  */
+/**
+ * Replace alias keys (e.g. `displayName`) with their canonical meta key (`title`)
+ * directly in the raw env string so that `parseAgentConfig`'s natural last-wins
+ * behaviour applies correctly when both an alias and its canonical key appear.
+ */
+const normalizeAliases = (envStr: string): string => {
+  const regex = /([^;=]+)(=[^;]*)/g;
+  return envStr.replace(regex, (_match, rawKey: string, rest: string) => {
+    const key = rawKey.trim();
+    const canonical = META_ALIASES[key];
+    return canonical ? canonical + rest : rawKey + rest;
+  });
+};
+
 export const parseDefaultAgentSettings = (envStr: string) => {
-  const flat = parseAgentConfig(envStr);
+  const flat = parseAgentConfig(normalizeAliases(envStr));
   if (!flat || Object.keys(flat).length === 0) return undefined;
 
   const config: Record<string, unknown> = {};
   const meta: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(flat)) {
-    const aliasedKey = META_ALIASES[key];
-    if (aliasedKey) {
-      meta[aliasedKey] = value;
-    } else if (META_KEYS.has(key)) {
+    if (META_KEYS.has(key)) {
       meta[key] = value;
     } else {
       config[key] = value;

--- a/src/server/globalConfig/parseDefaultAgent.ts
+++ b/src/server/globalConfig/parseDefaultAgent.ts
@@ -1,10 +1,31 @@
 import { set } from 'es-toolkit/compat';
 
-// Keys that belong in MetaData rather than LobeAgentConfig
-const META_KEYS = new Set(['avatar', 'backgroundColor', 'description', 'title', 'tags']);
+import { type MetaData } from '@/types/meta';
 
-// User-friendly aliases mapped to their canonical MetaData key
-const META_ALIASES: Record<string, string> = {
+/**
+ * Keys from MetaData that should be separated from LobeAgentConfig when parsing
+ * DEFAULT_AGENT_CONFIG. If MetaData gains new fields, add them here.
+ *
+ * `marketIdentifier` is intentionally excluded — it's not user-configurable via env var.
+ *
+ * The typed array literal ensures a compile error if a key is misspelled or
+ * removed from MetaData. The Set itself is `Set<string>` so `.has()` accepts
+ * any string without requiring a cast.
+ */
+const META_KEY_LIST: (keyof MetaData)[] = [
+  'avatar',
+  'backgroundColor',
+  'description',
+  'title',
+  'tags',
+];
+const META_KEYS: Set<string> = new Set(META_KEY_LIST);
+
+/**
+ * User-friendly aliases mapped to their canonical MetaData key.
+ * `displayName` is more intuitive in env vars than `title`.
+ */
+const META_ALIASES: Record<string, keyof MetaData> = {
   displayName: 'title',
 };
 
@@ -13,7 +34,7 @@ const META_ALIASES: Record<string, string> = {
  * @param {string} envStr - The environment variable string to be parsed.
  */
 export const parseAgentConfig = (envStr: string) => {
-  const config = {};
+  const config: Record<string, unknown> = {};
   // use regex to match key-value pairs, considering the possibility of semicolons in values
   const regex = /([^;=]+)=("[^"]+"|[^;]+)/g;
   let match;
@@ -23,14 +44,14 @@ export const parseAgentConfig = (envStr: string) => {
     const value = match[2].trim();
     if (!key || !value) return;
 
-    let finalValue: any = value;
+    let finalValue: unknown = value;
 
     // Handle string value
     if (value.startsWith('"') && value.endsWith('"')) {
       finalValue = value.slice(1, -1);
     }
     // Handle numeric values
-    else if (!isNaN(value as any)) {
+    else if (!Number.isNaN(Number(value))) {
       finalValue = Number(value);
     }
     // Handle boolean values
@@ -40,7 +61,7 @@ export const parseAgentConfig = (envStr: string) => {
     // Handle arrays
     else if (value.includes(',') || value.includes('，')) {
       const array = value.replaceAll('，', ',').split(',');
-      finalValue = array.map((item) => (isNaN(item as any) ? item : Number(item)));
+      finalValue = array.map((item) => (Number.isNaN(Number(item)) ? item : Number(item)));
     }
 
     // handle plugins if it's a string
@@ -62,8 +83,8 @@ export const parseDefaultAgentSettings = (envStr: string) => {
   const flat = parseAgentConfig(envStr);
   if (!flat || Object.keys(flat).length === 0) return undefined;
 
-  const config: Record<string, any> = {};
-  const meta: Record<string, any> = {};
+  const config: Record<string, unknown> = {};
+  const meta: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(flat)) {
     const aliasedKey = META_ALIASES[key];

--- a/src/server/globalConfig/parseDefaultAgent.ts
+++ b/src/server/globalConfig/parseDefaultAgent.ts
@@ -1,5 +1,13 @@
 import { set } from 'es-toolkit/compat';
 
+// Keys that belong in MetaData rather than LobeAgentConfig
+const META_KEYS = new Set(['avatar', 'backgroundColor', 'description', 'title', 'tags']);
+
+// User-friendly aliases mapped to their canonical MetaData key
+const META_ALIASES: Record<string, string> = {
+  displayName: 'title',
+};
+
 /**
  * Improved parsing function that handles numbers, booleans, semicolons, and equals signs in values.
  * @param {string} envStr - The environment variable string to be parsed.
@@ -44,4 +52,32 @@ export const parseAgentConfig = (envStr: string) => {
   }
 
   return config;
+};
+
+/**
+ * Parse DEFAULT_AGENT_CONFIG env string and split the result into { config, meta }
+ * so that meta keys (avatar, displayName, description, etc.) end up in the right bucket.
+ */
+export const parseDefaultAgentSettings = (envStr: string) => {
+  const flat = parseAgentConfig(envStr);
+  if (!flat || Object.keys(flat).length === 0) return undefined;
+
+  const config: Record<string, any> = {};
+  const meta: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(flat)) {
+    const aliasedKey = META_ALIASES[key];
+    if (aliasedKey) {
+      meta[aliasedKey] = value;
+    } else if (META_KEYS.has(key)) {
+      meta[key] = value;
+    } else {
+      config[key] = value;
+    }
+  }
+
+  return {
+    ...(Object.keys(config).length > 0 ? { config } : {}),
+    ...(Object.keys(meta).length > 0 ? { meta } : {}),
+  };
 };


### PR DESCRIPTION
DEFAULT_AGENT_CONFIG` env var keys like `avatar`, `displayName`, and `description` had no effect. The parser produced a flat object and the server placed **all** keys into `defaultAgent.config`. But the UI reads branding from `defaultAgent.meta` — so these keys were silently ignored.

For example, this config:
```
DEFAULT_AGENT_CONFIG="model=gemini-2.5-flash;provider=google;displayName=My Bot;avatar=https://example.com/logo.png;systemRole=Be helpful"
```

produced
```json
{
  "defaultAgent": {
    "config": {
      "model": "gemini-2.5-flash",
      "provider": "google",
      "displayName": "My Bot",
      "avatar": "https://example.com/logo.png",
      "systemRole": "Be helpful"
    }
  }
}
```

but the expected shape is
```json
{
  "defaultAgent": {
    "config": {
      "model": "gemini-2.5-flash",
      "provider": "google",
      "systemRole": "Be helpful"
    },
    "meta": {
      "title": "My Bot",
      "avatar": "https://example.com/logo.png"
    }
  }
}
```

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Added `parseDefaultAgentSettings()` that splits the flat parsed config into `{ config, meta }`:

- `avatar`, `backgroundColor`, `description`, `title`, `tags` → `meta`
- `displayName` → aliased to `meta.title` (MetaData uses `title` internally)
- Everything else (`model`, `provider`, `systemRole`, `params.*`, etc.) → `config`

`getServerDefaultAgentConfig()` (used for server-side agent config merging) continues to use the flat `parseAgentConfig()` — the extra meta keys are harmless there and this avoids breaking the merge chain.

## Summary by Sourcery

Parse DEFAULT_AGENT_CONFIG into separate config and meta sections so default agent branding fields are correctly exposed to the UI.

Bug Fixes:
- Ensure DEFAULT_AGENT_CONFIG branding keys like avatar, displayName, description, backgroundColor, and tags are placed under defaultAgent.meta instead of defaultAgent.config.

Enhancements:
- Introduce parseDefaultAgentSettings to split parsed default agent settings into config and meta buckets, including mapping displayName to meta.title.
- Update server global config to use parsed default agent meta for branding while keeping server-side config merging based on the flat config object.

Documentation:
- Document DEFAULT_AGENT_CONFIG branding-related keys and provide examples in both English and Chinese self-hosting environment variable docs.

Tests:
- Add unit tests covering parseDefaultAgentSettings behavior for config keys, meta keys, alias mapping, mixed configs, and empty or partial inputs.