### PR TITLE
🐛 fix: harden Anthropic message building and sampling parameter handling

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.test.ts
@@ -83,6 +83,43 @@ describe('Anthropic generateObject', () => {
       expect(result).toEqual({ age: 30, name: 'John' });
     });
 
+    it('should ignore whitespace-only system prompts', async () => {
+      const mockClient = {
+        messages: {
+          create: vi.fn().mockResolvedValue({
+            content: [
+              {
+                input: { status: 'ok' },
+                name: 'status_extractor',
+                type: 'tool_use',
+              },
+            ],
+          }),
+        },
+      };
+
+      const payload = {
+        messages: [
+          { content: '   \n\t  ', role: 'system' as const },
+          { content: 'Generate status', role: 'user' as const },
+        ],
+        model: 'claude-3-5-sonnet-20241022',
+        schema: {
+          name: 'status_extractor',
+          schema: { properties: { status: { type: 'string' } }, type: 'object' as const },
+        },
+      };
+
+      await createAnthropicGenerateObject(mockClient as any, payload);
+
+      expect(mockClient.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: undefined,
+        }),
+        expect.any(Object),
+      );
+    });
+
     it('should handle system messages correctly', async () => {
       const mockClient = {
         messages: {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -20,7 +20,8 @@ export const createAnthropicGenerateObject = async (
   log('schema: %O', schema);
   log('messages count: %d', messages.length);
 
-  // Convert messages to Anthropic format
+  // Convert messages to Anthropic format.
+  // Filter out empty/whitespace-only system prompts — Anthropic API rejects them.
   const system_message = messages.find((m) => m.role === 'system')?.content;
   const systemPromptText =
     typeof system_message === 'string' && system_message.trim() ? system_message : undefined;

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/generateObject.ts
@@ -22,15 +22,17 @@ export const createAnthropicGenerateObject = async (
 
   // Convert messages to Anthropic format
   const system_message = messages.find((m) => m.role === 'system')?.content;
+  const systemPromptText =
+    typeof system_message === 'string' && system_message.trim() ? system_message : undefined;
   const user_messages = messages.filter((m) => m.role !== 'system');
   const anthropicMessages = await buildAnthropicMessages(user_messages);
 
   log('converted %d messages to Anthropic format', anthropicMessages.length);
 
-  const systemPrompts = system_message
+  const systemPrompts = systemPromptText
     ? [
         {
-          text: system_message,
+          text: systemPromptText,
           type: 'text' as const,
         },
       ]

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -4,7 +4,6 @@ import { CURRENT_VERSION } from '@lobechat/const';
 import type { ChatModelCard } from '@lobechat/types';
 import debug from 'debug';
 
-import { hasTemperatureTopPConflict } from '../../const/models';
 import type {
   ChatCompletionErrorPayload,
   ChatMethodOptions,
@@ -29,7 +28,7 @@ import {
   buildAnthropicTools,
   buildSearchTool,
 } from '../contextBuilders/anthropic';
-import { resolveParameters } from '../parameterResolver';
+import { resolveModelSamplingParameters } from '../parameterResolver';
 import { AnthropicStream } from '../streams';
 import { type ComputeChatCostOptions } from '../usageConverters/utils/computeChatCost';
 import { createAnthropicGenerateObject } from './generateObject';
@@ -190,10 +189,10 @@ export const buildDefaultAnthropicPayload = async (
     } as Anthropic.MessageCreateParams;
   }
 
-  const hasConflict = hasTemperatureTopPConflict(model);
-  const resolvedParams = resolveParameters(
+  const resolvedSamplingParams = resolveModelSamplingParameters(
+    model,
     { temperature, top_p },
-    { hasConflict, normalizeTemperature: true, preferTemperature: true },
+    { normalizeTemperature: true, preferTemperature: true },
   );
 
   // Support effort parameter even without thinking (per Claude 4.6 guidance)
@@ -202,9 +201,9 @@ export const buildDefaultAnthropicPayload = async (
     messages: postMessages,
     model,
     system: systemPrompts,
-    temperature: resolvedParams.temperature,
+    temperature: resolvedSamplingParams.temperature,
     tools: postTools as Anthropic.MessageCreateParams['tools'],
-    top_p: resolvedParams.top_p,
+    top_p: resolvedSamplingParams.top_p,
   };
 
   // If effort is specified without thinking mode, add output_config

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -136,6 +136,7 @@ export const buildDefaultAnthropicPayload = async (
     thinking,
   });
 
+  // Filter out empty/whitespace-only system prompts — Anthropic API rejects them
   const systemMessage = messages.find((message) => message.role === 'system');
   const userMessages = messages.filter((message) => message.role !== 'system');
   const systemPromptText =
@@ -189,6 +190,8 @@ export const buildDefaultAnthropicPayload = async (
     } as Anthropic.MessageCreateParams;
   }
 
+  // Resolve temperature/top_p: Claude 4+ doesn't allow both simultaneously.
+  // normalizeTemperature divides by 2 to map LobeChat's 0-2 range to Anthropic's 0-1 range.
   const resolvedSamplingParams = resolveModelSamplingParameters(
     model,
     { temperature, top_p },

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -139,12 +139,16 @@ export const buildDefaultAnthropicPayload = async (
 
   const systemMessage = messages.find((message) => message.role === 'system');
   const userMessages = messages.filter((message) => message.role !== 'system');
+  const systemPromptText =
+    typeof systemMessage?.content === 'string' && systemMessage.content.trim()
+      ? systemMessage.content
+      : undefined;
 
-  const systemPrompts = systemMessage?.content
+  const systemPrompts = systemPromptText
     ? ([
         {
           cache_control: enabledContextCaching ? { type: 'ephemeral' } : undefined,
-          text: systemMessage.content as string,
+          text: systemPromptText,
           type: 'text',
         },
       ] as Anthropic.TextBlockParam[])

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -184,6 +184,24 @@ describe('anthropicHelpers', () => {
       expect(result).toEqual({ content: 'Hello!', role: 'user' });
     });
 
+    it('should return undefined for user message with empty string content', async () => {
+      const message: OpenAIChatMessage = {
+        content: '',
+        role: 'user',
+      };
+      const result = await buildAnthropicMessage(message);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for user message with whitespace-only string content', async () => {
+      const message: OpenAIChatMessage = {
+        content: '   \n\t  ',
+        role: 'user',
+      };
+      const result = await buildAnthropicMessage(message);
+      expect(result).toBeUndefined();
+    });
+
     it('should correctly convert user message with content parts', async () => {
       const message: OpenAIChatMessage = {
         content: [
@@ -196,6 +214,15 @@ describe('anthropicHelpers', () => {
       expect(result!.role).toBe('user');
       expect(result!.content).toHaveLength(2);
       expect((result!.content[1] as any).type).toBe('image');
+    });
+
+    it('should return undefined for user message when content parts are all filtered out', async () => {
+      const message: OpenAIChatMessage = {
+        content: [{ type: 'text', text: '' }],
+        role: 'user',
+      };
+      const result = await buildAnthropicMessage(message);
+      expect(result).toBeUndefined();
     });
 
     it('should correctly convert tool message', async () => {
@@ -1096,6 +1123,22 @@ describe('anthropicHelpers', () => {
         {
           content: [{ cache_control: { type: 'ephemeral' }, text: 'Hi', type: 'text' }],
           role: 'assistant',
+        },
+      ]);
+    });
+
+    it('should filter empty user messages before applying cache control', async () => {
+      const messages: OpenAIChatMessage[] = [
+        { content: '   \n\t  ', role: 'user' },
+        { content: 'Hello', role: 'user' },
+      ];
+
+      const contents = await buildAnthropicMessages(messages, { enabledContextCaching: true });
+
+      expect(contents).toEqual([
+        {
+          content: [{ cache_control: { type: 'ephemeral' }, text: 'Hello', type: 'text' }],
+          role: 'user',
         },
       ]);
     });

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -18,6 +18,10 @@ const isImageTypeSupported = (mimeType: string | null): boolean => {
   return ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(mimeType.toLowerCase());
 };
 
+/**
+ * Check if a text value contains visible (non-whitespace) characters.
+ * Used to filter out empty/whitespace-only messages that would cause Anthropic API errors.
+ */
 const hasVisibleText = (text: string | null | undefined): text is string => !!text?.trim();
 
 export const buildAnthropicBlock = async (
@@ -81,6 +85,11 @@ const buildArrayContent = async (content: UserMessageContentPart[]) => {
   return messageContent;
 };
 
+/**
+ * Build a single Anthropic tool_result block from an OpenAI tool message.
+ * Returns undefined if tool_call_id is missing. Uses '<empty_content>' placeholder
+ * when content is empty, as Anthropic requires non-empty tool_result content.
+ */
 const buildAnthropicToolResultBlock = async (
   message: Pick<OpenAIChatMessage, 'content' | 'tool_call_id'>,
 ): Promise<Anthropic.ToolResultBlockParam | undefined> => {
@@ -114,6 +123,8 @@ export const buildAnthropicMessage = async (
     }
 
     case 'user': {
+      // Filter out empty user messages to prevent Anthropic API validation errors.
+      // Empty messages can appear after context truncation or user edits.
       if (Array.isArray(content)) {
         const messageContent = await buildArrayContent(content);
         if (messageContent.length === 0) return undefined;
@@ -201,6 +212,21 @@ export const buildAnthropicMessages = async (
 ): Promise<Anthropic.Messages.MessageParam[]> => {
   const messages: Anthropic.Messages.MessageParam[] = [];
 
+  // === Two-pass strategy to guarantee tool_use / tool_result pairing ===
+  //
+  // Anthropic requires every tool_use block in an assistant message to have a
+  // matching tool_result block in the immediately following user message. The old
+  // sequential approach relied on message ordering, which broke when messages were
+  // truncated, reordered, or deleted — causing "tool_use ids were found without
+  // tool_result blocks" errors.
+  //
+  // Pass 1: Collect all valid tool_call_ids from assistant messages, then build a
+  //         Map<tool_call_id, ToolResultBlock> from matching tool messages.
+  // Pass 2: For each assistant message, only keep tool_calls that have a paired
+  //         tool_result, and emit the paired tool_results right after.
+  //         Unpaired tool messages degrade to plain-text user messages.
+
+  // Pass 1a: Collect valid tool_call_ids from assistant messages
   const validToolCallIds = new Set<string>();
   for (const message of oaiMessages) {
     if (message.role === 'assistant' && message.tool_calls?.length) {
@@ -212,6 +238,7 @@ export const buildAnthropicMessages = async (
     }
   }
 
+  // Pass 1b: Pre-build tool_result blocks indexed by tool_call_id
   const toolResultsByCallId = new Map<string, Anthropic.ToolResultBlockParam>();
   for (const message of oaiMessages) {
     if (
@@ -227,8 +254,10 @@ export const buildAnthropicMessages = async (
     }
   }
 
+  // Pass 2: Build final message array with guaranteed tool_use/tool_result pairing
   for (const message of oaiMessages) {
     if (message.role === 'assistant') {
+      // Only keep tool_calls that have a matching tool_result in the Map
       const pairedToolCalls = message.tool_calls?.filter(
         (toolCall) => !!toolCall.id && toolResultsByCallId.has(toolCall.id),
       );
@@ -242,6 +271,7 @@ export const buildAnthropicMessages = async (
         messages.push(anthropicMessage);
       }
 
+      // Emit paired tool_results as a user message immediately after the assistant message
       if (pairedToolCalls?.length) {
         messages.push({
           content: pairedToolCalls.flatMap((toolCall) => {
@@ -256,10 +286,12 @@ export const buildAnthropicMessages = async (
     }
 
     if (message.role === 'tool') {
+      // Already handled in Pass 1b and emitted above — skip
       if (message.tool_call_id && validToolCallIds.has(message.tool_call_id)) {
         continue;
       }
 
+      // Orphan tool message (no matching assistant tool_call) — degrade to plain text
       const fallbackContent = Array.isArray(message.content)
         ? JSON.stringify(message.content)
         : message.content || '<empty_content>';

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -18,6 +18,8 @@ const isImageTypeSupported = (mimeType: string | null): boolean => {
   return ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(mimeType.toLowerCase());
 };
 
+const hasVisibleText = (text: string | null | undefined): text is string => !!text?.trim();
+
 export const buildAnthropicBlock = async (
   content: UserMessageContentPart,
 ): Promise<Anthropic.ContentBlock | Anthropic.ImageBlockParam | undefined> => {
@@ -79,6 +81,28 @@ const buildArrayContent = async (content: UserMessageContentPart[]) => {
   return messageContent;
 };
 
+const buildAnthropicToolResultBlock = async (
+  message: Pick<OpenAIChatMessage, 'content' | 'tool_call_id'>,
+): Promise<Anthropic.ToolResultBlockParam | undefined> => {
+  if (!message.tool_call_id) return undefined;
+
+  const toolResultContent = Array.isArray(message.content)
+    ? await buildArrayContent(message.content)
+    : hasVisibleText(message.content)
+      ? [{ text: message.content, type: 'text' as const }]
+      : [];
+
+  return {
+    content: (toolResultContent.length > 0
+      ? toolResultContent
+      : [
+          { text: '<empty_content>', type: 'text' as const },
+        ]) as Anthropic.ToolResultBlockParam['content'],
+    tool_use_id: message.tool_call_id,
+    type: 'tool_result',
+  };
+};
+
 export const buildAnthropicMessage = async (
   message: OpenAIChatMessage,
 ): Promise<Anthropic.Messages.MessageParam | undefined> => {
@@ -90,8 +114,20 @@ export const buildAnthropicMessage = async (
     }
 
     case 'user': {
+      if (Array.isArray(content)) {
+        const messageContent = await buildArrayContent(content);
+        if (messageContent.length === 0) return undefined;
+
+        return {
+          content: messageContent,
+          role: 'user',
+        };
+      }
+
+      if (!hasVisibleText(content)) return undefined;
+
       return {
-        content: typeof content === 'string' ? content : await buildArrayContent(content),
+        content,
         role: 'user',
       };
     }
@@ -164,9 +200,7 @@ export const buildAnthropicMessages = async (
   options: { enabledContextCaching?: boolean } = {},
 ): Promise<Anthropic.Messages.MessageParam[]> => {
   const messages: Anthropic.Messages.MessageParam[] = [];
-  let pendingToolResults: Anthropic.ToolResultBlockParam[] = [];
 
-  // First collect all tool_call_id from assistant messages for subsequent lookup
   const validToolCallIds = new Set<string>();
   for (const message of oaiMessages) {
     if (message.role === 'assistant' && message.tool_calls?.length) {
@@ -178,50 +212,68 @@ export const buildAnthropicMessages = async (
     }
   }
 
+  const toolResultsByCallId = new Map<string, Anthropic.ToolResultBlockParam>();
   for (const message of oaiMessages) {
-    const index = oaiMessages.indexOf(message);
+    if (
+      message.role !== 'tool' ||
+      !message.tool_call_id ||
+      !validToolCallIds.has(message.tool_call_id)
+    )
+      continue;
 
-    // refs: https://docs.anthropic.com/claude/docs/tool-use#tool-use-and-tool-result-content-blocks
-    if (message.role === 'tool') {
-      // Handle different content types in tool messages
-      const toolResultContent = Array.isArray(message.content)
-        ? await buildArrayContent(message.content)
-        : !message.content
-          ? [{ text: '<empty_content>', type: 'text' as const }]
-          : [{ text: message.content, type: 'text' as const }];
+    const toolResultBlock = await buildAnthropicToolResultBlock(message);
+    if (toolResultBlock) {
+      toolResultsByCallId.set(message.tool_call_id, toolResultBlock);
+    }
+  }
 
-      // Check if this tool message has a corresponding assistant tool call
-      if (message.tool_call_id && validToolCallIds.has(message.tool_call_id)) {
-        pendingToolResults.push({
-          content: toolResultContent as Anthropic.ToolResultBlockParam['content'],
-          tool_use_id: message.tool_call_id,
-          type: 'tool_result',
-        });
+  for (const message of oaiMessages) {
+    if (message.role === 'assistant') {
+      const pairedToolCalls = message.tool_calls?.filter(
+        (toolCall) => !!toolCall.id && toolResultsByCallId.has(toolCall.id),
+      );
 
-        // If this is the last message or the next message is not 'tool', add accumulated tool results as a 'user' message
-        if (index === oaiMessages.length - 1 || oaiMessages[index + 1].role !== 'tool') {
-          messages.push({
-            content: pendingToolResults,
-            role: 'user',
-          });
-          pendingToolResults = [];
-        }
-      } else {
-        // If tool message has no corresponding assistant tool call, treat as plain text
-        const fallbackContent = Array.isArray(message.content)
-          ? JSON.stringify(message.content)
-          : message.content || '<empty_content>';
-        messages.push({
-          content: fallbackContent,
-          role: 'user',
-        });
-      }
-    } else {
-      const anthropicMessage = await buildAnthropicMessage(message);
-      // Filter out undefined messages (e.g., empty assistant messages)
+      const anthropicMessage = await buildAnthropicMessage({
+        ...message,
+        tool_calls: pairedToolCalls?.length ? pairedToolCalls : undefined,
+      });
+
       if (anthropicMessage) {
         messages.push(anthropicMessage);
       }
+
+      if (pairedToolCalls?.length) {
+        messages.push({
+          content: pairedToolCalls.flatMap((toolCall) => {
+            const toolResultBlock = toolResultsByCallId.get(toolCall.id);
+            return toolResultBlock ? [toolResultBlock] : [];
+          }),
+          role: 'user',
+        });
+      }
+
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      if (message.tool_call_id && validToolCallIds.has(message.tool_call_id)) {
+        continue;
+      }
+
+      const fallbackContent = Array.isArray(message.content)
+        ? JSON.stringify(message.content)
+        : message.content || '<empty_content>';
+      messages.push({
+        content: fallbackContent,
+        role: 'user',
+      });
+
+      continue;
+    }
+
+    const anthropicMessage = await buildAnthropicMessage(message);
+    if (anthropicMessage) {
+      messages.push(anthropicMessage);
     }
   }
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -44,6 +44,7 @@ import { postProcessModelList } from '../../utils/postProcessModelList';
 import { StreamingResponse } from '../../utils/response';
 import type { LobeRuntimeAI } from '../BaseAI';
 import { convertOpenAIMessages, convertOpenAIResponseInputs } from '../contextBuilders/openai';
+import { resolveModelSamplingParameters } from '../parameterResolver';
 import type { OpenAIStreamOptions } from '../streams';
 import { OpenAIResponsesStream, OpenAIStream } from '../streams';
 import { createOpenAICompatibleImage } from './createImage';
@@ -361,16 +362,24 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         }
 
         // Then perform factory-level processing
-        const postPayload = chatCompletion?.handlePayload
+        const handledPayload = chatCompletion?.handlePayload
           ? chatCompletion.handlePayload(processedPayload, this._options)
           : ({
               ...processedPayload,
               stream: processedPayload.stream ?? true,
             } as OpenAI.ChatCompletionCreateParamsStreaming);
 
-        if ((postPayload as any).apiMode === 'responses') {
+        if ((handledPayload as any).apiMode === 'responses') {
           return await this.handleResponseAPIMode(processedPayload, options);
         }
+
+        const postPayload = {
+          ...handledPayload,
+          ...resolveModelSamplingParameters(handledPayload.model, handledPayload, {
+            normalizeTemperature: false,
+            preferTemperature: true,
+          }),
+        };
 
         const computedBaseURL =
           typeof this._options.baseURL === 'string' && this._options.baseURL
@@ -434,7 +443,13 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           log('using custom client for chat completion stream');
           response = customClient.createChatCompletionStream(
             this.client,
-            processedPayload,
+            {
+              ...processedPayload,
+              ...resolveModelSamplingParameters(processedPayload.model, processedPayload, {
+                normalizeTemperature: false,
+                preferTemperature: true,
+              }),
+            },
             this,
           ) as any;
         } else {
@@ -979,6 +994,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
         user: options?.user,
+        ...resolveModelSamplingParameters(res.model, res, {
+          normalizeTemperature: false,
+          preferTemperature: true,
+        }),
       } as OpenAI.Responses.ResponseCreateParamsStreaming | OpenAI.Responses.ResponseCreateParams;
 
       if (debugParams?.responses?.()) {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -373,6 +373,8 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           return await this.handleResponseAPIMode(processedPayload, options);
         }
 
+        // Sanitize temperature/top_p conflict for Claude 4+ models routed via OpenAI-compatible API.
+        // normalizeTemperature is false here because OpenAI-compatible providers use the raw range.
         const postPayload = {
           ...handledPayload,
           ...resolveModelSamplingParameters(handledPayload.model, handledPayload, {
@@ -441,6 +443,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
         if (customClient?.createChatCompletionStream) {
           log('using custom client for chat completion stream');
+          // Also sanitize sampling params for custom client path (e.g. OpenRouter)
           response = customClient.createChatCompletionStream(
             this.client,
             {
@@ -994,6 +997,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
         user: options?.user,
+        // Sanitize sampling params for Responses API path
         ...resolveModelSamplingParameters(res.model, res, {
           normalizeTemperature: false,
           preferTemperature: true,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -443,7 +443,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
         if (customClient?.createChatCompletionStream) {
           log('using custom client for chat completion stream');
-          // Also sanitize sampling params for custom client path (e.g. OpenRouter)
+          // Apply sampling sanitization to processedPayload for the custom client path.
+          // We use processedPayload (ChatStreamPayload type) here because
+          // createChatCompletionStream expects ChatStreamPayload, not the OpenAI SDK format.
           response = customClient.createChatCompletionStream(
             this.client,
             {

--- a/packages/model-runtime/src/core/parameterResolver.test.ts
+++ b/packages/model-runtime/src/core/parameterResolver.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { hasTemperatureTopPConflict } from '../const/models';
-import { createParameterResolver, resolveParameters } from './parameterResolver';
+import {
+  createParameterResolver,
+  resolveModelSamplingParameters,
+  resolveParameters,
+} from './parameterResolver';
 
 describe('resolveParameters', () => {
   describe('Basic functionality', () => {
@@ -213,10 +217,50 @@ describe('resolveParameters', () => {
       expect(result).toEqual({ top_p: 0.9 });
     });
 
+    it('should treat null values as undefined', () => {
+      const result = resolveParameters(
+        { frequency_penalty: null, temperature: null, top_p: 0.9 },
+        {},
+      );
+      expect(result).toEqual({ top_p: 0.9 });
+    });
+
     it('should handle both parameters undefined with conflict', () => {
       const result = resolveParameters({}, { hasConflict: true });
       expect(result).toEqual({});
     });
+  });
+});
+
+describe('resolveModelSamplingParameters', () => {
+  it('should omit top_p for Claude 4+ models when temperature is also set', () => {
+    const result = resolveModelSamplingParameters(
+      'claude-haiku-4-5-20251001',
+      { temperature: 0.7, top_p: 0.9 },
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({ temperature: 0.7 });
+  });
+
+  it('should keep both parameters for non-conflict models', () => {
+    const result = resolveModelSamplingParameters(
+      'claude-3-5-sonnet-20240620',
+      { temperature: 0.7, top_p: 0.9 },
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({ temperature: 0.7, top_p: 0.9 });
+  });
+
+  it('should treat null sampling values as undefined', () => {
+    const result = resolveModelSamplingParameters(
+      'claude-haiku-4-5-20251001',
+      { temperature: null, top_p: 0.9 },
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({ top_p: 0.9 });
   });
 });
 

--- a/packages/model-runtime/src/core/parameterResolver.test.ts
+++ b/packages/model-runtime/src/core/parameterResolver.test.ts
@@ -240,7 +240,8 @@ describe('resolveModelSamplingParameters', () => {
       { normalizeTemperature: false, preferTemperature: true },
     );
 
-    expect(result).toEqual({ temperature: 0.7 });
+    // Always returns both keys so spreading onto a payload clears the conflicting field
+    expect(result).toEqual({ temperature: 0.7, top_p: undefined });
   });
 
   it('should keep both parameters for non-conflict models', () => {
@@ -260,7 +261,7 @@ describe('resolveModelSamplingParameters', () => {
       { normalizeTemperature: false, preferTemperature: true },
     );
 
-    expect(result).toEqual({ top_p: 0.9 });
+    expect(result).toEqual({ temperature: undefined, top_p: 0.9 });
   });
 });
 

--- a/packages/model-runtime/src/core/parameterResolver.test.ts
+++ b/packages/model-runtime/src/core/parameterResolver.test.ts
@@ -254,14 +254,28 @@ describe('resolveModelSamplingParameters', () => {
     expect(result).toEqual({ temperature: 0.7, top_p: 0.9 });
   });
 
-  it('should treat null sampling values as undefined', () => {
+  it('should treat null sampling values as undefined and not include them in result', () => {
     const result = resolveModelSamplingParameters(
       'claude-haiku-4-5-20251001',
       { temperature: null, top_p: 0.9 },
       { normalizeTemperature: false, preferTemperature: true },
     );
 
-    expect(result).toEqual({ temperature: undefined, top_p: 0.9 });
+    // temperature was null (treated as not provided), so it should not appear in result
+    expect(result).toEqual({ top_p: 0.9 });
+    expect(result).not.toHaveProperty('temperature');
+  });
+
+  it('should not add spurious undefined keys when input omits fields', () => {
+    const result = resolveModelSamplingParameters(
+      'gpt-4o',
+      {},
+      { normalizeTemperature: false, preferTemperature: true },
+    );
+
+    expect(result).toEqual({});
+    expect(result).not.toHaveProperty('temperature');
+    expect(result).not.toHaveProperty('top_p');
   });
 });
 

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -1,3 +1,5 @@
+import { hasTemperatureTopPConflict } from '../const/models';
+
 /**
  * Chat completion parameter configuration
  */
@@ -5,23 +7,23 @@ interface ParameterConfig {
   /**
    * Frequency penalty (reduces repetition)
    */
-  frequency_penalty?: number;
+  frequency_penalty?: number | null;
   /**
    * Maximum tokens to generate
    */
-  max_tokens?: number;
+  max_tokens?: number | null;
   /**
    * Presence penalty (reduces topic repetition)
    */
-  presence_penalty?: number;
+  presence_penalty?: number | null;
   /**
    * Temperature value (0-2 range, controls randomness)
    */
-  temperature?: number;
+  temperature?: number | null;
   /**
    * Top P value (0-1 range, nucleus sampling)
    */
-  top_p?: number;
+  top_p?: number | null;
 }
 
 /**
@@ -172,7 +174,11 @@ export const resolveParameters = (
     maxTokensRange,
   } = options;
 
-  const { temperature, top_p, frequency_penalty, presence_penalty, max_tokens } = config;
+  const temperature = config.temperature ?? undefined;
+  const top_p = config.top_p ?? undefined;
+  const frequency_penalty = config.frequency_penalty ?? undefined;
+  const presence_penalty = config.presence_penalty ?? undefined;
+  const max_tokens = config.max_tokens ?? undefined;
 
   const result: ResolvedParameters = {};
 
@@ -218,6 +224,37 @@ export const resolveParameters = (
   }
 
   return result;
+};
+
+interface SamplingParameterResolverOptions {
+  /**
+   * Whether to normalize temperature (divide by 2)
+   * @default true
+   */
+  normalizeTemperature?: boolean;
+  /**
+   * Whether to prefer temperature over top_p when both are set and there's a conflict
+   * @default true
+   */
+  preferTemperature?: boolean;
+}
+
+export const resolveModelSamplingParameters = (
+  model: string | undefined,
+  config: Pick<ParameterConfig, 'temperature' | 'top_p'>,
+  options: SamplingParameterResolverOptions = {},
+): Pick<ResolvedParameters, 'temperature' | 'top_p'> => {
+  return resolveParameters(
+    {
+      temperature: config.temperature ?? undefined,
+      top_p: config.top_p ?? undefined,
+    },
+    {
+      hasConflict: !!model && hasTemperatureTopPConflict(model),
+      normalizeTemperature: options.normalizeTemperature,
+      preferTemperature: options.preferTemperature,
+    },
+  );
 };
 
 /**

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -239,6 +239,23 @@ interface SamplingParameterResolverOptions {
   preferTemperature?: boolean;
 }
 
+/**
+ * High-level helper that resolves temperature and top_p for a given model.
+ *
+ * Automatically detects whether the model has a temperature/top_p conflict
+ * (e.g. Claude 4+ series) and delegates to `resolveParameters` with the
+ * appropriate conflict flag. This avoids duplicating the model-detection +
+ * parameter-resolution pattern across multiple call sites.
+ *
+ * @example
+ * // Claude 4+ with both params → keeps temperature only
+ * resolveModelSamplingParameters('claude-sonnet-4-5-20250929', { temperature: 0.8, top_p: 0.9 })
+ * // → { temperature: 0.4 }   (temperature / 2, top_p omitted)
+ *
+ * // Non-conflict model → keeps both
+ * resolveModelSamplingParameters('claude-3-haiku-20240307', { temperature: 0.8, top_p: 0.9 })
+ * // → { temperature: 0.4, top_p: 0.9 }
+ */
 export const resolveModelSamplingParameters = (
   model: string | undefined,
   config: Pick<ParameterConfig, 'temperature' | 'top_p'>,

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -260,12 +260,12 @@ export const resolveModelSamplingParameters = (
   model: string | undefined,
   config: Pick<ParameterConfig, 'temperature' | 'top_p'>,
   options: SamplingParameterResolverOptions = {},
-): { temperature: number | undefined; top_p: number | undefined } => {
+): { temperature?: number; top_p?: number } => {
+  const temperature = config.temperature ?? undefined;
+  const top_p = config.top_p ?? undefined;
+
   const resolved = resolveParameters(
-    {
-      temperature: config.temperature ?? undefined,
-      top_p: config.top_p ?? undefined,
-    },
+    { temperature, top_p },
     {
       hasConflict: !!model && hasTemperatureTopPConflict(model),
       normalizeTemperature: options.normalizeTemperature,
@@ -273,14 +273,18 @@ export const resolveModelSamplingParameters = (
     },
   );
 
-  // Always return both keys so that spreading the result onto a payload
-  // explicitly clears the conflicting field (e.g. sets top_p to undefined
-  // when temperature wins). Without this, a plain spread would leave the
-  // original top_p intact and the API would still receive both.
-  return {
-    temperature: resolved.temperature,
-    top_p: resolved.top_p,
-  };
+  // Only include a key if the input originally provided it.
+  // This ensures:
+  //  - Conflict case: if input has both, the dropped one is set to undefined
+  //    (e.g. { temperature: 0.4, top_p: undefined }), which overwrites the
+  //    original value when spread onto the payload.
+  //  - No-input case: if input didn't have a field, we don't add it, so
+  //    spreading won't introduce spurious undefined properties.
+  const result: { temperature?: number; top_p?: number } = {};
+  if (temperature !== undefined) result.temperature = resolved.temperature;
+  if (top_p !== undefined) result.top_p = resolved.top_p;
+
+  return result;
 };
 
 /**

--- a/packages/model-runtime/src/core/parameterResolver.ts
+++ b/packages/model-runtime/src/core/parameterResolver.ts
@@ -260,8 +260,8 @@ export const resolveModelSamplingParameters = (
   model: string | undefined,
   config: Pick<ParameterConfig, 'temperature' | 'top_p'>,
   options: SamplingParameterResolverOptions = {},
-): Pick<ResolvedParameters, 'temperature' | 'top_p'> => {
-  return resolveParameters(
+): { temperature: number | undefined; top_p: number | undefined } => {
+  const resolved = resolveParameters(
     {
       temperature: config.temperature ?? undefined,
       top_p: config.top_p ?? undefined,
@@ -272,6 +272,15 @@ export const resolveModelSamplingParameters = (
       preferTemperature: options.preferTemperature,
     },
   );
+
+  // Always return both keys so that spreading the result onto a payload
+  // explicitly clears the conflicting field (e.g. sets top_p to undefined
+  // when temperature wins). Without this, a plain spread would leave the
+  // original top_p intact and the API would still receive both.
+  return {
+    temperature: resolved.temperature,
+    top_p: resolved.top_p,
+  };
 };
 
 /**

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -633,6 +633,43 @@ describe('LobeAnthropicAI', () => {
         );
       });
 
+      it('should omit top_p for Claude 4+ models when both temperature and top_p are set', async () => {
+        const payload: ChatStreamPayload = {
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'claude-sonnet-4-5-20250929',
+          temperature: 0.8,
+          top_p: 0.9,
+        };
+
+        const result = await buildDefaultAnthropicPayload(payload);
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            model: 'claude-sonnet-4-5-20250929',
+            temperature: 0.4,
+            top_p: undefined,
+          }),
+        );
+      });
+
+      it('should keep top_p for Claude 4+ models when only top_p is set', async () => {
+        const payload: ChatStreamPayload = {
+          messages: [{ content: 'Hello', role: 'user' }],
+          model: 'claude-sonnet-4-5-20250929',
+          top_p: 0.9,
+        };
+
+        const result = await buildDefaultAnthropicPayload(payload);
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            model: 'claude-sonnet-4-5-20250929',
+            temperature: undefined,
+            top_p: 0.9,
+          }),
+        );
+      });
+
       it('should ignore whitespace-only system prompts', async () => {
         const payload: ChatStreamPayload = {
           messages: [

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -633,6 +633,31 @@ describe('LobeAnthropicAI', () => {
         );
       });
 
+      it('should ignore whitespace-only system prompts', async () => {
+        const payload: ChatStreamPayload = {
+          messages: [
+            { content: '   \n\t  ', role: 'system' },
+            { content: 'Hello', role: 'user' },
+          ],
+          model: 'claude-3-haiku-20240307',
+          temperature: 0.7,
+        };
+
+        const result = await buildDefaultAnthropicPayload(payload);
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            messages: [
+              {
+                content: [{ cache_control: { type: 'ephemeral' }, text: 'Hello', type: 'text' }],
+                role: 'user',
+              },
+            ],
+            system: undefined,
+          }),
+        );
+      });
+
       it('should correctly build payload with tools', async () => {
         const tools: ChatCompletionTool[] = [
           { function: { name: 'tool1', description: 'desc1' }, type: 'function' },

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -7,12 +7,11 @@ import {
 import { cloudModelIdMapping } from '@lobechat/business-const';
 import { ModelProvider } from 'model-bank';
 
-import { hasTemperatureTopPConflict } from '../../const/models';
 import { resolveCacheTTL } from '../../core/anthropicCompatibleFactory/resolveCacheTTL';
 import { resolveMaxTokens } from '../../core/anthropicCompatibleFactory/resolveMaxTokens';
 import type { LobeRuntimeAI } from '../../core/BaseAI';
 import { buildAnthropicMessages, buildAnthropicTools } from '../../core/contextBuilders/anthropic';
-import { resolveParameters } from '../../core/parameterResolver';
+import { resolveModelSamplingParameters } from '../../core/parameterResolver';
 import {
   AWSBedrockClaudeStream,
   AWSBedrockLlamaStream,
@@ -234,16 +233,16 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       };
     } else {
       // Resolve temperature and top_p parameters based on model constraints
-      const hasConflict = hasTemperatureTopPConflict(model);
-      const resolvedParams = resolveParameters(
+      const resolvedSamplingParams = resolveModelSamplingParameters(
+        model,
         { temperature, top_p },
-        { hasConflict, normalizeTemperature: true, preferTemperature: true },
+        { normalizeTemperature: true, preferTemperature: true },
       );
 
       anthropicPayload = {
         ...anthropicBase,
-        temperature: resolvedParams.temperature,
-        top_p: resolvedParams.top_p,
+        temperature: resolvedSamplingParams.temperature,
+        top_p: resolvedSamplingParams.top_p,
       };
     }
 

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -173,6 +173,10 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     const inputStartAt = Date.now();
     const system_message = messages.find((m) => m.role === 'system');
     const user_messages = messages.filter((m) => m.role !== 'system');
+    const systemPromptText =
+      typeof system_message?.content === 'string' && system_message.content.trim()
+        ? system_message.content
+        : undefined;
 
     const { bedrock: bedrockModels } = await import('model-bank');
 
@@ -183,11 +187,11 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       thinking,
     });
 
-    const systemPrompts = !!system_message?.content
+    const systemPrompts = !!systemPromptText
       ? ([
           {
             cache_control: enabledContextCaching ? { type: 'ephemeral' } : undefined,
-            text: system_message.content as string,
+            text: systemPromptText,
             type: 'text',
           },
         ] as Anthropic.TextBlockParam[])

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -172,6 +172,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     const inputStartAt = Date.now();
     const system_message = messages.find((m) => m.role === 'system');
     const user_messages = messages.filter((m) => m.role !== 'system');
+    // Filter out empty/whitespace-only system prompts — Anthropic API rejects them
     const systemPromptText =
       typeof system_message?.content === 'string' && system_message.content.trim()
         ? system_message.content
@@ -232,7 +233,8 @@ export class LobeBedrockAI implements LobeRuntimeAI {
         thinking: resolvedThinking,
       };
     } else {
-      // Resolve temperature and top_p parameters based on model constraints
+      // Resolve temperature/top_p: Claude 4+ on Bedrock doesn't allow both simultaneously.
+      // normalizeTemperature divides by 2 to map LobeChat's 0-2 range to Anthropic's 0-1 range.
       const resolvedSamplingParams = resolveModelSamplingParameters(
         model,
         { temperature, top_p },

--- a/src/app/(backend)/api/auth/check-user/route.ts
+++ b/src/app/(backend)/api/auth/check-user/route.ts
@@ -60,5 +60,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Internal server error', exists: false }, { status: 500 });
   }
 }
-
-export const runtime = 'nodejs';

--- a/src/app/(backend)/api/auth/resolve-username/route.ts
+++ b/src/app/(backend)/api/auth/resolve-username/route.ts
@@ -49,5 +49,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Internal server error', exists: false }, { status: 500 });
   }
 }
-
-export const runtime = 'nodejs';

--- a/src/app/(backend)/webapi/create-image/comfyui/route.ts
+++ b/src/app/(backend)/webapi/create-image/comfyui/route.ts
@@ -5,7 +5,6 @@ import { getServerDBConfig } from '@/config/db';
 import { createCallerFactory } from '@/libs/trpc/lambda';
 import { lambdaRouter } from '@/server/routers/lambda';
 
-export const runtime = 'nodejs';
 export const maxDuration = 300;
 
 const serverDBEnv = getServerDBConfig();

--- a/src/app/(backend)/webapi/user/avatar/[id]/[image]/route.ts
+++ b/src/app/(backend)/webapi/user/avatar/[id]/[image]/route.ts
@@ -1,8 +1,6 @@
 import { serverDB } from '@/database/server';
 import { UserService } from '@/server/services/user';
 
-export const runtime = 'nodejs';
-
 type Params = Promise<{ id: string; image: string }>;
 
 // 扩展名到内容类型的映射


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

This PR addresses multiple Anthropic API request validation errors:

**1. Guard tool_use/tool_result message sequence**
- Replaced fragile sequential `pendingToolResults` accumulation with a two-pass Map-based pairing strategy
- Unpaired `tool_use` blocks are now filtered from assistant messages, preventing `tool_use ids were found without tool_result blocks` errors
- Unpaired `tool` messages gracefully degrade to plain text user messages

**2. Filter empty system prompts and user messages**
- Empty/whitespace-only system prompts are now treated as `undefined` across all Anthropic-compatible factories (anthropicCompatibleFactory, generateObject, bedrock)
- Empty/whitespace-only user messages return `undefined` and are skipped during message building
- User messages with all content parts filtered out also return `undefined`

**3. Resolve temperature/top_p conflict for Claude 4+ models**
- Extracted `resolveModelSamplingParameters` in `parameterResolver.ts` to encapsulate model conflict detection + parameter resolution
- Applied sanitization across all code paths: Chat Completion, custom client stream, and Responses API
- `ParameterConfig` now accepts `null` values (converted to `undefined` internally)

#### 🧪 How to Test

- [x] Added/updated tests

#### 📝 Additional Information

All three fixes target production errors observed with Claude 4+ models (Opus 4.6, Sonnet 4.6, etc.).

## Summary by Sourcery

Harden Anthropic-compatible message construction and sampling parameter resolution to avoid API validation errors and model-specific conflicts.

Bug Fixes:
- Ensure tool_use and tool_result messages are correctly paired and filter out unpaired tool_use blocks while degrading orphaned tool messages to plain user text.
- Skip empty or whitespace-only system prompts and user messages, including cases where all user content parts are filtered out, when building Anthropic and Bedrock payloads.
- Resolve temperature and top_p conflicts for Claude 4+ models by centralizing sampling parameter handling and respecting model-specific constraints across all Anthropic-compatible entry points.

Enhancements:
- Allow null sampling-related parameter values in configuration and normalize them to undefined in parameter resolution logic.
- Reuse a shared sampling parameter resolver across chat completions, custom streaming clients, and Responses API to consistently sanitize temperature and top_p inputs.

Tests:
- Add and update unit tests for Anthropic message building, system prompt filtering, parameter resolution, and model-specific sampling parameter behavior.