### PR TITLE
🐛 fix(chat): recover group agent streams and keep tool-call messages …

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -102,7 +102,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
       onOpenShareModal: handleOpenShareModal,
     });
 
-    const hasTools = !!tools;
+    const hasTools = !!tools?.length;
 
     // Get collapse/expand action based on current state
     const collapseAction = isCollapsed ? defaultActions.expand : defaultActions.collapse;

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.test.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MessageContent from './MessageContent';
+
+const mockConversationState = {
+  addReaction: vi.fn(),
+  collapsed: false,
+  generating: false,
+  reasoning: false,
+  removeReaction: vi.fn(),
+};
+
+const mockUserState = {
+  userId: 'user-1',
+};
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: typeof mockUserState) => unknown) => selector(mockUserState),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: {
+    userId: (state: typeof mockUserState) => state.userId,
+  },
+}));
+
+vi.mock('../../../store', () => ({
+  messageStateSelectors: {
+    isMessageCollapsed: () => () => mockConversationState.collapsed,
+    isMessageGenerating: () => () => mockConversationState.generating,
+    isMessageInReasoning: () => () => mockConversationState.reasoning,
+  },
+  useConversationStore: (
+    selector: (state: {
+      addReaction: typeof mockConversationState.addReaction;
+      removeReaction: typeof mockConversationState.removeReaction;
+    }) => unknown,
+  ) =>
+    selector({
+      addReaction: mockConversationState.addReaction,
+      removeReaction: mockConversationState.removeReaction,
+    }),
+}));
+
+vi.mock('../useMarkdown', () => ({
+  useMarkdown: () => ({}),
+}));
+
+vi.mock('../../AssistantGroup/Tools', () => ({
+  Tools: ({ tools }: { tools: unknown[] }) => (
+    <div data-testid="assistant-tools">{tools.length}</div>
+  ),
+}));
+
+vi.mock('../../components/DisplayContent', () => ({
+  default: ({
+    content,
+    isToolCallGenerating,
+  }: {
+    content: string;
+    isToolCallGenerating?: boolean;
+  }) => (
+    <div
+      data-state={isToolCallGenerating ? 'tool-loading' : content ? 'content' : 'loading'}
+      data-testid="display-content"
+    />
+  ),
+}));
+
+vi.mock('../../../components/Reaction', () => ({
+  ReactionDisplay: () => null,
+}));
+
+vi.mock('../../AssistantGroup/components/CollapsedMessage', () => ({
+  CollapsedMessage: ({ content }: { content: string }) => (
+    <div data-testid="collapsed-message">{content}</div>
+  ),
+}));
+
+vi.mock('../../components/FileChunks', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/ImageFileListViewer', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/Reasoning', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/SearchGrounding', () => ({
+  default: () => null,
+}));
+
+const createMessage = (overrides: Record<string, unknown> = {}) =>
+  ({
+    content: '',
+    createdAt: Date.now(),
+    id: 'msg-1',
+    role: 'assistant',
+    updatedAt: Date.now(),
+    ...overrides,
+  }) as ComponentProps<typeof MessageContent>;
+
+describe('Assistant MessageContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConversationState.collapsed = false;
+    mockConversationState.generating = false;
+    mockConversationState.reasoning = false;
+  });
+
+  it('should render tool progress when a tool call is running without text content yet', () => {
+    mockConversationState.generating = true;
+
+    render(
+      <MessageContent
+        {...createMessage({
+          tools: [{ apiName: 'search', id: 'tool-1', identifier: 'web-browsing' }],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('display-content')).toHaveAttribute('data-state', 'tool-loading');
+    expect(screen.getByTestId('assistant-tools')).toHaveTextContent('1');
+  });
+
+  it('should keep the loading state visible when the tool list is still empty', () => {
+    mockConversationState.generating = true;
+
+    render(<MessageContent {...createMessage({ tools: [] })} />);
+
+    expect(screen.getByTestId('display-content')).toHaveAttribute('data-state', 'loading');
+    expect(screen.queryByTestId('assistant-tools')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -9,6 +9,7 @@ import { userProfileSelectors } from '@/store/user/selectors';
 import { ReactionDisplay } from '../../../components/Reaction';
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessage';
+import { Tools } from '../../AssistantGroup/Tools';
 import DisplayContent from '../../components/DisplayContent';
 import FileChunks from '../../components/FileChunks';
 import ImageFileListViewer from '../../components/ImageFileListViewer';
@@ -27,7 +28,9 @@ const MessageContent = memo<UIChatMessage>(
     const removeReaction = useConversationStore((s) => s.removeReaction);
     const userId = useUserStore(userProfileSelectors.userId)!;
 
-    const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && !!tools;
+    const messageTools = tools ?? [];
+    const hasTools = messageTools.length > 0;
+    const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && hasTools;
 
     const showSearch = !!search && (!!search.citations?.length || !!search.imageResults?.length);
     const showImageItems = !!imageList && imageList.length > 0;
@@ -86,6 +89,7 @@ const MessageContent = memo<UIChatMessage>(
           tempDisplayContent={metadata?.tempDisplayContent}
         />
         {showImageItems && <ImageFileListViewer items={imageList} />}
+        {hasTools && <Tools messageId={id} tools={messageTools} />}
         {reactions.length > 0 && (
           <ReactionDisplay
             isActive={isActive}

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -103,7 +103,7 @@ const WithContentId = memo<GroupActionsProps>(({ actionsConfig, id, data, conten
     onOpenShareModal: handleOpenShareModal,
   });
 
-  const hasTools = !!tools;
+  const hasTools = !!tools?.length;
 
   // Get collapse/expand action based on current state
   const collapseAction = isCollapsed ? defaultActions.expand : defaultActions.collapse;

--- a/src/features/Conversation/Messages/Task/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Task/Actions/index.tsx
@@ -95,7 +95,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(
       onOpenShareModal: handleOpenShareModal,
     });
 
-    const hasTools = !!tools;
+    const hasTools = !!tools?.length;
 
     // Get collapse/expand action based on current state
     const collapseAction = defaultActions.collapse;

--- a/src/features/Conversation/Messages/Task/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Task/components/MessageContent.tsx
@@ -6,6 +6,7 @@ import { memo } from 'react';
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import { useMarkdown } from '../../Assistant/useMarkdown';
 import { CollapsedMessage } from '../../AssistantGroup/components/CollapsedMessage';
+import { Tools } from '../../AssistantGroup/Tools';
 import DisplayContent from '../../components/DisplayContent';
 import FileChunks from '../../components/FileChunks';
 import ImageFileListViewer from '../../components/ImageFileListViewer';
@@ -21,7 +22,9 @@ const MessageContent = memo<UIChatMessage>(
     const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
     const isReasoning = useConversationStore(messageStateSelectors.isMessageInReasoning(id));
 
-    const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && !!tools;
+    const messageTools = tools ?? [];
+    const hasTools = messageTools.length > 0;
+    const isToolCallGenerating = generating && (content === LOADING_FLAT || !content) && hasTools;
 
     // TODO: Need to implement isIntentUnderstanding selector in ConversationStore if needed
     const isIntentUnderstanding = false;
@@ -65,6 +68,7 @@ const MessageContent = memo<UIChatMessage>(
           />
         )}
         {showImageItems && <ImageFileListViewer items={imageList} />}
+        {hasTools && <Tools messageId={id} tools={messageTools} />}
       </Flexbox>
     );
   },

--- a/src/features/Conversation/Messages/components/DisplayContent.test.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DisplayContent from './DisplayContent';
+
+const mockDeserializeParts = vi.fn();
+
+vi.mock('@lobechat/utils', () => ({
+  deserializeParts: (...args: unknown[]) => mockDeserializeParts(...args),
+}));
+
+vi.mock('@/features/Conversation/Markdown', () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="markdown-message">{children}</div>,
+}));
+
+vi.mock('../../utils/markdown', () => ({
+  normalizeThinkTags: (content: string) => content,
+  processWithArtifact: (content: string) => content,
+}));
+
+vi.mock('./ContentLoading', () => ({
+  default: ({ id }: { id: string }) => <div data-testid="content-loading">{id}</div>,
+}));
+
+vi.mock('./RichContentRenderer', () => ({
+  RichContentRenderer: ({ parts }: { parts: unknown }) => (
+    <div data-testid="rich-content">{JSON.stringify(parts)}</div>
+  ),
+}));
+
+describe('DisplayContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeserializeParts.mockReturnValue(null);
+  });
+
+  it('should render loading instead of a blank area while tool calls are generating', () => {
+    render(<DisplayContent content={''} id={'msg-1'} isToolCallGenerating />);
+
+    expect(screen.getByTestId('content-loading')).toHaveTextContent('msg-1');
+    expect(screen.queryByTestId('markdown-message')).not.toBeInTheDocument();
+  });
+
+  it('should render markdown when content is ready', () => {
+    render(<DisplayContent content={'hello'} id={'msg-2'} />);
+
+    expect(screen.getByTestId('markdown-message')).toHaveTextContent('hello');
+    expect(screen.queryByTestId('content-loading')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -29,7 +29,7 @@ const DisplayContent = memo<{
     id,
   }) => {
     const message = normalizeThinkTags(processWithArtifact(content));
-    if (isToolCallGenerating) return;
+    if (isToolCallGenerating) return <ContentLoading id={id} />;
 
     if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;
 

--- a/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { lambdaClient } from '@/libs/trpc/client';
-import { agentRuntimeClient } from '@/services/agentRuntime';
+import { agentRuntimeClient, agentRuntimeService } from '@/services/agentRuntime';
 import { useChatStore } from '@/store/chat/store';
 
 // Keep zustand mock as it's needed globally
@@ -29,6 +29,9 @@ vi.mock('@/services/agentRuntime', () => ({
   agentRuntimeClient: {
     createStreamConnection: vi.fn(),
   },
+  agentRuntimeService: {
+    getOperationStatus: vi.fn(),
+  },
   StreamEvent: {},
 }));
 
@@ -45,6 +48,14 @@ const TEST_IDS = {
 const TEST_CONTENT = {
   GROUP_MESSAGE: 'Hello group!',
   EMPTY: '',
+} as const;
+
+const COMPLETED_OPERATION_STATUS = {
+  currentState: { status: 'done' },
+  hasError: false,
+  isActive: false,
+  isCompleted: true,
+  needsHumanInput: false,
 } as const;
 
 // Helper to reset test environment
@@ -107,6 +118,9 @@ const createMockExecGroupAgentResponse = (overrides: any = {}) => ({
 describe('agentGroup actions', () => {
   beforeEach(() => {
     resetTestEnvironment();
+    vi.mocked(agentRuntimeService.getOperationStatus).mockResolvedValue(
+      COMPLETED_OPERATION_STATUS as any,
+    );
 
     // Setup default mocks for store methods
     act(() => {
@@ -118,6 +132,7 @@ describe('agentGroup actions', () => {
         internal_cleanupAgentOperation: vi.fn(),
         internal_handleAgentError: vi.fn(),
         internal_updateTopics: vi.fn(),
+        refreshMessages: vi.fn(),
         replaceMessages: vi.fn(),
         startOperation: vi
           .fn()
@@ -415,6 +430,48 @@ describe('agentGroup actions', () => {
         );
       });
 
+      it('should not reconcile or complete operations after client-side stream cancellation', async () => {
+        const { result } = renderHook(() => useChatStore());
+
+        vi.mocked(lambdaClient.aiAgent.execGroupAgent.mutate).mockResolvedValue(
+          createMockExecGroupAgentResponse(),
+        );
+
+        const abort = vi.fn();
+        let onDisconnectCallback: (() => void) | undefined;
+
+        vi.mocked(agentRuntimeClient.createStreamConnection).mockImplementation(
+          (_operationId, options) => {
+            onDisconnectCallback = options?.onDisconnect;
+            return { abort } as any;
+          },
+        );
+
+        await act(async () => {
+          await result.current.sendGroupMessage({
+            context: createTestContext(),
+            message: TEST_CONTENT.GROUP_MESSAGE,
+          });
+        });
+
+        const cancelHandler = vi.mocked(result.current.onOperationCancel).mock.calls[0]?.[1];
+
+        await act(async () => {
+          await cancelHandler?.({
+            metadata: {},
+            operationId: TEST_IDS.OPERATION_ID,
+            reason: 'User cancelled',
+            type: 'groupAgentStream',
+          });
+          onDisconnectCallback?.();
+        });
+
+        expect(abort).toHaveBeenCalledTimes(1);
+        expect(agentRuntimeService.getOperationStatus).not.toHaveBeenCalled();
+        expect(result.current.refreshMessages).not.toHaveBeenCalled();
+        expect(result.current.completeOperation).not.toHaveBeenCalled();
+      });
+
       it('should associate assistant message with both execServerAgentRuntime and groupAgentStream operations', async () => {
         const { result } = renderHook(() => useChatStore());
 
@@ -446,7 +503,7 @@ describe('agentGroup actions', () => {
         expect(result.current.associateMessageWithOperation).toHaveBeenCalledTimes(2);
       });
 
-      it('should create stream connection with operationId', async () => {
+      it('should create stream connection with history replay enabled', async () => {
         const { result } = renderHook(() => useChatStore());
 
         vi.mocked(lambdaClient.aiAgent.execGroupAgent.mutate).mockResolvedValue(
@@ -464,7 +521,8 @@ describe('agentGroup actions', () => {
         expect(agentRuntimeClient.createStreamConnection).toHaveBeenCalledWith(
           TEST_IDS.OPERATION_ID,
           expect.objectContaining({
-            includeHistory: false,
+            includeHistory: true,
+            lastEventId: '0',
             onConnect: expect.any(Function),
             onDisconnect: expect.any(Function),
             onError: expect.any(Function),
@@ -473,7 +531,7 @@ describe('agentGroup actions', () => {
         );
       });
 
-      it('should complete operations on stream disconnect', async () => {
+      it('should reconcile backend status before completing operations on stream disconnect', async () => {
         const { result } = renderHook(() => useChatStore());
 
         vi.mocked(lambdaClient.aiAgent.execGroupAgent.mutate).mockResolvedValue(
@@ -500,9 +558,73 @@ describe('agentGroup actions', () => {
           onDisconnectCallback?.();
         });
 
+        expect(result.current.refreshMessages).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: TEST_IDS.AGENT_ID,
+            groupId: TEST_IDS.GROUP_ID,
+            topicId: TEST_IDS.TOPIC_ID,
+          }),
+        );
+        expect(agentRuntimeService.getOperationStatus).toHaveBeenCalledWith(
+          TEST_IDS.OPERATION_ID,
+          true,
+        );
         // Should complete both the stream operation and the main execServerAgentRuntime operation
         expect(result.current.completeOperation).toHaveBeenCalledWith(TEST_IDS.OPERATION_ID);
         expect(result.current.completeOperation).toHaveBeenCalledWith('op-exec');
+      });
+
+      it('should reconnect with history when stream disconnects before completion', async () => {
+        const { result } = renderHook(() => useChatStore());
+
+        vi.mocked(lambdaClient.aiAgent.execGroupAgent.mutate).mockResolvedValue(
+          createMockExecGroupAgentResponse(),
+        );
+        vi.mocked(agentRuntimeService.getOperationStatus).mockResolvedValue({
+          currentState: { status: 'running' },
+          hasError: false,
+          isActive: true,
+          isCompleted: false,
+          needsHumanInput: false,
+        } as any);
+
+        let onDisconnectCallback: (() => void) | undefined;
+        let onEventCallback: ((event: any) => Promise<void>) | undefined;
+
+        vi.mocked(agentRuntimeClient.createStreamConnection).mockImplementation(
+          (_operationId, options) => {
+            onDisconnectCallback = options?.onDisconnect;
+            onEventCallback = options?.onEvent;
+            return {} as any;
+          },
+        );
+
+        await act(async () => {
+          await result.current.sendGroupMessage({
+            context: createTestContext(),
+            message: TEST_CONTENT.GROUP_MESSAGE,
+          });
+        });
+
+        await act(async () => {
+          await onEventCallback?.({
+            data: {},
+            operationId: TEST_IDS.OPERATION_ID,
+            stepIndex: 0,
+            timestamp: 123456,
+            type: 'stream_chunk',
+          });
+          onDisconnectCallback?.();
+        });
+
+        expect(agentRuntimeClient.createStreamConnection).toHaveBeenNthCalledWith(
+          2,
+          TEST_IDS.OPERATION_ID,
+          expect.objectContaining({
+            includeHistory: true,
+            lastEventId: '123456',
+          }),
+        );
       });
 
       it('should update topics when new topic is created', async () => {

--- a/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
@@ -472,6 +472,69 @@ describe('agentGroup actions', () => {
         expect(result.current.completeOperation).not.toHaveBeenCalled();
       });
 
+      it('should not reconnect or complete when user cancels during async reconciliation', async () => {
+        const { result } = renderHook(() => useChatStore());
+
+        vi.mocked(lambdaClient.aiAgent.execGroupAgent.mutate).mockResolvedValue(
+          createMockExecGroupAgentResponse(),
+        );
+
+        // Make getOperationStatus slow so we can cancel during the await
+        let resolveStatus: ((v: any) => void) | undefined;
+        vi.mocked(agentRuntimeService.getOperationStatus).mockImplementation(
+          () => new Promise((resolve) => { resolveStatus = resolve; }),
+        );
+
+        const abort = vi.fn();
+        let onDisconnectCallback: (() => void) | undefined;
+
+        vi.mocked(agentRuntimeClient.createStreamConnection).mockImplementation(
+          (_operationId, options) => {
+            onDisconnectCallback = options?.onDisconnect;
+            return { abort } as any;
+          },
+        );
+
+        await act(async () => {
+          await result.current.sendGroupMessage({
+            context: createTestContext(),
+            message: TEST_CONTENT.GROUP_MESSAGE,
+          });
+        });
+
+        const cancelHandler = vi.mocked(result.current.onOperationCancel).mock.calls[0]?.[1];
+
+        // Trigger disconnect — starts reconciliation which awaits getOperationStatus
+        await act(async () => {
+          onDisconnectCallback?.();
+        });
+
+        // While reconciliation is awaiting, user cancels
+        await act(async () => {
+          await cancelHandler?.({
+            metadata: {},
+            operationId: TEST_IDS.OPERATION_ID,
+            reason: 'User cancelled',
+            type: 'groupAgentStream',
+          });
+        });
+
+        // Now resolve the pending getOperationStatus — reconciliation resumes
+        await act(async () => {
+          resolveStatus?.({
+            currentState: { status: 'running' },
+            hasError: false,
+            isActive: true,
+            isCompleted: false,
+            needsHumanInput: false,
+          });
+        });
+
+        // Should NOT reconnect or complete because user already cancelled
+        expect(agentRuntimeClient.createStreamConnection).toHaveBeenCalledTimes(1); // only the initial
+        expect(result.current.completeOperation).not.toHaveBeenCalled();
+      });
+
       it('should associate assistant message with both execServerAgentRuntime and groupAgentStream operations', async () => {
         const { result } = renderHook(() => useChatStore());
 

--- a/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts
@@ -458,7 +458,7 @@ describe('agentGroup actions', () => {
 
         await act(async () => {
           await cancelHandler?.({
-            metadata: {},
+            metadata: { startTime: Date.now() },
             operationId: TEST_IDS.OPERATION_ID,
             reason: 'User cancelled',
             type: 'groupAgentStream',
@@ -482,7 +482,10 @@ describe('agentGroup actions', () => {
         // Make getOperationStatus slow so we can cancel during the await
         let resolveStatus: ((v: any) => void) | undefined;
         vi.mocked(agentRuntimeService.getOperationStatus).mockImplementation(
-          () => new Promise((resolve) => { resolveStatus = resolve; }),
+          () =>
+            new Promise((resolve) => {
+              resolveStatus = resolve;
+            }),
         );
 
         const abort = vi.fn();
@@ -512,7 +515,7 @@ describe('agentGroup actions', () => {
         // While reconciliation is awaiting, user cancels
         await act(async () => {
           await cancelHandler?.({
-            metadata: {},
+            metadata: { startTime: Date.now() },
             operationId: TEST_IDS.OPERATION_ID,
             reason: 'User cancelled',
             type: 'groupAgentStream',
@@ -652,7 +655,7 @@ describe('agentGroup actions', () => {
         } as any);
 
         let onDisconnectCallback: (() => void) | undefined;
-        let onEventCallback: ((event: any) => Promise<void>) | undefined;
+        let onEventCallback: ((event: any) => void) | undefined;
 
         vi.mocked(agentRuntimeClient.createStreamConnection).mockImplementation(
           (_operationId, options) => {

--- a/src/store/chat/slices/aiAgent/actions/agentGroup.ts
+++ b/src/store/chat/slices/aiAgent/actions/agentGroup.ts
@@ -6,7 +6,7 @@ import debug from 'debug';
 
 import { lambdaClient } from '@/libs/trpc/client';
 import { type StreamEvent } from '@/services/agentRuntime';
-import { agentRuntimeClient } from '@/services/agentRuntime';
+import { agentRuntimeClient, agentRuntimeService } from '@/services/agentRuntime';
 import { type ChatStore } from '@/store/chat/store';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -14,6 +14,7 @@ import { setNamespace } from '@/utils/storeDebug';
 const log = debug('store:chat:ai-agent:agentGroup');
 
 const n = setNamespace('aiAgentGroup');
+const MAX_STREAM_RECONNECT_ATTEMPTS = 1;
 
 type Setter = StoreSetter<ChatStore>;
 export const agentGroupSlice = (set: Setter, get: () => ChatStore, _api?: unknown) =>
@@ -163,7 +164,110 @@ export class ChatGroupChatActionImpl {
         assistantId: result.assistantMessageId,
         content: '',
         reasoning: '',
+        receivedTerminalEvent: false,
         tmpAssistantId: tempAssistantId, // Used for cleanup if needed
+      };
+
+      let lastEventId = '0';
+      let reconnectAttempts = 0;
+      let currentStreamConnection: AbortController | undefined;
+      let reconnectInFlight = false;
+      let streamClosedByClient = false;
+
+      const completeStreamOperations = () => {
+        this.#get().completeOperation(result.operationId);
+        this.#get().completeOperation(execOperationId);
+      };
+
+      const failStreamOperations = (message: string) => {
+        this.#get().failOperation(result.operationId, {
+          message,
+          type: 'AgentStreamDisconnected',
+        });
+        this.#get().failOperation(execOperationId, {
+          message,
+          type: 'AgentStreamDisconnected',
+        });
+      };
+
+      const reconcileUnexpectedStreamClose = async (error?: Error) => {
+        if (reconnectInFlight) return;
+        reconnectInFlight = true;
+
+        try {
+          if (streamClosedByClient) return;
+
+          if (streamContext.receivedTerminalEvent) {
+            completeStreamOperations();
+            return;
+          }
+
+          const status = await agentRuntimeService.getOperationStatus(result.operationId, true);
+          await this.#get().refreshMessages(execContext);
+
+          if (!status) {
+            failStreamOperations(error?.message || 'Agent stream state is no longer available');
+            return;
+          }
+
+          if (status?.hasError) {
+            const errorMessage =
+              status.currentState?.error?.message || error?.message || 'Agent runtime failed';
+            failStreamOperations(errorMessage);
+            return;
+          }
+
+          if (status.needsHumanInput || status.isCompleted || !status.isActive) {
+            completeStreamOperations();
+            return;
+          }
+
+          if (reconnectAttempts < MAX_STREAM_RECONNECT_ATTEMPTS) {
+            reconnectAttempts += 1;
+            log(
+              'Stream closed before completion for %s, reconnecting with history from %s (attempt %d)',
+              result.operationId,
+              lastEventId,
+              reconnectAttempts,
+            );
+            connectStream();
+            return;
+          }
+
+          failStreamOperations(error?.message || 'Agent stream disconnected before completion');
+        } catch (streamError) {
+          console.error('Failed to reconcile group agent stream state:', streamError);
+          failStreamOperations(error?.message || 'Agent stream disconnected before completion');
+        } finally {
+          reconnectInFlight = false;
+        }
+      };
+
+      const connectStream = () => {
+        currentStreamConnection = agentRuntimeClient.createStreamConnection(result.operationId, {
+          includeHistory: true,
+          lastEventId,
+          onConnect: () => {
+            log('Stream connected to %s from %s', result.operationId, lastEventId);
+          },
+          onDisconnect: () => {
+            log('Stream disconnected from %s', result.operationId);
+            void reconcileUnexpectedStreamClose();
+          },
+          onError: (error: Error) => {
+            log('Stream error for %s: %O', result.operationId, error);
+            void reconcileUnexpectedStreamClose(error);
+          },
+          onEvent: async (event: StreamEvent) => {
+            lastEventId = event.timestamp.toString();
+
+            if (event.type === 'agent_runtime_end' || event.type === 'stream_end') {
+              streamContext.receivedTerminalEvent = true;
+            }
+
+            await internal_handleAgentStreamEvent(result.operationId, event, streamContext);
+          },
+        });
       };
 
       // 9. Start child operation for SSE stream using backend operationId
@@ -181,39 +285,15 @@ export class ChatGroupChatActionImpl {
       this.#get().associateMessageWithOperation(result.assistantMessageId, execOperationId);
       this.#get().associateMessageWithOperation(result.assistantMessageId, result.operationId);
 
-      // 10. Connect to SSE stream
-      // Server will automatically close the connection after sending agent_runtime_end event
-      const eventSource = agentRuntimeClient.createStreamConnection(result.operationId, {
-        includeHistory: false,
-        onConnect: () => {
-          log('Stream connected to %s', result.operationId);
-        },
-        onDisconnect: () => {
-          log('Stream disconnected from %s', result.operationId);
-          // Complete both operations when stream disconnects (either by server close or client abort)
-          this.#get().completeOperation(result.operationId);
-          this.#get().completeOperation(execOperationId);
-        },
-        onError: (error: Error) => {
-          log('Stream error for %s: %O', result.operationId, error);
-          // Fail the stream operation on error
-          this.#get().failOperation(result.operationId, {
-            message: error.message,
-            type: 'AgentStreamError',
-          });
-          if (streamContext.assistantId) {
-            this.#get().internal_handleAgentError(streamContext.assistantId, error.message);
-          }
-        },
-        onEvent: async (event: StreamEvent) => {
-          await internal_handleAgentStreamEvent(result.operationId, event, streamContext);
-        },
-      });
+      // 10. Connect to SSE stream.
+      // Enable history replay so fast operations don't outrun the client connection.
+      connectStream();
 
       // 11. Register cancel handler for aborting SSE stream
       this.#get().onOperationCancel(result.operationId, () => {
         log('Cancelling SSE stream for operation %s', result.operationId);
-        eventSource.abort();
+        streamClosedByClient = true;
+        currentStreamConnection?.abort();
       });
     } catch (error) {
       // Check if this is an abort error (user cancelled the operation)

--- a/src/store/chat/slices/aiAgent/actions/agentGroup.ts
+++ b/src/store/chat/slices/aiAgent/actions/agentGroup.ts
@@ -173,13 +173,16 @@ export class ChatGroupChatActionImpl {
       let currentStreamConnection: AbortController | undefined;
       let reconnectInFlight = false;
       let streamClosedByClient = false;
+      let streamReconciled = false;
 
       const completeStreamOperations = () => {
+        streamReconciled = true;
         this.#get().completeOperation(result.operationId);
         this.#get().completeOperation(execOperationId);
       };
 
       const failStreamOperations = (message: string) => {
+        streamReconciled = true;
         this.#get().failOperation(result.operationId, {
           message,
           type: 'AgentStreamDisconnected',
@@ -191,7 +194,7 @@ export class ChatGroupChatActionImpl {
       };
 
       const reconcileUnexpectedStreamClose = async (error?: Error) => {
-        if (reconnectInFlight) return;
+        if (reconnectInFlight || streamReconciled) return;
         reconnectInFlight = true;
 
         try {

--- a/src/store/chat/slices/aiAgent/actions/agentGroup.ts
+++ b/src/store/chat/slices/aiAgent/actions/agentGroup.ts
@@ -205,6 +205,9 @@ export class ChatGroupChatActionImpl {
           const status = await agentRuntimeService.getOperationStatus(result.operationId, true);
           await this.#get().refreshMessages(execContext);
 
+          // Re-check after async calls — user may have cancelled during the awaits
+          if (streamClosedByClient) return;
+
           if (!status) {
             failStreamOperations(error?.message || 'Agent stream state is no longer available');
             return;


### PR DESCRIPTION
…visible

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

N/A


#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
- Recover group agent SSE streams by enabling history replay on connect, reconciling backend operation state on disconnect, and retrying once from the last received event when the stream closes before completion.
- Prevent client-side stream cancellation and unexpected disconnects from being treated as successful completion before the operation state is refreshed.
- Keep assistant and task messages visible during tool execution by showing loading/progress instead of rendering a blank content area when tool calls start before text content is available.
- Add regression coverage for stream recovery, disconnect handling, cancellation behavior, and tool-call loading visibility.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->
- Start a group conversation and verify the assistant reply still appears when the SSE stream connects late or disconnects before the final event.
- Cancel an in-flight group stream and verify the operation is not reconciled as completed after client-side cancellation.
- Trigger a tool call before any text content is emitted and verify the message shows loading/progress instead of a blank area.
- Run:
  `bunx vitest run --silent='passed-only' 'src/store/chat/slices/aiAgent/actions/__tests__/agentGroup.test.ts' 'src/features/Conversation/Messages/components/DisplayContent.test.tsx' 'src/features/Conversation/Messages/Assistant/components/MessageContent.test.tsx'`

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| Group agent replies could be lost when SSE connected late or disconnected mid-run. Tool-call-only messages could render as a blank area. | Group agent streams recover through history replay/reconnect, and tool-call progress remains visible while the final answer is pending. |



#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
- No breaking changes or migration steps are required.
- This change is scoped to client-side stream handling and assistant/task message rendering.
