### PR TITLE
🐛 fix(onboarding): unify footer visibility behind AGENT_ONBOARDING_ENABLED

### DIFF
--- a/src/routes/onboarding/_layout/index.tsx
+++ b/src/routes/onboarding/_layout/index.tsx
@@ -4,7 +4,7 @@ import { AGENT_ONBOARDING_ENABLED } from '@lobechat/business-const';
 import { Center, Flexbox, FluentEmoji, Text } from '@lobehub/ui';
 import { Divider, Popconfirm } from 'antd';
 import { cx, useTheme } from 'antd-style';
-import { type FC, type MouseEvent, type PropsWithChildren, useCallback, useMemo } from 'react';
+import { type FC, type MouseEvent, type PropsWithChildren, useCallback } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -25,11 +25,7 @@ const OnBoardingContainer: FC<PropsWithChildren> = ({ children }) => {
   const finishOnboarding = useUserStore((s) => s.finishOnboarding);
   const isAgentOnboarding = pathname.startsWith('/onboarding/agent');
 
-  const showModeSwitchAndSkipFooter = useMemo(() => {
-    if (!isAgentOnboarding) return true;
-
-    return AGENT_ONBOARDING_ENABLED;
-  }, [isAgentOnboarding]);
+  const showModeSwitchAndSkipFooter = AGENT_ONBOARDING_ENABLED;
 
   const handleConfirmSkip = useCallback(() => {
     finishOnboarding();


### PR DESCRIPTION
## Summary
Unify the onboarding layout footer visibility logic so it is controlled entirely by `AGENT_ONBOARDING_ENABLED`, regardless of the current onboarding route (classic or agent).

Previously, the footer was always shown on non-agent onboarding routes and conditionally shown on agent routes. This change simplifies the logic and ensures consistent behavior.

## Changes
- Remove route-based conditional (`isAgentOnboarding`) from `showModeSwitchAndSkipFooter`
- Remove unused `useMemo` import