### PR TITLE
fix(locale): provide Base UI DirectionProvider for RTL language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "@lobehub/market-sdk": "0.32.2",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.6.1",
+    "@base-ui/react": "1.0.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/layout/SPAGlobalProvider/Locale.tsx
+++ b/src/layout/SPAGlobalProvider/Locale.tsx
@@ -1,3 +1,4 @@
+import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { ConfigProvider } from 'antd';
 import dayjs from 'dayjs';
 import { memo, type PropsWithChildren, useEffect, useState } from 'react';
@@ -84,7 +85,9 @@ const Locale = memo<LocaleLayoutProps>(({ children, defaultLang, antdLocale }) =
         },
       }}
     >
-      <Editor>{children}</Editor>
+      <DirectionProvider direction={documentDir}>
+        <Editor>{children}</Editor>
+      </DirectionProvider>
     </ConfigProvider>
   );
 });


### PR DESCRIPTION
Fixes #13588

## Problem

When using RTL languages (Arabic, Farsi, Hebrew, etc.), floating UI elements from `@lobehub/ui` — including `DropdownMenu`, `Popover`, and the `UserPanel` — were rendering with incorrect positioning. The menu popover appeared on the wrong side and had broken layout in RTL mode.

The root cause: `@lobehub/ui` v5+ internally uses `@base-ui/react` for `DropdownMenu` and `Popover` components. Base UI's positioning system calls `useDirection()` internally to determine whether to use `start`/`end` as left or right. Without a `DirectionProvider` in the React tree, `useDirection()` always returns `'ltr'` (its default), so menus always align to the physical left — regardless of the active language direction.

While antd's `ConfigProvider direction="rtl"` was already set correctly in `Locale.tsx`, this only affects antd's own components — not Base UI's floating elements.

## Solution

Wrap the content in `SPAGlobalProvider/Locale.tsx` with Base UI's `DirectionProvider`, passing the same `documentDir` value already computed for antd's `ConfigProvider`. This makes `useDirection()` return the correct value (`'rtl'` or `'ltr'`) inside all `@lobehub/ui` components.

Added `@base-ui/react: 1.0.0` as an explicit dependency (matching the version already used by `@lobehub/ui`).

## Testing

1. Switch the app language to Arabic (`ar`) or another RTL language
2. Open the help menu (bottom of sidebar), user panel, or agent switcher popover
3. Verify menus open correctly aligned to the right side in RTL