### PR TITLE
✨ feat(provider): add Chutes AI as a new model provider

### DIFF
--- a/packages/model-bank/src/aiModels/chutes.ts
+++ b/packages/model-bank/src/aiModels/chutes.ts
@@ -1,0 +1,37 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// ref https://chutes.ai/app/chute?type=llm
+
+const chutesChatModels: AIChatModelCard[] = [
+  {
+    contextWindowTokens: 64_000,
+    description:
+      'DeepSeek-V3.2-TEE runs in a Trusted Execution Environment on Bittensor Subnet 64, providing verifiable private inference with state-of-the-art performance.',
+    displayName: 'DeepSeek-V3.2-TEE',
+    enabled: true,
+    id: 'deepseek-ai/DeepSeek-V3-0324',
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 128_000,
+    description:
+      'Qwen3-32B-TEE runs in a Trusted Execution Environment on Bittensor Subnet 64, offering high-quality reasoning with privacy guarantees.',
+    displayName: 'Qwen3-32B-TEE',
+    enabled: true,
+    id: 'Qwen/Qwen3-32B',
+    type: 'chat',
+  },
+  {
+    contextWindowTokens: 256_000,
+    description:
+      'Kimi-K2.5-TEE runs in a Trusted Execution Environment on Bittensor Subnet 64, providing a large context window with secure decentralized inference.',
+    displayName: 'Kimi-K2.5-TEE',
+    enabled: true,
+    id: 'moonshotai/Kimi-K2-Instruct',
+    type: 'chat',
+  },
+];
+
+export const allModels = [...chutesChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -12,6 +12,7 @@ export enum ModelProvider {
   Bedrock = 'bedrock',
   Bfl = 'bfl',
   Cerebras = 'cerebras',
+  Chutes = 'chutes',
   Cloudflare = 'cloudflare',
   Cohere = 'cohere',
   CometAPI = 'cometapi',

--- a/packages/model-bank/src/modelProviders/chutes.ts
+++ b/packages/model-bank/src/modelProviders/chutes.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref https://chutes.ai
+const Chutes: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'deepseek-ai/DeepSeek-V3-0324',
+  description:
+    'Chutes AI provides decentralized AI inference on Bittensor Subnet 64. All models run in Trusted Execution Environments (TEE), ensuring privacy and security for every inference.',
+  id: 'chutes',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://chutes.ai/app/chute?type=llm',
+  name: 'Chutes AI',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://llm.chutes.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://chutes.ai',
+};
+
+export default Chutes;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -15,6 +15,7 @@ import BailianCodingPlanProvider from './bailianCodingPlan';
 import BedrockProvider from './bedrock';
 import BflProvider from './bfl';
 import CerebrasProvider from './cerebras';
+import ChutesProvider from './chutes';
 import CloudflareProvider from './cloudflare';
 import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
@@ -92,6 +93,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   DeepSeekProvider.chatModels,
   GoogleProvider.chatModels,
   GroqProvider.chatModels,
+  ChutesProvider.chatModels,
   GithubProvider.chatModels,
   MinimaxProvider.chatModels,
   MistralProvider.chatModels,
@@ -212,6 +214,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   CometAPIProvider,
   VercelAIGatewayProvider,
   CerebrasProvider,
+  ChutesProvider,
   ZenMuxProvider,
   StraicoProvider,
   XiaomiMiMoProvider,
@@ -242,6 +245,7 @@ export { default as BailianCodingPlanProviderCard } from './bailianCodingPlan';
 export { default as BedrockProviderCard } from './bedrock';
 export { default as BflProviderCard } from './bfl';
 export { default as CerebrasProviderCard } from './cerebras';
+export { default as ChutesProviderCard } from './chutes';
 export { default as CloudflareProviderCard } from './cloudflare';
 export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -15,6 +15,7 @@ export { LobeBailianCodingPlanAI } from './providers/bailianCodingPlan';
 export { LobeBedrockAI } from './providers/bedrock';
 export { LobeBflAI } from './providers/bfl';
 export { LobeCerebrasAI } from './providers/cerebras';
+export { LobeChutesAI } from './providers/chutes';
 export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
 export { LobeDeepSeekAI } from './providers/deepseek';

--- a/packages/model-runtime/src/providers/chutes/index.ts
+++ b/packages/model-runtime/src/providers/chutes/index.ts
@@ -1,0 +1,14 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const params = {
+  baseURL: 'https://llm.chutes.ai/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_CHUTES_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Chutes,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeChutesAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -11,6 +11,7 @@ import { LobeBailianCodingPlanAI } from './providers/bailianCodingPlan';
 import { LobeBedrockAI } from './providers/bedrock';
 import { LobeBflAI } from './providers/bfl';
 import { LobeCerebrasAI } from './providers/cerebras';
+import { LobeChutesAI } from './providers/chutes';
 import { LobeCloudflareAI } from './providers/cloudflare';
 import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
@@ -90,6 +91,7 @@ export const providerRuntimeMap = {
   bedrock: LobeBedrockAI,
   bfl: LobeBflAI,
   cerebras: LobeCerebrasAI,
+  chutes: LobeChutesAI,
   cloudflare: LobeCloudflareAI,
   cohere: LobeCohereAI,
   cometapi: LobeCometAPIAI,

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -47,6 +47,9 @@ export const getLLMConfig = () => {
       ENABLED_GROQ: z.boolean(),
       GROQ_API_KEY: z.string().optional(),
 
+      ENABLED_CHUTES: z.boolean(),
+      CHUTES_API_KEY: z.string().optional(),
+
       ENABLED_GITHUB: z.boolean(),
       GITHUB_TOKEN: z.string().optional(),
 
@@ -283,6 +286,9 @@ export const getLLMConfig = () => {
 
       ENABLED_GROQ: !!process.env.GROQ_API_KEY,
       GROQ_API_KEY: process.env.GROQ_API_KEY,
+
+      ENABLED_CHUTES: !!process.env.CHUTES_API_KEY,
+      CHUTES_API_KEY: process.env.CHUTES_API_KEY,
 
       ENABLED_GITHUB: !!process.env.GITHUB_TOKEN,
       GITHUB_TOKEN: process.env.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary

- Adds **Chutes AI** as a new OpenAI-compatible model provider
- Chutes provides decentralized AI inference on **Bittensor Subnet 64**, with all models running in **Trusted Execution Environments (TEE)** for verifiable privacy
- Base URL: `https://llm.chutes.ai/v1`
- API key env var: `CHUTES_API_KEY`

### Changes

| File | Change |
|------|--------|
| `packages/model-bank/src/const/modelProvider.ts` | Add `Chutes = 'chutes'` to `ModelProvider` enum |
| `packages/model-bank/src/modelProviders/chutes.ts` | New provider card (OpenAI-compatible, model fetcher enabled) |
| `packages/model-bank/src/aiModels/chutes.ts` | Model definitions: DeepSeek-V3.2-TEE (64k), Qwen3-32B-TEE (128k), Kimi-K2.5-TEE (256k) |
| `packages/model-bank/src/modelProviders/index.ts` | Register import, list entry, and export |
| `src/envs/llm.ts` | Add `ENABLED_CHUTES` / `CHUTES_API_KEY` env vars |
| `packages/model-runtime/src/providers/chutes/index.ts` | New runtime using `createOpenAICompatibleRuntime` |
| `packages/model-runtime/src/runtimeMap.ts` | Register `chutes` → `LobeChutesAI` |
| `packages/model-runtime/src/index.ts` | Export `LobeChutesAI` |

## Notes

- Follows the same pattern as Groq, Cerebras, and other OpenAI-compatible providers
- OpenClaw has already merged Chutes as a provider — this brings the same support to LobeChat
- The provider card uses `showModelFetcher: true` so users can dynamically fetch available Chutes models
- No special auth handling needed; uses the standard default case in `ModelRuntime`

## Test plan

- [ ] Set `CHUTES_API_KEY` in env and verify provider appears in the UI as enabled
- [ ] Verify model list fetches correctly from `https://llm.chutes.ai/v1`
- [ ] Send a test message using one of the pre-defined models

🤖 Generated with [Claude Code](https://claude.com/claude-code)