### PR TITLE
🐛 fix: skill page redirect & activeTab handling in Details component

### DIFF
--- a/src/routes/(main)/community/(detail)/_layout/Header.tsx
+++ b/src/routes/(main)/community/(detail)/_layout/Header.tsx
@@ -29,7 +29,7 @@ const Header = memo(() => {
     }
 
     // Types that have their own list pages
-    const typesWithListPage = ['agent', 'model', 'provider', 'mcp'];
+    const typesWithListPage = ['agent', 'model', 'provider', 'mcp', 'skill'];
 
     if (detailType && typesWithListPage.includes(detailType)) {
       navigate(urlJoin('/community', detailType));

--- a/src/routes/(main)/community/(detail)/skill/features/Details/index.tsx
+++ b/src/routes/(main)/community/(detail)/skill/features/Details/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox, Markdown } from '@lobehub/ui';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useDetailContext } from '../DetailProvider';
@@ -16,18 +16,28 @@ import Versions from './Versions';
 
 const Details = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const activeTabParam = searchParams.get('activeTab') as SkillNavKey | null;
-  const [activeTab, setActiveTab] = useState<SkillNavKey>(activeTabParam || SkillNavKey.Overview);
+  const activeTabParam = searchParams.get('activeTab');
+  const urlActiveTab = Object.values(SkillNavKey).includes(activeTabParam as SkillNavKey)
+    ? (activeTabParam as SkillNavKey)
+    : SkillNavKey.Overview;
+  const [activeTab, setActiveTab] = useState<SkillNavKey>(urlActiveTab);
   const { content } = useDetailContext();
+
+  useEffect(() => {
+    setActiveTab(urlActiveTab);
+  }, [urlActiveTab]);
 
   const handleSetActiveTab = (tab: SkillNavKey) => {
     setActiveTab(tab);
+    const nextSearchParams = new URLSearchParams(searchParams);
+
     if (tab === SkillNavKey.Overview) {
-      searchParams.delete('activeTab');
+      nextSearchParams.delete('activeTab');
     } else {
-      searchParams.set('activeTab', tab);
+      nextSearchParams.set('activeTab', tab);
     }
-    setSearchParams(searchParams, { replace: true });
+
+    setSearchParams(nextSearchParams, { replace: true });
   };
 
   const skillContent = <Markdown variant={'chat'}>{content ?? ''}</Markdown>;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 修复在 /community/skill/{id} 页点击返回按钮失效
2. 修复在 /community/skill{id} 页点击文件树 - 详情按钮，未跳转到【资源】Tab

<img width="1406" height="1053" alt="image" src="https://github.com/user-attachments/assets/6421ab03-3c6c-407b-9deb-2469ce83dc60" />


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
