### PR TITLE
docs: remove broken APK download link

### DIFF
--- a/docs/usage/getting-started/get-lobehub.mdx
+++ b/docs/usage/getting-started/get-lobehub.mdx
@@ -24,7 +24,7 @@ LobeHub runs wherever you work — browser, desktop, or phone. Sign in once and 
 | **macOS**   | Native app         | [Download](https://lobehub.com/download)                                                                           |
 | **Windows** | Native app         | [Download](https://lobehub.com/download)                                                                           |
 | **iOS**     | App Store          | [App Store](https://apps.apple.com/app/id6471212236)                                                               |
-| **Android** | Google Play / APK  | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) · [APK](https://lobehub.com/download) |
+| **Android** | Google Play        | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
 
 ## Web
 
@@ -40,10 +40,11 @@ Download the native app from the [Download Page](https://lobehub.com/download). 
 
 ## Mobile
 
-|                  | iOS                                                  | Android                                                                      |
-| ---------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **Store**        | [App Store](https://apps.apple.com/app/id6471212236) | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
-| **Alt download** | —                                                    | [APK from Download Page](https://lobehub.com/download)                       |
+|           | iOS                                                  | Android                                                                      |
+| --------- | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Store** | [App Store](https://apps.apple.com/app/id6471212236) | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
+
+There is currently no working direct APK download page linked from the docs. Until that page is restored, use Google Play for Android installs.
 
 Sign in with your LobeHub account to access Agents and conversations on the go.
 

--- a/docs/usage/getting-started/get-lobehub.zh-CN.mdx
+++ b/docs/usage/getting-started/get-lobehub.zh-CN.mdx
@@ -22,7 +22,7 @@ LobeHub 随你所在 —— 浏览器、桌面或手机均可使用。登录同�
 | **macOS**   | 原生应用              | [下载](https://lobehub.com/download)                                                                                 |
 | **Windows** | 原生应用              | [下载](https://lobehub.com/download)                                                                                 |
 | **iOS**     | App Store         | [App Store](https://apps.apple.com/app/id6471212236)                                                               |
-| **Android** | Google Play / APK | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) · [APK](https://lobehub.com/download) |
+| **Android** | Google Play       | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
 
 ## 网页端
 
@@ -38,10 +38,11 @@ LobeHub 随你所在 —— 浏览器、桌面或手机均可使用。登录同�
 
 ## 移动端
 
-|          | iOS                                                  | Android                                                                      |
-| -------- | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **商店**   | [App Store](https://apps.apple.com/app/id6471212236) | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
-| **其他下载** | —                                                    | [从下载页获取 APK](https://lobehub.com/download)                                   |
+|        | iOS                                                  | Android                                                                      |
+| ------ | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **商店** | [App Store](https://apps.apple.com/app/id6471212236) | [Google Play](https://play.google.com/store/apps/details?id=com.lobehub.app) |
+
+文档中此前提供的 APK 直链下载页当前不可用。在该页面恢复之前，请通过 Google Play 安装 Android 版本。
 
 使用 LobeHub 账号登录，即可在手机上访问助理和对话。
 


### PR DESCRIPTION
## Summary
- remove the broken direct APK link from the getting started docs
- keep the Android install path pointed at Google Play until a working APK download page exists
- align the English and Chinese pages so they no longer point users to a 404 download target

## Testing
- `git diff --check`
- verified `https://lobehub.com/download` currently returns `404`

Related to #12768.
