### PR TITLE
💄 style(todo-progress): vertically center collapsed header row

### DIFF
--- a/src/features/Conversation/TodoProgress/index.tsx
+++ b/src/features/Conversation/TodoProgress/index.tsx
@@ -21,7 +21,10 @@ const RING_CIRCUM = 2 * Math.PI * RING_RADIUS;
 const styles = createStaticStyles(({ css, cssVar }) => ({
   collapsed: css`
     max-height: 0;
+    margin-block-start: 0 !important;
     padding-block: 0 !important;
+    border-block-start: none !important;
+
     opacity: 0;
   `,
   container: css`
@@ -30,7 +33,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     margin-block-end: 8px;
     margin-inline: 10px;
-    padding-block: 8px;
+    padding-block: 8px 10px;
     padding-inline: 12px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-start-start-radius: 12px;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The collapsed `TodoProgress` header row looked vertically off-center — the text sat a few pixels above the visual middle of the bar.

Root cause: when collapsed, the inner `listContainer` only zeroed out `max-height` and `padding-block`, but `margin-block-start: 8px` and `border-block-start: 1px` were still applied. Those residuals added ~9px of phantom space below the header, pushing the header visually up.

Fix:

- Clear `margin-block-start` and `border-block-start` on the `collapsed` state so the listContainer contributes 0 height when hidden.
- Slightly raise the container's bottom padding (`padding-block: 8px` → `8px 10px`) so the collapsed header sits on the bar's visual center.

Left/right margins and the expanded layout are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a TODO-style tool that renders a progress bar above the chat input and verify the collapsed header text sits at the visual center of the bar. Expand/collapse a few times to confirm the transition still feels right.

#### 📸 Screenshots / Videos

UI-only tweak; see the TodoProgress bar above the chat input.

#### 📝 Additional Information

No breaking changes.