### PR TITLE
🐛 fix: slove the market oidc lost the call tools error

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.0.0",
     "@lobehub/icons": "^5.0.0",
-    "@lobehub/market-sdk": "0.32.0-beta.1",
+    "@lobehub/market-sdk": "^0.31.3",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.4.0",
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.0.0",
     "@lobehub/icons": "^5.0.0",
-    "@lobehub/market-sdk": "^0.31.3",
+    "@lobehub/market-sdk": "0.32.0-beta.1",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.4.0",
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -191,8 +191,9 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
         refreshToken: refreshTokenValue,
       });
 
-      // Calculate new expiration time
-      const expiresAt = Date.now() + response.expiresIn * 1000;
+      // Calculate new expiration time (default to 1 hour if not provided)
+      const expiresIn = response.expiresIn ?? 3600;
+      const expiresAt = Date.now() + expiresIn * 1000;
 
       // Save new tokens to DB
       await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
@@ -204,7 +205,7 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
       const newSession: MarketAuthSession = {
         accessToken: response.accessToken,
         expiresAt,
-        expiresIn: response.expiresIn,
+        expiresIn,
         scope: response.scope || 'openid profile email',
         tokenType: 'Bearer',
         userInfo: userInfo || undefined,
@@ -513,8 +514,9 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
         refreshToken: dbTokens.refreshToken,
       });
 
-      // Calculate new expiration time
-      const expiresAt = Date.now() + response.expiresIn * 1000;
+      // Calculate new expiration time (default to 1 hour if not provided)
+      const expiresIn = response.expiresIn ?? 3600;
+      const expiresAt = Date.now() + expiresIn * 1000;
 
       // Save new tokens to DB
       await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
@@ -526,7 +528,7 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
       const newSession: MarketAuthSession = {
         accessToken: response.accessToken,
         expiresAt,
-        expiresIn: response.expiresIn,
+        expiresIn,
         scope: response.scope || 'openid profile email',
         tokenType: 'Bearer',
         userInfo: userInfo || undefined,

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -14,6 +14,7 @@ import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/slices/settings/selectors/settings';
 
 import { MarketAuthError } from './errors';
+import { marketAuthEvents } from './events';
 import MarketAuthConfirmModal from './MarketAuthConfirmModal';
 import { MarketOIDC } from './oidc';
 import ProfileSetupModal from './ProfileSetupModal';
@@ -112,13 +113,6 @@ const getRefreshToken = (): string | null => {
 };
 
 /**
- * Refresh token (simplified for now; refresh token logic can be implemented later)
- */
-const refreshToken = async (): Promise<boolean> => {
-  return false;
-};
-
-/**
  * Check if the user needs to set up a username (first-time login)
  */
 const checkNeedsProfileSetup = async (username: string): Promise<boolean> => {
@@ -185,6 +179,49 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   }, [isDesktop]);
 
   /**
+   * Try to refresh the access token using a refresh token
+   * This is used during initialization when the access token is expired or invalid
+   */
+  const tryRefreshToken = async (refreshTokenValue: string): Promise<boolean> => {
+    try {
+      const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+
+      const response = await lambdaClient.market.oidc.refreshToken.mutate({
+        clientId,
+        refreshToken: refreshTokenValue,
+      });
+
+      // Calculate new expiration time
+      const expiresAt = Date.now() + response.expiresIn * 1000;
+
+      // Save new tokens to DB
+      await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
+
+      // Fetch user info with new token
+      const userInfo = await fetchUserInfo(response.accessToken);
+
+      // Update session state
+      const newSession: MarketAuthSession = {
+        accessToken: response.accessToken,
+        expiresAt,
+        expiresIn: response.expiresIn,
+        scope: response.scope || 'openid profile email',
+        tokenType: 'Bearer',
+        userInfo: userInfo || undefined,
+      };
+
+      setSession(newSession);
+      setStatus('authenticated');
+
+      console.info('[MarketAuth] Token refreshed successfully during initialization');
+      return true;
+    } catch (error) {
+      console.error('[MarketAuth] Failed to refresh token during initialization:', error);
+      return false;
+    }
+  };
+
+  /**
    * Initialize: check and restore session, fetch user info
    */
   const initializeSession = async () => {
@@ -226,7 +263,16 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
 
     // Check if token is expired
     if (!dbTokens.expiresAt || dbTokens.expiresAt <= Date.now()) {
-      // Clear expired DB tokens
+      // Try to refresh the token if refresh token is available
+      if (dbTokens.refreshToken) {
+        console.info('[MarketAuth] Access token expired, attempting refresh...');
+        const refreshed = await tryRefreshToken(dbTokens.refreshToken);
+        if (refreshed) {
+          return; // Session already updated in tryRefreshToken
+        }
+      }
+
+      // Clear expired DB tokens if refresh failed or no refresh token
       await clearMarketTokensFromDB();
       setStatus('unauthenticated');
       return;
@@ -236,7 +282,16 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
     const userInfo = await fetchUserInfo(dbTokens.accessToken);
 
     if (!userInfo) {
-      // Clear invalid token
+      // Token might be invalid, try to refresh
+      if (dbTokens.refreshToken) {
+        console.info('[MarketAuth] Access token invalid, attempting refresh...');
+        const refreshed = await tryRefreshToken(dbTokens.refreshToken);
+        if (refreshed) {
+          return; // Session already updated in tryRefreshToken
+        }
+      }
+
+      // Clear invalid token if refresh failed
       await clearMarketTokensFromDB();
       setStatus('unauthenticated');
       return;
@@ -327,13 +382,13 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   /**
    * Sign-in method (shows confirmation dialog first)
    */
-  const signIn = async (): Promise<number | null> => {
+  const signIn = useCallback(async (): Promise<number | null> => {
     return new Promise<number | null>((resolve, reject) => {
       setPendingSignInResolve(() => resolve);
       setPendingSignInReject(() => reject);
       setShowConfirmModal(true);
     });
-  };
+  }, []);
 
   /**
    * Handle authorization confirmation
@@ -438,6 +493,91 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   }, []);
 
   /**
+   * Refresh access token using refresh token
+   * Returns true if refresh was successful, false otherwise
+   */
+  const refreshToken = useCallback(async (): Promise<boolean> => {
+    const dbTokens = getMarketTokensFromDB();
+
+    // No refresh token available
+    if (!dbTokens?.refreshToken) {
+      console.warn('[MarketAuth] No refresh token available');
+      return false;
+    }
+
+    try {
+      const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+
+      const response = await lambdaClient.market.oidc.refreshToken.mutate({
+        clientId,
+        refreshToken: dbTokens.refreshToken,
+      });
+
+      // Calculate new expiration time
+      const expiresAt = Date.now() + response.expiresIn * 1000;
+
+      // Save new tokens to DB
+      await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
+
+      // Fetch user info with new token
+      const userInfo = await fetchUserInfo(response.accessToken);
+
+      // Update session state
+      const newSession: MarketAuthSession = {
+        accessToken: response.accessToken,
+        expiresAt,
+        expiresIn: response.expiresIn,
+        scope: response.scope || 'openid profile email',
+        tokenType: 'Bearer',
+        userInfo: userInfo || undefined,
+      };
+
+      setSession(newSession);
+      setStatus('authenticated');
+
+      console.info('[MarketAuth] Token refreshed successfully');
+      return true;
+    } catch (error) {
+      console.error('[MarketAuth] Failed to refresh token:', error);
+      // Clear invalid tokens
+      await clearMarketTokensFromDB();
+      setSession(null);
+      setStatus('unauthenticated');
+      return false;
+    }
+  }, [isDesktop]);
+
+  /**
+   * Handle unauthorized (401) error from Market API
+   * Attempts to refresh token first, then triggers signIn if refresh fails
+   * @returns true if successfully re-authenticated, false if user cancelled or failed
+   */
+  const handleUnauthorized = useCallback(async (): Promise<boolean> => {
+    console.info('[MarketAuth] Handling unauthorized error, attempting recovery...');
+
+    // First try to refresh the token
+    const refreshed = await refreshToken();
+    if (refreshed) {
+      console.info('[MarketAuth] Token refresh successful, recovered from 401');
+      return true;
+    }
+
+    // Refresh failed, need to re-authenticate
+    console.info('[MarketAuth] Token refresh failed, triggering signIn...');
+    try {
+      const accountId = await signIn();
+      if (accountId !== null) {
+        console.info('[MarketAuth] Re-authentication successful');
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('[MarketAuth] Re-authentication failed:', error);
+      return false;
+    }
+  }, [refreshToken, signIn]);
+
+  /**
    * Restore session and fetch user info on initialization
    * Wait for isUserStateInit to be true, at which point the SWR request from useInitUserState is complete and settings data is loaded
    */
@@ -445,12 +585,60 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
     if (isUserStateInit) {
       initializeSession();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isUserStateInit, enableMarketTrustedClient]);
+
+  /**
+   * Auto-refresh token before expiration
+   * Refreshes the token 5 minutes before it expires to ensure continuous access
+   */
+  useEffect(() => {
+    // Skip if using trusted client (no token expiration)
+    if (enableMarketTrustedClient) return;
+
+    // Skip if not authenticated or no session
+    if (status !== 'authenticated' || !session?.expiresAt) return;
+
+    const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes before expiration
+    const timeUntilExpiry = session.expiresAt - Date.now();
+    const timeUntilRefresh = timeUntilExpiry - REFRESH_BUFFER_MS;
+
+    // If token is already expired or will expire very soon, refresh immediately
+    if (timeUntilRefresh <= 0) {
+      refreshToken();
+      return;
+    }
+
+    // Set a timer to refresh the token before it expires
+    const refreshTimer = setTimeout(() => {
+      console.info('[MarketAuth] Auto-refreshing token before expiration...');
+      refreshToken();
+    }, timeUntilRefresh);
+
+    return () => {
+      clearTimeout(refreshTimer);
+    };
+  }, [status, session?.expiresAt, enableMarketTrustedClient, refreshToken]);
+
+  /**
+   * Listen for market-unauthorized events from tRPC error handler
+   * Automatically attempt to recover from 401 errors
+   */
+  useEffect(() => {
+    const unsubscribe = marketAuthEvents.on('market-unauthorized', async (event) => {
+      console.info('[MarketAuth] Received unauthorized event for path:', event.path);
+      // Attempt to recover (refresh token or re-authenticate)
+      await handleUnauthorized();
+    });
+
+    return unsubscribe;
+  }, [handleUnauthorized]);
 
   const contextValue: MarketAuthContextType = {
     getAccessToken,
     getCurrentUserInfo,
     getRefreshToken,
+    handleUnauthorized,
     // When Trusted Client authentication is enabled, automatically treat as authenticated (backend uses trustedClientToken)
     isAuthenticated: enableMarketTrustedClient || status === 'authenticated',
     isLoading: status === 'loading',

--- a/src/layout/AuthProvider/MarketAuth/events.ts
+++ b/src/layout/AuthProvider/MarketAuth/events.ts
@@ -1,0 +1,43 @@
+/**
+ * Market Auth Event System
+ *
+ * Provides a simple event-based communication mechanism for handling
+ * Market API 401 errors across the application.
+ */
+
+export type MarketAuthEventType = 'market-unauthorized';
+
+export interface MarketUnauthorizedEvent {
+  path: string;
+  timestamp: number;
+}
+
+type EventCallback = (event: MarketUnauthorizedEvent) => void;
+
+class MarketAuthEventEmitter {
+  private listeners: Map<MarketAuthEventType, Set<EventCallback>> = new Map();
+
+  on(event: MarketAuthEventType, callback: EventCallback): () => void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(callback);
+
+    // Return unsubscribe function
+    return () => {
+      this.listeners.get(event)?.delete(callback);
+    };
+  }
+
+  emit(event: MarketAuthEventType, data: MarketUnauthorizedEvent): void {
+    this.listeners.get(event)?.forEach((callback) => {
+      try {
+        callback(data);
+      } catch (error) {
+        console.error('[MarketAuthEvents] Error in event callback:', error);
+      }
+    });
+  }
+}
+
+export const marketAuthEvents = new MarketAuthEventEmitter();

--- a/src/layout/AuthProvider/MarketAuth/types.ts
+++ b/src/layout/AuthProvider/MarketAuth/types.ts
@@ -59,6 +59,12 @@ export interface MarketAuthContextType extends MarketAuthState {
   getAccessToken: () => string | null;
   getCurrentUserInfo: () => MarketUserInfo | null;
   getRefreshToken: () => string | null;
+  /**
+   * Handle unauthorized (401) error from Market API
+   * Attempts to refresh token first, then triggers signIn if refresh fails
+   * @returns true if successfully re-authenticated, false if user cancelled or failed
+   */
+  handleUnauthorized: () => Promise<boolean>;
   openProfileSetup: (onSuccess?: (profile: MarketUserProfile) => void) => void;
   refreshToken: () => Promise<boolean>;
   signIn: () => Promise<number | null>;

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -14,6 +14,7 @@ const log = debug('lobe-image:lambda-client');
 
 // 401 error debouncing: prevent showing multiple login notifications in short time
 let last401Time = 0;
+let lastMarket401Time = 0;
 const MIN_401_INTERVAL = 5000; // 5 seconds
 
 // handle error
@@ -33,27 +34,46 @@ const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
           const showError = (op.context?.showNotification as boolean) ?? true;
           const status = err.data?.httpStatus as number;
 
+          // Check if this is a market API call
+          const isMarketApi = op.path.startsWith('market.');
+
           // Don't show notifications for abort errors
           if (showError && !isAbortError) {
             switch (status) {
               case 401: {
-                // Debounce: only show login notification once every 5 seconds
-                const now = Date.now();
-                if (now - last401Time > MIN_401_INTERVAL) {
-                  last401Time = now;
-                  // Desktop app doesn't have the web auth routes like `/signin`,
-                  // so skip the login redirect/notification there.
-                  if (!isDesktop) {
-                    const { getUserStoreState } = await import('@/store/user/store');
-                    const { isSignedIn, logout } = getUserStoreState();
-                    // If user is still marked as signed in but got 401,
-                    // session is invalid - clear client state first
-                    if (isSignedIn) {
-                      await logout();
+                if (isMarketApi) {
+                  // Market API 401: emit event for MarketAuthProvider to handle
+                  // Don't trigger LobeChat logout for market auth issues
+                  const now = Date.now();
+                  if (now - lastMarket401Time > MIN_401_INTERVAL) {
+                    lastMarket401Time = now;
+                    // Dynamically import to avoid circular dependencies
+                    const { marketAuthEvents } =
+                      await import('@/layout/AuthProvider/MarketAuth/events');
+                    marketAuthEvents.emit('market-unauthorized', {
+                      path: op.path,
+                      timestamp: now,
+                    });
+                  }
+                } else {
+                  // Non-market 401: handle as before (LobeChat session expired)
+                  const now = Date.now();
+                  if (now - last401Time > MIN_401_INTERVAL) {
+                    last401Time = now;
+                    // Desktop app doesn't have the web auth routes like `/signin`,
+                    // so skip the login redirect/notification there.
+                    if (!isDesktop) {
+                      const { getUserStoreState } = await import('@/store/user/store');
+                      const { isSignedIn, logout } = getUserStoreState();
+                      // If user is still marked as signed in but got 401,
+                      // session is invalid - clear client state first
+                      if (isSignedIn) {
+                        await logout();
+                      }
+                      const { loginRequired } =
+                        await import('@/components/Error/loginRequiredNotification');
+                      loginRequired.redirect();
                     }
-                    const { loginRequired } =
-                      await import('@/components/Error/loginRequiredNotification');
-                    loginRequired.redirect();
                   }
                 }
                 // Mark error as non-retryable to prevent SWR infinite retry loop

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -17,12 +17,23 @@ const errorHandlingLink: TRPCLink<ToolsRouter> = () => {
         complete: () => observer.complete(),
         error: async (err) => {
           const status = err.data?.httpStatus as number;
+          const code = err.data?.code as string;
+
+          console.info('[toolsClient] Error:', {
+            code,
+            message: err.message,
+            path: op.path,
+            status,
+          });
 
           // Check if this is a market API call with 401 error
-          if (status === 401 && op.path.startsWith('market.')) {
+          // UNAUTHORIZED tRPC code maps to HTTP 401
+          const is401 = status === 401 || code === 'UNAUTHORIZED';
+          if (is401 && op.path.startsWith('market.')) {
             const now = Date.now();
             if (now - lastMarket401Time > MIN_401_INTERVAL) {
               lastMarket401Time = now;
+              console.info('[toolsClient] Emitting market-unauthorized event for path:', op.path);
               // Emit event for MarketAuthProvider to handle
               const { marketAuthEvents } = await import('@/layout/AuthProvider/MarketAuth/events');
               marketAuthEvents.emit('market-unauthorized', {

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -1,11 +1,47 @@
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCClient, httpBatchLink, type TRPCLink } from '@trpc/client';
+import { observable } from '@trpc/server/observable';
 import superjson from 'superjson';
 
 import { withElectronProtocolIfElectron } from '@/const/protocol';
 import { type ToolsRouter } from '@/server/routers/tools';
 
+// 401 error debouncing for market auth
+let lastMarket401Time = 0;
+const MIN_401_INTERVAL = 5000; // 5 seconds
+
+// Error handling link for tools client
+const errorHandlingLink: TRPCLink<ToolsRouter> = () => {
+  return ({ op, next }) =>
+    observable((observer) =>
+      next(op).subscribe({
+        complete: () => observer.complete(),
+        error: async (err) => {
+          const status = err.data?.httpStatus as number;
+
+          // Check if this is a market API call with 401 error
+          if (status === 401 && op.path.startsWith('market.')) {
+            const now = Date.now();
+            if (now - lastMarket401Time > MIN_401_INTERVAL) {
+              lastMarket401Time = now;
+              // Emit event for MarketAuthProvider to handle
+              const { marketAuthEvents } = await import('@/layout/AuthProvider/MarketAuth/events');
+              marketAuthEvents.emit('market-unauthorized', {
+                path: op.path,
+                timestamp: now,
+              });
+            }
+          }
+
+          observer.error(err);
+        },
+        next: (value) => observer.next(value),
+      }),
+    );
+};
+
 export const toolsClient = createTRPCClient<ToolsRouter>({
   links: [
+    errorHandlingLink,
     httpBatchLink({
       headers: async () => {
         // dynamic import to avoid circular dependency

--- a/src/server/routers/tools/market.ts
+++ b/src/server/routers/tools/market.ts
@@ -216,10 +216,28 @@ const execInSandboxHandler = async ({
     log('execInSandbox response for %s: %O', toolName, response);
 
     if (!response.success) {
+      const errorCode = response.error?.code;
+      const errorMessage = response.error?.message || 'Unknown error';
+
+      // Check for authentication errors and throw UNAUTHORIZED to trigger market auth flow
+      if (
+        errorCode === 'invalid_token' ||
+        errorCode === 'token_expired' ||
+        errorCode === 'unauthorized' ||
+        errorMessage.toLowerCase().includes('invalid_token') ||
+        errorMessage.toLowerCase().includes('token expired')
+      ) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message:
+            'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+        });
+      }
+
       return {
         error: {
-          message: response.error?.message || 'Unknown error',
-          name: response.error?.code,
+          message: errorMessage,
+          name: errorCode,
         },
         result: null,
         sessionExpiredAndRecreated: false,
@@ -235,9 +253,29 @@ const execInSandboxHandler = async ({
   } catch (error) {
     log('execInSandbox error for %s: %O', toolName, error);
 
+    // Re-throw TRPCError as-is (e.g., UNAUTHORIZED from above)
+    if (error instanceof TRPCError) {
+      throw error;
+    }
+
+    const errorMessage = (error as Error).message;
+
+    // Check for authentication errors thrown as exceptions
+    if (
+      errorMessage.toLowerCase().includes('invalid_token') ||
+      errorMessage.toLowerCase().includes('token expired') ||
+      errorMessage.toLowerCase().includes('unauthorized')
+    ) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message:
+          'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+      });
+    }
+
     return {
       error: {
-        message: (error as Error).message,
+        message: errorMessage,
         name: (error as Error).name,
       },
       result: null,
@@ -631,8 +669,26 @@ export const marketRouter = router({
         log('Sandbox exportFile response: %O', response);
 
         if (!response.success) {
+          const errorCode = response.error?.code;
+          const errorMessage = response.error?.message || 'Failed to export file from sandbox';
+
+          // Check for authentication errors and throw UNAUTHORIZED
+          if (
+            errorCode === 'invalid_token' ||
+            errorCode === 'token_expired' ||
+            errorCode === 'unauthorized' ||
+            errorMessage.toLowerCase().includes('invalid_token') ||
+            errorMessage.toLowerCase().includes('token expired')
+          ) {
+            throw new TRPCError({
+              code: 'UNAUTHORIZED',
+              message:
+                'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+            });
+          }
+
           return {
-            error: { message: response.error?.message || 'Failed to export file from sandbox' },
+            error: { message: errorMessage },
             filename,
             success: false,
           } as ExportAndUploadFileResult;
@@ -679,8 +735,28 @@ export const marketRouter = router({
       } catch (error) {
         log('Error in exportAndUploadFile: %O', error);
 
+        // Re-throw TRPCError as-is
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+
+        const errorMessage = (error as Error).message;
+
+        // Check for authentication errors
+        if (
+          errorMessage.toLowerCase().includes('invalid_token') ||
+          errorMessage.toLowerCase().includes('token expired') ||
+          errorMessage.toLowerCase().includes('unauthorized')
+        ) {
+          throw new TRPCError({
+            code: 'UNAUTHORIZED',
+            message:
+              'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+          });
+        }
+
         return {
-          error: { message: (error as Error).message },
+          error: { message: errorMessage },
           filename,
           success: false,
         } as ExportAndUploadFileResult;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Improve Market OIDC authentication robustness and recovery for tools and sandbox calls.

Bug Fixes:
- Handle expired or invalid Market access tokens by attempting refresh and falling back to re-authentication when needed.
- Correctly surface Market authentication failures from tools and sandbox APIs as UNAUTHORIZED errors to trigger the auth flow.
- Prevent global LobeChat logout on Market-specific 401s and route them through a dedicated Market auth event system.
- Ensure Market tools client also participates in 401 handling and emits centralized market-unauthorized events.

Enhancements:
- Add automatic Market token refresh on initialization and shortly before expiry to maintain continuous authenticated sessions.
- Introduce a Market auth event emitter and handler to coordinate 401 recovery between client, tools, and auth provider.
- Stabilize Market sign-in and refresh behavior using memoized callbacks in the auth provider context.