### PR TITLE
🐛 fix: select first provider on click for multi-provider model items

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -75,7 +75,11 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
             if (allRestricted) {
               onRestrictedModelClick?.();
               onClose();
+              return;
             }
+            setSubmenuOpen(false);
+            onModelChange(data.model.id, data.providers[0].id);
+            onClose();
           }}
         >
           <ModelItemRender


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

When a model has multiple providers and the user is in **group-by-model** mode, clicking the model item now directly selects the **first provider** instead of requiring a second click to open the provider submenu and select from it.

This applies in both dev mode and non-dev mode — the submenu is still accessible via hover for users who want to pick a specific provider.

#### 🧪 How to Test

1. Enable at least one model that has multiple providers (e.g. configured under different provider accounts)
2. Open the Model Switch Panel in group-by-model mode
3. Click a model with multiple providers — it should immediately switch to that model using the first provider without needing to open the submenu

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

## Summary by Sourcery

Bug Fixes:
- Fix model list items with multiple providers requiring an extra click by automatically selecting the first provider on item click.