### PR TITLE
Fix: Add 'experience' to TypesEnum for toolAddExperienceMemory validation

### DIFF
--- a/packages/memory-user-memory/src/schemas/common.ts
+++ b/packages/memory-user-memory/src/schemas/common.ts
@@ -26,6 +26,7 @@ export const MEMORY_TYPES = [
   'context',
   'activity',
   'event',
+  'experience',
   'location',
   'people',
   'topic',

--- a/packages/types/src/userMemory/shared.ts
+++ b/packages/types/src/userMemory/shared.ts
@@ -58,6 +58,7 @@ export enum TypesEnum {
   Activity = 'activity',
   Context = 'context',
   Event = 'event',
+  Experience = 'experience',
   Fact = 'fact',
   Location = 'location',
   Other = 'other',


### PR DESCRIPTION
Fixes #12608. The toolAddExperienceMemory tool sends memoryType: 'experience' but TypesEnum did not include this value, causing Zod validation errors. Added Experience = 'experience' to TypesEnum in packages/types/src/userMemory/shared.ts and 'experience' to MEMORY_TYPES array in packages/memory-user-memory/src/schemas/common.ts.

## Summary by Sourcery

Bug Fixes:
- Include the 'experience' memory type in validation schemas to prevent Zod errors when toolAddExperienceMemory sends this type.