### PR TITLE
🐛 fix: keep artifact script content in card

### DIFF
--- a/src/features/Conversation/utils/markdown.test.ts
+++ b/src/features/Conversation/utils/markdown.test.ts
@@ -323,7 +323,7 @@ Content 2 still going`;
 <lobeArtifact identifier="generating" type="text/markdown" title="Generating">Content 2 still going`);
   });
 
-  it('should preserve HTML script blocks while flattening artifact markup', () => {
+  it('should keep HTML script blocks inside flattened artifact markup', () => {
     const input = `<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game">
 <!DOCTYPE html>
 <html>
@@ -340,16 +340,10 @@ window.snakeStarted = true;
 
     const output = processWithArtifact(input);
 
-    expect(output).toContain(`<script>
-// Move the snake every frame
-const url = " // keep string content untouched";
-window.snakeStarted = true;
-</script	
- bar>`);
-    expect(output).not.toContain('// Move the snake every framewindow.snakeStarted = true;');
     expect(output).toContain(
-      '<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game"><!DOCTYPE html><html><body><script>',
+      '<lobeArtifact identifier="snake-game" type="text/html" title="Snake Game"><!DOCTYPE html><html><body><script>// Move the snake every frameconst url = " // keep string content untouched";window.snakeStarted = true;</script\t bar></body></html></lobeArtifact>',
     );
+    expect(output).not.toContain('<script>\n');
   });
 });
 

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -2,22 +2,6 @@ import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 
 const ARTIFACT_TAG_REGEX_GLOBAL =
   /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
-const HTML_SCRIPT_TAG_REGEX = /<script\b[^>]*>[\S\s]*?<\/script(?:\s[^>]*)?>/gi;
-const SCRIPT_PLACEHOLDER_PREFIX = '____LOBE_ARTIFACT_SCRIPT_BLOCK_';
-
-const removeArtifactLineBreaks = (content: string) => {
-  const scripts: string[] = [];
-  const contentWithoutScripts = content.replaceAll(HTML_SCRIPT_TAG_REGEX, (script) => {
-    const index = scripts.length;
-    scripts.push(script);
-    return `${SCRIPT_PLACEHOLDER_PREFIX}${index}____`;
-  });
-
-  return scripts.reduce(
-    (result, script, index) => result.replace(`${SCRIPT_PLACEHOLDER_PREFIX}${index}____`, script),
-    contentWithoutScripts.replaceAll(/\r?\n|\r/g, ''),
-  );
-};
 
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
@@ -67,7 +51,11 @@ export const processWithArtifact = (input: string = '') => {
 
   // If the input contains `lobeArtifact` tags, replace all line breaks with an empty string
   // Use global regex to handle multiple artifacts in the same message
-  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, removeArtifactLineBreaks);
+  // Keep artifact markup as one raw HTML segment for the rehype artifact plugin. Preserving
+  // script block newlines here can make Markdown parse script text outside the custom tag.
+  output = output.replaceAll(ARTIFACT_TAG_REGEX_GLOBAL, (match) =>
+    match.replaceAll(/\r?\n|\r/g, ''),
+  );
 
   // if not match, check if it's start with <lobeArtifact but not closed
   const regex = /<lobeArtifact\b(?:(?!\/?>)[\s\S])*$/;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8157

#### 🔀 Description of Change

This PR restores artifact markdown preprocessing so the full `<lobeArtifact>` block is flattened into one raw HTML segment. Preserving script block line breaks in the chat display path can make Markdown parse script text outside the artifact card, leaking JavaScript below the card.

The iframe preview still reads artifact code from the original message content, so runtime HTML scripts keep their original line breaks.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx eslint 'src/features/Conversation/utils/markdown.ts' 'src/features/Conversation/utils/markdown.test.ts'\nbunx vitest run --silent='passed-only' 'src/features/Conversation/utils/markdown.test.ts' 'src/features/Portal/Artifacts/Body/Renderer/HTML.test.ts'\n```\n\n#### 📸 Screenshots / Videos\n\n| Before | After |\n| ------ | ----- |\n| HTML artifact script content could appear below the artifact card. | Script content stays inside the artifact card parsing boundary. |\n\n#### 📝 Additional Information\n\nThis only changes the chat Markdown display preprocessing path; the artifact preview renderer remains unchanged.