### PR TITLE
🐛 fix(ci): add version prefix to S3 update manifest URLs

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -83,32 +83,19 @@ runs:
           fi
         done
 
-        # 2. 为所有 latest*.yml 的 URL 加版本目录前缀
-        # electron-builder 始终生成 latest*.yml，不区分 channel
+        # 2. 为所有 yml manifest 的 URL 加版本目录前缀
+        # merge-mac-files 步骤已生成 {channel}*.yml (如 canary-mac.yml)
         # 安装包在 s3://$BUCKET/$CHANNEL/$VERSION/ 下，URL 需加 $VERSION/ 前缀
         echo ""
-        echo "📋 Adding version prefix to latest*.yml URLs..."
-        for yml in release/latest*.yml; do
+        echo "📋 Adding version prefix to yml manifest URLs..."
+        for yml in release/${CHANNEL}*.yml release/latest*.yml; do
           if [ -f "$yml" ]; then
-            # url: xxx.dmg -> url: {VERSION}/xxx.dmg
             sed -i "s|url: |url: $VERSION/|g" "$yml"
             echo "   📄 Updated $(basename $yml) with URL prefix: $VERSION/"
           fi
         done
 
-        # 3. 创建 {channel}*.yml (从已修改的 latest*.yml 复制)
-        # electron-updater 在对应 channel 时会找 {channel}-mac.yml
-        echo ""
-        echo "📋 Creating ${CHANNEL}*.yml files from latest*.yml..."
-        for yml in release/latest*.yml; do
-          if [ -f "$yml" ]; then
-            channel_name=$(basename "$yml" | sed "s/latest/$CHANNEL/")
-            cp "$yml" "release/$channel_name"
-            echo "   📄 Created $channel_name from $(basename $yml)"
-          fi
-        done
-
-        # 4. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
+        # 3. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
         RENDERER_TAR="release/lobehub-renderer.tar.gz"
         if [ -f "$RENDERER_TAR" ]; then
           echo ""
@@ -129,7 +116,7 @@ runs:
           echo "   📄 Created ${CHANNEL}-renderer.yml"
         fi
 
-        # 5. 上传 manifest 到根目录和版本目录
+        # 4. 上传 manifest 到根目录和版本目录
         # 根目录: electron-updater 需要，每次发版覆盖
         # 版本目录: 作为存档保留
         echo ""


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The `merge-mac-files` step already renames `latest*.yml` to `{channel}*.yml` (e.g., `canary-mac.yml`, `canary-linux.yml`). The S3 publish action was only targeting `release/latest*.yml` for URL prefix injection, which matched **nothing** — so the `sed` was a no-op.

As a result, `canary-mac.yml` uploaded to S3 had URLs like:
```
url: LobeHub-Canary-2.1.38-canary.2-arm64-mac.zip
```

Resolving to `cdn.../canary/LobeHub-Canary-xxx.zip` (404), when the actual file is at:
```
cdn.../canary/2.1.38-canary.2/LobeHub-Canary-xxx.zip
```

**Fix:** Target `release/${CHANNEL}*.yml` (with `latest*.yml` as fallback) for the `sed -i` version prefix injection.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a canary desktop release and verify `canary-mac.yml` in S3 contains version-prefixed URLs (e.g., `url: 2.1.38-canary.3/LobeHub-Canary-...`).

## Summary by Sourcery

Bug Fixes:
- Update the S3 manifest URL rewrite step to operate on channel-specific and latest YAML files so generated URLs include the version directory prefix.