### PR TITLE
🐛 fix(mobile): correct session list skeleton row layout

### DIFF
--- a/src/routes/(mobile)/(home)/features/SkeletonList.tsx
+++ b/src/routes/(mobile)/(home)/features/SkeletonList.tsx
@@ -49,7 +49,7 @@ const SkeletonList = memo<SkeletonListProps>(({ count = 4 }) => {
   return (
     <Flexbox gap={4}>
       {Array.from({ length: count }).map((_, index) => (
-        <Flexbox className={styles.item} key={index}>
+        <Flexbox horizontal align="center" className={styles.item} gap={12} key={index}>
           <Skeleton.Avatar
             active
             shape="square"


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The `SkeletonList` used for the mobile Home session list rendered each row as **column** instead of **row**, causing only the avatar squares to be visible while the title/paragraph lines collapsed to zero width.

Root cause: `@lobehub/ui`'s `<Flexbox>` defaults `--lobe-flex-direction: column` via the `.lobe-flex` global base style. The component relied on CSS-side `display: flex; align-items: center;` which doesn't override the inherited `flex-flow: column nowrap`. The surrounding \`flex: 1\` inner wrapper then shared only vertical space, collapsing the skeleton text rows.

Fix: pass `horizontal` to the row container (plus move `align`/`gap` to `Flexbox` props so they always win over the base class).

| Before | After |
| ------ | ----- |
| Only avatar squares, vertically centered | Avatar + title/paragraph skeleton lines in a proper row |

#### 🧪 How to Test

- [x] Tested locally on mobile SPA via the debug proxy (`app.lobehub.com/_dangerous_local_dev_proxy`), session list skeleton now renders correctly
- [ ] No tests needed

#### 📝 Additional Information

The cloud-side mobile SPA is served from a S3-hosted bundle (cloud repo's \`workflow:mobile-spa\`). After this PR lands on canary, the cloud side needs a follow-up bundle rebuild for the fix to hit production.