### PR TITLE
✨ feat(desktop): unify canary with stable app name/icon, add channel tag in About

### DIFF
--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -89,8 +89,8 @@ const protocolScheme = getProtocolScheme();
 
 // Determine icon file based on version type
 const getIconFileName = () => {
-  if (isStable) return 'Icon';
-  // nightly, canary share pre-release icon
+  if (isStable || isCanary) return 'Icon';
+  // nightly uses pre-release icon
   return 'Icon-nightly';
 };
 

--- a/apps/desktop/src/main/controllers/UpdaterCtr.ts
+++ b/apps/desktop/src/main/controllers/UpdaterCtr.ts
@@ -49,6 +49,16 @@ export default class UpdaterCtr extends ControllerModule {
     return this.app.storeManager.get('updateChannel') ?? 'stable';
   }
 
+  /**
+   * Get the build-time channel (stable, nightly, canary, beta).
+   * Used for display in About page to distinguish pre-release builds.
+   */
+  @IpcMethod()
+  async getBuildChannel(): Promise<string> {
+    const { BUILD_CHANNEL } = await import('@/modules/updater/configs');
+    return BUILD_CHANNEL;
+  }
+
   @IpcMethod()
   async setUpdateChannel(channel: UpdateChannel): Promise<void> {
     const validChannels = new Set(['stable', 'nightly', 'canary']);

--- a/apps/desktop/src/main/modules/updater/configs.ts
+++ b/apps/desktop/src/main/modules/updater/configs.ts
@@ -6,6 +6,8 @@ import { getDesktopEnv } from '@/env';
 // Build-time default channel, can be overridden at runtime via store
 const rawChannel = getDesktopEnv().UPDATE_CHANNEL || 'stable';
 const VALID_CHANNELS = new Set<UpdateChannel>(['stable', 'nightly', 'canary']);
+/** Raw build channel for display (stable, nightly, canary, beta) */
+export const BUILD_CHANNEL: string = rawChannel;
 export const UPDATE_CHANNEL: UpdateChannel = VALID_CHANNELS.has(rawChannel as UpdateChannel)
   ? (rawChannel as UpdateChannel)
   : rawChannel === 'beta'

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -697,6 +697,7 @@
   "tab.all": "全部",
   "tab.apikey": "API Key 管理",
   "tab.beta": "Beta",
+  "tab.beta.updateChannel.beta": "Beta",
   "tab.beta.updateChannel.canary": "Canary",
   "tab.beta.updateChannel.canaryDesc": "每次 PR 合并触发构建，一天可能多次。最不稳定。",
   "tab.beta.updateChannel.desc": "默认接收稳定版更新通知。Nightly 和 Canary 通道将接收预发布版本，可能不适合生产使用。",

--- a/scripts/electronWorkflow/setDesktopVersion.ts
+++ b/scripts/electronWorkflow/setDesktopVersion.ts
@@ -96,10 +96,9 @@ function updatePackageJson() {
         break;
       }
       case 'canary': {
-        packageJson.productName = 'LobeHub-Canary';
+        packageJson.productName = 'LobeHub';
         packageJson.name = 'lobehub-desktop-canary';
-        console.log('🐤 Setting as Canary version.');
-        updateAppIcon('nightly');
+        console.log('🐤 Setting as Canary version (same app name and icon as stable).');
         break;
       }
     }

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -797,6 +797,7 @@ When I am ___, I need ___
   'tab.advanced': 'Advanced',
   'tab.addAgentSkill': 'Add Agent Skill',
   'tab.beta': 'Beta',
+  'tab.beta.updateChannel.beta': 'Beta',
   'tab.beta.updateChannel.canary': 'Canary',
   'tab.beta.updateChannel.canaryDesc':
     'Triggered on every PR merge, multiple builds per day. Most unstable.',

--- a/src/routes/(main)/settings/about/features/Version.tsx
+++ b/src/routes/(main)/settings/about/features/Version.tsx
@@ -29,7 +29,7 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
     s.serverVersion,
     s.useCheckServerVersion,
   ]);
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(['common', 'setting']);
 
   useCheckServerVersion();
 
@@ -37,10 +37,16 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
   const isDesktop = useMemo(() => !!getElectronIpc(), []);
 
   const [updaterState, setUpdaterState] = useState<UpdaterState>({ stage: 'idle' });
+  const [buildChannel, setBuildChannel] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isDesktop) return;
     autoUpdateService.getUpdaterState().then(setUpdaterState);
+  }, [isDesktop]);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    autoUpdateService.getBuildChannel().then(setBuildChannel);
   }, [isDesktop]);
 
   useWatchBroadcast('updaterStateChanged', (state: UpdaterState) => {
@@ -128,6 +134,14 @@ const Version = memo<{ mobile?: boolean }>(({ mobile }) => {
           <div style={{ fontSize: 18, fontWeight: 'bolder' }}>{BRANDING_NAME}</div>
           <Flexbox gap={6} horizontal={!mobile}>
             <Tag>v{CURRENT_VERSION}</Tag>
+
+            {buildChannel && buildChannel !== 'stable' && (
+              <Tag color={'gold'}>
+                {t(`setting:tab.beta.updateChannel.${buildChannel}`, {
+                  defaultValue: buildChannel.charAt(0).toUpperCase() + buildChannel.slice(1),
+                })}
+              </Tag>
+            )}
             {showServerVersion && (
               <Tag>{t('upgradeVersion.serverVersion', { version: `v${serverVersion}` })}</Tag>
             )}

--- a/src/services/electron/autoUpdate.ts
+++ b/src/services/electron/autoUpdate.ts
@@ -23,6 +23,10 @@ class AutoUpdateService {
     return ensureElectronIpc().autoUpdate.getUpdateChannel();
   };
 
+  getBuildChannel = async (): Promise<string> => {
+    return ensureElectronIpc().autoUpdate.getBuildChannel();
+  };
+
   setUpdateChannel = async (channel: UpdateChannel): Promise<void> => {
     return ensureElectronIpc().autoUpdate.setUpdateChannel(channel);
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- None -->

#### 🔀 Description of Change

- **Canary builds** now use the same app name (LobeHub) and icon as stable, so they are visually indistinguishable from the outside
- **About page** in Settings now displays a channel tag (Canary, Nightly, Beta) next to the version number for non-stable builds, so users can still identify which channel they are running
- Added `getBuildChannel` IPC to expose the build-time channel for display

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Canary had different app name/icon | Canary uses same as stable; About shows "Canary" tag |

#### 📝 Additional Information

- Canary and stable can now coexist with identical appearance; users distinguish via Settings > About > channel tag

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Unify desktop Canary build branding with the stable app while exposing the build-time update channel for display in the Settings About page.

New Features:
- Expose the desktop build-time update channel over IPC and through the auto-update service for use in the renderer.
- Display a non-stable build channel tag next to the app version in the Settings About page.

Enhancements:
- Align Canary desktop builds to use the same app name and icon as the stable build.
- Add localization entries needed to label update channels, including Beta, in the settings UI.