### PR TITLE
🎨 style(claude-code): tool inspector polish + unstick Read-on-image spinner

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
@@ -37,7 +37,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   icon: css`
     flex-shrink: 0;
-    margin-inline-end: 6px;
+    margin-inline: 6px;
     color: ${cssVar.colorTextDescription};
   `,
   label: css`
@@ -70,8 +70,9 @@ export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
 
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <span className={styles.label}>Agent:</span>
         <Icon className={styles.icon} size={14} />
-        <span className={styles.label}>Agent: {labelText}</span>
+        <span className={styles.label}>{labelText}</span>
         {description && (
           <span className={styles.chip}>
             <span className={styles.chipText}>{description}</span>

--- a/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
@@ -18,7 +18,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 60%;
     margin-inline-start: 6px;
     padding-block: 2px;
     padding-inline: 10px;
@@ -42,16 +41,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextDescription};
   `,
   label: css`
+    flex-shrink: 0;
     color: ${cssVar.colorText};
   `,
 }));
 
 /**
- * CC's subagent-spawn tool. `subagent_type` is the template ("Explore",
- * "general-purpose", ...) and becomes the primary label — saying "Agent"
- * is redundant once we're already rendering inside the Agent inspector.
- * `description` is the 3-5 word title the model writes ("Run pwd command")
- * and goes in the chip; the full `prompt` is too long for a collapsed header.
+ * CC's subagent-spawn tool. `subagent_type` ("Explore", "general-purpose", ...)
+ * is the variant; we prefix it with "Agent:" so the row visibly reads as a
+ * subagent dispatch rather than a regular tool — the icon alone isn't enough
+ * signal. `description` is the 3-5 word title the model writes and goes in the
+ * chip; the full `prompt` is too long for a collapsed header.
  */
 export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
   ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
@@ -71,7 +71,7 @@ export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
         <Icon className={styles.icon} size={14} />
-        <span className={styles.label}>{labelText}</span>
+        <span className={styles.label}>Agent: {labelText}</span>
         {description && (
           <span className={styles.chip}>
             <span className={styles.chipText}>{description}</span>

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -304,6 +304,83 @@ describe('ClaudeCodeAdapter', () => {
     });
   });
 
+  describe('Read tool image content (LOBE-7338)', () => {
+    // CC's `Read` on images returns a `tool_result` whose `content` is an
+    // `image` block (base64). The generic mapper had no branch for it so
+    // resultContent collapsed to '' and the UI's StatusIndicator stuck on the
+    // spinner. Minimal fix: emit a placeholder so the tool ends in completed
+    // state. Image echo (thumbnails) is deferred.
+    it('renders image blocks as a non-empty placeholder', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt({ subtype: 'init', type: 'system' });
+      adapter.adapt({
+        message: {
+          id: 'msg_1',
+          content: [{ id: 'r1', input: { file_path: 'x.png' }, name: 'Read', type: 'tool_use' }],
+        },
+        type: 'assistant',
+      });
+
+      const events = adapter.adapt({
+        message: {
+          content: [
+            {
+              content: [
+                {
+                  source: { data: 'AAAA', media_type: 'image/png', type: 'base64' },
+                  type: 'image',
+                },
+              ],
+              tool_use_id: 'r1',
+              type: 'tool_result',
+            },
+          ],
+          role: 'user',
+        },
+        type: 'user',
+      });
+
+      const result = events.find((e) => e.type === 'tool_result');
+      expect(result).toBeDefined();
+      expect(result!.data.toolCallId).toBe('r1');
+      expect(result!.data.content).toBe('[Image: image/png]');
+      expect(result!.data.isError).toBe(false);
+
+      const end = events.find((e) => e.type === 'tool_end');
+      expect(end).toBeDefined();
+      expect(end!.data.toolCallId).toBe('r1');
+    });
+
+    it('falls back to generic label when media_type is missing', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt({ subtype: 'init', type: 'system' });
+      adapter.adapt({
+        message: {
+          id: 'msg_1',
+          content: [{ id: 'r1', input: { file_path: 'x' }, name: 'Read', type: 'tool_use' }],
+        },
+        type: 'assistant',
+      });
+
+      const events = adapter.adapt({
+        message: {
+          content: [
+            {
+              content: [{ source: { data: 'AAAA', type: 'base64' }, type: 'image' }],
+              tool_use_id: 'r1',
+              type: 'tool_result',
+            },
+          ],
+          role: 'user',
+        },
+        type: 'user',
+      });
+
+      const result = events.find((e) => e.type === 'tool_result');
+      expect(result!.data.content).toBe('[Image: image]');
+    });
+  });
+
   describe('TodoWrite pluginState synthesis', () => {
     const driveTodoWrite = (adapter: ClaudeCodeAdapter, input: unknown, toolId = 't1') => {
       adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -529,6 +529,14 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
                   // and the tool message lands in DB with empty content — leaving
                   // the UI's StatusIndicator stuck on the spinner (LOBE-7369).
                   if (c?.type === 'tool_reference' && c.tool_name) return c.tool_name;
+                  // `Read` on images yields `{type: 'image', source: {...}}` blocks
+                  // with no text. Drop a minimal placeholder so the tool message
+                  // has non-empty content (LOBE-7338); richer image echo is a
+                  // follow-up that needs structured ToolResultData.
+                  if (c?.type === 'image') {
+                    const mediaType = c.source?.media_type || 'image';
+                    return `[Image: ${mediaType}]`;
+                  }
                   return c.text || c.content || '';
                 })
                 .filter(Boolean)


### PR DESCRIPTION
## Summary

Bundles two unrelated CC follow-ups onto one branch.

### 1. Inspector label / chip cap (style)

- Prefix the subagent label with `Agent:` so the inspector row visibly reads as a subagent dispatch (e.g. `Agent: Explore` instead of bare `Explore`) — the icon alone isn't enough signal, and sibling inspectors (`TaskOutput:` / `TaskStop:` / `ScheduleWakeup:` / `ToolSearch:`) already follow this `label:` pattern.
- Drop the chip's `max-width: 60%` cap so the description chip uses the available width to the right of the label instead of ellipsizing prematurely. The chip still has `flex-shrink: 1` + `min-width: 0`, and the parent `inspectorTextStyles.root` clips overflow, so it still shrinks gracefully when space is tight.
- Add `flex-shrink: 0` to `.label` as a safety net so the `Agent: <type>` text itself never gets ellipsized when descriptions are long.
- Update the doc comment that previously argued against the `Agent:` prefix.

#### Before / after

Before: chip clipped at 60% even when the rest of the row was empty space, and `Explore` alone gave no visual cue that this row is a subagent.
After: chip expands to fit the description (still bounded by the row's `overflow: hidden`), and the `Agent:` prefix names what the row represents.

### 2. Read-on-image spinner (bug, fix LOBE-7338)

CC's `Read` on images returns a `tool_result` whose `content` is an `image` block (base64). The generic array mapper in `claudeCode.ts` had no branch for it so resultContent collapsed to `''` and the UI's StatusIndicator stuck on the spinner — even though CC had already finished and moved on.

Minimal fix: emit a `[Image: <media_type>]` placeholder so the tool message lands in the DB with non-empty content and the UI ends in the completed state. Richer image echo (thumbnails / structured `ToolResultData.contentBlocks` / DB-side rich storage) is a follow-up tracked under LOBE-6801 and intentionally out of scope here.

## Test plan

### Inspector label / chip cap

- [ ] In a chat with a CC subagent dispatch (e.g. Explore), confirm the inspector row reads `Agent: Explore` followed by the description chip.
- [ ] With a description like `Find frontend invalid-args fe…`, verify the chip now shows the full text in a wide row (no `60%` cap) and only collapses when the row is genuinely narrow.
- [ ] With an extremely long description, verify the `Agent: <type>` label stays intact and only the chip text gets ellipsized.

### Read-on-image (LOBE-7338)

- [x] Unit: `tool_result` with an `image` block produces non-empty content and emits `tool_end`.
- [x] Unit: missing `media_type` falls back to `[Image: image]`.
- [ ] In CC mode, ask CC to `Read tmp/<some>.png` and confirm the Read row settles into the completed state instead of hanging on the spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)