### PR TITLE
✨ feat(env): add Kimi Coding Plan API environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,11 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 
 # MOONSHOT_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# ## Kimi Code Plan  ####
+
+# KIMICODINGPLAN_PROXY_URL=https://api.kimi.com/coding
+# KIMICODINGPLAN_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # ## Minimax AI  ####
 
 # MINIMAX_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -32,6 +32,9 @@ export const getLLMConfig = () => {
       ENABLED_MOONSHOT: z.boolean(),
       MOONSHOT_API_KEY: z.string().optional(),
 
+      ENABLED_KIMICODINGPLAN: z.boolean(),
+      KIMICODINGPLAN_API_KEY: z.string().optional(),
+
       ENABLED_PERPLEXITY: z.boolean(),
       PERPLEXITY_API_KEY: z.string().optional(),
 
@@ -283,6 +286,9 @@ export const getLLMConfig = () => {
 
       ENABLED_MOONSHOT: !!process.env.MOONSHOT_API_KEY,
       MOONSHOT_API_KEY: process.env.MOONSHOT_API_KEY,
+
+      ENABLED_KIMICODINGPLAN: !!process.env.KIMICODINGPLAN_API_KEY,
+      KIMICODINGPLAN_API_KEY: process.env.KIMICODINGPLAN_API_KEY,
 
       ENABLED_GROQ: !!process.env.GROQ_API_KEY,
       GROQ_API_KEY: process.env.GROQ_API_KEY,

--- a/src/features/Conversation/InterventionBar/style.ts
+++ b/src/features/Conversation/InterventionBar/style.ts
@@ -12,7 +12,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   content: css`
     overflow-y: auto;
     flex: 1;
-
     min-height: 0;
     padding-block: 8px 12px;
   `,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add `ENABLED_KIMICODINGPLAN` and `KIMICODINGPLAN_API_KEY` to the LLM environment schema and runtime mapping in `getLLMConfig`, mirroring other provider env patterns (enabled flag derived from presence of API key).
- Remove an extra blank line in `InterventionBar` static styles (formatting only).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Set `KIMICODINGPLAN_API_KEY` in the environment and confirm `getLLMConfig()` exposes the expected values where LLM config is consumed.

#### 📸 Screenshots / Videos

N/A (no visual behavior change intended)

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)