### PR TITLE
✨ feat(builtin-tools): include skills manifest in always-on tool IDs

### DIFF
--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -61,6 +61,7 @@ export const alwaysOnToolIds = [
  */
 export const manualModeExcludeToolIds = [
   LobeActivatorManifest.identifier,
+  SkillsManifest.identifier,
   SkillStoreManifest.identifier,
 ];
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Adds `SkillsManifest.identifier` to `alwaysOnToolIds` so the skills discovery tool stays aligned with other always-on builtin tools (e.g. skill store).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Paired with cloud repo PR that bumps the submodule pointer.


Made with [Cursor](https://cursor.com)