### PR TITLE
🐛 fix(desktop): surface human approval notifications

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -99,7 +99,9 @@ export default class NotificationCtr extends ControllerModule {
     }
   }
   /**
-   * Show system desktop notification (only when window is hidden)
+   * Show system desktop notification.
+   * By default notifications only appear when the main window is hidden or unfocused.
+   * High-priority callers can pass `force` to surface a banner even while focused.
    */
   @IpcMethod()
   async showDesktopNotification(
@@ -117,12 +119,16 @@ export default class NotificationCtr extends ControllerModule {
       // Check if window is hidden
       const isWindowHidden = this.isMainWindowHidden();
 
-      if (!isWindowHidden) {
+      if (!params.force && !isWindowHidden) {
         logger.debug('Main window is visible, skipping desktop notification');
         return { reason: 'Window is visible', skipped: true, success: true };
       }
 
-      logger.info('Window is hidden, showing desktop notification:', params.title);
+      if (params.requestAttention && isWindowHidden) {
+        this.requestUserAttention();
+      }
+
+      logger.info('Showing desktop notification:', params.title);
 
       const notification = new Notification({
         body: params.body,
@@ -175,6 +181,23 @@ export default class NotificationCtr extends ControllerModule {
         error: error instanceof Error ? error.message : 'Unknown error',
         success: false,
       };
+    }
+  }
+
+  private requestUserAttention(): void {
+    try {
+      const mainWindow = this.app.browserManager.getMainWindow().browserWindow;
+
+      if (mainWindow.isDestroyed()) return;
+
+      if (electronIs.macOS()) {
+        app.dock?.bounce?.('informational');
+        return;
+      }
+
+      mainWindow.flashFrame(true);
+    } catch (error) {
+      logger.error('Failed to request user attention:', error);
     }
   }
 

--- a/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
@@ -34,6 +34,9 @@ vi.mock('electron', () => {
     },
     Notification: MockNotification,
     app: {
+      dock: {
+        bounce: vi.fn(),
+      },
       setAppUserModelId: vi.fn(),
     },
   };
@@ -48,6 +51,7 @@ vi.mock('electron-is', () => ({
 
 // Mock browserManager
 const mockBrowserWindow = {
+  flashFrame: vi.fn(),
   focus: vi.fn(),
   isDestroyed: vi.fn(() => false),
   isFocused: vi.fn(() => true),
@@ -181,6 +185,24 @@ describe('NotificationCtr', () => {
       expect(result).toEqual({ success: true });
     });
 
+    it('should show notification when force is true even if window is visible and focused', async () => {
+      const { Notification } = await import('electron');
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(true);
+      mockBrowserWindow.isFocused.mockReturnValue(true);
+      mockBrowserWindow.isMinimized.mockReturnValue(false);
+
+      const promise = controller.showDesktopNotification({
+        ...params,
+        force: true,
+      });
+      vi.advanceTimersByTime(100);
+      const result = await promise;
+
+      expect(Notification).toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+
     it('should use low urgency on Linux to prevent GNOME Shell freeze', async () => {
       const { linux } = await import('electron-is');
       const { Notification } = await import('electron');
@@ -250,6 +272,40 @@ describe('NotificationCtr', () => {
           silent: true,
         }),
       );
+    });
+
+    it('should request window attention when requested and window is hidden', async () => {
+      const { Notification } = await import('electron');
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(false);
+
+      const promise = controller.showDesktopNotification({
+        ...params,
+        requestAttention: true,
+      });
+      vi.advanceTimersByTime(100);
+      await promise;
+
+      expect(mockBrowserWindow.flashFrame).toHaveBeenCalledWith(true);
+    });
+
+    it('should bounce dock on macOS when attention is requested', async () => {
+      const { app, Notification } = await import('electron');
+      const { macOS } = await import('electron-is');
+      vi.mocked(macOS).mockReturnValue(true);
+      vi.mocked(Notification.isSupported).mockReturnValue(true);
+      mockBrowserWindow.isVisible.mockReturnValue(false);
+
+      const promise = controller.showDesktopNotification({
+        ...params,
+        requestAttention: true,
+      });
+      vi.advanceTimersByTime(100);
+      await promise;
+
+      expect(app.dock.bounce).toHaveBeenCalledWith('informational');
+
+      vi.mocked(macOS).mockReturnValue(false);
     });
 
     it('should register click handler to show main window', async () => {

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -105,6 +105,8 @@
   "defaultSession": "Default Agent",
   "desktopNotification.aiReplyCompleted.body": "Agent reply is ready",
   "desktopNotification.aiReplyCompleted.title": "Reply completed",
+  "desktopNotification.humanApprovalRequired.body": "An Agent needs your approval to continue",
+  "desktopNotification.humanApprovalRequired.title": "Approval required",
   "dm.placeholder": "Your private messages with {{agentTitle}} will appear here.",
   "dm.tooltip": "Send a private message",
   "dm.visibleTo": "Visible to {{target}} only",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -105,6 +105,8 @@
   "defaultSession": "自定义助理",
   "desktopNotification.aiReplyCompleted.body": "AI 回复生成完成",
   "desktopNotification.aiReplyCompleted.title": "AI 回复完成",
+  "desktopNotification.humanApprovalRequired.body": "Agent 需要你的批准后才能继续",
+  "desktopNotification.humanApprovalRequired.title": "需要你的批准",
   "dm.placeholder": "你与 {{agentTitle}} 的私信会显示在这里。",
   "dm.tooltip": "发送私信",
   "dm.visibleTo": "仅 {{target}} 可见",

--- a/packages/electron-client-ipc/src/types/notification.ts
+++ b/packages/electron-client-ipc/src/types/notification.ts
@@ -1,5 +1,7 @@
 export interface ShowDesktopNotificationParams {
   body: string;
+  force?: boolean;
+  requestAttention?: boolean;
   silent?: boolean;
   title: string;
 }

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -68,6 +68,8 @@ export default {
   'defaultSession': 'Default Agent',
   'desktopNotification.aiReplyCompleted.body': 'Agent reply is ready',
   'desktopNotification.aiReplyCompleted.title': 'Reply completed',
+  'desktopNotification.humanApprovalRequired.body': 'An Agent needs your approval to continue',
+  'desktopNotification.humanApprovalRequired.title': 'Approval required',
   'dm.placeholder': 'Your private messages with {{agentTitle}} will appear here.',
   'dm.tooltip': 'Send a private message',
   'dm.visibleTo': 'Visible to {{target}} only',

--- a/src/services/electron/desktopNotification.ts
+++ b/src/services/electron/desktopNotification.ts
@@ -10,7 +10,9 @@ import { ensureElectronIpc } from '@/utils/electron/ipc';
  */
 export class DesktopNotificationService {
   /**
-   * Show desktop notification (only when window is hidden)
+   * Show a desktop notification.
+   * By default notifications only appear when the main window is hidden or unfocused.
+   * Callers can override this with `force` for high-priority reminders.
    * @param params Notification parameters
    * @returns Notification result
    */

--- a/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
@@ -3,9 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type StreamEvent } from '@/services/agentRuntime';
 import { useChatStore } from '@/store/chat/store';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 
 // Keep zustand mock as it's needed globally
 vi.mock('zustand/traditional');
+vi.mock('@/store/chat/utils/desktopNotification', () => ({
+  notifyDesktopHumanApprovalRequired: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Test Constants
 const TEST_IDS = {
@@ -312,6 +316,67 @@ describe('runAgent actions', () => {
 
         // Should not process event
         expect(result.current.internal_dispatchMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('step_start event', () => {
+      it('should notify desktop when human approval is required', async () => {
+        const { result } = renderHook(() => useChatStore());
+
+        act(() => {
+          useChatStore.setState({
+            operations: {
+              [TEST_IDS.OPERATION_ID]: {
+                abortController: new AbortController(),
+                context: { agentId: 'agent-1', groupId: 'group-1', topicId: 'topic-1' },
+                id: TEST_IDS.OPERATION_ID,
+                metadata: {
+                  lastEventId: '0',
+                  startTime: Date.now(),
+                  stepCount: 0,
+                },
+                status: 'running',
+                type: 'groupAgentGenerate',
+              },
+            },
+          });
+        });
+
+        const context = createStreamingContext({
+          assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+        });
+
+        const event: StreamEvent = {
+          type: 'step_start',
+          timestamp: Date.now(),
+          operationId: TEST_IDS.OPERATION_ID,
+          data: {
+            pendingToolsCalling: [{ id: 'tool-1' }],
+            phase: 'human_approval',
+            requiresApproval: true,
+          },
+        };
+
+        await act(async () => {
+          await result.current.internal_handleAgentStreamEvent(
+            TEST_IDS.OPERATION_ID,
+            event,
+            context,
+          );
+        });
+
+        expect(result.current.updateOperationMetadata).toHaveBeenCalledWith(TEST_IDS.OPERATION_ID, {
+          needsHumanInput: true,
+          pendingApproval: [{ id: 'tool-1' }],
+        });
+        expect(notifyDesktopHumanApprovalRequired).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.objectContaining({
+            agentId: 'agent-1',
+            groupId: 'group-1',
+            topicId: 'topic-1',
+          }),
+        );
       });
     });
   });

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -8,6 +8,7 @@ import { agentRuntimeService } from '@/services/agentRuntime';
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { type ChatStore } from '@/store/chat/store';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { type StoreSetter } from '@/store/types';
 
@@ -284,6 +285,8 @@ export class AgentActionImpl {
             needsHumanInput: true,
             pendingApproval: pendingToolsCalling,
           });
+
+          await notifyDesktopHumanApprovalRequired(this.#get, operation.context);
 
           // Stop loading state, waiting for human intervention
           log(`Stopping loading for human approval: ${assistantId}`);

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -2,6 +2,7 @@ import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { messageService } from '@/services/message';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 
 import { createGatewayEventHandler } from '../gatewayEventHandler';
 
@@ -10,6 +11,9 @@ vi.mock('@/services/message', () => ({
     getMessages: vi.fn().mockResolvedValue([]),
     updateMessageError: vi.fn().mockResolvedValue({ success: true }),
   },
+}));
+vi.mock('@/store/chat/utils/desktopNotification', () => ({
+  notifyDesktopHumanApprovalRequired: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ─── Test Helpers ───
@@ -208,6 +212,29 @@ describe('createGatewayEventHandler', () => {
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
       expect(store.replaceMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('step_start', () => {
+    it('should notify desktop when human approval is required', () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(
+        makeEvent('step_start', {
+          pendingToolsCalling: [{ id: 'tool-1' }],
+          phase: 'human_approval',
+          requiresApproval: true,
+        }),
+      );
+
+      expect(notifyDesktopHumanApprovalRequired).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          agentId: 'agent-1',
+          topicId: 'topic-1',
+        }),
+      );
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -10,6 +10,7 @@ import { AgentRuntimeErrorType } from '@lobechat/types';
 
 import { messageService } from '@/services/message';
 import type { ChatStore } from '@/store/chat/store';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 
 /**
  * Fetch messages from DB and replace them in the chat store's dbMessagesMap.
@@ -194,6 +195,20 @@ export const createGatewayEventHandler = (
       case 'tool_start': {
         // Server creates tool messages in DB.
         // Loading is already active from stream_start (not cleared by stream_end).
+        break;
+      }
+
+      case 'step_start': {
+        const data = event.data as {
+          pendingToolsCalling?: unknown[];
+          phase?: string;
+          requiresApproval?: boolean;
+        };
+
+        if (data?.phase === 'human_approval' && data.requiresApproval && data.pendingToolsCalling) {
+          void notifyDesktopHumanApprovalRequired(get, context);
+        }
+
         break;
       }
 

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -29,6 +29,7 @@ import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { createAgentExecutors } from '@/store/chat/agents/createAgentExecutors';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 import { getTaskStoreState } from '@/store/task';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { type StoreSetter } from '@/store/types';
@@ -634,6 +635,15 @@ export class StreamingExecutorActionImpl {
         switch (event.type) {
           case 'done': {
             log('[internal_execAgentRuntime] Received done event');
+            break;
+          }
+
+          case 'human_approve_required': {
+            await notifyDesktopHumanApprovalRequired(this.#get, {
+              agentId,
+              groupId,
+              topicId,
+            });
             break;
           }
 

--- a/src/store/chat/utils/desktopNotification.ts
+++ b/src/store/chat/utils/desktopNotification.ts
@@ -1,0 +1,62 @@
+import { isDesktop } from '@lobechat/const';
+import type { ConversationContext } from '@lobechat/types';
+import { t } from 'i18next';
+
+import { getAgentStoreState } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import type { ChatStore } from '@/store/chat/store';
+
+import { topicMapKey } from './topicMapKey';
+
+interface DesktopNotificationContext {
+  agentId?: ConversationContext['agentId'];
+  groupId?: ConversationContext['groupId'];
+  topicId?: ConversationContext['topicId'];
+}
+
+const resolveNotificationTitle = (
+  get: () => ChatStore,
+  context: DesktopNotificationContext,
+): string => {
+  const title = t('desktopNotification.humanApprovalRequired.title', { ns: 'chat' });
+
+  if (context.topicId && context.agentId) {
+    const key = topicMapKey({ agentId: context.agentId, groupId: context.groupId });
+    const topicData = get().topicDataMap[key];
+    const topic = topicData?.items?.find((item) => item.id === context.topicId);
+
+    if (topic?.title) return topic.title;
+  }
+
+  if (context.agentId) {
+    const agentMeta = agentSelectors.getAgentMetaById(context.agentId)(getAgentStoreState());
+
+    if (agentMeta?.title) return agentMeta.title;
+  }
+
+  return title;
+};
+
+export const notifyDesktopHumanApprovalRequired = async (
+  get: () => ChatStore,
+  context: DesktopNotificationContext,
+): Promise<void> => {
+  if (!isDesktop) return;
+
+  try {
+    const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
+    const title = resolveNotificationTitle(get, context);
+
+    await Promise.allSettled([
+      desktopNotificationService.setBadgeCount(1),
+      desktopNotificationService.showNotification({
+        body: t('desktopNotification.humanApprovalRequired.body', { ns: 'chat' }),
+        force: true,
+        requestAttention: true,
+        title,
+      }),
+    ]);
+  } catch (error) {
+    console.error('Human approval desktop notification failed:', error);
+  }
+};


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

This PR makes human-approval requests much more visible in the desktop app.

- add a dedicated desktop notification helper for human approval requests
- extend Electron notification IPC with `force` and `requestAttention` so approval prompts can surface even when the app is focused
- request stronger desktop attention when the window is hidden by using Dock bounce on macOS and frame flashing on other desktop platforms
- wire the reminder into the local runtime, gateway runtime, and legacy agent stream handling paths
- add approval-specific notification copy and update targeted tests

#### 🧪 How to Test

- Run `bunx vitest run --silent='passed-only' 'src/main/controllers/__tests__/NotificationCtr.test.ts'` in `apps/desktop`
- Run `bunx vitest run --silent='passed-only' 'src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts'`
- Trigger a tool call that enters manual human approval and confirm the desktop app surfaces a visible notification/reminder

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

- `src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts` is not included in the verified test run because the current workspace hits a pre-existing `buffer.js` import-resolution failure before the suite executes.
- `bun run type-check` still reports many unrelated pre-existing errors in the workspace, so it is not a clean signal for this PR.
