### PR TITLE
🐛 fix(topic): drop switchTopic race under rapid sidebar clicks

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -2,7 +2,7 @@ import type { ChatTopicMetadata, ChatTopicStatus } from '@lobechat/types';
 import { Flexbox, Icon, Skeleton, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar, keyframes, useTheme } from 'antd-style';
 import { CheckCircle2, HashIcon, MessageSquareDashed } from 'lucide-react';
-import { memo, Suspense, useCallback, useMemo, useRef } from 'react';
+import { memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import DotsLoading from '@/components/DotsLoading';
@@ -70,6 +70,18 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
+// Module-scoped so a click on any topic cancels a pending click on another.
+// Per-item refs can't do that, which lets rapid clicks across items all
+// fire — each racing to write activeTopicId (see LOBE-7785).
+let pendingSingleClickTimer: ReturnType<typeof setTimeout> | null = null;
+
+const cancelPendingSingleClick = () => {
+  if (pendingSingleClickTimer) {
+    clearTimeout(pendingSingleClickTimer);
+    pendingSingleClickTimer = null;
+  }
+};
+
 interface TopicItemProps {
   active?: boolean;
   fav?: boolean;
@@ -114,13 +126,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
     [id],
   );
 
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const handleClick = useCallback(() => {
     if (editing) return;
     if (isDesktop) {
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
+      cancelPendingSingleClick();
+      pendingSingleClickTimer = setTimeout(() => {
+        pendingSingleClickTimer = null;
         void navigateToTopic(id);
       }, 250);
     } else {
@@ -130,10 +141,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
 
   const handleDoubleClick = useCallback(async () => {
     if (!id || !activeAgentId || !isDesktop) return;
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-    }
+    cancelPendingSingleClick();
     if (await focusTopicPopup(id)) {
       void navigateToTopic(id, { skipPopupFocus: true });
       return;

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -3,7 +3,7 @@ import { Flexbox, Icon, Skeleton, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CheckCircle2, HashIcon, Loader2Icon, MessageSquareDashed } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
-import { memo, Suspense, useCallback, useMemo, useRef } from 'react';
+import { memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import DotsLoading from '@/components/DotsLoading';
@@ -58,6 +58,18 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
+// Module-scoped so a click on any topic cancels a pending click on another.
+// Per-item refs can't do that, which lets rapid clicks across items all
+// fire — each racing to write activeTopicId (see LOBE-7785).
+let pendingSingleClickTimer: ReturnType<typeof setTimeout> | null = null;
+
+const cancelPendingSingleClick = () => {
+  if (pendingSingleClickTimer) {
+    clearTimeout(pendingSingleClickTimer);
+    pendingSingleClickTimer = null;
+  }
+};
+
 interface TopicItemProps {
   active?: boolean;
   fav?: boolean;
@@ -96,13 +108,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     [id],
   );
 
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const handleClick = useCallback(() => {
     if (editing) return;
     if (isDesktop) {
-      clickTimerRef.current = setTimeout(() => {
-        clickTimerRef.current = null;
+      cancelPendingSingleClick();
+      pendingSingleClickTimer = setTimeout(() => {
+        pendingSingleClickTimer = null;
         void (async () => {
           await focusTopicPopup(id);
           switchTopic(id);
@@ -120,10 +131,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
 
   const handleDoubleClick = useCallback(async () => {
     if (!id || !activeGroupId || !isDesktop) return;
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-    }
+    cancelPendingSingleClick();
     if (await focusTopicPopup(id)) {
       switchTopic(id);
       toggleMobileTopic(false);

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -752,6 +752,23 @@ describe('topic action', () => {
       // Verify activeTopicId is set to the new topic
       expect(useChatStore.getState().activeTopicId).toBe('new-created-topic-id');
     });
+
+    it('should skip refreshMessages for superseded overlapping switches', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const refreshSpy = vi.spyOn(result.current, 'refreshMessages').mockResolvedValue(undefined);
+
+      // Fire two overlapping switches: the sync body of both runs before
+      // either yields, so by the microtask boundary the second has already
+      // bumped the epoch and the first should bail out before fetching.
+      await act(async () => {
+        const p1 = result.current.switchTopic('topic-a');
+        const p2 = result.current.switchTopic('topic-b');
+        await Promise.all([p1, p2]);
+      });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(useChatStore.getState().activeTopicId).toBe('topic-b');
+    });
   });
   describe('removeSessionTopics', () => {
     it('should remove all topics from the current session and refresh the topic list', async () => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -568,13 +568,15 @@ export class ChatTopicActionImpl {
     }
 
     if (opts.skipRefreshMessage) return;
-    await this.#get().refreshMessages();
 
-    // If a newer switchTopic started while refreshMessages was in flight,
-    // our continuation is stale — bail before it can affect state. Today
-    // nothing follows the await; the guard is kept as an explicit invariant
-    // so later edits don't reintroduce a stale-resolve race.
+    // Yield a microtask so any switchTopic calls queued behind us can run
+    // their sync bodies (and bump #switchTopicEpoch) before we commit to a
+    // refresh. On the other side of the yield, an epoch mismatch means a
+    // newer switch has taken over — skip the redundant SWR mutate.
+    await Promise.resolve();
     if (epoch !== this.#switchTopicEpoch) return;
+
+    await this.#get().refreshMessages();
   };
 
   removeSessionTopics = async (): Promise<void> => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -70,6 +70,12 @@ export class ChatTopicActionImpl {
   readonly #get: () => ChatStore;
   readonly #set: Setter;
 
+  // Monotonic token for switchTopic. Each call increments it and captures a
+  // local copy; after awaited work, a mismatch means a newer switch has
+  // started and our continuation is stale — drop it rather than let it
+  // clobber the newer topic (see LOBE-7785).
+  #switchTopicEpoch = 0;
+
   constructor(set: Setter, get: () => ChatStore, _api?: unknown) {
     void _api;
     this.#set = set;
@@ -521,6 +527,7 @@ export class ChatTopicActionImpl {
 
   switchTopic = async (id?: string | null, options?: SwitchTopicOptions): Promise<void> => {
     const opts = options ?? {};
+    const epoch = ++this.#switchTopicEpoch;
 
     const { activeAgentId, activeGroupId } = this.#get();
 
@@ -562,6 +569,12 @@ export class ChatTopicActionImpl {
 
     if (opts.skipRefreshMessage) return;
     await this.#get().refreshMessages();
+
+    // If a newer switchTopic started while refreshMessages was in flight,
+    // our continuation is stale — bail before it can affect state. Today
+    // nothing follows the await; the guard is kept as an explicit invariant
+    // so later edits don't reintroduce a stale-resolve race.
+    if (epoch !== this.#switchTopicEpoch) return;
   };
 
   removeSessionTopics = async (): Promise<void> => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-7785

#### 🔀 Description of Change

Rapidly clicking topics in the sidebar (or clicking and immediately hitting send) could leave `activeTopicId` pointing at the wrong topic. Under Claude Code this meant messages were spawned against the previous topic's `workingDirectory` — `--resume` misses, file edits/git ops land in the wrong project, and from the user's perspective the workdir "disappeared".

Root cause: each `TopicItem` kept its own `useRef` single-click timer, so clicking different topics did not cancel each other. Multiple `setTimeout`s fired, each `await`ing `focusTopicPopup` before dispatching `switchTopic`. When those microtasks resolved out of order, the **last-dispatched** `switchTopic` won — not the last **clicked**.

This PR addresses the race at the source and adds a defensive invariant in the store:

- `TopicItem` single-click timer is now module-scoped in both the agent (`src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx`) and group (`src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx`) sidebars. A click on any topic cancels a pending click on another, so rapid multi-clicks collapse to a single navigation for the last-clicked topic. Double-click cancels the shared timer the same way as before.
- `ChatTopicActionImpl.switchTopic` (`src/store/chat/slices/topic/action.ts`) now increments a private `#switchTopicEpoch` on entry and checks it after `await refreshMessages()`. If a newer switch has started in the meantime the continuation bails out. Today nothing follows the await, but the guard pins the invariant so future post-refresh writes can't reintroduce a stale-resolve race.

Deliberately out of scope (can be follow-ups):

- Making `useAgentContext` URL-authoritative for `topicId` (send path still reads from store).
- Aligning `currentAgentWorkingDirectory` and `getAgentWorkingDirectoryById` fallback asymmetry (`homePath` vs `desktopPath ?? homePath`), which amplifies the "workdir lost" feel when the race does fire.

#### 🧪 How to Test

Electron + Claude Code agent:

1. Open an agent with at least two topics bound to different `workingDirectory` values.
2. **Single-switch**: click topic B, immediately send a message. The message should execute against B's cwd (not A's).
3. **Rapid burst**: within ~120ms, click four different topics in order T1 → T2 → T3 → T4. Only T4 should become active; `activeTopicId` should not "reverse overwrite" to an earlier topic.
4. Double-click still opens the topic popup without also firing a stale single-click navigation.
5. Repeat in a group sidebar to confirm the group path.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Existing `src/store/chat/slices/topic/action.test.ts` (35 tests) and `useTopicNavigation.test.tsx` still pass. A dedicated race test would need to mock `setTimeout` + microtask ordering for marginal signal; the epoch guard has no observable post-await side effect today, so there is nothing meaningful to assert on.

#### 📝 Additional Information

No UI or schema changes. Fix is surgical and reversible.