### PR TITLE
🐛 fix: filter out delisted lobehub provider models from DB residuals

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,6 +14,7 @@
     "test:server-db": "vitest run --config vitest.config.server.mts"
   },
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/const": "workspace:*",
     "@lobechat/conversation-flow": "workspace:*",
     "@lobechat/types": "workspace:*",

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -1,3 +1,4 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import type {
   AiProviderDetailItem,
   AiProviderListItem,
@@ -239,10 +240,12 @@ export class AiInfraRepos {
 
     const enabledProviderIds = new Set(enabledProviders.map((item) => item.id));
     // User database models, check search settings
+    // Exclude DB residual models for branding provider since they are already handled in builtinModelList
     const appendedUserModels = allModels
-      .filter((item) =>
-        filterEnabled ? enabledProviderIds.has(item.providerId) && item.enabled : true,
-      )
+      .filter((item) => {
+        if (item.providerId === BRANDING_PROVIDER) return false;
+        return filterEnabled ? enabledProviderIds.has(item.providerId) && item.enabled : true;
+      })
       .map((item) => injectSearchSettings(item.providerId, item));
 
     return [...builtinModelList.flat(), ...appendedUserModels].sort(
@@ -271,9 +274,7 @@ export class AiInfraRepos {
       return allModels.some((model) => model.providerId === provider.id && model.type === 'image');
     });
     const enabledVideoAiProviders = enabledAiProviders.filter((provider) => {
-      return allModels.some(
-        (model) => model.providerId === provider.id && model.type === 'video',
-      );
+      return allModels.some((model) => model.providerId === provider.id && model.type === 'video');
     });
 
     return {
@@ -400,7 +401,13 @@ export class AiInfraRepos {
     const defaultModels: AiProviderModelListItem[] =
       (await this.fetchBuiltinModels(providerId)) || [];
     // Not modifying search settings here doesn't affect usage, but done for data consistency on get
-    const mergedModel = mergeArrayById(defaultModels, aiModels) as AiProviderModelListItem[];
+    let mergedModel = mergeArrayById(defaultModels, aiModels) as AiProviderModelListItem[];
+
+    // Filter out DB residual models that are no longer in the builtin list for branding provider
+    if (providerId === BRANDING_PROVIDER) {
+      const builtinIds = new Set(defaultModels.map((m) => m.id));
+      mergedModel = mergedModel.filter((m) => builtinIds.has(m.id));
+    }
 
     let list = mergedModel.map((m) =>
       injectSearchSettings(providerId, m),

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -95,37 +95,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 200_000,
     description:
-      "Claude Sonnet 3.7 is Anthropic's most intelligent model and the first hybrid reasoning model on the market, supporting near-instant responses or extended thinking with fine-grained control.",
-    displayName: 'Claude Sonnet 3.7',
-    id: 'claude-3-7-sonnet-20250219',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    settings: {
-      extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',
     enabled: true,
@@ -273,36 +242,6 @@ export const anthropicChatModels: AIChatModelCard[] = [
     releasedAt: '2025-10-16',
     settings: {
       extendParams: ['disableContextCaching', 'enableReasoning', 'reasoningBudgetToken'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      vision: true,
-    },
-    contextWindowTokens: 200_000,
-    description:
-      "Claude 3.5 Haiku is Anthropic's fastest next-gen model, improving across skills and surpassing the previous flagship Claude 3 Opus on many benchmarks.",
-    displayName: 'Claude 3.5 Haiku',
-    id: 'claude-3-5-haiku-20241022',
-    maxOutput: 8192,
-    pricing: {
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 4, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1.6, '5m': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
-    releasedAt: '2024-11-05',
-    settings: {
-      extendParams: ['disableContextCaching'],
     },
     type: 'chat',
   },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When models are removed from the lobehub provider's builtin model-bank list, residual records in the `ai_models` DB table (from user toggle preferences) are still returned by the backend API. This causes delisted models to appear in the model list.

**Changes:**
- **`getAiProviderModelList`**: After merging builtin + DB models, filter out DB residual models not in the builtin list for the branding provider
- **`getEnabledModels`**: Exclude branding provider models from `appendedUserModels` since they are already handled via the builtin model path
- **Remove retired Anthropic models**: `claude-3-7-sonnet-20250219` and `claude-3-5-haiku-20241022` (both retired Feb 19, 2026)
- **Add `@lobechat/business-const` dependency** to database package for `BRANDING_PROVIDER` constant

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed