### PR TITLE
💄 style: add GPT-5.4 mini and nano models

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
@@ -51,6 +51,7 @@ export const openaiChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-05',
     settings: {
       extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -93,7 +94,64 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-03-05',
     settings: {
-      extendParams: ['gpt5_2ProReasoningEffort'],
+      extendParams: ['gpt5_2ProReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "GPT-5.4 mini is OpenAI's strongest mini model for coding, computer use, and subagents.",
+    displayName: 'GPT-5.4 mini',
+    enabled: true,
+    id: 'gpt-5.4-mini',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "GPT-5.4 nano is OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks.",
+    displayName: 'GPT-5.4 nano',
+    enabled: true,
+    id: 'gpt-5.4-nano',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -123,7 +123,65 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-03-05',
     settings: {
-      extendParams: ['gpt5_2ProReasoningEffort'],
+      extendParams: ['gpt5_2ProReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "GPT-5.4 mini is OpenAI's strongest mini model for coding, computer use, and subagents.",
+    displayName: 'GPT-5.4 mini',
+    enabled: true,
+    id: 'gpt-5.4-mini',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.075, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 400_000,
+    description:
+      "GPT-5.4 nano is OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks.",
+    displayName: 'GPT-5.4 nano',
+    enabled: true,
+    id: 'gpt-5.4-nano',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-18',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
       searchImpl: 'params',
     },
     type: 'chat',

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -47,6 +47,8 @@ export const responsesAPIModels = new Set([
   'gpt-5.2-pro',
   'gpt-5.3-codex',
   'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
   'gpt-5.4-pro',
 ]);
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Related to https://openai.com/index/introducing-gpt-5-4-mini-and-nano/

#### 🔀 Description of Change

- Add GPT-5.4 mini and GPT-5.4 nano model cards to both LobeHub and OpenAI provider
- Add `gpt-5.4-mini` and `gpt-5.4-nano` to `responsesAPIModels` set
- Add `textVerbosity` to GPT-5.4 Pro extendParams for consistency with the GPT-5.4 family
- Add `searchImpl: 'params'` to GPT-5.4 and GPT-5.4 Pro (lobehub provider) for built-in search support

**GPT-5.4 mini** ($0.75/$4.50 per MTok): 400K context, 128K output, reasoning + search + vision + function calling
**GPT-5.4 nano** ($0.20/$1.25 per MTok): 400K context, 128K output, reasoning + search + vision + function calling

#### 🧪 How to Test

- [x] No tests needed

#### 📝 Additional Information

Pricing source: https://developers.openai.com/docs/pricing (Standard tier)
Model specs: https://developers.openai.com/docs/models/gpt-5.4-mini, https://developers.openai.com/docs/models/gpt-5.4-nano

## Summary by Sourcery

Add GPT-5.4 mini and GPT-5.4 nano chat models and align GPT-5.4 family settings for search and verbosity.

New Features:
- Introduce GPT-5.4 mini and GPT-5.4 nano chat model cards for both LobeHub and OpenAI providers, including pricing and capabilities, and make them available via the responses API.

Enhancements:
- Enable built-in search parameter handling for GPT-5.4 and GPT-5.4 Pro models across providers and include text verbosity controls for GPT-5.4 Pro to align with the rest of the GPT-5.4 family.