### PR TITLE
🐛 fix: return structured error from invokeBuiltinTool instead of undefined

### DIFF
--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -817,6 +817,28 @@ export const createAgentExecutors = (context: {
         context.get().completeOperation(executeToolOpId);
 
         const executionTime = Math.round(performance.now() - startTime);
+
+        // Fallback for undefined result (e.g. tool executor not found or returned nothing)
+        if (result === undefined || result === null) {
+          const fallbackResult = {
+            content: `Tool ${toolName} execution failed: no result returned`,
+            error: { type: 'ToolExecutionError', message: 'Tool returned no result' },
+            success: false,
+          };
+
+          if (toolOperationId) {
+            context.get().failOperation(toolOperationId, {
+              message: 'Tool returned no result',
+              type: 'ToolExecutionError',
+            });
+          }
+
+          events.push({ id: chatToolPayload.id, result: fallbackResult, type: 'tool_result' });
+
+          const updatedMessages = context.get().dbMessagesMap[context.messageKey] || [];
+          return { events, newState: { ...state, messages: updatedMessages } };
+        }
+
         const isSuccess = result && !result.error;
 
         log(

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -178,7 +178,11 @@ export class PluginTypesActionImpl {
     console.error(
       `[invokeBuiltinTool] No executor found for: ${payload.identifier}/${payload.apiName}`,
     );
-    return;
+    return {
+      content: `Tool ${payload.identifier}/${payload.apiName} is not available`,
+      error: { type: 'ToolNotFound', message: 'No executor found' },
+      success: false,
+    };
   };
 
   invokeDefaultTypePlugin = async (id: string, payload: any): Promise<string | undefined> => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-5318

#### 🔀 Description of Change

When `invokeBuiltinTool` cannot find a registered executor for a tool, it previously returned `undefined` silently, causing the `call_tool` executor to mark the operation as failed with no meaningful error message, and the agent loop to terminate abnormally.

**Changes:**
1. **`pluginTypes.ts`**: `invokeBuiltinTool` now returns a structured error object `{ content, error, success: false }` instead of `undefined`
2. **`createAgentExecutors.ts`**: `call_tool` executor adds a fallback for `undefined`/`null` results, generating a meaningful error result so the agent loop can continue and the LLM can adjust its strategy

#### 🧪 How to Test

- [x] No tests needed

#### 📝 Additional Information

This is a defensive fix. Fix 1 addresses the root cause (structured error return), and Fix 2 adds a safety net in `call_tool` for any other plugin type that might also return `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure built-in tool invocations always yield structured results instead of silent undefined values, allowing the agent loop to handle tool failures gracefully.

Bug Fixes:
- Return a structured error result when no executor is found for a built-in tool instead of returning undefined.
- Add a fallback in the call_tool executor to convert undefined or null tool results into a meaningful error result so the agent loop can continue.