### PR TITLE
🐛 fix(desktop): persist gateway toggle state across app restarts

### DIFF
--- a/apps/desktop/src/main/const/store.ts
+++ b/apps/desktop/src/main/const/store.ts
@@ -31,6 +31,7 @@ export const STORE_DEFAULTS: ElectronMainStore = {
   gatewayDeviceDescription: '',
   gatewayDeviceId: '',
   gatewayDeviceName: '',
+  gatewayEnabled: true,
   gatewayUrl: 'https://device-gateway.lobehub.com',
   locale: 'auto',
   networkProxy: defaultProxySettings,

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -55,11 +55,13 @@ export default class GatewayConnectionCtr extends ControllerModule {
 
   @IpcMethod()
   async connect(): Promise<{ error?: string; success: boolean }> {
+    this.app.storeManager.set('gatewayEnabled', true);
     return this.service.connect();
   }
 
   @IpcMethod()
   async disconnect(): Promise<{ success: boolean }> {
+    this.app.storeManager.set('gatewayEnabled', false);
     return this.service.disconnect();
   }
 
@@ -94,6 +96,9 @@ export default class GatewayConnectionCtr extends ControllerModule {
   // ─── Auto Connect ───
 
   private async tryAutoConnect() {
+    const gatewayEnabled = this.app.storeManager.get('gatewayEnabled');
+    if (!gatewayEnabled) return;
+
     const isConfigured = await this.remoteServerConfigCtr.isRemoteServerConfigured();
     if (!isConfigured) return;
 

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -196,7 +196,10 @@ describe('GatewayConnectionCtr', () => {
     vi.useFakeTimers();
     MockGatewayClient.lastInstance = null;
     MockGatewayClient.lastOptions = null;
-    mockStoreGet.mockReturnValue(undefined);
+    mockStoreGet.mockImplementation((key: string) => {
+      if (key === 'gatewayEnabled') return true;
+      return undefined;
+    });
 
     mockGatewayConnectionSrv = new GatewayConnectionService(mockApp);
     ctr = new GatewayConnectionCtr(mockApp);
@@ -212,6 +215,7 @@ describe('GatewayConnectionCtr', () => {
   describe('connect', () => {
     it('should create GatewayClient with correct options', async () => {
       mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'gatewayEnabled') return true;
         if (key === 'gatewayDeviceId') return 'stored-device-id';
         if (key === 'gatewayUrl') return undefined;
         return undefined;
@@ -231,6 +235,7 @@ describe('GatewayConnectionCtr', () => {
 
     it('should use custom gateway URL from store when set', async () => {
       mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'gatewayEnabled') return true;
         if (key === 'gatewayUrl') return 'http://localhost:8787';
         return undefined;
       });
@@ -253,6 +258,16 @@ describe('GatewayConnectionCtr', () => {
       const result = await ctr.connect();
       expect(result).toEqual({ error: 'No access token available', success: false });
       expect(MockGatewayClient.lastInstance).toBeNull();
+    });
+
+    it('should persist gatewayEnabled=true on connect', async () => {
+      vi.mocked(mockRemoteServerConfigCtr.isRemoteServerConfigured).mockResolvedValueOnce(false);
+      ctr.afterAppReady();
+      await vi.advanceTimersByTimeAsync(0);
+      mockStoreSet.mockClear();
+
+      await ctr.connect();
+      expect(mockStoreSet).toHaveBeenCalledWith('gatewayEnabled', true);
     });
 
     it('should no-op when already connected', async () => {
@@ -299,6 +314,16 @@ describe('GatewayConnectionCtr', () => {
       });
     });
 
+    it('should persist gatewayEnabled=false on disconnect', async () => {
+      ctr.afterAppReady();
+      await vi.advanceTimersByTimeAsync(0);
+      MockGatewayClient.lastInstance!.simulateConnected();
+      mockStoreSet.mockClear();
+
+      await ctr.disconnect();
+      expect(mockStoreSet).toHaveBeenCalledWith('gatewayEnabled', false);
+    });
+
     it('should not trigger reconnect after intentional disconnect', async () => {
       ctr.afterAppReady();
       await vi.advanceTimersByTimeAsync(0);
@@ -327,6 +352,19 @@ describe('GatewayConnectionCtr', () => {
       expect(MockGatewayClient.lastInstance!.connect).toHaveBeenCalled();
     });
 
+    it('should skip auto-connect when gatewayEnabled is false', async () => {
+      mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'gatewayEnabled') return false;
+        return undefined;
+      });
+
+      ctr = new GatewayConnectionCtr(mockApp);
+      ctr.afterAppReady();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(MockGatewayClient.lastInstance).toBeNull();
+    });
+
     it('should skip auto-connect when remote server not configured', async () => {
       vi.mocked(mockRemoteServerConfigCtr.isRemoteServerConfigured).mockResolvedValueOnce(false);
 
@@ -353,9 +391,11 @@ describe('GatewayConnectionCtr', () => {
     });
 
     it('should reuse persisted device ID', () => {
-      mockStoreGet.mockImplementation((key: string) =>
-        key === 'gatewayDeviceId' ? 'existing-id' : undefined,
-      );
+      mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'gatewayEnabled') return true;
+        if (key === 'gatewayDeviceId') return 'existing-id';
+        return undefined;
+      });
       ctr = new GatewayConnectionCtr(mockApp);
       ctr.afterAppReady();
 
@@ -545,9 +585,11 @@ describe('GatewayConnectionCtr', () => {
 
   describe('getDeviceInfo', () => {
     it('should return device information', async () => {
-      mockStoreGet.mockImplementation((key: string) =>
-        key === 'gatewayDeviceId' ? 'my-device' : undefined,
-      );
+      mockStoreGet.mockImplementation((key: string) => {
+        if (key === 'gatewayEnabled') return true;
+        if (key === 'gatewayDeviceId') return 'my-device';
+        return undefined;
+      });
       ctr = new GatewayConnectionCtr(mockApp);
       ctr.afterAppReady();
 

--- a/apps/desktop/src/main/types/store.ts
+++ b/apps/desktop/src/main/types/store.ts
@@ -15,6 +15,7 @@ export interface ElectronMainStore {
   gatewayDeviceDescription: string;
   gatewayDeviceId: string;
   gatewayDeviceName: string;
+  gatewayEnabled: boolean;
   gatewayUrl: string;
   locale: string;
   networkProxy: NetworkProxySettings;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The device gateway auto-connect logic (`tryAutoConnect`) only checked whether the user was logged in (had a token), but never checked whether they had manually turned off the gateway toggle. This caused the gateway to reconnect every time the app was restarted, even after the user explicitly disabled it.

**Fix:** Added a `gatewayEnabled` boolean flag to the Electron persistent store:
- Set to `true` when the user calls `connect()`
- Set to `false` when the user calls `disconnect()`
- Checked in `tryAutoConnect()` before attempting auto-connection on startup
- Defaults to `true` for new installations (preserves current first-launch behavior)

#### 🧪 How to Test

- [x] Added/updated tests

New test cases:
- `should skip auto-connect when gatewayEnabled is false`
- `should persist gatewayEnabled=true on connect`
- `should persist gatewayEnabled=false on disconnect`

Manual test:
1. Open the desktop app, toggle the gateway switch OFF
2. Restart the app
3. Verify the gateway does NOT auto-connect

#### 📝 Additional Information

Files changed:
- `apps/desktop/src/main/types/store.ts` — added `gatewayEnabled` to `ElectronMainStore`
- `apps/desktop/src/main/const/store.ts` — added default value (`true`)
- `apps/desktop/src/main/controllers/GatewayConnectionCtr.ts` — persist flag on connect/disconnect, check on auto-connect
- `apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts` — 3 new test cases + updated mocks