### PR TITLE
fix(image): preserve resolution with enum validation when changing aspect ratio

### DIFF
--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -583,6 +583,55 @@ describe('GenerationConfigAction', () => {
         });
       }).not.toThrow();
     });
+
+    it('should preserve resolution when changing aspect ratio for models with resolution enum', () => {
+      const { result } = renderHook(() => useImageStore());
+
+      useImageStore.setState({
+        parameters: createTestParameters({ resolution: '4K' }),
+        parametersSchema: createTestSchema({
+          resolution: { default: '1K', enum: ['1K', '2K', '4K'] },
+        }),
+      });
+
+      act(() => {
+        result.current.setAspectRatio('16:9');
+      });
+
+      expect(result.current.parameters?.resolution).toBe('4K');
+    });
+
+    it('should strip resolution when new schema does not support the current resolution value', () => {
+      const { result } = renderHook(() => useImageStore());
+
+      useImageStore.setState({
+        parameters: createTestParameters({ resolution: '4K' }),
+        parametersSchema: createTestSchema({
+          resolution: { default: '1K', enum: ['1K', '2K'] },
+        }),
+      });
+
+      act(() => {
+        result.current.setAspectRatio('16:9');
+      });
+
+      expect(result.current.parameters?.resolution).toBeUndefined();
+    });
+
+    it('should strip resolution when schema has no resolution enum', () => {
+      const { result } = renderHook(() => useImageStore());
+
+      useImageStore.setState({
+        parameters: createTestParameters({ resolution: '4K' }),
+        parametersSchema: createTestSchema(),
+      });
+
+      act(() => {
+        result.current.setAspectRatio('16:9');
+      });
+
+      expect(result.current.parameters?.resolution).toBeUndefined();
+    });
   });
 
   describe('Configuration Initialization', () => {

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -254,6 +254,25 @@ export class GenerationConfigActionImpl {
       newParams.aspectRatio = aspectRatio;
     }
 
+    // Preserve resolution if it exists in current parameters (models like nanoBanana2 use resolution enum)
+    // Only preserve if the new schema's resolution enum contains the current value
+    if (
+      'resolution' in parameters &&
+      parameters.resolution !== undefined &&
+      parametersSchema?.resolution?.enum &&
+      parametersSchema.resolution.enum.includes(parameters.resolution)
+    ) {
+      newParams.resolution = parameters.resolution;
+    } else if (
+      'resolution' in parameters &&
+      parameters.resolution !== undefined &&
+      ( !parametersSchema?.resolution?.enum ||
+        !parametersSchema.resolution.enum.includes(parameters.resolution))
+    ) {
+      // Resolution value is not valid for new schema - strip it
+      delete newParams.resolution;
+    }
+
     this.#set(
       { activeAspectRatio: aspectRatio, parameters: newParams },
       false,


### PR DESCRIPTION
## Summary

When using models that support resolution enum (1K/2K/4K), selecting a different aspect ratio would cause the resolution to be lost. This PR fixes the issue by:

1. **Preserving resolution** when changing aspect ratios for models that support the same resolution enum value
2. **Stripping resolution** when the new aspect ratio's schema doesn't support the current resolution value

Fixes #13283

## Changes

### Code Fix (`action.ts`)

Added validation logic to `setAspectRatio` that:
- Preserves `parameters.resolution` if the new schema's enum includes the current value
- Strips `parameters.resolution` if the new schema's enum doesn't include the value, or if the schema has no resolution enum

### Tests (`action.test.ts`)

Added 3 regression tests under **Aspect Ratio Setting** describe block:
- `should preserve resolution when changing aspect ratio for models with resolution enum`
- `should strip resolution when new schema does not support the current resolution value`
- `should strip resolution when schema has no resolution enum`

## Reviewer Feedback Addressed

This PR supersedes #13324 by addressing:
1. ✅ Adding regression test for resolution preservation
2. ✅ Validating preserved value against schema's enum

---