### PR TITLE
🐛 fix: align TokenTag component with history count and skill activation mode

### DIFF
--- a/packages/context-engine/src/index.ts
+++ b/packages/context-engine/src/index.ts
@@ -19,6 +19,7 @@ export type { PlaceholderValue, PlaceholderValueMap } from './processors';
 export {
   buildPlaceholderGenerators,
   formatPlaceholderValues,
+  getHistorySlicedMessages,
   GroupMessageFlattenProcessor,
   HistoryTruncateProcessor,
   InputTemplateProcessor,

--- a/packages/context-engine/src/processors/index.ts
+++ b/packages/context-engine/src/processors/index.ts
@@ -8,7 +8,10 @@ export {
   type OrchestrationAgentInfo,
 } from './GroupOrchestrationFilter';
 export { GroupRoleTransformProcessor } from './GroupRoleTransform';
-export { HistoryTruncateProcessor } from './HistoryTruncate';
+export {
+  getSlicedMessages as getHistorySlicedMessages,
+  HistoryTruncateProcessor,
+} from './HistoryTruncate';
 export { InputTemplateProcessor } from './InputTemplate';
 export { MessageCleanupProcessor } from './MessageCleanup';
 export { MessageContentProcessor } from './MessageContent';

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -4,7 +4,7 @@ import { Center, Flexbox, Tooltip } from '@lobehub/ui';
 import { TokenTag } from '@lobehub/ui/chat';
 import { cssVar } from 'antd-style';
 import numeral from 'numeral';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
@@ -12,9 +12,9 @@ import { useModelContextWindowTokens } from '@/hooks/useModelContextWindowTokens
 import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
 import { useTokenCount } from '@/hooks/useTokenCount';
 import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { dbMessageSelectors, topicSelectors } from '@/store/chat/selectors';
+import { topicSelectors } from '@/store/chat/selectors';
 import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { useUserStore } from '@/store/user';
@@ -43,19 +43,8 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
       agentByIdSelectors.getAgentSystemRoleById(agentId)(s),
       agentByIdSelectors.getAgentModelById(agentId)(s),
       agentByIdSelectors.getAgentModelProviderById(agentId)(s),
-      // add these two params to enable the component to re-render
-      chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
-      chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
     ];
   });
-
-  const [historyCount, enableHistoryCount] = useAgentStore((s) => [
-    chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
-    chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
-    // need to re-render by search mode
-    chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
-    chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
-  ]);
 
   const maxTokens = useModelContextWindowTokens(model, provider);
 
@@ -96,13 +85,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
 
   // Chat usage token
   const inputTokenCount = useTokenCount(input);
-
-  const chatsString = useMemo(() => {
-    const chats = dbMessageSelectors.activeDbMessages(useChatStore.getState());
-    return chats.map((chat) => chat.content).join('');
-  }, [messageString, historyCount, enableHistoryCount]);
-
-  const chatsToken = useTokenCount(chatsString) + inputTokenCount;
+  const chatsToken = useTokenCount(messageString) + inputTokenCount;
 
   // SystemRole token
   const systemRoleToken = useTokenCount(systemRole);

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -1,21 +1,21 @@
 import { ToolNameResolver } from '@lobechat/context-engine';
-import { pluginPrompts } from '@lobechat/prompts';
+import { pluginPrompts, skillsPrompts } from '@lobechat/prompts';
 import { Center, Flexbox, Tooltip } from '@lobehub/ui';
 import { TokenTag } from '@lobehub/ui/chat';
 import { cssVar } from 'antd-style';
 import numeral from 'numeral';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
 import { useModelContextWindowTokens } from '@/hooks/useModelContextWindowTokens';
 import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
 import { useTokenCount } from '@/hooks/useTokenCount';
+import { createSkillEngine } from '@/services/chat/mecha/skillEngineering';
 import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
@@ -50,16 +50,28 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
 
   // Tool usage token
   const canUseTool = useModelSupportToolUse(model, provider);
-  const pluginIds = useAgentStore((s) => agentByIdSelectors.getAgentPluginsById(agentId)(s));
+  const [pluginIds, skillActivateMode] = useAgentStore((s) => [
+    agentByIdSelectors.getAgentPluginsById(agentId)(s),
+    chatConfigByIdSelectors.getSkillActivateModeById(agentId)(s),
+  ]);
+  const isManualMode = skillActivateMode === 'manual';
 
-  const toolsString = useToolStore(() => {
+  const toolsString = useMemo(() => {
     const toolsEngine = createAgentToolsEngine({ model, provider });
+    const skillEngine = createSkillEngine();
 
     const { tools, enabledManifests } = toolsEngine.generateToolsDetailed({
       model,
       provider,
+      skipDefaultTools: isManualMode,
       toolIds: pluginIds,
     });
+
+    const enabledSkills = isManualMode
+      ? skillEngine.getEnabledSkills(pluginIds)
+      : skillEngine.getAllSkills();
+    const skillContextPrompt = enabledSkills.length > 0 ? skillsPrompts(enabledSkills) : '';
+
     const schemaNumber = tools?.map((i) => JSON.stringify(i)).join('') || '';
 
     // Generate plugin system roles from enabledManifests
@@ -78,8 +90,8 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
           })
         : '';
 
-    return toolsSystemRole + schemaNumber;
-  });
+    return skillContextPrompt + toolsSystemRole + schemaNumber;
+  }, [isManualMode, model, pluginIds, provider]);
 
   const toolsToken = useTokenCount(canUseTool ? toolsString : '');
 

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -21,6 +21,7 @@ import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
+import { useChatInputStore } from '../../store';
 import ActionPopover from '../components/ActionPopover';
 import TokenProgress from './TokenProgress';
 
@@ -32,10 +33,10 @@ interface TokenTagProps {
 const Token = memo<TokenTagProps>(({ total: messageString }) => {
   const { t } = useTranslation(['chat', 'components']);
 
-  const [input, historySummary] = useChatStore((s) => [
-    s.inputMessage,
-    topicSelectors.currentActiveTopicSummary(s)?.content || '',
-  ]);
+  const input = useChatInputStore((s) => s.markdownContent);
+  const historySummary = useChatStore(
+    (s) => topicSelectors.currentActiveTopicSummary(s)?.content || '',
+  );
 
   const agentId = useAgentId();
   const [systemRole, model, provider] = useAgentStore((s) => {

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -21,7 +21,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
-import { topicSelectors } from '@/store/chat/selectors';
+import { dbMessageSelectors, topicSelectors } from '@/store/chat/selectors';
 import { parseSelectedToolsFromEditorData } from '@/store/chat/slices/aiChat/actions/commandBus/parseCommands';
 import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
@@ -189,7 +189,11 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
 
   // Chat usage token
   const inputTokenCount = useTokenCount(input);
-  const chatsToken = useTokenCount(messageString) + inputTokenCount;
+  const chatsString = useMemo(() => {
+    const chats = dbMessageSelectors.activeDbMessages(useChatStore.getState());
+    return chats.map((chat) => chat.content).join('');
+  }, [messageString]);
+  const chatsToken = useTokenCount(chatsString) + inputTokenCount;
 
   // SystemRole token
   const systemRoleToken = useTokenCount(systemRole);

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -1,3 +1,8 @@
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
+import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
+import { MemoryManifest } from '@lobechat/builtin-tool-memory';
+import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { ToolNameResolver } from '@lobechat/context-engine';
 import { pluginPrompts, skillsPrompts } from '@lobechat/prompts';
 import { Center, Flexbox, Tooltip } from '@lobehub/ui';
@@ -10,7 +15,6 @@ import { shallow } from 'zustand/shallow';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
 import { useModelContextWindowTokens } from '@/hooks/useModelContextWindowTokens';
-import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
 import { useTokenCount } from '@/hooks/useTokenCount';
 import { createSkillEngine } from '@/services/chat/mecha/skillEngineering';
 import { useAgentStore } from '@/store/agent';
@@ -18,6 +22,7 @@ import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selec
 import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { parseSelectedToolsFromEditorData } from '@/store/chat/slices/aiChat/actions/commandBus/parseCommands';
 import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { useUserStore } from '@/store/user';
@@ -37,6 +42,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   const { t } = useTranslation(['chat', 'components']);
 
   const input = useChatInputStore((s) => s.markdownContent);
+  const inputEditorData = useChatInputStore((s) => s.getJSONState());
   const historySummary = useChatStore(
     (s) => topicSelectors.currentActiveTopicSummary(s)?.content || '',
   );
@@ -57,11 +63,43 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   );
 
   // Tool usage token
-  const canUseTool = useModelSupportToolUse(model, provider);
-  const [pluginIds, skillActivateMode] = useAgentStore((s) => [
+  const [
+    pluginIds,
+    skillActivateMode,
+    isSearchEnabled,
+    isMemoryToolEnabled,
+    runtimeMode,
+    knowledgeBases,
+  ] = useAgentStore((s) => [
     agentByIdSelectors.getAgentPluginsById(agentId)(s),
     chatConfigByIdSelectors.getSkillActivateModeById(agentId)(s),
+    chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
+    chatConfigByIdSelectors.isMemoryToolEnabledById(agentId)(s),
+    chatConfigByIdSelectors.getRuntimeModeById(agentId)(s),
+    agentByIdSelectors.getAgentKnowledgeBasesById(agentId)(s),
   ]);
+  const isManualMode = skillActivateMode === 'manual';
+  const selectedToolIds = useMemo(
+    () => parseSelectedToolsFromEditorData(inputEditorData).map((tool) => tool.identifier),
+    [inputEditorData],
+  );
+  const manualConfigToolIds = useMemo(
+    () =>
+      isManualMode
+        ? [
+            ...(isSearchEnabled ? [WebBrowsingManifest.identifier] : []),
+            ...(isMemoryToolEnabled ? [MemoryManifest.identifier] : []),
+            ...(runtimeMode === 'local' ? [LocalSystemManifest.identifier] : []),
+            ...(runtimeMode === 'cloud' ? [CloudSandboxManifest.identifier] : []),
+            ...(knowledgeBases.some((kb) => kb.enabled) ? [KnowledgeBaseManifest.identifier] : []),
+          ]
+        : [],
+    [isManualMode, isMemoryToolEnabled, isSearchEnabled, knowledgeBases, runtimeMode],
+  );
+  const effectiveToolIds = useMemo(
+    () => [...new Set([...pluginIds, ...selectedToolIds, ...manualConfigToolIds])],
+    [manualConfigToolIds, pluginIds, selectedToolIds],
+  );
   const agentToolsConfigSignal = useAgentStore(
     (s) => [
       chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
@@ -80,7 +118,6 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     ],
     shallow,
   );
-  const isManualMode = skillActivateMode === 'manual';
   const toolSkillStoreSignal = useToolStore(
     (s) => [
       s.installedPlugins,
@@ -106,7 +143,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
       model,
       provider,
       skipDefaultTools: isManualMode,
-      toolIds: pluginIds,
+      toolIds: effectiveToolIds,
     });
 
     const enabledSkills = isManualMode
@@ -142,12 +179,13 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     globalMemoryEnabled,
     isManualMode,
     model,
+    effectiveToolIds,
     pluginIds,
     provider,
     toolSkillStoreSignal,
   ]);
 
-  const toolsToken = useTokenCount(skillContextPrompt + (canUseTool ? toolContextString : ''));
+  const toolsToken = useTokenCount(skillContextPrompt + toolContextString);
 
   // Chat usage token
   const inputTokenCount = useTokenCount(input);

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -6,6 +6,7 @@ import { cssVar } from 'antd-style';
 import numeral from 'numeral';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { shallow } from 'zustand/shallow';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
 import { useModelContextWindowTokens } from '@/hooks/useModelContextWindowTokens';
@@ -14,11 +15,13 @@ import { useTokenCount } from '@/hooks/useTokenCount';
 import { createSkillEngine } from '@/services/chat/mecha/skillEngineering';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors } from '@/store/user/selectors';
+import { settingsSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useChatInputStore } from '../../store';
@@ -48,6 +51,10 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   });
 
   const maxTokens = useModelContextWindowTokens(model, provider);
+  const [isDevMode, globalMemoryEnabled] = useUserStore(
+    (s) => [userGeneralSettingsSelectors.config(s).isDevMode, settingsSelectors.memoryEnabled(s)],
+    shallow,
+  );
 
   // Tool usage token
   const canUseTool = useModelSupportToolUse(model, provider);
@@ -55,9 +62,43 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     agentByIdSelectors.getAgentPluginsById(agentId)(s),
     chatConfigByIdSelectors.getSkillActivateModeById(agentId)(s),
   ]);
+  const agentToolsConfigSignal = useAgentStore(
+    (s) => [
+      chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
+      chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
+      chatConfigByIdSelectors.getRuntimeModeById(agentId)(s),
+      chatConfigByIdSelectors.isMemoryToolEnabledById(agentId)(s),
+      agentByIdSelectors.getAgentKnowledgeBasesById(agentId)(s),
+    ],
+    shallow,
+  );
+  const aiInfraSearchSignal = useAiInfraStore(
+    (s) => [
+      aiProviderSelectors.isProviderHasBuiltinSearch(provider)(s),
+      aiModelSelectors.isModelHasBuiltinSearch(model, provider)(s),
+      aiModelSelectors.isModelBuiltinSearchInternal(model, provider)(s),
+    ],
+    shallow,
+  );
   const isManualMode = skillActivateMode === 'manual';
+  const toolSkillStoreSignal = useToolStore(
+    (s) => [
+      s.installedPlugins,
+      s.builtinTools,
+      s.servers,
+      s.lobehubSkillServers,
+      s.builtinSkills,
+      s.agentSkills,
+    ],
+    shallow,
+  );
 
   const toolsString = useMemo(() => {
+    void agentToolsConfigSignal;
+    void aiInfraSearchSignal;
+    void globalMemoryEnabled;
+    void toolSkillStoreSignal;
+
     const toolsEngine = createAgentToolsEngine({ model, provider });
     const skillEngine = createSkillEngine();
 
@@ -92,7 +133,16 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
         : '';
 
     return skillContextPrompt + toolsSystemRole + schemaNumber;
-  }, [isManualMode, model, pluginIds, provider]);
+  }, [
+    agentToolsConfigSignal,
+    aiInfraSearchSignal,
+    globalMemoryEnabled,
+    isManualMode,
+    model,
+    pluginIds,
+    provider,
+    toolSkillStoreSignal,
+  ]);
 
   const toolsToken = useTokenCount(canUseTool ? toolsString : '');
 
@@ -106,8 +156,6 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
 
   // Total token
   const totalToken = systemRoleToken + historySummaryToken + toolsToken + chatsToken;
-
-  const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
 
   if (!isDevMode && maxTokens > 0 && totalToken / maxTokens <= 0.5) return null;
 

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -93,7 +93,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     shallow,
   );
 
-  const toolsString = useMemo(() => {
+  const { skillContextPrompt, toolContextString } = useMemo(() => {
     void agentToolsConfigSignal;
     void aiInfraSearchSignal;
     void globalMemoryEnabled;
@@ -132,7 +132,10 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
           })
         : '';
 
-    return skillContextPrompt + toolsSystemRole + schemaNumber;
+    return {
+      skillContextPrompt,
+      toolContextString: toolsSystemRole + schemaNumber,
+    };
   }, [
     agentToolsConfigSignal,
     aiInfraSearchSignal,
@@ -144,7 +147,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
     toolSkillStoreSignal,
   ]);
 
-  const toolsToken = useTokenCount(canUseTool ? toolsString : '');
+  const toolsToken = useTokenCount(skillContextPrompt + (canUseTool ? toolContextString : ''));
 
   // Chat usage token
   const inputTokenCount = useTokenCount(input);

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -22,6 +22,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
+import { chatHelpers } from '@/store/chat/helpers';
 import {
   dbMessageSelectors,
   displayMessageSelectors,
@@ -108,7 +109,7 @@ const collectRawMessageEstimateText = (message: UIChatMessage): string => {
   }
 };
 
-const Token = memo<TokenTagProps>(({ total: messageString }) => {
+const Token = memo<TokenTagProps>(({ total: _messageString }) => {
   const { t } = useTranslation(['chat', 'components']);
 
   const input = useChatInputStore((s) => s.markdownContent);
@@ -125,6 +126,11 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
       agentByIdSelectors.getAgentModelProviderById(agentId)(s),
     ];
   });
+
+  const [historyCount, enableHistoryCount] = useAgentStore((s) => [
+    chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
+    chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
+  ]);
 
   const maxTokens = useModelContextWindowTokens(model, provider);
   const [isDevMode, globalMemoryEnabled] = useUserStore(
@@ -258,7 +264,16 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   const toolsToken = useTokenCount(skillContextPrompt + toolContextString);
 
   // Chat usage token
-  const chats = useChatStore(displayMessageSelectors.mainAIChatsWithHistoryConfig);
+  const mainAIChats = useChatStore(displayMessageSelectors.mainAIChats);
+  const chats = useMemo(
+    () =>
+      chatHelpers.getSlicedMessages(mainAIChats, {
+        enableHistoryCount,
+        historyCount,
+        includeNewUserMessage: Boolean(input?.trim()),
+      }),
+    [enableHistoryCount, historyCount, input, mainAIChats],
+  );
   const dbChats = useChatStore(dbMessageSelectors.activeDbMessages);
   const inputTokenCount = useTokenCount(input);
   const chatsString = useMemo(() => {
@@ -279,7 +294,7 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
       .filter(Boolean)
       .map((message) => collectRawMessageEstimateText(message!))
       .join('');
-  }, [chats, dbChats, messageString]);
+  }, [chats, dbChats]);
   const chatsToken = useTokenCount(chatsString) + inputTokenCount;
 
   // SystemRole token

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -5,6 +5,7 @@ import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { ToolNameResolver } from '@lobechat/context-engine';
 import { pluginPrompts, skillsPrompts } from '@lobechat/prompts';
+import type { AssistantContentBlock, UIChatMessage } from '@lobechat/types';
 import { Center, Flexbox, Tooltip } from '@lobehub/ui';
 import { TokenTag } from '@lobehub/ui/chat';
 import { cssVar } from 'antd-style';
@@ -21,7 +22,11 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
-import { dbMessageSelectors, topicSelectors } from '@/store/chat/selectors';
+import {
+  dbMessageSelectors,
+  displayMessageSelectors,
+  topicSelectors,
+} from '@/store/chat/selectors';
 import { parseSelectedToolsFromEditorData } from '@/store/chat/slices/aiChat/actions/commandBus/parseCommands';
 import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
@@ -38,6 +43,71 @@ const toolNameResolver = new ToolNameResolver();
 interface TokenTagProps {
   total: string;
 }
+
+const serializeEstimateText = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const collectRawMessageIdsFromBlock = (
+  block: AssistantContentBlock,
+  pushId: (id?: string) => void,
+) => {
+  pushId(block.id);
+  block.tools?.forEach((tool) => pushId(tool.result_msg_id));
+};
+
+const collectRawMessageIdsFromDisplayMessage = (
+  message: UIChatMessage,
+  pushId: (id?: string) => void,
+) => {
+  // Keep raw message identity aligned with real message records
+  pushId(message.id);
+
+  // Assistant/tool relation in raw messages
+  message.tools?.forEach((tool) => pushId(tool.result_msg_id));
+
+  if ((message.role === 'assistantGroup' || message.role === 'supervisor') && message.children) {
+    message.children.forEach((child) => collectRawMessageIdsFromBlock(child, pushId));
+  }
+
+  if (message.role === 'agentCouncil' && message.members) {
+    message.members.forEach((member) => collectRawMessageIdsFromDisplayMessage(member, pushId));
+  }
+
+  if ((message.role === 'tasks' || message.role === 'groupTasks') && message.tasks) {
+    message.tasks.forEach((task) => collectRawMessageIdsFromDisplayMessage(task, pushId));
+  }
+};
+
+const collectRawMessageEstimateText = (message: UIChatMessage): string => {
+  switch (message.role) {
+    case 'assistant': {
+      return [
+        serializeEstimateText(message.content),
+        message.reasoning?.content || '',
+        message.tools?.map((tool) => tool.arguments || '').join('') || '',
+      ].join('');
+    }
+
+    case 'tool':
+    case 'user':
+    case 'system': {
+      return serializeEstimateText(message.content);
+    }
+
+    default: {
+      return serializeEstimateText(message.content);
+    }
+  }
+};
+
 const Token = memo<TokenTagProps>(({ total: messageString }) => {
   const { t } = useTranslation(['chat', 'components']);
 
@@ -188,11 +258,28 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   const toolsToken = useTokenCount(skillContextPrompt + toolContextString);
 
   // Chat usage token
+  const chats = useChatStore(displayMessageSelectors.mainAIChatsWithHistoryConfig);
+  const dbChats = useChatStore(dbMessageSelectors.activeDbMessages);
   const inputTokenCount = useTokenCount(input);
   const chatsString = useMemo(() => {
-    const chats = dbMessageSelectors.activeDbMessages(useChatStore.getState());
-    return chats.map((chat) => chat.content).join('');
-  }, [messageString]);
+    const rawMessageMap = new Map(dbChats.map((message) => [message.id, message]));
+    const rawMessageIds: string[] = [];
+    const seenIds = new Set<string>();
+
+    const pushId = (id?: string) => {
+      if (!id || seenIds.has(id) || !rawMessageMap.has(id)) return;
+      seenIds.add(id);
+      rawMessageIds.push(id);
+    };
+
+    chats.forEach((chat) => collectRawMessageIdsFromDisplayMessage(chat, pushId));
+
+    return rawMessageIds
+      .map((id) => rawMessageMap.get(id))
+      .filter(Boolean)
+      .map((message) => collectRawMessageEstimateText(message!))
+      .join('');
+  }, [chats, dbChats, messageString]);
   const chatsToken = useTokenCount(chatsString) + inputTokenCount;
 
   // SystemRole token

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -3,6 +3,8 @@ import { memo } from 'react';
 
 import { useModelHasContextWindowToken } from '@/hooks/useModelHasContextWindowToken';
 import dynamic from '@/libs/next/dynamic';
+import { useAgentStore } from '@/store/agent';
+import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { displayMessageSelectors, threadSelectors } from '@/store/chat/selectors';
 
@@ -14,7 +16,20 @@ const Token = memo<PropsWithChildren>(({ children }) => {
   return showTag && children;
 });
 
+const useTokenRelatedConfigSubscription = () => {
+  const activeAgentId = useChatStore((s) => s.activeAgentId) ?? '';
+
+  useAgentStore((s) => [
+    chatConfigByIdSelectors.getHistoryCountById(activeAgentId)(s),
+    chatConfigByIdSelectors.getEnableHistoryCountById(activeAgentId)(s),
+    chatConfigByIdSelectors.isEnableSearchById(activeAgentId)(s),
+    chatConfigByIdSelectors.getUseModelBuiltinSearchById(activeAgentId)(s),
+  ]);
+};
+
 export const MainToken = memo(() => {
+  useTokenRelatedConfigSubscription();
+
   const total = useChatStore(displayMessageSelectors.mainAIChatsMessageString);
 
   return (
@@ -25,6 +40,8 @@ export const MainToken = memo(() => {
 });
 
 export const PortalToken = memo(() => {
+  useTokenRelatedConfigSubscription();
+
   const total = useChatStore(threadSelectors.portalDisplayChatsString);
 
   return (

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -1,12 +1,16 @@
 import { type PropsWithChildren } from 'react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { useModelHasContextWindowToken } from '@/hooks/useModelHasContextWindowToken';
 import dynamic from '@/libs/next/dynamic';
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { chatHelpers } from '@/store/chat/helpers';
 import { displayMessageSelectors, threadSelectors } from '@/store/chat/selectors';
+import { extractDisplayMessageContent } from '@/store/chat/slices/message/selectors/displayMessage';
+
+import { useAgentId } from '../../hooks/useAgentId';
 
 const LargeTokenContent = dynamic(() => import('./TokenTag'), { ssr: false });
 
@@ -16,21 +20,36 @@ const Token = memo<PropsWithChildren>(({ children }) => {
   return showTag && children;
 });
 
-const useTokenRelatedConfigSubscription = () => {
-  const activeAgentId = useChatStore((s) => s.activeAgentId) ?? '';
+const useTokenRelatedConfigSubscription = (agentId: string) => {
+  const [historyCount, enableHistoryCount] = useAgentStore((s) => [
+    chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
+    chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
+  ]);
 
   useAgentStore((s) => [
-    chatConfigByIdSelectors.getHistoryCountById(activeAgentId)(s),
-    chatConfigByIdSelectors.getEnableHistoryCountById(activeAgentId)(s),
-    chatConfigByIdSelectors.isEnableSearchById(activeAgentId)(s),
-    chatConfigByIdSelectors.getUseModelBuiltinSearchById(activeAgentId)(s),
+    chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
+    chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
   ]);
+
+  return { enableHistoryCount, historyCount };
 };
 
 export const MainToken = memo(() => {
-  useTokenRelatedConfigSubscription();
+  const agentId = useAgentId();
+  const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
+  const allChats = useChatStore(displayMessageSelectors.mainAIChats);
 
-  const total = useChatStore(displayMessageSelectors.mainAIChatsMessageString);
+  const total = useMemo(
+    () =>
+      chatHelpers
+        .getSlicedMessages(allChats, {
+          enableHistoryCount,
+          historyCount,
+        })
+        .map(extractDisplayMessageContent)
+        .join(''),
+    [allChats, enableHistoryCount, historyCount],
+  );
 
   return (
     <Token>
@@ -40,9 +59,21 @@ export const MainToken = memo(() => {
 });
 
 export const PortalToken = memo(() => {
-  useTokenRelatedConfigSubscription();
+  const agentId = useAgentId();
+  const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
+  const allPortalChats = useChatStore(threadSelectors.portalAIChats);
 
-  const total = useChatStore(threadSelectors.portalDisplayChatsString);
+  const total = useMemo(
+    () =>
+      chatHelpers
+        .getSlicedMessages(allPortalChats, {
+          enableHistoryCount,
+          historyCount,
+        })
+        .map(extractDisplayMessageContent)
+        .join(''),
+    [allPortalChats, enableHistoryCount, historyCount],
+  );
 
   return (
     <Token>

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -1,3 +1,4 @@
+import { getHistorySlicedMessages } from '@lobechat/context-engine';
 import { type PropsWithChildren } from 'react';
 import { memo, useMemo } from 'react';
 
@@ -6,13 +7,14 @@ import dynamic from '@/libs/next/dynamic';
 import { useAgentStore } from '@/store/agent';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { chatHelpers } from '@/store/chat/helpers';
 import { displayMessageSelectors, threadSelectors } from '@/store/chat/selectors';
 import { extractDisplayMessageContent } from '@/store/chat/slices/message/selectors/displayMessage';
 
 import { useAgentId } from '../../hooks/useAgentId';
+import { useChatInputStore } from '../../store';
 
 const LargeTokenContent = dynamic(() => import('./TokenTag'), { ssr: false });
+const RUNTIME_HISTORY_COUNT_BUFFER = 2;
 
 const Token = memo<PropsWithChildren>(({ children }) => {
   const showTag = useModelHasContextWindowToken();
@@ -38,17 +40,19 @@ export const MainToken = memo(() => {
   const agentId = useAgentId();
   const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
   const allChats = useChatStore(displayMessageSelectors.mainAIChats);
+  const hasPendingInput = !!useChatInputStore((s) => s.markdownContent.trim());
+  const effectiveHistoryCount =
+    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - (hasPendingInput ? 1 : 0);
 
   const total = useMemo(
     () =>
-      chatHelpers
-        .getSlicedMessages(allChats, {
-          enableHistoryCount,
-          historyCount,
-        })
+      getHistorySlicedMessages(allChats, {
+        enableHistoryCount,
+        historyCount: effectiveHistoryCount,
+      })
         .map(extractDisplayMessageContent)
         .join(''),
-    [allChats, enableHistoryCount, historyCount],
+    [allChats, effectiveHistoryCount, enableHistoryCount],
   );
 
   return (
@@ -62,17 +66,19 @@ export const PortalToken = memo(() => {
   const agentId = useAgentId();
   const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
   const allPortalChats = useChatStore(threadSelectors.portalAIChats);
+  const hasPendingInput = !!useChatInputStore((s) => s.markdownContent.trim());
+  const effectiveHistoryCount =
+    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - (hasPendingInput ? 1 : 0);
 
   const total = useMemo(
     () =>
-      chatHelpers
-        .getSlicedMessages(allPortalChats, {
-          enableHistoryCount,
-          historyCount,
-        })
+      getHistorySlicedMessages(allPortalChats, {
+        enableHistoryCount,
+        historyCount: effectiveHistoryCount,
+      })
         .map(extractDisplayMessageContent)
         .join(''),
-    [allPortalChats, enableHistoryCount, historyCount],
+    [allPortalChats, effectiveHistoryCount, enableHistoryCount],
   );
 
   return (

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -11,10 +11,10 @@ import { displayMessageSelectors, threadSelectors } from '@/store/chat/selectors
 import { extractDisplayMessageContent } from '@/store/chat/slices/message/selectors/displayMessage';
 
 import { useAgentId } from '../../hooks/useAgentId';
-import { useChatInputStore } from '../../store';
 
 const LargeTokenContent = dynamic(() => import('./TokenTag'), { ssr: false });
-const RUNTIME_HISTORY_COUNT_BUFFER = 2;
+const RUNTIME_HISTORY_COUNT_BUFFER = 1;
+const RESERVED_PENDING_INPUT_SLOT = 1;
 
 const Token = memo<PropsWithChildren>(({ children }) => {
   const showTag = useModelHasContextWindowToken();
@@ -40,9 +40,8 @@ export const MainToken = memo(() => {
   const agentId = useAgentId();
   const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
   const allChats = useChatStore(displayMessageSelectors.mainAIChats);
-  const hasPendingInput = !!useChatInputStore((s) => s.markdownContent.trim());
   const effectiveHistoryCount =
-    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - (hasPendingInput ? 1 : 0);
+    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - RESERVED_PENDING_INPUT_SLOT;
 
   const total = useMemo(
     () =>
@@ -66,9 +65,8 @@ export const PortalToken = memo(() => {
   const agentId = useAgentId();
   const { historyCount, enableHistoryCount } = useTokenRelatedConfigSubscription(agentId);
   const allPortalChats = useChatStore(threadSelectors.portalAIChats);
-  const hasPendingInput = !!useChatInputStore((s) => s.markdownContent.trim());
   const effectiveHistoryCount =
-    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - (hasPendingInput ? 1 : 0);
+    historyCount + RUNTIME_HISTORY_COUNT_BUFFER - RESERVED_PENDING_INPUT_SLOT;
 
   const total = useMemo(
     () =>

--- a/src/features/ChatInput/ActionBar/Token/index.tsx
+++ b/src/features/ChatInput/ActionBar/Token/index.tsx
@@ -21,15 +21,15 @@ const Token = memo<PropsWithChildren>(({ children }) => {
 });
 
 const useTokenRelatedConfigSubscription = (agentId: string) => {
-  const [historyCount, enableHistoryCount] = useAgentStore((s) => [
-    chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
-    chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
-  ]);
-
-  useAgentStore((s) => [
-    chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
-    chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
-  ]);
+  const [historyCount, enableHistoryCount] = useAgentStore(
+    (s) =>
+      [
+        chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
+        chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
+        chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
+        chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
+      ] as const,
+  );
 
   return { enableHistoryCount, historyCount };
 };

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1,13 +1,17 @@
 import type { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
 import { BUILTIN_AGENT_SLUGS, getAgentRuntimeConfig } from '@lobechat/builtin-agents';
 import { builtinSkills } from '@lobechat/builtin-skills';
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
+import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
+import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import {
   type DeviceAttachment,
   generateSystemPrompt,
   RemoteDeviceManifest,
 } from '@lobechat/builtin-tool-remote-device';
-import { builtinTools, manualModeExcludeToolIds } from '@lobechat/builtin-tools';
+import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
+import { builtinTools } from '@lobechat/builtin-tools';
 import { LOADING_FLAT } from '@lobechat/const';
 import type { LobeToolManifest } from '@lobechat/context-engine';
 import type { LobeChatDatabase } from '@lobechat/database';
@@ -477,15 +481,28 @@ export class AiAgentService {
     ];
     log('execAgent: agent configured plugins: %O', pluginIds);
 
-    // When skillActivateMode is 'manual', exclude only discovery tools (lobe-activator, lobe-skill-store)
-    // so that externally enabled tools (sandbox, web browsing, etc.) remain available
+    // When skillActivateMode is 'manual', skip all default tools,
+    // then explicitly include tools derived from chatConfig/runtime settings.
     const isManualMode = agentConfig.chatConfig?.skillActivateMode === 'manual';
+    const runtimeMode =
+      agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[gatewayConfigured ? 'desktop' : 'web'] ??
+      (gatewayConfigured ? 'local' : 'none');
+    const manualConfigToolIds = isManualMode
+      ? [
+          ...(agentConfig.chatConfig?.searchMode !== 'off' ? [WebBrowsingManifest.identifier] : []),
+          ...(agentConfig.chatConfig?.memory?.enabled ? [MemoryManifest.identifier] : []),
+          ...(runtimeMode === 'local' ? [LocalSystemManifest.identifier] : []),
+          ...(runtimeMode === 'cloud' ? [CloudSandboxManifest.identifier] : []),
+          ...(hasEnabledKnowledgeBases ? [KnowledgeBaseManifest.identifier] : []),
+        ]
+      : [];
+    const effectiveToolIds = [...new Set([...(pluginIds || []), ...manualConfigToolIds])];
 
     const toolsResult = toolsEngine.generateToolsDetailed({
-      excludeDefaultToolIds: isManualMode ? manualModeExcludeToolIds : undefined,
       model,
       provider,
-      toolIds: pluginIds,
+      skipDefaultTools: isManualMode,
+      toolIds: effectiveToolIds,
     });
 
     const tools = toolsResult.tools;
@@ -493,7 +510,7 @@ export class AiAgentService {
     log('execAgent: enabled tool ids: %O', toolsResult.enabledToolIds);
 
     // Get manifest map and convert from Map to Record
-    const manifestMap = toolsEngine.getEnabledPluginManifests(pluginIds);
+    const manifestMap = toolsEngine.getEnabledPluginManifests(effectiveToolIds);
     const toolManifestMap: Record<string, any> = {};
     manifestMap.forEach((manifest, id) => {
       toolManifestMap[id] = manifest;

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -10,6 +10,7 @@ import {
   generateSystemPrompt,
   RemoteDeviceManifest,
 } from '@lobechat/builtin-tool-remote-device';
+import { TopicReferenceManifest } from '@lobechat/builtin-tool-topic-reference';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { builtinTools } from '@lobechat/builtin-tools';
 import { LOADING_FLAT } from '@lobechat/const';
@@ -496,7 +497,13 @@ export class AiAgentService {
           ...(hasEnabledKnowledgeBases ? [KnowledgeBaseManifest.identifier] : []),
         ]
       : [];
-    const effectiveToolIds = [...new Set([...(pluginIds || []), ...manualConfigToolIds])];
+    const effectiveToolIds = [
+      ...new Set([
+        ...(pluginIds || []),
+        ...manualConfigToolIds,
+        ...(hasTopicReference ? [TopicReferenceManifest.identifier] : []),
+      ]),
+    ];
 
     const toolsResult = toolsEngine.generateToolsDetailed({
       model,

--- a/src/services/agentRuntime/index.ts
+++ b/src/services/agentRuntime/index.ts
@@ -51,6 +51,7 @@ class AgentRuntimeService {
       messages: data.messages as any,
       ...modelRuntimeConfig,
       plugins: agentConfig.plugins,
+      skillActivateMode: chatConfig.skillActivateMode,
       systemRole: agentConfig.systemRole,
       tools: enabledToolIds,
     });

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -255,6 +255,7 @@ class ChatService {
       plugins,
       provider: payload.provider!,
       sessionId: options?.trace?.sessionId,
+      skillActivateMode: chatConfig.skillActivateMode,
       stepContext: options?.stepContext,
       systemRole: agentConfig.systemRole,
       tools: enabledToolIds,
@@ -496,6 +497,8 @@ class ChatService {
         messages: params.messages as any,
         model: params.model!,
         provider: params.provider!,
+        skillActivateMode:
+          agentChatConfigSelectors.currentChatConfig(getAgentStoreState()).skillActivateMode,
       });
 
       await this.getChatCompletion(

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -325,6 +325,46 @@ describe('contextEngineering', () => {
     expect(result[1].content).not.toContain('<action type="lobe-notebook" category="tool" />');
   });
 
+  it('should expose only selected skills when skillActivateMode is manual', async () => {
+    const messages: UIChatMessage[] = [
+      {
+        content: 'hello',
+        createdAt: Date.now(),
+        id: 'manual-skill-mode',
+        role: 'user',
+        updatedAt: Date.now(),
+      },
+    ];
+
+    const autoResult = await contextEngineering({
+      messages,
+      model: 'gpt-4',
+      plugins: ['lobe-artifacts'],
+      provider: 'openai',
+      skillActivateMode: 'auto',
+    });
+
+    const manualResult = await contextEngineering({
+      messages,
+      model: 'gpt-4',
+      plugins: ['lobe-artifacts'],
+      provider: 'openai',
+      skillActivateMode: 'manual',
+    });
+
+    const autoSystemMessage = autoResult.find((msg) => msg.role === 'system');
+    const manualSystemMessage = manualResult.find((msg) => msg.role === 'system');
+
+    expect(autoSystemMessage).toBeDefined();
+    expect(manualSystemMessage).toBeDefined();
+
+    expect(autoSystemMessage!.content).toContain('<skill name="Artifacts">');
+    expect(manualSystemMessage!.content).toContain('<skill name="Artifacts">');
+
+    expect(autoSystemMessage!.content).toContain('<skill name="LobeHub">');
+    expect(manualSystemMessage!.content).not.toContain('<skill name="LobeHub">');
+  });
+
   describe('getAssistantContent', () => {
     it('should handle assistant message with imageList and content', async () => {
       // Mock isCanUseVision to return true for vision models

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -99,6 +99,8 @@ interface ContextEngineeringContext {
   plugins?: string[];
   provider: string;
   sessionId?: string;
+  /** Skill activate mode from chatConfig */
+  skillActivateMode?: 'auto' | 'manual';
   /**
    * Step context from Agent Runtime
    * Contains latest XML structure updated each step
@@ -161,6 +163,7 @@ export const contextEngineering = async ({
   groupId,
   initialContext,
   plugins,
+  skillActivateMode,
   stepContext,
   topicId,
   memoryContext,
@@ -642,9 +645,15 @@ export const contextEngineering = async ({
     initialContext,
     stepContext,
 
-    // Skills configuration — expose all installed skills so the AI can discover and activate them
+    // Skills configuration
+    // - auto (default): expose all installed skills for autonomous activation
+    // - manual: expose only explicitly enabled skills
     skillsConfig: {
-      enabledSkills: plugins ? createSkillEngine().getAllSkills() : undefined,
+      enabledSkills: plugins
+        ? skillActivateMode === 'manual'
+          ? createSkillEngine().getEnabledSkills(plugins)
+          : createSkillEngine().getAllSkills()
+        : undefined,
     },
 
     // Tool Discovery configuration

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -459,9 +459,9 @@ export const contextEngineering = async ({
   const userMemoryConfig =
     enableUserMemories && userMemoryData
       ? {
-          enabled: enableUserMemories,
-          memories: userMemoryData,
-        }
+        enabled: enableUserMemories,
+        memories: userMemoryData,
+      }
       : undefined;
 
   // Build tool discovery config if lobe-activator is enabled
@@ -590,6 +590,16 @@ export const contextEngineering = async ({
     log('mentionedAgents injected: %d agents', initialContext!.mentionedAgents!.length);
   }
 
+  const enabledSkills = (() => {
+    if (!plugins) return undefined;
+
+    const skillEngine = createSkillEngine();
+
+    return skillActivateMode === 'manual'
+      ? skillEngine.getEnabledSkills(plugins)
+      : skillEngine.getAllSkills();
+  })();
+
   // Resolve topic references from messages containing <refer_topic> tags
   const topicReferences = await resolveTopicReferences(
     messages,
@@ -649,11 +659,7 @@ export const contextEngineering = async ({
     // - auto (default): expose all installed skills for autonomous activation
     // - manual: expose only explicitly enabled skills
     skillsConfig: {
-      enabledSkills: plugins
-        ? skillActivateMode === 'manual'
-          ? createSkillEngine().getEnabledSkills(plugins)
-          : createSkillEngine().getAllSkills()
-        : undefined,
+      enabledSkills,
     },
 
     // Tool Discovery configuration

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -11,6 +11,7 @@ import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
+import { TopicReferenceManifest } from '@lobechat/builtin-tool-topic-reference';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { dynamicInterventionAudits } from '@lobechat/builtin-tools/dynamicInterventionAudits';
 import { isDesktop } from '@lobechat/const';
@@ -194,7 +195,13 @@ export class StreamingExecutorActionImpl {
           ...(hasEnabledKnowledgeBases ? [KnowledgeBaseManifest.identifier] : []),
         ]
       : [];
-    const effectiveToolIds = [...new Set([...(mergedToolIds || []), ...manualConfigToolIds])];
+    const effectiveToolIds = [
+      ...new Set([
+        ...(mergedToolIds || []),
+        ...manualConfigToolIds,
+        ...(hasTopicReference ? [TopicReferenceManifest.identifier] : []),
+      ]),
+    ];
 
     const toolsDetailed = toolsEngine.generateToolsDetailed({
       model: agentConfigData.model,

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -6,8 +6,12 @@ import {
   type Usage,
 } from '@lobechat/agent-runtime';
 import { AgentRuntime, computeStepContext, GeneralChatAgent } from '@lobechat/agent-runtime';
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
+import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
+import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
-import { manualModeExcludeToolIds } from '@lobechat/builtin-tools';
+import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { dynamicInterventionAudits } from '@lobechat/builtin-tools/dynamicInterventionAudits';
 import { isDesktop } from '@lobechat/const';
 import { type ToolsEngine } from '@lobechat/context-engine';
@@ -172,16 +176,31 @@ export class StreamingExecutorActionImpl {
       { model: agentConfigData.model, provider: agentConfigData.provider! },
       effectivePluginIds,
     );
-    // When skillActivateMode is 'manual', exclude only discovery tools (lobe-activator, lobe-skill-store)
-    // so that externally enabled tools (sandbox, web browsing, etc.) remain available
+    // When skillActivateMode is 'manual', skip all default tools,
+    // then explicitly include tools derived from chatConfig/runtime settings.
     const isManualMode = agentConfig.chatConfig?.skillActivateMode === 'manual';
+    const runtimeMode =
+      agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[isDesktop ? 'desktop' : 'web'] ??
+      (isDesktop ? 'local' : 'none');
+    const hasEnabledKnowledgeBases =
+      agentConfigData.knowledgeBases?.some((kb: { enabled?: boolean }) => kb.enabled) ?? false;
+
+    const manualConfigToolIds = isManualMode
+      ? [
+          ...(agentConfig.chatConfig?.searchMode !== 'off' ? [WebBrowsingManifest.identifier] : []),
+          ...(agentConfig.chatConfig?.memory?.enabled ? [MemoryManifest.identifier] : []),
+          ...(runtimeMode === 'local' ? [LocalSystemManifest.identifier] : []),
+          ...(runtimeMode === 'cloud' ? [CloudSandboxManifest.identifier] : []),
+          ...(hasEnabledKnowledgeBases ? [KnowledgeBaseManifest.identifier] : []),
+        ]
+      : [];
+    const effectiveToolIds = [...new Set([...(mergedToolIds || []), ...manualConfigToolIds])];
 
     const toolsDetailed = toolsEngine.generateToolsDetailed({
-      excludeDefaultToolIds: isManualMode ? manualModeExcludeToolIds : undefined,
       model: agentConfigData.model,
       provider: agentConfigData.provider!,
-      skipDefaultTools: disableTools,
-      toolIds: mergedToolIds,
+      skipDefaultTools: disableTools || isManualMode,
+      toolIds: effectiveToolIds,
     });
 
     const enabledToolIds = toolsDetailed.enabledToolIds;

--- a/src/store/chat/slices/message/selectors/displayMessage.test.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.test.ts
@@ -266,6 +266,36 @@ describe('displayMessageSelectors', () => {
         'User messageFirst assistant responseSecond assistant response',
       );
     });
+
+    it('should extract content from supervisor children instead of top-level content', () => {
+      const messagesWithSupervisor = [
+        {
+          id: 'msg1',
+          content: 'User message',
+          role: 'user',
+        },
+        {
+          id: 'supervisor-1',
+          content: '',
+          role: 'supervisor',
+          children: [
+            { id: 'child-1', content: 'Supervisor summary' },
+            { id: 'child-2', content: 'Supervisor conclusion' },
+          ],
+        },
+      ] as UIChatMessage[];
+
+      const state = merge(initialStore, {
+        messagesMap: {
+          [messageMapKey({ agentId: 'active-session' })]: messagesWithSupervisor,
+        },
+        activeAgentId: 'active-session',
+      });
+
+      const concatenatedString = displayMessageSelectors.mainAIChatsMessageString(state);
+
+      expect(concatenatedString).toBe('User messageSupervisor summarySupervisor conclusion');
+    });
   });
 
   describe('mainAILatestMessageReasoningContent', () => {

--- a/src/store/chat/slices/message/selectors/displayMessage.test.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.test.ts
@@ -234,6 +234,38 @@ describe('displayMessageSelectors', () => {
       // Restore the mocks after the test
       vi.restoreAllMocks();
     });
+
+    it('should extract content from assistantGroup children instead of top-level content', () => {
+      const messagesWithGroup = [
+        {
+          id: 'msg1',
+          content: 'User message',
+          role: 'user',
+        },
+        {
+          id: 'group-1',
+          content: '',
+          role: 'assistantGroup',
+          children: [
+            { id: 'child-1', content: 'First assistant response' },
+            { id: 'child-2', content: 'Second assistant response' },
+          ],
+        },
+      ] as UIChatMessage[];
+
+      const state = merge(initialStore, {
+        messagesMap: {
+          [messageMapKey({ agentId: 'active-session' })]: messagesWithGroup,
+        },
+        activeAgentId: 'active-session',
+      });
+
+      const concatenatedString = displayMessageSelectors.mainAIChatsMessageString(state);
+
+      expect(concatenatedString).toBe(
+        'User messageFirst assistant responseSecond assistant response',
+      );
+    });
   });
 
   describe('mainAILatestMessageReasoningContent', () => {

--- a/src/store/chat/slices/message/selectors/displayMessage.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.ts
@@ -119,11 +119,22 @@ const mainAIChatsWithHistoryConfig = (s: ChatStoreState): UIChatMessage[] => {
 };
 
 /**
+ * Extract content from a message, handling assistantGroup messages with children
+ */
+export const extractDisplayMessageContent = (message: UIChatMessage): string => {
+  if (message.role === 'assistantGroup' && message.children) {
+    return message.children.map((child) => child.content || '').join('');
+  }
+
+  return message.content || '';
+};
+
+/**
  * Concatenated message string from AI chats with history config
  */
 const mainAIChatsMessageString = (s: ChatStoreState): string => {
   const chats = mainAIChatsWithHistoryConfig(s);
-  return chats.map((m) => m.content).join('');
+  return chats.map(extractDisplayMessageContent).join('');
 };
 
 /**

--- a/src/store/chat/slices/message/selectors/displayMessage.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.ts
@@ -119,10 +119,10 @@ const mainAIChatsWithHistoryConfig = (s: ChatStoreState): UIChatMessage[] => {
 };
 
 /**
- * Extract content from a message, handling assistantGroup messages with children
+ * Extract content from a message, handling assistantGroup/supervisor messages with children
  */
 export const extractDisplayMessageContent = (message: UIChatMessage): string => {
-  if (message.role === 'assistantGroup' && message.children) {
+  if ((message.role === 'assistantGroup' || message.role === 'supervisor') && message.children) {
     return message.children.map((child) => child.content || '').join('');
   }
 

--- a/src/store/chat/slices/thread/selectors/index.ts
+++ b/src/store/chat/slices/thread/selectors/index.ts
@@ -6,6 +6,7 @@ import { type ChatStoreState } from '@/store/chat';
 import { chatHelpers } from '@/store/chat/helpers';
 
 import { displayMessageSelectors } from '../../message/selectors';
+import { extractDisplayMessageContent } from '../../message/selectors/displayMessage';
 import { genParentMessages } from './util';
 
 // ============= Thread List Selectors ============= //
@@ -102,8 +103,8 @@ const portalAIChatsWithHistoryConfig = (s: ChatStoreState) => {
  * Portal display chats string - used for Token calculation
  */
 const portalDisplayChatsString = (s: ChatStoreState) => {
-  const messages = portalAIChats(s);
-  return messages.map((m) => m.content).join('');
+  const messages = portalAIChatsWithHistoryConfig(s);
+  return messages.map(extractDisplayMessageContent).join('');
 };
 
 export const threadSelectors = {

--- a/src/store/chat/slices/thread/selectors/index.ts
+++ b/src/store/chat/slices/thread/selectors/index.ts
@@ -6,7 +6,6 @@ import { type ChatStoreState } from '@/store/chat';
 import { chatHelpers } from '@/store/chat/helpers';
 
 import { displayMessageSelectors } from '../../message/selectors';
-import { extractDisplayMessageContent } from '../../message/selectors/displayMessage';
 import { genParentMessages } from './util';
 
 // ============= Thread List Selectors ============= //
@@ -44,7 +43,7 @@ const hasThreadBySourceMsgId = (id: string) => (s: ChatStoreState) => {
 };
 
 // ============= Thread Messages Selectors ============= //
-// These are kept for Token calculation and AI title summarization
+// These are kept for AI title summarization and workflow
 // Thread Chat component now uses dbMessagesMap directly
 
 /**
@@ -99,14 +98,6 @@ const portalAIChatsWithHistoryConfig = (s: ChatStoreState) => {
   });
 };
 
-/**
- * Portal display chats string - used for Token calculation
- */
-const portalDisplayChatsString = (s: ChatStoreState) => {
-  const messages = portalAIChatsWithHistoryConfig(s);
-  return messages.map(extractDisplayMessageContent).join('');
-};
-
 export const threadSelectors = {
   currentPortalThread,
   currentTopicThreads,
@@ -115,7 +106,6 @@ export const threadSelectors = {
   hasThreadBySourceMsgId,
   portalAIChats,
   portalAIChatsWithHistoryConfig,
-  portalDisplayChatsString,
 };
 
 // Re-export utility function for use in action.ts


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- close #10336

- 建议先合并 #13051
<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

- 根据实际携带的历史消息数，实时更新 “会话消息”
- 正确计算 group 消息组，算进 “会话消息”
- “技能设定” 准确根据实际选取的技能计算 token 数
- 关闭自动启用技能时，不再传递全量 skill，而是只传递选中的 skill（需要 review，是否符合预期？）
- 修复关闭自动启用技能时，无法手动启用网络搜索、记忆工具
- 以白名单机制尽量正确计算 “会话消息” 数值，不会过于偏大

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
