### PR TITLE
🐛 fix: filter v-prefixed Docker tags in manifest creation

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -122,7 +122,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          # 过滤掉带 v 前缀的 tag（如 lobehub/lobehub:v2.1.29），只保留无 v 前缀的版本号和 latest
+          TAGS=$(jq -cr '.tags | map(select(test(":v\\d") | not)) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create $TAGS \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Fix the jq filter in `release-docker.yml` manifest creation step. The original filter operated on full image references (e.g. `lobehub/lobehub:v2.1.29`) but checked `startswith("v")` and `== "latest"` against the full string, which never matched. Changed to `test(":v\\d")` to correctly detect v-prefixed tags in full image references.

#### 🧪 How to Test

- [x] No tests needed

CI workflow change — verified jq logic manually.

## Summary by Sourcery

CI:
- Adjust release-docker workflow to filter out v-prefixed Docker tags when building the manifest list, keeping only non-v version tags and latest.