### PR TITLE
🐛 fix: default topic display mode to byUpdatedTime and fix nanoBanana2 resolution enum

### DIFF
--- a/packages/const/src/user.ts
+++ b/packages/const/src/user.ts
@@ -16,6 +16,6 @@ export const DEFAULT_PREFERENCE: UserPreference = {
   lab: {
     enableInputMarkdown: true,
   },
-  topicDisplayMode: TopicDisplayMode.ByCreatedTime,
+  topicDisplayMode: TopicDisplayMode.ByUpdatedTime,
   useCmdEnterToSend: false,
 };

--- a/packages/model-bank/src/aiModels/lobehub/utils.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.ts
@@ -68,7 +68,7 @@ export const nanoBanana2Parameters: ModelParamsSchema = {
   prompt: { default: '' },
   resolution: {
     default: '1K',
-    enum: ['0.5K', '1K', '2K', '4K'],
+    enum: ['512', '1K', '2K', '4K'],
   },
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up of https://github.com/lobehub/lobehub/pull/12774

#### 🔀 Description of Change

- Change default `topicDisplayMode` from `ByCreatedTime` to `ByUpdatedTime` so topics are sorted by last update time by default
- Fix nanoBanana2 resolution enum: `'0.5K'` → `'512'` to match actual supported values

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed