### PR TITLE
💄 style: add Seedance 1.5 Pro support for OSS

### DIFF
--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1258,22 +1258,136 @@ const volcengineVideoModels: AIVideoModelCard[] = [
     id: 'doubao-seedance-1-5-pro-251215',
     organization: 'ByteDance',
     parameters: seedance15ProParams,
-    pricing: {
-      approximatePricePerVideo: 0.25,
-      currency: 'CNY',
-      units: [
-        {
-          lookup: {
-            pricingParams: ['generateAudio'],
-            prices: { false: 1.2, true: 2.4 },
-          },
-          name: 'videoGeneration',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
-      ],
-    },
     releasedAt: '2025-12-15',
+    type: 'video',
+  },
+  {
+    description:
+      'Seedance 1.0 Pro Fast is a comprehensive model designed to minimize cost while maximizing performance, achieving an excellent balance between video generation quality, speed, and price. It inherits the core strengths of Seedance 1.0 Pro, while offering faster generation speeds and more competitive pricing, delivering creators a dual optimization of efficiency and cost.',
+    displayName: 'Seedance 1.0 Pro Fast',
+    id: 'doubao-seedance-1-0-pro-fast-251015',
+    organization: 'ByteDance',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['21:9', '16:9', '4:3', '1.1', '3:4', '9:16'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      imageUrl: {
+        aspectRatio: { max: 2.5, min: 0.4 },
+        default: null,
+        height: { max: 6000, min: 300 },
+        maxFileSize: 30 * 1024 * 1024,
+        width: { max: 6000, min: 300 },
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-10-15',
+    type: 'video',
+  },
+  {
+    description:
+      'Seedance 1.0 Pro is a video generation foundation model that supports multi-shot storytelling. It delivers strong performance across multiple dimensions. The model achieves breakthroughs in semantic understanding and instruction following, enabling it to generate 1080P high-definition videos with smooth motion, rich details, diverse styles, and cinematic-level visual aesthetics.',
+    displayName: 'Seedance 1.0 Pro',
+    id: 'doubao-seedance-1-0-pro-250528',
+    organization: 'ByteDance',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['21:9', '16:9', '4:3', '1.1', '3:4', '9:16'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      endImageUrl: {
+        aspectRatio: { max: 2.5, min: 0.4 },
+        default: null,
+        height: { max: 6000, min: 300 },
+        maxFileSize: 30 * 1024 * 1024,
+        requiresImageUrl: true,
+        width: { max: 6000, min: 300 },
+      },
+      imageUrl: {
+        aspectRatio: { max: 2.5, min: 0.4 },
+        default: null,
+        height: { max: 6000, min: 300 },
+        maxFileSize: 30 * 1024 * 1024,
+        width: { max: 6000, min: 300 },
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-05-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Stable generation quality with high cost-effectiveness, capable of generating videos from a first frame, first-and-last frames, or reference images.',
+    displayName: 'Seedance 1.0 Lite I2V',
+    id: 'doubao-seedance-1-0-lite-i2v-250428',
+    organization: 'ByteDance',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['21:9', '16:9', '4:3', '1.1', '3:4', '9:16'],
+      },
+      cameraFixed: { default: false },
+      endImageUrl: {
+        aspectRatio: { max: 2.5, min: 0.4 },
+        default: null,
+        height: { max: 6000, min: 300 },
+        maxFileSize: 30 * 1024 * 1024,
+        requiresImageUrl: true,
+        width: { max: 6000, min: 300 },
+      },
+      imageUrl: {
+        aspectRatio: { max: 2.5, min: 0.4 },
+        default: null,
+        height: { max: 6000, min: 300 },
+        maxFileSize: 30 * 1024 * 1024,
+        width: { max: 6000, min: 300 },
+      },
+      duration: { default: 5, max: 12, min: 2 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-04-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Stable generation quality with high cost-effectiveness, capable of generating videos based on text instructions.',
+    displayName: 'Seedance 1.0 Lite T2V',
+    id: 'doubao-seedance-1-0-lite-t2v-250428',
+    organization: 'ByteDance',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['21:9', '16:9', '4:3', '1.1', '3:4', '9:16'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-04-28',
     type: 'video',
   },
 ];

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1,4 +1,9 @@
-import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import {
+  type AIChatModelCard,
+  type AIImageModelCard,
+  type AIVideoModelCard,
+} from '../types/aiModel';
+import { seedance15ProParams } from './lobehub/video';
 
 // https://www.volcengine.com/docs/82379/1330310
 
@@ -1244,6 +1249,35 @@ const volcengineImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...doubaoChatModels, ...volcengineImageModels];
+const volcengineVideoModels: AIVideoModelCard[] = [
+  {
+    description:
+      'Seedance 1.5 Pro by ByteDance supports text-to-video, image-to-video (first frame, first+last frame), and audio generation synchronized with visuals.',
+    displayName: 'Seedance 1.5 Pro',
+    enabled: true,
+    id: 'doubao-seedance-1-5-pro-251215',
+    organization: 'ByteDance',
+    parameters: seedance15ProParams,
+    pricing: {
+      approximatePricePerVideo: 0.25,
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            pricingParams: ['generateAudio'],
+            prices: { false: 1.2, true: 2.4 },
+          },
+          name: 'videoGeneration',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2025-12-15',
+    type: 'video',
+  },
+];
+
+export const allModels = [...doubaoChatModels, ...volcengineImageModels, ...volcengineVideoModels];
 
 export default allModels;

--- a/src/app/(backend)/api/webhooks/video/[provider]/route.ts
+++ b/src/app/(backend)/api/webhooks/video/[provider]/route.ts
@@ -50,8 +50,9 @@ export const POST = async (req: Request, { params }: { params: Promise<{ provide
   let asyncTaskMetadata: VideoGenerationTaskMetadata | undefined;
 
   try {
-    // Parse webhook body using provider-specific handler
-    const runtime = ModelRuntime.initializeWithProvider(provider, {});
+    const runtime = ModelRuntime.initializeWithProvider(provider, {
+      apiKey: 'webhook-placeholder',
+    });
     const result = await runtime.handleCreateVideoWebhook({ body });
 
     if (!result) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 复用逻辑为 OSS 版本增加 Seedance 1.5 Pro 支持
2. 修正 Video-WebHook 提示无 APIKey 的错误

---

TODO:
1. 模型定价？https://bytedance.larkoffice.com/wiki/FXaYwxzJ5i5Zdik32ipcWzt7nxd?table=tblyYwswtJHVhCLb&view=vewJGEMo3E

---

|模型|截图|日志|
|-|-|-|
|`doubao-seedance-1-5-pro-251215`|<img width="931" height="716" alt="image" src="https://github.com/user-attachments/assets/b1014e6f-ecd4-4a44-9aca-205b6097817f" />|<img width="907" height="797" alt="image" src="https://github.com/user-attachments/assets/1869972c-ba1a-464b-8ed3-1f16c4fb309f" />|

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Add Seedance 1.5 Pro as a supported Volcengine video model and adjust video webhook handling to work without a real API key.

New Features:
- Introduce the Seedance 1.5 Pro ByteDance video model to the Volcengine model catalog, including pricing and metadata.

Bug Fixes:
- Ensure video webhook handling initializes the model runtime with a placeholder API key to avoid missing API key errors.