### PR TITLE
🐛 fix: harden error handling in agent run route and service fetch calls

### DIFF
--- a/src/app/(backend)/api/agent/run/route.ts
+++ b/src/app/(backend)/api/agent/run/route.ts
@@ -22,7 +22,12 @@ export async function POST(request: NextRequest) {
   }
 
   // Parse body after verification
-  const body = JSON.parse(rawBody);
+  let body: any;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
   const externalRetryCount = Number(request.headers.get('Upstash-Retried') ?? 0) || 0;
   try {
     const {

--- a/src/services/global.ts
+++ b/src/services/global.ts
@@ -18,6 +18,9 @@ class GlobalService extends BusinessGlobalService {
    */
   getLatestVersion = async (): Promise<string> => {
     const res = await fetch(VERSION_URL);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch latest version: ${res.status} ${res.statusText}`);
+    }
     const data = await res.json();
 
     return data['version'];

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -211,6 +211,9 @@ class UploadService {
    */
   getImageFileByUrlWithCORS = async (url: string, filename: string, fileType = 'image/png') => {
     const res = await fetch(API_ENDPOINTS.proxy, { body: url, method: 'POST' });
+    if (!res.ok) {
+      throw new Error(`Image proxy request failed: ${res.status} ${res.statusText}`);
+    }
     const data = await res.arrayBuffer();
 
     return new File([data], filename, { lastModified: Date.now(), type: fileType });


### PR DESCRIPTION
Noticed while reading through the API routes that `agent/run/route.ts` is missing a try-catch around `JSON.parse(rawBody)` — if Upstash delivers a malformed payload, the handler crashes with an unhandled SyntaxError instead of returning 400. The sibling `agent/route.ts` at line 54 already has the correct guard, so this just brings `run/route.ts` in line.

While I was in the area, also fixed two fetch calls that skip the `res.ok` check:

- `services/global.ts` `getLatestVersion()` — calls `.json()` directly without checking status. If npm returns an error page, this throws an opaque parse error. The other method in the same file (`getServerVersion`, line 51) already does `if (!res.ok)`.

- `services/upload.ts` `getImageFileByUrlWithCORS()` — calls `.arrayBuffer()` without a status check, so a proxy failure silently returns a corrupted `File` object.

All three are the same pattern: add the error guard that's already present in sibling code.