### PR TITLE
feat: support env variables for Github Copilot provider

### DIFF
--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -52,7 +52,8 @@ export const getLLMConfig = () => {
 
       ENABLED_GITHUB: z.boolean(),
       GITHUB_TOKEN: z.string().optional(),
-
+    ENABLED_GITHUB_COPILOT: z.boolean(),
+    GITHUB_COPILOT_TOKEN: z.string().optional(),
       ENABLED_OPENROUTER: z.boolean(),
       OPENROUTER_API_KEY: z.string().optional(),
 
@@ -295,7 +296,8 @@ export const getLLMConfig = () => {
 
       ENABLED_GITHUB: !!process.env.GITHUB_TOKEN,
       GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-
+    ENABLED_GITHUB_COPILOT: !!process.env.GITHUB_COPILOT_TOKEN,
+    GITHUB_COPILOT_TOKEN: process.env.GITHUB_COPILOT_TOKEN,
       ENABLED_ZEROONE: !!process.env.ZEROONE_API_KEY,
       ZEROONE_API_KEY: process.env.ZEROONE_API_KEY,
 

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -50,6 +50,9 @@ export const getServerGlobalConfig = async () => {
         enabledKey: 'ENABLED_GITEE_AI',
         modelListKey: 'GITEE_AI_MODEL_LIST',
       },
+      githubcopilot: {
+        enabledKey: 'ENABLED_GITHUB_COPILOT',
+      },
       lmstudio: {
         fetchOnClient: isDesktop ? false : undefined,
       },

--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -238,8 +238,10 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
 
     case ModelProvider.GithubCopilot: {
       // Support both traditional PAT (apiKey) and OAuth tokens
+      const { GITHUB_COPILOT_TOKEN } = llmConfig;
+
       return {
-        apiKey: payload.apiKey,
+        apiKey: apiKeyManager.pick(payload?.apiKey || GITHUB_COPILOT_TOKEN),
         bearerToken: payload.bearerToken,
         bearerTokenExpiresAt: payload.bearerTokenExpiresAt,
         oauthAccessToken: payload.oauthAccessToken,


### PR DESCRIPTION
### What this PR does   This PR introduces backend environment variable support for the GitHub Copilot provider.   Users can now define ENABLED_GITHUB_COPILOT and GITHUB_COPILOT_TOKEN in their deployment env files to globally enable and authenticate the GitHub Copilot provider without enforcing manual user OAuth setups.   ### Which issue(s) this PR fixes   Fixes #13750