### PR TITLE
✨ feat: add migration to enable pg_search extension

### DIFF
--- a/packages/database/migrations/0089_enable_pg_search.sql
+++ b/packages/database/migrations/0089_enable_pg_search.sql
@@ -1,0 +1,2 @@
+-- Custom SQL migration file, put you code below! --
+CREATE EXTENSION IF NOT EXISTS pg_search;

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -623,6 +623,13 @@
       "when": 1772277762014,
       "tag": "0088_fix_benchmark_add_bot_provider",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1772900000000,
+      "tag": "0089_enable_pg_search",
+      "breakpoints": true
     }
   ],
   "version": "6"


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-5848

#### 🔀 Description of Change

Add database migration `0089_enable_pg_search.sql` to enable the `pg_search` extension. This prepares the database for upcoming BM25 index and search refactoring.

#### 🧪 How to Test

- [x] No tests needed