### PR TITLE
🐛 fix: make tool and skill activation case-insensitive

### DIFF
--- a/packages/builtin-tool-activator/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-activator/src/ExecutionRuntime/index.ts
@@ -50,12 +50,16 @@ export class ActivatorExecutionRuntime {
     }
 
     try {
+      // Normalize identifiers to lowercase for case-insensitive matching
+      const normalizedIdentifiers = identifiers.map((id) => id.toLowerCase());
+
       const alreadyActive = this.service.getActivatedToolIds();
+      const alreadyActiveLower = new Set(alreadyActive.map((id) => id.toLowerCase()));
       const toActivate: string[] = [];
       const alreadyActiveList: string[] = [];
 
-      for (const id of identifiers) {
-        if (alreadyActive.includes(id)) {
+      for (const id of normalizedIdentifiers) {
+        if (alreadyActiveLower.has(id)) {
           alreadyActiveList.push(id);
         } else {
           toActivate.push(id);
@@ -65,7 +69,7 @@ export class ActivatorExecutionRuntime {
       // Fetch manifests for tools to activate
       const manifests = await this.service.getToolManifests(toActivate);
 
-      const foundIdentifiers = new Set(manifests.map((m) => m.identifier));
+      const foundIdentifiers = new Set(manifests.map((m) => m.identifier.toLowerCase()));
       const notFound = toActivate.filter((id) => !foundIdentifiers.has(id));
 
       const activatedTools: ActivatedToolInfo[] = manifests.map((m) => ({

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -177,8 +177,9 @@ export class SkillsExecutionRuntime {
     }
 
     try {
-      // Check builtin skills first
-      const builtinSkill = this.builtinSkills.find((s) => s.name === id);
+      // Check builtin skills first (case-insensitive)
+      const idLower = id.toLowerCase();
+      const builtinSkill = this.builtinSkills.find((s) => s.name.toLowerCase() === idLower);
       if (builtinSkill?.resources) {
         const meta = builtinSkill.resources[path];
         if (meta?.content !== undefined) {
@@ -231,8 +232,9 @@ export class SkillsExecutionRuntime {
   async activateSkill(args: ActivateSkillParams): Promise<BuiltinServerRuntimeOutput> {
     const { name } = args;
 
-    // Check builtin skills first — no DB query needed
-    const builtinSkill = this.builtinSkills.find((s) => s.name === name);
+    // Check builtin skills first — no DB query needed (case-insensitive)
+    const nameLower = name.toLowerCase();
+    const builtinSkill = this.builtinSkills.find((s) => s.name.toLowerCase() === nameLower);
     if (builtinSkill) {
       let content = builtinSkill.content;
       const hasResources = !!(

--- a/src/server/services/toolExecution/serverRuntimes/activator.ts
+++ b/src/server/services/toolExecution/serverRuntimes/activator.ts
@@ -45,8 +45,15 @@ export const activatorRuntime: ServerRuntimeRegistration = {
         // The caller is responsible for scoping this map to exclude hidden/internal tools.
         const results: ToolManifestInfo[] = [];
 
+        // Build a case-insensitive lookup map for tool manifests
+        const manifestMapLower: Record<string, string> = {};
+        for (const key of Object.keys(context.toolManifestMap)) {
+          manifestMapLower[key.toLowerCase()] = key;
+        }
+
         for (const id of identifiers) {
-          const manifest = context.toolManifestMap[id];
+          const actualKey = manifestMapLower[id.toLowerCase()];
+          const manifest = actualKey ? context.toolManifestMap[actualKey] : undefined;
           if (!manifest) continue;
 
           results.push({

--- a/src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts
@@ -96,6 +96,31 @@ describe('lobe-activator executor discovery allowlist', () => {
     expect(activatedIds).toHaveLength(0);
   });
 
+  it('should match identifiers case-insensitively', async () => {
+    const tool = makeBuiltinTool('lobe-web-browsing');
+
+    mockGetState.mockReturnValue({
+      builtinTools: [tool],
+      installedPlugins: [],
+    });
+
+    mockAvailableToolsForDiscovery.mockReturnValue([
+      { description: 'desc', identifier: 'lobe-web-browsing', name: 'lobe-web-browsing' },
+    ]);
+
+    const result = await activatorExecutor.invoke(
+      'activateTools',
+      { identifiers: ['Lobe-Web-Browsing'] },
+      { messageId: 'msg-1', operationId: 'op-1' },
+    );
+
+    expect(result.success).toBe(true);
+
+    const state = result.state as any;
+    const activatedIds = state.activatedTools?.map((t: any) => t.identifier) ?? [];
+    expect(activatedIds).toContain('lobe-web-browsing');
+  });
+
   it('should allow discoverable plugins', async () => {
     const plugin = makePlugin('community-plugin');
 

--- a/src/store/tool/slices/builtin/executors/lobe-activator.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-activator.ts
@@ -43,15 +43,17 @@ const service: ActivatorRuntimeService = {
     // Only allow activation of tools that passed discovery filters
     // (discoverable, platform-available, not internal/hidden)
     const discoverable = new Set(
-      toolSelectors.availableToolsForDiscovery(s).map((t) => t.identifier),
+      toolSelectors.availableToolsForDiscovery(s).map((t) => t.identifier.toLowerCase()),
     );
-    const allowedIds = identifiers.filter((id) => discoverable.has(id));
+    const allowedIds = identifiers.filter((id) => discoverable.has(id.toLowerCase()));
 
     const results: ToolManifestInfo[] = [];
 
     for (const id of allowedIds) {
+      const idLower = id.toLowerCase();
+
       // Search builtin tools
-      const builtin = s.builtinTools.find((t) => t.identifier === id);
+      const builtin = s.builtinTools.find((t) => t.identifier.toLowerCase() === idLower);
       if (builtin) {
         results.push({
           apiDescriptions: builtin.manifest.api.map((a) => ({
@@ -67,7 +69,7 @@ const service: ActivatorRuntimeService = {
       }
 
       // Search installed plugins
-      const plugin = s.installedPlugins.find((p) => p.identifier === id);
+      const plugin = s.installedPlugins.find((p) => p.identifier.toLowerCase() === idLower);
       if (plugin?.manifest) {
         results.push({
           apiDescriptions: (plugin.manifest.api || []).map((a) => ({
@@ -84,7 +86,9 @@ const service: ActivatorRuntimeService = {
 
       // Search LobeHub Skill servers
       const lobehubSkillServer = s.lobehubSkillServers?.find(
-        (server) => server.identifier === id && server.status === LobehubSkillStatus.CONNECTED,
+        (server) =>
+          server.identifier.toLowerCase() === idLower &&
+          server.status === LobehubSkillStatus.CONNECTED,
       );
       if (lobehubSkillServer?.tools) {
         results.push({


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #14008

#### 🔀 Description of Change

LLMs sometimes generate tool/skill identifiers with different casing (e.g. `lobehub` instead of `LobeHub`, `Lobe-Web-Browsing` instead of `lobe-web-browsing`), causing the activator to fail with "Not found".

This PR normalizes all identifier comparisons to be case-insensitive across 4 files:

- `packages/builtin-tool-activator/src/ExecutionRuntime/index.ts` — normalize input identifiers to lowercase, case-insensitive `alreadyActive` and `foundIdentifiers` checks
- `packages/builtin-tool-skills/src/ExecutionRuntime/index.ts` — case-insensitive `builtinSkills.find()` in `activateSkill()` and `readReference()`
- `src/store/tool/slices/builtin/executors/lobe-activator.ts` — case-insensitive `discoverable.has()`, builtin/plugin/skill server `.find()` lookups
- `src/server/services/toolExecution/serverRuntimes/activator.ts` — case-insensitive `toolManifestMap` key lookup

#### 🧪 How to Test

- [x] Added/updated tests

New test case verifies that `Lobe-Web-Browsing` (mixed case) successfully activates `lobe-web-browsing`.

#### 📝 Additional Information

No breaking changes. All existing identifiers remain canonical (lowercase kebab-case); the fix only adds tolerance for LLM-generated casing variations.