### PR TITLE
🐛 fix(editor-modal): keep toolbar tooltips above modal shadow

### DIFF
--- a/src/features/EditorModal/EditorCanvas.test.tsx
+++ b/src/features/EditorModal/EditorCanvas.test.tsx
@@ -10,8 +10,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import EditorCanvas from './EditorCanvas';
 
+const typoBarMock = vi.hoisted(() => vi.fn(() => null));
+
 vi.mock('./Typobar', () => ({
-  default: () => null,
+  default: typoBarMock,
 }));
 
 const mentionEditorState = {
@@ -45,28 +47,39 @@ interface TestWrapperProps {
   defaultValue?: string;
   editorData?: unknown;
   onEditorReady?: (editor: IEditor) => void;
+  tooltipPopupContainer?: HTMLElement | null;
 }
 
-const TestWrapper = memo<TestWrapperProps>(({ defaultValue, editorData, onEditorReady }) => {
-  const editor = useEditor();
-  const readyRef = useRef(false);
+const TestWrapper = memo<TestWrapperProps>(
+  ({ defaultValue, editorData, onEditorReady, tooltipPopupContainer }) => {
+    const editor = useEditor();
+    const readyRef = useRef(false);
 
-  useEffect(() => {
-    if (editor && !readyRef.current) {
-      readyRef.current = true;
-      onEditorReady?.(editor);
-    }
-  }, [editor, onEditorReady]);
+    useEffect(() => {
+      if (editor && !readyRef.current) {
+        readyRef.current = true;
+        onEditorReady?.(editor);
+      }
+    }, [editor, onEditorReady]);
 
-  if (!editor) return null;
+    if (!editor) return null;
 
-  return <EditorCanvas defaultValue={defaultValue} editor={editor} editorData={editorData} />;
-});
+    return (
+      <EditorCanvas
+        defaultValue={defaultValue}
+        editor={editor}
+        editorData={editorData}
+        tooltipPopupContainer={tooltipPopupContainer}
+      />
+    );
+  },
+);
 
 TestWrapper.displayName = 'EditorModalEditorCanvasTestWrapper';
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe('EditorModal EditorCanvas', () => {
@@ -88,5 +101,14 @@ describe('EditorModal EditorCanvas', () => {
     });
 
     expect(screen.getByText('Hello from markdown')).toBeInTheDocument();
+  });
+
+  it('should forward tooltip popup container to TypoBar', () => {
+    const popupContainer = document.createElement('div');
+
+    render(<TestWrapper defaultValue={'tooltip test'} tooltipPopupContainer={popupContainer} />);
+
+    expect(typoBarMock).toHaveBeenCalled();
+    expect(typoBarMock.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ popupContainer }));
   });
 });

--- a/src/features/EditorModal/EditorCanvas.tsx
+++ b/src/features/EditorModal/EditorCanvas.tsx
@@ -12,6 +12,7 @@ interface EditorCanvasProps {
   defaultValue?: string;
   editor?: IEditor;
   editorData?: unknown;
+  tooltipPopupContainer?: HTMLElement | null;
 }
 
 const EDITOR_PLUGINS = [
@@ -19,7 +20,12 @@ const EDITOR_PLUGINS = [
   ReactTablePlugin,
 ];
 
-const EditorCanvas: FC<EditorCanvasProps> = ({ defaultValue, editor, editorData }) => {
+const EditorCanvas: FC<EditorCanvasProps> = ({
+  defaultValue,
+  editor,
+  editorData,
+  tooltipPopupContainer,
+}) => {
   const { content, type } = useMemo(() => {
     const hasValidEditorData =
       editorData && typeof editorData === 'object' && Object.keys(editorData).length > 0;
@@ -33,7 +39,7 @@ const EditorCanvas: FC<EditorCanvasProps> = ({ defaultValue, editor, editorData 
 
   return (
     <>
-      <TypoBar editor={editor} />
+      <TypoBar editor={editor} popupContainer={tooltipPopupContainer} />
       <Flexbox
         padding={16}
         style={{ cursor: 'text', maxHeight: '80vh', minHeight: '50vh', overflowY: 'auto' }}

--- a/src/features/EditorModal/Typobar.test.tsx
+++ b/src/features/EditorModal/Typobar.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ChatInputActionsProps } from '@lobehub/editor/react';
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TypoBar from './Typobar';
+
+const chatInputActionsMock = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@lobehub/editor', () => ({
+  HotkeyEnum: {
+    Bold: 'bold',
+    BulletList: 'bulletList',
+    CodeInline: 'codeInline',
+    Italic: 'italic',
+    NumberList: 'numberList',
+    Strikethrough: 'strikethrough',
+    Underline: 'underline',
+  },
+  getHotkeyById: (id: string) => ({ keys: [`hotkey:${id}`] }),
+}));
+
+vi.mock('@lobehub/editor/react', () => ({
+  ChatInputActionBar: ({ left }: { left: ReactNode }) => <div>{left}</div>,
+  ChatInputActions: chatInputActionsMock,
+  useEditorState: () => ({
+    blockquote: vi.fn(),
+    bold: vi.fn(),
+    bulletList: vi.fn(),
+    checkList: vi.fn(),
+    code: vi.fn(),
+    codeblock: vi.fn(),
+    insertMath: vi.fn(),
+    isBlockquote: false,
+    isBold: false,
+    isCode: false,
+    isItalic: false,
+    isStrikethrough: false,
+    isUnderline: false,
+    italic: vi.fn(),
+    numberList: vi.fn(),
+    strikethrough: vi.fn(),
+    underline: vi.fn(),
+  }),
+}));
+
+vi.mock('antd-style', () => ({
+  cssVar: {
+    colorFillQuaternary: 'rgba(0, 0, 0, 0.04)',
+  },
+}));
+
+describe('EditorModal TypoBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should attach popupContainer to every tooltip config', () => {
+    const popupContainer = document.createElement('div');
+
+    render(<TypoBar popupContainer={popupContainer} />);
+
+    expect(chatInputActionsMock).toHaveBeenCalled();
+
+    const [{ items }] = chatInputActionsMock.mock.calls.at(-1) as [
+      { items: ChatInputActionsProps['items'] },
+    ];
+
+    const actionableItems = items.filter((item) => item.type !== 'divider');
+
+    expect(actionableItems).toHaveLength(11);
+
+    for (const item of actionableItems) {
+      expect(item.tooltipProps).toEqual(
+        expect.objectContaining({
+          popupContainer,
+        }),
+      );
+    }
+
+    const italicItem = actionableItems.find((item) => item.key === 'italic');
+    expect(italicItem?.tooltipProps).toEqual(
+      expect.objectContaining({
+        hotkey: ['hotkey:italic'],
+        popupContainer,
+      }),
+    );
+  });
+});

--- a/src/features/EditorModal/Typobar.tsx
+++ b/src/features/EditorModal/Typobar.tsx
@@ -16,12 +16,30 @@ import {
   StrikethroughIcon,
   UnderlineIcon,
 } from 'lucide-react';
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
+interface TypoBarProps {
+  editor?: IEditor;
+  popupContainer?: HTMLElement | null;
+}
+
+const TypoBar = memo<TypoBarProps>(({ editor, popupContainer }) => {
   const { t } = useTranslation('editor');
   const editorState = useEditorState(editor);
+
+  const baseTooltipProps = useMemo(
+    () => (popupContainer ? { popupContainer } : undefined),
+    [popupContainer],
+  );
+
+  const createTooltipProps = useCallback(
+    (hotkey?: string[]) => ({
+      ...baseTooltipProps,
+      ...(hotkey ? { hotkey } : {}),
+    }),
+    [baseTooltipProps],
+  );
 
   const items: ChatInputActionsProps['items'] = useMemo(
     () =>
@@ -32,7 +50,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'bold',
           label: t('typobar.bold'),
           onClick: editorState.bold,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Bold).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.Bold).keys),
         },
         {
           active: editorState.isItalic,
@@ -40,7 +58,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'italic',
           label: t('typobar.italic'),
           onClick: editorState.italic,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Italic).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.Italic).keys),
         },
         {
           active: editorState.isUnderline,
@@ -48,7 +66,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'underline',
           label: t('typobar.underline'),
           onClick: editorState.underline,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Underline).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.Underline).keys),
         },
         {
           active: editorState.isStrikethrough,
@@ -56,7 +74,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'strikethrough',
           label: t('typobar.strikethrough'),
           onClick: editorState.strikethrough,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.Strikethrough).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.Strikethrough).keys),
         },
         {
           type: 'divider',
@@ -67,20 +85,21 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'bulletList',
           label: t('typobar.bulletList'),
           onClick: editorState.bulletList,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.BulletList).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.BulletList).keys),
         },
         {
           icon: ListOrderedIcon,
           key: 'numberlist',
           label: t('typobar.numberList'),
           onClick: editorState.numberList,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.NumberList).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.NumberList).keys),
         },
         {
           icon: ListTodoIcon,
           key: 'tasklist',
           label: t('typobar.taskList'),
           onClick: editorState.checkList,
+          tooltipProps: baseTooltipProps,
         },
         {
           type: 'divider',
@@ -91,6 +110,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'blockquote',
           label: t('typobar.blockquote'),
           onClick: editorState.blockquote,
+          tooltipProps: baseTooltipProps,
         },
         {
           type: 'divider',
@@ -100,6 +120,7 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'math',
           label: t('typobar.tex'),
           onClick: editorState.insertMath,
+          tooltipProps: baseTooltipProps,
         },
         {
           active: editorState.isCode,
@@ -107,16 +128,17 @@ const TypoBar = memo<{ editor?: IEditor }>(({ editor }) => {
           key: 'code',
           label: t('typobar.code'),
           onClick: editorState.code,
-          tooltipProps: { hotkey: getHotkeyById(HotkeyEnum.CodeInline).keys },
+          tooltipProps: createTooltipProps(getHotkeyById(HotkeyEnum.CodeInline).keys),
         },
         {
           icon: SquareDashedBottomCodeIcon,
           key: 'codeblock',
           label: t('typobar.codeblock'),
           onClick: editorState.codeblock,
+          tooltipProps: baseTooltipProps,
         },
       ].filter(Boolean) as ChatInputActionsProps['items'],
-    [editorState],
+    [baseTooltipProps, createTooltipProps, editorState, t],
   );
 
   return (

--- a/src/features/EditorModal/index.test.tsx
+++ b/src/features/EditorModal/index.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EditorModal } from './index';
+
+const getDocumentMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@lobehub/editor/react', () => ({
+  useEditor: () => ({
+    getDocument: getDocumentMock,
+  }),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  createRawModal: vi.fn(),
+  Modal: ({
+    children,
+    confirmLoading,
+    okText,
+    onOk,
+    open,
+  }: {
+    children: ReactNode;
+    confirmLoading?: boolean;
+    okText?: string;
+    onOk?: () => Promise<void>;
+    open?: boolean;
+  }) =>
+    open ? (
+      <div>
+        <div data-testid="confirm-loading">{String(confirmLoading)}</div>
+        <button
+          onClick={() => {
+            void onOk?.().catch(() => {});
+          }}
+        >
+          {okText}
+        </button>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('./EditorCanvas', () => ({
+  default: ({ defaultValue }: HTMLAttributes<HTMLDivElement> & { defaultValue?: string }) => (
+    <div>{defaultValue}</div>
+  ),
+}));
+
+describe('EditorModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reset confirm loading when onConfirm rejects', async () => {
+    getDocumentMock.mockImplementation((type: string) =>
+      type === 'markdown' ? 'markdown value' : { type: 'doc' },
+    );
+
+    const onConfirm = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((_, reject) => {
+          setTimeout(() => reject(new Error('confirm failed')), 0);
+        }),
+    );
+
+    render(<EditorModal open={true} value={'hello'} onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ok' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-loading')).toHaveTextContent('true');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-loading')).toHaveTextContent('false');
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith('markdown value', { type: 'doc' });
+  });
+});

--- a/src/features/EditorModal/index.tsx
+++ b/src/features/EditorModal/index.tsx
@@ -15,6 +15,7 @@ interface EditorModalProps extends ModalProps {
 export const EditorModal = memo<EditorModalProps>(
   ({ value, editorData: initialEditorData, onConfirm, ...rest }) => {
     const [confirmLoading, setConfirmLoading] = useState(false);
+    const [modalPanel, setModalPanel] = useState<HTMLDivElement | null>(null);
     const { t } = useTranslation('common');
     const editor = useEditor();
 
@@ -25,6 +26,7 @@ export const EditorModal = memo<EditorModalProps>(
         closable={false}
         confirmLoading={confirmLoading}
         okText={t('ok')}
+        panelRef={setModalPanel}
         title={null}
         width={'min(90vw, 920px)'}
         styles={{
@@ -42,7 +44,12 @@ export const EditorModal = memo<EditorModalProps>(
         }}
         {...rest}
       >
-        <EditorCanvas defaultValue={value} editor={editor} editorData={initialEditorData} />
+        <EditorCanvas
+          defaultValue={value}
+          editor={editor}
+          editorData={initialEditorData}
+          tooltipPopupContainer={modalPanel}
+        />
       </Modal>
     );
   },

--- a/src/features/EditorModal/index.tsx
+++ b/src/features/EditorModal/index.tsx
@@ -39,8 +39,11 @@ export const EditorModal = memo<EditorModalProps>(
           setConfirmLoading(true);
           const finalValue = (editor?.getDocument('markdown') as unknown as string) || '';
           const editorData = editor?.getDocument('json');
-          await onConfirm?.(finalValue, editorData);
-          setConfirmLoading(false);
+          try {
+            await onConfirm?.(finalValue, editorData);
+          } finally {
+            setConfirmLoading(false);
+          }
         }}
         {...rest}
       >


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

This fixes the tooltip stacking issue in the chat edit modal.

Previously, toolbar tooltips from `ChatInputActions` could be rendered outside the modal stacking context, so hover labels such as `Italic` appeared underneath the modal blur/shadow layer.

This change captures the active modal panel via `panelRef`, passes it through `EditorModal` and `EditorCanvas`, and uses it as the tooltip `popupContainer` in `Typobar`. As a result, the tooltip portal stays inside the modal panel and renders above the modal shadow as expected.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

1. Open a chat edit flow that renders `EditorModal`.
2. Hover the toolbar buttons in the top action bar, especially `Italic`.
3. Confirm the tooltip renders above the modal shadow/blur instead of appearing dimmed or hidden behind it.
4. Verify the same behavior for the other toolbar actions.

Validation used for this change:
- Real `EditorModal` browser verification through `localhost` port forwarding
- `pnpm exec vitest run --silent='passed-only' 'src/features/EditorModal/EditorCanvas.test.tsx'`
- `pnpm exec eslint 'src/features/EditorModal/index.tsx' 'src/features/EditorModal/EditorCanvas.tsx' 'src/features/EditorModal/Typobar.tsx'`


<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| <img width="1440" height="1055" alt="Snipaste_2026-04-14_20-27-50" src="https://github.com/user-attachments/assets/5b7f685f-7f9b-4951-b360-e5ceda6f3e08" />  | <img width="1440" height="1055" alt="Snipaste_2026-04-14_20-25-26" src="https://github.com/user-attachments/assets/0a5b85f3-4449-4179-80f7-f94582dbc046" /> |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

This is a UI-only stacking fix scoped to `EditorModal` and does not change API behavior or data flow outside the tooltip container path.