### PR TITLE
♻️ refactor(store): replace dynamic imports with static imports in actions

### DIFF
--- a/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
@@ -13,7 +13,7 @@ import { type StoreSetter } from '@/store/types';
 import { merge } from '@/utils/merge';
 import { safeParseJSON } from '@/utils/safeParseJSON';
 
-import { displayMessageSelectors } from '../../message/selectors';
+import { dbMessageSelectors, displayMessageSelectors } from '../../message/selectors';
 
 /**
  * Params for batch updating tool message content, state, and error
@@ -207,7 +207,6 @@ export class PluginOptimisticUpdateActionImpl {
     id: string,
     context?: OptimisticUpdateContext,
   ): Promise<void> => {
-    const { dbMessageSelectors } = await import('../../message/selectors');
     const message = dbMessageSelectors.getDbMessageById(id)(this.#get());
     if (!message || !message.tools) return;
 

--- a/src/store/file/slices/fileManager/action.ts
+++ b/src/store/file/slices/fileManager/action.ts
@@ -321,7 +321,6 @@ export class FileManageActionImpl {
     );
 
     // Perform the actual update
-    const { documentService } = await import('@/services/document');
     await documentService.updateDocument({ id: folderId, title: newName });
 
     // Revalidate to get fresh data from server

--- a/src/store/userMemory/slices/base/action.ts
+++ b/src/store/userMemory/slices/base/action.ts
@@ -3,7 +3,7 @@ import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
 import { mutate, useClientDataSWR, useClientDataSWRWithSync } from '@/libs/swr';
-import { userMemoryService } from '@/services/userMemory';
+import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { type RetrieveMemoryParams, type RetrieveMemoryResult } from '@/types/userMemory';
 import { LayersEnum } from '@/types/userMemory';
@@ -79,7 +79,6 @@ export class BaseActionImpl {
   };
 
   updateMemory = async (id: string, content: string, layer: LayersEnum): Promise<void> => {
-    const { memoryCRUDService } = await import('@/services/userMemory');
     const {
       resetActivitiesList,
       resetContextsList,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Replace redundant dynamic `import()` calls with top-level static imports in store actions where the module was already imported (or can be co-imported with existing symbols):

- **Plugin optimistic update**: import `dbMessageSelectors` alongside `displayMessageSelectors`.
- **File manager**: rely on existing `documentService` import from `@/services/document`.
- **User memory**: import `memoryCRUDService` with `userMemoryService` from `@/services/userMemory`.

This keeps behavior the same while simplifying the module graph and avoiding unnecessary async import overhead in these paths.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Smoke: open chat with plugins, rename a knowledge folder, update a memory entry — flows should behave as before.

#### 📸 Screenshots / Videos

N/A (no UI changes)

#### 📝 Additional Information

None

Made with [Cursor](https://cursor.com)