### PR TITLE
✨ feat(langfuse): add LANGFUSE_TRACE_DATA support for trace field map…

### DIFF
--- a/docs/self-hosting/advanced/observability/langfuse.mdx
+++ b/docs/self-hosting/advanced/observability/langfuse.mdx
@@ -34,13 +34,14 @@ tags:
 
   <Tabs items={["Environment Variables", "Example in Docker Desktop"]}>
     <Tab>
-      Before deploying LobeHub, set the following four environment variables with the Langfuse API keys you created in the previous step.
+      Before deploying LobeHub, set the following environment variables with the Langfuse API keys you created in the previous step.
 
       ```sh
       ENABLE_LANGFUSE = '1'
       LANGFUSE_SECRET_KEY = 'sk-lf...'
       LANGFUSE_PUBLIC_KEY = 'pk-lf...'
       LANGFUSE_HOST = 'https://cloud.langfuse.com'
+      LANGFUSE_TRACE_DATA = 'userId:userId'
       ```
     </Tab>
 

--- a/docs/self-hosting/advanced/observability/langfuse.zh-CN.mdx
+++ b/docs/self-hosting/advanced/observability/langfuse.zh-CN.mdx
@@ -31,13 +31,14 @@ tags:
 
   <Tabs items={["环境变量", "Docker Desktop 示例"]}>
     <Tab>
-      在部署 LobeHub 之前，使用你在上一步创建的 Langfuse API 密钥设置以下四个环境变量。
+      在部署 LobeHub 之前，使用你在上一步创建的 Langfuse API 密钥设置以下环境变量。
 
       ```sh
       ENABLE_LANGFUSE = '1'
       LANGFUSE_SECRET_KEY = 'sk-lf...'
       LANGFUSE_PUBLIC_KEY = 'pk-lf...'
       LANGFUSE_HOST = 'https://cloud.langfuse.com'
+      LANGFUSE_TRACE_DATA = 'userId:userId'
       ```
     </Tab>
 

--- a/docs/self-hosting/environment-variables/analytics.mdx
+++ b/docs/self-hosting/environment-variables/analytics.mdx
@@ -111,3 +111,10 @@ We have integrated several free/open-source data analytics services in LobeHub f
 - Description: Langfuse host address. Use `https://us.cloud.langfuse.com` if your Langfuse project is in the US data region.
 - Default: `https://cloud.langfuse.com`
 - Example: `https://cloud.langfuse.com`
+
+### `LANGFUSE_TRACE_DATA`
+
+- Type: Optional
+- Description: Configure which request user field is mapped into Langfuse trace fields. Current supported format is `field:value_field;field:value_field`, and only `userId` field is configurable for now. Supported source values are `userId` and `email`. If the mapped field value is empty, it will fall back to the original `userId` value.
+- Default: `userId:userId`
+- Example: `userId:email`

--- a/docs/self-hosting/environment-variables/analytics.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/analytics.zh-CN.mdx
@@ -77,3 +77,42 @@ tags:
 - 描述：Umami 脚本的网址，默认为 Umami Cloud 提供的脚本网址
 - 默认值：`https://analytics.umami.is/script.js`
 - 示例：`https://umami.your-site.com/script.js`
+
+## Langfuse 可观测性
+
+[Langfuse](https://langfuse.com/) 是一个 [开源](https://github.com/langfuse/langfuse) 的 LLM 可观测性平台。启用 Langfuse 集成后，你可以将聊天追踪数据发送到 Langfuse，用于开发、监控和评估 LobeHub 的使用情况。
+
+### `ENABLE_LANGFUSE`
+
+- 类型：必选
+- 描述：用于控制是否启用 Langfuse 分析能力。
+- 默认值：`1`
+- 示例：`1`
+
+### `LANGFUSE_SECRET_KEY`
+
+- 类型：必选
+- 描述：Langfuse API Secret Key。你可以通过注册 [Langfuse Cloud](https://cloud.langfuse.com) 或自托管 Langfuse 获取。
+- 默认值：` `
+- 示例：`sk-lf-...`
+
+### `LANGFUSE_PUBLIC_KEY`
+
+- 类型：必选
+- 描述：Langfuse API Public Key。你可以通过注册 [Langfuse Cloud](https://cloud.langfuse.com) 或自托管 Langfuse 获取。
+- 默认值：` `
+- 示例：`pk-lf-...`
+
+### `LANGFUSE_HOST`
+
+- 类型：必选
+- 描述：Langfuse 服务地址。如果你的 Langfuse 项目在美国数据区，请使用 `https://us.cloud.langfuse.com`。
+- 默认值：`https://cloud.langfuse.com`
+- 示例：`https://cloud.langfuse.com`
+
+### `LANGFUSE_TRACE_DATA`
+
+- 类型：可选
+- 描述：用于配置请求中的用户字段如何映射到 Langfuse trace 字段。当前格式为 `field:value_field;field:value_field`，目前仅支持配置 `userId` 字段；可选映射值为 `userId`、`email`。若映射字段的值为空，则会回退为使用原始的 `userId` 值。
+- 默认值：`userId:userId`
+- 示例：`userId:email`

--- a/src/app/(backend)/webapi/chat/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.test.ts
@@ -5,9 +5,12 @@ import { ChatErrorType } from '@lobechat/types';
 import { getXorPayload } from '@lobechat/utils/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { UserModel } from '@/database/models/user';
 import type * as EnvsAuthModule from '@/envs/auth';
 import { LOBE_CHAT_AUTH_HEADER } from '@/envs/auth';
-import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { getLangfuseConfig } from '@/envs/langfuse';
+import { createTraceOptions, initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { getTracePayload } from '@/utils/trace';
 
 import { POST } from './route';
 
@@ -22,6 +25,20 @@ vi.mock('@lobechat/utils/server', () => ({
 vi.mock('@/server/modules/ModelRuntime', () => ({
   initModelRuntimeFromDB: vi.fn(),
   createTraceOptions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/database/models/user', () => ({
+  UserModel: {
+    findById: vi.fn(),
+  },
+}));
+
+vi.mock('@/envs/langfuse', () => ({
+  getLangfuseConfig: vi.fn().mockReturnValue({ LANGFUSE_TRACE_DATA: { userId: 'userId' } }),
+}));
+
+vi.mock('@/utils/trace', () => ({
+  getTracePayload: vi.fn(),
 }));
 
 vi.mock('@/envs/auth', async (importOriginal) => {
@@ -54,6 +71,10 @@ beforeEach(() => {
 afterEach(() => {
   // 清除模拟调用历史
   vi.clearAllMocks();
+  vi.mocked(getLangfuseConfig).mockReturnValue({
+    LANGFUSE_TRACE_DATA: { userId: 'userId' },
+  } as any);
+  vi.mocked(getTracePayload).mockReturnValue(undefined);
 });
 
 describe('POST handler', () => {
@@ -203,6 +224,55 @@ describe('POST handler', () => {
         },
         errorType: 500,
       });
+    });
+
+    it('should resolve request user profile when trace mapping uses email', async () => {
+      vi.mocked(getXorPayload).mockReturnValueOnce({
+        apiKey: 'test-api-key',
+        userId: 'user-1',
+      });
+
+      vi.mocked(getLangfuseConfig).mockReturnValue({
+        LANGFUSE_TRACE_DATA: { userId: 'email' },
+      } as any);
+
+      vi.mocked(getTracePayload).mockReturnValue({ enabled: true, traceId: 'trace-1' } as any);
+      vi.mocked(UserModel.findById).mockResolvedValue({
+        email: 'test@example.com',
+      } as any);
+
+      const mockParams = Promise.resolve({ provider: 'test-provider' });
+      const mockChatPayload = { message: 'Hello, world!' };
+
+      request = new Request(new URL('https://test.com'), {
+        headers: { [LOBE_CHAT_AUTH_HEADER]: 'Bearer some-valid-token' },
+        method: 'POST',
+        body: JSON.stringify(mockChatPayload),
+      });
+
+      const mockChatResponse = new Response(JSON.stringify({ success: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const mockRuntime: LobeRuntimeAI = {
+        baseURL: 'abc',
+        chat: vi.fn().mockResolvedValue(mockChatResponse),
+      };
+
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue(new ModelRuntime(mockRuntime));
+
+      await POST(request as unknown as Request, { params: mockParams });
+
+      expect(UserModel.findById).toHaveBeenCalledWith(expect.anything(), 'user-1');
+      expect(createTraceOptions).toHaveBeenCalledWith(
+        mockChatPayload,
+        expect.objectContaining({
+          provider: 'test-provider',
+          traceData: {
+            email: 'test@example.com',
+          },
+        }),
+      );
     });
   });
 });

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -3,6 +3,8 @@ import { AGENT_RUNTIME_ERROR_SET } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { UserModel } from '@/database/models/user';
+import { getLangfuseConfig } from '@/envs/langfuse';
 import { createTraceOptions, initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { type ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
@@ -36,7 +38,16 @@ export const POST = checkAuth(
       let traceOptions = {};
       // If user enable trace
       if (tracePayload?.enabled) {
-        traceOptions = createTraceOptions(data, { provider, trace: tracePayload });
+        const { LANGFUSE_TRACE_DATA } = getLangfuseConfig();
+        const shouldResolveTraceUser = ['email'].includes(LANGFUSE_TRACE_DATA.userId);
+
+        const traceData = shouldResolveTraceUser
+          ? await UserModel.findById(serverDB, userId).then((user) => ({
+              email: user?.email,
+            }))
+          : undefined;
+
+        traceOptions = createTraceOptions(data, { provider, trace: tracePayload, traceData });
       }
 
       return await modelRuntime.chat(data, {

--- a/src/envs/__tests__/langfuse.test.ts
+++ b/src/envs/__tests__/langfuse.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getLangfuseConfig } from '../langfuse';
+
+afterEach(() => {
+  delete process.env.LANGFUSE_TRACE_DATA;
+  vi.resetModules();
+});
+
+describe('getLangfuseConfig', () => {
+  it('should use userId:userId as default trace data mapping', () => {
+    const config = getLangfuseConfig();
+
+    expect(config.LANGFUSE_TRACE_DATA).toEqual({ userId: 'userId' });
+  });
+
+  it('should support mapping userId to email', () => {
+    process.env.LANGFUSE_TRACE_DATA = 'userId:email';
+
+    const config = getLangfuseConfig();
+
+    expect(config.LANGFUSE_TRACE_DATA).toEqual({ userId: 'email' });
+  });
+
+  it('should ignore invalid mapping values and keep default', () => {
+    process.env.LANGFUSE_TRACE_DATA = 'userId:unknown_field';
+
+    const config = getLangfuseConfig();
+
+    expect(config.LANGFUSE_TRACE_DATA).toEqual({ userId: 'userId' });
+  });
+
+  it('should trim spaces around mapping fields', () => {
+    process.env.LANGFUSE_TRACE_DATA = ' userId : email ';
+
+    const config = getLangfuseConfig();
+
+    expect(config.LANGFUSE_TRACE_DATA).toEqual({ userId: 'email' });
+  });
+});

--- a/src/envs/langfuse.ts
+++ b/src/envs/langfuse.ts
@@ -1,8 +1,43 @@
 import { createEnv } from '@t3-oss/env-core';
 import { z } from 'zod';
 
+export const LANGFUSE_TRACE_DATA_OPTIONS = ['userId', 'email'] as const;
+
+export type LangfuseTraceDataValue = (typeof LANGFUSE_TRACE_DATA_OPTIONS)[number];
+
+export interface LangfuseTraceDataMap {
+  userId: LangfuseTraceDataValue;
+}
+
+const DEFAULT_LANGFUSE_TRACE_DATA: LangfuseTraceDataMap = {
+  userId: 'userId',
+};
+
+const parseLangfuseTraceData = (traceData?: string): LangfuseTraceDataMap => {
+  if (!traceData) return DEFAULT_LANGFUSE_TRACE_DATA;
+
+  const parsed = new Map<string, LangfuseTraceDataValue>();
+  const items = traceData.split(';').filter(Boolean);
+
+  for (const item of items) {
+    const [rawField = '', rawMappedValue = ''] = item.split(':');
+    const field = rawField.trim();
+    const mappedValue = rawMappedValue.trim();
+
+    if (field !== 'userId') continue;
+    if (!LANGFUSE_TRACE_DATA_OPTIONS.includes(mappedValue as LangfuseTraceDataValue)) continue;
+
+    parsed.set(field, mappedValue as LangfuseTraceDataValue);
+  }
+
+  return {
+    ...DEFAULT_LANGFUSE_TRACE_DATA,
+    ...Object.fromEntries(parsed.entries()),
+  };
+};
+
 export const getLangfuseConfig = () => {
-  return createEnv({
+  const env = createEnv({
     runtimeEnv: {
       ENABLE_LANGFUSE: process.env.ENABLE_LANGFUSE === '1',
       LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY || '',
@@ -17,6 +52,11 @@ export const getLangfuseConfig = () => {
       LANGFUSE_HOST: z.string().url(),
     },
   });
+
+  return {
+    ...env,
+    LANGFUSE_TRACE_DATA: parseLangfuseTraceData(process.env.LANGFUSE_TRACE_DATA),
+  };
 };
 
 export const langfuseEnv = getLangfuseConfig();

--- a/src/server/modules/ModelRuntime/trace.ts
+++ b/src/server/modules/ModelRuntime/trace.ts
@@ -4,34 +4,48 @@ import { type TracePayload } from '@lobechat/types';
 import { TraceTagMap } from '@lobechat/types';
 import { after } from 'next/server';
 
+import { getLangfuseConfig } from '@/envs/langfuse';
 import { TraceClient } from '@/libs/traces';
+
+export interface LangfuseTraceDataPayload {
+  email?: string | null;
+  userId?: string;
+}
 
 export interface AgentChatOptions {
   enableTrace?: boolean;
   provider: string;
   trace?: TracePayload;
+  traceData?: LangfuseTraceDataPayload;
 }
 
 export const createTraceOptions = (
   payload: ChatStreamPayload,
-  { trace: tracePayload, provider }: AgentChatOptions,
+  { trace: tracePayload, traceData, provider }: AgentChatOptions,
 ) => {
   const { messages, model, tools, ...parameters } = payload;
   // create a trace to monitor the completion
   const traceClient = new TraceClient();
+  const { LANGFUSE_TRACE_DATA } = getLangfuseConfig();
   const messageLength = messages.length;
   const systemRole = messages.find((message) => message.role === 'system')?.content;
+
+  const traceDataMap: Record<string, string | undefined | null> = {
+    email: traceData?.email,
+    userId: traceData?.userId ?? tracePayload?.userId,
+  };
+
+  const originalUserId = traceData?.userId ?? tracePayload?.userId;
+  const traceUserId = traceDataMap[LANGFUSE_TRACE_DATA.userId] || originalUserId;
 
   const trace = traceClient.createTrace({
     id: tracePayload?.traceId,
     input: messages,
     metadata: { messageLength, model, provider, systemRole, tools },
     name: tracePayload?.traceName,
-    sessionId: tracePayload?.topicId
-      ? tracePayload.topicId
-      : `${tracePayload?.sessionId || INBOX_SESSION_ID}@default`,
+    sessionId: tracePayload?.topicId || `${tracePayload?.sessionId || INBOX_SESSION_ID}@default`,
     tags: tracePayload?.tags,
-    userId: tracePayload?.userId,
+    userId: traceUserId,
   });
 
   const generation = trace?.generation({


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

Related to observability and Langfuse trace metadata customization.

#### 🔀 Description of Change

This PR adds support for LANGFUSE_TRACE_DATA to control how user fields are mapped into Langfuse trace fields.

- Added LANGFUSE_TRACE_DATA parsing in Langfuse env config
- Added mapping support for userId field values
  - `userId:userId` (default)
  - `userId:email`
- Updated docs
  - Langfuse observability setup
  - analytics environment variable reference
  - documented format, defaults, and examples for LANGFUSE_TRACE_DATA

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

Validation scenarios:
- Default behavior without LANGFUSE_TRACE_DATA uses userId:userId
- LANGFUSE_TRACE_DATA=userId:email maps trace userId to user email when available
- Invalid values (for example userId:unknown_field) fall back to userId:userId

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| <img width="862" height="159" alt="image" src="https://github.com/user-attachments/assets/a2f99570-6037-43a2-a1c4-e36b19dc1f5c" /> | <img width="862" height="128" alt="image" src="https://github.com/user-attachments/assets/d29d6d4f-87a0-416d-bc74-d3eaebf9a00f" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
