### PR TITLE
♻️ refactor: alias buffer package as buffer.js for cleaner imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "better-auth-harmony": "^1.2.5",
     "better-call": "1.1.8",
     "brotli-wasm": "^3.0.1",
-    "buffer": "^6.0.3",
+    "buffer.js": "npm:buffer@^6.0.3",
     "chat": "^4.23.0",
     "chroma-js": "^3.2.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -1,5 +1,5 @@
 import { imageUrlToBase64, videoUrlToBase64 } from '@lobechat/utils';
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 import type OpenAI from 'openai';
 import { toFile } from 'openai';
 

--- a/packages/model-runtime/src/providers/replicate/index.ts
+++ b/packages/model-runtime/src/providers/replicate/index.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 import Replicate from 'replicate';
 
 import type { LobeRuntimeAI } from '../../core/BaseAI';

--- a/packages/utils/src/base64.ts
+++ b/packages/utils/src/base64.ts
@@ -3,7 +3,7 @@
  * Works in both browser and Node.js environments
  */
 
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 
 /**
  * Encode a string to base64

--- a/packages/utils/src/imageToBase64.ts
+++ b/packages/utils/src/imageToBase64.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 
 export const imageToBase64 = ({
   size,

--- a/packages/utils/src/trace.ts
+++ b/packages/utils/src/trace.ts
@@ -1,6 +1,6 @@
 import type { TracePayload } from '@lobechat/const';
 import { LOBE_CHAT_TRACE_HEADER, LOBE_CHAT_TRACE_ID } from '@lobechat/const';
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 
 export const getTracePayload = (req: Request): TracePayload | undefined => {
   const header = req.headers.get(LOBE_CHAT_TRACE_HEADER);

--- a/src/features/DevPanel/CacheViewer/schema.ts
+++ b/src/features/DevPanel/CacheViewer/schema.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 import { z } from 'zod';
 
 const unstableCacheFileSchema = z.object({

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -1,6 +1,6 @@
 import { type ChatContextContent } from '@lobechat/types';
 import { COMPRESSIBLE_IMAGE_TYPES, compressImageFile } from '@lobechat/utils/compressImage';
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer.js';
 import { t } from 'i18next';
 
 import { notification } from '@/components/AntdStaticMethods';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Historically we wrote `import { Buffer } from 'buffer/'` — the trailing slash was required to keep bundlers/Node from resolving to the built-in `buffer` module, and it looks ugly at every call site.

This PR replaces the trailing-slash workaround with a pnpm package alias:

- `package.json`: `"buffer": "^6.0.3"` → `"buffer.js": "npm:buffer@^6.0.3"`
- All 7 import sites updated from `'buffer/'` to `'buffer.js'`:
  - `packages/model-runtime/src/core/contextBuilders/openai.ts`
  - `packages/model-runtime/src/providers/replicate/index.ts`
  - `packages/utils/src/base64.ts`
  - `packages/utils/src/imageToBase64.ts`
  - `packages/utils/src/trace.ts`
  - `src/features/DevPanel/CacheViewer/schema.ts`
  - `src/store/file/slices/chat/action.ts`

Because `buffer.js` is no longer a name shared with Node's built-in module, the trailing slash is unnecessary. Runtime behavior is identical — it's still the same `buffer@6.0.3` package underneath.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified `pnpm install` links the alias correctly (`+ buffer.js <- buffer 6.0.3`) and IDE diagnostics are clean on all modified files.

#### 📝 Additional Information

No runtime/API changes — pure cosmetic rename via pnpm alias. No migration required for consumers of these files.