### PR TITLE
👷 build(ci): add dedicated docker canary tag

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -45,6 +45,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=canary,enable=${{ contains(github.event.release.tag_name, '-canary.') }}
             type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.prerelease }}
 
       - name: Docker login
@@ -111,6 +112,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=canary,enable=${{ contains(github.event.release.tag_name, '-canary.') }}
             type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event.release.prerelease }}
 
       - name: Docker login


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue


#### 🔀 Description of Change

- add a dedicated floating canary Docker tag for canary GitHub releases
- keep stable releases publishing latest and version tags as before
- keep other prereleases publishing only their version tag

#### 🧪 How to Test

- validate .github/workflows/release-docker.yml parses successfully with Ruby YAML
- confirm only canary prerelease tags match the new canary tag rule

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This PR targets canary to avoid mixing unrelated differences from main into the Docker workflow change.
