### PR TITLE
🔥 fix: remove promotional video starter and desktop app download ads

### DIFF
--- a/src/features/User/UserPanel/useMenu.tsx
+++ b/src/features/User/UserPanel/useMenu.tsx
@@ -1,10 +1,10 @@
 import { LOBE_CHAT_CLOUD, UTM_SOURCE } from '@lobechat/business-const';
-import { DOWNLOAD_URL, isDesktop } from '@lobechat/const';
+import { isDesktop } from '@lobechat/const';
 import { Flexbox, Hotkey, Icon, Tag } from '@lobehub/ui';
 import { type ItemType } from 'antd/es/menu/interface';
-import { BrainCircuit, Cloudy, Download, HardDriveDownload, LogOut, Settings2 } from 'lucide-react';
+import { BrainCircuit, Cloudy, HardDriveDownload, LogOut, Settings2 } from 'lucide-react';
 import { type PropsWithChildren } from 'react';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
@@ -14,7 +14,6 @@ import { DEFAULT_DESKTOP_HOTKEY_CONFIG } from '@/const/desktop';
 import { OFFICIAL_URL } from '@/const/url';
 import DataImporter from '@/features/DataImporter';
 import { useNavLayout } from '@/hooks/useNavLayout';
-import { usePlatform } from '@/hooks/usePlatform';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
@@ -55,13 +54,6 @@ export const useMenu = () => {
   ]);
   const { userPanel } = useNavLayout();
   const businessMenuItems = useBusinessMenuItems(isLogin);
-  const { isIOS, isAndroid } = usePlatform();
-
-  const downloadUrl = useMemo(() => {
-    if (isIOS) return DOWNLOAD_URL.ios;
-    if (isAndroid) return DOWNLOAD_URL.android;
-    return DOWNLOAD_URL.default;
-  }, [isIOS, isAndroid]);
 
   const settings: MenuProps['items'] = [
     {
@@ -89,18 +81,6 @@ export const useMenu = () => {
       : []),
   ];
 
-  const getDesktopApp: MenuProps['items'] = [
-    {
-      icon: <Icon icon={Download} />,
-      key: 'get-desktop-app',
-      label: (
-        <a href={downloadUrl} rel="noopener noreferrer" target="_blank">
-          {t('getDesktopApp')}
-        </a>
-      ),
-    },
-  ];
-
   const helps: MenuProps['items'] = [
     showCloudPromotion && {
       icon: <Icon icon={Cloudy} />,
@@ -124,7 +104,7 @@ export const useMenu = () => {
 
     ...(isLogin ? settings : []),
     ...businessMenuItems,
-    ...(!isDesktop ? [{ type: 'divider' as const }, ...getDesktopApp] : []),
+
     ...(userPanel.showDataImporter && isLogin
       ? [
           {

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -1,5 +1,5 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
-import { Jimeng } from '@lobehub/icons';
+
 import { type ButtonProps } from '@lobehub/ui';
 import { Button, Center, Tooltip } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
@@ -35,9 +35,7 @@ type StarterTitleKey =
   | 'starter.createAgent'
   | 'starter.createGroup'
   | 'starter.write'
-  | 'starter.imageGeneration'
-  | 'starter.videoGeneration'
-  | 'starter.deepResearch';
+  | 'starter.imageGeneration';
 
 interface StarterItem {
   disabled?: boolean;
@@ -83,12 +81,7 @@ const StarterList = memo(() => {
         key: 'image',
         titleKey: 'starter.imageGeneration',
       },
-      {
-        hot: true,
-        icon: Jimeng.Color,
-        key: 'video',
-        titleKey: 'starter.videoGeneration',
-      },
+
       // {
       //   disabled: true,
       //   icon: MicroscopeIcon,
@@ -101,11 +94,6 @@ const StarterList = memo(() => {
 
   const handleClick = useCallback(
     (key: StarterMode) => {
-      if (key === 'video') {
-        navigate('/video?model=doubao-seedance-2-0-260128');
-        return;
-      }
-
       if (key === 'image') {
         navigate('/image?model=gpt-image-2');
         return;

--- a/src/routes/(mobile)/me/(home)/features/useCategory.tsx
+++ b/src/routes/(mobile)/me/(home)/features/useCategory.tsx
@@ -1,22 +1,19 @@
 import { LOBE_CHAT_CLOUD, UTM_SOURCE } from '@lobechat/business-const';
-import { DOWNLOAD_URL, OFFICIAL_URL } from '@lobechat/const';
+import { OFFICIAL_URL } from '@lobechat/const';
 import {
   Book,
   CircleUserRound,
   Cloudy,
-  Download,
   Feather,
   FileClockIcon,
   Settings2,
 } from 'lucide-react';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
-import useBusinessMeCells from '@/business/client/features/User/useBusinessMeCells';
+
 import { type CellProps } from '@/components/Cell';
 import { DOCUMENTS, FEEDBACK } from '@/const/index';
-import { usePlatform } from '@/hooks/usePlatform';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
@@ -26,14 +23,6 @@ export const useCategory = (onOpenChangelogModal: () => void) => {
   const { t } = useTranslation(['common', 'setting', 'auth']);
   const { showCloudPromotion, hideDocs } = useServerConfigStore(featureFlagsSelectors);
   const [isLoginWithAuth] = useUserStore((s) => [authSelectors.isLoginWithAuth(s)]);
-  const { isIOS, isAndroid } = usePlatform();
-  const businessMeCells = useBusinessMeCells();
-
-  const downloadUrl = useMemo(() => {
-    if (isIOS) return DOWNLOAD_URL.ios;
-    if (isAndroid) return DOWNLOAD_URL.android;
-    return DOWNLOAD_URL.default;
-  }, [isIOS, isAndroid]);
 
   const profile: CellProps[] = [
     {
@@ -50,18 +39,6 @@ export const useCategory = (onOpenChangelogModal: () => void) => {
       key: 'setting',
       label: t('userPanel.setting'),
       onClick: () => navigate('/me/settings'),
-    },
-    {
-      type: 'divider',
-    },
-  ];
-
-  const getDesktopApp: CellProps[] = [
-    {
-      icon: Download,
-      key: 'get-desktop-app',
-      label: t('getDesktopApp'),
-      onClick: () => window.open(downloadUrl, '__blank'),
     },
     {
       type: 'divider',
@@ -101,8 +78,6 @@ export const useCategory = (onOpenChangelogModal: () => void) => {
     },
     ...(isLoginWithAuth ? profile : []),
     ...(isLoginWithAuth ? settings : []),
-    ...(isLoginWithAuth ? businessMeCells : []),
-    ...getDesktopApp,
     ...(!hideDocs ? helps : []),
   ].filter(Boolean) as CellProps[];
 


### PR DESCRIPTION
## Change Type

- [x] 🔥 Remove feature / code cleanup

## Description of Change

Remove promotional/advertising elements from the UI:

- **StarterList**: Remove video generation starter item (Jimeng/即梦) and its associated route handler
- **useCategory (mobile)**: Remove desktop app download link and business me cells
- **useMenu (desktop)**: Remove desktop app download menu item and related platform/download URL logic

Also cleans up unused imports (`Jimeng`, `Download`, `useMemo`, `usePlatform`, `DOWNLOAD_URL`, `useBusinessMeCells`) and type references (`starter.videoGeneration`, `starter.deepResearch`).

## How to Test

- [x] Verified StarterList renders without the video starter button
- [x] Verified mobile me/home page no longer shows download app entry
- [x] Verified desktop user panel menu no longer shows "Get Desktop App"
- [x] No type errors from removed imports/types