### PR TITLE
🐛 fix(markdown): prevent literal reserved tags from rendering as special blocks

### DIFF
--- a/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts
@@ -215,4 +215,47 @@ describe('rehypePlugin', () => {
     expect((tree.children[0] as any).tagName).toBe('lobeArtifact');
     expect((tree.children[1] as any).tagName).toBe('lobeArtifact');
   });
+
+  it('should keep inline literal artifact tags untouched when they are not leading content', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [
+            { type: 'text', value: 'Literal example ' },
+            {
+              type: 'raw',
+              value: '<lobeArtifact identifier="demo" type="text/plain" title="Demo">',
+            },
+            { type: 'text', value: 'body' },
+            { type: 'raw', value: '</lobeArtifact>' },
+          ],
+        },
+      ],
+    };
+
+    const plugin = rehypePlugin();
+    plugin(tree);
+
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          children: [
+            { type: 'text', value: 'Literal example ' },
+            {
+              type: 'raw',
+              value: '<lobeArtifact identifier="demo" type="text/plain" title="Demo">',
+            },
+            { type: 'text', value: 'body' },
+            { type: 'raw', value: '</lobeArtifact>' },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.ts
@@ -2,6 +2,17 @@ import { SKIP, visit } from 'unist-util-visit';
 
 import { ARTIFACT_TAG } from '@/const/plugin';
 
+const nodeToText = (node: any): string => {
+  if (!node || typeof node !== 'object') return '';
+  if (node.type === 'raw' || node.type === 'text') return String(node.value || '');
+  if (!Array.isArray(node.children)) return '';
+
+  return node.children.map(nodeToText).join('');
+};
+
+const isLeadingNodePosition = (parent: any, index: number) =>
+  nodeToText({ children: parent.children.slice(0, index), type: 'root' }).trim() === '';
+
 function rehypeAntArtifact() {
   return (tree: any) => {
     visit(tree, (node, index, parent) => {
@@ -55,6 +66,8 @@ function rehypeAntArtifact() {
       //     '<lobeArtifact identifier="ai-new-interpretation" type="image/svg+xml" title="New AI Interpretation">',
       // }
       else if (node.type === 'raw' && node.value.startsWith(`<${ARTIFACT_TAG}`)) {
+        if (!parent || index === undefined || !isLeadingNodePosition(parent, index)) return;
+
         // Create new lobeArtifact node
         const newNode = {
           children: [],

--- a/src/features/Conversation/Markdown/plugins/LobeThinking/index.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeThinking/index.ts
@@ -6,7 +6,7 @@ import Component from './Render';
 
 const LobeThinkingElement: MarkdownElement = {
   Component,
-  remarkPlugin: createRemarkCustomTagPlugin(ARTIFACT_THINKING_TAG),
+  remarkPlugin: createRemarkCustomTagPlugin(ARTIFACT_THINKING_TAG, { position: 'leading' }),
   scope: 'assistant',
   tag: ARTIFACT_THINKING_TAG,
 };

--- a/src/features/Conversation/Markdown/plugins/Thinking/index.ts
+++ b/src/features/Conversation/Markdown/plugins/Thinking/index.ts
@@ -6,7 +6,7 @@ import Component from './Render';
 
 const ThinkingElement: MarkdownElement = {
   Component,
-  remarkPlugin: createRemarkCustomTagPlugin(THINKING_TAG),
+  remarkPlugin: createRemarkCustomTagPlugin(THINKING_TAG, { position: 'leading' }),
   scope: 'assistant',
   tag: THINKING_TAG,
 };

--- a/src/features/Conversation/Markdown/plugins/index.test.ts
+++ b/src/features/Conversation/Markdown/plugins/index.test.ts
@@ -1,0 +1,9 @@
+import { THINKING_TAG } from '@/const/plugin';
+
+import { markdownElements } from './index';
+
+describe('markdownElements', () => {
+  it('should not register raw think tag rendering in conversation markdown', () => {
+    expect(markdownElements.map((element) => element.tag)).not.toContain(THINKING_TAG);
+  });
+});

--- a/src/features/Conversation/Markdown/plugins/index.ts
+++ b/src/features/Conversation/Markdown/plugins/index.ts
@@ -3,13 +3,11 @@ import LobeArtifact from './LobeArtifact';
 import LobeThinking from './LobeThinking';
 import LocalFile from './LocalFile';
 import Mention from './Mention';
-import Thinking from './Thinking';
 import { type MarkdownElement } from './type';
 
 export type { MarkdownElement } from './type';
 
 export const markdownElements: MarkdownElement[] = [
-  Thinking,
   LobeArtifact,
   LobeThinking,
   LocalFile,

--- a/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkCustomTagPlugin.test.ts
+++ b/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkCustomTagPlugin.test.ts
@@ -1,0 +1,65 @@
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { describe, expect, it } from 'vitest';
+
+import { createRemarkCustomTagPlugin } from './createRemarkCustomTagPlugin';
+
+const processMarkdown = (
+  markdown: string,
+  tagName: string,
+  options?: Parameters<typeof createRemarkCustomTagPlugin>[1],
+) => {
+  const processor = unified().use(remarkParse).use(createRemarkCustomTagPlugin(tagName, options));
+
+  const tree = processor.parse(markdown);
+  return processor.runSync(tree);
+};
+
+const collectNodesByType = (tree: any, type: string) => {
+  const nodes: any[] = [];
+
+  const walk = (node: any) => {
+    if (!node || typeof node !== 'object') return;
+    if (node.type === type) nodes.push(node);
+
+    const { children } = node as { children?: any[] };
+    if (!Array.isArray(children)) return;
+
+    for (const child of children) {
+      walk(child);
+    }
+  };
+
+  walk(tree);
+  return nodes;
+};
+
+describe('createRemarkCustomTagPlugin', () => {
+  it('should replace leading think blocks when restricted to leading position', () => {
+    const tree = processMarkdown('<think>Thinking</think>\n\nAnswer', 'think', {
+      position: 'leading',
+    });
+
+    const thinkNodes = collectNodesByType(tree, 'thinkBlock');
+
+    expect(thinkNodes).toHaveLength(1);
+    expect(thinkNodes[0].data?.hName).toBe('think');
+    expect(thinkNodes[0].data?.hChildren).toEqual([{ type: 'text', value: 'Thinking' }]);
+  });
+
+  it('should keep inline literal think tags as regular markdown when restricted to leading position', () => {
+    const markdown = 'The model literally prints <think>example</think> in the answer.';
+    const tree = processMarkdown(markdown, 'think', { position: 'leading' });
+    const root = tree as unknown as { children: Array<{ type: string }> };
+
+    expect(collectNodesByType(tree, 'thinkBlock')).toHaveLength(0);
+    expect(root.children[0].type).toBe('paragraph');
+  });
+
+  it('should preserve default behavior for non-leading custom tags', () => {
+    const markdown = 'Intro <lobeThinking>artifact planning</lobeThinking> outro';
+    const tree = processMarkdown(markdown, 'lobeThinking');
+
+    expect(collectNodesByType(tree, 'lobeThinkingBlock')).toHaveLength(1);
+  });
+});

--- a/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkCustomTagPlugin.ts
+++ b/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkCustomTagPlugin.ts
@@ -1,12 +1,26 @@
+import type { Parent } from 'unist';
 import { SKIP, visit } from 'unist-util-visit';
 
 import { treeNodeToString } from './getNodeContent';
 
-export const createRemarkCustomTagPlugin = (tag: string) => () => {
-  return (tree: any) => {
-    visit(tree, 'html', (node, index, parent) => {
-      if (node.value === `<${tag}>`) {
+interface CreateRemarkCustomTagPluginOptions {
+  position?: 'any' | 'leading';
+}
+
+const isLeadingTagPosition = (parent: Parent, startIndex: number) =>
+  treeNodeToString(parent.children.slice(0, startIndex) as Parent[]).trim() === '';
+
+export const createRemarkCustomTagPlugin =
+  (tag: string, { position = 'any' }: CreateRemarkCustomTagPluginOptions = {}) =>
+  () => {
+    return (tree: any) => {
+      visit(tree, 'html', (node, index, parent) => {
+        if (!parent || index === undefined || index === null || node.value !== `<${tag}>`) return;
+
         const startIndex = index as number;
+
+        if (position === 'leading' && !isLeadingTagPosition(parent as Parent, startIndex)) return;
+
         let endIndex = startIndex + 1;
         let hasCloseTag = false;
 
@@ -31,11 +45,8 @@ export const createRemarkCustomTagPlugin = (tag: string) => () => {
           hasCloseTag ? endIndex : undefined,
         );
 
-        // Convert to Markdown string
-
         const content = treeNodeToString(contentNodes);
 
-        // Create custom node
         const customNode = {
           data: {
             hChildren: [{ type: 'text', value: content }],
@@ -45,12 +56,9 @@ export const createRemarkCustomTagPlugin = (tag: string) => () => {
           type: `${tag}Block`,
         };
 
-        // Replace the original nodes
         parent.children.splice(startIndex, deleteCount, customNode);
 
-        // Skip already-processed nodes
         return [SKIP, startIndex + 1];
-      }
-    });
+      });
+    };
   };
-};

--- a/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkSelfClosingTagPlugin.test.ts
+++ b/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkSelfClosingTagPlugin.test.ts
@@ -246,9 +246,8 @@ describe('createRemarkSelfClosingTagPlugin', () => {
     const tree = processMarkdown(markdown, tagName);
     const localFiles = collectNodesByType(tree, tagName);
 
-    expect(localFiles).toHaveLength(8);
+    expect(localFiles).toHaveLength(7);
     expect(localFiles.map((n) => n.data?.hProperties?.name)).toEqual([
-      'Desktop',
       'CleanShot 2025-12-17 at 17.56.33@2x.jpg',
       'CleanShot 2025-12-17 at 17.56.39@2x.jpg',
       'CleanShot 2025-12-17 at 21.49.12@2x.jpg',
@@ -333,13 +332,9 @@ describe('createRemarkSelfClosingTagPlugin', () => {
     expect(paragraphChildren[0].type).toBe('text');
     expect(paragraphChildren[0].value).toBe('Use this file: ');
 
-    // The tag should be parsed even inside backticks
-    const tagNode = paragraphChildren[1];
-    expect(tagNode.type).toBe(tagName);
-    expect(tagNode.data?.hProperties).toEqual({
-      name: 'config.json',
-      path: '/app/config.json',
-    });
+    const inlineCodeNode = paragraphChildren[1];
+    expect(inlineCodeNode.type).toBe('inlineCode');
+    expect(inlineCodeNode.value).toBe(`<${tagName} name="config.json" path="/app/config.json" />`);
 
     expect(paragraphChildren[2].type).toBe('text');
     expect(paragraphChildren[2].value).toBe(' in your code.');

--- a/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkSelfClosingTagPlugin.ts
+++ b/src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkSelfClosingTagPlugin.ts
@@ -188,38 +188,5 @@ export const createRemarkSelfClosingTagPlugin =
           return [SKIP, index + newChildren.length]; // Skip new nodes
         }
       });
-
-      // 3. Visit inlineCode nodes (backtick-wrapped tags like `<localFile ... />`)
-      // @ts-ignore
-      visit(tree, 'inlineCode', (node: any, index: number, parent) => {
-        log('>>> Visiting inlineCode node: "%s"', node.value);
-
-        if (
-          !parent ||
-          typeof index !== 'number' ||
-          typeof node.value !== 'string' ||
-          !node.value.toLowerCase().includes(`<${tagName.toLowerCase()}`)
-        ) {
-          return;
-        }
-
-        const match = node.value.match(exactTagRegex);
-        if (match) {
-          const [, attributesString] = match;
-          const properties = attributesString ? parseAttributes(attributesString.trim()) : {};
-
-          const newNode = {
-            data: {
-              hName: tagName,
-              hProperties: properties,
-            },
-            type: tagName,
-          };
-
-          log('Replacing inlineCode node at index %d with %s node: %o', index, tagName, newNode);
-          parent.children.splice(index, 1, newNode);
-          return [SKIP, index + 1];
-        }
-      });
     };
   };

--- a/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
@@ -9,7 +9,7 @@ import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPorta
 import { ChatItem } from '@/features/Conversation/ChatItem';
 import ErrorMessageExtra, { useErrorContent } from '@/features/Conversation/Error';
 import { AssistantMessageExtra } from '@/features/Conversation/Messages/Assistant/Extra';
-import { normalizeThinkTags, processWithArtifact } from '@/features/Conversation/utils/markdown';
+import { processWithArtifact } from '@/features/Conversation/utils/markdown';
 import { type UIChatMessage } from '@/types/index';
 
 import { useAgentMeta } from '../../../hooks';
@@ -50,7 +50,7 @@ const CouncilMember = memo<CouncilMemberProps>(({ item, index }) => {
   const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const errorContent = useErrorContent(error);
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
+  const message = !editing ? processWithArtifact(content) : content;
 
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
   const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();

--- a/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
@@ -50,7 +50,7 @@ const CouncilMember = memo<CouncilMemberProps>(({ item, index }) => {
   const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const errorContent = useErrorContent(error);
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
+  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
 
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
   const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();

--- a/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/CouncilMember.tsx
@@ -50,7 +50,7 @@ const CouncilMember = memo<CouncilMemberProps>(({ item, index }) => {
   const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const errorContent = useErrorContent(error);
-  const message = !editing ? processWithArtifact(content) : content;
+  const message = !editing ? processWithArtifact(content, generating) : content;
 
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
   const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();

--- a/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Assistant/components/MessageContent.tsx
@@ -80,6 +80,7 @@ const MessageContent = memo<UIChatMessage>(
           content={content}
           hasImages={showImageItems}
           id={id}
+          isGenerating={generating}
           isMultimodal={metadata?.isMultimodal}
           isToolCallGenerating={isToolCallGenerating}
           markdownProps={markdownProps}

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -72,7 +72,7 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
     );
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
+  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -13,7 +13,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 import ErrorMessageExtra, { useErrorContent } from '../../Error';
 import { useAgentMeta, useDoubleClickEdit } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-import { normalizeThinkTags, processWithArtifact } from '../../utils/markdown';
+import { processWithArtifact } from '../../utils/markdown';
 import MessageBranch from '../components/MessageBranch';
 import {
   useSetMessageItemActionElementPortialContext,
@@ -72,7 +72,7 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
     );
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
+  const message = !editing ? processWithArtifact(content) : content;
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -72,7 +72,7 @@ const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditin
     );
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? processWithArtifact(content) : content;
+  const message = !editing ? processWithArtifact(content, generating) : content;
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
   const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();

--- a/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
@@ -41,6 +41,11 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
     [content, generating, isLocalSystemEnabled, search?.imageResults?.length, tools],
   );
 
+  // Derive a stable key from the set of active tags so that plugins/components
+  // only get recreated when the *set* of enabled elements changes, not on every
+  // content token during streaming.
+  const activeTagsKey = activeMarkdownElements.map((e) => e.tag).join(',');
+
   const components = useMemo(
     () =>
       Object.fromEntries(
@@ -49,16 +54,19 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
           return [element.tag, (props: any) => <Component {...props} id={id} />];
         }),
       ),
-    [activeMarkdownElements, id],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeTagsKey, id],
   );
 
   const rehypePlugins = useMemo(
     () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
-    [activeMarkdownElements],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeTagsKey],
   );
   const remarkPlugins = useMemo(
     () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
-    [activeMarkdownElements],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeTagsKey],
   );
 
   return useMemo(

--- a/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
@@ -5,11 +5,14 @@ import isEqual from 'fast-deep-equal';
 import { useMemo } from 'react';
 
 import { HtmlPreviewAction } from '@/components/HtmlPreview';
+import { useAgentStore } from '@/store/agent';
+import { agentChatConfigSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
+import { getActiveAssistantMarkdownElements } from '../../utils/markdown';
 
 const isHtmlCode = (content: string, language: string) => {
   return (
@@ -21,29 +24,41 @@ const isHtmlCode = (content: string, language: string) => {
 
 export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const item = useConversationStore(dataSelectors.getDbMessageById(id), isEqual)!;
-  const { role, search } = item || {};
+  const { content, search, tools } = item || {};
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
+  const isLocalSystemEnabled = useAgentStore(agentChatConfigSelectors.isLocalSystemEnabled);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const animated = transitionMode === 'fadeIn' && generating;
+  const activeMarkdownElements = useMemo(
+    () =>
+      getActiveAssistantMarkdownElements(markdownElements, {
+        content,
+        hasImageSearchResults: !!search?.imageResults?.length,
+        isGenerating: generating,
+        isLocalSystemEnabled,
+        tools,
+      }),
+    [content, generating, isLocalSystemEnabled, search?.imageResults?.length, tools],
+  );
 
   const components = useMemo(
     () =>
       Object.fromEntries(
-        markdownElements.map((element) => {
+        activeMarkdownElements.map((element) => {
           const Component = element.Component;
           return [element.tag, (props: any) => <Component {...props} id={id} />];
         }),
       ),
-    [id],
+    [activeMarkdownElements, id],
   );
 
   const rehypePlugins = useMemo(
-    () => markdownElements.map((element) => element.rehypePlugin).filter(Boolean),
-    [],
+    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [activeMarkdownElements],
   );
   const remarkPlugins = useMemo(
-    () => markdownElements.map((element) => element.remarkPlugin).filter(Boolean),
-    [],
+    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [activeMarkdownElements],
   );
 
   return useMemo(
@@ -76,6 +91,6 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
           // if the citations's url and title are all the same, we should not show the citations
           search?.citations.every((item) => item.title !== item.url),
       }) satisfies Partial<MarkdownProps>,
-    [animated, components, rehypePlugins, remarkPlugins, role, search],
+    [animated, components, rehypePlugins, remarkPlugins, search],
   );
 };

--- a/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
@@ -5,14 +5,13 @@ import isEqual from 'fast-deep-equal';
 import { useMemo } from 'react';
 
 import { HtmlPreviewAction } from '@/components/HtmlPreview';
+import { THINKING_TAG } from '@/const/plugin';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-
-const rehypePlugins = markdownElements.map((element) => element.rehypePlugin).filter(Boolean);
-const remarkPlugins = markdownElements.map((element) => element.remarkPlugin).filter(Boolean);
+import { shouldProcessThinkTags } from '../../utils/markdown';
 
 const isHtmlCode = (content: string, language: string) => {
   return (
@@ -28,6 +27,13 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const animated = transitionMode === 'fadeIn' && generating;
+  const shouldEnableThinkTag = shouldProcessThinkTags(item?.content, generating);
+
+  const activeMarkdownElements = useMemo(
+    () =>
+      markdownElements.filter((element) => element.tag !== THINKING_TAG || shouldEnableThinkTag),
+    [shouldEnableThinkTag],
+  );
 
   const components = useMemo(
     () =>
@@ -38,6 +44,15 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
         }),
       ),
     [id],
+  );
+
+  const rehypePlugins = useMemo(
+    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [activeMarkdownElements],
+  );
+  const remarkPlugins = useMemo(
+    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [activeMarkdownElements],
   );
 
   return useMemo(
@@ -70,6 +85,6 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
           // if the citations's url and title are all the same, we should not show the citations
           search?.citations.every((item) => item.title !== item.url),
       }) satisfies Partial<MarkdownProps>,
-    [animated, components, role, search],
+    [animated, components, rehypePlugins, remarkPlugins, role, search],
   );
 };

--- a/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
@@ -5,13 +5,11 @@ import isEqual from 'fast-deep-equal';
 import { useMemo } from 'react';
 
 import { HtmlPreviewAction } from '@/components/HtmlPreview';
-import { THINKING_TAG } from '@/const/plugin';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-import { shouldProcessThinkTags } from '../../utils/markdown';
 
 const isHtmlCode = (content: string, language: string) => {
   return (
@@ -27,13 +25,6 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const animated = transitionMode === 'fadeIn' && generating;
-  const shouldEnableThinkTag = shouldProcessThinkTags(item?.content, generating);
-
-  const activeMarkdownElements = useMemo(
-    () =>
-      markdownElements.filter((element) => element.tag !== THINKING_TAG || shouldEnableThinkTag),
-    [shouldEnableThinkTag],
-  );
 
   const components = useMemo(
     () =>
@@ -47,12 +38,12 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   );
 
   const rehypePlugins = useMemo(
-    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
-    [activeMarkdownElements],
+    () => markdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [],
   );
   const remarkPlugins = useMemo(
-    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
-    [activeMarkdownElements],
+    () => markdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [],
   );
 
   return useMemo(

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -26,7 +26,7 @@ interface ContentBlockProps {
 const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirstBlock }) => {
   const markdownProps = useMarkdown(id);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
-  const message = processWithArtifact(content);
+  const message = processWithArtifact(content, generating);
 
   if (!content && !hasTools) return <ContentLoading id={id} />;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -6,7 +6,7 @@ import MarkdownMessage from '@/features/Conversation/Markdown';
 import ContentLoading from '@/features/Conversation/Messages/components/ContentLoading';
 
 import { messageStateSelectors, useConversationStore } from '../../../store';
-import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
+import { processWithArtifact } from '../../../utils/markdown';
 import { useMarkdown } from '../useMarkdown';
 
 const styles = createStaticStyles(({ css, cssVar }) => {
@@ -26,7 +26,7 @@ interface ContentBlockProps {
 const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirstBlock }) => {
   const markdownProps = useMarkdown(id);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
-  const message = normalizeThinkTags(processWithArtifact(content), generating);
+  const message = processWithArtifact(content);
 
   if (!content && !hasTools) return <ContentLoading id={id} />;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -5,6 +5,7 @@ import { LOADING_FLAT } from '@/const/message';
 import MarkdownMessage from '@/features/Conversation/Markdown';
 import ContentLoading from '@/features/Conversation/Messages/components/ContentLoading';
 
+import { messageStateSelectors, useConversationStore } from '../../../store';
 import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
 import { useMarkdown } from '../useMarkdown';
 
@@ -23,8 +24,9 @@ interface ContentBlockProps {
 }
 
 const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id, isFirstBlock }) => {
-  const message = normalizeThinkTags(processWithArtifact(content));
   const markdownProps = useMarkdown(id);
+  const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
+  const message = normalizeThinkTags(processWithArtifact(content), generating);
 
   if (!content && !hasTools) return <ContentLoading id={id} />;
 

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -1,25 +1,28 @@
 import { type MarkdownProps } from '@lobehub/ui';
 import { useMemo } from 'react';
 
+import { THINKING_TAG } from '@/const/plugin';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { type MarkdownElement } from '../../Markdown/plugins';
 import { markdownElements } from '../../Markdown/plugins';
-import { messageStateSelectors, useConversationStore } from '../../store';
-
-const rehypePlugins = markdownElements
-  .map((element: MarkdownElement) => element.rehypePlugin)
-  .filter(Boolean);
-const remarkPlugins = markdownElements
-  .map((element: MarkdownElement) => element.remarkPlugin)
-  .filter(Boolean);
+import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
+import { shouldProcessThinkTags } from '../../utils/markdown';
 
 export const useMarkdown = (id: string): Partial<MarkdownProps> => {
+  const item = useConversationStore(dataSelectors.getDbMessageById(id));
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
   const animated = transitionMode === 'fadeIn' && generating;
+  const shouldEnableThinkTag = shouldProcessThinkTags(item?.content, generating);
+
+  const activeMarkdownElements = useMemo(
+    () =>
+      markdownElements.filter((element) => element.tag !== THINKING_TAG || shouldEnableThinkTag),
+    [shouldEnableThinkTag],
+  );
 
   const components = useMemo(
     () =>
@@ -32,6 +35,16 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
       ),
     [id],
   );
+
+  const rehypePlugins = useMemo(
+    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [activeMarkdownElements],
+  );
+  const remarkPlugins = useMemo(
+    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [activeMarkdownElements],
+  );
+
   return useMemo(
     () =>
       ({
@@ -42,6 +55,6 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
         rehypePlugins,
         remarkPlugins,
       }) satisfies Partial<MarkdownProps>,
-    [animated, components],
+    [animated, components, rehypePlugins, remarkPlugins],
   );
 };

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -1,39 +1,55 @@
 import { type MarkdownProps } from '@lobehub/ui';
 import { useMemo } from 'react';
 
+import { useAgentStore } from '@/store/agent';
+import { agentChatConfigSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { type MarkdownElement } from '../../Markdown/plugins';
 import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
+import { getActiveAssistantMarkdownElements } from '../../utils/markdown';
 
 export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const item = useConversationStore(dataSelectors.getDbMessageById(id));
+  const { content, search, tools } = item || {};
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
+  const isLocalSystemEnabled = useAgentStore(agentChatConfigSelectors.isLocalSystemEnabled);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
   const animated = transitionMode === 'fadeIn' && generating;
+  const activeMarkdownElements = useMemo(
+    () =>
+      getActiveAssistantMarkdownElements(markdownElements, {
+        content,
+        hasImageSearchResults: !!search?.imageResults?.length,
+        isGenerating: generating,
+        isLocalSystemEnabled,
+        tools,
+      }),
+    [content, generating, isLocalSystemEnabled, search?.imageResults?.length, tools],
+  );
 
   const components = useMemo(
     () =>
       Object.fromEntries(
-        markdownElements.map((element: MarkdownElement) => {
+        activeMarkdownElements.map((element: MarkdownElement) => {
           const Component = element.Component;
 
           return [element.tag, (props: any) => <Component {...props} id={id} />];
         }),
       ),
-    [id],
+    [activeMarkdownElements, id],
   );
 
   const rehypePlugins = useMemo(
-    () => markdownElements.map((element) => element.rehypePlugin).filter(Boolean),
-    [],
+    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [activeMarkdownElements],
   );
   const remarkPlugins = useMemo(
-    () => markdownElements.map((element) => element.remarkPlugin).filter(Boolean),
-    [],
+    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [activeMarkdownElements],
   );
 
   return useMemo(

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -1,14 +1,12 @@
 import { type MarkdownProps } from '@lobehub/ui';
 import { useMemo } from 'react';
 
-import { THINKING_TAG } from '@/const/plugin';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { type MarkdownElement } from '../../Markdown/plugins';
 import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-import { shouldProcessThinkTags } from '../../utils/markdown';
 
 export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const item = useConversationStore(dataSelectors.getDbMessageById(id));
@@ -16,13 +14,6 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
   const animated = transitionMode === 'fadeIn' && generating;
-  const shouldEnableThinkTag = shouldProcessThinkTags(item?.content, generating);
-
-  const activeMarkdownElements = useMemo(
-    () =>
-      markdownElements.filter((element) => element.tag !== THINKING_TAG || shouldEnableThinkTag),
-    [shouldEnableThinkTag],
-  );
 
   const components = useMemo(
     () =>
@@ -37,12 +28,12 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
   );
 
   const rehypePlugins = useMemo(
-    () => activeMarkdownElements.map((element) => element.rehypePlugin).filter(Boolean),
-    [activeMarkdownElements],
+    () => markdownElements.map((element) => element.rehypePlugin).filter(Boolean),
+    [],
   );
   const remarkPlugins = useMemo(
-    () => activeMarkdownElements.map((element) => element.remarkPlugin).filter(Boolean),
-    [activeMarkdownElements],
+    () => markdownElements.map((element) => element.remarkPlugin).filter(Boolean),
+    [],
   );
 
   return useMemo(

--- a/src/features/Conversation/Messages/Task/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/Task/components/MessageContent.tsx
@@ -58,6 +58,7 @@ const MessageContent = memo<UIChatMessage>(
             content={content}
             hasImages={showImageItems}
             id={id}
+            isGenerating={generating}
             isMultimodal={metadata?.isMultimodal}
             isToolCallGenerating={isToolCallGenerating}
             markdownProps={markdownProps}

--- a/src/features/Conversation/Messages/Task/index.tsx
+++ b/src/features/Conversation/Messages/Task/index.tsx
@@ -46,7 +46,7 @@ const TaskMessage = memo<TaskMessageProps>(({ id, index, disableEditing }) => {
   const errorContent = useErrorContent(error);
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? processWithArtifact(content) : content;
+  const message = !editing ? processWithArtifact(content, generating) : content;
 
   const isInbox = useAgentStore(builtinAgentSelectors.isInboxAgent);
   const [toggleSystemRole] = useGlobalStore((s) => [s.toggleSystemRole]);
@@ -58,7 +58,7 @@ const TaskMessage = memo<TaskMessageProps>(({ id, index, disableEditing }) => {
     } else {
       openChatSettings();
     }
-  }, [isInbox]);
+  }, [isInbox, openChatSettings, toggleSystemRole]);
 
   const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
 

--- a/src/features/Conversation/Messages/Task/index.tsx
+++ b/src/features/Conversation/Messages/Task/index.tsx
@@ -16,7 +16,7 @@ import { useGlobalStore } from '@/store/global';
 import ErrorMessageExtra, { useErrorContent } from '../../Error';
 import { useAgentMeta, useDoubleClickEdit } from '../../hooks';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
-import { normalizeThinkTags, processWithArtifact } from '../../utils/markdown';
+import { processWithArtifact } from '../../utils/markdown';
 import { AssistantActionsBar } from './Actions';
 import ClientTaskDetail from './ClientTaskDetail';
 import TaskDetailPanel from './TaskDetailPanel';
@@ -46,7 +46,7 @@ const TaskMessage = memo<TaskMessageProps>(({ id, index, disableEditing }) => {
   const errorContent = useErrorContent(error);
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
+  const message = !editing ? processWithArtifact(content) : content;
 
   const isInbox = useAgentStore(builtinAgentSelectors.isInboxAgent);
   const [toggleSystemRole] = useGlobalStore((s) => [s.toggleSystemRole]);

--- a/src/features/Conversation/Messages/Task/index.tsx
+++ b/src/features/Conversation/Messages/Task/index.tsx
@@ -46,7 +46,7 @@ const TaskMessage = memo<TaskMessageProps>(({ id, index, disableEditing }) => {
   const errorContent = useErrorContent(error);
 
   // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
+  const message = !editing ? normalizeThinkTags(processWithArtifact(content), generating) : content;
 
   const isInbox = useAgentStore(builtinAgentSelectors.isInboxAgent);
   const [toggleSystemRole] = useGlobalStore((s) => [s.toggleSystemRole]);

--- a/src/features/Conversation/Messages/components/DisplayContent.test.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DisplayContent from './DisplayContent';
+
+vi.mock('@/features/Conversation/Markdown', () => ({
+  default: ({ children }: any) => (
+    <div data-content={children} data-testid="markdown-message">
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('./ContentLoading', () => ({
+  default: ({ id }: { id: string }) => <div data-testid="content-loading">{id}</div>,
+}));
+
+vi.mock('./RichContentRenderer', () => ({
+  RichContentRenderer: () => <div data-testid="rich-content" />,
+}));
+
+describe('DisplayContent', () => {
+  it('should keep literal think tags in markdown content unchanged', () => {
+    const content = '<think>Reasoning example</think>\n\nFinal answer';
+
+    render(<DisplayContent content={content} id={'msg-1'} />);
+
+    expect(screen.getByTestId('markdown-message')).toHaveAttribute('data-content', content);
+  });
+});

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -5,7 +5,7 @@ import { memo } from 'react';
 import { LOADING_FLAT } from '@/const/message';
 import MarkdownMessage from '@/features/Conversation/Markdown';
 
-import { normalizeThinkTags, processWithArtifact } from '../../utils/markdown';
+import { processWithArtifact } from '../../utils/markdown';
 import ContentLoading from './ContentLoading';
 import { RichContentRenderer } from './RichContentRenderer';
 
@@ -30,7 +30,7 @@ const DisplayContent = memo<{
     id,
     isGenerating,
   }) => {
-    const message = normalizeThinkTags(processWithArtifact(content), isGenerating);
+    const message = processWithArtifact(content);
     if (isToolCallGenerating) return;
 
     if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -14,6 +14,7 @@ const DisplayContent = memo<{
   content: string;
   hasImages?: boolean;
   id: string;
+  isGenerating?: boolean;
   isMultimodal?: boolean;
   isToolCallGenerating?: boolean;
   markdownProps?: Omit<MarkdownProps, 'className' | 'style' | 'children'>;
@@ -27,8 +28,9 @@ const DisplayContent = memo<{
     isMultimodal,
     tempDisplayContent,
     id,
+    isGenerating,
   }) => {
-    const message = normalizeThinkTags(processWithArtifact(content));
+    const message = normalizeThinkTags(processWithArtifact(content), isGenerating);
     if (isToolCallGenerating) return;
 
     if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;

--- a/src/features/Conversation/Messages/components/DisplayContent.tsx
+++ b/src/features/Conversation/Messages/components/DisplayContent.tsx
@@ -30,7 +30,7 @@ const DisplayContent = memo<{
     id,
     isGenerating,
   }) => {
-    const message = processWithArtifact(content);
+    const message = processWithArtifact(content, isGenerating);
     if (isToolCallGenerating) return;
 
     if ((!content && !hasImages) || content === LOADING_FLAT) return <ContentLoading id={id} />;

--- a/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
+++ b/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
@@ -36,7 +36,7 @@ const Preview = memo<PreviewProps>(
     const isBuiltinAgent = useIsBuiltinAgent();
 
     // Process message content for proper rendering
-    const processedContent = normalizeThinkTags(processWithArtifact(message.content));
+    const processedContent = normalizeThinkTags(processWithArtifact(message.content), false);
 
     const { t } = useTranslation('chat');
 

--- a/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
+++ b/src/features/Conversation/components/ShareMessageModal/ShareImage/Preview.tsx
@@ -14,7 +14,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { useAgentMeta, useIsBuiltinAgent } from '../../../hooks';
-import { normalizeThinkTags, processWithArtifact } from '../../../utils/markdown';
+import { processWithArtifact } from '../../../utils/markdown';
 import { styles as containerStyles } from '../style';
 import { styles } from './style';
 import { type FieldType } from './type';
@@ -36,7 +36,7 @@ const Preview = memo<PreviewProps>(
     const isBuiltinAgent = useIsBuiltinAgent();
 
     // Process message content for proper rendering
-    const processedContent = normalizeThinkTags(processWithArtifact(message.content), false);
+    const processedContent = processWithArtifact(message.content);
 
     const { t } = useTranslation('chat');
 

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -1,6 +1,17 @@
+import { ARTIFACT_TAG, ARTIFACT_THINKING_TAG, LOCAL_FILE_TAG } from '@lobechat/const';
 import { describe, expect, it } from 'vitest';
 
-import { normalizeThinkTags, processWithArtifact, shouldProcessThinkTags } from './markdown';
+import { IMAGE_SEARCH_REF_TAG } from '../Markdown/plugins/ImageSearchRef/rehypePlugin';
+import {
+  getActiveAssistantMarkdownElements,
+  normalizeThinkTags,
+  processWithArtifact,
+  shouldEnableImageSearchRefTags,
+  shouldEnableLocalFileTags,
+  shouldProcessArtifactTags,
+  shouldProcessArtifactThinkingTags,
+  shouldProcessThinkTags,
+} from './markdown';
 
 describe('processWithArtifact', () => {
   it('should removeLineBreaks with closed tag', () => {
@@ -20,7 +31,7 @@ describe('processWithArtifact', () => {
 </svg>
 </lobeArtifact>`;
 
-    const output = processWithArtifact(input);
+    const output = processWithArtifact(input, true);
 
     expect(output).toEqual(`好的
 
@@ -39,7 +50,7 @@ describe('processWithArtifact', () => {
   </defs>
 `;
 
-    const output = processWithArtifact(input);
+    const output = processWithArtifact(input, true);
 
     expect(output).toEqual(`好的
 
@@ -352,6 +363,87 @@ describe('think tag helpers', () => {
   });
 });
 
+describe('assistant markdown activation helpers', () => {
+  it('should only process standalone artifact blocks', () => {
+    expect(
+      shouldProcessArtifactTags(
+        'Here is an artifact example: <lobeArtifact identifier="demo">literal</lobeArtifact>.',
+      ),
+    ).toBe(false);
+    expect(
+      shouldProcessArtifactTags(
+        'Intro text\n\n<lobeArtifact identifier="demo" type="text/html">body</lobeArtifact>',
+      ),
+    ).toBe(true);
+  });
+
+  it('should only process lobeThinking when it is tied to artifact flow', () => {
+    expect(
+      shouldProcessArtifactThinkingTags(
+        '<lobeThinking>This is a literal example tag.</lobeThinking>',
+      ),
+    ).toBe(false);
+    expect(
+      shouldProcessArtifactThinkingTags(
+        'Intro\n\n<lobeThinking>plan</lobeThinking>\n\n<lobeArtifact identifier="demo" type="text/html">body</lobeArtifact>',
+      ),
+    ).toBe(true);
+  });
+
+  it('should only enable local file tags when local system context exists', () => {
+    expect(
+      shouldEnableLocalFileTags({
+        isGenerating: false,
+        isLocalSystemEnabled: false,
+        tools: [{ identifier: 'lobe-local-system' }],
+      }),
+    ).toBe(false);
+    expect(
+      shouldEnableLocalFileTags({
+        isGenerating: false,
+        isLocalSystemEnabled: true,
+        tools: [{ identifier: 'lobe-local-system' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('should only enable image search refs when image search results exist', () => {
+    expect(shouldEnableImageSearchRefTags(false)).toBe(false);
+    expect(shouldEnableImageSearchRefTags(true)).toBe(true);
+  });
+
+  it('should filter assistant markdown elements by message context', () => {
+    const elements = [
+      { Component: (() => null) as any, scope: 'assistant', tag: ARTIFACT_TAG },
+      { Component: (() => null) as any, scope: 'assistant', tag: ARTIFACT_THINKING_TAG },
+      { Component: (() => null) as any, scope: 'assistant', tag: LOCAL_FILE_TAG },
+      { Component: (() => null) as any, scope: 'assistant', tag: IMAGE_SEARCH_REF_TAG },
+      { Component: (() => null) as any, scope: 'assistant', tag: 'plain' },
+    ];
+
+    expect(
+      getActiveAssistantMarkdownElements(elements as any, {
+        content: 'The answer literally mentions <lobeArtifact>example</lobeArtifact>.',
+        hasImageSearchResults: false,
+        isGenerating: false,
+        isLocalSystemEnabled: false,
+        tools: [],
+      }).map((element) => element.tag),
+    ).toEqual(['plain']);
+
+    expect(
+      getActiveAssistantMarkdownElements(elements as any, {
+        content:
+          'Intro\n\n<lobeThinking>plan</lobeThinking>\n\n<lobeArtifact identifier="demo" type="text/html">body</lobeArtifact>',
+        hasImageSearchResults: true,
+        isGenerating: false,
+        isLocalSystemEnabled: true,
+        tools: [{ identifier: 'lobe-local-system' }],
+      }).map((element) => element.tag),
+    ).toEqual([ARTIFACT_TAG, ARTIFACT_THINKING_TAG, LOCAL_FILE_TAG, IMAGE_SEARCH_REF_TAG, 'plain']);
+  });
+});
+
 describe('outer code block removal', () => {
   it('should remove outer html code block', () => {
     const input = `\`\`\`html
@@ -570,6 +662,19 @@ This HTML document includes the temperature converter with the requested feature
       // Should still have the space and not convert it to newlines
       expect(output).toContain('</lobeThinking> <lobeArtifact');
       expect(output).not.toContain('</lobeThinking>\n\n<lobeArtifact');
+    });
+
+    it('should keep literal lobeThinking tags unchanged when no artifact follows', () => {
+      const input = 'The model literally prints <lobeThinking>example</lobeThinking> here.';
+
+      expect(processWithArtifact(input)).toEqual(input);
+    });
+
+    it('should keep inline lobeArtifact examples unchanged when they are not block content', () => {
+      const input =
+        'Use <lobeArtifact identifier="demo" type="text/html">example</lobeArtifact> only as a literal tag example.';
+
+      expect(processWithArtifact(input)).toEqual(input);
     });
   });
 });

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -377,6 +377,14 @@ describe('assistant markdown activation helpers', () => {
     ).toBe(true);
   });
 
+  it('should keep artifact parsing enabled for truncated responses after generation stops', () => {
+    const truncated =
+      'Intro\n\n<lobeArtifact identifier="demo" type="text/html" title="Test">\n<html>partial';
+
+    expect(shouldProcessArtifactTags(truncated, false)).toBe(true);
+    expect(shouldProcessArtifactTags(truncated, true)).toBe(true);
+  });
+
   it('should only process lobeThinking when it is tied to artifact flow', () => {
     expect(
       shouldProcessArtifactThinkingTags(

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { processWithArtifact } from './markdown';
+import { normalizeThinkTags, processWithArtifact, shouldProcessThinkTags } from './markdown';
 
 describe('processWithArtifact', () => {
   it('should removeLineBreaks with closed tag', () => {
@@ -321,6 +321,34 @@ Content 2 still going`;
 <lobeArtifact identifier="done" type="text/markdown" title="Done">Content 1</lobeArtifact>
 
 <lobeArtifact identifier="generating" type="text/markdown" title="Generating">Content 2 still going`);
+  });
+});
+
+describe('think tag helpers', () => {
+  describe('shouldProcessThinkTags', () => {
+    it('should only enable think tags for leading completed think blocks', () => {
+      expect(shouldProcessThinkTags('<think>thinking</think>\n\nanswer')).toBe(true);
+      expect(shouldProcessThinkTags('Answer with <think>literal</think> text')).toBe(false);
+    });
+
+    it('should only enable unfinished think blocks while generating', () => {
+      expect(shouldProcessThinkTags('<think>thinking', false)).toBe(false);
+      expect(shouldProcessThinkTags('<think>thinking', true)).toBe(true);
+    });
+  });
+
+  describe('normalizeThinkTags', () => {
+    it('should normalize leading think tags for reasoning blocks', () => {
+      expect(normalizeThinkTags('<think>思考</think>回答')).toEqual(
+        '<think>\n\n思考\n\n</think>\n\n回答',
+      );
+    });
+
+    it('should leave literal think tags in regular content unchanged', () => {
+      const input = '模型会输出<think>这样的标签来举例说明';
+
+      expect(normalizeThinkTags(input)).toEqual(input);
+    });
   });
 });
 

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -26,7 +26,7 @@ const ARTIFACT_THINKING_BLOCK_REGEX = new RegExp(
 const OUTER_ARTIFACT_CODE_BLOCK_REGEX =
   /^([\s\S]*?)\s*```[^\n]*\n((?:<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*)?<lobeArtifact[\s\S]*?<\/lobeArtifact>\s*)\n```\s*([\s\S]*)$/;
 /* eslint-enable regexp/no-super-linear-backtracking */
-const UNTERMINATED_ARTIFACT_REGEX = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;
+const UNTERMINATED_ARTIFACT_REGEX = /<lobeArtifact\b(?:(?!<\/lobeArtifact>|\/?>)[\s\S])*$/;
 
 interface AssistantMarkdownElementContext {
   content?: string;

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -26,7 +26,12 @@ const ARTIFACT_THINKING_BLOCK_REGEX = new RegExp(
 const OUTER_ARTIFACT_CODE_BLOCK_REGEX =
   /^([\s\S]*?)\s*```[^\n]*\n((?:<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*)?<lobeArtifact[\s\S]*?<\/lobeArtifact>\s*)\n```\s*([\s\S]*)$/;
 /* eslint-enable regexp/no-super-linear-backtracking */
-const UNTERMINATED_ARTIFACT_REGEX = /<lobeArtifact\b(?:(?!<\/lobeArtifact>|\/?>)[\s\S])*$/;
+// Matches any <lobeArtifact ...> (complete or incomplete opening tag) that is never closed.
+// Used for detection in shouldProcessArtifactTags.
+const UNTERMINATED_ARTIFACT_REGEX = /<lobeArtifact\b(?:(?!<\/lobeArtifact>|\/>)[\s\S])*$/;
+// Matches an incomplete opening tag (no closing `>` yet), e.g. `<lobeArtifact identifier="x" titl`.
+// Used only for the placeholder replacement in processWithArtifact.
+const INCOMPLETE_OPENING_TAG_REGEX = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;
 
 interface AssistantMarkdownElementContext {
   content?: string;
@@ -165,9 +170,9 @@ export const processWithArtifact = (input: string = '', isGenerating = false) =>
       match.replaceAll(/\r?\n|\r/g, ''),
     );
 
-    // if not match, check if it's start with <lobeArtifact but not closed
-    if (UNTERMINATED_ARTIFACT_REGEX.test(output)) {
-      output = output.replace(UNTERMINATED_ARTIFACT_REGEX, '<lobeArtifact>');
+    // if not match, check if it's start with <lobeArtifact but the opening tag itself is incomplete
+    if (INCOMPLETE_OPENING_TAG_REGEX.test(output)) {
+      output = output.replace(INCOMPLETE_OPENING_TAG_REGEX, '<lobeArtifact>');
     }
   }
 

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -1,5 +1,8 @@
 import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
+const THINK_CLOSE_TAG = '</think>';
+const THINK_OPEN_TAG = '<think>';
+
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
  */
@@ -63,8 +66,18 @@ export const processWithArtifact = (input: string = '') => {
   return output;
 };
 
+export const shouldProcessThinkTags = (input: string = '', isGenerating = false) => {
+  const trimmedInput = input.trimStart();
+
+  if (!trimmedInput.startsWith(THINK_OPEN_TAG)) return false;
+
+  return trimmedInput.includes(THINK_CLOSE_TAG) || isGenerating;
+};
+
 // Preprocessing function: ensure two newlines before and after think tags
-export const normalizeThinkTags = (input: string) => {
+export const normalizeThinkTags = (input: string, isGenerating = false) => {
+  if (!shouldProcessThinkTags(input, isGenerating)) return input;
+
   return (
     input
       // Ensure two newlines before and after <think> tags

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -1,66 +1,174 @@
-import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
+import {
+  ARTIFACT_TAG,
+  ARTIFACT_THINKING_TAG,
+  ARTIFACT_THINKING_TAG_REGEX,
+  LOCAL_FILE_TAG,
+} from '@lobechat/const';
+import type { ChatToolPayload } from '@lobechat/types';
+
+import { IMAGE_SEARCH_REF_TAG } from '../Markdown/plugins/ImageSearchRef/rehypePlugin';
+import type { MarkdownElement } from '../Markdown/plugins/type';
 
 const THINK_CLOSE_TAG = '</think>';
 const THINK_OPEN_TAG = '<think>';
+const LOCAL_SYSTEM_IDENTIFIER = 'lobe-local-system';
+const BLOCK_TAG_PREFIX = '(?:^|\\n{2,})\\s*';
+const ARTIFACT_BLOCK_REGEX = new RegExp(`${BLOCK_TAG_PREFIX}<${ARTIFACT_TAG}\\b`, 'i');
+const ARTIFACT_SEQUENCE_REGEX = new RegExp(
+  `${BLOCK_TAG_PREFIX}<${ARTIFACT_THINKING_TAG}\\b[\\s\\S]*?<\\/${ARTIFACT_THINKING_TAG}>\\s*<${ARTIFACT_TAG}\\b`,
+  'i',
+);
+const ARTIFACT_THINKING_BLOCK_REGEX = new RegExp(
+  `${BLOCK_TAG_PREFIX}<${ARTIFACT_THINKING_TAG}\\b`,
+  'i',
+);
+/* eslint-disable regexp/no-super-linear-backtracking */
+const OUTER_ARTIFACT_CODE_BLOCK_REGEX =
+  /^([\s\S]*?)\s*```[^\n]*\n((?:<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*)?<lobeArtifact[\s\S]*?<\/lobeArtifact>\s*)\n```\s*([\s\S]*)$/;
+/* eslint-enable regexp/no-super-linear-backtracking */
+const UNTERMINATED_ARTIFACT_REGEX = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;
+
+interface AssistantMarkdownElementContext {
+  content?: string;
+  hasImageSearchResults?: boolean;
+  isGenerating?: boolean;
+  isLocalSystemEnabled?: boolean;
+  tools?: Array<Pick<ChatToolPayload, 'identifier'>>;
+}
+
+export const shouldProcessArtifactTags = (input: string = '', isGenerating = false) => {
+  if (OUTER_ARTIFACT_CODE_BLOCK_REGEX.test(input)) return true;
+
+  const trimmedInput = input.trim();
+  const hasArtifactContext =
+    ARTIFACT_BLOCK_REGEX.test(trimmedInput) || ARTIFACT_SEQUENCE_REGEX.test(trimmedInput);
+
+  if (UNTERMINATED_ARTIFACT_REGEX.test(trimmedInput)) return true;
+  if (!hasArtifactContext) return false;
+
+  return trimmedInput.includes(`</${ARTIFACT_TAG}>`) || isGenerating;
+};
+
+export const shouldProcessArtifactThinkingTags = (input: string = '', isGenerating = false) => {
+  if (OUTER_ARTIFACT_CODE_BLOCK_REGEX.test(input)) return true;
+
+  const trimmedInput = input.trim();
+
+  if (!ARTIFACT_THINKING_BLOCK_REGEX.test(trimmedInput)) return false;
+
+  const hasUnclosedArtifactThinking = !trimmedInput.includes(`</${ARTIFACT_THINKING_TAG}>`);
+
+  return ARTIFACT_SEQUENCE_REGEX.test(trimmedInput) || hasUnclosedArtifactThinking || isGenerating;
+};
+
+export const shouldEnableLocalFileTags = ({
+  isGenerating = false,
+  isLocalSystemEnabled = false,
+  tools,
+}: Pick<AssistantMarkdownElementContext, 'isGenerating' | 'isLocalSystemEnabled' | 'tools'>) => {
+  return (
+    isLocalSystemEnabled &&
+    (isGenerating || tools?.some((tool) => tool.identifier === LOCAL_SYSTEM_IDENTIFIER) === true)
+  );
+};
+
+export const shouldEnableImageSearchRefTags = (hasImageSearchResults = false) =>
+  hasImageSearchResults;
+
+export const getActiveAssistantMarkdownElements = (
+  elements: MarkdownElement[],
+  context: AssistantMarkdownElementContext,
+) => {
+  const {
+    content = '',
+    hasImageSearchResults,
+    isGenerating,
+    isLocalSystemEnabled,
+    tools,
+  } = context;
+
+  return elements.filter((element) => {
+    switch (element.tag) {
+      case ARTIFACT_TAG: {
+        return shouldProcessArtifactTags(content, isGenerating);
+      }
+      case ARTIFACT_THINKING_TAG: {
+        return shouldProcessArtifactThinkingTags(content, isGenerating);
+      }
+      case LOCAL_FILE_TAG: {
+        return shouldEnableLocalFileTags({ isGenerating, isLocalSystemEnabled, tools });
+      }
+      case IMAGE_SEARCH_REF_TAG: {
+        return shouldEnableImageSearchRefTags(hasImageSearchResults);
+      }
+      default: {
+        return true;
+      }
+    }
+  });
+};
 
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
  */
-export const processWithArtifact = (input: string = '') => {
+export const processWithArtifact = (input: string = '', isGenerating = false) => {
   // First remove outer fenced code block if it exists
-  /* eslint-disable regexp/no-super-linear-backtracking */
+
   let output = input.replace(
-    /^([\s\S]*?)\s*```[^\n]*\n((?:<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*)?<lobeArtifact[\s\S]*?<\/lobeArtifact>\s*)\n```\s*([\s\S]*)$/,
+    OUTER_ARTIFACT_CODE_BLOCK_REGEX,
     (_, before = '', content, after = '') => {
       return [before.trim(), content.trim(), after.trim()].filter(Boolean).join('\n\n');
     },
   );
-  /* eslint-enable regexp/no-super-linear-backtracking */
 
-  const thinkMatch = ARTIFACT_THINKING_TAG_REGEX.exec(output);
+  const shouldProcessArtifactThinking = shouldProcessArtifactThinkingTags(output, isGenerating);
+  const shouldProcessArtifact = shouldProcessArtifactTags(output, isGenerating);
+
+  if (!shouldProcessArtifactThinking && !shouldProcessArtifact) return output;
 
   // If the input contains the `lobeThinking` tag, replace all line breaks with an empty string
-  if (thinkMatch) {
+  if (shouldProcessArtifactThinking) {
     output = output.replace(ARTIFACT_THINKING_TAG_REGEX, (match) =>
       match.replaceAll(/\r?\n|\r/g, ''),
     );
+
+    // Add empty line between lobeThinking and lobeArtifact if they are adjacent
+    // Support both cases: with line break (e.g. from other models) and without (e.g. from Gemini)
+    output = output.replace(/(<\/lobeThinking>)(?:\r?\n)?(<lobeArtifact)/, '$1\n\n$2');
   }
 
-  // Add empty line between lobeThinking and lobeArtifact if they are adjacent
-  // Support both cases: with line break (e.g. from other models) and without (e.g. from Gemini)
-  output = output.replace(/(<\/lobeThinking>)(?:\r?\n)?(<lobeArtifact)/, '$1\n\n$2');
-
   // Remove fenced code block between lobeArtifact and HTML content
-  output = output.replace(
-    /(<lobeArtifact[^>]*>)\s*```[^\n]*\n([\s\S]*?)(```\n)?(<\/lobeArtifact>)/,
-    (_, start, content, __, end) => {
-      if (content.trim().startsWith('<!DOCTYPE html') || content.trim().startsWith('<html')) {
-        return start + content.trim() + end;
-      }
-      return start + content + (__ || '') + end;
-    },
-  );
+  if (shouldProcessArtifact) {
+    output = output.replace(
+      /(<lobeArtifact[^>]*>)\s*```[^\n]*\n([\s\S]*?)(```\n)?(<\/lobeArtifact>)/,
+      (_, start, content, __, end) => {
+        if (content.trim().startsWith('<!DOCTYPE html') || content.trim().startsWith('<html')) {
+          return start + content.trim() + end;
+        }
+        return start + content + (__ || '') + end;
+      },
+    );
 
-  // Keep existing code blocks that are not part of lobeArtifact
-  output = output.replace(
-    /^([\s\S]*?)(<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*<lobeArtifact[\s\S]*?<\/lobeArtifact>)([\s\S]*)$/,
-    (_, before, content, after) => {
-      return [before.trim(), content.trim(), after.trim()].filter(Boolean).join('\n\n');
-    },
-  );
+    // Keep existing code blocks that are not part of lobeArtifact
+    output = output.replace(
+      /^([\s\S]*?)(<lobeThinking>[\s\S]*?<\/lobeThinking>[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*<lobeArtifact[\s\S]*?<\/lobeArtifact>)([\s\S]*)$/,
+      (_, before, content, after) => {
+        return [before.trim(), content.trim(), after.trim()].filter(Boolean).join('\n\n');
+      },
+    );
 
-  // If the input contains `lobeArtifact` tags, replace all line breaks with an empty string
-  // Use global regex to handle multiple artifacts in the same message
-  const ARTIFACT_TAG_REGEX_GLOBAL =
-    /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
-  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, (match) =>
-    match.replaceAll(/\r?\n|\r/g, ''),
-  );
+    // If the input contains `lobeArtifact` tags, replace all line breaks with an empty string
+    // Use global regex to handle multiple artifacts in the same message
+    const ARTIFACT_TAG_REGEX_GLOBAL =
+      /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
+    output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, (match) =>
+      match.replaceAll(/\r?\n|\r/g, ''),
+    );
 
-  // if not match, check if it's start with <lobeArtifact but not closed
-  const regex = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;
-  if (regex.test(output)) {
-    output = output.replace(regex, '<lobeArtifact>');
+    // if not match, check if it's start with <lobeArtifact but not closed
+    if (UNTERMINATED_ARTIFACT_REGEX.test(output)) {
+      output = output.replace(UNTERMINATED_ARTIFACT_REGEX, '<lobeArtifact>');
+    }
   }
 
   return output;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
N/A

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
- Stop treating literal `<think>...</think>` content in assistant messages as reasoning blocks during markdown rendering.
- Restrict reserved tag rendering for `lobeThinking`, `lobeArtifact`, `localFile`, and image search references so they only activate when the message context explicitly matches the corresponding feature flow.
- Preserve literal reserved tags in normal assistant output, inline examples, and backticked content instead of converting them into special UI blocks.
- Add regression coverage for literal-tag rendering, artifact preprocessing, self-closing tag parsing, and reserved-tag activation rules.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->
- Send an assistant message that literally contains `<think>...</think>` and verify it renders as plain message text instead of a reasoning panel.
- Send assistant content that literally mentions `<lobeThinking>`, `<lobeArtifact>`, or ``<localFile ... />`` and verify those tags remain literal unless the message is in the corresponding artifact or local-tool context.
- Verify actual artifact output, local system output, and image search references still render with their special UI when the message context enables them.
- Run:
  `pnpm exec vitest run --silent='passed-only' 'src/features/Conversation/utils/markdown.test.ts' 'src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkCustomTagPlugin.test.ts' 'src/features/Conversation/Markdown/plugins/remarkPlugins/createRemarkSelfClosingTagPlugin.test.ts' 'src/features/Conversation/Markdown/plugins/LobeArtifact/rehypePlugin.test.ts' 'src/features/Conversation/Messages/components/DisplayContent.test.tsx' 'src/features/Conversation/Markdown/plugins/index.test.ts'`
- Run:
  `NODE_OPTIONS='--max-old-space-size=8192' pnpm exec tsc --noEmit --pretty false --incremental false`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| Literal reserved tags in assistant replies could be converted into reasoning, artifact, local file, or image-reference UI blocks. | Literal reserved tags stay as plain markdown unless the message context explicitly enables the corresponding special renderer. |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
- No breaking changes or migration steps are required.
- This change is limited to conversation markdown rendering and reserved-tag activation logic.
