### PR TITLE
fix(pageEditor): ensure page agent runtime receives editor instance reliably

### DIFF
--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -69,7 +69,9 @@ export class EditorRuntime {
    */
   private getEditor(): IEditor {
     if (!this.editor) {
-      throw new Error('Editor not initialized. Please set the editor instance first.');
+      throw new Error(
+        'The Page Editor is not open. Please navigate to a page document before using editing tools.',
+      );
     }
     return this.editor;
   }

--- a/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
+++ b/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
@@ -79,7 +79,7 @@ describe('EditorRuntime', () => {
       runtime.setEditor(null);
 
       await expect(runtime.initPage({ markdown: 'Test' })).rejects.toThrow(
-        'Editor not initialized',
+        'The Page Editor is not open',
       );
     });
   });

--- a/src/features/PageEditor/StoreUpdater.tsx
+++ b/src/features/PageEditor/StoreUpdater.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEditor } from '@lobehub/editor/react';
 import { memo, useEffect } from 'react';
 import { createStoreUpdater } from 'zustand-utils';
 
@@ -37,9 +38,13 @@ const StoreUpdater = memo<StoreUpdaterProps>(
     const storeApi = useStoreApi();
     const useStoreUpdater = createStoreUpdater(storeApi);
 
-    const editor = usePageEditorStore((s) => s.editor);
     const initMeta = usePageEditorStore((s) => s.initMeta);
-    const pageAgentEditor = editor as unknown as PageAgentEditor | undefined;
+
+    // Read the editor directly from the EditorProvider context so that the runtime
+    // always receives the latest editor instance, even if the store was created
+    // before the editor finished initializing.
+    const editorFromContext = useEditor();
+    const pageAgentEditor = editorFromContext as unknown as PageAgentEditor | undefined;
 
     // Update store with props
     useStoreUpdater('documentId', pageId);
@@ -57,7 +62,9 @@ const StoreUpdater = memo<StoreUpdaterProps>(
       initMeta(title, emoji);
     }, [pageId, title, emoji]);
 
-    // Connect editor to page agent runtime
+    // Connect editor to page agent runtime using the live context value so the
+    // runtime is updated as soon as the editor is available, regardless of when
+    // the store was initialized.
     useEffect(() => {
       if (pageAgentEditor) {
         pageAgentRuntime.setEditor(pageAgentEditor);


### PR DESCRIPTION
Fixes #13434

## Problem

When a user asks the page copilot to create or edit a document, the tool call fails with **"Editor not initialized. Please set the editor instance first."** — a confusing developer-facing message.

Root cause: `StoreUpdater` wired `pageAgentRuntime` to the editor value read from `PageEditorStore`. That store is created once at mount time (inside `PageEditorProvider`). If `@lobehub/editor`'s `EditorProvider` resolves the editor asynchronously or after the store snapshot is taken, `editor` in the store stays `undefined` and the runtime never receives a valid instance, causing every subsequent tool call to throw.

## Solution

1. **`StoreUpdater.tsx`** – read the editor directly from the live `EditorProvider` context via `useEditor()` instead of from the store. This guarantees the runtime is updated as soon as the editor becomes available, regardless of the store's initialisation order.

2. **`EditorRuntime.ts`** – replace the developer-facing error message with a user-friendly one: *"The Page Editor is not open. Please navigate to a page document before using editing tools."* The agent can relay this message directly to the user.

3. **`EditorRuntime.test.ts`** – update the test assertion to match the new message.

## Testing

- Unit test updated to match the new error message.
- Manual flow: open a page in the page editor → open the copilot → ask it to "create a document" → the `initPage` tool now succeeds (when editor is mounted) or returns a clear message (when it is not).