### PR TITLE
✨ feat: add OfoxAI as a new model provider

### DIFF
--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -42,6 +42,7 @@ import { default as nebius } from './nebius';
 import { default as newapi } from './newapi';
 import { default as novita } from './novita';
 import { default as nvidia } from './nvidia';
+import { default as ofoxai } from './ofoxai';
 import { default as ollama } from './ollama';
 import { default as ollamacloud } from './ollamacloud';
 import { default as openai } from './openai';
@@ -136,6 +137,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   newapi,
   novita,
   nvidia,
+  ofoxai,
   ollama,
   ollamacloud,
   openai,
@@ -211,6 +213,7 @@ export { default as nebius } from './nebius';
 export { default as newapi } from './newapi';
 export { default as novita } from './novita';
 export { default as nvidia } from './nvidia';
+export { default as ofoxai } from './ofoxai';
 export { default as ollama } from './ollama';
 export { default as ollamacloud } from './ollamacloud';
 export { gptImage1ParamsSchema, default as openai, openaiChatModels } from './openai';

--- a/packages/model-bank/src/aiModels/ofoxai.ts
+++ b/packages/model-bank/src/aiModels/ofoxai.ts
@@ -1,0 +1,8 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// OfoxAI is a unified API gateway - models are fetched dynamically via /v1/models
+const ofoxaiChatModels: AIChatModelCard[] = [];
+
+export const allModels = [...ofoxaiChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -40,6 +40,7 @@ export enum ModelProvider {
   NewAPI = 'newapi',
   Novita = 'novita',
   Nvidia = 'nvidia',
+  OfoxAI = 'ofoxai',
   Ollama = 'ollama',
   OllamaCloud = 'ollamacloud',
   OpenAI = 'openai',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -43,6 +43,7 @@ import NebiusProvider from './nebius';
 import NewAPIProvider from './newapi';
 import NovitaProvider from './novita';
 import NvidiaProvider from './nvidia';
+import OfoxAIProvider from './ofoxai';
 import OllamaProvider from './ollama';
 import OllamaCloudProvider from './ollamacloud';
 import OpenAIProvider from './openai';
@@ -200,6 +201,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   ReplicateProvider,
   NebiusProvider,
   CometAPIProvider,
+  OfoxAIProvider,
   VercelAIGatewayProvider,
   CerebrasProvider,
   ZenMuxProvider,
@@ -260,6 +262,7 @@ export { default as NebiusProviderCard } from './nebius';
 export { default as NewAPIProviderCard } from './newapi';
 export { default as NovitaProviderCard } from './novita';
 export { default as NvidiaProviderCard } from './nvidia';
+export { default as OfoxAIProviderCard } from './ofoxai';
 export { default as OllamaProviderCard } from './ollama';
 export { default as OllamaCloudProviderCard } from './ollamacloud';
 export { default as OpenAIProviderCard } from './openai';

--- a/packages/model-bank/src/modelProviders/ofoxai.ts
+++ b/packages/model-bank/src/modelProviders/ofoxai.ts
@@ -1,0 +1,22 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+const OfoxAI: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'gpt-4o-mini',
+  description:
+    'OfoxAI is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. OpenAI-compatible format.',
+  id: 'ofoxai',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://docs.ofox.ai/zh/api',
+  name: 'OfoxAI',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.ofox.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://ofox.ai',
+};
+
+export default OfoxAI;

--- a/packages/model-runtime/src/providers/ofoxai/index.ts
+++ b/packages/model-runtime/src/providers/ofoxai/index.ts
@@ -1,0 +1,52 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+
+export interface OfoxAIModelCard {
+  id: string;
+  object: string;
+  owned_by: string;
+}
+
+export const params = {
+  baseURL: 'https://api.ofox.ai/v1',
+  chatCompletion: {
+    handlePayload: (payload) => {
+      const { model, ...rest } = payload;
+
+      return {
+        ...rest,
+        model,
+        stream: true,
+      } as any;
+    },
+  },
+  debug: {
+    chatCompletion: () => process.env.DEBUG_OFOXAI_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    try {
+      const modelsPage = (await client.models.list()) as any;
+      const rawList: any[] = modelsPage.data || [];
+
+      const modelList: OfoxAIModelCard[] = rawList.map((model) => ({
+        id: model.id,
+        object: model.object,
+        owned_by: model.owned_by,
+      }));
+
+      return await processMultiProviderModelList(modelList, 'ofoxai');
+    } catch (error) {
+      console.warn(
+        'Failed to fetch OfoxAI models. Please ensure your OfoxAI API key is valid:',
+        error,
+      );
+      return [];
+    }
+  },
+  provider: ModelProvider.OfoxAI,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeOfoxAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -39,6 +39,7 @@ import { LobeNebiusAI } from './providers/nebius';
 import { LobeNewAPIAI } from './providers/newapi';
 import { LobeNovitaAI } from './providers/novita';
 import { LobeNvidiaAI } from './providers/nvidia';
+import { LobeOfoxAI } from './providers/ofoxai';
 import { LobeOllamaAI } from './providers/ollama';
 import { LobeOllamaCloudAI } from './providers/ollamacloud';
 import { LobeOpenAI } from './providers/openai';
@@ -113,6 +114,7 @@ export const providerRuntimeMap = {
   newapi: LobeNewAPIAI,
   novita: LobeNovitaAI,
   nvidia: LobeNvidiaAI,
+  ofoxai: LobeOfoxAI,
   ollama: LobeOllamaAI,
   ollamacloud: LobeOllamaCloudAI,
   openai: LobeOpenAI,


### PR DESCRIPTION
## Summary

Add [OfoxAI](https://ofox.ai) as a new model provider for LobeChat.

**OfoxAI** is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. It uses an OpenAI-compatible format.

- **Website**: https://ofox.ai
- **API Docs**: https://docs.ofox.ai/zh/api
- **Base URL**: `https://api.ofox.ai/v1`
- **Compatibility**: OpenAI API compatible (`sdkType: 'openai'`)
- **Model Fetcher**: Enabled — models are fetched dynamically via `/v1/models`

## Changes

### New files
- `packages/model-bank/src/aiModels/ofoxai.ts` — AI model definitions (empty, uses dynamic fetcher)
- `packages/model-bank/src/modelProviders/ofoxai.ts` — Provider card configuration
- `packages/model-runtime/src/providers/ofoxai/index.ts` — Runtime implementation using OpenAI-compatible factory

### Modified files
- `packages/model-bank/src/const/modelProvider.ts` — Added `OfoxAI` to ModelProvider enum
- `packages/model-bank/src/aiModels/index.ts` — Registered ofoxai model list
- `packages/model-bank/src/modelProviders/index.ts` — Registered OfoxAI provider card
- `packages/model-runtime/src/runtimeMap.ts` — Registered OfoxAI runtime

## Related

- Discussion: https://github.com/lobehub/lobehub/discussions/6157