### PR TITLE
✨ feat: add StepFunCodingPlan (Step Plan) provider

### DIFF
--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -66,6 +66,7 @@
     "./siliconcloud": "./src/aiModels/siliconcloud.ts",
     "./spark": "./src/aiModels/spark.ts",
     "./stepfun": "./src/aiModels/stepfun.ts",
+    "./stepfunCodingPlan": "./src/aiModels/stepfunCodingPlan.ts",
     "./straico": "./src/aiModels/straico.ts",
     "./taichu": "./src/aiModels/taichu.ts",
     "./tencentcloud": "./src/aiModels/tencentcloud.ts",

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -61,6 +61,7 @@ import { default as sensenova } from './sensenova';
 import { default as siliconcloud } from './siliconcloud';
 import { default as spark } from './spark';
 import { default as stepfun } from './stepfun';
+import { default as stepfuncodingplan } from './stepfunCodingPlan';
 import { default as straico } from './straico';
 import { default as taichu } from './taichu';
 import { default as tencentcloud } from './tencentcloud';
@@ -160,6 +161,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   siliconcloud,
   spark,
   stepfun,
+  stepfuncodingplan,
   straico,
   taichu,
   tencentcloud,
@@ -240,6 +242,7 @@ export { default as sensenova } from './sensenova';
 export { default as siliconcloud } from './siliconcloud';
 export { default as spark } from './spark';
 export { default as stepfun } from './stepfun';
+export { default as stepfuncodingplan } from './stepfunCodingPlan';
 export { default as straico } from './straico';
 export { default as taichu } from './taichu';
 export { default as tencentcloud } from './tencentcloud';

--- a/packages/model-bank/src/aiModels/stepfunCodingPlan.ts
+++ b/packages/model-bank/src/aiModels/stepfunCodingPlan.ts
@@ -1,0 +1,24 @@
+import { type AIChatModelCard } from '../types/aiModel';
+
+// ref: https://platform.stepfun.com/docs/zh/step-plan/integrations/cherry-studio
+
+const stepfunCodingPlanChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 256_000,
+    description:
+      'Step 3.5 Flash is a fast, sharp, and reliable agentic intelligence model optimized for coding tasks.',
+    displayName: 'Step 3.5 Flash',
+    enabled: true,
+    id: 'step-3.5-flash',
+    maxOutput: 131_072,
+    organization: 'StepFun',
+    releasedAt: '2026-02-12',
+    type: 'chat',
+  },
+];
+
+export default stepfunCodingPlanChatModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -59,6 +59,7 @@ export enum ModelProvider {
   SiliconCloud = 'siliconcloud',
   Spark = 'spark',
   Stepfun = 'stepfun',
+  StepFunCodingPlan = 'stepfuncodingplan',
   Straico = 'straico',
   Taichu = 'taichu',
   TencentCloud = 'tencentcloud',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -62,6 +62,7 @@ import SenseNovaProvider from './sensenova';
 import SiliconCloudProvider from './siliconcloud';
 import SparkProvider from './spark';
 import StepfunProvider from './stepfun';
+import StepFunCodingPlanProvider from './stepfunCodingPlan';
 import StraicoProvider from './straico';
 import TaichuProvider from './taichu';
 import TencentcloudProvider from './tencentcloud';
@@ -192,6 +193,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   SparkProvider,
   SenseNovaProvider,
   StepfunProvider,
+  StepFunCodingPlanProvider,
   BaichuanProvider,
   VolcengineProvider,
   VolcengineCodingPlanProvider,
@@ -289,6 +291,7 @@ export { default as SenseNovaProviderCard } from './sensenova';
 export { default as SiliconCloudProviderCard } from './siliconcloud';
 export { default as SparkProviderCard } from './spark';
 export { default as StepfunProviderCard } from './stepfun';
+export { default as StepFunCodingPlanProviderCard } from './stepfunCodingPlan';
 export { default as StraicoProviderCard } from './straico';
 export { default as TaichuProviderCard } from './taichu';
 export { default as TencentCloudProviderCard } from './tencentcloud';

--- a/packages/model-bank/src/modelProviders/stepfunCodingPlan.ts
+++ b/packages/model-bank/src/modelProviders/stepfunCodingPlan.ts
@@ -1,0 +1,30 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://platform.stepfun.com/docs/zh/step-plan/overview
+const StepFunCodingPlan: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'step-3.5-flash',
+  description:
+    'Step Plan provides access to StepFun models including Step 3.5 Flash for coding tasks via a fixed-fee subscription.',
+  disableBrowserRequest: true,
+  id: 'stepfuncodingplan',
+  modelList: { showModelFetcher: false },
+  modelsUrl: 'https://platform.stepfun.com/docs/zh/step-plan/overview',
+  name: 'Step Plan',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://api.stepfun.com/step_plan/v1',
+    },
+    responseAnimation: {
+      speed: 2,
+      text: 'smooth',
+    },
+    sdkType: 'openai',
+    showDeployName: true,
+    showModelFetcher: false,
+  },
+  url: 'https://platform.stepfun.com/step-plan',
+};
+
+export default StepFunCodingPlan;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -37,6 +37,7 @@ export { LobeOpenRouterAI } from './providers/openrouter';
 export { LobePerplexityAI } from './providers/perplexity';
 export { LobeQwenAI } from './providers/qwen';
 export { LobeStepfunAI } from './providers/stepfun';
+export { LobeStepFunCodingPlanAI } from './providers/stepfunCodingPlan';
 export { LobeStraicoAI } from './providers/straico';
 export { LobeTogetherAI } from './providers/togetherai';
 export { LobeVolcengineAI } from './providers/volcengine';

--- a/packages/model-runtime/src/providers/stepfunCodingPlan/index.test.ts
+++ b/packages/model-runtime/src/providers/stepfunCodingPlan/index.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeStepFunCodingPlanAI } from './index';
+
+const provider = ModelProvider.StepFunCodingPlan;
+const defaultBaseURL = 'https://api.stepfun.com/step_plan/v1';
+
+testProvider({
+  Runtime: LobeStepFunCodingPlanAI,
+  chatDebugEnv: 'DEBUG_STEPFUN_CODING_PLAN_CHAT_COMPLETION',
+  chatModel: 'step-3.5-flash',
+  defaultBaseURL,
+  provider,
+  test: {
+    skipAPICall: true,
+  },
+});
+
+describe('LobeStepFunCodingPlanAI', () => {
+  let instance: InstanceType<typeof LobeStepFunCodingPlanAI>;
+
+  beforeEach(() => {
+    instance = new LobeStepFunCodingPlanAI({ apiKey: 'test_api_key' });
+    vi.spyOn(instance['client'].chat.completions, 'create').mockResolvedValue(
+      new ReadableStream() as any,
+    );
+  });
+
+  describe('handlePayload', () => {
+    it('should set stream to true', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.stream).toBe(true);
+    });
+
+    it('should filter out thinking parameter', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+        thinking: { budget_tokens: 1000, type: 'enabled' },
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.thinking).toBeUndefined();
+      expect(calledPayload.enable_thinking).toBeUndefined();
+    });
+
+    it('should filter out enabledSearch parameter', async () => {
+      await instance.chat({
+        enabledSearch: true,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.enabledSearch).toBeUndefined();
+    });
+
+    it('should add parallel_tool_calls when tools are present', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+        tools: [{ function: { name: 'test' }, type: 'function' }],
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.parallel_tool_calls).toBe(true);
+    });
+
+    it('should not add parallel_tool_calls when no tools', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.parallel_tool_calls).toBeUndefined();
+    });
+
+    it('should preserve other payload properties', async () => {
+      await instance.chat({
+        max_tokens: 100,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'step-3.5-flash',
+        temperature: 0.7,
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.temperature).toBe(0.7);
+      expect(calledPayload.max_tokens).toBe(100);
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/stepfunCodingPlan/index.ts
+++ b/packages/model-runtime/src/providers/stepfunCodingPlan/index.ts
@@ -1,0 +1,33 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+
+export const LobeStepFunCodingPlanAI = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.stepfun.com/step_plan/v1',
+  chatCompletion: {
+    handlePayload: (payload) => {
+      const { enabledSearch, model, thinking, ...rest } = payload;
+
+      return {
+        ...rest,
+        model,
+        stream: true,
+        ...(payload.tools && {
+          parallel_tool_calls: true,
+        }),
+      } as any;
+    },
+  },
+  debug: {
+    chatCompletion: () => process.env.DEBUG_STEPFUN_CODING_PLAN_CHAT_COMPLETION === '1',
+  },
+  models: async () => {
+    const { stepfuncodingplan } = await import('model-bank');
+    return processMultiProviderModelList(
+      stepfuncodingplan.map((m: { id: string }) => ({ id: m.id })),
+      'stepfuncodingplan',
+    );
+  },
+  provider: ModelProvider.StepFunCodingPlan,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -58,6 +58,7 @@ import { LobeSenseNovaAI } from './providers/sensenova';
 import { LobeSiliconCloudAI } from './providers/siliconcloud';
 import { LobeSparkAI } from './providers/spark';
 import { LobeStepfunAI } from './providers/stepfun';
+import { LobeStepFunCodingPlanAI } from './providers/stepfunCodingPlan';
 import { LobeStraicoAI } from './providers/straico';
 import { LobeTaichuAI } from './providers/taichu';
 import { LobeTencentCloudAI } from './providers/tencentcloud';
@@ -138,6 +139,7 @@ export const providerRuntimeMap = {
   siliconcloud: LobeSiliconCloudAI,
   spark: LobeSparkAI,
   stepfun: LobeStepfunAI,
+  stepfuncodingplan: LobeStepFunCodingPlanAI,
   straico: LobeStraicoAI,
   taichu: LobeTaichuAI,
   tencentcloud: LobeTencentCloudAI,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- Add related issue if applicable -->

#### 🔀 Description of Change

Add StepFunCodingPlan provider implementation to support Step Plan API.

**Changes:**
- Add provider configuration in `model-bank`
- Add model definitions for Step 3.5 Flash
- Add runtime implementation with OpenAI SDK compatibility
- Add unit tests for the provider

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

**Test steps:**
1. Run type check: `bun run type-check`
2. Run unit tests: `bunx vitest run packages/model-runtime/src/providers/stepfunCodingPlan`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

Related icon PR: https://github.com/lobehub/lobe-icons/pull/282