### PR TITLE
🐛 fix: strip manifest link in Vite dev to silence 404 warning

### DIFF
--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -143,6 +143,14 @@ export function sharedRendererPlugins(options: SharedRendererOptions) {
     viteNodeModuleStub(),
     vitePlatformResolve(options.platform),
 
+    isDev && {
+      name: 'lobe-dev-strip-manifest',
+      transformIndexHtml: {
+        order: 'pre' as const,
+        handler: (html: string) => html.replace(/\s*<link\s+rel="manifest"[^>]*>\s*/i, '\n    '),
+      },
+    },
+
     isDev &&
       codeInspectorPlugin({
         bundler: 'vite',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

In Vite dev mode, `/manifest.webmanifest` is not served (only generated in production by VitePWA), so the browser console logs a 404 for the `<link rel="manifest">` tag declared in `index.html`.

Added a shared dev-only Vite plugin `lobe-dev-strip-manifest` in `plugins/vite/sharedRendererConfig.ts` that removes the tag via `transformIndexHtml` (pre order). It is wired through `sharedRendererPlugins`, so it applies to web / mobile / desktop renderers and is a no-op in production (short-circuited by `isDev`).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Run `bun run dev:spa` and confirm the browser no longer logs a 404 for `/manifest.webmanifest`. Production build unchanged (manifest tag still emitted as expected by VitePWA).

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No behavior change in production. The plugin only strips the tag during dev.