### PR TITLE
🐛 fix: reduce subagent task status error noise

### DIFF
--- a/src/server/routers/lambda/__tests__/aiAgent.getTaskStatus.test.ts
+++ b/src/server/routers/lambda/__tests__/aiAgent.getTaskStatus.test.ts
@@ -315,6 +315,42 @@ describe('aiAgentRouter.getSubAgentTaskStatus', () => {
       // Should not call Redis for completed tasks
       expect(mockGetOperationStatus).not.toHaveBeenCalled();
     });
+
+    it('should normalize nested Redis errors when task status becomes failed', async () => {
+      mockGetOperationStatus.mockResolvedValue({
+        currentState: {
+          error: {
+            body: {
+              error: {
+                message: 'Budget exceeded',
+              },
+            },
+            message: '[object Object]',
+            type: 'InvalidProviderAPIKey',
+          },
+          status: 'error',
+        },
+        hasError: true,
+        isCompleted: false,
+        metadata: {},
+      });
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+
+      const result = await caller.getSubAgentTaskStatus({
+        threadId: testThreadId,
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatchObject({
+        body: { error: { message: 'Budget exceeded' } },
+        message: 'Budget exceeded',
+      });
+      expect(result.taskDetail?.error).toMatchObject({
+        body: { error: { message: 'Budget exceeded' } },
+        message: 'Budget exceeded',
+      });
+    });
   });
 
   describe('error handling', () => {

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -19,6 +19,54 @@ import { nanoid } from '@/utils/uuid';
 
 const log = debug('lobe-server:ai-agent-router');
 
+const extractTaskErrorMessage = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const taskError = error as Record<string, any>;
+  const candidates = [
+    taskError.body?.error?.message,
+    taskError.body?.message,
+    taskError.error?.error?.message,
+    taskError.error?.message,
+    taskError.message,
+    taskError.type,
+    taskError.errorType,
+    taskError.name,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate !== '[object Object]' && candidate !== 'error') {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};
+
+const formatTaskError = (error: unknown): Record<string, unknown> | undefined => {
+  if (!error) return undefined;
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    };
+  }
+
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+
+  if (typeof error !== 'object') {
+    return { message: String(error) };
+  }
+
+  const taskError = error as Record<string, unknown>;
+  const message = extractTaskErrorMessage(error);
+
+  return message ? { ...taskError, message } : taskError;
+};
+
 // Zod schemas for agent operation
 const CreateAgentOperationSchema = z.object({
   agentConfig: z.record(z.any()).optional().default({}),
@@ -935,13 +983,8 @@ export const aiAgentRouter = router({
 
             log('getSubAgentTaskStatus: marked thread %s as completed', threadId);
           } else if (realtimeStatus.hasError || redisState.status === 'error') {
-            // Format error properly to avoid [object Object] in serialization
-            const errorObj = redisState.error as any;
-            const formattedError = errorObj
-              ? typeof errorObj === 'object' && 'message' in errorObj
-                ? { message: errorObj.message, ...errorObj }
-                : { message: String(errorObj) }
-              : undefined;
+            // Normalize nested runtime errors so task metadata keeps a readable message.
+            const formattedError = formatTaskError(redisState.error);
 
             updatedMetadata.error = formattedError;
             updatedMetadata.completedAt = new Date().toISOString();
@@ -982,7 +1025,7 @@ export const aiAgentRouter = router({
       const updatedTaskStatus = threadStatusToTaskStatus[updatedStatus] || 'processing';
 
       if (updatedTaskStatus === 'failed') {
-        console.error('getSubAgentTaskStatus: failed task metadata for thread %s: %O', threadId, {
+        log('getSubAgentTaskStatus: returning failed task status for thread %s: %O', threadId, {
           updatedMetadata,
           error: updatedMetadata?.error,
           updatedStatus,

--- a/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
@@ -1,10 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useClientDataSWR } from '@/libs/swr';
 import { useChatStore } from '@/store/chat/store';
 
 // Keep zustand mock as it's needed globally
 vi.mock('zustand/traditional');
+vi.mock('@/libs/swr', () => ({
+  useClientDataSWR: vi.fn(),
+}));
 
 // Test Constants
 const TEST_IDS = {
@@ -96,6 +100,25 @@ describe('groupOrchestration actions', () => {
           label: expect.stringContaining('Group Orchestration'),
         }),
       );
+    });
+  });
+
+  describe('useEnablePollingTaskStatus', () => {
+    it('should stop polling after a terminal task status is fetched', () => {
+      vi.mocked(useClientDataSWR).mockReturnValue({ data: undefined } as any);
+
+      const useEnablePollingTaskStatus = useChatStore.getState().useEnablePollingTaskStatus;
+      renderHook(() => useEnablePollingTaskStatus('thread-1', 'message-1', true));
+
+      const refreshInterval = vi.mocked(useClientDataSWR).mock.calls.at(-1)?.[2]
+        ?.refreshInterval as ((data?: { status?: string }) => number) | undefined;
+
+      expect(refreshInterval).toBeTypeOf('function');
+      expect(refreshInterval?.()).toBe(5000);
+      expect(refreshInterval?.({ status: 'processing' })).toBe(5000);
+      expect(refreshInterval?.({ status: 'completed' })).toBe(0);
+      expect(refreshInterval?.({ status: 'failed' })).toBe(0);
+      expect(refreshInterval?.({ status: 'cancel' })).toBe(0);
     });
   });
 

--- a/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
+++ b/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
@@ -378,7 +378,9 @@ export class GroupOrchestrationActionImpl {
       {
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
-        refreshInterval: POLLING_INTERVAL,
+        // Keep one fetch for terminal tasks so completed/failed detail panels can load messages,
+        // but stop interval polling afterward to avoid endless status requests.
+        refreshInterval: (data) => (!data || data.status === 'processing' ? POLLING_INTERVAL : 0),
         onSuccess: (data) => {
           if (data && messageId) {
             // Update taskDetail and tasks (intermediate messages)


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

This PR reduces noisy `status=200 level=error` logs for sub-agent task status polling.

- stop SWR polling after a task reaches a terminal status while still allowing one final fetch for task details/messages
- normalize nested runtime errors before persisting failed task metadata so the UI no longer falls back to `[object Object]`
- downgrade the repeated "returning failed task status" log from request-time `console.error` noise to debug logging
- add regression tests for terminal polling behavior and nested failed-task error normalization

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Notes:
- VS Code diagnostics are clean for the touched files.
- Targeted Vitest runs are currently blocked in this workspace by an existing import-time `z.enum` failure in `packages/types/src/agent/chatConfig.ts` before the new assertions execute.

#### 📝 Additional Information

This change is generic runtime/task handling only and does not expose any cloud-specific business logic.
