### PR TITLE
✨ feat: auto-dismiss upload dock after completion

### DIFF
--- a/src/features/ResourceManager/components/UploadDock/index.tsx
+++ b/src/features/ResourceManager/components/UploadDock/index.tsx
@@ -105,7 +105,9 @@ const UploadDock = memo(() => {
 
   useEffect(() => {
     if (isUploading || overviewUploadingStatus === 'pending') {
-      clearTimeout(autoDismissTimerRef.current);
+      if (autoDismissTimerRef.current) {
+        clearTimeout(autoDismissTimerRef.current);
+      }
       return;
     }
 
@@ -114,7 +116,11 @@ const UploadDock = memo(() => {
       dispatchDockFileList({ ids: fileList.map((item) => item.id), type: 'removeFiles' });
     }, 3000);
 
-    return () => clearTimeout(autoDismissTimerRef.current);
+    return () => {
+      if (autoDismissTimerRef.current) {
+        clearTimeout(autoDismissTimerRef.current);
+      }
+    };
   }, [isUploading, overviewUploadingStatus, fileList, dispatchDockFileList]);
 
   if (count === 0 || !show) return;

--- a/src/features/ResourceManager/components/UploadDock/index.tsx
+++ b/src/features/ResourceManager/components/UploadDock/index.tsx
@@ -101,7 +101,7 @@ const UploadDock = memo(() => {
     if (isUploading) setShow(true);
   }, [isUploading, show]);
 
-  const autoDismissTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const autoDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (isUploading || overviewUploadingStatus === 'pending') {

--- a/src/features/ResourceManager/components/UploadDock/index.tsx
+++ b/src/features/ResourceManager/components/UploadDock/index.tsx
@@ -4,7 +4,7 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { UploadIcon, XIcon } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { fileManagerSelectors, useFileStore } from '@/store/file';
@@ -100,6 +100,22 @@ const UploadDock = memo(() => {
     if (show) return;
     if (isUploading) setShow(true);
   }, [isUploading, show]);
+
+  const autoDismissTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (isUploading || overviewUploadingStatus === 'pending') {
+      clearTimeout(autoDismissTimerRef.current);
+      return;
+    }
+
+    autoDismissTimerRef.current = setTimeout(() => {
+      setShow(false);
+      dispatchDockFileList({ ids: fileList.map((item) => item.id), type: 'removeFiles' });
+    }, 3000);
+
+    return () => clearTimeout(autoDismissTimerRef.current);
+  }, [isUploading, overviewUploadingStatus, fileList, dispatchDockFileList]);
 
   if (count === 0 || !show) return;
 


### PR DESCRIPTION
## Summary
UploadDock 上传完成后面板永不消失，需手动点 X。现所有文件完成后 3 秒自动清除并隐藏。

## Changes
- 添加 `autoDismissTimerRef` 及 `useEffect`：当 `overviewUploadingStatus` 非 `uploading`/`pending` 时，3 秒后 `dispatchDockFileList({ type: 'removeFiles' })` 并 `setShow(false)`
- 期间若有新上传任务，计时器自动取消，面板保持可见

Closes #9605