### PR TITLE
🐛 fix: inject timezone and cron jobs list into cron tool system prompt

### DIFF
--- a/packages/builtin-tool-cron/src/helpers.ts
+++ b/packages/builtin-tool-cron/src/helpers.ts
@@ -1,0 +1,19 @@
+import type { CronJobSummaryForContext } from './types';
+
+const formatCronJob = (job: CronJobSummaryForContext): string => {
+  const status = job.enabled ? 'enabled' : 'disabled';
+  const execInfo =
+    job.remainingExecutions != null ? `${job.remainingExecutions} remaining` : 'unlimited';
+  const lastRun = job.lastExecutedAt ?? 'never';
+  const desc = job.description ? ` - ${job.description}` : '';
+
+  return `  - ${job.name || 'Unnamed'} (id: ${job.id}): ${job.cronPattern} [${job.timezone}] [${status}, ${execInfo}, ${job.totalExecutions} completed, last run: ${lastRun}]${desc}`;
+};
+
+export const generateCronJobsList = (jobs: CronJobSummaryForContext[]): string => {
+  if (jobs.length === 0) {
+    return 'No scheduled tasks configured for this agent.';
+  }
+
+  return jobs.map(formatCronJob).join('\n');
+};

--- a/packages/builtin-tool-cron/src/helpers.ts
+++ b/packages/builtin-tool-cron/src/helpers.ts
@@ -10,10 +10,16 @@ const formatCronJob = (job: CronJobSummaryForContext): string => {
   return `  - ${job.name || 'Unnamed'} (id: ${job.id}): ${job.cronPattern} [${job.timezone}] [${status}, ${execInfo}, ${job.totalExecutions} completed, last run: ${lastRun}]${desc}`;
 };
 
-export const generateCronJobsList = (jobs: CronJobSummaryForContext[]): string => {
+export const generateCronJobsList = (jobs: CronJobSummaryForContext[], total?: number): string => {
   if (jobs.length === 0) {
     return 'No scheduled tasks configured for this agent.';
   }
 
-  return jobs.map(formatCronJob).join('\n');
+  const lines = jobs.map(formatCronJob);
+
+  if (total && total > jobs.length) {
+    lines.push(`  (showing ${jobs.length} of ${total} tasks — use listCronJobs to see all)`);
+  }
+
+  return lines.join('\n');
 };

--- a/packages/builtin-tool-cron/src/index.ts
+++ b/packages/builtin-tool-cron/src/index.ts
@@ -1,4 +1,5 @@
 export { CronExecutionRuntime, type ICronService } from './ExecutionRuntime';
+export { generateCronJobsList } from './helpers';
 export { CronIdentifier, CronManifest } from './manifest';
 export { systemPrompt } from './systemRole';
 export {

--- a/packages/builtin-tool-cron/src/systemRole.ts
+++ b/packages/builtin-tool-cron/src/systemRole.ts
@@ -4,6 +4,7 @@ export const systemPrompt = `You have access to a LobeHub Scheduled Tasks Tool. 
 Current user: {{username}}
 Session date: {{date}}
 Current agent: {{agent_id}}
+User timezone: {{timezone}}
 </session_context>
 
 <existing_scheduled_tasks>

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -2,6 +2,11 @@ import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
 import { CredsIdentifier, type CredSummary, generateCredsList } from '@lobechat/builtin-tool-creds';
+import {
+  CronIdentifier,
+  type CronJobSummaryForContext,
+  generateCronJobsList,
+} from '@lobechat/builtin-tool-cron';
 import { GroupAgentBuilderIdentifier } from '@lobechat/builtin-tool-group-agent-builder';
 import { GTDIdentifier } from '@lobechat/builtin-tool-gtd';
 import { WebOnboardingIdentifier } from '@lobechat/builtin-tool-web-onboarding';
@@ -377,6 +382,34 @@ export const contextEngineering = async ({
     }
   }
 
+  // Resolve cron jobs context for cron tool
+  const isCronEnabled = tools?.includes(CronIdentifier) ?? false;
+  let cronJobsList: CronJobSummaryForContext[] | undefined;
+
+  if (isCronEnabled && agentId) {
+    try {
+      const cronResult = await lambdaClient.agentCronJob.list.query({ agentId });
+      const jobs = (cronResult as any)?.data ?? [];
+      cronJobsList = jobs.map(
+        (job: any): CronJobSummaryForContext => ({
+          cronPattern: job.cronPattern,
+          description: job.description,
+          enabled: job.enabled,
+          id: job.id,
+          lastExecutedAt: job.lastExecutedAt,
+          name: job.name,
+          remainingExecutions: job.remainingExecutions,
+          timezone: job.timezone ?? 'UTC',
+          totalExecutions: job.totalExecutions ?? 0,
+        }),
+      );
+      log('Cron jobs context resolved: count=%d', cronJobsList?.length ?? 0);
+    } catch (error) {
+      // Silently fail - cron context is optional
+      log('Failed to resolve cron jobs context:', error);
+    }
+  }
+
   const userMemoryConfig =
     enableUserMemories && userMemoryData
       ? {
@@ -694,6 +727,8 @@ export const contextEngineering = async ({
       ...VARIABLE_GENERATORS,
       // NOTICE: required by builtin-tool-creds/src/systemRole.ts
       CREDS_LIST: () => (credsList ? generateCredsList(credsList) : ''),
+      // NOTICE: required by builtin-tool-cron/src/systemRole.ts
+      CRON_JOBS_LIST: () => (cronJobsList ? generateCronJobsList(cronJobsList) : ''),
       // NOTICE(@nekomeowww): required by builtin-tool-memory/src/systemRole.ts
       memory_effort: () => (userMemoryConfig ? (memoryContext?.effort ?? '') : ''),
       // Current agent + topic identity — referenced by the LobeHub builtin

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -383,13 +383,17 @@ export const contextEngineering = async ({
   }
 
   // Resolve cron jobs context for cron tool
+  // Only inject a small preview (up to 4) to save context window;
+  // the model can call listCronJobs API for the full list.
   const isCronEnabled = tools?.includes(CronIdentifier) ?? false;
   let cronJobsList: CronJobSummaryForContext[] | undefined;
+  let cronJobsTotal = 0;
 
   if (isCronEnabled && agentId) {
     try {
-      const cronResult = await lambdaClient.agentCronJob.list.query({ agentId });
+      const cronResult = await lambdaClient.agentCronJob.list.query({ agentId, limit: 4 });
       const jobs = (cronResult as any)?.data ?? [];
+      cronJobsTotal = (cronResult as any)?.pagination?.total ?? jobs.length;
       cronJobsList = jobs.map(
         (job: any): CronJobSummaryForContext => ({
           cronPattern: job.cronPattern,
@@ -403,7 +407,11 @@ export const contextEngineering = async ({
           totalExecutions: job.totalExecutions ?? 0,
         }),
       );
-      log('Cron jobs context resolved: count=%d', cronJobsList?.length ?? 0);
+      log(
+        'Cron jobs context resolved: count=%d, total=%d',
+        cronJobsList?.length ?? 0,
+        cronJobsTotal,
+      );
     } catch (error) {
       // Silently fail - cron context is optional
       log('Failed to resolve cron jobs context:', error);
@@ -728,7 +736,7 @@ export const contextEngineering = async ({
       // NOTICE: required by builtin-tool-creds/src/systemRole.ts
       CREDS_LIST: () => (credsList ? generateCredsList(credsList) : ''),
       // NOTICE: required by builtin-tool-cron/src/systemRole.ts
-      CRON_JOBS_LIST: () => (cronJobsList ? generateCronJobsList(cronJobsList) : ''),
+      CRON_JOBS_LIST: () => (cronJobsList ? generateCronJobsList(cronJobsList, cronJobsTotal) : ''),
       // NOTICE(@nekomeowww): required by builtin-tool-memory/src/systemRole.ts
       memory_effort: () => (userMemoryConfig ? (memoryContext?.effort ?? '') : ''),
       // Current agent + topic identity — referenced by the LobeHub builtin


### PR DESCRIPTION
## Summary

fix：LOBE-7012

- Add `{{timezone}}` to cron tool's `<session_context>` so the model knows the user's local timezone when creating/managing scheduled tasks
- Wire up the `{{CRON_JOBS_LIST}}` placeholder — it was already referenced in the cron systemRole but never populated. Now fetches the agent's existing cron jobs via `lambdaClient.agentCronJob.list` and injects them, following the same pattern as `CREDS_LIST`
- Add `generateCronJobsList` helper in `builtin-tool-cron` package

## Test plan

- [ ] Verify `{{timezone}}` is replaced with the user's browser timezone in cron tool system prompt
- [ ] Verify `{{CRON_JOBS_LIST}}` is populated with existing cron jobs when lobe-cron tool is enabled
- [ ] Verify empty state text when no cron jobs exist for the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->