### PR TITLE
📝 docs: add catch error logging rule to TypeScript skill

### DIFF
--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -50,3 +50,4 @@ description: TypeScript code style and optimization guidelines. Use when writing
 - Never log user private information (API keys, etc.)
 - Don't use `import { log } from 'debug'` directly (logs to console)
 - Use `console.error` in catch blocks instead of debug package
+- Always log the error in `.catch()` callbacks — silent `.catch(() => fallback)` swallows failures and makes debugging impossible


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔀 Description of Change

Add a rule to the TypeScript skill guide: always log errors in `.catch()` callbacks instead of silently swallowing them. Silent catches make debugging impossible when failures occur in production.

## Summary by Sourcery

Documentation:
- Add guidance to always log errors in `.catch()` callbacks instead of using silent fallbacks.