### PR TITLE
🐛 fix(model-runtime): tolerate null function.name in streaming tool_call deltas

### DIFF
--- a/packages/model-runtime/src/helpers/parseToolCalls.test.ts
+++ b/packages/model-runtime/src/helpers/parseToolCalls.test.ts
@@ -163,6 +163,83 @@ describe('parseToolCalls', () => {
     ]);
   });
 
+  // LOBE-8199: NVIDIA NIM (z-ai/glm5, qwen3.5-MoE) and some proxies open a
+  // tool_call with function.name=null as a start marker; the real name
+  // arrives in a subsequent delta.
+  it('should coerce null function.name on the first delta and patch it in from a later delta', () => {
+    const chunk1 = [
+      {
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: null as any, arguments: '' },
+      },
+    ];
+    const result1 = parseToolCalls([], chunk1);
+    expect(result1).toEqual([
+      { id: 'call_1', type: 'function', function: { name: '', arguments: '' } },
+    ]);
+
+    const chunk2 = [{ index: 0, function: { name: 'get_weather', arguments: '{"loc' } }];
+    const result2 = parseToolCalls(result1, chunk2);
+    expect(result2).toEqual([
+      { id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{"loc' } },
+    ]);
+
+    const chunk3 = [{ index: 0, function: { arguments: 'ation":"Paris"}' } }];
+    const result3 = parseToolCalls(result2, chunk3);
+    expect(result3).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"location":"Paris"}' },
+      },
+    ]);
+  });
+
+  it('should accept a first chunk with null name when merging into existing tool calls', () => {
+    const origin = [
+      {
+        id: 'call_a',
+        type: 'function',
+        function: { name: 'get_a', arguments: '{"x":1}' },
+      },
+    ];
+    // Second parallel tool_call opens with null name at a fresh index
+    const chunk = [
+      {
+        index: 1,
+        id: 'call_b',
+        type: 'function',
+        function: { name: null as any, arguments: '' },
+      },
+    ];
+    const result = parseToolCalls(origin, chunk);
+    expect(result).toEqual([
+      { id: 'call_a', type: 'function', function: { name: 'get_a', arguments: '{"x":1}' } },
+      { id: 'call_b', type: 'function', function: { name: '', arguments: '' } },
+    ]);
+  });
+
+  it('should not overwrite an already-resolved name with a later empty name delta', () => {
+    const origin = [
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"loc' },
+      },
+    ];
+    const chunk = [{ index: 0, function: { name: '', arguments: 'ation":"Paris"}' } }];
+    const result = parseToolCalls(origin, chunk);
+    expect(result).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"location":"Paris"}' },
+      },
+    ]);
+  });
+
   it('should throw error if incomplete tool calls data', () => {
     const origin = [
       {

--- a/packages/model-runtime/src/helpers/parseToolCalls.ts
+++ b/packages/model-runtime/src/helpers/parseToolCalls.ts
@@ -3,11 +3,25 @@ import { produce } from 'immer';
 import type { MessageToolCall, MessageToolCallChunk } from '../types';
 import { MessageToolCallSchema } from '../types';
 
+// Some providers (e.g. NVIDIA NIM serving z-ai/glm5 and qwen3.5-MoE, plus some
+// aihubmix-style proxies) emit the opening tool_call delta with
+// `function.name = null` or `''` as a start-of-tool marker. The real name is
+// carried by a subsequent delta. Passing `null` through the strict
+// MessageToolCallSchema throws ZodError mid-stream and kills the entire
+// operation. Coerce to '' so parsing succeeds; the merge logic below patches
+// the name in once a later delta supplies it. See LOBE-8199.
+const normalizeChunkForParse = <T extends Omit<MessageToolCallChunk, 'index'>>(chunk: T): T => {
+  if (chunk.function && chunk.function.name == null) {
+    return { ...chunk, function: { ...chunk.function, name: '' } };
+  }
+  return chunk;
+};
+
 export const parseToolCalls = (origin: MessageToolCall[], value: MessageToolCallChunk[]) =>
   produce(origin, (draft) => {
     // if there is no origin, we should parse all the value and set it to draft
     if (draft.length === 0) {
-      draft.push(...value.map((item) => MessageToolCallSchema.parse(item)));
+      draft.push(...value.map((item) => MessageToolCallSchema.parse(normalizeChunkForParse(item))));
       return;
     }
 
@@ -17,21 +31,28 @@ export const parseToolCalls = (origin: MessageToolCall[], value: MessageToolCall
       const existingByIdIndex = item.id ? draft.findIndex((d) => d.id === item.id) : -1;
 
       if (existingByIdIndex !== -1) {
-        // Found existing tool call with same id - merge arguments
+        // Found existing tool call with same id - merge arguments and (if the
+        // first delta had null/empty name) patch in the name from this delta.
         if (item.function?.arguments) {
           draft[existingByIdIndex].function.arguments += item.function.arguments;
         }
+        if (item.function?.name && !draft[existingByIdIndex].function.name) {
+          draft[existingByIdIndex].function.name = item.function.name;
+        }
       } else if (!draft?.[index]) {
         // No item at this index - insert new tool call
-        draft?.splice(index, 0, MessageToolCallSchema.parse(item));
+        draft?.splice(index, 0, MessageToolCallSchema.parse(normalizeChunkForParse(item)));
       } else if (item.id && draft[index].id !== item.id) {
         // Different id at same index - this is a new parallel tool call (e.g., from Gemini)
         // Push to end of draft instead of overwriting
-        draft.push(MessageToolCallSchema.parse(item));
+        draft.push(MessageToolCallSchema.parse(normalizeChunkForParse(item)));
       } else {
-        // Same index and same id (or no id) - merge arguments
+        // Same index and same id (or no id) - merge arguments and patch name.
         if (item.function?.arguments) {
           draft[index].function.arguments += item.function.arguments;
+        }
+        if (item.function?.name && !draft[index].function.name) {
+          draft[index].function.name = item.function.name;
         }
       }
     });

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -941,25 +941,11 @@ export const createRuntimeExecutors = (
           // ===== 2. Then accumulate to AgentState =====
           const newState = structuredClone(state);
 
-          // Carry the persisted DB id so downstream executors (notably
-          // `request_human_approve`) can look up the parent assistant from
-          // `state.messages` without an extra DB round-trip. Without the id
-          // the lookup at `request_human_approve` (which filters on `m.id`)
-          // falls through to a DB query; when human-approve fires on the
-          // fresh LLM turn, both code paths miss and the op errors with
-          // "No assistant message found as parent for pending tool messages".
-          // Sanitize mirrors the DB write above — state.messages flows into the
-          // next LLM call payload, so the same poisoning risk applies here.
-          // See LOBE-7761.
-          //
-          // Also drop tool_calls whose function.name never resolved to a
-          // non-empty string across all streaming deltas (LOBE-8199): some
-          // providers (NVIDIA NIM with z-ai/glm5, qwen3.5-MoE) open a
-          // tool_call with `name: null` and never supply the real name,
-          // typically when max_tokens is exhausted mid-stream. The tool
-          // executor can't dispatch them (ToolNameResolver filters them out),
-          // so keeping them in state.messages would only poison subsequent
-          // requests — strict providers 400 on nameless tool_calls.
+          // state.messages flows into the next LLM call payload, so entries
+          // must be safe for strict-provider history replay:
+          //   - drop tool_calls with empty name (undispatchable, and strict
+          //     providers 400 on nameless entries)
+          //   - coerce malformed JSON `arguments` to valid JSON
           const sanitizedToolCalls =
             tool_calls.length > 0
               ? tool_calls

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -951,16 +951,28 @@ export const createRuntimeExecutors = (
           // Sanitize mirrors the DB write above — state.messages flows into the
           // next LLM call payload, so the same poisoning risk applies here.
           // See LOBE-7761.
-          const stateToolCalls =
+          //
+          // Also drop tool_calls whose function.name never resolved to a
+          // non-empty string across all streaming deltas (LOBE-8199): some
+          // providers (NVIDIA NIM with z-ai/glm5, qwen3.5-MoE) open a
+          // tool_call with `name: null` and never supply the real name,
+          // typically when max_tokens is exhausted mid-stream. The tool
+          // executor can't dispatch them (ToolNameResolver filters them out),
+          // so keeping them in state.messages would only poison subsequent
+          // requests — strict providers 400 on nameless tool_calls.
+          const sanitizedToolCalls =
             tool_calls.length > 0
-              ? tool_calls.map((tc) => ({
-                  ...tc,
-                  function: {
-                    ...tc.function,
-                    arguments: sanitizeToolCallArguments(tc.function.arguments),
-                  },
-                }))
-              : undefined;
+              ? tool_calls
+                  .filter((tc) => !!tc.function.name)
+                  .map((tc) => ({
+                    ...tc,
+                    function: {
+                      ...tc.function,
+                      arguments: sanitizeToolCallArguments(tc.function.arguments),
+                    },
+                  }))
+              : [];
+          const stateToolCalls = sanitizedToolCalls.length > 0 ? sanitizedToolCalls : undefined;
 
           newState.messages.push({
             content,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes LOBE-8199.

#### 🔀 Description of Change

Some providers (NVIDIA NIM serving `z-ai/glm5` and `qwen/qwen3.5-397b-a17b`, plus some aihubmix-style proxies) open a streaming `tool_call` delta with `function.name = null` as a start marker, and only supply the real name in a later delta. The strict `MessageToolCallSchema` threw `ZodError` mid-stream and killed the entire operation — in one sampled op the agent had been running for **58 minutes and 113 steps** before dying on this.

```
path: ["function", "name"]
expected: "string"  received: "null"
```

This behavior is the same shape that the `zhipu` provider already preprocesses per-provider (see [zhipu/index.ts:104](https://github.com/lobehub/lobehub/blob/canary/packages/model-runtime/src/providers/zhipu/index.ts#L104)). This PR promotes the same tolerance to the central aggregation layer so it covers any provider exhibiting the same streaming pattern, instead of handling it one provider at a time.

**Changes:**

- **`packages/model-runtime/src/helpers/parseToolCalls.ts`** — coerce `function.name: null/undefined` to `''` before the Zod parse so streaming doesn't die; merge `function.name` from subsequent deltas (previously only `arguments` merged) so the real name patched in later replaces the placeholder. Once-resolved names are not overwritten by later empty-name deltas.

- **`src/server/modules/AgentRuntime/RuntimeExecutors.ts`** — defense-in-depth at the state persist boundary: drop `tool_calls` whose `function.name` never resolved to a non-empty string before pushing to `state.messages`. `ToolNameResolver` already filters these out of the dispatch path, but keeping them in replay history would still 400 on strict providers (which is exactly how this bug surfaced). Mirrors the existing LOBE-7761 `sanitizeToolCallArguments` pattern at the same boundary.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit tests in `parseToolCalls.test.ts` cover three new scenarios:

1. First delta with `name: null` + later delta patches in the real name + final delta appends arguments → full resolution.
2. New parallel tool_call opening with `name: null` is accepted when merging into existing tool_calls.
3. Already-resolved names are not overwritten by a later `name: ''` delta.

The existing `"should throw error if incomplete tool calls data"` test still passes — we only loosen for `null name`; chunks missing `function` entirely still throw.

```
bunx vitest run 'packages/model-runtime/src/helpers/parseToolCalls.test.ts'
  → 10 passed (7 existing + 3 new)

bunx vitest run 'packages/model-runtime/src/providers/zhipu'
  → 83 passed

bunx vitest run 'packages/model-runtime/src/core/streams'
  → 220 passed

bunx vitest run 'src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts'
  → 93 passed

bun run type-check
  → clean
```

#### 📝 Additional Information

Observed in 3 production ops (all on `provider: nvidia`):

| OP | Model | Steps | Duration |
|---|---|---|---|
| `op_1777033807076_…` | qwen3.5-397b-a17b | 1 | 1.5s (died on first chunk) |
| `op_1777026389129_…` | z-ai/glm5 | 113 | **58 min** |
| `op_1776906827308_…` | z-ai/glm5 | 7 | 10 min |

Op 3's final step is particularly clarifying: the harness' existing `TRUNCATED_ARGUMENTS` path ([builtin.ts:38](https://github.com/lobehub/lobehub/blob/canary/src/server/services/toolExecution/builtin.ts#L38)) was already gracefully catching truncated `arguments` strings (extended-thinking exhausting `max_tokens`), but the same root cause producing `name: null` had no corresponding graceful path and took down the whole op. This PR closes that asymmetry at the aggregation layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)