### PR TITLE
🐛 fix(editor): correct empty editor state structure and wide screen layout

### DIFF
--- a/src/features/WideScreenContainer/index.tsx
+++ b/src/features/WideScreenContainer/index.tsx
@@ -13,6 +13,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
+    flex-grow: 1;
     align-self: center;
     transition: width 0.25s ${cssVar.motionEaseInOut};
   `,

--- a/src/routes/(main)/agent/profile/features/constants.ts
+++ b/src/routes/(main)/agent/profile/features/constants.ts
@@ -5,32 +5,24 @@
  */
 export const EMPTY_EDITOR_STATE = {
   root: {
+    id: 'root',
+    type: 'root',
+    format: '',
+    indent: 0,
+    version: 1,
     children: [
       {
-        children: [
-          {
-            detail: 0,
-            format: 0,
-            mode: 'normal',
-            style: '',
-            text: '',
-            type: 'text',
-            version: 1,
-          },
-        ],
-        direction: null,
+        id: '42',
+        type: 'paragraph',
         format: '',
         indent: 0,
-        textFormat: 0,
-        textStyle: '',
-        type: 'paragraph',
         version: 1,
+        children: [],
+        direction: null,
+        textStyle: '',
+        textFormat: 0,
       },
     ],
     direction: null,
-    format: '',
-    indent: 0,
-    type: 'root',
-    version: 1,
   },
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

N/A

#### 🔀 Description of Change

- **EMPTY_EDITOR_STATE**: Fix Lexical editor empty state structure with proper node format (root id, paragraph id, correct child structure)
- **WideScreenContainer**: Add `flex-grow: 1` to allow the editor canvas to expand properly in wide screen mode

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Fix the default empty editor state structure and adjust wide screen editor layout to expand correctly.

Bug Fixes:
- Correct the EMPTY_EDITOR_STATE structure to use a valid Lexical root and paragraph node configuration.
- Allow the wide screen editor container to grow and use available horizontal space by enabling flex growth on the container.