### PR TITLE
🐛 fix: skip disabled skills from context injection

### DIFF
--- a/packages/context-engine/src/engine/skills/SkillEngine.ts
+++ b/packages/context-engine/src/engine/skills/SkillEngine.ts
@@ -32,16 +32,26 @@ export class SkillEngine {
    */
   generate(pluginIds: string[]): OperationSkillSet {
     const allSkills = Array.from(this.skills.values());
+    const enabledPluginIdSet = new Set(pluginIds);
 
-    const filteredSkills = this.enableChecker
-      ? allSkills.filter((skill) => {
-          const enabled = this.enableChecker!(skill);
-          if (!enabled) {
-            log('Skill filtered out by enableChecker: %s', skill.identifier);
-          }
-          return enabled;
-        })
-      : allSkills;
+    const filteredSkills = allSkills.filter((skill) => {
+      // Only include skills that are enabled by the agent (present in pluginIds)
+      if (!enabledPluginIdSet.has(skill.identifier)) {
+        log('Skill filtered out (not in pluginIds): %s', skill.identifier);
+        return false;
+      }
+
+      // Then apply platform/environment enableChecker if provided
+      if (this.enableChecker) {
+        const enabled = this.enableChecker(skill);
+        if (!enabled) {
+          log('Skill filtered out by enableChecker: %s', skill.identifier);
+          return false;
+        }
+      }
+
+      return true;
+    });
 
     log(
       'Generated OperationSkillSet: %d/%d skills, pluginIds=%o',

--- a/packages/context-engine/src/engine/skills/__tests__/SkillEngine.test.ts
+++ b/packages/context-engine/src/engine/skills/__tests__/SkillEngine.test.ts
@@ -23,24 +23,33 @@ describe('SkillEngine', () => {
     },
   ];
 
-  it('should include all skills when no enableChecker is provided', () => {
+  it('should only include skills whose identifier is in pluginIds', () => {
     const engine = new SkillEngine({ skills: rawSkills });
     const result = engine.generate(['artifacts']);
 
-    expect(result.skills).toHaveLength(3);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].identifier).toBe('artifacts');
     expect(result.enabledPluginIds).toEqual(['artifacts']);
   });
 
-  it('should filter skills via enableChecker', () => {
+  it('should return no skills when pluginIds is empty', () => {
+    const engine = new SkillEngine({ skills: rawSkills });
+    const result = engine.generate([]);
+
+    expect(result.skills).toHaveLength(0);
+  });
+
+  it('should filter skills via enableChecker after pluginIds filter', () => {
     const desktopOnlySkills = new Set(['agent-browser']);
     const engine = new SkillEngine({
       enableChecker: (skill) => !desktopOnlySkills.has(skill.identifier),
       skills: rawSkills,
     });
 
-    const result = engine.generate([]);
+    const result = engine.generate(['artifacts', 'agent-browser']);
 
-    expect(result.skills).toHaveLength(2);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].identifier).toBe('artifacts');
     expect(result.skills.find((s) => s.identifier === 'agent-browser')).toBeUndefined();
   });
 
@@ -49,11 +58,12 @@ describe('SkillEngine', () => {
     const result = engine.generate(['artifacts', 'lobehub-cli']);
 
     expect(result.enabledPluginIds).toEqual(['artifacts', 'lobehub-cli']);
+    expect(result.skills).toHaveLength(2);
   });
 
   it('should preserve skill content in output', () => {
     const engine = new SkillEngine({ skills: rawSkills });
-    const result = engine.generate([]);
+    const result = engine.generate(['artifacts']);
 
     const artifacts = result.skills.find((s) => s.identifier === 'artifacts');
     expect(artifacts?.content).toBe('<artifacts_guide>...</artifacts_guide>');

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -642,7 +642,7 @@ export const contextEngineering = async ({
     initialContext,
     stepContext,
 
-    // Skills configuration — expose all installed skills so the AI can discover and activate them
+    // Skills configuration — only expose agent-enabled skills (filtered by pluginIds in SkillEngine)
     skillsConfig: {
       enabledSkills: plugins ? resolveClientSkills(plugins).skills : undefined,
     },


### PR DESCRIPTION

#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #13363

#### 🔀 Description of Change

`SkillEngine.generate()` was returning **all** registered skills regardless of whether the user had enabled them on the agent. The `pluginIds` (the agent's enabled plugins) were only used downstream to mark skills as "activated" (injecting full content), but non-activated skills were still listed as `<available_skills>` in the system prompt — wasting ~11.6k tokens even when the user had explicitly disabled those skills.

**Fix:** Filter `skills` in `SkillEngine.generate()` to only include skills whose `identifier` is present in `pluginIds`. Skills the user hasn't enabled are excluded entirely before reaching `SkillContextProvider`.

**Problem chain:**

```
User disables skill → agent's plugins list does not contain the skill ID
        ↓
SkillEngine.generate(pluginIds) → returned ALL skills anyway
        ↓
SkillResolver marks non-matching skills as non-activated
        ↓
SkillContextProvider injects them as <available_skills> list
        ↓
~11.6k tokens wasted per request
```

**Files changed:**
- `packages/context-engine/src/engine/skills/SkillEngine.ts` — core fix: filter by `pluginIds` first, then apply `enableChecker` as a second-pass platform filter
- `packages/context-engine/src/engine/skills/__tests__/SkillEngine.test.ts` — updated tests to reflect new behavior
- `src/services/chat/mecha/contextEngineering.ts` — corrected misleading comment

#### 🧪 How to Test

- [x] Added/updated tests

1. Enable only one skill (e.g. Artifacts) on an agent, disable the rest
2. Send a message — verify the system prompt only contains the enabled skill, not all installed skills
3. Run unit tests: `npx vitest run "SkillEngine"` in `packages/context-engine`

#### 📸 Screenshots / Videos

N/A — prompt/token reduction, no UI changes.

#### 📝 Additional Information

- The `enableChecker` (platform filtering, e.g. desktop-only `agent-browser`) is preserved as a second-pass filter after the `pluginIds` check.
- `SkillResolver` is unaffected — it still correctly handles step-level dynamic skill activations (`activateSkill` tool calls) for skills that are in the operation set.
- Token savings: up to ~11.6k tokens per request for users who have disabled built-in skills.
