### PR TITLE
🐛 fix: stabilize artifact html scripts

### DIFF
--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -323,42 +323,30 @@ Content 2 still going`;
 <lobeArtifact identifier="generating" type="text/markdown" title="Generating">Content 2 still going`);
   });
 
-  it('should prevent HTML script line comments from swallowing following statements', () => {
+  it('should preserve HTML script blocks while flattening artifact markup', () => {
     const input = `<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game">
 <!DOCTYPE html>
 <html>
 <body>
 <script>
 // Move the snake every frame
+const url = " // keep string content untouched";
 window.snakeStarted = true;
-</script>
+</script >
 </body>
 </html>
 </lobeArtifact>`;
 
     const output = processWithArtifact(input);
 
-    expect(output).toContain(
-      '<script>/* Move the snake every frame */window.snakeStarted = true;</script>',
-    );
+    expect(output).toContain(`<script>
+// Move the snake every frame
+const url = " // keep string content untouched";
+window.snakeStarted = true;
+</script >`);
     expect(output).not.toContain('// Move the snake every framewindow.snakeStarted = true;');
-  });
-
-  it('should prevent React artifact line comments from swallowing following statements', () => {
-    const input = `<lobeArtifact identifier="react-counter" type="application/lobe.artifacts.react" title="React Counter">
-import { useState } from "react";
-
-// Keep this comment isolated from the next statement.
-export default function Counter() {
-  const [count] = useState(0);
-  return <div>{count}</div>;
-}
-</lobeArtifact>`;
-
-    const output = processWithArtifact(input);
-
     expect(output).toContain(
-      '/* Keep this comment isolated from the next statement. */export default function Counter()',
+      '<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game"><!DOCTYPE html><html><body><script>',
     );
   });
 });

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -332,7 +332,8 @@ Content 2 still going`;
 // Move the snake every frame
 const url = " // keep string content untouched";
 window.snakeStarted = true;
-</script >
+</script	
+ bar>
 </body>
 </html>
 </lobeArtifact>`;
@@ -343,7 +344,8 @@ window.snakeStarted = true;
 // Move the snake every frame
 const url = " // keep string content untouched";
 window.snakeStarted = true;
-</script >`);
+</script	
+ bar>`);
     expect(output).not.toContain('// Move the snake every framewindow.snakeStarted = true;');
     expect(output).toContain(
       '<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game"><!DOCTYPE html><html><body><script>',

--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -322,6 +322,45 @@ Content 2 still going`;
 
 <lobeArtifact identifier="generating" type="text/markdown" title="Generating">Content 2 still going`);
   });
+
+  it('should prevent HTML script line comments from swallowing following statements', () => {
+    const input = `<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game">
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// Move the snake every frame
+window.snakeStarted = true;
+</script>
+</body>
+</html>
+</lobeArtifact>`;
+
+    const output = processWithArtifact(input);
+
+    expect(output).toContain(
+      '<script>/* Move the snake every frame */window.snakeStarted = true;</script>',
+    );
+    expect(output).not.toContain('// Move the snake every framewindow.snakeStarted = true;');
+  });
+
+  it('should prevent React artifact line comments from swallowing following statements', () => {
+    const input = `<lobeArtifact identifier="react-counter" type="application/lobe.artifacts.react" title="React Counter">
+import { useState } from "react";
+
+// Keep this comment isolated from the next statement.
+export default function Counter() {
+  const [count] = useState(0);
+  return <div>{count}</div>;
+}
+</lobeArtifact>`;
+
+    const output = processWithArtifact(input);
+
+    expect(output).toContain(
+      '/* Keep this comment isolated from the next statement. */export default function Counter()',
+    );
+  });
 });
 
 describe('outer code block removal', () => {

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -2,23 +2,21 @@ import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
 const ARTIFACT_TAG_REGEX_GLOBAL =
   /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
-const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script>/gi;
-const REACT_ARTIFACT_TYPE_REGEX = /type="application\/lobe\.artifacts\.react"/;
-const JS_LINE_COMMENT_REGEX = /(^|[^\S\r\n])\/\/([^\r\n]*)/gm;
-
-const normalizeJsLineComments = (code: string) =>
-  code.replaceAll(JS_LINE_COMMENT_REGEX, (_, prefix: string, comment: string) => {
-    return `${prefix}/*${comment.replaceAll('*/', '* /').trimEnd()} */`;
-  });
+const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script\s*>/gi;
+const SCRIPT_PLACEHOLDER_PREFIX = '____LOBE_ARTIFACT_SCRIPT_BLOCK_';
 
 const removeArtifactLineBreaks = (content: string) => {
-  // Artifact cards still rely on flattened tags for Markdown parsing, but flattening JS after
-  // `//` comments comments out the following statement. Convert those comments first.
-  const safeContent = REACT_ARTIFACT_TYPE_REGEX.test(content)
-    ? normalizeJsLineComments(content)
-    : content.replaceAll(HTML_SCRIPT_TAG_REGEX, normalizeJsLineComments);
+  const scripts: string[] = [];
+  const contentWithoutScripts = content.replaceAll(HTML_SCRIPT_TAG_REGEX, (script) => {
+    const index = scripts.length;
+    scripts.push(script);
+    return `${SCRIPT_PLACEHOLDER_PREFIX}${index}____`;
+  });
 
-  return safeContent.replaceAll(/\r?\n|\r/g, '');
+  return scripts.reduce(
+    (result, script, index) => result.replace(`${SCRIPT_PLACEHOLDER_PREFIX}${index}____`, script),
+    contentWithoutScripts.replaceAll(/\r?\n|\r/g, ''),
+  );
 };
 
 /**

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -1,5 +1,26 @@
 import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
+const ARTIFACT_TAG_REGEX_GLOBAL =
+  /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
+const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script>/gi;
+const REACT_ARTIFACT_TYPE_REGEX = /type="application\/lobe\.artifacts\.react"/;
+const JS_LINE_COMMENT_REGEX = /(^|[^\S\r\n])\/\/([^\r\n]*)/gm;
+
+const normalizeJsLineComments = (code: string) =>
+  code.replaceAll(JS_LINE_COMMENT_REGEX, (_, prefix: string, comment: string) => {
+    return `${prefix}/*${comment.replaceAll('*/', '* /').trimEnd()} */`;
+  });
+
+const removeArtifactLineBreaks = (content: string) => {
+  // Artifact cards still rely on flattened tags for Markdown parsing, but flattening JS after
+  // `//` comments comments out the following statement. Convert those comments first.
+  const safeContent = REACT_ARTIFACT_TYPE_REGEX.test(content)
+    ? normalizeJsLineComments(content)
+    : content.replaceAll(HTML_SCRIPT_TAG_REGEX, normalizeJsLineComments);
+
+  return safeContent.replaceAll(/\r?\n|\r/g, '');
+};
+
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
  */
@@ -48,11 +69,7 @@ export const processWithArtifact = (input: string = '') => {
 
   // If the input contains `lobeArtifact` tags, replace all line breaks with an empty string
   // Use global regex to handle multiple artifacts in the same message
-  const ARTIFACT_TAG_REGEX_GLOBAL =
-    /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
-  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, (match) =>
-    match.replaceAll(/\r?\n|\r/g, ''),
-  );
+  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, removeArtifactLineBreaks);
 
   // if not match, check if it's start with <lobeArtifact but not closed
   const regex = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -2,7 +2,7 @@ import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
 const ARTIFACT_TAG_REGEX_GLOBAL =
   /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
-const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script\s*>/gi;
+const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script(?:\s[^>]*)?>/gi;
 const SCRIPT_PLACEHOLDER_PREFIX = '____LOBE_ARTIFACT_SCRIPT_BLOCK_';
 
 const removeArtifactLineBreaks = (content: string) => {

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts
@@ -26,4 +26,22 @@ describe('injectSandboxStorageShim', () => {
 
     expect(result.match(/data-lobe-artifact-storage-shim/g)).toHaveLength(1);
   });
+
+  it('should not inject into head-like strings inside scripts', () => {
+    const html = `<!DOCTYPE html>
+<html>
+<body>
+  <script>
+    const template = "<head><title>Preview</title></head>";
+  </script>
+</body>
+</html>`;
+
+    const result = injectSandboxStorageShim(html);
+
+    expect(result).toContain('const template = "<head><title>Preview</title></head>";');
+    expect(result.indexOf('data-lobe-artifact-storage-shim')).toBeLessThan(
+      result.indexOf('const template'),
+    );
+  });
 });

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { injectSandboxStorageShim } from './HTML';
+
+describe('injectSandboxStorageShim', () => {
+  it('should inject the storage shim before user scripts in head', () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+  <script>localStorage.getItem('snakeHighScore');</script>
+</head>
+<body></body>
+</html>`;
+
+    const result = injectSandboxStorageShim(html);
+
+    expect(result.indexOf('data-lobe-artifact-storage-shim')).toBeGreaterThan(-1);
+    expect(result.indexOf('data-lobe-artifact-storage-shim')).toBeLessThan(
+      result.indexOf("localStorage.getItem('snakeHighScore')"),
+    );
+  });
+
+  it('should not inject the storage shim twice', () => {
+    const html = '<html><head></head><body></body></html>';
+    const result = injectSandboxStorageShim(injectSandboxStorageShim(html));
+
+    expect(result.match(/data-lobe-artifact-storage-shim/g)).toHaveLength(1);
+  });
+});

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
@@ -54,18 +54,43 @@ const SANDBOX_STORAGE_SHIM = `<script data-lobe-artifact-storage-shim>
 })();
 </script>`;
 
+const SCRIPT_TAG_REGEX = /<script\b/i;
+const HEAD_TAG_REGEX = /<head(?:\s[^>]*)?>/i;
+const HTML_TAG_REGEX = /<html(?:\s[^>]*)?>/i;
+
+const findTagBeforeFirstScript = (htmlContent: string, tagRegex: RegExp) => {
+  const firstScriptIndex = htmlContent.search(SCRIPT_TAG_REGEX);
+  const searchableContent =
+    firstScriptIndex === -1 ? htmlContent : htmlContent.slice(0, firstScriptIndex);
+  const match = searchableContent.match(tagRegex);
+
+  if (!match?.[0] || match.index === undefined) return;
+
+  return {
+    index: match.index,
+    value: match[0],
+  };
+};
+
+const insertAfterTag = (htmlContent: string, tag: { index: number; value: string }) => {
+  const insertIndex = tag.index + tag.value.length;
+  return `${htmlContent.slice(0, insertIndex)}\n${SANDBOX_STORAGE_SHIM}${htmlContent.slice(
+    insertIndex,
+  )}`;
+};
+
 export const injectSandboxStorageShim = (htmlContent: string) => {
   if (htmlContent.includes('data-lobe-artifact-storage-shim')) return htmlContent;
 
-  if (/<head(?:\s[^>]*)?>/i.test(htmlContent)) {
-    return htmlContent.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}\n${SANDBOX_STORAGE_SHIM}`);
-  }
+  const headTag = findTagBeforeFirstScript(htmlContent, HEAD_TAG_REGEX);
+  if (headTag) return insertAfterTag(htmlContent, headTag);
 
-  if (/<html(?:\s[^>]*)?>/i.test(htmlContent)) {
-    return htmlContent.replace(
-      /<html(?:\s[^>]*)?>/i,
-      (html) => `${html}\n<head>${SANDBOX_STORAGE_SHIM}</head>`,
-    );
+  const htmlTag = findTagBeforeFirstScript(htmlContent, HTML_TAG_REGEX);
+  if (htmlTag) {
+    const insertIndex = htmlTag.index + htmlTag.value.length;
+    return `${htmlContent.slice(0, insertIndex)}\n<head>${SANDBOX_STORAGE_SHIM}</head>${htmlContent.slice(
+      insertIndex,
+    )}`;
   }
 
   return `${SANDBOX_STORAGE_SHIM}\n${htmlContent}`;

--- a/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/HTML.tsx
@@ -6,6 +6,71 @@ interface HTMLRendererProps {
   width?: string;
 }
 
+const SANDBOX_STORAGE_SHIM = `<script data-lobe-artifact-storage-shim>
+(() => {
+  if (window.__lobeArtifactStorageShim) return;
+  Object.defineProperty(window, '__lobeArtifactStorageShim', { value: true });
+
+  const createStorage = () => {
+    const data = Object.create(null);
+
+    return {
+      clear() {
+        for (const key of Object.keys(data)) delete data[key];
+      },
+      getItem(key) {
+        const normalizedKey = String(key);
+        return Object.prototype.hasOwnProperty.call(data, normalizedKey) ? data[normalizedKey] : null;
+      },
+      key(index) {
+        return Object.keys(data)[index] ?? null;
+      },
+      get length() {
+        return Object.keys(data).length;
+      },
+      removeItem(key) {
+        delete data[String(key)];
+      },
+      setItem(key, value) {
+        data[String(key)] = String(value);
+      },
+    };
+  };
+
+  const defineStorage = (name) => {
+    try {
+      void window[name];
+      return;
+    } catch {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        value: createStorage(),
+      });
+    }
+  };
+
+  defineStorage('localStorage');
+  defineStorage('sessionStorage');
+})();
+</script>`;
+
+export const injectSandboxStorageShim = (htmlContent: string) => {
+  if (htmlContent.includes('data-lobe-artifact-storage-shim')) return htmlContent;
+
+  if (/<head(?:\s[^>]*)?>/i.test(htmlContent)) {
+    return htmlContent.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}\n${SANDBOX_STORAGE_SHIM}`);
+  }
+
+  if (/<html(?:\s[^>]*)?>/i.test(htmlContent)) {
+    return htmlContent.replace(
+      /<html(?:\s[^>]*)?>/i,
+      (html) => `${html}\n<head>${SANDBOX_STORAGE_SHIM}</head>`,
+    );
+  }
+
+  return `${SANDBOX_STORAGE_SHIM}\n${htmlContent}`;
+};
+
 // Security boundary: the iframe runs in a unique opaque origin because the
 // sandbox attribute does NOT include `allow-same-origin`. This blocks
 // `window.parent.*` access (the GHSA-xq4x-622m-q8fq XSS-to-RCE path on
@@ -27,7 +92,7 @@ const HTMLRenderer = memo<HTMLRendererProps>(({ htmlContent, width = '100%', hei
   return (
     <iframe
       sandbox="allow-scripts allow-forms allow-modals"
-      srcDoc={htmlContent}
+      srcDoc={injectSandboxStorageShim(htmlContent)}
       style={{ border: 'none', height, width }}
       title="html-renderer"
     />


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8157

#### 🔀 Description of Change

This PR stabilizes HTML artifacts rendered in sandboxed iframes:

- Injects an in-memory localStorage/sessionStorage shim before user scripts so common single-file demos do not crash in opaque-origin sandboxes.
- Keeps the existing sandbox boundary and does not add allow-same-origin.
- Preserves the existing artifact flattening behavior while converting JS line comments in artifact scripts before flattening, preventing // comments from swallowing following statements.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts' 'src/features/Conversation/utils/markdown.test.ts'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| HTML artifacts that read localStorage can crash before binding UI events in sandbox. | A memory storage shim is injected before user scripts, while the sandbox security boundary remains unchanged. |

#### 📝 Additional Information

The storage shim is scoped to each artifact iframe and does not expose host page storage.
