### PR TITLE
🐛 fix(stream): fix cleanup never firing on SSE stream cancel

### DIFF
--- a/src/app/(backend)/api/agent/stream/route.ts
+++ b/src/app/(backend)/api/agent/stream/route.ts
@@ -33,14 +33,12 @@ export async function GET(request: NextRequest) {
   log(`Starting SSE connection for operation ${operationId} from eventId ${lastEventId}`);
 
   // Create Server-Sent Events stream
+  let cleanupRef: (() => void) | undefined;
+
   const stream = new ReadableStream({
     cancel(reason) {
       log(`SSE connection cancelled for operation ${operationId}:`, reason);
-
-      // Call cleanup function
-      if ((this as any)._cleanup) {
-        (this as any)._cleanup();
-      }
+      cleanupRef?.();
     },
 
     start(controller) {
@@ -201,8 +199,8 @@ export async function GET(request: NextRequest) {
       // Listen for connection close
       request.signal?.addEventListener('abort', cleanup);
 
-      // Store cleanup function for calling during cancel
-      (controller as any)._cleanup = cleanup;
+      // Store cleanup function so the cancel() callback can invoke it
+      cleanupRef = cleanup;
     },
   });
 


### PR DESCRIPTION
Was debugging a memory leak in a self-hosted deployment where heartbeat intervals kept running after clients disconnected. Traced it to the SSE stream route.

The `cancel()` callback tries to invoke cleanup via `(this as any)._cleanup`, but `_cleanup` is assigned to the `controller` object in `start()` — not to `this`. In the Web Streams API, `this` inside `cancel()` refers to the underlying source object, so the property is never found and cleanup never runs.

The `request.signal` abort listener at line 202 partially covers HTTP disconnects, but if the stream is cancelled programmatically (e.g., via `stream.cancel()`), the heartbeat interval and event subscription leak.

Replaced the `_cleanup` property hack with a closure variable that both `start()` and `cancel()` can access — standard pattern for sharing state between ReadableStream callbacks.