### PR TITLE
🐛 fix(model-runtime): filter internal thinking content in openai-compatible payloads

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -302,6 +302,36 @@ describe('convertOpenAIMessages', () => {
     expect((result[0] as any).reasoning_content).toBe('some reasoning content');
   });
 
+  it('should filter internal thinking content parts but preserve reasoning_content', async () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            signature: 'sig_123',
+            thinking: 'internal reasoning',
+            type: 'thinking',
+          },
+          {
+            text: 'Visible answer',
+            type: 'text',
+          },
+        ],
+        reasoning_content: 'internal reasoning',
+      },
+    ] as any;
+
+    const result = await convertOpenAIMessages(messages);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: [{ text: 'Visible answer', type: 'text' }],
+        reasoning_content: 'internal reasoning',
+      },
+    ]);
+  });
+
   it('should filter out reasoning but preserve reasoning_content field', async () => {
     const messages = [
       {

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -3,7 +3,7 @@ import type OpenAI from 'openai';
 import { toFile } from 'openai';
 
 import { disableStreamModels, systemToUserModels } from '../../const/models';
-import type { ChatStreamPayload, OpenAIChatMessage } from '../../types';
+import type { ChatStreamPayload, OpenAIChatMessage, UserMessageContentPart } from '../../types';
 import { parseDataUri } from '../../utils/uriParser';
 
 export type ExtendedChatCompletionContentPart = {
@@ -17,6 +17,15 @@ type ConvertMessageContentOptions = {
   forceImageBase64?: boolean;
   forceVideoBase64?: boolean;
 };
+
+type OpenAICompatibleContentPart =
+  | ExtendedChatCompletionContentPart
+  | OpenAI.ChatCompletionContentPart
+  | UserMessageContentPart;
+
+const isInternalThinkingContentPart = (
+  content: OpenAICompatibleContentPart,
+): content is Extract<UserMessageContentPart, { type: 'thinking' }> => content.type === 'thinking';
 
 export const convertMessageContent = async (
   content: OpenAI.ChatCompletionContentPart | ExtendedChatCompletionContentPart,
@@ -77,9 +86,11 @@ export const convertOpenAIMessages = async (
           typeof message.content === 'string'
             ? message.content
             : await Promise.all(
-                (message.content || []).map((c) =>
-                  convertMessageContent(c as OpenAI.ChatCompletionContentPart, options),
-                ),
+                (message.content || [])
+                  .filter((c) => !isInternalThinkingContentPart(c as OpenAICompatibleContentPart))
+                  .map((c) =>
+                    convertMessageContent(c as OpenAI.ChatCompletionContentPart, options),
+                  ),
               ),
         role: msg.role,
       };
@@ -153,6 +164,10 @@ export const convertOpenAIResponseInputs = async (
           ? message.content
           : await Promise.all(
               (message.content || []).map(async (c) => {
+                if (isInternalThinkingContentPart(c as OpenAICompatibleContentPart)) {
+                  return undefined;
+                }
+
                 if (c.type === 'text') {
                   // if assistant message, set type to output_text
                   // https://platform.openai.com/docs/guides/text


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue


#### 🔀 Description of Change

- Filter internal `thinking` content parts before sending OpenAI-compatible chat payloads.
- Preserve provider-compatible reasoning fields such as `reasoning_content` while removing unsupported message variants.
- Prevent DeepSeek official API requests from failing when assistant history contains signed reasoning blocks.

#### 🧪 How to Test

- Run `bunx vitest run --silent='passed-only' 'src/core/contextBuilders/openai.test.ts'`
- Run `bunx vitest run --silent='passed-only' 'src/providers/deepseek/index.test.ts'`

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

- This change targets OpenAI-compatible payload serialization only.
- It fixes provider compatibility without changing displayed reasoning behavior in the UI.

## Summary by Sourcery

Bug Fixes:
- Exclude internal 'thinking' content parts from user and assistant message histories before building OpenAI-compatible payloads to prevent provider API failures.