### PR TITLE
🐛 fix: use display messages for token counting in group chats

### DIFF
--- a/packages/context-engine/src/engine/tools/ToolArgumentsRepairer.ts
+++ b/packages/context-engine/src/engine/tools/ToolArgumentsRepairer.ts
@@ -1,3 +1,5 @@
+import { parse as parsePartialJSON } from 'partial-json';
+
 import type { LobeToolManifest } from './types';
 
 /**
@@ -10,14 +12,20 @@ export interface ToolParameterSchema {
 }
 
 /**
- * Safe JSON parse utility
+ * Safe JSON parse with partial JSON fallback.
+ * When strict JSON.parse fails (e.g. stream interrupted mid-arguments),
+ * falls back to partial-json to recover as many fields as possible.
  */
 const safeParseJSON = <T = Record<string, unknown>>(text?: string): T | undefined => {
   if (typeof text !== 'string') return undefined;
   try {
     return JSON.parse(text) as T;
   } catch {
-    return undefined;
+    try {
+      return parsePartialJSON(text) as T;
+    } catch {
+      return undefined;
+    }
   }
 };
 

--- a/packages/context-engine/src/engine/tools/__tests__/ToolArgumentsRepairer.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/ToolArgumentsRepairer.test.ts
@@ -183,4 +183,85 @@ describe('ToolArgumentsRepairer', () => {
       expect(result).toEqual({});
     });
   });
+
+  describe('parse - partial JSON recovery (stream interruption)', () => {
+    it('should recover fields from incomplete JSON when stream is interrupted', () => {
+      const repairer = new ToolArgumentsRepairer();
+
+      // Simulates stream dropping after title, description, type were sent but before content
+      const incompleteArgs =
+        '{"title": "My Document", "description": "A brief summary", "type": "report"';
+
+      const result = repairer.parse('createDocument', incompleteArgs);
+
+      expect(result).toEqual({
+        title: 'My Document',
+        description: 'A brief summary',
+        type: 'report',
+      });
+    });
+
+    it('should recover fields when stream drops mid-value', () => {
+      const repairer = new ToolArgumentsRepairer();
+
+      // Stream drops in the middle of the content value
+      const incompleteArgs = '{"title": "My Document", "content": "This is the beginning of';
+
+      const result = repairer.parse('createDocument', incompleteArgs);
+
+      expect(result.title).toBe('My Document');
+      expect(result.content).toBe('This is the beginning of');
+    });
+
+    it('should recover when stream drops after first field', () => {
+      const repairer = new ToolArgumentsRepairer();
+
+      const incompleteArgs = '{"title": "My Document"';
+
+      const result = repairer.parse('createDocument', incompleteArgs);
+
+      expect(result).toEqual({ title: 'My Document' });
+    });
+
+    it('should return empty object when stream drops before any field value', () => {
+      const repairer = new ToolArgumentsRepairer();
+
+      const result = repairer.parse('createDocument', '{');
+
+      expect(result).toEqual({});
+    });
+
+    it('should recover partial JSON and still apply repair if needed', () => {
+      const manifest: LobeToolManifest = {
+        identifier: 'lobe-notebook',
+        api: [
+          {
+            name: 'createDocument',
+            description: 'Create a document',
+            parameters: {
+              type: 'object',
+              required: ['title', 'description', 'content'],
+              properties: {
+                title: { type: 'string' },
+                description: { type: 'string' },
+                content: { type: 'string' },
+              },
+            },
+          },
+        ],
+        type: 'builtin',
+      } as unknown as LobeToolManifest;
+
+      const repairer = new ToolArgumentsRepairer(manifest);
+
+      // Stream interrupted - has title and description but no content
+      const incompleteArgs = '{"title": "Test", "description": "Summary"';
+
+      const result = repairer.parse('createDocument', incompleteArgs);
+
+      // Should recover available fields instead of returning {}
+      expect(result.title).toBe('Test');
+      expect(result.description).toBe('Summary');
+    });
+  });
 });

--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -4,7 +4,7 @@ import { Center, Flexbox, Tooltip } from '@lobehub/ui';
 import { TokenTag } from '@lobehub/ui/chat';
 import { cssVar } from 'antd-style';
 import numeral from 'numeral';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
@@ -14,7 +14,7 @@ import { useTokenCount } from '@/hooks/useTokenCount';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { dbMessageSelectors, topicSelectors } from '@/store/chat/selectors';
+import { topicSelectors } from '@/store/chat/selectors';
 import { useToolStore } from '@/store/tool';
 import { pluginHelpers } from '@/store/tool/helpers';
 import { useUserStore } from '@/store/user';
@@ -48,14 +48,6 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
       chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
     ];
   });
-
-  const [historyCount, enableHistoryCount] = useAgentStore((s) => [
-    chatConfigByIdSelectors.getHistoryCountById(agentId)(s),
-    chatConfigByIdSelectors.getEnableHistoryCountById(agentId)(s),
-    // need to re-render by search mode
-    chatConfigByIdSelectors.isEnableSearchById(agentId)(s),
-    chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
-  ]);
 
   const maxTokens = useModelContextWindowTokens(model, provider);
 
@@ -97,12 +89,9 @@ const Token = memo<TokenTagProps>(({ total: messageString }) => {
   // Chat usage token
   const inputTokenCount = useTokenCount(input);
 
-  const chatsString = useMemo(() => {
-    const chats = dbMessageSelectors.activeDbMessages(useChatStore.getState());
-    return chats.map((chat) => chat.content).join('');
-  }, [messageString, historyCount, enableHistoryCount]);
-
-  const chatsToken = useTokenCount(chatsString) + inputTokenCount;
+  // Use messageString directly (from displayMessageSelectors.mainAIChatsMessageString)
+  // which correctly handles group chats via currentDisplayChatKey (includes groupId)
+  const chatsToken = useTokenCount(messageString) + inputTokenCount;
 
   // SystemRole token
   const systemRoleToken = useTokenCount(systemRole);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-4447

#### 🔀 Description of Change

The `TokenTag` component used `dbMessageSelectors.activeDbMessages` to count chat message tokens. This selector generates a message map key via `currentDbChatKey` which does **not** include `groupId`, causing it to return an empty array in group chats.

As a result, in Group Agent mode:
- `chatsToken` was always ~0
- `totalToken / maxTokens` was always far below 0.5
- The Context Details token tag was completely hidden (non-dev mode) or showed incorrect data (dev mode)

**Fix**: Use the `messageString` prop directly (sourced from `displayMessageSelectors.mainAIChatsMessageString`) which correctly generates the key via `currentDisplayChatKey` that includes `groupId`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open a Group Agent conversation
2. Send a few messages
3. Check the Context Details token popup in the chat input action bar
4. Verify "Chat Messages" shows a non-zero token count
5. Verify the TOKEN tag appears when usage exceeds 50% of context window

#### 📝 Additional Information

Removed unused imports (`useMemo`, `dbMessageSelectors`) and the now-unnecessary `historyCount`/`enableHistoryCount` subscription since `messageString` already reflects history config changes.