### PR TITLE
refactor: replace semantic-release with manual changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_TOKEN }}
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -90,13 +92,21 @@ jobs:
             console.log('✅ Version OK:', actual);
           "
 
-      - name: Release
-        run: bun run release
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Pass version to semantic-release
-          SEMANTIC_RELEASE_VERSION: ${{ steps.get-version.outputs.version }}
+      - name: Generate Changelog
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          echo "📝 Generating changelog for v$VERSION"
+
+          # Use conventional-changelog with gitmoji preset to update CHANGELOG.md
+          # -p gitmoji-config: uses the same preset as semantic-release-config-gitmoji
+          # -i CHANGELOG.md -s: read from and write back to CHANGELOG.md
+          # -r 1: regenerate only the latest release entry
+          npx -p conventional-changelog-cli -p conventional-changelog-gitmoji-config conventional-changelog -p gitmoji-config -i CHANGELOG.md -s -r 1
+
+          echo "✅ CHANGELOG.md updated"
+
+      - name: Build Static Changelog
+        run: bun run workflow:changelog
 
       - name: Workflow
         run: bun run workflow:readme
@@ -107,7 +117,7 @@ jobs:
           git config --global user.name "lobehubbot"
           git config --global user.email "i@lobehub.com"
           git add .
-          git commit -m "📝 docs(bot): Auto sync agents & plugin to readme" || exit 0
-          git push
+          git commit -m "📝 docs(bot): Auto update changelog and readme" || exit 0
+          git push origin main
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor
- [x] 👷 build

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

This PR refactors the release workflow to replace the `semantic-release` command with a manual changelog generation approach using `conventional-changelog-cli`.

**Key Changes:**

1. **Checkout Configuration**: Added `ref: main` and `fetch-depth: 0` to the checkout step to ensure we're working with the full git history on the main branch.

2. **Removed Semantic Release Step**: Replaced the `Release` step that ran `bun run release` with a new `Generate Changelog` step that:
   - Uses `conventional-changelog-cli` with the `gitmoji-config` preset
   - Generates changelog entries for the latest release only (`-r 1`)
   - Updates `CHANGELOG.md` in place

3. **Added Build Static Changelog Step**: Introduced a new step that runs `bun run workflow:changelog` to build static changelog artifacts.

4. **Updated Git Commit Message**: Changed the commit message from "Auto sync agents & plugin to readme" to "Auto update changelog and readme" to reflect the new workflow.

5. **Explicit Push Target**: Changed `git push` to `git push origin main` for clarity and consistency.

**Rationale:**

This change moves away from the automated semantic-release tool to a more controlled, manual changelog generation process. This allows for greater flexibility in how changelogs are generated and formatted while maintaining the same gitmoji-based conventional commit structure.

#### 🧪 How to Test

- [x] No tests needed

The changes are workflow configuration updates that will be validated by the CI/CD pipeline on the next release. The workflow syntax is correct and the commands reference existing npm packages and bun scripts.

#### 📝 Additional Information

This is a build/workflow refactor with no impact on the actual source code or public API. The release process will now rely on manual changelog generation instead of the semantic-release tool.

https://claude.ai/code/session_01BejUKHVstM3VtG6nYrV1BA

## Summary by Sourcery

Refactor the release workflow to replace semantic-release with manual changelog generation and updated automation around changelog and README updates.

Build:
- Update release workflow checkout to use the main branch with full git history.
- Replace the semantic-release step with a conventional-changelog-based step that regenerates the latest changelog entry.
- Add a step to build static changelog artifacts before updating the repository.
- Adjust the bot commit message to reflect changelog and README updates and push explicitly to the main branch.