### PR TITLE
🐛 fix(user-panel): remove consecutive dividers in user panel menu

### DIFF
--- a/src/features/User/UserPanel/useMenu.tsx
+++ b/src/features/User/UserPanel/useMenu.tsx
@@ -138,7 +138,14 @@ export const useMenu = () => {
         ]
       : []),
     ...(!hideDocs ? helps : []),
-  ].filter(Boolean) as MenuProps['items'];
+  ]
+    .filter(Boolean)
+    // Remove consecutive dividers to prevent double divider lines
+    .filter((item, index, arr) => {
+      if (index === 0) return true;
+      const isDivider = (i: any) => i && typeof i === 'object' && i.type === 'divider';
+      return !(isDivider(item) && isDivider(arr[index - 1]));
+    }) as MenuProps['items'];
 
   const logoutItems: MenuProps['items'] = isLoginWithAuth
     ? [

--- a/src/features/User/__tests__/useMenu.test.tsx
+++ b/src/features/User/__tests__/useMenu.test.tsx
@@ -77,4 +77,24 @@ describe('useMenu', () => {
       expect(logoutItems.some((item) => item?.key === 'logout')).toBe(false);
     });
   });
+
+  it('should not have consecutive dividers in mainItems', () => {
+    act(() => {
+      useUserStore.setState({ isSignedIn: true });
+    });
+
+    const { result } = renderHook(() => useMenu(), { wrapper });
+
+    act(() => {
+      const { mainItems } = result.current;
+      if (!mainItems) return;
+
+      for (let i = 1; i < mainItems.length; i++) {
+        const prev = mainItems[i - 1];
+        const curr = mainItems[i];
+        const isDivider = (item: any) => item && typeof item === 'object' && item.type === 'divider';
+        expect(isDivider(prev) && isDivider(curr)).toBe(false);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fix double divider lines appearing between **Credits** and **Get Desktop App** in the user panel dropdown menu.

## Root Cause

In `src/features/User/UserPanel/useMenu.tsx`, the `mainItems` array is assembled by spreading several conditional item groups:

```ts
const mainItems = [
  { type: 'divider' },
  ...(isLogin ? settings : []),
  ...businessMenuItems,          // ← cloud: may include trailing divider
  ...(!isDesktop ? [{ type: 'divider' }, ...getDesktopApp] : []),  // ← another divider
  ...
];
```

When `businessMenuItems` (injected by the cloud business module) returns items that end with a divider, and the `getDesktopApp` section unconditionally prepends its own divider, two dividers appear back-to-back.

## Fix

Add a post-filter on `mainItems` that strips any consecutive divider, regardless of which module injected them. This is a defensive approach that works no matter what `businessMenuItems` returns.

Also added a test to ensure no consecutive dividers exist in `mainItems`.

## Changes

- `src/features/User/UserPanel/useMenu.tsx` — filter consecutive dividers
- `src/features/User/__tests__/useMenu.test.tsx` — add regression test