### PR TITLE
🌐 i18n: add pending_reward status translation for referral table

### DIFF
--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -352,6 +352,7 @@
   "referral.table.columns.rewardedAt": "Reward Time",
   "referral.table.columns.status": "Status",
   "referral.table.columns.suspectedReason": "Anomaly Reason",
+  "referral.table.status.pending_reward": "Pending Reward",
   "referral.table.status.registered": "Registered",
   "referral.table.status.revoked": "Revoked",
   "referral.table.status.rewarded": "Rewarded",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -352,6 +352,7 @@
   "referral.table.columns.rewardedAt": "奖励时间",
   "referral.table.columns.status": "状态",
   "referral.table.columns.suspectedReason": "异常原因",
+  "referral.table.status.pending_reward": "待发放",
   "referral.table.status.registered": "已注册",
   "referral.table.status.revoked": "已撤销",
   "referral.table.status.rewarded": "已奖励",

--- a/src/locales/default/subscription.ts
+++ b/src/locales/default/subscription.ts
@@ -409,6 +409,7 @@ export default {
   'referral.table.columns.rewardedAt': 'Reward Time',
   'referral.table.columns.status': 'Status',
   'referral.table.columns.suspectedReason': 'Anomaly Reason',
+  'referral.table.status.pending_reward': 'Pending Reward',
   'referral.table.status.registered': 'Registered',
   'referral.table.status.revoked': 'Revoked',
   'referral.table.status.rewarded': 'Rewarded',


### PR DESCRIPTION
## Summary
- Add `referral.table.status.pending_reward` i18n key for the new `PendingReward` referral status
- Translate en-US ("Pending Reward") and zh-CN ("待发放")

## Test plan
- [ ] Verify referral table StatusTag renders correctly for `pending_reward` status

## Summary by Sourcery

New Features:
- Introduce translation key for the referral table pending_reward status in subscription localization files.