### PR TITLE
🐛 fix(database): add drizzle-zod and zod as peer dependencies to fix type-check errors

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -32,7 +32,9 @@
   "peerDependencies": {
     "dayjs": "*",
     "drizzle-orm": "*",
+    "drizzle-zod": "*",
     "nanoid": "*",
-    "pg": "*"
+    "pg": "*",
+    "zod": "*"
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`packages/database/src/schemas/*.ts` files import `drizzle-zod` (`createInsertSchema`, `createSelectSchema`), but `packages/database/package.json` did not declare it as a dependency. This caused pnpm to resolve `drizzle-zod` from the root context, where its peer `drizzle-orm` was resolved to a different virtual store instance (due to inconsistent `better-sqlite3` optional peer auto-install), resulting in 12 TS2345 type errors:

```
Types have separate declarations of a private property 'shouldInlineParams'
```

This PR adds `drizzle-zod` and `zod` (required peer of `drizzle-zod`) as peer dependencies of `@lobechat/database`, ensuring pnpm resolves them in the same context as `drizzle-orm`, eliminating the duplicate instance mismatch.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Run `pnpm run type-check` — should pass with 0 errors (previously had 12 errors across 7 files).