### PR TITLE
✨ feat: add GPT-5.5 model support

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
@@ -10,6 +10,58 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_050_000,
     description:
+      "GPT-5.5 is OpenAI's latest frontier model for complex professional work, coding, and agentic tasks.",
+    displayName: 'GPT-5.5',
+    enabled: true,
+    id: 'gpt-5.5',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 5, upTo: 272_000 },
+            { rate: 10, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.5, upTo: 272_000 },
+            { rate: 1, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 30, upTo: 272_000 },
+            { rate: 45, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-04-23',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
       "GPT-5.4 is OpenAI's latest model for complex professional work and a drop-in replacement for GPT-5.2 and GPT-5.3 Codex.",
     displayName: 'GPT-5.4',
     enabled: true,

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -29,6 +29,68 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_050_000,
     description:
+      'GPT-5.5 is the frontier model for the most complex professional work, coding, and agentic tasks.',
+    displayName: 'GPT-5.5',
+    enabled: true,
+    id: 'gpt-5.5',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        {
+          lookup: {
+            prices: {
+              '[0, 0.272]': 5,
+              '[0.272, infinity]': 10,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.272]': 0.5,
+              '[0.272, infinity]': 1,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textInput_cacheRead',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+        {
+          lookup: {
+            prices: {
+              '[0, 0.272]': 30,
+              '[0.272, infinity]': 45,
+            },
+            pricingParams: ['textInput'],
+          },
+          name: 'textOutput',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-04-23',
+    settings: {
+      extendParams: ['gpt5_2ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
       'GPT-5.4 is the frontier model for complex professional work with highest reasoning capability.',
     displayName: 'GPT-5.4',
     enabled: true,

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -22,6 +22,6 @@ export default LobeHub;
 export const planCardModels = [
   'claude-sonnet-4-6',
   'gemini-3.1-pro-preview',
-  'gpt-5.4',
+  'gpt-5.5',
   'deepseek-v4-flash',
 ];

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -50,6 +50,7 @@ export const responsesAPIModels = new Set([
   'gpt-5.4-mini',
   'gpt-5.4-nano',
   'gpt-5.4-pro',
+  'gpt-5.5',
 ]);
 
 /**

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -273,6 +273,20 @@ describe('LobeOpenAI', () => {
       expect(createCall.model).toBe('o1-pro');
     });
 
+    it('should use responses API for gpt-5.5', async () => {
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'gpt-5.5',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      expect(instance['client'].responses.create).toHaveBeenCalled();
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.model).toBe('gpt-5.5');
+    });
+
     it('should use responses API when enabledSearch is true', async () => {
       const payload = {
         enabledSearch: true,

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -482,6 +482,16 @@ describe('LobeOpenRouterAI - custom features', () => {
           architecture: { input_modalities: ['text'] },
           created: 1_700_000_000,
           description: 'Test model',
+          id: 'openai/gpt-5.5',
+          name: 'openai/gpt-5.5',
+          pricing: { completion: '0.00001', prompt: '0.00001' },
+          supported_parameters: ['reasoning'],
+          top_provider: { context_length: 8192, max_completion_tokens: 1024 },
+        },
+        {
+          architecture: { input_modalities: ['text'] },
+          created: 1_700_000_000,
+          description: 'Test model',
           id: 'openai/gpt-5.2-mini',
           name: 'openai/gpt-5.2-mini',
           pricing: { completion: '0.00001', prompt: '0.00001' },
@@ -509,9 +519,13 @@ describe('LobeOpenRouterAI - custom features', () => {
       );
 
       const models = await params.models();
+      const gpt55 = models.find((m) => m.id === 'openai/gpt-5.5');
       const gpt52 = models.find((m) => m.id === 'openai/gpt-5.2-mini');
       const gpt51 = models.find((m) => m.id === 'openai/gpt-5.1-mini');
 
+      expect(gpt55?.settings?.extendParams).toEqual(
+        expect.arrayContaining(['gpt5_2ReasoningEffort', 'textVerbosity']),
+      );
       expect(gpt52?.settings?.extendParams).toEqual(
         expect.arrayContaining(['gpt5_2ReasoningEffort', 'textVerbosity']),
       );

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -166,7 +166,12 @@ export const params = {
           if (model.description && model.description.includes('`reasoning` `enabled`')) {
             extendParams.push('enableReasoning');
           }
-          if (hasReasoning && (model.id.includes('gpt-5.2') || model.id.includes('gpt-5.4'))) {
+          if (
+            hasReasoning &&
+            (model.id.includes('gpt-5.2') ||
+              model.id.includes('gpt-5.4') ||
+              model.id.includes('gpt-5.5'))
+          ) {
             extendParams.push('gpt5_2ReasoningEffort', 'textVerbosity');
           } else if (hasReasoning && model.id.includes('gpt-5.1')) {
             extendParams.push('gpt5_1ReasoningEffort', 'textVerbosity');

--- a/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
@@ -249,6 +249,13 @@ describe('LobeVercelAIGatewayAI - custom features', () => {
     it('should map extendParams for gpt-5.x reasoning models', async () => {
       const mockModelData: VercelAIGatewayModelCard[] = [
         {
+          id: 'openai/gpt-5.5',
+          name: 'GPT-5.5',
+          pricing: { input: 0.000_005, output: 0.000_03 },
+          tags: ['reasoning'],
+          type: 'chat',
+        },
+        {
           id: 'openai/gpt-5.2-mini',
           name: 'GPT-5.2 Mini',
           pricing: { input: 0.000_003, output: 0.000_015 },
@@ -278,10 +285,14 @@ describe('LobeVercelAIGatewayAI - custom features', () => {
       };
 
       const models = await params.models({ client: mockClient as any });
+      const gpt55 = models.find((m) => m.id === 'openai/gpt-5.5');
       const gpt52 = models.find((m) => m.id === 'openai/gpt-5.2-mini');
       const gpt51 = models.find((m) => m.id === 'openai/gpt-5.1-mini');
       const gpt5 = models.find((m) => m.id === 'openai/gpt-5-mini');
 
+      expect(gpt55?.settings?.extendParams).toEqual(
+        expect.arrayContaining(['gpt5_2ReasoningEffort', 'textVerbosity']),
+      );
       expect(gpt52?.settings?.extendParams).toEqual(
         expect.arrayContaining(['gpt5_2ReasoningEffort', 'textVerbosity']),
       );

--- a/packages/model-runtime/src/providers/vercelaigateway/index.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.ts
@@ -127,7 +127,8 @@ export const params = {
             m.id.includes('gpt-5') &&
             !m.id.includes('gpt-5.1') &&
             !m.id.includes('gpt-5.2') &&
-            !m.id.includes('gpt-5.4')
+            !m.id.includes('gpt-5.4') &&
+            !m.id.includes('gpt-5.5')
           ) {
             extendParams.push('gpt5ReasoningEffort', 'textVerbosity');
           }
@@ -136,7 +137,7 @@ export const params = {
           }
           if (
             tags.includes('reasoning') &&
-            (m.id.includes('gpt-5.2') || m.id.includes('gpt-5.4'))
+            (m.id.includes('gpt-5.2') || m.id.includes('gpt-5.4') || m.id.includes('gpt-5.5'))
           ) {
             extendParams.push('gpt5_2ReasoningEffort', 'textVerbosity');
           }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add GPT-5.5 to OpenAI and LobeHub-hosted model cards with Standard-tier pricing.
- Route GPT-5.5 through the Responses API.
- Map GPT-5.5 dynamic OpenRouter and Vercel AI Gateway entries to GPT-5.2 reasoning effort and text verbosity controls.
- Update LobeHub plan card models to feature GPT-5.5.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx prettier --check 'packages/model-bank/src/aiModels/openai.ts' 'packages/model-bank/src/aiModels/lobehub/chat/openai.ts' 'packages/model-runtime/src/const/models.ts' 'packages/model-runtime/src/providers/openai/index.test.ts' 'packages/model-runtime/src/providers/openrouter/index.ts' 'packages/model-runtime/src/providers/openrouter/index.test.ts' 'packages/model-runtime/src/providers/vercelaigateway/index.ts' 'packages/model-runtime/src/providers/vercelaigateway/index.test.ts' 'packages/model-bank/src/modelProviders/lobehub.ts'\ncd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/openai/index.test.ts' 'src/providers/openrouter/index.test.ts' 'src/providers/vercelaigateway/index.test.ts'\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nGPT-5.5 uses the existing GPT-5.2 reasoning effort control family: `none`, `low`, `medium`, `high`, and `xhigh`.\n