### PR TITLE
🐛 fix: prevent full page reload when switching topics during agent execution

### DIFF
--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -102,12 +102,12 @@ const NavItem = memo<NavItemProps>(
         paddingInline={4}
         variant={variant}
         onClick={(e) => {
-          if (disabled || loading) return;
-          // Prevent default link behavior for normal clicks (let onClick handle it)
-          // But allow cmd+click to open in new tab
+          // Always prevent default <a> navigation for normal clicks to avoid full page reload.
+          // This must run before any early return to ensure SPA navigation is never bypassed.
           if (href && !isModifierClick(e)) {
             e.preventDefault();
           }
+          if (disabled || loading) return;
           onClick?.(e);
         }}
         {...linkProps}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When switching between topics within the same agent while agent execution is in progress, the entire page would do a full browser navigation (reload) instead of SPA routing.

**Root cause:** In `NavItem.tsx`, the `onClick` handler had an early return for `disabled || loading` states that skipped `e.preventDefault()`. Since NavItem renders as an `<a>` tag with `href` (for cmd+click support), the browser's default link navigation would fire, causing a full page load to the href URL instead of React Router handling it.

**Fix:** Move `e.preventDefault()` before the `disabled || loading` check so the default `<a>` navigation is always prevented, regardless of component state.

#### 🧪 How to Test

1. Open an agent with multiple topics
2. Send a message to start agent execution in one topic
3. Switch to another topic and start a second execution
4. Switch back to the first topic while both are executing
5. Verify the page does **not** fully reload (no flash, no loss of JS state)

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Confirmed via `agent-browser` + CDP that `performance.getEntriesByType('navigation')[0].type` was `"navigate"` (full browser navigation) before the fix, and the injected `window.__monitorActive` variable survived after the fix (proving no reload occurred).