### PR TITLE
✅ test: fix GatewayManager tests to include platform parameter

### DIFF
--- a/src/server/services/gateway/GatewayManager.test.ts
+++ b/src/server/services/gateway/GatewayManager.test.ts
@@ -203,7 +203,11 @@ describe('GatewayManager', () => {
 
       await manager.startBot('slack', 'app-123', 'user-abc');
 
-      expect(BotClass).toHaveBeenCalledWith({ token: 'tok123', applicationId: 'app-123' });
+      expect(BotClass).toHaveBeenCalledWith({
+        token: 'tok123',
+        applicationId: 'app-123',
+        platform: 'slack',
+      });
       expect(mockBot.start).toHaveBeenCalled();
     });
 
@@ -248,6 +252,7 @@ describe('GatewayManager', () => {
         apiKey: 'key-abc',
         secret: 'sec-xyz',
         applicationId: 'my-app',
+        platform: 'discord',
       });
     });
   });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 🔗 Related Issue

Related to #12784

#### 🔀 Description of Change

Fix two failing GatewayManager tests that didn't account for the `platform` property now being passed to the bot constructor in `createBot()`.

- `should start a bot and register it` — added `platform: 'slack'` to expected args
- `should pass credentials merged with applicationId to the bot constructor` — added `platform: 'discord'` to expected args

#### 🧪 How to Test

- [x] Added/updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Tests:
- Adjust GatewayManager bot startup tests to expect the platform field in BotClass constructor arguments for Slack and Discord.