### PR TITLE
✨ feat: preload bundled i18n resources and lazy-load target language

### DIFF
--- a/src/locales/create.ts
+++ b/src/locales/create.ts
@@ -17,7 +17,14 @@ import { unwrapESMModule } from '@/utils/esm/unwrapESMModule';
 
 import { loadI18nNamespaceModule } from '../utils/i18n/loadI18nNamespaceModule';
 
-const defaultResources = { chat, common, error };
+const createBundledResources = () => ({
+  chat: { ...chat },
+  common: { ...common },
+  error: { ...error },
+});
+
+const defaultResources = createBundledResources();
+const bundledNamespaces = Object.keys(defaultResources);
 
 const { I18N_DEBUG, I18N_DEBUG_BROWSER, I18N_DEBUG_SERVER } = getDebugConfig();
 const debugMode = (I18N_DEBUG ?? isOnServerSide) ? I18N_DEBUG_SERVER : I18N_DEBUG_BROWSER;
@@ -48,17 +55,29 @@ export const createI18nNext = (lang?: string) => {
   return {
     init: (params: { initAsync?: boolean } = {}) => {
       const { initAsync = true } = params;
+      const initialLang = normalizeLocale(lang);
+      const bundledLanguageResources =
+        initialLang === DEFAULT_LANG
+          ? {
+              [DEFAULT_LANG]: defaultResources,
+            }
+          : {
+              [DEFAULT_LANG]: defaultResources,
+              [initialLang]: createBundledResources(),
+            };
 
-      return instance.init({
+      const initPromise = instance.init({
         debug: debugMode,
         defaultNS: ['error', 'common', 'chat'],
         fallbackLng: DEFAULT_LANG,
-
         initAsync,
+        // Keep init synchronous so components can render with bundled en-US resources
+        // before the user's actual language finishes loading in the background.
+        ns: [],
 
         // Preload default language (en-US) synchronously to avoid Suspense on first render
         resources: {
-          [DEFAULT_LANG]: defaultResources,
+          ...bundledLanguageResources,
         },
         // Keep backend loading enabled for namespaces that are not preloaded above.
         partialBundledLanguages: true,
@@ -66,10 +85,24 @@ export const createI18nNext = (lang?: string) => {
         interpolation: {
           escapeValue: false,
         },
+        // Re-render components when new language resources are loaded from backend,
+        // so preloaded en-US fallback gets replaced by the user's actual language.
+        react: {
+          bindI18nStore: 'added',
+          useSuspense: false,
+        },
         keySeparator: false,
 
-        lng: lang,
+        lng: initialLang,
       });
+
+      if (initialLang !== DEFAULT_LANG) {
+        initPromise.then(() => {
+          void instance.reloadResources([initialLang], bundledNamespaces);
+        });
+      }
+
+      return initPromise;
     },
     instance,
   };

--- a/src/utils/i18n/createI18n.test.ts
+++ b/src/utils/i18n/createI18n.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+const loadI18nNamespaceModule = vi.fn(async ({ lng, ns }: { lng: string; ns: string }) => ({
+  default: {
+    key: `${lng}:${ns}`,
+  },
+}));
+
+vi.mock('./loadI18nNamespaceModule', () => ({
+  loadI18nNamespaceModule,
+}));
+
+describe('createI18nNext', () => {
+  it('initializes synchronously with bundled fallback resources and reloads the actual language in background', async () => {
+    const { createI18nNext } = await import('@/locales/create');
+
+    const i18n = createI18nNext('zh-CN');
+    const reloadSpy = vi.spyOn(i18n.instance, 'reloadResources');
+    const initPromise = i18n.init({ initAsync: false });
+
+    expect(i18n.instance.isInitialized).toBe(true);
+    expect(i18n.instance.getResource('zh-CN', 'common', 'copy')).toBeDefined();
+
+    await initPromise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(i18n.instance.hasResourceBundle('zh-CN', 'common')).toBe(true);
+    expect(i18n.instance.hasResourceBundle('zh-CN', 'chat')).toBe(true);
+    expect(i18n.instance.hasResourceBundle('zh-CN', 'error')).toBe(true);
+
+    expect(reloadSpy).toHaveBeenCalledWith(['zh-CN'], ['chat', 'common', 'error']);
+    expect(loadI18nNamespaceModule).toHaveBeenCalledWith(
+      expect.objectContaining({ lng: 'zh-CN', ns: 'common' }),
+    );
+    expect(loadI18nNamespaceModule).toHaveBeenCalledWith(
+      expect.objectContaining({ lng: 'zh-CN', ns: 'chat' }),
+    );
+    expect(loadI18nNamespaceModule).toHaveBeenCalledWith(
+      expect.objectContaining({ lng: 'zh-CN', ns: 'error' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Preload bundled en-US resources synchronously to avoid Suspense on first render
- For non-default languages, also bundle a shallow copy as immediate fallback, then reload actual translations from backend in background
- Add `react.bindI18nStore: 'added'` and `useSuspense: false` so components re-render when backend resources arrive

## Test plan
- [x] Added unit test verifying sync init + background reload behavior (`createI18n.test.ts`)
- [ ] Verify non-en-US language loads correctly in browser (fallback text briefly visible, then replaced)
- [ ] Confirm en-US users see no behavior change

## Summary by Sourcery

Preload bundled i18n resources for the default language and a shallow copy for the target language, then reload the target language from the backend in the background while ensuring React components re-render when translations arrive.

New Features:
- Support synchronous i18n initialization using bundled resources as an immediate fallback for both default and non-default languages.

Enhancements:
- Trigger background reload of full translation resources for non-default languages after initial synchronous setup.
- Configure React i18n integration to avoid Suspense and re-render components when backend language resources are added.

Tests:
- Add a unit test verifying synchronous initialization with bundled fallback resources and background reload of the actual language namespaces.