### PR TITLE
✨ feat(chat): inline resend when editing last user message

### DIFF
--- a/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
+++ b/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
@@ -75,17 +75,16 @@ const MessageContent = memo<MessageContentProps>(
       (s) => dataSelectors.getDisplayMessageById(id)(s)?.editorData,
     );
 
-    const role = useConversationStore((s) => dataSelectors.getDisplayMessageById(id)(s)?.role);
-
-    const isLastUserMessage = useConversationStore(
-      (s) => s.displayMessages.findLast((m) => m.role === 'user')?.id === id,
-    );
-
-    const isAIGenerating = useConversationStore(messageStateSelectors.isAIGenerating);
+    // Short-circuit on non-editing rows so streaming token updates stay O(1) per row
+    // instead of each row running `findLast` on displayMessages (O(N²) per update).
+    const shouldSendOnConfirm = useConversationStore((s) => {
+      if (!editing) return false;
+      if (dataSelectors.getDisplayMessageById(id)(s)?.role !== 'user') return false;
+      if (s.displayMessages.findLast((m) => m.role === 'user')?.id !== id) return false;
+      return !messageStateSelectors.isAIGenerating(s);
+    });
 
     const { t } = useTranslation('common');
-
-    const shouldSendOnConfirm = role === 'user' && isLastUserMessage && !isAIGenerating;
 
     const onEditingChange = useCallback(
       (edit: boolean) => toggleMessageEditing(id, edit),

--- a/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
+++ b/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
@@ -2,8 +2,13 @@ import { Flexbox } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { type ReactNode } from 'react';
 import { memo, Suspense, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { dataSelectors, useConversationStore } from '@/features/Conversation/store';
+import {
+  dataSelectors,
+  messageStateSelectors,
+  useConversationStore,
+} from '@/features/Conversation/store';
 import dynamic from '@/libs/next/dynamic';
 
 import { type ChatItemProps } from '../../type';
@@ -59,14 +64,28 @@ const MessageContent = memo<MessageContentProps>(
     className,
     variant,
   }) => {
-    const [toggleMessageEditing, updateMessageContent] = useConversationStore((s) => [
-      s.toggleMessageEditing,
-      s.updateMessageContent,
-    ]);
+    const [toggleMessageEditing, updateMessageContent, regenerateUserMessage] =
+      useConversationStore((s) => [
+        s.toggleMessageEditing,
+        s.updateMessageContent,
+        s.regenerateUserMessage,
+      ]);
 
     const editorData = useConversationStore(
       (s) => dataSelectors.getDisplayMessageById(id)(s)?.editorData,
     );
+
+    const role = useConversationStore((s) => dataSelectors.getDisplayMessageById(id)(s)?.role);
+
+    const isLastUserMessage = useConversationStore(
+      (s) => s.displayMessages.findLast((m) => m.role === 'user')?.id === id,
+    );
+
+    const isAIGenerating = useConversationStore(messageStateSelectors.isAIGenerating);
+
+    const { t } = useTranslation('common');
+
+    const shouldSendOnConfirm = role === 'user' && isLastUserMessage && !isAIGenerating;
 
     const onEditingChange = useCallback(
       (edit: boolean) => toggleMessageEditing(id, edit),
@@ -93,6 +112,7 @@ const MessageContent = memo<MessageContentProps>(
           {editing && (
             <EditorModal
               editorData={editorData}
+              okText={shouldSendOnConfirm ? t('send') : t('save')}
               open={editing}
               value={message ? String(message) : ''}
               onCancel={() => onEditingChange(false)}
@@ -101,6 +121,9 @@ const MessageContent = memo<MessageContentProps>(
                   editorData: newEditorData as Record<string, any> | undefined,
                 });
                 onEditingChange(false);
+                if (shouldSendOnConfirm) {
+                  await regenerateUserMessage(id);
+                }
               }}
             />
           )}

--- a/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
+++ b/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
@@ -77,11 +77,15 @@ const MessageContent = memo<MessageContentProps>(
 
     // Short-circuit on non-editing rows so streaming token updates stay O(1) per row
     // instead of each row running `findLast` on displayMessages (O(N²) per update).
+    // Use isInputLoading (covers sendMessage + AI runtime) rather than isAIGenerating,
+    // otherwise the initial send phase — where the persisted id has just swapped in
+    // under an optimistic tmp_* op — would flip to Send and kick off a duplicate
+    // regenerate for the same prompt.
     const shouldSendOnConfirm = useConversationStore((s) => {
       if (!editing) return false;
       if (dataSelectors.getDisplayMessageById(id)(s)?.role !== 'user') return false;
       if (s.displayMessages.findLast((m) => m.role === 'user')?.id !== id) return false;
-      return !messageStateSelectors.isAIGenerating(s);
+      return !messageStateSelectors.isInputLoading(s);
     });
 
     const { t } = useTranslation('common');

--- a/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
+++ b/src/features/Conversation/ChatItem/components/MessageContent/index.tsx
@@ -116,13 +116,17 @@ const MessageContent = memo<MessageContentProps>(
               value={message ? String(message) : ''}
               onCancel={() => onEditingChange(false)}
               onConfirm={async (value, newEditorData) => {
-                await updateMessageContent(id, value, {
+                onEditingChange(false);
+                // updateMessageContent does an optimistic state update synchronously before
+                // awaiting the DB round trip. Kick off regenerate in parallel so the old
+                // assistant reply is replaced by switchMessageBranch without waiting for persistence.
+                const save = updateMessageContent(id, value, {
                   editorData: newEditorData as Record<string, any> | undefined,
                 });
-                onEditingChange(false);
                 if (shouldSendOnConfirm) {
                   await regenerateUserMessage(id);
                 }
+                await save;
               }}
             />
           )}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Make the edit confirm button in the user message edit modal reflect user intent:

- When the edited message is the **last user message** AND the AI is **not currently generating**, the confirm button is labeled **Send**. Clicking it saves the edit and immediately triggers `regenerateUserMessage` so the AI produces a new reply in one step.
- In all other cases (not the last user message, or a reply is still streaming / waiting), the button is labeled **Save** and only persists the text — avoiding destructive regeneration on mid-conversation edits and avoiding interference with in-flight generations.

Rationale: editing the last message is almost always a "re-ask" — merging save + regenerate removes a redundant extra click. Mid-conversation edits are typically just text fixes, where silently discarding subsequent messages would be unsafe.

Implementation lives entirely in `src/features/Conversation/ChatItem/components/MessageContent/index.tsx`:

- Added subscriptions for `role`, `isLastUserMessage` (derived from `displayMessages.findLast(role === 'user')`), and `messageStateSelectors.isAIGenerating`.
- Defensive `role === 'user'` guard ensures Send never shows on non-user content.
- Reuses the existing `regenerateUserMessage` action (which already covers thread contexts via `resendThreadMessage`).
- No changes to `EditorModal` (uses existing `okText` prop passthrough) and no new i18n keys (`send` and `save` already exist in `common.ts`).

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual test scenarios:

1. **Send path**: send a user message, wait for the AI reply to finish. Click edit on that user message — button reads **Send**. Modify the text and confirm — content updates and a new AI reply is generated in a new branch.
2. **Save path — not last**: edit a user message that has subsequent messages after it. Button reads **Save** and only persists the text.
3. **Save path — AI generating**: open the edit modal on the last user message while the AI is still streaming or waiting. Button reads **Save**.
4. **Reactivity**: open the edit modal on the last user message while streaming (button: Save), keep it open, let the stream complete — button should flip to **Send**.
5. **Regression**: assistant message editing (handled by `EditState.tsx`, not touched) continues to show **OK**.

Type check passes (`bun run type-check`).

#### 📸 Screenshots / Videos

UI change is limited to the label of the confirm button in the message edit modal (`OK` → `Save` / `Send`).

| Before | After |
| ------ | ----- |
| Confirm button always shows `OK` — user must perform a separate regenerate action after editing the last message. | Confirm button shows `Send` for the last user message (when AI is idle) and `Save` otherwise. |

#### 📝 Additional Information

No breaking changes, no migration, no performance impact. The additional selectors are cheap (`findLast` single-pass on `displayMessages`, which is bounded by visible message count).