### PR TITLE
✨ feat(model-runtime): add xiaomimimo to RouterRuntime base runtime map

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/apiTypes.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/apiTypes.ts
@@ -14,6 +14,7 @@ export type ApiType =
   | 'qwen'
   | 'vertexai'
   | 'volcengine'
-  | 'xai';
+  | 'xai'
+  | 'xiaomimimo';
 
 export type RuntimeClass = new (options?: any) => LobeRuntimeAI;

--- a/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/baseRuntimeMap.ts
@@ -12,6 +12,7 @@ import { LobeQwenAI } from '../../providers/qwen';
 import { LobeVertexAI } from '../../providers/vertexai';
 import { LobeVolcengineAI } from '../../providers/volcengine';
 import { LobeXAI } from '../../providers/xai';
+import { LobeXiaomiMiMoAI } from '../../providers/xiaomimimo';
 import type { ApiType, RuntimeClass } from './apiTypes';
 
 export const baseRuntimeMap = {
@@ -29,4 +30,5 @@ export const baseRuntimeMap = {
   vertexai: LobeVertexAI,
   volcengine: LobeVolcengineAI,
   xai: LobeXAI,
+  xiaomimimo: LobeXiaomiMiMoAI,
 } satisfies Record<ApiType, RuntimeClass>;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add `xiaomimimo` to `ApiType` union and `baseRuntimeMap` so the RouterRuntime can use XiaomiMiMo as a base runtime provider, enabling proper fallback support for XiaomiMiMo channels.

#### 🧪 How to Test

- [x] No tests needed

## Summary by Sourcery

Add XiaomiMiMo as a supported base runtime provider in RouterRuntime to enable routing and fallback for XiaomiMiMo channels.

New Features:
- Introduce the `xiaomimimo` API type to the RouterRuntime API type union.
- Register `xiaomimimo` in the base runtime map using the `LobeXiaomiMiMoAI` provider.