### PR TITLE
🐛 fix(desktop): auto-focus ChatPanel input on screen capture overlay mount

### DIFF
--- a/apps/desktop/src/overlay/ChatPanel.tsx
+++ b/apps/desktop/src/overlay/ChatPanel.tsx
@@ -252,7 +252,7 @@ const ChatPanel = memo<ChatPanelProps>(
     }, [theme]);
 
     useLayoutEffect(() => {
-      if (selected && !hidden && textareaRef.current) {
+      if (!hidden && textareaRef.current) {
         textareaRef.current.focus();
       }
     }, [hidden, selected]);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Remove the `selected` guard from the `useLayoutEffect` that auto-focuses the ChatPanel textarea. Previously the textarea was only focused after a screenshot selection was made; now it is focused as soon as the overlay window appears, allowing the user to start typing immediately.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Launch the Electron desktop app on macOS
2. Trigger the screen capture overlay
3. Verify the textarea input receives focus automatically on overlay mount (before any selection is made)

#### 📝 Additional Information

One-line change in `ChatPanel.tsx`: `if (selected && !hidden …)` → `if (!hidden …)`.