### PR TITLE
🔧 chore(vercel): add SPA asset cache headers and no-store for dev proxy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,54 @@
 {
   "buildCommand": "bun run build:vercel",
+  "headers": [
+    {
+      "source": "/spa/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable"
+        },
+        {
+          "key": "CDN-Cache-Control",
+          "value": "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=86400, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/_dangerous_local_dev_proxy",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "source": "/_dangerous_local_dev_proxy/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    }
+  ],
   "installCommand": "npx pnpm@10.26.2 install",
   "rewrites": [
     {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔀 Description of Change

- Configure Vercel headers for `/spa/assets/*` with long-lived cache and `immutable` for hashed SPA assets.
- Set `no-store` / `no-cache` headers for `/_dangerous_local_dev_proxy` routes so the local dev proxy page is not incorrectly cached.

#### 🧪 How to Test

- Verify response headers on deploy preview for `/spa/assets/...` and `/_dangerous_local_dev_proxy`.
- [x] No tests needed


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Configure Vercel caching headers for SPA assets and local dev proxy routes.

Build:
- Add long-lived immutable cache headers for `/spa/assets/*` in Vercel configuration.
- Set no-store/no-cache headers for `/_dangerous_local_dev_proxy` routes in Vercel configuration.