### PR TITLE
🐛 fix: add trpc mock.vite stub to stop Vite SPA warmup from traversing server router

### DIFF
--- a/src/libs/trpc/mock.vite.ts
+++ b/src/libs/trpc/mock.vite.ts
@@ -1,0 +1,7 @@
+/**
+ * Browser-only stub to stop Vite SPA warmup from traversing the server router graph.
+ * The real implementation is only valid in server and test environments.
+ */
+export const createCaller = () => {
+  throw new Error('`@/libs/trpc/mock` is server-only and unavailable in the Vite browser build.');
+};


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

Add `mock.vite.ts` as a browser-only stub for `@/libs/trpc/mock`. The real implementation imports server-side code (lambda router, createCallerFactory) which is invalid in the Vite browser build. The platform resolve plugin picks up `.vite` variants, so this stub stops Vite SPA warmup from traversing the server router graph.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Run `bun run dev:spa` and verify the SPA warmup completes without errors.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Prevent Vite SPA warmup from importing server-only trpc mock implementation by providing a browser-safe stub.