### PR TITLE
👷 ci(desktop): add S3 cleanup for canary/nightly (keep latest 15)

### DIFF
--- a/.github/actions/desktop-cleanup-s3/action.yml
+++ b/.github/actions/desktop-cleanup-s3/action.yml
@@ -1,0 +1,93 @@
+name: Desktop Cleanup S3
+description: Remove old release versions from S3, keeping the most recent N versions
+
+inputs:
+  channel:
+    description: 'Update channel (stable, canary, nightly)'
+    required: true
+  keep-count:
+    description: 'Number of recent versions to keep'
+    required: false
+    default: '15'
+  aws-access-key-id:
+    description: 'AWS access key ID'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS secret access key'
+    required: true
+  s3-bucket:
+    description: 'S3 bucket name'
+    required: true
+  s3-region:
+    description: 'S3 region (defaults to us-east-1)'
+    required: false
+    default: 'us-east-1'
+  s3-endpoint:
+    description: 'Custom S3 endpoint (for R2/MinIO etc.)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Cleanup old S3 versions
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_REGION: ${{ inputs.s3-region }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_ENDPOINT: ${{ inputs.s3-endpoint }}
+        CHANNEL: ${{ inputs.channel }}
+        KEEP_COUNT: ${{ inputs.keep-count }}
+      run: |
+        if [ -z "$S3_BUCKET" ]; then
+          echo "⚠️ S3 bucket is not configured, skipping cleanup"
+          exit 0
+        fi
+
+        ENDPOINT_ARG=""
+        if [ -n "$S3_ENDPOINT" ]; then
+          ENDPOINT_ARG="--endpoint-url $S3_ENDPOINT"
+        fi
+
+        echo "🧹 Cleaning up old $CHANNEL versions from S3 (keeping latest $KEEP_COUNT)"
+        echo ""
+
+        # List all version directories under {channel}/
+        # S3 ls output format: "PRE {version}/" for directories
+        all_versions=$(aws s3 ls "s3://$S3_BUCKET/$CHANNEL/" $ENDPOINT_ARG 2>/dev/null \
+          | grep 'PRE ' \
+          | awk '{print $2}' \
+          | sed 's|/$||' \
+          | sort -V)
+
+        if [ -z "$all_versions" ]; then
+          echo "📭 No version directories found in s3://$S3_BUCKET/$CHANNEL/"
+          exit 0
+        fi
+
+        total=$(echo "$all_versions" | wc -l | tr -d ' ')
+        echo "📋 Found $total version(s) in s3://$S3_BUCKET/$CHANNEL/"
+
+        if [ "$total" -le "$KEEP_COUNT" ]; then
+          echo "✅ Nothing to clean up ($total <= $KEEP_COUNT)"
+          exit 0
+        fi
+
+        delete_count=$((total - KEEP_COUNT))
+        to_delete=$(echo "$all_versions" | head -n "$delete_count")
+
+        echo "🗑️ Will delete $delete_count old version(s):"
+        echo "$to_delete" | while read -r version; do
+          echo "   - $version"
+        done
+        echo ""
+
+        echo "$to_delete" | while read -r version; do
+          echo "🗑️ Deleting s3://$S3_BUCKET/$CHANNEL/$version/ ..."
+          aws s3 rm "s3://$S3_BUCKET/$CHANNEL/$version/" --recursive $ENDPOINT_ARG
+        done
+
+        echo ""
+        echo "✅ Cleanup complete. Deleted $delete_count version(s), kept $KEEP_COUNT."

--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -41,6 +41,9 @@ runs:
         echo "📦 Artifacts to upload to S3:"
         ls -lah release/
         echo ""
+        echo "📋 YML files in release/:"
+        ls -la release/*.yml 2>/dev/null || echo "   ⚠️ No yml files found!"
+        echo ""
         echo "📋 Version: ${{ inputs.version }}, Channel: ${{ inputs.channel }}"
 
     - name: Upload to S3
@@ -81,6 +84,7 @@ runs:
         done
 
         # 2. 创建 {channel}*.yml (从 latest*.yml 复制，URL 加版本目录前缀)
+        # electron-builder 始终生成 latest*.yml，不区分 channel
         # electron-updater 在对应 channel 时会找 {channel}-mac.yml
         echo ""
         echo "📋 Creating ${CHANNEL}*.yml files from latest*.yml..."

--- a/.github/actions/desktop-upload-artifacts/action.yml
+++ b/.github/actions/desktop-upload-artifacts/action.yml
@@ -13,28 +13,37 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Rename macOS latest-mac.yml for multi-architecture support
+    - name: Rename macOS *-mac.yml for multi-architecture support
       if: runner.os == 'macOS'
       shell: bash
       run: |
         cd apps/desktop/release
-        if [ -f "latest-mac.yml" ]; then
-          SYSTEM_ARCH=$(uname -m)
-          if [[ "$SYSTEM_ARCH" == "arm64" ]]; then
-            ARCH_SUFFIX="arm64"
-          else
-            ARCH_SUFFIX="x64"
-          fi
-          mv latest-mac.yml "latest-mac-${ARCH_SUFFIX}.yml"
-          echo "✅ Renamed latest-mac.yml to latest-mac-${ARCH_SUFFIX}.yml"
+        SYSTEM_ARCH=$(uname -m)
+        if [[ "$SYSTEM_ARCH" == "arm64" ]]; then
+          ARCH_SUFFIX="arm64"
+        else
+          ARCH_SUFFIX="x64"
         fi
+        for yml in *-mac.yml; do
+          if [ -f "$yml" ]; then
+            new_name="${yml%.yml}-${ARCH_SUFFIX}.yml"
+            mv "$yml" "$new_name"
+            echo "✅ Renamed $yml to $new_name"
+          fi
+        done
+
+    - name: List yml files before upload
+      shell: bash
+      run: |
+        echo "📋 YML files to upload:"
+        ls -la apps/desktop/release/*.yml 2>/dev/null || echo "   ⚠️ No yml files found!"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact-name }}
         path: |
-          apps/desktop/release/latest*
+          apps/desktop/release/*.yml
           apps/desktop/release/*.dmg*
           apps/desktop/release/*.zip*
           apps/desktop/release/*.exe*

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -369,13 +369,15 @@ jobs:
   # 清理旧的 Canary Releases (保留最近 7 个)
   # ============================================
   cleanup-old-canaries:
-    needs: [publish-release]
+    needs: [publish-release, publish-s3]
     name: Cleanup Old Canary Releases
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Delete old canary releases
+      - uses: actions/checkout@v6
+
+      - name: Delete old canary GitHub releases
         uses: actions/github-script@v7
         with:
           script: |
@@ -414,3 +416,14 @@ jobs:
             }
 
             console.log(`✅ Cleanup complete. Kept ${Math.min(canaryReleases.length, 7)} canary releases, deleted ${toDelete.length}.`);
+
+      - name: Cleanup old S3 versions
+        uses: ./.github/actions/desktop-cleanup-s3
+        with:
+          channel: canary
+          keep-count: '15'
+          aws-access-key-id: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
+          s3-bucket: ${{ secrets.UPDATE_S3_BUCKET }}
+          s3-region: ${{ secrets.UPDATE_S3_REGION }}
+          s3-endpoint: ${{ secrets.UPDATE_S3_ENDPOINT }}

--- a/.github/workflows/release-desktop-nightly.yml
+++ b/.github/workflows/release-desktop-nightly.yml
@@ -367,13 +367,15 @@ jobs:
   # 清理旧的 Nightly Releases (保留最近 7 个)
   # ============================================
   cleanup-old-nightlies:
-    needs: [publish-release]
+    needs: [publish-release, publish-s3]
     name: Cleanup Old Nightly Releases
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Delete old nightly releases
+      - uses: actions/checkout@v6
+
+      - name: Delete old nightly GitHub releases
         uses: actions/github-script@v7
         with:
           script: |
@@ -412,3 +414,14 @@ jobs:
             }
 
             console.log(`✅ Cleanup complete. Kept ${Math.min(nightlyReleases.length, 7)} nightly releases, deleted ${toDelete.length}.`);
+
+      - name: Cleanup old S3 versions
+        uses: ./.github/actions/desktop-cleanup-s3
+        with:
+          channel: nightly
+          keep-count: '15'
+          aws-access-key-id: ${{ secrets.UPDATE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.UPDATE_AWS_SECRET_ACCESS_KEY }}
+          s3-bucket: ${{ secrets.UPDATE_S3_BUCKET }}
+          s3-region: ${{ secrets.UPDATE_S3_REGION }}
+          s3-endpoint: ${{ secrets.UPDATE_S3_ENDPOINT }}


### PR DESCRIPTION
## Summary

- Create `.github/actions/desktop-cleanup-s3/` reusable composite action for cleaning up old S3 release versions
- Add S3 cleanup step to canary and nightly workflows, keeping the latest 15 versions
- Cleanup job now waits for both `publish-release` and `publish-s3` to complete before running

## Problem

After #12721 added S3 upload for canary/nightly, old version directories accumulate in S3 with no cleanup mechanism. Each release creates a `{channel}/{version}/` directory with full installers (~500MB+), leading to unbounded storage growth.

## Changes

| File | Change |
|------|--------|
| `.github/actions/desktop-cleanup-s3/action.yml` | **New** — reusable composite action |
| `.github/workflows/release-desktop-canary.yml` | Add S3 cleanup step, `needs` includes `publish-s3` |
| `.github/workflows/release-desktop-nightly.yml` | Add S3 cleanup step, `needs` includes `publish-s3` |

## How it works

1. Lists all version directories under `s3://{bucket}/{channel}/`
2. Sorts by version (`sort -V`)
3. Keeps the latest 15, recursively deletes older ones
4. Gracefully skips if S3 bucket is not configured

## Summary by Sourcery

Add automated cleanup of old desktop release artifacts from S3 for canary and nightly channels, keeping only the most recent versions.

CI:
- Introduce a reusable composite GitHub Action to prune old S3 desktop release versions while retaining a configurable number of latest versions.
- Extend canary and nightly release workflows to run the S3 cleanup after both GitHub release and S3 publish jobs complete, keeping the latest 15 versions per channel.