### PR TITLE
feat: add Chuizi.AI as model provider

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -12,6 +12,7 @@
   "bedrock.description": "Amazon Bedrock provides enterprises with advanced language and vision models, including Anthropic Claude and Meta Llama 3.1, spanning lightweight to high-performance options for text, chat, and image tasks.",
   "bfl.description": "A leading frontier AI research lab building the visual infrastructure of tomorrow.",
   "cerebras.description": "Cerebras is an inference platform built on its CS-3 system, focused on ultra-low latency and high-throughput LLM service for real-time workloads like code generation and agent tasks.",
+  "chuizi.description": "Chuizi.AI is a unified AI gateway providing access to 100+ models across 17 providers through a single OpenAI-compatible endpoint, with native Anthropic Messages API and Gemini API protocols plus built-in routing and automatic failover.",
   "cloudflare.description": "Run serverless GPU-powered ML models across Cloudflare’s global network.",
   "cohere.description": "Cohere delivers cutting-edge multilingual models, advanced retrieval, and AI workspaces for modern enterprises—all in one secure platform.",
   "cometapi.description": "CometAPI provides access to frontier models from OpenAI, Anthropic, Google, and more, letting users choose the best model and pricing for diverse use cases.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -12,6 +12,7 @@
   "bedrock.description": "Amazon Bedrock 为企业提供先进的语言与视觉模型，包括 Anthropic Claude 和 Meta Llama 3.1，涵盖轻量级到高性能选项，支持文本、对话与图像任务。",
   "bfl.description": "一家前沿 AI 研究实验室，致力于构建未来的视觉基础设施。",
   "cerebras.description": "Cerebras 是基于其 CS-3 系统构建的推理平台，专注于超低延迟和高吞吐量的大模型服务，适用于代码生成和智能体等实时任务。",
+  "chuizi.description": "锤子AI (Chuizi.AI) 是一个统一的 AI 网关，通过单一的 OpenAI 兼容接口访问 17 家供应商的 100+ 模型，并原生支持 Anthropic Messages API 与 Gemini API 协议，内置路由与自动故障切换。",
   "cloudflare.description": "在 Cloudflare 全球网络上运行无服务器、GPU 加速的机器学习模型。",
   "cohere.description": "Cohere 提供前沿的多语言模型、先进的检索能力和 AI 工作空间，为现代企业提供一体化、安全的平台。",
   "cometapi.description": "CometAPI 提供对 OpenAI、Anthropic、Google 等前沿模型的访问，用户可根据不同需求选择最优模型与价格。",

--- a/packages/model-bank/src/aiModels/chuizi.ts
+++ b/packages/model-bank/src/aiModels/chuizi.ts
@@ -1,0 +1,290 @@
+import { type AIChatModelCard } from '../types/aiModel';
+
+// Chuizi.AI routes through provider/model naming and applies a unified
+// upstream-cost × 1.05 multiplier. Pricing below reflects the final USD
+// price per 1M tokens that Chuizi.AI charges (already includes the 5%
+// gateway margin on top of upstream list prices).
+// Models use the `provider/model` format required by Chuizi.AI's router.
+
+const chuiziChatModels: AIChatModelCard[] = [
+  // ----- Anthropic -----
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 200_000,
+    description:
+      'Claude Opus 4.6 — Anthropic’s most capable model, optimized for complex reasoning, agents, and long-form analysis.',
+    displayName: 'Claude Opus 4.6',
+    enabled: true,
+    id: 'anthropic/claude-opus-4-6',
+    maxOutput: 32_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 15.75, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 78.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 200_000,
+    description:
+      'Claude Sonnet 4.6 — balanced model, default choice for Claude Code, Cursor, Cline and most agent workflows.',
+    displayName: 'Claude Sonnet 4.6',
+    enabled: true,
+    id: 'anthropic/claude-sonnet-4-6',
+    maxOutput: 64_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-02-15',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, vision: true },
+    contextWindowTokens: 200_000,
+    description:
+      'Claude Haiku 4.5 — fastest Claude model, ideal for high-volume and latency-sensitive tasks.',
+    displayName: 'Claude Haiku 4.5',
+    enabled: true,
+    id: 'anthropic/claude-haiku-4-5',
+    maxOutput: 32_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.05, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-10-15',
+    type: 'chat',
+  },
+
+  // ----- OpenAI -----
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 400_000,
+    description: 'GPT-5 — frontier reasoning model from OpenAI via Azure.',
+    displayName: 'GPT-5',
+    enabled: true,
+    id: 'openai/gpt-5',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.3125, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-01',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 400_000,
+    description: 'GPT-5.1 — latest general-purpose flagship, improved reasoning and multimodality.',
+    displayName: 'GPT-5.1',
+    enabled: true,
+    id: 'openai/gpt-5.1',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.3125, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-20',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, vision: true },
+    contextWindowTokens: 200_000,
+    description: 'GPT-4.1 — flagship with 200K context, excellent balance of price and capability.',
+    displayName: 'GPT-4.1',
+    enabled: true,
+    id: 'openai/gpt-4.1',
+    maxOutput: 32_768,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 8.4, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-04-14',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 200_000,
+    description: 'o4-mini — fast compact reasoning model, strong on STEM and code.',
+    displayName: 'o4-mini',
+    enabled: true,
+    id: 'openai/o4-mini',
+    maxOutput: 100_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.155, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 4.62, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-04-16',
+    type: 'chat',
+  },
+
+  // ----- Google -----
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 2_097_152,
+    description:
+      'Gemini 2.5 Pro — Google’s flagship with 2M context, strong multimodality and reasoning.',
+    displayName: 'Gemini 2.5 Pro',
+    enabled: true,
+    id: 'google/gemini-2.5-pro',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1.3125, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-06-17',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_048_576,
+    description: 'Gemini 2.5 Flash — fast, cost-effective multimodal model.',
+    displayName: 'Gemini 2.5 Flash',
+    enabled: true,
+    id: 'google/gemini-2.5-flash',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.315, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.625, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-06-17',
+    type: 'chat',
+  },
+
+  // ----- DeepSeek -----
+  {
+    abilities: { functionCall: true },
+    contextWindowTokens: 131_072,
+    description: 'DeepSeek V3.2 — latest general model with hybrid reasoning and agent skills.',
+    displayName: 'DeepSeek V3.2',
+    enabled: true,
+    id: 'deepseek/deepseek-chat',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.294, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.176, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-12-01',
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 131_072,
+    description:
+      'DeepSeek R1 — reasoning-optimized model with full chain-of-thought output.',
+    displayName: 'DeepSeek R1',
+    enabled: true,
+    id: 'deepseek/deepseek-r1',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.588, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.352, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-01-20',
+    type: 'chat',
+  },
+
+  // ----- Qwen -----
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 1_048_576,
+    description:
+      'Qwen3 Max — Alibaba’s flagship, 1M context, strong on Chinese and multimodal tasks.',
+    displayName: 'Qwen3 Max',
+    enabled: true,
+    id: 'qwen/qwen3-max',
+    maxOutput: 8192,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 2.52, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10.08, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-09-05',
+    type: 'chat',
+  },
+
+  // ----- xAI -----
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 256_000,
+    description: 'Grok 4 — xAI flagship with strong reasoning and realtime context.',
+    displayName: 'Grok 4',
+    enabled: true,
+    id: 'xai/grok-4',
+    maxOutput: 32_768,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 3.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15.75, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-07-10',
+    type: 'chat',
+  },
+
+  // ----- Moonshot -----
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 200_000,
+    description: 'Kimi K2.5 — Moonshot’s latest long-context flagship, excellent for code agents.',
+    displayName: 'Kimi K2.5',
+    enabled: true,
+    id: 'moonshot/kimi-k2.5',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 2.52, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 12.6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-11-01',
+    type: 'chat',
+  },
+
+  // ----- ZhiPu -----
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 128_000,
+    description: 'GLM-4.6 — ZhiPu’s flagship with strong Chinese reasoning and tool use.',
+    displayName: 'GLM-4.6',
+    enabled: true,
+    id: 'zhipu/glm-4.6',
+    maxOutput: 32_768,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.525, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2.1, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2025-10-01',
+    type: 'chat',
+  },
+];
+
+export const allModels = [...chuiziChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -14,6 +14,7 @@ import { default as bailiancodingplan } from './bailianCodingPlan';
 import { default as bedrock } from './bedrock';
 import { default as bfl } from './bfl';
 import { default as cerebras } from './cerebras';
+import { default as chuizi } from './chuizi';
 import { default as cloudflare } from './cloudflare';
 import { default as cohere } from './cohere';
 import { default as cometapi } from './cometapi';
@@ -113,6 +114,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   bedrock,
   bfl,
   cerebras,
+  chuizi,
   cloudflare,
   cohere,
   cometapi,
@@ -193,6 +195,7 @@ export { default as bailiancodingplan } from './bailianCodingPlan';
 export { default as bedrock } from './bedrock';
 export { default as bfl } from './bfl';
 export { default as cerebras } from './cerebras';
+export { default as chuizi } from './chuizi';
 export { default as cloudflare } from './cloudflare';
 export { default as cohere } from './cohere';
 export { default as cometapi } from './cometapi';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -12,6 +12,7 @@ export enum ModelProvider {
   Bedrock = 'bedrock',
   Bfl = 'bfl',
   Cerebras = 'cerebras',
+  Chuizi = 'chuizi',
   Cloudflare = 'cloudflare',
   Cohere = 'cohere',
   CometAPI = 'cometapi',

--- a/packages/model-bank/src/modelProviders/chuizi.ts
+++ b/packages/model-bank/src/modelProviders/chuizi.ts
@@ -1,0 +1,22 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+const Chuizi: ModelProviderCard = {
+  apiKeyUrl: 'https://chuizi.ai/console/keys',
+  chatModels: [],
+  checkModel: 'anthropic/claude-haiku-4-5',
+  description:
+    'Chuizi.AI is a unified AI gateway providing access to 100+ models across 17 providers through a single OpenAI-compatible endpoint, with native Anthropic Messages API and Gemini API support.',
+  id: 'chuizi',
+  modelsUrl: 'https://chuizi.ai/models',
+  name: 'Chuizi.AI',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.chuizi.ai/v1',
+    },
+    sdkType: 'router',
+    showModelFetcher: true,
+  },
+  url: 'https://chuizi.ai',
+};
+
+export default Chuizi;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -15,6 +15,7 @@ import BailianCodingPlanProvider from './bailianCodingPlan';
 import BedrockProvider from './bedrock';
 import BflProvider from './bfl';
 import CerebrasProvider from './cerebras';
+import ChuiziProvider from './chuizi';
 import CloudflareProvider from './cloudflare';
 import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
@@ -153,6 +154,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   { ...AzureProvider, chatModels: [] },
   AzureAIProvider,
   AiHubMixProvider,
+  ChuiziProvider,
   OpenRouterProvider,
   FalProvider,
   OllamaProvider,
@@ -242,6 +244,7 @@ export { default as BailianCodingPlanProviderCard } from './bailianCodingPlan';
 export { default as BedrockProviderCard } from './bedrock';
 export { default as BflProviderCard } from './bfl';
 export { default as CerebrasProviderCard } from './cerebras';
+export { default as ChuiziProviderCard } from './chuizi';
 export { default as CloudflareProviderCard } from './cloudflare';
 export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';

--- a/packages/model-runtime/src/providers/chuizi/index.ts
+++ b/packages/model-runtime/src/providers/chuizi/index.ts
@@ -1,0 +1,68 @@
+import { ModelProvider } from 'model-bank';
+import urlJoin from 'url-join';
+
+import { responsesAPIModels } from '../../const/models';
+import { createRouterRuntime } from '../../core/RouterRuntime';
+import type { CreateRouterRuntimeOptions } from '../../core/RouterRuntime/createRuntime';
+import { detectModelProvider, processMultiProviderModelList } from '../../utils/modelParse';
+
+export interface ChuiziModelCard {
+  created: number;
+  id: string;
+  object: string;
+  owned_by: string;
+}
+
+const baseURL = 'https://api.chuizi.ai';
+
+export const params: CreateRouterRuntimeOptions = {
+  debug: {
+    chatCompletion: () => process.env.DEBUG_CHUIZI_CHAT_COMPLETION === '1',
+  },
+  defaultHeaders: {
+    'X-Client': 'LobeHub',
+  },
+  id: ModelProvider.Chuizi,
+  models: async ({ client }) => {
+    try {
+      const modelsPage = (await client.models.list()) as any;
+      const modelList: ChuiziModelCard[] = modelsPage.data || [];
+
+      return await processMultiProviderModelList(modelList, 'chuizi');
+    } catch (error) {
+      console.warn(
+        'Failed to fetch Chuizi.AI models. Please ensure your Chuizi.AI API key is valid:',
+        error,
+      );
+      return [];
+    }
+  },
+  routers: [
+    {
+      apiType: 'anthropic',
+      models: async ({ client }) => {
+        try {
+          const modelsPage = (await client.models.list()) as any;
+          const modelList: ChuiziModelCard[] = modelsPage.data || [];
+          return modelList
+            .map((m) => m.id)
+            .filter((id) => detectModelProvider(id) === 'anthropic');
+        } catch {
+          return [];
+        }
+      },
+      options: { baseURL: urlJoin(baseURL, '/anthropic') },
+    },
+    {
+      apiType: 'openai',
+      options: {
+        baseURL: urlJoin(baseURL, '/v1'),
+        chatCompletion: {
+          useResponseModels: [...Array.from(responsesAPIModels), /gpt-\d(?!\d)/, /^o\d/],
+        },
+      },
+    },
+  ],
+};
+
+export const LobeChuiziAI = createRouterRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -11,6 +11,7 @@ import { LobeBailianCodingPlanAI } from './providers/bailianCodingPlan';
 import { LobeBedrockAI } from './providers/bedrock';
 import { LobeBflAI } from './providers/bfl';
 import { LobeCerebrasAI } from './providers/cerebras';
+import { LobeChuiziAI } from './providers/chuizi';
 import { LobeCloudflareAI } from './providers/cloudflare';
 import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
@@ -90,6 +91,7 @@ export const providerRuntimeMap = {
   bedrock: LobeBedrockAI,
   bfl: LobeBflAI,
   cerebras: LobeCerebrasAI,
+  chuizi: LobeChuiziAI,
   cloudflare: LobeCloudflareAI,
   cohere: LobeCohereAI,
   cometapi: LobeCometAPIAI,

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -207,6 +207,9 @@ export const getLLMConfig = () => {
       ENABLED_AIHUBMIX: z.boolean(),
       AIHUBMIX_API_KEY: z.string().optional(),
 
+      ENABLED_CHUIZI: z.boolean(),
+      CHUIZI_API_KEY: z.string().optional(),
+
       ENABLED_NEWAPI: z.boolean(),
       NEWAPI_API_KEY: z.string().optional(),
       NEWAPI_PROXY_URL: z.string().optional(),
@@ -429,6 +432,9 @@ export const getLLMConfig = () => {
 
       ENABLED_AIHUBMIX: !!process.env.AIHUBMIX_API_KEY,
       AIHUBMIX_API_KEY: process.env.AIHUBMIX_API_KEY,
+
+      ENABLED_CHUIZI: !!process.env.CHUIZI_API_KEY,
+      CHUIZI_API_KEY: process.env.CHUIZI_API_KEY,
 
       ENABLED_NEWAPI: !!process.env.NEWAPI_API_KEY,
       NEWAPI_API_KEY: process.env.NEWAPI_API_KEY,


### PR DESCRIPTION
## Summary

Add [Chuizi.AI](https://chuizi.ai) as an OpenAI-compatible model provider.

Chuizi.AI is a unified AI gateway providing access to 100+ models across 16 providers (Anthropic, OpenAI, Google, DeepSeek, Qwen, GLM, etc.) through a single endpoint.

## Changes (8 files, 250 lines)

- `packages/model-bank/src/const/modelProvider.ts` — Add `Chuizi` to enum
- `packages/model-runtime/src/providers/chuizi/index.ts` — Runtime via `createOpenAICompatibleRuntime`
- `packages/model-runtime/src/runtimeMap.ts` — Register runtime
- `packages/model-bank/src/modelProviders/chuizi.ts` — Provider card with model fetcher
- `packages/model-bank/src/modelProviders/index.ts` — Register provider
- `packages/model-bank/src/aiModels/chuizi.ts` — 8 predefined models with pricing
- `packages/model-bank/src/aiModels/index.ts` — Register models
- `locales/en-US/providers.json` — Description

## Predefined Models

| Model | Context | Pricing (in/out per 1M) |
|-------|---------|------------------------|
| anthropic/claude-sonnet-4-6 | 200K | $3 / $15 |
| anthropic/claude-opus-4-6 | 200K | $5 / $25 |
| anthropic/claude-haiku-4-5 | 200K | $1 / $5 |
| openai/gpt-4.1 | 200K | $2 / $8 |
| openai/o4-mini | 200K | $1.10 / $4.40 |
| google/gemini-2.5-pro | 1M | $1.25 / $10 |
| deepseek/deepseek-chat | 128K | $0.28 / $0.42 |
| deepseek/deepseek-r1 | 128K | $0.28 / $0.42 |

Additional models available via model fetcher (dynamic from API).

## Provider Details

| Field | Value |
|-------|-------|
| Base URL | `https://api.chuizi.ai/v1` |
| Auth | API Key |
| SDK | OpenAI-compatible |
| Model Fetcher | Enabled |