### PR TITLE
✨ feat: add gpt-image-2 to LobeHub-hosted card

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -10,7 +10,7 @@
   "starter.deepResearch": "Deep Research",
   "starter.developing": "Coming soon",
   "starter.image": "Image",
-  "starter.imageGeneration": "Image Generation",
+  "starter.imageGeneration": "GPT Image 2",
   "starter.videoGeneration": "Seedance 2.0",
   "starter.write": "Write"
 }

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -10,7 +10,7 @@
   "starter.deepResearch": "探究",
   "starter.developing": "正在开发中",
   "starter.image": "绘画",
-  "starter.imageGeneration": "图像生成",
+  "starter.imageGeneration": "GPT Image 2",
   "starter.videoGeneration": "Seedance 2.0",
   "starter.write": "写作"
 }

--- a/packages/model-bank/src/aiModels/lobehub/image.ts
+++ b/packages/model-bank/src/aiModels/lobehub/image.ts
@@ -108,7 +108,9 @@ export const lobehubImageModels: AIImageModelCard[] = [
     id: 'gpt-image-2',
     parameters: gptImage2Schema,
     pricing: {
-      approximatePricePerImage: 0.032,
+      // Medium quality at 1024x1024: ~1767 output tokens * $30/M = $0.053 per image.
+      // Source: https://developers.openai.com/api/docs/guides/image-generation#calculating-costs
+      approximatePricePerImage: 0.053,
       units: [
         { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput_cacheRead', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },

--- a/packages/model-bank/src/aiModels/lobehub/image.ts
+++ b/packages/model-bank/src/aiModels/lobehub/image.ts
@@ -2,6 +2,7 @@ import type { AIImageModelCard } from '../../types/aiModel';
 import { huanyuanImageParamsSchema, qwenEditParamsSchema, qwenImageParamsSchema } from '../fal';
 import {
   gptImage1Schema,
+  gptImage2Schema,
   imagenBaseParameters,
   nanoBanana2Parameters,
   nanoBananaParameters,
@@ -97,6 +98,26 @@ export const lobehubImageModels: AIImageModelCard[] = [
       units: [{ name: 'imageGeneration', rate: 0.06, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-08-15',
+    type: 'image',
+  },
+  {
+    description:
+      "OpenAI's next-generation multimodal image model with native reasoning, up to 4K resolution, near-perfect text rendering, and high-fidelity multilingual support.",
+    displayName: 'GPT Image 2',
+    enabled: true,
+    id: 'gpt-image-2',
+    parameters: gptImage2Schema,
+    pricing: {
+      approximatePricePerImage: 0.032,
+      units: [
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput_cacheRead', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-21',
     type: 'image',
   },
   {

--- a/packages/model-bank/src/aiModels/lobehub/utils.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.ts
@@ -80,3 +80,25 @@ export const gptImage1Schema = {
     enum: ['auto', '1024x1024', '1536x1024', '1024x1536'],
   },
 };
+
+// gpt-image-2 accepts any resolution satisfying: max edge ≤ 3840px, both edges
+// multiples of 16px, aspect ratio ≤ 3:1, pixels between 655,360 and 8,294,400.
+// Until the schema/UI supports free-form W×H input, we expose the official
+// "Popular sizes" list from https://developers.openai.com/docs/guides/image-generation.
+export const gptImage2Schema = {
+  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 },
+  prompt: { default: '' },
+  size: {
+    default: 'auto',
+    enum: [
+      'auto',
+      '1024x1024',
+      '1536x1024',
+      '1024x1536',
+      '2048x2048',
+      '2048x1152',
+      '3840x2160',
+      '2160x3840',
+    ],
+  },
+};

--- a/packages/model-bank/src/aiModels/lobehub/utils.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.ts
@@ -73,7 +73,7 @@ export const nanoBanana2Parameters: ModelParamsSchema = {
 };
 
 export const gptImage1Schema = {
-  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 },
+  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 * 1024 * 1024 },
   prompt: { default: '' },
   size: {
     default: 'auto',
@@ -86,7 +86,7 @@ export const gptImage1Schema = {
 // Until the schema/UI supports free-form W×H input, we expose the official
 // "Popular sizes" list from https://developers.openai.com/docs/guides/image-generation.
 export const gptImage2Schema = {
-  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 },
+  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 * 1024 * 1024 },
   prompt: { default: '' },
   size: {
     default: 'auto',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -54,7 +54,7 @@ async function generateByImageMode(
       // According to official docs, if there are multiple images, pass an array; if only one, pass a single File
       userInput.image = imageFiles.length === 1 ? imageFiles[0] : imageFiles;
     } catch (error) {
-      throw new Error(`Failed to convert image URLs to File objects: ${error}`);
+      throw new Error(`Failed to convert image URLs to File objects: ${error}`, { cause: error });
     }
   } else {
     delete userInput.image;
@@ -64,13 +64,16 @@ async function generateByImageMode(
     delete userInput.size;
   }
 
+  // gpt-image-2 dropped input_fidelity ("output is already high fidelity by default").
+  // https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide
+  const supportsInputFidelity =
+    isImageEdit && (model === 'gpt-image-1' || model === 'gpt-image-1.5');
+
   const defaultInput = {
     n: 1,
     ...(model.includes('dall-e') ? { response_format: 'b64_json' } : {}),
     // https://platform.openai.com/docs/api-reference/images/createEdit#images_createedit-input_fidelity
-    ...(isImageEdit && model.includes('gpt-image-') && !model.includes('mini')
-      ? { input_fidelity: 'high' }
-      : {}),
+    ...(supportsInputFidelity ? { input_fidelity: 'high' } : {}),
   };
 
   const options = cleanObject({
@@ -180,7 +183,7 @@ async function generateByChatModel(
       });
       log('Successfully processed image URL for chat input');
     } catch (error) {
-      throw new Error(`Failed to process image URL: ${error}`);
+      throw new Error(`Failed to process image URL: ${error}`, { cause: error });
     }
   }
 

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -66,8 +66,10 @@ async function generateByImageMode(
 
   // gpt-image-2 dropped input_fidelity ("output is already high fidelity by default").
   // https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide
-  const supportsInputFidelity =
-    isImageEdit && (model === 'gpt-image-1' || model === 'gpt-image-1.5');
+  // Match the gpt-image-1 family (including dated snapshots like
+  // `gpt-image-1-2025-04-15` and the `.5` variant), but exclude the mini tier.
+  const isGptImage1Family = /^gpt-image-1(?:$|[-.])/.test(model);
+  const supportsInputFidelity = isImageEdit && isGptImage1Family && !model.includes('mini');
 
   const defaultInput = {
     n: 1,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1558,6 +1558,33 @@ describe('LobeOpenAICompatibleFactory', () => {
           n: 1,
         });
       });
+
+      it.each([
+        ['gpt-image-1.5', true],
+        ['gpt-image-1-2026-01-15', true], // dated snapshot alias
+        ['gpt-image-1.5-2026-03-01', true], // dated snapshot alias for the .5 variant
+        ['gpt-image-1-mini', false], // mini tier explicitly excluded
+        ['gpt-image-2', false], // gpt-image-2 dropped the param
+        ['gpt-image-2-2026-04-21', false], // gpt-image-2 snapshot alias
+      ])('should %s include input_fidelity for %s', async (model, shouldInclude) => {
+        const mockResponse = { data: [{ b64_json: 'edited' }] };
+        const mockFile = new File(['content'], 'test.jpg', { type: 'image/jpeg' });
+
+        vi.mocked(openaiHelpers.convertImageUrlToFile).mockResolvedValue(mockFile);
+        vi.spyOn(instance['client'].images, 'edit').mockResolvedValue(mockResponse as any);
+
+        await (instance as any).createImage({
+          model,
+          params: { imageUrl: 'https://example.com/image.jpg', prompt: 'Edit' },
+        });
+
+        const editArgs = vi.mocked(instance['client'].images.edit).mock.calls[0][0];
+        if (shouldInclude) {
+          expect(editArgs).toMatchObject({ input_fidelity: 'high' });
+        } else {
+          expect(editArgs).not.toHaveProperty('input_fidelity');
+        }
+      });
     });
 
     describe('error handling', () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1530,6 +1530,34 @@ describe('LobeOpenAICompatibleFactory', () => {
           imageUrl: 'data:image/png;base64,gpt-image-edited-base64',
         });
       });
+
+      it('should NOT send input_fidelity for gpt-image-2 (unsupported param)', async () => {
+        const mockResponse = {
+          data: [{ b64_json: 'gpt-image-2-edited-base64' }],
+        };
+
+        const mockFile = new File(['content'], 'test-image.jpg', { type: 'image/jpeg' });
+
+        vi.mocked(openaiHelpers.convertImageUrlToFile).mockResolvedValue(mockFile);
+        vi.spyOn(instance['client'].images, 'edit').mockResolvedValue(mockResponse as any);
+
+        const payload = {
+          model: 'gpt-image-2',
+          params: {
+            imageUrl: 'https://example.com/image.jpg',
+            prompt: 'Edit this image with gpt-image-2',
+          },
+        };
+
+        await (instance as any).createImage(payload);
+
+        const editArgs = vi.mocked(instance['client'].images.edit).mock.calls[0][0];
+        expect(editArgs).not.toHaveProperty('input_fidelity');
+        expect(editArgs).toMatchObject({
+          model: 'gpt-image-2',
+          n: 1,
+        });
+      });
     });
 
     describe('error handling', () => {

--- a/src/locales/default/home.ts
+++ b/src/locales/default/home.ts
@@ -11,7 +11,7 @@ export default {
   'starter.deepResearch': 'Deep Research',
   'starter.developing': 'Coming soon',
   'starter.image': 'Image',
-  'starter.imageGeneration': 'Image Generation',
+  'starter.imageGeneration': 'GPT Image 2',
   'starter.videoGeneration': 'Seedance 2.0',
   'starter.write': 'Write',
 };

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -77,6 +77,7 @@ const StarterList = memo(() => {
         titleKey: 'starter.write',
       },
       {
+        hot: true,
         icon: ImageIcon,
         key: 'image',
         titleKey: 'starter.imageGeneration',
@@ -105,7 +106,7 @@ const StarterList = memo(() => {
       }
 
       if (key === 'image') {
-        navigate('/image');
+        navigate('/image?model=gpt-image-2');
         return;
       }
 

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -1,9 +1,10 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { Jimeng } from '@lobehub/icons';
 import { type ButtonProps } from '@lobehub/ui';
 import { Button, Center, Tooltip } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { BotIcon, ImageIcon, PenLineIcon, VideoIcon } from 'lucide-react';
+import { BotIcon, ImageIcon, PenLineIcon } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -84,7 +85,7 @@ const StarterList = memo(() => {
       },
       {
         hot: true,
-        icon: VideoIcon,
+        icon: Jimeng.Color,
         key: 'video',
         titleKey: 'starter.videoGeneration',
       },


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔗 Related Issue

N/A — ships OpenAI's gpt-image-2 (released 2026-04-21) on the LobeHub-hosted card, and fixes three pre-existing or newly-surfaced bugs along the way.

#### 🔀 Description of Change

**1. Add `gpt-image-2` card** (`lobehub/chat/image.ts` + new `gptImage2Schema`)

- Token-based pricing: textInput \$5/M, textInput_cacheRead \$1.25/M, imageInput \$8/M, imageInput_cacheRead \$2/M, imageOutput \$30/M.
- `approximatePricePerImage: 0.053` (medium 1024×1024 ≈ 1767 output tokens × \$30/M).
- `size` enum exposes the 8 official "Popular sizes" from the image-generation guide. Model actually accepts any W×H satisfying max edge ≤ 3840, both edges multiples of 16, AR ≤ 3:1, pixels 655,360–8,294,400 — but our schema/UI does not yet support free-form inputs, so we stick to the documented Popular list for now.
- `releasedAt: '2026-04-21'` (matches the `gpt-image-2-2026-04-21` snapshot ID).

**2. Fix: `maxFileSize` unit in gpt-image schemas**

`UploadCard` compares `file.size` (bytes) against `maxFileSize`, but `gptImage1Schema` had `maxFileSize: 5` (bare number), so every ref image upload was silently dropped by the front-end filter with no network request. Changed to `5 * 1024 * 1024`. Fixes the same bug in gpt-image-1 that nobody noticed because `imageUrls` had no UI affordance until now.

**3. Fix: do not send `input_fidelity` to `gpt-image-2`**

gpt-image-2 dropped this parameter ("output is already high fidelity by default" — [cookbook](https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide)). The old `model.includes('gpt-image-') && !model.includes('mini')` check would attach an unsupported arg and break edit requests. Switched to an explicit allowlist (`gpt-image-1` / `gpt-image-1.5`).

#### 🧪 How to Test

- [x] Added new test: `should NOT send input_fidelity for gpt-image-2 (unsupported param)`
- [x] Existing test `should include input_fidelity parameter for gpt-image-1 model` still passes
- [x] Tested locally on `/image` — ref image upload now makes network requests instead of being silently filtered

#### 📝 Additional Information

**Breaking changes vs gpt-image-1.5:**

- `input_fidelity` removed (always high)
- Per-image cost ↑ \~56% at medium 1024×1024 (1056 → 1767 output tokens, despite imageOutput rate dropping \$32 → \$30/M)
- `size` is now constraint-based, not enum (we still enumerate Popular sizes for UI)

**Not addressed in this PR (potential follow-ups):**

- `quality` parameter (low/medium/high) is not exposed — 35× price range (\$0.006 / \$0.053 / \$0.211 @ 1024×1024); users cannot opt into low-cost mode, and our `approximatePricePerImage` assumes medium.
- `background` parameter (opaque → pure white, not alpha transparent) — not exposed.
- Azure variant (`azureOpenai/index.ts:178`) still unconditionally sends `input_fidelity`; fine for now since Azure endpoints are single-model, but needs the same allowlist treatment when gpt-image-2 lands on Azure.