### PR TITLE
🐛 fix(build): enable Rolldown strictExecutionOrder for production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,7 +84,7 @@ export default defineConfig({
     reportCompressedSize: false,
     rolldownOptions: {
       input: path.resolve(__dirname, isMobile ? 'index.mobile.html' : 'index.html'),
-      output: createSharedRolldownOutput({ strictExecutionOrder: isDev }),
+      output: createSharedRolldownOutput({ strictExecutionOrder: true }),
     },
   },
   define: sharedRendererDefine({ isMobile, isElectron: false }),


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`createSharedRolldownOutput` previously passed `strictExecutionOrder: isDev`, so strict chunk execution order was only applied during development. Production builds used `false`, which can allow non-deterministic ordering and subtle runtime issues for code that assumes a stable module graph order.

This change sets `strictExecutionOrder: true` for all modes so production Rolldown output matches the stricter dev behavior.

#### 🧪 How to Test

- Run `bun run build` (or the SPA/desktop build you normally use) and confirm the app bundles and runs as expected.
- Spot-check a production-like preview if you rely on chunk ordering edge cases.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A (build config only)

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)