### PR TITLE
fix(topic): show star icon for favorited topics instead of hash icon

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,6 +1,6 @@
 import { Flexbox, Icon, Skeleton, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { HashIcon, MessageSquareDashed } from 'lucide-react';
+import { HashIcon, MessageSquareDashed, Star } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
 import { memo, Suspense, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -214,6 +214,9 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
             if (ProviderIcon) {
               return <ProviderIcon color={cssVar.colorTextDescription} size={16} />;
             }
+          }
+          if (fav) {
+            return <Icon icon={Star} size={'small'} style={{ color: cssVar.colorWarning }} />;
           }
           return (
             <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,6 +1,6 @@
 import { Flexbox, Icon, Skeleton, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { HashIcon, MessageSquareDashed } from 'lucide-react';
+import { HashIcon, MessageSquareDashed, Star } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
 import { memo, Suspense, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -207,7 +207,11 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId }) =>
         loading={isLoading}
         title={title}
         icon={
-          <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
+          fav ? (
+            <Icon icon={Star} size={'small'} style={{ color: cssVar.colorWarning }} />
+          ) : (
+            <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
+          )
         }
         slots={{
           iconPostfix: unreadNode,


### PR DESCRIPTION
Fixes #13827

## Problem

The `fav` prop was passed to `TopicItem` components in both the agent and group sidebars but was completely ignored in the icon rendering logic. As a result, **all topics** always displayed the `HashIcon` (`#`) symbol, regardless of whether they were favorited or not.

## Solution

Added a conditional check on the `fav` prop in the icon rendering code:
- When `fav` is `true`: renders a yellow `Star` icon (`cssVar.colorWarning`) to clearly indicate the topic is favorited
- Otherwise: renders the default `HashIcon` as before

Both affected components were fixed:
- `src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx`
- `src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx`

## Testing

Verified that:
1. Favorited topics now display a yellow star icon in the sidebar
2. Non-favorited topics continue to display the `#` hash icon
3. Bot platform topics (agent sidebar only) still display their provider icon when available