### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/minimax.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/minimax.ts
@@ -5,6 +5,29 @@ export const minimaxChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 524_288,
+    description:
+      'Latest flagship model with 512K context, 128K max output, and image input support.',
+    displayName: 'MiniMax M3',
+    enabled: true,
+    id: 'MiniMax-M3',
+    maxOutput: 131_072,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.12, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-02',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
     },
     contextWindowTokens: 204_800,
     description:
@@ -44,144 +67,6 @@ export const minimaxChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2026-03-18',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Optimized for code generation and refactoring, delivering peak performance with ultimate value to master complex tasks.',
-    displayName: 'MiniMax M2.5',
-    enabled: true,
-    id: 'MiniMax-M2.5',
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-02-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description: 'Same performance as M2.5 with significantly faster inference.',
-    displayName: 'MiniMax M2.5 Highspeed',
-    enabled: true,
-    id: 'MiniMax-M2.5-highspeed',
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.06, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-02-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Powerful multilingual programming capabilities, comprehensively upgraded programming experience.',
-    displayName: 'MiniMax M2.1',
-    id: 'MiniMax-M2.1',
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Powerful multilingual programming capabilities with faster and more efficient inference.',
-    displayName: 'MiniMax M2.1 Highspeed',
-    id: 'MiniMax-M2.1-highspeed',
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.6, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.06, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Powerful multilingual programming capabilities with faster and more efficient inference.',
-    displayName: 'MiniMax M2.1 Lightning',
-    enabled: false,
-    id: 'MiniMax-M2.1-Lightning',
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-      search: true,
-    },
-    contextWindowTokens: 204_800,
-    description: 'Built for efficient coding and agent workflows.',
-    displayName: 'MiniMax M2',
-    id: 'MiniMax-M2-Stable',
-    enabled: false,
-    maxOutput: 131_072,
-    pricing: {
-      units: [
-        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 0.375, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.03, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-10-27',
-    settings: {
-      searchImpl: 'params',
-    },
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -5,6 +5,30 @@ const minimaxChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
       reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 524_288,
+    description:
+      'Latest flagship model with 512K context, 128K max output, and image input support.',
+    displayName: 'MiniMax M3',
+    enabled: true,
+    id: 'MiniMax-M3',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.84, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 4.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-02',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
     },
     contextWindowTokens: 204_800,
     description:
@@ -45,185 +69,6 @@ const minimaxChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2026-03-18',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Top-tier performance and ultimate cost-effectiveness, easily handling complex tasks (approx. 60 tps).',
-    displayName: 'MiniMax M2.5',
-    enabled: true,
-    id: 'MiniMax-M2.5',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-02-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description: 'M2.5 Lightning: Same performance, faster and more agile (approx. 100 tps).',
-    displayName: 'MiniMax M2.5 Lightning',
-    id: 'MiniMax-M2.5-Lightning',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-02-12',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Powerful multilingual programming capabilities, comprehensively upgraded programming experience',
-    displayName: 'MiniMax M2.1',
-    id: 'MiniMax-M2.1',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Powerful multilingual programming capabilities, comprehensively upgraded programming experience. Faster and more efficient.',
-    displayName: 'MiniMax M2.1 Lightning',
-    id: 'MiniMax-M2.1-Lightning',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16.8, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-12-23',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description: 'Built specifically for efficient coding and Agent workflows',
-    displayName: 'MiniMax M2',
-    id: 'MiniMax-M2',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-10-27',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 204_800,
-    description:
-      'Built for efficient coding and agent workflows, with higher concurrency for commercial use.',
-    displayName: 'MiniMax M2 Stable',
-    id: 'MiniMax-M2-Stable',
-    maxOutput: 131_072,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.21, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheWrite', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-10-27',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 1_000_192,
-    description:
-      'A new in-house reasoning model with 80K chain-of-thought and 1M input, delivering performance comparable to top global models.',
-    displayName: 'MiniMax M1',
-    id: 'MiniMax-M1',
-    maxOutput: 40_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 16, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-06-16',
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      vision: true,
-    },
-    contextWindowTokens: 1_000_192,
-    description:
-      'MiniMax-01 introduces large-scale linear attention beyond classic Transformers, with 456B parameters and 45.9B activated per pass. It achieves top-tier performance and supports up to 4M tokens of context (32× GPT-4o, 20× Claude-3.5-Sonnet).',
-    displayName: 'MiniMax Text 01',
-    id: 'MiniMax-Text-01',
-    maxOutput: 40_000,
-    pricing: {
-      currency: 'CNY',
-      units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2025-01-15',
     type: 'chat',
   },
 ];

--- a/packages/model-bank/src/modelProviders/minimax.ts
+++ b/packages/model-bank/src/modelProviders/minimax.ts
@@ -3,7 +3,7 @@ import { type ModelProviderCard } from '@/types/llm';
 // ref: https://platform.minimaxi.com/document/Models
 const Minimax: ModelProviderCard = {
   chatModels: [],
-  checkModel: 'MiniMax-M2.5',
+  checkModel: 'MiniMax-M3',
   description:
     'Founded in 2021, MiniMax builds general-purpose AI with multimodal foundation models, including trillion-parameter MoE text models, speech models, and vision models, along with apps like Hailuo AI.',
   id: 'minimax',

--- a/packages/model-bank/src/modelProviders/minimax.ts
+++ b/packages/model-bank/src/modelProviders/minimax.ts
@@ -3,7 +3,7 @@ import { type ModelProviderCard } from '@/types/llm';
 // ref: https://platform.minimaxi.com/document/Models
 const Minimax: ModelProviderCard = {
   chatModels: [],
-  checkModel: 'MiniMax-M2.7',
+  checkModel: 'MiniMax-M2.5',
   description:
     'Founded in 2021, MiniMax builds general-purpose AI with multimodal foundation models, including trillion-parameter MoE text models, speech models, and vision models, along with apps like Hailuo AI.',
   id: 'minimax',

--- a/packages/model-bank/src/modelProviders/minimax.ts
+++ b/packages/model-bank/src/modelProviders/minimax.ts
@@ -3,7 +3,7 @@ import { type ModelProviderCard } from '@/types/llm';
 // ref: https://platform.minimaxi.com/document/Models
 const Minimax: ModelProviderCard = {
   chatModels: [],
-  checkModel: 'MiniMax-M2.1',
+  checkModel: 'MiniMax-M2.7',
   description:
     'Founded in 2021, MiniMax builds general-purpose AI with multimodal foundation models, including trillion-parameter MoE text models, speech models, and vision models, along with apps like Hailuo AI.',
   id: 'minimax',


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default (CNY + USD pricing)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5`, `M2.1`, `M2`, `M1`, `Text-01`)
- Update `checkModel` in provider config to `MiniMax-M3`

## Why
`MiniMax-M3` is the latest flagship model with a 512K context window, 128K max output, and image input support, [announced on the MiniMax platform](https://platform.minimax.io/docs/guides/pricing-paygo).

## Files Changed
- `packages/model-bank/src/aiModels/minimax.ts` — Added M3 entry (CNY), removed M2.5/M2.1/M2/M1/Text-01
- `packages/model-bank/src/aiModels/lobehub/chat/minimax.ts` — Added M3 entry (USD), removed M2.5/M2.1/M2/M1/Text-01
- `packages/model-bank/src/modelProviders/minimax.ts` — Updated `checkModel` to M3

## Pricing (from official docs, USD ≤512K standard tier)
| Model | Input | Output | Cache Read | Cache Write |
|-------|-------|--------|------------|-------------|
| MiniMax-M3 | $0.6/M | $2.4/M | $0.12/M | — (not supported) |
| MiniMax-M2.7 | $0.3/M | $1.2/M | $0.06/M | $0.375/M |
| MiniMax-M2.7-highspeed | $0.6/M | $2.4/M | $0.06/M | $0.375/M |