### PR TITLE
🐛 fix(model-runtime): preserve cloudflare provider error context

### DIFF
--- a/packages/model-runtime/src/providers/cloudflare/index.test.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.test.ts
@@ -327,9 +327,38 @@ describe('LobeCloudflareAI', () => {
             endpoint: expect.stringMatching(/https:\/\/.+/),
             error: apiError,
             errorType: bizErrorType,
+            message: 'invalid x-api-key',
             provider,
           });
         }
+      });
+
+      it('should surface upstream 400 body as ProviderBizError with message', async () => {
+        // Arrange: fetch resolves with a real 400 Response whose body carries the upstream error detail.
+        const upstreamBody = {
+          error: { message: 'model input exceeds limit', type: 'invalid_request_error' },
+        };
+        (globalThis.fetch as Mock).mockResolvedValue(
+          new Response(JSON.stringify(upstreamBody), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 400,
+          }),
+        );
+
+        // Act & Assert
+        await expect(
+          instance.chat({
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: '@hf/meta-llama/meta-llama-3-8b-instruct',
+            temperature: 0,
+          }),
+        ).rejects.toEqual({
+          endpoint: expect.stringMatching(/https:\/\/.+/),
+          error: upstreamBody,
+          errorType: bizErrorType,
+          message: 'model input exceeds limit',
+          provider,
+        });
       });
 
       it('should throw InvalidProviderAPIKey if no accountID is provided', async () => {
@@ -379,6 +408,7 @@ describe('LobeCloudflareAI', () => {
           endpoint: expect.stringMatching(/https:\/\/.+/),
           error: apiError,
           errorType: bizErrorType,
+          message: 'HTTP 400',
           provider,
         });
       });
@@ -403,6 +433,7 @@ describe('LobeCloudflareAI', () => {
           endpoint: expect.not.stringContaining(accountID),
           error: apiError,
           errorType: bizErrorType,
+          message: 'HTTP 400',
           provider,
         });
       });

--- a/packages/model-runtime/src/providers/cloudflare/index.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.ts
@@ -25,6 +25,28 @@ export interface CloudflareModelCard {
   };
 }
 
+/**
+ * Walks common upstream error shapes (Error, { message }, { error: { message } },
+ * { error: { error: { message } } }, strings, { status }) and returns the most
+ * informative human-readable string available. Returns undefined when nothing
+ * useful can be recovered, letting the caller decide on a fallback.
+ */
+function extractProviderErrorMessage(err: unknown): string | undefined {
+  if (err === null || err === undefined) return undefined;
+  if (typeof err === 'string') return err || undefined;
+  if (err instanceof Error) return err.message;
+  if (typeof err !== 'object') return String(err);
+
+  const obj = err as Record<string, unknown>;
+  if (typeof obj.message === 'string' && obj.message) return obj.message;
+  if (obj.error !== undefined) {
+    const inner = extractProviderErrorMessage(obj.error);
+    if (inner) return inner;
+  }
+  if (typeof obj.status === 'number') return `HTTP ${obj.status}`;
+  return undefined;
+}
+
 export interface LobeCloudflareParams {
   apiKey?: string;
   baseURLOrAccountID?: string;
@@ -56,62 +78,75 @@ export class LobeCloudflareAI implements LobeRuntimeAI {
   }
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions): Promise<Response> {
-    try {
-      // Remove internal apiMode parameter to prevent sending to Cloudflare API
+    // Remove internal apiMode parameter to prevent sending to Cloudflare API
+    const { model, tools, apiMode: _, ...restPayload } = payload;
+    const functions = tools?.map((tool) => tool.function);
+    const headers = options?.headers || {};
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+    const url = new URL(model, this.baseURL);
+    const desensitizedEndpoint = desensitizeCloudflareUrl(url.toString());
 
-      const { model, tools, apiMode: _, ...restPayload } = payload;
-      const functions = tools?.map((tool) => tool.function);
-      const headers = options?.headers || {};
-      if (this.apiKey) {
-        headers['Authorization'] = `Bearer ${this.apiKey}`;
-      }
-      const url = new URL(model, this.baseURL);
-      const response = await fetch(url, {
+    let response: Response;
+    try {
+      response = await fetch(url, {
         body: JSON.stringify({ tools: functions, ...restPayload }),
         headers: { 'Content-Type': 'application/json', ...headers },
         method: 'POST',
         signal: options?.signal,
       });
-
-      const desensitizedEndpoint = desensitizeCloudflareUrl(url.toString());
-
-      switch (response.status) {
-        case 400: {
-          throw AgentRuntimeError.chat({
-            endpoint: desensitizedEndpoint,
-            error: response,
-            errorType: AgentRuntimeErrorType.ProviderBizError,
-            provider: ModelProvider.Cloudflare,
-          });
-        }
-      }
-
-      // Only tee when debugging
-      let responseBody: ReadableStream;
-      if (process.env.DEBUG_CLOUDFLARE_CHAT_COMPLETION === '1') {
-        const [prod, useForDebug] = response.body!.tee();
-        debugStream(useForDebug).catch();
-        responseBody = prod;
-      } else {
-        responseBody = response.body!;
-      }
-
-      return StreamingResponse(
-        responseBody
-          .pipeThrough(new TransformStream(new CloudflareStreamTransformer()))
-          .pipeThrough(createCallbacksTransformer(options?.callback)),
-        { headers: options?.headers },
-      );
     } catch (error) {
-      const desensitizedEndpoint = desensitizeCloudflareUrl(this.baseURL);
-
       throw AgentRuntimeError.chat({
-        endpoint: desensitizedEndpoint,
+        endpoint: desensitizeCloudflareUrl(this.baseURL),
         error: error as any,
         errorType: AgentRuntimeErrorType.ProviderBizError,
+        message: extractProviderErrorMessage(error) ?? 'Cloudflare API request failed',
         provider: ModelProvider.Cloudflare,
       });
     }
+
+    if (response.status === 400) {
+      const bodyText = await response.text().catch(() => '');
+      let parsedBody: unknown = bodyText;
+      if (bodyText) {
+        try {
+          parsedBody = JSON.parse(bodyText);
+        } catch {
+          // keep raw text
+        }
+      }
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizedEndpoint,
+        error:
+          parsedBody && typeof parsedBody === 'object'
+            ? parsedBody
+            : { body: bodyText, status: 400 },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        message:
+          extractProviderErrorMessage(parsedBody) ||
+          bodyText ||
+          'Cloudflare API returned 400 Bad Request',
+        provider: ModelProvider.Cloudflare,
+      });
+    }
+
+    // Only tee when debugging
+    let responseBody: ReadableStream;
+    if (process.env.DEBUG_CLOUDFLARE_CHAT_COMPLETION === '1') {
+      const [prod, useForDebug] = response.body!.tee();
+      debugStream(useForDebug).catch();
+      responseBody = prod;
+    } else {
+      responseBody = response.body!;
+    }
+
+    return StreamingResponse(
+      responseBody
+        .pipeThrough(new TransformStream(new CloudflareStreamTransformer()))
+        .pipeThrough(createCallbacksTransformer(options?.callback)),
+      { headers: options?.headers },
+    );
   }
 
   async models(): Promise<ChatModelCard[]> {


### PR DESCRIPTION
## Summary

- Cloudflare provider threw `AgentRuntimeError` payloads without `message`, passing the raw `Response` / outer error as `error`. Downstream serializers (`extractReasonFromError`) hit `[object Object]` and fell back to the `errorType` literal, producing dashboard entries where `message === errorType === "ProviderBizError"` with no upstream context.
- Split `fetch` and 400 handling so the outer `catch` no longer double-wraps an already-constructed payload; read + parse the 400 body and surface the upstream `error.message` as `message`, with the parsed body in `error` instead of the raw `Response`.
- Added `extractProviderErrorMessage` to walk common shapes (`Error` / `{ message }` / `{ error: { message } }` / `{ status }`) and feed both throw paths; fallback strings for the remaining unknown cases.

Refs [LOBE-7778](https://linear.app/lobehub/issue/LOBE-7778). This is fix A only — B (lobehub-cloud `extractReasonFromError` fallback) and C (agent-gateway recording-layer guard) are separate.

close [LOBE-8193](https://linear.app/lobehub/issue/LOBE-8193)
## Test plan

- [x] `pnpm exec vitest run src/providers/cloudflare/index.test.ts` — 20/20 pass (3 existing assertions now require `message`; added one new test that resolves a real 400 `Response` with a JSON body and asserts the upstream `error.message` is surfaced).
- [x] `pnpm exec tsc --noEmit` in `packages/model-runtime` — clean.
- [ ] After merge: watch the dashboard for new cloudflare entries — should now carry upstream message instead of bare `"ProviderBizError"`. Be ready to extend `agent-gateway/src/errors.ts#USER_ERROR_MESSAGE_PATTERNS` as previously-hidden real errors (quota, auth, etc.) start surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)