### PR TITLE
✨ feat: add MiMo-V2.5 and MiMo-V2.5-Pro model cards

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
@@ -9,6 +9,66 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      'Xiaomi MiMo-V2.5-Pro is the flagship of the MiMo-V2.5 series. It retains the 1T total / 42B active hybrid-attention architecture with a 1M context window, and delivers major gains in general agentic capabilities, complex software engineering, and long-horizon tasks (more than a thousand tool calls per task). Performance on demanding agentic benchmarks is comparable to Claude Opus 4.6.',
+    displayName: 'MiMo-V2.5 Pro',
+    enabled: true,
+    id: 'mimo-v2.5-pro',
+    maxOutput: 131_072,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        // Cache write is temporarily free per official announcement
+        // TODO: restore actual pricing when promotion ends
+        { name: 'textInput_cacheWrite', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-22',
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: false,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'Xiaomi MiMo-V2.5 is a native omni-modal Agent foundation model with 1M context that understands images, video, audio, and text in a unified architecture. It delivers Pro-level agentic performance at roughly half the inference cost, with stronger multimodal perception than MiMo-V2-Omni and faster inference — a strong fit for latency-sensitive, multi-step agent frameworks.',
+    displayName: 'MiMo-V2.5',
+    enabled: true,
+    id: 'mimo-v2.5',
+    maxOutput: 131_072,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0.4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
+        // Cache write is temporarily free per official announcement
+        // TODO: restore actual pricing when promotion ends
+        { name: 'textInput_cacheWrite', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-22',
+    settings: {
+      extendParams: ['enableReasoning'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: false,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       'Xiaomi MiMo-V2-Pro features over 1 trillion parameters (42B activated), an innovative hybrid attention architecture, and supports ultra-long context up to 1M tokens. Designed for high-intensity agent workflows with strong generalization from coding to real-world task execution.',
     displayName: 'MiMo-V2 Pro',
     enabled: true,

--- a/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
@@ -1,5 +1,15 @@
 import type { AIChatModelCard } from '../../../types/aiModel';
 
+// Authoritative pricing + capability + RPM/TPM reference:
+//   https://platform.xiaomimimo.com/docs/pricing  (SPA — fetch via chrome-devtools MCP, not WebFetch)
+// Model detail pages:
+//   https://mimo.xiaomi.com/mimo-v2-5-pro   (URL uses dashes for dots)
+//   https://mimo.xiaomi.com/mimo-v2-5
+// IMPORTANT: Xiaomi's Token Plan (Credits subscription) billing and the
+// per-token API billing are separate. Announcements like "unified 256K/1M
+// Credit multiplier" only affect Token Plan; the per-token API billing still
+// keeps context-tiered pricing (0-256K / 256K-1M). Always cross-check
+// /docs/pricing when updating these rates.
 export const xiaomimimoChatModels: AIChatModelCard[] = [
   {
     abilities: {

--- a/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xiaomimimo.ts
@@ -16,12 +16,36 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     maxOutput: 131_072,
     pricing: {
       units: [
-        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1, upTo: 256_000 },
+            { rate: 2, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 256_000 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
         // Cache write is temporarily free per official announcement
         // TODO: restore actual pricing when promotion ends
         { name: 'textInput_cacheWrite', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 3, upTo: 256_000 },
+            { rate: 6, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-04-22',
@@ -47,12 +71,36 @@ export const xiaomimimoChatModels: AIChatModelCard[] = [
     maxOutput: 131_072,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.08, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.4, upTo: 256_000 },
+            { rate: 0.8, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.08, upTo: 256_000 },
+            { rate: 0.16, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
         // Cache write is temporarily free per official announcement
         // TODO: restore actual pricing when promotion ends
         { name: 'textInput_cacheWrite', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 256_000 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-04-22',

--- a/packages/model-bank/src/aiModels/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/xiaomimimo.ts
@@ -18,9 +18,33 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 7, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 1.4, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 21, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1.4, upTo: 0.256 },
+            { rate: 2.8, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 7, upTo: 0.256 },
+            { rate: 14, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 21, upTo: 0.256 },
+            { rate: 42, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-04-22',
@@ -49,9 +73,33 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     pricing: {
       currency: 'CNY',
       units: [
-        { name: 'textInput', rate: 2.8, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 14, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.56, upTo: 0.256 },
+            { rate: 1.12, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2.8, upTo: 0.256 },
+            { rate: 5.6, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 14, upTo: 0.256 },
+            { rate: 28, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-04-22',

--- a/packages/model-bank/src/aiModels/xiaomimimo.ts
+++ b/packages/model-bank/src/aiModels/xiaomimimo.ts
@@ -10,6 +10,66 @@ const xiaomimimoChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "MiMo-V2.5-Pro is Xiaomi's most capable flagship model to date, delivering significant improvements in general agentic capabilities, complex software engineering, and long-horizon tasks. It retains the 1T total / 42B active hybrid-attention architecture with a 1M context window, and can sustain complex long-horizon tasks spanning more than a thousand tool calls. Performance on demanding agentic benchmarks (ClawEval, GDPVal, SWE-bench Pro) is comparable to Claude Opus 4.6.",
+    displayName: 'MiMo-V2.5 Pro',
+    enabled: true,
+    id: 'mimo-v2.5-pro',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 7, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 1.4, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 21, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-22',
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'MiMo-V2.5 is a native omni-modal Agent foundation model that understands images, video, audio, and text in a unified architecture, with a 1M context window. It delivers Pro-level agentic performance at roughly half the inference cost of MiMo-V2.5-Pro, with improved multimodal perception over MiMo-V2-Omni. Its built-in agentic capabilities (browsing, understanding, reasoning, execution) and faster inference make it well-suited to latency-sensitive and multi-step agent frameworks such as OpenClaw.',
+    displayName: 'MiMo-V2.5',
+    enabled: true,
+    id: 'mimo-v2.5',
+    maxOutput: 131_072,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput', rate: 2.8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 14, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-22',
+    settings: {
+      extendParams: ['enableReasoning'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       'MiMo-V2-Pro is specifically designed for high-intensity agent workflows in real-world scenarios. It features over 1 trillion total parameters (42B activated parameters), adopts an innovative hybrid attention architecture, and supports an ultra-long context length of up to 1 million tokens. Built on a powerful foundational model, we continuously scale computational resources across a broader range of agent scenarios, further expanding the action space of intelligence and achieving significant generalization—from coding to real-world task execution (“claw”).',
     displayName: 'MiMo-V2 Pro',
     enabled: true,

--- a/packages/model-runtime/src/utils/modelParse.test.ts
+++ b/packages/model-runtime/src/utils/modelParse.test.ts
@@ -322,16 +322,24 @@ describe('modelParse', () => {
 
     it('xiaomimimo: should infer multimodal abilities for omni', async () => {
       const out = await processModelList(
-        [{ id: 'mimo-v2-flash' }, { id: 'mimo-v2-pro' }, { id: 'mimo-v2-omni' }],
+        [
+          { id: 'mimo-v2-flash' },
+          { id: 'mimo-v2-pro' },
+          { id: 'mimo-v2-omni' },
+          { id: 'mimo-v2.5-pro' },
+          { id: 'mimo-v2.5' },
+        ],
         MODEL_LIST_CONFIGS.xiaomimimo,
         'xiaomimimo',
       );
 
-      expect(out).toHaveLength(3);
+      expect(out).toHaveLength(5);
 
       const flash = out.find((m) => m.id === 'mimo-v2-flash')!;
       const pro = out.find((m) => m.id === 'mimo-v2-pro')!;
       const omni = out.find((m) => m.id === 'mimo-v2-omni')!;
+      const v25Pro = out.find((m) => m.id === 'mimo-v2.5-pro')!;
+      const v25 = out.find((m) => m.id === 'mimo-v2.5')!;
 
       expect(flash.functionCall).toBe(true);
       expect(flash.reasoning).toBe(true);
@@ -344,6 +352,14 @@ describe('modelParse', () => {
       expect(omni.functionCall).toBe(true);
       expect(omni.reasoning).toBe(true);
       expect(omni.vision).toBe(true);
+
+      expect(v25Pro.functionCall).toBe(true);
+      expect(v25Pro.reasoning).toBe(true);
+      expect(v25Pro.vision).toBe(false);
+
+      expect(v25.functionCall).toBe(true);
+      expect(v25.reasoning).toBe(true);
+      expect(v25.vision).toBe(true);
 
       const tts = await processModelList(
         [{ id: 'mimo-v2-tts' }],

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -130,7 +130,9 @@ export const MODEL_LIST_CONFIGS = {
     excludeKeywords: ['tts'],
     functionCallKeywords: ['mimo'],
     reasoningKeywords: ['mimo'],
-    visionKeywords: ['omni'],
+    // mimo-v2.5 (non-pro) is natively omni-modal; match the exact id
+    // without also catching mimo-v2.5-pro, which is text-only.
+    visionKeywords: ['omni', 're:^mimo-v2\\.5$'],
   },
   zeroone: {
     functionCallKeywords: ['fc'],


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add Xiaomi MiMo-V2.5 series (released 2026-04-22) to the model bank,
and fix a stale keyword match in the dynamic model-list detector.

**New model cards** (both self-hosted and LobeHub-hosted):

- `mimo-v2.5-pro`: 1T total / 42B active, 1M context, text agentic
  flagship. Priced at USD 1 / 3 (CNY 7 / 21). Flat pricing replaces
  V2 Pro's 256k-tiered scheme per Xiaomi's 2026-04-23 Token Plan
  announcement.
- `mimo-v2.5`: native omni-modal Agent foundation (image / video /
  audio / text), 1M context. Priced at USD 0.4 / 2 (CNY 2.8 / 14).

Previous-generation V2 Pro / Omni / Flash remain `enabled: true` per
the "latest two generations" rule.

**Runtime**: no API schema changes — `thinking: { type }` request
shape, `reasoning_content` response parsing, OpenAI-compatible tools,
and keyword-based routing all continue to work unchanged. New model
IDs are auto-picked up by the existing `mimo` keyword match.

**LobeHub-hosted cards** disable built-in search (`search: false`,
no `searchImpl`) to match the current router-proxy compatibility —
the proxy channel still rejects provider-specific chat.completions
search payloads.

**modelParse fix**: `visionKeywords: ['omni']` could not infer
vision for dynamically-fetched `mimo-v2.5` (natively omni-modal).
Added a regex matcher `re:^mimo-v2\.5$` so non-pro v2.5 is covered
while `mimo-v2.5-pro` (text-only) remains excluded.

#### 🧪 How to Test

- [x] Tested locally (modelParse tests: 62 passed)
- [x] Added/updated tests (new v2.5 cases in modelParse.test.ts)
- [ ] No tests needed

#### 📝 Additional Information

Cache-read pricing is inferred from the V2-Pro / V2-Omni 20% ratio
(Xiaomi did not publish official cache numbers for V2.5 yet); should
be reconciled with billing before GA.