### PR TITLE
🐛 fix: correct extend params reasoning payloads and persist cleared model settings & add MiniMax M2.7

### DIFF
--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';
-export const DEFAULT_MINI_MODEL = 'gpt-5-mini';
+export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 
 export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
 

--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -68,6 +68,63 @@ const aihubmixModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'GPT-5.4 mini brings GPT-5.4 strengths to a faster, more efficient model for high-volume coding and agentic workflows.',
+    displayName: 'GPT-5.4 mini',
+    enabled: true,
+    id: 'gpt-5.4-mini',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-17',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'GPT-5.4 nano is our lowest-cost GPT-5.4-class model for high-throughput tasks where speed and cost matter most.',
+    displayName: 'GPT-5.4 nano',
+    id: 'gpt-5.4-nano',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-17',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 1_050_000,
@@ -121,7 +178,6 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'GPT-5.3 Chat is the latest ChatGPT model used in ChatGPT with improved conversation experiences.',
     displayName: 'GPT-5.3 Chat',
-    enabled: true,
     id: 'gpt-5.3-chat-latest',
     maxOutput: 16_384,
     pricing: {
@@ -406,7 +462,6 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'A faster, more cost-effective GPT-5 variant for well-defined tasks, delivering faster responses while maintaining quality.',
     displayName: 'GPT-5 mini',
-    enabled: true,
     id: 'gpt-5-mini',
     maxOutput: 128_000,
     pricing: {
@@ -1385,6 +1440,36 @@ const aihubmixModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      "Gemini 3.1 Flash-Lite Preview is Google's most cost-efficient multimodal model, optimized for high-volume agentic tasks, translation, and data processing.",
+    displayName: 'Gemini 3.1 Flash-Lite Preview',
+    id: 'gemini-3.1-flash-lite-preview',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-04',
+    settings: {
+      extendParams: ['thinkingLevel5', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },
@@ -1486,7 +1571,6 @@ const aihubmixModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro Image (Nano Banana Pro) is Google’s image generation model with multimodal chat support.',
     displayName: 'Nano Banana Pro',
-    enabled: true,
     id: 'gemini-3-pro-image-preview',
     maxOutput: 32_768,
     pricing: {

--- a/packages/model-bank/src/aiModels/infiniai.ts
+++ b/packages/model-bank/src/aiModels/infiniai.ts
@@ -6,6 +6,27 @@ const infiniaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax-M2.7 has reached or refreshed the latest SOTA benchmark in programming, tool calling and search, office productivity and many other scenarios, officially starting the journey of model recursive self-improvement.',
+    displayName: 'MiniMax M2.7',
+    enabled: true,
+    id: 'minimax-m2.7',
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-17',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       vision: true,
     },
     contextWindowTokens: 131_072,
@@ -56,7 +77,6 @@ const infiniaiChatModels: AIChatModelCard[] = [
     description:
       'MiniMax-M2.5 is a state-of-the-art large language model designed for real-world productivity and coding tasks.',
     displayName: 'MiniMax M2.5',
-    enabled: true,
     id: 'minimax-m2.5',
     pricing: {
       currency: 'CNY',
@@ -118,7 +138,6 @@ const infiniaiChatModels: AIChatModelCard[] = [
     description:
       'MiniMax-M2.1 is the latest version of the MiniMax series, optimized for multilingual programming and real-world complex tasks. As an AI-native model, MiniMax-M2.1 achieves significant improvements in model performance, agent framework support, and multi-scenario adaptation, aiming to help enterprises and individuals find AI-native work and lifestyle more quickly.',
     displayName: 'MiniMax M2.1',
-    enabled: true,
     id: 'minimax-m2.1',
     maxOutput: 200_000,
     pricing: {
@@ -159,7 +178,6 @@ const infiniaiChatModels: AIChatModelCard[] = [
     description:
       'GLM-4.7 is the latest large language model launched by Zhipu AI, with enhanced reasoning and generation capabilities.',
     displayName: 'GLM-4.7',
-    enabled: true,
     id: 'glm-4.7',
     maxOutput: 4096,
     pricing: {

--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -5,6 +5,55 @@ const minimaxChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'Beginning the journey of recursive self-improvement. Optimized for top real-world engineering, professional office delivery, and character-rich interaction.',
+    displayName: 'MiniMax M2.7',
+    enabled: true,
+    id: 'MiniMax-M2.7',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.42, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'Same performance as M2.7, with significantly faster inference for low-latency coding and refactoring.',
+    displayName: 'MiniMax M2.7 highspeed',
+    id: 'MiniMax-M2.7-highspeed',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.42, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
     },
     contextWindowTokens: 204_800,
     description:
@@ -56,7 +105,6 @@ const minimaxChatModels: AIChatModelCard[] = [
     description:
       'Top-tier performance and ultimate cost-effectiveness, easily handling complex tasks (approx. 60 tps).',
     displayName: 'MiniMax M2.5',
-    enabled: true,
     id: 'MiniMax-M2.5',
     maxOutput: 131_072,
     pricing: {
@@ -77,20 +125,37 @@ const minimaxChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 204_800,
-    description: 'M2.5 Lightning: Same performance, faster and more agile (approx. 100 tps).',
-    displayName: 'MiniMax M2.5 Lightning',
-    id: 'MiniMax-M2.5-Lightning',
+    description: 'M2.5 highspeed: Same performance, faster and more agile (approx. 100 tps).',
+    displayName: 'MiniMax M2.5 highspeed',
+    id: 'MiniMax-M2.5-highspeed',
     maxOutput: 131_072,
     pricing: {
       currency: 'CNY',
       units: [
         { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-02-12',
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 655_36,
+    description:
+      'A text dialogue model designed for role-playing and multi-turn conversations, with character customization and emotional expression.',
+    displayName: 'MiniMax M2-her',
+    id: 'M2-her',
+    maxOutput: 2048,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-01-23',
     type: 'chat',
   },
   {
@@ -124,15 +189,15 @@ const minimaxChatModels: AIChatModelCard[] = [
     contextWindowTokens: 204_800,
     description:
       'Powerful multilingual programming capabilities, comprehensively upgraded programming experience. Faster and more efficient.',
-    displayName: 'MiniMax M2.1 Lightning',
-    id: 'MiniMax-M2.1-Lightning',
+    displayName: 'MiniMax M2.1 highspeed',
+    id: 'MiniMax-M2.1-highspeed',
     maxOutput: 131_072,
     pricing: {
       currency: 'CNY',
       units: [
         { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },

--- a/packages/model-bank/src/aiModels/nvidia.ts
+++ b/packages/model-bank/src/aiModels/nvidia.ts
@@ -6,26 +6,32 @@ const nvidiaChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 128_000,
+    contextWindowTokens: 204_800,
     description:
-      'MiniMax-M2 is a compact, fast, cost-effective MoE model (230B total, 10B active) built for top-tier coding and agent performance while retaining strong general intelligence. It excels at multi-file edits, code-run-fix loops, test validation, and complex toolchains.',
-    displayName: 'MiniMax-M2',
-    id: 'minimaxai/minimax-m2',
-    maxOutput: 16_384,
+      'MiniMax-M2.5 is the latest large language model from MiniMax, featuring a Mixture-of-Experts (MoE) architecture with 229 billion total parameters. It achieves industry-leading performance in programming, agent tool calling, search tasks, and office scenarios.',
+    displayName: 'MiniMax-M2.5',
+    enabled: true,
+    id: 'minimaxai/minimax-m2.5',
+    maxOutput: 131_072,
     type: 'chat',
   },
   {
     abilities: {
       functionCall: true,
       reasoning: true,
+      vision: true,
+      video: true,
     },
-    contextWindowTokens: 204_800,
+    contextWindowTokens: 1_010_000,
     description:
-      'MiniMax-M2.1 is a compact, fast, cost-effective MoE model built for top-tier coding and agent performance.',
-    displayName: 'MiniMax-M2.1',
+      'Supports text, image, and video inputs. For text-only tasks, its performance is comparable to Qwen3 Max, offering higher efficiency and lower cost. In multimodal capabilities, it delivers significant improvements over the Qwen3 VL series.',
+    displayName: 'Qwen3.5-397B-A17B',
     enabled: true,
-    id: 'minimaxai/minimax-m2.1',
-    maxOutput: 131_072,
+    id: 'qwen/qwen3.5-397b-a17b',
+    maxOutput: 65_536,
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
     type: 'chat',
   },
   {
@@ -54,89 +60,6 @@ const nvidiaChatModels: AIChatModelCard[] = [
     description:
       'GLM-4.7 is Zhipu latest flagship model, enhanced for Agentic Coding scenarios with improved coding capabilities.',
     displayName: 'GLM-4.7',
-    enabled: true,
-    id: 'z-ai/glm4.7',
-    maxOutput: 131_072,
-    settings: {
-      extendParams: ['enableReasoning'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      "GLM-5 is Zhipu AI's new flagship foundation model for agent engineering, achieving open-source SOTA performance in coding and agent capabilities. It matches Claude Opus 4.5 in performance.",
-    displayName: 'GLM-5',
-    enabled: true,
-    id: 'z-ai/glm5',
-    maxOutput: 131_072,
-    settings: {
-      extendParams: ['enableReasoning'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 262_144,
-    description:
-      'Kimi K2.5 is the most intelligent Kimi model to date, featuring native multimodal architecture.',
-    displayName: 'Kimi K2.5',
-    enabled: true,
-    id: 'moonshotai/kimi-k2.5',
-    maxOutput: 65_536,
-    settings: {
-      extendParams: ['enableReasoning'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'MiniMax-M2.1 is a compact, fast, cost-effective MoE model built for top-tier coding and agent performance.',
-    displayName: 'MiniMax-M2.1',
-    enabled: true,
-    id: 'minimaxai/minimax-m2.1',
-    maxOutput: 131_072,
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 131_072,
-    description:
-      'DeepSeek V3.2 is a next-gen reasoning model with stronger complex reasoning and chain-of-thought capabilities.',
-    displayName: 'DeepSeek V3.2',
-    enabled: true,
-    id: 'deepseek-ai/deepseek-v3.2',
-    maxOutput: 65_536,
-    settings: {
-      extendParams: ['enableReasoning'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      'GLM-4.7 is Zhipu latest flagship model, enhanced for Agentic Coding scenarios with improved coding capabilities.',
-    displayName: 'GLM-4.7',
-    enabled: true,
     id: 'z-ai/glm4.7',
     maxOutput: 131_072,
     settings: {
@@ -354,39 +277,6 @@ const nvidiaChatModels: AIChatModelCard[] = [
       'An advanced LLM for code generation, reasoning, and repair across mainstream programming languages.',
     displayName: 'Qwen2.5 Coder 32B Instruct',
     id: 'qwen/qwen2.5-coder-32b-instruct',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'MiniMax-M2.5 is the latest large language model from MiniMax, featuring a Mixture-of-Experts (MoE) architecture with 229 billion total parameters. It achieves industry-leading performance in programming, agent tool calling, search tasks, and office scenarios.',
-    displayName: 'MiniMax-M2.5',
-    enabled: true,
-    id: 'minimaxai/minimax-m2.5',
-    maxOutput: 131_072,
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      vision: true,
-      video: true,
-    },
-    contextWindowTokens: 1_010_000,
-    description:
-      'Supports text, image, and video inputs. For text-only tasks, its performance is comparable to Qwen3 Max, offering higher efficiency and lower cost. In multimodal capabilities, it delivers significant improvements over the Qwen3 VL series.',
-    displayName: 'Qwen3.5-397B-A17B',
-    enabled: true,
-    id: 'qwen/qwen3.5-397b-a17b',
-    maxOutput: 65_536,
-    settings: {
-      extendParams: ['enableReasoning'],
-    },
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/ollamacloud.ts
+++ b/packages/model-bank/src/aiModels/ollamacloud.ts
@@ -5,6 +5,19 @@ const ollamaCloudModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+    },
+    contextWindowTokens: 204_800,
+    description:
+      'MiniMax M2.7 is an efficient large language model built specifically for coding and agent workflows.',
+    displayName: 'MiniMax M2.7',
+    enabled: true,
+    id: 'minimax-m2.7',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
       vision: true,
     },
     contextWindowTokens: 262_144,
@@ -34,7 +47,6 @@ const ollamaCloudModels: AIChatModelCard[] = [
     description:
       'MiniMax-M2.5 is a state-of-the-art large language model designed for real-world productivity and coding tasks.',
     displayName: 'MiniMax M2.5',
-    enabled: true,
     id: 'minimax-m2.5',
     type: 'chat',
   },
@@ -47,7 +59,6 @@ const ollamaCloudModels: AIChatModelCard[] = [
     description:
       'K2 long thinking model supports 256k contexts, supports multi-step tool calling and thinking, and is good at solving more complex problems.',
     displayName: 'Kimi K2 Thinking',
-    enabled: true,
     id: 'kimi-k2-thinking',
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -85,6 +85,63 @@ export const openaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'GPT-5.4 mini brings GPT-5.4 strengths to a faster, more efficient model for high-volume coding and agentic workflows.',
+    displayName: 'GPT-5.4 mini',
+    enabled: true,
+    id: 'gpt-5.4-mini',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-17',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      'GPT-5.4 nano is our lowest-cost GPT-5.4-class model for high-throughput tasks where speed and cost matter most.',
+    displayName: 'GPT-5.4 nano',
+    id: 'gpt-5.4-nano',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-17',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       vision: true,
     },
     contextWindowTokens: 1_050_000,
@@ -561,7 +618,6 @@ export const openaiChatModels: AIChatModelCard[] = [
     description:
       'A faster, more cost-efficient GPT-5 variant for well-defined tasks, delivering quicker responses while maintaining quality.',
     displayName: 'GPT-5 mini',
-    enabled: true,
     id: 'gpt-5-mini',
     maxOutput: 128_000,
     pricing: {

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -85,63 +85,6 @@ export const openaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
-      structuredOutput: true,
-      vision: true,
-    },
-    contextWindowTokens: 400_000,
-    description:
-      'GPT-5.4 mini brings GPT-5.4 strengths to a faster, more efficient model for high-volume coding and agentic workflows.',
-    displayName: 'GPT-5.4 mini',
-    enabled: true,
-    id: 'gpt-5.4-mini',
-    maxOutput: 128_000,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-03-17',
-    settings: {
-      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      structuredOutput: true,
-      vision: true,
-    },
-    contextWindowTokens: 400_000,
-    description:
-      'GPT-5.4 nano is our lowest-cost GPT-5.4-class model for high-throughput tasks where speed and cost matter most.',
-    displayName: 'GPT-5.4 nano',
-    id: 'gpt-5.4-nano',
-    maxOutput: 128_000,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-03-17',
-    settings: {
-      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
-      searchImpl: 'params',
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
       vision: true,
     },
     contextWindowTokens: 1_050_000,
@@ -253,7 +196,6 @@ export const openaiChatModels: AIChatModelCard[] = [
     description:
       'GPT-5.3 Chat is the latest ChatGPT model used in ChatGPT with improved conversation experiences.',
     displayName: 'GPT-5.3 Chat',
-    enabled: true,
     id: 'gpt-5.3-chat-latest',
     maxOutput: 16_384,
     pricing: {

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -1843,11 +1843,11 @@ const qwenChatModels: AIChatModelCard[] = [
       vision: true,
     },
     config: {
-      deploymentName: 'qwen3.5-omni-plus-2026-03-15',
+      deploymentName: 'qwen3.5-omni-plus',
     },
     contextWindowTokens: 262_144,
     description:
-      'Qwen3.5-Omni is the latest generation multimodal large model from Qwen. It supports understanding and interaction across text, images, audio, and video. As a comprehensive evolution of Qwen3-Omni, it enables audio understanding for over 10 hours and supports video understanding and dialogue for more than 400 seconds of 720P (1 FPS) content. It further expands language coverage, supporting audio input in over 60 languages and speech output in more than 30 languages. Additionally, it features powerful structured audio-video understanding capabilities and is widely applicable in scenarios such as text creation, voice assistants, and multimedia analysis, delivering a natural and seamless multimodal interaction experience.',
+      'Qwen3.5 Omni Plus supports text, image, and video input. It is the latest full-modal Qwen model for high-quality multimodal understanding and generation.',
     displayName: 'Qwen3.5 Omni Plus',
     id: 'qwen3.5-omni-plus',
     maxOutput: 65_536,
@@ -1859,7 +1859,7 @@ const qwenChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.128]': 0.8,
-              '[0.128, infinity]': 2,
+              '[0.128, 0.256]': 2,
             },
             pricingParams: ['textInputRange'],
           },
@@ -1884,7 +1884,7 @@ const qwenChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.128]': 9.6,
-              '[0.128, infinity]': 24,
+              '[0.128, 0.256]': 24,
             },
             pricingParams: ['textInputRange'],
           },
@@ -1907,11 +1907,11 @@ const qwenChatModels: AIChatModelCard[] = [
       vision: true,
     },
     config: {
-      deploymentName: 'qwen3.5-omni-flash-2026-03-15',
+      deploymentName: 'qwen3.5-omni-flash',
     },
     contextWindowTokens: 262_144,
     description:
-      'Qwen3.5-Omni is the latest generation multimodal large model from Qwen. It supports understanding and interaction across text, images, audio, and video. As a comprehensive evolution of Qwen3-Omni, it enables audio understanding for over 10 hours and supports video understanding and dialogue for more than 400 seconds of 720P (1 FPS) content. It further expands language coverage, supporting audio input in over 60 languages and speech output in more than 30 languages. Additionally, it features powerful structured audio-video understanding capabilities and is widely applicable in scenarios such as text creation, voice assistants, and multimedia analysis, delivering a natural and seamless multimodal interaction experience.',
+      'Qwen3.5 Omni Flash is a fast, cost-effective full-modal Qwen model that supports text, image, and video input.',
     displayName: 'Qwen3.5 Omni Flash',
     id: 'qwen3.5-omni-flash',
     maxOutput: 65_536,
@@ -1923,7 +1923,7 @@ const qwenChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.128]': 0.2,
-              '[0.128, infinity]': 0.8,
+              '[0.128, 0.256]': 0.8,
             },
             pricingParams: ['textInputRange'],
           },
@@ -1948,7 +1948,7 @@ const qwenChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.128]': 4,
-              '[0.128, infinity]': 16,
+              '[0.128, 0.256]': 16,
             },
             pricingParams: ['textInputRange'],
           },

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -723,29 +723,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 192_000,
-    description:
-      'MiniMax-M2.1 is an open-source large language model optimized for agent capabilities, excelling in programming, tool usage, instruction following, and long-term planning. The model supports multilingual software development and complex multi-step workflow execution, achieving a score of 74.0 on SWE-bench Verified and surpassing Claude Sonnet 4.5 in multilingual scenarios.',
-    displayName: 'MiniMax-M2.1 (Pro)',
-    id: 'Pro/MiniMaxAI/MiniMax-M2.1',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    settings: {
-      extendParams: ['reasoningBudgetToken'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
     contextWindowTokens: 200_000,
     description:
       "GLM-4.7 is Zhipu's new generation flagship model with 355B total parameters and 32B active parameters, fully upgraded in general dialogue, reasoning, and agent capabilities. GLM-4.7 enhances Interleaved Thinking and introduces Preserved Thinking and Turn-level Thinking.",

--- a/packages/model-bank/src/aiModels/siliconcloud.ts
+++ b/packages/model-bank/src/aiModels/siliconcloud.ts
@@ -459,7 +459,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.131072]': 0.8,
-              '[0.131072, infinity]': 2.0,
+              '[0.131072, infinity]': 2,
             },
             pricingParams: ['textInput'],
           },
@@ -471,7 +471,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.131072]': 4.8,
-              '[0.131072, infinity]': 12.0,
+              '[0.131072, infinity]': 12,
             },
             pricingParams: ['textInput'],
           },
@@ -506,7 +506,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.131072]': 0.8,
-              '[0.131072, infinity]': 2.0,
+              '[0.131072, infinity]': 2,
             },
             pricingParams: ['textInput'],
           },
@@ -518,7 +518,7 @@ const siliconcloudChatModels: AIChatModelCard[] = [
           lookup: {
             prices: {
               '[0, 0.131072]': 6.4,
-              '[0.131072, infinity]': 16.0,
+              '[0.131072, infinity]': 16,
             },
             pricingParams: ['textInput'],
           },
@@ -658,8 +658,8 @@ const siliconcloudChatModels: AIChatModelCard[] = [
         {
           lookup: {
             prices: {
-              '[0, 0.131072]': 4.0,
-              '[0.131072, infinity]': 12.0,
+              '[0, 0.131072]': 4,
+              '[0.131072, infinity]': 12,
             },
             pricingParams: ['textInput'],
           },
@@ -1058,46 +1058,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 256_000,
-    description:
-      'Qwen3-Next-80B-A3B-Thinking is a next-gen base model for complex reasoning. It uses the Qwen3-Next architecture with hybrid attention (Gated DeltaNet + Gated Attention) and highly sparse MoE for extreme training/inference efficiency. With 80B total parameters but ~3B active at inference, it cuts compute and delivers 10x+ throughput over Qwen3-32B on >32K contexts. This Thinking version targets multi-step tasks like proofs, code synthesis, logic analysis, and planning, outputting structured chain-of-thought. It outperforms Qwen3-32B-Thinking and beats Gemini-2.5-Flash-Thinking on several benchmarks.',
-    displayName: 'Qwen3 Next 80B A3B Thinking',
-    id: 'Qwen/Qwen3-Next-80B-A3B-Thinking',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-09-10',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 131_072,
-    description:
-      'Qwen3-Next-80B-A3B-Instruct is a next-gen base model using the Qwen3-Next architecture for extreme training and inference efficiency. It combines hybrid attention (Gated DeltaNet + Gated Attention), highly sparse MoE, and training stability optimizations. With 80B total parameters but ~3B active at inference, it reduces compute and delivers 10x+ throughput over Qwen3-32B on >32K contexts. This instruction-tuned version targets general tasks (no Thinking mode). It performs comparably to Qwen3-235B on some benchmarks and shows strong advantages in ultra-long context tasks.',
-    displayName: 'Qwen3 Next 80B A3B Instruct',
-    id: 'Qwen/Qwen3-Next-80B-A3B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-09-10',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      video: true,
       vision: true,
     },
     contextWindowTokens: 256_000,
@@ -1899,44 +1859,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 131_072,
-    description:
-      'GLM-4-9B-Chat is the open-source GLM-4 model from Zhipu AI. It performs strongly across semantics, math, reasoning, code, and knowledge. Beyond multi-turn chat, it supports web browsing, code execution, custom tool calls, and long-text reasoning. It supports 26 languages (including Chinese, English, Japanese, Korean, German). It performs well on AlignBench-v2, MT-Bench, MMLU, and C-Eval, and supports up to 128K context for academic and business use.',
-    displayName: 'GLM-4 9B Chat (Free)',
-    id: 'THUDM/glm-4-9b-chat',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-06-04',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-    },
-    contextWindowTokens: 131_072,
-    description:
-      'GLM-4-9B-Chat is the open-source GLM-4 model from Zhipu AI. It performs strongly across semantics, math, reasoning, code, and knowledge. Beyond multi-turn chat, it supports web browsing, code execution, custom tool calls, and long-text reasoning. It supports 26 languages (including Chinese, English, Japanese, Korean, German). It performs well on AlignBench-v2, MT-Bench, MMLU, and C-Eval, and supports up to 128K context for academic and business use.',
-    displayName: 'GLM-4 9B Chat (Pro)',
-    id: 'Pro/THUDM/glm-4-9b-chat',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2024-06-04',
-    type: 'chat',
-  },
-  {
-    abilities: {
       reasoning: true,
     },
     contextWindowTokens: 131_072,
@@ -2129,24 +2051,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 4096,
-    description:
-      'DeepSeek-VL2 is a MoE vision-language model based on DeepSeekMoE-27B with sparse activation, achieving strong performance with only 4.5B active parameters. It excels at visual QA, OCR, document/table/chart understanding, and visual grounding.',
-    displayName: 'DeepSeek VL2',
-    id: 'deepseek-ai/deepseek-vl2',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.99, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.99, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
       reasoning: true,
       vision: true,
     },
@@ -2297,36 +2201,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
   {
     contextWindowTokens: 32_768,
     description:
-      'Qwen2.5-Coder-7B-Instruct is the latest Alibaba Cloud code-focused LLM. Built on Qwen2.5 and trained on 5.5T tokens, it significantly improves code generation, reasoning, and repair while retaining math and general strengths, providing a solid base for coding agents.',
-    displayName: 'Qwen2.5 Coder 7B Instruct (Free)',
-    id: 'Qwen/Qwen2.5-Coder-7B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_768,
-    description:
-      'Qwen2.5-Coder-7B-Instruct is the latest Alibaba Cloud code-focused LLM. Built on Qwen2.5 and trained on 5.5T tokens, it significantly improves code generation, reasoning, and repair while retaining math and general strengths, providing a solid base for coding agents.',
-    displayName: 'Qwen2.5 Coder 7B Instruct (Pro)',
-    id: 'Pro/Qwen/Qwen2.5-Coder-7B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_768,
-    description:
       'Qwen2.5-Coder-32B-Instruct is a code-focused model built on Qwen2.5. Trained on 5.5T tokens, it significantly improves code generation, reasoning, and repair. It is among the most advanced open code models, with coding ability comparable to GPT-4, while retaining math and general strengths and supporting long text.',
     displayName: 'Qwen2.5 Coder 32B Instruct',
     id: 'Qwen/Qwen2.5-Coder-32B-Instruct',
@@ -2335,36 +2209,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput', rate: 1.26, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.26, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_768,
-    description:
-      'Qwen2-7B-Instruct is a 7B instruction-tuned LLM in the Qwen2 series. It uses Transformer architecture with SwiGLU, attention QKV bias, and grouped-query attention, and handles large inputs. It performs strongly across language understanding, generation, multilingual tasks, coding, math, and reasoning, outperforming most open models and competing with proprietary ones. It surpasses Qwen1.5-7B-Chat on multiple benchmarks.',
-    displayName: 'Qwen2 7B Instruct (Free)',
-    id: 'Qwen/Qwen2-7B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    contextWindowTokens: 32_768,
-    description:
-      'Qwen2-7B-Instruct is a 7B instruction-tuned LLM in the Qwen2 series. It uses Transformer architecture with SwiGLU, attention QKV bias, and grouped-query attention, and handles large inputs. It performs strongly across language understanding, generation, multilingual tasks, coding, math, and reasoning, outperforming most open models and competing with proprietary ones. It surpasses Qwen1.5-7B-Chat on multiple benchmarks.',
-    displayName: 'Qwen2 7B Instruct (Pro)',
-    id: 'Pro/Qwen/Qwen2-7B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',
@@ -2383,24 +2227,6 @@ const siliconcloudChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput', rate: 4.13, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 4.13, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      vision: true,
-    },
-    contextWindowTokens: 32_768,
-    description:
-      'Qwen2.5-VL is a new Qwen vision-language model with strong visual understanding. It analyzes text, charts, and layouts in images, understands long videos and events, supports reasoning and tool use, multi-format object grounding, and structured outputs. It improves dynamic resolution and frame-rate training for video understanding and boosts vision encoder efficiency.',
-    displayName: 'Qwen2.5 VL 7B Instruct (Pro)',
-    id: 'Pro/Qwen/Qwen2.5-VL-7B-Instruct',
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.35, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     type: 'chat',

--- a/packages/model-bank/src/aiModels/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/xiaomimimo.ts
@@ -10,7 +10,7 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
-      'MiMo-V2-Pro: A flagship agent model with long context, deep reasoning, coding, and tool use.',
+      'MiMo-V2-Pro is specifically designed for high-intensity agent workflows in real-world scenarios. It features over 1 trillion total parameters (42B activated parameters), adopts an innovative hybrid attention architecture, and supports an ultra-long context length of up to 1 million tokens. Built on a powerful foundational model, we continuously scale computational resources across a broader range of agent scenarios, further expanding the action space of intelligence and achieving significant generalization—from coding to real-world task execution (“claw”).',
     displayName: 'MiMo-V2 Pro',
     enabled: true,
     id: 'mimo-v2-pro',
@@ -47,8 +47,10 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
         },
       ],
     },
+    releasedAt: '2026-03-18',
     settings: {
       extendParams: ['enableReasoning'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -56,6 +58,9 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
       vision: true,
     },
     contextWindowTokens: 262_144,

--- a/packages/model-bank/src/aiModels/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/xiaomimimo.ts
@@ -10,7 +10,7 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
-      'Xiaomi MiMo-V2-Pro is specifically designed for high-intensity agent workflows in real-world scenarios. It features over 1 trillion total parameters (42B activated parameters), adopts an innovative hybrid attention architecture, and supports an ultra-long context length of up to 1 million tokens. Built on a powerful foundational model, we continuously scale computational resources across a broader range of agent scenarios, further expanding the action space of intelligence and achieving significant generalization—from coding to real-world task execution (“claw”).',
+      'MiMo-V2-Pro: A flagship agent model with long context, deep reasoning, coding, and tool use.',
     displayName: 'MiMo-V2 Pro',
     enabled: true,
     id: 'mimo-v2-pro',
@@ -19,20 +19,20 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
       currency: 'CNY',
       units: [
         {
-          name: 'textInput',
+          name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 7, upTo: 256_000 },
-            { rate: 14, upTo: 'infinity' },
+            { rate: 1.4, upTo: 0.256 },
+            { rate: 2.8, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
         {
-          name: 'textInput_cacheRead',
+          name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.4, upTo: 256_000 },
-            { rate: 2.8, upTo: 'infinity' },
+            { rate: 7, upTo: 0.256 },
+            { rate: 14, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
@@ -40,17 +40,15 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 21, upTo: 256_000 },
+            { rate: 21, upTo: 0.256 },
             { rate: 42, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
         },
       ],
     },
-    releasedAt: '2026-03-18',
     settings: {
       extendParams: ['enableReasoning'],
-      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -58,9 +56,6 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
-      structuredOutput: true,
-      video: true,
       vision: true,
     },
     contextWindowTokens: 262_144,

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -47,6 +47,8 @@ export const responsesAPIModels = new Set([
   'gpt-5.2-pro',
   'gpt-5.3-codex',
   'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
   'gpt-5.4-pro',
 ]);
 

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -47,8 +47,6 @@ export const responsesAPIModels = new Set([
   'gpt-5.2-pro',
   'gpt-5.3-codex',
   'gpt-5.4',
-  'gpt-5.4-mini',
-  'gpt-5.4-nano',
   'gpt-5.4-pro',
 ]);
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1881,7 +1881,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
       const payload = {
         messages: [{ content: 'Generate data', role: 'user' as const }],
-        model: 'gpt-5-mini',
+        model: 'gpt-5.4-mini',
         responseApi: true,
         schema: {
           name: 'test_tool',

--- a/packages/model-runtime/src/providers/qwen/index.test.ts
+++ b/packages/model-runtime/src/providers/qwen/index.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { ModelProvider } from 'model-bank';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { LobeOpenAICompatibleRuntime } from '../../core/BaseAI';
 import { testProvider } from '../../providerTestUtils';
 import { LobeQwenAI } from './index';
 
@@ -16,4 +18,48 @@ testProvider({
   test: {
     skipAPICall: true,
   },
+});
+
+let instance: LobeOpenAICompatibleRuntime;
+
+beforeEach(() => {
+  instance = new LobeQwenAI({ apiKey: 'test' });
+
+  vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
+    new ReadableStream() as any,
+  );
+});
+
+describe('LobeQwenAI - custom features', () => {
+  describe('thinking payload mapping', () => {
+    it('should only send thinking_budget for budget-only non-thinking models', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'deepseek-r1-0528',
+        thinking: {
+          budget_tokens: 2048,
+        },
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+
+      expect(calledPayload.enable_thinking).toBeUndefined();
+      expect(calledPayload.thinking_budget).toBe(2048);
+    });
+
+    it('should still force enable_thinking for dedicated thinking models', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'qwen3-235b-a22b-thinking-2507',
+        thinking: {
+          budget_tokens: 4096,
+        },
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+
+      expect(calledPayload.enable_thinking).toBe(true);
+      expect(calledPayload.thinking_budget).toBe(4096);
+    });
+  });
 });

--- a/packages/model-runtime/src/providers/siliconcloud/index.test.ts
+++ b/packages/model-runtime/src/providers/siliconcloud/index.test.ts
@@ -143,10 +143,10 @@ describe('LobeSiliconCloudAI - custom features', () => {
       expect(calledPayload.thinking_budget).toBe(1000);
     });
 
-    it('should only set thinking_budget when type is not provided', async () => {
+    it('should only set thinking_budget for budget-only models when type is not provided', async () => {
       await instance.chat({
         messages: [{ content: 'Hello', role: 'user' }],
-        model: 'Qwen/Qwen3-8B',
+        model: 'Pro/MiniMaxAI/MiniMax-M2.5',
         thinking: {
           budget_tokens: 1500,
         },
@@ -155,6 +155,20 @@ describe('LobeSiliconCloudAI - custom features', () => {
       const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
       expect(calledPayload.enable_thinking).toBeUndefined();
       expect(calledPayload.thinking_budget).toBe(1500);
+    });
+
+    it('should not send enable_thinking for DeepSeek R1 budget-only models without type', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'deepseek-ai/DeepSeek-R1',
+        thinking: {
+          budget_tokens: 2048,
+        },
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.enable_thinking).toBeUndefined();
+      expect(calledPayload.thinking_budget).toBe(2048);
     });
   });
 

--- a/packages/model-runtime/src/providers/wenxin/index.test.ts
+++ b/packages/model-runtime/src/providers/wenxin/index.test.ts
@@ -260,5 +260,20 @@ describe('LobeWenxinAI - Custom Features', () => {
       const result2 = params.chatCompletion!.handlePayload!(payloadWithStreamFalse as any);
       expect(result2.stream).toBe(true);
     });
+
+    it('should only send thinking_budget for budget-only models without thinking type', () => {
+      const payload = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'deepseek-r1-250528',
+        thinking: {
+          budget_tokens: 2048,
+        },
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.enable_thinking).toBeUndefined();
+      expect(result.thinking_budget).toBe(2048);
+    });
   });
 });

--- a/packages/model-runtime/src/utils/modelParse.test.ts
+++ b/packages/model-runtime/src/utils/modelParse.test.ts
@@ -302,7 +302,7 @@ describe('modelParse', () => {
       });
     });
 
-    it('xiaomimimo: should infer multimodal abilities for omni without search flag', async () => {
+    it('xiaomimimo: should infer multimodal abilities for omni', async () => {
       const out = await processModelList(
         [{ id: 'mimo-v2-flash' }, { id: 'mimo-v2-pro' }, { id: 'mimo-v2-omni' }],
         MODEL_LIST_CONFIGS.xiaomimimo,
@@ -317,17 +317,14 @@ describe('modelParse', () => {
 
       expect(flash.functionCall).toBe(true);
       expect(flash.reasoning).toBe(true);
-      expect(flash.search).toBe(false);
       expect(flash.vision).toBe(false);
 
       expect(pro.functionCall).toBe(true);
       expect(pro.reasoning).toBe(true);
-      expect(pro.search).toBe(false);
       expect(pro.vision).toBe(false);
 
       expect(omni.functionCall).toBe(true);
       expect(omni.reasoning).toBe(true);
-      expect(omni.search).toBe(false);
       expect(omni.vision).toBe(true);
 
       const tts = await processModelList(

--- a/packages/model-runtime/src/utils/modelParse.test.ts
+++ b/packages/model-runtime/src/utils/modelParse.test.ts
@@ -302,6 +302,47 @@ describe('modelParse', () => {
       });
     });
 
+    it('xiaomimimo: should infer multimodal abilities for omni without search flag', async () => {
+      const out = await processModelList(
+        [{ id: 'mimo-v2-flash' }, { id: 'mimo-v2-pro' }, { id: 'mimo-v2-omni' }],
+        MODEL_LIST_CONFIGS.xiaomimimo,
+        'xiaomimimo',
+      );
+
+      expect(out).toHaveLength(3);
+
+      const flash = out.find((m) => m.id === 'mimo-v2-flash')!;
+      const pro = out.find((m) => m.id === 'mimo-v2-pro')!;
+      const omni = out.find((m) => m.id === 'mimo-v2-omni')!;
+
+      expect(flash.functionCall).toBe(true);
+      expect(flash.reasoning).toBe(true);
+      expect(flash.search).toBe(false);
+      expect(flash.vision).toBe(false);
+
+      expect(pro.functionCall).toBe(true);
+      expect(pro.reasoning).toBe(true);
+      expect(pro.search).toBe(false);
+      expect(pro.vision).toBe(false);
+
+      expect(omni.functionCall).toBe(true);
+      expect(omni.reasoning).toBe(true);
+      expect(omni.search).toBe(false);
+      expect(omni.vision).toBe(true);
+
+      const tts = await processModelList(
+        [{ id: 'mimo-v2-tts' }],
+        MODEL_LIST_CONFIGS.xiaomimimo,
+        'xiaomimimo',
+      );
+
+      expect(tts).toHaveLength(1);
+      expect(tts[0].functionCall).toBe(false);
+      expect(tts[0].reasoning).toBe(false);
+      expect(tts[0].search).toBe(false);
+      expect(tts[0].vision).toBe(false);
+    });
+
     describe('Detailed capability and property processing in processModelList', () => {
       const config = MODEL_LIST_CONFIGS.openai;
 

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -121,9 +121,10 @@ export const MODEL_LIST_CONFIGS = {
     visionKeywords: ['vision', 'grok-4'],
   },
   xiaomimimo: {
+    excludeKeywords: ['tts'],
     functionCallKeywords: ['mimo'],
     reasoningKeywords: ['mimo'],
-    visionKeywords: [],
+    visionKeywords: ['omni'],
   },
   zeroone: {
     functionCallKeywords: ['fc'],

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -235,9 +235,20 @@ type ExtendParamsDefinition = {
 };
 
 interface ExtendParamsSelectProps {
-  onChange?: (value: ExtendParamsType[] | undefined) => void;
+  onChange?: (value: ExtendParamsType[]) => void;
   value?: ExtendParamsType[];
 }
+
+export const normalizeExtendParamsValue = (
+  value: ExtendParamsType[] | undefined,
+  definitionMap: Map<ExtendParamsType, ExtendParamsDefinition>,
+): ExtendParamsType[] => {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [];
+  }
+
+  return value.filter((item) => definitionMap.has(item));
+};
 
 const PreviewContent = ({
   desc,
@@ -416,13 +427,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
 
   const placeholder = String(t('providerModels.item.modelConfig.extendParams.placeholder'));
   const handleChange = (val: ExtendParamsType[]) => {
-    if (!Array.isArray(val) || val.length === 0) {
-      onChange?.(undefined);
-      return;
-    }
-
-    const filtered = val.filter((item) => definitionMap.has(item));
-    onChange?.(filtered.length ? filtered : undefined);
+    onChange?.(normalizeExtendParamsValue(val, definitionMap));
   };
 
   return (

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/ExtendParamsSelect.test.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/ExtendParamsSelect.test.tsx
@@ -1,9 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
+import { normalizeExtendParamsValue } from '../ExtendParamsSelect';
+
 // Import the constant directly for testing
 // We'll need to test the TITLE_KEY_ALIASES logic
 
 describe('ExtendParamsSelect', () => {
+  describe('normalizeExtendParamsValue', () => {
+    const definitionMap = new Map([
+      ['enableReasoning', { key: 'enableReasoning' }],
+      ['reasoningBudgetToken', { key: 'reasoningBudgetToken' }],
+    ]) as any;
+
+    it('should keep an explicit empty array when cleared', () => {
+      expect(normalizeExtendParamsValue([], definitionMap)).toEqual([]);
+      expect(normalizeExtendParamsValue(undefined, definitionMap)).toEqual([]);
+    });
+
+    it('should filter unsupported extend params while keeping valid values', () => {
+      expect(
+        normalizeExtendParamsValue(
+          ['enableReasoning', 'unsupportedParam', 'reasoningBudgetToken'] as any,
+          definitionMap,
+        ),
+      ).toEqual(['enableReasoning', 'reasoningBudgetToken']);
+    });
+  });
+
   describe('TITLE_KEY_ALIASES mapping', () => {
     // This mapping should be synced with ControlsForm.tsx
     const TITLE_KEY_ALIASES: Record<string, string> = {

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -136,7 +136,7 @@ describe('resolveModelExtendParams', () => {
         ]);
       });
 
-      it('should set thinking to enabled when only reasoningBudgetToken is supported', () => {
+      it('should only set thinking budget when only reasoningBudgetToken is supported', () => {
         const result = resolveModelExtendParams({
           chatConfig: {
             reasoningBudgetToken: 4096,
@@ -147,7 +147,6 @@ describe('resolveModelExtendParams', () => {
 
         expect(result.thinking).toEqual({
           budget_tokens: 4096,
-          type: 'enabled',
         });
       });
 
@@ -160,7 +159,6 @@ describe('resolveModelExtendParams', () => {
 
         expect(result.thinking).toEqual({
           budget_tokens: 1024,
-          type: 'enabled',
         });
       });
     });

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -22,7 +22,7 @@ export interface ModelExtendParams {
   reasoning_effort?: string;
   thinking?: {
     budget_tokens?: number;
-    type: string;
+    type?: string;
   };
   thinkingBudget?: number;
   thinkingLevel?: string;
@@ -95,7 +95,6 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     // For models that only have reasoningBudgetToken without enableReasoning
     extendParams.thinking = {
       budget_tokens: chatConfig.reasoningBudgetToken || 1024,
-      type: 'enabled',
     };
   }
 

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -56,7 +56,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
   },
   "enableAutoReply": true,
   "generationTopic": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-mini",
     "provider": "openai",
   },
   "historyCompress": {
@@ -65,7 +65,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
   },
   "queryRewrite": {
     "enabled": true,
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-mini",
     "provider": "openai",
   },
   "replyMessage": "Custom auto reply",
@@ -74,11 +74,11 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
     "provider": "anthropic",
   },
   "topic": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-mini",
     "provider": "openai",
   },
   "translation": {
-    "model": "gpt-5-mini",
+    "model": "gpt-5.4-mini",
     "provider": "openai",
   },
 }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 修复 SiliconCloud 单独传递 `thinking.budget_tokens` 出现报错：
"message": "Value error, current model does not support parameter enable_thinking."

3. 修复模型扩展参数清空后无法保存。

4. 默认使用 gpt-5.4-mini

已验证可用。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust reasoning/thinking parameter handling for budget-only models and ensure extended model parameters can be cleared and persisted correctly.

Bug Fixes:
- Prevent sending unsupported enable_thinking flag when only a thinking budget is specified for budget-only models across Qwen, SiliconCloud, and Wenxin providers.
- Allow clearing extended model parameters in the model settings UI by normalizing empty selections to an empty list instead of undefined.

Enhancements:
- Relax thinking.type to be optional and stop forcing a default type when only reasoningBudgetToken is configured, aligning payloads with provider capabilities.

Tests:
- Add and update provider and resolver tests to cover budget-only thinking payload behavior and extend params normalization.