### PR TITLE
fix(topic): show star icon for favorited topics in sidebar

### DIFF
--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,6 +1,6 @@
 import { Flexbox, Icon, Skeleton, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { HashIcon, MessageSquareDashed } from 'lucide-react';
+import { HashIcon, MessageSquareDashed, StarIcon } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
 import { memo, Suspense, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -207,7 +207,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId }) =>
         loading={isLoading}
         title={title}
         icon={
-          <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
+          <Icon
+            color={fav ? cssVar.colorWarning : cssVar.colorTextDescription}
+            fill={fav ? cssVar.colorWarning : undefined}
+            icon={fav ? StarIcon : HashIcon}
+            size={'small'}
+          />
         }
         slots={{
           iconPostfix: unreadNode,


### PR DESCRIPTION
## Fix #13827: Topic collection stars display as # instead of star icon

### Description
Before this fix, when a topic was marked as favorite (starred), the sidebar topic list would still display the HashIcon (#) instead of a star icon. This made it unclear which topics were favorited.

### Changes
- Changed TopicItem icon from always showing HashIcon to conditionally showing StarIcon (with yellow fill) when  prop is true, and HashIcon otherwise

### Before
Favorited topics displayed with a # (HashIcon) icon regardless of favorite status.

### After
Favorited topics now display with a ⭐ (StarIcon) icon with yellow fill color. Non-favorited topics continue to show the # (HashIcon) icon.

### Files Changed
- `src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx`