### PR TITLE
🐛 fix: prevent first assistant message re-animation on assistantGroup transition

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -15,9 +15,20 @@ import MessageContent from './MessageContent';
 interface ContentBlockProps extends AssistantContentBlock {
   assistantId: string;
   disableEditing?: boolean;
+  isFirstBlock?: boolean;
 }
 const ContentBlock = memo<ContentBlockProps>(
-  ({ id, tools, content, imageList, reasoning, error, assistantId, disableEditing }) => {
+  ({
+    id,
+    tools,
+    content,
+    imageList,
+    reasoning,
+    error,
+    assistantId,
+    disableEditing,
+    isFirstBlock,
+  }) => {
     const errorContent = useErrorContent(error);
     const showImageItems = !!imageList && imageList.length > 0;
     const [isReasoning, deleteMessage, continueGeneration] = useConversationStore((s) => [
@@ -65,7 +76,7 @@ const ContentBlock = memo<ContentBlockProps>(
         {showReasoning && <Reasoning {...reasoning} id={id} />}
 
         {/* Content - markdown text */}
-        <MessageContent content={content} hasTools={hasTools} id={id} />
+        <MessageContent content={content} hasTools={hasTools} id={id} isFirstBlock={isFirstBlock} />
 
         {/* Image files */}
         {showImageItems && <ImageFileListViewer items={imageList} />}

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -46,13 +46,14 @@ const Group = memo<GroupChildrenProps>(
     return (
       <MessageAggregationContext value={contextValue}>
         <Flexbox className={styles.container} gap={8}>
-          {blocks.map((item) => {
+          {blocks.map((item, index) => {
             return (
               <GroupItem
                 {...item}
                 assistantId={id}
                 contentId={contentId}
                 disableEditing={disableEditing}
+                isFirstBlock={index === 0}
                 key={id + '.' + item.id}
                 messageIndex={messageIndex}
               />

--- a/src/features/Conversation/Messages/AssistantGroup/components/GroupItem.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/GroupItem.tsx
@@ -11,11 +11,12 @@ interface GroupItemProps extends AssistantContentBlock {
   assistantId: string;
   contentId?: string;
   disableEditing?: boolean;
+  isFirstBlock?: boolean;
   messageIndex: number;
 }
 
 const GroupItem = memo<GroupItemProps>(
-  ({ contentId, disableEditing, error, assistantId, ...item }) => {
+  ({ contentId, disableEditing, error, assistantId, isFirstBlock, ...item }) => {
     const toggleMessageEditing = useConversationStore((s) => s.toggleMessageEditing);
 
     return item.id === contentId ? (
@@ -30,6 +31,7 @@ const GroupItem = memo<GroupItemProps>(
           assistantId={assistantId}
           disableEditing={disableEditing}
           error={error}
+          isFirstBlock={isFirstBlock}
         />
       </Flexbox>
     ) : (
@@ -38,6 +40,7 @@ const GroupItem = memo<GroupItemProps>(
         assistantId={assistantId}
         disableEditing={disableEditing}
         error={error}
+        isFirstBlock={isFirstBlock}
       />
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -19,9 +19,10 @@ interface ContentBlockProps {
   content: string;
   hasTools?: boolean;
   id: string;
+  isFirstBlock?: boolean;
 }
 
-const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
+const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirstBlock }) => {
   const message = normalizeThinkTags(processWithArtifact(content));
   const markdownProps = useMarkdown(id);
 
@@ -38,7 +39,7 @@ const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
     content && (
       <MarkdownMessage
         {...markdownProps}
-        animated={isToolSingleLine ? false : markdownProps.animated}
+        animated={isFirstBlock || isToolSingleLine ? false : markdownProps.animated}
         className={cx(isToolSingleLine && styles.pWithTool)}
       >
         {message}

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -39,7 +39,7 @@ const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirst
     content && (
       <MarkdownMessage
         {...markdownProps}
-        animated={isFirstBlock || isToolSingleLine ? false : markdownProps.animated}
+        animated={isFirstBlock ? false : markdownProps.animated}
         className={cx(isToolSingleLine && styles.pWithTool)}
       >
         {message}


### PR DESCRIPTION
## Summary

- 修复流式输出中 assistant 转 assistantGroup 时，第一条 assistant 消息文本内容重新执行 fade-in 动画的问题
- 通过 `Group` → `GroupItem` → `ContentBlock` → `MessageContent` 传递 `isFirstBlock` 属性，确保 group 中第一个 content block 不执行流式动画
- 后续 assistant 消息仍保持正常流式动画行为

### 根因分析

当 tool call 到达时，消息从 `role: 'assistant'` 转换为 `role: 'assistantGroup'`，导致 React 组件完全卸载/重新挂载。此时 `isGenerating` 仍为 `true`（tool 执行中），使得已显示完成的文本内容重新执行 fade-in 动画。

Fixes LOBE-6414

## Test plan

- [ ] 发送一条会触发 tool call 的消息，观察 assistant 文本内容在 tool call 到达时是否不再闪烁
- [ ] 验证多轮 tool call（assistant → tool → assistant → tool）中，后续 assistant 消息仍正常流式动画
- [ ] 验证无 tool call 的纯文本回复流式动画不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)