### PR TITLE
🐛 fix(desktop): add Linux icon configuration to electron-builder

### DIFF
--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -255,6 +255,7 @@ const config = {
   generateUpdatesFilesForAllChannels: true,
   linux: {
     category: 'Utility',
+    icon: 'build/icon.png',
     maintainer: 'electronjs.org',
     target: ['AppImage', 'snap', 'deb', 'rpm', 'tar.gz'],
   },


### PR DESCRIPTION
## Summary
- Add `icon: 'build/icon.png'` to the Linux target config in `electron-builder.mjs`
- Fixes missing application icon on Ubuntu when installed via `.deb` package

## Test plan
- [x] Build Linux `.deb` package and verify icon appears in application launcher
- [x] Verify AppImage also shows correct icon

Closes #9785