### PR TITLE
🐛 fix: redirect to desktop onboarding when not completed

### DIFF
--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -49,15 +49,12 @@ export const useDesktopUserStateRedirect = () => {
     [dataSyncConfig.remoteServerUrl, logout],
   );
 
-  return useCallback(
-    (state: UserInitializationState) => {
-      if (!getDesktopOnboardingCompleted()) {
-        redirectIfNotOn(window.location.pathname, '/desktop-onboarding');
-        return;
-      }
-    },
-    [openExternalAndLogout],
-  );
+  return useCallback(() => {
+    if (!getDesktopOnboardingCompleted()) {
+      redirectIfNotOn(window.location.pathname, '/desktop-onboarding');
+      return;
+    }
+  }, [openExternalAndLogout]);
 };
 
 export const useWebUserStateRedirect = () =>

--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -51,8 +51,10 @@ export const useDesktopUserStateRedirect = () => {
 
   return useCallback(
     (state: UserInitializationState) => {
-      if (!getDesktopOnboardingCompleted()) return;
-      // Desktop onboarding is handled by desktop-only flow.
+      if (!getDesktopOnboardingCompleted()) {
+        redirectIfNotOn(window.location.pathname, '/desktop-onboarding');
+        return;
+      }
     },
     [openExternalAndLogout],
   );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,8 +29,7 @@ export const config = {
     '/me',
     '/me(.*)',
     '/share(.*)',
-    '/desktop-onboarding',
-    '/desktop-onboarding(.*)',
+
     '/onboarding',
 
     '/signup(.*)',


### PR DESCRIPTION
## Summary
- Desktop app was missing the redirect to `/desktop-onboarding` when onboarding hadn't been completed
- `useDesktopUserStateRedirect` silently returned instead of calling `redirectIfNotOn`
- This caused two issues:
  1. Users never see the onboarding flow on fresh install
  2. `AuthRequiredModal` is suppressed because the onboarding completion guard fails

## Root Cause
The redirect was **never implemented** since the file was first created in `34a6312668`. The comment "Desktop onboarding is handled by desktop-only flow" referenced a flow that was never built.

## Test plan
- [x] Fresh desktop install: verify redirect to `/desktop-onboarding`
- [x] After completing onboarding: verify no redirect, normal app usage
- [x] 401 with `X-Auth-Required: true`: verify `AuthRequiredModal` shows after onboarding is completed

## Summary by Sourcery

Bug Fixes:
- Restore the missing redirect to the desktop onboarding route when onboarding has not been completed, preventing users from skipping the flow and ensuring auth gating works as intended.