### PR TITLE
💄 style(conversation): align user rich text line height with LexicalRenderer

### DIFF
--- a/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
+++ b/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
@@ -1,5 +1,6 @@
 import { LexicalRenderer } from '@lobehub/editor/renderer';
 import type { SerializedEditorState } from 'lexical';
+import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ActionTagNode } from '@/features/ChatInput/InputEditor/ActionTag/ActionTagNode';
@@ -9,6 +10,8 @@ interface RichTextMessageProps {
   editorState: unknown;
 }
 
+const LINE_HEIGHT = 1.6;
+const style: CSSProperties = { '--common-line-height': LINE_HEIGHT } as CSSProperties;
 const EXTRA_NODES = [ActionTagNode, ReferTopicNode];
 
 const RichTextMessage = memo<RichTextMessageProps>(({ editorState }) => {
@@ -20,7 +23,7 @@ const RichTextMessage = memo<RichTextMessageProps>(({ editorState }) => {
 
   if (!value) return null;
 
-  return <LexicalRenderer extraNodes={EXTRA_NODES} value={value} variant="chat" />;
+  return <LexicalRenderer extraNodes={EXTRA_NODES} style={style} value={value} variant="chat" />;
 });
 
 RichTextMessage.displayName = 'RichTextMessage';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

User message rich text uses `LexicalRenderer` with variant `chat`. This PR passes a CSS custom property `--common-line-height` (1.6) via the renderer `style` prop so wrapped content matches chat typography and avoids overly tight default line-height.

Files: `src/features/Conversation/Messages/User/components/RichTextMessage.tsx`.

#### 🧪 How to Test

- Send or open a user message that renders rich text; confirm line spacing looks consistent with surrounding chat copy.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| …      | …     |

#### 📝 Additional Information

Branch was reset onto `canary` and scoped to this UI tweak only (previous PR text described a larger onboarding set that is no longer on this branch).