### PR TITLE
feat(workflow): skip collapse for single-tool workflows

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -341,4 +341,53 @@ describe('WorkflowCollapse', () => {
     const icon = screen.getByTestId('icon');
     expect(icon).toHaveAttribute('data-icon', 'X');
   });
+
+  it('renders flat without accordion when single tool completes', () => {
+    mockIsGenerating = false;
+    const blocks: AssistantContentBlock[] = [
+      {
+        content: '',
+        id: 'block-1',
+        tools: [
+          {
+            apiName: 'search',
+            arguments: '{}',
+            id: 'tool-1',
+            identifier: 'search',
+            type: 'builtin',
+            result: { content: 'ok' },
+          } as any,
+        ],
+      } as AssistantContentBlock,
+    ];
+
+    render(<WorkflowCollapse assistantMessageId="msg-1" blocks={blocks} />);
+
+    expect(screen.queryByTestId('workflow-accordion')).not.toBeInTheDocument();
+    expect(screen.getByText('workflow-expanded-list')).toBeInTheDocument();
+  });
+
+  it('still uses accordion for single tool while streaming', () => {
+    mockIsGenerating = true;
+    const blocks: AssistantContentBlock[] = [
+      {
+        content: '',
+        id: 'block-1',
+        tools: [
+          {
+            apiName: 'search',
+            arguments: '{}',
+            id: 'tool-1',
+            identifier: 'search',
+            type: 'builtin',
+            result: { content: 'ok' },
+          } as any,
+        ],
+      } as AssistantContentBlock,
+    ];
+
+    render(<WorkflowCollapse assistantMessageId="msg-1" blocks={blocks} />);
+
+    expect(screen.getByTestId('workflow-accordion')).toBeInTheDocument();
+  });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -92,6 +92,16 @@ vi.mock('../../../store', () => ({
   useConversationStore: (selector: (state: unknown) => unknown) => selector({}),
 }));
 
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: unknown) => unknown) => selector({ operations: {} }),
+}));
+
+vi.mock('@/store/chat/slices/operation/selectors', () => ({
+  operationSelectors: {
+    getOperationsByMessage: () => () => [],
+  },
+}));
+
 vi.mock('./WorkflowExpandedList', () => ({
   default: () => <div>workflow-expanded-list</div>,
 }));

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -334,6 +334,21 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
       }
     };
 
+    // When only 1 tool and not streaming, render flat without Accordion wrapper
+    // Only flatten after streaming completes to avoid layout shifts during generation
+    const shouldRenderFlat = allComplete && allTools.length === 1;
+
+    if (shouldRenderFlat) {
+      return (
+        <WorkflowExpandedList
+          assistantId={assistantMessageId}
+          blocks={blocks}
+          constrained={false}
+          disableEditing={disableEditing}
+        />
+      );
+    }
+
     const title = (
       <Flexbox horizontal align="center" gap={6} width="100%">
         <Block


### PR DESCRIPTION
## Summary

- When there's only one tool in a workflow and streaming is complete, render the tool flat without the Accordion wrapper
- Only flatten after streaming completes to prevent layout shifts during generation when additional tools might be added

## Test plan

- [ ] Test single-tool workflow displays flat (no collapse header)
- [ ] Test multi-tool workflow still shows Accordion collapse
- [ ] Test during streaming, single tool still shows Accordion (since more tools might come)
- [ ] Test transition from streaming to complete with single tool

Slack thread: https://inneioss.slack.com/archives/D0APF747P6K/p1776534187919349

https://claude.ai/code/session_01VG4BZEtgBrDCc7PH9io2zT