### PR TITLE
Add Twitter to recommended skills

### DIFF
--- a/packages/const/src/recommendedSkill.ts
+++ b/packages/const/src/recommendedSkill.ts
@@ -17,6 +17,8 @@ export const RECOMMENDED_SKILLS: RecommendedSkillItem[] = [
   { id: 'lobe-gtd', type: RecommendedSkillType.Builtin },
   { id: 'lobe-agent-documents', type: RecommendedSkillType.Builtin },
   { id: 'lobe-message', type: RecommendedSkillType.Builtin },
+  // LobeHub skills
+  { id: 'twitter', type: RecommendedSkillType.Lobehub },
   // Klavis skills
   { id: 'gmail', type: RecommendedSkillType.Klavis },
   { id: 'notion', type: RecommendedSkillType.Klavis },


### PR DESCRIPTION
## Summary
- Add `twitter` to the default recommended skill list as a LobeHub integration
- Ensure X (Twitter) appears alongside the other no-install, OAuth-only recommended skills

## Testing
- Not run (not requested)