### PR TITLE
🔒 fix: add rate limit custom rules for password reset and email verification

### DIFF
--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -253,6 +253,12 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
         },
       },
     },
+    rateLimit: {
+      customRules: {
+        '/request-password-reset': { max: 3, window: 60 },
+        '/send-verification-email': { max: 3, window: 60 },
+      },
+    },
     plugins: [
       ...customOptions.plugins,
       emailWhitelist(),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-2887

#### 🔀 Description of Change

Add stricter rate limiting (`customRules`) for two Better Auth endpoints that previously only had the loose global rate limit (10s/100 requests):

- `/request-password-reset`: 60s window, max 3 requests
- `/send-verification-email`: 60s window, max 3 requests

This mitigates brute-force password reset attempts and email abuse.

#### 🧪 How to Test

- [x] No tests needed

## Summary by Sourcery

Tighten Better Auth configuration by introducing endpoint-specific rate limiting rules for sensitive password reset and email verification flows.

New Features:
- Add custom rate limit rules for the /request-password-reset endpoint.
- Add custom rate limit rules for the /send-verification-email endpoint.

Bug Fixes:
- Mitigate potential brute-force and abuse scenarios by restricting request frequency for password reset and verification email endpoints.