### PR TITLE
🐛 fix: force-finish after terminal media tool results in browser runtime

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -523,7 +523,7 @@ export class GeneralChatAgent implements Agent {
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,
-            tools: state.tools,
+            tools: state.forceFinish ? undefined : state.tools,
           } as GeneralAgentCallLLMInstructionPayload,
           type: 'call_llm',
         };
@@ -556,7 +556,7 @@ export class GeneralChatAgent implements Agent {
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,
-            tools: state.tools,
+            tools: state.forceFinish ? undefined : state.tools,
           } as GeneralAgentCallLLMInstructionPayload,
           type: 'call_llm',
         };
@@ -573,7 +573,7 @@ export class GeneralChatAgent implements Agent {
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,
-            tools: state.tools,
+            tools: state.forceFinish ? undefined : state.tools,
           } as GeneralAgentCallLLMInstructionPayload,
           type: 'call_llm',
         };
@@ -602,7 +602,7 @@ export class GeneralChatAgent implements Agent {
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,
-            tools: state.tools,
+            tools: state.forceFinish ? undefined : state.tools,
           } as GeneralAgentCallLLMInstructionPayload,
           type: 'call_llm',
         };
@@ -623,7 +623,7 @@ export class GeneralChatAgent implements Agent {
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId: compressionPayload.parentMessageId,
             provider: this.config.modelRuntimeConfig?.provider,
-            tools: state.tools,
+            tools: state.forceFinish ? undefined : state.tools,
           } as GeneralAgentCallLLMInstructionPayload,
           type: 'call_llm',
         };

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -2507,4 +2507,66 @@ describe('GeneralChatAgent', () => {
       ]);
     });
   });
+
+  describe('forceFinish tool stripping', () => {
+    it('should strip tools after tool_result when forceFinish is enabled', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        forceFinish: true,
+        messages: [{ role: 'tool', content: 'done' }] as any,
+        tools: [{ function: { name: 'plugin____tool' }, type: 'function' }] as any,
+      });
+
+      const result = await agent.runner(
+        createMockContext('tool_result', { parentMessageId: 'tool-msg-1' }),
+        state,
+      );
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-1',
+          provider: 'openai',
+          tools: undefined,
+        },
+      });
+    });
+
+    it('should strip tools after tools_batch_result when forceFinish is enabled', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        forceFinish: true,
+        messages: [{ role: 'tool', content: 'done' }] as any,
+        tools: [{ function: { name: 'plugin____tool' }, type: 'function' }] as any,
+      });
+
+      const result = await agent.runner(
+        createMockContext('tools_batch_result', { parentMessageId: 'tool-msg-2' }),
+        state,
+      );
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-2',
+          provider: 'openai',
+          tools: undefined,
+        },
+      });
+    });
+  });
 });

--- a/packages/agent-runtime/src/utils/index.ts
+++ b/packages/agent-runtime/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './messageSelectors';
+export * from './shouldForceFinishAfterToolResult';
 export * from './stepContextComputer';
 export * from './tokenCounter';

--- a/packages/agent-runtime/src/utils/shouldForceFinishAfterToolResult.test.ts
+++ b/packages/agent-runtime/src/utils/shouldForceFinishAfterToolResult.test.ts
@@ -1,0 +1,50 @@
+import type { ChatToolPayload } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { shouldForceFinishAfterToolResult } from './shouldForceFinishAfterToolResult';
+
+const createToolCall = (overrides?: Partial<ChatToolPayload>): ChatToolPayload => ({
+  apiName: 'edit_image',
+  arguments: '{}',
+  id: 'tool-call-1',
+  identifier: 'doubao_grok',
+  type: 'mcp',
+  ...overrides,
+});
+
+describe('shouldForceFinishAfterToolResult', () => {
+  it('returns true for successful terminal image edit results', () => {
+    expect(
+      shouldForceFinishAfterToolResult({
+        isSuccess: true,
+        result: {
+          kind: 'edit_image',
+          result: 'https://example.com/generated/image.jpg',
+        },
+        toolCall: createToolCall(),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for non-terminal tools even when urls are present', () => {
+    expect(
+      shouldForceFinishAfterToolResult({
+        isSuccess: true,
+        result: {
+          results: ['https://example.com/image-1.jpg', 'https://example.com/image-2.jpg'],
+        },
+        toolCall: createToolCall({ apiName: 'search_images', identifier: 'web-search' }),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when media tool succeeds without concrete output', () => {
+    expect(
+      shouldForceFinishAfterToolResult({
+        isSuccess: true,
+        result: { kind: 'edit_image', status: 'queued' },
+        toolCall: createToolCall(),
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/agent-runtime/src/utils/shouldForceFinishAfterToolResult.ts
+++ b/packages/agent-runtime/src/utils/shouldForceFinishAfterToolResult.ts
@@ -1,0 +1,91 @@
+import type { ChatToolPayload } from '@lobechat/types';
+
+const MEDIA_KIND_RE = /image|video/i;
+const TERMINAL_MEDIA_NAME_RE =
+  /(?:edit|generate|create|variation|upscale|stylize|transform|render|draw|paint|convert|txt2img|img2img).*(?:image|video)|(?:image|video).*(?:edit|generate|create|variation|upscale|stylize|transform|render|draw|paint|convert|txt2img|img2img)/i;
+const MEDIA_DATA_URL_RE = /^data:(?:image|video)\//i;
+const HTTP_URL_RE = /^https?:\/\//i;
+const MEDIA_OUTPUT_KEYS = [
+  'asset',
+  'assets',
+  'data',
+  'image',
+  'imageUrl',
+  'image_url',
+  'images',
+  'output',
+  'result',
+  'results',
+  'thumbnailUrl',
+  'thumbnail_url',
+  'url',
+  'urls',
+  'video',
+  'videoUrl',
+  'video_url',
+] as const;
+
+const tryParseJson = (value: string) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const hasTerminalMediaOutput = (value: unknown, depth = 0): boolean => {
+  if (value == null || depth > 4) return false;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return false;
+    if (MEDIA_DATA_URL_RE.test(trimmed) || HTTP_URL_RE.test(trimmed)) return true;
+
+    const parsed = tryParseJson(trimmed);
+    return parsed ? hasTerminalMediaOutput(parsed, depth + 1) : false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasTerminalMediaOutput(item, depth + 1));
+  }
+
+  if (typeof value !== 'object') return false;
+
+  const record = value as Record<string, unknown>;
+  const kind = typeof record.kind === 'string' ? record.kind : undefined;
+
+  if (kind && MEDIA_KIND_RE.test(kind)) {
+    for (const key of MEDIA_OUTPUT_KEYS) {
+      if (hasTerminalMediaOutput(record[key], depth + 1)) return true;
+    }
+  }
+
+  for (const key of MEDIA_OUTPUT_KEYS) {
+    if (hasTerminalMediaOutput(record[key], depth + 1)) return true;
+  }
+
+  return false;
+};
+
+const isTerminalMediaToolName = (toolCall?: ChatToolPayload) => {
+  if (!toolCall) return false;
+
+  return TERMINAL_MEDIA_NAME_RE.test(
+    [toolCall.identifier, toolCall.apiName].filter(Boolean).join(' '),
+  );
+};
+
+export const shouldForceFinishAfterToolResult = ({
+  isSuccess,
+  result,
+  toolCall,
+}: {
+  isSuccess: boolean;
+  result: unknown;
+  toolCall?: ChatToolPayload;
+}) => {
+  if (!isSuccess || !toolCall) return false;
+  if (!isTerminalMediaToolName(toolCall)) return false;
+
+  return hasTerminalMediaOutput(result);
+};

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -160,6 +160,36 @@ describe('ChatService', () => {
       );
     });
 
+    it('should strip tools from the final llm call when forceFinish is true', async () => {
+      const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');
+      const messages = [{ content: 'Finalize this media result', role: 'user' }] as UIChatMessage[];
+      const mockTools = [
+        {
+          type: 'function' as const,
+          function: {
+            name: 'plugin1____api1',
+          },
+        },
+      ];
+
+      await chatService.createAssistantMessage({
+        messages,
+        forceFinish: true,
+        resolvedAgentConfig: createMockResolvedConfig({
+          plugins: ['plugin1'],
+          tools: mockTools,
+          enabledToolIds: ['plugin1'],
+        }),
+      });
+
+      expect(getChatCompletionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: undefined,
+        }),
+        expect.anything(),
+      );
+    });
+
     describe('extendParams functionality', () => {
       it('should add reasoning parameters when model supports enableReasoning and user enables it', async () => {
         const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -59,12 +59,13 @@ import { type FetchOptions } from './types';
 
 interface GetChatCompletionPayload extends Partial<Omit<ChatStreamPayload, 'messages'>> {
   agentId?: string;
-  groupId?: string;
-  messages: UIChatMessage[];
   /**
    * Pre-resolved agent config from AgentRuntime layer.
    * Required to ensure config consistency and proper isSubTask filtering.
    */
+  forceFinish?: boolean;
+  groupId?: string;
+  messages: UIChatMessage[];
   resolvedAgentConfig: ResolvedAgentConfig;
   topicId?: string;
 }
@@ -107,6 +108,7 @@ class ChatService {
       groupId,
       topicId,
       resolvedAgentConfig,
+      forceFinish,
       ...params
     }: GetChatCompletionPayload,
     options?: FetchOptions,
@@ -137,6 +139,10 @@ class ChatService {
       tools,
     } = resolvedAgentConfig;
 
+    const effectiveEnabledManifests = forceFinish ? [] : enabledManifests;
+    const effectiveEnabledToolIds = forceFinish ? [] : enabledToolIds;
+    const effectiveTools = forceFinish ? undefined : tools;
+
     // Get search config with agentId for agent-specific settings
     const searchConfig = getSearchConfig(payload.model, payload.provider!, targetAgentId);
 
@@ -152,7 +158,7 @@ class ChatService {
     // Check if Agent Builder tool is enabled and build context for it
     // Note: When Agent Builder is active, we need to get the context of the agent being edited,
     // which is stored in chatStore.activeAgentId, not the targetAgentId (which is the Agent Builder itself)
-    const isAgentBuilderEnabled = enabledToolIds.includes(AgentBuilderIdentifier);
+    const isAgentBuilderEnabled = effectiveEnabledToolIds.includes(AgentBuilderIdentifier);
     let agentBuilderContext;
 
     if (isAgentBuilderEnabled) {
@@ -250,7 +256,8 @@ class ChatService {
       // Page editor context from agent runtime
       initialContext: options?.initialContext,
       inputTemplate: chatConfig.inputTemplate,
-      manifests: enabledManifests,
+      forceFinish,
+      manifests: effectiveEnabledManifests,
       messages,
       model: payload.model,
       plugins,
@@ -258,7 +265,7 @@ class ChatService {
       sessionId: options?.trace?.sessionId,
       stepContext: options?.stepContext,
       systemRole: agentConfig.systemRole,
-      tools: enabledToolIds,
+      tools: effectiveEnabledToolIds,
       topicId,
       memoryContext: {
         effort: effectiveMemoryEffort,
@@ -281,7 +288,7 @@ class ChatService {
         messages: modelMessages,
         // Use the chatConfig from the target agent for streaming preference
         stream: chatConfig.enableStreaming !== false,
-        tools,
+        tools: effectiveTools,
       },
       { ...options, agentId: targetAgentId, topicId },
     );

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -56,6 +56,7 @@ interface ContextEngineeringContext {
   agentId?: string;
   enableHistoryCount?: boolean;
   enableUserMemories?: boolean;
+  forceFinish?: boolean;
   /** Group ID for multi-agent scenarios */
   groupId?: string;
   historyCount?: number;
@@ -98,6 +99,7 @@ export const contextEngineering = async ({
   inputTemplate,
   enableUserMemories,
   enableHistoryCount,
+  forceFinish,
   historyCount,
   historySummary,
   agentBuilderContext,
@@ -484,6 +486,8 @@ export const contextEngineering = async ({
 
     // File context configuration
     fileContext: { enabled: true, includeFileUrl: !isDesktop },
+
+    forceFinish,
 
     // Knowledge injection
     knowledge: {

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1584,4 +1584,36 @@ describe('call_llm executor', () => {
       expect(mockStore.optimisticCreateMessage).toHaveBeenCalled();
     });
   });
+
+  describe('Force Finish', () => {
+    it('should forward forceFinish to chatService.createAssistantMessageStream', async () => {
+      const mockStore = createMockStore();
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction({
+        model: 'gpt-4',
+        provider: 'openai',
+        messages: [createUserMessage({ content: 'Finalize this result' })],
+      });
+      const state = createInitialState({ forceFinish: true });
+
+      mockStreamResponse({ content: 'Done' });
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        state,
+        mockStore,
+        context,
+      });
+
+      expect(chatService.createAssistantMessageStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            forceFinish: true,
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-tool.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-tool.test.ts
@@ -2421,4 +2421,38 @@ describe('call_tool executor', () => {
       );
     });
   });
+
+  describe('Force Finish', () => {
+    it('should enable forceFinish after a successful terminal media tool result', async () => {
+      const mockStore = createMockStore({
+        internal_invokeDifferentTypePlugin: vi.fn().mockResolvedValue({
+          kind: 'edit_image',
+          result: 'https://example.com/generated/image.jpg',
+        }),
+      });
+      const context = createTestContext();
+
+      const assistantMessage = createAssistantMessage();
+      mockStore.dbMessagesMap[context.messageKey] = [assistantMessage];
+
+      const toolCall: ChatToolPayload = {
+        id: 'tool_media_1',
+        identifier: 'doubao_grok',
+        apiName: 'edit_image',
+        arguments: JSON.stringify({ prompt: 'make it anime' }),
+        type: 'mcp',
+      };
+
+      const result = await executeWithMockContext({
+        executor: 'call_tool',
+        instruction: createCallToolInstruction(toolCall),
+        state: createInitialState(),
+        mockStore,
+        context,
+      });
+
+      expect(result.newState.forceFinish).toBe(true);
+      expect(result.nextContext?.phase).toBe('tool_result');
+    });
+  });
 });

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -18,7 +18,11 @@ import type {
   TaskResultPayload,
   TasksBatchResultPayload,
 } from '@lobechat/agent-runtime';
-import { calculateMessageTokens, UsageCounter } from '@lobechat/agent-runtime';
+import {
+  calculateMessageTokens,
+  shouldForceFinishAfterToolResult,
+  UsageCounter,
+} from '@lobechat/agent-runtime';
 import { isDesktop } from '@lobechat/const';
 import type { ToolsEngine } from '@lobechat/context-engine';
 import { chainCompressContext } from '@lobechat/prompts';
@@ -388,6 +392,7 @@ export const createAgentExecutors = (context: {
           messages,
           model: llmPayload.model,
           provider: llmPayload.provider,
+          forceFinish: state.forceFinish,
           resolvedAgentConfig,
           topicId: topicId ?? undefined,
           ...agentConfigData.params,
@@ -850,6 +855,21 @@ export const createAgentExecutors = (context: {
 
         newState.usage = usage;
         if (cost) newState.cost = cost;
+
+        if (
+          shouldForceFinishAfterToolResult({
+            isSuccess,
+            result,
+            toolCall: chatToolPayload,
+          })
+        ) {
+          newState.forceFinish = true;
+          log(
+            '[%s][call_tool] Tool %s produced terminal media output, enabling forceFinish',
+            sessionLogId,
+            toolName,
+          );
+        }
 
         // Find current tool statistics
         const currentToolStats = usage.tools.byTool.find((t) => t.name === toolName);


### PR DESCRIPTION
﻿#### ?? Change Type

- [ ] ? feat
- [x] ?? fix
- [ ] ?? refactor
- [ ] ?? style
- [ ] ?? build
- [ ] ?? perf
- [ ] ? test
- [ ] ?? docs
- [ ] ?? chore

#### ?? Related Issue

Fixes #12822
Supersedes #12823

#### ?? Description of Change

This PR refreshes the closed fix from #12823 onto the latest `canary` branch.

It prevents the browser agent runtime from re-entering a tool-calling loop after a successful terminal media tool result.

What changed:

- add a shared `shouldForceFinishAfterToolResult` helper for successful terminal media tool outputs
- mark browser runtime state as `forceFinish` after a successful terminal media tool result
- strip tools from the next `call_llm` when `forceFinish` is active in `GeneralChatAgent`
- pass `forceFinish` through browser context engineering so the final step mirrors the existing server-side force-finish behavior
- add targeted tests for the helper, `GeneralChatAgent`, browser `call_tool`, browser `call_llm`, and `chatService`

#### ?? How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Targeted validation used locally:

- `packages/agent-runtime/src/utils/shouldForceFinishAfterToolResult.test.ts`
- `packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts`
- `src/store/chat/agents/__tests__/createAgentExecutors/call-tool.test.ts`
- `src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts`
- `src/services/chat/chat.test.ts`

#### ?? Screenshots / Videos

| Before | After |
| ------ | ----- |
| terminal media tool could re-enter `call_llm` with tools still enabled | terminal media tool flips `forceFinish`, strips tools, and finalizes as plain text |

#### ?? Additional Information

The previous PR #12823 was closed because it became outdated and conflicted with `main`. This PR reapplies the same fix and tests on top of the current `canary` branch.
