### PR TITLE
🐛 fix: harden market auth popup handoff and storage fallback

### DIFF
--- a/src/app/[variants]/(auth)/market-auth-callback/page.tsx
+++ b/src/app/[variants]/(auth)/market-auth-callback/page.tsx
@@ -5,6 +5,8 @@ import { Result } from 'antd';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { persistMarketAuthResult } from '@/layout/AuthProvider/MarketAuth/handoff';
+
 type CallbackStatus = 'loading' | 'success' | 'error';
 
 /**
@@ -31,11 +33,18 @@ const MarketAuthCallbackPage = () => {
       setStatus('error');
       setMessage(t('callback.messages.authFailed', { error: errorDescription || error }));
 
+      persistMarketAuthResult({
+        error: errorDescription || error,
+        state: state || undefined,
+        type: 'MARKET_AUTH_ERROR',
+      });
+
       // Send error message to parent window
       if (window.opener) {
         window.opener.postMessage(
           {
             error: errorDescription || error,
+            state,
             type: 'MARKET_AUTH_ERROR',
           },
           window.location.origin,
@@ -48,6 +57,12 @@ const MarketAuthCallbackPage = () => {
       console.info('[MarketAuthCallback] Authorization successful, code received');
       setStatus('success');
       setMessage(t('callback.messages.successWithRedirect'));
+
+      persistMarketAuthResult({
+        code,
+        state,
+        type: 'MARKET_AUTH_SUCCESS',
+      });
 
       // Send success message to parent window
       if (window.opener) {
@@ -83,6 +98,7 @@ const MarketAuthCallbackPage = () => {
         window.opener.postMessage(
           {
             error: 'Missing authorization parameters',
+            state,
             type: 'MARKET_AUTH_ERROR',
           },
           window.location.origin,

--- a/src/app/[variants]/(auth)/market-auth-callback/page.tsx
+++ b/src/app/[variants]/(auth)/market-auth-callback/page.tsx
@@ -94,6 +94,12 @@ const MarketAuthCallbackPage = () => {
       setStatus('error');
       setMessage(t('callback.messages.missingParams'));
 
+      persistMarketAuthResult({
+        error: 'Missing authorization parameters',
+        state: state || undefined,
+        type: 'MARKET_AUTH_ERROR',
+      });
+
       if (window.opener) {
         window.opener.postMessage(
           {

--- a/src/layout/AuthProvider/MarketAuth/handoff.test.ts
+++ b/src/layout/AuthProvider/MarketAuth/handoff.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { persistMarketAuthResult } from './handoff';
+
+describe('persistMarketAuthResult', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should swallow storage write failures and return false', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(
+      persistMarketAuthResult({
+        code: 'auth_code',
+        state: 'state_value',
+        type: 'MARKET_AUTH_SUCCESS',
+      }),
+    ).toBe(false);
+
+    expect(setItemSpy).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/layout/AuthProvider/MarketAuth/handoff.test.ts
+++ b/src/layout/AuthProvider/MarketAuth/handoff.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { persistMarketAuthResult } from './handoff';
+import { clearMarketAuthResult, persistMarketAuthResult, readMarketAuthResult } from './handoff';
 
-describe('persistMarketAuthResult', () => {
+describe('MarketAuth handoff storage helpers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -22,6 +22,30 @@ describe('persistMarketAuthResult', () => {
     ).toBe(false);
 
     expect(setItemSpy).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should swallow storage read failures and return null', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(readMarketAuthResult('state_value')).toBeNull();
+
+    expect(getItemSpy).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should swallow storage clear failures and return false', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    expect(clearMarketAuthResult('state_value')).toBe(false);
+
+    expect(removeItemSpy).toHaveBeenCalledOnce();
     expect(consoleErrorSpy).toHaveBeenCalledOnce();
   });
 });

--- a/src/layout/AuthProvider/MarketAuth/handoff.ts
+++ b/src/layout/AuthProvider/MarketAuth/handoff.ts
@@ -51,10 +51,16 @@ export const resolveMarketAuthHandoffPayload = (
   return null;
 };
 
-export const persistMarketAuthResult = (payload: MarketAuthHandoffPayload) => {
-  if (!isBrowser() || !payload.state) return;
+export const persistMarketAuthResult = (payload: MarketAuthHandoffPayload): boolean => {
+  if (!isBrowser() || !payload.state) return false;
 
-  localStorage.setItem(getMarketAuthResultStorageKey(payload.state), JSON.stringify(payload));
+  try {
+    localStorage.setItem(getMarketAuthResultStorageKey(payload.state), JSON.stringify(payload));
+    return true;
+  } catch (error) {
+    console.error('[MarketAuthHandoff] Failed to persist auth result:', error);
+    return false;
+  }
 };
 
 export const readMarketAuthResult = (state: string): MarketAuthHandoffPayload | null => {

--- a/src/layout/AuthProvider/MarketAuth/handoff.ts
+++ b/src/layout/AuthProvider/MarketAuth/handoff.ts
@@ -66,18 +66,25 @@ export const persistMarketAuthResult = (payload: MarketAuthHandoffPayload): bool
 export const readMarketAuthResult = (state: string): MarketAuthHandoffPayload | null => {
   if (!isBrowser()) return null;
 
-  const rawValue = localStorage.getItem(getMarketAuthResultStorageKey(state));
-  if (!rawValue) return null;
-
   try {
+    const rawValue = localStorage.getItem(getMarketAuthResultStorageKey(state));
+    if (!rawValue) return null;
+
     return resolveMarketAuthHandoffPayload(JSON.parse(rawValue));
-  } catch {
+  } catch (error) {
+    console.error('[MarketAuthHandoff] Failed to read auth result:', error);
     return null;
   }
 };
 
-export const clearMarketAuthResult = (state: string) => {
-  if (!isBrowser()) return;
+export const clearMarketAuthResult = (state: string): boolean => {
+  if (!isBrowser()) return false;
 
-  localStorage.removeItem(getMarketAuthResultStorageKey(state));
+  try {
+    localStorage.removeItem(getMarketAuthResultStorageKey(state));
+    return true;
+  } catch (error) {
+    console.error('[MarketAuthHandoff] Failed to clear auth result:', error);
+    return false;
+  }
 };

--- a/src/layout/AuthProvider/MarketAuth/handoff.ts
+++ b/src/layout/AuthProvider/MarketAuth/handoff.ts
@@ -1,0 +1,77 @@
+interface MarketAuthSuccessHandoffPayload {
+  code: string;
+  state: string;
+  type: 'MARKET_AUTH_SUCCESS';
+}
+
+interface MarketAuthErrorHandoffPayload {
+  error: string;
+  state?: string;
+  type: 'MARKET_AUTH_ERROR';
+}
+
+export type MarketAuthHandoffPayload =
+  | MarketAuthErrorHandoffPayload
+  | MarketAuthSuccessHandoffPayload;
+
+const MARKET_AUTH_RESULT_STORAGE_PREFIX = 'market_auth_result:';
+
+const isBrowser = () => typeof window !== 'undefined';
+
+export const getMarketAuthResultStorageKey = (state: string) =>
+  `${MARKET_AUTH_RESULT_STORAGE_PREFIX}${state}`;
+
+export const resolveMarketAuthHandoffPayload = (
+  value: unknown,
+): MarketAuthHandoffPayload | null => {
+  if (!value || typeof value !== 'object') return null;
+
+  const payload = value as Partial<MarketAuthHandoffPayload>;
+
+  if (payload.type === 'MARKET_AUTH_SUCCESS') {
+    if (typeof payload.code !== 'string' || typeof payload.state !== 'string') return null;
+
+    return {
+      code: payload.code,
+      state: payload.state,
+      type: payload.type,
+    };
+  }
+
+  if (payload.type === 'MARKET_AUTH_ERROR') {
+    if (typeof payload.error !== 'string') return null;
+
+    return {
+      error: payload.error,
+      state: typeof payload.state === 'string' ? payload.state : undefined,
+      type: payload.type,
+    };
+  }
+
+  return null;
+};
+
+export const persistMarketAuthResult = (payload: MarketAuthHandoffPayload) => {
+  if (!isBrowser() || !payload.state) return;
+
+  localStorage.setItem(getMarketAuthResultStorageKey(payload.state), JSON.stringify(payload));
+};
+
+export const readMarketAuthResult = (state: string): MarketAuthHandoffPayload | null => {
+  if (!isBrowser()) return null;
+
+  const rawValue = localStorage.getItem(getMarketAuthResultStorageKey(state));
+  if (!rawValue) return null;
+
+  try {
+    return resolveMarketAuthHandoffPayload(JSON.parse(rawValue));
+  } catch {
+    return null;
+  }
+};
+
+export const clearMarketAuthResult = (state: string) => {
+  if (!isBrowser()) return;
+
+  localStorage.removeItem(getMarketAuthResultStorageKey(state));
+};

--- a/src/layout/AuthProvider/MarketAuth/oidc.test.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.test.ts
@@ -50,7 +50,41 @@ describe('MarketOIDC.startAuthorization', () => {
     vi.useRealTimers();
   });
 
-  it('should resolve from storage handoff when popup monitoring reports closed early', async () => {
+  it('should reject promptly when popup closes without a handoff result', async () => {
+    const client = new MarketOIDC({
+      baseUrl: 'https://market.lobehub.com',
+      clientId: 'lobechat-com',
+      redirectUri: 'http://localhost:3010/market-auth-callback',
+      scope: 'openid profile email',
+    });
+
+    sessionStorage.setItem('market_state', 'state_value');
+    vi.spyOn(client, 'buildAuthUrl').mockResolvedValue(
+      'https://market.lobehub.com/lobehub-oidc/auth',
+    );
+
+    let isClosed = false;
+    const popup = {
+      get closed() {
+        return isClosed;
+      },
+    } as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popup);
+
+    const authPromise = client.startAuthorization();
+    const rejection = expect(authPromise).rejects.toMatchObject({
+      code: 'popupClosed',
+      name: 'MarketAuthError',
+    });
+
+    isClosed = true;
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await rejection;
+  });
+
+  it('should resolve from storage handoff when popup closes after callback persistence', async () => {
     const client = new MarketOIDC({
       baseUrl: 'https://market.lobehub.com',
       clientId: 'lobechat-com',

--- a/src/layout/AuthProvider/MarketAuth/oidc.test.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MARKET_OIDC_ENDPOINTS } from '@/services/_url';
 
+import { getMarketAuthResultStorageKey } from './handoff';
 import { MarketOIDC } from './oidc';
 
 describe('MarketOIDC.buildAuthUrl', () => {
@@ -23,7 +24,9 @@ describe('MarketOIDC.buildAuthUrl', () => {
 
     expect(url).toContain('https://market.lobehub.com/lobehub-oidc/auth?');
     expect(url).toContain(`client_id=${encodeURIComponent('lobehub-desktop')}`);
-    expect(url).toContain(`redirect_uri=${encodeURIComponent('https://market.lobehub.com/lobehub-oidc/callback/desktop')}`);
+    expect(url).toContain(
+      `redirect_uri=${encodeURIComponent('https://market.lobehub.com/lobehub-oidc/callback/desktop')}`,
+    );
     expect(url).toContain(`state=${encodeURIComponent('state_value')}`);
     expect(url).toContain(`code_challenge=${encodeURIComponent('code_challenge')}`);
 
@@ -35,4 +38,66 @@ describe('MarketOIDC.buildAuthUrl', () => {
   });
 });
 
+describe('MarketOIDC.startAuthorization', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.useFakeTimers();
+  });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should resolve from storage handoff when popup monitoring reports closed early', async () => {
+    const client = new MarketOIDC({
+      baseUrl: 'https://market.lobehub.com',
+      clientId: 'lobechat-com',
+      redirectUri: 'http://localhost:3010/market-auth-callback',
+      scope: 'openid profile email',
+    });
+    const state = 'state_value';
+    const storageKey = getMarketAuthResultStorageKey(state);
+
+    sessionStorage.setItem('market_state', state);
+    vi.spyOn(client, 'buildAuthUrl').mockResolvedValue(
+      'https://market.lobehub.com/lobehub-oidc/auth',
+    );
+
+    let isClosed = false;
+    const popup = {
+      get closed() {
+        return isClosed;
+      },
+    } as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popup);
+
+    const authPromise = client.startAuthorization();
+
+    isClosed = true;
+    await vi.advanceTimersByTimeAsync(500);
+
+    const payload = JSON.stringify({
+      code: 'auth_code',
+      state,
+      type: 'MARKET_AUTH_SUCCESS',
+    });
+
+    localStorage.setItem(storageKey, payload);
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: storageKey,
+        newValue: payload,
+        storageArea: localStorage,
+      }),
+    );
+
+    await expect(authPromise).resolves.toEqual({
+      code: 'auth_code',
+      state,
+    });
+    expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+});

--- a/src/layout/AuthProvider/MarketAuth/oidc.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.ts
@@ -5,9 +5,9 @@ import { MarketAuthError } from './errors';
 import {
   clearMarketAuthResult,
   getMarketAuthResultStorageKey,
+  type MarketAuthHandoffPayload,
   readMarketAuthResult,
   resolveMarketAuthHandoffPayload,
-  type MarketAuthHandoffPayload,
 } from './handoff';
 import { type OIDCConfig, type PKCEParams, type TokenResponse } from './types';
 
@@ -22,6 +22,8 @@ export class MarketOIDC {
   private static readonly DESKTOP_HANDOFF_POLL_INTERVAL = 1500;
 
   private static readonly DESKTOP_HANDOFF_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+  private static readonly WEB_POPUP_CLOSE_GRACE_PERIOD = 1500;
 
   private static readonly WEB_POPUP_MONITOR_INTERVAL = 500;
 
@@ -241,15 +243,26 @@ export class MarketOIDC {
 
     return new Promise((resolve, reject) => {
       let checkClosed: number | undefined;
-      let authTimeout: number | undefined;
       let fallbackPolling: number | undefined;
+      let popupClosedGraceTimeout: number | undefined;
+
+      const authTimeout = setTimeout(() => {
+        cleanup();
+        reject(
+          new MarketAuthError('handoffTimeout', {
+            message:
+              'Authorization timeout. Please complete the authorization in the browser and try again.',
+          }),
+        );
+      }, MarketOIDC.WEB_POPUP_TIMEOUT) as unknown as number;
 
       const cleanup = () => {
         window.removeEventListener('message', messageHandler);
         window.removeEventListener('storage', storageHandler);
-        if (authTimeout) clearTimeout(authTimeout);
+        clearTimeout(authTimeout);
         if (checkClosed) clearInterval(checkClosed);
         if (fallbackPolling) clearInterval(fallbackPolling);
+        if (popupClosedGraceTimeout) clearTimeout(popupClosedGraceTimeout);
         clearMarketAuthResult(state);
       };
 
@@ -268,7 +281,7 @@ export class MarketOIDC {
         try {
           popup?.close();
         } catch {
-          // Ignore close failures from COOP-isolated popup windows.
+          // Ignore close failures from cross-origin popup contexts.
         }
 
         reject(
@@ -289,17 +302,34 @@ export class MarketOIDC {
 
       const flushStoredResult = () => handleHandoffPayload(readMarketAuthResult(state));
 
-      const startFallbackPolling = () => {
+      const startStoragePolling = () => {
         if (fallbackPolling) return;
 
+        fallbackPolling = setInterval(() => {
+          flushStoredResult();
+        }, MarketOIDC.WEB_POPUP_MONITOR_INTERVAL) as unknown as number;
+      };
+
+      const rejectPopupClosed = () => {
+        cleanup();
+        reject(new MarketAuthError('popupClosed', { message: 'Authorization popup was closed' }));
+      };
+
+      const handlePopupClosed = () => {
+        if (popupClosedGraceTimeout) return;
         if (checkClosed) {
           clearInterval(checkClosed);
           checkClosed = undefined;
         }
 
-        fallbackPolling = setInterval(() => {
-          flushStoredResult();
-        }, MarketOIDC.WEB_POPUP_MONITOR_INTERVAL) as unknown as number;
+        if (flushStoredResult()) return;
+
+        startStoragePolling();
+
+        popupClosedGraceTimeout = setTimeout(() => {
+          if (flushStoredResult()) return;
+          rejectPopupClosed();
+        }, MarketOIDC.WEB_POPUP_CLOSE_GRACE_PERIOD) as unknown as number;
       };
 
       // Listen for message events, waiting for authorization to complete
@@ -323,39 +353,36 @@ export class MarketOIDC {
         try {
           handleHandoffPayload(resolveMarketAuthHandoffPayload(JSON.parse(event.newValue)));
         } catch {
-          // Ignore malformed storage payloads and keep waiting.
+          // Ignore malformed storage payloads and keep waiting for a valid handoff.
         }
       };
 
       window.addEventListener('message', messageHandler);
       window.addEventListener('storage', storageHandler);
 
-      authTimeout = setTimeout(() => {
-        cleanup();
-        reject(
-          new MarketAuthError('handoffTimeout', {
-            message:
-              'Authorization timeout. Please complete the authorization in the browser and try again.',
-          }),
-        );
-      }, MarketOIDC.WEB_POPUP_TIMEOUT) as unknown as number;
-
       if (flushStoredResult()) return;
 
-      // Monitor the popup while the opener relationship is still reliable.
-      // If COOP or a browsing-context switch breaks direct access, fall back
-      // to same-origin storage handoff instead of failing immediately.
+      // Check if the popup was closed. A readable `closed === true` means the
+      // window is genuinely gone, so only wait a short grace period for the
+      // callback page to persist its handoff result. If accessing popup state
+      // throws, assume COOP isolation and keep waiting on storage handoff.
       if (popup) {
         checkClosed = setInterval(() => {
           try {
             if (popup.closed) {
-              startFallbackPolling();
+              handlePopupClosed();
             }
           } catch {
             console.info(
               '[MarketOIDC] COOP blocked popup monitoring, falling back to storage handoff',
             );
-            startFallbackPolling();
+
+            if (checkClosed) {
+              clearInterval(checkClosed);
+              checkClosed = undefined;
+            }
+
+            startStoragePolling();
           }
         }, MarketOIDC.WEB_POPUP_MONITOR_INTERVAL) as unknown as number;
       }

--- a/src/layout/AuthProvider/MarketAuth/oidc.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.ts
@@ -2,6 +2,13 @@ import { isDesktop } from '@/const/version';
 import { MARKET_OIDC_ENDPOINTS } from '@/services/_url';
 
 import { MarketAuthError } from './errors';
+import {
+  clearMarketAuthResult,
+  getMarketAuthResultStorageKey,
+  readMarketAuthResult,
+  resolveMarketAuthHandoffPayload,
+  type MarketAuthHandoffPayload,
+} from './handoff';
 import { type OIDCConfig, type PKCEParams, type TokenResponse } from './types';
 
 /**
@@ -15,6 +22,10 @@ export class MarketOIDC {
   private static readonly DESKTOP_HANDOFF_POLL_INTERVAL = 1500;
 
   private static readonly DESKTOP_HANDOFF_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+  private static readonly WEB_POPUP_MONITOR_INTERVAL = 500;
+
+  private static readonly WEB_POPUP_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
   constructor(config: OIDCConfig) {
     this.config = config;
@@ -226,52 +237,127 @@ export class MarketOIDC {
       }
     }
 
+    clearMarketAuthResult(state);
+
     return new Promise((resolve, reject) => {
       let checkClosed: number | undefined;
+      let authTimeout: number | undefined;
+      let fallbackPolling: number | undefined;
+
+      const cleanup = () => {
+        window.removeEventListener('message', messageHandler);
+        window.removeEventListener('storage', storageHandler);
+        if (authTimeout) clearTimeout(authTimeout);
+        if (checkClosed) clearInterval(checkClosed);
+        if (fallbackPolling) clearInterval(fallbackPolling);
+        clearMarketAuthResult(state);
+      };
+
+      const settle = (payload: MarketAuthHandoffPayload) => {
+        cleanup();
+
+        if (payload.type === 'MARKET_AUTH_SUCCESS') {
+          resolve({
+            code: payload.code,
+            state: payload.state,
+          });
+
+          return;
+        }
+
+        try {
+          popup?.close();
+        } catch {
+          // Ignore close failures from COOP-isolated popup windows.
+        }
+
+        reject(
+          new MarketAuthError('authorizationFailed', {
+            message: payload.error || 'Authorization failed',
+            meta: { error: payload.error },
+          }),
+        );
+      };
+
+      const handleHandoffPayload = (payload: MarketAuthHandoffPayload | null) => {
+        if (!payload) return false;
+        if (payload.state && payload.state !== state) return false;
+
+        settle(payload);
+        return true;
+      };
+
+      const flushStoredResult = () => handleHandoffPayload(readMarketAuthResult(state));
+
+      const startFallbackPolling = () => {
+        if (fallbackPolling) return;
+
+        if (checkClosed) {
+          clearInterval(checkClosed);
+          checkClosed = undefined;
+        }
+
+        fallbackPolling = setInterval(() => {
+          flushStoredResult();
+        }, MarketOIDC.WEB_POPUP_MONITOR_INTERVAL) as unknown as number;
+      };
 
       // Listen for message events, waiting for authorization to complete
       const messageHandler = (event: MessageEvent) => {
+        if (event.origin !== window.location.origin) return;
+
         console.info('[MarketOIDC] Received message from popup:', event.data);
 
-        if (event.data.type === 'MARKET_AUTH_SUCCESS') {
-          cleanup();
+        handleHandoffPayload(resolveMarketAuthHandoffPayload(event.data));
+      };
 
-          // Don't close the popup immediately, let the user see the success state
-          // The popup will close automatically after 3 seconds
-          resolve({
-            code: event.data.code,
-            state: event.data.state,
-          });
-        } else if (event.data.type === 'MARKET_AUTH_ERROR') {
-          cleanup();
-          popup?.close();
-          reject(
-            new MarketAuthError('authorizationFailed', {
-              message: event.data.error || 'Authorization failed',
-              meta: { error: event.data.error },
-            }),
-          );
+      const storageHandler = (event: StorageEvent) => {
+        if (event.storageArea !== localStorage) return;
+        if (event.key !== getMarketAuthResultStorageKey(state)) return;
+
+        if (!event.newValue) {
+          flushStoredResult();
+          return;
+        }
+
+        try {
+          handleHandoffPayload(resolveMarketAuthHandoffPayload(JSON.parse(event.newValue)));
+        } catch {
+          // Ignore malformed storage payloads and keep waiting.
         }
       };
 
-      // Cleanup function
-      function cleanup() {
-        window.removeEventListener('message', messageHandler);
-        if (checkClosed) clearInterval(checkClosed);
-      }
-
       window.addEventListener('message', messageHandler);
+      window.addEventListener('storage', storageHandler);
 
-      // Check if the popup was closed
+      authTimeout = setTimeout(() => {
+        cleanup();
+        reject(
+          new MarketAuthError('handoffTimeout', {
+            message:
+              'Authorization timeout. Please complete the authorization in the browser and try again.',
+          }),
+        );
+      }, MarketOIDC.WEB_POPUP_TIMEOUT) as unknown as number;
+
+      if (flushStoredResult()) return;
+
+      // Monitor the popup while the opener relationship is still reliable.
+      // If COOP or a browsing-context switch breaks direct access, fall back
+      // to same-origin storage handoff instead of failing immediately.
       if (popup) {
         checkClosed = setInterval(() => {
-          if (popup.closed) {
-            cleanup();
-            reject(
-              new MarketAuthError('popupClosed', { message: 'Authorization popup was closed' }),
+          try {
+            if (popup.closed) {
+              startFallbackPolling();
+            }
+          } catch {
+            console.info(
+              '[MarketOIDC] COOP blocked popup monitoring, falling back to storage handoff',
             );
+            startFallbackPolling();
           }
-        }, 1000) as unknown as number;
+        }, MarketOIDC.WEB_POPUP_MONITOR_INTERVAL) as unknown as number;
       }
     });
   }


### PR DESCRIPTION
#### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

 #### 🔀 Description of Change

  This PR hardens the Community Market authorization popup flow for browser edge cases.

  Previously, the parent page relied too heavily on direct popup state and could incorrectly treat the authorization window as closed before completion. In practice, users could see the popup success countdown while the parent page had already failed the flow. There were also storage-related failure paths that could break the handoff unexpectedly in privacy-restricted browser environments.

https://github.com/user-attachments/assets/b87d6977-747a-4d02-a65d-5f273c106286

  This change improves the Market auth flow by:

  - adding a COOP-safe same-origin storage handoff fallback alongside the existing postMessage path
  - rejecting promptly when the popup is actually closed by the user without any handoff result
  - making handoff storage access best-effort, so storage read/write/clear failures do not break the existing message-based auth path
  - keeping the callback page compatible with both storage fallback and existing opener-based communication

  #### 🧪 How to Test

  - [x] Tested locally
  - [x] Added/updated tests
  - [ ] No tests needed

  Tested with:

  - pnpm exec vitest run --silent='passed-only' 'src/layout/AuthProvider/MarketAuth/oidc.test.ts' 'src/layout/AuthProvider/MarketAuth/handoff.test.ts'
  - targeted eslint on the changed Market auth files
  - targeted stylelint on the changed Market auth files

  Manual verification scenarios:

  1. Open Community and click Become a Creator
  2. Complete Market authorization in the popup
  3. Confirm the popup shows the success countdown
  4. Confirm the parent page no longer reports that the authorization window was closed before completion
  5. Re-run the flow and manually close the popup before reaching the callback page
  6. Confirm the parent page fails quickly instead of staying stuck in loading for minutes

  #### 📸 Screenshots / Videos


  #### 📝 Additional Information
This PR is scoped to the Community Market auth popup flow and its handoff mechanism. It does not change Market trusted-client token selection or unrelated market event reporting behavior.