### PR TITLE
🐛 fix: pass contextWindowTokens to compression threshold

### DIFF
--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -102,6 +102,7 @@ export interface GeneralAgentConfig {
       model: string;
       provider: string;
     };
+    contextWindowTokens?: number;
     model: string;
     provider: string;
   };

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -1489,6 +1489,7 @@ export class AgentRuntimeService {
       agentConfig: metadata?.agentConfig,
       compressionConfig: {
         enabled: metadata?.agentConfig?.chatConfig?.enableContextCompression ?? true,
+        maxWindowToken: metadata?.modelRuntimeConfig?.contextWindowTokens,
       },
       dynamicInterventionAudits,
       modelRuntimeConfig: metadata?.modelRuntimeConfig,

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -887,6 +887,18 @@ export class AiAgentService {
 
     // Wrap in try-catch to handle operation startup failures (e.g., QStash unavailable)
     // If createOperation fails, we still have valid messages that need error info
+    let contextWindowTokens: number | undefined;
+    try {
+      contextWindowTokens =
+        (await new AiModelModel(this.db, this.userId).getModelListByProviderId(provider))
+          .find((item) => item.id === model)?.contextWindowTokens;
+    } catch {
+      // DB lookup is non-critical, fall through to builtin fallback
+    }
+    contextWindowTokens ??= LOBE_DEFAULT_MODEL_LIST.find(
+      (item) => item.id === model && item.providerId === provider,
+    )?.contextWindowTokens;
+
     try {
       const result = await this.agentRuntimeService.createOperation({
         activeDeviceId,
@@ -909,7 +921,11 @@ export class AiAgentService {
         initialContext,
         initialMessages: allMessages,
         maxSteps,
-        modelRuntimeConfig: { model, provider },
+        modelRuntimeConfig: {
+          contextWindowTokens,
+          model,
+          provider,
+        },
         hooks,
         operationId,
         signal,

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -26,6 +26,7 @@ import { localFileService } from '@/services/electron/localFileService';
 import { messageService } from '@/services/message';
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 import { createAgentExecutors } from '@/store/chat/agents/createAgentExecutors';
 import { type ChatStore } from '@/store/chat/store';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
@@ -229,6 +230,10 @@ export class StreamingExecutorActionImpl {
         model: agentConfigData.model,
         provider: agentConfigData.provider!,
       },
+      contextWindowTokens: aiModelSelectors.modelContextWindowTokens(
+        agentConfigData.model,
+        agentConfigData.provider!,
+      )(getAiInfraStoreState()),
       model: agentConfigData.model,
       provider: agentConfigData.provider!,
     };
@@ -439,6 +444,10 @@ export class StreamingExecutorActionImpl {
     const modelRuntimeConfig = {
       model,
       provider: provider!,
+      contextWindowTokens: aiModelSelectors.modelContextWindowTokens(
+        model,
+        provider!,
+      )(getAiInfraStoreState()),
       // TODO: Support dedicated compression model from chatConfig.compressionModelId
       compressionModel: { model, provider: provider! },
     };
@@ -451,6 +460,7 @@ export class StreamingExecutorActionImpl {
       agentConfig: { maxSteps: 1000 },
       compressionConfig: {
         enabled: agentConfigData.chatConfig?.enableContextCompression ?? true, // Default to enabled
+        maxWindowToken: modelRuntimeConfig.contextWindowTokens,
       },
       dynamicInterventionAudits,
       operationId: `${messageKey}/${params.parentMessageId}`,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

**Problem**

The context compression threshold is hardcoded to `128_000 * 0.5 = 64000` tokens regardless of the model's actual context window size. `GeneralAgentConfig.compressionConfig.maxWindowToken` is defined in the type but never populated, so `shouldCompress()` always falls back to `DEFAULT_MAX_CONTEXT` (128k).

This causes:
- 1M context models: compression triggers at ~6.4% usage
- 200k context models: compression triggers at ~32% usage
- Small context models (8k/16k): threshold of 64k is never reached, compression never fires

**Fix**

Pass the model's `contextWindowTokens` from model metadata into `compressionConfig.maxWindowToken` via `modelRuntimeConfig`, so the compression threshold scales correctly with each model's actual context window.

Changes across 4 files:

- `packages/agent-runtime/src/types/generalAgent.ts` — Add `contextWindowTokens` to `modelRuntimeConfig` type
- `src/store/chat/slices/aiChat/actions/streamingExecutor.ts` (client) — Look up `contextWindowTokens` from `aiModelSelectors` when building `modelRuntimeConfig`, pass it to `compressionConfig.maxWindowToken`
- `src/server/services/aiAgent/index.ts` (server) — Look up `contextWindowTokens` from user model DB (scoped by provider), falling back to `LOBE_DEFAULT_MODEL_LIST` for builtin models. DB lookup is wrapped in try/catch so transient failures don't break agent execution.
- `src/server/services/agentRuntime/AgentRuntimeService.ts` (server) — Read `contextWindowTokens` from `metadata.modelRuntimeConfig` and pass to `compressionConfig.maxWindowToken`

Fallback behavior is preserved: if `contextWindowTokens` is unavailable (undefined), `shouldCompress()` falls back to `DEFAULT_MAX_CONTEXT` (128k) as before.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

A debug image with comparison logging is available: `docker.io/mmx233/lobehub:fix-compression-threshold-debug-v4`

1. Deploy the debug image and start a conversation using a non-128k model (e.g. Gemini 1M, Claude 200k)
2. Open browser DevTools console (client-side) or check container logs (server-side agent runtime)
3. Send messages until token count grows, then observe logs with prefix `[compression-debug]`:

```
[compression-debug][toLLMCall] fixed threshold=500000 (maxWindowToken=1000000), original threshold=64000 (hardcoded 128k), tokens=342160, fixed=false, original=true
```

- `fixed threshold` vs `original threshold` — confirms the two values differ for non-128k models
- `fixed=false, original=true` — the old logic would incorrectly trigger compression, the fix correctly skips it

Clean fix image (no debug logging): `docker.io/mmx233/lobehub:fix-compression-threshold-v4`

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
