### PR TITLE
 🐛 fix: should add m2m token to use community agents/mcp/skill list

### DIFF
--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -76,6 +76,8 @@ class DiscoverService {
   };
 
   getAssistantList = async (params: AssistantQueryParams = {}): Promise<AssistantListResponse> => {
+    await this.injectMPToken();
+
     const locale = globalHelpers.getCurrentLanguage();
     return lambdaClient.market.getAssistantList.query(
       {
@@ -126,6 +128,8 @@ class DiscoverService {
   };
 
   getMcpList = async (params: McpQueryParams = {}): Promise<McpListResponse> => {
+    await this.injectMPToken();
+
     const locale = globalHelpers.getCurrentLanguage();
     return lambdaClient.market.getMcpList.query({
       ...params,

--- a/src/services/marketApi.ts
+++ b/src/services/marketApi.ts
@@ -5,6 +5,7 @@ import {
 } from '@lobehub/market-sdk';
 
 import { lambdaClient } from '@/libs/trpc/client';
+import { discoverService } from '@/services/discover';
 import {
   type AgentForkRequest,
   type AgentForkResponse,
@@ -241,6 +242,8 @@ export class MarketApiService {
     pageSize: number;
     total: number;
   }> {
+    await discoverService.injectMPToken();
+
     return lambdaClient.market.skill.searchSkill.query(params);
   }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure marketplace discovery and skill search requests include the machine-to-machine token before fetching data.

Bug Fixes:
- Add M2M token injection before retrieving the assistant list from the marketplace API.
- Add M2M token injection before retrieving the MCP list from the marketplace API.
- Add M2M token injection before performing skill search requests.