### PR TITLE
🐛 fix: use fileId for proxy URL in knowledge queries

### DIFF
--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -314,7 +314,7 @@ export const fileRouter = router({
         resultItems.push({
           ...item,
           editorData: null,
-          url: getFileProxyUrl(item.id),
+          url: getFileProxyUrl(item.fileId || item.id),
           ...status,
         } as FileListItem);
       } else {
@@ -475,7 +475,7 @@ export const fileRouter = router({
           embeddingStatus: embeddingTask?.status as AsyncTaskStatus,
           finishEmbedding: embeddingTask?.status === AsyncTaskStatus.Success,
           sourceType: 'file' as const,
-          url: getFileProxyUrl(item.id),
+          url: getFileProxyUrl(item.fileId || item.id),
         } as FileListItem);
       }
 


### PR DESCRIPTION
## Summary
Chat 中上传的 PDF 在资源库中无法下载，路径为 `/f/docs_xxx`（应为 `/f/file_xxx`）。

## Root Cause
`KnowledgeRepo.query()` 使用 `COALESCE(d.id, f.id) as id`，当文件已被解析为文档时，`id` 返回 `docs_xxx` 而非 `file_xxx`。`getKnowledgeItems` 和 `recentFiles` handler 将此 ID 用于 `getFileProxyUrl()`，导致 `/f/docs_xxx` 路径在 file proxy route 中查不到记录。

## Fix
在 `getFileProxyUrl()` 中使用 `item.fileId`（始终为 `file_xxx`）替代 `item.id`。

## Test plan
- [x] Chat 上传 PDF 后，资源库中下载链接为 `/f/file_xxx` 格式
- [x] 资源库直接上传 PDF 不受影响

Closes #12196