### PR TITLE
🐛 fix: add ffmpeg-static to default serverExternalPackages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,12 +18,6 @@ const vercelConfig = {
       'packages/database/migrations/**',
     ],
   },
-  outputFileTracingIncludes: {
-    '/api/webhooks/video/*': [
-      './node_modules/ffmpeg-static/ffmpeg',
-      './node_modules/.pnpm/ffmpeg-static@*/node_modules/ffmpeg-static/ffmpeg',
-    ],
-  },
 };
 const nextConfig = defineConfig({
   ...(isVercel ? vercelConfig : {}),

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -356,6 +356,7 @@ export function defineConfig(config: CustomNextConfig) {
       'pdfkit',
       '@napi-rs/canvas',
       'discord.js',
+      'ffmpeg-static',
       'pdfjs-dist',
       'ajv',
       'oidc-provider',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #12838 and #12844

#### 🔀 Description of Change

On Vercel with pnpm, `ffmpeg-static` must be in `serverExternalPackages` so turbopack preserves the `require('ffmpeg-static')` call. This allows NFT to trace the module through pnpm's resolution chain and automatically include the binary in the serverless function.

Changes:
1. **`define-config.ts`**: Add `ffmpeg-static` to the default `serverExternalPackages` list
2. **`next.config.ts`**: Remove `outputFileTracingIncludes` for ffmpeg (no longer needed)

This restores the approach from the original video generation PR that was inadvertently broken by a later optimization attempt.

#### 🧪 How to Test

- [x] No tests needed

Deploy to Vercel and verify `/api/webhooks/video/[provider]` processes videos without ENOENT.