### PR TITLE
✨ feat: add client-side executor skeleton for builtin-tool-task

### DIFF
--- a/packages/builtin-tool-task/package.json
+++ b/packages/builtin-tool-task/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./executor": "./src/executor/index.ts"
   },
   "main": "./src/index.ts",
   "devDependencies": {

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -1,0 +1,45 @@
+import type { BuiltinToolContext, BuiltinToolResult } from '@lobechat/types';
+import { BaseExecutor } from '@lobechat/types';
+
+import { TaskIdentifier } from '../manifest';
+import { TaskApiName } from '../types';
+
+class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
+  readonly identifier = TaskIdentifier;
+  protected readonly apiEnum = TaskApiName;
+
+  // TODO (LOBE-6597): wire to store.createTask()
+  createTask = async (_params: any, _ctx?: BuiltinToolContext): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: createTask', success: false };
+  };
+
+  // TODO (LOBE-6597): wire to store.deleteTask()
+  deleteTask = async (_params: any, _ctx?: BuiltinToolContext): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: deleteTask', success: false };
+  };
+
+  // TODO (LOBE-6597): wire to store.updateTask() + addDependency/removeDependency
+  editTask = async (_params: any, _ctx?: BuiltinToolContext): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: editTask', success: false };
+  };
+
+  // TODO (LOBE-6597): wire to service.list() or store.tasks
+  listTasks = async (_params: any, _ctx?: BuiltinToolContext): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: listTasks', success: false };
+  };
+
+  // TODO (LOBE-6597): wire to lifecycle slice actions (runTask/pauseTask/cancelTask etc.)
+  updateTaskStatus = async (
+    _params: any,
+    _ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: updateTaskStatus', success: false };
+  };
+
+  // TODO (LOBE-6597): wire to service.detail() or store.taskDetailMap
+  viewTask = async (_params: any, _ctx?: BuiltinToolContext): Promise<BuiltinToolResult> => {
+    return { content: 'Not implemented: viewTask', success: false };
+  };
+}
+
+export const taskExecutor = new TaskExecutor();

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -16,6 +16,7 @@ import { gtdExecutor } from '@lobechat/builtin-tool-gtd/executor';
 import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/executor';
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
+import { taskExecutor } from '@lobechat/builtin-tool-task/executor';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
 import { activatorExecutor } from './lobe-activator';
@@ -150,6 +151,7 @@ registerExecutors([
   pageAgentExecutor,
   skillStoreExecutor,
   skillsExecutor,
+  taskExecutor,
   activatorExecutor,
   topicReferenceExecutor,
   userInteractionExecutor,


### PR DESCRIPTION
Add TaskExecutor class extending BaseExecutor with 6 stub methods (createTask, listTasks, viewTask, editTask, updateTaskStatus, deleteTask). Register in the builtin executor registry. Methods return not-implemented for now — will be wired to Task Store actions once LOBE-6597 is ready.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
