### PR TITLE
🐛 fix(agent-runtime): preserve Gemini 3 thoughtSignature in call_tools_batch normalization

### DIFF
--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -1172,6 +1172,59 @@ describe('AgentRuntime', () => {
       expect(result.nextContext?.payload).toHaveProperty('toolCount', 3);
     });
 
+    // Regression test for LOBE-7759: Gemini 3 thoughtSignature must survive the
+    // OpenAI ToolsCalling -> ChatToolPayload normalization in call_tools_batch,
+    // otherwise Gemini 3 400s on the second tool_call turn.
+    it('should preserve thoughtSignature when normalizing call_tools_batch ToolsCalling payload', async () => {
+      const signature = 'EoMYCoAYA_gemini3_thought_signature_fixture';
+
+      class ThoughtSignatureAgent implements Agent {
+        tools = {
+          gemini_tool: vi.fn().mockResolvedValue({ result: 'ok' }),
+        };
+
+        async runner(context: AgentRuntimeContext, _state: AgentState) {
+          if (context.phase === 'user_input') {
+            return {
+              payload: [
+                {
+                  function: { arguments: '{}', name: 'gemini_tool' },
+                  id: 'call_gemini_1',
+                  thoughtSignature: signature,
+                  type: 'function' as const,
+                },
+              ],
+              type: 'call_tools_batch' as const,
+            };
+          }
+          return { type: 'finish' as const, reason: 'completed' as const };
+        }
+      }
+
+      // Intercept normalized call_tools_batch to capture the ChatToolPayload handed downstream.
+      let capturedToolsCalling: ChatToolPayload[] | undefined;
+      const agent = new ThoughtSignatureAgent();
+      const runtime = new AgentRuntime(agent, {
+        executors: {
+          call_tools_batch: async (instruction: any, state: AgentState) => {
+            capturedToolsCalling = instruction.payload.toolsCalling;
+            return { events: [], newState: state };
+          },
+        },
+      });
+
+      const state = AgentRuntime.createInitialState({
+        operationId: 'thought-signature-test',
+        messages: [{ role: 'user', content: 'Call Gemini 3 tool' }],
+      });
+
+      await runtime.step(state);
+
+      expect(capturedToolsCalling).toHaveLength(1);
+      expect(capturedToolsCalling![0].thoughtSignature).toBe(signature);
+      expect(capturedToolsCalling![0].apiName).toBe('gemini_tool');
+    });
+
     it('should support agent returning instruction array', async () => {
       // Agent that returns array of instructions
       class ArrayReturnAgent implements Agent {

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -140,6 +140,7 @@ export class AgentRuntime {
             arguments: tc.function.arguments,
             id: tc.id,
             identifier: tc.function.name,
+            thoughtSignature: tc.thoughtSignature,
             type: 'default' as any,
           }));
 

--- a/packages/agent-runtime/src/types/state.ts
+++ b/packages/agent-runtime/src/types/state.ts
@@ -155,6 +155,12 @@ export interface ToolsCalling {
     name: string; // A JSON string of arguments
   };
   id: string;
+  /**
+   * Gemini 3.x thought signature, captured from `functionCall.thoughtSignature` in the
+   * streaming response. Must be round-tripped back in subsequent requests or Gemini will
+   * 400 with a misleading "ordering" error. Optional; only set for Gemini 3.x tool calls.
+   */
+  thoughtSignature?: string;
   type: 'function';
 }
 


### PR DESCRIPTION
## Summary

- `agent-runtime` was dropping `thoughtSignature` when normalizing the legacy OpenAI `ToolsCalling` payload into `ChatToolPayload` inside `runtime.ts`: the field wasn't declared on `ToolsCalling`, and the explicit `map(...)` at `runtime.ts:138` enumerated only 5 fields.
- As a consequence, the second (and later) Gemini 3.x tool-call turn in a conversation always failed with a misleading Google 400: `"Please ensure that function call turn comes immediately after a user turn or after a function response turn."` — Google's validator maps "missing thoughtSignature" to that generic ordering message.
- Added `thoughtSignature?: string` to `ToolsCalling` (`packages/agent-runtime/src/types/state.ts`), propagated it through the normalization map (`packages/agent-runtime/src/core/runtime.ts:138`), and added a regression test.
- Scope is Gemini 3.x thinking-mode models only (gemini-3-pro-preview / gemini-3-flash-preview / gemini-3.1-pro-preview); OpenAI, Anthropic, and pre-3 Gemini are unaffected.

Fixes [LOBE-7759](https://linear.app/lobehub/issue/LOBE-7759).

## Test plan

- [x] `bunx vitest run --silent='passed-only' 'packages/agent-runtime/src/core/__tests__/runtime.test.ts'` — 50/50 passing, including new `should preserve thoughtSignature when normalizing call_tools_batch ToolsCalling payload`.
- [x] `bun run type-check` — no new errors on modified files.
- [ ] Manual replay with reproducer op `op_1776830406224_agt_S0NUOfRPn18H_tpc_7mBFhy97hrV4_VbnBOoa1` to confirm step 8 no longer 400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)