### PR TITLE
🐛 fix(cli): fix type errors in generate image/video commands

### DIFF
--- a/apps/cli/src/commands/generate/image.ts
+++ b/apps/cli/src/commands/generate/image.ts
@@ -34,7 +34,7 @@ export function registerImageCommand(parent: Command) {
         // Create a generation topic first
         const topicId = await client.generationTopic.createTopic.mutate({ type: 'image' });
 
-        const params: Record<string, any> = { prompt };
+        const params: { prompt: string } & Record<string, any> = { prompt };
         if (options.width) params.width = Number.parseInt(options.width, 10);
         if (options.height) params.height = Number.parseInt(options.height, 10);
         if (options.steps) params.steps = Number.parseInt(options.steps, 10);

--- a/apps/cli/src/commands/generate/video.ts
+++ b/apps/cli/src/commands/generate/video.ts
@@ -30,7 +30,7 @@ export function registerVideoCommand(parent: Command) {
         const client = await getTrpcClient();
         const topicId = await client.generationTopic.createTopic.mutate({ type: 'video' });
 
-        const params: Record<string, any> = { prompt };
+        const params: { prompt: string } & Record<string, any> = { prompt };
         if (options.aspectRatio) params.aspectRatio = options.aspectRatio;
         if (options.duration) params.duration = Number.parseInt(options.duration, 10);
         if (options.resolution) params.resolution = options.resolution;


### PR DESCRIPTION
## Summary
- Fix TypeScript type errors in `apps/cli/src/commands/generate/image.ts` and `video.ts` where `params` was typed as `Record<string, any>` but TRPC expected `{ prompt: string }` intersection type

## Relates
LOBE-5772

## Test plan
- [ ] Verify `bunx tsc --noEmit` produces no errors in `apps/cli/src/` 
- [ ] Test `lh generate image` and `lh generate video` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct parameter typing for image and video generation commands so the prompt field satisfies TRPC's required type constraints.