### PR TITLE
🐛 fix: move nodrag from TabBar container to individual TabItems

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -7,6 +7,7 @@ import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { type ResolvedPageData } from '@/features/Electron/titlebar/RecentlyViewed/types';
+import { electronStylish } from '@/styles/electron';
 
 import { useStyles } from './styles';
 
@@ -86,7 +87,7 @@ const TabItem = memo<TabItemProps>(
         <Flexbox
           horizontal
           align="center"
-          className={cx(styles.tab, isActive && styles.tabActive)}
+          className={cx(electronStylish.nodrag, styles.tab, isActive && styles.tabActive)}
           gap={6}
           onClick={handleClick}
         >

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { pluginRegistry } from '@/features/Electron/titlebar/RecentlyViewed/plugins';
 import { useElectronStore } from '@/store/electron';
-import { electronStylish } from '@/styles/electron';
 
 import { useResolvedTabs } from './hooks/useResolvedTabs';
 import { useStyles } from './styles';
@@ -121,7 +120,7 @@ const TabBar = () => {
 
   return (
     <ScrollArea
-      className={`${electronStylish.nodrag} ${styles.container}`}
+      className={styles.container}
       viewportProps={{ ref: viewportRef }}
       contentProps={{
         style: { alignItems: 'center', flexDirection: 'row', gap: TAB_GAP },


### PR DESCRIPTION
The TabBar's ScrollArea had `electronStylish.nodrag` with `flex: 1`,
causing the entire middle section of the title bar to be non-draggable.
Move `nodrag` to individual TabItem components so empty space in the
tab bar area inherits `drag` from the parent TitleBar.

https://claude.ai/code/session_013t1RAaCfJCQ2kfnuTKZrYx