### PR TITLE
🐛 fix(ci): add version prefix to latest*.yml URLs in S3 upload

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -83,21 +83,32 @@ runs:
           fi
         done
 
-        # 2. 创建 {channel}*.yml (从 latest*.yml 复制，URL 加版本目录前缀)
+        # 2. 为所有 latest*.yml 的 URL 加版本目录前缀
         # electron-builder 始终生成 latest*.yml，不区分 channel
+        # 安装包在 s3://$BUCKET/$CHANNEL/$VERSION/ 下，URL 需加 $VERSION/ 前缀
+        echo ""
+        echo "📋 Adding version prefix to latest*.yml URLs..."
+        for yml in release/latest*.yml; do
+          if [ -f "$yml" ]; then
+            # url: xxx.dmg -> url: {VERSION}/xxx.dmg
+            sed -i "s|url: |url: $VERSION/|g" "$yml"
+            echo "   📄 Updated $(basename $yml) with URL prefix: $VERSION/"
+          fi
+        done
+
+        # 3. 创建 {channel}*.yml (从已修改的 latest*.yml 复制)
         # electron-updater 在对应 channel 时会找 {channel}-mac.yml
         echo ""
         echo "📋 Creating ${CHANNEL}*.yml files from latest*.yml..."
         for yml in release/latest*.yml; do
           if [ -f "$yml" ]; then
             channel_name=$(basename "$yml" | sed "s/latest/$CHANNEL/")
-            # url: xxx.dmg -> url: {VERSION}/xxx.dmg
-            sed "s|url: |url: $VERSION/|g" "$yml" > "release/$channel_name"
-            echo "   📄 Created $channel_name from $(basename $yml) with URL prefix: $VERSION/"
+            cp "$yml" "release/$channel_name"
+            echo "   📄 Created $channel_name from $(basename $yml)"
           fi
         done
 
-        # 3. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
+        # 4. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
         RENDERER_TAR="release/lobehub-renderer.tar.gz"
         if [ -f "$RENDERER_TAR" ]; then
           echo ""
@@ -118,7 +129,7 @@ runs:
           echo "   📄 Created ${CHANNEL}-renderer.yml"
         fi
 
-        # 4. 上传 manifest 到根目录和版本目录
+        # 5. 上传 manifest 到根目录和版本目录
         # 根目录: electron-updater 需要，每次发版覆盖
         # 版本目录: 作为存档保留
         echo ""

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -72,6 +72,23 @@ jobs:
           git checkout main
           git pull --rebase origin main
 
+      - name: Setup Node.js
+        if: steps.release.outputs.should_tag == 'true' || steps.patch.outputs.should_tag == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.11.1
+          package-manager-cache: false
+
+      - name: Install bun
+        if: steps.release.outputs.should_tag == 'true' || steps.patch.outputs.should_tag == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        if: steps.release.outputs.should_tag == 'true' || steps.patch.outputs.should_tag == 'true'
+        run: bun i
+
       - name: Resolve patch version (patch bump)
         id: patch-version
         if: steps.patch.outputs.should_tag == 'true'
@@ -117,12 +134,10 @@ jobs:
             echo "✅ Tag v$VERSION does not exist, can create"
           fi
 
-      - name: Bump package.json version (before tagging)
+      - name: Bump package.json version
         if: env.SHOULD_TAG == 'true' && steps.check-tag.outputs.exists == 'false'
-        id: bump-version
         run: |
           VERSION="${{ env.VERSION }}"
-          KIND="${{ env.KIND }}"
           echo "📝 Bumping package.json version to: $VERSION"
 
           # Validate VERSION is strict semver before writing
@@ -130,10 +145,6 @@ jobs:
             echo "❌ Invalid semver version: $VERSION"
             exit 1
           fi
-
-          # Configure git
-          git config --global user.name "lobehubbot"
-          git config --global user.email "i@lobehub.com"
 
           # Update package.json using Node.js
           node -e "
@@ -149,8 +160,26 @@ jobs:
             console.log('✅ package.json updated to', target);
           "
 
+      - name: Generate changelog
+        if: env.SHOULD_TAG == 'true' && steps.check-tag.outputs.exists == 'false'
+        run: bun run workflow:changelog:gen
+
+      - name: Build static changelog
+        if: env.SHOULD_TAG == 'true' && steps.check-tag.outputs.exists == 'false'
+        run: bun run workflow:changelog
+
+      - name: Commit release changes and push
+        if: env.SHOULD_TAG == 'true' && steps.check-tag.outputs.exists == 'false'
+        id: bump-version
+        run: |
+          VERSION="${{ env.VERSION }}"
+
+          # Configure git
+          git config --global user.name "lobehubbot"
+          git config --global user.email "i@lobehub.com"
+
           # Commit changes (if any) and push
-          git add package.json
+          git add package.json CHANGELOG.md changelog/
           COMMIT_MSG="🔖 chore(release): release version v$VERSION [skip ci]"
           git commit -m "$COMMIT_MSG" || echo "Nothing to commit"
           git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,38 +66,6 @@ jobs:
       - name: Test App
         run: bun run test-app
 
-      - name: Extract version from tag
-        id: get-version
-        run: |
-          # Extract version from github.ref (refs/tags/v1.0.0 -> 1.0.0)
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "📦 Release version: v$VERSION"
-
-      - name: Verify package.json version matches tag
-        run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-          echo "🔎 Checking package.json version equals tag: $VERSION"
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-            const expected = '$VERSION';
-            const actual = pkg.version;
-            if (actual !== expected) {
-              console.error('❌ Version mismatch: package.json=' + actual + ' tag=' + expected);
-              process.exit(1);
-            }
-            console.log('✅ Version OK:', actual);
-          "
-
-      - name: Release
-        run: bun run release
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Pass version to semantic-release
-          SEMANTIC_RELEASE_VERSION: ${{ steps.get-version.outputs.version }}
-
       - name: Workflow
         run: bun run workflow:readme
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "type-check:tsc": "tsc --noEmit",
     "workflow:cdn": "tsx ./scripts/cdnWorkflow/index.ts",
     "workflow:changelog": "tsx ./scripts/changelogWorkflow/index.ts",
+    "workflow:changelog:gen": "tsx ./scripts/changelogWorkflow/generateChangelog.ts",
     "workflow:countCharters": "tsx scripts/countEnWord.ts",
     "workflow:dbml": "tsx ./scripts/dbmlWorkflow/index.ts",
     "workflow:docs": "tsx ./scripts/docsWorkflow/index.ts",

--- a/scripts/changelogWorkflow/generateChangelog.ts
+++ b/scripts/changelogWorkflow/generateChangelog.ts
@@ -1,0 +1,209 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { consola } from 'consola';
+
+const REPO_URL = 'https://github.com/lobehub/lobe-chat';
+const CHANGELOG_TITLE = '<a name="readme-top"></a>\n\n# Changelog';
+const BACK_TO_TOP = `<div align="right">
+
+[![](https://img.shields.io/badge/-BACK_TO_TOP-151515?style=flat-square)](#readme-top)
+
+</div>`;
+
+interface Commit {
+  hash: string;
+  issues: string[];
+  scope: string;
+  subject: string;
+  type: string;
+}
+
+interface TypeConfig {
+  detail: string;
+  emoji: string;
+  summary: string;
+}
+
+const TYPE_MAP: Record<string, TypeConfig> = {
+  feat: { emoji: '✨', summary: 'Features', detail: "What's improved" },
+  fix: { emoji: '🐛', summary: 'Bug Fixes', detail: "What's fixed" },
+  hotfix: { emoji: '🐛', summary: 'Bug Fixes', detail: "What's fixed" },
+  perf: { emoji: '⚡', summary: 'Performance Improvements', detail: 'Performance Improvements' },
+  style: { emoji: '💄', summary: 'Styles', detail: 'Styles' },
+  refactor: { emoji: '♻️', summary: 'Code Refactoring', detail: 'Code Refactoring' },
+  build: { emoji: '👷', summary: 'Build System', detail: 'Build System' },
+};
+
+const git = (cmd: string) => execSync(`git ${cmd}`, { encoding: 'utf8' }).trim();
+
+const getLastTag = (): string | null => {
+  try {
+    return git('describe --tags --abbrev=0 HEAD');
+  } catch {
+    return null;
+  }
+};
+
+const getPreviousTag = (currentTag: string): string | null => {
+  try {
+    return git(`describe --tags --abbrev=0 ${currentTag}^`);
+  } catch {
+    return null;
+  }
+};
+
+const getCommits = (from: string | null): Commit[] => {
+  const range = from ? `${from}..HEAD` : 'HEAD';
+  const SEP = '---COMMIT_SEP---';
+  let log: string;
+  try {
+    log = git(`log ${range} --format="%H %s${SEP}"`);
+  } catch {
+    return [];
+  }
+
+  const commits: Commit[] = [];
+  for (const entry of log.split(SEP)) {
+    const line = entry.trim();
+    if (!line) continue;
+
+    const spaceIdx = line.indexOf(' ');
+    if (spaceIdx === -1) continue;
+    const hash = line.slice(0, spaceIdx);
+    let subject = line.slice(spaceIdx + 1);
+
+    // Strip leading gitmoji (unicode emoji or :shortcode: format)
+    subject = subject
+      .replace(/^[\p{Emoji_Presentation}\p{Extended_Pictographic}]+\s*/u, '')
+      .replace(/^:[a-z_]+:\s*/i, '');
+
+    // Parse conventional commit: type(scope): message
+    const match = subject.match(/^(\w+)(?:\(([^)]*)\))?:\s*(.+)/);
+    if (!match) continue;
+
+    const [, type, scope, msg] = match;
+    if (!TYPE_MAP[type]) continue;
+
+    // Extract issue references
+    const issues: string[] = [];
+    const issueRe = /#(\d+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = issueRe.exec(msg)) !== null) {
+      issues.push(m[1]);
+    }
+
+    // Strip issue refs from subject: "closes #123", "(#123)"
+    const cleanSubject = msg
+      .replaceAll(/,?\s*closes?\s+#\d+/gi, '')
+      .replaceAll(/\s*\(#\d+\)/g, '')
+      .trim();
+
+    commits.push({
+      hash: hash.slice(0, 7),
+      issues,
+      scope: scope || 'misc',
+      subject: cleanSubject,
+      type,
+    });
+  }
+
+  return commits;
+};
+
+const groupByType = (commits: Commit[]) => {
+  const groups: Record<string, Commit[]> = {};
+  for (const commit of commits) {
+    const key = commit.type === 'hotfix' ? 'fix' : commit.type;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(commit);
+  }
+  return groups;
+};
+
+const formatSummarySection = (groups: Record<string, Commit[]>): string => {
+  const sections: string[] = [];
+  for (const [type, commits] of Object.entries(groups)) {
+    const cfg = TYPE_MAP[type];
+    if (!cfg) continue;
+    sections.push(`#### ${cfg.emoji} ${cfg.summary}\n`);
+    for (const c of commits) {
+      sections.push(`- **${c.scope}**: ${c.subject}.`);
+    }
+    sections.push('');
+  }
+  return sections.join('\n');
+};
+
+const formatDetailSection = (groups: Record<string, Commit[]>): string => {
+  const sections: string[] = [];
+  for (const [type, commits] of Object.entries(groups)) {
+    const cfg = TYPE_MAP[type];
+    if (!cfg) continue;
+    sections.push(`#### ${cfg.detail}\n`);
+    for (const c of commits) {
+      const closes = c.issues.map((i) => `closes [#${i}](${REPO_URL}/issues/${i})`).join(', ');
+      const ref = `([${c.hash}](${REPO_URL}/commit/${c.hash}))`;
+      const suffix = [closes, ref].filter(Boolean).join(' ');
+      sections.push(`- **${c.scope}**: ${c.subject}${closes ? ', ' : ' '}${suffix}`);
+    }
+    sections.push('');
+  }
+  return sections.join('\n');
+};
+
+const run = () => {
+  const root = path.resolve(__dirname, '../..');
+  const pkgPath = path.resolve(root, 'package.json');
+  const changelogPath = path.resolve(root, 'CHANGELOG.md');
+  const version = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+  const today = new Date().toISOString().split('T')[0];
+
+  const lastTag = getLastTag();
+  const prevTag = lastTag ? getPreviousTag(lastTag) : null;
+  const fromTag = lastTag ?? prevTag;
+
+  const commits = getCommits(fromTag);
+
+  if (commits.length === 0) {
+    consola.warn('No conventional commits found since last tag, skipping changelog generation');
+    return;
+  }
+
+  const groups = groupByType(commits);
+
+  // Determine heading level: minor (feat) -> ##, patch -> ###
+  const headingLevel = groups['feat'] ? '##' : '###';
+  const compareUrl = fromTag
+    ? `${REPO_URL}/compare/${fromTag}...v${version}`
+    : `${REPO_URL}/releases/tag/v${version}`;
+
+  const entry = [
+    `${headingLevel} [Version ${version}](${compareUrl})`,
+    '',
+    `<sup>Released on **${today}**</sup>`,
+    '',
+    formatSummarySection(groups),
+    '<br/>',
+    '',
+    '<details>',
+    '<summary><kbd>Improvements and Fixes</kbd></summary>',
+    '',
+    formatDetailSection(groups),
+    '</details>',
+    '',
+    BACK_TO_TOP,
+  ].join('\n');
+
+  const currentFile = readFileSync(changelogPath, 'utf8').trim();
+  const currentContent = currentFile.startsWith(CHANGELOG_TITLE)
+    ? currentFile.slice(CHANGELOG_TITLE.length).trim()
+    : currentFile;
+
+  const newContent = `${CHANGELOG_TITLE}\n\n${entry}\n\n${currentContent}\n`;
+  writeFileSync(changelogPath, newContent);
+  consola.success(`Changelog updated for v${version}`);
+};
+
+run();

--- a/src/services/discover.ts
+++ b/src/services/discover.ts
@@ -42,6 +42,29 @@ class DiscoverService {
   private _isRetrying = false;
   private _tokenRefreshPromise: Promise<void> | null = null;
 
+  private isMarketTrustedClientEnabled = (): boolean => {
+    if (typeof window === 'undefined' || !window.global_serverConfigStore) return false;
+    try {
+      const state = window.global_serverConfigStore.getState();
+      return state.serverConfig.enableMarketTrustedClient || false;
+    } catch {
+      return false;
+    }
+  };
+
+  safeInjectMPToken = async () => {
+    // If trusted client is enabled, authentication is handled by backend
+    // No need to inject M2M token from client side
+    if (this.isMarketTrustedClientEnabled()) return;
+
+    try {
+      await this.injectMPToken();
+    } catch (error) {
+      // Log error but don't block the request
+      console.warn('Failed to inject MP token, continuing without it:', error);
+    }
+  };
+
   // ============================== Assistant Market ==============================
   getAssistantCategories = async (
     params: CategoryListQuery & { source?: AssistantMarketSource } = {},
@@ -77,7 +100,7 @@ class DiscoverService {
   };
 
   getAssistantList = async (params: AssistantQueryParams = {}): Promise<AssistantListResponse> => {
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const locale = globalHelpers.getCurrentLanguage();
     return lambdaClient.market.getAssistantList.query(
@@ -129,7 +152,7 @@ class DiscoverService {
   };
 
   getMcpList = async (params: McpQueryParams = {}): Promise<McpListResponse> => {
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const locale = globalHelpers.getCurrentLanguage();
     return lambdaClient.market.getMcpList.query({
@@ -141,7 +164,7 @@ class DiscoverService {
   };
 
   getMCPPluginList = async (params: MCPPluginListParams): Promise<McpListResponse> => {
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const locale = globalHelpers.getCurrentLanguage();
 
@@ -192,7 +215,7 @@ class DiscoverService {
     const allow = userGeneralSettingsSelectors.telemetry(useUserStore.getState());
 
     if (!allow) return;
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const reportData = {
       errorCode: success ? undefined : errorCode,
@@ -218,7 +241,7 @@ class DiscoverService {
 
     if (!allow) return;
 
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     lambdaClient.market.reportCall.mutate(cleanObject(reportData)).catch((reportError) => {
       console.warn('Failed to report call:', reportError);
@@ -229,7 +252,7 @@ class DiscoverService {
     const allow = userGeneralSettingsSelectors.telemetry(useUserStore.getState());
     if (!allow) return;
 
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const payload = cleanObject({
       ...eventData,
@@ -250,7 +273,7 @@ class DiscoverService {
 
     if (!allow) return;
 
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     lambdaClient.market.reportAgentInstall.mutate({ identifier }).catch((reportError) => {
       console.warn('Failed to report agent installation:', reportError);
@@ -261,7 +284,7 @@ class DiscoverService {
     const allow = userGeneralSettingsSelectors.telemetry(useUserStore.getState());
     if (!allow) return;
 
-    await this.injectMPToken();
+    await this.safeInjectMPToken();
 
     const payload = cleanObject({
       ...eventData,

--- a/src/services/marketApi.ts
+++ b/src/services/marketApi.ts
@@ -242,7 +242,7 @@ export class MarketApiService {
     pageSize: number;
     total: number;
   }> {
-    await discoverService.injectMPToken();
+    await discoverService.safeInjectMPToken();
 
     return lambdaClient.market.skill.searchSkill.query(params);
   }

--- a/src/services/mcp.test.ts
+++ b/src/services/mcp.test.ts
@@ -57,7 +57,7 @@ vi.mock('@/utils/electron/ipc', () => ({
 
 vi.mock('./discover', () => ({
   discoverService: {
-    injectMPToken: vi.fn().mockResolvedValue(undefined),
+    safeInjectMPToken: vi.fn().mockResolvedValue(undefined),
     reportPluginCall: vi.fn().mockResolvedValue(undefined),
   },
 }));

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -35,7 +35,7 @@ class MCPService {
     payload: ChatToolPayload,
     { signal, topicId }: { signal?: AbortSignal; topicId?: string },
   ) {
-    await discoverService.injectMPToken();
+    await discoverService.safeInjectMPToken();
 
     const { pluginSelectors } = await import('@/store/tool/selectors');
     const { getToolStoreState } = await import('@/store/tool/store');


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The `latest*.yml` files uploaded to the S3 channel root directory lacked the `$VERSION/` prefix in their `url:` fields. When electron-updater reads `latest-mac.yml`, it resolves URLs like:

```
https://cdn-desktop-releases.lobehub.com/canary/LobeHub-Canary-2.1.38-canary.1-arm64-mac.zip
```

But the actual files are stored at:

```
https://cdn-desktop-releases.lobehub.com/canary/2.1.38-canary.1/LobeHub-Canary-2.1.38-canary.1-arm64-mac.zip
```

This results in **404 errors** during auto-update, preventing differential and full downloads.

**Fix:** Apply `sed -i` to `latest*.yml` in-place before uploading, adding the `$VERSION/` prefix to all `url:` fields. The `${CHANNEL}*.yml` files are then copied from the already-modified `latest*.yml` instead of re-running `sed`.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a canary/nightly desktop release and verify the uploaded `latest-mac.yml` contains version-prefixed URLs (e.g., `url: 2.1.39-canary.1/LobeHub-Canary-...`).

#### 📝 Additional Information

This fixes the 404 auto-update failure reported for canary desktop builds. The `stable` channel was unaffected because electron-updater reads `stable-mac.yml` (which already had the prefix), but `latest-mac.yml` was also served without it.

## Summary by Sourcery

Update desktop release workflows and market services to fix updater URLs, improve changelog generation, and make marketplace token injection resilient and configurable.

New Features:
- Add a changelog generation script and workflow steps to automatically build and commit changelog artifacts during auto-tag releases.

Bug Fixes:
- Ensure desktop S3 publish step prefixes URLs in latest*.yml manifests with the version directory to prevent 404 errors during auto-update.
- Guard marketplace MP token injection behind a trusted-client configuration flag and prevent token injection failures from breaking market calls.

Enhancements:
- Refine the auto-tag release workflow to install dependencies, separate version bumping from committing, and include changelog assets in release commits.
- Simplify the release workflow by removing tag-based version validation and semantic-release invocation.
- Update market-related services and tests to use a safer token injection helper shared across assistant, MCP, skill search, telemetry, and reporting flows.

Build:
- Add Node.js and Bun setup steps to the auto-tag-release GitHub Actions workflow and wire in the new changelog generation script.

Tests:
- Adjust MCP service tests to mock the new safe MP token injection method instead of the old direct injector.