### PR TITLE
🐛 fix(chat-input): support pasting tables from Excel/Word/Sheets

### DIFF
--- a/src/components/DragUploadZone/usePasteFile.ts
+++ b/src/components/DragUploadZone/usePasteFile.ts
@@ -19,6 +19,13 @@ export const usePasteFile = (
       if (!event.clipboardData) return;
 
       const items = Array.from(event.clipboardData.items);
+      // When copying from Excel, Word, or Sheets, the clipboard may contain both text/html (plus text/plain) and image/png.
+      // In these cases, the image is just a preview for rendering and should be handled by the editor as rich text or table paste,
+      // and should NOT trigger file upload. In the case of pure screenshot clipboard content, it usually only includes image/* and will not be affected.
+      const types = event.clipboardData.types;
+      const hasRichText = types.includes('text/html') || types.includes('text/plain');
+      const hasFile = items.some((i) => i.kind === 'file');
+      if (hasRichText && hasFile) return;
       const files = await getFileListFromDataTransferItems(items);
 
       if (files.length === 0) return;

--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -1,11 +1,12 @@
 import {
-  ReactCodemirrorPlugin,
   ReactCodePlugin,
+  ReactCodemirrorPlugin,
   ReactHRPlugin,
   ReactLinkHighlightPlugin,
   ReactListPlugin,
   ReactMathPlugin,
   ReactMentionPlugin,
+  ReactTablePlugin,
   ReactVirtualBlockPlugin,
 } from '@lobehub/editor';
 import { type Editor } from '@lobehub/editor/react';
@@ -34,6 +35,7 @@ export const createChatInputRichPlugins = ({
   ReactCodePlugin,
   ReactCodemirrorPlugin,
   ReactHRPlugin,
+  ReactTablePlugin,
   linkPlugin,
   ReactVirtualBlockPlugin,
   mathPlugin,

--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -1,6 +1,6 @@
 import {
-  ReactCodePlugin,
   ReactCodemirrorPlugin,
+  ReactCodePlugin,
   ReactHRPlugin,
   ReactLinkHighlightPlugin,
   ReactListPlugin,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracked issue. -->

#### 🔀 Description of Change

When copying a table from Excel, Google Sheets or Word, the system clipboard carries **both** rich text (`text/html` + `text/plain`) and a rendered preview image (`image/png`). The previous paste handler took the image and uploaded it as a file attachment, so the user ended up with an image instead of an editable table.

This PR makes two small changes to fix that:

1. **`src/components/DragUploadZone/usePasteFile.ts`** — short-circuit file upload when the clipboard contains rich text alongside a file item. Pure screenshot paste (image-only clipboard) is unaffected, because there is no `text/html` / `text/plain` in that case.
2. **`src/features/ChatInput/InputEditor/plugins.ts`** — register `ReactTablePlugin` in the chat input rich plugin list so pasted tables are rendered by the editor.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Paste table content from Excel / Google Sheets / Word into the chat input → rendered as a table, no image upload triggered.
Paste a screenshot (Cmd+Shift+4 or similar) → still uploaded as an image attachment as before.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Table paste was uploaded as an image preview | Table paste is rendered inline as a table |

#### 📝 Additional Information

No breaking changes. No migration required.