### PR TITLE
🐛 fix: prevent model panel crash without chat input provider

### DIFF
--- a/src/features/ChatInput/hooks/useAgentId.test.tsx
+++ b/src/features/ChatInput/hooks/useAgentId.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useAgentStore } from '@/store/agent';
+
+import { createStore, Provider } from '../store';
+import { useAgentId } from './useAgentId';
+
+const initialActiveAgentId = useAgentStore.getState().activeAgentId;
+
+const createWrapper = (agentId?: string) => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <Provider createStore={() => createStore({ agentId })}>{children}</Provider>
+  );
+
+  return Wrapper;
+};
+
+afterEach(() => {
+  act(() => {
+    useAgentStore.setState({ activeAgentId: initialActiveAgentId });
+  });
+});
+
+describe('useAgentId', () => {
+  it('falls back to activeAgentId without ChatInputProvider', () => {
+    act(() => {
+      useAgentStore.setState({ activeAgentId: 'active-agent' });
+    });
+
+    const { result } = renderHook(() => useAgentId());
+
+    expect(result.current).toBe('active-agent');
+  });
+
+  it('prefers agentId from ChatInputProvider when available', () => {
+    act(() => {
+      useAgentStore.setState({ activeAgentId: 'active-agent' });
+    });
+
+    const { result } = renderHook(() => useAgentId(), {
+      wrapper: createWrapper('input-agent'),
+    });
+
+    expect(result.current).toBe('input-agent');
+  });
+
+  it('keeps empty string from ChatInputProvider instead of falling back', () => {
+    act(() => {
+      useAgentStore.setState({ activeAgentId: 'active-agent' });
+    });
+
+    const { result } = renderHook(() => useAgentId(), {
+      wrapper: createWrapper(''),
+    });
+
+    expect(result.current).toBe('');
+  });
+});

--- a/src/features/ChatInput/hooks/useAgentId.ts
+++ b/src/features/ChatInput/hooks/useAgentId.ts
@@ -2,18 +2,18 @@
 
 import { useAgentStore } from '@/store/agent';
 
-import { useChatInputStore } from '../store';
+import { useOptionalChatInputStore } from '../store';
 
 /**
  * Hook to get the effective agentId for ChatInput components.
- * Returns agentId from ChatInput store if provided (including empty string),
+ * Returns agentId from ChatInput store when the provider exists,
  * otherwise falls back to activeAgentId.
  *
  * Note: Empty string is a valid value (e.g., when Group's supervisorAgentId is not loaded yet),
  * so we only fallback when agentId is undefined (not provided).
  */
 export const useAgentId = () => {
-  const agentIdFromChatInput = useChatInputStore((s) => s.agentId);
+  const agentIdFromChatInput = useOptionalChatInputStore((s) => s.agentId);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
 
   // Only fallback to activeAgentId when agentIdFromChatInput is undefined (not provided)

--- a/src/features/ChatInput/store/index.ts
+++ b/src/features/ChatInput/store/index.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { type StoreApiWithSelector } from '@lobechat/types';
+import { createContext, createElement, type ReactNode, useContext, useRef } from 'react';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
-import { createWithEqualityFn } from 'zustand/traditional';
-import { createContext } from 'zustand-utils';
+import { createWithEqualityFn, useStoreWithEqualityFn } from 'zustand/traditional';
 
 import { type Store } from './action';
 import { store } from './action';
@@ -15,10 +15,66 @@ export type { PublicState, State } from './initialState';
 export const createStore = (initState?: Partial<State>) =>
   createWithEqualityFn(subscribeWithSelector(store(initState)), shallow);
 
-export const {
-  useStore: useChatInputStore,
-  useStoreApi,
-  Provider,
-} = createContext<StoreApiWithSelector<Store>>();
+type ChatInputStoreApi = StoreApiWithSelector<Store>;
+
+type UseChatInputStore = {
+  (): Store;
+  <U>(selector: (state: Store) => U, equalityFn?: (a: U, b: U) => boolean): U;
+};
+
+type UseOptionalChatInputStore = {
+  (): Store | undefined;
+  <U>(selector: (state: Store) => U, equalityFn?: (a: U, b: U) => boolean): U | undefined;
+};
+
+const ChatInputStoreContext = createContext<ChatInputStoreApi | undefined>(undefined);
+const FALLBACK_STORE = createStore();
+
+const identity = (state: Store) => state;
+
+export const Provider = ({
+  children,
+  createStore: createStoreFn,
+}: {
+  children: ReactNode;
+  createStore: () => ChatInputStoreApi;
+}) => {
+  const storeRef = useRef<ChatInputStoreApi | undefined>(undefined);
+
+  if (!storeRef.current) {
+    storeRef.current = createStoreFn();
+  }
+
+  return createElement(ChatInputStoreContext.Provider, { value: storeRef.current }, children);
+};
+
+export const useOptionalStoreApi = () => useContext(ChatInputStoreContext);
+
+export const useStoreApi = () => {
+  const storeApi = useOptionalStoreApi();
+
+  if (!storeApi) {
+    throw new Error('Seems like you have not used zustand provider as an ancestor.');
+  }
+
+  return storeApi;
+};
+
+export const useChatInputStore = ((selector?: (state: Store) => unknown, equalityFn = shallow) =>
+  useStoreWithEqualityFn(useStoreApi(), selector ?? identity, equalityFn)) as UseChatInputStore;
+
+export const useOptionalChatInputStore = ((
+  selector?: (state: Store) => unknown,
+  equalityFn = shallow,
+) => {
+  const storeApi = useOptionalStoreApi();
+  const value = useStoreWithEqualityFn(
+    storeApi ?? FALLBACK_STORE,
+    selector ?? identity,
+    equalityFn,
+  );
+
+  return storeApi ? value : undefined;
+}) as UseOptionalChatInputStore;
 
 export { selectors } from './selectors';


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue
  - 根因是 src/features/ChatInput/hooks/useAgentId.ts:15 之前会直接读取 ChatInput 的 zustand context；agent 页的模型面板复用了ControlsForm，但它不一定处在 ChatInputProvider 下，所以打开模型选择框时会报 provider 缺失。
  - 修复方式是在 src/features/ChatInput/store/index.ts:30 增加可选读取能力 useOptionalChatInputStore，无 provider 时不抛错；src/features/ChatInput/hooks/useAgentId.ts:15 再安全回退到 activeAgentId。
  - 补了回归测试 src/features/ChatInput/hooks/useAgentId.test.tsx:1，覆盖无 provider、存在 provider、空字符串 agentId 三种场景。


#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Prevent ChatInput-dependent components from crashing when rendered outside of ChatInputProvider by making the chat input store access optional and falling back to the active agent ID.

Bug Fixes:
- Handle missing ChatInputProvider by introducing an optional chat input store hook that avoids throwing when the provider is absent and falls back to the active agent ID for useAgentId.

Tests:
- Add unit tests for useAgentId covering behavior with no provider, with a provider-specified agentId, and with an empty string agentId.