### PR TITLE
🐛 fix: adjust historyCount calculation to include accurate user messages

### DIFF
--- a/src/services/agentRuntime/index.ts
+++ b/src/services/agentRuntime/index.ts
@@ -44,8 +44,8 @@ class AgentRuntimeService {
     // Apply context engineering with preprocessing configuration
     const llmMessages = await contextEngineering({
       enableHistoryCount: agentChatConfigSelectors.enableHistoryCount(agentStoreState),
-      // include user messages
-      historyCount: agentChatConfigSelectors.historyCount(agentStoreState) + 2,
+      // historyCount is number of history messages; add 1 for current user message
+      historyCount: agentChatConfigSelectors.historyCount(agentStoreState) + 1,
       inputTemplate: chatConfig.inputTemplate,
       messages: data.messages as any,
       ...modelRuntimeConfig,

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -160,6 +160,182 @@ describe('ChatService', () => {
       );
     });
 
+    describe('historyCount functionality', () => {
+      it('should include historyCount + 1 messages when historyCount is enabled', async () => {
+        const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');
+
+        const messages = [
+          {
+            content: 'History 1',
+            createdAt: Date.now(),
+            id: '1',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Response 1',
+            createdAt: Date.now(),
+            id: '2',
+            role: 'assistant',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'History 2',
+            createdAt: Date.now(),
+            id: '3',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Response 2',
+            createdAt: Date.now(),
+            id: '4',
+            role: 'assistant',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Current message',
+            createdAt: Date.now(),
+            id: '5',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+        ] as UIChatMessage[];
+
+        await chatService.createAssistantMessage({
+          messages,
+          model: 'gpt-4',
+          provider: 'openai',
+          resolvedAgentConfig: createMockResolvedConfig({
+            agentConfig: { model: 'gpt-4', provider: 'openai' },
+            chatConfig: { enableHistoryCount: true, historyCount: 2, searchMode: 'off' },
+          }),
+        });
+
+        const calledMessages = getChatCompletionSpy.mock.calls[0][0].messages as any[];
+
+        // System date + (2 history messages + 1 current user message)
+        expect(calledMessages).toHaveLength(4);
+        expect(calledMessages[0]).toEqual(
+          expect.objectContaining({
+            content: expect.stringContaining(getCurrentDateContent()),
+            role: 'system',
+          }),
+        );
+        expect(calledMessages.slice(1)).toEqual([
+          expect.objectContaining({ content: 'History 2', role: 'user' }),
+          expect.objectContaining({ content: 'Response 2', role: 'assistant' }),
+          expect.objectContaining({ content: 'Current message', role: 'user' }),
+        ]);
+      });
+
+      it('should include only current message when historyCount is 0 and enabled', async () => {
+        const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');
+
+        const messages = [
+          {
+            content: 'History 1',
+            createdAt: Date.now(),
+            id: '1',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Response 1',
+            createdAt: Date.now(),
+            id: '2',
+            role: 'assistant',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Current message',
+            createdAt: Date.now(),
+            id: '3',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+        ] as UIChatMessage[];
+
+        await chatService.createAssistantMessage({
+          messages,
+          model: 'gpt-4',
+          provider: 'openai',
+          resolvedAgentConfig: createMockResolvedConfig({
+            agentConfig: { model: 'gpt-4', provider: 'openai' },
+            chatConfig: { enableHistoryCount: true, historyCount: 0, searchMode: 'off' },
+          }),
+        });
+
+        const calledMessages = getChatCompletionSpy.mock.calls[0][0].messages as any[];
+
+        // System date + current user message only
+        expect(calledMessages).toHaveLength(2);
+        expect(calledMessages[0]).toEqual(
+          expect.objectContaining({
+            content: expect.stringContaining(getCurrentDateContent()),
+            role: 'system',
+          }),
+        );
+        expect(calledMessages[1]).toEqual(
+          expect.objectContaining({ content: 'Current message', role: 'user' }),
+        );
+      });
+
+      it('should include all messages when historyCount is disabled', async () => {
+        const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');
+
+        const messages = [
+          {
+            content: 'History 1',
+            createdAt: Date.now(),
+            id: '1',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Response 1',
+            createdAt: Date.now(),
+            id: '2',
+            role: 'assistant',
+            updatedAt: Date.now(),
+          },
+          {
+            content: 'Current message',
+            createdAt: Date.now(),
+            id: '3',
+            role: 'user',
+            updatedAt: Date.now(),
+          },
+        ] as UIChatMessage[];
+
+        await chatService.createAssistantMessage({
+          messages,
+          model: 'gpt-4',
+          provider: 'openai',
+          resolvedAgentConfig: createMockResolvedConfig({
+            agentConfig: { model: 'gpt-4', provider: 'openai' },
+            chatConfig: { enableHistoryCount: false, historyCount: 0, searchMode: 'off' },
+          }),
+        });
+
+        const calledMessages = getChatCompletionSpy.mock.calls[0][0].messages as any[];
+
+        // System date + all original messages
+        expect(calledMessages).toHaveLength(4);
+        expect(calledMessages[0]).toEqual(
+          expect.objectContaining({
+            content: expect.stringContaining(getCurrentDateContent()),
+            role: 'system',
+          }),
+        );
+        expect(calledMessages.slice(1)).toEqual([
+          expect.objectContaining({ content: 'History 1', role: 'user' }),
+          expect.objectContaining({ content: 'Response 1', role: 'assistant' }),
+          expect.objectContaining({ content: 'Current message', role: 'user' }),
+        ]);
+      });
+    });
+
     describe('extendParams functionality', () => {
       it('should add reasoning parameters when model supports enableReasoning and user enables it', async () => {
         const getChatCompletionSpy = vi.spyOn(chatService, 'getChatCompletion');

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -244,8 +244,8 @@ class ChatService {
       enableHistoryCount: chatConfig.enableHistoryCount,
       enableUserMemories,
       groupId,
-      // historyCount + 2 accounts for: 1 user message + 1 assistant response being added
-      historyCount: (chatConfig.historyCount ?? 20) + 2,
+      // historyCount is number of history messages; add 1 for current user message
+      historyCount: (chatConfig.historyCount ?? 20) + 1,
       // Page editor context from agent runtime
       initialContext: options?.initialContext,
       inputTemplate: chatConfig.inputTemplate,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

目前当附带历史消息数为 0 时，实际会携带 3 条 message ，包括 system + 最近一条 assistance + user 

理论上不应该携带任何 assistance 消息才对。

包括设为 1 时会携带两条历史消息。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Adjust chat history trimming logic so historyCount represents only prior messages and ensure the current user message is always included once.

Bug Fixes:
- Correct the historyCount calculation so that a configured value of 0 no longer includes assistant history messages.
- Fix message selection when historyCount is enabled to avoid sending extra historical exchanges beyond the configured limit.

Tests:
- Add unit tests to verify behavior for enabled historyCount with a positive value, enabled historyCount with 0, and disabled historyCount, ensuring the correct number of messages are sent to the LLM.