### PR TITLE
🐛 fix(conversation): preserve mention runtime context

### DIFF
--- a/src/features/Conversation/store/slices/generation/action.test.ts
+++ b/src/features/Conversation/store/slices/generation/action.test.ts
@@ -1,3 +1,4 @@
+import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
 import { act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -734,6 +735,77 @@ describe('Generation Actions', () => {
           parentMessageId: 'msg-1',
           parentMessageType: 'user',
           parentOperationId: 'test-op-id',
+        }),
+      );
+    });
+
+    it('should restore mention-based initialContext when regenerating a user message', async () => {
+      const { useChatStore } = await import('@/store/chat');
+      vi.mocked(useChatStore.getState).mockReturnValue({
+        messagesMap: {},
+        operations: {},
+        messageLoadingIds: [],
+        cancelOperations: mockCancelOperations,
+        cancelOperation: mockCancelOperation,
+        deleteMessage: mockDeleteMessage,
+        switchMessageBranch: mockSwitchMessageBranch,
+        startOperation: mockStartOperation,
+        completeOperation: mockCompleteOperation,
+        failOperation: mockFailOperation,
+        internal_execAgentRuntime: mockInternalExecAgentRuntime,
+      } as any);
+
+      const context: ConversationContext = {
+        agentId: 'session-1',
+        topicId: 'topic-1',
+        threadId: null,
+      };
+
+      const store = createStore({ context });
+
+      act(() => {
+        store.setState({
+          displayMessages: [
+            {
+              id: 'msg-1',
+              role: 'user',
+              content: '<mention name="Agent A" id="agent-a" /> hello',
+              editorData: {
+                root: {
+                  type: 'root',
+                  children: [
+                    {
+                      type: 'paragraph',
+                      children: [
+                        {
+                          type: 'mention',
+                          label: 'Agent A',
+                          metadata: { id: 'agent-a', type: 'agent' },
+                        },
+                        { type: 'text', text: ' hello' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        } as any);
+      });
+
+      await act(async () => {
+        await store.getState().regenerateUserMessage('msg-1');
+      });
+
+      expect(mockInternalExecAgentRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialContext: {
+            initialContext: {
+              mentionedAgents: [{ id: 'agent-a', name: 'Agent A' }],
+              selectedTools: [{ identifier: AgentManagementIdentifier, name: 'Agent Management' }],
+            },
+            phase: 'init',
+          },
         }),
       );
     });

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -1,10 +1,45 @@
+import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
 import { type StateCreator } from 'zustand';
 
 import { MESSAGE_CANCEL_FLAT } from '@/const/index';
 import { useChatStore } from '@/store/chat';
+import {
+  parseMentionedAgentsFromEditorData,
+  parseSelectedSkillsFromEditorData,
+  parseSelectedToolsFromEditorData,
+} from '@/store/chat/slices/aiChat/actions/commandBus';
 import { INPUT_LOADING_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 
 import { type Store as ConversationStore } from '../../action';
+
+const buildRetryInitialContext = (editorData: Record<string, any> | null | undefined) => {
+  const normalizedEditorData = editorData ?? undefined;
+  const selectedSkills = parseSelectedSkillsFromEditorData(normalizedEditorData);
+  const selectedTools = parseSelectedToolsFromEditorData(normalizedEditorData);
+  const mentionedAgents = parseMentionedAgentsFromEditorData(normalizedEditorData);
+
+  const effectiveSelectedTools =
+    mentionedAgents.length > 0 &&
+    !selectedTools.some((tool) => tool.identifier === AgentManagementIdentifier)
+      ? [...selectedTools, { identifier: AgentManagementIdentifier, name: 'Agent Management' }]
+      : selectedTools;
+
+  const hasInitialContext =
+    effectiveSelectedTools.length > 0 || selectedSkills.length > 0 || mentionedAgents.length > 0;
+
+  if (!hasInitialContext) return undefined;
+
+  return {
+    initialContext: {
+      ...(selectedSkills.length > 0 ? { selectedSkills } : undefined),
+      ...(effectiveSelectedTools.length > 0
+        ? { selectedTools: effectiveSelectedTools }
+        : undefined),
+      ...(mentionedAgents.length > 0 ? { mentionedAgents } : undefined),
+    },
+    phase: 'init' as const,
+  };
+};
 
 /**
  * Generation Actions
@@ -287,6 +322,7 @@ export const generationSlice: StateCreator<
     const currentIndex = displayMessages.findIndex((c) => c.id === messageId);
     const item = displayMessages[currentIndex];
     if (!item) return;
+    const initialContext = buildRetryInitialContext(item.editorData);
 
     // Get context messages up to and including the target message
     const contextMessages = displayMessages.slice(0, currentIndex + 1);
@@ -320,6 +356,7 @@ export const generationSlice: StateCreator<
       // Execute agent runtime with full context from ConversationStore
       await chatStore.internal_execAgentRuntime({
         context,
+        initialContext,
         messages: contextMessages,
         parentMessageId: messageId,
         parentMessageType: 'user',

--- a/src/store/agent/store.ts
+++ b/src/store/agent/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type AgentStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -57,5 +58,7 @@ const createStore: StateCreator<AgentStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('agent');
 
 export const useAgentStore = createWithEqualityFn<AgentStore>()(devtools(createStore), shallow);
+
+expose('agent', useAgentStore);
 
 export const getAgentStoreState = () => useAgentStore.getState();

--- a/src/store/agentGroup/store.ts
+++ b/src/store/agentGroup/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { type ChatGroupAction } from './action';
 import { chatGroupAction } from './action';
 import { type ChatGroupState } from './initialState';
@@ -23,5 +24,7 @@ export const useAgentGroupStore = createWithEqualityFn<ChatGroupStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('agentGroup', useAgentGroupStore);
 
 export const getChatGroupStoreState = () => useAgentGroupStore.getState();

--- a/src/store/aiInfra/store.ts
+++ b/src/store/aiInfra/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type AIProviderStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -33,5 +34,7 @@ const createStore: StateCreator<AiInfraStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('aiInfra');
 
 export const useAiInfraStore = createWithEqualityFn<AiInfraStore>()(devtools(createStore), shallow);
+
+expose('aiInfra', useAiInfraStore);
 
 export const getAiInfraStoreState = () => useAiInfraStore.getState();

--- a/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
@@ -899,6 +899,59 @@ describe('StreamingExecutor actions', () => {
       );
     });
 
+    it('should preserve default model/provider payload when initialContext is provided', () => {
+      act(() => {
+        useChatStore.setState({ internal_execAgentRuntime: realExecAgentRuntime });
+      });
+
+      const { result } = renderHook(() => useChatStore());
+      const userMessage = {
+        id: TEST_IDS.USER_MESSAGE_ID,
+        role: 'user',
+        content: TEST_CONTENT.USER_MESSAGE,
+        sessionId: TEST_IDS.SESSION_ID,
+        topicId: TEST_IDS.TOPIC_ID,
+      } as UIChatMessage;
+
+      vi.spyOn(agentConfigResolver, 'resolveAgentConfig').mockReturnValue({
+        agentConfig: createMockAgentConfig({
+          model: 'claude-sonnet-4-6',
+          provider: 'lobehub',
+        }),
+        chatConfig: createMockChatConfig(),
+        isBuiltinAgent: false,
+        plugins: [],
+      });
+      vi.spyOn(toolEngineering, 'createAgentToolsEngine').mockReturnValue({
+        generateToolsDetailed: vi.fn().mockReturnValue({
+          enabledManifests: [],
+          enabledToolIds: [],
+          tools: [],
+        }),
+      } as any);
+
+      const { context } = result.current.internal_createAgentState({
+        messages: [userMessage],
+        parentMessageId: userMessage.id,
+        agentId: TEST_IDS.SESSION_ID,
+        topicId: TEST_IDS.TOPIC_ID,
+        initialContext: {
+          phase: 'init',
+          initialContext: {
+            selectedTools: [{ identifier: 'lobe-notebook', name: 'Notebook' }],
+          },
+        },
+      });
+
+      expect(context.payload).toEqual(
+        expect.objectContaining({
+          model: 'claude-sonnet-4-6',
+          parentMessageId: TEST_IDS.USER_MESSAGE_ID,
+          provider: 'lobehub',
+        }),
+      );
+    });
+
     it('should pass merged resolvedAgentConfig to chatService when selectedTools are provided', async () => {
       act(() => {
         useChatStore.setState({ internal_execAgentRuntime: realExecAgentRuntime });

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -289,6 +289,10 @@ export class StreamingExecutorActionImpl {
       parentMessageId,
       provider: agentConfigData.provider,
     };
+    const existingPayload =
+      initialContext?.payload && typeof initialContext.payload === 'object'
+        ? (initialContext.payload as Record<string, unknown>)
+        : undefined;
 
     // Create initial context or use provided context
     const context: AgentRuntimeContext = initialContext
@@ -296,7 +300,7 @@ export class StreamingExecutorActionImpl {
           ...initialContext,
           payload: {
             ...defaultPayload,
-            ...initialContext.payload,
+            ...existingPayload,
           },
           initialContext: mergedRuntimeInitialContext,
         }

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -174,7 +174,6 @@ export class StreamingExecutorActionImpl {
     // When skillActivateMode is 'manual', skipDefaultTools gives user precise control
     const isManualMode = agentConfig.chatConfig?.skillActivateMode === 'manual';
 
-
     const toolsDetailed = toolsEngine.generateToolsDetailed({
       model: agentConfigData.model,
       provider: agentConfigData.provider!,
@@ -285,19 +284,25 @@ export class StreamingExecutorActionImpl {
           }
         : undefined;
 
+    const defaultPayload = {
+      model: agentConfigData.model,
+      parentMessageId,
+      provider: agentConfigData.provider,
+    };
+
     // Create initial context or use provided context
     const context: AgentRuntimeContext = initialContext
       ? {
           ...initialContext,
+          payload: {
+            ...defaultPayload,
+            ...initialContext.payload,
+          },
           initialContext: mergedRuntimeInitialContext,
         }
       : {
           phase: 'init',
-          payload: {
-            model: agentConfigData.model,
-            provider: agentConfigData.provider,
-            parentMessageId,
-          },
+          payload: defaultPayload,
           session: {
             sessionId: agentId,
             messageCount: messages.length,

--- a/src/store/chat/store.ts
+++ b/src/store/chat/store.ts
@@ -5,6 +5,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type ChatStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -76,8 +77,6 @@ export const useChatStore = createWithEqualityFn<ChatStore>()(
   shallow,
 );
 
-if (typeof window !== 'undefined') {
-  window.__CHAT_STORE__ = useChatStore;
-}
+expose('chat', useChatStore);
 
 export const getChatStoreState = () => useChatStore.getState();

--- a/src/store/discover/store.ts
+++ b/src/store/discover/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type AssistantAction } from './slices/assistant/action';
 import { createAssistantSlice } from './slices/assistant/action';
@@ -68,5 +69,7 @@ export const useDiscoverStore = createWithEqualityFn<DiscoverStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('discover', useDiscoverStore);
 
 export const getDiscoverStoreState = () => useDiscoverStore.getState();

--- a/src/store/document/store.ts
+++ b/src/store/document/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type DocumentAction } from './slices/document';
 import { createDocumentSlice } from './slices/document';
@@ -39,5 +40,7 @@ export const useDocumentStore = createWithEqualityFn<DocumentStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('document', useDocumentStore);
 
 export const getDocumentStoreState = () => useDocumentStore.getState();

--- a/src/store/electron/store.ts
+++ b/src/store/electron/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type ElectronAppAction } from './actions/app';
 import { createElectronAppSlice } from './actions/app';
@@ -62,5 +63,7 @@ export const useElectronStore = createWithEqualityFn<ElectronStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('electron', useElectronStore);
 
 export const getElectronStoreState = () => useElectronStore.getState();

--- a/src/store/eval/store.ts
+++ b/src/store/eval/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import type { StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { type EvalStoreState, initialState } from './initialState';
 import { type BenchmarkAction, createBenchmarkSlice } from './slices/benchmark/action';
 import { createDatasetSlice, type DatasetAction } from './slices/dataset/action';
@@ -26,3 +27,5 @@ const createStore: StateCreator<EvalStore, [['zustand/devtools', never]]> = (set
 const devtools = createDevtools('eval');
 
 export const useEvalStore = createWithEqualityFn<EvalStore>()(devtools(createStore), shallow);
+
+expose('eval', useEvalStore);

--- a/src/store/file/store.ts
+++ b/src/store/file/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type FilesStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -61,5 +62,7 @@ const createStore: StateCreator<FileStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('file');
 
 export const useFileStore = createWithEqualityFn<FileStore>()(devtools(createStore), shallow);
+
+expose('file', useFileStore);
 
 export const getFileStoreState = () => useFileStore.getState();

--- a/src/store/global/store.ts
+++ b/src/store/global/store.ts
@@ -4,6 +4,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type GlobalGeneralAction } from './actions/general';
 import { generalActionSlice } from './actions/general';
@@ -38,3 +39,5 @@ export const useGlobalStore = createWithEqualityFn<GlobalStore>()(
   subscribeWithSelector(devtools(createStore)),
   shallow,
 );
+
+expose('global', useGlobalStore);

--- a/src/store/home/store.ts
+++ b/src/store/home/store.ts
@@ -6,6 +6,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { isDev } from '@/utils/env';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type HomeStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -61,5 +62,7 @@ export const useHomeStore = createWithEqualityFn<HomeStore>()(
   ),
   shallow,
 );
+
+expose('home', useHomeStore);
 
 export const getHomeStoreState = () => useHomeStore.getState();

--- a/src/store/image/store.ts
+++ b/src/store/image/store.ts
@@ -4,6 +4,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type ImageStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -51,5 +52,7 @@ export const useImageStore = createWithEqualityFn<ImageStore>()(
   subscribeWithSelector(devtools(createStore)),
   shallow,
 );
+
+expose('image', useImageStore);
 
 export const getImageStoreState = () => useImageStore.getState();

--- a/src/store/library/store.ts
+++ b/src/store/library/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type KnowledgeBaseStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -46,3 +47,5 @@ export const useKnowledgeBaseStore = createWithEqualityFn<KnowledgeBaseStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('library', useKnowledgeBaseStore);

--- a/src/store/mention/store.ts
+++ b/src/store/mention/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type MentionAction } from './action';
 import { createMentionSlice } from './action';
@@ -21,5 +22,7 @@ const createStore: StateCreator<MentionStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('mention');
 
 export const useMentionStore = createWithEqualityFn<MentionStore>()(devtools(createStore), shallow);
+
+expose('mention', useMentionStore);
 
 export const getMentionStoreState = () => useMentionStore.getState();

--- a/src/store/middleware/expose.ts
+++ b/src/store/middleware/expose.ts
@@ -1,0 +1,12 @@
+import { isDev } from '@/utils/env';
+
+/**
+ * In development, registers the store on `window.__LOBE_STORES[name]` as a getter that returns
+ * the current snapshot from `store.getState()`.
+ */
+export function expose<T>(name: string, store: { getState: () => T }): void {
+  if (!isDev || typeof window === 'undefined') return;
+
+  window.__LOBE_STORES ??= {};
+  window.__LOBE_STORES[name] = () => store.getState();
+}

--- a/src/store/notebook/store.ts
+++ b/src/store/notebook/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type NotebookAction } from './action';
 import { createNotebookAction } from './action';
@@ -24,5 +25,7 @@ export const useNotebookStore = createWithEqualityFn<NotebookStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('notebook', useNotebookStore);
 
 export const getNotebookStoreState = () => useNotebookStore.getState();

--- a/src/store/page/store.ts
+++ b/src/store/page/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type PageState } from './initialState';
 import { initialState } from './initialState';
@@ -37,5 +38,7 @@ const createStore: StateCreator<PageStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('page');
 
 export const usePageStore = createWithEqualityFn<PageStore>()(devtools(createStore), shallow);
+
+expose('page', usePageStore);
 
 export const getPageStoreState = () => usePageStore.getState();

--- a/src/store/serverConfig/store.ts
+++ b/src/store/serverConfig/store.ts
@@ -8,6 +8,7 @@ import { createContext } from 'zustand-utils';
 import { type IFeatureFlagsState } from '@/config/featureFlags';
 import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from '@/config/featureFlags';
 import { createDevtools } from '@/store/middleware/createDevtools';
+import { expose } from '@/store/middleware/expose';
 import { type GlobalServerConfig } from '@/types/serverConfig';
 import { merge } from '@/utils/merge';
 
@@ -73,6 +74,8 @@ export const createServerConfigStore = (initState?: Partial<ServerConfigStore>) 
     if (typeof window !== 'undefined') {
       window.global_serverConfigStore = store;
     }
+
+    expose('serverConfig', store);
   }
 
   return store;

--- a/src/store/session/store.ts
+++ b/src/store/session/store.ts
@@ -6,6 +6,7 @@ import { type StateCreator } from 'zustand/vanilla';
 import { isDev } from '@/utils/env';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type SessionStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -48,5 +49,7 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
   ),
   shallow,
 );
+
+expose('session', useSessionStore);
 
 export const getSessionStoreState = () => useSessionStore.getState();

--- a/src/store/tool/store.ts
+++ b/src/store/tool/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { initialState, type ToolStoreState } from './initialState';
 import { type AgentSkillsAction, createAgentSkillsSlice } from './slices/agentSkills';
@@ -59,5 +60,7 @@ const createStore: StateCreator<ToolStore, [['zustand/devtools', never]]> = (
 const devtools = createDevtools('tools');
 
 export const useToolStore = createWithEqualityFn<ToolStore>()(devtools(createStore), shallow);
+
+expose('tool', useToolStore);
 
 export const getToolStoreState = () => useToolStore.getState();

--- a/src/store/user/store.ts
+++ b/src/store/user/store.ts
@@ -4,6 +4,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type UserState } from './initialState';
 import { initialState } from './initialState';
@@ -54,5 +55,7 @@ export const useUserStore = createWithEqualityFn<UserStore>()(
   subscribeWithSelector(devtools(createStore)),
   shallow,
 );
+
+expose('user', useUserStore);
 
 export const getUserStoreState = () => useUserStore.getState();

--- a/src/store/userMemory/store.ts
+++ b/src/store/userMemory/store.ts
@@ -3,6 +3,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { flattenActions } from '../utils/flattenActions';
 import { type UserMemoryStoreState } from './initialState';
 import { initialState } from './initialState';
@@ -66,5 +67,7 @@ export const useUserMemoryStore = createWithEqualityFn<UserMemoryStore>()(
   devtools(createStore),
   shallow,
 );
+
+expose('userMemory', useUserMemoryStore);
 
 export const getUserMemoryStoreState = () => useUserMemoryStore.getState();

--- a/src/store/video/store.ts
+++ b/src/store/video/store.ts
@@ -4,6 +4,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { createDevtools } from '../middleware/createDevtools';
+import { expose } from '../middleware/expose';
 import { initialState, type VideoStoreState } from './initialState';
 import { createCreateVideoSlice, type CreateVideoAction } from './slices/createVideo/action';
 import {
@@ -45,5 +46,7 @@ export const useVideoStore = createWithEqualityFn<VideoStore>()(
   subscribeWithSelector(devtools(createStore)),
   shallow,
 );
+
+expose('video', useVideoStore);
 
 export const getVideoStoreState = () => useVideoStore.getState();

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -18,9 +18,10 @@ declare module 'styled-components' {
 
 declare global {
   interface Window {
-    __CHAT_STORE__?: any;
     __DEBUG_PROXY__: boolean | undefined;
     __editor?: IEditor;
+    /** Dev-only: Zustand store snapshots via `getState()` keyed by store name */
+    __LOBE_STORES?: Record<string, () => unknown>;
     __SERVER_CONFIG__: SPAServerConfig | undefined;
     lobeEnv?: {
       darwinMajorVersion?: number;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #10088

#### 🔀 Description of Change

This PR fixes two mention-related conversation issues:

1. Preserve the default `model`, `provider`, and `parentMessageId` in the initial runtime payload when `@agent` builds an `initialContext`, so the first LLM hop does not fall back to `/webapi/chat/openai` unexpectedly.
2. Rebuild mention-derived runtime context during user-message retry, including `mentionedAgents` and the auto-injected `agent-management` tool, so delegation prompts are injected consistently on regenerate.

Regression tests were added for both paths.

#### 🧪 How to Test

- Run `bun run type-check`
- Run `bunx vitest run --silent='passed-only' 'src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts' 'src/features/Conversation/store/slices/generation/action.test.ts'`
- Reproduce `@agent` send and retry flows to verify provider selection and prompt injection remain correct

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The branch contains only the two conversation/runtime fixes. A separate uncommitted local debug change was intentionally left out of this PR.
