### PR TITLE
✨ feat(chat-input): gate prompt optimize by image output capability

### DIFF
--- a/src/features/AgentBuilder/AgentBuilderConversation.tsx
+++ b/src/features/AgentBuilder/AgentBuilderConversation.tsx
@@ -14,6 +14,7 @@ interface AgentBuilderConversationProps {
   agentId: string;
 }
 const actions: ActionKeys[] = ['model'];
+const rightActions: ActionKeys[] = [];
 
 /**
  * Agent Builder Conversation Component
@@ -32,7 +33,7 @@ const AgentBuilderConversation = memo<AgentBuilderConversationProps>(({ agentId 
         <Flexbox flex={1} style={{ overflow: 'hidden' }}>
           <ChatList welcome={<AgentBuilderWelcome />} />
         </Flexbox>
-        <ChatInput leftActions={actions} showRuntimeConfig={false} />
+        <ChatInput leftActions={actions} rightActions={rightActions} showRuntimeConfig={false} />
       </Flexbox>
     </DragUploadZone>
   );

--- a/src/features/ChatInput/ActionBar/PromptTransform/index.tsx
+++ b/src/features/ChatInput/ActionBar/PromptTransform/index.tsx
@@ -12,13 +12,19 @@ const PromptTransform = memo(() => {
   const onPromptChange = useCallback(
     (prompt: string) => {
       if (!editor) return;
-      editor.setDocument('markdown', prompt);
+      // `keepHistory` prevents setDocument from wiping the undo/redo stacks.
+      editor.setDocument('markdown', prompt, { keepHistory: true });
     },
     [editor],
   );
 
+  // Image mode expands vague inputs; text mode forbids expansion.
   return (
-    <PromptTransformAction mode={'text'} prompt={markdownContent} onPromptChange={onPromptChange} />
+    <PromptTransformAction
+      mode={'image'}
+      prompt={markdownContent}
+      onPromptChange={onPromptChange}
+    />
   );
 });
 

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -124,7 +124,7 @@ const ChatInput = memo<ChatInputProps>(
     allowExpand,
     leftActions = [],
     leftContent,
-    rightActions = ['promptTransform'],
+    rightActions = [],
     children,
     extraActionItems,
     mentionItems,

--- a/src/features/PromptTransform/usePromptTransform.ts
+++ b/src/features/PromptTransform/usePromptTransform.ts
@@ -23,8 +23,12 @@ export const usePromptTransform = ({ mode, prompt, onPromptChange }: UsePromptTr
   const isRewriteActionEnabled = rewriteConfig?.enabled ?? false;
 
   const getConfigByAction = useCallback(
-    (action: PromptTransformAction) =>
-      action === 'rewrite' ? (rewriteConfig ?? {}) : (translateConfig ?? {}),
+    (action: PromptTransformAction) => {
+      // Strip config-only fields (enabled, customPrompt); strict upstreams reject unknown OpenAI params.
+      const config = action === 'rewrite' ? rewriteConfig : translateConfig;
+      if (!config) return {};
+      return { model: config.model, provider: config.provider };
+    },
     [rewriteConfig, translateConfig],
   );
 

--- a/src/hooks/useModelSupportImageOutput.ts
+++ b/src/hooks/useModelSupportImageOutput.ts
@@ -1,0 +1,10 @@
+import { useAiInfraStore } from '@/store/aiInfra';
+import { aiModelSelectors } from '@/store/aiInfra/selectors';
+
+export const useModelSupportImageOutput = (id?: string, provider?: string) => {
+  return useAiInfraStore((s) => {
+    if (!id || !provider) return false;
+
+    return aiModelSelectors.isModelSupportImageOutput(id, provider)(s);
+  });
+};

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/index.tsx
@@ -4,13 +4,17 @@ import { memo, useMemo } from 'react';
 
 import { type ActionKeys } from '@/features/ChatInput';
 import { ChatInput } from '@/features/Conversation';
+import { useModelSupportImageOutput } from '@/hooks/useModelSupportImageOutput';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import { useSendMenuItems } from './useSendMenuItems';
 
-const rightActions: ActionKeys[] = ['promptTransform'];
+const emptyRightActions: ActionKeys[] = [];
+const promptTransformRightActions: ActionKeys[] = ['promptTransform'];
 
 /**
  * MainChatInput
@@ -23,6 +27,11 @@ const rightActions: ActionKeys[] = ['promptTransform'];
 const MainChatInput = memo(() => {
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
   const sendMenuItems = useSendMenuItems();
+
+  const model = useAgentStore(agentSelectors.currentAgentModel);
+  const provider = useAgentStore(agentSelectors.currentAgentModelProvider);
+  const supportsImageOutput = useModelSupportImageOutput(model, provider);
+  const rightActions = supportsImageOutput ? promptTransformRightActions : emptyRightActions;
 
   const leftActions: ActionKeys[] = useMemo(
     () => [

--- a/src/routes/(main)/group/profile/features/AgentBuilder/AgentBuilderConversation.tsx
+++ b/src/routes/(main)/group/profile/features/AgentBuilder/AgentBuilderConversation.tsx
@@ -11,6 +11,7 @@ interface AgentBuilderConversationProps {
   agentId: string;
 }
 const actions: ActionKeys[] = ['model'];
+const rightActions: ActionKeys[] = [];
 
 /**
  * Agent Builder Conversation Component
@@ -23,7 +24,7 @@ const AgentBuilderConversation = memo<AgentBuilderConversationProps>(({ agentId 
       <Flexbox flex={1} style={{ overflow: 'hidden' }}>
         <ChatList welcome={<AgentBuilderWelcome mode="group" />} />
       </Flexbox>
-      <ChatInput leftActions={actions} showRuntimeConfig={false} />
+      <ChatInput leftActions={actions} rightActions={rightActions} showRuntimeConfig={false} />
     </Flexbox>
   );
 });

--- a/src/store/aiInfra/slices/aiModel/selectors.test.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.test.ts
@@ -45,6 +45,7 @@ describe('aiModelSelectors', () => {
           functionCall: true,
           vision: true,
           reasoning: true,
+          imageOutput: true,
         },
         contextWindowTokens: 4000,
         settings: {
@@ -207,6 +208,20 @@ describe('aiModelSelectors', () => {
     it('should check reasoning support', () => {
       expect(aiModelSelectors.isModelSupportReasoning('model1', 'provider1')(mockState)).toBe(true);
       expect(aiModelSelectors.isModelSupportReasoning('model4', 'provider2')(mockState)).toBe(
+        false,
+      );
+    });
+
+    it('should check image output support', () => {
+      expect(aiModelSelectors.isModelSupportImageOutput('model1', 'provider1')(mockState)).toBe(
+        true,
+      );
+      // Missing ability defaults to false via `|| false` coercion.
+      expect(aiModelSelectors.isModelSupportImageOutput('model4', 'provider2')(mockState)).toBe(
+        false,
+      );
+      // Unknown model returns false instead of throwing.
+      expect(aiModelSelectors.isModelSupportImageOutput('missing', 'provider1')(mockState)).toBe(
         false,
       );
     });

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -68,6 +68,12 @@ const isModelSupportVideo = (id: string, provider: string) => (s: AIProviderStor
   return model?.abilities?.video;
 };
 
+const isModelSupportImageOutput = (id: string, provider: string) => (s: AIProviderStoreState) => {
+  const model = getEnabledModelById(id, provider)(s);
+
+  return model?.abilities?.imageOutput || false;
+};
+
 const isModelSupportReasoning = (id: string, provider: string) => (s: AIProviderStoreState) => {
   const model = getEnabledModelById(id, provider)(s);
 
@@ -155,6 +161,7 @@ export const aiModelSelectors = {
   isModelHasExtendParams,
   isModelLoading,
   isModelSupportFiles,
+  isModelSupportImageOutput,
   isModelSupportReasoning,
   isModelSupportToolUse,
   isModelSupportVideo,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔀 Description of Change

Rework the Refine Idea (lightbulb) action in the chat input so it only surfaces for models that actually benefit from it, and fix two bugs surfaced while testing the flow.

**Behavior changes:**

- Remove promptTransform from `ChatInput`'s default `rightActions`.
- In `agent/MainChatInput`, enable the button only when the currently selected model's `abilities.imageOutput === true` (e.g. GPT image, Gemini Flash Image). Regular chat models no longer show the lightbulb.
- When triggered, use the `image`-mode rewrite system prompt. The `text` prompt explicitly forbids expansion, which makes short inputs round-trip unchanged; image mode fills in visual detail which is what users expect when optimizing an image prompt.
- Both `AgentBuilder` entries explicitly pass `rightActions={[]}` to pin the "no button" intent.

**Bug fixes:**

- Refining a prompt no longer 400s on strict OpenAI-compatible upstreams. The old code merged the whole `systemAgent` config into chat params, leaking config-only fields (`enabled`, `customPrompt`); now only `{ model, provider }` flows through.
- `cmd+z` after refining can now revert to the pre-optimize content. `editor.setDocument` wipes the undo/redo stacks by default; passing `{ keepHistory: true }` preserves them.

**Infra:**

- New `isModelSupportImageOutput` selector and `useModelSupportImageOutput` hook, following the sibling `useModelSupportVision` / `useModelSupportVideo` pattern. Covered by a new unit test in `selectors.test.ts`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Scenarios to verify:

1. Select a non-image model in chat → lightbulb button hidden.
2. Select an image-output model (e.g. `gpt-image-1`, `gemini-flash-image`) → lightbulb shows; click it, short prompt gets expanded with visual detail.
3. Refine a prompt, then press `cmd+z` → editor restores the pre-optimize content.
4. Refine against an upstream that used to 400 with `Unknown parameter: 'enabled'` → request succeeds.
5. `AgentBuilder` conversations show no lightbulb regardless of model.

#### 📝 Additional Information

Follow-ups (optional, not in this PR):

- Gating could additionally respect `systemAgent.promptRewrite.enabled`; today if a user disables rewrite in settings but uses an image model, the lightbulb still shows and degrades to translate-only.
- Consider extracting a shared `pickChatModelConfig(config)` util so other systemAgent consumers (queryRewrite, topic, etc.) don't repeat the same payload-leak class of bug.