### PR TITLE
🐛 fix(conversation): avoid stale loading for empty assistant messages

### DIFF
--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -80,6 +80,7 @@ const MessageContent = memo<UIChatMessage>(
           content={content}
           hasImages={showImageItems}
           id={id}
+          isMessageGenerating={generating}
           isMultimodal={metadata?.isMultimodal}
           isToolCallGenerating={isToolCallGenerating}
           markdownProps={markdownProps}

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -29,9 +29,7 @@ const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
 
   if (!content && !hasTools) return isGenerating ? <ContentLoading id={id} /> : null;
 
-  if (content === LOADING_FLAT) {
-    return <ContentLoading id={id} />;
-  }
+  if (content === LOADING_FLAT) return isGenerating ? <ContentLoading id={id} /> : null;
 
   const isSingleLine = (message || '').split('\n').length <= 2;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { LOADING_FLAT } from '@/const/message';
 import MarkdownMessage from '@/features/Conversation/Markdown';
 import ContentLoading from '@/features/Conversation/Messages/components/ContentLoading';
+import { messageStateSelectors, useConversationStore } from '@/features/Conversation/store';
 
 import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
 import { useMarkdown } from '../useMarkdown';
@@ -24,8 +25,9 @@ interface ContentBlockProps {
 const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
   const message = normalizeThinkTags(processWithArtifact(content));
   const markdownProps = useMarkdown(id);
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
-  if (!content && !hasTools) return <ContentLoading id={id} />;
+  if (!content && !hasTools) return isGenerating ? <ContentLoading id={id} /> : null;
 
   if (content === LOADING_FLAT) {
     return <ContentLoading id={id} />;

--- a/src/features/Conversation/Messages/Task/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Task/components/MessageContent.tsx
@@ -58,6 +58,7 @@ const MessageContent = memo<UIChatMessage>(
             content={content}
             hasImages={showImageItems}
             id={id}
+            isMessageGenerating={generating}
             isMultimodal={metadata?.isMultimodal}
             isToolCallGenerating={isToolCallGenerating}
             markdownProps={markdownProps}

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -14,6 +14,7 @@ const DisplayContent = memo<{
   content: string;
   hasImages?: boolean;
   id: string;
+  isMessageGenerating?: boolean;
   isMultimodal?: boolean;
   isToolCallGenerating?: boolean;
   markdownProps?: Omit<MarkdownProps, 'className' | 'style' | 'children'>;
@@ -23,6 +24,7 @@ const DisplayContent = memo<{
     markdownProps,
     content,
     isToolCallGenerating,
+    isMessageGenerating,
     hasImages,
     isMultimodal,
     tempDisplayContent,
@@ -31,7 +33,9 @@ const DisplayContent = memo<{
     const message = normalizeThinkTags(processWithArtifact(content));
     if (isToolCallGenerating) return;
 
-    if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;
+    if ((!content && !hasImages) || content === LOADING_FLAT) {
+      return isMessageGenerating ? <ContentLoading id={id} /> : null;
+    }
 
     const contentParts = isMultimodal ? deserializeParts(tempDisplayContent || content) : null;
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #12726

#### 🔀 Description of Change

This PR fixes a stale loading state for assistant messages:
- `DisplayContent` now shows `ContentLoading` only when `isMessageGenerating` is true.
- `Assistant` and `Task` message content now pass message generating state into `DisplayContent`.
- `AssistantGroup` message content also avoids showing loading for empty non-generating messages.

This prevents empty assistant messages from showing a perpetual loading indicator after generation has already stopped.

#### 🧪 How to Test

1. Start a conversation and trigger assistant generation.
2. Reproduce a case where assistant content is empty after generation stops.
3. Confirm loading no longer persists when operation is not generating.
4. Confirm loading still appears while generation is actively running.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Loading could remain after generation ended for empty content | Loading disappears once generation ends; only shown while generating |

#### 📝 Additional Information

No API or data schema changes.

## Summary by Sourcery

Bug Fixes:
- Prevent perpetual loading indicators for empty assistant and assistant-group messages once generation has stopped by gating ContentLoading on the message generation state.