### PR TITLE
🔨 chore(desktop): bust stable release manifest cache

### DIFF
--- a/src/server/services/desktopRelease/index.ts
+++ b/src/server/services/desktopRelease/index.ts
@@ -175,10 +175,12 @@ export const getStableDesktopReleaseInfoFromUpdateServer = async (options?: {
     options?.baseUrl || process.env.DESKTOP_UPDATE_SERVER_URL || process.env.UPDATE_SERVER_URL;
   if (!baseUrl) return null;
 
+  const timestamp = Date.now();
+
   const [mac, win, linux] = await Promise.all([
-    fetchUpdateServerManifest(baseUrl, 'stable-mac.yml').catch(() => null),
-    fetchUpdateServerManifest(baseUrl, 'stable.yml').catch(() => null),
-    fetchUpdateServerManifest(baseUrl, 'stable-linux.yml').catch(() => null),
+    fetchUpdateServerManifest(baseUrl, 'stable-mac.yml?t=' + timestamp).catch(() => null),
+    fetchUpdateServerManifest(baseUrl, 'stable.yml?t=' + timestamp).catch(() => null),
+    fetchUpdateServerManifest(baseUrl, 'stable-linux.yml?t=' + timestamp).catch(() => null),
   ]);
 
   const manifests = [mac, win, linux].filter(Boolean) as UpdateServerManifest[];


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Add a cache-busting timestamp query to stable desktop manifest requests.
This avoids stale `stable*.yml` responses from the update server or intermediate caches, so desktop release metadata stays in sync with the latest published artifacts.

#### 🧪 How to Test

- Run `bunx vitest run --silent='passed-only' 'src/server/services/desktopRelease/index.test.ts'`
- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This change only appends a shared timestamp query string when fetching `stable-mac.yml`, `stable.yml`, and `stable-linux.yml`.
