### PR TITLE
fix: expose s3PublicDomain in SPAClientEnv and use public URL in file proxy

### DIFF
--- a/src/app/(backend)/f/[id]/route.ts
+++ b/src/app/(backend)/f/[id]/route.ts
@@ -68,9 +68,11 @@ export const GET = async (_req: Request, segmentData: { params: Params }) => {
     // Create file service with file owner's userId
     const fileService = new FileService(db, file.userId);
 
-    // Web: Generate S3 presigned URL (5 minutes expiry)
-    const redirectUrl = await fileService.createPreSignedUrlForPreview(file.url, 300);
-    log('Web S3 presigned URL generated (expires in 5 min)');
+    // Web: Generate file URL — uses public domain URL when S3_PUBLIC_DOMAIN + S3_SET_ACL are
+    // configured (avoids browser CORS issues with raw S3 endpoints), falls back to a 5-minute
+    // pre-signed URL otherwise.
+    const redirectUrl = await fileService.getFullFileUrl(file.url, 300);
+    log('File URL resolved for: %s', id);
 
     // Cache the presigned URL in Redis
     if (redisClient) {

--- a/src/app/spa/[variants]/[[...path]]/route.ts
+++ b/src/app/spa/[variants]/[[...path]]/route.ts
@@ -161,6 +161,7 @@ function buildClientEnv(): SPAClientEnv {
     pyodideIndexUrl: pythonEnv.NEXT_PUBLIC_PYODIDE_INDEX_URL,
     pyodidePipIndexUrl: pythonEnv.NEXT_PUBLIC_PYODIDE_PIP_INDEX_URL,
     s3FilePath: fileEnv.NEXT_PUBLIC_S3_FILE_PATH,
+    s3PublicDomain: fileEnv.S3_PUBLIC_DOMAIN,
   };
 }
 

--- a/src/types/spaServerConfig.ts
+++ b/src/types/spaServerConfig.ts
@@ -17,6 +17,7 @@ export interface SPAClientEnv {
   pyodideIndexUrl?: string;
   pyodidePipIndexUrl?: string;
   s3FilePath?: string;
+  s3PublicDomain?: string;
 }
 
 export interface SPAServerConfig {


### PR DESCRIPTION
Fixes #13385

## Problem

After the Vite SPA migration (PR #12404), `S3_PUBLIC_DOMAIN` stopped being available to the browser SPA. This caused two related issues:

1. **Missing `s3PublicDomain` in `SPAClientEnv`**: The `S3_PUBLIC_DOMAIN` env var is server-only (no `NEXT_PUBLIC_` prefix), so it is not bundled by Vite. It was never added to `window.__SERVER_CONFIG__.clientEnv`, leaving client-side code unable to discover the custom S3 domain at runtime.

2. **CORS errors when converting images to base64**: The `/f/:id` file proxy always called `createPreSignedUrlForPreview()`, which returns a raw S3/R2 endpoint URL (e.g. `r2.cloudflarestorage.com`). When the browser fetches this URL to convert an image to base64 before sending to a vision LLM, the raw endpoint often lacks CORS headers, causing the request to fail. Users who configured `S3_PUBLIC_DOMAIN` (with a custom CDN domain that has proper CORS headers) were not benefiting from it in the proxy.

## Solution

- **`src/types/spaServerConfig.ts`**: Add `s3PublicDomain?: string` to the `SPAClientEnv` interface.
- **`src/app/spa/[variants]/[[...path]]/route.ts`**: Inject `fileEnv.S3_PUBLIC_DOMAIN` as `s3PublicDomain` in `buildClientEnv()`, making it available in `window.__SERVER_CONFIG__.clientEnv` at runtime.
- **`src/app/(backend)/f/[id]/route.ts`**: Replace `createPreSignedUrlForPreview()` with `getFullFileUrl()`. When `S3_SET_ACL=true` and `S3_PUBLIC_DOMAIN` is configured, the proxy now redirects to the custom public domain URL (which has user-configured CORS headers). For private buckets without `S3_PUBLIC_DOMAIN`, behavior is unchanged — `getFullFileUrl()` falls back to a pre-signed URL.

## Testing

- Without `S3_PUBLIC_DOMAIN`: file proxy behavior is unchanged (pre-signed URL redirect).
- With `S3_PUBLIC_DOMAIN` + `S3_SET_ACL=1`: file proxy redirects to the public CDN URL; `window.__SERVER_CONFIG__.clientEnv.s3PublicDomain` is populated for client-side use.