### PR TITLE
fix(web-crawler): respect CRAWLER_IMPLS config when applying URL rules

### DIFF
--- a/packages/web-crawler/src/__tests__/crawler.test.ts
+++ b/packages/web-crawler/src/__tests__/crawler.test.ts
@@ -187,6 +187,40 @@ describe('Crawler', () => {
     });
   });
 
+  it('should fall back to configured impls when rule impls are not in user-configured impls', async () => {
+    const mockResult = {
+      content: 'test content'.padEnd(101, ' '),
+      contentType: 'text' as const,
+      url: 'https://example.com',
+    };
+
+    // Create crawler with only 'naive' configured
+    const naiveCrawler = new Crawler({ impls: ['naive'] });
+
+    const { crawlImpls } = await import('../crawImpl');
+    vi.mocked(crawlImpls.naive).mockResolvedValue(mockResult);
+
+    const { applyUrlRules } = await import('../utils/appUrlRules');
+    // URL rule says to use 'jina', but user hasn't configured jina
+    vi.mocked(applyUrlRules).mockReturnValue({
+      transformedUrl: 'https://example.com',
+      filterOptions: {},
+      impls: ['jina'],
+    });
+
+    const result = await naiveCrawler.crawl({
+      url: 'https://example.com',
+    });
+
+    // Should use 'naive' (user-configured) instead of 'jina' (rule-specified but not configured)
+    expect(result).toEqual({
+      crawler: 'naive',
+      data: mockResult,
+      originalUrl: 'https://example.com',
+      transformedUrl: undefined,
+    });
+  });
+
   it('should skip results with content length <= 100', async () => {
     const mockResult = {
       content: 'short content', // Content length <= 100

--- a/packages/web-crawler/src/crawler.ts
+++ b/packages/web-crawler/src/crawler.ts
@@ -48,7 +48,12 @@ export class Crawler {
     let finalCrawler: string | undefined;
     let finalError: Error | undefined;
 
-    const systemImpls = (ruleImpls ?? this.impls) as CrawlImplType[];
+    // When URL rules specify impls, filter them through user-configured impls
+    // so that crawlers not enabled by the user are never called (fixes #13379)
+    const filteredRuleImpls = ruleImpls
+      ? (ruleImpls.filter((impl) => this.impls.includes(impl as CrawlImplType)) as CrawlImplType[])
+      : undefined;
+    const systemImpls = (filteredRuleImpls?.length ? filteredRuleImpls : this.impls) as CrawlImplType[];
 
     const finalImpls = userImpls
       ? (userImpls.filter((impl) => Object.keys(crawlImpls).includes(impl)) as CrawlImplType[])


### PR DESCRIPTION
Fixes #13379

## Problem

URL-specific crawler rules in `urlRules.ts` (e.g., use `jina` for PDFs, WeChat links, Zhihu, etc.) were overriding the user's `CRAWLER_IMPLS` environment variable. This caused unconfigured crawlers like Jina to be called even when the user explicitly excluded them from their configuration.

For example, a user with `CRAWLER_IMPLS="tavily,naive"` would still have Jina invoked when crawling a PDF or a WeChat article, resulting in failures if Jina is not configured/available.

## Solution

In `crawler.ts`, when URL rules specify preferred impls, intersect them with the user-configured impls (`this.impls`). If the intersection is non-empty, use those filtered impls (honoring both the URL rule preference and the user's config). If the intersection is empty (none of the rule-preferred impls are configured by the user), fall back to the user's configured impls.

This ensures the user's `CRAWLER_IMPLS` setting is always respected, while URL rules can still guide crawler selection when the preferred crawlers are available.

## Testing

- Added a test case: when URL rules specify `jina` but the crawler is initialized with only `naive`, it falls back to `naive` instead of calling `jina`.
- Existing test "should use rule impls when provided" still passes: when URL rules specify `jina` and `jina` is in the default impls, `jina` is used as before.