### PR TITLE
style: add MiniMax M2.5 Highspeed model and fix Lightning input price

### DIFF
--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -31,6 +31,28 @@ const minimaxChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 204_800,
+    description: 'M2.5 Highspeed: Same performance, faster and more agile (approx. 100 tps).',
+    displayName: 'MiniMax M2.5 Highspeed',
+    id: 'MiniMax-M2.5-highspeed',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-12',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 204_800,
     description: 'M2.5 Lightning: Same performance, faster and more agile (approx. 100 tps).',
     displayName: 'MiniMax M2.5 Lightning',
     id: 'MiniMax-M2.5-Lightning',
@@ -40,7 +62,7 @@ const minimaxChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

MiniMax 官网文档已经找不到 Lightning 了，只有 MiniMax-M2.5-highspeed 了。
另外测试了 MiniMax-M2.5-Lightning，现在实际跟 MiniMax-M2.5-highspeed 是一个价格，输入是按普通版(50TPS)的两倍算的。不再是普通版的价格了。

- https://platform.minimaxi.com/docs/guides/pricing-paygo
- https://platform.minimax.io/docs/guides/pricing-paygo

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add a new MiniMax M2.5 Highspeed chat model and align MiniMax M2.5 Lightning pricing with current MiniMax rates.

New Features:
- Add the MiniMax M2.5 Highspeed chat model with its capabilities and pricing metadata.

Bug Fixes:
- Update MiniMax M2.5 Lightning text input pricing to reflect the latest MiniMax pay-as-you-go rates.