### PR TITLE
💄 style(cc): default-expand Edit/Write and surface line-diff on Edit inspector

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/EditInspector.tsx
+++ b/packages/builtin-tool-claude-code/src/client/EditInspector.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { createEditLocalFileInspector } from '@lobechat/shared-tool-ui/inspectors';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { memo, useMemo } from 'react';
+
+import { ClaudeCodeApiName } from '../types';
+
+interface CCEditArgs {
+  file_path?: string;
+  new_string?: string;
+  old_string?: string;
+  replace_all?: boolean;
+}
+
+// Mirrors `EditFileState` from `@lobechat/tool-runtime` — duplicated locally to
+// keep this package free of a tool-runtime dep (it only reads the two line
+// counts; the shared inspector accepts the shape via `any`).
+interface SynthesizedEditState {
+  linesAdded: number;
+  linesDeleted: number;
+  path: string;
+  replacements: number;
+}
+
+/**
+ * LCS-based line-diff counter. Compares two snippets line-by-line and returns
+ * the number of added / deleted lines — matches what `CodeDiff` shows in the
+ * render header. Cheap enough for Edit payloads (typically a handful of lines).
+ */
+const countLineDiff = (oldText: string, newText: string) => {
+  if (oldText === newText) return { linesAdded: 0, linesDeleted: 0 };
+  if (!oldText) return { linesAdded: newText.split('\n').length, linesDeleted: 0 };
+  if (!newText) return { linesAdded: 0, linesDeleted: oldText.split('\n').length };
+
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+  const m = oldLines.length;
+  const n = newLines.length;
+
+  const prev: number[] = Array.from({ length: n + 1 }, () => 0);
+  const curr: number[] = Array.from({ length: n + 1 }, () => 0);
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      curr[j] =
+        oldLines[i - 1] === newLines[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], curr[j - 1]);
+    }
+    for (let j = 0; j <= n; j++) prev[j] = curr[j];
+  }
+
+  const unchanged = prev[n];
+  return { linesAdded: n - unchanged, linesDeleted: m - unchanged };
+};
+
+const SharedInspector = createEditLocalFileInspector(ClaudeCodeApiName.Edit);
+
+/**
+ * CC Edit runs remotely via Anthropic tool_use blocks, so there's no local
+ * runtime producing `EditFileState`. Synthesize `linesAdded` / `linesDeleted`
+ * from the args' `old_string` / `new_string` so the collapsed header carries
+ * change magnitude alongside the file path.
+ */
+export const EditInspector = memo<BuiltinInspectorProps<CCEditArgs, SynthesizedEditState>>(
+  ({ args, pluginState, ...rest }) => {
+    const synthesized = useMemo<SynthesizedEditState | undefined>(() => {
+      if (pluginState) return pluginState;
+      if (!args?.old_string && !args?.new_string) return undefined;
+
+      const { linesAdded, linesDeleted } = countLineDiff(
+        args.old_string ?? '',
+        args.new_string ?? '',
+      );
+
+      return {
+        linesAdded,
+        linesDeleted,
+        path: args.file_path ?? '',
+        replacements: args.replace_all ? 0 : 1,
+      };
+    }, [args, pluginState]);
+
+    return <SharedInspector {...rest} args={args} pluginState={synthesized} />;
+  },
+);
+EditInspector.displayName = 'ClaudeCodeEditInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import {
-  createEditLocalFileInspector,
   createGlobLocalFilesInspector,
   createGrepContentInspector,
   createRunCommandInspector,
 } from '@lobechat/shared-tool-ui/inspectors';
 
 import { ClaudeCodeApiName } from '../types';
+import { EditInspector } from './EditInspector';
 import { ReadInspector } from './ReadInspector';
 import { SkillInspector } from './SkillInspector';
 import { TodoWriteInspector } from './TodoWriteInspector';
@@ -19,12 +19,12 @@ import { WriteInspector } from './WriteInspector';
 // the "translation key" and let react-i18next's missing-key fallback echo it
 // back verbatim. Keeps this package out of the plugin locale file.
 //
-// Bash / Edit / Glob / Grep can use the shared factories directly — Edit
-// already reads `file_path`, and Glob / Grep only need `pattern`. Read and
-// Write need arg mapping, so they live in their own sibling files.
+// Bash / Glob / Grep can use the shared factories directly — Glob / Grep only
+// need `pattern`. Edit / Read / Write need arg mapping (or synthesized plugin
+// state for diff stats), so they live in their own sibling files.
 export const ClaudeCodeInspectors = {
   [ClaudeCodeApiName.Bash]: createRunCommandInspector(ClaudeCodeApiName.Bash),
-  [ClaudeCodeApiName.Edit]: createEditLocalFileInspector(ClaudeCodeApiName.Edit),
+  [ClaudeCodeApiName.Edit]: EditInspector,
   [ClaudeCodeApiName.Glob]: createGlobLocalFilesInspector(ClaudeCodeApiName.Glob),
   [ClaudeCodeApiName.Grep]: createGrepContentInspector({
     noResultsKey: 'No results',

--- a/packages/builtin-tool-claude-code/src/client/Render/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Render/index.ts
@@ -38,5 +38,7 @@ export const ClaudeCodeRenders = {
  * `getBuiltinRenderDisplayControl` as a fallback.
  */
 export const ClaudeCodeRenderDisplayControls: Record<string, RenderDisplayControl> = {
+  [ClaudeCodeApiName.Edit]: 'expand',
   [ClaudeCodeApiName.TodoWrite]: 'expand',
+  [ClaudeCodeApiName.Write]: 'expand',
 };


### PR DESCRIPTION
## Summary

Two small UX polish fixes for Claude Code tool call rendering:

- **Default-expand Edit / Write renders.** These are the key tool-call paths (they represent code changes) and deserve the same default-expanded treatment that `TodoWrite` already gets — not collapsed behind a caret. Added `Edit` and `Write` to `ClaudeCodeRenderDisplayControls`.
- **Edit inspector now shows line-diff magnitude.** The shared `EditLocalFileInspector` already knows how to render `+N / -N` badges, but it reads them from `pluginState.linesAdded / linesDeleted` — a field only populated by the local-file-shell runtime. CC's Edit runs remotely via Anthropic `tool_use` blocks, so that state never arrived and the badge was silently missing. New `EditInspector` computes the counts from `args.old_string` / `args.new_string` via a small LCS-based line diff (same result `CodeDiff` shows in the expanded render) and feeds a synthesized `EditFileState` into the shared inspector.

### Before → After

- **Before:** collapsed Edit row shows only `Edit: path/to/file.tsx ▶`; user has to expand to see change size.
- **After:** collapsed row shows `Edit: path/to/file.tsx  +1` (or `+N / -M`), matching the badge `CodeDiff` already renders inline.

## Scope

- `packages/builtin-tool-claude-code/src/client/Render/index.ts` — add Edit/Write to default-expand list
- `packages/builtin-tool-claude-code/src/client/EditInspector.tsx` — new file, wraps shared EditLocalFile inspector with synthesized plugin state
- `packages/builtin-tool-claude-code/src/client/Inspector.tsx` — swap factory call for the new inspector

## Test plan

- [ ] Trigger a CC Edit that changes 1 line inside a larger `old_string` — confirm collapsed header shows `+1`, not `+N / -M` of the full snippet.
- [ ] Trigger a CC Edit that replaces everything (old_string with no unchanged lines) — confirm both `+N` and `-M` badges render.
- [ ] Trigger a CC Write — confirm it still renders expanded by default with the existing `+lineCount` badge on the collapsed header.
- [ ] Verify Bash and other tools still default-collapsed (no regression in display controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)