### PR TITLE
🐛 fix: preserve scroll position when switching sessions

### DIFF
--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -85,8 +85,6 @@ const StoreUpdater = memo<StoreUpdaterProps>(
         // when calling onMessagesChange (otherwise writes to the old topic key)
         storeApi.setState({
           context,
-          dbMessages: messages ?? [],
-          displayMessages: [],
           messagesInit: false,
         });
 
@@ -94,6 +92,8 @@ const StoreUpdater = memo<StoreUpdaterProps>(
         if (messages) {
           storeApi.getState().replaceMessages(messages);
           storeApi.setState({ messagesInit: true });
+        } else {
+          storeApi.setState({ dbMessages: [], displayMessages: [] });
         }
       }
     }, [contextKey]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- When switching between topics/sessions, `displayMessages` was cleared to empty before `replaceMessages` was called
- This caused the virtual list to reset its scroll position to the bottom, losing the user's reading position
- Now `replaceMessages` is called directly without clearing first, preserving the scroll position
- Empty state is only set when no messages are available (loading state)

## Test plan
- [ ] Switch between sessions with messages - scroll position should be preserved
- [ ] Open a new session - should show empty state
- [ ] Delete a message and switch sessions - no scroll jitter

Closes #4984