### PR TITLE
fix(share): include assistantGroup children content in text/PDF export

### DIFF
--- a/src/features/ShareModal/ShareText/template.test.ts
+++ b/src/features/ShareModal/ShareText/template.test.ts
@@ -193,4 +193,54 @@ describe('generateMarkdown', () => {
 
     expect(result).toContain('Intro\n\n<think>\n\nReasoning\n\n</think>\n\nOutro');
   });
+
+  it('should include assistantGroup children content in export', () => {
+    const messagesWithAssistantGroup = [
+      {
+        id: '1',
+        content: 'What is the weather?',
+        role: 'user',
+        createdAt: Date.now(),
+      },
+      {
+        id: '2',
+        content: '',
+        role: 'assistantGroup',
+        createdAt: Date.now(),
+        children: [
+          { id: 'block-1', content: 'Let me check the weather for you.' },
+          { id: 'block-2', content: 'The weather is sunny today.' },
+        ],
+      },
+    ] as UIChatMessage[];
+
+    const result = generateMarkdown({
+      ...defaultParams,
+      messages: messagesWithAssistantGroup,
+    });
+
+    expect(result).toContain('Let me check the weather for you.');
+    expect(result).toContain('The weather is sunny today.');
+  });
+
+  it('should render assistantGroup as Assistant role when withRole is true', () => {
+    const messagesWithAssistantGroup = [
+      {
+        id: '1',
+        content: '',
+        role: 'assistantGroup',
+        createdAt: Date.now(),
+        children: [{ id: 'block-1', content: 'Agent response content.' }],
+      },
+    ] as UIChatMessage[];
+
+    const result = generateMarkdown({
+      ...defaultParams,
+      withRole: true,
+      messages: messagesWithAssistantGroup,
+    });
+
+    expect(result).toContain('##### Assistant:');
+    expect(result).toContain('Agent response content.');
+  });
 });

--- a/src/features/ShareModal/ShareText/template.ts
+++ b/src/features/ShareModal/ShareText/template.ts
@@ -74,10 +74,20 @@ export const generateMarkdown = ({
       .filter((m) => m.content !== LOADING_FLAT)
       .filter((m) => (!includeUser ? m.role !== 'user' : true))
       .filter((m) => (!includeTool ? m.role !== 'tool' : true))
-      .map((message) => ({
-        ...message,
-        content: normalizeThinkTags(processWithArtifact(message.content)),
-      })),
+      .map((message) => {
+        // For assistantGroup messages, content is stored in children blocks
+        if (message.role === 'assistantGroup' && message.children?.length) {
+          const combinedContent = message.children
+            .map((child) => normalizeThinkTags(processWithArtifact(child.content)))
+            .filter(Boolean)
+            .join('\n\n');
+          return { ...message, content: combinedContent, role: 'assistant' as const };
+        }
+        return {
+          ...message,
+          content: normalizeThinkTags(processWithArtifact(message.content)),
+        };
+      }),
     systemRole: withSystemRole ? systemRole : undefined,
     title,
     withRole,


### PR DESCRIPTION
Fixes #13695

## Problem

In LobeHub's multi-agent architecture, assistant responses are stored as `assistantGroup` messages. These messages have `content: ''` (empty) at the top level, with the actual text content stored in `children[].content` (`AssistantContentBlock[]`).

The text and PDF export feature uses `generateMarkdown()` in `src/features/ShareModal/ShareText/template.ts`, which only reads `chat.content` directly. Since `assistantGroup` messages have empty `content`, agent responses are silently omitted from the exported text/PDF files.

This explains why:
- ✅ Screenshot export works — it renders the actual React UI which handles `assistantGroup` messages via their `children`
- ✅ JSON export works — it serializes the full message structure including `children`
- ❌ Text/PDF export fails — it only reads the empty `content` field

## Solution

In the `.map()` step of `generateMarkdown()`, detect `assistantGroup` messages and concatenate their `children[].content` blocks into a single text content. These messages are also remapped to role `assistant` so the markdown template renders the "Assistant:" header correctly.

## Testing

- Added tests to `template.test.ts` verifying that `assistantGroup` messages with children are included in the markdown output and render with the correct `##### Assistant:` role header.