### PR TITLE
🐛 fix: should record unique case id in eval dataset

### DIFF
--- a/src/routes/(main)/eval/config/datasetPresets.ts
+++ b/src/routes/(main)/eval/config/datasetPresets.ts
@@ -44,7 +44,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: Topic (category/tags), Question (input), Answer (expected)',
     requiredFields: ['question', 'answer', 'problem_topic', 'canary'],
-    optionalFields: [],
+    optionalFields: ['id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -65,7 +65,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: Topic (category/tags), Question (input), Answer (expected)',
     requiredFields: ['Question', 'Answer'],
-    optionalFields: ['Topic', 'canary'],
+    optionalFields: ['Topic', 'canary', 'id'],
     fieldInference: {
       input: ['Question', 'question', 'prompt'],
       expected: ['Answer', 'answer'],
@@ -87,7 +87,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: instance_id, query (input), evaluation (expected), language',
     requiredFields: ['instance_id', 'query', 'evaluation', 'language'],
-    optionalFields: [],
+    optionalFields: ['id'],
     fieldInference: {
       input: ['query'],
       expected: ['evaluation'],
@@ -165,7 +165,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'problem, problem_category, answer, answer_type',
     requiredFields: ['problem', 'answer', 'problem_category', 'answer_type'],
-    optionalFields: [],
+    optionalFields: ['id'],
     fieldInference: {
       input: ['problem'],
       expected: ['answer'],
@@ -188,7 +188,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: question (input), answer (expected), topic (category)',
     requiredFields: ['question', 'answer', 'topic', 'canary'],
-    optionalFields: [],
+    optionalFields: ['id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -234,7 +234,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     formatDescription:
       'format: question, choices array (or A/B/C/D columns), answer (index/letter)',
     requiredFields: ['question', 'choices', 'answer'],
-    optionalFields: ['subject', 'difficulty'],
+    optionalFields: ['subject', 'difficulty', 'id'],
     fieldInference: {
       input: ['question', 'prompt', 'query'],
       expected: ['answer', 'correct_answer', 'label'],

--- a/src/routes/(main)/eval/config/datasetPresets.ts
+++ b/src/routes/(main)/eval/config/datasetPresets.ts
@@ -44,7 +44,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: Topic (category/tags), Question (input), Answer (expected)',
     requiredFields: ['question', 'answer', 'problem_topic', 'canary'],
-    optionalFields: ['id'],
+    optionalFields: ['case_id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -65,7 +65,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: Topic (category/tags), Question (input), Answer (expected)',
     requiredFields: ['Question', 'Answer'],
-    optionalFields: ['Topic', 'canary', 'id'],
+    optionalFields: ['Topic', 'canary', 'case_id'],
     fieldInference: {
       input: ['Question', 'question', 'prompt'],
       expected: ['Answer', 'answer'],
@@ -87,7 +87,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: instance_id, query (input), evaluation (expected), language',
     requiredFields: ['instance_id', 'query', 'evaluation', 'language'],
-    optionalFields: ['id'],
+    optionalFields: ['case_id'],
     fieldInference: {
       input: ['query'],
       expected: ['evaluation'],
@@ -119,7 +119,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
       'raw_subject',
       'category',
     ],
-    optionalFields: ['canary'],
+    optionalFields: ['canary', 'case_id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -147,7 +147,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
       'category',
       'Verified_Classes',
     ],
-    optionalFields: ['canary'],
+    optionalFields: ['canary', 'case_id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -165,7 +165,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'problem, problem_category, answer, answer_type',
     requiredFields: ['problem', 'answer', 'problem_category', 'answer_type'],
-    optionalFields: ['id'],
+    optionalFields: ['case_id'],
     fieldInference: {
       input: ['problem'],
       expected: ['answer'],
@@ -188,7 +188,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     icon: Globe,
     formatDescription: 'format: question (input), answer (expected), topic (category)',
     requiredFields: ['question', 'answer', 'topic', 'canary'],
-    optionalFields: ['id'],
+    optionalFields: ['case_id'],
     fieldInference: {
       input: ['question'],
       expected: ['answer'],
@@ -234,7 +234,7 @@ export const DATASET_PRESETS: Record<string, DatasetPreset> = {
     formatDescription:
       'format: question, choices array (or A/B/C/D columns), answer (index/letter)',
     requiredFields: ['question', 'choices', 'answer'],
-    optionalFields: ['subject', 'difficulty', 'id'],
+    optionalFields: ['subject', 'difficulty'],
     fieldInference: {
       input: ['question', 'prompt', 'query'],
       expected: ['answer', 'correct_answer', 'label'],


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

补齐 id 用于外部套件与内部 case 追踪

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

New Features:
- Add support for an optional case_id field across multiple eval dataset presets to carry case identifiers when present.