### PR TITLE
🐛 fix: ModelSwitchPanel crashes with zustand provider error when scrolling model list

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -32,10 +32,11 @@ interface ListItemRendererProps {
   newLabel: string;
   onClose: () => void;
   onModelChange: (modelId: string, providerId: string) => Promise<void>;
+  showModelDetailPanel?: boolean;
 }
 
 export const ListItemRenderer = memo<ListItemRendererProps>(
-  ({ activeKey, item, newLabel, onModelChange, onClose }) => {
+  ({ activeKey, item, newLabel, onModelChange, onClose, showModelDetailPanel = true }) => {
     const { t } = useTranslation('components');
     const navigate = useNavigate();
     const [detailOpen, setDetailOpen] = useState(false);
@@ -115,6 +116,28 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
         const key = menuKey(item.provider.id, item.model.id);
         const isActive = key === activeKey;
 
+        if (!showModelDetailPanel) {
+          return (
+            <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
+              <Flexbox
+                className={cx(menuSharedStyles.item, isActive && styles.menuItemActive)}
+                style={{ paddingBlock: 8, paddingInline: 8 }}
+                onClick={async () => {
+                  await onModelChange(item.model.id, item.provider.id);
+                  onClose();
+                }}
+              >
+                <ModelItemRender
+                  {...item.model}
+                  {...item.model.abilities}
+                  showInfoTag
+                  newBadgeLabel={newLabel}
+                />
+              </Flexbox>
+            </Flexbox>
+          );
+        }
+
         return (
           <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
             <DropdownMenuSubmenuRoot open={detailOpen} onOpenChange={setDetailOpen}>
@@ -123,7 +146,7 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
                 style={{ paddingBlock: 8, paddingInline: 8 }}
                 onClick={async () => {
                   setDetailOpen(false);
-                  onModelChange(item.model.id, item.provider.id);
+                  await onModelChange(item.model.id, item.provider.id);
                   onClose();
                 }}
               >
@@ -151,6 +174,23 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
         const key = menuKey(singleProvider.id, item.data.model.id);
         const isActive = key === activeKey;
 
+        if (!showModelDetailPanel) {
+          return (
+            <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
+              <Flexbox
+                className={cx(menuSharedStyles.item, isActive && styles.menuItemActive)}
+                style={{ paddingBlock: 8, paddingInline: 8 }}
+                onClick={async () => {
+                  await onModelChange(item.data.model.id, singleProvider.id);
+                  onClose();
+                }}
+              >
+                <SingleProviderModelItem data={item.data} newLabel={newLabel} />
+              </Flexbox>
+            </Flexbox>
+          );
+        }
+
         return (
           <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
             <DropdownMenuSubmenuRoot open={detailOpen} onOpenChange={setDetailOpen}>
@@ -159,7 +199,7 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
                 style={{ paddingBlock: 8, paddingInline: 8 }}
                 onClick={async () => {
                   setDetailOpen(false);
-                  onModelChange(item.data.model.id, singleProvider.id);
+                  await onModelChange(item.data.model.id, singleProvider.id);
                   onClose();
                 }}
               >
@@ -184,6 +224,7 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
               activeKey={activeKey}
               data={item.data}
               newLabel={newLabel}
+              showModelDetailPanel={showModelDetailPanel}
               onClose={onClose}
               onModelChange={onModelChange}
             />

--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -33,10 +33,11 @@ interface MultipleProvidersModelItemProps {
   newLabel: string;
   onClose: () => void;
   onModelChange: (modelId: string, providerId: string) => Promise<void>;
+  showModelDetailPanel?: boolean;
 }
 
 export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
-  ({ activeKey, data, newLabel, onModelChange, onClose }) => {
+  ({ activeKey, data, newLabel, onModelChange, onClose, showModelDetailPanel = true }) => {
     const { t } = useTranslation('components');
     const navigate = useNavigate();
     const [submenuOpen, setSubmenuOpen] = useState(false);
@@ -60,14 +61,14 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
         <DropdownMenuPortal>
           <DropdownMenuPositioner anchor={null} placement="right" sideOffset={12}>
             <DropdownMenuPopup className={cx(styles.detailPopup, styles.dropdownMenu)}>
-              <ModelDetailPanel
-                model={data.model.id}
-                provider={(activeProvider ?? data.providers[0]).id}
-              />
+              {showModelDetailPanel && (
+                <ModelDetailPanel
+                  model={data.model.id}
+                  provider={(activeProvider ?? data.providers[0]).id}
+                />
+              )}
               <DropdownMenuGroup>
-                <DropdownMenuGroupLabel>
-                  {t('ModelSwitchPanel.useModelFrom')}
-                </DropdownMenuGroupLabel>
+                <DropdownMenuGroupLabel>{t('ModelSwitchPanel.useModelFrom')}</DropdownMenuGroupLabel>
                 {data.providers.map((p) => {
                   const key = menuKey(p.id, data.model.id);
                   const isProviderActive = activeKey === key;

--- a/src/features/ModelSwitchPanel/components/List/index.tsx
+++ b/src/features/ModelSwitchPanel/components/List/index.tsx
@@ -21,6 +21,7 @@ interface ListProps {
   onOpenChange?: (open: boolean) => void;
   provider?: string;
   searchKeyword?: string;
+  showModelDetailPanel?: boolean;
 }
 
 export const List: FC<ListProps> = ({
@@ -30,6 +31,7 @@ export const List: FC<ListProps> = ({
   onOpenChange,
   provider: providerProp,
   searchKeyword = '',
+  showModelDetailPanel = true,
 }) => {
   const { t: tCommon } = useTranslation('common');
   const newLabel = tCommon('new');
@@ -52,7 +54,6 @@ export const List: FC<ListProps> = ({
 
   const activeKey = menuKey(provider, model);
 
-  // Set initial scroll position to keep active model centered
   const listRef = useRef<HTMLDivElement | null>(null);
   const activeNodeRef = useRef<HTMLDivElement | null>(null);
   const hasInitializedPositionRef = useRef(false);
@@ -101,6 +102,7 @@ export const List: FC<ListProps> = ({
             item={item}
             key={key}
             newLabel={newLabel}
+            showModelDetailPanel={showModelDetailPanel}
             onClose={handleClose}
             onModelChange={handleModelChange}
           />

--- a/src/features/ModelSwitchPanel/components/PanelContent.tsx
+++ b/src/features/ModelSwitchPanel/components/PanelContent.tsx
@@ -17,6 +17,7 @@ interface PanelContentProps {
   onModelChange?: (params: { model: string; provider: string }) => Promise<void>;
   onOpenChange?: (open: boolean) => void;
   provider?: string;
+  showModelDetailPanel?: boolean;
 }
 
 export const PanelContent: FC<PanelContentProps> = ({
@@ -24,6 +25,7 @@ export const PanelContent: FC<PanelContentProps> = ({
   onModelChange: onModelChangeProp,
   onOpenChange,
   provider: providerProp,
+  showModelDetailPanel = true,
 }) => {
   const enabledList = useEnabledChatModels();
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -58,6 +60,7 @@ export const PanelContent: FC<PanelContentProps> = ({
         model={modelProp}
         provider={providerProp}
         searchKeyword={searchKeyword}
+        showModelDetailPanel={showModelDetailPanel}
         onModelChange={onModelChangeProp}
         onOpenChange={onOpenChange}
       />

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -23,6 +23,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
     placement = 'topLeft',
     provider: providerProp,
     openOnHover = true,
+    showModelDetailPanel = true,
   }) => {
     const [internalOpen, setInternalOpen] = useState(false);
     const isOpen = open ?? internalOpen;
@@ -45,6 +46,7 @@ const ModelSwitchPanel = memo<ModelSwitchPanelProps>(
                 <PanelContent
                   model={modelProp}
                   provider={providerProp}
+                  showModelDetailPanel={showModelDetailPanel}
                   onModelChange={onModelChange}
                   onOpenChange={handleOpenChange}
                 />

--- a/src/features/ModelSwitchPanel/types.ts
+++ b/src/features/ModelSwitchPanel/types.ts
@@ -68,4 +68,8 @@ export interface ModelSwitchPanelProps {
    * Current provider ID. If not provided, uses currentAgentModelProvider from store.
    */
   provider?: string;
+  /**
+   * Whether to show the model detail popup on submenu hover. Defaults to true.
+   */
+  showModelDetailPanel?: boolean;
 }

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
@@ -47,7 +47,7 @@ const TitleTags = memo(() => {
     <Skeleton.Button active size={'small'} style={{ height: 20 }} />
   ) : (
     <Flexbox horizontal align={'center'} gap={4}>
-      <ModelSwitchPanel>
+      <ModelSwitchPanel showModelDetailPanel={false}>
         <ModelTag model={model} />
       </ModelSwitchPanel>
       {isAgentEnableSearch && <SearchTags />}


### PR DESCRIPTION
#### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

  Fixes #12780 
  Fixes #12789 

  #### 🔀 Description of Change

  This PR fixes the crash triggered from the agent conversation header model switcher.

  Previously, hovering model items from the header switcher could open the right-side model detail popup, which eventually reached model actions that are
  intended to run under a ChatInput instance. Since the header switcher is outside that context, this could cause the panel to crash.

  To align with the intended interaction model, this PR keeps the header model switcher available but disables the model detail popup for that entry point
  only. Model switching remains available, while the detail/config popup stays enabled in ChatInput-scoped usages.

  #### 🧪 How to Test

  - Open an agent conversation page
  - Hover the model switcher in the top header
  - Verify the model menu opens normally
  - Verify model items no longer open the model detail/config popup from the header entry
  - Verify selecting a model from the header still works
  - Verify the bottom ChatInput model switcher still shows the model detail/config popup as before
  - [x] Tested locally
  - [ ] Added/updated tests
  - [x] No tests needed

  #### 📸 Screenshots / Videos


  #### 📝 Additional Information

  - This is a targeted UI-level fix for the header switcher only
  - ModelSwitchPanel now supports disabling the detail popup via a scoped prop
  - The goal is to avoid lifting ChatInput-scoped model actions into header usage while keeping the existing switching behavior intact

## Summary by Sourcery

Add an option to disable the model detail popup in the model switcher and use it in the agent conversation header to prevent crashes while preserving model switching.

Bug Fixes:
- Prevent ModelSwitchPanel from crashing in the agent conversation header by disabling the model detail popup for that entry point.

Enhancements:
- Introduce a showModelDetailPanel prop that allows ModelSwitchPanel consumers to toggle the detail/config popup in list and multiple-provider model items.