### PR TITLE
🐛 fix(agent-runtime): guard missing parent messages during generation

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/useAssistantActions.ts
+++ b/src/features/Conversation/Messages/Assistant/Actions/useAssistantActions.ts
@@ -65,6 +65,7 @@ export const useAssistantActions = ({
 
   // Get state from ConversationStore
   const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const isRegenerating = useConversationStore(messageStateSelectors.isMessageRegenerating(id));
 
   // Get actions from ConversationStore
@@ -105,13 +106,14 @@ export const useAssistantActions = ({
       },
       del: {
         danger: true,
+        disabled: isGenerating,
         handleClick: () => deleteMessage(id),
         icon: Trash,
         key: 'del',
         label: t('delete'),
       },
       delAndRegenerate: {
-        disabled: isRegenerating,
+        disabled: isGenerating || isRegenerating,
         handleClick: () => delAndRegenerateMessage(id),
         icon: ListRestart,
         key: 'delAndRegenerate',
@@ -174,6 +176,7 @@ export const useAssistantActions = ({
       id,
       data.content,
       data.error,
+      isGenerating,
       isRegenerating,
       isCollapsed,
       toggleMessageEditing,

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/useGroupActions.ts
@@ -58,6 +58,7 @@ export const useGroupActions = ({
 
   // Get state from ConversationStore
   const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const isRegenerating = useConversationStore(messageStateSelectors.isMessageRegenerating(id));
   const lastBlockId = useConversationStore(dataSelectors.findLastMessageId(id));
   const isContinuing = useConversationStore((s) =>
@@ -114,13 +115,14 @@ export const useGroupActions = ({
       },
       del: {
         danger: true,
+        disabled: isGenerating,
         handleClick: () => deleteMessage(id),
         icon: Trash,
         key: 'del',
         label: t('delete'),
       },
       delAndRegenerate: {
-        disabled: isRegenerating,
+        disabled: isGenerating || isRegenerating,
         handleClick: () => delAndRegenerateMessage(id),
         icon: ListRestart,
         key: 'delAndRegenerate',
@@ -177,6 +179,7 @@ export const useGroupActions = ({
       id,
       contentBlock,
       data.error,
+      isGenerating,
       isRegenerating,
       isContinuing,
       isCollapsed,

--- a/src/features/Conversation/Messages/Supervisor/Actions/useGroupActions.ts
+++ b/src/features/Conversation/Messages/Supervisor/Actions/useGroupActions.ts
@@ -54,6 +54,7 @@ export const useGroupActions = ({
 
   // Get state from ConversationStore
   const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const isRegenerating = useConversationStore(messageStateSelectors.isMessageRegenerating(id));
   const lastBlockId = useConversationStore(dataSelectors.findLastMessageId(id));
   const isContinuing = useConversationStore((s) =>
@@ -99,13 +100,14 @@ export const useGroupActions = ({
       },
       del: {
         danger: true,
+        disabled: isGenerating,
         handleClick: () => deleteMessage(id),
         icon: Trash,
         key: 'del',
         label: t('delete'),
       },
       delAndRegenerate: {
-        disabled: isRegenerating,
+        disabled: isGenerating || isRegenerating,
         handleClick: () => delAndRegenerateMessage(id),
         icon: ListRestart,
         key: 'delAndRegenerate',
@@ -153,6 +155,7 @@ export const useGroupActions = ({
       id,
       contentBlock,
       data.error,
+      isGenerating,
       isRegenerating,
       isContinuing,
       isCollapsed,

--- a/src/features/Conversation/Messages/Task/Actions/useAssistantActions.ts
+++ b/src/features/Conversation/Messages/Task/Actions/useAssistantActions.ts
@@ -49,6 +49,7 @@ export const useAssistantActions = ({
 
   // Get state from ConversationStore
   const isCollapsed = useConversationStore(messageStateSelectors.isMessageCollapsed(id));
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
   const isRegenerating = useConversationStore(messageStateSelectors.isMessageRegenerating(id));
 
   // Get actions from ConversationStore
@@ -89,13 +90,14 @@ export const useAssistantActions = ({
       },
       del: {
         danger: true,
+        disabled: isGenerating,
         handleClick: () => deleteMessage(id),
         icon: Trash,
         key: 'del',
         label: t('delete'),
       },
       delAndRegenerate: {
-        disabled: isRegenerating,
+        disabled: isGenerating || isRegenerating,
         handleClick: () => delAndRegenerateMessage(id),
         icon: ListRestart,
         key: 'delAndRegenerate',
@@ -135,6 +137,7 @@ export const useAssistantActions = ({
       id,
       data.content,
       data.error,
+      isGenerating,
       isRegenerating,
       isCollapsed,
       toggleMessageEditing,

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -59,21 +59,25 @@ export const useChatItemContextMenu = ({
 
   const storeApi = useConversationStoreApi();
 
-  const [role, error, isCollapsed, hasThread, isRegenerating] = useConversationStore((s) => {
-    const item = dataSelectors.getDisplayMessageById(id)(s);
-    return [
-      item?.role,
-      item?.error,
-      messageStateSelectors.isMessageCollapsed(id)(s),
-      messageStateSelectors.hasThreadBySourceMsgId(id)(s),
-      messageStateSelectors.isMessageRegenerating(id)(s),
-    ];
-  }, isEqual);
+  const [role, error, isCollapsed, hasThread, isGenerating, isRegenerating] = useConversationStore(
+    (s) => {
+      const item = dataSelectors.getDisplayMessageById(id)(s);
+      return [
+        item?.role,
+        item?.error,
+        messageStateSelectors.isMessageCollapsed(id)(s),
+        messageStateSelectors.hasThreadBySourceMsgId(id)(s),
+        messageStateSelectors.isMessageGenerating(id)(s),
+        messageStateSelectors.isMessageRegenerating(id)(s),
+      ];
+    },
+    isEqual,
+  );
 
   const isThreadMode = useConversationStore(messageStateSelectors.isThreadMode);
   const isGroupSession = useSessionStore(sessionSelectors.isCurrentSessionGroupSession);
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
-  const actionsBar = useChatListActionsBar({ hasThread, isRegenerating });
+  const actionsBar = useChatListActionsBar({ hasThread, isGenerating, isRegenerating });
   const inThread = isThreadMode || inPortalThread;
 
   const [

--- a/src/features/Conversation/hooks/useChatListActionsBar.tsx
+++ b/src/features/Conversation/hooks/useChatListActionsBar.tsx
@@ -46,10 +46,12 @@ interface ChatListActionsBar {
 
 export const useChatListActionsBar = ({
   hasThread,
+  isGenerating,
   isContinuing,
   isRegenerating,
 }: {
   hasThread?: boolean;
+  isGenerating?: boolean;
   isContinuing?: boolean;
   isRegenerating?: boolean;
 } = {}): ChatListActionsBar => {
@@ -81,13 +83,13 @@ export const useChatListActionsBar = ({
       },
       del: {
         danger: true,
-        disabled: hasThread,
+        disabled: hasThread || isGenerating,
         icon: Trash,
         key: 'del',
         label: hasThread ? t('messageAction.deleteDisabledByThreads', { ns: 'chat' }) : t('delete'),
       },
       delAndRegenerate: {
-        disabled: hasThread || isRegenerating,
+        disabled: hasThread || isGenerating || isRegenerating,
         icon: ListRestart,
         key: 'delAndRegenerate',
         label: t('messageAction.delAndRegenerate', {
@@ -140,6 +142,6 @@ export const useChatListActionsBar = ({
         label: t('tts.action', { ns: 'chat' }),
       },
     }),
-    [hasThread, isContinuing, isRegenerating],
+    [hasThread, isGenerating, isContinuing, isRegenerating, t],
   );
 };

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -118,6 +118,29 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const getLLMRetryDelayMs = (attempt: number) =>
   Math.min(LLM_RETRY_BASE_DELAY_MS * 2 ** Math.max(attempt - 1, 0), LLM_RETRY_MAX_DELAY_MS);
 
+const MESSAGE_PARENT_FK_CONSTRAINT = 'messages_parent_id_messages_id_fk';
+
+const getErrorValue = (error: unknown, key: string) => {
+  if (!error || typeof error !== 'object') return;
+
+  return (error as Record<string, unknown>)[key];
+};
+
+const isMissingMessageParentError = (error: unknown) =>
+  getErrorValue(error, 'code') === '23503' &&
+  getErrorValue(error, 'constraint') === MESSAGE_PARENT_FK_CONSTRAINT;
+
+const createMissingMessageError = (messageId: string) => {
+  const error = new Error(
+    `Message "${messageId}" no longer exists. The conversation changed while this operation was running.`,
+  ) as Error & { code?: string; errorType?: string };
+
+  error.code = 'MESSAGE_PARENT_MISSING';
+  error.errorType = 'MessageParentMissing';
+
+  return error;
+};
+
 const isOperationInterrupted = async (ctx: RuntimeExecutorContext) => {
   if (!ctx.loadAgentState) return false;
 
@@ -334,10 +357,22 @@ export const createRuntimeExecutors = (
     let assistantMessageItem: { id: string };
 
     if (existingAssistantMessageId) {
+      const existingAssistantMessage = await ctx.messageModel.findById(existingAssistantMessageId);
+      if (!existingAssistantMessage) {
+        throw createMissingMessageError(existingAssistantMessageId);
+      }
+
       // Use existing assistant message (created by execAgent)
       assistantMessageItem = { id: existingAssistantMessageId };
       log(`${stagePrefix} Using existing assistant message: %s`, existingAssistantMessageId);
     } else {
+      if (parentId) {
+        const parentMessage = await ctx.messageModel.findById(parentId);
+        if (!parentMessage) {
+          throw createMissingMessageError(parentId);
+        }
+      }
+
       // Create new assistant message (legacy behavior)
       assistantMessageItem = await ctx.messageModel.create({
         agentId: state.metadata!.agentId!,
@@ -1729,6 +1764,11 @@ export const createRuntimeExecutors = (
 
           // Create tool message in database
           try {
+            const parentMessage = await ctx.messageModel.findById(parentMessageId);
+            if (!parentMessage) {
+              throw createMissingMessageError(parentMessageId);
+            }
+
             const toolMessage = await ctx.messageModel.create({
               agentId: state.metadata!.agentId!,
               content: executionResult.content,
@@ -1745,6 +1785,13 @@ export const createRuntimeExecutors = (
             toolMessageIds.push(toolMessage.id);
             log(`[${operationLogId}] Created tool message ${toolMessage.id} for ${toolName}`);
           } catch (error) {
+            if (
+              isMissingMessageParentError(error) ||
+              getErrorValue(error, 'code') === 'MESSAGE_PARENT_MISSING'
+            ) {
+              throw error;
+            }
+
             console.error(
               `[${operationLogId}] Failed to create tool message for ${toolName}:`,
               error,
@@ -1771,6 +1818,13 @@ export const createRuntimeExecutors = (
             toolName,
           };
         } catch (error) {
+          if (
+            isMissingMessageParentError(error) ||
+            getErrorValue(error, 'code') === 'MESSAGE_PARENT_MISSING'
+          ) {
+            throw error;
+          }
+
           console.error(`[${operationLogId}] Tool execution failed for ${toolName}:`, error);
 
           // Publish error event


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- None

#### 🔀 Description of Change

This PR fixes a race where an in-flight agent operation could keep referencing an assistant placeholder that had already been removed from `messages`.

It includes two focused commits:

1. Fail fast in `RuntimeExecutors` when an existing assistant message or parent message is missing, instead of continuing until a later foreign key violation crashes the operation.
2. Disable `delete` and `delete + regenerate` actions for messages that are still generating, reducing the chance of removing the active placeholder from the frontend while the backend is still running.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Checked with VS Code diagnostics after the changes.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

- This PR intentionally keeps the backend guard even with the frontend restriction, because the race can still happen from other clients or stale UI state.
