### PR TITLE
🐛 fix(model-runtime): use `safety_identifier` for OpenAI Responses API

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -1754,7 +1754,7 @@ describe('LobeOpenAICompatibleFactory', () => {
           model: payload.model,
           // @ts-ignore
           text: { format: { strict: true, type: 'json_schema', ...payload.schema } },
-          user: undefined,
+          safety_identifier: undefined,
         },
         { headers: undefined, signal: undefined },
       );
@@ -1793,7 +1793,7 @@ describe('LobeOpenAICompatibleFactory', () => {
           model: payload.model,
           // @ts-ignore
           text: { format: { strict: true, type: 'json_schema', ...payload.schema } },
-          user: options.user,
+          safety_identifier: options.user,
         },
         { headers: options.headers, signal: options.signal },
       );

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -801,8 +801,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
               input: messages,
               model,
               text: { format: { strict: true, type: 'json_schema', ...processedSchema } },
-              user: options?.user,
-            },
+              // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
+              safety_identifier: options?.user,
+            } as any,
             { headers: options?.headers, signal: options?.signal },
           );
 
@@ -1108,7 +1109,8 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         store: false,
         stream: !isStreaming ? undefined : isStreaming,
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
-        user: options?.user,
+        // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
+        safety_identifier: options?.user,
         // Sanitize sampling params for Responses API path
         ...resolveModelSamplingParameters(res.model, res, {
           normalizeTemperature: false,
@@ -1233,8 +1235,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             model,
             tool_choice: 'required',
             tools: tools!.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
-            user: options?.user,
-          },
+            // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
+            safety_identifier: options?.user,
+          } as any,
           { headers: options?.headers, signal: options?.signal },
         );
 


### PR DESCRIPTION
## Summary

- OpenAI Responses API 拒绝已废弃的 `user` 参数（错误：`Unsupported parameter: user`），改为新的 `safety_identifier` 字段
- 仅替换 Responses API 路径上的三处调用（`generateObject` 结构化输出、`handleResponseAPIMode` 主聊天流、`generateObjectWithTools` 工具调用）
- Chat Completions 路径保持 `user` 不变 —— 这个 factory 同时服务于所有 openai-compatible provider，它们大多仍接受 `user`

Fixes LOBE-8202
Closes #12326

## Implementation Notes

- 当前安装的 SDK 版本 `openai@^4.104.0` 的类型尚未声明 `safety_identifier`，两处对象字面量加了 `as any` 以绕过；主流程那处 `postPayload` 本身有 `as ResponseCreateParams...` 断言，直接通过
- 单测期望同步从 `user: ...` 改为 `safety_identifier: ...`
- SDK 升级到 v6（届时类型已声明 `safety_identifier`，可去掉 `as any`）跟进于 LOBE-8212

## Test plan

- [x] `bun run type-check` 通过
- [x] `bunx vitest run packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts` — 76/76 通过
- [ ] 线上 `gpt-5.4` 模型回归验证 Responses API 调用不再报 `Unsupported parameter: user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)