### PR TITLE
🐛 fix(settings): remove system tools full-page loading

### DIFF
--- a/src/routes/(main)/settings/system-tools/features/ToolDetectorSection.tsx
+++ b/src/routes/(main)/settings/system-tools/features/ToolDetectorSection.tsx
@@ -2,7 +2,7 @@
 
 import { type ToolStatus } from '@lobechat/electron-client-ipc';
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Button, CopyButton, Flexbox, Form, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
+import { Button, CopyButton, Flexbox, Form, Icon, Tag, Text, Tooltip } from '@lobehub/ui';
 import { CheckCircle2, Loader2Icon, RefreshCw, XCircle } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -108,36 +108,28 @@ const ToolStatusDisplay = memo<ToolStatusDisplayProps>(({ status, isDetecting })
 const ToolDetectorSection = memo(() => {
   const { t } = useTranslation('setting');
   const [toolStatuses, setToolStatuses] = useState<Record<string, ToolStatus>>({});
-  const [loading, setLoading] = useState(true);
-  const [detecting, setDetecting] = useState(false);
+  const [detecting, setDetecting] = useState(true);
 
   const detectTools = useCallback(async (force = false) => {
     try {
-      if (force) {
-        setDetecting(true);
-      }
+      setDetecting(true);
       const statuses = await toolDetectorService.detectAllTools(force);
       setToolStatuses(statuses);
     } catch (error) {
       console.error('Failed to detect tools:', error);
     } finally {
-      setLoading(false);
       setDetecting(false);
     }
   }, []);
 
   // Auto-detect on mount
   useEffect(() => {
-    detectTools(true);
+    void detectTools(true);
   }, [detectTools]);
 
   const handleRedetect = useCallback(() => {
     detectTools(true);
   }, [detectTools]);
-
-  if (loading) {
-    return <Skeleton active paragraph={{ rows: 8 }} title={false} />;
-  }
 
   const formItems: FormGroupItemType[] = Object.entries(TOOL_CATEGORIES).map(
     ([, categoryConfig]) => ({


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Remove the page-level skeleton from the system tools settings page.
- Render the predefined tool groups immediately on entry.
- Keep tool availability in the per-item detecting state while the IPC detection request is in flight.

#### 🧪 How to Test

- Open `Settings > System Tools` in the desktop app.
- Confirm the tool list renders immediately instead of showing a full-page skeleton.
- Confirm each tool row shows the detecting state until IPC detection completes.
- Run `bunx eslint 'src/routes/(main)/settings/system-tools/features/ToolDetectorSection.tsx'`.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Full-page skeleton while detecting tools | Tool groups render immediately with per-item detecting state |

#### 📝 Additional Information

- `bun run type-check` currently fails in unrelated existing files due missing `@lobechat/agent-templates` module references and pre-existing type errors outside this change.
