### PR TITLE
🐛 fix(page-editor): use remoteServerUrl for copy link on desktop

### DIFF
--- a/src/features/PageEditor/store/action.ts
+++ b/src/features/PageEditor/store/action.ts
@@ -1,9 +1,11 @@
-import { EDITOR_DEBOUNCE_TIME, EDITOR_MAX_WAIT } from '@lobechat/const';
+import { EDITOR_DEBOUNCE_TIME, EDITOR_MAX_WAIT, isDesktop } from '@lobechat/const';
 import debug from 'debug';
 import { debounce } from 'es-toolkit/compat';
 import { type StateCreator } from 'zustand';
 
 import { useDocumentStore } from '@/store/document';
+import { getElectronStoreState } from '@/store/electron';
+import { electronSyncSelectors } from '@/store/electron/selectors';
 import { useFileStore } from '@/store/file';
 
 import { type RightPanelMode, type State } from './initialState';
@@ -64,7 +66,10 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
       handleCopyLink: (t, message) => {
         const { documentId } = get();
         if (documentId) {
-          const url = `${window.location.origin}${window.location.pathname}`;
+          const appOrigin = isDesktop
+            ? electronSyncSelectors.remoteServerUrl(getElectronStoreState())
+            : window.location.origin;
+          const url = `${appOrigin}${window.location.pathname}`;
           navigator.clipboard.writeText(url);
           message.success(t('pageEditor.linkCopied'));
         }


### PR DESCRIPTION
## Summary

Fix LOBE-7356 — PageEditor `handleCopyLink` used `window.location.origin` which resolves to `app://renderer` on desktop, making copied links unsharable.

- Use `electronSyncSelectors.remoteServerUrl(getElectronStoreState())` on desktop
- Keep `window.location.origin` on web
- Consistent with existing pattern in `global.ts` and Topic dropdown (`useDropdownMenu.tsx`)

## Test plan

- [ ] Desktop: copy link from PageEditor → pastes correct remote URL (e.g. `https://app.lobehub.com/...`)
- [ ] Web: copy link from PageEditor → pastes `window.location.origin` as before