### PR TITLE
🐛 fix(model-runtime): Stabilize Responses API input ordering with async image handling

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -562,6 +562,48 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
+  it('should preserve input order when earlier messages include async image conversion', async () => {
+    const previousUseBase64 = process.env.LLM_VISION_IMAGE_USE_BASE64;
+
+    try {
+      process.env.LLM_VISION_IMAGE_USE_BASE64 = '1';
+      vi.mocked(parseDataUri).mockReturnValue({ type: 'url', base64: null, mimeType: null });
+      vi.mocked(imageUrlToBase64).mockImplementation(async (url: string) => {
+        if (url.includes('slow')) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+
+        return { base64: 'base64String', mimeType: 'image/jpeg' };
+      });
+
+      const messages: OpenAIChatMessage[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'First message' },
+            { type: 'image_url', image_url: { url: 'https://example.com/slow-image.jpg' } },
+          ],
+        },
+        { role: 'assistant', content: 'Second message' },
+      ];
+
+      const result = await convertOpenAIResponseInputs(messages);
+
+      expect(result).toEqual([
+        {
+          content: [
+            { text: 'First message', type: 'input_text' },
+            { image_url: 'data:image/jpeg;base64,base64String', type: 'input_image' },
+          ],
+          role: 'user',
+        },
+        { content: 'Second message', role: 'assistant' },
+      ]);
+    } finally {
+      process.env.LLM_VISION_IMAGE_USE_BASE64 = previousUseBase64;
+    }
+  });
+
   it('should extract reasoning.content into a separate reasoning item', async () => {
     const messages: OpenAIChatMessage[] = [
       { content: 'system prompts', role: 'system' },


### PR DESCRIPTION
#### 💻 Change Type
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

  Fixes lobehub/lobehub#12917

  #### 🔀 Description of Change

  - Build Responses API input as per-message item arrays, then flatten after Promise.all resolves.
  - Avoid non-deterministic ordering caused by async image handling completing out of order.
  - Keep final input ordering aligned with the original message/content sequence (text + images).

  #### 🧪 How to Test

  1. Use any model/provider path that sends requests via the Responses API.
  2. Send a single user message that includes both text and multiple images.
  3. Repeat a few times (and/or send messages quickly) to confirm images/text are no longer shuffled.
  4. (Optional) Inspect the request payload and verify input item ordering matches the message order.

  - [ ] Tested locally
  - [ ] Added/updated tests
  - [x] No tests needed

  #### 📸 Screenshots / Videos

  | Before | After |
  | ------ | ----- |
  | N/A    | N/A   |

  #### 📝 Additional Information

  - No UI changes.
  - No breaking changes expected; internal request-building only.

## Summary by Sourcery

Tests:
- Add regression test verifying message and content order is preserved when image URL-to-base64 conversion completes out of order.