### PR TITLE
🔨 chore: temporarily disable notification triggers

### DIFF
--- a/src/app/(backend)/api/webhooks/video/[provider]/route.ts
+++ b/src/app/(backend)/api/webhooks/video/[provider]/route.ts
@@ -15,7 +15,8 @@ import { type RuntimeVideoGenParams } from 'model-bank';
 import { NextResponse } from 'next/server';
 
 import { chargeAfterGenerate } from '@/business/server/video-generation/chargeAfterGenerate';
-import { notifyVideoCompleted } from '@/business/server/video-generation/notifyVideoCompleted';
+// TODO: temporarily disabled until notification UI is polished
+// import { notifyVideoCompleted } from '@/business/server/video-generation/notifyVideoCompleted';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
 import { generationBatches } from '@/database/schemas';
@@ -202,13 +203,14 @@ export const POST = async (req: Request, { params }: { params: Promise<{ provide
       status: AsyncTaskStatus.Success,
     });
 
-    notifyVideoCompleted({
-      generationBatchId: generation.generationBatchId!,
-      model: resolvedModel,
-      prompt: batch?.prompt ?? '',
-      topicId: batch?.generationTopicId,
-      userId: asyncTask.userId,
-    }).catch((err) => console.error('[video-webhook] notification failed:', err));
+    // TODO: temporarily disabled until notification UI is polished
+    // notifyVideoCompleted({
+    //   generationBatchId: generation.generationBatchId!,
+    //   model: resolvedModel,
+    //   prompt: batch?.prompt ?? '',
+    //   topicId: batch?.generationTopicId,
+    //   userId: asyncTask.userId,
+    // }).catch((err) => console.error('[video-webhook] notification failed:', err));
 
     // Charge after successful video generation
     try {

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -8,7 +8,8 @@ import { type RuntimeImageGenParams } from 'model-bank';
 import { z } from 'zod';
 
 import { chargeAfterGenerate } from '@/business/server/image-generation/chargeAfterGenerate';
-import { notifyImageCompleted } from '@/business/server/image-generation/notifyImageCompleted';
+// TODO: temporarily disabled until notification UI is polished
+// import { notifyImageCompleted } from '@/business/server/image-generation/notifyImageCompleted';
 import { createImageBusinessMiddleware } from '@/business/server/trpc-middlewares/async';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { FileModel } from '@/database/models/file';
@@ -359,14 +360,15 @@ export const imageRouter = router({
             status: AsyncTaskStatus.Success,
           });
 
-          notifyImageCompleted({
-            duration,
-            generationBatchId,
-            model,
-            prompt: params.prompt,
-            topicId: generationTopicId,
-            userId: ctx.userId,
-          }).catch((err) => console.error('[image-async] notification failed:', err));
+          // TODO: temporarily disabled until notification UI is polished
+          // notifyImageCompleted({
+          //   duration,
+          //   generationBatchId,
+          //   model,
+          //   prompt: params.prompt,
+          //   topicId: generationTopicId,
+          //   userId: ctx.userId,
+          // }).catch((err) => console.error('[image-async] notification failed:', err));
 
           if (ENABLE_BUSINESS_FEATURES) {
             await chargeAfterGenerate({


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Related to https://github.com/lobehub/lobehub/pull/13301

#### 🔀 Description of Change

Comment out notification trigger call sites (`notifyImageCompleted` and `notifyVideoCompleted`) until the notification UI is polished. The function implementations remain intact in the cloud override — only the invocations are disabled.

#### 🧪 How to Test

- [x] No tests needed