### PR TITLE
🐛 fix(model-runtime): set type:"message" on Responses API input items

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -363,8 +363,8 @@ describe('convertOpenAIResponseInputs', () => {
     const result = await convertOpenAIResponseInputs(messages);
 
     expect(result).toEqual([
-      { role: 'user', content: 'Hello' },
-      { role: 'assistant', content: 'Hi there!' },
+      { role: 'user', content: 'Hello', type: 'message' },
+      { role: 'assistant', content: 'Hi there!', type: 'message' },
     ]);
   });
 
@@ -446,6 +446,7 @@ describe('convertOpenAIResponseInputs', () => {
             image_url: 'data:image/jpeg;base64,test123',
           },
         ],
+        type: 'message',
       },
     ]);
   });
@@ -478,6 +479,7 @@ describe('convertOpenAIResponseInputs', () => {
             video_url: 'data:video/mp4;base64,test123',
           },
         ],
+        type: 'message',
       },
     ]);
   });
@@ -520,6 +522,7 @@ describe('convertOpenAIResponseInputs', () => {
             video_url: 'data:video/mp4;base64,test456',
           },
         ],
+        type: 'message',
       },
     ]);
   });
@@ -546,6 +549,7 @@ describe('convertOpenAIResponseInputs', () => {
       {
         role: 'user',
         content: [{ type: 'input_text', text: 'Here is a video' }],
+        type: 'message',
       },
     ]);
   });
@@ -577,7 +581,7 @@ describe('convertOpenAIResponseInputs', () => {
     const result = await convertOpenAIResponseInputs(messages);
 
     expect(result).toEqual([
-      { role: 'user', content: 'I need help with a function' },
+      { role: 'user', content: 'I need help with a function', type: 'message' },
       {
         arguments: 'get_data',
         call_id: 'call_456',
@@ -627,7 +631,7 @@ describe('convertOpenAIResponseInputs', () => {
     const result = await convertOpenAIResponseInputs(messages, { strictToolPairing: true });
 
     expect(result).toEqual([
-      { role: 'user', content: 'Use tools carefully' },
+      { role: 'user', content: 'Use tools carefully', type: 'message' },
       {
         arguments: '{"city":"Hangzhou"}',
         call_id: 'call_paired',
@@ -669,8 +673,8 @@ describe('convertOpenAIResponseInputs', () => {
     // The assistant message with all-orphaned tool_calls should produce no items,
     // NOT fall through to the default builder which would spread tool_calls back.
     expect(result).toEqual([
-      { role: 'user', content: 'Do something' },
-      { role: 'assistant', content: 'Final answer' },
+      { role: 'user', content: 'Do something', type: 'message' },
+      { role: 'assistant', content: 'Final answer', type: 'message' },
     ]);
   });
 
@@ -689,11 +693,11 @@ describe('convertOpenAIResponseInputs', () => {
     const result = await convertOpenAIResponseInputs(messages);
 
     expect(result).toEqual([
-      { content: 'system prompts', role: 'developer' },
-      { content: '你好', role: 'user' },
+      { content: 'system prompts', role: 'developer', type: 'message' },
+      { content: '你好', role: 'user', type: 'message' },
       { summary: [{ text: 'reasoning content', type: 'summary_text' }], type: 'reasoning' },
-      { content: 'hello', role: 'assistant' },
-      { content: '杭州天气如何', role: 'user' },
+      { content: 'hello', role: 'assistant', type: 'message' },
+      { content: '杭州天气如何', role: 'user', type: 'message' },
     ]);
   });
 
@@ -718,17 +722,18 @@ describe('convertOpenAIResponseInputs', () => {
     const result = await convertOpenAIResponseInputs(messages);
 
     expect(result).toEqual([
-      { content: 'system prompts', role: 'developer' },
+      { content: 'system prompts', role: 'developer', type: 'message' },
       {
         content: [
           { type: 'input_text', text: 'describe this image' },
           { type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
         ],
         role: 'user',
+        type: 'message',
       },
       { summary: [{ text: 'analyzing the image', type: 'summary_text' }], type: 'reasoning' },
-      { content: 'The image shows a green car.', role: 'assistant' },
-      { content: '1 + 1 = ?', role: 'user' },
+      { content: 'The image shows a green car.', role: 'assistant', type: 'message' },
+      { content: '1 + 1 = ?', role: 'user', type: 'message' },
     ]);
   });
 
@@ -766,8 +771,8 @@ describe('convertOpenAIResponseInputs', () => {
     ];
     const result = await convertOpenAIResponseInputs(messages);
     expect(result).toEqual([
-      { content: 'system prompts', role: 'developer' },
-      { content: '你是谁', role: 'user' },
+      { content: 'system prompts', role: 'developer', type: 'message' },
+      { content: '你是谁', role: 'user', type: 'message' },
       {
         summary: [{ text: 'The user is asking', type: 'summary_text' }],
         type: 'reasoning',
@@ -775,6 +780,7 @@ describe('convertOpenAIResponseInputs', () => {
       {
         content: [{ text: '我是 Claude', type: 'output_text' }],
         role: 'assistant',
+        type: 'message',
       },
     ]);
   });
@@ -815,6 +821,7 @@ describe('convertOpenAIResponseInputs', () => {
             video_url: 'data:video/mp4;base64,forcedBase64',
           },
         ],
+        type: 'message',
       },
     ]);
 
@@ -857,10 +864,42 @@ describe('convertOpenAIResponseInputs', () => {
             image_url: 'data:image/jpeg;base64,forcedBase64',
           },
         ],
+        type: 'message',
       },
     ]);
 
     expect(imageUrlToBase64).toHaveBeenCalledWith('https://example.com/image.jpg');
+  });
+
+  // Regression: LOBE-7657
+  // Strict OpenAI-compatible proxies reject input items that omit `type`, returning
+  // `Invalid value: ''. Supported values are: 'apply_patch_call', ...`. The OpenAI
+  // SDK marks `type` as optional and the official endpoint defaults it to 'message',
+  // but we must emit it explicitly so the payload also passes strict validators.
+  it('should set type:"message" on every message-shaped input item (LOBE-7657)', async () => {
+    const messages: OpenAIChatMessage[] = [
+      { content: 'system prompts', role: 'system' },
+      { content: 'plain user text', role: 'user' },
+      {
+        content: [{ type: 'text', text: 'user with structured content' }],
+        role: 'user',
+      },
+      { content: 'assistant reply', role: 'assistant' },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result.every((item: any) => item.type === 'message')).toBe(true);
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer', type: 'message' },
+      { content: 'plain user text', role: 'user', type: 'message' },
+      {
+        content: [{ type: 'input_text', text: 'user with structured content' }],
+        role: 'user',
+        type: 'message',
+      },
+      { content: 'assistant reply', role: 'assistant', type: 'message' },
+    ]);
   });
 });
 

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -188,7 +188,11 @@ export const convertOpenAIResponseInputs = async (
       }
 
       if (message.role === 'system') {
-        items.push({ ...message, role: 'developer' } as OpenAI.Responses.ResponseInputItem);
+        items.push({
+          ...message,
+          role: 'developer',
+          type: 'message',
+        } as OpenAI.Responses.ResponseInputItem);
         return items;
       }
 
@@ -242,6 +246,7 @@ export const convertOpenAIResponseInputs = async (
           typeof processedContent === 'string'
             ? processedContent
             : processedContent.filter((m) => m !== undefined),
+        type: 'message',
       } as OpenAI.Responses.ResponseInputItem;
 
       // remove reasoning field from the message item


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

Refs LOBE-7657

#### 🔀 Description of Change

`convertOpenAIResponseInputs` builds Responses API `input` items by spreading the source `ChatCompletionMessageParam` (which has no top-level `type` field) and casting to `ResponseInputItem`. The `function_call` / `function_call_output` / `reasoning` branches set `type` explicitly, but the **system→developer** and the **default user/assistant** branches do not.

OpenAI's SDK marks `type` as optional on `EasyInputMessage` and the official endpoint defaults missing values to `'message'`, so this never broke against `api.openai.com`. But strict OpenAI-compatible proxies treat the missing field as an empty string and reject the request:

```
400 Invalid value: ''. Supported values are: 'apply_patch_call',
'apply_patch_call_output', ..., 'message', 'reasoning', ...
param: input[1], code: invalid_value
```

This was observed against a third-party gateway with model `gpt-5.4` — see the LOBE-7657 op trace. The fix sets `type: 'message'` explicitly in both branches; this is a no-op against the official endpoint and unblocks strict validators.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' 'src/core/contextBuilders/openai.test.ts'
```

- Updated 12 existing `convertOpenAIResponseInputs` cases to assert the new `type: 'message'` field (previous expectations silently codified the buggy shape).
- Added one LOBE-7657 regression test asserting every message-shaped input item carries `type: 'message'`.
- Sibling tests (`openaiCompatibleFactory`, `githubCopilot`, `responsesStream`) re-run green — no behavioral regression.

#### 📝 Additional Information

Backwards compatible. The OpenAI SDK already types `type` as `'message'` for `EasyInputMessage`, so this just makes the wire payload match what the type system already promised.