### PR TITLE
🐛 fix(desktop): fix release notes not rendering as markdown & add simulate update found

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -280,6 +280,29 @@ export class UpdaterManager {
   };
 
   /**
+   * Test mode: Simulate update found (shows "new version available" prompt)
+   */
+  public simulateUpdateFound = () => {
+    if (!isDev) return;
+
+    logger.info('Simulating update found...');
+
+    const mockUpdateInfo: UpdateInfo = {
+      releaseDate: new Date().toISOString(),
+      releaseNotes: `## Version 99.0.0 Release Notes\n- Added some great new features\n- Fixed bugs affecting usability\n- Optimized overall application performance\n- Updated dependency libraries\n`,
+      version: '99.0.0',
+    };
+
+    this.downloading = false;
+    this.updateAvailable = true;
+    this.setStage('checking');
+
+    setTimeout(() => {
+      this.setStage('available', { updateInfo: mockUpdateInfo });
+    }, 1000);
+  };
+
+  /**
    * Test mode: Simulate update available
    */
   public simulateUpdateAvailable = () => {

--- a/apps/desktop/src/main/locales/default/menu.ts
+++ b/apps/desktop/src/main/locales/default/menu.ts
@@ -2,6 +2,7 @@ const menu = {
   'common.checkUpdates': 'Check for updates...',
   'common.checkingUpdates': 'Checking for updates...',
   'common.downloadingUpdate': 'Downloading update...',
+  'common.updateAvailable': 'Update available...',
   'common.isLatestVersion': 'Already up to date',
   'common.restartToUpdate': 'Restart to update',
   'context.copyImage': 'Copy Image',

--- a/apps/desktop/src/main/locales/default/menu.ts
+++ b/apps/desktop/src/main/locales/default/menu.ts
@@ -29,6 +29,7 @@ const menu = {
   'dev.refreshMenu': 'Refresh Menu',
   'dev.reload': 'Reload',
   'dev.simulateAutoDownload': 'Simulate Auto Download (3s)',
+  'dev.simulateUpdateFound': 'Simulate Update Found',
   'dev.simulateDownloadComplete': 'Simulate Download Complete',
   'dev.simulateDownloadProgress': 'Simulate Download Progress',
   'dev.title': 'Development',

--- a/apps/desktop/src/main/menus/impls/macOS.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.ts
@@ -399,6 +399,12 @@ export class MacOSMenu extends BaseMenuPlatform implements IMenuPlatform {
       case 'checking': {
         return { enabled: false, label: t('common.checkingUpdates') };
       }
+      case 'available': {
+        return {
+          click: () => this.app.updaterManager.downloadUpdate(),
+          label: t('common.updateAvailable'),
+        };
+      }
       case 'downloading': {
         return { enabled: false, label: t('common.downloadingUpdate') };
       }

--- a/apps/desktop/src/main/menus/impls/macOS.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.ts
@@ -361,6 +361,12 @@ export class MacOSMenu extends BaseMenuPlatform implements IMenuPlatform {
             submenu: [
               {
                 click: () => {
+                  this.app.updaterManager.simulateUpdateFound();
+                },
+                label: t('dev.simulateUpdateFound'),
+              },
+              {
+                click: () => {
                   this.app.updaterManager.simulateUpdateAvailable();
                 },
                 label: t('dev.simulateAutoDownload'),

--- a/apps/desktop/src/main/menus/impls/windows.ts
+++ b/apps/desktop/src/main/menus/impls/windows.ts
@@ -215,6 +215,12 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
       case 'checking': {
         return { enabled: false, label: t('common.checkingUpdates') };
       }
+      case 'available': {
+        return {
+          click: () => this.app.updaterManager.downloadUpdate(),
+          label: t('common.updateAvailable'),
+        };
+      }
       case 'downloading': {
         return { enabled: false, label: t('common.downloadingUpdate') };
       }

--- a/packages/electron-client-ipc/src/types/update.ts
+++ b/packages/electron-client-ipc/src/types/update.ts
@@ -24,7 +24,14 @@ export interface UpdateInfo {
   version: string;
 }
 
-export type UpdaterStage = 'idle' | 'checking' | 'downloading' | 'downloaded' | 'latest' | 'error';
+export type UpdaterStage =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'downloaded'
+  | 'latest'
+  | 'error';
 
 export interface UpdaterState {
   errorMessage?: string;

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,6 +1,6 @@
-import { type UpdateInfo } from '@lobechat/electron-client-ipc';
+import { type UpdateInfo, type UpdaterState } from '@lobechat/electron-client-ipc';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { Button, Flexbox, Icon } from '@lobehub/ui';
+import { Button, Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Modal } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CircleFadingArrowUp } from 'lucide-react';
@@ -39,6 +39,13 @@ export const UpdateNotification: React.FC = () => {
   const [detailVisible, setDetailVisible] = useState(false);
   const [isInstalling, setIsInstalling] = useState(false);
 
+  useWatchBroadcast('updaterStateChanged', (state: UpdaterState) => {
+    if (state.stage !== 'available') return;
+    setUpdateAvailable(true);
+    setUpdateDownloaded(false);
+    if (state.updateInfo) setUpdateInfo(state.updateInfo);
+  });
+
   useWatchBroadcast('updateDownloaded', (info: UpdateInfo) => {
     setUpdateInfo(info);
     setUpdateDownloaded(true);
@@ -55,6 +62,44 @@ export const UpdateNotification: React.FC = () => {
 
   // 没有更新或正在下载时不显示任何内容
   if (!updateDownloaded && !updateAvailable) return null;
+
+  // 仅用于模拟发现更新
+  if (import.meta.env.DEV && updateAvailable && !updateDownloaded)
+    return (
+      <Modal
+        open
+        footer={null}
+        title={t('updater.newVersionAvailable')}
+        width={520}
+        onCancel={() => setUpdateAvailable(false)}
+      >
+        <Flexbox gap={12} style={{ maxWidth: 480 }}>
+          <div style={{ color: cssVar.colorTextSecondary, fontSize: 13 }}>
+            {t('updater.newVersionAvailableDesc', { version: updateInfo?.version })}
+          </div>
+          {typeof updateInfo?.releaseNotes === 'string' && (
+            <div className={styles.releaseNote}>
+              <Markdown>{updateInfo.releaseNotes}</Markdown>
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <Button size="small" onClick={() => setUpdateAvailable(false)}>
+              {t('updater.later')}
+            </Button>
+            <Button
+              size="small"
+              type="primary"
+              onClick={() => {
+                setUpdateAvailable(false);
+                autoUpdateService.downloadUpdate();
+              }}
+            >
+              {t('updater.downloadNewVersion')}
+            </Button>
+          </div>
+        </Flexbox>
+      </Modal>
+    );
 
   if (installConfirmMode === 'installLater') {
     return (
@@ -134,11 +179,10 @@ export const UpdateNotification: React.FC = () => {
             <div style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>
               {updateInfo?.version}
             </div>
-            {updateInfo?.releaseNotes && (
-              <div
-                className={styles.releaseNote}
-                dangerouslySetInnerHTML={{ __html: updateInfo.releaseNotes }}
-              />
+            {typeof updateInfo?.releaseNotes === 'string' && (
+              <div className={styles.releaseNote}>
+                <Markdown>{updateInfo.releaseNotes}</Markdown>
+              </div>
             )}
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <Button size="small" onClick={() => autoUpdateService.installLater()}>

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,4 +1,4 @@
-import { type UpdateInfo, type UpdaterState } from '@lobechat/electron-client-ipc';
+import { type UpdateInfo } from '@lobechat/electron-client-ipc';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { Button, Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Modal } from 'antd';
@@ -28,10 +28,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
+const normalizeReleaseNotes = (notes: UpdateInfo['releaseNotes']): string | null => {
+  if (!notes) return null;
+  if (typeof notes === 'string') return notes;
+  const items = notes.filter((n) => n.note);
+  if (items.length === 0) return null;
+  return items.map((n) => `### ${n.version}\n\n${n.note}`).join('\n\n');
+};
+
 export const UpdateNotification: React.FC = () => {
   const { t } = useTranslation('electron');
-  const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [updateDownloaded, setUpdateDownloaded] = useState(false);
+  const [updateStage, setUpdateStage] = useState<'available' | 'downloaded' | null>(null);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const [installConfirmMode, setInstallConfirmMode] = useState<
     'unconfirm' | 'installLater' | 'installNow' | null
@@ -39,17 +46,15 @@ export const UpdateNotification: React.FC = () => {
   const [detailVisible, setDetailVisible] = useState(false);
   const [isInstalling, setIsInstalling] = useState(false);
 
-  useWatchBroadcast('updaterStateChanged', (state: UpdaterState) => {
+  useWatchBroadcast('updaterStateChanged', (state) => {
     if (state.stage !== 'available') return;
-    setUpdateAvailable(true);
-    setUpdateDownloaded(false);
+    setUpdateStage('available');
     if (state.updateInfo) setUpdateInfo(state.updateInfo);
   });
 
-  useWatchBroadcast('updateDownloaded', (info: UpdateInfo) => {
+  useWatchBroadcast('updateDownloaded', (info) => {
     setUpdateInfo(info);
-    setUpdateDownloaded(true);
-    setUpdateAvailable(false);
+    setUpdateStage('downloaded');
     setInstallConfirmMode('unconfirm');
     setDetailVisible(false);
   });
@@ -60,37 +65,39 @@ export const UpdateNotification: React.FC = () => {
     setTimeout(() => setInstallConfirmMode(null), 5000); // 5秒后自动隐藏提示
   });
 
-  // 没有更新或正在下载时不显示任何内容
-  if (!updateDownloaded && !updateAvailable) return null;
+  const releaseNotes = normalizeReleaseNotes(updateInfo?.releaseNotes);
 
-  // 仅用于模拟发现更新
-  if (import.meta.env.DEV && updateAvailable && !updateDownloaded)
+  // 没有更新或正在下载时不显示任何内容
+  if (!updateStage) return null;
+
+  // 仅用于模拟发现更新（DEV only）
+  if (import.meta.env.DEV && updateStage === 'available')
     return (
       <Modal
         open
         footer={null}
         title={t('updater.newVersionAvailable')}
         width={520}
-        onCancel={() => setUpdateAvailable(false)}
+        onCancel={() => setUpdateStage(null)}
       >
         <Flexbox gap={12} style={{ maxWidth: 480 }}>
           <div style={{ color: cssVar.colorTextSecondary, fontSize: 13 }}>
             {t('updater.newVersionAvailableDesc', { version: updateInfo?.version })}
           </div>
-          {typeof updateInfo?.releaseNotes === 'string' && (
+          {releaseNotes && (
             <div className={styles.releaseNote}>
-              <Markdown>{updateInfo.releaseNotes}</Markdown>
+              <Markdown>{releaseNotes}</Markdown>
             </div>
           )}
           <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-            <Button size="small" onClick={() => setUpdateAvailable(false)}>
+            <Button size="small" onClick={() => setUpdateStage(null)}>
               {t('updater.later')}
             </Button>
             <Button
               size="small"
               type="primary"
               onClick={() => {
-                setUpdateAvailable(false);
+                setUpdateStage(null);
                 autoUpdateService.downloadUpdate();
               }}
             >

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -36,6 +36,7 @@ export default {
   'changelog': 'Changelog',
   'alreadyUpToDate': 'Already Up to Date',
   'checkForUpdates': 'Check for Updates',
+  'downloadNewVersion': 'Download Update',
   'downloadingUpdate': 'Downloading {{percent}}%',
   'restartToUpdate': 'Restart to Update',
   'clientDB.autoInit.title': 'Initializing PGlite Database',

--- a/src/routes/(main)/settings/about/features/Version.tsx
+++ b/src/routes/(main)/settings/about/features/Version.tsx
@@ -1,9 +1,6 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
-import {
-  getElectronIpc,
-  type UpdaterState,
-  useWatchBroadcast,
-} from '@lobechat/electron-client-ipc';
+import type { UpdaterState } from '@lobechat/electron-client-ipc';
+import { getElectronIpc, useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { Block, Button, Flexbox, Tag } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo, useEffect, useMemo, useState } from 'react';
@@ -43,7 +40,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
     autoUpdateService.getUpdaterState().then(setUpdaterState);
   }, [isDesktop]);
 
-  useWatchBroadcast('updaterStateChanged', (state: UpdaterState) => {
+  useWatchBroadcast('updaterStateChanged', (state) => {
     setUpdaterState(state);
   });
 
@@ -68,6 +65,17 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
         return (
           <Button loading block={mobile}>
             {t('checkForUpdates')}
+          </Button>
+        );
+      }
+      case 'available': {
+        return (
+          <Button
+            block={mobile}
+            type="primary"
+            onClick={() => void autoUpdateService.downloadUpdate()}
+          >
+            {t('downloadNewVersion')}
           </Button>
         );
       }


### PR DESCRIPTION
- Replace dangerouslySetInnerHTML with <Markdown> component for release notes rendering
- Add 'available' stage to UpdaterStage type
- Add simulateUpdateFound() dev method and menu entry to test update-available prompt

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->
Triggered an update check (or used the new "Simulate Update Found" dev menu entry) to open the update notification dialog. Confirmed that release notes with Markdown syntax (headers, bold, lists, links) now render correctly instead of showing raw HTML/Markdown text

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| <img width="1424" height="818" alt="Screenshot 2026-03-06 at 21 48 58" src="https://github.com/user-attachments/assets/17ab2272-3d95-48a3-9878-cb03ac8f2fbf" /> | <img width="1157" height="805" alt="Screenshot 2026-03-06 at 21 46 55" src="https://github.com/user-attachments/assets/2d4660d0-47ea-4f98-b749-0b85c22036d7" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve desktop app update notifications by correctly rendering markdown release notes and adding a development-only flow to simulate an available update.

New Features:
- Add a development-only "Simulate Update Found" menu action to trigger the new-version-available prompt with mock data.

Bug Fixes:
- Fix release notes in the update notification dialog not rendering markdown content correctly.

Enhancements:
- Extend updater state tracking with an explicit "available" stage and wire it to the update notification UI to show pre-download availability prompts.