### PR TITLE
🐛 fix(markdown): promote display-only LaTeX in inline messages

### DIFF
--- a/src/features/Conversation/Markdown/index.tsx
+++ b/src/features/Conversation/Markdown/index.tsx
@@ -2,6 +2,7 @@ import { type MarkdownProps } from '@lobehub/ui';
 import { Markdown } from '@lobehub/ui';
 import { memo } from 'react';
 
+import { promoteDisplayOnlyLatex } from '@/features/Conversation/utils/markdown';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
@@ -9,6 +10,8 @@ const MarkdownMessage = memo<MarkdownProps>(({ children, componentProps, ...rest
   const { highlighterTheme, mermaidTheme, fontSize } = useUserStore(
     userGeneralSettingsSelectors.config,
   );
+  const normalizedChildren =
+    typeof children === 'string' ? promoteDisplayOnlyLatex(children) : children;
 
   return (
     <Markdown
@@ -25,7 +28,7 @@ const MarkdownMessage = memo<MarkdownProps>(({ children, componentProps, ...rest
       }}
       {...rest}
     >
-      {children}
+      {normalizedChildren}
     </Markdown>
   );
 });

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { processWithArtifact } from './markdown';
+import { processWithArtifact, promoteDisplayOnlyLatex } from './markdown';
 
 describe('processWithArtifact', () => {
   it('should removeLineBreaks with closed tag', () => {
@@ -496,5 +496,84 @@ This HTML document includes the temperature converter with the requested feature
       expect(output).toContain('</lobeThinking> <lobeArtifact');
       expect(output).not.toContain('</lobeThinking>\n\n<lobeArtifact');
     });
+  });
+});
+
+describe('promoteDisplayOnlyLatex', () => {
+  it('should promote inline dollar math with \\tag to display math', () => {
+    const input = 'Before $\\hat{\\sigma}\\tag{1}$ after';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      'Before \n$$\n\\hat{\\sigma}\\tag{1}\n$$\n after',
+    );
+  });
+
+  it('should promote inline parenthesis math with \\tag* to display math', () => {
+    const input = 'Before \\(E=mc^2 \\tag*{Energy}\\) after';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      'Before \n$$\nE=mc^2 \\tag*{Energy}\n$$\n after',
+    );
+  });
+
+  it('should promote display-only environments used inside inline math', () => {
+    const input = '$\\begin{equation}a=b\\end{equation}$ and $\\begin{split}x&=1\\end{split}$';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      '\n$$\n\\begin{equation}a=b\\end{equation}\n$$\n and \n$$\n\\begin{split}x&=1\\end{split}\n$$\n',
+    );
+  });
+
+  it('should promote other display-only environments used inside inline math', () => {
+    const input =
+      '$\\begin{align}a&=b\\\\c&=d\\end{align}$ $\\begin{alignat}{2}a&=b\\\\c&=d\\end{alignat}$ $\\begin{gather}a\\\\b\\end{gather}$ $\\begin{CD}A@>>>B\\end{CD}$';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      '\n$$\n\\begin{align}a&=b\\\\c&=d\\end{align}\n$$\n \n$$\n\\begin{alignat}{2}a&=b\\\\c&=d\\end{alignat}\n$$\n \n$$\n\\begin{gather}a\\\\b\\end{gather}\n$$\n \n$$\n\\begin{CD}A@>>>B\\end{CD}\n$$\n',
+    );
+  });
+
+  it('should keep inline-safe environments unchanged', () => {
+    const input =
+      '$\\begin{aligned}a&=b\\end{aligned}$ $\\begin{alignedat}{2}a&=b\\end{alignedat}$ $\\begin{gathered}a\\\\b\\end{gathered}$ and $x^2$';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(input);
+  });
+
+  it('should not rewrite formulas inside inline code or fenced code blocks', () => {
+    const input = [
+      'Inline code: `$\\hat{\\sigma}\\tag{1}$`',
+      '',
+      '```tex',
+      '$\\hat{\\sigma}\\tag{1}$',
+      '```',
+      '',
+    ].join('\n');
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(input);
+  });
+
+  it('should not rewrite formulas inside lobeArtifact content', () => {
+    const input =
+      'Before $\\hat{\\sigma}\\tag{1}$ after\n\n<lobeArtifact identifier="demo" type="text/html" title="Demo"><script>const raw = "$\\\\tag{artifact}$";</script></lobeArtifact>';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      'Before \n$$\n\\hat{\\sigma}\\tag{1}\n$$\n after\n\n<lobeArtifact identifier="demo" type="text/html" title="Demo"><script>const raw = "$\\\\tag{artifact}$";</script></lobeArtifact>',
+    );
+  });
+
+  it('should keep existing display math blocks unchanged', () => {
+    const input =
+      'Before $$\\begin{align}a&=b\\\\c&=d\\end{align}$$ after\n\n\\[\n\\hat{\\sigma}\\tag{1}\n\\]';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(input);
+  });
+
+  it('should be idempotent', () => {
+    const input =
+      'Before $\\hat{\\sigma}\\tag{1}$ after and $$\\begin{align}a&=b\\\\c&=d\\end{align}$$';
+    const firstPass = promoteDisplayOnlyLatex(input);
+
+    expect(promoteDisplayOnlyLatex(firstPass)).toEqual(firstPass);
   });
 });

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -553,6 +553,12 @@ describe('promoteDisplayOnlyLatex', () => {
     expect(promoteDisplayOnlyLatex(input)).toEqual(input);
   });
 
+  it('should not rewrite formulas inside multi-backtick inline code spans', () => {
+    const input = 'Use ``$\\hat{\\sigma}\\tag{1}$`` for display-only math';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(input);
+  });
+
   it('should not rewrite formulas inside lobeArtifact content', () => {
     const input =
       'Before $\\hat{\\sigma}\\tag{1}$ after\n\n<lobeArtifact identifier="demo" type="text/html" title="Demo"><script>const raw = "$\\\\tag{artifact}$";</script></lobeArtifact>';

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -533,6 +533,15 @@ describe('promoteDisplayOnlyLatex', () => {
     );
   });
 
+  it('should promote flalign and multline environments used inside inline math', () => {
+    const input =
+      '$\\begin{flalign}a&=b\\\\c&=d\\end{flalign}$ $\\begin{flalign*}a&=b\\end{flalign*}$ $\\begin{multline}a\\\\b\\end{multline}$ $\\begin{multline*}a\\\\b\\end{multline*}$';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(
+      '\n$$\n\\begin{flalign}a&=b\\\\c&=d\\end{flalign}\n$$\n \n$$\n\\begin{flalign*}a&=b\\end{flalign*}\n$$\n \n$$\n\\begin{multline}a\\\\b\\end{multline}\n$$\n \n$$\n\\begin{multline*}a\\\\b\\end{multline*}\n$$\n',
+    );
+  });
+
   it('should keep inline-safe environments unchanged', () => {
     const input =
       '$\\begin{aligned}a&=b\\end{aligned}$ $\\begin{alignedat}{2}a&=b\\end{alignedat}$ $\\begin{gathered}a\\\\b\\end{gathered}$ and $x^2$';

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -584,6 +584,20 @@ describe('promoteDisplayOnlyLatex', () => {
     expect(promoteDisplayOnlyLatex(input)).toEqual(input);
   });
 
+  it('should return plain text without math delimiters unchanged', () => {
+    const input = 'Hello, this is a normal message with no math at all.';
+
+    expect(promoteDisplayOnlyLatex(input)).toEqual(input);
+  });
+
+  it('should handle empty string input', () => {
+    expect(promoteDisplayOnlyLatex('')).toEqual('');
+  });
+
+  it('should handle undefined input', () => {
+    expect(promoteDisplayOnlyLatex(undefined as unknown as string)).toEqual('');
+  });
+
   it('should be idempotent', () => {
     const input =
       'Before $\\hat{\\sigma}\\tag{1}$ after and $$\\begin{align}a&=b\\\\c&=d\\end{align}$$';

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -9,8 +9,12 @@ const DISPLAY_ONLY_LATEX_ENVIRONMENTS = [
   'CD',
   'equation',
   'equation*',
+  'flalign',
+  'flalign*',
   'gather',
   'gather*',
+  'multline',
+  'multline*',
   'split',
 ] as const;
 const PROTECTED_MARKDOWN_SEGMENT_PATTERN =

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -14,7 +14,7 @@ const DISPLAY_ONLY_LATEX_ENVIRONMENTS = [
   'split',
 ] as const;
 const PROTECTED_MARKDOWN_SEGMENT_PATTERN =
-  /(```[\s\S]*?```|`[^\n`]*`|(?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|\\\[[\s\S]*?(?<!\\)\\\]|<lobeArtifact\b[^>]*>[\s\S]*?(?:<\/lobeArtifact>|$))/g;
+  /(```[\s\S]*?```|(`{2,})[\s\S]*?\2|`[^\n`]*`|(?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|\\\[[\s\S]*?(?<!\\)\\\]|<lobeArtifact\b[^>]*>[\s\S]*?(?:<\/lobeArtifact>|$))/g;
 
 const escapeRegExp = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const DISPLAY_ONLY_LATEX_ENVIRONMENT_PATTERN = new RegExp(

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -48,14 +48,17 @@ const withProtectedMarkdownSegments = (input: string, transformer: (content: str
   );
 };
 
-export const promoteDisplayOnlyLatex = (input: string = '') =>
-  withProtectedMarkdownSegments(input, (content) =>
+export const promoteDisplayOnlyLatex = (input: string = '') => {
+  if (!input.includes('$') && !input.includes('\\(')) return input;
+
+  return withProtectedMarkdownSegments(input, (content) =>
     content.replaceAll(INLINE_LATEX_PATTERN, (match, parenFormula, dollarFormula) => {
       const formula = parenFormula || dollarFormula;
 
       return shouldPromoteInlineLatex(formula) ? toDisplayMathBlock(formula) : match;
     }),
   );
+};
 
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -1,5 +1,58 @@
 import { ARTIFACT_TAG_REGEX, ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
+const DISPLAY_ONLY_LATEX_COMMAND_PATTERN = /\\tag(?:\*|\b)/;
+const DISPLAY_ONLY_LATEX_ENVIRONMENTS = [
+  'align',
+  'align*',
+  'alignat',
+  'alignat*',
+  'CD',
+  'equation',
+  'equation*',
+  'gather',
+  'gather*',
+  'split',
+] as const;
+const PROTECTED_MARKDOWN_SEGMENT_PATTERN =
+  /(```[\s\S]*?```|`[^\n`]*`|(?<!\\)\$\$[\s\S]*?(?<!\\)\$\$|\\\[[\s\S]*?(?<!\\)\\\]|<lobeArtifact\b[^>]*>[\s\S]*?(?:<\/lobeArtifact>|$))/g;
+
+const escapeRegExp = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const DISPLAY_ONLY_LATEX_ENVIRONMENT_PATTERN = new RegExp(
+  String.raw`\\begin\{(?:${DISPLAY_ONLY_LATEX_ENVIRONMENTS.map(escapeRegExp).join('|')})\}`,
+);
+const INLINE_LATEX_PATTERN = /\\\(([\s\S]*?)(?<!\\)\\\)|(?<!\\)\$(?!\$)([\s\S]+?)(?<!\\)\$(?!\$)/g;
+const PROTECTED_MARKDOWN_PLACEHOLDER_PATTERN = /<<LOBE_MD_PROTECTED_(\d+)>>/g;
+
+const shouldPromoteInlineLatex = (formula: string) =>
+  DISPLAY_ONLY_LATEX_COMMAND_PATTERN.test(formula) ||
+  DISPLAY_ONLY_LATEX_ENVIRONMENT_PATTERN.test(formula);
+
+const toDisplayMathBlock = (formula: string) => `\n$$\n${formula.trim()}\n$$\n`;
+
+const withProtectedMarkdownSegments = (input: string, transformer: (content: string) => string) => {
+  const protectedSegments: string[] = [];
+  const protectedInput = input.replaceAll(PROTECTED_MARKDOWN_SEGMENT_PATTERN, (match) => {
+    const index = protectedSegments.push(match) - 1;
+    return `<<LOBE_MD_PROTECTED_${index}>>`;
+  });
+
+  return transformer(protectedInput).replaceAll(
+    PROTECTED_MARKDOWN_PLACEHOLDER_PATTERN,
+    (_, index) => {
+      return protectedSegments[Number(index)] || '';
+    },
+  );
+};
+
+export const promoteDisplayOnlyLatex = (input: string = '') =>
+  withProtectedMarkdownSegments(input, (content) =>
+    content.replaceAll(INLINE_LATEX_PATTERN, (match, parenFormula, dollarFormula) => {
+      const formula = parenFormula || dollarFormula;
+
+      return shouldPromoteInlineLatex(formula) ? toDisplayMathBlock(formula) : match;
+    }),
+  );
+
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
  */


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
N/A

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
- Promote inline LaTeX to display math when the content uses KaTeX syntax that only works in display mode, including `\tag`, `\tag*`, and display-only environments such as `align`, `alignat`, `gather`, `equation`, `split`, and `CD`.
- Apply the normalization in the conversation markdown wrapper so affected assistant and user messages render without KaTeX parse errors.
- Protect existing display math blocks, inline code, fenced code blocks, and `lobeArtifact` content from being rewritten.
- Add regression coverage for display-only environment promotion, protected content, and idempotent preprocessing.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- Send a message containing inline math with display-only syntax such as `$\\hat{\\sigma}\\tag{1}$` or `$\\begin{align}a&=b\\\\c&=d\\end{align}$` and verify it renders as a block formula instead of showing a KaTeX parse error.
- Verify that inline-safe environments such as `$\\begin{aligned}a&=b\\end{aligned}$` remain unchanged.
- Verify that formulas inside inline code, fenced code blocks, and `lobeArtifact` content are not rewritten.
- Run:
  `pnpm exec vitest run --silent='passed-only' 'src/features/Conversation/utils/markdown.test.ts'`
- Run:
  `NODE_OPTIONS='--max-old-space-size=8192' pnpm exec tsc --noEmit --pretty false --incremental false`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| Inline formulas containing `\tag` or display-only environments could throw KaTeX parse errors and fail to render. | The same formulas are promoted to display math automatically and render correctly in conversation messages. |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
- No breaking changes or migration steps are required.
- This change is limited to the conversation markdown rendering path.

