### PR TITLE
🔧 chore(locales): missing category locale for productivity

### DIFF
--- a/locales/ar/discover.json
+++ b/locales/ar/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "الحياة",
   "category.assistant.marketing": "تسويق",
   "category.assistant.office": "مكتب",
+  "category.assistant.productivity": "الإنتاجية",
   "category.assistant.programming": "برمجة",
   "category.assistant.translation": "ترجمة",
   "category.plugin.all": "الكل",

--- a/locales/bg-BG/discover.json
+++ b/locales/bg-BG/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Живот",
   "category.assistant.marketing": "Маркетинг",
   "category.assistant.office": "Офис",
+  "category.assistant.productivity": "Продуктивност",
   "category.assistant.programming": "Програмиране",
   "category.assistant.translation": "Превод",
   "category.plugin.all": "Всички",

--- a/locales/de-DE/discover.json
+++ b/locales/de-DE/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Leben",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Büro",
+  "category.assistant.productivity": "Produktivität",
   "category.assistant.programming": "Programmierung",
   "category.assistant.translation": "Übersetzung",
   "category.plugin.all": "Alle",

--- a/locales/en-US/discover.json
+++ b/locales/en-US/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Life",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Office",
+  "category.assistant.productivity": "Productivity",
   "category.assistant.programming": "Programming",
   "category.assistant.translation": "Translation",
   "category.plugin.all": "All",

--- a/locales/es-ES/discover.json
+++ b/locales/es-ES/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Vida",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Oficina",
+  "category.assistant.productivity": "Productividad",
   "category.assistant.programming": "Programación",
   "category.assistant.translation": "Traducción",
   "category.plugin.all": "Todos",

--- a/locales/fa-IR/discover.json
+++ b/locales/fa-IR/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "زندگی",
   "category.assistant.marketing": "بازاریابی",
   "category.assistant.office": "اداری",
+  "category.assistant.productivity": "بهره‌وری",
   "category.assistant.programming": "برنامه‌نویسی",
   "category.assistant.translation": "ترجمه",
   "category.plugin.all": "همه",

--- a/locales/fr-FR/discover.json
+++ b/locales/fr-FR/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Vie quotidienne",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Bureau",
+  "category.assistant.productivity": "Productivité",
   "category.assistant.programming": "Programmation",
   "category.assistant.translation": "Traduction",
   "category.plugin.all": "Tous",

--- a/locales/it-IT/discover.json
+++ b/locales/it-IT/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Vita",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Ufficio",
+  "category.assistant.productivity": "Produttività",
   "category.assistant.programming": "Programmazione",
   "category.assistant.translation": "Traduzione",
   "category.plugin.all": "Tutti",

--- a/locales/ja-JP/discover.json
+++ b/locales/ja-JP/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "生活",
   "category.assistant.marketing": "マーケティング",
   "category.assistant.office": "オフィス",
+  "category.assistant.productivity": "生産性",
   "category.assistant.programming": "プログラミング",
   "category.assistant.translation": "翻訳",
   "category.plugin.all": "すべて",

--- a/locales/ko-KR/discover.json
+++ b/locales/ko-KR/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "생활",
   "category.assistant.marketing": "비즈니스",
   "category.assistant.office": "오피스",
+  "category.assistant.productivity": "생산성",
   "category.assistant.programming": "프로그래밍",
   "category.assistant.translation": "번역",
   "category.plugin.all": "전체",

--- a/locales/nl-NL/discover.json
+++ b/locales/nl-NL/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Leven",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Kantoor",
+  "category.assistant.productivity": "Productiviteit",
   "category.assistant.programming": "Programmeren",
   "category.assistant.translation": "Vertaling",
   "category.plugin.all": "Alle",

--- a/locales/pl-PL/discover.json
+++ b/locales/pl-PL/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Życie",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Biuro",
+  "category.assistant.productivity": "Produktywność",
   "category.assistant.programming": "Programowanie",
   "category.assistant.translation": "Tłumaczenie",
   "category.plugin.all": "Wszystkie",

--- a/locales/pt-BR/discover.json
+++ b/locales/pt-BR/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Vida",
   "category.assistant.marketing": "Marketing",
   "category.assistant.office": "Escritório",
+  "category.assistant.productivity": "Produtividade",
   "category.assistant.programming": "Programação",
   "category.assistant.translation": "Tradução",
   "category.plugin.all": "Todos",

--- a/locales/ru-RU/discover.json
+++ b/locales/ru-RU/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Жизнь",
   "category.assistant.marketing": "Маркетинг",
   "category.assistant.office": "Офис",
+  "category.assistant.productivity": "Продуктивность",
   "category.assistant.programming": "Программирование",
   "category.assistant.translation": "Перевод",
   "category.plugin.all": "Все",

--- a/locales/tr-TR/discover.json
+++ b/locales/tr-TR/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Yaşam",
   "category.assistant.marketing": "Pazarlama",
   "category.assistant.office": "Ofis",
+  "category.assistant.productivity": "Üretkenlik",
   "category.assistant.programming": "Programlama",
   "category.assistant.translation": "Çeviri",
   "category.plugin.all": "Tümü",

--- a/locales/vi-VN/discover.json
+++ b/locales/vi-VN/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "Cuộc sống",
   "category.assistant.marketing": "Tiếp thị",
   "category.assistant.office": "Văn phòng",
+  "category.assistant.productivity": "Năng suất",
   "category.assistant.programming": "Lập trình",
   "category.assistant.translation": "Dịch thuật",
   "category.plugin.all": "Tất cả",

--- a/locales/zh-CN/discover.json
+++ b/locales/zh-CN/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "生活",
   "category.assistant.marketing": "商业",
   "category.assistant.office": "办公",
+  "category.assistant.productivity": "效率",
   "category.assistant.programming": "编程",
   "category.assistant.translation": "翻译",
   "category.plugin.all": "全部",

--- a/locales/zh-TW/discover.json
+++ b/locales/zh-TW/discover.json
@@ -94,6 +94,7 @@
   "category.assistant.life": "生活",
   "category.assistant.marketing": "商業",
   "category.assistant.office": "辦公",
+  "category.assistant.productivity": "生產力",
   "category.assistant.programming": "編程",
   "category.assistant.translation": "翻譯",
   "category.plugin.all": "全部",

--- a/src/locales/default/discover.ts
+++ b/src/locales/default/discover.ts
@@ -101,6 +101,7 @@ export default {
   'category.assistant.life': 'Life',
   'category.assistant.marketing': 'Marketing',
   'category.assistant.office': 'Office',
+  'category.assistant.productivity': 'Productivity',
   'category.assistant.programming': 'Programming',
   'category.assistant.translation': 'Translation',
   'category.plugin.all': 'All',


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

Bug Fixes:
- Provide the missing Productivity assistant category label in discover locale files.