### PR TITLE
🐛 fix: MCP audio upload throws "Invalid image url" error

### DIFF
--- a/src/server/services/file/index.ts
+++ b/src/server/services/file/index.ts
@@ -1,5 +1,5 @@
 import { type LobeChatDatabase } from '@lobechat/database';
-import { inferContentTypeFromImageUrl, nanoid, uuid } from '@lobechat/utils';
+import { getMimeType, inferContentTypeFromImageUrl, nanoid, uuid } from '@lobechat/utils';
 import { TRPCError } from '@trpc/server';
 import { sha256 } from 'js-sha256';
 
@@ -267,7 +267,7 @@ export class FileService {
 
     // Calculate file metadata
     const size = buffer.length;
-    const fileType = inferContentTypeFromImageUrl(pathname) || 'application/octet-stream';
+    const fileType = getMimeType(pathname);
     const hash = sha256(buffer);
 
     // Generate UUID for cleaner URLs


### PR DESCRIPTION
## Summary
- `uploadBase64` 调用 `inferContentTypeFromImageUrl(pathname)` 对非图片扩展名（如 `.mp3`）直接 throw，导致 `|| 'application/octet-stream'` 兜底永不生效
- 替换为 `getMimeType(pathname)`，支持所有文件类型，内部已有 `'application/octet-stream'` 兜底

## Test plan
- [x] MCP 返回 audio content 时不再报 "Invalid image url"
- [x] 原有 image 上传路径不受影响（`getMimeType` 对 `.png/.jpg/.webp` 返回正确的 image MIME type）

Closes #10778