### PR TITLE
👷 build: enable pg_search extension

### DIFF
--- a/packages/database/migrations/0089_enable_pg_search.sql
+++ b/packages/database/migrations/0089_enable_pg_search.sql
@@ -1,0 +1,2 @@
+-- Custom SQL migration file, put you code below! --
+CREATE EXTENSION IF NOT EXISTS pg_search;

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -623,6 +623,13 @@
       "when": 1772277762014,
       "tag": "0088_fix_benchmark_add_bot_provider",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1772900000000,
+      "tag": "0089_enable_pg_search",
+      "breakpoints": true
     }
   ],
   "version": "6"

--- a/packages/database/src/core/getTestDB.ts
+++ b/packages/database/src/core/getTestDB.ts
@@ -1,3 +1,4 @@
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { PGlite } from '@electric-sql/pglite';
@@ -5,7 +6,6 @@ import { vector } from '@electric-sql/pglite/vector';
 import { drizzle as nodeDrizzle } from 'drizzle-orm/node-postgres';
 import { migrate as nodeMigrate } from 'drizzle-orm/node-postgres/migrator';
 import { drizzle as pgliteDrizzle } from 'drizzle-orm/pglite';
-import { migrate as pgliteMigrate } from 'drizzle-orm/pglite/migrator';
 import { Pool as NodePool } from 'pg';
 
 import { serverDBEnv } from '@/config/db';
@@ -19,6 +19,27 @@ const isServerDBMode = process.env.TEST_SERVER_DB === '1';
 
 let testClientDB: ReturnType<typeof pgliteDrizzle<typeof schema>> | null = null;
 let testServerDB: ReturnType<typeof nodeDrizzle<typeof schema>> | null = null;
+
+/**
+ * Run migrations manually for PGlite, skipping unsupported extensions (e.g. pg_search)
+ */
+const pgliteMigrateManual = async (pglite: PGlite): Promise<void> => {
+  const migrationFiles = readdirSync(migrationsFolder)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const filename of migrationFiles) {
+    const filePath = join(migrationsFolder, filename);
+    const sql = readFileSync(filePath, 'utf8');
+
+    if (!sql.trim()) continue;
+
+    // PGlite doesn't support pg_search extension, skip related migrations
+    if (sql.includes('pg_search') || sql.includes('bm25')) continue;
+
+    await pglite.exec(sql);
+  }
+};
 
 export const getTestDB = async (): Promise<LobeChatDatabase> => {
   // Server DB mode (node-postgres)
@@ -45,7 +66,7 @@ export const getTestDB = async (): Promise<LobeChatDatabase> => {
   const pglite = new PGlite({ extensions: { vector } });
   testClientDB = pgliteDrizzle({ client: pglite, schema });
 
-  await pgliteMigrate(testClientDB, { migrationsFolder });
+  await pgliteMigrateManual(pglite);
 
   return testClientDB as unknown as LobeChatDatabase;
 };


### PR DESCRIPTION
This release includes a **database schema migration** adding the `pg_search` extension.

### Migration: Enable pg_search Extension

- Added migration `0089_enable_pg_search.sql`: `CREATE EXTENSION IF NOT EXISTS pg_search`
- Prepares the database for upcoming BM25 index and search refactoring
- Fixed PGlite test compatibility: skip `pg_search`/`bm25` related migrations in PGlite test mode

### Notes for Self-hosted Users

- The migration runs automatically on application startup
- No manual intervention required
- Requires PostgreSQL with `pg_search` extension available (e.g. via ParadeDB)

The migration owner: @pstrMrc — responsible for this database schema change, reach out for any migration-related issues.

## Summary by Sourcery

Enable the pg_search PostgreSQL extension via a new database migration while keeping PGlite-based tests compatible by skipping unsupported migrations.

New Features:
- Add a database migration that enables the pg_search extension if available.

Bug Fixes:
- Ensure PGlite test database setup skips migrations that rely on unsupported pg_search or bm25 extensions to prevent test failures.