### PR TITLE
💄 style: update claude 4.6 series 1M contextWindow

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -806,7 +806,7 @@ const aihubmixModels: AIChatModelCard[] = [
       structuredOutput: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description:
       'Claude Opus 4.6 is Anthropic’s most intelligent model for building agents and coding.',
     displayName: 'Claude Opus 4.6',
@@ -943,7 +943,7 @@ const aihubmixModels: AIChatModelCard[] = [
       structuredOutput: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description: 'Claude Sonnet 4.6 is Anthropic’s best combination of speed and intelligence.',
     displayName: 'Claude Sonnet 4.6',
     enabled: true,

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -9,7 +9,7 @@ const anthropicChatModels: AIChatModelCard[] = [
       structuredOutput: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description:
       'Claude Opus 4.6 is Anthropic’s most intelligent model for building agents and coding.',
     displayName: 'Claude Opus 4.6',
@@ -44,7 +44,7 @@ const anthropicChatModels: AIChatModelCard[] = [
       structuredOutput: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description: 'Claude Sonnet 4.6 is Anthropic’s best combination of speed and intelligence.',
     displayName: 'Claude Sonnet 4.6',
     enabled: true,

--- a/packages/model-bank/src/aiModels/bedrock.ts
+++ b/packages/model-bank/src/aiModels/bedrock.ts
@@ -9,7 +9,7 @@ const bedrockChatModels: AIChatModelCard[] = [
       structuredOutput: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description:
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',
@@ -32,6 +32,46 @@ const bedrockChatModels: AIChatModelCard[] = [
     releasedAt: '2026-02-05',
     settings: {
       extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'effort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description: 'Claude Sonnet 4.6 is Anthropic’s best combination of speed and intelligence.',
+    displayName: 'Claude Sonnet 4.6',
+    enabled: true,
+    id: 'us.anthropic.claude-sonnet-4-6',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 6, '5m': 3.75 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-02-17',
+    settings: {
+      extendParams: [
+        'disableContextCaching',
+        'enableAdaptiveThinking',
+        'enableReasoning',
+        'reasoningBudgetToken',
+        'effort',
+      ],
+      searchImpl: 'params',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/bedrock.ts
+++ b/packages/model-bank/src/aiModels/bedrock.ts
@@ -5,7 +5,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },
@@ -14,7 +13,7 @@ const bedrockChatModels: AIChatModelCard[] = [
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',
     enabled: true,
-    id: 'us.anthropic.claude-opus-4-6-v1',
+    id: 'global.anthropic.claude-opus-4-6-v1',
     maxOutput: 128_000,
     pricing: {
       units: [
@@ -39,7 +38,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },
@@ -47,7 +45,7 @@ const bedrockChatModels: AIChatModelCard[] = [
     description: 'Claude Sonnet 4.6 is Anthropic’s best combination of speed and intelligence.',
     displayName: 'Claude Sonnet 4.6',
     enabled: true,
-    id: 'us.anthropic.claude-sonnet-4-6',
+    id: 'global.anthropic.claude-sonnet-4-6',
     maxOutput: 64_000,
     pricing: {
       units: [
@@ -71,7 +69,6 @@ const bedrockChatModels: AIChatModelCard[] = [
         'reasoningBudgetToken',
         'effort',
       ],
-      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -79,7 +76,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },
@@ -87,7 +83,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     description:
       "Claude Opus 4.5 is Anthropic's flagship model, combining exceptional intelligence and scalable performance for complex tasks requiring the highest-quality responses and reasoning.",
     displayName: 'Claude Opus 4.5',
-    enabled: true,
     id: 'global.anthropic.claude-opus-4-5-20251101-v1:0',
     maxOutput: 64_000,
     pricing: {
@@ -107,15 +102,13 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 200_000,
     description: "Claude Sonnet 4.5 is Anthropic's most intelligent model to date.",
     displayName: 'Claude Sonnet 4.5',
-    enabled: true,
-    id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    id: 'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
     maxOutput: 64_000,
     pricing: {
       units: [
@@ -133,7 +126,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },
@@ -142,7 +134,7 @@ const bedrockChatModels: AIChatModelCard[] = [
       "Claude Haiku 4.5 is Anthropic's fastest and most intelligent Haiku model, with lightning speed and extended thinking.",
     displayName: 'Claude Haiku 4.5',
     enabled: true,
-    id: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    id: 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
     maxOutput: 64_000,
     pricing: {
       units: [
@@ -181,7 +173,6 @@ const bedrockChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
-      search: true,
       structuredOutput: true,
       vision: true,
     },

--- a/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/anthropic.ts
@@ -8,7 +8,7 @@ export const anthropicChatModels: AIChatModelCard[] = [
       search: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description: "Claude Sonnet 4.6 is Anthropic's best combination of speed and intelligence.",
     displayName: 'Claude Sonnet 4.6',
     enabled: true,
@@ -93,7 +93,7 @@ export const anthropicChatModels: AIChatModelCard[] = [
       search: true,
       vision: true,
     },
-    contextWindowTokens: 200_000,
+    contextWindowTokens: 1_000_000,
     description:
       "Claude Opus 4.6 is Anthropic's most intelligent model for building agents and coding.",
     displayName: 'Claude Opus 4.6',

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -609,7 +609,7 @@ describe('LobeBedrockAI', () => {
             accept: 'application/json',
             body: JSON.stringify({
               anthropic_version: 'bedrock-2023-05-31',
-              max_tokens: 64_000,
+              max_tokens: 8192,
               messages: [
                 {
                   content: [


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 更新 Claude 4.6 系列 1M 上下文窗口
<img width="885" height="794" alt="image" src="https://github.com/user-attachments/assets/4a6f8450-79a2-40d5-bd20-f6574fad7ac8" />

ref: https://x.com/claudeai/status/2032509548297343196
ref: https://claude.com/blog/1m-context-ga
ref: https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Update Anthropic Claude 4.6 model definitions to reflect the new 1M token context window across providers and add the Bedrock Claude Sonnet 4.6 variant.

New Features:
- Add the Claude Sonnet 4.6 chat model configuration for the Bedrock provider.

Enhancements:
- Increase the configured context window for Claude Opus 4.6 and Claude Sonnet 4.6 models from 200k to 1M tokens across Anthropic, Bedrock, AIHubMix, and LobeHub integrations.