### PR TITLE
🐛 fix: load PDF.js worker from local assets via Vite ?url import

### DIFF
--- a/src/libs/pdfjs/index.tsx
+++ b/src/libs/pdfjs/index.tsx
@@ -4,19 +4,16 @@ import { type ComponentProps } from 'react';
 import { type Page as PdfPage } from 'react-pdf';
 import { Document as PdfDocument, pdfjs } from 'react-pdf';
 
-const workerSrc = `https://registry.npmmirror.com/pdfjs-dist/${pdfjs.version}/files/build/pdf.worker.min.mjs`;
+// Use Vite's ?url import to get the correct hashed asset path (e.g. /spa/assets/pdf.worker-xxx.mjs)
+// This overrides react-pdf's auto-detected bare filename which breaks under SPA routing.
+import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
-function ensureWorker() {
-  if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
-  }
-}
+pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
 
 export type DocumentProps = ComponentProps<typeof PdfDocument>;
 export type PageProps = ComponentProps<typeof PdfPage>;
 
 export const Document = (props: DocumentProps) => {
-  ensureWorker();
   return <PdfDocument {...props} />;
 };
 

--- a/src/vite.d.ts
+++ b/src/vite.d.ts
@@ -1,3 +1,8 @@
 import 'vite/client';
 
+declare module 'pdfjs-dist/build/pdf.worker.min.mjs?url' {
+  const url: string;
+  export default url;
+}
+
 export {};


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Related to PDF viewer worker loading failures in SPA routing context.

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

`react-pdf` auto-detects and sets `pdfjs.GlobalWorkerOptions.workerSrc` to a bare filename `pdf.worker.mjs` at import time. The existing `ensureWorker()` guard (`if (!workerSrc)`) never overrides it because it's already set.

In the SPA, this bare filename resolves relative to the current page URL — e.g. when viewing a PDF on `/agent/xxx`, the browser requests `/agent/pdf.worker.mjs` which returns 404 since it's not a real static file.

This PR replaces the conditional workerSrc assignment with Vite's `?url` import:

```ts
import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
```

Vite copies the worker file into the SPA assets directory at build time and returns the correct hashed path (e.g. /spa/assets/pdf.worker.min-abc123.mjs), which works regardless of the current page route.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

N/A — no UI changes, only fixes worker file resolution path.


#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Ensure the PDF.js worker is always loaded from a Vite-managed local asset URL instead of a route-dependent or CDN-based path to fix worker loading failures in the SPA.

Bug Fixes:
- Force pdfjs GlobalWorkerOptions.workerSrc to use a Vite ?url-imported worker asset so PDF rendering works reliably across SPA routes.

Enhancements:
- Add a Vite type declaration for the pdf.js worker ?url import to maintain proper TypeScript support.