### PR TITLE
🐛 fix(cc): persist workingDirectory when CC topic is created

### DIFF
--- a/packages/types/src/aiChat.ts
+++ b/packages/types/src/aiChat.ts
@@ -8,7 +8,7 @@ import { PageSelectionSchema } from './message/ui/params';
 import type { OpenAIChatMessage } from './openai/chat';
 import type { LobeUniformTool } from './tool';
 import { LobeUniformToolSchema } from './tool';
-import type { ChatTopic } from './topic';
+import type { ChatTopic, ChatTopicMetadata } from './topic';
 import type { ChatThreadType } from './topic/thread';
 import { ThreadType } from './topic/thread';
 
@@ -66,6 +66,14 @@ export interface SendMessageServerParams {
    */
   newThread?: CreateThreadWithMessageParams;
   newTopic?: {
+    /**
+     * Topic metadata persisted at creation time. For CC/heterogeneous
+     * agents this carries `workingDirectory` so the topic is bound to a
+     * project from the moment it's created (used by By-Project grouping
+     * and CC `--resume` cwd verification), instead of waiting for the
+     * post-execution metadata write which can be skipped on cancel/error.
+     */
+    metadata?: ChatTopicMetadata;
     title?: string;
     topicMessageIds?: string[];
   };
@@ -111,6 +119,7 @@ export const AiSendMessageServerSchema = z.object({
   newThread: CreateThreadWithMessageSchema.optional(),
   newTopic: z
     .object({
+      metadata: z.custom<ChatTopicMetadata>().optional(),
       title: z.string().optional(),
       topicMessageIds: z.array(z.string()).optional(),
     })

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -85,6 +85,7 @@ export const aiChatRouter = router({
           agentId: input.agentId,
           groupId: input.groupId,
           messages: input.newTopic.topicMessageIds,
+          metadata: input.newTopic.metadata,
           sessionId,
           title: input.newTopic.title,
         });

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -347,6 +347,13 @@ export class ConversationLifecycleActionImpl {
     const agentConfig = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
     const heterogeneousProvider = agentConfig?.agencyConfig?.heterogeneousProvider;
     if (isDesktop && heterogeneousProvider?.type === 'claude-code') {
+      // Resolve cwd up-front so the new topic is bound to a project at
+      // creation time. Otherwise the row stays NULL until the post-execution
+      // metadata write — which never lands on cancel/error and meanwhile
+      // makes By-Project grouping miss the topic and `--resume` unsafe.
+      const workingDirectory =
+        agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(getAgentStoreState());
+
       // Persist messages to DB first (same as client mode)
       let heteroData: SendMessageServerResponse | undefined;
       try {
@@ -358,6 +365,7 @@ export class ConversationLifecycleActionImpl {
             newAssistantMessage: { model, provider: 'claude-code' },
             newTopic: !operationContext.topicId
               ? {
+                  metadata: workingDirectory ? { workingDirectory } : undefined,
                   title: message.slice(0, 20) || t('defaultTitle', { ns: 'topic' }),
                   topicMessageIds: messages.map((m) => m.id),
                 }
@@ -437,8 +445,6 @@ export class ConversationLifecycleActionImpl {
 
       try {
         const { executeHeterogeneousAgent } = await import('./heterogeneousAgentExecutor');
-        const workingDirectory =
-          agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(getAgentStoreState());
         // Extract imageList from the persisted user message (chatUploadFileList
         // may already be cleared by this point, so we read from DB instead)
         const userMsg = heteroData.messages.find((m: any) => m.id === heteroData.userMessageId);


### PR DESCRIPTION
## Summary

- Hetero-agent topic creation goes through `aiChat.sendMessageInServer`'s `newTopic` payload, which had no `metadata` field — so the topic row was inserted with `metadata.workingDirectory = NULL`.
- The only existing writer was the post-execution `updateTopicMetadata` in `heterogeneousAgentExecutor`, which never lands when CC is cancelled or errors before completion. While it's pending, By-Project grouping (`packages/utils/src/client/topic.ts:120`) misses the topic and `--resume` cwd verification (`ccResume.ts`) has nothing to compare against.
- Source the cwd at the top of the hetero branch in `conversationLifecycle.ts` and thread it through `newTopic.metadata`. The post-exec metadata write still runs (still needed for `ccSessionId`).

## Changes

- `packages/types/src/aiChat.ts` — add optional `metadata: ChatTopicMetadata` to `SendMessageServerParams.newTopic` + matching Zod field.
- `src/server/routers/lambda/aiChat.ts` — forward `input.newTopic.metadata` into `topicModel.create` (the model already accepts it via `CreateTopicParams`, no DB change needed).
- `src/store/chat/slices/aiChat/actions/conversationLifecycle.ts` — hoist `workingDirectory` resolution above the `sendMessageInServer` call so it can be passed in `newTopic.metadata`; reuse the same value below for the executor invocation (drops a duplicate selector call).

## Test plan

- [x] `bun run type-check`
- [x] `bunx vitest run src/server/routers/lambda/__tests__/aiChat.test.ts src/store/chat/slices/aiChat/actions/__tests__/conversationLifecycle.test.ts` — 42/42
- [x] `bunx vitest run src/store/chat/slices/topic/action.test.ts src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts src/store/chat/slices/aiChat/actions/__tests__/ccResume.test.ts packages/utils/src/client/topic.test.ts` — 60/60
- [x] `(cd packages/database && bunx vitest run src/models/__tests__/topics)` — 118/118
- [ ] Manual: create a fresh CC topic in desktop, verify `metadata.workingDirectory` is populated immediately (not only after CC finishes), and that the topic shows up in the correct By-Project group right away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)