### PR TITLE
:sparkles: feat(desktop): add process registry with task-manager settings tab

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "@lobechat/electron-server-ipc": "workspace:*",
     "@lobechat/file-loaders": "workspace:*",
     "@lobechat/local-file-shell": "workspace:*",
+    "@lobechat/process-registry": "workspace:*",
     "@lobehub/i18n-cli": "^1.25.1",
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@t3-oss/env-core": "^0.13.8",

--- a/apps/desktop/pnpm-workspace.yaml
+++ b/apps/desktop/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - '../../packages/desktop-bridge'
   - '../../packages/device-gateway-client'
   - '../../packages/local-file-shell'
+  - '../../packages/process-registry'
   - './stubs/business-const'
   - './stubs/types'
   - '.'

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -9,6 +9,7 @@ import { app as electronApp, BrowserWindow } from 'electron';
 
 import { buildProxyEnv } from '@/modules/networkProxy/envBuilder';
 import { createLogger } from '@/utils/logger';
+import { processRegistry } from '@/utils/processRegistry';
 
 import { ControllerModule, IpcMethod } from './index';
 
@@ -316,6 +317,22 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
         detached: process.platform !== 'win32',
         env: { ...process.env, ...proxyEnv, ...session.env },
         stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      });
+
+      // Expose this spawn in the task-manager IPC. Tagging with `sessionId`
+      // lets the UI (and registry-based kill filters) group all invocations
+      // of the same agent session together. `cancellationGracePeriod` is
+      // intentionally unset — cancel/stop paths below still drive the
+      // registry-side status through `process.kill(-pgid)`.
+      processRegistry.register({
+        args: cliArgs,
+        command: session.command,
+        process: proc,
+        tags: {
+          agentType: session.agentType,
+          ownerModule: 'heteroAgent',
+          sessionId: session.sessionId,
+        },
       });
 
       // In stdin mode, write the stream-json message and close stdin.

--- a/apps/desktop/src/main/controllers/ProcessManagerCtr.ts
+++ b/apps/desktop/src/main/controllers/ProcessManagerCtr.ts
@@ -1,0 +1,80 @@
+import type {
+  KillProcessParams,
+  KillProcessResult,
+  ListProcessesParams,
+  ListProcessesResult,
+  ProcessInfo,
+} from '@lobechat/electron-client-ipc';
+import type { ProcessRegistryEvent, RegisteredProcess } from '@lobechat/process-registry';
+import { app as electronApp } from 'electron';
+
+import { createLogger } from '@/utils/logger';
+import { processRegistry } from '@/utils/processRegistry';
+
+import { ControllerModule, IpcMethod } from './index';
+
+const logger = createLogger('controllers:ProcessManagerCtr');
+
+function toInfo(p: RegisteredProcess): ProcessInfo {
+  return {
+    args: p.args,
+    command: p.command,
+    exitCode: p.exitCode,
+    exitedAt: p.exitedAt,
+    ownerModule: p.tags.ownerModule,
+    pgid: p.pgid,
+    pid: p.pid,
+    sessionId: p.tags.sessionId,
+    shellId: p.shellId,
+    startedAt: p.startedAt,
+    status: p.status,
+    tags: p.tags,
+    toolCallId: p.tags.toolCallId,
+    topicId: p.tags.topicId,
+  };
+}
+
+export default class ProcessManagerCtr extends ControllerModule {
+  static override readonly groupName = 'processManager';
+
+  afterAppReady() {
+    processRegistry.subscribe((event: ProcessRegistryEvent) => {
+      try {
+        this.app.browserManager.broadcastToAllWindows('processManagerChanged', {
+          process: toInfo(event.process),
+          type: event.type,
+        });
+      } catch (err) {
+        logger.warn('Failed to broadcast process event:', err);
+      }
+    });
+
+    // Detached unix children survive main-process death; explicitly sweep
+    // them on normal quit so a user-initiated exit doesn't leak processes.
+    electronApp.on('before-quit', () => {
+      const running = processRegistry.list({ status: 'running' });
+      if (running.length === 0) return;
+      logger.info(`Cleaning up ${running.length} tracked processes on quit`);
+      processRegistry.cleanupAll('SIGTERM');
+    });
+  }
+
+  @IpcMethod()
+  async listProcesses(params: ListProcessesParams = {}): Promise<ListProcessesResult> {
+    const processes = processRegistry.list(params).map(toInfo);
+    return { processes };
+  }
+
+  @IpcMethod()
+  async killProcess(params: KillProcessParams): Promise<KillProcessResult> {
+    try {
+      const killedShellIds = processRegistry.kill(params);
+      logger.info('Killed processes:', { filter: params, killedShellIds });
+      return { killedShellIds, success: true };
+    } catch (error) {
+      const message = (error as Error).message;
+      logger.warn('killProcess refused:', message);
+      return { error: message, killedShellIds: [], success: false };
+    }
+  }
+}

--- a/apps/desktop/src/main/controllers/ShellCommandCtr.ts
+++ b/apps/desktop/src/main/controllers/ShellCommandCtr.ts
@@ -9,13 +9,14 @@ import type {
 import { runCommand, ShellProcessManager } from '@lobechat/local-file-shell';
 
 import { createLogger } from '@/utils/logger';
+import { processRegistry } from '@/utils/processRegistry';
 
 import CliCtr from './CliCtr';
 import { ControllerModule, IpcMethod } from './index';
 
 const logger = createLogger('controllers:ShellCommandCtr');
 
-const processManager = new ShellProcessManager();
+const processManager = new ShellProcessManager({ registry: processRegistry });
 
 /** Prefix for a simple `lh`/`lobe`/`lobehub` invocation (keyword + boundary, args via slice). */
 const SIMPLE_LH_PREFIX = /^\s*(?:lh|lobe|lobehub)(?=\s|$)/;

--- a/apps/desktop/src/main/controllers/__tests__/ProcessManagerCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ProcessManagerCtr.test.ts
@@ -1,0 +1,91 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { App } from '@/core/App';
+import { processRegistry } from '@/utils/processRegistry';
+
+import ProcessManagerCtr from '../ProcessManagerCtr';
+
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('electron', () => ({
+  app: { on: vi.fn() },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+function mkChild(pid: number): ChildProcess {
+  const e = new EventEmitter() as ChildProcess;
+  (e as any).pid = pid;
+  (e as any).kill = vi.fn();
+  return e;
+}
+
+describe('ProcessManagerCtr', () => {
+  let controller: ProcessManagerCtr;
+  const broadcastToAllWindows = vi.fn();
+  const mockApp = { browserManager: { broadcastToAllWindows } } as unknown as App;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Empty the shared registry between tests so state doesn't leak.
+    for (const p of processRegistry.list()) processRegistry.forget(p.shellId);
+    controller = new ProcessManagerCtr(mockApp);
+  });
+
+  afterEach(() => {
+    for (const p of processRegistry.list()) processRegistry.forget(p.shellId);
+  });
+
+  it('listProcesses returns current registry entries as ProcessInfo', async () => {
+    processRegistry.register({
+      command: 'ls',
+      process: mkChild(100),
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+
+    const res = await controller.listProcesses({});
+    expect(res.processes).toHaveLength(1);
+    expect(res.processes[0].topicId).toBe('t1');
+    expect(res.processes[0].ownerModule).toBe('shell');
+  });
+
+  it('listProcesses filters by topicId', async () => {
+    processRegistry.register({
+      command: 'a',
+      process: mkChild(1),
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    processRegistry.register({
+      command: 'b',
+      process: mkChild(2),
+      tags: { ownerModule: 'shell', topicId: 't2' },
+    });
+    const res = await controller.listProcesses({ topicId: 't1' });
+    expect(res.processes).toHaveLength(1);
+    expect(res.processes[0].topicId).toBe('t1');
+  });
+
+  it('killProcess refuses ownerModule-only and returns success: false', async () => {
+    const res = await controller.killProcess({ ownerModule: 'shell' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/ownerModule alone/);
+    expect(res.killedShellIds).toEqual([]);
+  });
+
+  it('killProcess kills by shellId and returns shellIds', async () => {
+    const entry = processRegistry.register({
+      command: 'sleep',
+      process: mkChild(123),
+      tags: { ownerModule: 'shell' },
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const res = await controller.killProcess({ shellId: entry.shellId });
+    expect(res.success).toBe(true);
+    expect(res.killedShellIds).toEqual([entry.shellId]);
+    killSpy.mockRestore();
+  });
+});

--- a/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
@@ -60,8 +60,12 @@ describe('ShellCommandCtr (thin wrapper)', () => {
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
       on: vi.fn(),
+      once: vi.fn(),
       kill: vi.fn(),
       exitCode: null,
+      // pid so process-registry keeps the entry in 'running' state (pid=0 marks
+      // a failed-to-start child and gets auto-exited).
+      pid: 99999,
     };
 
     mockSpawn.mockReturnValue(mockChildProcess);
@@ -111,8 +115,9 @@ describe('ShellCommandCtr (thin wrapper)', () => {
     expect(result.stdout).toContain('bg output');
   });
 
-  it('should delegate handleKillCommand to processManager', async () => {
+  it('should delegate handleKillCommand to processManager (tree-kill via registry)', async () => {
     mockChildProcess.on.mockImplementation(() => mockChildProcess);
+    mockChildProcess.once.mockImplementation(() => mockChildProcess);
     mockChildProcess.stdout.on.mockImplementation(() => mockChildProcess.stdout);
     mockChildProcess.stderr.on.mockImplementation(() => mockChildProcess.stderr);
 
@@ -121,12 +126,20 @@ describe('ShellCommandCtr (thin wrapper)', () => {
       run_in_background: true,
     });
 
+    // The registry takes the tree-kill path: `process.kill(-pgid)` on unix,
+    // `taskkill /T /F` on windows. Spy on `process.kill` instead of the
+    // child's kill method.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
     const result = await ctr.handleKillCommand({
       shell_id: 'test-uuid-123',
     });
 
     expect(result.success).toBe(true);
-    expect(mockChildProcess.kill).toHaveBeenCalled();
+    if (process.platform !== 'win32') {
+      expect(killSpy).toHaveBeenCalled();
+    }
+    killSpy.mockRestore();
   });
 
   it('should route lh commands to CliCtr.runCliCommand', async () => {

--- a/apps/desktop/src/main/controllers/registry.ts
+++ b/apps/desktop/src/main/controllers/registry.ts
@@ -13,6 +13,7 @@ import McpInstallCtr from './McpInstallCtr';
 import MenuController from './MenuCtr';
 import NetworkProxyCtr from './NetworkProxyCtr';
 import NotificationCtr from './NotificationCtr';
+import ProcessManagerCtr from './ProcessManagerCtr';
 import RemoteServerConfigCtr from './RemoteServerConfigCtr';
 import RemoteServerSyncCtr from './RemoteServerSyncCtr';
 import ShellCommandCtr from './ShellCommandCtr';
@@ -37,6 +38,7 @@ export const controllerIpcConstructors = [
   MenuController,
   NetworkProxyCtr,
   NotificationCtr,
+  ProcessManagerCtr,
   RemoteServerConfigCtr,
   RemoteServerSyncCtr,
   ShellCommandCtr,

--- a/apps/desktop/src/main/utils/processRegistry.ts
+++ b/apps/desktop/src/main/utils/processRegistry.ts
@@ -1,0 +1,9 @@
+import { ProcessRegistry } from '@lobechat/process-registry';
+
+/**
+ * Single, main-process-wide registry that tracks every child spawned through
+ * `@lobechat/process-registry`. Consumed by both ShellCommandCtr (as the
+ * tree-kill backend for its ShellProcessManager) and ProcessManagerCtr (to
+ * answer list/kill/subscribe IPC from the renderer).
+ */
+export const processRegistry = new ProcessRegistry();

--- a/apps/desktop/vitest.config.mts
+++ b/apps/desktop/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
       '@': resolve(__dirname, './src/main'),
       '~common': resolve(__dirname, './src/common'),
       '@lobechat/local-file-shell': resolve(__dirname, '../../packages/local-file-shell/src'),
+      '@lobechat/process-registry': resolve(__dirname, '../../packages/process-registry/src'),
     },
     coverage: {
       all: false,

--- a/packages/electron-client-ipc/src/events/index.ts
+++ b/packages/electron-client-ipc/src/events/index.ts
@@ -1,6 +1,7 @@
 import type { ACPBroadcastEvents } from './acp';
 import type { GatewayConnectionBroadcastEvents } from './gatewayConnection';
 import type { NavigationBroadcastEvents } from './navigation';
+import type { ProcessManagerBroadcastEvents } from './processManager';
 import type { ProtocolBroadcastEvents } from './protocol';
 import type { RemoteServerBroadcastEvents } from './remoteServer';
 import type { SystemBroadcastEvents } from './system';
@@ -17,6 +18,7 @@ export interface MainBroadcastEvents
     AutoUpdateBroadcastEvents,
     GatewayConnectionBroadcastEvents,
     NavigationBroadcastEvents,
+    ProcessManagerBroadcastEvents,
     RemoteServerBroadcastEvents,
     SystemBroadcastEvents,
     TopicPopupBroadcastEvents,

--- a/packages/electron-client-ipc/src/events/processManager.ts
+++ b/packages/electron-client-ipc/src/events/processManager.ts
@@ -1,0 +1,8 @@
+import type { ProcessInfo } from '../types/processManager';
+
+export interface ProcessManagerBroadcastEvents {
+  processManagerChanged: (data: {
+    process: ProcessInfo;
+    type: 'registered' | 'exited' | 'killed';
+  }) => void;
+}

--- a/packages/electron-client-ipc/src/types/index.ts
+++ b/packages/electron-client-ipc/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './dataSync';
 export * from './localSystem';
 export * from './mcpInstall';
 export * from './notification';
+export * from './processManager';
 export * from './proxy';
 export * from './proxyTRPCRequest';
 export * from './route';

--- a/packages/electron-client-ipc/src/types/processManager.ts
+++ b/packages/electron-client-ipc/src/types/processManager.ts
@@ -1,0 +1,47 @@
+// ─── Process Manager (spawned child process tracking) ─────────────────────
+
+export type ProcessStatus = 'running' | 'exited' | 'killed';
+
+export interface ProcessInfo {
+  args: string[];
+  command: string;
+  exitCode: number | null;
+  exitedAt?: number;
+  ownerModule: string;
+  pgid?: number;
+  pid: number;
+  sessionId?: string;
+  shellId: string;
+  startedAt: number;
+  status: ProcessStatus;
+  tags: Record<string, string | undefined>;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export interface ListProcessesParams {
+  ownerModule?: string;
+  sessionId?: string;
+  status?: ProcessStatus;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export interface ListProcessesResult {
+  processes: ProcessInfo[];
+}
+
+export interface KillProcessParams {
+  /** One of these must be provided. `ownerModule` alone is rejected. */
+  ownerModule?: string;
+  sessionId?: string;
+  shellId?: string;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export interface KillProcessResult {
+  error?: string;
+  killedShellIds: string[];
+  success: boolean;
+}

--- a/packages/local-file-shell/package.json
+++ b/packages/local-file-shell/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "dependencies": {
     "@lobechat/file-loaders": "workspace:*",
+    "@lobechat/process-registry": "workspace:*",
     "diff": "^8.0.2",
     "fast-glob": "^3.3.3"
   }

--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -1,5 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 
+import { ProcessRegistry } from '@lobechat/process-registry';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ShellProcessManager } from '../process-manager';
@@ -9,6 +11,14 @@ function createMockProcess(exitCode: number | null = null): ChildProcess {
     exitCode,
     kill: vi.fn(),
   } as unknown as ChildProcess;
+}
+
+function createRegistryProcess(pid = 4321): ChildProcess {
+  const emitter = new EventEmitter() as ChildProcess;
+  (emitter as any).pid = pid;
+  (emitter as any).exitCode = null;
+  (emitter as any).kill = vi.fn();
+  return emitter;
 }
 
 describe('ShellProcessManager', () => {
@@ -249,6 +259,57 @@ describe('ShellProcessManager', () => {
 
       // Should not throw
       expect(() => manager.cleanupAll()).not.toThrow();
+    });
+  });
+
+  describe('with ProcessRegistry', () => {
+    it('delegates register to the registry when command + tags are provided', () => {
+      const registry = new ProcessRegistry();
+      const m = new ShellProcessManager({ registry });
+      const child = createRegistryProcess(111);
+
+      m.register(
+        'test-1',
+        { lastReadStderr: 0, lastReadStdout: 0, process: child, stderr: [], stdout: [] },
+        { command: 'ls', tags: { ownerModule: 'shell', topicId: 't1' } },
+      );
+
+      expect(registry.get('test-1')?.tags.topicId).toBe('t1');
+      expect(registry.get('test-1')?.pid).toBe(111);
+    });
+
+    it('skips registry when meta is missing (back-compat)', () => {
+      const registry = new ProcessRegistry();
+      const m = new ShellProcessManager({ registry });
+      const child = createMockProcess();
+      m.register('test-1', {
+        lastReadStderr: 0,
+        lastReadStdout: 0,
+        process: child,
+        stderr: [],
+        stdout: [],
+      });
+      expect(registry.get('test-1')).toBeUndefined();
+    });
+
+    it('kill() delegates to registry.kill (tree-kill path)', () => {
+      const registry = new ProcessRegistry();
+      const m = new ShellProcessManager({ registry });
+      const child = createRegistryProcess(222);
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      m.register(
+        'test-1',
+        { lastReadStderr: 0, lastReadStdout: 0, process: child, stderr: [], stdout: [] },
+        { command: 'sleep', tags: { ownerModule: 'shell' } },
+      );
+      const result = m.kill('test-1');
+
+      expect(result.success).toBe(true);
+      expect(registry.get('test-1')?.status).toBe('killed');
+      // Raw child.kill is NOT used; registry path uses process.kill(-pgid) on unix
+      expect((child as any).kill).not.toHaveBeenCalled();
+      killSpy.mockRestore();
     });
   });
 });

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -1,5 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 
+import type { ProcessRegistry, ProcessTags } from '@lobechat/process-registry';
+
 import type { GetCommandOutputParams, GetCommandOutputResult, KillCommandResult } from '../types';
 import { truncateOutput } from './utils';
 
@@ -11,11 +13,40 @@ export interface ShellProcess {
   stdout: string[];
 }
 
+export interface ShellProcessManagerOptions {
+  /**
+   * When provided, the manager also registers each process with a shared
+   * ProcessRegistry and delegates kill() to it so tree-kill (unix pgid /
+   * windows taskkill /T) is used instead of a plain SIGTERM to the leader.
+   */
+  registry?: ProcessRegistry;
+}
+
+export interface RegisterMetadata {
+  args?: string[];
+  command?: string;
+  tags?: ProcessTags;
+}
+
 export class ShellProcessManager {
   private processes = new Map<string, ShellProcess>();
+  private registry?: ProcessRegistry;
 
-  register(shellId: string, shellProcess: ShellProcess): void {
+  constructor(options: ShellProcessManagerOptions = {}) {
+    this.registry = options.registry;
+  }
+
+  register(shellId: string, shellProcess: ShellProcess, meta?: RegisterMetadata): void {
     this.processes.set(shellId, shellProcess);
+    if (this.registry && meta?.command && meta.tags) {
+      this.registry.register({
+        args: meta.args,
+        command: meta.command,
+        process: shellProcess.process,
+        shellId,
+        tags: meta.tags,
+      });
+    }
   }
 
   getOutput({ shell_id, filter }: GetCommandOutputParams): GetCommandOutputResult {
@@ -68,7 +99,11 @@ export class ShellProcessManager {
     }
 
     try {
-      shellProcess.process.kill();
+      if (this.registry && this.registry.get(shell_id)) {
+        this.registry.kill({ shellId: shell_id });
+      } else {
+        shellProcess.process.kill();
+      }
       this.processes.delete(shell_id);
       return { success: true };
     } catch (error) {
@@ -77,6 +112,11 @@ export class ShellProcessManager {
   }
 
   cleanupAll(): void {
+    if (this.registry) {
+      this.registry.cleanupAll();
+      this.processes.clear();
+      return;
+    }
     for (const [id, sp] of this.processes) {
       try {
         sp.process.kill();

--- a/packages/local-file-shell/src/shell/runner.ts
+++ b/packages/local-file-shell/src/shell/runner.ts
@@ -1,6 +1,9 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 
+import type { ProcessTags } from '@lobechat/process-registry';
+import { getProcessContext } from '@lobechat/process-registry';
+
 import type { RunCommandParams, RunCommandResult } from '../types';
 import type { ShellProcess, ShellProcessManager } from './process-manager';
 import { getShellConfig, truncateOutput } from './utils';
@@ -11,6 +14,11 @@ export interface RunCommandOptions {
     error: (...args: any[]) => void;
     info: (...args: any[]) => void;
   };
+  /**
+   * Identifies the caller (default: 'shell'). Merged with the current
+   * AsyncLocalStorage context to form the registry tags.
+   */
+  ownerModule?: string;
   processManager: ShellProcessManager;
 }
 
@@ -23,8 +31,9 @@ export async function runCommand(
     run_in_background,
     timeout = 120_000,
   }: RunCommandParams,
-  { processManager, logger }: RunCommandOptions,
+  { processManager, logger, ownerModule = 'shell' }: RunCommandOptions,
 ): Promise<RunCommandResult> {
+  const tags: ProcessTags = { ...getProcessContext(), ownerModule };
   const logPrefix = `[runCommand: ${description || command.slice(0, 50)}]`;
   logger?.debug(`${logPrefix} Starting`, { background: run_in_background, cwd, timeout });
 
@@ -37,6 +46,7 @@ export async function runCommand(
       const shellId = randomUUID();
       const childProcess = spawn(shellConfig.cmd, shellConfig.args, {
         cwd,
+        detached: process.platform !== 'win32',
         env: childEnv,
         shell: false,
       });
@@ -61,7 +71,11 @@ export async function runCommand(
         logger?.debug(`${logPrefix} Background process exited`, { code, shellId });
       });
 
-      processManager.register(shellId, shellProcess);
+      processManager.register(shellId, shellProcess, {
+        args: shellConfig.args,
+        command: shellConfig.cmd,
+        tags,
+      });
 
       logger?.info?.(`${logPrefix} Started background`, { shellId });
       return { shell_id: shellId, success: true };

--- a/packages/process-registry/package.json
+++ b/packages/process-registry/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@lobechat/process-registry",
+  "version": "1.0.0",
+  "private": true,
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "dependencies": {}
+}

--- a/packages/process-registry/src/__tests__/context.test.ts
+++ b/packages/process-registry/src/__tests__/context.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProcessContext, runWithProcessContext } from '../context';
+
+describe('runWithProcessContext', () => {
+  it('returns empty object when no context is set', () => {
+    expect(getProcessContext()).toEqual({});
+  });
+
+  it('sets context inside fn', () => {
+    runWithProcessContext({ topicId: 't1' }, () => {
+      expect(getProcessContext()).toEqual({ topicId: 't1' });
+    });
+    expect(getProcessContext()).toEqual({});
+  });
+
+  it('merges nested contexts — inner wins', () => {
+    runWithProcessContext({ topicId: 't1', sessionId: 's1' }, () => {
+      runWithProcessContext({ topicId: 't2' }, () => {
+        const ctx = getProcessContext();
+        expect(ctx.topicId).toBe('t2');
+        expect(ctx.sessionId).toBe('s1');
+      });
+    });
+  });
+
+  it('propagates context across async awaits', async () => {
+    await runWithProcessContext({ topicId: 't1' }, async () => {
+      await Promise.resolve();
+      expect(getProcessContext().topicId).toBe('t1');
+    });
+  });
+});

--- a/packages/process-registry/src/__tests__/registry.test.ts
+++ b/packages/process-registry/src/__tests__/registry.test.ts
@@ -1,0 +1,193 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProcessRegistry } from '../registry';
+import type { ProcessRegistryEvent } from '../types';
+
+function makeChild(pid = 1234): ChildProcess {
+  const emitter = new EventEmitter() as ChildProcess;
+  (emitter as any).pid = pid;
+  (emitter as any).kill = vi.fn();
+  return emitter;
+}
+
+describe('ProcessRegistry', () => {
+  let registry: ProcessRegistry;
+
+  beforeEach(() => {
+    registry = new ProcessRegistry();
+  });
+
+  it('registers a process and emits a registered event', () => {
+    const events: ProcessRegistryEvent[] = [];
+    registry.subscribe((e) => events.push(e));
+    const child = makeChild();
+
+    const entry = registry.register({
+      command: 'ls',
+      process: child,
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+
+    expect(entry.pid).toBe(1234);
+    expect(entry.status).toBe('running');
+    expect(entry.tags.topicId).toBe('t1');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('registered');
+  });
+
+  it('marks process as exited when child emits exit', () => {
+    const child = makeChild();
+    const entry = registry.register({
+      command: 'ls',
+      process: child,
+      tags: { ownerModule: 'shell' },
+    });
+    const events: ProcessRegistryEvent[] = [];
+    registry.subscribe((e) => events.push(e));
+
+    child.emit('exit', 0);
+
+    expect(entry.status).toBe('exited');
+    expect(entry.exitCode).toBe(0);
+    expect(events.some((e) => e.type === 'exited')).toBe(true);
+  });
+
+  it('filters list by tags and status', () => {
+    registry.register({
+      command: 'a',
+      process: makeChild(1),
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    registry.register({
+      command: 'b',
+      process: makeChild(2),
+      tags: { ownerModule: 'acp', topicId: 't1' },
+    });
+    registry.register({
+      command: 'c',
+      process: makeChild(3),
+      tags: { ownerModule: 'shell', topicId: 't2' },
+    });
+
+    expect(registry.list({ topicId: 't1' })).toHaveLength(2);
+    expect(registry.list({ ownerModule: 'shell' })).toHaveLength(2);
+    expect(registry.list({ topicId: 't1', ownerModule: 'acp' })).toHaveLength(1);
+    expect(registry.list({ status: 'running' })).toHaveLength(3);
+  });
+
+  it('rejects kill with empty filter', () => {
+    expect(() => registry.kill({})).toThrow(/shellId/);
+  });
+
+  it('rejects kill by ownerModule alone (too broad)', () => {
+    expect(() => registry.kill({ ownerModule: 'shell' })).toThrow(/ownerModule alone/);
+  });
+
+  it('accepts ownerModule when combined with a scope tag', () => {
+    registry.register({
+      command: 'a',
+      process: makeChild(1),
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    expect(() => registry.kill({ ownerModule: 'shell', topicId: 't1' })).not.toThrow();
+    killSpy.mockRestore();
+  });
+
+  it('returns only actually-killed shellIds (skips already-exited)', () => {
+    const c1 = makeChild(1);
+    registry.register({
+      command: 'a',
+      process: c1,
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    c1.emit('exit', 0); // exited before kill
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const killed = registry.kill({ topicId: 't1' });
+    expect(killed).toHaveLength(0);
+    killSpy.mockRestore();
+  });
+
+  it('marks process without pid as exited immediately', () => {
+    const events: ProcessRegistryEvent[] = [];
+    registry.subscribe((e) => events.push(e));
+    const child = makeChild(0);
+    (child as any).pid = undefined;
+    const entry = registry.register({
+      command: 'ghost',
+      process: child,
+      tags: { ownerModule: 'shell' },
+    });
+    expect(entry.status).toBe('exited');
+    expect(events.map((e) => e.type)).toEqual(['registered', 'exited']);
+  });
+
+  it('cleanupAll emits killed events for running processes', () => {
+    registry.register({
+      command: 'a',
+      process: makeChild(1),
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    const events: ProcessRegistryEvent[] = [];
+    registry.subscribe((e) => events.push(e));
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    registry.cleanupAll();
+    expect(events.some((e) => e.type === 'killed')).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it('kills matching processes and marks them killed', () => {
+    const c1 = makeChild(1);
+    const c2 = makeChild(2);
+    const c3 = makeChild(3);
+    registry.register({
+      command: 'a',
+      process: c1,
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    registry.register({
+      command: 'b',
+      process: c2,
+      tags: { ownerModule: 'shell', topicId: 't1' },
+    });
+    registry.register({
+      command: 'c',
+      process: c3,
+      tags: { ownerModule: 'shell', topicId: 't2' },
+    });
+
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const killed = registry.kill({ topicId: 't1' });
+
+    expect(killed).toHaveLength(2);
+    expect(registry.list({ status: 'killed' })).toHaveLength(2);
+    expect(registry.list({ status: 'running' })).toHaveLength(1);
+    killSpy.mockRestore();
+  });
+
+  it('forget removes entry', () => {
+    const child = makeChild();
+    const entry = registry.register({
+      command: 'ls',
+      process: child,
+      tags: { ownerModule: 'shell' },
+    });
+    registry.forget(entry.shellId);
+    expect(registry.get(entry.shellId)).toBeUndefined();
+  });
+
+  it('unsubscribe stops further events', () => {
+    const events: ProcessRegistryEvent[] = [];
+    const unsubscribe = registry.subscribe((e) => events.push(e));
+    unsubscribe();
+    registry.register({
+      command: 'ls',
+      process: makeChild(),
+      tags: { ownerModule: 'shell' },
+    });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/process-registry/src/context.ts
+++ b/packages/process-registry/src/context.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { ProcessTags } from './types';
+
+const storage = new AsyncLocalStorage<Partial<ProcessTags>>();
+
+/**
+ * Run `fn` with a set of process tags attached to the async context.
+ * Nested calls merge tags — inner keys win.
+ */
+export function runWithProcessContext<T>(tags: Partial<ProcessTags>, fn: () => T): T {
+  const parent = storage.getStore() ?? {};
+  return storage.run({ ...parent, ...tags }, fn);
+}
+
+export function getProcessContext(): Partial<ProcessTags> {
+  return storage.getStore() ?? {};
+}

--- a/packages/process-registry/src/index.ts
+++ b/packages/process-registry/src/index.ts
@@ -1,0 +1,13 @@
+export { getProcessContext, runWithProcessContext } from './context';
+export { killProcessTree } from './kill';
+export { ProcessRegistry, type RegisterOptions } from './registry';
+export { registrySpawn, type RegistrySpawnDeps, type RegistrySpawnOptions } from './spawn';
+export type {
+  ProcessKillFilter,
+  ProcessListFilter,
+  ProcessRegistryEvent,
+  ProcessRegistryListener,
+  ProcessStatus,
+  ProcessTags,
+  RegisteredProcess,
+} from './types';

--- a/packages/process-registry/src/kill.ts
+++ b/packages/process-registry/src/kill.ts
@@ -1,0 +1,34 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Signal the whole process tree rooted at `pid`.
+ *
+ * Unix: the caller should have spawned with `detached: true` so a pgid exists.
+ * We send the signal to `-pid` which reaches every descendant in the group.
+ * Falls back to a direct signal if the group kill raises (ESRCH when the
+ * leader already exited).
+ *
+ * Windows: shell out to `taskkill /T /F` which walks the descendant tree.
+ */
+export function killProcessTree(pid: number, signal: NodeJS.Signals = 'SIGTERM'): void {
+  if (!pid) return;
+
+  if (process.platform === 'win32') {
+    try {
+      spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    } catch {
+      // ignore
+    }
+    return;
+  }
+
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // already exited
+    }
+  }
+}

--- a/packages/process-registry/src/registry.ts
+++ b/packages/process-registry/src/registry.ts
@@ -103,7 +103,7 @@ export class ProcessRegistry {
     const killed: string[] = [];
     for (const entry of targets) {
       if (entry.status !== 'running') continue;
-      killProcessTree(entry.pid, signal);
+      killProcessTree(entry.pgid ?? entry.pid, signal);
       entry.status = 'killed';
       entry.exitedAt = Date.now();
       this.emit({ process: entry, type: 'killed' });
@@ -120,7 +120,7 @@ export class ProcessRegistry {
   cleanupAll(signal: NodeJS.Signals = 'SIGTERM'): void {
     for (const entry of this.processes.values()) {
       if (entry.status === 'running') {
-        killProcessTree(entry.pid, signal);
+        killProcessTree(entry.pgid ?? entry.pid, signal);
         entry.status = 'killed';
         entry.exitedAt = Date.now();
         this.emit({ process: entry, type: 'killed' });

--- a/packages/process-registry/src/registry.ts
+++ b/packages/process-registry/src/registry.ts
@@ -1,0 +1,168 @@
+import type { ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+import { killProcessTree } from './kill';
+import type {
+  ProcessKillFilter,
+  ProcessListFilter,
+  ProcessRegistryEvent,
+  ProcessRegistryListener,
+  ProcessTags,
+  RegisteredProcess,
+} from './types';
+
+export interface RegisterOptions {
+  args?: string[];
+  command: string;
+  /** Override pgid detection. Defaults to proc.pid when proc was spawned detached on unix. */
+  pgid?: number;
+  process: ChildProcess;
+  shellId?: string;
+  tags: ProcessTags;
+}
+
+/**
+ * In-process registry of all spawned child processes. Metadata only — stdout /
+ * stderr buffering remains the caller's concern.
+ *
+ * Kill filters must include at least one of `shellId` or a scope tag
+ * (`topicId` / `sessionId` / `toolCallId` / `ownerModule`). Empty filters are
+ * rejected to avoid accidental kill-all.
+ */
+export class ProcessRegistry {
+  private processes = new Map<string, RegisteredProcess>();
+  private listeners = new Set<ProcessRegistryListener>();
+
+  register(options: RegisterOptions): RegisteredProcess {
+    const { process: child, command, args = [], tags, pgid, shellId = randomUUID() } = options;
+    const pid = child.pid ?? 0;
+    const hasPid = pid > 0;
+    const entry: RegisteredProcess = {
+      args,
+      command,
+      exitCode: null,
+      pgid: pgid ?? (process.platform === 'win32' || !hasPid ? undefined : pid),
+      pid,
+      shellId,
+      // A child without a pid failed to start synchronously (e.g. ENOENT).
+      // Mark it exited immediately — the node 'error' event will fire on
+      // nextTick, at which point `kill()` against it would be a no-op anyway.
+      startedAt: Date.now(),
+      status: hasPid ? 'running' : 'exited',
+      tags,
+    };
+    if (!hasPid) entry.exitedAt = entry.startedAt;
+    this.processes.set(shellId, entry);
+    this.emit({ process: entry, type: 'registered' });
+    if (!hasPid) this.emit({ process: entry, type: 'exited' });
+
+    const onExit = (code: number | null) => {
+      // Guard against post-forget() callbacks and killed-then-natural-exit races.
+      if (!this.processes.has(shellId)) return;
+      if (entry.status !== 'running') return;
+      entry.status = 'exited';
+      entry.exitCode = code;
+      entry.exitedAt = Date.now();
+      this.emit({ process: entry, type: 'exited' });
+    };
+    const onError = () => {
+      if (!this.processes.has(shellId)) return;
+      if (entry.status !== 'running') return;
+      entry.status = 'exited';
+      entry.exitedAt = Date.now();
+      this.emit({ process: entry, type: 'exited' });
+    };
+    child.once('exit', onExit);
+    child.once('error', onError);
+
+    return entry;
+  }
+
+  list(filter: ProcessListFilter = {}): RegisteredProcess[] {
+    return [...this.processes.values()].filter((p) => matches(p, filter));
+  }
+
+  get(shellId: string): RegisteredProcess | undefined {
+    return this.processes.get(shellId);
+  }
+
+  /**
+   * Kill all processes matching `filter`. Returns the shellIds that actually
+   * received a signal. `ownerModule` alone is refused — kill-by-module could
+   * span unrelated conversations; callers must narrow by `shellId` or at
+   * least one of `topicId` / `sessionId` / `toolCallId`.
+   */
+  kill(filter: ProcessKillFilter, signal: NodeJS.Signals = 'SIGTERM'): string[] {
+    if (!hasScope(filter)) {
+      throw new Error(
+        'ProcessRegistry.kill requires shellId, topicId, sessionId, or toolCallId (ownerModule alone is rejected)',
+      );
+    }
+
+    const targets = [...this.processes.values()].filter((p) => matchesKill(p, filter));
+    const killed: string[] = [];
+    for (const entry of targets) {
+      if (entry.status !== 'running') continue;
+      killProcessTree(entry.pid, signal);
+      entry.status = 'killed';
+      entry.exitedAt = Date.now();
+      this.emit({ process: entry, type: 'killed' });
+      killed.push(entry.shellId);
+    }
+    return killed;
+  }
+
+  /** Force-delete an entry from the registry (e.g. after consumer drains buffers). */
+  forget(shellId: string): void {
+    this.processes.delete(shellId);
+  }
+
+  cleanupAll(signal: NodeJS.Signals = 'SIGTERM'): void {
+    for (const entry of this.processes.values()) {
+      if (entry.status === 'running') {
+        killProcessTree(entry.pid, signal);
+        entry.status = 'killed';
+        entry.exitedAt = Date.now();
+        this.emit({ process: entry, type: 'killed' });
+      }
+    }
+    this.processes.clear();
+  }
+
+  subscribe(listener: ProcessRegistryListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(event: ProcessRegistryEvent): void {
+    for (const l of this.listeners) {
+      try {
+        l(event);
+      } catch {
+        // listener error ignored; registry should not break on consumer faults
+      }
+    }
+  }
+}
+
+function matches(p: RegisteredProcess, f: ProcessListFilter): boolean {
+  if (f.ownerModule && p.tags.ownerModule !== f.ownerModule) return false;
+  if (f.topicId && p.tags.topicId !== f.topicId) return false;
+  if (f.sessionId && p.tags.sessionId !== f.sessionId) return false;
+  if (f.toolCallId && p.tags.toolCallId !== f.toolCallId) return false;
+  if (f.status && p.status !== f.status) return false;
+  return true;
+}
+
+function hasScope(f: ProcessKillFilter): boolean {
+  return !!(f.shellId || f.topicId || f.sessionId || f.toolCallId);
+}
+
+function matchesKill(p: RegisteredProcess, f: ProcessKillFilter): boolean {
+  if (f.shellId && p.shellId !== f.shellId) return false;
+  if (f.ownerModule && p.tags.ownerModule !== f.ownerModule) return false;
+  if (f.topicId && p.tags.topicId !== f.topicId) return false;
+  if (f.sessionId && p.tags.sessionId !== f.sessionId) return false;
+  if (f.toolCallId && p.tags.toolCallId !== f.toolCallId) return false;
+  return true;
+}

--- a/packages/process-registry/src/spawn.ts
+++ b/packages/process-registry/src/spawn.ts
@@ -1,0 +1,54 @@
+import { type ChildProcess, spawn, type SpawnOptions } from 'node:child_process';
+
+import { getProcessContext } from './context';
+import type { ProcessRegistry } from './registry';
+import type { ProcessTags } from './types';
+
+export interface RegistrySpawnOptions extends SpawnOptions {
+  /** Explicit tags. Merged over ALS context (explicit wins). */
+  tags?: Partial<ProcessTags> & { ownerModule: string };
+}
+
+export interface RegistrySpawnDeps {
+  registry: ProcessRegistry;
+}
+
+/**
+ * spawn() wrapper that registers the child with a ProcessRegistry and applies
+ * unix-safe defaults for tree-killing (detached: true so a pgid exists).
+ *
+ * Tags are resolved by merging the AsyncLocalStorage context with
+ * `options.tags` (explicit wins). `ownerModule` MUST be provided explicitly —
+ * we never infer it from context to avoid silent mis-attribution.
+ */
+export function registrySpawn(
+  command: string,
+  args: readonly string[],
+  options: RegistrySpawnOptions,
+  deps: RegistrySpawnDeps,
+): ChildProcess {
+  const { tags: explicitTags, ...spawnOpts } = options;
+  if (!explicitTags?.ownerModule) {
+    throw new Error('registrySpawn: options.tags.ownerModule is required');
+  }
+
+  const merged: ProcessTags = {
+    ...getProcessContext(),
+    ...explicitTags,
+    ownerModule: explicitTags.ownerModule,
+  };
+
+  const finalOpts: SpawnOptions = {
+    detached: process.platform !== 'win32',
+    ...spawnOpts,
+  };
+
+  const child = spawn(command, [...args], finalOpts);
+  deps.registry.register({
+    args: [...args],
+    command,
+    process: child,
+    tags: merged,
+  });
+  return child;
+}

--- a/packages/process-registry/src/types.ts
+++ b/packages/process-registry/src/types.ts
@@ -1,0 +1,47 @@
+export interface ProcessTags {
+  [k: string]: string | undefined;
+  messageId?: string;
+  /** Required. Short identifier of the subsystem that spawned the process (e.g. 'shell', 'acp', 'heteroAgent', 'cli', 'git', 'toolDetector'). */
+  ownerModule: string;
+  sessionId?: string;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export type ProcessStatus = 'running' | 'exited' | 'killed';
+
+export interface RegisteredProcess {
+  args: string[];
+  command: string;
+  exitCode: number | null;
+  exitedAt?: number;
+  pgid?: number;
+  pid: number;
+  shellId: string;
+  startedAt: number;
+  status: ProcessStatus;
+  tags: ProcessTags;
+}
+
+export interface ProcessListFilter {
+  ownerModule?: string;
+  sessionId?: string;
+  status?: ProcessStatus;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export interface ProcessKillFilter {
+  ownerModule?: string;
+  sessionId?: string;
+  shellId?: string;
+  toolCallId?: string;
+  topicId?: string;
+}
+
+export type ProcessRegistryEvent =
+  | { process: RegisteredProcess; type: 'registered' }
+  | { process: RegisteredProcess; type: 'exited' }
+  | { process: RegisteredProcess; type: 'killed' };
+
+export type ProcessRegistryListener = (event: ProcessRegistryEvent) => void;

--- a/packages/process-registry/vitest.config.mts
+++ b/packages/process-registry/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/src/features/ProcessManager/ProcessRow.tsx
+++ b/src/features/ProcessManager/ProcessRow.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { ProcessInfo } from '@lobechat/electron-client-ipc';
+import { ActionIcon, Tag } from '@lobehub/ui';
+import { XIcon } from 'lucide-react';
+import { memo } from 'react';
+
+import { styles } from './style';
+
+interface Props {
+  onKill: (shellId: string) => void;
+  process: ProcessInfo;
+}
+
+const formatRuntime = (p: ProcessInfo): string => {
+  const end = p.exitedAt ?? Date.now();
+  const ms = Math.max(0, end - p.startedAt);
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  return `${m}m${rs.toString().padStart(2, '0')}s`;
+};
+
+const ProcessRow = memo<Props>(({ process, onKill }) => {
+  const statusClass =
+    process.status === 'running'
+      ? styles.statusRunning
+      : process.status === 'killed'
+        ? styles.statusKilled
+        : styles.statusExited;
+
+  const commandLine = [process.command, ...process.args].join(' ');
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.commandCell} title={commandLine}>
+        {commandLine}
+      </div>
+      <div>
+        <Tag>{process.ownerModule}</Tag>
+      </div>
+      <div>{process.topicId ? <Tag>{process.topicId.slice(0, 8)}</Tag> : '—'}</div>
+      <div>{process.pid || '—'}</div>
+      <div className={statusClass}>
+        {process.status} · {formatRuntime(process)}
+      </div>
+      <div>
+        {process.status === 'running' && (
+          <ActionIcon
+            danger
+            icon={XIcon}
+            size={'small'}
+            title={'Kill'}
+            onClick={() => onKill(process.shellId)}
+          />
+        )}
+      </div>
+    </div>
+  );
+});
+
+export default ProcessRow;

--- a/src/features/ProcessManager/index.tsx
+++ b/src/features/ProcessManager/index.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { ProcessInfo } from '@lobechat/electron-client-ipc';
+import { Button, Segmented, Text } from '@lobehub/ui';
+import { memo, useMemo, useState } from 'react';
+
+import ProcessRow from './ProcessRow';
+import { styles } from './style';
+import { useProcessList } from './useProcessList';
+
+type GroupBy = 'none' | 'topic' | 'module' | 'status';
+
+const groupProcesses = (processes: ProcessInfo[], by: GroupBy): [string, ProcessInfo[]][] => {
+  if (by === 'none') return [['All', processes]];
+  const groups = new Map<string, ProcessInfo[]>();
+  for (const p of processes) {
+    const key =
+      by === 'topic' ? (p.topicId ?? '(no topic)') : by === 'module' ? p.ownerModule : p.status;
+    const arr = groups.get(key) ?? [];
+    arr.push(p);
+    groups.set(key, arr);
+  }
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+};
+
+const ProcessManagerPanel = memo(() => {
+  const { items, loading, kill, refetch } = useProcessList();
+  const [groupBy, setGroupBy] = useState<GroupBy>('module');
+  const [showExited, setShowExited] = useState(false);
+
+  const filtered = useMemo(
+    () => (showExited ? items : items.filter((p) => p.status === 'running')),
+    [items, showExited],
+  );
+
+  const grouped = useMemo(() => groupProcesses(filtered, groupBy), [filtered, groupBy]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <Text strong>
+          Processes ({filtered.length} / {items.length})
+        </Text>
+        <Segmented
+          size={'small'}
+          value={groupBy}
+          options={[
+            { label: 'By Module', value: 'module' },
+            { label: 'By Topic', value: 'topic' },
+            { label: 'By Status', value: 'status' },
+            { label: 'Flat', value: 'none' },
+          ]}
+          onChange={(v) => setGroupBy(v as GroupBy)}
+        />
+        <Button size={'small'} type={'text'} onClick={() => setShowExited((v) => !v)}>
+          {showExited ? 'Hide exited' : 'Show exited'}
+        </Button>
+        <Button size={'small'} type={'text'} onClick={refetch}>
+          Refresh
+        </Button>
+      </div>
+
+      {loading && <div className={styles.empty}>Loading…</div>}
+
+      {!loading && filtered.length === 0 && (
+        <div className={styles.empty}>No tracked processes.</div>
+      )}
+
+      {!loading &&
+        grouped.map(([groupKey, rows]) => (
+          <div key={groupKey}>
+            {groupBy !== 'none' && (
+              <div className={styles.groupHeader}>
+                {groupKey} ({rows.length})
+              </div>
+            )}
+            <div className={styles.rowHeader}>
+              <div>Command</div>
+              <div>Module</div>
+              <div>Topic</div>
+              <div>PID</div>
+              <div>Status</div>
+              <div />
+            </div>
+            {rows.map((p) => (
+              <ProcessRow key={p.shellId} process={p} onKill={kill} />
+            ))}
+          </div>
+        ))}
+    </div>
+  );
+});
+
+export default ProcessManagerPanel;

--- a/src/features/ProcessManager/style.ts
+++ b/src/features/ProcessManager/style.ts
@@ -1,0 +1,91 @@
+import { createStaticStyles } from 'antd-style';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  container: css`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    padding-block: 16px;
+    padding-inline: 20px;
+  `,
+
+  empty: css`
+    padding-block: 48px;
+    padding-inline: 0;
+    color: ${cssVar.colorTextSecondary};
+    text-align: center;
+  `,
+
+  groupHeader: css`
+    padding-block: 8px;
+    padding-inline: 4px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-size: 12px;
+    font-weight: 600;
+    color: ${cssVar.colorTextSecondary};
+    text-transform: uppercase;
+  `,
+
+  row: css`
+    display: grid;
+    grid-template-columns: 1fr 140px 120px 100px 80px 64px;
+    gap: 12px;
+    align-items: center;
+
+    padding-block: 10px;
+    padding-inline: 8px;
+    border-radius: ${cssVar.borderRadius};
+
+    transition: background-color 120ms ease;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+
+  rowHeader: css`
+    display: grid;
+    grid-template-columns: 1fr 140px 120px 100px 80px 64px;
+    gap: 12px;
+
+    padding: 8px;
+
+    font-size: 12px;
+    font-weight: 600;
+    color: ${cssVar.colorTextSecondary};
+    text-transform: uppercase;
+  `,
+
+  commandCell: css`
+    overflow: hidden;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 13px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+
+  statusExited: css`
+    color: ${cssVar.colorTextSecondary};
+  `,
+
+  statusKilled: css`
+    color: ${cssVar.colorError};
+  `,
+
+  statusRunning: css`
+    color: ${cssVar.colorSuccess};
+  `,
+
+  toolbar: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+
+    padding-block-end: 8px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));

--- a/src/features/ProcessManager/useProcessList.ts
+++ b/src/features/ProcessManager/useProcessList.ts
@@ -1,0 +1,41 @@
+import type { ProcessInfo } from '@lobechat/electron-client-ipc';
+import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
+import { useCallback, useEffect, useState } from 'react';
+
+import { processManagerService } from '@/services/electron/processManagerService';
+
+/**
+ * Subscribes to the ProcessManagerCtr broadcast and keeps a live list of
+ * tracked processes. Reconciles incoming events against an internal Map keyed
+ * by shellId so registered / exited / killed flips are cheap.
+ */
+export const useProcessList = () => {
+  const [items, setItems] = useState<Map<string, ProcessInfo>>(new Map());
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    const res = await processManagerService.listProcesses();
+    const next = new Map<string, ProcessInfo>();
+    for (const p of res.processes) next.set(p.shellId, p);
+    setItems(next);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  useWatchBroadcast('processManagerChanged', ({ process }) => {
+    setItems((prev) => {
+      const next = new Map(prev);
+      next.set(process.shellId, process);
+      return next;
+    });
+  });
+
+  const kill = useCallback(async (shellId: string) => {
+    await processManagerService.killProcess({ shellId });
+  }, []);
+
+  return { items: [...items.values()], kill, loading, refetch };
+};

--- a/src/features/ProcessManager/useProcessList.ts
+++ b/src/features/ProcessManager/useProcessList.ts
@@ -14,11 +14,17 @@ export const useProcessList = () => {
   const [loading, setLoading] = useState(true);
 
   const refetch = useCallback(async () => {
-    const res = await processManagerService.listProcesses();
-    const next = new Map<string, ProcessInfo>();
-    for (const p of res.processes) next.set(p.shellId, p);
-    setItems(next);
-    setLoading(false);
+    try {
+      const res = await processManagerService.listProcesses();
+      const next = new Map<string, ProcessInfo>();
+      for (const p of res.processes) next.set(p.shellId, p);
+      setItems(next);
+    } catch {
+      // IPC failure (missing preload, main-process error, etc.) — leave existing
+      // items in place so the UI doesn't flash to empty, but stop loading.
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -968,6 +968,7 @@ When I am ___, I need ___
   'tab.manualFill.desc': 'Configure a custom MCP skill manually',
   'tab.memory': 'Memory',
   'tab.notification': 'Notifications',
+  'tab.processes': 'Processes',
   'tab.profile': 'My Account',
   'tab.provider': 'Provider',
   'tab.proxy': 'Proxy',

--- a/src/routes/(main)/settings/features/componentMap.desktop.ts
+++ b/src/routes/(main)/settings/features/componentMap.desktop.ts
@@ -13,6 +13,7 @@ import Appearance from '../appearance';
 import Creds from '../creds';
 import Hotkey from '../hotkey';
 import Memory from '../memory';
+import Processes from '../processes';
 import Profile from '../profile';
 import Provider from '../provider';
 import Proxy from '../proxy';
@@ -34,6 +35,7 @@ export const componentMap = {
   [SettingsTabs.Hotkey]: Hotkey,
   [SettingsTabs.Proxy]: Proxy,
   [SettingsTabs.SystemTools]: SystemTools,
+  [SettingsTabs.Processes]: Processes,
   [SettingsTabs.Storage]: Storage,
   // Profile related tabs
   [SettingsTabs.Profile]: Profile,

--- a/src/routes/(main)/settings/features/componentMap.ts
+++ b/src/routes/(main)/settings/features/componentMap.ts
@@ -40,6 +40,9 @@ export const componentMap = {
   [SettingsTabs.SystemTools]: dynamic(() => import('../system-tools'), {
     loading: loading('Settings > SystemTools'),
   }),
+  [SettingsTabs.Processes]: dynamic(() => import('../processes'), {
+    loading: loading('Settings > Processes'),
+  }),
   [SettingsTabs.Storage]: dynamic(() => import('../storage'), {
     loading: loading('Settings > Storage'),
   }),

--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -16,6 +16,7 @@ import {
   KeyboardIcon,
   KeyIcon,
   KeyRound,
+  ListChecks,
   Map,
   PaletteIcon,
   Sparkles,
@@ -183,6 +184,11 @@ export const useCategory = () => {
         icon: TerminalSquare,
         key: SettingsTabs.SystemTools,
         label: t('tab.systemTools'),
+      },
+      isDesktop && {
+        icon: ListChecks,
+        key: SettingsTabs.Processes,
+        label: t('tab.processes'),
       },
       {
         icon: Database,

--- a/src/routes/(main)/settings/processes/index.tsx
+++ b/src/routes/(main)/settings/processes/index.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from 'react-i18next';
+
+import ProcessManagerPanel from '@/features/ProcessManager';
+import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
+
+const Page = () => {
+  const { t } = useTranslation('setting');
+
+  return (
+    <>
+      <SettingHeader title={t('tab.processes')} />
+      <ProcessManagerPanel />
+    </>
+  );
+};
+
+export default Page;

--- a/src/services/electron/processManagerService.ts
+++ b/src/services/electron/processManagerService.ts
@@ -1,0 +1,20 @@
+import type {
+  KillProcessParams,
+  KillProcessResult,
+  ListProcessesParams,
+  ListProcessesResult,
+} from '@lobechat/electron-client-ipc';
+
+import { ensureElectronIpc } from '@/utils/electron/ipc';
+
+class ProcessManagerService {
+  async listProcesses(params: ListProcessesParams = {}): Promise<ListProcessesResult> {
+    return ensureElectronIpc().processManager.listProcesses(params);
+  }
+
+  async killProcess(params: KillProcessParams): Promise<KillProcessResult> {
+    return ensureElectronIpc().processManager.killProcess(params);
+  }
+}
+
+export const processManagerService = new ProcessManagerService();

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -59,6 +59,7 @@ export enum SettingsTabs {
   Notification = 'notification',
   // business
   Plans = 'plans',
+  Processes = 'processes',
   Profile = 'profile',
   Provider = 'provider',
   Proxy = 'proxy',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Central tracking for every child process spawned from the Electron main process so orphan grandchildren can be killed and a task-manager UI can list / kill them.

**New `@lobechat/process-registry` package**
- Flat multi-dimensional tag model (`ownerModule`, `topicId`, `sessionId`, `toolCallId`, …) — auto-populated via `AsyncLocalStorage`, explicit override supported
- `killProcessTree` — unix `process.kill(-pgid)` / windows `taskkill /T /F`
- Events: `registered` / `exited` / `killed` with subscribe/unsubscribe
- `kill(filter)` refuses empty filter and `ownerModule`-only to prevent cross-conversation mis-kills
- Handles pid=0 (failed-to-start), post-forget() race guards, pre-emptive `cleanupAll` event emission

**Main-process integration**
- `apps/desktop/src/main/utils/processRegistry.ts` — shared singleton
- `ShellCommandCtr` — background shell commands now register via `ShellProcessManager` (extended with an optional registry delegate, preserving existing API)
- `HeterogeneousAgentCtr` — claude-code / codex agent sessions tagged with `sessionId` + `agentType`
- `ProcessManagerCtr` — new IPC group: `listProcesses`, `killProcess`, plus `processManagerChanged` broadcast and a `before-quit` cleanup hook

**UI**
- `Settings → Processes` tab (desktop-only) under the System group
- Live list with group-by module/topic/status/flat, show/hide exited, per-row kill action
- Subscribes to `processManagerChanged` broadcast for real-time updates

**Not migrated (by design)**
- `CliCtr`, `GitCtr`, `toolDetectors/*` — all use short-lived `exec()` where registry tracking would add churn without user value
- `libs/acp/client.ts` — no consumer yet; wire when a feature starts using it

#### 🧪 How to Test

- [x] Added/updated tests (16 registry tests, 4 controller tests, 3 delegation tests)
- [ ] Tested locally

Unit test commands:

\`\`\`
cd packages/process-registry && bunx vitest run
cd packages/local-file-shell && bunx vitest run src/shell
cd apps/desktop && bunx vitest run src/main/controllers/__tests__/ProcessManagerCtr src/main/controllers/__tests__/ShellCommandCtr src/main/controllers/__tests__/HeterogeneousAgentCtr
\`\`\`

Manual verification path:
1. Start the desktop app
2. Open **Settings → Processes**
3. In another session, start a background shell command (e.g. via the local-system tool) or a claude-code agent session
4. Confirm the process appears in the list with correct owner/tags
5. Click the kill icon — confirm the row flips to \`killed\` and the actual child process (and its descendants) exits

#### 📸 Screenshots / Videos

UI not yet verified in a running Electron app — code-level checks (typecheck, unit tests, router sync) all green.

#### 📝 Additional Information

- **Workspace linking**: \`apps/desktop\` is its own pnpm workspace; \`apps/desktop/pnpm-workspace.yaml\` was updated to include \`packages/process-registry\`
- **Windows compatibility**: \`killProcessTree\` uses \`taskkill /T /F\` on win32 (same pattern as the pre-existing \`HeterogeneousAgentCtr.killProcessTree\`)
- **No breaking changes** — existing shell IPC shape preserved