### PR TITLE
🐛 fix: improve upstream sync workflow for forks

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,8 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Clean issue notice
+        if: ${{ github.event.repository.has_issues }}
         uses: actions-cool/issues-helper@v3
         with:
           actions: 'close-issues'
@@ -32,11 +35,12 @@ jobs:
           upstream_sync_repo: lobehub/lobehub
           upstream_sync_branch: main
           target_sync_branch: main
-          target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
+          # Use a PAT with workflow permission when syncing changes under .github/workflows.
+          target_repo_token: ${{ secrets.UPSTREAM_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
           test_mode: false
 
       - name: Sync check
-        if: failure()
+        if: ${{ failure() && github.event.repository.has_issues }}
         uses: actions-cool/issues-helper@v3
         with:
           actions: 'create-issue'


### PR DESCRIPTION
## Summary
- disable checkout credential persistence so fork sync can use the configured push token
- allow an optional `UPSTREAM_SYNC_TOKEN` for syncing workflow file changes in forks
- skip issue helper steps when issues are disabled on the fork

## Why
Forks that sync upstream workflow file changes can fail at push time because the persisted checkout credentials keep using the default GitHub Actions token, which cannot update workflow files. Forks with Issues disabled also fail in the notification steps.

## Testing
- triggered the workflow on the fork and verified the sync job completed successfully after these changes

## Summary by Sourcery

Improve the upstream sync GitHub Actions workflow to better support forks and repositories without issues.

Enhancements:
- Disable persisted checkout credentials so fork sync uses the configured push token instead of the default GitHub Actions token.
- Allow an optional UPSTREAM_SYNC_TOKEN secret for syncing workflow file changes that require elevated workflow permissions.
- Guard issue helper steps with repository issue availability checks to avoid failures on forks with issues disabled.