### PR TITLE
🐛 fix(runtime): include tool state in AI model context for multi-step...

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -672,8 +672,14 @@ export const createRuntimeExecutors = (
 
       const newState = structuredClone(state);
 
+      // Append state to content so AI model can see resource IDs for multi-step workflows
+      let modelContent = executionResult.content;
+      if (executionResult.state && Object.keys(executionResult.state).length > 0) {
+        modelContent += `\n\n${JSON.stringify(executionResult.state)}`;
+      }
+
       newState.messages.push({
-        content: executionResult.content,
+        content: modelContent,
         role: 'tool',
         tool_call_id: chatToolPayload.id,
       });
@@ -993,7 +999,17 @@ export const createRuntimeExecutors = (
     // Use conversation-flow parse to resolve branching into linear flat list
     // parse() handles assistantGroup, compare, supervisor, etc. virtual message types
     const { flatList } = parse(latestMessages);
-    newState.messages = flatList;
+
+    // Append pluginState to content for tool messages so AI model can see resource IDs
+    newState.messages = flatList.map((msg) => {
+      if (msg.role === 'tool' && msg.pluginState && Object.keys(msg.pluginState).length > 0) {
+        return {
+          ...msg,
+          content: `${msg.content}\n\n${JSON.stringify(msg.pluginState)}`,
+        };
+      }
+      return msg;
+    });
 
     log(
       `[${operationLogId}][call_tools_batch] Refreshed ${newState.messages.length} messages from database`,


### PR DESCRIPTION
Fixes #12558

#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

This PR fixes an issue where tool return values (stored in `state`/`pluginState`) were saved to the database but not included in the AI model's message context. This caused multi-step workflows to fail when the AI needed to reference previously created resources (document IDs, plan IDs, etc.) in subsequent tool calls.

The fix appends the `pluginState` to the tool message `content` before adding it to the messages that are sent to the AI model. This ensures resource IDs are visible to the AI for subsequent operations.

**Changes made:**
1. In `call_tool` executor: Append `executionResult.state` to the content before pushing to `newState.messages`
2. In `call_tools_batch` executor: After refreshing messages from database, map over tool messages and append `pluginState` to their content

#### 🧪 How to Test

1. Ask AI to create a document: "Create a document titled 'Hello World' with content 'This is a test'"
2. Verify the document is created successfully
3. Ask AI to update the document: "Update the document you just created, change the title to 'Updated Title'"
4. **Expected**: AI should now know the document ID and successfully update it without asking for the ID

#### 📝 Additional Information

**Root cause**: The OpenAI Function Calling specification only includes `content` in tool messages sent to the model. LobeHub's internal `pluginState` field was saved to the database but not included in the model context.

**Solution**: Append the state as JSON to the content field for tool messages in the AI model context (not in database storage). This way:
- Users still see clean content in the frontend (database stores original content)
- AI model sees resource IDs in the context (messages sent to LLM include state)

**Diff stats:**
```
src/server/modules/AgentRuntime/RuntimeExecutors.ts | 20 ++++++++++++++++++--
 1 file changed, 18 insertions(+), 2 deletions(-)
```

## Summary by Sourcery

Ensure tool execution state is included in the AI model context for multi-step workflows so previously created resources can be referenced in subsequent tool calls.

Bug Fixes:
- Include execution state in single-tool call messages sent to the AI model to expose resource identifiers for later steps.
- Enhance batched tool call message reconstruction to append stored plugin state to tool message content for the AI model context.