### PR TITLE
🐛 fix(model-runtime): buffer incomplete JSON in Bedrock stream parser

### DIFF
--- a/packages/model-runtime/src/core/streams/bedrock/common.ts
+++ b/packages/model-runtime/src/core/streams/bedrock/common.ts
@@ -6,22 +6,34 @@ import type {
 import { readableFromAsyncIterable } from '../protocol';
 
 const chatStreamable = async function* (stream: AsyncIterable<ResponseStream>) {
+  const decoder = new TextDecoder();
+  let buffer = '';
+
   for await (const response of stream) {
     if (response.chunk) {
-      const decoder = new TextDecoder();
+      buffer += decoder.decode(response.chunk.bytes, { stream: true });
 
-      const value = decoder.decode(response.chunk.bytes, { stream: true });
+      // Bedrock sends one JSON object per chunk, but TextDecoder with
+      // stream: true may split a multi-byte character across boundaries.
+      // Buffer until we can parse a complete JSON value.
       try {
-        const chunk = JSON.parse(value);
-
+        const chunk = JSON.parse(buffer);
+        buffer = '';
         yield chunk;
-      } catch (e) {
-        console.log('bedrock stream parser error:', e);
-
-        yield value;
+      } catch {
+        // Incomplete JSON — keep buffering until the next chunk completes it
       }
     } else {
       yield response;
+    }
+  }
+
+  // Flush any remaining buffered data
+  if (buffer.trim()) {
+    try {
+      yield JSON.parse(buffer);
+    } catch (e) {
+      console.error('bedrock stream: unable to parse final buffered chunk:', e);
     }
   }
 };

--- a/packages/model-runtime/src/core/streams/bedrock/llama.test.ts
+++ b/packages/model-runtime/src/core/streams/bedrock/llama.test.ts
@@ -161,6 +161,54 @@ describe('AWSBedrockLlamaStream', () => {
     expect(onCompletionMock).toHaveBeenCalledTimes(1);
   });
 
+  it('should handle JSON split across chunk boundaries (multi-byte UTF-8)', async () => {
+    vi.spyOn(uuidModule, 'nanoid').mockReturnValueOnce('3');
+
+    // Simulate Bedrock splitting a JSON payload mid-emoji. TextDecoder with
+    // stream: true buffers the incomplete multi-byte sequence, but the
+    // resulting string is still incomplete JSON that fails JSON.parse().
+    // Without buffering, the old code would yield the raw string, and
+    // downstream transformers that access chunk.generation would get
+    // undefined — silently dropping the content.
+    const fullJson = '{"generation":"Hello 🌍","generation_token_count":1}';
+    const bytes = new TextEncoder().encode(fullJson);
+
+    // Split at byte 23 — inside the 4-byte 🌍 emoji (U+1F30D)
+    const chunk1Bytes = bytes.slice(0, 23);
+    const chunk2Bytes = bytes.slice(23);
+
+    const mockBedrockStream: InvokeModelWithResponseStreamResponse = {
+      body: {
+        // @ts-ignore
+        async *[Symbol.asyncIterator]() {
+          yield { chunk: { bytes: chunk1Bytes } };
+          yield { chunk: { bytes: chunk2Bytes } };
+          yield {
+            chunk: { bytes: new TextEncoder().encode('{"stop_reason":"stop"}') },
+          };
+        },
+      },
+    };
+
+    const protocolStream = AWSBedrockLlamaStream(mockBedrockStream, {});
+
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    // The split JSON must be reassembled — "Hello 🌍" should appear intact
+    expect(chunks).toEqual([
+      'id: chat_3\n',
+      'event: text\n',
+      'data: "Hello 🌍"\n\n',
+      'id: chat_3\n',
+      'event: stop\n',
+      'data: "finished"\n\n',
+    ]);
+  });
+
   it('should handle empty stream', async () => {
     const mockBedrockStream = new ReadableStream({
       start(controller) {


### PR DESCRIPTION
Ran into dropped tokens when using Bedrock with Claude — some assistant responses would silently lose chunks mid-sentence. The issue is in the stream parser.

`TextDecoder` with `{ stream: true }` can split multi-byte UTF-8 characters across chunk boundaries, returning an incomplete string. The current code calls `JSON.parse()` on each decoded fragment individually, and when it fails, yields the raw string. But downstream transformers (`llama.ts`, `claude.ts`) expect parsed objects — accessing `chunk.generation` or `chunk.type` on a string returns `undefined`, so the content just vanishes.

The fix accumulates decoded text in a buffer and only yields once `JSON.parse()` succeeds. This also moves the `TextDecoder` outside the loop (no need to re-create it per chunk) and adds a flush step for any remaining buffered data when the stream ends.

The old `yield value` fallback that yielded raw strings is removed entirely — it was the root cause of the type mismatch with downstream code.