### PR TITLE
🐛 fix: pass userId in initModelRuntimeFromDB

### DIFF
--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -425,5 +425,5 @@ export const initModelRuntimeFromDB = async (
   const hooks = getBusinessModelRuntimeHooks(userId, provider);
 
   // 5. Initialize ModelRuntime with the payload and hooks
-  return initModelRuntimeWithUserPayload(provider, payload, {}, hooks);
+  return initModelRuntimeWithUserPayload(provider, payload, { userId }, hooks);
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

`initModelRuntimeFromDB` was passing `{}` as params to `initModelRuntimeWithUserPayload`, which meant `userId` was not included in the runtime constructor options. This caused the router runtime's `this._options.userId` to be `undefined`, so `onRouteAttempt` recorded route attempt logs without `userId`.

Fixed by passing `{ userId }` as params so the router runtime has access to `userId` for route attempt logging.

#### 🧪 How to Test

- [x] No tests needed