### PR TITLE
🐛 fix(chat): clear input immediately on send to preserve drafts during streaming

### DIFF
--- a/src/features/Conversation/store.test.ts
+++ b/src/features/Conversation/store.test.ts
@@ -1,6 +1,8 @@
 import { act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useChatStore } from '@/store/chat';
+
 import { createStore } from './store';
 import { type ConversationContext, type ConversationHooks } from './types';
 
@@ -37,6 +39,7 @@ vi.mock('@/store/chat', () => ({
       internal_dispatchMessage: vi.fn(),
       internal_dispatchTopic: vi.fn(),
       internal_execAgentRuntime: vi.fn(),
+      sendMessage: vi.fn(),
       switchTopic: vi.fn(),
       summaryTopicTitle: vi.fn(),
       internal_updateTopicLoading: vi.fn(),
@@ -295,6 +298,64 @@ describe('ConversationStore', () => {
 
         expect(store.getState().inputMessage).toBe('');
         expect(store.getState().editor).toBeNull();
+      });
+    });
+
+    describe('sendMessage', () => {
+      it('should preserve draft typed during pending send after streaming completes', async () => {
+        const context: ConversationContext = {
+          agentId: 'session-1',
+          topicId: 'topic-1',
+          threadId: null,
+        };
+
+        let resolveSend: (value: {
+          assistantMessageId: string;
+          createdThreadId?: string;
+          userMessageId: string;
+        }) => void;
+        const pendingSend = new Promise<{
+          assistantMessageId: string;
+          createdThreadId?: string;
+          userMessageId: string;
+        }>((resolve) => {
+          resolveSend = resolve;
+        });
+
+        vi.mocked(useChatStore.getState).mockReturnValue({
+          ...useChatStore.getState(),
+          sendMessage: vi.fn(() => pendingSend),
+        } as any);
+
+        const store = createStore({ context });
+
+        act(() => {
+          store.getState().updateInputMessage('first message');
+        });
+
+        let sendPromise: Promise<void>;
+        act(() => {
+          sendPromise = store.getState().sendMessage({ message: 'first message' } as any);
+        });
+
+        expect(store.getState().inputMessage).toBe('');
+
+        act(() => {
+          store.getState().updateInputMessage('draft during streaming');
+        });
+
+        expect(store.getState().inputMessage).toBe('draft during streaming');
+
+        resolveSend!({
+          assistantMessageId: 'assistant-1',
+          userMessageId: 'user-1',
+        });
+
+        await act(async () => {
+          await sendPromise;
+        });
+
+        expect(store.getState().inputMessage).toBe('draft during streaming');
       });
     });
   });

--- a/src/features/Conversation/store/slices/message/action/sendMessage.ts
+++ b/src/features/Conversation/store/slices/message/action/sendMessage.ts
@@ -31,6 +31,11 @@ export const sendMessage = (
       }
     }
 
+    // Keep ConversationStore in sync with the editor, which is cleared immediately on send.
+    // Do this before awaiting the full streaming lifecycle so drafts typed during generation
+    // are not overwritten when the request completes.
+    set({ inputMessage: '' });
+
     // Get global chat store
     const chatStore = useChatStore.getState();
 
@@ -56,8 +61,5 @@ export const sendMessage = (
     if (hooks.onAfterSendMessage) {
       await hooks.onAfterSendMessage();
     }
-
-    // Clear input message
-    set({ inputMessage: '' });
   };
 };

--- a/src/hooks/useOperationState.test.ts
+++ b/src/hooks/useOperationState.test.ts
@@ -267,4 +267,45 @@ describe('useOperationState', () => {
       });
     });
   });
+
+  describe('isInputLoading', () => {
+    it('should clear loading after cancelling an operation in a null-topic context', () => {
+      const context = {
+        agentId: 'test-agent-id',
+        topicId: null,
+        threadId: null,
+      } as const;
+
+      const { result } = renderHook(() => useOperationState(context));
+
+      expect(result.current.isInputLoading).toBe(false);
+
+      let operationId: string;
+      act(() => {
+        operationId = useChatStore.getState().startOperation({
+          type: 'execAgentRuntime',
+          context: {
+            agentId: context.agentId,
+            topicId: undefined,
+            threadId: undefined,
+          },
+        }).operationId;
+      });
+
+      expect(result.current.isInputLoading).toBe(true);
+
+      act(() => {
+        useChatStore.getState().cancelOperations({
+          agentId: context.agentId,
+          status: 'running',
+          threadId: context.threadId,
+          topicId: context.topicId,
+          type: ['sendMessage', 'execAgentRuntime', 'execServerAgentRuntime'],
+        });
+      });
+
+      expect(useChatStore.getState().operations[operationId!].status).toBe('cancelled');
+      expect(result.current.isInputLoading).toBe(false);
+    });
+  });
 });

--- a/src/hooks/useOperationState.test.ts
+++ b/src/hooks/useOperationState.test.ts
@@ -298,8 +298,8 @@ describe('useOperationState', () => {
         useChatStore.getState().cancelOperations({
           agentId: context.agentId,
           status: 'running',
-          threadId: context.threadId,
-          topicId: context.topicId,
+          threadId: context.threadId ?? undefined,
+          topicId: context.topicId ?? undefined,
           type: ['sendMessage', 'execAgentRuntime', 'execServerAgentRuntime'],
         });
       });

--- a/src/store/chat/slices/operation/__tests__/actions.test.ts
+++ b/src/store/chat/slices/operation/__tests__/actions.test.ts
@@ -396,6 +396,31 @@ describe('Operation Actions', () => {
       expect(result.current.operations[op2!].status).toBe('cancelled');
       expect(result.current.operations[op3!].status).toBe('running'); // Not cancelled
     });
+
+    it('should treat null and undefined topicId as the same context when cancelling', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      let operationId: string;
+
+      act(() => {
+        operationId = result.current.startOperation({
+          type: 'execAgentRuntime',
+          context: { agentId: 'session1', topicId: undefined },
+        }).operationId;
+      });
+
+      act(() => {
+        const cancelled = result.current.cancelOperations({
+          agentId: 'session1',
+          status: 'running',
+          topicId: null,
+          type: ['sendMessage', 'execAgentRuntime', 'execServerAgentRuntime'],
+        });
+        expect(cancelled).toContain(operationId!);
+      });
+
+      expect(result.current.operations[operationId!].status).toBe('cancelled');
+    });
   });
 
   describe('cleanupCompletedOperations', () => {

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -22,6 +22,9 @@ import {
 const n = setNamespace('operation');
 const log = debug('lobe-store:operation');
 
+const isSameNullableContextValue = (left?: string | null, right?: string | null): boolean =>
+  (left ?? null) === (right ?? null);
+
 /**
  * Operation Actions
  */
@@ -494,13 +497,13 @@ export class OperationActionsImpl {
         matches = matches && op.context.agentId === filter.agentId;
       }
       if (filter.topicId !== undefined) {
-        matches = matches && op.context.topicId === filter.topicId;
+        matches = matches && isSameNullableContextValue(op.context.topicId, filter.topicId);
       }
       if (filter.messageId !== undefined) {
         matches = matches && op.context.messageId === filter.messageId;
       }
       if (filter.threadId !== undefined) {
-        matches = matches && op.context.threadId === filter.threadId;
+        matches = matches && isSameNullableContextValue(op.context.threadId, filter.threadId);
       }
       if (filter.groupId !== undefined) {
         matches = matches && op.context.groupId === filter.groupId;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-2647

#### 🔀 Description of Change

When the AI is still streaming a response, text typed into the input box was being silently discarded because `inputMessage` was cleared **after** the full streaming lifecycle completed, overwriting any draft the user had entered in the meantime.

This PR fixes two issues:

1. **Input draft overwritten on send completion** — Move the `set({ inputMessage: '' })` call to **before** the async streaming lifecycle in `sendMessage`, so the editor is cleared immediately and any new text typed during streaming is preserved.

2. **Cancel operations fails in null-topic sessions** — `cancelOperations` compared `topicId` and `threadId` with strict equality, causing `null !== undefined` mismatches. Added a `isSameNullableContextValue` helper that normalizes both to `null` before comparison, so operations in sessions without a topic can be correctly cancelled.

#### 🧪 How to Test

1. Start a conversation and send a message
2. While the AI is streaming, type new text in the input box
3. After streaming completes, verify the new text is still in the input box and the send button is active
4. In a session without a topic, verify that cancelling an operation works correctly

- [x] Added/updated tests

#### 📝 Additional Information

Three test files updated covering both fixes:
- `store.test.ts` — verifies draft preservation during pending send
- `useOperationState.test.ts` — verifies loading clears after cancel in null-topic context
- `actions.test.ts` — verifies null/undefined topicId treated as same context

## Summary by Sourcery

Fix message sending and operation cancellation behavior to preserve user drafts during streaming and correctly handle null-topic sessions.

Bug Fixes:
- Clear the conversation input state immediately on send so drafts typed during AI streaming are preserved after the response completes.
- Normalize nullable context values when filtering operations so cancellations work correctly in sessions without a topic or with null/undefined identifiers.

Tests:
- Add conversation store tests to verify drafts are preserved during pending sends and after streaming completes.
- Extend operation state and actions tests to ensure input loading clears and cancellations succeed in null-topic and mixed null/undefined topicId contexts.