### PR TITLE
✨ feat(runtime-config): add redis-backed feature flag provider

### DIFF
--- a/src/config/featureFlags/index.ts
+++ b/src/config/featureFlags/index.ts
@@ -1,14 +1,10 @@
-import { EdgeConfig } from '@lobechat/edge-config';
 import { createEnv } from '@t3-oss/env-nextjs';
-import debug from 'debug';
 import { z } from 'zod';
 
 import { merge } from '@/utils/merge';
 
 import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from './schema';
 import { parseFeatureFlag } from './utils/parser';
-
-const log = debug('lobe-feature-flags');
 
 const env = createEnv({
   runtimeEnv: {
@@ -27,56 +23,10 @@ export const getServerFeatureFlagsValue = () => {
   return result;
 };
 
-/**
- * Get feature flags from EdgeConfig with fallback to environment variables
- * @param userId - Optional user ID for user-specific feature flag evaluation
- */
-export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
-  // Try to get feature flags from EdgeConfig first
-  if (EdgeConfig.isEnabled()) {
-    try {
-      const edgeConfig = new EdgeConfig();
-      const edgeFeatureFlags = await edgeConfig.getFeatureFlags();
-
-      if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
-        // Merge EdgeConfig flags with defaults
-        const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
-        log('[FeatureFlags] Using EdgeConfig flags for user:', userId || 'anonymous');
-        return mergedFlags;
-      } else {
-        log(
-          '[FeatureFlags] EdgeConfig returned empty/null/undefined, falling back to environment variables',
-        );
-      }
-    } catch (error) {
-      log(
-        '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
-        error,
-      );
-    }
-  } else {
-    log('[FeatureFlags] EdgeConfig not enabled, using environment variables');
-  }
-
-  // Fallback to environment variable-based feature flags
-  const envFlags = getServerFeatureFlagsValue();
-  log('[FeatureFlags] Using environment variable flags for user:', userId || 'anonymous');
-  return envFlags;
-};
-
 export const serverFeatureFlags = (userId?: string) => {
   const serverConfig = getServerFeatureFlagsValue();
 
   return mapFeatureFlagsEnvToState(serverConfig, userId);
-};
-
-/**
- * Get server feature flags from EdgeConfig and map them to state with user ID
- * @param userId - Optional user ID for user-specific feature flag evaluation
- */
-export const getServerFeatureFlagsStateFromEdgeConfig = async (userId?: string) => {
-  const flags = await getServerFeatureFlagsFromEdgeConfig(userId);
-  return mapFeatureFlagsEnvToState(flags, userId);
 };
 
 export * from './schema';

--- a/src/server/featureFlags/index.ts
+++ b/src/server/featureFlags/index.ts
@@ -1,55 +1,104 @@
-import { EdgeConfig } from '@lobechat/edge-config';
 import createDebug from 'debug';
+import { z } from 'zod';
 
 import {
   DEFAULT_FEATURE_FLAGS,
+  FeatureFlagsSchema,
   getServerFeatureFlagsValue,
   mapFeatureFlagsEnvToState,
 } from '@/config/featureFlags';
+import type { IFeatureFlags } from '@/config/featureFlags';
+import {
+  CompositeRuntimeConfigProvider,
+  EnvRuntimeConfigProvider,
+  RedisRuntimeConfigProvider,
+} from '@/server/runtimeConfig';
+import type {
+  RuntimeConfigDomain,
+  RuntimeConfigProvider,
+  RuntimeConfigSelector,
+} from '@/server/runtimeConfig';
 import { merge } from '@/utils/merge';
 
 const debug = createDebug('lobe:featureFlags');
 
-/**
- * Get feature flags from EdgeConfig with fallback to environment variables
- * @param userId - Optional user ID for user-specific feature flag evaluation
- */
-export const getServerFeatureFlagsFromEdgeConfig = async (userId?: string) => {
-  // Try to get feature flags from EdgeConfig first
-  if (EdgeConfig.isEnabled()) {
-    try {
-      const edgeConfig = new EdgeConfig();
-      const edgeFeatureFlags = await edgeConfig.getFeatureFlags();
+const FEATURE_FLAGS_DOMAIN: RuntimeConfigDomain<IFeatureFlags> = {
+  cacheTtlMs: 5000,
+  getStorageKey: () => 'runtime-config:feature-flags:published',
+  getVersionKey: () => 'runtime-config:feature-flags:version',
+  key: 'feature-flags',
+  schema: FeatureFlagsSchema,
+};
 
-      if (edgeFeatureFlags && Object.keys(edgeFeatureFlags).length > 0) {
-        // Merge EdgeConfig flags with defaults
-        const mergedFlags = merge(DEFAULT_FEATURE_FLAGS, edgeFeatureFlags);
-        debug('Using EdgeConfig flags for user: %s', userId || 'anonymous');
-        return mergedFlags;
-      } else {
-        debug('EdgeConfig returned empty/null/undefined, falling back to environment variables');
-      }
-    } catch (error) {
-      console.error(
-        '[FeatureFlags] Failed to fetch feature flags from EdgeConfig, falling back to environment variables:',
-        error,
-      );
-    }
-  } else {
-    debug('EdgeConfig not enabled, using environment variables');
+const FEATURE_FLAG_OVERRIDE_DOMAIN: RuntimeConfigDomain<Record<string, boolean>> = {
+  cacheTtlMs: 30_000,
+  getStorageKey: (selector?: RuntimeConfigSelector) => {
+    if (!selector || selector.scope !== 'user') return 'runtime-config:feature-flags:user:anonymous';
+
+    return `runtime-config:feature-flags:user:${selector.id}`;
+  },
+  key: 'feature-flags-user-overrides',
+  schema: z.record(z.string(), z.boolean()),
+};
+
+let featureFlagsProvider: RuntimeConfigProvider<IFeatureFlags> | null = null;
+let featureFlagsOverrideProvider: RuntimeConfigProvider<Record<string, boolean>> | null = null;
+
+const getFeatureFlagsProvider = () => {
+  featureFlagsProvider ??= new CompositeRuntimeConfigProvider(
+    new RedisRuntimeConfigProvider(FEATURE_FLAGS_DOMAIN),
+    new EnvRuntimeConfigProvider(FEATURE_FLAGS_DOMAIN, {
+      getSnapshotData: () => getServerFeatureFlagsValue(),
+    }),
+  );
+
+  return featureFlagsProvider;
+};
+
+const getFeatureFlagOverrideProvider = () => {
+  featureFlagsOverrideProvider ??= new RedisRuntimeConfigProvider(FEATURE_FLAG_OVERRIDE_DOMAIN);
+
+  return featureFlagsOverrideProvider;
+};
+
+const getMergedFeatureFlags = async (userId?: string) => {
+  const globalSnapshot = await getFeatureFlagsProvider().getSnapshot({ scope: 'global' });
+
+  const globalFlags = merge(DEFAULT_FEATURE_FLAGS, globalSnapshot?.data || {});
+
+  if (!userId) {
+    return globalFlags;
   }
 
-  // Fallback to environment variable-based feature flags
-  const envFlags = getServerFeatureFlagsValue();
-  debug('Using environment variable flags for user: %s', userId || 'anonymous');
-  return envFlags;
+  const userOverrideSnapshot = await getFeatureFlagOverrideProvider().getSnapshot({
+    id: userId,
+    scope: 'user',
+  });
+
+  if (!userOverrideSnapshot) {
+    return globalFlags;
+  }
+
+  return merge(globalFlags, userOverrideSnapshot.data as Partial<IFeatureFlags>);
 };
 
 /**
- * Get server feature flags from EdgeConfig and map them to state with user ID
+ * Get feature flags from RuntimeConfig with fallback to environment variables
  * @param userId - Optional user ID for user-specific feature flag evaluation
  */
-export const getServerFeatureFlagsStateFromEdgeConfig = async (userId?: string) => {
-  const flags = await getServerFeatureFlagsFromEdgeConfig(userId);
+export const getServerFeatureFlagsFromRuntimeConfig = async (userId?: string) => {
+  const flags = await getMergedFeatureFlags(userId);
+
+  debug('Using runtime feature flags for user: %s', userId || 'anonymous');
+
+  return flags;
+};
+
+/**
+ * Get server feature flags from RuntimeConfig and map them to state with user ID
+ * @param userId - Optional user ID for user-specific feature flag evaluation
+ */
+export const getServerFeatureFlagsStateFromRuntimeConfig = async (userId?: string) => {
+  const flags = await getServerFeatureFlagsFromRuntimeConfig(userId);
   return mapFeatureFlagsEnvToState(flags, userId);
 };

--- a/src/server/featureFlags/index.ts
+++ b/src/server/featureFlags/index.ts
@@ -1,22 +1,22 @@
 import createDebug from 'debug';
 import { z } from 'zod';
 
+import type { IFeatureFlags } from '@/config/featureFlags';
 import {
   DEFAULT_FEATURE_FLAGS,
   FeatureFlagsSchema,
   getServerFeatureFlagsValue,
   mapFeatureFlagsEnvToState,
 } from '@/config/featureFlags';
-import type { IFeatureFlags } from '@/config/featureFlags';
-import {
-  CompositeRuntimeConfigProvider,
-  EnvRuntimeConfigProvider,
-  RedisRuntimeConfigProvider,
-} from '@/server/runtimeConfig';
 import type {
   RuntimeConfigDomain,
   RuntimeConfigProvider,
   RuntimeConfigSelector,
+} from '@/server/runtimeConfig';
+import {
+  CompositeRuntimeConfigProvider,
+  EnvRuntimeConfigProvider,
+  RedisRuntimeConfigProvider,
 } from '@/server/runtimeConfig';
 import { merge } from '@/utils/merge';
 
@@ -33,7 +33,8 @@ const FEATURE_FLAGS_DOMAIN: RuntimeConfigDomain<IFeatureFlags> = {
 const FEATURE_FLAG_OVERRIDE_DOMAIN: RuntimeConfigDomain<Record<string, boolean>> = {
   cacheTtlMs: 30_000,
   getStorageKey: (selector?: RuntimeConfigSelector) => {
-    if (!selector || selector.scope !== 'user') return 'runtime-config:feature-flags:user:anonymous';
+    if (!selector || selector.scope !== 'user')
+      return 'runtime-config:feature-flags:user:anonymous';
 
     return `runtime-config:feature-flags:user:${selector.id}`;
   },

--- a/src/server/routers/lambda/config/index.ts
+++ b/src/server/routers/lambda/config/index.ts
@@ -2,7 +2,7 @@ import { EdgeConfig } from '@lobechat/edge-config';
 import debug from 'debug';
 
 import { businessConfigEndpoints } from '@/business/server/lambda-routers/config';
-import { getServerFeatureFlagsStateFromEdgeConfig } from '@/config/featureFlags';
+import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 import { getServerDefaultAgentConfig, getServerGlobalConfig } from '@/server/globalConfig';
 import {
@@ -64,7 +64,7 @@ export const configRouter = router({
 
     const [serverConfig, serverFeatureFlags, billboard] = await Promise.all([
       getServerGlobalConfig(),
-      getServerFeatureFlagsStateFromEdgeConfig(ctx.userId || undefined),
+      getServerFeatureFlagsStateFromRuntimeConfig(ctx.userId || undefined),
       getActiveBillboard(),
     ]);
 

--- a/src/server/routers/lambda/config/index.ts
+++ b/src/server/routers/lambda/config/index.ts
@@ -2,8 +2,8 @@ import { EdgeConfig } from '@lobechat/edge-config';
 import debug from 'debug';
 
 import { businessConfigEndpoints } from '@/business/server/lambda-routers/config';
-import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
 import { publicProcedure, router } from '@/libs/trpc/lambda';
+import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
 import { getServerDefaultAgentConfig, getServerGlobalConfig } from '@/server/globalConfig';
 import {
   type GlobalBillboard,

--- a/src/server/runtimeConfig/index.ts
+++ b/src/server/runtimeConfig/index.ts
@@ -1,0 +1,2 @@
+export * from './providers';
+export * from './types';

--- a/src/server/runtimeConfig/providers/CompositeRuntimeConfigProvider.ts
+++ b/src/server/runtimeConfig/providers/CompositeRuntimeConfigProvider.ts
@@ -1,0 +1,31 @@
+import type {
+  RuntimeConfigProvider,
+  RuntimeConfigSelector,
+  VersionedSnapshot,
+} from '../types';
+
+export class CompositeRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
+  domain: RuntimeConfigProvider<T>['domain'];
+
+  constructor(
+    private primary: RuntimeConfigProvider<T>,
+    private fallback: RuntimeConfigProvider<T>,
+  ) {
+    this.domain = primary.domain;
+  }
+
+  isEnabled() {
+    return this.primary.isEnabled() || this.fallback.isEnabled();
+  }
+
+  async getSnapshot(selector?: RuntimeConfigSelector): Promise<VersionedSnapshot<T> | null> {
+    if (this.primary.isEnabled()) {
+      const snapshot = await this.primary.getSnapshot(selector);
+      if (snapshot) return snapshot;
+    }
+
+    if (!this.fallback.isEnabled()) return null;
+
+    return this.fallback.getSnapshot(selector);
+  }
+}

--- a/src/server/runtimeConfig/providers/EnvRuntimeConfigProvider.ts
+++ b/src/server/runtimeConfig/providers/EnvRuntimeConfigProvider.ts
@@ -1,0 +1,36 @@
+import type {
+  RuntimeConfigDomain,
+  RuntimeConfigProvider,
+  RuntimeConfigSelector,
+  VersionedSnapshot,
+} from '../types';
+
+interface EnvRuntimeConfigProviderOptions<T> {
+  getSnapshotData: (selector?: RuntimeConfigSelector) => T | null;
+}
+
+const ENV_SNAPSHOT_VERSION = 0;
+const ENV_SNAPSHOT_UPDATED_AT = '1970-01-01T00:00:00.000Z';
+
+export class EnvRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
+  constructor(
+    public domain: RuntimeConfigDomain<T>,
+    private options: EnvRuntimeConfigProviderOptions<T>,
+  ) {}
+
+  isEnabled() {
+    return true;
+  }
+
+  async getSnapshot(selector?: RuntimeConfigSelector): Promise<VersionedSnapshot<T> | null> {
+    const data = this.options.getSnapshotData(selector);
+
+    if (!data) return null;
+
+    return {
+      data,
+      updatedAt: ENV_SNAPSHOT_UPDATED_AT,
+      version: ENV_SNAPSHOT_VERSION,
+    };
+  }
+}

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { RedisRuntimeConfigProvider } from './RedisRuntimeConfigProvider';
+
+const getRedisConfigMock = vi.fn();
+const initializeRedisMock = vi.fn();
+
+vi.mock('@/envs/redis', () => ({
+  getRedisConfig: getRedisConfigMock,
+}));
+
+vi.mock('@/libs/redis', () => ({
+  initializeRedis: initializeRedisMock,
+}));
+
+const testDomain = {
+  cacheTtlMs: 5000,
+  getStorageKey: () => 'runtime-config:test:published',
+  key: 'test',
+  schema: z.object({ enabled: z.boolean() }),
+};
+
+describe('RedisRuntimeConfigProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return parsed snapshot data from versioned envelope', async () => {
+    getRedisConfigMock.mockReturnValue({ enabled: true });
+    initializeRedisMock.mockResolvedValue({
+      get: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          data: { enabled: true },
+          updatedAt: '2026-04-23T00:00:00.000Z',
+          version: 12,
+        }),
+      ),
+    });
+
+    const provider = new RedisRuntimeConfigProvider(testDomain);
+    const snapshot = await provider.getSnapshot({ scope: 'global' });
+
+    expect(snapshot).toEqual({
+      data: { enabled: true },
+      updatedAt: '2026-04-23T00:00:00.000Z',
+      version: 12,
+    });
+  });
+
+  it('should return null when redis is disabled', async () => {
+    getRedisConfigMock.mockReturnValue({ enabled: false });
+
+    const provider = new RedisRuntimeConfigProvider(testDomain);
+
+    expect(provider.isEnabled()).toBe(false);
+  });
+});

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
@@ -27,6 +27,7 @@ const testDomain = {
 describe('RedisRuntimeConfigProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('should return parsed snapshot data from versioned envelope', async () => {
@@ -72,5 +73,29 @@ describe('RedisRuntimeConfigProvider', () => {
 
     expect(initializeRedisMock).toHaveBeenCalledTimes(1);
     expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should proactively evict expired selector cache entries', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T00:00:00.000Z'));
+
+    const getMock = vi.fn().mockResolvedValue(null);
+
+    getRedisConfigMock.mockReturnValue({ enabled: true });
+    initializeRedisMock.mockResolvedValue({ get: getMock });
+
+    const provider = new RedisRuntimeConfigProvider(testDomain);
+
+    await expect(provider.getSnapshot({ id: 'user-1', scope: 'user' })).resolves.toBeNull();
+    expect((provider as any).cache.size).toBe(1);
+
+    vi.setSystemTime(new Date('2026-04-23T00:00:06.000Z'));
+
+    await expect(provider.getSnapshot({ id: 'user-2', scope: 'user' })).resolves.toBeNull();
+
+    expect((provider as any).cache.has('user:user-1')).toBe(false);
+    expect((provider as any).cache.has('user:user-2')).toBe(true);
+    expect((provider as any).cache.size).toBe(1);
+    expect(getMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 
 import { RedisRuntimeConfigProvider } from './RedisRuntimeConfigProvider';
 
-const getRedisConfigMock = vi.fn();
-const initializeRedisMock = vi.fn();
+const { getRedisConfigMock, initializeRedisMock } = vi.hoisted(() => ({
+  getRedisConfigMock: vi.fn(),
+  initializeRedisMock: vi.fn(),
+}));
 
 vi.mock('@/envs/redis', () => ({
   getRedisConfig: getRedisConfigMock,
@@ -55,5 +57,20 @@ describe('RedisRuntimeConfigProvider', () => {
     const provider = new RedisRuntimeConfigProvider(testDomain);
 
     expect(provider.isEnabled()).toBe(false);
+  });
+
+  it('should treat cached null snapshots as cache hits', async () => {
+    const getMock = vi.fn().mockResolvedValue(null);
+
+    getRedisConfigMock.mockReturnValue({ enabled: true });
+    initializeRedisMock.mockResolvedValue({ get: getMock });
+
+    const provider = new RedisRuntimeConfigProvider(testDomain);
+
+    await expect(provider.getSnapshot({ scope: 'global' })).resolves.toBeNull();
+    await expect(provider.getSnapshot({ scope: 'global' })).resolves.toBeNull();
+
+    expect(initializeRedisMock).toHaveBeenCalledTimes(1);
+    expect(getMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
@@ -1,0 +1,127 @@
+import debug from 'debug';
+
+import { getRedisConfig } from '@/envs/redis';
+import { initializeRedis } from '@/libs/redis';
+
+import type {
+  RuntimeConfigDomain,
+  RuntimeConfigProvider,
+  RuntimeConfigSelector,
+  VersionedSnapshot,
+} from '../types';
+
+const log = debug('lobe:runtime-config');
+
+interface CacheRecord<T> {
+  expiresAt: number;
+  snapshot: VersionedSnapshot<T> | null;
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isVersionedSnapshotEnvelope = (value: unknown): value is VersionedSnapshot<unknown> => {
+  if (!isObject(value)) return false;
+
+  return 'data' in value && 'updatedAt' in value && 'version' in value;
+};
+
+export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
+  private cache = new Map<string, CacheRecord<T>>();
+
+  constructor(public domain: RuntimeConfigDomain<T>) {}
+
+  isEnabled() {
+    return getRedisConfig().enabled;
+  }
+
+  private getCacheKey(selector?: RuntimeConfigSelector) {
+    if (!selector || selector.scope === 'global') {
+      return 'global';
+    }
+
+    return `${selector.scope}:${selector.id}`;
+  }
+
+  private getCacheRecord(selector?: RuntimeConfigSelector) {
+    const record = this.cache.get(this.getCacheKey(selector));
+    if (!record) return null;
+    if (record.expiresAt <= Date.now()) {
+      this.cache.delete(this.getCacheKey(selector));
+      return null;
+    }
+
+    return record.snapshot;
+  }
+
+  private setCacheRecord(snapshot: VersionedSnapshot<T> | null, selector?: RuntimeConfigSelector) {
+    this.cache.set(this.getCacheKey(selector), {
+      expiresAt: Date.now() + this.domain.cacheTtlMs,
+      snapshot,
+    });
+  }
+
+  private resolveEnvelopeData(raw: string): VersionedSnapshot<T> | null {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      console.error('[RuntimeConfig] Failed to parse snapshot payload from Redis:', error);
+      return null;
+    }
+
+    if (isVersionedSnapshotEnvelope(parsed)) {
+      const result = this.domain.schema.safeParse(parsed.data);
+
+      if (!result.success) {
+        log('[RuntimeConfig] Domain %s schema validation failed', this.domain.key, result.error);
+        return null;
+      }
+
+      return {
+        data: result.data,
+        updatedAt: String(parsed.updatedAt),
+        version: Number(parsed.version) || 0,
+      };
+    }
+
+    const result = this.domain.schema.safeParse(parsed);
+
+    if (!result.success) {
+      log('[RuntimeConfig] Domain %s schema validation failed', this.domain.key, result.error);
+      return null;
+    }
+
+    return {
+      data: result.data,
+      updatedAt: new Date().toISOString(),
+      version: 0,
+    };
+  }
+
+  async getSnapshot(selector?: RuntimeConfigSelector): Promise<VersionedSnapshot<T> | null> {
+    const cached = this.getCacheRecord(selector);
+    if (cached) return cached;
+
+    try {
+      const redis = await initializeRedis(getRedisConfig());
+      if (!redis) return null;
+
+      const key = this.domain.getStorageKey(selector);
+      const raw = await redis.get(key);
+
+      if (!raw) {
+        this.setCacheRecord(null, selector);
+        return null;
+      }
+
+      const envelope = this.resolveEnvelopeData(raw);
+      this.setCacheRecord(envelope, selector);
+      return envelope;
+    } catch (error) {
+      console.error('[RuntimeConfig] Failed to read runtime config from Redis:', error);
+      return null;
+    }
+  }
+}

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
@@ -28,6 +28,7 @@ const isVersionedSnapshotEnvelope = (value: unknown): value is VersionedSnapshot
 
 export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
   private cache = new Map<string, CacheRecord<T>>();
+  private nextExpiredEntryAt = Number.POSITIVE_INFINITY;
 
   constructor(public domain: RuntimeConfigDomain<T>) {}
 
@@ -43,22 +44,51 @@ export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
     return `${selector.scope}:${selector.id}`;
   }
 
+  private evictExpiredEntriesIfNeeded(now: number) {
+    if (this.cache.size === 0) {
+      this.nextExpiredEntryAt = Number.POSITIVE_INFINITY;
+      return;
+    }
+
+    if (now < this.nextExpiredEntryAt) return;
+
+    let nextExpiredEntryAt = Number.POSITIVE_INFINITY;
+
+    for (const [key, record] of this.cache) {
+      if (record.expiresAt <= now) {
+        this.cache.delete(key);
+        continue;
+      }
+
+      if (record.expiresAt < nextExpiredEntryAt) {
+        nextExpiredEntryAt = record.expiresAt;
+      }
+    }
+
+    this.nextExpiredEntryAt = nextExpiredEntryAt;
+  }
+
   private getCacheRecord(selector?: RuntimeConfigSelector) {
+    const now = Date.now();
+    this.evictExpiredEntriesIfNeeded(now);
+
     const record = this.cache.get(this.getCacheKey(selector));
     if (!record) return null;
-    if (record.expiresAt <= Date.now()) {
-      this.cache.delete(this.getCacheKey(selector));
-      return null;
-    }
 
     return record;
   }
 
   private setCacheRecord(snapshot: VersionedSnapshot<T> | null, selector?: RuntimeConfigSelector) {
+    const expiresAt = Date.now() + this.domain.cacheTtlMs;
+
     this.cache.set(this.getCacheKey(selector), {
-      expiresAt: Date.now() + this.domain.cacheTtlMs,
+      expiresAt,
       snapshot,
     });
+
+    if (expiresAt < this.nextExpiredEntryAt) {
+      this.nextExpiredEntryAt = expiresAt;
+    }
   }
 
   private resolveEnvelopeData(raw: string): VersionedSnapshot<T> | null {

--- a/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
+++ b/src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.ts
@@ -51,7 +51,7 @@ export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
       return null;
     }
 
-    return record.snapshot;
+    return record;
   }
 
   private setCacheRecord(snapshot: VersionedSnapshot<T> | null, selector?: RuntimeConfigSelector) {
@@ -102,7 +102,7 @@ export class RedisRuntimeConfigProvider<T> implements RuntimeConfigProvider<T> {
 
   async getSnapshot(selector?: RuntimeConfigSelector): Promise<VersionedSnapshot<T> | null> {
     const cached = this.getCacheRecord(selector);
-    if (cached) return cached;
+    if (cached) return cached.snapshot;
 
     try {
       const redis = await initializeRedis(getRedisConfig());

--- a/src/server/runtimeConfig/providers/index.ts
+++ b/src/server/runtimeConfig/providers/index.ts
@@ -1,0 +1,3 @@
+export * from './CompositeRuntimeConfigProvider';
+export * from './EnvRuntimeConfigProvider';
+export * from './RedisRuntimeConfigProvider';

--- a/src/server/runtimeConfig/types.ts
+++ b/src/server/runtimeConfig/types.ts
@@ -1,0 +1,32 @@
+import type { ZodSchema } from 'zod';
+
+export interface RuntimeConfigGlobalSelector {
+  scope: 'global';
+}
+
+export interface RuntimeConfigUserSelector {
+  id: string;
+  scope: 'user';
+}
+
+export type RuntimeConfigSelector = RuntimeConfigGlobalSelector | RuntimeConfigUserSelector;
+
+export interface VersionedSnapshot<T> {
+  data: T;
+  updatedAt: string;
+  version: number;
+}
+
+export interface RuntimeConfigDomain<T> {
+  cacheTtlMs: number;
+  getStorageKey: (selector?: RuntimeConfigSelector) => string;
+  getVersionKey?: (selector?: RuntimeConfigSelector) => string;
+  key: string;
+  schema: ZodSchema<T>;
+}
+
+export interface RuntimeConfigProvider<T> {
+  domain: RuntimeConfigDomain<T>;
+  getSnapshot: (selector?: RuntimeConfigSelector) => Promise<VersionedSnapshot<T> | null>;
+  isEnabled: () => boolean;
+}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- add a Redis-backed runtime config provider for feature flags with env fallback
- wire feature-flag reads through the runtime config provider path
- cache null Redis snapshots as negative cache hits to avoid repeated misses
- add provider tests for envelope parsing and cached-null behavior

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Test command:

```bash
bunx vitest run --silent=passed-only src/server/runtimeConfig/providers/RedisRuntimeConfigProvider.test.ts\n```\n\n#### 📝 Additional Information\n\n- rebased onto the latest `canary` before opening this PR\n- no UI changes in this PR\n