### PR TITLE
🐛 fix(desktop): sanitize heterogeneous-agent attachment cache filenames

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
@@ -137,14 +137,27 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   }
 
   /**
+   * Derive a filesystem-safe cache key for attachments.
+   *
+   * Never use the raw image id as a path segment — upstream callers can persist
+   * arbitrary ids and path.join would treat traversal sequences as real
+   * directories. A stable hash preserves cache hits without trusting the id as a
+   * filename.
+   */
+  private getImageCacheKey(imageId: string): string {
+    return createHash('sha256').update(imageId).digest('hex');
+  }
+
+  /**
    * Download an image by URL, with local disk cache keyed by id.
    */
   private async resolveImage(
     image: ImageAttachment,
   ): Promise<{ buffer: Buffer; mimeType: string }> {
     const cacheDir = this.fileCacheDir;
-    const metaPath = join(cacheDir, `${image.id}.meta`);
-    const dataPath = join(cacheDir, image.id);
+    const cacheKey = this.getImageCacheKey(image.id);
+    const metaPath = join(cacheDir, `${cacheKey}.meta`);
+    const dataPath = join(cacheDir, cacheKey);
 
     // Check cache first
     try {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -71,7 +71,7 @@ describe('HeterogeneousAgentCtr', () => {
       });
 
       expect(Buffer.from(result.buffer).toString('utf8')).toBe('IGNORED');
-      expect(result.mimeType).toBe('image/png');
+      expect(result.mimeType).toBe('text/plain');
       await expect(readFile(outOfRootDataPath, 'utf8')).resolves.toBe('SECRET');
     });
   });

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -37,14 +37,15 @@ describe('HeterogeneousAgentCtr', () => {
     it('stores traversal-looking ids inside the cache root via a stable hash key', async () => {
       const ctr = new HeterogeneousAgentCtr({ appStoragePath } as any);
       const cacheDir = path.join(appStoragePath, 'heteroAgent/files');
-      const escapePath = path.join(cacheDir, '../../../outside-storage');
+      const escapedTargetName = `${path.basename(appStoragePath)}-outside-storage`;
+      const escapePath = path.join(cacheDir, `../../../${escapedTargetName}`);
 
       try {
         await unlink(escapePath);
       } catch {}
 
       await (ctr as any).resolveImage({
-        id: '../../../outside-storage',
+        id: `../../../${escapedTargetName}`,
         url: 'data:text/plain;base64,T1VUU0lERQ==',
       });
 
@@ -53,6 +54,10 @@ describe('HeterogeneousAgentCtr', () => {
       expect(cacheEntries).toHaveLength(2);
       expect(cacheEntries.every((entry) => /^[a-f0-9]{64}(\.meta)?$/.test(entry))).toBe(true);
       await expect(access(escapePath)).rejects.toThrow();
+
+      try {
+        await unlink(escapePath);
+      } catch {}
     });
 
     it('does not trust pre-seeded out-of-root traversal cache files as cache hits', async () => {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1,0 +1,78 @@
+import { access, mkdtemp, readdir, readFile, rm, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+  app: { on: vi.fn() },
+  ipcMain: { handle: vi.fn() },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import HeterogeneousAgentCtr from '../HeterogeneousAgentCtr';
+
+describe('HeterogeneousAgentCtr', () => {
+  let appStoragePath: string;
+
+  beforeEach(async () => {
+    appStoragePath = await mkdtemp(path.join(tmpdir(), 'lobehub-hetero-'));
+  });
+
+  afterEach(async () => {
+    await rm(appStoragePath, { force: true, recursive: true });
+  });
+
+  describe('resolveImage', () => {
+    it('stores traversal-looking ids inside the cache root via a stable hash key', async () => {
+      const ctr = new HeterogeneousAgentCtr({ appStoragePath } as any);
+      const cacheDir = path.join(appStoragePath, 'heteroAgent/files');
+      const escapePath = path.join(cacheDir, '../../../outside-storage');
+
+      try {
+        await unlink(escapePath);
+      } catch {}
+
+      await (ctr as any).resolveImage({
+        id: '../../../outside-storage',
+        url: 'data:text/plain;base64,T1VUU0lERQ==',
+      });
+
+      const cacheEntries = await readdir(cacheDir);
+
+      expect(cacheEntries).toHaveLength(2);
+      expect(cacheEntries.every((entry) => /^[a-f0-9]{64}(\.meta)?$/.test(entry))).toBe(true);
+      await expect(access(escapePath)).rejects.toThrow();
+    });
+
+    it('does not trust pre-seeded out-of-root traversal cache files as cache hits', async () => {
+      const ctr = new HeterogeneousAgentCtr({ appStoragePath } as any);
+      const cacheDir = path.join(appStoragePath, 'heteroAgent/files');
+      const traversalId = '../../preexisting-secret';
+      const outOfRootDataPath = path.join(cacheDir, traversalId);
+      const outOfRootMetaPath = path.join(cacheDir, `${traversalId}.meta`);
+
+      await writeFile(outOfRootDataPath, 'SECRET');
+      await writeFile(outOfRootMetaPath, JSON.stringify({ id: traversalId, mimeType: 'text/plain' }));
+
+      const result = await (ctr as any).resolveImage({
+        id: traversalId,
+        url: 'data:text/plain;base64,SUdOT1JFRA==',
+      });
+
+      expect(Buffer.from(result.buffer).toString('utf8')).toBe('IGNORED');
+      expect(result.mimeType).toBe('image/png');
+      await expect(readFile(outOfRootDataPath, 'utf8')).resolves.toBe('SECRET');
+    });
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [ ] ✅ test

#### 🔗 Related Issue

Closes #13936

#### 🔀 Description of Change

This keeps the fix intentionally narrow to improve mergeability:

- replace raw `image.id` path segments in `HeterogeneousAgentCtr.resolveImage()` with a stable SHA-256 cache key
- preserve deterministic cache hits without trusting user-controlled ids as filesystem paths
- add desktop regression tests that cover:
  - traversal-looking ids must not create files outside `heteroAgent/files`
  - pre-seeded out-of-root traversal targets must not be treated as cache hits

Why this shape:
- `path.basename(image.id)` would prevent some escapes, but it can still collapse different ids onto the same filename
- a stable hash keeps the cache behavior deterministic while removing all path semantics from the identifier
- the change stays local to the desktop heterogeneous-agent cache implementation and does not alter message schemas or attachment UX

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally
- [ ] No tests needed

Local validation performed:
- executed the current controller logic with traversal ids and confirmed out-of-root writes / cache-hit reads before the fix
- re-ran the same validation against this patch and confirmed the cache now stores only hash-derived filenames inside `heteroAgent/files`
- confirmed that pre-seeded traversal targets are no longer reused as cache hits after the patch

Suggested CI/local test command:

```bash
cd apps/desktop && bunx vitest run --silent='passed-only' 'src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts'
```

#### 📝 Additional Information

- The issue currently affects the canary-only heterogeneous-agent path (`v2.1.52-canary.6` contains the feature; latest stable `v2.1.51` does not yet include this controller)
- This mirrors the same class of path-handling bug that was fixed earlier in `TempFileManager.writeTempFile()`, but keeps the scope limited to the desktop attachment cache
