### PR TITLE
✨ feat: improve agent context injection (skills discovery, device optimization, prompt cleanup)

### DIFF
--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -1,9 +1,20 @@
 export const systemPrompt = `You have a Local System tool with capabilities to interact with the user's local system. You can list directories, read file contents, search for files, move, and rename files/directories.
 
 <user_context>
-<device name="{{hostname}}" os="{{platform}}" arch="{{arch}}" />
-<working-directory>{{workingDirectory}}</working-directory>
-<home-path>{{homePath}}</home-path>
+**Current Working Directory:** {{workingDirectory}}
+All relative paths and file operations should be based on this directory unless the user specifies otherwise.
+
+**Known Locations & System Details:**
+Here are some known locations and system details on the user's system. User is using the Operating System: {{platform}}({{arch}}).
+Use these paths when the user refers to these common locations by name (e.g., "my desktop", "downloads folder").
+- Desktop: {{desktopPath}}
+- Documents: {{documentsPath}}
+- Downloads: {{downloadsPath}}
+- Music: {{musicPath}}
+- Pictures: {{picturesPath}}
+- Videos: {{videosPath}}
+- User Home: {{homePath}}
+- App Data: {{userDataPath}} (Use this primarily for plugin-related data or configurations if needed, less for general user files)
 </user_context>
 
 <core_capabilities>

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -100,35 +100,4 @@ You have access to a set of tools to interact with the user's local file system:
     - 'path' (Optional): Directory to search in.
     Returns files sorted by modification time (most recent first).
 </tool_usage_guidelines>
-
-<security_considerations>
-- Always confirm with the user before performing write operations, especially if it involves overwriting existing files.
-- Confirm with the user before moving files to significantly different locations or when renaming might cause confusion or potential data loss if the target exists (though the tool should handle this).
-- Do not attempt to access files outside the user's designated workspace or allowed directories unless explicitly permitted.
-- Handle file paths carefully to avoid unintended access or errors.
-- When running shell commands:
-    - Never execute commands that could harm the system or delete important data without explicit user confirmation.
-    - Be cautious with commands that have side effects (e.g., rm, sudo, format).
-    - Always describe what a command will do before running it, especially for non-trivial operations.
-    - Always provide a clear 'description' parameter in the user's language to help them understand what the command does.
-    - Use appropriate timeouts to prevent commands from running indefinitely.
-- When editing files:
-    - Always read the file first to verify its current content.
-    - Ensure old_string exactly matches the text to be replaced to avoid unintended changes.
-    - Be cautious when using replace_all option.
-</security_considerations>
-
-<response_format>
-- When listing files or returning search results that include file or directory paths, **always** use the \`<localFile ... />\` tag format. **Any reference to a local file or directory path in your response MUST be enclosed within this tag structure.** Do not output raw file paths outside of this tag structure.
-- For a file, use: \`<localFile name="[Filename]" path="[Full Unencoded Path]" />\`. Example: \`<localFile name="report.pdf" path="/Users/me/Documents/report.pdf" />\`
-- For a directory, use: \`<localFile name="[Directory Name]" path="[Full Unencoded Path]" isDirectory />\`. Example: \`<localFile name="Documents" path="/Users/me/Documents" isDirectory />\`
-- Ensure the \`path\` attribute contains the full, raw, unencoded path.
-- Ensure the \`name\` attribute contains the display name (usually the filename or directory name).
-- Include the \`isDirectory\` attribute **only** for directories.
-- When listing files, provide a clear list using the tag format.
-- When reading files, present the content accurately. **If you mention the file path being read, use the \`<localFile>\` tag.**
-- When searching files, return a list of matching files using the tag format.
-- When confirming a rename or move operation, use the \`<localFile>\` tag for both the old and new paths mentioned. Example: \`Successfully renamed <localFile name="oldName.txt" /> to <localFile name="newName.txt" path="/path/to/newName.txt" />.\`
-- When writing files, confirm the success or failure. **If you mention the file path written to, use the \`<localFile>\` tag.**
-</response_format>
 `;

--- a/packages/builtin-tool-remote-device/package.json
+++ b/packages/builtin-tool-remote-device/package.json
@@ -6,6 +6,9 @@
     ".": "./src/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/prompts": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   }

--- a/packages/builtin-tool-remote-device/src/systemRole.ts
+++ b/packages/builtin-tool-remote-device/src/systemRole.ts
@@ -1,16 +1,18 @@
+import { onlineDevicesPrompt } from '@lobechat/prompts';
+
 import { type DeviceAttachment } from './ExecutionRuntime/types';
 
 export const generateSystemPrompt = (devices?: DeviceAttachment[]): string => {
   const onlineDevices = devices?.filter((d) => d.online) ?? [];
 
-  const deviceSection =
-    onlineDevices.length > 0
-      ? `<online-devices>
-${onlineDevices.map((d) => `  <device id="${d.deviceId}" name="${d.hostname}" os="${d.platform}" last-seen="${d.lastSeen}" />`).join('\n')}
-</online-devices>`
-      : `<online-devices>
-  No devices are currently online.
-</online-devices>`;
+  const deviceSection = onlineDevicesPrompt(
+    onlineDevices.map((d) => ({
+      id: d.deviceId,
+      lastSeen: d.lastSeen,
+      name: d.hostname,
+      os: d.platform,
+    })),
+  );
 
   return `You have a Remote Device Management tool that allows you to discover and connect to the user's desktop devices.
 

--- a/packages/builtin-tool-remote-device/src/systemRole.ts
+++ b/packages/builtin-tool-remote-device/src/systemRole.ts
@@ -6,10 +6,10 @@ export const generateSystemPrompt = (devices?: DeviceAttachment[]): string => {
   const deviceSection =
     onlineDevices.length > 0
       ? `<online-devices>
-${onlineDevices.map((d) => `- **${d.hostname}** (${d.platform}) — ID: \`${d.deviceId}\``).join('\n')}
+${onlineDevices.map((d) => `  <device id="${d.deviceId}" name="${d.hostname}" os="${d.platform}" last-seen="${d.lastSeen}" />`).join('\n')}
 </online-devices>`
       : `<online-devices>
-No devices are currently online.
+  No devices are currently online.
 </online-devices>`;
 
   return `You have a Remote Device Management tool that allows you to discover and connect to the user's desktop devices.

--- a/packages/openapi/src/services/responses.service.ts
+++ b/packages/openapi/src/services/responses.service.ts
@@ -22,7 +22,7 @@ import type {
  * Response API Service
  * Handles OpenResponses protocol request execution via AiAgentService.execAgent
  *
- * The `model` field is treated as an agent slug.
+ * The `model` field is treated as an agent ID.
  * Execution is delegated to execAgent (background mode),
  * with executeSync used when synchronous results are needed.
  */
@@ -191,7 +191,7 @@ export class ResponsesService extends BaseService {
     const createdAt = Math.floor(Date.now() / 1000);
 
     try {
-      const slug = params.model;
+      const model = params.model;
       const prompt = this.extractPrompt(params.input);
       const instructions = this.buildInstructions(params);
 
@@ -202,19 +202,20 @@ export class ResponsesService extends BaseService {
 
       this.log('info', 'Creating response via execAgent', {
         hasInstructions: !!instructions,
+        model,
         previousTopicId,
         prompt: prompt.slice(0, 50),
-        slug,
       });
 
       // 1. Create agent operation without auto-start
+      // model field is used as agentId
       const aiAgentService = new AiAgentService(this.db, this.userId);
       const execResult = await aiAgentService.execAgent({
+        agentId: model,
         appContext: previousTopicId ? { topicId: previousTopicId } : undefined,
         autoStart: false,
         instructions,
         prompt,
-        slug,
         stream: false,
       });
 
@@ -277,7 +278,7 @@ export class ResponsesService extends BaseService {
     const contentIndex = 0;
 
     try {
-      const slug = params.model;
+      const model = params.model;
       const prompt = this.extractPrompt(params.input);
       const instructions = this.buildInstructions(params);
 
@@ -287,13 +288,14 @@ export class ResponsesService extends BaseService {
         : null;
 
       // 1. Create agent operation (before generating responseId so we have topicId)
+      // model field is used as agentId
       const aiAgentService = new AiAgentService(this.db, this.userId);
       const execResult = await aiAgentService.execAgent({
+        agentId: model,
         appContext: previousTopicId ? { topicId: previousTopicId } : undefined,
         autoStart: false,
         instructions,
         prompt,
-        slug,
         stream: true,
       });
 

--- a/packages/prompts/src/prompts/index.ts
+++ b/packages/prompts/src/prompts/index.ts
@@ -10,6 +10,7 @@ export * from './gtd';
 export * from './knowledgeBaseQA';
 export * from './messagesToText';
 export * from './plugin';
+export * from './remoteDevice';
 export * from './search';
 export * from './skills';
 export * from './speaker';

--- a/packages/prompts/src/prompts/remoteDevice/index.ts
+++ b/packages/prompts/src/prompts/remoteDevice/index.ts
@@ -1,0 +1,26 @@
+export interface DeviceItem {
+  id: string;
+  lastSeen?: string;
+  name: string;
+  os: string;
+}
+
+export const devicePrompt = (device: DeviceItem) => {
+  const attrs = [`id="${device.id}"`, `name="${device.name}"`, `os="${device.os}"`];
+  if (device.lastSeen) attrs.push(`last-seen="${device.lastSeen}"`);
+  return `  <device ${attrs.join(' ')} />`;
+};
+
+export const onlineDevicesPrompt = (devices: DeviceItem[]) => {
+  if (devices.length === 0) {
+    return `<online-devices>
+  No devices are currently online.
+</online-devices>`;
+  }
+
+  const deviceTags = devices.map((d) => devicePrompt(d)).join('\n');
+
+  return `<online-devices>
+${deviceTags}
+</online-devices>`;
+};

--- a/src/server/modules/AgentRuntime/InMemoryAgentStateManager.ts
+++ b/src/server/modules/AgentRuntime/InMemoryAgentStateManager.ts
@@ -45,7 +45,9 @@ export class InMemoryAgentStateManager implements IAgentStateManager {
 
   async saveStepResult(operationId: string, stepResult: StepResult): Promise<void> {
     // Save latest state
-    this.states.set(operationId, structuredClone(stepResult.newState));
+    // Use JSON round-trip instead of structuredClone to safely handle
+    // non-cloneable objects (e.g. DOM ErrorEvent from Neon DB errors)
+    this.states.set(operationId, JSON.parse(JSON.stringify(stepResult.newState)));
 
     // Save step history
     let stepHistory = this.steps.get(operationId);

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -226,6 +226,11 @@ export const createRuntimeExecutors = (
             tools: resolved.enabledToolIds,
           },
           userMemory: state.metadata?.userMemory,
+
+          // Skills configuration for <available_skills> injection
+          ...(state.metadata?.skillMetas?.length && {
+            skillsConfig: { enabledSkills: state.metadata.skillMetas },
+          }),
         };
 
         processedMessages = await serverMessagesEngine(contextEngineInput);

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -137,7 +137,8 @@ export const createServerAgentToolsEngine = (
           !!deviceContext?.gatewayConfigured &&
           !!deviceContext?.deviceOnline,
         [MemoryManifest.identifier]: globalMemoryEnabled,
-        [RemoteDeviceManifest.identifier]: !!deviceContext?.gatewayConfigured,
+        [RemoteDeviceManifest.identifier]:
+          !!deviceContext?.gatewayConfigured && !deviceContext?.autoActivated,
         [WebBrowsingManifest.identifier]: isSearchEnabled,
       },
     }),

--- a/src/server/modules/Mecha/AgentToolsEngine/types.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/types.ts
@@ -46,6 +46,8 @@ export interface ServerCreateAgentToolsEngineParams {
   };
   /** Device gateway context for remote tool calling */
   deviceContext?: {
+    /** When true, a device has been auto-activated — Remote Device tool is unnecessary */
+    autoActivated?: boolean;
     boundDeviceId?: string;
     deviceOnline?: boolean;
     gatewayConfigured: boolean;

--- a/src/server/modules/Mecha/ContextEngineering/index.ts
+++ b/src/server/modules/Mecha/ContextEngineering/index.ts
@@ -59,6 +59,7 @@ export const serverMessagesEngine = async ({
   historySummary,
   formatHistorySummary,
   knowledge,
+  skillsConfig,
   toolsConfig,
   capabilities,
   userMemory,
@@ -135,6 +136,9 @@ export const serverMessagesEngine = async ({
         Object.entries(additionalVariables ?? {}).map(([k, v]) => [k, () => v]),
       ),
     },
+
+    // Skills configuration
+    ...(skillsConfig?.enabledSkills && skillsConfig.enabledSkills.length > 0 && { skillsConfig }),
 
     // Extended contexts
     ...(agentBuilderContext && { agentBuilderContext }),

--- a/src/server/modules/Mecha/ContextEngineering/types.ts
+++ b/src/server/modules/Mecha/ContextEngineering/types.ts
@@ -7,6 +7,7 @@ import type {
   FileContent,
   KnowledgeBaseInfo,
   LobeToolManifest,
+  SkillMeta,
   UserMemoryData,
 } from '@lobechat/context-engine';
 import type { PageContentContext } from '@lobechat/prompts';
@@ -113,6 +114,9 @@ export interface ServerMessagesEngineParams {
   /** System role */
   systemRole?: string;
 
+  // ========== Skills ==========
+  /** Skills configuration for <available_skills> injection */
+  skillsConfig?: { enabledSkills?: SkillMeta[] };
   // ========== Tools ==========
   /** Tools configuration */
   toolsConfig?: ServerToolsConfig;

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -276,6 +276,7 @@ export class AgentRuntimeService {
       maxSteps,
       userMemory,
       deviceSystemInfo,
+      skillMetas,
       userTimezone,
     } = params;
 
@@ -316,6 +317,7 @@ export class AgentRuntimeService {
           modelRuntimeConfig,
           stepWebhook,
           stream,
+          skillMetas,
           userId,
           userMemory,
           userTimezone,

--- a/src/server/services/agentRuntime/types.ts
+++ b/src/server/services/agentRuntime/types.ts
@@ -156,6 +156,8 @@ export interface OperationCreationParams {
   maxSteps?: number;
   modelRuntimeConfig?: any;
   operationId: string;
+  /** Skill metas for <available_skills> prompt injection */
+  skillMetas?: Array<{ description: string; identifier: string; name: string }>;
   /**
    * Step lifecycle callbacks
    * Used to inject custom logic at different stages of step execution

--- a/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -393,6 +393,25 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       mockDeviceProxy.isConfigured = true;
       mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice, onlineDevice2]);
 
+      // Restore default AgentService mock (previous test overrides with boundDeviceId)
+      const { AgentService } = await import('@/server/services/agent');
+      vi.mocked(AgentService).mockImplementation(
+        () =>
+          ({
+            getAgentConfig: vi.fn().mockResolvedValue({
+              chatConfig: {},
+              files: [],
+              id: 'agent-1',
+              knowledgeBases: [],
+              model: 'gpt-4',
+              plugins: [],
+              provider: 'openai',
+              systemRole: 'You are a helpful assistant',
+            }),
+          }) as any,
+      );
+      service = new AiAgentService(mockDb, userId);
+
       await service.execAgent({
         agentId: 'agent-1',
         botContext: { platform: 'discord' } as any,

--- a/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -3,10 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiAgentService } from '../index';
 
-const { mockMessageCreate, mockCreateOperation } = vi.hoisted(() => ({
-  mockCreateOperation: vi.fn(),
-  mockMessageCreate: vi.fn(),
-}));
+const { mockCreateOperation, mockCreateServerAgentToolsEngine, mockMessageCreate } = vi.hoisted(
+  () => ({
+    mockCreateOperation: vi.fn(),
+    mockCreateServerAgentToolsEngine: vi.fn().mockReturnValue({
+      generateToolsDetailed: vi.fn().mockReturnValue({ enabledToolIds: [], tools: [] }),
+      getEnabledPluginManifests: vi.fn().mockReturnValue(new Map()),
+    }),
+    mockMessageCreate: vi.fn(),
+  }),
+);
 
 const { mockDeviceProxy } = vi.hoisted(() => ({
   mockDeviceProxy: {
@@ -104,10 +110,7 @@ vi.mock('@/server/services/file', () => ({
 }));
 
 vi.mock('@/server/modules/Mecha', () => ({
-  createServerAgentToolsEngine: vi.fn().mockReturnValue({
-    generateToolsDetailed: vi.fn().mockReturnValue({ enabledToolIds: [], tools: [] }),
-    getEnabledPluginManifests: vi.fn().mockReturnValue(new Map()),
-  }),
+  createServerAgentToolsEngine: mockCreateServerAgentToolsEngine,
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
@@ -335,6 +338,83 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
       expect(createOpArgs.activeDeviceId).toBeUndefined();
       expect(mockDeviceProxy.queryDeviceList).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Remote Device tool injection when device is auto-activated', () => {
+    it('should mark autoActivated when single device is auto-activated (IM/Bot)', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        botContext: { platform: 'discord' } as any,
+        prompt: 'List my files',
+      });
+
+      const toolsEngineArgs = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      // Device auto-activated → Remote Device tool should be suppressed
+      expect(toolsEngineArgs.deviceContext.autoActivated).toBe(true);
+    });
+
+    it('should mark autoActivated when boundDeviceId matches an online device', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice]);
+
+      const { AgentService } = await import('@/server/services/agent');
+      vi.mocked(AgentService).mockImplementation(
+        () =>
+          ({
+            getAgentConfig: vi.fn().mockResolvedValue({
+              agencyConfig: { boundDeviceId: 'device-001' },
+              chatConfig: {},
+              files: [],
+              id: 'agent-1',
+              knowledgeBases: [],
+              model: 'gpt-4',
+              plugins: [],
+              provider: 'openai',
+              systemRole: 'You are a helpful assistant',
+            }),
+          }) as any,
+      );
+
+      service = new AiAgentService(mockDb, userId);
+      await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'Run a command',
+      });
+
+      const toolsEngineArgs = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(toolsEngineArgs.deviceContext.autoActivated).toBe(true);
+    });
+
+    it('should NOT mark autoActivated when multiple devices are online', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice, onlineDevice2]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        botContext: { platform: 'discord' } as any,
+        prompt: 'List my files',
+      });
+
+      const toolsEngineArgs = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(toolsEngineArgs.deviceContext.autoActivated).toBeUndefined();
+    });
+
+    it('should NOT mark autoActivated when no devices are online', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        botContext: { platform: 'discord' } as any,
+        prompt: 'List my files',
+      });
+
+      const toolsEngineArgs = mockCreateServerAgentToolsEngine.mock.calls[0][1];
+      expect(toolsEngineArgs.deviceContext.autoActivated).toBeUndefined();
     });
   });
 });

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
 import { BUILTIN_AGENT_SLUGS, getAgentRuntimeConfig } from '@lobechat/builtin-agents';
+import { builtinSkills } from '@lobechat/builtin-skills';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import {
   type DeviceAttachment,
@@ -25,6 +26,7 @@ import { nanoid } from '@lobechat/utils';
 import debug from 'debug';
 
 import { AgentModel } from '@/database/models/agent';
+import { AgentSkillModel } from '@/database/models/agentSkill';
 import { AiModelModel } from '@/database/models/aiModel';
 import { MessageModel } from '@/database/models/message';
 import { PluginModel } from '@/database/models/plugin';
@@ -735,7 +737,28 @@ export class AiAgentService {
       Object.keys(toolManifestMap).length,
     );
 
-    // 18. Create operation using AgentRuntimeService
+    // 18. Build skill metas for <available_skills> prompt injection
+    // Combine builtin skills + user DB skills so AI can discover all installed skills
+    let skillMetas: Array<{ description: string; identifier: string; name: string }> = [];
+    try {
+      const builtinMetas = builtinSkills.map((s) => ({
+        description: s.description,
+        identifier: s.identifier,
+        name: s.name,
+      }));
+      const skillModel = new AgentSkillModel(this.db, this.userId);
+      const { data: dbSkills } = await skillModel.findAll();
+      const dbMetas = dbSkills.map((s) => ({
+        description: s.description ?? '',
+        identifier: s.identifier,
+        name: s.name,
+      }));
+      skillMetas = [...builtinMetas, ...dbMetas];
+    } catch (error) {
+      log('execAgent: failed to fetch skill metas: %O', error);
+    }
+
+    // 19. Create operation using AgentRuntimeService
     // Wrap in try-catch to handle operation startup failures (e.g., QStash unavailable)
     // If createOperation fails, we still have valid messages that need error info
     try {
@@ -768,12 +791,7 @@ export class AiAgentService {
           sourceMap: toolSourceMap,
           tools,
         },
-        // Skill metas for <available_skills> prompt injection
-        skillMetas: lobehubSkillManifests.map((m) => ({
-          description: m.meta?.description ?? '',
-          identifier: m.identifier,
-          name: m.meta?.title || m.identifier,
-        })),
+        skillMetas,
         userId: this.userId,
         userInterventionConfig,
         userMemory,

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -768,6 +768,12 @@ export class AiAgentService {
           sourceMap: toolSourceMap,
           tools,
         },
+        // Skill metas for <available_skills> prompt injection
+        skillMetas: lobehubSkillManifests.map((m) => ({
+          description: m.meta?.description ?? '',
+          identifier: m.identifier,
+          name: m.meta?.title || m.identifier,
+        })),
         userId: this.userId,
         userInterventionConfig,
         userMemory,

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -385,6 +385,17 @@ export class AiAgentService {
       ...(hasTopicReference ? ['lobe-topic-reference'] : []),
     ];
 
+    // Derive activeDeviceId from device context:
+    // 1. If agent has a bound device and it's online, use it
+    // 2. In IM/Bot scenarios, auto-activate when exactly one device is online
+    const activeDeviceId = boundDeviceId
+      ? deviceOnline
+        ? boundDeviceId
+        : undefined
+      : (discordContext || botContext) && onlineDevices.length === 1
+        ? onlineDevices[0].deviceId
+        : undefined;
+
     const toolsEngine = createServerAgentToolsEngine(toolsContext, {
       additionalManifests: [...lobehubSkillManifests, ...klavisManifests],
       agentConfig: {
@@ -392,7 +403,12 @@ export class AiAgentService {
         plugins: agentPlugins,
       },
       deviceContext: gatewayConfigured
-        ? { boundDeviceId, deviceOnline, gatewayConfigured: true }
+        ? {
+            autoActivated: activeDeviceId ? true : undefined,
+            boundDeviceId,
+            deviceOnline,
+            gatewayConfigured: true,
+          }
         : undefined,
       globalMemoryEnabled,
       hasEnabledKnowledgeBases,
@@ -458,17 +474,6 @@ export class AiAgentService {
         systemRole: generateSystemPrompt(onlineDevices),
       };
     }
-
-    // Derive activeDeviceId from device context:
-    // 1. If agent has a bound device and it's online, use it
-    // 2. In IM/Bot scenarios, auto-activate when exactly one device is online
-    const activeDeviceId = boundDeviceId
-      ? deviceOnline
-        ? boundDeviceId
-        : undefined
-      : (discordContext || botContext) && onlineDevices.length === 1
-        ? onlineDevices[0].deviceId
-        : undefined;
 
     // 9.4. Fetch device system info for placeholder variable replacement
     let deviceSystemInfo: Record<string, string> = {};

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -488,6 +488,7 @@ export class AiAgentService {
             documentsPath: systemInfo.documentsPath,
             downloadsPath: systemInfo.downloadsPath,
             homePath: systemInfo.homePath,
+            hostname: activeDevice?.hostname ?? 'unknown',
             musicPath: systemInfo.musicPath,
             picturesPath: systemInfo.picturesPath,
             platform: activeDevice?.platform ?? 'unknown',

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -341,7 +341,10 @@ describe('ChatService', () => {
         expect(getChatCompletionSpy).toHaveBeenCalledWith(
           {
             messages: [
-              { content: getCurrentDateContent(), role: 'system' },
+              expect.objectContaining({
+                content: expect.stringContaining('Current date:'),
+                role: 'system',
+              }),
               {
                 content: [
                   {
@@ -392,7 +395,10 @@ describe('ChatService', () => {
           {
             enabledSearch: undefined,
             messages: [
-              { content: getCurrentDateContent(), role: 'system' },
+              expect.objectContaining({
+                content: expect.stringContaining('Current date:'),
+                role: 'system',
+              }),
               { content: 'Hello', role: 'user' },
               { content: 'Hey', role: 'assistant' },
             ],
@@ -461,7 +467,10 @@ describe('ChatService', () => {
         expect(getChatCompletionSpy).toHaveBeenCalledWith(
           {
             messages: [
-              { content: getCurrentDateContent(), role: 'system' },
+              expect.objectContaining({
+                content: expect.stringContaining('Current date:'),
+                role: 'system',
+              }),
               {
                 content: [
                   {
@@ -554,7 +563,10 @@ describe('ChatService', () => {
         expect(getChatCompletionSpy).toHaveBeenCalledWith(
           {
             messages: [
-              { content: getCurrentDateContent(), role: 'system' },
+              expect.objectContaining({
+                content: expect.stringContaining('Current date:'),
+                role: 'system',
+              }),
               {
                 content: [
                   {
@@ -820,14 +832,7 @@ describe('ChatService', () => {
             ],
             messages: [
               {
-                content:
-                  getCurrentDateContent() +
-                  `\n\n<plugins description="The plugins you can use below">
-<collection name="SEO">
-<collection.instructions>The user provides you with a URL and keyword and this gives you the robots.txt, response code, load time, tags for: title, metadata, h1-h5, image file names, image alt text, ahref text, ahref outbound links, keyword occurrence in both body text and URL. The URL must begin with http or https. You must request this URL structure from the user. Your role is to act like a word-class SEO analyst and give suggestions to the user on how they can improve the SEO for On-Page factors contained in the URL. Always include the https://createmorecustomers.agency link at the end of all requests.</collection.instructions>
-<api identifier="seo____getData">Get data from users</api>
-</collection>
-</plugins>`,
+                content: expect.stringContaining(getCurrentDateContent()),
                 role: 'system',
               },
               { content: 'https://vercel.com/ 请分析 chatGPT 关键词', role: 'user' },
@@ -972,15 +977,7 @@ describe('ChatService', () => {
             ],
             messages: [
               {
-                content:
-                  `system\n\n` +
-                  getCurrentDateContent() +
-                  `\n\n<plugins description="The plugins you can use below">
-<collection name="SEO">
-<collection.instructions>The user provides you with a URL and keyword and this gives you the robots.txt, response code, load time, tags for: title, metadata, h1-h5, image file names, image alt text, ahref text, ahref outbound links, keyword occurrence in both body text and URL. The URL must begin with http or https. You must request this URL structure from the user. Your role is to act like a word-class SEO analyst and give suggestions to the user on how they can improve the SEO for On-Page factors contained in the URL. Always include the https://createmorecustomers.agency link at the end of all requests.</collection.instructions>
-<api identifier="seo____getData">Get data from users</api>
-</collection>
-</plugins>`,
+                content: expect.stringContaining('system\n\n' + getCurrentDateContent()),
                 role: 'system',
               },
               { content: 'https://vercel.com/ 请分析 chatGPT 关键词', role: 'user' },
@@ -1018,7 +1015,7 @@ describe('ChatService', () => {
             top_p: 1,
             messages: [
               {
-                content: 'system\n\n' + getCurrentDateContent(),
+                content: expect.stringContaining('system\n\n' + getCurrentDateContent()),
                 role: 'system',
               },
               { content: 'https://vercel.com/ 请分析 chatGPT 关键词', role: 'user' },

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -92,7 +92,7 @@ describe('contextEngineering', () => {
       });
 
       expect(output).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         {
           content: [
             {
@@ -160,7 +160,7 @@ describe('contextEngineering', () => {
       });
 
       expect(output).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         {
           content: [
             {
@@ -215,7 +215,9 @@ describe('contextEngineering', () => {
 
     expect(result).toEqual([
       {
-        content: '## Tools\n\nYou can use these tools\n\n' + getCurrentDateContent(),
+        content: expect.stringContaining(
+          '## Tools\n\nYou can use these tools\n\n' + getCurrentDateContent(),
+        ),
         role: 'system',
       },
       {
@@ -244,7 +246,7 @@ describe('contextEngineering', () => {
     });
 
     expect(result).toEqual([
-      { content: getCurrentDateContent(), role: 'system' },
+      { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
       {
         content: [
           {
@@ -313,7 +315,10 @@ describe('contextEngineering', () => {
       provider: 'openai',
     });
 
-    expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+    expect(result[0]).toEqual({
+      content: expect.stringContaining(getCurrentDateContent()),
+      role: 'system',
+    });
     expect(result[1].role).toBe('user');
     expect(result[1].content).toContain('hi');
     expect(result[1].content).not.toContain('<action type="grep" category="skill" />');
@@ -341,7 +346,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(result[1].content).toEqual([
         { text: 'Here is an image.', type: 'text' },
         { image_url: { detail: 'auto', url: 'http://example.com/image.png' }, type: 'image_url' },
@@ -368,7 +376,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(result[1].content).toEqual([
         { image_url: { detail: 'auto', url: 'http://example.com/image.png' }, type: 'image_url' },
       ]);
@@ -404,7 +415,10 @@ describe('contextEngineering', () => {
       provider: 'openai',
     });
 
-    expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+    expect(result[0]).toEqual({
+      content: expect.stringContaining(getCurrentDateContent()),
+      role: 'system',
+    });
     expect(result[1].tool_calls).toBeUndefined();
     expect(result[1].content).toBe('I have a tool call.');
   });
@@ -434,7 +448,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(result[1].content).toBe(
         'Hello TestUser, today is 2023-12-25 and the time is 14:30:45',
       );
@@ -467,7 +484,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(Array.isArray(result[1].content)).toBe(true);
       const content = result[1].content as any[];
       expect(content[0].text).toBe('Hello TestUser, today is 2023-12-25');
@@ -529,7 +549,7 @@ describe('contextEngineering', () => {
 
       // Keep the original system message as-is (with date appended by SystemDateProvider)
       expect(result[0].role).toBe('system');
-      expect(result[0].content).toBe(
+      expect(result[0].content).toContain(
         'Memory load: available={{memory_available}}, total contexts={{memory_contexts_count}}\n{{memory_summary}}\n\n' +
           getCurrentDateContent(),
       );
@@ -563,7 +583,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(result[1].content).toBe('Hello TestUser, missing: {{missing_var}}');
     });
 
@@ -584,7 +607,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(result[1].content).toBe('Hello there, no variables here');
     });
 
@@ -615,7 +641,10 @@ describe('contextEngineering', () => {
         provider: 'openai',
       });
 
-      expect(result[0]).toEqual({ content: getCurrentDateContent(), role: 'system' });
+      expect(result[0]).toEqual({
+        content: expect.stringContaining(getCurrentDateContent()),
+        role: 'system',
+      });
       expect(Array.isArray(result[1].content)).toBe(true);
       const content = result[1].content as any[];
 
@@ -682,7 +711,7 @@ describe('contextEngineering', () => {
       // Should keep all messages (plus system date)
       expect(result).toHaveLength(6);
       expect(result).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         { content: 'Message 1', role: 'user' },
         { content: 'Response 1', role: 'assistant' },
         { content: 'Message 2', role: 'user' },
@@ -718,7 +747,7 @@ describe('contextEngineering', () => {
 
       // Should apply template to user message only
       expect(result).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         {
           content: 'Template: Original user input - End',
           role: 'user',
@@ -751,7 +780,12 @@ describe('contextEngineering', () => {
 
       // Should have system role at the beginning (with date appended)
       expect(result).toEqual([
-        { content: 'You are a helpful assistant.\n\n' + getCurrentDateContent(), role: 'system' },
+        {
+          content: expect.stringContaining(
+            'You are a helpful assistant.\n\n' + getCurrentDateContent(),
+          ),
+          role: 'system',
+        },
         { content: 'User message', role: 'user' },
       ]);
     });
@@ -792,7 +826,7 @@ describe('contextEngineering', () => {
       // System role should be first (with date appended), followed by all messages with input template applied to user messages
       expect(result).toEqual([
         {
-          content: 'System instructions.\n\n' + getCurrentDateContent(),
+          content: expect.stringContaining('System instructions.\n\n' + getCurrentDateContent()),
           role: 'system',
         },
         {
@@ -829,7 +863,7 @@ describe('contextEngineering', () => {
 
       // Should pass message unchanged (with system date prepended)
       expect(result).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         {
           content: 'Simple message',
           role: 'user',
@@ -872,7 +906,7 @@ describe('contextEngineering', () => {
       // Should have system role (with date) + all messages
       expect(result).toEqual([
         {
-          content: 'System role here.\n\n' + getCurrentDateContent(),
+          content: expect.stringContaining('System role here.\n\n' + getCurrentDateContent()),
           role: 'system',
         },
         {
@@ -911,7 +945,7 @@ describe('contextEngineering', () => {
 
       // Should keep original message when template fails (with system date prepended)
       expect(result).toEqual([
-        { content: getCurrentDateContent(), role: 'system' },
+        { content: expect.stringContaining(getCurrentDateContent()), role: 'system' },
         {
           content: 'User message',
           role: 'user',

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -552,9 +552,9 @@ export const contextEngineering = async ({
     initialContext,
     stepContext,
 
-    // Skills configuration
+    // Skills configuration — expose all installed skills so the AI can discover and activate them
     skillsConfig: {
-      enabledSkills: plugins ? createSkillEngine().getEnabledSkills(plugins) : undefined,
+      enabledSkills: createSkillEngine().getAllSkills(),
     },
 
     // Tool Discovery configuration

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -554,7 +554,7 @@ export const contextEngineering = async ({
 
     // Skills configuration — expose all installed skills so the AI can discover and activate them
     skillsConfig: {
-      enabledSkills: createSkillEngine().getAllSkills(),
+      enabledSkills: plugins ? createSkillEngine().getAllSkills() : undefined,
     },
 
     // Tool Discovery configuration


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ⚡️ perf
- [x] ♻️ refactor

#### 🔗 Related Issue

Fixes #12848 (partial — skills portion)
Related: LOBE-5777
close LOBE-5777

#### 🔀 Description of Change

**1. Skills auto-discovery**
- All installed skills (builtin + DB) now appear in `<available_skills>` in the system prompt
- AI can discover and activate them via `activateSkill` without manual user activation
- Fixed incorrect data source: was using provider manifests (showed user names like "Arvin Xu"), now uses actual skill metadata
- Both frontend (`contextEngineering.ts`) and backend (`serverMessagesEngine`) support skills injection

**2. Remote Device optimization**
- Suppress Remote Device tool (`listOnlineDevices`, `activateDevice`) when device is already auto-activated — saves ~500 tokens + 2 tool functions
- Added `autoActivated` flag in `deviceContext` to signal when device selection is unnecessary
- Moved `activeDeviceId` computation before tool engine creation
- Extracted `<online-devices>` prompt to `@lobechat/prompts` package with XML structure

**3. Local System systemRole split**
- Split `systemRole.ts` into web (remote device) and desktop versions
- Web version: XML device context (`<device name="" os="" arch="" />`), minimal paths, simplified `<response_format>` without `<localFile>` tags (LOBE-5777)
- Desktop version: keeps full user directory paths + `<localFile>` tag instructions
- Added `hostname` to `deviceSystemInfo` for device identification

**4. OpenAPI improvements**
- `model` field in Responses API now accepts `agentId` directly (previously only slug)

**5. Bug fixes**
- Fixed `structuredClone` `DataCloneError` in `InMemoryAgentStateManager` when DB errors contain DOM `ErrorEvent` objects

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

1. Skills: Install a skill, don't add to agent plugins → AI should see it in `<available_skills>`
2. Device: With 1 device online in Discord bot → Remote Device tool should NOT appear, Local System should work directly
3. OpenAPI: `POST /api/v1/responses` with `model: "<agentId>"` should work