### PR TITLE
🐛 fix(model-runtime): prune unsupported xAI reasoning penalties

### DIFF
--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -45,6 +45,22 @@ describe('LobeXAI - custom features', () => {
       expect(createCall.stream).toBe(true);
     });
 
+    it('should remove unsupported penalty parameters for grok-4.1 reasoning variants', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequency_penalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-1-fast-reasoning',
+        presence_penalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequency_penalty).toBeUndefined();
+      expect(createCall.presence_penalty).toBeUndefined();
+      expect(createCall.stream).toBe(true);
+    });
+
     it('should preserve penalty parameters for non-reasoning models', async () => {
       await instance.chat({
         apiMode: 'chatCompletion',

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -22,7 +22,42 @@ describe('LobeXAI - custom features', () => {
 
   beforeEach(() => {
     instance = new LobeXAI({ apiKey: 'test_api_key' });
+    vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
+      new ReadableStream() as any,
+    );
     vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(new ReadableStream() as any);
+  });
+
+  describe('chatCompletion.handlePayload', () => {
+    it('should remove unsupported penalty parameters for reasoning models', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequency_penalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4',
+        presence_penalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequency_penalty).toBeUndefined();
+      expect(createCall.presence_penalty).toBeUndefined();
+    });
+
+    it('should preserve penalty parameters for non-reasoning models', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequency_penalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-fast-non-reasoning',
+        presence_penalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequency_penalty).toBe(0.4);
+      expect(createCall.presence_penalty).toBe(0.6);
+    });
   });
 
   describe('responses.handlePayload', () => {

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -42,6 +42,7 @@ describe('LobeXAI - custom features', () => {
 
       expect(createCall.frequency_penalty).toBeUndefined();
       expect(createCall.presence_penalty).toBeUndefined();
+      expect(createCall.stream).toBe(true);
     });
 
     it('should preserve penalty parameters for non-reasoning models', async () => {

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -1,6 +1,7 @@
 import { ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import type { ChatStreamPayload } from '../../types';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
 import { createXAIImage } from './createImage';
 
@@ -8,9 +9,34 @@ export interface XAIModelCard {
   id: string;
 }
 
+const isXAIReasoningModel = (model: string) => {
+  if (model.includes('non-reasoning')) return false;
+
+  return (
+    model === 'grok-3-mini' ||
+    model === 'grok-4' ||
+    model === 'grok-code-fast-1' ||
+    model.includes('multi-agent') ||
+    model.includes('reasoning')
+  );
+};
+
+const pruneUnsupportedReasoningParameters = (payload: ChatStreamPayload) => {
+  if (!isXAIReasoningModel(payload.model)) return payload;
+
+  return {
+    ...payload,
+    // xAI rejects penalties on reasoning models such as grok-4.
+    frequency_penalty: undefined,
+    presence_penalty: undefined,
+    stop: undefined,
+  } as ChatStreamPayload;
+};
+
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
   chatCompletion: {
+    handlePayload: (payload) => pruneUnsupportedReasoningParameters(payload) as any,
     useResponse: true,
   },
   createImage: createXAIImage,
@@ -27,7 +53,7 @@ export const LobeXAI = createOpenAICompatibleRuntime({
   provider: ModelProvider.XAI,
   responses: {
     handlePayload: (payload) => {
-      const { enabledSearch, tools, ...rest } = payload;
+      const { enabledSearch, tools, ...rest } = pruneUnsupportedReasoningParameters(payload);
 
       const xaiTools = enabledSearch
         ? [...(tools || []), { type: 'web_search' }, { type: 'x_search' }]

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -1,4 +1,4 @@
-import { ModelProvider } from 'model-bank';
+import { LOBE_DEFAULT_MODEL_LIST, ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import type { ChatStreamPayload } from '../../types';
@@ -9,24 +9,24 @@ export interface XAIModelCard {
   id: string;
 }
 
-const isXAIReasoningModel = (model: string) => {
-  if (model.includes('non-reasoning')) return false;
+const xaiReasoningModels = new Set(
+  LOBE_DEFAULT_MODEL_LIST.filter(
+    (model) =>
+      model.providerId === ModelProvider.XAI &&
+      model.type === 'chat' &&
+      !!model.abilities?.reasoning,
+  ).map((model) => model.id),
+);
 
-  return (
-    model === 'grok-3-mini' ||
-    model === 'grok-4' ||
-    model === 'grok-code-fast-1' ||
-    model.includes('multi-agent') ||
-    model.includes('reasoning')
-  );
-};
+const isXAIReasoningModel = (model: string) => xaiReasoningModels.has(model);
 
 const pruneUnsupportedReasoningParameters = (payload: ChatStreamPayload) => {
   if (!isXAIReasoningModel(payload.model)) return payload;
 
   return {
     ...payload,
-    // xAI rejects penalties on reasoning models such as grok-4.
+    // xAI reasoning models reject these parameters:
+    // https://docs.x.ai/developers/model-capabilities/text/reasoning
     frequency_penalty: undefined,
     presence_penalty: undefined,
     stop: undefined,

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -36,7 +36,11 @@ const pruneUnsupportedReasoningParameters = (payload: ChatStreamPayload) => {
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
   chatCompletion: {
-    handlePayload: (payload) => pruneUnsupportedReasoningParameters(payload) as any,
+    handlePayload: (payload) =>
+      ({
+        ...pruneUnsupportedReasoningParameters(payload),
+        stream: payload.stream ?? true,
+      }) as any,
     useResponse: true,
   },
   createImage: createXAIImage,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #12971

#### 🔀 Description of Change

This PR prunes unsupported penalty parameters for xAI reasoning models before requests are sent.

It fixes `grok-4` compatibility by removing `presence_penalty` and `frequency_penalty` from xAI reasoning model payloads in both the Chat Completions and Responses API paths, while preserving those parameters for non-reasoning variants.

It also adds regression tests to cover both reasoning and non-reasoning xAI model behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Local verification:

- `bunx vitest run --config vitest.config.mts 'src/providers/xai/index.test.ts'`
- `mcp__vscode_mcp__get_diagnostics` on the modified files

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This change is intentionally scoped to the xAI provider runtime layer to avoid changing shared parameter behavior for other OpenAI-compatible providers.
