### PR TITLE
🐛 fix: clarify lobe-gtd and lobe-cron tool descriptions to prevent routing confusion

### DIFF
--- a/packages/builtin-tool-cron/src/manifest.ts
+++ b/packages/builtin-tool-cron/src/manifest.ts
@@ -10,7 +10,7 @@ export const CronManifest: BuiltinToolManifest = {
   api: [
     {
       description:
-        'Create a new scheduled task for the current agent. The task will run automatically at the specified schedule. Minimum interval is 30 minutes.',
+        'Create a new automated recurring task. Use this when the user wants something done regularly/repeatedly — e.g., "set as daily task", "do this every morning", "make it a routine", "daily briefing", "weekly summary". The task will run automatically at the specified schedule without user intervention. Minimum interval is 30 minutes.',
       name: CronApiName.createCronJob,
       parameters: {
         additionalProperties: false,
@@ -215,7 +215,7 @@ export const CronManifest: BuiltinToolManifest = {
   meta: {
     avatar: '⏰',
     description:
-      'Manage scheduled tasks that run automatically at specified times. Create, update, enable/disable, and monitor recurring tasks for your agents.',
+      'Automate recurring tasks that repeat on a schedule — daily routines, periodic reports, regular reminders, and any task the user wants done automatically every day/week/hour. Use this whenever the user says "daily task", "routine", "recurring", "every day", "every morning", "regular", "periodic", "set as daily", or implies something should happen repeatedly without manual trigger.',
     title: 'Scheduled Tasks',
   },
   systemRole: systemPrompt,

--- a/packages/builtin-tool-cron/src/systemRole.ts
+++ b/packages/builtin-tool-cron/src/systemRole.ts
@@ -10,6 +10,19 @@ Current agent: {{agent_id}}
 {{CRON_JOBS_LIST}}
 </existing_scheduled_tasks>
 
+<when_to_use>
+**Use this tool (lobe-cron) when the user wants tasks to run automatically and repeatedly.** Common trigger phrases include:
+- "daily task", "set as daily task", "make it a daily routine"
+- "every day", "every morning", "every week", "every hour"
+- "recurring", "routine", "regular", "periodic", "scheduled"
+- "automatically do X at Y time"
+- "remind me every day to..."
+
+**Do NOT confuse with lobe-gtd.** GTD is for one-time planning and manual todo tracking. If the user says "daily task" or "routine task", they almost always mean automated repetition (lobe-cron), NOT a one-time todo item (lobe-gtd).
+
+**Do NOT confuse with lobe-user-memory.** Memory is for saving user preferences and long-term knowledge. "Set as daily task" means schedule it to run repeatedly, NOT save it as a memory.
+</when_to_use>
+
 <core_capabilities>
 1. **Create Tasks**: Set up recurring tasks with custom schedules (daily, hourly, weekly patterns)
 2. **Manage Tasks**: Update, enable/disable, or delete existing scheduled tasks

--- a/packages/builtin-tool-gtd/src/manifest.ts
+++ b/packages/builtin-tool-gtd/src/manifest.ts
@@ -236,7 +236,8 @@ export const GTDManifest: BuiltinToolManifest = {
   identifier: GTDIdentifier,
   meta: {
     avatar: '✅',
-    description: 'Create plans, manage todo lists with status tracking, and run background tasks',
+    description:
+      'Plan and track one-time goals, manage todo checklists, and run background tasks. For tasks that need to be done once or tracked manually — NOT for tasks that should repeat automatically on a schedule (use lobe-cron for daily/weekly/recurring automation).',
     title: 'GTD Tools',
   },
   systemRole: systemPrompt,

--- a/packages/builtin-tool-gtd/src/systemRole.ts
+++ b/packages/builtin-tool-gtd/src/systemRole.ts
@@ -96,6 +96,7 @@ export const systemPrompt = `You have GTD (Getting Things Done) tools to help ma
 - The task can be done in one action (rename, delete, send, search, etc.)
 - The user just wants something done, not organized
 - The task will be completed in this single conversation
+- The user wants a task to repeat automatically on a schedule (daily/weekly/hourly) — use **lobe-cron** instead. Keywords like "daily task", "routine", "recurring", "every day/morning/week", "set as daily", "make it regular" all indicate scheduled automation, not GTD todo management.
 
 **Use Async Tasks when:**
 - **The request requires gathering external information**: User wants you to research, investigate, or find information that you don't already know. This requires web searches, reading multiple sources, and synthesizing information.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-7486

#### 🔀 Description of Change

When users say "日常任务" (daily task) or "routine", the model confused lobe-gtd (one-time todos) with lobe-cron (recurring automation), often falling back to user-memory or GTD instead of cron.

**Changes:**

- **lobe-cron `meta.description`**: Added trigger keywords — "daily routines", "recurring", "routine", "periodic", "set as daily" — so the model matches cron on ambiguous phrases like "日常任务"
- **lobe-cron `createCronJob` description**: Added common user phrases ("set as daily task", "do this every morning", "make it a routine") as examples
- **lobe-cron `systemRole`**: Added `<when_to_use>` section with trigger phrase list and explicit disambiguation from lobe-gtd and lobe-user-memory
- **lobe-gtd `meta.description`**: Emphasized "one-time goals" and explicitly excluded recurring/scheduled scenarios with pointer to lobe-cron
- **lobe-gtd `systemRole`**: Added exclusion rule in "DO NOT use Plans/Todos when" list for recurring automation keywords

#### 🧪 How to Test

- [x] No tests needed

Test with the reproduction prompt from the issue: `帮我把这个任务总结为日常任务` — the model should now prefer lobe-cron over lobe-gtd/lobe-user-memory.

#### 📝 Additional Information

This is a prompt engineering fix. No runtime behavior changes — only tool description and system prompt text updates to improve model tool selection accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)