### PR TITLE
fix(agent-runtime): register onContentPart callback for Gemini 3+ streaming output

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -622,6 +622,20 @@ export const createRuntimeExecutors = (
                   grounding: groundingData,
                 });
               },
+              onContentPart: async (data) => {
+                // Handle multimodal content_part events emitted by Gemini 3+ models.
+                // These carry the same text payload as onText but via a different callback.
+                if (data.partType === 'text' && data.content) {
+                  content += data.content;
+                  textBuffer += data.content;
+                  if (!textBufferTimer) {
+                    textBufferTimer = setTimeout(async () => {
+                      await flushTextBuffer();
+                      textBufferTimer = null;
+                    }, BUFFER_INTERVAL);
+                  }
+                }
+              },
               onText: async (text) => {
                 timing(
                   '[%s] onText received chunk at %d, length: %d',


### PR DESCRIPTION
Fixes #13602

## Problem

Gemini 3+ models are forced into multimodal processing mode in `packages/model-runtime/src/core/streams/google/index.ts`, which causes them to emit `content_part` SSE events (with `partType: 'text'`) instead of the standard `text` events. The `onContentPart` callback is already defined in the `ChatStreamCallbacks` interface but was never registered in `createRuntimeExecutors`, causing all Gemini 3+ text output to be silently discarded — resulting in empty `output` and `output_text` despite `output_tokens > 0`.

## Solution

Register `onContentPart` in the `callback` object passed to `modelRuntime.chat()` in `RuntimeExecutors.ts`. When `data.partType === 'text'`, the handler accumulates content into `content` and `textBuffer` using the same buffered-flush logic as the existing `onText` handler (50ms interval timer). This mirrors the `onText` accumulation exactly, so Gemini 3+ text responses now surface correctly.

## Testing

- The fix is a one-function addition that follows existing patterns exactly
- Manual verification: call `/api/v1/responses` with a Gemini 3+ backed agent — output should now contain the generated text
- No existing tests broken; the `onContentPart` path was previously unreachable