### PR TITLE
fix: set showInfoTag={false} to prevent React error #185

### DIFF
--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -128,7 +128,7 @@ const ModelSelect = memo<ModelSelectProps>(
             <ModelItemRender
               {...(option as ModelOption)}
               {...(option as ModelOption).abilities}
-              showInfoTag
+              showInfoTag={false} // Must be false to prevent React Error #185
             />
           )}
           style={{


### PR DESCRIPTION
PR #12587 inadvertently reverted the fix from #11905 by changing
showInfoTag={false} back to showInfoTag (implicit true).

This causes React Error #185 when clicking model selection dropdown
during onboarding.

Restores showInfoTag={false} to prevent the crash.

Fixes #12817

## Summary by Sourcery

Bug Fixes:
- Disable the info tag in the model selector to avoid React Error #185 when opening the dropdown during onboarding.