### PR TITLE
🐛 fix(skills): repair db-migrations frontmatter

### DIFF
--- a/.agents/skills/db-migrations/SKILL.md
+++ b/.agents/skills/db-migrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: db-migrations
-description: Database migration guide (Drizzle ORM + PostgreSQL). MUST USE when any of these occur: (1) generating or regenerating migration files (drizzle-kit generate), (2) adding/removing/modifying columns or tables in database schema, (3) resolving migration sequence conflicts after rebase, (4) writing or reviewing migration SQL (idempotent patterns), (5) renaming migration files. Triggers on keywords: migration, db:generate, ALTER TABLE, ADD COLUMN, CREATE TABLE, schema change, migration conflict.
+description: 'Use when generating or regenerating Drizzle migration files, changing database schema tables or columns, resolving migration sequence conflicts after rebase, reviewing migration SQL for idempotent patterns, or renaming migration files.'
 ---
 
 # Database Migrations Guide


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

- Fix invalid YAML frontmatter in the `db-migrations` skill.
- Quote and simplify the `description` field so skill loading can parse `SKILL.md` correctly.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated by parsing the frontmatter as YAML after the change.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This PR only changes the skill metadata line; the skill content remains intact.

## Summary by Sourcery

Bug Fixes:
- Correct YAML frontmatter description for the db-migrations skill to ensure the SKILL.md file can be parsed successfully.