### PR TITLE
🐛 fix(model-bank): publish initial npm package publicly

### DIFF
--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -118,7 +118,7 @@ jobs:
           echo "Prepared model-bank@${MODEL_BANK_VERSION}"
 
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm publish --provenance --access public
         working-directory: packages/model-bank
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #14015.

#### 🔀 Description of Change

- Add `--access public` to the `model-bank` npm publish command.
- This is required when publishing a new package with npm provenance enabled; otherwise npm fails with: `Can't generate provenance for new or private package, you must set access to public`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Verified with:

```bash
pnpm exec prettier --check .github/workflows/release-model-bank.yml
git diff --check
```

The prior workflow run confirmed that build and publish package preparation pass; the failure was isolated to the npm publish command.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Failed workflow run: https://github.com/lobehub/lobehub/actions/runs/24710211198