### PR TITLE
🐛 fix(ci): correct stable renderer tar source path

### DIFF
--- a/.github/workflows/release-desktop-stable.yml
+++ b/.github/workflows/release-desktop-stable.yml
@@ -236,7 +236,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           npm run desktop:package:app
-          tar -czf apps/desktop/release/lobehub-renderer.tar.gz -C out .
+          test -d apps/desktop/dist/renderer
+          tar -czf apps/desktop/release/lobehub-renderer.tar.gz -C apps/desktop/dist/renderer .
         env:
           UPDATE_CHANNEL: stable
           UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This hotfix updates the stable desktop release workflow to archive the renderer assets from the current Electron renderer output directory instead of the removed `out/` directory.

It prevents the Linux stable desktop build from failing after packaging succeeds when creating `lobehub-renderer.tar.gz`.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified the workflow change by checking the final diff against `canary` and running `bunx prettier --check .github/workflows/release-desktop-stable.yml`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This is a workflow-only hotfix. The desktop packages were already building successfully; the failure came from the extra stable-only renderer archive step using an outdated path.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Correct the source path used when creating the stable renderer tarball in the Linux desktop release workflow to match the current build output structure.