### PR TITLE
✨ feat: support batch topic deletion from file

### DIFF
--- a/apps/cli/src/commands/topic.ts
+++ b/apps/cli/src/commands/topic.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import type { Command } from 'commander';
 import pc from 'picocolors';
 
@@ -134,12 +136,46 @@ export function registerTopicCommand(program: Command) {
   // ── delete ────────────────────────────────────────────
 
   topic
-    .command('delete <ids...>')
-    .description('Delete one or more topics')
+    .command('delete [ids...]')
+    .description('Delete one or more topics (pass IDs as args or via --file)')
+    .option('-f, --file <path>', 'Read topic IDs from a file (one per line, or a JSON array)')
     .option('--yes', 'Skip confirmation prompt')
-    .action(async (ids: string[], options: { yes?: boolean }) => {
+    .action(async (ids: string[], options: { file?: string; yes?: boolean }) => {
+      let allIds = [...ids];
+
+      if (options.file) {
+        const content = fs.readFileSync(options.file, 'utf8').trim();
+        let fileIds: string[];
+        try {
+          const parsed = JSON.parse(content);
+          if (Array.isArray(parsed)) {
+            fileIds = parsed.map(String).filter(Boolean);
+          } else {
+            log.error('JSON file must contain an array of topic IDs.');
+            process.exit(1);
+          }
+        } catch {
+          // Not JSON, treat as one ID per line
+          fileIds = content
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean);
+        }
+        allIds = [...allIds, ...fileIds];
+      }
+
+      if (allIds.length === 0) {
+        log.error('No topic IDs provided. Pass IDs as arguments or use --file.');
+        process.exit(1);
+      }
+
+      // Deduplicate
+      allIds = [...new Set(allIds)];
+
       if (!options.yes) {
-        const confirmed = await confirm(`Are you sure you want to delete ${ids.length} topic(s)?`);
+        const confirmed = await confirm(
+          `Are you sure you want to delete ${allIds.length} topic(s)?`,
+        );
         if (!confirmed) {
           console.log('Cancelled.');
           return;
@@ -148,13 +184,13 @@ export function registerTopicCommand(program: Command) {
 
       const client = await getTrpcClient();
 
-      if (ids.length === 1) {
-        await client.topic.removeTopic.mutate({ id: ids[0] });
+      if (allIds.length === 1) {
+        await client.topic.removeTopic.mutate({ id: allIds[0] });
       } else {
-        await client.topic.batchDelete.mutate({ ids });
+        await client.topic.batchDelete.mutate({ ids: allIds });
       }
 
-      console.log(`${pc.green('✓')} Deleted ${ids.length} topic(s)`);
+      console.log(`${pc.green('✓')} Deleted ${allIds.length} topic(s)`);
     });
 
   // ── clone ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `--file` (`-f`) option to `lh topic delete` command for bulk deletion
- Supports two file formats: plain text (one ID per line) and JSON array
- Auto-deduplicates IDs from both file and CLI arguments

## Usage

```bash
# From plain text file (one ID per line)
lh topic delete --file ids.txt --yes

# From JSON array file
lh topic delete --file ids.json --yes

# Mix file + CLI args
lh topic delete id1 id2 --file more-ids.txt
```

## Test plan
- [ ] Verify `--file` with plain text file (one ID per line)
- [ ] Verify `--file` with JSON array file
- [ ] Verify mixed usage (file + CLI args)
- [ ] Verify deduplication works
- [ ] Verify error when no IDs provided and no file given
- [ ] Verify error when JSON file is not an array

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support deleting topics from CLI by accepting IDs via arguments or an optional file input and apply unified validation and deduplication before batch deletion.

New Features:
- Allow the topic delete command to read topic IDs from a file in either newline-delimited or JSON array format.

Enhancements:
- Make topic deletion accept optional IDs, aggregating and deduplicating IDs from both CLI arguments and file input before executing single or batch deletion, and improve validation and messaging when no IDs are provided or the JSON file shape is invalid.