### PR TITLE
📝 docs: use official Discord vanity URL (discord.gg/lobehub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ This project is [LobeHub Community License](./LICENSE) licensed.
 [deploy-on-sealos-link]: https://template.usw.sealos.io/deploy?templateName=lobe-chat-db
 [deploy-on-zeabur-button-image]: https://zeabur.com/button.svg
 [deploy-on-zeabur-link]: https://zeabur.com/templates/VZGGTI
-[discord-link]: https://discord.gg/AYFPHvv2jT
+[discord-link]: https://discord.gg/lobehub
 [discord-shield]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
 [discord-shield-badge]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -854,7 +854,7 @@ This project is [LobeHub Community License](./LICENSE) licensed.
 [deploy-on-sealos-link]: https://template.hzh.sealos.run/deploy?templateName=lobe-chat-db
 [deploy-on-zeabur-button-image]: https://zeabur.com/button.svg
 [deploy-on-zeabur-link]: https://zeabur.com/templates/VZGGTI
-[discord-link]: https://discord.gg/AYFPHvv2jT
+[discord-link]: https://discord.gg/lobehub
 [discord-shield]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
 [discord-shield-badge]: https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [docker-pulls-link]: https://hub.docker.com/r/lobehub/lobehub

--- a/docs/development/basic/resources.mdx
+++ b/docs/development/basic/resources.mdx
@@ -40,6 +40,6 @@ The design and development of LobeHub would not have been possible without the e
 - [🔌 MCP Market](https://lobehub.com/mcp): Discover and share MCP tools
 - [🎬 YouTube](https://www.youtube.com/@lobehub): Official video tutorials and demos
 - [🐦 X (Twitter)](https://x.com/lobehub): Project updates and announcements
-- [💬 Discord](https://discord.com/invite/AYFPHvv2jT): Community discussion and support
+- [💬 Discord](https://discord.gg/lobehub): Community discussion and support
 
 We will continue to update and supplement this list to provide developers with more reference resources.

--- a/docs/development/basic/resources.zh-CN.mdx
+++ b/docs/development/basic/resources.zh-CN.mdx
@@ -38,6 +38,6 @@ LobeHub 的设计和开发离不开社区和生态中的优秀项目。我们在
 - [🔌 MCP 市场](https://lobehub.com/zh/mcp)：发现和分享 MCP 工具
 - [🎬 YouTube](https://www.youtube.com/@lobehub)：官方视频教程与演示
 - [🐦 X (Twitter)](https://x.com/lobehub)：项目动态与公告
-- [💬 Discord](https://discord.com/invite/AYFPHvv2jT)：社区讨论与技术支持
+- [💬 Discord](https://discord.gg/lobehub)：社区讨论与技术支持
 
 我们会持续更新和补充这个列表，为开发者提供更多的参考资源。

--- a/docs/development/start.mdx
+++ b/docs/development/start.mdx
@@ -107,6 +107,6 @@ For a detailed guide on internationalization implementation, please refer to [In
 
 To support developers in better understanding and using the technology stack of LobeHub, we provide a comprehensive list of resources and references — [LobeHub Resources and References](/docs/development/basic/resources) - Visit our maintained list of resources, including tutorials, articles, and other useful links.
 
-We encourage developers to utilize these resources to deepen their learning and enhance their skills, join community discussions through [LobeHub GitHub Discussions](https://github.com/lobehub/lobehub/discussions) or [Discord](https://discord.com/invite/AYFPHvv2jT), ask questions, or share your experiences.
+We encourage developers to utilize these resources to deepen their learning and enhance their skills, join community discussions through [LobeHub GitHub Discussions](https://github.com/lobehub/lobehub/discussions) or [Discord](https://discord.gg/lobehub), ask questions, or share your experiences.
 
 If you have any questions or need further assistance, please do not hesitate to contact us through the above channels.

--- a/docs/development/start.zh-CN.mdx
+++ b/docs/development/start.zh-CN.mdx
@@ -100,6 +100,6 @@ CI 会自动生成其他语言的翻译文件。
 
 为了支持开发者更好地理解和使用 LobeHub 的技术栈，我们提供了一份详尽的资源与参考列表 —— [LobeHub 资源与参考](/zh/docs/development/basic/resources) - 访问我们维护的资源列表，包括教程、文章和其他有用的链接。
 
-我们鼓励开发者利用这些资源深入学习和提升技能，通过 [LobeHub GitHub Discussions](https://github.com/lobehub/lobehub/discussions) 或者 [Discord](https://discord.com/invite/AYFPHvv2jT) 加入社区讨论，提出问题或分享你的经验。
+我们鼓励开发者利用这些资源深入学习和提升技能，通过 [LobeHub GitHub Discussions](https://github.com/lobehub/lobehub/discussions) 或者 [Discord](https://discord.gg/lobehub) 加入社区讨论，提出问题或分享你的经验。
 
 如果你有任何疑问，或者需要进一步的帮助，请不要犹豫，请通过上述渠道与我们联系。

--- a/docs/self-hosting/migration/v2/auth/clerk-to-betterauth.mdx
+++ b/docs/self-hosting/migration/v2/auth/clerk-to-betterauth.mdx
@@ -24,7 +24,7 @@ This guide helps you migrate your existing Clerk-based LobeHub deployment to Bet
   - **Always backup your database first!** For Neon users, create a backup via [Fork Branch](https://neon.tech/docs/manage/branches#create-a-branch)
   - LobeHub is not responsible for any data loss or issues that may occur during the migration process
   - This guide is intended for users with development experience; not recommended for users without technical background
-  - If you have any questions, feel free to ask in our [Discord](https://discord.com/invite/AYFPHvv2jT) community or [GitHub Issue](https://github.com/lobehub/lobe-chat/issues/11707)
+  - If you have any questions, feel free to ask in our [Discord](https://discord.gg/lobehub) community or [GitHub Issue](https://github.com/lobehub/lobe-chat/issues/11707)
 </Callout>
 
 ## Choose Your Migration Path

--- a/docs/self-hosting/migration/v2/auth/clerk-to-betterauth.zh-CN.mdx
+++ b/docs/self-hosting/migration/v2/auth/clerk-to-betterauth.zh-CN.mdx
@@ -22,7 +22,7 @@ tags:
   - **务必先备份数据库**！如使用 Neon，可通过 [Fork 分支](https://neon.tech/docs/manage/branches#create-a-branch) 创建备份
   - 迁移过程中可能出现的任何数据丢失或问题，LobeHub 概不负责
   - 本指南适合有一定开发背景的用户，不建议无技术经验的用户自行操作
-  - 如有任何疑问，欢迎到 [Discord](https://discord.com/invite/AYFPHvv2jT) 社区或 [GitHub Issue](https://github.com/lobehub/lobe-chat/issues/11707) 提问
+  - 如有任何疑问，欢迎到 [Discord](https://discord.gg/lobehub) 社区或 [GitHub Issue](https://github.com/lobehub/lobe-chat/issues/11707) 提问
 </Callout>
 
 ## 选择迁移方式

--- a/docs/self-hosting/migration/v2/auth/nextauth-to-betterauth.mdx
+++ b/docs/self-hosting/migration/v2/auth/nextauth-to-betterauth.mdx
@@ -24,7 +24,7 @@ This guide helps you migrate your existing NextAuth-based LobeHub deployment to 
   - **Always backup your database first!** For Neon users, create a backup via [Fork Branch](https://neon.tech/docs/manage/branches#create-a-branch)
   - LobeHub is not responsible for any data loss or issues that may occur during the migration process
   - This guide is intended for users with development experience; not recommended for users without technical background
-  - If you have any questions, feel free to ask in our [Discord](https://discord.com/invite/AYFPHvv2jT) community or [GitHub Issue](https://github.com/lobehub/lobe-chat/issues)
+  - If you have any questions, feel free to ask in our [Discord](https://discord.gg/lobehub) community or [GitHub Issue](https://github.com/lobehub/lobe-chat/issues)
 </Callout>
 
 ## Choose Your Migration Path

--- a/docs/self-hosting/migration/v2/auth/nextauth-to-betterauth.zh-CN.mdx
+++ b/docs/self-hosting/migration/v2/auth/nextauth-to-betterauth.zh-CN.mdx
@@ -22,7 +22,7 @@ tags:
   - **务必先备份数据库**！如使用 Neon，可通过 [Fork 分支](https://neon.tech/docs/manage/branches#create-a-branch) 创建备份
   - 迁移过程中可能出现的任何数据丢失或问题，LobeHub 概不负责
   - 本指南适合有一定开发背景的用户，不建议无技术经验的用户自行操作
-  - 如有任何疑问，欢迎到 [Discord](https://discord.com/invite/AYFPHvv2jT) 社区或 [GitHub Issue](https://github.com/lobehub/lobe-chat/issues) 提问
+  - 如有任何疑问，欢迎到 [Discord](https://discord.gg/lobehub) 社区或 [GitHub Issue](https://github.com/lobehub/lobe-chat/issues) 提问
 </Callout>
 
 ## 选择迁移方式

--- a/docs/usage/help.mdx
+++ b/docs/usage/help.mdx
@@ -41,7 +41,7 @@ Before submitting, search existing issues to avoid duplicates. Include steps to 
 
 | Channel           | Best for                                  | Link                                                                    |
 | ----------------- | ----------------------------------------- | ----------------------------------------------------------------------- |
-| **Discord**       | Real-time chat, quick Q\&A, announcements | [Join](https://discord.com/invite/AYFPHvv2jT)                           |
+| **Discord**       | Real-time chat, quick Q\&A, announcements | [Join](https://discord.gg/lobehub)                           |
 | **Reddit**        | Discussions and community updates         | [r/LobeHub](https://www.reddit.com/r/LobeHub/)                          |
 | **GitHub Issues** | Bug reports, feature requests             | [Open an Issue](https://github.com/lobehub/lobe-chat/issues/new/choose) |
 | **Email**         | Partnerships, enterprise inquiries        | [hi@lobehub.com](mailto:hi@lobehub.com)                                 |

--- a/docs/usage/help.zh-CN.mdx
+++ b/docs/usage/help.zh-CN.mdx
@@ -39,7 +39,7 @@ tags:
 
 | 渠道                | 适合           | 链接                                                                 |
 | ----------------- | ------------ | ------------------------------------------------------------------ |
-| **Discord**       | 实时交流、快速问答、公告 | [加入](https://discord.com/invite/AYFPHvv2jT)                        |
+| **Discord**       | 实时交流、快速问答、公告 | [加入](https://discord.gg/lobehub)                        |
 | **Reddit**        | 讨论与社区动态      | [r/LobeHub](https://www.reddit.com/r/LobeHub/)                     |
 | **GitHub Issues** | Bug 反馈、功能建议  | [提交 Issue](https://github.com/lobehub/lobe-chat/issues/new/choose) |
 | **邮箱**            | 合作、企业咨询      | [hi@lobehub.com](mailto:hi@lobehub.com)                            |

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -18,7 +18,7 @@ export const BRANDING_URL = {
 };
 
 export const SOCIAL_URL = {
-  discord: 'https://discord.gg/AYFPHvv2jT',
+  discord: 'https://discord.gg/lobehub',
   github: 'https://github.com/lobehub',
   medium: 'https://medium.com/@lobehub',
   x: 'https://x.com/lobehub',

--- a/packages/web-crawler/src/utils/html/terms.html
+++ b/packages/web-crawler/src/utils/html/terms.html
@@ -1079,7 +1079,7 @@
                         ></path></svg
                     ></span>
                   </div> </a
-                ><a target="_blank" href="https://discord.gg/AYFPHvv2jT">
+                ><a target="_blank" href="https://discord.gg/lobehub">
                   <div
                     style="border-radius: 5px; height: 36px; width: 36px"
                     aria-describedby=":R1orniiqdfb:"


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #10580

#### 🔀 Description of Change

Updates the expired Discord invitation link (`AYFPHvv2jT`) to the active vanity URL (`lobehub`) across all documentation, HTML, and source files.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

## Summary by Sourcery

Update Discord community links to the new vanity URL across documentation, shared constants, and embedded HTML templates.

Enhancements:
- Update the shared SOCIAL_URL.discord constant and HTML terms template to use the new Discord vanity URL for consistency across the app and web crawler output.

Documentation:
- Replace the expired Discord invite URL with the new vanity URL in English and Chinese READMEs and multiple usage, development, and migration guide pages.