### PR TITLE
💄 style: compact kanban card layout with variant prop

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
@@ -171,7 +171,7 @@ const KanbanBoard = memo<KanbanBoardProps>(({ agentId }) => {
               width: COLUMN_WIDTH - 8,
             }}
           >
-            <AgentTaskItem task={activeTask} />
+            <AgentTaskItem task={activeTask} variant="compact" />
           </div>
         ) : null}
       </DragOverlay>

--- a/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
@@ -10,7 +10,7 @@ import type { TaskListItem } from '@/store/task/slices/list/initialState';
 import AgentTaskItem from '../features/AgentTaskItem';
 import TaskStatusIcon from '../features/TaskStatusIcon';
 
-export const COLUMN_WIDTH = 520;
+export const COLUMN_WIDTH = 300;
 
 const cardStyles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
@@ -45,7 +45,7 @@ const DraggableTaskCard = memo<{ task: TaskListItem }>(({ task }) => {
       {...listeners}
       {...attributes}
     >
-      <AgentTaskItem task={task} />
+      <AgentTaskItem task={task} variant="compact" />
     </div>
   );
 });

--- a/src/features/AgentTasks/features/AgentTaskItem.tsx
+++ b/src/features/AgentTasks/features/AgentTaskItem.tsx
@@ -18,6 +18,7 @@ import TaskTriggerTag from './TaskTriggerTag';
 
 interface TaskItemProps {
   task: TaskListItem;
+  variant?: 'compact' | 'default';
 }
 
 const formatTime = (time?: string | Date | null) => {
@@ -40,7 +41,7 @@ type TaskStatus = 'backlog' | 'canceled' | 'completed' | 'failed' | 'paused' | '
 const toTaskStatus = (status: string): TaskStatus =>
   TASK_STATUS_SET.has(status) ? (status as TaskStatus) : 'backlog';
 
-const AgentTaskItem = memo<TaskItemProps>(({ task }) => {
+const AgentTaskItem = memo<TaskItemProps>(({ task, variant = 'default' }) => {
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
   useFetchTaskDetail(task.identifier);
@@ -60,55 +61,70 @@ const AgentTaskItem = memo<TaskItemProps>(({ task }) => {
     if (targetAgentId) navigate(`/agent/${targetAgentId}/tasks/${task.identifier}`);
   }, [targetAgentId, navigate, task.identifier]);
 
+  const titleRow = (
+    <Flexbox horizontal align={'center'} gap={8}>
+      <TaskPriorityTag priority={task.priority} taskIdentifier={task.identifier} />
+      <TaskStatusTag status={status} taskIdentifier={task.identifier} />
+      <Text ellipsis weight={500}>
+        {task.name || task.identifier}
+      </Text>
+      <TaskSubtaskProgressTag
+        currentIdentifier={task.identifier}
+        subtasks={taskDetail?.subtasks}
+        onSubtaskClick={(identifier) => {
+          if (targetAgentId) navigate(`/agent/${targetAgentId}/tasks/${identifier}`);
+        }}
+      />
+    </Flexbox>
+  );
+
+  const metaRow = (
+    <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
+      <TaskScheduleConfig
+        currentInterval={taskDetail?.heartbeat?.interval ?? 0}
+        taskId={task.identifier}
+      >
+        <TaskTriggerTag
+          heartbeatInterval={taskDetail?.heartbeat?.interval}
+          schedulePattern={task.schedulePattern}
+          scheduleTimezone={task.scheduleTimezone}
+        />
+      </TaskScheduleConfig>
+      <AssigneeAgentSelector
+        currentAgentId={task.assigneeAgentId}
+        disabled={status === 'running'}
+        taskIdentifier={task.identifier}
+      >
+        <AssigneeAvatar agentId={task.assigneeAgentId} />
+      </AssigneeAgentSelector>
+      {time && (
+        <Text
+          align={'right'}
+          fontSize={12}
+          style={{ whiteSpace: 'nowrap', width: variant === 'compact' ? undefined : 76 }}
+          type={'secondary'}
+        >
+          {time}
+        </Text>
+      )}
+    </Flexbox>
+  );
+
+  if (variant === 'compact') {
+    return (
+      <Block clickable gap={4} padding={12} variant={'borderless'} onClick={handleClick}>
+        {titleRow}
+        <TaskLatestActivity activities={taskDetail?.activities} />
+        {metaRow}
+      </Block>
+    );
+  }
+
   return (
     <Block clickable gap={4} padding={12} variant={'borderless'} onClick={handleClick}>
       <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
-        <Flexbox horizontal align="center" gap={8}>
-          <TaskPriorityTag priority={task.priority} taskIdentifier={task.identifier} />
-          <TaskStatusTag status={status} taskIdentifier={task.identifier} />
-          <Text ellipsis weight={500}>
-            {task.name || task.identifier}
-          </Text>
-          <TaskSubtaskProgressTag
-            currentIdentifier={task.identifier}
-            subtasks={taskDetail?.subtasks}
-            onSubtaskClick={(identifier) => {
-              if (targetAgentId) navigate(`/agent/${targetAgentId}/tasks/${identifier}`);
-            }}
-          />
-        </Flexbox>
-        <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
-          <TaskScheduleConfig
-            currentInterval={taskDetail?.heartbeat?.interval ?? 0}
-            taskId={task.identifier}
-          >
-            <TaskTriggerTag
-              heartbeatInterval={taskDetail?.heartbeat?.interval}
-              schedulePattern={task.schedulePattern}
-              scheduleTimezone={task.scheduleTimezone}
-            />
-          </TaskScheduleConfig>
-          <AssigneeAgentSelector
-            currentAgentId={task.assigneeAgentId}
-            disabled={status === 'running'}
-            taskIdentifier={task.identifier}
-          >
-            <AssigneeAvatar agentId={task.assigneeAgentId} />
-          </AssigneeAgentSelector>
-          {time && (
-            <Text
-              align={'right'}
-              fontSize={12}
-              type={'secondary'}
-              style={{
-                whiteSpace: 'nowrap',
-                width: 76,
-              }}
-            >
-              {time}
-            </Text>
-          )}
-        </Flexbox>
+        {titleRow}
+        {metaRow}
       </Flexbox>
       <TaskLatestActivity activities={taskDetail?.activities} />
     </Block>

--- a/src/features/AgentTasks/features/AssigneeAvatar.tsx
+++ b/src/features/AgentTasks/features/AssigneeAvatar.tsx
@@ -9,7 +9,7 @@ interface AssigneeAvatarProps {
   size?: number;
 }
 
-const AssigneeAvatar = memo<AssigneeAvatarProps>(({ agentId, size = 22 }) => {
+const AssigneeAvatar = memo<AssigneeAvatarProps>(({ agentId, size = 18 }) => {
   const displayMeta = useAgentDisplayMeta(agentId);
 
   if (!displayMeta) return null;


### PR DESCRIPTION
## Summary
- Add `variant` prop (`'compact' | 'default'`) to `AgentTaskItem` for kanban board cards
- Compact layout moves metadata (schedule, avatar, time) to a separate bottom row
- Reduce kanban column width from 520px to 300px so 4 columns fit in ~one screen

<img width="1684" height="1076" alt="image" src="https://github.com/user-attachments/assets/9671585a-4f8c-43e2-8b41-26d0090a90ba" />


## Changes
- `AgentTaskItem.tsx`: Extract shared `titleRow` and `metaRow`, add `variant` prop with compact layout
- `KanbanColumn.tsx`: Column width 520 → 300, pass `variant="compact"`
- `KanbanBoard.tsx`: DragOverlay uses compact variant

Closes LOBE-8091

## Test plan
- [ ] Switch to kanban board view, verify compact card layout (title row + activity + meta row)
- [ ] Verify list view still uses default horizontal layout unchanged
- [ ] Verify 4 columns visible in ~one screen on standard display
- [ ] Drag cards between columns, verify DragOverlay uses compact layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)