### PR TITLE
🐛 fix: include pnpm store path for ffmpeg-static in Vercel tracing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,10 @@ const vercelConfig = {
     ],
   },
   outputFileTracingIncludes: {
-    '/api/webhooks/video/*': ['./node_modules/ffmpeg-static/ffmpeg'],
+    '/api/webhooks/video/*': [
+      './node_modules/ffmpeg-static/ffmpeg',
+      './node_modules/.pnpm/ffmpeg-static@*/node_modules/ffmpeg-static/ffmpeg',
+    ],
   },
 };
 const nextConfig = defineConfig({


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

On Vercel with pnpm, `outputFileTracingExcludes` removes ffmpeg-static from all routes (both `node_modules/ffmpeg-static/**` and `node_modules/.pnpm/ffmpeg-static*/**`). The `outputFileTracingIncludes` only added back `./node_modules/ffmpeg-static/ffmpeg` (the hoisted symlink) for the video webhook route, but the actual binary at the pnpm store path (`.pnpm/ffmpeg-static@*/node_modules/ffmpeg-static/ffmpeg`) was never re-included — causing `ENOENT` at runtime.

This fix adds the pnpm virtual store glob path to `outputFileTracingIncludes` so both the symlink and the real binary are bundled into the video webhook serverless function.

#### 🧪 How to Test

- [x] No tests needed

Deploy to Vercel and verify video generation webhook processes videos without `spawn ffmpeg ENOENT` error.

## Summary by Sourcery

Bug Fixes:
- Ensure the ffmpeg-static binary from pnpm's virtual store is included in Vercel output file tracing for the video webhook route to prevent ENOENT errors at runtime.