### PR TITLE
♻️ refactor(desktop): increase recent working directories from 5 to 20 with scroll container

### DIFF
--- a/src/features/ChatInput/RuntimeConfig/BranchSwitcher.tsx
+++ b/src/features/ChatInput/RuntimeConfig/BranchSwitcher.tsx
@@ -36,29 +36,33 @@ const styles = createStaticStyles(({ css }) => ({
     display: flex;
     flex-direction: column;
 
-    width: 320px;
-    height: 380px;
+    width: 300px;
+    height: 360px;
 
     /* Cancel DropdownMenuPopup's default 4px padding so our sections align edge-to-edge */
     margin: -4px;
   `,
   createFooter: css`
     display: flex;
-    gap: 8px;
+    gap: 6px;
     align-items: center;
 
-    padding: 8px;
+    padding-block: 6px;
+    padding-inline: 8px;
     border-block-start: 1px solid ${cssVar.colorSplit};
   `,
   createItemWrapper: css`
     padding: 4px;
     border-block-start: 1px solid ${cssVar.colorSplit};
   `,
+  createItem: css`
+    border-radius: calc(${cssVar.borderRadius} - 4px);
+  `,
   createInput: css`
     flex: 1;
   `,
   emptyState: css`
-    padding-block: 16px;
+    padding-block: 12px;
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
     text-align: center;
@@ -66,13 +70,14 @@ const styles = createStaticStyles(({ css }) => ({
   item: css`
     display: flex;
     gap: 8px;
-    align-items: flex-start;
+    align-items: center;
 
-    padding-block: 8px;
-    padding-inline: 10px;
-    border-radius: 6px;
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 4px;
 
     font-size: 13px;
+    line-height: 1.3;
     color: ${cssVar.colorText};
   `,
   itemCheck: css`
@@ -81,7 +86,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   itemIcon: css`
     flex: none;
-    margin-block-start: 2px;
     color: ${cssVar.colorTextSecondary};
   `,
   itemMain: css`
@@ -90,17 +94,28 @@ const styles = createStaticStyles(({ css }) => ({
     min-width: 0;
   `,
   itemMeta: css`
-    margin-block-start: 2px;
-    font-size: 12px;
+    margin-block-start: 1px;
+    font-size: 11px;
     color: ${cssVar.colorTextTertiary};
   `,
   list: css`
     overflow-y: auto;
     flex: 1;
-    padding: 4px;
+    padding-block: 2px;
+    padding-inline: 4px;
   `,
   searchBar: css`
-    padding: 8px;
+    padding-block: 4px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorSplit};
+
+    .ant-input-affix-wrapper {
+      padding-inline: 0;
+    }
+
+    .ant-input-prefix {
+      margin-inline-end: 8px;
+    }
   `,
   refreshButton: css`
     cursor: pointer;
@@ -135,8 +150,8 @@ const styles = createStaticStyles(({ css }) => ({
     gap: 4px;
     align-items: center;
 
-    padding-block: 6px 2px;
-    padding-inline: 10px;
+    padding-block: 4px 2px;
+    padding-inline: 8px;
   `,
   spinning: css`
     animation: branch-switcher-spin 0.8s linear infinite;
@@ -262,8 +277,9 @@ const BranchSwitcher = memo<BranchSwitcherProps>(
                     prefix={<Icon icon={SearchIcon} size={14} />}
                     size="small"
                     value={search}
-                    variant="filled"
+                    variant="borderless"
                     onChange={(e) => setSearch(e.target.value)}
+                    onKeyDown={(e) => e.stopPropagation()}
                   />
                 </div>
 
@@ -345,6 +361,7 @@ const BranchSwitcher = memo<BranchSwitcherProps>(
                       value={newBranch}
                       variant="filled"
                       onChange={(e) => setNewBranch(e.target.value)}
+                      onKeyDown={(e) => e.stopPropagation()}
                       onPressEnter={handleCreateSubmit}
                     />
                     <Button
@@ -370,7 +387,7 @@ const BranchSwitcher = memo<BranchSwitcherProps>(
                 ) : (
                   <div className={styles.createItemWrapper}>
                     <DropdownMenuItem
-                      className={styles.item}
+                      className={cx(styles.item, styles.createItem)}
                       closeOnClick={false}
                       onClick={() => setIsCreating(true)}
                     >

--- a/src/features/ChatInput/RuntimeConfig/WorkingDirectory.tsx
+++ b/src/features/ChatInput/RuntimeConfig/WorkingDirectory.tsx
@@ -84,6 +84,10 @@ const styles = createStaticStyles(({ css }) => ({
       background: ${cssVar.colorFillSecondary};
     }
   `,
+  scrollContainer: css`
+    overflow-y: auto;
+    max-height: 360px;
+  `,
   sectionTitle: css`
     padding-block: 6px 2px;
     padding-inline: 8px;
@@ -213,50 +217,52 @@ const WorkingDirectoryContent = memo<WorkingDirectoryContentProps>(({ agentId, o
   return (
     <Flexbox gap={4} style={{ minWidth: 280 }}>
       <div className={styles.sectionTitle}>{t('localSystem.workingDirectory.recent')}</div>
-      {displayDirs.length === 0 ? (
-        <Flexbox
-          align={'center'}
-          justify={'center'}
-          style={{ color: cssVar.colorTextQuaternary, fontSize: 12, padding: '12px 8px' }}
-        >
-          {t('localSystem.workingDirectory.noRecent')}
-        </Flexbox>
-      ) : (
-        displayDirs.map((entry) => {
-          const isActive = entry.path === effectiveDir;
-          return (
-            <Flexbox
-              horizontal
-              align={'center'}
-              className={`${styles.dirItem} ${isActive ? styles.dirItemActive : ''}`}
-              gap={8}
-              key={entry.path}
-              onClick={() => selectDir(entry)}
-            >
-              <RecentDirIcon entry={entry} />
-              <Flexbox flex={1} style={{ minWidth: 0 }}>
-                <div className={styles.dirName}>{getDirName(entry.path)}</div>
-                <div className={styles.dirPath}>{entry.path}</div>
+      <div className={styles.scrollContainer}>
+        {displayDirs.length === 0 ? (
+          <Flexbox
+            align={'center'}
+            justify={'center'}
+            style={{ color: cssVar.colorTextQuaternary, fontSize: 12, padding: '12px 8px' }}
+          >
+            {t('localSystem.workingDirectory.noRecent')}
+          </Flexbox>
+        ) : (
+          displayDirs.map((entry) => {
+            const isActive = entry.path === effectiveDir;
+            return (
+              <Flexbox
+                horizontal
+                align={'center'}
+                className={`${styles.dirItem} ${isActive ? styles.dirItemActive : ''}`}
+                gap={8}
+                key={entry.path}
+                onClick={() => selectDir(entry)}
+              >
+                <RecentDirIcon entry={entry} />
+                <Flexbox flex={1} style={{ minWidth: 0 }}>
+                  <div className={styles.dirName}>{getDirName(entry.path)}</div>
+                  <div className={styles.dirPath}>{entry.path}</div>
+                </Flexbox>
+                {isActive ? (
+                  <Icon
+                    icon={CheckIcon}
+                    size={16}
+                    style={{ color: cssVar.colorSuccess, flex: 'none' }}
+                  />
+                ) : (
+                  <div
+                    className={styles.removeBtn}
+                    title={t('localSystem.workingDirectory.removeRecent')}
+                    onClick={(e) => handleRemoveRecent(e, entry.path)}
+                  >
+                    <Icon icon={XIcon} size={12} />
+                  </div>
+                )}
               </Flexbox>
-              {isActive ? (
-                <Icon
-                  icon={CheckIcon}
-                  size={16}
-                  style={{ color: cssVar.colorSuccess, flex: 'none' }}
-                />
-              ) : (
-                <div
-                  className={styles.removeBtn}
-                  title={t('localSystem.workingDirectory.removeRecent')}
-                  onClick={(e) => handleRemoveRecent(e, entry.path)}
-                >
-                  <Icon icon={XIcon} size={12} />
-                </div>
-              )}
-            </Flexbox>
-          );
-        })
-      )}
+            );
+          })
+        )}
+      </div>
 
       {isDesktop && (
         <Flexbox

--- a/src/features/ChatInput/RuntimeConfig/recentDirs.ts
+++ b/src/features/ChatInput/RuntimeConfig/recentDirs.ts
@@ -1,5 +1,5 @@
 export const RECENT_DIRS_KEY = 'lobechat-recent-working-directories';
-export const MAX_RECENT_DIRS = 5;
+export const MAX_RECENT_DIRS = 20;
 
 export interface RecentDirEntry {
   path: string;


### PR DESCRIPTION
## Summary
- `MAX_RECENT_DIRS` 5 → 20，扩大最近工作目录记录上限
- 目录列表外层加 scroll container（`max-height: 360px` + `overflow-y: auto`），底部"选择其他文件夹"按钮永驻可视区外

## Test plan
- [ ] 桌面端 WorkingDirectory popover 可展示最多 20 条最近目录
- [ ] 超过可视高度时出现纵向滚动条
- [ ] "选择其他文件夹"按钮始终可见，不随列表滚动