### PR TITLE
fix(gateway): deduplicate concurrent GatewayManager.start() calls

### DIFF
--- a/src/server/services/gateway/GatewayManager.test.ts
+++ b/src/server/services/gateway/GatewayManager.test.ts
@@ -138,6 +138,42 @@ describe('GatewayManager', () => {
       await expect(manager.start()).resolves.toBeUndefined();
       expect(manager.isRunning).toBe(true);
     });
+
+    it('should not initialize twice when called concurrently', async () => {
+      const manager = new GatewayManager({ definitions: [] });
+
+      // Call start() twice concurrently without awaiting the first
+      await Promise.all([manager.start(), manager.start()]);
+
+      expect(manager.isRunning).toBe(true);
+      // getServerDB is called inside sync() → each platform triggers one call.
+      // With empty definitions, sync() iterates 0 platforms, so getServerDB is not called.
+      // The key assertion: start() is idempotent for concurrent callers.
+      const dbCallCount = vi.mocked(getServerDB).mock.calls.length;
+      expect(dbCallCount).toBe(0); // no platforms registered, so no DB calls
+
+      // A third concurrent call after start completes should also be a no-op
+      await manager.start();
+      expect(vi.mocked(getServerDB).mock.calls.length).toBe(0);
+    });
+
+    it('should dedup concurrent start() calls with active platforms', async () => {
+      const mockBot = createMockBot();
+      mockFindEnabledByPlatform.mockResolvedValue([
+        { applicationId: 'app-1', credentials: { token: 'tok' } },
+      ]);
+
+      const manager = new GatewayManager({
+        definitions: [createFakeDefinition('slack', () => mockBot)],
+      });
+
+      // Fire two concurrent starts — only one sync should occur
+      await Promise.all([manager.start(), manager.start()]);
+
+      expect(manager.isRunning).toBe(true);
+      // Bot should only be started once despite two concurrent start() calls
+      expect(mockBot.start).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('stop', () => {

--- a/src/server/services/gateway/GatewayManager.ts
+++ b/src/server/services/gateway/GatewayManager.ts
@@ -21,6 +21,7 @@ export interface GatewayManagerConfig {
 export class GatewayManager {
   private clients = new Map<string, PlatformClient>();
   private running = false;
+  private _startPromise: Promise<void> | null = null;
   private config: GatewayManagerConfig;
 
   private definitionByPlatform: Map<string, PlatformDefinition>;
@@ -44,14 +45,28 @@ export class GatewayManager {
       return;
     }
 
-    log('Starting GatewayManager');
+    // If start() is already in progress (concurrent calls), wait for it
+    if (this._startPromise) {
+      log('GatewayManager start already in progress, waiting');
+      return this._startPromise;
+    }
 
-    await this.sync().catch((err) => {
-      console.error('[GatewayManager] Initial sync failed:', err);
-    });
+    this._startPromise = (async () => {
+      log('Starting GatewayManager');
 
-    this.running = true;
-    log('GatewayManager started with %d clients', this.clients.size);
+      await this.sync().catch((err) => {
+        console.error('[GatewayManager] Initial sync failed:', err);
+      });
+
+      this.running = true;
+      log('GatewayManager started with %d clients', this.clients.size);
+    })();
+
+    try {
+      await this._startPromise;
+    } finally {
+      this._startPromise = null;
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
Fixes #13709

## Problem

When the server starts, two code paths concurrently trigger `GatewayService.ensureRunning()`:
1. `instrumentation.ts` — fires `service.ensureRunning()` without awaiting
2. `startServer.js` — calls `POST /api/agent/gateway/start` also without awaiting

Both paths call `GatewayManager.start()` at roughly the same time. Because `start()` is async and sets `this.running = true` only after `await this.sync()` completes, two concurrent callers can both pass the `if (this.running)` guard before either finishes — causing `sync()` to run twice and bot clients (e.g. QQ chat-sdk) to be initialized twice.

The double initialization produces:
- Two WebSocket connections to the bot platform
- Duplicate message delivery (every user message gets two replies)

## Solution

Add a promise-based deduplication guard in `GatewayManager.start()`. If a start is already in progress, subsequent concurrent callers return the same in-flight promise instead of re-entering the initialization path:

```ts
if (this._startPromise) {
  return this._startPromise; // wait for the already-running start
}
this._startPromise = (async () => { /* ... sync() ... */ })();
try { await this._startPromise; } finally { this._startPromise = null; }
```

This is a standard singleton-initialization pattern that ensures `sync()` and all bot `client.start()` calls run exactly once regardless of how many concurrent callers invoke `start()`.

## Testing

Added two unit tests in `GatewayManager.test.ts`:
- `should not initialize twice when called concurrently` — verifies `Promise.all([start(), start()])` only runs one sync
- `should dedup concurrent start() calls with active platforms` — verifies bot `client.start()` is called exactly once when two `start()` calls race