### PR TITLE
🐛 fix: remove desktop tracker legacy imports

### DIFF
--- a/src/routes/(main)/agent/index.desktop.test.tsx
+++ b/src/routes/(main)/agent/index.desktop.test.tsx
@@ -42,10 +42,6 @@ vi.mock('@lobehub/ui', () => ({
   ShikiLobeTheme: {},
 }));
 
-vi.mock('@/components/Analytics/MainInterfaceTracker', () => ({
-  default: () => <div data-testid="main-interface-tracker" />,
-}));
-
 vi.mock('@/features/TopicPopupGuard', () => ({
   default: () => <div data-testid="topic-popup-guard" />,
 }));

--- a/src/routes/(main)/agent/index.desktop.tsx
+++ b/src/routes/(main)/agent/index.desktop.tsx
@@ -3,7 +3,6 @@
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
-import MainInterfaceTracker from '@/components/Analytics/MainInterfaceTracker';
 import TopicInPopupGuard from '@/features/TopicPopupGuard';
 import { useTopicInPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useChatStore } from '@/store/chat';
@@ -49,7 +48,6 @@ const ChatPage = memo(() => {
         <Portal />
         <AgentWorkingSidebar />
       </Flexbox>
-      <MainInterfaceTracker />
       <TelemetryNotification mobile={false} />
     </>
   );

--- a/src/routes/(main)/group/index.desktop.tsx
+++ b/src/routes/(main)/group/index.desktop.tsx
@@ -3,7 +3,6 @@
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
-import MainInterfaceTracker from '@/components/Analytics/MainInterfaceTracker';
 import TopicInPopupGuard from '@/features/TopicPopupGuard';
 import { useTopicInPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useChatStore } from '@/store/chat';
@@ -44,7 +43,6 @@ const ChatPage = memo(() => {
         <Conversation />
         <Portal />
       </Flexbox>
-      <MainInterfaceTracker />
       <TelemetryNotification mobile={false} />
     </>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-7120

#### 🔀 Description of Change

- remove stale `MainInterfaceTracker` imports from the new desktop agent/group route entries
- keep `main_page_view` scoped to the homepage instead of desktop chat routes
- avoid requiring a cloud-side compatibility shim for the deleted tracker component

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Local verification:
- confirmed the updated files no longer reference `@/components/Analytics/MainInterfaceTracker`
- attempted `bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/index.desktop.test.tsx'` in the standalone worktree, but this worktree is missing shared test dependencies (`vite-tsconfig-paths`), which is a pre-existing environment issue for this repo copy

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

- This is a follow-up clean fix after the original X Ads tracking PR merged
- It removes the need for the cloud-side `MainInterfaceTracker` compatibility workaround
