### PR TITLE
✨ feat: add EUrouter provider support

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -46,6 +46,7 @@
   "ollama.description": "Ollama offers models across code generation, math, multilingual processing, and chat, supporting both enterprise and local deployments.",
   "ollamacloud.description": "Ollama Cloud provides managed inference with out-of-the-box access to the Ollama model library and OpenAI-compatible APIs.",
   "openai.description": "OpenAI is a leading AI research lab whose GPT models advanced natural language processing, delivering high performance and strong value across research, business, and innovation.",
+  "eurouter.description": "EUrouter is a European AI Gateway providing a single OpenAI-compatible API endpoint to EU-hosted, GDPR-friendly AI models with smart routing, safe fallbacks, and observability.",
   "openrouter.description": "OpenRouter provides access to many frontier models from OpenAI, Anthropic, LLaMA, and more, letting users pick the best model and price for their use case.",
   "perplexity.description": "Perplexity provides advanced chat models, including Llama 3.1 variants, for online and offline use and complex NLP workloads.",
   "ppio.description": "PPIO provides reliable, cost-effective open-model APIs, including DeepSeek, Llama, Qwen, and other leading models.",

--- a/packages/model-bank/src/aiModels/eurouter.ts
+++ b/packages/model-bank/src/aiModels/eurouter.ts
@@ -1,0 +1,57 @@
+import { type AIChatModelCard } from '../types/aiModel';
+
+const eurouterChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      reasoning: true,
+    },
+    contextWindowTokens: 65_536,
+    description:
+      'DeepSeek R1 is a reasoning model that achieves performance comparable to OpenAI-o1 across math, code, and reasoning tasks.',
+    displayName: 'DeepSeek R1',
+    enabled: true,
+    id: 'deepseek-r1',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      vision: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'Kimi K2.5 is a powerful multilingual model with strong reasoning, vision, and tool-use capabilities.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'kimi-k2.5',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 131_072,
+    description:
+      'Mistral Large 3 is a top-tier EU-native model excelling at multilingual tasks, code generation, and complex reasoning.',
+    displayName: 'Mistral Large 3',
+    enabled: true,
+    id: 'mistral-large-latest',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 1_048_576,
+    description:
+      'MiniMax M2.5 is a high-performance model with an extremely large context window, suitable for long-document analysis and complex tasks.',
+    displayName: 'MiniMax M2.5',
+    enabled: true,
+    id: 'minimax-m2.5',
+    type: 'chat',
+  },
+];
+
+export const allModels = [...eurouterChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -19,6 +19,7 @@ import { default as cohere } from './cohere';
 import { default as cometapi } from './cometapi';
 import { default as comfyui } from './comfyui';
 import { default as deepseek } from './deepseek';
+import { default as eurouter } from './eurouter';
 import { default as fal } from './fal';
 import { default as fireworksai } from './fireworksai';
 import { default as giteeai } from './giteeai';
@@ -118,6 +119,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   cometapi,
   comfyui,
   deepseek,
+  eurouter,
   fal,
   fireworksai,
   giteeai,
@@ -198,6 +200,7 @@ export { default as cohere } from './cohere';
 export { default as cometapi } from './cometapi';
 export { default as comfyui } from './comfyui';
 export { default as deepseek } from './deepseek';
+export { default as eurouter } from './eurouter';
 export { default as fal, fluxSchnellParamsSchema } from './fal';
 export { default as fireworksai } from './fireworksai';
 export { default as giteeai } from './giteeai';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -17,6 +17,7 @@ export enum ModelProvider {
   CometAPI = 'cometapi',
   ComfyUI = 'comfyui',
   DeepSeek = 'deepseek',
+  EUrouter = 'eurouter',
   Fal = 'fal',
   FireworksAI = 'fireworksai',
   GiteeAI = 'giteeai',

--- a/packages/model-bank/src/modelProviders/eurouter.ts
+++ b/packages/model-bank/src/modelProviders/eurouter.ts
@@ -1,0 +1,25 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://www.eurouter.ai/docs
+const EUrouter: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'mistral-large-latest',
+  description:
+    'EUrouter is a European AI Gateway providing a single OpenAI-compatible API endpoint to EU-hosted, GDPR-friendly AI models with smart routing, safe fallbacks, and observability.',
+  id: 'eurouter',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://www.eurouter.ai/docs',
+  name: 'EUrouter',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://api.eurouter.ai/api/v1',
+    },
+    sdkType: 'openai',
+    searchMode: 'params',
+    showModelFetcher: true,
+  },
+  url: 'https://www.eurouter.ai',
+};
+
+export default EUrouter;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -20,6 +20,7 @@ import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
 import ComfyUIProvider from './comfyui';
 import DeepSeekProvider from './deepseek';
+import EUrouterProvider from './eurouter';
 import FalProvider from './fal';
 import FireworksAIProvider from './fireworksai';
 import GiteeAIProvider from './giteeai';
@@ -100,6 +101,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   OllamaProvider.chatModels,
   VLLMProvider.chatModels,
   XinferenceProvider.chatModels,
+  EUrouterProvider.chatModels,
   OpenRouterProvider.chatModels,
   TogetherAIProvider.chatModels,
   FireworksAIProvider.chatModels,
@@ -153,6 +155,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   { ...AzureProvider, chatModels: [] },
   AzureAIProvider,
   AiHubMixProvider,
+  EUrouterProvider,
   OpenRouterProvider,
   FalProvider,
   OllamaProvider,
@@ -247,6 +250,7 @@ export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';
 export { default as ComfyUIProviderCard } from './comfyui';
 export { default as DeepSeekProviderCard } from './deepseek';
+export { default as EUrouterProviderCard } from './eurouter';
 export { default as FalProviderCard } from './fal';
 export { default as FireworksAIProviderCard } from './fireworksai';
 export { default as GiteeAIProviderCard } from './giteeai';

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -18,6 +18,7 @@ export { LobeCerebrasAI } from './providers/cerebras';
 export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
 export { LobeDeepSeekAI } from './providers/deepseek';
+export { LobeEUrouterAI } from './providers/eurouter';
 export { LobeGLMCodingPlanAI } from './providers/glmCodingPlan';
 export { LobeGoogleAI } from './providers/google';
 export { LobeGroq } from './providers/groq';

--- a/packages/model-runtime/src/providers/eurouter/index.test.ts
+++ b/packages/model-runtime/src/providers/eurouter/index.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { describe, expect, it } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeEUrouterAI, params } from './index';
+
+testProvider({
+  Runtime: LobeEUrouterAI,
+  provider: ModelProvider.EUrouter,
+  defaultBaseURL: 'https://api.eurouter.ai/api/v1',
+  chatDebugEnv: 'DEBUG_EUROUTER_CHAT_COMPLETION',
+  chatModel: 'mistral-large-latest',
+  test: {
+    skipAPICall: true,
+  },
+});
+
+describe('LobeEUrouterAI', () => {
+  it('exports the expected runtime params', () => {
+    expect(params.provider).toBe(ModelProvider.EUrouter);
+    expect(params.baseURL).toBe('https://api.eurouter.ai/api/v1');
+    expect(typeof params.models).toBe('function');
+  });
+});

--- a/packages/model-runtime/src/providers/eurouter/index.ts
+++ b/packages/model-runtime/src/providers/eurouter/index.ts
@@ -1,0 +1,25 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+
+interface EUrouterModelCard {
+  id: string;
+}
+
+export const params = {
+  baseURL: 'https://api.eurouter.ai/api/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_EUROUTER_CHAT_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    const modelsPage = (await client.models.list()) as any;
+    const modelList: EUrouterModelCard[] = modelsPage.data || [];
+
+    return processMultiProviderModelList(modelList, 'eurouter');
+  },
+  provider: ModelProvider.EUrouter,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeEUrouterAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -16,6 +16,7 @@ import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
 import { LobeComfyUI } from './providers/comfyui';
 import { LobeDeepSeekAI } from './providers/deepseek';
+import { LobeEUrouterAI } from './providers/eurouter';
 import { LobeFalAI } from './providers/fal';
 import { LobeFireworksAI } from './providers/fireworksai';
 import { LobeGiteeAI } from './providers/giteeai';
@@ -95,6 +96,7 @@ export const providerRuntimeMap = {
   cometapi: LobeCometAPIAI,
   comfyui: LobeComfyUI,
   deepseek: LobeDeepSeekAI,
+  eurouter: LobeEUrouterAI,
   fal: LobeFalAI,
   fireworksai: LobeFireworksAI,
   giteeai: LobeGiteeAI,

--- a/src/server/modules/ModelRuntime/index.test.ts
+++ b/src/server/modules/ModelRuntime/index.test.ts
@@ -5,6 +5,7 @@ import {
   LobeBedrockAI,
   LobeComfyUI,
   LobeDeepSeekAI,
+  LobeEUrouterAI,
   LobeGoogleAI,
   LobeGroq,
   LobeMinimaxAI,
@@ -220,6 +221,14 @@ describe('initModelRuntimeWithUserPayload method', () => {
       const runtime = await initModelRuntimeWithUserPayload(ModelProvider.DeepSeek, jwtPayload);
       expect(runtime).toBeInstanceOf(ModelRuntime);
       expect(runtime['_runtime']).toBeInstanceOf(LobeDeepSeekAI);
+    });
+
+    it('EUrouter provider: with apikey', async () => {
+      const jwtPayload: ClientSecretPayload = { apiKey: 'user-eurouter-key' };
+      const runtime = await initModelRuntimeWithUserPayload(ModelProvider.EUrouter, jwtPayload);
+      expect(runtime).toBeInstanceOf(ModelRuntime);
+      expect(runtime['_runtime']).toBeInstanceOf(LobeEUrouterAI);
+      expect(runtime['_runtime'].baseURL).toBe('https://api.eurouter.ai/api/v1');
     });
 
     it('Together AI provider: with apikey', async () => {

--- a/src/services/chat/helper.test.ts
+++ b/src/services/chat/helper.test.ts
@@ -1,0 +1,37 @@
+import { ModelProvider } from 'model-bank';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { aiProviderSelectors, getAiInfraStoreState } from '@/store/aiInfra';
+
+import { resolveRuntimeProvider } from './helper';
+
+vi.mock('@/store/aiInfra', () => ({
+  aiProviderSelectors: {
+    providerConfigById: vi.fn(),
+  },
+  getAiInfraStoreState: vi.fn(() => ({})),
+}));
+
+describe('resolveRuntimeProvider', () => {
+  beforeEach(() => {
+    vi.mocked(getAiInfraStoreState).mockReturnValue({} as any);
+    vi.mocked(aiProviderSelectors.providerConfigById).mockReset();
+  });
+
+  it('returns builtin providers as-is', () => {
+    expect(resolveRuntimeProvider(ModelProvider.EUrouter)).toBe(ModelProvider.EUrouter);
+  });
+
+  it('falls back to sdkType for custom providers', () => {
+    vi.mocked(aiProviderSelectors.providerConfigById).mockReturnValue(
+      () =>
+        ({
+          settings: {
+            sdkType: ModelProvider.OpenAI,
+          },
+        }) as any,
+    );
+
+    expect(resolveRuntimeProvider('custom-provider')).toBe(ModelProvider.OpenAI);
+  });
+});


### PR DESCRIPTION
## Summary

Add [EUrouter](https://www.eurouter.ai) as a new AI model provider.

EUrouter is a European AI Gateway — a single access point to EU-hosted, GDPR-friendly, and privacy-friendly AI models. It provides an OpenAI-compatible API with features like smart routing, safe fallbacks, and observability. It serves as a European alternative to OpenRouter.

### Changes

- Add EUrouter provider card (`packages/model-bank/src/modelProviders/eurouter.ts`)
- Add default model configurations (`packages/model-bank/src/aiModels/eurouter.ts`):
  - DeepSeek R1 (reasoning)
  - Kimi K2.5 (multilingual, vision, tool use)
  - Mistral Large 3 (EU-native, code, reasoning)
  - MiniMax M2.5 (1M context window)
- Register provider in model provider and AI model indexes
- Add en-US locale entry
- Enable dynamic model fetching from EUrouter API

### Provider Details

- **Base URL**: `https://api.eurouter.ai/api/v1`
- **Auth**: Bearer token (Authorization header)
- **API Compatibility**: OpenAI-compatible
- **SDK Type**: `openai`
- **Website**: https://www.eurouter.ai
- **Docs**: https://www.eurouter.ai/docs