### PR TITLE
🐛 fix: remove ffmpeg-static from outputFileTracingExcludes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,16 +3,13 @@ import { defineConfig } from './src/libs/next/config/define-config';
 const isVercel = !!process.env.VERCEL_ENV;
 
 const vercelConfig = {
-  // Vercel serverless optimization: exclude musl binaries and ffmpeg from all routes
+  // Vercel serverless optimization: exclude musl binaries from all routes
   // Vercel uses Amazon Linux (glibc), not Alpine Linux (musl)
-  // ffmpeg-static (~76MB) is only needed by /api/webhooks/video/* route
-  // This saves ~120MB (29MB canvas-musl + 16MB sharp-musl + 76MB ffmpeg)
+  // This saves ~45MB (29MB canvas-musl + 16MB sharp-musl) per serverless function
   outputFileTracingExcludes: {
     '*': [
       'node_modules/.pnpm/@napi-rs+canvas-*-musl*',
       'node_modules/.pnpm/@img+sharp-libvips-*musl*',
-      'node_modules/ffmpeg-static/**',
-      'node_modules/.pnpm/ffmpeg-static*/**',
       // Exclude SPA/desktop/mobile build artifacts from serverless functions
       'public/spa/**',
       'dist/desktop/**',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #12838

#### 🔀 Description of Change

The previous fix (#12838) added ffmpeg pnpm store path to `outputFileTracingIncludes`, but this didn't work because **Next.js applies `outputFileTracingExcludes` AFTER `outputFileTracingIncludes`** — excludes always win.

The fix: remove ffmpeg-static patterns from `outputFileTracingExcludes` entirely. The ffmpeg binary will be naturally traced by NFT (via `path.join(__dirname, ...)` detection in `ffmpeg-static/index.js`) only into routes that import the video service. The `outputFileTracingIncludes` remains as a safety net.

#### 🧪 How to Test

- [x] No tests needed

Deploy to Vercel and verify `/api/webhooks/video/[provider]` can spawn ffmpeg without ENOENT.

## Summary by Sourcery

Ensure ffmpeg-static binaries are included in Next.js output file tracing for serverless functions on Vercel by adjusting tracing exclusions.

Bug Fixes:
- Allow ffmpeg-static to be traced and bundled into relevant serverless routes by removing its patterns from outputFileTracingExcludes.

Enhancements:
- Update Next.js config comments to reflect the new output file tracing behavior and adjusted bundle size savings.