### PR TITLE
🐛 fix(model-runtime): guard tool_use.input against non-object parsed arguments

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -308,9 +308,44 @@ describe('anthropicHelpers', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('warns and falls back to empty input when tool_call arguments parse to a JSON array', async () => {
+    it('recovers tool_call input from a single-element array (model wrapped args in [])', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const message: OpenAIChatMessage = {
+        content: '',
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_wrapped',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '[{"query":"anthropic"}]',
+            },
+          },
+        ],
+      };
+
+      const result = await buildAnthropicMessage(message);
+
+      expect(result!.content).toEqual([
+        { id: 'call_wrapped', input: { query: 'anthropic' }, name: 'search', type: 'tool_use' },
+      ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('recovered from array'),
+        expect.objectContaining({
+          arrayLength: 1,
+          id: 'call_wrapped',
+          name: 'search',
+        }),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('recovers tool_call input from element[0] when arguments parse to a multi-element array', async () => {
       // LOBE-8201 — model emitted long writeLocalFile args containing many
       // unescaped quotes, which JSON.parse re-segmented into a top-level array.
+      // element[0] usually still carries the first legit key (e.g. `content`),
+      // so prefer partial recovery over total loss.
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const message: OpenAIChatMessage = {
         content: 'fix:',
@@ -331,15 +366,46 @@ describe('anthropicHelpers', () => {
 
       expect(result!.content).toEqual([
         { text: 'fix:', type: 'text' },
-        { id: 'call_array', input: {}, name: 'writeLocalFile', type: 'tool_use' },
+        {
+          id: 'call_array',
+          input: { content: 'a' },
+          name: 'writeLocalFile',
+          type: 'tool_use',
+        },
       ]);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('tool_use.input fallback to {}'),
+        expect.stringContaining('recovered from array'),
         expect.objectContaining({
+          arrayLength: 2,
           id: 'call_array',
           name: 'writeLocalFile',
-          parsedType: 'array',
         }),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('falls back to {} when arguments parse to an empty array', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const message: OpenAIChatMessage = {
+        content: '',
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_empty_array',
+            type: 'function',
+            function: { name: 'noop', arguments: '[]' },
+          },
+        ],
+      };
+
+      const result = await buildAnthropicMessage(message);
+
+      expect(result!.content).toEqual([
+        { id: 'call_empty_array', input: {}, name: 'noop', type: 'tool_use' },
+      ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fallback to {}'),
+        expect.objectContaining({ id: 'call_empty_array', parsedType: 'array' }),
       );
       consoleWarnSpy.mockRestore();
     });

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -308,6 +308,68 @@ describe('anthropicHelpers', () => {
       consoleErrorSpy.mockRestore();
     });
 
+    it('warns and falls back to empty input when tool_call arguments parse to a JSON array', async () => {
+      // LOBE-8201 — model emitted long writeLocalFile args containing many
+      // unescaped quotes, which JSON.parse re-segmented into a top-level array.
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const message: OpenAIChatMessage = {
+        content: 'fix:',
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_array',
+            type: 'function',
+            function: {
+              name: 'writeLocalFile',
+              arguments: '[{"content":"a"},{"content":"b"}]',
+            },
+          },
+        ],
+      };
+
+      const result = await buildAnthropicMessage(message);
+
+      expect(result!.content).toEqual([
+        { text: 'fix:', type: 'text' },
+        { id: 'call_array', input: {}, name: 'writeLocalFile', type: 'tool_use' },
+      ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('tool_use.input fallback to {}'),
+        expect.objectContaining({
+          id: 'call_array',
+          name: 'writeLocalFile',
+          parsedType: 'array',
+        }),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('warns and falls back to empty input when tool_call arguments parse to null', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const message: OpenAIChatMessage = {
+        content: '',
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_null',
+            type: 'function',
+            function: { name: 'noop', arguments: 'null' },
+          },
+        ],
+      };
+
+      const result = await buildAnthropicMessage(message);
+
+      expect(result!.content).toEqual([
+        { id: 'call_null', input: {}, name: 'noop', type: 'tool_use' },
+      ]);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('tool_use.input fallback to {}'),
+        expect.objectContaining({ id: 'call_null', parsedType: 'null' }),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
     it('should correctly convert function message', async () => {
       const message: OpenAIChatMessage = {
         content: 'def hello(name):\n  return f"Hello {name}"',

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -178,7 +178,30 @@ export const buildAnthropicMessage = async (
             ...(message.tool_calls.map((tool) => {
               let input: Record<string, unknown> = {};
               try {
-                input = JSON.parse(tool.function.arguments);
+                const parsed = JSON.parse(tool.function.arguments);
+                // Anthropic requires tool_use.input to be a plain object.
+                // Models occasionally emit malformed JSON whose top-level shape
+                // is an array / null / primitive (e.g. unescaped quotes inside
+                // a long string arg make the parser re-segment the payload).
+                // Degrade to {} instead of letting Anthropic 400 the whole
+                // request.
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                  input = parsed;
+                } else {
+                  console.warn(
+                    '[anthropic] tool_use.input fallback to {} — parsed arguments is not a plain object',
+                    {
+                      argumentsLength: tool.function.arguments?.length,
+                      id: tool.id,
+                      name: tool.function.name,
+                      parsedType: Array.isArray(parsed)
+                        ? 'array'
+                        : parsed === null
+                          ? 'null'
+                          : typeof parsed,
+                    },
+                  );
+                }
               } catch (error) {
                 // Surface the failure instead of silently falling back to `{}`.
                 // Bad arguments should be sanitized upstream (context-engine

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -183,10 +183,30 @@ export const buildAnthropicMessage = async (
                 // Models occasionally emit malformed JSON whose top-level shape
                 // is an array / null / primitive (e.g. unescaped quotes inside
                 // a long string arg make the parser re-segment the payload).
-                // Degrade to {} instead of letting Anthropic 400 the whole
-                // request.
                 if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
                   input = parsed;
+                } else if (
+                  Array.isArray(parsed) &&
+                  parsed.length > 0 &&
+                  parsed[0] &&
+                  typeof parsed[0] === 'object' &&
+                  !Array.isArray(parsed[0])
+                ) {
+                  // Best-effort recovery: either the model wrapped the args
+                  // in `[...]` (length === 1, full recovery) or unescaped
+                  // quotes re-segmented the payload (partial recovery —
+                  // parsed[0] usually still carries the first legit key,
+                  // e.g. `content` for writeLocalFile).
+                  input = parsed[0] as Record<string, unknown>;
+                  console.warn(
+                    '[anthropic] tool_use.input recovered from array — parsed arguments was wrapped in []',
+                    {
+                      argumentsLength: tool.function.arguments?.length,
+                      arrayLength: parsed.length,
+                      id: tool.id,
+                      name: tool.function.name,
+                    },
+                  );
                 } else {
                   console.warn(
                     '[anthropic] tool_use.input fallback to {} — parsed arguments is not a plain object',

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -288,9 +288,9 @@ describe('google contextBuilders', () => {
       });
     });
 
-    it('warns and falls back to empty args when tool_call arguments parse to a JSON array', async () => {
-      // LOBE-8201 — same defense as Anthropic: model emits malformed JSON whose
-      // top-level shape is an array, would otherwise break Gemini schema.
+    it('recovers functionCall.args from element[0] when arguments parse to an array', async () => {
+      // LOBE-8201 — same defense as Anthropic: prefer partial recovery from
+      // element[0] over total loss when malformed JSON parses to an array.
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const message = {
         role: 'assistant',
@@ -311,14 +311,17 @@ describe('google contextBuilders', () => {
       expect(converted).toEqual({
         parts: [
           {
-            functionCall: { args: {}, name: 'writeLocalFile' },
+            functionCall: { args: { content: 'a' }, name: 'writeLocalFile' },
           },
         ],
         role: 'model',
       });
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('functionCall.args fallback to {}'),
-        expect.objectContaining({ name: 'writeLocalFile', parsedType: 'array' }),
+        expect.stringContaining('functionCall.args recovered from array'),
+        expect.objectContaining({
+          arrayLength: 2,
+          name: 'writeLocalFile',
+        }),
       );
       consoleWarnSpy.mockRestore();
     });

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -288,6 +288,41 @@ describe('google contextBuilders', () => {
       });
     });
 
+    it('warns and falls back to empty args when tool_call arguments parse to a JSON array', async () => {
+      // LOBE-8201 — same defense as Anthropic: model emits malformed JSON whose
+      // top-level shape is an array, would otherwise break Gemini schema.
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const message = {
+        role: 'assistant',
+        tool_calls: [
+          {
+            function: {
+              arguments: '[{"content":"a"},{"content":"b"}]',
+              name: 'writeLocalFile',
+            },
+            id: 'call_array',
+            type: 'function',
+          },
+        ],
+      } as OpenAIChatMessage;
+
+      const converted = await buildGoogleMessage(message);
+
+      expect(converted).toEqual({
+        parts: [
+          {
+            functionCall: { args: {}, name: 'writeLocalFile' },
+          },
+        ],
+        role: 'model',
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('functionCall.args fallback to {}'),
+        expect.objectContaining({ name: 'writeLocalFile', parsedType: 'array' }),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
     it('should correctly convert function call message with thoughtSignature', async () => {
       const message = {
         role: 'assistant',

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -124,12 +124,29 @@ export const buildGoogleMessage = async (
     return {
       parts: message.tool_calls.map<Part>((tool) => {
         const parsed = safeParseJSON(tool.function.arguments);
-        // Gemini's functionCall.args requires a plain object, same as
-        // Anthropic's tool_use.input. Models occasionally emit malformed JSON
-        // whose top-level shape ends up as an array / null / primitive — fall
-        // back to {} to keep the request valid.
-        const isPlainObject = !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
-        if (parsed !== undefined && !isPlainObject) {
+        // Gemini's functionCall.args requires a plain object, same constraint
+        // as Anthropic's tool_use.input. See anthropic.ts for the full
+        // recovery rationale.
+        let args: Record<string, unknown> = {};
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          args = parsed as Record<string, unknown>;
+        } else if (
+          Array.isArray(parsed) &&
+          parsed.length > 0 &&
+          parsed[0] &&
+          typeof parsed[0] === 'object' &&
+          !Array.isArray(parsed[0])
+        ) {
+          args = parsed[0] as Record<string, unknown>;
+          console.warn(
+            '[google] functionCall.args recovered from array — parsed arguments was wrapped in []',
+            {
+              argumentsLength: tool.function.arguments?.length,
+              arrayLength: parsed.length,
+              name: tool.function.name,
+            },
+          );
+        } else if (parsed !== undefined) {
           console.warn(
             '[google] functionCall.args fallback to {} — parsed arguments is not a plain object',
             {
@@ -144,10 +161,7 @@ export const buildGoogleMessage = async (
           );
         }
         return {
-          functionCall: {
-            args: isPlainObject ? (parsed as Record<string, unknown>) : {},
-            name: tool.function.name,
-          },
+          functionCall: { args, name: tool.function.name },
           thoughtSignature: tool.thoughtSignature,
         };
       }),

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -122,13 +122,35 @@ export const buildGoogleMessage = async (
   // Handle assistant messages with tool_calls
   if (!!message.tool_calls) {
     return {
-      parts: message.tool_calls.map<Part>((tool) => ({
-        functionCall: {
-          args: safeParseJSON(tool.function.arguments)!,
-          name: tool.function.name,
-        },
-        thoughtSignature: tool.thoughtSignature,
-      })),
+      parts: message.tool_calls.map<Part>((tool) => {
+        const parsed = safeParseJSON(tool.function.arguments);
+        // Gemini's functionCall.args requires a plain object, same as
+        // Anthropic's tool_use.input. Models occasionally emit malformed JSON
+        // whose top-level shape ends up as an array / null / primitive — fall
+        // back to {} to keep the request valid.
+        const isPlainObject = !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
+        if (parsed !== undefined && !isPlainObject) {
+          console.warn(
+            '[google] functionCall.args fallback to {} — parsed arguments is not a plain object',
+            {
+              argumentsLength: tool.function.arguments?.length,
+              name: tool.function.name,
+              parsedType: Array.isArray(parsed)
+                ? 'array'
+                : parsed === null
+                  ? 'null'
+                  : typeof parsed,
+            },
+          );
+        }
+        return {
+          functionCall: {
+            args: isPlainObject ? (parsed as Record<string, unknown>) : {},
+            name: tool.function.name,
+          },
+          thoughtSignature: tool.thoughtSignature,
+        };
+      }),
       role: 'model',
     };
   }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Refs LOBE-8201

#### 🔀 Description of Change

When Sonnet (or any model) emits a long tool argument that contains many `"` characters (e.g. a `writeLocalFile` call whose `content` is an R script with `cat("…")` everywhere), the model occasionally fails to escape them. The resulting JSON string is technically parseable but `JSON.parse` re-segments it into a top-level **array** (or null / primitive) — keys end up being script fragments.

Previously we assigned the parsed value straight into:

- Anthropic `tool_use.input`
- Gemini `functionCall.args`

Both providers require a plain object, so the API rejects with `Input should be a valid dictionary` (Anthropic) or its Gemini equivalent. The whole conversation gets stuck because the bad `arguments` is persisted in DB and replayed on every retry.

This PR adds a guard around the parsed value:

1. **Plain object** → use directly (unchanged)
2. **Array with first element being a plain object** → use `parsed[0]` as best-effort recovery + `console.warn`. This covers two real failure modes:
   - Model wrapped args in `[...]` (`length === 1`, full recovery)
   - Unescaped quotes re-segmented the payload (`length > 1`, partial recovery — `parsed[0]` still carries the first legit key like `content`)
3. **Anything else** (empty array, non-object first element, null, primitive) → fall back to `{}` + `console.warn`

The original `JSON.parse` `catch` branch (already present) is unchanged — invalid-JSON still uses the existing `console.error` path.

Long-term we may want stricter validation in the streaming accumulator so malformed `arguments` never reach DB; this PR keeps the conversation alive when it does.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' 'src/core/contextBuilders/anthropic.test.ts'
# 43 passed
```

New cases on `anthropic.test.ts`:

- recovers tool_call input from a single-element array (model wrapped args in `[]`)
- recovers tool_call input from element[0] when arguments parse to a multi-element array
- falls back to `{}` when arguments parse to an empty array
- warns and falls back to empty input when tool_call arguments parse to null

`google.test.ts` mirrors the array-recovery case. Note: `google.test.ts` currently fails to load on canary due to a pre-existing `import { Buffer } from 'buffer.js'` in `@lobechat/utils/src/base64.ts` (unrelated to this PR — same failure on clean canary).

#### 📝 Additional Information

Real-world trace example:

- `op_1776850537217_agt_FZepIOIxezgP_tpc_dj1eDTkX2uz0_x6FkRgOT`
- `op_1776850442127_agt_FZepIOIxezgP_tpc_dj1eDTkX2uz0_4jFCQFvq`

Both fail at message 146 (`writeLocalFile`) whose `arguments` parses to a 2-element array — keys of `element[0]` are R-script fragments like `'v4\n")\ncat("日期'`, confirming the unescaped-quote root cause. With this PR the conversation can replay (using `parsed[0].content` as best-effort) instead of permanently breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)