### PR TITLE
💄 style(workflow): render single tool directly without collapse wrapper

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -96,22 +96,27 @@ vi.mock('./WorkflowExpandedList', () => ({
   default: () => <div>workflow-expanded-list</div>,
 }));
 
-const makeBlocks = (toolOverrides: Record<string, unknown> = {}): AssistantContentBlock[] => [
+const makeBlocks = (
+  toolOverrides: Record<string, unknown> = {},
+  toolCount: number = 2,
+): AssistantContentBlock[] => [
   {
     content: '',
     id: 'block-1',
-    tools: [
-      {
-        apiName: 'search',
-        arguments: '{"query":"workflow"}',
-        id: 'tool-1',
-        identifier: 'search',
-        type: 'builtin',
-        ...toolOverrides,
-      } as any,
-    ],
+    tools: Array.from({ length: toolCount }, (_, i) => ({
+      apiName: i === 0 ? 'search' : 'calculate',
+      arguments: '{"query":"workflow"}',
+      id: `tool-${i + 1}`,
+      identifier: i === 0 ? 'search' : 'calculate',
+      type: 'builtin',
+      ...toolOverrides,
+    })) as any[],
   } as AssistantContentBlock,
 ];
+
+const makeSingleToolBlocks = (
+  toolOverrides: Record<string, unknown> = {},
+): AssistantContentBlock[] => makeBlocks(toolOverrides, 1);
 
 const getExpandedKeys = () =>
   screen.getByTestId('workflow-accordion').getAttribute('data-expanded-keys');
@@ -121,6 +126,19 @@ describe('WorkflowCollapse', () => {
     cleanup();
     mockIsGenerating = true;
     vi.useRealTimers();
+  });
+
+  it('renders directly without accordion when only one tool', () => {
+    render(<WorkflowCollapse assistantMessageId="msg-1" blocks={makeSingleToolBlocks()} />);
+
+    expect(screen.queryByTestId('workflow-accordion')).not.toBeInTheDocument();
+    expect(screen.getByText('workflow-expanded-list')).toBeInTheDocument();
+  });
+
+  it('renders with accordion when multiple tools', () => {
+    render(<WorkflowCollapse assistantMessageId="msg-1" blocks={makeBlocks()} />);
+
+    expect(screen.getByTestId('workflow-accordion')).toBeInTheDocument();
   });
 
   it('defaults to expanded while streaming', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -3,7 +3,7 @@ import { Accordion, AccordionItem, Block, Flexbox, Icon, Text } from '@lobehub/u
 import { cssVar } from 'antd-style';
 import { AlertTriangle, Check, HandIcon, Maximize2, Minimize2, X } from 'lucide-react';
 import { AnimatePresence, m as motion } from 'motion/react';
-import { type Key, memo, useEffect, useMemo, useRef, useState } from 'react';
+import { type Key, memo, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
@@ -32,6 +32,30 @@ import {
 } from '../toolDisplayNames';
 import type { RenderableAssistantContentBlock } from './types';
 import WorkflowExpandedList from './WorkflowExpandedList';
+
+interface WorkflowContentProps {
+  assistantId: string;
+  blocks: RenderableAssistantContentBlock[];
+  constrained: boolean;
+  disableEditing?: boolean;
+  onScroll?: () => void;
+  scrollRef?: RefObject<HTMLDivElement | null>;
+}
+
+const WorkflowContent = memo<WorkflowContentProps>(
+  ({ assistantId, blocks, constrained, disableEditing, onScroll, scrollRef }) => (
+    <WorkflowExpandedList
+      assistantId={assistantId}
+      blocks={blocks}
+      constrained={constrained}
+      disableEditing={disableEditing}
+      scrollRef={scrollRef}
+      onScroll={onScroll}
+    />
+  ),
+);
+
+WorkflowContent.displayName = 'WorkflowContent';
 
 const WORKFLOW_EXPAND_TOGGLE_ICON_SIZE = 12;
 const WORKFLOW_EXPAND_TOGGLE_TRANSITION = {
@@ -460,6 +484,19 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
       </Flexbox>
     );
 
+    const isSingleTool = allTools.length === 1;
+
+    if (isSingleTool) {
+      return (
+        <WorkflowContent
+          assistantId={assistantMessageId}
+          blocks={blocks}
+          constrained={false}
+          disableEditing={disableEditing}
+        />
+      );
+    }
+
     return (
       <Accordion
         expandedKeys={isExpanded ? ['workflow'] : []}
@@ -467,7 +504,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
         onExpandedChange={handleExpandedChange}
       >
         <AccordionItem itemKey="workflow" paddingBlock={4} paddingInline={4} title={title}>
-          <WorkflowExpandedList
+          <WorkflowContent
             assistantId={assistantMessageId}
             blocks={blocks}
             constrained={constrained}


### PR DESCRIPTION
## Summary

- When there's only one tool in the workflow, display it flat without the Accordion collapse wrapper
- Extracts `WorkflowContent` as a memoized component to optimize re-renders during tool count transitions (1 → 2+ tools)
- Updates tests to cover both single-tool (flat) and multi-tool (accordion) rendering modes

## Test plan

- [ ] Verify single tool workflows render without accordion wrapper
- [ ] Verify multi-tool workflows still use accordion collapse
- [ ] Check transition from 1 to 2+ tools renders smoothly without excessive re-renders
- [ ] Confirm all existing WorkflowCollapse tests pass

Slack thread: https://inneioss.slack.com/archives/D0APF747P6K/p1776533773088449?thread_ts=1776533726.284529&cid=D0APF747P6K

https://claude.ai/code/session_01F3y38HmsN69gdPZvMR1CKH