### PR TITLE
🐛 fix: restore message action bar on tap after deletion

### DIFF
--- a/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import isEqual from 'fast-deep-equal';
-import { type MouseEventHandler } from 'react';
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 
 import { LOADING_FLAT } from '@/const/message';
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
@@ -15,10 +14,7 @@ import { type UIChatMessage } from '@/types/index';
 import { useAgentMeta } from '../../../hooks';
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import MessageContent from '../../Assistant/components/MessageContent';
-import {
-  useSetMessageItemActionElementPortialContext,
-  useSetMessageItemActionTypeContext,
-} from '../../Contexts/message-action-context';
+import { useActivateMessageActionsBar } from '../../Contexts/useActivateMessageActionsBar';
 import AutoScrollShadow from './AutoScrollShadow';
 
 const actionBarHolder = (
@@ -52,16 +48,7 @@ const CouncilMember = memo<CouncilMemberProps>(({ item, index }) => {
   const errorContent = useErrorContent(error);
   const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
 
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'assistant' });
-    },
-    [id, index, setMessageItemActionElementPortialContext, setMessageItemActionTypeContext],
-  );
+  const activateActionsBar = useActivateMessageActionsBar({ id, index, type: 'assistant' });
 
   return (
     <ChatItem
@@ -91,7 +78,8 @@ const CouncilMember = memo<CouncilMemberProps>(({ item, index }) => {
           usage={usage! || metadata}
         />
       }
-      onMouseEnter={onMouseEnter}
+      onClick={activateActionsBar}
+      onMouseEnter={activateActionsBar}
     >
       <AutoScrollShadow content={content} streaming={generating}>
         <MessageContent {...item} />

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -2,8 +2,7 @@
 
 import { LOADING_FLAT } from '@lobechat/const';
 import isEqual from 'fast-deep-equal';
-import { type MouseEventHandler } from 'react';
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
 import { ChatItem } from '@/features/Conversation/ChatItem';
@@ -15,10 +14,7 @@ import { useAgentMeta, useDoubleClickEdit } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
 import { normalizeThinkTags, processWithArtifact } from '../../utils/markdown';
 import MessageBranch from '../components/MessageBranch';
-import {
-  useSetMessageItemActionElementPortialContext,
-  useSetMessageItemActionTypeContext,
-} from '../Contexts/message-action-context';
+import { useActivateMessageActionsBar } from '../Contexts/useActivateMessageActionsBar';
 import MessageContent from './components/MessageContent';
 import { AssistantMessageExtra } from './Extra';
 
@@ -65,18 +61,9 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
   const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
+  const activateActionsBar = useActivateMessageActionsBar({ id, index, type: 'assistant' });
 
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'assistant' });
-    },
-    [id, index, setMessageItemActionElementPortialContext, setMessageItemActionTypeContext],
-  );
 
   return (
     <ChatItem
@@ -118,7 +105,8 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
         />
       }
       onDoubleClick={onDoubleClick}
-      onMouseEnter={onMouseEnter}
+      onClick={activateActionsBar}
+      onMouseEnter={activateActionsBar}
     >
       <MessageContent {...item} />
     </ChatItem>

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -2,7 +2,6 @@
 
 import type { AssistantContentBlock, EmojiReaction } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
-import type { MouseEventHandler } from 'react';
 import { memo, Suspense, useCallback, useMemo } from 'react';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
@@ -20,10 +19,7 @@ import { useAgentMeta } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
 import Usage from '../components/Extras/Usage';
 import MessageBranch from '../components/MessageBranch';
-import {
-  useSetMessageItemActionElementPortialContext,
-  useSetMessageItemActionTypeContext,
-} from '../Contexts/message-action-context';
+import { useActivateMessageActionsBar } from '../Contexts/useActivateMessageActionsBar';
 import FileListViewer from '../User/components/FileListViewer';
 import Group from './components/Group';
 
@@ -98,23 +94,12 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing }) => 
     [reactions],
   );
 
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      if (disableEditing) return;
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'assistantGroup' });
-    },
-    [
-      disableEditing,
-      id,
-      index,
-      setMessageItemActionElementPortialContext,
-      setMessageItemActionTypeContext,
-    ],
-  );
+  const activateActionsBar = useActivateMessageActionsBar({
+    disabled: disableEditing,
+    id,
+    index,
+    type: 'assistantGroup',
+  });
 
   const onAvatarClick = useCallback(() => {
     if (!isInbox) {
@@ -145,7 +130,8 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing }) => 
         )
       }
       onAvatarClick={onAvatarClick}
-      onMouseEnter={onMouseEnter}
+      onClick={activateActionsBar}
+      onMouseEnter={activateActionsBar}
     >
       {children && children.length > 0 && (
         <Group

--- a/src/features/Conversation/Messages/Contexts/useActivateMessageActionsBar.ts
+++ b/src/features/Conversation/Messages/Contexts/useActivateMessageActionsBar.ts
@@ -1,0 +1,38 @@
+import { type MouseEventHandler, useCallback } from 'react';
+
+import {
+  type MessageActionType,
+  useSetMessageItemActionElementPortialContext,
+  useSetMessageItemActionTypeContext,
+} from './message-action-context';
+
+type UseActivateMessageActionsBarParams = MessageActionType & {
+  disabled?: boolean;
+};
+
+export const useActivateMessageActionsBar = ({
+  disabled,
+  id,
+  index,
+  type,
+}: UseActivateMessageActionsBarParams): MouseEventHandler<HTMLDivElement> => {
+  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
+  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
+
+  return useCallback(
+    (e) => {
+      if (disabled) return;
+
+      setMessageItemActionElementPortialContext(e.currentTarget);
+      setMessageItemActionTypeContext({ id, index, type });
+    },
+    [
+      disabled,
+      id,
+      index,
+      setMessageItemActionElementPortialContext,
+      setMessageItemActionTypeContext,
+      type,
+    ],
+  );
+};

--- a/src/features/Conversation/Messages/Supervisor/index.tsx
+++ b/src/features/Conversation/Messages/Supervisor/index.tsx
@@ -3,7 +3,6 @@
 import type { EmojiReaction } from '@lobechat/types';
 import { Tag } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { type MouseEventHandler } from 'react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,10 +19,7 @@ import { useAgentMeta } from '../../hooks';
 import { dataSelectors, useConversationStore } from '../../store';
 import Usage from '../components/Extras/Usage';
 import MessageBranch from '../components/MessageBranch';
-import {
-  useSetMessageItemActionElementPortialContext,
-  useSetMessageItemActionTypeContext,
-} from '../Contexts/message-action-context';
+import { useActivateMessageActionsBar } from '../Contexts/useActivateMessageActionsBar';
 import Group from './components/Group';
 
 const actionBarHolder = (
@@ -85,23 +81,12 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing }) => 
     [reactions],
   );
 
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      if (disableEditing) return;
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'assistantGroup' });
-    },
-    [
-      disableEditing,
-      id,
-      index,
-      setMessageItemActionElementPortialContext,
-      setMessageItemActionTypeContext,
-    ],
-  );
+  const activateActionsBar = useActivateMessageActionsBar({
+    disabled: disableEditing,
+    id,
+    index,
+    type: 'assistantGroup',
+  });
 
   return (
     <ChatItem
@@ -129,7 +114,8 @@ const GroupMessage = memo<GroupMessageProps>(({ id, index, disableEditing }) => 
           memberAvatars={memberAvatars}
         />
       )}
-      onMouseEnter={onMouseEnter}
+      onClick={activateActionsBar}
+      onMouseEnter={activateActionsBar}
     >
       {children && children.length > 0 && (
         <Group

--- a/src/features/Conversation/Messages/User/index.tsx
+++ b/src/features/Conversation/Messages/User/index.tsx
@@ -1,7 +1,6 @@
 import { Tag } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { type MouseEventHandler } from 'react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ChatItem } from '@/features/Conversation/ChatItem';
@@ -13,10 +12,7 @@ import { userProfileSelectors } from '@/store/user/selectors';
 
 import { useDoubleClickEdit } from '../../hooks/useDoubleClickEdit';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-import {
-  useSetMessageItemActionElementPortialContext,
-  useSetMessageItemActionTypeContext,
-} from '../Contexts/message-action-context';
+import { useActivateMessageActionsBar } from '../Contexts/useActivateMessageActionsBar';
 import Actions from './Actions';
 import UserMessageContent from './components/MessageContent';
 import { UserMessageExtra } from './Extra';
@@ -55,24 +51,12 @@ const UserMessage = memo<UserMessageProps>(({ id, disableEditing, index }) => {
   }, [targetId, userName, agents, t]);
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
-
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      if (disableEditing) return;
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'user' });
-    },
-    [
-      disableEditing,
-      id,
-      index,
-      setMessageItemActionElementPortialContext,
-      setMessageItemActionTypeContext,
-    ],
-  );
+  const activateActionsBar = useActivateMessageActionsBar({
+    disabled: disableEditing,
+    id,
+    index,
+    type: 'user',
+  });
 
   return (
     <ChatItem
@@ -96,7 +80,8 @@ const UserMessage = memo<UserMessageProps>(({ id, disableEditing, index }) => {
         />
       }
       onDoubleClick={onDoubleClick}
-      onMouseEnter={onMouseEnter}
+      onClick={activateActionsBar}
+      onMouseEnter={activateActionsBar}
     >
       <UserMessageContent {...item} />
     </ChatItem>


### PR DESCRIPTION
  #### 💻 Change Type

  - [ ] ✨ feat
  - [x] 🐛 fix
  - [ ] ♻️ refactor
  - [ ] 💄 style
  - [ ] 👷 build
  - [ ] ⚡️ perf
  - [ ] ✅ test
  - [ ] 📝 docs
  - [ ] 🔨 chore

  #### 🔗 Related Issue

  N/A

  #### 🔀 Description of Change

  This PR fixes a message action bar activation issue that could be reproduced reliably on mobile.

  Previously, after deleting a message, tapping the message currently visible in the same screen position would not show the action buttons below it. The buttons would only reappear after interacting with another message or the input area first.

  The root cause was that the singleton message action bar was only re-activated through `mouseenter`, which is not reliable for mobile tap interactions and also fails when a new message shifts into the same visual position after deletion.

  Changes in this PR:
  - Add a shared helper to activate the message action bar target
  - Keep existing hover behavior for desktop
  - Also activate the action bar on click/tap for message items
  - Apply the fix to user, assistant, assistant group, supervisor, and agent council message items

  #### 🧪 How to Test

  - [x] Tested locally
  - [ ] Added/updated tests
  - [x] No tests needed

  Static check performed:
  - `pnpm exec eslint src/features/Conversation/Messages/Contexts/useActivateMessageActionsBar.ts src/features/Conversation/Messages/User/index.tsx src/features/Conversation/Messages/Assistant/index.tsx src/features/Conversation/Messages/AssistantGroup/index.tsx src/features/Conversation/Messages/Supervisor/index.tsx src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx`

  Manual verification scenario:
  1. Open a conversation on mobile
  2. Tap a message and delete it
  3. Tap the message now visible in the current screen position
  4. Confirm the action buttons appear immediately without needing to tap another message or the input box first

  #### 📸 Screenshots / Videos

  | Before | After |
  | ------ | ----- |
  | After deleting a message, tapping the current visible message does not show the action bar until another element is tapped first. | After deleting a message, tapping the current visible message shows the action bar immediately. |

  #### 📝 Additional Information

  This change is intentionally minimal and only updates action bar activation behavior. It does not change the message deletion flow itself.