### PR TITLE
fix: resolve dropdown menu layering issue in knowledge library modal

### DIFF
--- a/src/features/LibraryModal/AssignKnowledgeBase/Item/Action.tsx
+++ b/src/features/LibraryModal/AssignKnowledgeBase/Item/Action.tsx
@@ -1,6 +1,6 @@
-import { ActionIcon, Button, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, Button, DropdownMenu, Flexbox, Icon, LOBE_THEME_APP_ID } from '@lobehub/ui';
 import { InfoIcon, MoreVerticalIcon, Trash2 } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAgentStore } from '@/store/agent';
@@ -12,6 +12,12 @@ interface ActionsProps {
   id: string;
   type: KnowledgeType;
 }
+
+const getAppOverlayContainer = () => {
+  if (typeof document === 'undefined') return undefined;
+
+  return document.getElementById(LOBE_THEME_APP_ID) || document.body;
+};
 
 const Actions = memo<ActionsProps>(({ id, type, enabled }) => {
   const { t } = useTranslation('chat');
@@ -30,6 +36,13 @@ const Actions = memo<ActionsProps>(({ id, type, enabled }) => {
   ]);
 
   const [loading, setLoading] = useState(false);
+  const dropdownPortalProps = useMemo(() => {
+    const container = getAppOverlayContainer();
+
+    if (!container) return undefined;
+
+    return { container };
+  }, []);
 
   const assignKnowledge = async () => {
     setLoading(true);
@@ -56,6 +69,7 @@ const Actions = memo<ActionsProps>(({ id, type, enabled }) => {
       {enabled ? (
         <DropdownMenu
           placement="bottomRight"
+          portalProps={dropdownPortalProps}
           items={[
             {
               icon: <Icon icon={InfoIcon} />,

--- a/src/features/LibraryModal/AssignKnowledgeBase/index.tsx
+++ b/src/features/LibraryModal/AssignKnowledgeBase/index.tsx
@@ -1,10 +1,12 @@
-import { Flexbox, Modal } from '@lobehub/ui';
+import { Flexbox, LOBE_THEME_APP_ID, Modal } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useServerConfigStore } from '@/store/serverConfig';
 
 import List from './List';
+
+const getAppOverlayContainer = () => document.getElementById(LOBE_THEME_APP_ID) || document.body;
 
 interface AttachKnowledgeModalProps {
   open?: boolean;
@@ -19,6 +21,7 @@ export const AttachKnowledgeModal = memo<AttachKnowledgeModalProps>(({ setOpen, 
     <Modal
       allowFullscreen
       footer={null}
+      getContainer={getAppOverlayContainer}
       open={open}
       styles={{ body: { overflow: 'hidden' } }}
       title={t('knowledgeBase.library.title')}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #12389 #12710

#### 🔀 Description of Change

Portaled both the Modal and the DropdownMenu to a unified app-level container using LOBE_THEME_APP_ID. Used getContainer for the Modal and portalProps for the DropdownMenu to ensure they are siblings in the DOM, allowing z-indexes to resolve correctly.

#### 🧪 How to Test

1. On the main chatting page (Home), hover your mouse on the button which is used to upload a file, which then triggers a dropdown menu.
2. On the menu, click "View More" to open the "Files / Libraries" panel.
3. Upload a few files so that the panel is not empty.
4. Try clicking the three-dot menu (⋮) button next to any file.
4. Expected: A dropdown menu should be visible, as opposed to not appearing in the issues.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

Before:
<img width="218" height="202" alt="image" src="https://github.com/user-attachments/assets/8d968432-5853-44c6-a20b-811ae8fcf265" />

After:
<img width="179" height="179" alt="image" src="https://github.com/user-attachments/assets/36a127aa-d330-407e-8e7c-e56bf17dbe87" />

