### PR TITLE
🐛 fix(ModelSelect): restore showInfoTag fix (regression of #11905)

### DIFF
--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -128,7 +128,7 @@ const ModelSelect = memo<ModelSelectProps>(
             <ModelItemRender
               {...(option as ModelOption)}
               {...(option as ModelOption).abilities}
-              showInfoTag
+              showInfoTag={false}
             />
           )}
           style={{


### PR DESCRIPTION
### 🐛 Fix Type
- [x] 🐛 fix

### 🔗 Related Issue
Fixes #12817 (also duplicates #12667 - regression of #11905)

### 🔀 Description of Change
Restores the fix from #11905 that was inadvertently reverted during PR #12587 (base-ui migration).

**Problem:**
During the base-ui migration refactor, the `optionRender` function in `ModelSelect` was rewritten and the fix from #11905 was lost:
```tsx
// Before refactor (working from #11905):
showInfoTag={false}

// After refactor (broken - current):
showInfoTag  // implicit true, causes React Error `#185`
```

**Solution:**
Changed `showInfoTag` back to `showInfoTag={false}` to prevent the onboarding crash.

### 🧪 How to Test
1. Navigate to `/onboarding` page
2. Click the model selection dropdown
3. ✅ Verify no React Error `#185` appears
4. ✅ Verify dropdown opens and model selection works

### 📝 Additional Information
- **File:** `src/features/ModelSelect/index.tsx`
- **Line:** 131
- **Change Type:** Regression fix
- **Impact:** Low risk - restores previously validated fix from #11905
- **Duplicates:** Also fixes #12667 (same issue reported by different user)

## Summary by Sourcery

Bug Fixes:
- Restore the ModelSelect option renderer behavior to explicitly disable showInfoTag to avoid React runtime errors in the onboarding flow.