### PR TITLE
fix(anthropic): send thinking.display for adaptive thinking

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -179,8 +179,9 @@ export const buildDefaultAnthropicPayload = async (
         ? {
             budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
             type: 'enabled',
+            ...(thinking.display ? { display: thinking.display } : {}),
           }
-        : { type: 'adaptive' };
+        : { type: 'adaptive', display: thinking.display ?? 'summarized' };
 
     return {
       max_tokens: resolvedMaxTokens,

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -790,7 +790,7 @@ describe('LobeAnthropicAI', () => {
           model: 'claude-opus-4-6',
           output_config: { effort: 'high' },
           system: undefined,
-          thinking: { type: 'adaptive' },
+          thinking: { display: 'summarized', type: 'adaptive' },
           tools: undefined,
         });
       });
@@ -819,7 +819,7 @@ describe('LobeAnthropicAI', () => {
           model: 'claude-opus-4-7',
           output_config: { effort: 'xhigh' },
           system: undefined,
-          thinking: { type: 'adaptive' },
+          thinking: { display: 'summarized', type: 'adaptive' },
           tools: undefined,
         });
       });

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -225,8 +225,9 @@ export class LobeBedrockAI implements LobeRuntimeAI {
           ? {
               budget_tokens: Math.min(thinking?.budget_tokens || 1024, resolvedMaxTokens - 1),
               type: 'enabled' as const,
+              ...(thinking.display ? { display: thinking.display } : {}),
             }
-          : { type: 'adaptive' as const };
+          : { type: 'adaptive' as const, display: thinking.display ?? 'summarized' };
 
       anthropicPayload = {
         ...anthropicBase,

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -145,6 +145,7 @@ export interface ChatStreamPayload {
    */
   thinking?: {
     budget_tokens: number;
+    display?: 'summarized' | 'omitted';
     type?: 'enabled' | 'disabled' | 'adaptive';
   };
   thinkingBudget?: number;

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -1146,7 +1146,7 @@ describe('resolveModelExtendParams', () => {
           provider: 'anthropic',
         });
 
-        expect(result.thinking).toEqual({ type: 'adaptive' });
+        expect(result.thinking).toEqual({ display: 'summarized', type: 'adaptive' });
       });
 
       it('should disable adaptive thinking when off', () => {

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -115,10 +115,11 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     };
   }
 
-  // Adaptive thinking (Claude Opus/Sonnet 4.6)
+  // Adaptive thinking (Claude Opus/Sonnet 4.6+)
   if (modelExtendParams.includes('enableAdaptiveThinking')) {
     if (chatConfig.enableAdaptiveThinking) {
       extendParams.thinking = {
+        display: 'summarized',
         type: 'adaptive',
       };
     } else if (!modelExtendParams.includes('enableReasoning')) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Claude Opus 4.7 changed `thinking.display` default from `"summarized"` to `"omitted"`, causing blank thinking panels when adaptive thinking is enabled.

Related: PR #13909

#### 🔀 Description of Change

When adaptive thinking is active, send `display: "summarized"` so thinking content is visible. Without this, Opus 4.7 returns empty thinking blocks.

Changes across Anthropic direct API and Bedrock paths.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Ref: [Anthropic docs — Controlling thinking display](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#controlling-thinking-display)