### PR TITLE
🐛 fix: cli login and run browser in Windows

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,6 +10,8 @@
   ],
   "scripts": {
     "build": "npx tsup",
+    "cli:link": "bun link",
+    "cli:unlink": "bun unlink",
     "dev": "bun src/index.ts",
     "prepublishOnly": "npm run build",
     "test": "bunx vitest run --config vitest.config.mts --silent='passed-only'",

--- a/apps/cli/src/commands/login.test.ts
+++ b/apps/cli/src/commands/login.test.ts
@@ -1,9 +1,11 @@
+import fs from 'node:fs';
+
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { saveCredentials } from '../auth/credentials';
 import { log } from '../utils/logger';
-import { registerLoginCommand } from './login';
+import { registerLoginCommand, resolveCommandExecutable } from './login';
 
 vi.mock('../auth/credentials', () => ({
   saveCredentials: vi.fn(),
@@ -26,6 +28,9 @@ vi.mock('node:child_process', () => ({
 
 describe('login command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  const originalPath = process.env.PATH;
+  const originalPathext = process.env.PATHEXT;
+  const originalSystemRoot = process.env.SystemRoot;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -36,6 +41,9 @@ describe('login command', () => {
   afterEach(() => {
     vi.useRealTimers();
     exitSpy.mockRestore();
+    process.env.PATH = originalPath;
+    process.env.PATHEXT = originalPathext;
+    process.env.SystemRoot = originalSystemRoot;
     vi.restoreAllMocks();
   });
 
@@ -247,5 +255,18 @@ describe('login command', () => {
 
     expect(log.error).toHaveBeenCalledWith(expect.stringContaining('expired'));
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should resolve Windows executable via PATHEXT', () => {
+    process.env.PATH = 'C:\\Tools';
+    process.env.PATHEXT = '.EXE;.CMD';
+    process.env.SystemRoot = 'C:\\Windows';
+
+    vi.spyOn(fs, 'existsSync').mockImplementation(
+      (targetPath) => String(targetPath).toLowerCase() === 'c:\\tools\\rundll32.exe',
+    );
+
+    const resolved = resolveCommandExecutable('rundll32', 'win32');
+    expect(resolved?.toLowerCase()).toBe('c:\\tools\\rundll32.exe');
   });
 });

--- a/apps/cli/src/commands/login.test.ts
+++ b/apps/cli/src/commands/login.test.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs';
-
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -25,9 +23,6 @@ vi.mock('node:child_process', () => ({
   exec: vi.fn((_cmd: string, cb: any) => cb?.(null)),
   execFile: vi.fn((_cmd: string, _args: string[], cb: any) => cb?.(null)),
 }));
-
-// eslint-disable-next-line import-x/first
-import { execFile } from 'node:child_process';
 
 describe('login command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -117,41 +112,6 @@ describe('login command', () => {
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Login successful'));
   });
 
-  it('should print manual open instructions when browser open fails', async () => {
-    vi.mocked(execFile).mockImplementationOnce((_cmd: any, _args: any, cb: any) => {
-      cb(new Error('xdg-open not found'));
-      return {} as any;
-    });
-
-    vi.mocked(fetch)
-      .mockResolvedValueOnce(deviceAuthResponse())
-      .mockResolvedValueOnce(tokenSuccessResponse());
-
-    const program = createProgram();
-    await runLoginAndAdvanceTimers(program);
-
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not open browser'));
-    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Please open this URL manually'));
-  });
-
-  it('should fallback gracefully when execFile throws synchronously', async () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-    vi.spyOn(fs, 'accessSync').mockImplementation(() => {});
-    vi.mocked(execFile).mockImplementationOnce(() => {
-      throw new TypeError('Executable not found in $PATH: "xdg-open"');
-    });
-
-    vi.mocked(fetch)
-      .mockResolvedValueOnce(deviceAuthResponse())
-      .mockResolvedValueOnce(tokenSuccessResponse());
-
-    const program = createProgram();
-    await runLoginAndAdvanceTimers(program);
-
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not open browser'));
-    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Please open this URL manually'));
-  });
-
   it('should strip trailing slash from server URL', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(deviceAuthResponse())
@@ -194,29 +154,6 @@ describe('login command', () => {
     await runLoginAndAdvanceTimers(program).catch(() => {});
 
     expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Failed to reach'));
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it('should show clear error when device auth returns non-json', async () => {
-    exitSpy.mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    vi.mocked(fetch).mockResolvedValueOnce({
-      headers: {
-        get: vi.fn().mockReturnValue('text/html'),
-      },
-      json: vi.fn().mockRejectedValue(new Error('Failed to parse JSON')),
-      ok: true,
-      status: 200,
-    } as any);
-
-    const program = createProgram();
-    await runLoginAndAdvanceTimers(program).catch(() => {});
-
-    expect(log.error).toHaveBeenCalledWith(
-      expect.stringContaining('Expected JSON from /oidc/device/auth'),
-    );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/apps/cli/src/commands/login.test.ts
+++ b/apps/cli/src/commands/login.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -23,6 +25,9 @@ vi.mock('node:child_process', () => ({
   exec: vi.fn((_cmd: string, cb: any) => cb?.(null)),
   execFile: vi.fn((_cmd: string, _args: string[], cb: any) => cb?.(null)),
 }));
+
+// eslint-disable-next-line import-x/first
+import { execFile } from 'node:child_process';
 
 describe('login command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -112,6 +117,41 @@ describe('login command', () => {
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Login successful'));
   });
 
+  it('should print manual open instructions when browser open fails', async () => {
+    vi.mocked(execFile).mockImplementationOnce((_cmd: any, _args: any, cb: any) => {
+      cb(new Error('xdg-open not found'));
+      return {} as any;
+    });
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(deviceAuthResponse())
+      .mockResolvedValueOnce(tokenSuccessResponse());
+
+    const program = createProgram();
+    await runLoginAndAdvanceTimers(program);
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not open browser'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Please open this URL manually'));
+  });
+
+  it('should fallback gracefully when execFile throws synchronously', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'accessSync').mockImplementation(() => {});
+    vi.mocked(execFile).mockImplementationOnce(() => {
+      throw new TypeError('Executable not found in $PATH: "xdg-open"');
+    });
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(deviceAuthResponse())
+      .mockResolvedValueOnce(tokenSuccessResponse());
+
+    const program = createProgram();
+    await runLoginAndAdvanceTimers(program);
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not open browser'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Please open this URL manually'));
+  });
+
   it('should strip trailing slash from server URL', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(deviceAuthResponse())
@@ -154,6 +194,29 @@ describe('login command', () => {
     await runLoginAndAdvanceTimers(program).catch(() => {});
 
     expect(log.error).toHaveBeenCalledWith(expect.stringContaining('Failed to reach'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should show clear error when device auth returns non-json', async () => {
+    exitSpy.mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      headers: {
+        get: vi.fn().mockReturnValue('text/html'),
+      },
+      json: vi.fn().mockRejectedValue(new Error('Failed to parse JSON')),
+      ok: true,
+      status: 200,
+    } as any);
+
+    const program = createProgram();
+    await runLoginAndAdvanceTimers(program).catch(() => {});
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('Expected JSON from /oidc/device/auth'),
+    );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -178,27 +178,63 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function resolveCommandExecutable(
+  cmd: string,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (!cmd) return undefined;
+
+  // If command already contains a path, only check that exact location.
+  if (cmd.includes('/') || cmd.includes('\\')) {
+    return fs.existsSync(cmd) ? cmd : undefined;
+  }
+
+  const pathValue = process.env.PATH || '';
+  if (!pathValue) return undefined;
+
+  const pathEntries = pathValue.split(path.delimiter).filter(Boolean);
+
+  if (platform === 'win32') {
+    const pathext = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+    const hasExtension = path.extname(cmd).length > 0;
+    const candidateNames = hasExtension ? [cmd] : [cmd, ...pathext.map((ext) => `${cmd}${ext}`)];
+
+    // Prefer PATH lookup, then fall back to System32 for built-in tools like rundll32.
+    const systemRoot = process.env.SystemRoot || process.env.WINDIR;
+    if (systemRoot) {
+      pathEntries.push(path.join(systemRoot, 'System32'));
+    }
+
+    for (const entry of pathEntries) {
+      for (const candidate of candidateNames) {
+        const resolved = path.join(entry, candidate);
+        if (fs.existsSync(resolved)) return resolved;
+      }
+    }
+
+    return undefined;
+  }
+
+  for (const entry of pathEntries) {
+    const resolved = path.join(entry, cmd);
+    if (fs.existsSync(resolved)) return resolved;
+  }
+
+  return undefined;
+}
+
 async function openBrowser(url: string): Promise<boolean> {
-  const commandExists = (cmd: string): boolean => {
-    const pathValue = process.env.PATH || '';
-    if (!pathValue) return false;
-
-    return pathValue
-      .split(path.delimiter)
-      .filter(Boolean)
-      .some((entry) => fs.existsSync(path.join(entry, cmd)));
-  };
-
   const runCommand = (cmd: string, args: string[]) =>
     new Promise<boolean>((resolve) => {
-      if (!commandExists(cmd)) {
+      const executable = resolveCommandExecutable(cmd);
+      if (!executable) {
         log.debug(`Could not open browser automatically: command not found in PATH: ${cmd}`);
         resolve(false);
         return;
       }
 
       try {
-        execFile(cmd, args, (err) => {
+        execFile(executable, args, (err) => {
           if (err) {
             log.debug(`Could not open browser automatically: ${err.message}`);
             resolve(false);

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type { Command } from 'commander';
 
@@ -33,6 +35,17 @@ interface TokenErrorResponse {
   error_description?: string;
 }
 
+async function parseJsonResponse<T>(res: Response, endpoint: string): Promise<T> {
+  try {
+    return (await res.json()) as T;
+  } catch {
+    const contentType = res.headers.get('content-type') || 'unknown';
+    throw new Error(
+      `Expected JSON from ${endpoint}, got non-JSON response (status=${res.status}, content-type=${contentType}).`,
+    );
+  }
+}
+
 export function registerLoginCommand(program: Command) {
   program
     .command('login')
@@ -62,7 +75,7 @@ export function registerLoginCommand(program: Command) {
           process.exit(1);
         }
 
-        deviceAuth = (await res.json()) as DeviceAuthResponse;
+        deviceAuth = await parseJsonResponse<DeviceAuthResponse>(res, '/oidc/device/auth');
       } catch (error: any) {
         log.error(`Failed to reach server: ${error.message}`);
         log.error(`Make sure ${serverUrl} is reachable.`);
@@ -80,7 +93,13 @@ export function registerLoginCommand(program: Command) {
       log.info('');
 
       // Try to open browser automatically
-      openBrowser(verifyUrl);
+      const opened = await openBrowser(verifyUrl);
+      if (!opened) {
+        log.warn('Could not open browser automatically.');
+        log.info('Please open this URL manually:');
+        log.info(`  ${verifyUrl}`);
+        log.info(`Then enter code: ${deviceAuth.user_code}`);
+      }
 
       log.info('Waiting for authorization...');
 
@@ -104,7 +123,10 @@ export function registerLoginCommand(program: Command) {
             method: 'POST',
           });
 
-          const body = (await res.json()) as TokenResponse & TokenErrorResponse;
+          const body = await parseJsonResponse<TokenResponse & TokenErrorResponse>(
+            res,
+            '/oidc/token',
+          );
 
           // Check body for error field — some proxies may return 200 for error responses
           if (body.error) {
@@ -159,20 +181,68 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function openBrowser(url: string) {
+async function openBrowser(url: string): Promise<boolean> {
+  const commandExists = (cmd: string): boolean => {
+    const pathValue = process.env.PATH || '';
+    if (!pathValue) return false;
+
+    const pathEntries = pathValue.split(path.delimiter);
+    const extensions =
+      process.platform === 'win32'
+        ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+        : [''];
+
+    const hasFileExtension = path.extname(cmd) !== '';
+
+    for (const entry of pathEntries) {
+      if (!entry) continue;
+
+      for (const ext of extensions) {
+        const filename = process.platform === 'win32' && !hasFileExtension ? `${cmd}${ext}` : cmd;
+        const fullPath = path.join(entry, filename);
+
+        if (!fs.existsSync(fullPath)) continue;
+
+        try {
+          fs.accessSync(fullPath, fs.constants.X_OK);
+          return true;
+        } catch {
+          // Not executable, keep searching other PATH entries.
+        }
+      }
+    }
+
+    return false;
+  };
+
+  const runCommand = (cmd: string, args: string[]) =>
+    new Promise<boolean>((resolve) => {
+      if (!commandExists(cmd)) {
+        log.debug(`Could not open browser automatically: command not found in PATH: ${cmd}`);
+        resolve(false);
+        return;
+      }
+
+      try {
+        execFile(cmd, args, (err) => {
+          if (err) {
+            log.debug(`Could not open browser automatically: ${err.message}`);
+            resolve(false);
+            return;
+          }
+          resolve(true);
+        });
+      } catch (error: any) {
+        log.debug(`Could not open browser automatically: ${error?.message || String(error)}`);
+        resolve(false);
+      }
+    });
+
   if (process.platform === 'win32') {
     // On Windows, use rundll32 to invoke the default URL handler without a shell.
-    execFile('rundll32', ['url.dll,FileProtocolHandler', url], (err) => {
-      if (err) {
-        log.debug(`Could not open browser automatically: ${err.message}`);
-      }
-    });
-  } else {
-    const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
-    execFile(cmd, [url], (err) => {
-      if (err) {
-        log.debug(`Could not open browser automatically: ${err.message}`);
-      }
-    });
+    return runCommand('rundll32', ['url.dll,FileProtocolHandler', url]);
   }
+
+  const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+  return runCommand(cmd, [url]);
 }

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -96,9 +96,6 @@ export function registerLoginCommand(program: Command) {
       const opened = await openBrowser(verifyUrl);
       if (!opened) {
         log.warn('Could not open browser automatically.');
-        log.info('Please open this URL manually:');
-        log.info(`  ${verifyUrl}`);
-        log.info(`Then enter code: ${deviceAuth.user_code}`);
       }
 
       log.info('Waiting for authorization...');
@@ -186,33 +183,10 @@ async function openBrowser(url: string): Promise<boolean> {
     const pathValue = process.env.PATH || '';
     if (!pathValue) return false;
 
-    const pathEntries = pathValue.split(path.delimiter);
-    const extensions =
-      process.platform === 'win32'
-        ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
-        : [''];
-
-    const hasFileExtension = path.extname(cmd) !== '';
-
-    for (const entry of pathEntries) {
-      if (!entry) continue;
-
-      for (const ext of extensions) {
-        const filename = process.platform === 'win32' && !hasFileExtension ? `${cmd}${ext}` : cmd;
-        const fullPath = path.join(entry, filename);
-
-        if (!fs.existsSync(fullPath)) continue;
-
-        try {
-          fs.accessSync(fullPath, fs.constants.X_OK);
-          return true;
-        } catch {
-          // Not executable, keep searching other PATH entries.
-        }
-      }
-    }
-
-    return false;
+    return pathValue
+      .split(path.delimiter)
+      .filter(Boolean)
+      .some((entry) => fs.existsSync(path.join(entry, cmd)));
   };
 
   const runCommand = (cmd: string, args: string[]) =>

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -188,6 +188,7 @@ export function defineConfig() {
     // Make only the consent view public (GET page), not other oauth paths
     '/oauth/consent/(.*)',
     '/oidc/handoff',
+    '/oidc/device/auth',
     '/oidc/token',
     // market
     '/market-auth-callback',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

- openBrowser: 
  - 先判断有没有浏览器，然后再执行
  - Windows 下唤起浏览器
- route 
  - 不拦截用于 device 认证的接口


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| fix | Before | After |
| --- | ------ | ----- |
| 1| <img width="719" height="184" alt="image" src="https://github.com/user-attachments/assets/3438f977-dfab-4935-9f16-085cf9a2d822" /> | <img width="685" height="242" alt="image" src="https://github.com/user-attachments/assets/0de120b9-5ea2-4027-bdc2-23e5ae93e21b" /> |
| 2 |  <img width="854" height="326" alt="image" src="https://github.com/user-attachments/assets/c7e0dff3-377c-40be-8d47-28c91fb815d6" />| <img width="724" height="378" alt="image" src="https://github.com/user-attachments/assets/d327664f-5f0d-4acb-8511-e1e1d7179e0b" /> |
| 3 | | ![fix-browser](https://github.com/user-attachments/assets/87261f60-2a75-435f-8be5-fd1ca43c49dd) |


#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve CLI login robustness and cross-platform browser launching, and adjust proxy configuration for device authorization.

Bug Fixes:
- Handle non-JSON responses from authentication endpoints with clearer error messages instead of failing silently.
- Fix automatic browser launching for CLI login across platforms, including Windows, and surface a warning when it cannot be opened.
- Ensure Windows executables like rundll32 are resolved correctly using PATH, PATHEXT, and SystemRoot to avoid failures when opening the browser.
- Expose the OIDC device authorization endpoint through the Next.js proxy configuration so CLI device login works correctly.

Enhancements:
- Add a reusable helper for resolving command executables and a dedicated JSON parsing utility to centralize response handling.

Tests:
- Add a unit test to verify Windows executable resolution via PATH and PATHEXT for the login command.