### PR TITLE
✨ feat(auth): display expanded SSO provider profile details

### DIFF
--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -108,9 +108,15 @@ export const OAuthAccountSchema = z.object({
  * SSO Provider info displayed in profile page
  */
 export interface SSOProvider {
+  /** Raw OIDC claims from the provider's userInfo endpoint */
+  claims?: Record<string, unknown>;
   email?: string;
   /** Expiration time - Date for better-auth */
   expiresAt?: Date | number | null;
+  /** Profile image URL from the provider */
+  image?: string;
+  /** Display name from the provider */
+  name?: string;
   provider: string;
   providerAccountId: string;
 }

--- a/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
@@ -1,8 +1,10 @@
 import { isDesktop } from '@lobechat/const';
 import { type MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Flexbox, Text } from '@lobehub/ui';
-import { ArrowRight, Plus, Unlink } from 'lucide-react';
-import { type CSSProperties } from 'react';
+import { Avatar } from 'antd';
+import { cssVar } from 'antd-style';
+import { ArrowRight, ChevronDown, ChevronRight, Plus, Unlink } from 'lucide-react';
+import { type CSSProperties, useCallback, useState } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,6 +20,49 @@ const providerNameStyle: CSSProperties = {
   textTransform: 'capitalize',
 };
 
+/** Allowlisted OIDC profile claim keys to display in expanded details */
+const VISIBLE_CLAIM_KEYS = new Set([
+  'given_name',
+  'family_name',
+  'nickname',
+  'preferred_username',
+  'login', // GitHub username
+  'email_verified',
+  'phone_number',
+  'phone_number_verified',
+  'locale',
+  'zoneinfo',
+  'gender',
+  'birthdate',
+  'company',
+  'location',
+  'bio',
+  'blog',
+  'html_url',
+  'profile', // profile URL
+  'updated_at',
+]);
+
+/** Claim keys whose value should be rendered as a clickable link */
+const URL_CLAIM_KEYS = new Set(['html_url', 'profile', 'blog']);
+
+/** Convert snake_case claim key to a readable label */
+const formatClaimLabel = (key: string): string =>
+  key.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase());
+
+/** Format claim value for display */
+const formatClaimValue = (key: string, value: unknown): string => {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (key === 'updated_at' || key === 'created_at') {
+    const date = new Date(value as string | number);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleDateString();
+  }
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+const breakAllStyle: CSSProperties = { wordBreak: 'break-all' };
+
 export const SSOProvidersList = memo(() => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const providers = useUserStore(authSelectors.authProviders);
@@ -25,6 +70,16 @@ export const SSOProvidersList = memo(() => {
   const refreshAuthProviders = useUserStore((s) => s.refreshAuthProviders);
   const oAuthSSOProviders = useServerConfigStore(serverConfigSelectors.oAuthSSOProviders);
   const { t } = useTranslation('auth');
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() => new Set());
+
+  const toggleExpand = useCallback((key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
 
   // Allow unlink if user has multiple SSO providers OR has email/password login
   const allowUnlink = providers.length > 1 || hasPasswordAccount;
@@ -99,33 +154,98 @@ export const SSOProvidersList = memo(() => {
 
   return (
     <Flexbox gap={8}>
-      {providers.map((item) => (
-        <Flexbox
-          horizontal
-          align={'center'}
-          gap={8}
-          justify={'space-between'}
-          key={[item.provider, item.providerAccountId].join('-')}
-        >
-          <Flexbox horizontal align={'center'} gap={6} style={{ fontSize: 12 }}>
-            {AuthIcons(item.provider, 16)}
-            <span style={providerNameStyle}>{item.provider}</span>
-            {item.email && (
-              <Text fontSize={11} type="secondary">
-                · {item.email}
-              </Text>
+      {providers.map((item) => {
+        const itemKey = [item.provider, item.providerAccountId].join('-');
+        const isExpanded = expandedKeys.has(itemKey);
+
+        // Filter claims: only show allowlisted keys with non-empty values
+        const visibleClaims = item.claims
+          ? Object.entries(item.claims).filter(
+              ([key, value]) =>
+                VISIBLE_CLAIM_KEYS.has(key) &&
+                value !== null &&
+                value !== undefined &&
+                value !== '',
+            )
+          : [];
+        const hasDetails = visibleClaims.length > 0;
+
+        return (
+          <Flexbox gap={4} key={itemKey}>
+            <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
+              <Flexbox
+                horizontal
+                align={'center'}
+                gap={6}
+                style={{ cursor: hasDetails ? 'pointer' : undefined, fontSize: 12 }}
+                onClick={hasDetails ? () => toggleExpand(itemKey) : undefined}
+              >
+                {hasDetails && (
+                  <ActionIcon
+                    icon={isExpanded ? ChevronDown : ChevronRight}
+                    size={{ blockSize: 18 }}
+                  />
+                )}
+                {AuthIcons(item.provider, 16)}
+                {item.image && <Avatar size={20} src={item.image} />}
+                <span style={providerNameStyle}>{item.provider}</span>
+                {(item.email || item.name) && (
+                  <Text fontSize={11} type="secondary">
+                    ·{' '}
+                    {item.name && item.email
+                      ? `${item.name} (${item.email})`
+                      : (item.name ?? item.email)}
+                  </Text>
+                )}
+              </Flexbox>
+              {!isDesktop && (
+                <ActionIcon
+                  disabled={!allowUnlink}
+                  icon={Unlink}
+                  size={'small'}
+                  onClick={() => handleUnlinkSSO(item.provider)}
+                />
+              )}
+            </Flexbox>
+
+            {/* Expanded claims detail */}
+            {isExpanded && hasDetails && (
+              <Flexbox
+                gap={6}
+                style={{
+                  background: cssVar.colorFillQuaternary,
+                  borderRadius: 6,
+                  fontSize: 12,
+                  marginLeft: 18,
+                  padding: '8px 12px',
+                }}
+              >
+                {visibleClaims.map(([key, value]) => (
+                  <Flexbox horizontal align={'baseline'} gap={8} key={key}>
+                    <Text fontSize={11} style={{ flexShrink: 0, minWidth: 100 }} type="secondary">
+                      {formatClaimLabel(key)}
+                    </Text>
+                    {URL_CLAIM_KEYS.has(key) && typeof value === 'string' ? (
+                      <a
+                        href={value}
+                        rel="noopener noreferrer"
+                        style={breakAllStyle}
+                        target="_blank"
+                      >
+                        <Text fontSize={11}>{value}</Text>
+                      </a>
+                    ) : (
+                      <Text fontSize={11} style={breakAllStyle}>
+                        {formatClaimValue(key, value)}
+                      </Text>
+                    )}
+                  </Flexbox>
+                ))}
+              </Flexbox>
             )}
           </Flexbox>
-          {!isDesktop && (
-            <ActionIcon
-              disabled={!allowUnlink}
-              icon={Unlink}
-              size={'small'}
-              onClick={() => handleUnlinkSSO(item.provider)}
-            />
-          )}
-        </Flexbox>
-      ))}
+        );
+      })}
 
       {/* Link Account Button - Only show for logged in users with available providers */}
       {enableAuthActions && availableProviders.length > 0 && (

--- a/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
@@ -43,8 +43,8 @@ const VISIBLE_CLAIM_KEYS = new Set([
   'updated_at',
 ]);
 
-/** Claim keys whose value should be rendered as a clickable link */
-const URL_CLAIM_KEYS = new Set(['html_url', 'profile', 'blog']);
+const isUrl = (value: unknown): value is string =>
+  typeof value === 'string' && (value.startsWith('https://') || value.startsWith('http://'));
 
 /** Convert snake_case claim key to a readable label */
 const formatClaimLabel = (key: string): string =>
@@ -225,7 +225,7 @@ export const SSOProvidersList = memo(() => {
                     <Text fontSize={11} style={{ flexShrink: 0, minWidth: 100 }} type="secondary">
                       {formatClaimLabel(key)}
                     </Text>
-                    {URL_CLAIM_KEYS.has(key) && typeof value === 'string' ? (
+                    {isUrl(value) ? (
                       <a
                         href={value}
                         rel="noopener noreferrer"

--- a/src/store/user/slices/auth/action.ts
+++ b/src/store/user/slices/auth/action.ts
@@ -22,8 +22,12 @@ const fetchAuthProvidersData = async (): Promise<AuthProvidersData> => {
         const info = await accountInfo({
           query: { accountId: account.accountId },
         });
+        const claims = (info.data?.data as Record<string, unknown>) ?? undefined;
         return {
+          claims,
           email: info.data?.user?.email ?? undefined,
+          image: info.data?.user?.image ?? undefined,
+          name: info.data?.user?.name ?? undefined,
           provider: account.providerId,
           providerAccountId: account.accountId,
         };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-4787

#### 🔀 Description of Change

Display richer SSO provider profile information in the settings page with an expandable detail panel.

**Changes:**
- **Type extension**: Added `name`, `image`, and `claims` fields to `SSOProvider` interface
- **Data extraction**: Extract `user.name`, `user.image`, and raw OIDC claims from `accountInfo` API response
- **UI enhancements**:
  - Provider row now shows avatar (when available) and display name alongside email
  - Expandable detail panel with allowlisted OIDC profile claims (login, company, location, bio, etc.)
  - URL claims rendered as clickable links; dates formatted; booleans shown as Yes/No
  - Theme-aware background color (`colorFillQuaternary`) for dark mode compatibility
  - Human-readable labels (snake_case → Title Case)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Log in with a SSO provider (GitHub, Google, etc.)
2. Go to Settings → Profile → Linked Accounts
3. Verify provider row shows avatar and name
4. Click the expand chevron to see profile details
5. Verify URLs are clickable and dates are formatted

#### 📝 Additional Information

- Uses an **allowlist** strategy for visible claims (only well-known OIDC profile fields) rather than a blocklist, to avoid leaking sensitive/internal token fields
- Row header already shows `name`, `email`, and `image` — these are excluded from the expanded detail area to avoid duplication