### PR TITLE
🐛 fix(model-bank): add repository metadata for provenance

### DIFF
--- a/.github/workflows/release-model-bank.yml
+++ b/.github/workflows/release-model-bank.yml
@@ -82,6 +82,11 @@ jobs:
           packageJson.main = './dist/index.mjs';
           packageJson.types = './dist/index.d.mts';
           packageJson.files = ['dist'];
+          packageJson.repository = {
+            type: 'git',
+            url: 'https://github.com/lobehub/lobehub',
+            directory: 'packages/model-bank',
+          };
           packageJson.exports = Object.fromEntries(
             Object.entries(packageJson.exports).map(([key, value]) => {
               if (typeof value !== 'string') return [key, value];


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to failed workflow run: https://github.com/lobehub/lobehub/actions/runs/24710692562

#### 🔀 Description of Change

Adds `repository` metadata to the temporary `packages/model-bank/package.json` generated during the release workflow.

The latest manual release reached `npm publish --provenance --access public`, generated the provenance statement, then npm rejected the package because `package.json.repository.url` was empty and did not match the GitHub repository from the provenance bundle.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
pnpm exec prettier --check .github/workflows/release-model-bank.yml
git diff --check
git diff --cached --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The package is still unpublished on npm after the failed run. After this PR is merged, manually rerun `Release ModelBank` to verify the first public publish succeeds.