### PR TITLE
✨ feat: improve model switch panel with provider settings shortcut and default highlight

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
@@ -76,7 +76,7 @@ const GenerationMultipleProvidersItem = memo<GenerationMultipleProvidersItemProp
                   </Flexbox>
                   {item.data.providers.map((p) => {
                     const pKey = menuKey(p.id, item.data.model.id);
-                    const isProviderActive = activeKey === pKey;
+                    const isProviderActive = isActive ? activeKey === pKey : p.id === 'lobehub';
                     return (
                       <Flexbox
                         horizontal

--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -1,4 +1,5 @@
 import {
+  ActionIcon,
   Block,
   DropdownMenuPopup,
   DropdownMenuPortal,
@@ -10,10 +11,11 @@ import {
   menuSharedStyles,
 } from '@lobehub/ui';
 import { cssVar, cx } from 'antd-style';
-import { LucideArrowRight } from 'lucide-react';
+import { LucideArrowRight, LucideBolt } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import urlJoin from 'url-join';
 
 import { ModelItemRender, ProviderItemRender } from '@/components/ModelSelect';
 import { useUserStore } from '@/store/user';
@@ -83,6 +85,7 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
           <Flexbox
             horizontal
             className={styles.groupHeader}
+            justify="space-between"
             key={`header-${item.provider.id}`}
             paddingBlock={'12px 4px'}
             paddingInline={'12px 8px'}
@@ -92,6 +95,23 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
               name={item.provider.name}
               provider={item.provider.id}
               source={item.provider.source}
+            />
+            <ActionIcon
+              className="settings-icon"
+              icon={LucideBolt}
+              size="small"
+              title={t('ModelSwitchPanel.goToSettings')}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const url = urlJoin('/settings/provider', item.provider.id || 'all');
+                if (e.ctrlKey || e.metaKey) {
+                  window.open(url, '_blank');
+                } else {
+                  navigate(url);
+                }
+                onClose();
+              }}
             />
           </Flexbox>
         );

--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -28,6 +28,7 @@ import ModelDetailPanel from '../ModelDetailPanel';
 interface MultipleProvidersModelItemProps {
   activeKey: string;
   data: ModelWithProviders;
+  defaultProviderId?: string;
   isModelRestricted?: (modelId: string, providerId: string) => boolean;
   newLabel: string;
   onClose: () => void;
@@ -105,7 +106,7 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
                 </DropdownMenuGroupLabel>
                 {data.providers.map((p) => {
                   const key = menuKey(p.id, data.model.id);
-                  const isProviderActive = activeKey === key;
+                  const isProviderActive = isActive ? activeKey === key : p.id === 'lobehub';
                   const providerRestricted = isModelRestricted?.(data.model.id, p.id);
 
                   return (


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a settings shortcut icon (bolt) on each provider group header in model switch panel, clicking navigates to `/settings/provider/:id`
- Supports Ctrl/Cmd+Click to open in new tab
- When a model with multiple providers is not currently selected, highlight the `lobehub` provider as default recommendation

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed