### PR TITLE
💄 style(shared-tool-ui): wrap Bash inspector in a rounded chip

### DIFF
--- a/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
@@ -10,8 +10,20 @@ import { useTranslation } from 'react-i18next';
 import { inspectorTextStyles, shinyTextStyles } from '../../styles';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  baseline: css`
-    align-items: baseline;
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    gap: 6px;
+    align-items: center;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    padding-block: 2px;
+    padding-inline: 10px;
+    border-radius: 999px;
+
+    background: ${cssVar.colorFillTertiary};
   `,
   command: css`
     overflow: hidden;
@@ -22,15 +34,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     color: ${cssVar.colorText};
     text-overflow: ellipsis;
+    white-space: nowrap;
   `,
   statusIcon: css`
-    align-self: center;
     margin-inline-start: 4px;
   `,
   terminalIcon: css`
     flex-shrink: 0;
-    align-self: center;
-    margin-inline: 6px 4px;
     color: ${cssVar.colorTextDescription};
   `,
 }));
@@ -59,16 +69,18 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
     if (isArgumentsStreaming) {
       if (!description)
         return (
-          <div className={cx(inspectorTextStyles.root, styles.baseline, shinyTextStyles.shinyText)}>
+          <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
             <span>{t(translationKey as any)}</span>
           </div>
         );
 
       return (
-        <div className={cx(inspectorTextStyles.root, styles.baseline, shinyTextStyles.shinyText)}>
+        <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
           <span>{t(translationKey as any)}:</span>
-          <SquareChevronRight className={styles.terminalIcon} size={14} />
-          <span className={styles.command}>{description}</span>
+          <span className={styles.chip}>
+            <SquareChevronRight className={styles.terminalIcon} size={14} />
+            <span className={styles.command}>{description}</span>
+          </span>
         </div>
       );
     }
@@ -76,19 +88,13 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
     const isSuccess = pluginState?.success || pluginState?.exitCode === 0;
 
     return (
-      <div
-        className={cx(
-          inspectorTextStyles.root,
-          styles.baseline,
-          isLoading && shinyTextStyles.shinyText,
-        )}
-      >
+      <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
         <span>{t(translationKey as any)}:</span>
         {description && (
-          <>
+          <span className={styles.chip}>
             <SquareChevronRight className={styles.terminalIcon} size={14} />
             <span className={styles.command}>{description}</span>
-          </>
+          </span>
         )}
         {isLoading ? null : pluginState?.success !== undefined ? (
           isSuccess ? (


### PR DESCRIPTION
## Summary

Follow-up polish on the RunCommand inspector row (Bash / Skills / local-system / cloud-sandbox shell tools).

- Wrap the terminal-prompt icon and the mono command text in a single pill-shaped chip (\`colorFillTertiary\` background, \`border-radius: 999px\`), so the command reads as one unit instead of two loose pieces next to the \`Bash:\` label
- Row is back to center alignment — baseline override is no longer needed now that the chip has its own vertical padding

## Test plan

- [ ] Desktop app: trigger a Claude Code Bash call and confirm the chip renders centered against the \`Bash:\` label
- [ ] Skills / cloud-sandbox / local-system run-command inspectors render the same chip style
- [ ] Streaming-args state (partial command) still shows the chip
- [ ] Success / failure status icons still appear after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)