### PR TITLE
✨ feat(calculator): add ln() natural logarithm function support

### DIFF
--- a/packages/builtin-tool-calculator/src/calculate.test.ts
+++ b/packages/builtin-tool-calculator/src/calculate.test.ts
@@ -339,6 +339,49 @@ describe('Unit Conversion', () => {
     expect(parseFloat(e.content || '0')).toBeCloseTo(2.71828, 5);
   });
 
+  it('should handle ln (natural logarithm) function', async () => {
+    const result = await calculatorExecutor.calculate({ expression: 'ln(2.71828)' });
+    expect(result.success).toBe(true);
+    expect(parseFloat(result.content || '0')).toBeCloseTo(1, 5);
+  });
+
+  it('should handle ln(e) equals 1', async () => {
+    const result = await calculatorExecutor.calculate({ expression: 'ln(e)' });
+    expect(result.success).toBe(true);
+    expect(parseFloat(result.content || '0')).toBeCloseTo(1, 5);
+  });
+
+  it('should handle ln(1) equals 0', async () => {
+    const result = await calculatorExecutor.calculate({ expression: 'ln(1)' });
+    expect(result.success).toBe(true);
+    expect(parseFloat(result.content || '0')).toBeCloseTo(0, 5);
+  });
+
+  it('should handle ln in complex expressions', async () => {
+    const result = await calculatorExecutor.calculate({ expression: 'ln(10) + ln(10)' });
+    expect(result.success).toBe(true);
+    const expected = Math.log(10) + Math.log(10);
+    expect(parseFloat(result.content || '0')).toBeCloseTo(expected, 5);
+  });
+
+  it('should handle ln in evaluate with variables', async () => {
+    const result = await calculatorExecutor.evaluate({
+      expression: 'ln(x)',
+      variables: { x: 2.71828 },
+    });
+    expect(result.success).toBe(true);
+    expect(parseFloat(result.content || '0')).toBeCloseTo(1, 5);
+  });
+
+  it('should handle ln with precision', async () => {
+    const result = await calculatorExecutor.calculate({
+      expression: 'ln(10)',
+      precision: 4,
+    });
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('2.3026');
+  });
+
   it('should handle constants in scientific notation', async () => {
     const result = await calculatorExecutor.calculate({ expression: 'pi * 1e3' });
     expect(result.success).toBe(true);

--- a/packages/builtin-tool-calculator/src/calculate.test.ts
+++ b/packages/builtin-tool-calculator/src/calculate.test.ts
@@ -382,6 +382,22 @@ describe('Unit Conversion', () => {
     expect(result.content).toBe('2.3026');
   });
 
+  it('should handle ln with complex numbers (ln(-1) = πi)', async () => {
+    const result = await calculatorExecutor.calculate({ expression: 'ln(-1)' });
+    expect(result.success).toBe(true);
+    // ln(-1) = i * π ≈ 3.141592654i
+    expect(result.content).toContain('i');
+    expect(parseFloat(result.content || '0')).not.toBeNaN();
+  });
+
+  it('should handle ln consistent with log(x, e)', async () => {
+    const lnResult = await calculatorExecutor.calculate({ expression: 'ln(5)' });
+    const logResult = await calculatorExecutor.calculate({ expression: 'log(5, e)' });
+    expect(lnResult.success).toBe(true);
+    expect(logResult.success).toBe(true);
+    expect(lnResult.content).toBe(logResult.content);
+  });
+
   it('should handle constants in scientific notation', async () => {
     const result = await calculatorExecutor.calculate({ expression: 'pi * 1e3' });
     expect(result.success).toBe(true);

--- a/packages/builtin-tool-calculator/src/executor/index.ts
+++ b/packages/builtin-tool-calculator/src/executor/index.ts
@@ -23,10 +23,11 @@ import {
 const math = create(all);
 
 // Add ln() as a natural logarithm function (log base e)
+// Uses mathjs's log function to support all mathjs numeric types (complex, units, etc.)
 math.import(
   {
-    ln: function (x: number) {
-      return Math.log(x);
+    ln: function (x: any) {
+      return math.log(x, math.e);
     },
   },
   { override: true },

--- a/packages/builtin-tool-calculator/src/executor/index.ts
+++ b/packages/builtin-tool-calculator/src/executor/index.ts
@@ -22,6 +22,16 @@ import {
 // Create a mathjs instance with all functions
 const math = create(all);
 
+// Add ln() as a natural logarithm function (log base e)
+math.import(
+  {
+    ln: function (x: number) {
+      return Math.log(x);
+    },
+  },
+  { override: true },
+);
+
 /**
  * Calculator Tool Executor
  *
@@ -50,6 +60,7 @@ class CalculatorExecutor
     } catch (error) {
       throw new Error(
         `Failed to evaluate expression: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error },
       );
     }
   }

--- a/packages/builtin-tool-calculator/src/manifest.ts
+++ b/packages/builtin-tool-calculator/src/manifest.ts
@@ -13,7 +13,7 @@ export const CalculatorManifest: BuiltinToolManifest = {
         properties: {
           expression: {
             description:
-              'Mathematical expression to calculate (e.g., "2 + 3 * 4", "sqrt(16)", "sin(30 deg)", "det([[1,2],[3,4]])", "5 cm to inch")',
+              'Mathematical expression to calculate (e.g., "2 + 3 * 4", "sqrt(16)", "ln(10)", "sin(30 deg)", "det([[1,2],[3,4]])", "5 cm to inch")',
             type: 'string',
           },
           precision: {
@@ -35,7 +35,7 @@ export const CalculatorManifest: BuiltinToolManifest = {
         properties: {
           expression: {
             description:
-              'Mathematical expression to evaluate (e.g., "x^2 + 2*x + 1", "det([[a,b],[c,d]])", "sqrt(a^2 + b^2)")',
+              'Mathematical expression to evaluate (e.g., "x^2 + 2*x + 1", "det([[a,b],[c,d]])", "ln(x)", "sqrt(a^2 + b^2)")',
             type: 'string',
           },
           precision: {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

在测试过程中发现，模型会频繁调用 `ln(1)` 这样的自然对数表达式，但该表达式默认并不支持。尽管已在 system prompt 中明确提示，模型仍会偶尔生成此类表达式，导致计算失败。

本次 PR 决定直接支持 `ln()` 表达式，将其实现为等效于 `log(x, e)` 的计算逻辑，其中 `e` 为自然常数。这样既提升了模型的可用性，也减少了因提示词限制导致的错误。

**主要变更：**
- 新增 `ln()` 函数支持，等价于 `log(x, e)`
- 添加了对应的测试用例，确保 `ln(1) = 0` 等边界情况正确

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

本地测试通过以下表达式验证功能：

```
ln(1)        // 应返回 0
ln(e)        // 应返回 1
ln(2)        // 应返回约 0.693147
ln(10)       // 应返回约 2.302585
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

同时更新了测试用例

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

N/A (纯功能增强，无 UI 变更)

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

**兼容性说明：**
- 此变更为向后兼容，不影响现有功能
- 新增的 `ln()` 函数与现有的 `log(x, base)` 函数保持数学等价性

**性能影响：**
- 无显著性能影响，仅增加一个函数解析入口