### PR TITLE
🐛 fix: resolve message reordering in Responses API input conversion

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -398,6 +398,41 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
+  it('should preserve message order when earlier messages have async content (images)', async () => {
+    const messages: OpenAIChatMessage[] = [
+      { content: 'system prompts', role: 'system' },
+      {
+        content: [
+          { type: 'text', text: 'describe this image' },
+          { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,abc123' } },
+        ],
+        role: 'user',
+      },
+      {
+        content: 'The image shows a green car.',
+        role: 'assistant',
+        reasoning: { content: 'analyzing the image', duration: 3000 },
+      },
+      { content: '1 + 1 = ?', role: 'user' },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer' },
+      {
+        content: [
+          { type: 'input_text', text: 'describe this image' },
+          { type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+        ],
+        role: 'user',
+      },
+      { summary: [{ text: 'analyzing the image', type: 'summary_text' }], type: 'reasoning' },
+      { content: 'The image shows a green car.', role: 'assistant' },
+      { content: '1 + 1 = ?', role: 'user' },
+    ]);
+  });
+
   it('should handle openai and claude mixed message', async () => {
     // See: https://github.com/lobehub/lobehub/pull/12017
     const messages: OpenAIChatMessage[] = [

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -75,12 +75,13 @@ export const convertOpenAIResponseInputs = async (
   messages: OpenAIChatMessage[],
   options?: ConvertMessageContentOptions,
 ) => {
-  const input: OpenAI.Responses.ResponseInputItem[] = [];
-  await Promise.all(
+  const inputGroups = await Promise.all(
     messages.map(async (message) => {
+      const items: OpenAI.Responses.ResponseInputItem[] = [];
+
       // if message has reasoning, add it as a separate reasoning item
       if (message.reasoning?.content) {
-        input.push({
+        items.push({
           summary: [{ text: message.reasoning.content, type: 'summary_text' }],
           type: 'reasoning',
         } as OpenAI.Responses.ResponseReasoningItem);
@@ -89,7 +90,7 @@ export const convertOpenAIResponseInputs = async (
       // if message is assistant messages with tool calls , transform it to function type item
       if (message.role === 'assistant' && message.tool_calls && message.tool_calls?.length > 0) {
         message.tool_calls?.forEach((tool) => {
-          input.push({
+          items.push({
             arguments: tool.function.name,
             call_id: tool.id,
             name: tool.function.name,
@@ -97,22 +98,22 @@ export const convertOpenAIResponseInputs = async (
           });
         });
 
-        return;
+        return items;
       }
 
       if (message.role === 'tool') {
-        input.push({
+        items.push({
           call_id: message.tool_call_id,
           output: message.content,
           type: 'function_call_output',
         } as OpenAI.Responses.ResponseFunctionToolCallOutputItem);
 
-        return;
+        return items;
       }
 
       if (message.role === 'system') {
-        input.push({ ...message, role: 'developer' } as OpenAI.Responses.ResponseInputItem);
-        return;
+        items.push({ ...message, role: 'developer' } as OpenAI.Responses.ResponseInputItem);
+        return items;
       }
 
       // default item
@@ -153,11 +154,12 @@ export const convertOpenAIResponseInputs = async (
       // remove reasoning field from the message item
       delete (item as any).reasoning;
 
-      input.push(item);
+      items.push(item);
+      return items;
     }),
   );
 
-  return input;
+  return inputGroups.flat();
 };
 
 export const pruneReasoningPayload = (payload: ChatStreamPayload) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #9900

#### 🔀 Description of Change

`convertOpenAIResponseInputs` used `Promise.all(messages.map(...))` with side-effect pushes to a shared `input` array. When a message contained array content (e.g. images) requiring async processing, the `await` yielded control, allowing subsequent synchronous iterations to push their items first — resulting in out-of-order Responses API input.

**Root cause:** `await Promise.all(resolvedPromises)` always yields to the microtask queue, even when all inner promises are already resolved. This means messages with array content (which hit `await`) get pushed after messages that follow them in the original array but execute synchronously.

**Impact:** In multi-turn conversations where an earlier message has image content, later messages (including the latest user query) could appear before the image message in the API input. The model would then respond to the image message instead of the actual latest query.

**Fix:** Changed from side-effect pushes to a shared array to collecting items per-message and flattening, which preserves the original message order regardless of async timing.

#### 🧪 How to Test

1. Start a conversation with an image message (e.g. "describe this image")
2. After getting a response, send a text-only follow-up (e.g. "1+1=?")
3. Verify the model answers the follow-up correctly instead of re-describing the image

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

## Summary by Sourcery

Bug Fixes:
- Fix message reordering in Responses API input caused by shared array mutations during async message processing.