### PR TITLE
🐛 fix(electron): align TabBar left padding with NavPanel width on initial load

### DIFF
--- a/src/features/Electron/titlebar/NavigationBar.tsx
+++ b/src/features/Electron/titlebar/NavigationBar.tsx
@@ -87,6 +87,7 @@ const NavigationBar = memo(() => {
       data-width={leftPanelWidth}
       justify="end"
       style={{
+        paddingRight: 8,
         width: isLeftPanelVisible ? `${leftPanelWidth - 12}px` : '150px',
         transition: !isLeftPanelVisible ? 'width 0.2s' : 'none',
       }}

--- a/src/features/NavPanel/components/NavPanelDraggable.tsx
+++ b/src/features/NavPanel/components/NavPanelDraggable.tsx
@@ -106,24 +106,20 @@ const classNames = {
 };
 
 export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }) => {
-  const [expand, togglePanel] = useGlobalStore((s) => [
+  const [expand, togglePanel, isStatusInit] = useGlobalStore((s) => [
     systemStatusSelectors.showLeftPanel(s),
     s.toggleLeftPanel,
+    systemStatusSelectors.isStatusInit(s),
   ]);
   const handleSizeChange = useNavPanelSizeChangeHandler();
 
+  // Defer DraggablePanel mount until system status hydrates; otherwise defaultSize
+  // captures the pre-hydration default and the DOM drifts off NavigationBar's live width.
   const defaultWidthRef = useRef(0);
-  if (defaultWidthRef.current === 0) {
+  if (defaultWidthRef.current === 0 && isStatusInit) {
     defaultWidthRef.current = systemStatusSelectors.leftPanelWidth(useGlobalStore.getState());
   }
 
-  const defaultSize = useMemo(
-    () => ({
-      height: '100%',
-      width: defaultWidthRef.current,
-    }),
-    [],
-  );
   const styles = useMemo(
     () => ({
       background: isDesktop && isMacOS() ? 'transparent' : cssVar.colorBgLayout,
@@ -131,6 +127,13 @@ export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }
     }),
     [],
   );
+
+  if (defaultWidthRef.current === 0) {
+    const pendingWidth = systemStatusSelectors.leftPanelWidth(useGlobalStore.getState());
+    return <div aria-hidden style={{ flexShrink: 0, height: '100%', width: pendingWidth }} />;
+  }
+
+  const defaultSize = { height: '100%', width: defaultWidthRef.current };
 
   return (
     <DraggablePanel


### PR DESCRIPTION
## Summary

- Defer `DraggablePanel` mount inside `NavPanelDraggable` until `isStatusInit` hydrates so `defaultSize` captures the user's persisted `leftPanelWidth` instead of the 320px pre-hydration default.
- Before hydration, render a placeholder `<div>` at the current store width so `NavigationBar`'s live-read width and the DOM stay aligned.
- Add a small `paddingRight: 8` to `NavigationBar` for visual balance against the TabBar.

### Why

`NavigationBar` reads `leftPanelWidth` live from the store, while `NavPanelDraggable` previously captured it **once** on first render — which ran before `useInitSystemStatus` resolved from localStorage. Once hydration landed, the store advanced to the user's persisted width but the panel DOM stayed at the default 320px, so `NavigationBar`'s computed width (and therefore the TabBar's left edge) drifted off the real panel edge.

Gating the first mount on `isStatusInit` keeps the captured default and the live-read width in sync at every frame, without introducing controlled `size` (which would re-render the panel on every drag mousemove).

## Test plan

- [ ] `bun run dev:spa`, open desktop window with a persisted left-panel width ≠ 320; verify TabBar left edge aligns with NavPanel right edge on first paint.
- [ ] Drag the panel resize handle; verify TabBar follows smoothly with no extra re-renders of `NavPanelDraggable` subtree.
- [ ] Toggle the panel (collapse/expand); NavigationBar width transitions as before.
- [ ] Reload with `showLeftPanel: false` persisted; NavigationBar collapses to 150px without layout jump.