### PR TITLE
🐛 fix: resolve ModelSelect crash and update default model

### DIFF
--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_MINI_MODEL = 'gpt-5-mini';
 
 export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -38,7 +38,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
     contextWindowTokens: 200_000,
     description: "Claude Sonnet 4.5 is Anthropic's most intelligent model to date.",
     displayName: 'Claude Sonnet 4.5',
-    enabled: true,
     id: 'claude-sonnet-4-5-20250929',
     maxOutput: 8192,
     pricing: {
@@ -158,7 +157,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
     description:
       "Claude Opus 4.5 is Anthropic's flagship model, combining excellent intelligence and scalable performance for the highest-quality reasoning tasks.",
     displayName: 'Claude Opus 4.5',
-    enabled: true,
     id: 'claude-opus-4-5-20251101',
     maxOutput: 64_000,
     pricing: {

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -128,7 +128,7 @@ const ModelSelect = memo<ModelSelectProps>(
             <ModelItemRender
               {...(option as ModelOption)}
               {...(option as ModelOption).abilities}
-              showInfoTag
+              showInfoTag={false}
             />
           )}
           style={{

--- a/src/services/aiModel/index.test.ts
+++ b/src/services/aiModel/index.test.ts
@@ -1,7 +1,30 @@
+import { DEFAULT_MINI_MODEL, DEFAULT_MODEL } from '@lobechat/const';
+import { LOBE_DEFAULT_MODEL_LIST } from 'model-bank';
+
 import { testService } from '~test-utils';
 
 import { AiModelService } from './index';
 
 describe('AiModelService', () => {
   testService(AiModelService);
+});
+
+describe('Default model configuration', () => {
+  it('DEFAULT_MODEL should be enabled in LOBE_DEFAULT_MODEL_LIST', () => {
+    const match = LOBE_DEFAULT_MODEL_LIST.find((m) => m.id === DEFAULT_MODEL);
+    expect(
+      match,
+      `DEFAULT_MODEL "${DEFAULT_MODEL}" not found in LOBE_DEFAULT_MODEL_LIST`,
+    ).toBeDefined();
+    expect(match!.enabled, `DEFAULT_MODEL "${DEFAULT_MODEL}" is not enabled`).toBe(true);
+  });
+
+  it('DEFAULT_MINI_MODEL should be enabled in LOBE_DEFAULT_MODEL_LIST', () => {
+    const match = LOBE_DEFAULT_MODEL_LIST.find((m) => m.id === DEFAULT_MINI_MODEL);
+    expect(
+      match,
+      `DEFAULT_MINI_MODEL "${DEFAULT_MINI_MODEL}" not found in LOBE_DEFAULT_MODEL_LIST`,
+    ).toBeDefined();
+    expect(match!.enabled, `DEFAULT_MINI_MODEL "${DEFAULT_MINI_MODEL}" is not enabled`).toBe(true);
+  });
 });

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -51,7 +51,7 @@ exports[`settingsSelectors > currentSettings > should merge DEFAULT_SETTINGS and
 exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AGENT_CONFIG and s.settings.systemAgent correctly 1`] = `
 {
   "agentMeta": {
-    "model": "claude-sonnet-4-5-20250929",
+    "model": "claude-sonnet-4-6",
     "provider": "anthropic",
   },
   "enableAutoReply": true,
@@ -60,7 +60,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
     "provider": "openai",
   },
   "historyCompress": {
-    "model": "claude-sonnet-4-5-20250929",
+    "model": "claude-sonnet-4-6",
     "provider": "anthropic",
   },
   "queryRewrite": {
@@ -70,7 +70,7 @@ exports[`settingsSelectors > currentSystemAgent > should merge DEFAULT_SYSTEM_AG
   },
   "replyMessage": "Custom auto reply",
   "thread": {
-    "model": "claude-sonnet-4-5-20250929",
+    "model": "claude-sonnet-4-6",
     "provider": "anthropic",
   },
   "topic": {
@@ -109,7 +109,7 @@ exports[`settingsSelectors > defaultAgent > should merge DEFAULT_AGENT and s.set
       "historyCount": 20,
       "reasoningBudgetToken": 1024,
       "searchFCModel": {
-        "model": "claude-sonnet-4-5-20250929",
+        "model": "claude-sonnet-4-6",
         "provider": "anthropic",
       },
       "searchMode": "auto",
@@ -154,7 +154,7 @@ exports[`settingsSelectors > defaultAgentConfig > should merge DEFAULT_AGENT_CON
     "historyCount": 20,
     "reasoningBudgetToken": 1024,
     "searchFCModel": {
-      "model": "claude-sonnet-4-5-20250929",
+      "model": "claude-sonnet-4-6",
       "provider": "anthropic",
     },
     "searchMode": "auto",


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 🔨 chore
- [x] ✅ test

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- **Fix ModelSelect crash**: Rendering `ModelInfoTags` (with `Tag`/`Tooltip` components) inside `@base-ui/react` Select popup triggers a `forkRef` ref cleanup infinite loop (`Maximum update depth exceeded`). Fixed by setting `showInfoTag={false}` in `optionRender`.
- **Update default model**: Change `DEFAULT_MODEL` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`. Remove `enabled` flag from legacy models (`claude-sonnet-4-5-20250929`, `claude-opus-4-5-20251101`) in lobehub provider.
- **Add guard test**: Verify that `DEFAULT_MODEL` and `DEFAULT_MINI_MODEL` are always present and enabled in `LOBE_DEFAULT_MODEL_LIST`, preventing future misconfigurations.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

1. Delete user account from database, re-login through onboarding
2. On the last onboarding step, click the model dropdown — should no longer crash
3. Run `bunx vitest run src/services/aiModel/index.test.ts` — all tests pass

## Summary by Sourcery

Update default AI model configuration and prevent model selection crashes in the UI.

Bug Fixes:
- Prevent ModelSelect dropdown from crashing by disabling info tag rendering within options.

Enhancements:
- Change the global DEFAULT_MODEL constant to use the new claude-sonnet-4-6 model and mark older Anthropic models as non-default by removing their enabled flags.

Tests:
- Add guard tests ensuring DEFAULT_MODEL and DEFAULT_MINI_MODEL are present and enabled in the default model list.