### PR TITLE
🐛 fix(auth): add BusinessAuthProvider slot to auth layout

### DIFF
--- a/src/app/[variants]/(auth)/layout.tsx
+++ b/src/app/[variants]/(auth)/layout.tsx
@@ -1,6 +1,7 @@
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { type PropsWithChildren } from 'react';
 
+import BusinessAuthProvider from '@/business/client/BusinessAuthProvider';
 import ClientOnly from '@/components/client/ClientOnly';
 import { type DynamicLayoutProps } from '@/types/next';
 
@@ -14,7 +15,9 @@ const AuthLayout = async ({ children, params }: PropsWithChildren<DynamicLayoutP
     <AuthGlobalProvider variants={variants}>
       <ClientOnly>
         <NuqsAdapter>
-          <AuthContainer>{children}</AuthContainer>
+          <BusinessAuthProvider>
+            <AuthContainer>{children}</AuthContainer>
+          </BusinessAuthProvider>
         </NuqsAdapter>
       </ClientOnly>
     </AuthGlobalProvider>

--- a/src/business/client/BusinessAuthProvider.tsx
+++ b/src/business/client/BusinessAuthProvider.tsx
@@ -1,0 +1,5 @@
+import { type ReactNode } from 'react';
+
+export default function BusinessAuthProvider({ children }: { children: ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Add `BusinessAuthProvider` business slot to the auth layout, following the same pattern as `BusinessGlobalProvider` for SPA routes.

- New `BusinessAuthProvider` stub in `src/business/client/` (no-op passthrough)
- Auth layout wraps `AuthContainer` with `BusinessAuthProvider` inside `NuqsAdapter`

This allows cloud repo to inject auth-page-specific providers (e.g., referral code persistence) without overriding the entire auth layout file.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

## Summary by Sourcery

Introduce a business-specific provider slot into the auth layout to allow injecting custom auth-page behavior without overriding the layout.

Enhancements:
- Add a BusinessAuthProvider client stub as a passthrough wrapper for auth-related business logic injection.
- Wrap the auth layout’s AuthContainer with BusinessAuthProvider to enable cloud-specific auth providers while preserving existing structure.