### PR TITLE
♻️ refactor: add generic SafeBoundary error boundary with tiered fallback

### DIFF
--- a/src/components/ErrorBoundary/AlertFallback.tsx
+++ b/src/components/ErrorBoundary/AlertFallback.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Alert, Highlighter } from '@lobehub/ui';
+import { memo } from 'react';
+
+interface AlertFallbackProps {
+  error: Error;
+  resetErrorBoundary: (...args: unknown[]) => void;
+  title?: string;
+}
+
+const AlertFallback = memo<AlertFallbackProps>(({ error, resetErrorBoundary, title }) => {
+  return (
+    <Alert
+      closable
+      showIcon
+      extraIsolate={false}
+      message={error?.message || 'An unknown error occurred'}
+      style={{ overflow: 'hidden', position: 'relative', width: '100%' }}
+      title={title || 'Render Error'}
+      type="secondary"
+      extra={
+        error?.stack ? (
+          <Highlighter actionIconSize="small" language="plaintext" padding={8} variant="borderless">
+            {error.stack}
+          </Highlighter>
+        ) : undefined
+      }
+      onClose={resetErrorBoundary}
+    />
+  );
+});
+
+AlertFallback.displayName = 'AlertFallback';
+
+export default AlertFallback;

--- a/src/components/ErrorBoundary/SilentFallback.tsx
+++ b/src/components/ErrorBoundary/SilentFallback.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Icon } from '@lobehub/ui';
+import { useTheme } from 'antd-style';
+import { TriangleAlert } from 'lucide-react';
+import { type CSSProperties, memo } from 'react';
+
+interface SilentFallbackProps {
+  minHeight?: number;
+  style?: CSSProperties;
+}
+
+const SilentFallback = memo<SilentFallbackProps>(({ minHeight = 36, style }) => {
+  const theme = useTheme();
+
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        border: `1px dashed ${theme.colorBorderSecondary}`,
+        borderRadius: theme.borderRadiusSM,
+        color: theme.colorTextQuaternary,
+        display: 'flex',
+        fontSize: 12,
+        gap: 4,
+        justifyContent: 'center',
+        minHeight,
+        ...style,
+      }}
+    >
+      <Icon icon={TriangleAlert} size={'small'} />
+      <span>Render Error</span>
+    </div>
+  );
+});
+
+SilentFallback.displayName = 'SilentFallback';
+
+export default SilentFallback;

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { ErrorBoundary } from '@lobehub/ui';
+import { type ComponentType, memo, type ReactNode, useCallback } from 'react';
+
+import AlertFallback from './AlertFallback';
+import SilentFallback from './SilentFallback';
+
+export type ErrorBoundaryVariant = 'alert' | 'silent';
+
+interface FallbackRenderProps {
+  error: unknown;
+  resetErrorBoundary: (...args: unknown[]) => void;
+}
+
+interface SafeBoundaryProps {
+  alertTitle?: string;
+  children: ReactNode;
+  minHeight?: number;
+  onError?: (error: unknown, info: { componentStack?: string | null }) => void;
+  resetKeys?: unknown[];
+  variant?: ErrorBoundaryVariant;
+}
+
+const SafeBoundary = memo<SafeBoundaryProps>(
+  ({ children, variant = 'silent', alertTitle, minHeight, resetKeys, onError }) => {
+    const fallbackRender = useCallback(
+      (props: FallbackRenderProps) => {
+        const error = props.error instanceof Error ? props.error : new Error(String(props.error));
+        if (variant === 'alert') {
+          return (
+            <AlertFallback
+              error={error}
+              resetErrorBoundary={props.resetErrorBoundary}
+              title={alertTitle}
+            />
+          );
+        }
+        return <SilentFallback minHeight={minHeight} />;
+      },
+      [variant, alertTitle, minHeight],
+    );
+
+    return (
+      <ErrorBoundary fallbackRender={fallbackRender} resetKeys={resetKeys} onError={onError}>
+        {children}
+      </ErrorBoundary>
+    );
+  },
+);
+
+SafeBoundary.displayName = 'SafeBoundary';
+
+export function withErrorBoundary<P extends object>(
+  Component: ComponentType<P>,
+  options?: { alertTitle?: string; minHeight?: number; variant?: ErrorBoundaryVariant },
+): ComponentType<P> {
+  const Wrapped = (props: P) => (
+    <SafeBoundary
+      alertTitle={options?.alertTitle}
+      minHeight={options?.minHeight}
+      variant={options?.variant}
+    >
+      <Component {...props} />
+    </SafeBoundary>
+  );
+
+  Wrapped.displayName = `withErrorBoundary(${Component.displayName || Component.name || 'Component'})`;
+  return Wrapped;
+}
+
+export { AlertFallback, SafeBoundary, SilentFallback };
+export default SafeBoundary;

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/index.tsx
@@ -4,6 +4,7 @@ import { safeParseJSON, safeParsePartialJSON } from '@lobechat/utils';
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
+import SafeBoundary from '@/components/ErrorBoundary';
 import { LOADING_FLAT } from '@/const/message';
 
 import StatusIndicator from './StatusIndicator';
@@ -43,16 +44,18 @@ const Inspectors = memo<InspectorProps>(
       return (
         <Flexbox allowShrink horizontal align={'center'} gap={6}>
           <StatusIndicator intervention={intervention} result={result} />
-          <CustomInspector
-            apiName={apiName}
-            args={args || {}}
-            identifier={identifier}
-            isArgumentsStreaming={isArgumentsStreaming}
-            isLoading={isTitleLoading}
-            partialArgs={partialJson}
-            pluginState={result?.state}
-            result={result}
-          />
+          <SafeBoundary minHeight={22} resetKeys={[argsStr, result]}>
+            <CustomInspector
+              apiName={apiName}
+              args={args || {}}
+              identifier={identifier}
+              isArgumentsStreaming={isArgumentsStreaming}
+              isLoading={isTitleLoading}
+              partialArgs={partialJson}
+              pluginState={result?.state}
+              result={result}
+            />
+          </SafeBoundary>
         </Flexbox>
       );
     }

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/index.tsx
@@ -6,13 +6,13 @@ import { AccordionItem, Flexbox, Skeleton } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { memo, useEffect, useState } from 'react';
 
+import SafeBoundary from '@/components/ErrorBoundary';
 import dynamic from '@/libs/next/dynamic';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { useToolStore } from '@/store/tool';
 import { toolSelectors } from '@/store/tool/selectors';
 
-import { ToolErrorBoundary } from '../../Tool/ErrorBoundary';
 import Actions from './Actions';
 import Inspectors from './Inspector';
 
@@ -158,7 +158,7 @@ const Tool = memo<GroupToolProps>(
               type={type}
             />
           )}
-          <ToolErrorBoundary apiName={apiName} identifier={identifier}>
+          <SafeBoundary alertTitle={`${identifier} / ${apiName}`} variant="alert">
             <Detail
               apiName={apiName}
               arguments={requestArgs}
@@ -174,7 +174,7 @@ const Tool = memo<GroupToolProps>(
               toolMessageId={toolMessageId}
               type={type}
             />
-          </ToolErrorBoundary>
+          </SafeBoundary>
           <Divider dashed style={{ marginBottom: 0, marginTop: 8 }} />
         </Flexbox>
       </AccordionItem>

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -1,6 +1,7 @@
 import { Flexbox, Highlighter } from '@lobehub/ui';
 import { memo, useCallback } from 'react';
 
+import SafeBoundary from '@/components/ErrorBoundary';
 import { LOADING_FLAT } from '@/const/message';
 import { useErrorContent } from '@/features/Conversation/Error';
 import { type AssistantContentBlock } from '@/types/index';
@@ -73,16 +74,32 @@ const ContentBlock = memo<ContentBlockProps>(
 
     return (
       <Flexbox gap={8} id={id}>
-        {showReasoning && <Reasoning {...reasoning} id={id} />}
+        {showReasoning && (
+          <SafeBoundary>
+            <Reasoning {...reasoning} id={id} />
+          </SafeBoundary>
+        )}
 
-        {/* Content - markdown text */}
-        <MessageContent content={content} hasTools={hasTools} id={id} isFirstBlock={isFirstBlock} />
+        <SafeBoundary variant="alert">
+          <MessageContent
+            content={content}
+            hasTools={hasTools}
+            id={id}
+            isFirstBlock={isFirstBlock}
+          />
+        </SafeBoundary>
 
-        {/* Image files */}
-        {showImageItems && <ImageFileListViewer items={imageList} />}
+        {showImageItems && (
+          <SafeBoundary>
+            <ImageFileListViewer items={imageList} />
+          </SafeBoundary>
+        )}
 
-        {/* Tools */}
-        {hasTools && <Tools disableEditing={disableEditing} messageId={id} tools={tools} />}
+        {hasTools && (
+          <SafeBoundary>
+            <Tools disableEditing={disableEditing} messageId={id} tools={tools} />
+          </SafeBoundary>
+        )}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -8,6 +8,7 @@ import { type MouseEvent, type ReactNode } from 'react';
 import { memo, Suspense, useCallback } from 'react';
 
 import BubblesLoading from '@/components/BubblesLoading';
+import SafeBoundary from '@/components/ErrorBoundary';
 
 import History from '../components/History';
 import { useChatItemContextMenu } from '../hooks/useChatItemContextMenu';
@@ -191,7 +192,9 @@ const MessageItem = memo<MessageItemProps>(
           data-index={index}
           onContextMenu={onContextMenu}
         >
-          <Suspense fallback={<BubblesLoading />}>{renderContent()}</Suspense>
+          <SafeBoundary variant="alert">
+            <Suspense fallback={<BubblesLoading />}>{renderContent()}</Suspense>
+          </SafeBoundary>
           {endRender}
         </Flexbox>
       </>

--- a/src/features/EditorCanvas/EditorCanvas.test.tsx
+++ b/src/features/EditorCanvas/EditorCanvas.test.tsx
@@ -26,9 +26,9 @@ vi.mock('./InternalEditor', () => ({
   default: vi.fn(() => <div data-testid="internal-editor">InternalEditor</div>),
 }));
 
-// Mock ErrorBoundary to pass through children
-vi.mock('./ErrorBoundary', () => ({
-  EditorErrorBoundary: vi.fn(({ children }) => <>{children}</>),
+// Mock SafeBoundary to pass through children
+vi.mock('@/components/ErrorBoundary', () => ({
+  default: vi.fn(({ children }) => <>{children}</>),
 }));
 
 describe('EditorCanvas', () => {
@@ -184,25 +184,25 @@ describe('EditorCanvas', () => {
   });
 
   describe('error boundary wrapping', () => {
-    it('should wrap DocumentIdMode with ErrorBoundary', async () => {
+    it('should wrap DocumentIdMode with SafeBoundary', async () => {
       render(<EditorCanvas documentId="doc-123" editor={mockEditor} />);
 
-      const ErrorBoundary = await vi.importMock('./ErrorBoundary');
-      expect(ErrorBoundary.EditorErrorBoundary).toHaveBeenCalled();
+      const SafeBoundary = await vi.importMock('@/components/ErrorBoundary');
+      expect(SafeBoundary.default).toHaveBeenCalled();
     });
 
-    it('should wrap EditorDataMode with ErrorBoundary', async () => {
+    it('should wrap EditorDataMode with SafeBoundary', async () => {
       render(<EditorCanvas editor={mockEditor} editorData={{ content: 'test' }} />);
 
-      const ErrorBoundary = await vi.importMock('./ErrorBoundary');
-      expect(ErrorBoundary.EditorErrorBoundary).toHaveBeenCalled();
+      const SafeBoundary = await vi.importMock('@/components/ErrorBoundary');
+      expect(SafeBoundary.default).toHaveBeenCalled();
     });
 
-    it('should wrap InternalEditor with ErrorBoundary in basic mode', async () => {
+    it('should wrap InternalEditor with SafeBoundary in basic mode', async () => {
       render(<EditorCanvas editor={mockEditor} />);
 
-      const ErrorBoundary = await vi.importMock('./ErrorBoundary');
-      expect(ErrorBoundary.EditorErrorBoundary).toHaveBeenCalled();
+      const SafeBoundary = await vi.importMock('@/components/ErrorBoundary');
+      expect(SafeBoundary.default).toHaveBeenCalled();
     });
   });
 });

--- a/src/features/EditorCanvas/EditorCanvas.tsx
+++ b/src/features/EditorCanvas/EditorCanvas.tsx
@@ -5,9 +5,10 @@ import { type ChatInputActionsProps, type Editor } from '@lobehub/editor/react';
 import { type CSSProperties } from 'react';
 import { memo } from 'react';
 
+import SafeBoundary from '@/components/ErrorBoundary';
+
 import DocumentIdMode from './DocumentIdMode';
 import EditorDataMode from './EditorDataMode';
-import { EditorErrorBoundary } from './ErrorBoundary';
 import InternalEditor from './InternalEditor';
 
 /**
@@ -148,18 +149,18 @@ export const EditorCanvas = memo<EditorCanvasWithEditorProps>(
     // documentId mode - fetch and render with loading/error states
     if (documentId) {
       return (
-        <EditorErrorBoundary>
+        <SafeBoundary alertTitle="Editor Error" variant="alert">
           <DocumentIdMode documentId={documentId} editor={editor} {...props} />
-        </EditorErrorBoundary>
+        </SafeBoundary>
       );
     }
 
     // editorData mode - render with provided data
     if (editorData) {
       return (
-        <EditorErrorBoundary>
+        <SafeBoundary alertTitle="Editor Error" variant="alert">
           <EditorDataMode editor={editor} editorData={editorData} entityId={entityId} {...props} />
-        </EditorErrorBoundary>
+        </SafeBoundary>
       );
     }
 
@@ -167,9 +168,9 @@ export const EditorCanvas = memo<EditorCanvasWithEditorProps>(
     if (!editor) return null;
 
     return (
-      <EditorErrorBoundary>
+      <SafeBoundary alertTitle="Editor Error" variant="alert">
         <InternalEditor editor={editor} {...props} />
-      </EditorErrorBoundary>
+      </SafeBoundary>
     );
   },
 );

--- a/src/features/EditorCanvas/index.ts
+++ b/src/features/EditorCanvas/index.ts
@@ -5,6 +5,5 @@ export {
   type EditorCanvasProps,
   type EditorCanvasWithEditorProps,
 } from './EditorCanvas';
-export { EditorErrorBoundary } from './ErrorBoundary';
 export { default as InlineToolbar, type InlineToolbarProps } from './InlineToolbar';
 export { useImageUpload } from './useImageUpload';

--- a/src/features/PluginsUI/Render/index.tsx
+++ b/src/features/PluginsUI/Render/index.tsx
@@ -2,7 +2,7 @@ import { type LobeToolRenderType } from '@lobechat/types';
 import { type PluginRequestPayload } from '@lobehub/chat-plugin-sdk';
 import { memo } from 'react';
 
-import { ToolErrorBoundary } from '@/features/Conversation/Messages/Tool/ErrorBoundary';
+import SafeBoundary from '@/components/ErrorBoundary';
 
 import BuiltinType from './BuiltinType';
 import DefaultType from './DefaultType';
@@ -97,9 +97,17 @@ const PluginRender = memo<PluginRenderProps>(
     const boundaryKey = `${identifier}-${payload?.apiName}-${toolCallId || messageId}`;
 
     return (
-      <ToolErrorBoundary apiName={payload?.apiName} identifier={identifier} key={boundaryKey}>
+      <SafeBoundary
+        alertTitle={
+          identifier
+            ? `${identifier}${payload?.apiName ? ` / ${payload.apiName}` : ''}`
+            : 'Tool Render Error'
+        }
+        key={boundaryKey}
+        variant="alert"
+      >
         {renderContent()}
-      </ToolErrorBoundary>
+      </SafeBoundary>
     );
   },
 );


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Introduce a unified `SafeBoundary` component that replaces scattered custom `ErrorBoundary` class components (`ToolErrorBoundary`, `EditorErrorBoundary`) with a single, generic implementation backed by `react-error-boundary` (re-exported from `@lobehub/ui`).

**Two-variant fallback strategy:**
- **`silent`** (default): minimal dashed-border placeholder with warning icon — for non-critical areas (Inspector, Reasoning, ImageViewer, Tools)
- **`alert`**: full Alert card with error stack + close/retry — for core content (MessageContent, ToolDetail, EditorCanvas)

**Injection points (container layer):**
- `ContentBlock`: wraps Reasoning (silent), MessageContent (alert), ImageFileListViewer (silent), Tools (silent)
- `MessageItem`: wraps entire message rendering (alert) as a top-level fallback
- `Inspector`: wraps CustomInspector with `resetKeys` for streaming recovery
- `Tool/Detail`: migrated from `ToolErrorBoundary` → `SafeBoundary` (alert)
- `PluginRender`: migrated from `ToolErrorBoundary` → `SafeBoundary` (alert)
- `EditorCanvas`: migrated from `EditorErrorBoundary` → `SafeBoundary` (alert)

**Key features:**
- `resetKeys` prop for automatic error recovery when props change (e.g., streaming)
- `onError` callback for custom error logging
- `withErrorBoundary` HOC for wrapping components declaratively
- Business developers don't need to manually add error boundaries

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

1. Verify existing EditorCanvas tests pass
2. Verify no TypeScript errors across changed files
3. Manually test: tool calls, inspector rendering, markdown messages, editor canvas should all render normally
4. To test error boundary: temporarily throw in a CustomInspector component — should show silent placeholder instead of crashing the app

#### 📝 Additional Information

- Old `ErrorBoundary.tsx` files (`ToolErrorBoundary`, `EditorErrorBoundary`) are now unused but not deleted — can be cleaned up in a follow-up
- `BootErrorBoundary` is intentionally NOT migrated as it has specialized reload-recovery logic