### PR TITLE
fix(activator): add Klavis service triggers to lobe-creds activation rules

### DIFF
--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -59,6 +59,12 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 - User wants to store or manage sensitive information securely
 - Sandbox code execution requires credentials/secrets to be injected
 - User asks to connect to services like GitHub, Linear, Twitter, Microsoft, etc.
+- User wants to use, open, connect, or interact with a third-party integration service
+  (e.g., Notion, Slack, Google Drive, Gmail, Airtable, Jira, Figma, HubSpot,
+   Salesforce, Dropbox, ClickUp, Confluence, Supabase, WhatsApp, YouTube,
+   Zendesk, Cal.com, OneDrive, Outlook Mail, Google Sheets, Google Docs)
+- User says things like "help me use Notion", "connect my Slack", "open Google Drive",
+  "I want to use Jira", "set up Airtable" — these are Klavis-managed OAuth services
 
 **Decision flow:**
 1. **If ANY trigger condition above is met** → Immediately activate \`lobe-creds\`
@@ -66,6 +72,10 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
 4. If credential doesn't exist:
    - For OAuth services (GitHub, Linear, Microsoft, Twitter) → use \`initiateOAuthConnect\`
+   - For Klavis-managed services (Notion, Slack, Google Drive, Airtable, Jira, etc.)
+     → use \`connectKlavisService\` after activating \`lobe-creds\`. The full list of
+     available Klavis services is shown in \`<klavis_integrations>\` inside the
+     lobe-creds system prompt.
    - For API keys/tokens → guide user to save with \`saveCreds\`
 5. For sandbox code that needs credentials → use \`injectCredsToSandbox\` to inject them as environment variables
 


### PR DESCRIPTION
## Problem

When a user says "help me use Notion" or "connect my Slack", the Agent needs to recognize this as a Klavis service connection intent and activate `lobe-creds` to initiate the OAuth flow.

Currently, the `<credentials_management>` section in `lobe-activator/src/systemRole.ts` only lists generic triggers (GitHub, Linear, Twitter, Microsoft) — Klavis-managed services are not mentioned, so the Agent never activates `lobe-creds` for them.

## Change

Added Klavis-managed service names to the trigger conditions and decision flow in `lobe-activator/src/systemRole.ts`, so the Agent automatically activates `lobe-creds` when users mention services like Notion, Slack, Google Drive, Airtable, Jira, etc.

## Related

Follows up on #14090 which added the `connectKlavisService` API and Klavis status injection into lobe-creds.