### PR TITLE
🎨 style(claude-code): tool inspectors + heterogeneous-agent follow-ups

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -496,7 +496,7 @@
   "workflow.expandFull": "Expand fully",
   "workflow.failedSuffix": "(failed)",
   "workflow.summaryFailed": "{{count}} failed",
-  "workflow.summaryMoreTools": "+{{count}} more",
+  "workflow.summaryMoreTools": "{{count}} tool kinds",
   "workflow.summaryTotalCalls": "{{count}} calls total",
   "workflow.thoughtForDuration": "Thought for {{duration}}",
   "workflow.toolDisplayName.activateDevice": "Activated device",

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -287,7 +287,7 @@
   "searchAgents": "Search agents...",
   "selectedAgents": "Selected agents",
   "sendPlaceholder": "Ask, create, or start a task, <hotkey><hotkey/>",
-  "sendPlaceholderHeterogeneous": "Ask {{name}} to do a task, <hotkey><hotkey/>",
+  "sendPlaceholderHeterogeneous": "Ask {{name}} to do a task...",
   "sendPlaceholderWithAgentAssignment": "Ask, create, or start a task. @ to assign tasks to other agents.",
   "sessionGroup.config": "Category Management",
   "sessionGroup.confirmRemoveGroupAlert": "This category is about to be deleted. After deletion, the agents in this category will be moved to the default list. Please confirm your operation.",

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -287,6 +287,7 @@
   "searchAgents": "Search agents...",
   "selectedAgents": "Selected agents",
   "sendPlaceholder": "Ask, create, or start a task, <hotkey><hotkey/>",
+  "sendPlaceholderHeterogeneous": "Ask {{name}} to do a task, <hotkey><hotkey/>",
   "sendPlaceholderWithAgentAssignment": "Ask, create, or start a task. @ to assign tasks to other agents.",
   "sessionGroup.config": "Category Management",
   "sessionGroup.confirmRemoveGroupAlert": "This category is about to be deleted. After deletion, the agents in this category will be moved to the default list. Please confirm your operation.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -496,7 +496,7 @@
   "workflow.expandFull": "全部展开",
   "workflow.failedSuffix": "（失败）",
   "workflow.summaryFailed": "{{count}} 次失败",
-  "workflow.summaryMoreTools": "等 {{count}} 种工具",
+  "workflow.summaryMoreTools": "共 {{count}} 种工具",
   "workflow.summaryTotalCalls": "共 {{count}} 次调用",
   "workflow.thoughtForDuration": "思考了 {{duration}}",
   "workflow.toolDisplayName.activateDevice": "激活了设备",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -287,7 +287,7 @@
   "searchAgents": "搜索助理…",
   "selectedAgents": "已选助理",
   "sendPlaceholder": "从任何想法开始… <hotkey><hotkey/>",
-  "sendPlaceholderHeterogeneous": "让 {{name}} 帮你完成任务，<hotkey><hotkey/>",
+  "sendPlaceholderHeterogeneous": "让 {{name}} 帮你完成任务…",
   "sendPlaceholderWithAgentAssignment": "提问、创建或发起任务。输入 @ 可将任务分配给其他助理。",
   "sessionGroup.config": "分类管理",
   "sessionGroup.confirmRemoveGroupAlert": "确认删除该分类吗？分类内的助理会移回默认列表",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -287,6 +287,7 @@
   "searchAgents": "搜索助理…",
   "selectedAgents": "已选助理",
   "sendPlaceholder": "从任何想法开始… <hotkey><hotkey/>",
+  "sendPlaceholderHeterogeneous": "让 {{name}} 帮你完成任务，<hotkey><hotkey/>",
   "sendPlaceholderWithAgentAssignment": "提问、创建或发起任务。输入 @ 可将任务分配给其他助理。",
   "sessionGroup.config": "分类管理",
   "sessionGroup.confirmRemoveGroupAlert": "确认删除该分类吗？分类内的助理会移回默认列表",

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
@@ -3,7 +3,6 @@
 import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
 import type { BuiltinInspectorProps } from '@lobechat/types';
 import { createStaticStyles, cx } from 'antd-style';
-import { AlarmClock } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,35 +10,29 @@ import { ClaudeCodeApiName, type ScheduleWakeupArgs } from '../../types';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
+    overflow: hidden;
     display: inline-flex;
-    flex-shrink: 0;
+    flex-shrink: 1;
     align-items: center;
 
+    min-width: 0;
+    max-width: 60%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;
     border-radius: 999px;
 
-    font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
     color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     background: ${cssVar.colorFillTertiary};
   `,
-  icon: css`
+  delay: css`
     flex-shrink: 0;
-    margin-inline-end: 6px;
-    color: ${cssVar.colorTextDescription};
-  `,
-  reason: css`
-    overflow: hidden;
-
-    min-width: 0;
     margin-inline-start: 8px;
-
     color: ${cssVar.colorTextDescription};
-    text-overflow: ellipsis;
-    white-space: nowrap;
   `,
 }));
 
@@ -57,9 +50,9 @@ const formatDelay = (seconds: number): string => {
 };
 
 /**
- * CC's self-paced wakeup scheduler. Primary signal is `delaySeconds` (what
- * gets shown in the chip as a readable duration); `reason` is the model's
- * own one-sentence justification and trails after as secondary context.
+ * CC's self-paced wakeup scheduler. `reason` (the model's one-sentence
+ * justification) goes in the chip as the primary signal; `delaySeconds`
+ * trails at the end as secondary context.
  */
 export const ScheduleWakeupInspector = memo<BuiltinInspectorProps<ScheduleWakeupArgs>>(
   ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
@@ -78,10 +71,9 @@ export const ScheduleWakeupInspector = memo<BuiltinInspectorProps<ScheduleWakeup
 
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <AlarmClock className={styles.icon} size={14} />
-        <span>{label}</span>
-        {typeof delay === 'number' && <span className={styles.chip}>{formatDelay(delay)}</span>}
-        {reason && <span className={styles.reason}>· {reason}</span>}
+        <span>{reason || typeof delay === 'number' ? `${label}:` : label}</span>
+        {reason && <span className={styles.chip}>{reason}</span>}
+        {typeof delay === 'number' && <span className={styles.delay}>· {formatDelay(delay)}</span>}
       </div>
     );
   },

--- a/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/ScheduleWakeup.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { AlarmClock } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ClaudeCodeApiName, type ScheduleWakeupArgs } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+
+    margin-inline-start: 6px;
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  icon: css`
+    flex-shrink: 0;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  reason: css`
+    overflow: hidden;
+
+    min-width: 0;
+    margin-inline-start: 8px;
+
+    color: ${cssVar.colorTextDescription};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+}));
+
+const formatDelay = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return `${seconds}s`;
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) {
+    return remSeconds > 0 ? `${minutes}m ${remSeconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+};
+
+/**
+ * CC's self-paced wakeup scheduler. Primary signal is `delaySeconds` (what
+ * gets shown in the chip as a readable duration); `reason` is the model's
+ * own one-sentence justification and trails after as secondary context.
+ */
+export const ScheduleWakeupInspector = memo<BuiltinInspectorProps<ScheduleWakeupArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.ScheduleWakeup as any);
+
+    const source = args ?? partialArgs;
+    const delay = source?.delaySeconds;
+    const reason = source?.reason?.trim();
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    if (isArgumentsStreaming && delay === undefined && !reason) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <AlarmClock className={styles.icon} size={14} />
+        <span>{label}</span>
+        {typeof delay === 'number' && <span className={styles.chip}>{formatDelay(delay)}</span>}
+        {reason && <span className={styles.reason}>· {reason}</span>}
+      </div>
+    );
+  },
+);
+
+ScheduleWakeupInspector.displayName = 'ClaudeCodeScheduleWakeupInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
@@ -3,7 +3,6 @@
 import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
 import type { BuiltinInspectorProps } from '@lobechat/types';
 import { createStaticStyles, cx } from 'antd-style';
-import { ScrollText } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -31,11 +30,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorFillTertiary};
   `,
-  icon: css`
-    flex-shrink: 0;
-    margin-inline-end: 6px;
-    color: ${cssVar.colorTextDescription};
-  `,
 }));
 
 /**
@@ -57,8 +51,7 @@ export const TaskOutputInspector = memo<BuiltinInspectorProps<TaskOutputArgs>>(
 
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <ScrollText className={styles.icon} size={14} />
-        <span>{label}</span>
+        <span>{taskId ? `${label}:` : label}</span>
         {taskId && <span className={styles.chip}>{taskId}</span>}
       </div>
     );

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskOutput.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { ScrollText } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ClaudeCodeApiName, type TaskOutputArgs } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 60%;
+    margin-inline-start: 6px;
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  icon: css`
+    flex-shrink: 0;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextDescription};
+  `,
+}));
+
+/**
+ * CC's tool for reading output from a background task. The only user-relevant
+ * arg is `task_id` — `block`/`timeout` are plumbing and live in the expanded
+ * args view.
+ */
+export const TaskOutputInspector = memo<BuiltinInspectorProps<TaskOutputArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.TaskOutput as any);
+    const taskId = (args?.task_id ?? partialArgs?.task_id)?.trim();
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    if (isArgumentsStreaming && !taskId) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <ScrollText className={styles.icon} size={14} />
+        <span>{label}</span>
+        {taskId && <span className={styles.chip}>{taskId}</span>}
+      </div>
+    );
+  },
+);
+
+TaskOutputInspector.displayName = 'ClaudeCodeTaskOutputInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
@@ -3,7 +3,6 @@
 import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
 import type { BuiltinInspectorProps } from '@lobechat/types';
 import { createStaticStyles, cx } from 'antd-style';
-import { CircleStop } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -31,11 +30,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorFillTertiary};
   `,
-  icon: css`
-    flex-shrink: 0;
-    margin-inline-end: 6px;
-    color: ${cssVar.colorTextDescription};
-  `,
 }));
 
 /**
@@ -57,8 +51,7 @@ export const TaskStopInspector = memo<BuiltinInspectorProps<TaskStopArgs>>(
 
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <CircleStop className={styles.icon} size={14} />
-        <span>{label}</span>
+        <span>{taskId ? `${label}:` : label}</span>
         {taskId && <span className={styles.chip}>{taskId}</span>}
       </div>
     );

--- a/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/TaskStop.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { CircleStop } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ClaudeCodeApiName, type TaskStopArgs } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 60%;
+    margin-inline-start: 6px;
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  icon: css`
+    flex-shrink: 0;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextDescription};
+  `,
+}));
+
+/**
+ * CC's tool for terminating a background task. Falls back to the legacy
+ * `shell_id` field when `task_id` is absent — older CC builds emitted that.
+ */
+export const TaskStopInspector = memo<BuiltinInspectorProps<TaskStopArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.TaskStop as any);
+    const source = args ?? partialArgs;
+    const taskId = (source?.task_id ?? source?.shell_id)?.trim();
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    if (isArgumentsStreaming && !taskId) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <CircleStop className={styles.icon} size={14} />
+        <span>{label}</span>
+        {taskId && <span className={styles.chip}>{taskId}</span>}
+      </div>
+    );
+  },
+);
+
+TaskStopInspector.displayName = 'ClaudeCodeTaskStopInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
@@ -10,7 +10,10 @@ import { ClaudeCodeApiName } from '../../types';
 import { AgentInspector } from './Agent';
 import { EditInspector } from './Edit';
 import { ReadInspector } from './Read';
+import { ScheduleWakeupInspector } from './ScheduleWakeup';
 import { SkillInspector } from './Skill';
+import { TaskOutputInspector } from './TaskOutput';
+import { TaskStopInspector } from './TaskStop';
 import { TodoWriteInspector } from './TodoWrite';
 import { ToolSearchInspector } from './ToolSearch';
 import { WriteInspector } from './Write';
@@ -33,7 +36,10 @@ export const ClaudeCodeInspectors = {
     translationKey: ClaudeCodeApiName.Grep,
   }),
   [ClaudeCodeApiName.Read]: ReadInspector,
+  [ClaudeCodeApiName.ScheduleWakeup]: ScheduleWakeupInspector,
   [ClaudeCodeApiName.Skill]: SkillInspector,
+  [ClaudeCodeApiName.TaskOutput]: TaskOutputInspector,
+  [ClaudeCodeApiName.TaskStop]: TaskStopInspector,
   [ClaudeCodeApiName.TodoWrite]: TodoWriteInspector,
   [ClaudeCodeApiName.ToolSearch]: ToolSearchInspector,
   [ClaudeCodeApiName.Write]: WriteInspector,

--- a/packages/builtin-tool-claude-code/src/index.ts
+++ b/packages/builtin-tool-claude-code/src/index.ts
@@ -4,7 +4,10 @@ export {
   ClaudeCodeIdentifier,
   type ClaudeCodeTodoItem,
   type ClaudeCodeTodoStatus,
+  type ScheduleWakeupArgs,
   type SkillArgs,
+  type TaskOutputArgs,
+  type TaskStopArgs,
   type TodoWriteArgs,
   type ToolSearchArgs,
 } from './types';

--- a/packages/builtin-tool-claude-code/src/types.ts
+++ b/packages/builtin-tool-claude-code/src/types.ts
@@ -28,7 +28,10 @@ export enum ClaudeCodeApiName {
   Glob = 'Glob',
   Grep = 'Grep',
   Read = 'Read',
+  ScheduleWakeup = 'ScheduleWakeup',
   Skill = 'Skill',
+  TaskOutput = 'TaskOutput',
+  TaskStop = 'TaskStop',
   TodoWrite = 'TodoWrite',
   ToolSearch = 'ToolSearch',
   Write = 'Write',
@@ -83,4 +86,34 @@ export interface AgentArgs {
   description?: string;
   prompt?: string;
   subagent_type?: string;
+}
+
+/**
+ * Arguments for CC's built-in `ScheduleWakeup` tool — self-paced /loop mode.
+ * `delaySeconds` is clamped to [60, 3600] by the runtime; `reason` is a
+ * short human sentence shown back to the user in telemetry.
+ */
+export interface ScheduleWakeupArgs {
+  delaySeconds?: number;
+  prompt?: string;
+  reason?: string;
+}
+
+/**
+ * Arguments for CC's built-in `TaskOutput` tool. Retrieves output from a
+ * running or completed background task (bash, agent, remote session) by id.
+ */
+export interface TaskOutputArgs {
+  block?: boolean;
+  task_id?: string;
+  timeout?: number;
+}
+
+/**
+ * Arguments for CC's built-in `TaskStop` tool. `shell_id` is the legacy
+ * field name — CC still emits it occasionally, so we accept both.
+ */
+export interface TaskStopArgs {
+  shell_id?: string;
+  task_id?: string;
 }

--- a/src/features/ChatInput/InputEditor/Placeholder.tsx
+++ b/src/features/ChatInput/InputEditor/Placeholder.tsx
@@ -9,12 +9,13 @@ import { preferenceSelectors } from '@/store/user/selectors';
 export type PlaceholderVariant = 'default' | 'followUp';
 
 interface PlaceholderProps {
+  heterogeneousName?: string;
   showAgentAssignmentHint?: boolean;
   variant?: PlaceholderVariant;
 }
 
 const Placeholder = memo<PlaceholderProps>(
-  ({ showAgentAssignmentHint = false, variant = 'default' }) => {
+  ({ heterogeneousName, showAgentAssignmentHint = false, variant = 'default' }) => {
     const useCmdEnterToSend = useUserStore(preferenceSelectors.useCmdEnterToSend);
     const wrapperShortcut = useCmdEnterToSend
       ? KeyEnum.Enter
@@ -25,15 +26,19 @@ const Placeholder = memo<PlaceholderProps>(
       return <span>{t('followUpPlaceholder')}</span>;
     }
 
-    const i18nKey = showAgentAssignmentHint
-      ? 'sendPlaceholderWithAgentAssignment'
-      : 'sendPlaceholder';
+    const isHeterogeneous = !!heterogeneousName;
+    const i18nKey = isHeterogeneous
+      ? 'sendPlaceholderHeterogeneous'
+      : showAgentAssignmentHint
+        ? 'sendPlaceholderWithAgentAssignment'
+        : 'sendPlaceholder';
 
     return (
       <Flexbox horizontal align={'center'} as={'span'} gap={4} wrap={'wrap'}>
         <Trans
           i18nKey={i18nKey}
           ns={'chat'}
+          values={isHeterogeneous ? { name: heterogeneousName } : undefined}
           components={{
             hotkey: (
               <Trans
@@ -54,7 +59,7 @@ const Placeholder = memo<PlaceholderProps>(
             ),
           }}
         />
-        {!showAgentAssignmentHint && '...'}
+        {!showAgentAssignmentHint && !isHeterogeneous && '...'}
       </Flexbox>
     );
   },

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -102,12 +102,18 @@ const InputEditor = memo<{
   const MentionMenuComp = useMemo(() => createMentionMenu(stateRef, categoriesRef), []);
 
   const enableMention = allMentionItems.length > 0;
-  const showAgentAssignmentHint = categories.some((category) => category.id === 'agent');
 
   // Get agent's model info for vision support check and handle paste upload
   const agentId = useAgentId();
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
   const provider = useAgentStore((s) => agentByIdSelectors.getAgentModelProviderById(agentId)(s));
+  const heterogeneousType = useAgentStore(
+    (s) => agentByIdSelectors.getAgencyConfigById(agentId)(s)?.heterogeneousProvider?.type,
+  );
+  const heterogeneousName = heterogeneousType === 'claude-code' ? 'Claude Code' : undefined;
+  // Heterogeneous agents (e.g. Claude Code) don't yet support @-assigning to other agents
+  const showAgentAssignmentHint =
+    !heterogeneousName && categories.some((category) => category.id === 'agent');
   const { handleUploadFiles } = useUploadFiles({ model, provider });
 
   // Listen to editor's paste event for file uploads
@@ -298,6 +304,7 @@ const InputEditor = memo<{
       placeholder={
         placeholder ?? (
           <Placeholder
+            heterogeneousName={heterogeneousName}
             showAgentAssignmentHint={showAgentAssignmentHint}
             variant={placeholderVariant}
           />

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -398,56 +398,48 @@ export const getWorkflowSummaryText = (blocks: AssistantContentBlock[]): string 
   }
 
   const entries = [...groups.entries()];
+  const totalKinds = entries.length;
   const totalCalls = entries.reduce((sum, [, { count }]) => sum + count, 0);
   const totalErrors = entries.reduce((sum, [, { errorCount }]) => sum + errorCount, 0);
 
-  let result: string;
-  // Few tool kinds: list each one fully (current behavior). "+1 more" reads awkwardly,
-  // so we only collapse when there are at least 2 extra kinds beyond the top N.
-  if (entries.length <= WORKFLOW_SUMMARY_TOP_N + 1) {
-    const toolParts = entries.map(([apiName, { count, errorCount }]) => {
-      let part = getToolDisplayName(apiName);
-      if (count > 1) part += ` (${count})`;
-      if (errorCount > 0)
-        part += ` ${t('workflow.failedSuffix', { defaultValue: '(failed)', ns: 'chat' })}`;
-      return part;
-    });
-    result = toolParts.join(', ');
-  } else {
-    const sorted = [...entries].sort(([, a], [, b]) => b.count - a.count);
-    const top = sorted.slice(0, WORKFLOW_SUMMARY_TOP_N);
-    const remainingKinds = sorted.length - WORKFLOW_SUMMARY_TOP_N;
+  const formatToolPart = ([apiName, info]: [string, { count: number }]): string => {
+    const name = getToolDisplayName(apiName);
+    return info.count > 1 ? `${name} (${info.count})` : name;
+  };
 
-    const topText = top
-      .map(([apiName, { count }]) => {
-        const name = getToolDisplayName(apiName);
-        return count > 1 ? `${name} (${count})` : name;
-      })
-      .join(', ');
+  // List all kinds when few; truncate to top N (by call count) when many.
+  // "+1 more" reads awkwardly, so we only collapse when there are ≥2 extra kinds beyond top N.
+  const displayedEntries =
+    totalKinds <= WORKFLOW_SUMMARY_TOP_N + 1
+      ? entries
+      : [...entries].sort(([, a], [, b]) => b.count - a.count).slice(0, WORKFLOW_SUMMARY_TOP_N);
 
-    const segments: string[] = [
-      `${topText} ${t('workflow.summaryMoreTools', {
-        count: remainingKinds,
-        defaultValue: '+{{count}} more',
+  const segments: string[] = [displayedEntries.map(formatToolPart).join(', ')];
+
+  if (totalKinds > 1) {
+    segments.push(
+      t('workflow.summaryMoreTools', {
+        count: totalKinds,
+        defaultValue: '{{count}} tool kinds',
         ns: 'chat',
-      })}`,
+      }),
       t('workflow.summaryTotalCalls', {
         count: totalCalls,
         defaultValue: '{{count}} calls total',
         ns: 'chat',
       }),
-    ];
-    if (totalErrors > 0) {
-      segments.push(
-        t('workflow.summaryFailed', {
-          count: totalErrors,
-          defaultValue: '{{count}} failed',
-          ns: 'chat',
-        }),
-      );
-    }
-    result = segments.join(' · ');
+    );
   }
+  if (totalErrors > 0) {
+    segments.push(
+      t('workflow.summaryFailed', {
+        count: totalErrors,
+        defaultValue: '{{count}} failed',
+        ns: 'chat',
+      }),
+    );
+  }
+  let result = segments.join(' · ');
 
   const totalReasoningMs = blocks.reduce((sum, b) => sum + (b.reasoning?.duration ?? 0), 0);
   if (totalReasoningMs > 0) {

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -416,13 +416,20 @@ export const getWorkflowSummaryText = (blocks: AssistantContentBlock[]): string 
 
   const segments: string[] = [displayedEntries.map(formatToolPart).join(', ')];
 
-  if (totalKinds > 1) {
+  // Only show "N tool kinds" when the list is truncated — otherwise it duplicates the visible list.
+  if (displayedEntries.length < totalKinds) {
     segments.push(
       t('workflow.summaryMoreTools', {
         count: totalKinds,
         defaultValue: '{{count}} tool kinds',
         ns: 'chat',
       }),
+    );
+  }
+  // Only show total calls when a tool was called more than once — otherwise totalCalls
+  // equals totalKinds and the suffix duplicates info already in the list.
+  if (totalKinds > 1 && totalCalls > totalKinds) {
+    segments.push(
       t('workflow.summaryTotalCalls', {
         count: totalCalls,
         defaultValue: '{{count}} calls total',

--- a/src/hooks/useFetchChatTopics.ts
+++ b/src/hooks/useFetchChatTopics.ts
@@ -1,0 +1,26 @@
+import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useUserStore } from '@/store/user';
+import { preferenceSelectors } from '@/store/user/selectors';
+
+const EXCLUDE_STATUSES_COMPLETED = ['completed'];
+const EXCLUDE_TRIGGERS = ['cron', 'eval'];
+
+/**
+ * Canonical topic fetch for chat sidebars (agent + group). Reads every
+ * filter from a single source so all call sites in the same route mount
+ * the same SWR key — otherwise two sibling `useFetchTopics()` calls with
+ * different args both write to `topicDataMap[containerKey]` and whichever
+ * response lands last wins, which is how completed topics used to leak
+ * into the list despite the `excludeStatuses` filter.
+ *
+ * Extend this hook when adding more preference-driven topic params; don't
+ * spread them across individual components.
+ */
+export const useFetchChatTopics = () => {
+  const includeCompleted = useUserStore(preferenceSelectors.topicIncludeCompleted);
+
+  return useFetchTopics({
+    excludeStatuses: includeCompleted ? undefined : EXCLUDE_STATUSES_COMPLETED,
+    excludeTriggers: EXCLUDE_TRIGGERS,
+  });
+};

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -541,7 +541,7 @@ export default {
   'viewMode.wideScreen': 'Widescreen',
   'workflow.failedSuffix': '(failed)',
   'workflow.summaryFailed': '{{count}} failed',
-  'workflow.summaryMoreTools': '+{{count}} more',
+  'workflow.summaryMoreTools': '{{count}} tool kinds',
   'workflow.summaryTotalCalls': '{{count}} calls total',
   'workflow.thoughtForDuration': 'Thought for {{duration}}',
   'workflow.toolDisplayName.activateDevice': 'Activated device',

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -322,7 +322,7 @@ export default {
   'selectedAgents': 'Selected agents',
   'followUpPlaceholder': 'Follow up. @ to assign tasks to other agents.',
   'sendPlaceholder': 'Ask, create, or start a task, <hotkey><hotkey/>',
-  'sendPlaceholderHeterogeneous': 'Ask {{name}} to do a task, <hotkey><hotkey/>',
+  'sendPlaceholderHeterogeneous': 'Ask {{name}} to do a task...',
   'sendPlaceholderWithAgentAssignment':
     'Ask, create, or start a task. @ to assign tasks to other agents.',
   'sessionGroup.config': 'Category Management',

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -322,6 +322,7 @@ export default {
   'selectedAgents': 'Selected agents',
   'followUpPlaceholder': 'Follow up. @ to assign tasks to other agents.',
   'sendPlaceholder': 'Ask, create, or start a task, <hotkey><hotkey/>',
+  'sendPlaceholderHeterogeneous': 'Ask {{name}} to do a task, <hotkey><hotkey/>',
   'sendPlaceholderWithAgentAssignment':
     'Ask, create, or start a task. @ to assign tasks to other agents.',
   'sessionGroup.config': 'Category Management',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
@@ -6,7 +6,7 @@ import urlJoin from 'url-join';
 
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
@@ -17,8 +17,6 @@ import AllTopicsDrawer from '../AllTopicsDrawer';
 import ByProjectMode from '../TopicListContent/ByProjectMode';
 import ByTimeMode from '../TopicListContent/ByTimeMode';
 import FlatMode from '../TopicListContent/FlatMode';
-
-const fetchParams = { excludeTriggers: ['cron', 'eval'] };
 
 const TopicList = memo(() => {
   const { t } = useTranslation('topic');
@@ -34,7 +32,7 @@ const TopicList = memo(() => {
 
   const topicGroupMode = useUserStore(preferenceSelectors.topicGroupMode);
 
-  useFetchTopics(fetchParams);
+  useFetchChatTopics();
 
   // Show skeleton when current session's topic data is not yet loaded
   if (isUndefinedTopics) return <SkeletonList />;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/index.tsx
@@ -6,7 +6,7 @@ import urlJoin from 'url-join';
 
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
@@ -30,7 +30,7 @@ const TopicListContent = memo(() => {
 
   const topicGroupMode = useUserStore(preferenceSelectors.topicGroupMode);
 
-  useFetchTopics({ excludeTriggers: ['cron', 'eval'] });
+  useFetchChatTopics();
 
   if (isInSearchMode) return <SearchResult />;
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
@@ -6,11 +6,9 @@ import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useUserStore } from '@/store/user';
-import { preferenceSelectors } from '@/store/user/selectors';
 
 import Actions from './Actions';
 import Filter from './Filter';
@@ -24,12 +22,8 @@ interface TopicProps {
 const Topic = memo<TopicProps>(({ itemKey }) => {
   const { t } = useTranslation(['topic', 'common']);
   const [topicCount] = useChatStore((s) => [topicSelectors.currentTopicCount(s)]);
-  const includeCompleted = useUserStore(preferenceSelectors.topicIncludeCompleted);
   const dropdownMenu = useTopicActionsDropdownMenu();
-  const { isRevalidating } = useFetchTopics({
-    excludeStatuses: includeCompleted ? undefined : ['completed'],
-    excludeTriggers: ['cron', 'eval'],
-  });
+  const { isRevalidating } = useFetchChatTopics();
 
   return (
     <AccordionItem

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/index.tsx
@@ -6,7 +6,7 @@ import urlJoin from 'url-join';
 
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
@@ -31,7 +31,7 @@ const TopicList = memo(() => {
 
   const topicGroupMode = useUserStore(preferenceSelectors.topicGroupMode);
 
-  useFetchTopics();
+  useFetchChatTopics();
 
   // Show skeleton when current session's topic data is not yet loaded
   if (isUndefinedTopics) return <SkeletonList />;

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/index.tsx
@@ -6,7 +6,7 @@ import urlJoin from 'url-join';
 
 import EmptyNavItem from '@/features/NavPanel/components/EmptyNavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
@@ -29,7 +29,7 @@ const TopicListContent = memo(() => {
   const activeGroupId = useAgentGroupStore((s) => s.activeGroupId);
   const topicGroupMode = useUserStore(preferenceSelectors.topicGroupMode);
 
-  useFetchTopics();
+  useFetchChatTopics();
 
   if (isInSearchMode) return <SearchResult />;
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/index.tsx
@@ -6,11 +6,9 @@ import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchTopics } from '@/hooks/useFetchTopics';
+import { useFetchChatTopics } from '@/hooks/useFetchChatTopics';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useUserStore } from '@/store/user';
-import { preferenceSelectors } from '@/store/user/selectors';
 
 import Actions from './Actions';
 import Filter from './Filter';
@@ -24,11 +22,8 @@ interface TopicProps {
 const Topic = memo<TopicProps>(({ itemKey }) => {
   const { t } = useTranslation(['topic', 'common']);
   const [topicCount] = useChatStore((s) => [topicSelectors.currentTopicCount(s)]);
-  const includeCompleted = useUserStore(preferenceSelectors.topicIncludeCompleted);
   const dropdownMenu = useTopicActionsDropdownMenu();
-  const { isRevalidating } = useFetchTopics({
-    excludeStatuses: includeCompleted ? undefined : ['completed'],
-  });
+  const { isRevalidating } = useFetchChatTopics();
 
   return (
     <AccordionItem

--- a/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -1413,6 +1413,43 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(threadAssistants.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('routes delayed tool_result to thread bucket when it arrives after subagent turn has rolled over', async () => {
+      // Regression: `findRunByInnerToolCallId` must resolve across ALL
+      // turns of a subagent run, not just the current one. Previously
+      // it only consulted `state.persistedIds`, which `ensureSubagentRun`
+      // wipes on every turn advance — so a `tool_result` for a prior
+      // turn's `tool_use` silently skipped `run.stream.update` and left
+      // the in-thread tool bubble stuck on its loading spinner until the
+      // user re-opened the Thread (main-topic `fetchAndReplaceMessages`
+      // does not rehydrate thread buckets).
+      const { store } = await runWithEvents([
+        ccInit(),
+        ccToolUse('msg_main', 'toolu_task', 'Task', { description: 'x', subagent_type: 'Plan' }),
+        // Turn 1: lifetimeToolCallIds gets `toolu_child_1`.
+        ccSubagentToolUse('msg_sub_1', 'toolu_task', 'toolu_child_1', 'Read'),
+        // Turn 2: ensureSubagentRun wipes state.persistedIds. The
+        // run-lifetime set must still remember `toolu_child_1`.
+        ccSubagentToolUse('msg_sub_2', 'toolu_task', 'toolu_child_2', 'Write'),
+        // Delayed tool_result for the FIRST turn's tool_use.
+        ccToolResult('toolu_child_1', 'turn 1 output'),
+        ccResult(),
+      ]);
+
+      const startOpMock = (store.startOperation as ReturnType<typeof vi.fn>).mock;
+      const subOpIdx = startOpMock.calls.findIndex(([p]: any) => p?.type === 'subagentThread');
+      expect(subOpIdx).toBeGreaterThanOrEqual(0);
+      const subOperationId = startOpMock.results[subOpIdx].value.operationId;
+
+      const dispatches = (store.internal_dispatchMessage as ReturnType<typeof vi.fn>).mock.calls;
+      const delayedResultDispatch = dispatches.find(
+        ([payload, ctx]: any) =>
+          ctx?.operationId === subOperationId &&
+          payload.type === 'updateMessage' &&
+          payload.value?.content === 'turn 1 output',
+      );
+      expect(delayedResultDispatch).toBeDefined();
+    });
+
     it('records subagent tool_uses on IN-THREAD assistant tools[], not on main', async () => {
       await runWithEvents([
         ccInit(),

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -318,6 +318,19 @@ interface SubagentRunState {
    */
   lastChainParentId: string;
   /**
+   * Run-lifetime set of every inner tool_call_id this subagent has ever
+   * persisted into its thread. Unlike `state.persistedIds`, which is
+   * turn-scoped and wiped when `currentSubagentMessageId` advances, this
+   * set only grows — so a delayed `tool_result` that lands after the
+   * owning turn has rolled over still resolves back to the right run via
+   * `findRunByInnerToolCallId`. Without this, the thread-bucket
+   * `updateMessage` path is skipped and the in-thread tool bubble stays
+   * stuck on the loading spinner until the user re-opens the Thread
+   * (main-topic `fetchAndReplaceMessages` does not rehydrate thread
+   * buckets).
+   */
+  lifetimeToolCallIds: Set<string>;
+  /**
    * Assistant message id that a deferred buffer flush is still owed to.
    * Set when `finalizeSubagentRun` captures the flush target but the DB
    * write fails; the next retry (typically the `onComplete` fallback)
@@ -512,6 +525,7 @@ const ensureSubagentRun = async (
       currentSubagentMessageId: subagentCtx.subagentMessageId ?? '',
       lastBatchToolMsgIds: [],
       lastChainParentId: firstAssistantId,
+      lifetimeToolCallIds: new Set(),
       state: { payloads: [], persistedIds: new Set() },
       stream,
       subOperationId,
@@ -607,6 +621,13 @@ const persistSubagentToolChunk = async (
     onThreadCreated,
   );
   if (!run) return;
+
+  // Record every incoming tool_use id in the run-lifetime lookup set
+  // before persisting, so a `tool_result` that arrives after this turn
+  // has rolled over still finds its owning run via
+  // `findRunByInnerToolCallId` (which can't rely on `state.persistedIds`
+  // alone — that one is wiped on turn advance).
+  for (const tool of tools) run.lifetimeToolCallIds.add(tool.id);
 
   // Snapshot the tool id set BEFORE the batch so we can compute which
   // ids this call added (for chain-parent advancement below).
@@ -1025,10 +1046,19 @@ export const executeHeterogeneousAgent = async (
     get().completeOperation(subOperationId);
   };
 
-  /** Look up a subagent run by the tool_call_id of ANY tool inside it. */
+  /**
+   * Look up a subagent run by the tool_call_id of ANY tool inside it —
+   * across ALL turns of the run, not just the current one. Uses
+   * `lifetimeToolCallIds` (run-scoped, append-only) rather than
+   * `state.persistedIds` (turn-scoped, wiped by `ensureSubagentRun` when
+   * the subagent advances to a new `subagentMessageId`), so a delayed
+   * `tool_result` arriving after the owning turn has rolled over still
+   * routes to the right run and clears the in-thread tool bubble's
+   * loading state.
+   */
   const findRunByInnerToolCallId = (toolCallId: string): SubagentRunState | undefined => {
     for (const run of subagentRuns.values()) {
-      if (run.state.persistedIds.has(toolCallId)) return run;
+      if (run.lifetimeToolCallIds.has(toolCallId)) return run;
     }
     return undefined;
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [x] 🎨 style

#### 🔗 Related Issue

Follow-up polish after LOBE-7365 / #14024 landed in canary.

#### 🔀 Description of Change

Nine commits across five independent threads; no shared code path so each can be reviewed in isolation.

**CC tool inspectors (new)**
- `f96e06201f` ✨ render dedicated inspectors for `ScheduleWakeup` (self-paced /loop), `TaskOutput` (read from background task), and `TaskStop` (terminate background task). These three were falling back to the generic `(param:value 等 N 个参数)` row. `TaskStop` accepts both `task_id` and the legacy `shell_id` field name since older CC builds still emit the latter.
- `6391860a9f` 🎨 align those inspectors with the existing `ToolSearch` shape: drop the leading lucide icon, add the `:` label suffix, and put ScheduleWakeup's human-readable `reason` in the chip with `delaySeconds` trailing as secondary context.

**Heterogeneous-agent subagent regression fix**
- `3d6fd113e8` 🐛 retain subagent tool-call lookup across turn boundaries. `findRunByInnerToolCallId` consulted `run.state.persistedIds`, but that set is wiped each time `ensureSubagentRun` advances `subagentMessageId`. A delayed `tool_result` for a prior turn's `tool_use` therefore missed the lookup and skipped the thread-bucket `run.stream.update`, leaving the in-thread tool bubble stuck on its loading spinner until the user re-opened the Thread (main-topic `fetchAndReplaceMessages` does not rehydrate thread buckets). Adds a run-lifetime `lifetimeToolCallIds` set (append-only) and routes the lookup through it; `state.persistedIds` stays turn-scoped for `persistToolBatch`'s dedupe.

**Chat input placeholder for CC sessions**
- `08ddddebc2` ✨ swap the generic chat-input placeholder for a task-specific variant when the active agent is backed by a heterogeneous provider (e.g. "Ask Claude Code to do a task"). Suppresses the @-mention assignment hint in that mode since heterogeneous agents don't yet route to sibling agents.
- `fb52b7d6d6` 🌐 en-US + zh-CN dev preview translations for the new placeholder key (CI regenerates locale JSON on release).
- `0517b6b7f9` 🎨 drop the trailing ⌘↵ hotkey hint for the heterogeneous variant — it read awkwardly attached to a short single-clause prompt.

**Workflow summary polish**
- `732137e145` ♻️ unify both branches of `getWorkflowSummaryText` onto one suffix structure: `list · 共 N 种工具 · 共 X 次调用 · N 次失败`. Replaces the inline per-tool `(failed)` marker with the global error suffix.
- `3151d2bb7f` ♻️ hide the kinds/calls suffixes when they would duplicate what the per-tool list already shows (N kinds only when truncated, X calls only when at least one tool was called more than once).

**Sidebar topic filter**
- `67ea4c6858` 🐛 stop completed topics from leaking past the sidebar filter. The outer `Topic` and inner `List` / `TopicListContent` each mounted `useFetchTopics` with different args — outer passed `excludeStatuses: ['completed']`, inner called it bare. Since `excludeStatuses` is part of the SWR key, both fired independent requests whose `onData` handlers wrote back to the same `topicDataMap[containerKey]` slot, and whichever landed last won. Introduces `useFetchChatTopics` as the single call site so every sibling mounts with identical args and SWR dedupes to one request.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression test added to `src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts` under `CC subagent thread-container > routes delayed tool_result to thread bucket when it arrives after subagent turn has rolled over`: subagent emits turn-1 tool_use, turn advances (`subagentMessageId` changes), turn-1's delayed `tool_result` lands — asserts the thread-scoped `updateMessage` dispatch still fires with the result content. Verified the test fails on the pre-fix lookup.

Manual smoke:
- CC session with a multi-step subagent that spawns background tools — confirm the new inspector chips render and any delayed `tool_result` clears the loading spinner without reopening the Thread.
- Claude Code agent chat input — confirm placeholder reads "Ask Claude Code to do a task" / "让 Claude Code 帮你完成任务" with no trailing hotkey hint.
- Sidebar with "Include completed" toggle off — confirm completed topics stay hidden across session switches and SWR revalidations.
- Workflow summary after a CC run — confirm the suffix reads cleanly and doesn't duplicate the per-tool list.

#### 📸 Screenshots / Videos

ToolSearch-style inspector layout shared inline in the review thread.

#### 📝 Additional Information

No breaking changes, no migrations. `useFetchChatTopics` is a thin wrapper over `useFetchTopics` — the popup and mobile-modal call sites intentionally keep using raw `useFetchTopics` because they need the unfiltered set to resolve titles for already-completed topics.