### PR TITLE
🐛 fix: add env var support for Coding Plan and OpenCode providers

### DIFF
--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -237,6 +237,12 @@ export const getLLMConfig = () => {
 
       ENABLED_LOBEHUB: z.boolean(),
 
+      ENABLED_OPENCODEZEN: z.boolean(),
+      OPENCODEZEN_API_KEY: z.string().optional(),
+
+      ENABLED_OPENCODECODINGPLAN: z.boolean(),
+      OPENCODECODINGPLAN_API_KEY: z.string().optional(),
+
       ENABLED_XIAOMIMIMO: z.boolean(),
       XIAOMIMIMO_API_KEY: z.string().optional(),
 
@@ -480,6 +486,12 @@ export const getLLMConfig = () => {
       STRAICO_API_KEY: process.env.STRAICO_API_KEY,
 
       ENABLED_LOBEHUB: !!process.env.ENABLED_LOBEHUB,
+
+      ENABLED_OPENCODEZEN: !!process.env.OPENCODEZEN_API_KEY,
+      OPENCODEZEN_API_KEY: process.env.OPENCODEZEN_API_KEY,
+
+      ENABLED_OPENCODECODINGPLAN: !!process.env.OPENCODECODINGPLAN_API_KEY,
+      OPENCODECODINGPLAN_API_KEY: process.env.OPENCODECODINGPLAN_API_KEY,
 
       ENABLED_XIAOMIMIMO: !!process.env.XIAOMIMIMO_API_KEY,
       XIAOMIMIMO_API_KEY: process.env.XIAOMIMIMO_API_KEY,

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -35,6 +35,18 @@ export const getLLMConfig = () => {
       ENABLED_KIMICODINGPLAN: z.boolean(),
       KIMICODINGPLAN_API_KEY: z.string().optional(),
 
+      ENABLED_BAILIANCODINGPLAN: z.boolean(),
+      BAILIANCODINGPLAN_API_KEY: z.string().optional(),
+
+      ENABLED_GLMCODINGPLAN: z.boolean(),
+      GLMCODINGPLAN_API_KEY: z.string().optional(),
+
+      ENABLED_MINIMAXCODINGPLAN: z.boolean(),
+      MINIMAXCODINGPLAN_API_KEY: z.string().optional(),
+
+      ENABLED_VOLCENGINECODINGPLAN: z.boolean(),
+      VOLCENGINECODINGPLAN_API_KEY: z.string().optional(),
+
       ENABLED_PERPLEXITY: z.boolean(),
       PERPLEXITY_API_KEY: z.string().optional(),
 
@@ -289,6 +301,18 @@ export const getLLMConfig = () => {
 
       ENABLED_KIMICODINGPLAN: !!process.env.KIMICODINGPLAN_API_KEY,
       KIMICODINGPLAN_API_KEY: process.env.KIMICODINGPLAN_API_KEY,
+
+      ENABLED_BAILIANCODINGPLAN: !!process.env.BAILIANCODINGPLAN_API_KEY,
+      BAILIANCODINGPLAN_API_KEY: process.env.BAILIANCODINGPLAN_API_KEY,
+
+      ENABLED_GLMCODINGPLAN: !!process.env.GLMCODINGPLAN_API_KEY,
+      GLMCODINGPLAN_API_KEY: process.env.GLMCODINGPLAN_API_KEY,
+
+      ENABLED_MINIMAXCODINGPLAN: !!process.env.MINIMAXCODINGPLAN_API_KEY,
+      MINIMAXCODINGPLAN_API_KEY: process.env.MINIMAXCODINGPLAN_API_KEY,
+
+      ENABLED_VOLCENGINECODINGPLAN: !!process.env.VOLCENGINECODINGPLAN_API_KEY,
+      VOLCENGINECODINGPLAN_API_KEY: process.env.VOLCENGINECODINGPLAN_API_KEY,
 
       ENABLED_GROQ: !!process.env.GROQ_API_KEY,
       GROQ_API_KEY: process.env.GROQ_API_KEY,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

在 `src/envs/llm.ts` 中为以下 provider 补充 zod schema 校验和 runtimeEnv 映射：

**Coding Plan providers**（#13203 遗漏）：
- `BAILIANCODINGPLAN_API_KEY` - BailianCodingPlan (百炼)
- `GLMCODINGPLAN_API_KEY` - GLMCodingPlan (智谱)
- `MINIMAXCODINGPLAN_API_KEY` - MinimaxCodingPlan
- `VOLCENGINECODINGPLAN_API_KEY` - VolcengineCodingPlan (火山引擎)

**OpenCode providers**（#13943 遗漏）：
- `OPENCODEZEN_API_KEY` - OpenCode Zen
- `OPENCODECODINGPLAN_API_KEY` - OpenCode CodingPlan

缺少这些配置时，`getParamsFromPayload` 的 default case 会因找不到对应 key 而回退使用 `OPENAI_API_KEY`，导致自部署用户无法为各 provider 独立配置 API key。

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->