### PR TITLE
🐛 fix(chat): strip forkedFromIdentifier before LLM API request

### DIFF
--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -345,6 +345,8 @@ class ChatService {
     const chatConfig = agentChatConfigSelectors.currentChatConfig(getAgentStoreState());
 
     delete (res as any).scope;
+    // Fork flow stores market metadata in agent.params; must not reach OpenAI-compatible / Responses API
+    delete (res as any).forkedFromIdentifier;
 
     const payload = merge(
       {


### PR DESCRIPTION
## Summary
Fork \& Chat stores `forkedFromIdentifier` in `agent.params` for resolving the source market agent. That object was merged into the outbound chat / Responses API payload, so strict OpenAI-compatible gateways (e.g. AiHubMix with `gpt-5.4`) rejected the request with `Unknown parameter: 'forkedFromIdentifier'`.

## Change
Delete `forkedFromIdentifier` from the request object in `getChatCompletion`, next to the existing strip of `scope` (also non-API metadata).

## Issue
Fixes #13071

Made with [Cursor](https://cursor.com)