### PR TITLE
✨ feat(mobile-router): add aiAgentRouter to mobileRouter

### DIFF
--- a/src/server/routers/mobile/index.ts
+++ b/src/server/routers/mobile/index.ts
@@ -6,6 +6,7 @@ import { mobileSubscriptionRouter } from '@/business/server/mobile-routers/mobil
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 
 import { agentRouter } from '../lambda/agent';
+import { aiAgentRouter } from '../lambda/aiAgent';
 import { aiChatRouter } from '../lambda/aiChat';
 import { aiModelRouter } from '../lambda/aiModel';
 import { aiProviderRouter } from '../lambda/aiProvider';
@@ -24,6 +25,7 @@ import { userRouter } from '../lambda/user';
 
 export const mobileRouter = router({
   agent: agentRouter,
+  aiAgent: aiAgentRouter,
   aiChat: aiChatRouter,
   aiModel: aiModelRouter,
   aiProvider: aiProviderRouter,


### PR DESCRIPTION
## Summary
- Add `aiAgentRouter` to `mobileRouter` to expose `execAgent`, `interruptTask`, and `refreshGatewayToken` tRPC procedures to the mobile client
- This is the server-side prerequisite for RN Gateway mode integration (LOBE-8123)

## Context
The mobile app is implementing Agent Gateway support (LOBE-7231) for server-side agent execution with WebSocket streaming. The mobile tRPC client derives its type from `typeof mobileRouter`, so adding the router here automatically makes the procedures available on the client side.

## Changes
- `src/server/routers/mobile/index.ts`: Import and register `aiAgentRouter`

## Test plan
- [ ] Verify `trpcClient.aiAgent.execAgent.mutate()` is callable from mobile client
- [ ] Verify existing mobile tRPC calls are unaffected
- [ ] Verify type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LOBE-8123 -->