### PR TITLE
✨ feat(deepseek): add V4 Flash/Pro cards + reasoning_effort slider

### DIFF
--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -5,21 +5,79 @@ const deepseekChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'DeepSeek V4 Flash is the cost-efficient member of the V4 family with a 1M context window and hybrid thinking. Thinking mode is on by default and can be toggled via the `thinking` parameter; non-thinking mode is optimized for latency-sensitive workflows.',
+    displayName: 'DeepSeek V4 Flash',
+    enabled: true,
+    id: 'deepseek-v4-flash',
+    maxOutput: 384_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-24',
+    settings: {
+      extendParams: ['thinking'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'DeepSeek V4 Pro is the flagship of the V4 family, optimized for high-intensity reasoning, agentic workflows, and long-horizon planning. Thinking mode is on by default and can be toggled via the `thinking` parameter.',
+    displayName: 'DeepSeek V4 Pro',
+    enabled: true,
+    id: 'deepseek-v4-pro',
+    maxOutput: 384_000,
+    pricing: {
+      currency: 'CNY',
+      units: [
+        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 24, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-24',
+    settings: {
+      extendParams: ['thinking'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       structuredOutput: true,
     },
     contextWindowTokens: 131_072,
+    // Per official docs: deepseek-chat is now a compatibility alias pointing to
+    // the non-thinking mode of deepseek-v4-flash and is slated for deprecation.
+    // Pricing is therefore the same as deepseek-v4-flash, not the former V3.2 rate.
     description:
-      'DeepSeek V3.2 is DeepSeek’s latest general model with a hybrid reasoning architecture and stronger agent capabilities.',
-    displayName: 'DeepSeek V3.2',
-    enabled: true,
+      'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
+    displayName: 'DeepSeek V3.2 (Legacy alias)',
+    enabled: false,
     id: 'deepseek-chat',
+    legacy: true,
     maxOutput: 8192,
     pricing: {
       currency: 'CNY',
       units: [
         { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',
@@ -31,18 +89,21 @@ const deepseekChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 131_072,
+    // Per official docs: deepseek-reasoner is now a compatibility alias pointing
+    // to the thinking mode of deepseek-v4-flash and is slated for deprecation.
     description:
-      'DeepSeek V3.2 thinking mode outputs a chain-of-thought before the final answer to improve accuracy.',
-    displayName: 'DeepSeek V3.2 Thinking',
-    enabled: true,
+      'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
+    displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
+    enabled: false,
     id: 'deepseek-reasoner',
+    legacy: true,
     maxOutput: 65_536,
     pricing: {
       currency: 'CNY',
       units: [
         { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -67,7 +67,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     // Pricing and sizing mirror deepseek-v4-flash since that is what the endpoint serves.
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
-    displayName: 'DeepSeek V4 Flash Non-thinking (legacy alias)',
+    displayName: 'DeepSeek V3.2 (routes to V4 Flash)',
     enabled: true,
     id: 'deepseek-chat',
     legacy: true,
@@ -93,7 +93,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     // to the thinking mode of deepseek-v4-flash and is slated for deprecation.
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
-    displayName: 'DeepSeek V4 Flash Thinking (legacy alias)',
+    displayName: 'DeepSeek V3.2 Thinking (routes to V4 Flash)',
     enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -61,17 +61,17 @@ const deepseekChatModels: AIChatModelCard[] = [
       functionCall: true,
       structuredOutput: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 1_000_000,
     // Per official docs: deepseek-chat is now a compatibility alias pointing to
     // the non-thinking mode of deepseek-v4-flash and is slated for deprecation.
-    // Pricing is therefore the same as deepseek-v4-flash, not the former V3.2 rate.
+    // Pricing and sizing mirror deepseek-v4-flash since that is what the endpoint serves.
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
-    displayName: 'DeepSeek V3.2 (Legacy alias)',
+    displayName: 'DeepSeek V4 Flash Non-thinking (legacy alias)',
     enabled: true,
     id: 'deepseek-chat',
     legacy: true,
-    maxOutput: 8192,
+    maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
       units: [
@@ -88,16 +88,16 @@ const deepseekChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 131_072,
+    contextWindowTokens: 1_000_000,
     // Per official docs: deepseek-reasoner is now a compatibility alias pointing
     // to the thinking mode of deepseek-v4-flash and is slated for deprecation.
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
-    displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
+    displayName: 'DeepSeek V4 Flash Thinking (legacy alias)',
     enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,
-    maxOutput: 65_536,
+    maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
       units: [

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -25,7 +25,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-04-24',
     settings: {
-      extendParams: ['thinking'],
+      extendParams: ['thinking', 'deepseekV4ReasoningEffort'],
     },
     type: 'chat',
   },
@@ -52,7 +52,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-04-24',
     settings: {
-      extendParams: ['thinking'],
+      extendParams: ['thinking', 'deepseekV4ReasoningEffort'],
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -68,7 +68,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
     displayName: 'DeepSeek V3.2 (Legacy alias)',
-    enabled: false,
+    enabled: true,
     id: 'deepseek-chat',
     legacy: true,
     maxOutput: 8192,
@@ -94,7 +94,7 @@ const deepseekChatModels: AIChatModelCard[] = [
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use deepseek-v4-flash instead.',
     displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
-    enabled: false,
+    enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,
     maxOutput: 65_536,

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -61,7 +61,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     // Pricing and sizing mirror deepseek-v4-flash since that is what the endpoint serves.
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
-    displayName: 'DeepSeek V4 Flash Non-thinking (legacy alias)',
+    displayName: 'DeepSeek V3.2 (routes to V4 Flash)',
     enabled: true,
     id: 'deepseek-chat',
     legacy: true,
@@ -86,7 +86,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     // points to the thinking mode of deepseek-v4-flash and will be deprecated.
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
-    displayName: 'DeepSeek V4 Flash Thinking (legacy alias)',
+    displayName: 'DeepSeek V3.2 Thinking (routes to V4 Flash)',
     enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -55,16 +55,17 @@ export const deepseekChatModels: AIChatModelCard[] = [
     abilities: {
       functionCall: true,
     },
-    contextWindowTokens: 65_536,
+    contextWindowTokens: 1_000_000,
     // Per official docs: deepseek-chat is now a compatibility alias that points
     // to the non-thinking mode of deepseek-v4-flash and will be deprecated.
-    // Pricing mirrors deepseek-v4-flash since that is what the endpoint charges.
+    // Pricing and sizing mirror deepseek-v4-flash since that is what the endpoint serves.
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
-    displayName: 'DeepSeek V3.2 (Legacy alias)',
+    displayName: 'DeepSeek V4 Flash Non-thinking (legacy alias)',
     enabled: true,
     id: 'deepseek-chat',
     legacy: true,
+    maxOutput: 384_000,
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
@@ -80,15 +81,16 @@ export const deepseekChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
     },
-    contextWindowTokens: 65_536,
+    contextWindowTokens: 1_000_000,
     // Per official docs: deepseek-reasoner is now a compatibility alias that
     // points to the thinking mode of deepseek-v4-flash and will be deprecated.
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
-    displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
+    displayName: 'DeepSeek V4 Flash Thinking (legacy alias)',
     enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,
+    maxOutput: 384_000,
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -62,7 +62,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     description:
       'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
     displayName: 'DeepSeek V3.2 (Legacy alias)',
-    enabled: false,
+    enabled: true,
     id: 'deepseek-chat',
     legacy: true,
     pricing: {
@@ -86,7 +86,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     description:
       'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
     displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
-    enabled: false,
+    enabled: true,
     id: 'deepseek-reasoner',
     legacy: true,
     pricing: {

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -4,18 +4,72 @@ export const deepseekChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
     },
-    contextWindowTokens: 65_536,
+    contextWindowTokens: 1_000_000,
     description:
-      'DeepSeek V3.2 balances reasoning and output length for daily QA and agent tasks. Public benchmarks reach GPT-5 levels, and it is the first to integrate thinking into tool use, leading open-source agent evaluations.',
-    displayName: 'DeepSeek V3.2',
+      'DeepSeek V4 Flash is the cost-efficient member of the V4 family with a 1M context window and hybrid thinking. Toggle thinking via the `thinking` parameter; non-thinking mode targets latency-sensitive workflows while thinking mode enables deeper reasoning.',
+    displayName: 'DeepSeek V4 Flash',
     enabled: true,
-    id: 'deepseek-chat',
+    id: 'deepseek-v4-flash',
+    maxOutput: 384_000,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.56, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.07, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 1.68, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-24',
+    settings: {
+      extendParams: ['thinking'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'DeepSeek V4 Pro is the flagship of the V4 family, purpose-built for high-intensity reasoning, agent workflows, and long-horizon planning with a 1M context window. Thinking mode is on by default and toggleable via the `thinking` parameter.',
+    displayName: 'DeepSeek V4 Pro',
+    enabled: true,
+    id: 'deepseek-v4-pro',
+    maxOutput: 384_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.145, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1.74, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 3.48, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-24',
+    settings: {
+      extendParams: ['thinking'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 65_536,
+    // Per official docs: deepseek-chat is now a compatibility alias that points
+    // to the non-thinking mode of deepseek-v4-flash and will be deprecated.
+    // Pricing mirrors deepseek-v4-flash since that is what the endpoint charges.
+    description:
+      'Compatibility alias for DeepSeek V4 Flash non-thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
+    displayName: 'DeepSeek V3.2 (Legacy alias)',
+    enabled: false,
+    id: 'deepseek-chat',
+    legacy: true,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',
@@ -27,16 +81,19 @@ export const deepseekChatModels: AIChatModelCard[] = [
       reasoning: true,
     },
     contextWindowTokens: 65_536,
+    // Per official docs: deepseek-reasoner is now a compatibility alias that
+    // points to the thinking mode of deepseek-v4-flash and will be deprecated.
     description:
-      'DeepSeek V3.2 Thinking is a deep reasoning model that generates chain-of-thought before outputs for higher accuracy, with top competition results and reasoning comparable to Gemini-3.0-Pro.',
-    displayName: 'DeepSeek V3.2 Thinking',
-    enabled: true,
+      'Compatibility alias for DeepSeek V4 Flash thinking mode. Slated for deprecation — use DeepSeek V4 Flash instead.',
+    displayName: 'DeepSeek V3.2 Thinking (Legacy alias)',
+    enabled: false,
     id: 'deepseek-reasoner',
+    legacy: true,
     pricing: {
       units: [
-        { name: 'textInput', rate: 0.55, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 2.19, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput_cacheRead', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -22,7 +22,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-04-24',
     settings: {
-      extendParams: ['thinking'],
+      extendParams: ['thinking', 'deepseekV4ReasoningEffort'],
     },
     type: 'chat',
   },
@@ -47,7 +47,7 @@ export const deepseekChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-04-24',
     settings: {
-      extendParams: ['thinking'],
+      extendParams: ['thinking', 'deepseekV4ReasoningEffort'],
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/modelProviders/deepseek.ts
+++ b/packages/model-bank/src/modelProviders/deepseek.ts
@@ -2,9 +2,9 @@ import type { ModelProviderCard } from '@/types/llm';
 
 const DeepSeek: ModelProviderCard = {
   chatModels: [],
-  checkModel: 'deepseek-chat',
+  checkModel: 'deepseek-v4-flash',
   description:
-    'DeepSeek focuses on AI research and applications; its latest DeepSeek-V3 benchmarks surpass open models like Qwen2.5-72B and Llama-3.1-405B, aligning with leading closed models such as GPT-4o and Claude-3.5-Sonnet.',
+    'DeepSeek focuses on AI research and applications. Its latest DeepSeek V4 family ships in Flash and Pro variants with a 1M context window and hybrid thinking — competitive with leading closed frontier models on reasoning and agent benchmarks.',
   id: 'deepseek',
   modelList: { showModelFetcher: true },
   modelsUrl: 'https://platform.deepseek.com/api-docs/zh-cn/quick_start/pricing',

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -23,5 +23,5 @@ export const planCardModels = [
   'claude-sonnet-4-6',
   'gemini-3.1-pro-preview',
   'gpt-5.4',
-  'deepseek-chat',
+  'deepseek-v4-flash',
 ];

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -254,6 +254,7 @@ export type ExtendParamsType =
   | 'gpt5_2ReasoningEffort'
   | 'gpt5_2ProReasoningEffort'
   | 'grok4_20ReasoningEffort'
+  | 'deepseekV4ReasoningEffort'
   | 'codexMaxReasoningEffort'
   | 'opus47Effort'
   | 'textVerbosity'
@@ -301,6 +302,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'gpt5_2ReasoningEffort',
   'gpt5_2ProReasoningEffort',
   'grok4_20ReasoningEffort',
+  'deepseekV4ReasoningEffort',
   'codexMaxReasoningEffort',
   'opus47Effort',
   'textVerbosity',

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -173,6 +173,127 @@ describe('LobeDeepSeekAI - custom features', () => {
         },
       ]);
     });
+
+    // DeepSeek V4 models default to thinking mode unless thinking.type === 'disabled'.
+    // In thinking mode the API rejects follow-up turns whose assistant messages omit
+    // reasoning_content when tool calls are involved — see index.ts for details.
+    describe('deepseek-v4 thinking mode reasoning_content enforcement', () => {
+      it('should force reasoning_content on v4-flash assistant messages by default', () => {
+        const payload = {
+          messages: [
+            { role: 'user', content: 'Search weather' },
+            {
+              role: 'assistant',
+              content: '',
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'search', arguments: '{"q":"weather"}' },
+                },
+              ],
+            },
+          ],
+          model: 'deepseek-v4-flash',
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[1]).toEqual({
+          role: 'assistant',
+          content: '',
+          reasoning_content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"q":"weather"}' },
+            },
+          ],
+        });
+      });
+
+      it('should force reasoning_content on v4-pro assistant messages by default', () => {
+        const payload = {
+          messages: [{ role: 'assistant', content: 'hi' }],
+          model: 'deepseek-v4-pro',
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[0]).toEqual({
+          role: 'assistant',
+          content: 'hi',
+          reasoning_content: '',
+        });
+      });
+
+      it('should force reasoning_content when thinking.type is explicitly enabled', () => {
+        const payload = {
+          messages: [{ role: 'assistant', content: 'hi' }],
+          model: 'deepseek-v4-flash',
+          thinking: { type: 'enabled' },
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[0]).toEqual({
+          role: 'assistant',
+          content: 'hi',
+          reasoning_content: '',
+        });
+      });
+
+      it('should NOT force reasoning_content when thinking.type is disabled', () => {
+        const payload = {
+          messages: [{ role: 'assistant', content: 'hi' }],
+          model: 'deepseek-v4-flash',
+          thinking: { type: 'disabled' },
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[0]).toEqual({
+          role: 'assistant',
+          content: 'hi',
+        });
+      });
+
+      it('should preserve existing reasoning_content on v4 assistant messages', () => {
+        const payload = {
+          messages: [
+            {
+              role: 'assistant',
+              content: 'answer',
+              reasoning_content: 'prior reasoning',
+            },
+          ],
+          model: 'deepseek-v4-flash',
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[0]).toEqual({
+          role: 'assistant',
+          content: 'answer',
+          reasoning_content: 'prior reasoning',
+        });
+      });
+
+      it('should NOT force reasoning_content on non-v4 / non-reasoner models', () => {
+        const payload = {
+          messages: [{ role: 'assistant', content: 'hi' }],
+          model: 'deepseek-chat',
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.messages[0]).toEqual({
+          role: 'assistant',
+          content: 'hi',
+        });
+      });
+    });
   });
 
   describe('Debug Configuration', () => {

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -12,7 +12,16 @@ export const params = {
   baseURL: 'https://api.deepseek.com/v1',
   chatCompletion: {
     handlePayload: (payload) => {
-      const shouldForceAssistantReasoningContent = payload.model === 'deepseek-reasoner';
+      // deepseek-v4-* defaults to thinking=enabled unless the caller explicitly
+      // sets thinking.type === 'disabled'. In thinking mode the API rejects
+      // (HTTP 400) follow-up turns that omit reasoning_content on assistant
+      // messages with tool calls — see
+      // https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+      const isV4Model =
+        typeof payload.model === 'string' && payload.model.startsWith('deepseek-v4');
+      const thinkingExplicitlyDisabled = payload.thinking?.type === 'disabled';
+      const shouldForceAssistantReasoningContent =
+        payload.model === 'deepseek-reasoner' || (isV4Model && !thinkingExplicitlyDisabled);
 
       // Transform reasoning object to reasoning_content string for multi-turn conversations
       const messages = payload.messages.map((message: any) => {
@@ -25,7 +34,8 @@ export const params = {
               ? reasoning.content
               : undefined;
 
-        // DeepSeek reasoner with tool calls requires assistant history messages to carry reasoning_content
+        // DeepSeek thinking mode with tool calls requires assistant history
+        // messages to carry reasoning_content, or the API returns a 400.
         if (message.role === 'assistant' && shouldForceAssistantReasoningContent) {
           return {
             ...rest,

--- a/packages/model-runtime/src/utils/modelParse.test.ts
+++ b/packages/model-runtime/src/utils/modelParse.test.ts
@@ -760,6 +760,18 @@ describe('modelParse', () => {
         expect(results[3][0].reasoning).toBe(true); // Deepseek 'r1'
         expect(results[4][0].reasoning).toBe(true); // Volcengine 'thinking'
       });
+
+      it('should detect v4 keyword for deepseek model capabilities', async () => {
+        // Cover the new 'v4' keyword added to the deepseek config so unknown
+        // model IDs like deepseek-v4-custom still get functionCall + reasoning.
+        const result = await processModelList(
+          [{ id: 'deepseek-v4-custom' }],
+          MODEL_LIST_CONFIGS.deepseek,
+        );
+
+        expect(result[0].functionCall).toBe(true);
+        expect(result[0].reasoning).toBe(true);
+      });
     });
 
     describe('Extended tests for processMultiProviderModelList', () => {

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -31,8 +31,8 @@ export const MODEL_LIST_CONFIGS = {
     visionKeywords: [],
   },
   deepseek: {
-    functionCallKeywords: ['v3', 'r1', 'deepseek-chat'],
-    reasoningKeywords: ['r1', 'deepseek-reasoner', 'v3.'],
+    functionCallKeywords: ['v3', 'v4', 'r1', 'deepseek-chat'],
+    reasoningKeywords: ['r1', 'deepseek-reasoner', 'v3.', 'v4'],
     visionKeywords: ['ocr'],
   },
   google: {

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -25,13 +25,14 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig {
    */
   compressionModelId?: string;
 
+  deepseekV4ReasoningEffort?: 'high' | 'max';
+
   /**
    * Disable context caching
    */
   disableContextCaching?: boolean;
 
   effort?: 'low' | 'medium' | 'high' | 'max';
-
   /**
    * Whether to enable adaptive thinking (Claude Opus 4.6)
    */
@@ -191,6 +192,7 @@ export const AgentChatConfigSchema = z
     gpt5_2ProReasoningEffort: z.enum(['medium', 'high', 'xhigh']).optional(),
     gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
     grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
+    deepseekV4ReasoningEffort: z.enum(['high', 'max']).optional(),
     historyCount: z.number().optional(),
     imageAspectRatio: z.string().optional(),
     imageAspectRatio2: z.string().optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -13,6 +13,7 @@ import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 import CodexMaxReasoningEffortSlider from './CodexMaxReasoningEffortSlider';
 import ContextCachingSwitch from './ContextCachingSwitch';
+import DeepseekV4ReasoningEffortSlider from './DeepseekV4ReasoningEffortSlider';
 import EffortSlider from './EffortSlider';
 import GPT5ReasoningEffortSlider from './GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
@@ -253,6 +254,17 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
       layout: 'horizontal',
       minWidth: undefined,
       name: 'grok4_20ReasoningEffort',
+      style: {
+        paddingBottom: 0,
+      },
+    },
+    {
+      children: <DeepseekV4ReasoningEffortSlider />,
+      desc: 'reasoning_effort',
+      label: t('extendParams.reasoningEffort.title'),
+      layout: 'horizontal',
+      minWidth: undefined,
+      name: 'deepseekV4ReasoningEffort',
       style: {
         paddingBottom: 0,
       },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/DeepseekV4ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/DeepseekV4ReasoningEffortSlider.tsx
@@ -1,0 +1,17 @@
+import { type CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+const DEEPSEEK_V4_REASONING_EFFORT_LEVELS = ['high', 'max'] as const;
+type DeepseekV4ReasoningEffort = (typeof DEEPSEEK_V4_REASONING_EFFORT_LEVELS)[number];
+
+export type DeepseekV4ReasoningEffortSliderProps =
+  CreatedLevelSliderProps<DeepseekV4ReasoningEffort>;
+
+const DeepseekV4ReasoningEffortSlider = createLevelSliderComponent<DeepseekV4ReasoningEffort>({
+  configKey: 'deepseekV4ReasoningEffort',
+  defaultValue: 'high',
+  levels: DEEPSEEK_V4_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 200 },
+});
+
+export default DeepseekV4ReasoningEffortSlider;

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -266,6 +266,8 @@ export default {
     'For GPT-5.2 series; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint':
     'For Grok 4.20 series; controls reasoning intensity. Low/Medium uses 4 agents, High/XHigh uses 16 agents.',
+  'providerModels.item.modelConfig.extendParams.options.deepseekV4ReasoningEffort.hint':
+    'For DeepSeek V4 thinking mode; controls reasoning intensity. `high` is the default, `max` unlocks the deepest reasoning used by complex agent workflows.',
   'providerModels.item.modelConfig.extendParams.options.imageAspectRatio.hint':
     'For Gemini image generation models; controls aspect ratio of generated images.',
   'providerModels.item.modelConfig.extendParams.options.imageAspectRatio2.hint':

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -6,6 +6,7 @@ import { memo, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import CodexMaxReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/CodexMaxReasoningEffortSlider';
+import DeepseekV4ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/DeepseekV4ReasoningEffortSlider';
 import EffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/EffortSlider';
 import GPT5ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT51ReasoningEffortSlider';
@@ -93,6 +94,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'grok4_20ReasoningEffort',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.deepseekV4ReasoningEffort.hint',
+    key: 'deepseekV4ReasoningEffort',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.codexMaxReasoningEffort.hint',
     key: 'codexMaxReasoningEffort',
   },
@@ -154,6 +159,7 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
 // This allows reusing existing i18n translations instead of adding new ones
 const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   codexMaxReasoningEffort: 'reasoningEffort',
+  deepseekV4ReasoningEffort: 'reasoningEffort',
   gpt5ReasoningEffort: 'reasoningEffort',
   gpt5_1ReasoningEffort: 'reasoningEffort',
   gpt5_2ProReasoningEffort: 'reasoningEffort',
@@ -201,6 +207,11 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   grok4_20ReasoningEffort: {
     labelSuffix: ' (Grok 4.20)',
     previewWidth: 300,
+    tag: 'reasoning_effort',
+  },
+  deepseekV4ReasoningEffort: {
+    labelSuffix: ' (DeepSeek V4)',
+    previewWidth: 220,
     tag: 'reasoning_effort',
   },
   imageAspectRatio: { labelSuffix: '', previewWidth: 350, tag: 'aspect_ratio' },
@@ -332,6 +343,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       gpt5_2ProReasoningEffort: <GPT52ProReasoningEffortSlider value="medium" />,
       gpt5_2ReasoningEffort: <GPT52ReasoningEffortSlider value="none" />,
       grok4_20ReasoningEffort: <Grok420ReasoningEffortSlider value="medium" />,
+      deepseekV4ReasoningEffort: <DeepseekV4ReasoningEffortSlider value="high" />,
       imageAspectRatio: <ImageAspectRatioSelect value="1:1" />,
       imageAspectRatio2: <ImageAspectRatio2Select value="1:1" />,
       imageResolution: <ImageResolutionSlider value="1K" />,

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -334,6 +334,39 @@ describe('resolveModelExtendParams', () => {
         expect(result.reasoning_effort).toBe('high');
       });
     });
+
+    describe('deepseekV4ReasoningEffort param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'deepseekV4ReasoningEffort',
+        ]);
+      });
+
+      it('should set reasoning_effort for deepseek-v4 variant', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            deepseekV4ReasoningEffort: 'max',
+          } as any,
+          model: 'deepseek-v4-flash',
+          provider: 'deepseek',
+        });
+
+        expect(result.reasoning_effort).toBe('max');
+      });
+
+      it('should not set reasoning_effort when deepseekV4ReasoningEffort is not configured', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {} as any,
+          model: 'deepseek-v4-flash',
+          provider: 'deepseek',
+        });
+
+        expect(result.reasoning_effort).toBeUndefined();
+      });
+    });
   });
 
   describe('text verbosity', () => {

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -163,6 +163,13 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.reasoning_effort = chatConfig.grok4_20ReasoningEffort;
   }
 
+  if (
+    modelExtendParams.includes('deepseekV4ReasoningEffort') &&
+    chatConfig.deepseekV4ReasoningEffort
+  ) {
+    extendParams.reasoning_effort = chatConfig.deepseekV4ReasoningEffort;
+  }
+
   if (modelExtendParams.includes('codexMaxReasoningEffort') && chatConfig.codexMaxReasoningEffort) {
     extendParams.reasoning_effort = chatConfig.codexMaxReasoningEffort;
   }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔗 Related Issue

N/A — model rollout follow-up for DeepSeek V4.

#### 🔀 Description of Change

Adds support for DeepSeek V4 (Flash + Pro) across the model bank, runtime, and UI.

**Model cards** (`packages/model-bank`)

- New `deepseek-v4-flash` and `deepseek-v4-pro` entries in both self-hosted (CNY) and LobeHub-hosted (USD) banks.
- 1M context / 384K max output, function call, reasoning, and `thinking` extendParam.
- Per official docs, `deepseek-chat` and `deepseek-reasoner` are now compatibility aliases for v4-flash's non-thinking / thinking modes and are slated for deprecation. Marked `legacy: true`, disabled by default, and repriced to match v4-flash's actual endpoint rates.
- `planCardModels` and `checkModel` now point to `deepseek-v4-flash`.
- `modelParse` keyword list recognizes `v4` for automatic ability inference.

**Runtime** (`packages/model-runtime`)

- Extends the existing `reasoning_content` fallback from `deepseek-reasoner` only to cover all `deepseek-v4-*` models unless `thinking.type === 'disabled'`. Per [official docs](https://api-docs.deepseek.com/guides/thinking_mode#tool-calls), follow-up turns with tool calls in thinking mode return HTTP 400 without this payback — this patch prevents the regression for V4.

**Reasoning effort UI**

- New `deepseekV4ReasoningEffort` extend param (2 levels: `high` / `max`, default `high`) wired through `ExtendParamsType` + zod schema + agent `chatConfig` + resolver mapping to `reasoning_effort`.
- New `DeepseekV4ReasoningEffortSlider` registered in ControlsForm and ExtendParamsSelect with i18n hint.
- Only `high` / `max` are meaningfully distinct per official docs (`low`/`medium` → `high`, `xhigh` → `max`), so the slider exposes just the two effective levels.

Reference: https://api-docs.deepseek.com/quick_start/pricing · https://api-docs.deepseek.com/guides/thinking_mode

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Select `DeepSeek V4 Flash` or `DeepSeek V4 Pro` from the model list.
2. Confirm the Model Config panel shows both `Thinking` (OFF/Auto/ON) and `Reasoning Effort` (high/max) sliders.
3. Run a simple conversation; then run a tool-call workflow (e.g. artifacts snake game) to exercise multi-turn + thinking + tool calls — should not see HTTP 400 on the 2nd turn.
4. Toggle thinking off, send a message — confirm `reasoning_content` is not forced and the API accepts it.

#### 📸 Screenshots / Videos

N/A — attach before/after of the Model Config panel when reviewing.

#### 📝 Additional Information

**Breaking changes for downstream users**

- Existing conversations using `deepseek-chat` / `deepseek-reasoner` continue to work. The model IDs stay resolvable; they are hidden from the default model picker via `enabled: false` + `legacy: true`.
- Their pricing in the model bank was updated to match v4-flash rates since the upstream endpoint now bills at v4-flash rates for these aliases.

**Runtime behavior**

- `shouldForceAssistantReasoningContent` now also triggers for `deepseek-v4-*` unless the caller explicitly disables thinking. API silently ignores `reasoning_content` outside thinking mode, so this is a conservative expansion.