### PR TITLE
feat(userMemories,memory-user-memory): now default to inject user persona instead of identities

### DIFF
--- a/src/layout/GlobalProvider/DeferredStoreInitialization.tsx
+++ b/src/layout/GlobalProvider/DeferredStoreInitialization.tsx
@@ -13,11 +13,11 @@ interface DeferredStoreInitializationProps {
 
 const DeferredStoreInitialization = memo<DeferredStoreInitializationProps>(({ isLogin }) => {
   const useInitAiProviderKeyVaults = useAiInfraStore((s) => s.useFetchAiProviderRuntimeState);
-  const useInitIdentities = useUserMemoryStore((s) => s.useInitIdentities);
+  const useFetchPersona = useUserMemoryStore((s) => s.useFetchPersona);
   const isSyncActive = useElectronStore((s) => electronSyncSelectors.isSyncActive(s));
 
   useInitAiProviderKeyVaults(isLogin, isSyncActive);
-  useInitIdentities(isLogin);
+  useFetchPersona(isLogin);
 
   return null;
 });

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -464,7 +464,7 @@ describe('contextEngineering', () => {
         },
       ];
 
-      // Mock topic memories and global identities separately
+      // Mock topic memories and user persona separately
       vi.spyOn(memoryManager, 'resolveTopicMemories').mockReturnValue({
         activities: [],
         contexts: [
@@ -489,7 +489,7 @@ describe('contextEngineering', () => {
         experiences: [],
         preferences: [],
       });
-      vi.spyOn(memoryManager, 'resolveGlobalIdentities').mockReturnValue([]);
+      vi.spyOn(memoryManager, 'resolveUserPersona').mockReturnValue(undefined);
 
       const result = await contextEngineering({
         enableUserMemories: true,

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -44,11 +44,7 @@ import {
 } from '@/store/tool/selectors';
 
 import { isCanUseVideo, isCanUseVision } from '../helper';
-import {
-  combineUserMemoryData,
-  resolveGlobalIdentities,
-  resolveTopicMemories,
-} from './memoryManager';
+import { combineUserMemoryData, resolveTopicMemories, resolveUserPersona } from './memoryManager';
 import { createSkillEngine } from './skillEngineering';
 
 const log = debug('context-engine:contextEngineering');
@@ -296,13 +292,13 @@ export const contextEngineering = async ({
     .filter((kb) => kb.enabled)
     .map((kb) => ({ description: kb.description, id: kb.id, name: kb.name }));
 
-  // Resolve user memories: topic memories and global identities are independent layers
+  // Resolve user memories: topic memories and user persona are independent layers
   // Both functions now read from cache only (no network requests) to avoid blocking sendMessage
   let userMemoryData: UserMemoryData | undefined;
   if (enableUserMemories) {
     const topicMemories = resolveTopicMemories();
-    const globalIdentities = resolveGlobalIdentities();
-    userMemoryData = combineUserMemoryData(topicMemories, globalIdentities);
+    const persona = resolveUserPersona();
+    userMemoryData = combineUserMemoryData(topicMemories, persona);
   }
 
   // Resolve GTD context: plan and todos

--- a/src/services/chat/mecha/index.ts
+++ b/src/services/chat/mecha/index.ts
@@ -22,8 +22,4 @@ export { resolveModelExtendParams } from './modelParamsResolver';
 
 // Memory management
 export type { TopicMemoryResolverContext } from './memoryManager';
-export {
-  combineUserMemoryData,
-  resolveGlobalIdentities,
-  resolveTopicMemories,
-} from './memoryManager';
+export { combineUserMemoryData, resolveTopicMemories, resolveUserPersona } from './memoryManager';

--- a/src/services/chat/mecha/memoryManager.ts
+++ b/src/services/chat/mecha/memoryManager.ts
@@ -1,9 +1,11 @@
-import { type UserMemoryData, type UserMemoryIdentityItem } from '@lobechat/context-engine';
+import { type UserMemoryData } from '@lobechat/context-engine';
 import { type RetrieveMemoryResult } from '@lobechat/types';
 
 import { getChatStoreState } from '@/store/chat';
 import { getUserMemoryStoreState } from '@/store/userMemory';
-import { agentMemorySelectors, identitySelectors } from '@/store/userMemory/selectors';
+import { agentMemorySelectors } from '@/store/userMemory/selectors';
+
+type UserMemoryPersona = UserMemoryData['persona'];
 
 const EMPTY_MEMORIES: RetrieveMemoryResult = {
   activities: [],
@@ -13,20 +15,18 @@ const EMPTY_MEMORIES: RetrieveMemoryResult = {
 };
 
 /**
- * Resolves global identities from user memory store
- * Returns identities that apply across all topics
+ * Resolves user persona from user memory store
  */
-export const resolveGlobalIdentities = (): UserMemoryIdentityItem[] => {
+export const resolveUserPersona = (): UserMemoryPersona | undefined => {
   const memoryState = getUserMemoryStoreState();
-  const globalIdentities = identitySelectors.globalIdentities(memoryState);
+  const persona = memoryState.persona;
 
-  return globalIdentities.map((identity) => ({
-    capturedAt: identity.capturedAt,
-    description: identity.description,
-    id: identity.id,
-    role: identity.role,
-    type: identity.type,
-  }));
+  if (!persona?.content && !persona?.summary) return undefined;
+
+  return {
+    narrative: persona.content,
+    tagline: persona.summary,
+  };
 };
 
 /**
@@ -63,16 +63,16 @@ export const resolveTopicMemories = (ctx?: TopicMemoryResolverContext): Retrieve
 };
 
 /**
- * Combines topic memories and global identities into UserMemoryData
+ * Combines topic memories and user persona into UserMemoryData
  * This is a utility for assembling the final memory data structure
  */
 export const combineUserMemoryData = (
   topicMemories: RetrieveMemoryResult,
-  identities: UserMemoryIdentityItem[],
+  persona?: UserMemoryPersona,
 ): UserMemoryData => ({
   activities: topicMemories.activities,
   contexts: topicMemories.contexts,
   experiences: topicMemories.experiences,
-  identities,
+  persona,
   preferences: topicMemories.preferences,
 });

--- a/src/store/userMemory/slices/home/action.ts
+++ b/src/store/userMemory/slices/home/action.ts
@@ -25,19 +25,23 @@ export class HomeActionImpl {
     void get;
   }
 
-  useFetchPersona = (): SWRResponse<PersonaData | null> => {
-    return useClientDataSWR(FETCH_PERSONA_KEY, () => userMemoryService.getPersona(), {
-      onSuccess: (data: PersonaData | null | undefined) => {
-        this.#set(
-          {
-            persona: data ?? undefined,
-            personaInit: true,
-          },
-          false,
-          n('useFetchPersona/onSuccess'),
-        );
+  useFetchPersona = (isLogin = true): SWRResponse<PersonaData | null> => {
+    return useClientDataSWR(
+      isLogin ? FETCH_PERSONA_KEY : null,
+      () => userMemoryService.getPersona(),
+      {
+        onSuccess: (data: PersonaData | null | undefined) => {
+          this.#set(
+            {
+              persona: data ?? undefined,
+              personaInit: true,
+            },
+            false,
+            n('useFetchPersona/onSuccess'),
+          );
+        },
       },
-    });
+    );
   };
 
   useFetchTags = (): SWRResponse<QueryIdentityRolesResult> => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Default user memory handling to use a persona object instead of global identities and wire persona fetching into initialization.

New Features:
- Support resolving and combining a user persona with topic memories into the UserMemoryData passed to the context engine.

Enhancements:
- Update memory manager and context engineering to work with persona-based user memories rather than identity lists.
- Gate persona fetching by login state and initialize it during deferred store initialization.
- Adjust tests and exports to reflect the persona-based memory resolution flow.