### PR TITLE
🐛 fix(ci): create stable update manifests for S3 publish

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -83,7 +83,21 @@ runs:
           fi
         done
 
-        # 2. 为所有 yml manifest 的 URL 加版本目录前缀
+        # 2. stable 渠道补充 stable*.yml
+        # electron-builder 对稳定版默认生成 latest*.yml
+        echo ""
+        if [ "$CHANNEL" = "stable" ]; then
+          echo "📋 Creating stable*.yml from latest*.yml..."
+          for yml in release/latest*.yml; do
+            if [ -f "$yml" ]; then
+              stable_yml=$(basename "$yml" | sed 's/^latest/stable/')
+              cp "$yml" "release/$stable_yml"
+              echo "   📄 Created $stable_yml from $(basename "$yml")"
+            fi
+          done
+        fi
+
+        # 3. 为所有 yml manifest 的 URL 加版本目录前缀
         # merge-mac-files 步骤已生成 {channel}*.yml (如 canary-mac.yml)
         # 安装包在 s3://$BUCKET/$CHANNEL/$VERSION/ 下，URL 需加 $VERSION/ 前缀
         echo ""
@@ -95,7 +109,7 @@ runs:
           fi
         done
 
-        # 3. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
+        # 4. 创建 renderer manifest (仅 stable 渠道有 renderer tar)
         RENDERER_TAR="release/lobehub-renderer.tar.gz"
         if [ -f "$RENDERER_TAR" ]; then
           echo ""
@@ -116,7 +130,7 @@ runs:
           echo "   📄 Created ${CHANNEL}-renderer.yml"
         fi
 
-        # 4. 上传 manifest 到根目录和版本目录
+        # 5. 上传 manifest 到根目录和版本目录
         # 根目录: electron-updater 需要，每次发版覆盖
         # 版本目录: 作为存档保留
         echo ""


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- create `stable*.yml` from `latest*.yml` during stable desktop S3 publishing
- keep canary and nightly behavior unchanged
- preserve the existing version-prefixed manifest URLs used for archived assets

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated the release shell flow locally by simulating stable manifest generation and confirming `stable.yml` and `stable-mac.yml` are created with version-prefixed URLs.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This is a hotfix for stable desktop release publishing to S3. Electron Builder emits `latest*.yml` for stable releases by default, while our update server expects `stable*.yml` under the `stable/` channel path.

## Summary by Sourcery

Ensure stable desktop releases published to S3 include correctly named update manifests for the stable channel.

Bug Fixes:
- Generate stable*.yml manifests from latest*.yml during stable channel S3 publishing so the update server can resolve stable update metadata correctly.

CI:
- Adjust desktop S3 publish GitHub Action to create stable*.yml manifests before URL rewriting and upload, keeping canary and nightly behavior unchanged.