### PR TITLE
🐛 fix: remove systemRole truncation in getAgentDetail

### DIFF
--- a/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
+++ b/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
@@ -314,11 +314,7 @@ export class AgentManagerRuntime {
         parts.push(`Model: ${detail.config.provider || ''}/${detail.config.model}`);
       if (detail.config.plugins?.length) parts.push(`Plugins: ${detail.config.plugins.join(', ')}`);
       if (detail.config.systemRole) {
-        const truncated =
-          detail.config.systemRole.length > 200
-            ? detail.config.systemRole.slice(0, 200) + '...'
-            : detail.config.systemRole;
-        parts.push(`System Prompt: ${truncated}`);
+        parts.push(`System Prompt: ${detail.config.systemRole}`);
       }
 
       return {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Remove the 200-character truncation of `systemRole` in `AgentManagerRuntime.getAgentDetail`. The caller already handles length limits, so the truncation here is redundant and causes incomplete prompt display.

#### 🧪 How to Test

- [x] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>