### PR TITLE
🐛 fix: pass userId to all embeddings API calls

### DIFF
--- a/src/server/routers/async/file.ts
+++ b/src/server/routers/async/file.ts
@@ -104,7 +104,7 @@ export const fileRouter = router({
                     input: chunks.map((c) => c.text),
                     model,
                   },
-                  { metadata: { trigger: RequestTrigger.FileEmbedding } },
+                  { metadata: { trigger: RequestTrigger.FileEmbedding }, user: ctx.userId },
                 );
 
                 const items: NewEmbeddingsItem[] =

--- a/src/server/routers/async/ragEval.ts
+++ b/src/server/routers/async/ragEval.ts
@@ -71,7 +71,7 @@ export const ragEvalRouter = router({
               input: question,
               model: !!embeddingModel ? embeddingModel : DEFAULT_EMBEDDING_MODEL,
             },
-            { metadata: { trigger: RequestTrigger.Eval } },
+            { metadata: { trigger: RequestTrigger.Eval }, user: ctx.userId },
           );
 
           const embeddingId = await ctx.embeddingModel.create({

--- a/src/server/routers/lambda/chunk.ts
+++ b/src/server/routers/lambda/chunk.ts
@@ -230,7 +230,7 @@ export const chunkRouter = router({
           input: input.query,
           model,
         },
-        { metadata: { trigger: RequestTrigger.SemanticSearch } },
+        { metadata: { trigger: RequestTrigger.SemanticSearch }, user: ctx.userId },
       );
 
       return ctx.chunkModel.semanticSearch({
@@ -258,7 +258,7 @@ export const chunkRouter = router({
             input: query,
             model,
           },
-          { metadata: { trigger: RequestTrigger.SemanticSearch } },
+          { metadata: { trigger: RequestTrigger.SemanticSearch }, user: ctx.userId },
         );
 
         const embedding = embeddings![0];

--- a/src/server/routers/lambda/userMemories.test.ts
+++ b/src/server/routers/lambda/userMemories.test.ts
@@ -157,6 +157,10 @@ describe('memoryRouter.reEmbedMemories', () => {
     });
 
     expect(embeddingsMock).toHaveBeenCalledTimes(6);
+
+    for (const call of embeddingsMock.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ user: 'test-user' }));
+    }
   });
 });
 
@@ -359,6 +363,10 @@ describe('userMemories.retrieveMemory', () => {
     });
 
     expect(embeddingsMock).toHaveBeenCalledTimes(1);
+    expect(embeddingsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ user: 'test-user' }),
+    );
     expect(searchWithEmbedding.mock.calls[0][0]).toBeTypeOf('object');
     expect(searchWithEmbedding.mock.calls[0][0]).toStrictEqual({
       embedding: [1],
@@ -456,5 +464,9 @@ describe('userMemories.toolAddActivityMemory', () => {
       success: true,
     });
     expect(embeddingsMock).toHaveBeenCalledTimes(4);
+
+    for (const call of embeddingsMock.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ user: 'test-user' }));
+    }
   });
 });

--- a/src/server/routers/lambda/userMemories.ts
+++ b/src/server/routers/lambda/userMemories.ts
@@ -173,7 +173,7 @@ const searchUserMemories = async (
       input: input.query,
       model: embeddingModel,
     },
-    { metadata: { trigger: RequestTrigger.Memory } },
+    { metadata: { trigger: RequestTrigger.Memory }, user: ctx.userId },
   );
 
   const effectiveEffort = normalizeMemoryEffort(input.effort ?? ctx.memoryEffort);
@@ -209,7 +209,7 @@ const getEmbeddingRuntime = async (serverDB: LobeChatDatabase, userId: string) =
   return { agentRuntime, embeddingModel };
 };
 
-const createEmbedder = (agentRuntime: any, embeddingModel: string) => {
+const createEmbedder = (agentRuntime: any, embeddingModel: string, userId: string) => {
   return async (value?: string | null): Promise<number[] | undefined> => {
     if (!value || value.trim().length === 0) return undefined;
 
@@ -219,7 +219,7 @@ const createEmbedder = (agentRuntime: any, embeddingModel: string) => {
         input: value,
         model: embeddingModel,
       },
-      { metadata: { trigger: RequestTrigger.Memory } },
+      { metadata: { trigger: RequestTrigger.Memory }, user: userId },
     );
 
     return embeddings?.[0];
@@ -497,7 +497,7 @@ export const userMemoriesRouter = router({
               input: texts,
               model: embeddingModel,
             },
-            { metadata: { trigger: RequestTrigger.Memory } },
+            { metadata: { trigger: RequestTrigger.Memory }, user: ctx.userId },
           );
 
           if (!response || response.length !== texts.length) {
@@ -983,7 +983,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         const summaryEmbedding = await embed(input.summary);
         const detailsEmbedding = await embed(input.details);
@@ -1045,7 +1045,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         const summaryEmbedding = await embed(input.summary);
         const detailsEmbedding = await embed(input.details);
@@ -1100,7 +1100,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         const summaryEmbedding = await embed(input.summary);
         const detailsEmbedding = await embed(input.details);
@@ -1156,7 +1156,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         const summaryEmbedding = await embed(input.summary);
         const detailsEmbedding = await embed(input.details);
@@ -1224,7 +1224,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         const summaryEmbedding = await embed(input.summary);
         const detailsEmbedding = await embed(input.details);
@@ -1317,7 +1317,7 @@ export const userMemoriesRouter = router({
           ctx.serverDB,
           ctx.userId,
         );
-        const embed = createEmbedder(agentRuntime, embeddingModel);
+        const embed = createEmbedder(agentRuntime, embeddingModel, ctx.userId);
 
         let summaryVector1024: number[] | null | undefined;
         if (input.set.summary !== undefined) {

--- a/src/server/services/memory/userMemory/extract.ts
+++ b/src/server/services/memory/userMemory/extract.ts
@@ -574,6 +574,7 @@ export class MemoryExtractionExecutor {
     runtimes: ModelRuntime,
     model: string,
     texts: Array<string | undefined | null>,
+    userId: string,
     tokenLimit?: number,
   ) {
     const attributes = {
@@ -610,7 +611,7 @@ export class MemoryExtractionExecutor {
             input: requests.map((item) => item.text),
             model,
           },
-          { metadata: { trigger: RequestTrigger.Memory }, user: 'memory-extraction' },
+          { metadata: { trigger: RequestTrigger.Memory }, user: userId },
         );
 
         const vectors = texts.map<Embeddings | null>(() => null);
@@ -668,6 +669,7 @@ export class MemoryExtractionExecutor {
           runtime,
           model,
           [item.summary, item.details, item.withActivity?.narrative, item.withActivity?.feedback],
+          job.userId,
           tokenLimit,
         );
       const baseMetadata = this.buildBaseMetadata(
@@ -730,6 +732,7 @@ export class MemoryExtractionExecutor {
         runtime,
         model,
         [item.summary, item.details, item.withContext?.description],
+        job.userId,
         tokenLimit,
       );
       const baseMetadata = this.buildBaseMetadata(
@@ -799,6 +802,7 @@ export class MemoryExtractionExecutor {
             item.withExperience?.action,
             item.withExperience?.keyLearning,
           ],
+          job.userId,
           tokenLimit,
         );
       const baseMetadata = this.buildBaseMetadata(
@@ -858,6 +862,7 @@ export class MemoryExtractionExecutor {
         runtime,
         model,
         [item.summary, item.details, item.withPreference?.conclusionDirectives],
+        job.userId,
         tokenLimit,
       );
       const baseMetadata = this.buildBaseMetadata(
@@ -919,6 +924,7 @@ export class MemoryExtractionExecutor {
         runtime,
         model,
         [action.summary, action.details, action.withIdentity.description],
+        job.userId,
         tokenLimit,
       );
       const metadata = this.buildBaseMetadata(
@@ -964,6 +970,7 @@ export class MemoryExtractionExecutor {
             runtime,
             model,
             [set.summary, set.details, set.withIdentity.description],
+            job.userId,
             tokenLimit,
           )
         : [];
@@ -1063,7 +1070,7 @@ export class MemoryExtractionExecutor {
         input: [aggregatedContent],
         model: embeddingModel,
       },
-      { metadata: { trigger: RequestTrigger.Memory } },
+      { metadata: { trigger: RequestTrigger.Memory }, user: userId },
     );
 
     const vector = embeddings?.[0];

--- a/src/server/services/toolExecution/serverRuntimes/memory.ts
+++ b/src/server/services/toolExecution/serverRuntimes/memory.ts
@@ -155,7 +155,7 @@ const getEmbeddingRuntime = async (serverDB: LobeChatDatabase, userId: string) =
   return { agentRuntime, embeddingModel };
 };
 
-const createEmbedder = (agentRuntime: any, embeddingModel: string) => {
+const createEmbedder = (agentRuntime: any, embeddingModel: string, userId: string) => {
   return async (value?: string | null): Promise<number[] | undefined> => {
     if (!value || value.trim().length === 0) return undefined;
 
@@ -165,7 +165,7 @@ const createEmbedder = (agentRuntime: any, embeddingModel: string) => {
         input: value,
         model: embeddingModel,
       },
-      { metadata: { trigger: RequestTrigger.Memory } },
+      { metadata: { trigger: RequestTrigger.Memory }, user: userId },
     );
 
     return embeddings?.[0];
@@ -202,7 +202,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         input: params.query,
         model: embeddingModel,
       },
-      { metadata: { trigger: RequestTrigger.Memory } },
+      { metadata: { trigger: RequestTrigger.Memory }, user: this.userId },
     );
 
     const effectiveEffort = normalizeMemoryEffort(params.effort ?? this.memoryEffort);
@@ -233,7 +233,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       const summaryEmbedding = await embed(input.summary);
       const detailsEmbedding = await embed(input.details);
@@ -287,7 +287,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       const summaryEmbedding = await embed(input.summary);
       const detailsEmbedding = await embed(input.details);
@@ -348,7 +348,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       const summaryEmbedding = await embed(input.summary);
       const detailsEmbedding = await embed(input.details);
@@ -403,7 +403,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       const summaryEmbedding = await embed(input.summary);
       const detailsEmbedding = await embed(input.details);
@@ -470,7 +470,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       const summaryEmbedding = await embed(input.summary);
       const detailsEmbedding = await embed(input.details);
@@ -529,7 +529,7 @@ class MemoryServerRuntimeService implements MemoryRuntimeService {
         this.serverDB,
         this.userId,
       );
-      const embed = createEmbedder(agentRuntime, embeddingModel);
+      const embed = createEmbedder(agentRuntime, embeddingModel, this.userId);
 
       let summaryVector1024: number[] | null | undefined;
       if (input.set.summary !== undefined) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Chat calls already pass `user: ctx.userId` to the OpenAI API via `options.user`, but all embedding call sites were missing this field. This caused the `user` parameter in OpenAI `embeddings.create` requests to be `undefined`.

- Add `user: userId` to all embedding call sites across routers and services
- Add `userId` parameter to `createEmbedder` helpers in `userMemories.ts` and `memory.ts`
- Add `userId` parameter to `generateEmbeddings` private method in `extract.ts`
- Replace hardcoded `'memory-extraction'` string with actual userId in `extract.ts`
- Add test assertions to verify `user` field is passed correctly

#### 🧪 How to Test

- [x] Added/updated tests

Existing `userMemories.test.ts` tests updated with assertions verifying `user: userId` is passed to all embedding calls.