### PR TITLE
fix(provider): preserve specific errors over generic ConnectionCheckFailed

### DIFF
--- a/src/routes/(main)/settings/provider/features/ProviderConfig/Checker.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/Checker.tsx
@@ -127,7 +127,11 @@ const Checker = memo<ConnectionCheckerProps>(
         },
 
         onFinish: async (value) => {
-          if (!isError && value) {
+          // If onError already fired, keep that specific error rather than
+          // overwriting it with the generic ConnectionCheckFailed message.
+          if (isError) return;
+
+          if (value) {
             setError(undefined);
             setPass(true);
           } else {


### PR DESCRIPTION
Fixes #14027

## Problem

When the connection checker calls `fetchPresetTaskResult`, both `onError` and `onFinish` can fire in sequence for certain failure modes (e.g., an SSE stream that returns HTTP 200 but then encounters a parse error). The previous `onFinish` logic:

```js
if (!isError && value) {
  setPass(true);
} else {
  setError({ message: t('response.ConnectionCheckFailed') });
}
```

entered the `else` branch whenever `isError === true`, silently overwriting the descriptive error already set by `onError` with the generic "The request returned empty. Please check if the API proxy address does not end with /v1" message. Users saw this confusing message even when the root cause was an authentication failure, rate-limit error, or provider-specific error — not an empty response.

## Solution

Add an early `return` in `onFinish` when `isError` is already `true`. This keeps the specific error captured by `onError` visible and avoids misleading users with a proxy-URL hint that is irrelevant for official API configurations.

## Testing

- Simulated an authentication error during connection check: the provider-specific error (e.g., "Invalid API key") is now shown correctly instead of the generic "request returned empty" message.
- Valid API key with a proper response: still marks the check as passed.
- Valid API key with an empty response (no text token): still shows `ConnectionCheckFailed`.