### PR TITLE
🐛 fix(ci): add version prefix to latest*.yml URLs in S3 upload

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -83,21 +83,32 @@ runs:
           fi
         done
 
-        # 2. 创建 {channel}*.yml (从 latest*.yml 复制，URL 加版本目录前缀)
+        # 2. 为所有 latest*.yml 的 URL 加版本目录前缀
         # electron-builder 始终生成 latest*.yml，不区分 channel
+        # 安装包在 s3://$BUCKET/$CHANNEL/$VERSION/ 下，URL 需加 $VERSION/ 前缀
+        echo ""
+        echo "📋 Adding version prefix to latest*.yml URLs..."
+        for yml in release/latest*.yml; do
+          if [ -f "$yml" ]; then
+            # url: xxx.dmg -> url: {VERSION}/xxx.dmg
+            sed -i "s|url: |url: $VERSION/|g" "$yml"
+            echo "   📄 Updated $(basename $yml) with URL prefix: $VERSION/"
+          fi
+        done
+
+        # 3. 创建 {channel}*.yml (从已修改的 latest*.yml 复制)
         # electron-updater 在对应 channel 时会找 {channel}-mac.yml
         echo ""
         echo "📋 Creating ${CHANNEL}*.yml files from latest*.yml..."
         for yml in release/latest*.yml; do
           if [ -f "$yml" ]; then
             channel_name=$(basename "$yml" | sed "s/latest/$CHANNEL/")
-            # url: xxx.dmg -> url: {VERSION}/xxx.dmg
-            sed "s|url: |url: $VERSION/|g" "$yml" > "release/$channel_name"
-            echo "   📄 Created $channel_name from $(basename $yml) with URL prefix: $VERSION/"
+            cp "$yml" "release/$channel_name"
+            echo "   📄 Created $channel_name from $(basename $yml)"
           fi
         done
 
-        # 3. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
+        # 4. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
         RENDERER_TAR="release/lobehub-renderer.tar.gz"
         if [ -f "$RENDERER_TAR" ]; then
           echo ""
@@ -118,7 +129,7 @@ runs:
           echo "   📄 Created ${CHANNEL}-renderer.yml"
         fi
 
-        # 4. 上传 manifest 到根目录和版本目录
+        # 5. 上传 manifest 到根目录和版本目录
         # 根目录: electron-updater 需要，每次发版覆盖
         # 版本目录: 作为存档保留
         echo ""


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The `latest*.yml` files uploaded to the S3 channel root directory lacked the `$VERSION/` prefix in their `url:` fields. When electron-updater reads `latest-mac.yml`, it resolves URLs like:

```
https://cdn-desktop-releases.lobehub.com/canary/LobeHub-Canary-2.1.38-canary.1-arm64-mac.zip
```

But the actual files are stored at:

```
https://cdn-desktop-releases.lobehub.com/canary/2.1.38-canary.1/LobeHub-Canary-2.1.38-canary.1-arm64-mac.zip
```

This results in **404 errors** during auto-update, preventing differential and full downloads.

**Fix:** Apply `sed -i` to `latest*.yml` in-place before uploading, adding the `$VERSION/` prefix to all `url:` fields. The `${CHANNEL}*.yml` files are then copied from the already-modified `latest*.yml` instead of re-running `sed`.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a canary/nightly desktop release and verify the uploaded `latest-mac.yml` contains version-prefixed URLs (e.g., `url: 2.1.39-canary.1/LobeHub-Canary-...`).

#### 📝 Additional Information

This fixes the 404 auto-update failure reported for canary desktop builds. The `stable` channel was unaffected because electron-updater reads `stable-mac.yml` (which already had the prefix), but `latest-mac.yml` was also served without it.

## Summary by Sourcery

Ensure desktop release manifests in S3 use version-prefixed URLs to match the actual artifact storage layout and prevent updater 404s.

Bug Fixes:
- Add the version directory prefix to all URLs in latest*.yml manifests before upload so auto-updates resolve to existing files.

CI:
- Adjust the desktop S3 publish GitHub Action to modify latest*.yml in-place and reuse them when generating channel-specific manifest files.