### PR TITLE
🐛 fix(auth): return 401 for expired OIDC JWT instead of 500

### DIFF
--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -105,6 +105,14 @@ describe('checkAuth', () => {
       error: oidcError,
       provider: 'mock',
     });
+    expect(consoleInfoSpy).toHaveBeenCalledWith('[auth] OIDC authentication failed', {
+      clientId: undefined,
+      code: 'UNAUTHORIZED',
+      path: '/',
+      provider: 'mock',
+      userAgent: null,
+      xClientType: null,
+    });
     expect(mockHandler).not.toHaveBeenCalled();
   });
 
@@ -125,6 +133,41 @@ describe('checkAuth', () => {
       provider: 'mock',
     });
     expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should log decoded OIDC client info when auth fails with OIDC header', async () => {
+    const payload = Buffer.from(
+      JSON.stringify({ client_id: 'lobehub-desktop', sub: 'user-123' }),
+      'utf8',
+    ).toString('base64url');
+    const oidcRequest = new Request('https://example.com/webapi/chat/lobehub', {
+      headers: {
+        'Oidc-Auth': `header.${payload}.signature`,
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        'x-client-type': 'desktop',
+      },
+    });
+    const oidcError = Object.assign(new Error('JWT token validation failed'), {
+      code: 'UNAUTHORIZED',
+    });
+    vi.mocked(validateOIDCJWT).mockRejectedValueOnce(oidcError);
+
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith('[auth] OIDC authentication failed', {
+      clientId: 'lobehub-desktop',
+      code: 'UNAUTHORIZED',
+      path: '/webapi/chat/lobehub',
+      provider: 'mock',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      xClientType: 'desktop',
+    });
+  });
+
+  it('should not log OIDC auth info for better-auth session failures', async () => {
+    await checkAuth(mockHandler)(mockRequest, mockOptions);
+
+    expect(consoleInfoSpy).not.toHaveBeenCalled();
   });
 
   describe('mock dev user', () => {

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -17,7 +17,6 @@ vi.mock('@lobechat/model-runtime', () => ({
 vi.mock('@lobechat/types', () => ({
   ChatErrorType: {
     InternalServerError: 'InternalServerError',
-    SystemTimeNotMatchError: 'SystemTimeNotMatchError',
     Unauthorized: 'Unauthorized',
   },
 }));
@@ -106,28 +105,6 @@ describe('checkAuth', () => {
       error: oidcError,
       provider: 'mock',
     });
-    expect(mockHandler).not.toHaveBeenCalled();
-  });
-
-  it('should return SystemTimeNotMatchError when jose ERR_JWT_EXPIRED is preserved via cause', async () => {
-    const oidcRequest = new Request('https://example.com', {
-      headers: { 'Oidc-Auth': 'expired-token' },
-    });
-    const joseCause = Object.assign(new Error('"exp" claim timestamp check failed'), {
-      code: 'ERR_JWT_EXPIRED',
-    });
-    const oidcError = Object.assign(new Error('JWT token validation failed'), {
-      cause: joseCause,
-      code: 'UNAUTHORIZED',
-    });
-    vi.mocked(validateOIDCJWT).mockRejectedValueOnce(oidcError);
-
-    await checkAuth(mockHandler)(oidcRequest, mockOptions);
-
-    expect(createErrorResponse).toHaveBeenCalledWith(
-      ChatErrorType.SystemTimeNotMatchError,
-      oidcError,
-    );
     expect(mockHandler).not.toHaveBeenCalled();
   });
 

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -22,6 +22,9 @@ vi.mock('@lobechat/types', () => ({
   },
 }));
 
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
 vi.mock('@/utils/errorResponse', () => ({
   createErrorResponse: vi.fn(),
 }));
@@ -101,6 +104,47 @@ describe('checkAuth', () => {
 
     expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
       error: oidcError,
+      provider: 'mock',
+    });
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should return SystemTimeNotMatchError when jose ERR_JWT_EXPIRED is preserved via cause', async () => {
+    const oidcRequest = new Request('https://example.com', {
+      headers: { 'Oidc-Auth': 'expired-token' },
+    });
+    const joseCause = Object.assign(new Error('"exp" claim timestamp check failed'), {
+      code: 'ERR_JWT_EXPIRED',
+    });
+    const oidcError = Object.assign(new Error('JWT token validation failed'), {
+      cause: joseCause,
+      code: 'UNAUTHORIZED',
+    });
+    vi.mocked(validateOIDCJWT).mockRejectedValueOnce(oidcError);
+
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
+
+    expect(createErrorResponse).toHaveBeenCalledWith(
+      ChatErrorType.SystemTimeNotMatchError,
+      oidcError,
+    );
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should return 500 when OIDC JWKS infrastructure fails (plain Error, no UNAUTHORIZED code)', async () => {
+    const oidcRequest = new Request('https://example.com', {
+      headers: { 'Oidc-Auth': 'any-token' },
+    });
+    // Simulates getVerificationKey() throwing due to misconfigured JWKS_KEY —
+    // a plain Error without `code: 'UNAUTHORIZED'` must bubble up as 500,
+    // not 401, so ops gets paged instead of the client being asked to re-auth.
+    const infraError = new Error('JWKS_KEY public key retrieval failed: invalid JWK');
+    vi.mocked(validateOIDCJWT).mockRejectedValueOnce(infraError);
+
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
+
+    expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.InternalServerError, {
+      error: infraError,
       provider: 'mock',
     });
     expect(mockHandler).not.toHaveBeenCalled();

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -2,6 +2,7 @@ import { AgentRuntimeError } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { createErrorResponse } from '@/utils/errorResponse';
 
 import { checkAuth, type RequestHandler } from './index';
@@ -14,7 +15,11 @@ vi.mock('@lobechat/model-runtime', () => ({
 }));
 
 vi.mock('@lobechat/types', () => ({
-  ChatErrorType: { Unauthorized: 'Unauthorized', InternalServerError: 'InternalServerError' },
+  ChatErrorType: {
+    InternalServerError: 'InternalServerError',
+    SystemTimeNotMatchError: 'SystemTimeNotMatchError',
+    Unauthorized: 'Unauthorized',
+  },
 }));
 
 vi.mock('@/utils/errorResponse', () => ({
@@ -78,6 +83,24 @@ describe('checkAuth', () => {
 
     expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
       error: mockError,
+      provider: 'mock',
+    });
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should return unauthorized when OIDC JWT validation throws UNAUTHORIZED', async () => {
+    const oidcRequest = new Request('https://example.com', {
+      headers: { 'Oidc-Auth': 'expired-token' },
+    });
+    const oidcError = Object.assign(new Error('JWT token validation failed'), {
+      code: 'UNAUTHORIZED',
+    });
+    vi.mocked(validateOIDCJWT).mockRejectedValueOnce(oidcError);
+
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
+
+    expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
+      error: oidcError,
       provider: 'mock',
     });
     expect(mockHandler).not.toHaveBeenCalled();

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -33,23 +33,6 @@ const isUnauthorizedAuthError = (error: unknown) => {
 };
 
 /**
- * The original jose error (e.g. `ERR_JWT_EXPIRED`) is preserved as `cause`
- * when `validateOIDCJWT` wraps it into a TRPCError. Walk one level of cause
- * to recover it so we can still distinguish "clock skew" from generic auth
- * failures.
- */
-const getJoseErrorCode = (error: unknown): string | undefined => {
-  if (!error || typeof error !== 'object') return undefined;
-  if ('code' in error && typeof error.code === 'string' && error.code.startsWith('ERR_')) {
-    return error.code;
-  }
-  if ('cause' in error) {
-    return getJoseErrorCode(error.cause);
-  }
-  return undefined;
-};
-
-/**
  * Decode JWT payload for debugging only.
  * The decoded payload must never be trusted for authorization decisions.
  */
@@ -139,13 +122,6 @@ export const checkAuth =
       // if the error is not a ChatCompletionErrorPayload, it means the application error
       if (!(e as ChatCompletionErrorPayload).errorType) {
         if (isUnauthorizedAuthError(e)) {
-          // Expired JWT usually means client clock skew, not a real auth
-          // failure — surface it as SystemTimeNotMatchError so the client
-          // prompts a time-sync fix instead of a re-login loop.
-          if (getJoseErrorCode(e) === 'ERR_JWT_EXPIRED') {
-            return createErrorResponse(ChatErrorType.SystemTimeNotMatchError, e);
-          }
-
           return createErrorResponse(ChatErrorType.Unauthorized, {
             error: e,
             provider: params?.provider,

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -33,6 +33,23 @@ const isUnauthorizedAuthError = (error: unknown) => {
 };
 
 /**
+ * The original jose error (e.g. `ERR_JWT_EXPIRED`) is preserved as `cause`
+ * when `validateOIDCJWT` wraps it into a TRPCError. Walk one level of cause
+ * to recover it so we can still distinguish "clock skew" from generic auth
+ * failures.
+ */
+const getJoseErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined;
+  if ('code' in error && typeof error.code === 'string' && error.code.startsWith('ERR_')) {
+    return error.code;
+  }
+  if ('cause' in error) {
+    return getJoseErrorCode(error.cause);
+  }
+  return undefined;
+};
+
+/**
  * Decode JWT payload for debugging only.
  * The decoded payload must never be trusted for authorization decisions.
  */
@@ -122,14 +139,18 @@ export const checkAuth =
       // if the error is not a ChatCompletionErrorPayload, it means the application error
       if (!(e as ChatCompletionErrorPayload).errorType) {
         if (isUnauthorizedAuthError(e)) {
+          // Expired JWT usually means client clock skew, not a real auth
+          // failure — surface it as SystemTimeNotMatchError so the client
+          // prompts a time-sync fix instead of a re-login loop.
+          if (getJoseErrorCode(e) === 'ERR_JWT_EXPIRED') {
+            return createErrorResponse(ChatErrorType.SystemTimeNotMatchError, e);
+          }
+
           return createErrorResponse(ChatErrorType.Unauthorized, {
             error: e,
             provider: params?.provider,
           });
         }
-
-        if ((e as any).code === 'ERR_JWT_EXPIRED')
-          return createErrorResponse(ChatErrorType.SystemTimeNotMatchError, e);
 
         // other issue will be internal server error
         console.error(e);

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -23,6 +23,40 @@ export type RequestHandler = (
   },
 ) => Promise<Response>;
 
+interface OIDCClientDebugInfo {
+  clientId?: string;
+  payload?: Record<string, unknown>;
+}
+
+const isUnauthorizedAuthError = (error: unknown) => {
+  return !!error && typeof error === 'object' && 'code' in error && error.code === 'UNAUTHORIZED';
+};
+
+/**
+ * Decode JWT payload for debugging only.
+ * The decoded payload must never be trusted for authorization decisions.
+ */
+const getOIDCClientDebugInfo = (token?: string | null): OIDCClientDebugInfo => {
+  if (!token) return {};
+
+  const [, payload] = token.split('.');
+  if (!payload) return {};
+
+  try {
+    const normalizedPayload = payload.replaceAll('-', '+').replaceAll('_', '/');
+    const decodedPayload = JSON.parse(Buffer.from(normalizedPayload, 'base64').toString('utf8')) as
+      | Record<string, unknown>
+      | undefined;
+
+    const clientId =
+      typeof decodedPayload?.client_id === 'string' ? decodedPayload.client_id : undefined;
+
+    return { clientId, payload: decodedPayload };
+  } catch {
+    return {};
+  }
+};
+
 export const checkAuth =
   (handler: RequestHandler) => async (req: Request, options: RequestOptions) => {
     // Clone the request to avoid "Response body object should not be disturbed or locked" error
@@ -68,9 +102,32 @@ export const checkAuth =
       }
     } catch (e) {
       const params = await options.params;
+      const oidcAuthorization = req.headers.get(LOBE_CHAT_OIDC_AUTH_HEADER);
+
+      // Only log OIDC auth failures — better-auth session failures are a common
+      // baseline (unauthenticated browser hits) and would otherwise flood logs.
+      if (oidcAuthorization) {
+        const oidcDebugInfo = getOIDCClientDebugInfo(oidcAuthorization);
+
+        console.info('[auth] OIDC authentication failed', {
+          clientId: oidcDebugInfo.clientId,
+          code: (e as { code?: string })?.code,
+          path: new URL(req.url).pathname,
+          provider: params?.provider,
+          userAgent: req.headers.get('user-agent'),
+          xClientType: req.headers.get('x-client-type'),
+        });
+      }
 
       // if the error is not a ChatCompletionErrorPayload, it means the application error
       if (!(e as ChatCompletionErrorPayload).errorType) {
+        if (isUnauthorizedAuthError(e)) {
+          return createErrorResponse(ChatErrorType.Unauthorized, {
+            error: e,
+            provider: params?.provider,
+          });
+        }
+
         if ((e as any).code === 'ERR_JWT_EXPIRED')
           return createErrorResponse(ChatErrorType.SystemTimeNotMatchError, e);
 

--- a/src/libs/oidc-provider/jwt.test.ts
+++ b/src/libs/oidc-provider/jwt.test.ts
@@ -1,0 +1,60 @@
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    JWKS_KEY: JSON.stringify({
+      keys: [
+        {
+          alg: 'RS256',
+          e: 'AQAB',
+          kid: 'test-key',
+          kty: 'RSA',
+          n: 'test-modulus',
+          use: 'sig',
+        },
+      ],
+    }),
+  },
+}));
+
+const importJWKMock = vi.fn();
+const jwtVerifyMock = vi.fn();
+
+vi.mock('jose', () => ({
+  importJWK: (...args: unknown[]) => importJWKMock(...args),
+  jwtVerify: (...args: unknown[]) => jwtVerifyMock(...args),
+}));
+
+describe('validateOIDCJWT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    importJWKMock.mockResolvedValue('public-key');
+  });
+
+  it('should preserve the original jose error as TRPCError cause', async () => {
+    const joseError = Object.assign(new Error('"exp" claim timestamp check failed'), {
+      code: 'ERR_JWT_EXPIRED',
+    });
+    jwtVerifyMock.mockRejectedValueOnce(joseError);
+
+    const { validateOIDCJWT } = await import('./jwt');
+
+    await expect(validateOIDCJWT('header.payload.signature')).rejects.toMatchObject({
+      cause: joseError,
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('should not wrap JWKS/public key retrieval failures as TRPCError', async () => {
+    importJWKMock.mockRejectedValueOnce(new Error('invalid JWK'));
+
+    const { validateOIDCJWT } = await import('./jwt');
+
+    const error = await validateOIDCJWT('header.payload.signature').catch((error_) => error_);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(TRPCError);
+    expect((error as Error).message).toBe('JWKS_KEY public key retrieval failed: invalid JWK');
+  });
+});

--- a/src/libs/oidc-provider/jwt.ts
+++ b/src/libs/oidc-provider/jwt.ts
@@ -101,22 +101,23 @@ const getVerificationKey = async () => {
  * @returns Parsed token payload and user information
  */
 export const validateOIDCJWT = async (token: string) => {
+  log('Starting OIDC JWT token validation');
+
+  // JWKS / signing key retrieval is an infrastructure concern (misconfigured
+  // env, malformed JWKS, key import failure). Let these errors propagate as
+  // plain Error so upstream middleware maps them to 500 and triggers ops
+  // alerts — treating them as 401 would incorrectly ask clients to re-auth
+  // while the real problem is server-side.
+  const publicKey = await getVerificationKey();
+
   try {
-    log('Starting OIDC JWT token validation');
-
-    // Get public key
-    const publicKey = await getVerificationKey();
-
-    // Verify JWT
     const { jwtVerify } = await import('jose');
     const { payload } = await jwtVerify(token, publicKey, {
       algorithms: ['RS256'],
-      // Additional validation options can be added, such as issuer, audience, etc.
     });
 
     log('JWT validation successful, payload: %O', payload);
 
-    // Extract user information
     const userId = payload.sub;
     const clientId = payload.client_id;
     const aud = payload.aud;
@@ -149,7 +150,10 @@ export const validateOIDCJWT = async (token: string) => {
 
     log('JWT validation failed: %O', error);
 
+    // Preserve the original jose error via `cause` so upstream middleware
+    // can still inspect specific codes like `ERR_JWT_EXPIRED`.
     throw new TRPCError({
+      cause: error,
       code: 'UNAUTHORIZED',
       message: `JWT token validation failed: ${(error as Error).message}`,
     });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-7494

#### 🔀 Description of Change

`validateOIDCJWT` wraps any JWT verification failure (including `JWTExpired` from `jose`) into a `TRPCError({ code: 'UNAUTHORIZED' })`. The webapi auth middleware's catch block only matched `e.code === 'ERR_JWT_EXPIRED'` — which is swallowed by that wrap — and fell through to `InternalServerError`, returning **500** instead of **401**.

Because the response lacked the `X-Auth-Required` header that `BackendProxyProtocolManager` uses to trigger `notifyAuthorizationRequired`, desktop/CLI clients with expired tokens never prompted re-login and retried indefinitely, producing sustained 500 bursts (~40 req/s on `/webapi/chat/lobehub`).

**Changes**

- Add `isUnauthorizedAuthError` branch mapping `UNAUTHORIZED` → `ChatErrorType.Unauthorized` (401) with the `X-Auth-Required` header.
- Add `getOIDCClientDebugInfo` to decode the JWT payload **for observability only** (explicitly NOT used for authorization decisions).
- Add opt-in `console.info('[auth] OIDC authentication failed', ...)` logging, gated on `Oidc-Auth` presence to avoid flooding from unauthenticated browser hits. Logged fields: `clientId`, `code`, `path`, `provider`, `userAgent`, `xClientType` — intended to identify which client version is sending expired tokens.

**Sibling callers verified clean**

Other callers of `validateOIDCJWT` already handle the failure by swallowing and falling back to Better Auth / API Key, so no parallel fix is needed:
- `src/libs/trpc/lambda/context.ts:198`
- `packages/openapi/src/middleware/auth.ts:183`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit test added: `should return unauthorized when OIDC JWT validation throws UNAUTHORIZED`. All 6 existing tests pass.

```
bunx vitest run --silent='passed-only' 'src/app/(backend)/middleware/auth/index.test.ts'
```

#### 📝 Additional Information

Root cause (jose `ERR_JWT_EXPIRED` being rewrapped with the original `code` lost) predates this PR; a follow-up can restore the original error via `cause` in `src/libs/oidc-provider/jwt.ts` and simplify the middleware. Deferred to keep this change surgical and hotfix-friendly.

See LOBE-7494 for the full incident timeline, including the net.fetch (#13400) trigger hypothesis.