### PR TITLE
🐛 fix: use jsonb ? operator to avoid Neon rt_fetch bug

### DIFF
--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -778,8 +778,8 @@ export class TopicModel {
           eq(topics.userId, this.userId),
           eq(topics.agentId, agentId),
           eq(topics.trigger, 'cron'),
-          // Check if metadata contains cronJobId
-          sql`${topics.metadata}->>'cronJobId' IS NOT NULL`,
+          // Check if metadata contains cronJobId (use ? operator to avoid Neon rt_fetch bug with ->>)
+          sql`${topics.metadata} ? 'cronJobId'`,
         ),
       )
       .orderBy(desc(topics.updatedAt));


### PR DESCRIPTION
## Summary
- Replace `metadata->>'cronJobId' IS NOT NULL` with `metadata ? 'cronJobId'` in `getCronTopicsGroupedByCronJob`
- The `->>` operator in WHERE clauses triggers a Neon-specific `rt_fetch used out-of-bounds` error
- The `?` operator is semantically equivalent (checks jsonb key existence) and works correctly on Neon

## Test plan
- [x] Verified via direct DB query that `metadata ? 'cronJobId'` returns results correctly
- [x] Verified `metadata->>'cronJobId' IS NOT NULL` reproduces the error on both pooler and direct connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Replace the JSONB text-extraction condition in cron topic queries with a key-existence operator to avoid the Neon rt_fetch error.