### PR TITLE
♻️ refactor(devtools): split RenderGallery into routed sub-pages

### DIFF
--- a/packages/builtin-tools/src/inspectors.ts
+++ b/packages/builtin-tools/src/inspectors.ts
@@ -95,6 +95,23 @@ const BuiltinToolInspectors: Record<string, Record<string, BuiltinInspector>> = 
   },
 };
 
+export interface BuiltinInspectorRegistryEntry {
+  apiName: string;
+  identifier: string;
+  inspector: BuiltinInspector;
+}
+
+export const listBuiltinInspectorEntries = (): BuiltinInspectorRegistryEntry[] =>
+  Object.entries(BuiltinToolInspectors).flatMap(([identifier, toolset]) =>
+    Object.entries(toolset)
+      .filter((entry): entry is [string, BuiltinInspector] => !!entry[1])
+      .map(([apiName, inspector]) => ({
+        apiName,
+        identifier,
+        inspector,
+      })),
+  );
+
 /**
  * Get builtin inspector component for a specific API
  * @param identifier - Tool identifier (e.g., 'lobe-code-interpreter')

--- a/packages/builtin-tools/src/interventions.ts
+++ b/packages/builtin-tools/src/interventions.ts
@@ -45,6 +45,23 @@ export const BuiltinToolInterventions: Record<string, Record<string, any>> = {
   [WebOnboardingManifest.identifier]: WebOnboardingInterventions,
 };
 
+export interface BuiltinInterventionRegistryEntry {
+  apiName: string;
+  identifier: string;
+  intervention: BuiltinIntervention;
+}
+
+export const listBuiltinInterventionEntries = (): BuiltinInterventionRegistryEntry[] =>
+  Object.entries(BuiltinToolInterventions).flatMap(([identifier, toolset]) =>
+    Object.entries(toolset)
+      .filter((entry): entry is [string, BuiltinIntervention] => !!entry[1])
+      .map(([apiName, intervention]) => ({
+        apiName,
+        identifier,
+        intervention,
+      })),
+  );
+
 /**
  * Get builtin intervention component for a specific API
  * @param identifier - Tool identifier (e.g., 'lobe-local-system')

--- a/packages/builtin-tools/src/placeholders.ts
+++ b/packages/builtin-tools/src/placeholders.ts
@@ -24,6 +24,23 @@ export const BuiltinToolPlaceholders: Record<string, Record<string, any>> = {
   [WebBrowsingManifest.identifier]: WebBrowsingPlaceholders as Record<string, any>,
 };
 
+export interface BuiltinPlaceholderRegistryEntry {
+  apiName: string;
+  identifier: string;
+  placeholder: BuiltinPlaceholder;
+}
+
+export const listBuiltinPlaceholderEntries = (): BuiltinPlaceholderRegistryEntry[] =>
+  Object.entries(BuiltinToolPlaceholders).flatMap(([identifier, toolset]) =>
+    Object.entries(toolset)
+      .filter((entry): entry is [string, BuiltinPlaceholder] => !!entry[1])
+      .map(([apiName, placeholder]) => ({
+        apiName,
+        identifier,
+        placeholder,
+      })),
+  );
+
 /**
  * Get builtin placeholder component for a specific API
  * @param identifier - Tool identifier (e.g., 'lobe-local-system')

--- a/packages/builtin-tools/src/streamings.ts
+++ b/packages/builtin-tools/src/streamings.ts
@@ -68,6 +68,23 @@ const BuiltinToolStreamings: Record<string, Record<string, BuiltinStreaming>> = 
   [NotebookManifest.identifier]: NotebookStreamings as Record<string, BuiltinStreaming>,
 };
 
+export interface BuiltinStreamingRegistryEntry {
+  apiName: string;
+  identifier: string;
+  streaming: BuiltinStreaming;
+}
+
+export const listBuiltinStreamingEntries = (): BuiltinStreamingRegistryEntry[] =>
+  Object.entries(BuiltinToolStreamings).flatMap(([identifier, toolset]) =>
+    Object.entries(toolset)
+      .filter((entry): entry is [string, BuiltinStreaming] => !!entry[1])
+      .map(([apiName, streaming]) => ({
+        apiName,
+        identifier,
+        streaming,
+      })),
+  );
+
 /**
  * Get builtin streaming component for a specific API
  * @param identifier - Tool identifier (e.g., 'lobe-code-interpreter')

--- a/src/features/DevPanel/RenderGallery/IndexPage.tsx
+++ b/src/features/DevPanel/RenderGallery/IndexPage.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { Navigate } from 'react-router-dom';
+
+import { toToolsetPath, useDevtoolsEntries } from './useDevtoolsEntries';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  empty: css`
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 14px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+}));
+
+const DevtoolsIndex = () => {
+  const { defaultToolset } = useDevtoolsEntries();
+
+  if (defaultToolset) {
+    return <Navigate replace to={toToolsetPath(defaultToolset.identifier)} />;
+  }
+
+  return <Flexbox className={styles.empty}>No builtin tool renders registered.</Flexbox>;
+};
+
+export default DevtoolsIndex;

--- a/src/features/DevPanel/RenderGallery/Sidebar.tsx
+++ b/src/features/DevPanel/RenderGallery/Sidebar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Menu, type MenuProps, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  header: css`
+    padding-block: 16px 12px;
+    padding-inline: 20px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  menu: css`
+    padding-block: 8px;
+    border-inline-end: none !important;
+  `,
+  sidebar: css`
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+
+    width: 260px;
+    height: 100%;
+    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  scroll: css`
+    overflow: auto;
+    flex: 1;
+  `,
+}));
+
+interface SidebarProps {
+  items: MenuProps['items'];
+  onSelect: (key: string) => void;
+  selectedKey?: string;
+}
+
+const Sidebar = memo<SidebarProps>(({ items, selectedKey, onSelect }) => (
+  <aside className={styles.sidebar}>
+    <div className={styles.header}>
+      <Text fontSize={13} type={'secondary'} weight={600}>
+        Builtin Tool Renders
+      </Text>
+    </div>
+    <div className={styles.scroll}>
+      <Menu
+        className={styles.menu}
+        items={items}
+        mode={'inline'}
+        selectedKeys={selectedKey ? [selectedKey] : []}
+        onClick={({ key }) => onSelect(key)}
+      />
+    </div>
+  </aside>
+));
+
+export default Sidebar;

--- a/src/features/DevPanel/RenderGallery/ToolPage.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPage.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Flexbox, Tag, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { useParams } from 'react-router-dom';
+
+import ToolPreview from './ToolPreview';
+import { useDevtoolsEntries } from './useDevtoolsEntries';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  body: css`
+    gap: 24px;
+    max-width: 1200px;
+    padding: 28px;
+  `,
+  empty: css`
+    flex: 1;
+    gap: 6px;
+    align-items: center;
+    justify-content: center;
+
+    color: ${cssVar.colorTextTertiary};
+  `,
+  header: css`
+    gap: 8px;
+    padding-block-end: 4px;
+  `,
+}));
+
+const DevtoolsToolPage = () => {
+  const { toolsetMap } = useDevtoolsEntries();
+  const { identifier } = useParams<{ identifier: string }>();
+  const toolset = identifier ? toolsetMap.get(identifier) : undefined;
+
+  if (!toolset) {
+    return (
+      <Flexbox className={styles.empty}>
+        <Text fontSize={14} weight={500}>
+          Unknown toolset
+        </Text>
+        <Text fontSize={12} type={'secondary'}>
+          {identifier}
+        </Text>
+      </Flexbox>
+    );
+  }
+
+  return (
+    <Flexbox className={styles.body}>
+      <Flexbox className={styles.header}>
+        <Flexbox horizontal align={'center'} gap={10} wrap={'wrap'}>
+          <Text fontSize={22} weight={700}>
+            {toolset.toolsetName}
+          </Text>
+          <Tag>{toolset.identifier}</Tag>
+          <Text fontSize={12} type={'secondary'}>
+            {toolset.apis.length} API{toolset.apis.length === 1 ? '' : 's'}
+          </Text>
+        </Flexbox>
+        {toolset.toolsetDescription && (
+          <Text fontSize={13} type={'secondary'}>
+            {toolset.toolsetDescription}
+          </Text>
+        )}
+      </Flexbox>
+
+      {toolset.apis.map((api) => (
+        <ToolPreview api={api} key={`${api.identifier}:${api.apiName}`} />
+      ))}
+    </Flexbox>
+  );
+};
+
+export default DevtoolsToolPage;

--- a/src/features/DevPanel/RenderGallery/ToolPreview.tsx
+++ b/src/features/DevPanel/RenderGallery/ToolPreview.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { Block, Flexbox, Segmented, Tag, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { Component, type ReactNode, useMemo, useState } from 'react';
+
+import type { ApiEntry } from './useDevtoolsEntries';
+import { toApiAnchor } from './useDevtoolsEntries';
+
+type BodyKind = 'render' | 'streaming' | 'placeholder' | 'intervention';
+
+const BODY_ORDER: BodyKind[] = ['render', 'streaming', 'placeholder', 'intervention'];
+
+const BODY_LABEL: Record<BodyKind, string> = {
+  intervention: 'Intervention',
+  placeholder: 'Placeholder',
+  render: 'Render',
+  streaming: 'Streaming',
+};
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  card: css`
+    scroll-margin-block-start: 16px;
+
+    overflow: hidden;
+
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 20px;
+
+    background: ${cssVar.colorBgContainer};
+    box-shadow: ${cssVar.boxShadowSecondary};
+  `,
+  cardBody: css`
+    padding: 20px;
+  `,
+  cardHeader: css`
+    gap: 10px;
+
+    padding-block: 20px;
+    padding-inline: 24px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    background: linear-gradient(
+      180deg,
+      ${cssVar.colorFillQuaternary} 0%,
+      ${cssVar.colorBgContainer} 100%
+    );
+  `,
+  code: css`
+    overflow: auto;
+
+    max-height: 320px;
+    margin: 0;
+    padding: 12px;
+    border-radius: 12px;
+
+    font-size: 12px;
+    line-height: 1.55;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  fixtureSummary: css`
+    cursor: pointer;
+    user-select: none;
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  missingShell: css`
+    padding-block: 12px;
+    padding-inline: 16px;
+    border: 1px dashed ${cssVar.colorBorderSecondary};
+    border-radius: 12px;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  previewShell: css`
+    padding: 16px;
+    border-radius: 16px;
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  sectionLabel: css`
+    gap: 8px;
+    align-items: center;
+  `,
+}));
+
+class RenderBoundary extends Component<
+  { children: ReactNode; label: string },
+  { error?: Error | undefined }
+> {
+  constructor(props: { children: ReactNode; label: string }) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  override render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <Block padding={16} variant={'outlined'}>
+        <Flexbox gap={8}>
+          <Text fontSize={14} type={'danger'} weight={500}>
+            {this.props.label} crashed
+          </Text>
+          <Text fontSize={12} type={'secondary'}>
+            {this.state.error.message}
+          </Text>
+        </Flexbox>
+      </Block>
+    );
+  }
+}
+
+const coerceInspectorContent = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const Missing = ({ kind }: { kind: string }) => (
+  <div className={styles.missingShell}>No {kind} registered for this API.</div>
+);
+
+interface ToolPreviewProps {
+  api: ApiEntry;
+}
+
+const ToolPreview = ({ api }: ToolPreviewProps) => {
+  const { fixture } = api;
+  const messageId = `devtools-${api.identifier}-${api.apiName}`;
+  const toolCallId = `${messageId}-tool`;
+
+  const Inspector = api.inspector;
+  const Render = api.render;
+  const Streaming = api.streaming;
+  const Placeholder = api.placeholder;
+  const Intervention = api.intervention;
+
+  const availableBodyKinds = useMemo<BodyKind[]>(
+    () =>
+      BODY_ORDER.filter((kind) => {
+        switch (kind) {
+          case 'render': {
+            return Boolean(Render);
+          }
+          case 'streaming': {
+            return Boolean(Streaming);
+          }
+          case 'placeholder': {
+            return Boolean(Placeholder);
+          }
+          case 'intervention': {
+            return Boolean(Intervention);
+          }
+          default: {
+            return false;
+          }
+        }
+      }),
+    [Render, Streaming, Placeholder, Intervention],
+  );
+
+  const defaultBody = availableBodyKinds[0] ?? 'render';
+  const [activeBody, setActiveBody] = useState<BodyKind>(defaultBody);
+
+  const effectiveBody = availableBodyKinds.includes(activeBody) ? activeBody : defaultBody;
+
+  const segmentOptions = BODY_ORDER.map((kind) => ({
+    disabled: !availableBodyKinds.includes(kind),
+    label: BODY_LABEL[kind],
+    value: kind,
+  }));
+
+  const inspectorResult = {
+    content: coerceInspectorContent(fixture.content),
+    error: fixture.pluginError,
+    state: fixture.pluginState,
+  };
+
+  const renderBody = () => {
+    switch (effectiveBody) {
+      case 'render': {
+        return Render ? (
+          <RenderBoundary label={'Render'}>
+            <Render
+              apiName={api.apiName}
+              args={fixture.args}
+              content={fixture.content}
+              identifier={api.identifier}
+              messageId={messageId}
+              pluginError={fixture.pluginError}
+              pluginState={fixture.pluginState}
+              toolCallId={toolCallId}
+            />
+          </RenderBoundary>
+        ) : (
+          <Missing kind={'render'} />
+        );
+      }
+      case 'streaming': {
+        return Streaming ? (
+          <RenderBoundary label={'Streaming'}>
+            <Streaming
+              apiName={api.apiName}
+              args={fixture.args ?? {}}
+              identifier={api.identifier}
+              messageId={messageId}
+              toolCallId={toolCallId}
+            />
+          </RenderBoundary>
+        ) : (
+          <Missing kind={'streaming'} />
+        );
+      }
+      case 'placeholder': {
+        return Placeholder ? (
+          <RenderBoundary label={'Placeholder'}>
+            <Placeholder
+              apiName={api.apiName}
+              args={fixture.args ?? {}}
+              identifier={api.identifier}
+            />
+          </RenderBoundary>
+        ) : (
+          <Missing kind={'placeholder'} />
+        );
+      }
+      case 'intervention': {
+        return Intervention ? (
+          <RenderBoundary label={'Intervention'}>
+            <Intervention
+              apiName={api.apiName}
+              args={fixture.args ?? {}}
+              identifier={api.identifier}
+              interactionMode={'approval'}
+              messageId={messageId}
+            />
+          </RenderBoundary>
+        ) : (
+          <Missing kind={'intervention'} />
+        );
+      }
+      default: {
+        return null;
+      }
+    }
+  };
+
+  return (
+    <Flexbox className={styles.card} id={toApiAnchor(api.apiName)}>
+      <Flexbox className={styles.cardHeader}>
+        <Flexbox horizontal align={'center'} gap={8} wrap={'wrap'}>
+          <Text fontSize={18} weight={600}>
+            {api.apiName}
+          </Text>
+          <Tag>{api.identifier}</Tag>
+          {!Inspector && availableBodyKinds.length === 0 && <Tag color={'warning'}>no renders</Tag>}
+        </Flexbox>
+        {api.description && (
+          <Text fontSize={13} type={'secondary'}>
+            {api.description}
+          </Text>
+        )}
+      </Flexbox>
+
+      <Flexbox className={styles.cardBody} gap={16}>
+        <Flexbox gap={8}>
+          <Flexbox horizontal className={styles.sectionLabel}>
+            <Text fontSize={12} type={'secondary'} weight={600}>
+              Inspector
+            </Text>
+          </Flexbox>
+          <div className={styles.previewShell}>
+            {Inspector ? (
+              <RenderBoundary label={'Inspector'}>
+                <Inspector
+                  apiName={api.apiName}
+                  args={fixture.args ?? {}}
+                  identifier={api.identifier}
+                  isLoading={false}
+                  pluginState={fixture.pluginState}
+                  result={inspectorResult}
+                />
+              </RenderBoundary>
+            ) : (
+              <Missing kind={'inspector'} />
+            )}
+          </div>
+        </Flexbox>
+
+        <Flexbox gap={8}>
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={styles.sectionLabel}
+            justify={'space-between'}
+          >
+            <Text fontSize={12} type={'secondary'} weight={600}>
+              Body
+            </Text>
+            <Segmented
+              options={segmentOptions}
+              size={'small'}
+              value={effectiveBody}
+              onChange={(value) => setActiveBody(value as BodyKind)}
+            />
+          </Flexbox>
+          <div className={styles.previewShell}>{renderBody()}</div>
+        </Flexbox>
+
+        <details>
+          <summary className={styles.fixtureSummary}>Fixture payload</summary>
+          <pre className={styles.code}>
+            {JSON.stringify(
+              {
+                args: fixture.args,
+                content: fixture.content,
+                pluginError: fixture.pluginError,
+                pluginState: fixture.pluginState,
+              },
+              null,
+              2,
+            )}
+          </pre>
+        </details>
+      </Flexbox>
+    </Flexbox>
+  );
+};
+
+export default ToolPreview;

--- a/src/features/DevPanel/RenderGallery/index.tsx
+++ b/src/features/DevPanel/RenderGallery/index.tsx
@@ -1,131 +1,36 @@
 'use client';
 
-import { listBuiltinRenderEntries } from '@lobechat/builtin-tools/renders';
-import type { BuiltinRender } from '@lobechat/types';
-import { Block, Flexbox, Tag, Text } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { Component, type ReactNode, useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
 
 import { useAgentGroupStore } from '@/store/agentGroup';
 
-import {
-  DEVTOOLS_GROUP_DETAIL,
-  DEVTOOLS_GROUP_ID,
-  getToolRenderFixture,
-  getToolRenderMeta,
-} from './toolRenderFixtures';
+import Sidebar from './Sidebar';
+import { DEVTOOLS_GROUP_DETAIL, DEVTOOLS_GROUP_ID } from './toolRenderFixtures';
+import { toToolsetPath, useDevtoolsEntries } from './useDevtoolsEntries';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  body: css`
-    gap: 24px;
-    max-width: 1400px;
-    padding: 28px;
-  `,
-  card: css`
-    overflow: hidden;
-
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 20px;
-
-    background: ${cssVar.colorBgContainer};
-    box-shadow: ${cssVar.boxShadowSecondary};
-  `,
-  cardBody: css`
-    padding: 16px;
-  `,
-  cardHeader: css`
-    gap: 10px;
-    padding: 16px;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
-    background: linear-gradient(
-      180deg,
-      ${cssVar.colorFillQuaternary} 0%,
-      ${cssVar.colorBgContainer} 100%
-    );
-  `,
-  code: css`
+  main: css`
     overflow: auto;
-
-    max-height: 280px;
-    margin: 0;
-    padding: 12px;
-    border-radius: 12px;
-
-    font-size: 12px;
-    line-height: 1.55;
-    color: ${cssVar.colorTextSecondary};
-
-    background: ${cssVar.colorFillQuaternary};
-  `,
-  fixtureSummary: css`
-    cursor: pointer;
-    user-select: none;
-    font-size: 12px;
-    color: ${cssVar.colorTextTertiary};
-  `,
-  group: css`
-    gap: 16px;
-  `,
-  groupHeader: css`
-    gap: 8px;
-    padding-block-end: 4px;
-  `,
-  page: css`
-    overflow: auto;
-    width: 100%;
-    height: 100%;
+    flex: 1;
     background:
       radial-gradient(circle at top, ${cssVar.colorFillTertiary} 0%, transparent 35%),
       ${cssVar.colorBgLayout};
   `,
-  previewShell: css`
-    padding: 16px;
-    border-radius: 16px;
-    background: ${cssVar.colorFillQuaternary};
-  `,
-  subtitle: css`
-    max-width: 900px;
-    font-size: 14px;
-    line-height: 1.6;
-    color: ${cssVar.colorTextSecondary};
-  `,
-  title: css`
-    font-size: 36px;
-    font-weight: 700;
-    line-height: 1.1;
-    color: ${cssVar.colorText};
+  page: css`
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
   `,
 }));
 
-class RenderBoundary extends Component<{ children: ReactNode }, { error?: Error | undefined }> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { error: undefined };
-  }
+const DevtoolsLayout = () => {
+  const { menuItems } = useDevtoolsEntries();
+  const { identifier } = useParams<{ identifier: string }>();
+  const navigate = useNavigate();
 
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-
-  override render() {
-    if (!this.state.error) return this.props.children;
-
-    return (
-      <Block padding={16} variant={'outlined'}>
-        <Flexbox gap={8}>
-          <Text fontSize={14} type={'danger'} weight={500}>
-            Render crashed
-          </Text>
-          <Text fontSize={12} type={'secondary'}>
-            {this.state.error.message}
-          </Text>
-        </Flexbox>
-      </Block>
-    );
-  }
-}
-
-const DevtoolsPage = () => {
   useEffect(() => {
     const previousGroupState = useAgentGroupStore.getState();
 
@@ -145,146 +50,18 @@ const DevtoolsPage = () => {
     };
   }, []);
 
-  const groupedEntries = useMemo(() => {
-    const sections = new Map<
-      string,
-      {
-        description?: string;
-        entries: Array<{
-          apiName: string;
-          description?: string;
-          fixture: ReturnType<typeof getToolRenderFixture>;
-          identifier: string;
-          render: BuiltinRender;
-          toolsetName: string;
-        }>;
-        toolsetName: string;
-      }
-    >();
-
-    const entries = listBuiltinRenderEntries().sort((left, right) => {
-      const identifierCompare = left.identifier.localeCompare(right.identifier);
-      if (identifierCompare !== 0) return identifierCompare;
-      return left.apiName.localeCompare(right.apiName);
-    });
-
-    for (const entry of entries) {
-      const meta = getToolRenderMeta(entry.identifier, entry.apiName);
-      const fixture = getToolRenderFixture(entry.identifier, entry.apiName, meta.api);
-      const group = sections.get(entry.identifier);
-
-      const normalizedEntry = {
-        apiName: entry.apiName,
-        description: meta.description,
-        fixture,
-        identifier: entry.identifier,
-        render: entry.render,
-        toolsetName: meta.toolsetName,
-      };
-
-      if (group) {
-        group.entries.push(normalizedEntry);
-      } else {
-        sections.set(entry.identifier, {
-          description: meta.toolsetDescription,
-          entries: [normalizedEntry],
-          toolsetName: meta.toolsetName,
-        });
-      }
-    }
-
-    return [...sections.values()];
-  }, []);
-
   return (
-    <div className={styles.page}>
-      <Flexbox className={styles.body}>
-        <Flexbox gap={12}>
-          <div className={styles.title}>Devtools Render Gallery</div>
-          <div className={styles.subtitle}>
-            Development-only preview page for every registered builtin tool render. Each card is
-            driven by a stable local fixture so we can visually smoke test new tool UIs without
-            reproducing a full conversation flow first.
-          </div>
-        </Flexbox>
-
-        {groupedEntries.map((group) => (
-          <Flexbox className={styles.group} key={group.toolsetName}>
-            <Flexbox className={styles.groupHeader}>
-              <Flexbox horizontal align={'center'} gap={8}>
-                <Text fontSize={20} weight={600}>
-                  {group.toolsetName}
-                </Text>
-                <Tag>{group.entries.length} renders</Tag>
-              </Flexbox>
-              {group.description && (
-                <Text fontSize={13} type={'secondary'}>
-                  {group.description}
-                </Text>
-              )}
-            </Flexbox>
-
-            {group.entries.map((entry) => {
-              const Render = entry.render as BuiltinRender;
-              const fixture = entry.fixture;
-              const messageId = `devtools-${entry.identifier}-${entry.apiName}`;
-
-              return (
-                <Flexbox className={styles.card} key={`${entry.identifier}-${entry.apiName}`}>
-                  <Flexbox className={styles.cardHeader}>
-                    <Flexbox horizontal align={'center'} gap={8}>
-                      <Text fontSize={16} weight={600}>
-                        {entry.apiName}
-                      </Text>
-                      <Tag>{entry.identifier}</Tag>
-                    </Flexbox>
-                    {entry.description && (
-                      <Text fontSize={13} type={'secondary'}>
-                        {entry.description}
-                      </Text>
-                    )}
-                  </Flexbox>
-
-                  <Flexbox className={styles.cardBody} gap={12}>
-                    <div className={styles.previewShell}>
-                      <RenderBoundary>
-                        <Render
-                          apiName={entry.apiName}
-                          args={fixture.args}
-                          content={fixture.content}
-                          identifier={entry.identifier}
-                          messageId={messageId}
-                          pluginError={fixture.pluginError}
-                          pluginState={fixture.pluginState}
-                          toolCallId={`${messageId}-tool`}
-                        />
-                      </RenderBoundary>
-                    </div>
-
-                    <details>
-                      <summary className={styles.fixtureSummary}>Fixture payload</summary>
-                      <pre className={styles.code}>
-                        {JSON.stringify(
-                          {
-                            args: fixture.args,
-                            content: fixture.content,
-                            pluginError: fixture.pluginError,
-                            pluginState: fixture.pluginState,
-                          },
-                          null,
-                          2,
-                        )}
-                      </pre>
-                    </details>
-                  </Flexbox>
-                </Flexbox>
-              );
-            })}
-          </Flexbox>
-        ))}
+    <Flexbox horizontal className={styles.page}>
+      <Sidebar
+        items={menuItems}
+        selectedKey={identifier}
+        onSelect={(key) => navigate(toToolsetPath(key))}
+      />
+      <Flexbox className={styles.main}>
+        <Outlet />
       </Flexbox>
-    </div>
+    </Flexbox>
   );
 };
 
-export default DevtoolsPage;
+export default DevtoolsLayout;

--- a/src/features/DevPanel/RenderGallery/toolRenderFixtures.ts
+++ b/src/features/DevPanel/RenderGallery/toolRenderFixtures.ts
@@ -56,8 +56,12 @@ const customToolsets: Record<
       { description: 'Find files by glob pattern.', name: 'Glob' },
       { description: 'Search file contents.', name: 'Grep' },
       { description: 'Read file content.', name: 'Read' },
+      { description: 'Schedule when to resume work.', name: 'ScheduleWakeup' },
       { description: 'Run a Claude Code skill.', name: 'Skill' },
+      { description: 'Read output from a background task.', name: 'TaskOutput' },
+      { description: 'Stop a background task.', name: 'TaskStop' },
       { description: 'Track todo progress.', name: 'TodoWrite' },
+      { description: 'Look up deferred tools by name or keyword.', name: 'ToolSearch' },
       { description: 'Write a new file.', name: 'Write' },
     ],
     meta: {
@@ -65,7 +69,7 @@ const customToolsets: Record<
       title: 'Claude Code',
     },
   },
-  codex: {
+  'codex': {
     api: [
       { description: 'Run a shell command in Codex.', name: 'command_execution' },
       { description: 'Preview Codex file change summaries.', name: 'file_change' },
@@ -74,6 +78,47 @@ const customToolsets: Record<
     meta: {
       description: 'Codex-specific render previews and shared command cards.',
       title: 'Codex',
+    },
+  },
+  'lobe-page-agent': {
+    api: [
+      { description: 'Initialize a new document with markdown content.', name: 'initPage' },
+      { description: 'Edit the title of the current document.', name: 'editTitle' },
+      { description: 'Read the structured XML content of the page.', name: 'getPageContent' },
+      { description: 'Insert, modify, or remove document nodes.', name: 'modifyNodes' },
+      { description: 'Find-and-replace text across the document.', name: 'replaceText' },
+    ],
+    meta: {
+      description: 'Page Agent inspector previews for document operations.',
+      title: 'Page Agent',
+    },
+  },
+  'lobe-tools': {
+    api: [{ description: 'Activate a builtin tool (legacy alias).', name: 'activateSkill' }],
+    meta: {
+      description: 'Deprecated alias of Tools Activator kept for legacy messages.',
+      title: 'Lobe Tools (legacy)',
+    },
+  },
+  'lobe-user-interaction': {
+    api: [
+      { description: 'Render an inline question card with form fields.', name: 'askUserQuestion' },
+    ],
+    meta: {
+      description: 'User Interaction intervention previews.',
+      title: 'User Interaction',
+    },
+  },
+  'lobe-web-onboarding': {
+    api: [
+      {
+        description: 'Save the agent identity collected during web onboarding.',
+        name: 'saveUserQuestion',
+      },
+    ],
+    meta: {
+      description: 'Web onboarding intervention previews.',
+      title: 'Web Onboarding',
     },
   },
 };
@@ -262,9 +307,24 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
     content:
       "1  import { RunCommandRender } from '@lobechat/shared-tool-ui/renders';\n2  export interface BuiltinRenderRegistryEntry { ... }",
   },
+  [keyOf(ClaudeCodeIdentifier, 'ScheduleWakeup')]: {
+    args: {
+      delaySeconds: 1200,
+      reason: 'Recheck the failing build once dependencies finish installing.',
+    },
+  },
   [keyOf(ClaudeCodeIdentifier, 'Skill')]: {
     args: { skill: 'codebase-search' },
     content: 'Use ripgrep first, then open only the relevant files to keep context sharp.',
+  },
+  [keyOf(ClaudeCodeIdentifier, 'TaskOutput')]: {
+    args: { block: false, task_id: 'task-build-2025-04-25', timeout_ms: 8000 },
+    content:
+      '✅  Vite: compile and bundle finished (200) http://localhost:9876/\nDebug Proxy: https://app.lobehub.com/_dangerous_local_dev_proxy?debug-host=http://localhost:9876',
+  },
+  [keyOf(ClaudeCodeIdentifier, 'TaskStop')]: {
+    args: { task_id: 'task-build-2025-04-25' },
+    content: 'Background task stopped (exit code 0).',
   },
   [keyOf(ClaudeCodeIdentifier, 'TodoWrite')]: {
     args: {
@@ -286,6 +346,10 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
         },
       ],
     },
+  },
+  [keyOf(ClaudeCodeIdentifier, 'ToolSearch')]: {
+    args: { max_results: 5, query: 'select:Read,Edit,Grep' },
+    content: 'Loaded 3 deferred tool schemas: Read, Edit, Grep.',
   },
   [keyOf(ClaudeCodeIdentifier, 'Write')]: {
     args: {
@@ -487,7 +551,8 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
   [keyOf('lobe-cloud-sandbox', 'editLocalFile')]: {
     args: { path: '/sandbox/src/routes/devtools.tsx' },
     pluginState: {
-      diffText: '@@ -1,2 +1,3 @@\n export const devtools = true;\n+export const previews = true;\n',
+      diffText:
+        '--- a/sandbox/src/routes/devtools.tsx\n+++ b/sandbox/src/routes/devtools.tsx\n@@ -1,2 +1,3 @@\n export const devtools = true;\n+export const previews = true;\n',
       linesAdded: 1,
       linesDeleted: 0,
       replacements: 1,
@@ -760,7 +825,7 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
     args: { path: '/workspace/src/spa/router/desktopRouter.config.tsx' },
     pluginState: {
       diffText:
-        "@@ -1,3 +1,7 @@\n export const desktopRoutes = [\n+  {\n+    path: 'devtools',\n+  },\n ];\n",
+        "--- a/workspace/src/spa/router/desktopRouter.config.tsx\n+++ b/workspace/src/spa/router/desktopRouter.config.tsx\n@@ -1,3 +1,7 @@\n export const desktopRoutes = [\n+  {\n+    path: 'devtools',\n+  },\n ];\n",
     },
   },
   [keyOf('lobe-local-system', 'listLocalFiles')]: {
@@ -1047,6 +1112,99 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
           url: 'https://linear.example.com/issue/LOBE-8114',
         },
       ],
+    },
+  },
+
+  [keyOf('lobe-page-agent', 'initPage')]: {
+    args: {
+      markdown:
+        '# Devtools Render Gallery\n\nA development-only preview surface for every builtin tool render.\n\n- Inspector previews mirror the chat title bar.\n- Body segments switch between Render, Streaming, Placeholder, and Intervention.\n',
+    },
+    pluginState: { nodeCount: 6 },
+  },
+  [keyOf('lobe-page-agent', 'editTitle')]: {
+    args: { title: 'Devtools Render Gallery — Builtin Tool Previews' },
+    pluginState: { previousTitle: 'Devtools Render Gallery' },
+  },
+  [keyOf('lobe-page-agent', 'getPageContent')]: {
+    args: {},
+    pluginState: { nodeCount: 12 },
+    content:
+      '<doc><heading id="h-1">Devtools Render Gallery</heading><para id="p-1">Preview every registered builtin tool component.</para></doc>',
+  },
+  [keyOf('lobe-page-agent', 'modifyNodes')]: {
+    args: {
+      operations: [
+        { afterId: 'h-1', kind: 'insertAfter', xml: '<para>Updated description.</para>' },
+        {
+          id: 'p-2',
+          kind: 'modify',
+          xml: '<para id="p-2">Now mentions Segmented body tabs.</para>',
+        },
+        { id: 'p-3', kind: 'remove' },
+      ],
+    },
+    pluginState: { applied: 3 },
+  },
+  [keyOf('lobe-page-agent', 'replaceText')]: {
+    args: {
+      isRegex: false,
+      newText: 'Body segments',
+      replaceAll: true,
+      searchText: 'Body section',
+    },
+    pluginState: { replacements: 2 },
+  },
+
+  [keyOf('lobe-tools', 'activateSkill')]: {
+    args: { skill: 'lobe-image-generator' },
+    content: 'Activated skill: lobe-image-generator (legacy alias path).',
+    pluginState: {
+      activatedTools: ['lobe-image-generator'],
+      notFound: [],
+    },
+  },
+
+  [keyOf('lobe-user-interaction', 'askUserQuestion')]: {
+    args: {
+      question: {
+        description:
+          'Help us tailor the next reply. Pick the rendering surface you want previewed.',
+        fields: [
+          {
+            key: 'surface',
+            kind: 'select',
+            label: 'Preview surface',
+            options: [
+              { label: 'Render', value: 'render' },
+              { label: 'Streaming', value: 'streaming' },
+              { label: 'Placeholder', value: 'placeholder' },
+              { label: 'Intervention', value: 'intervention' },
+            ],
+            placeholder: 'Choose one',
+            required: true,
+          },
+          {
+            key: 'note',
+            kind: 'textarea',
+            label: 'Optional note',
+            placeholder: 'Anything to call out about the preview?',
+          },
+        ],
+        id: 'devtools-preview-question',
+        mode: 'form',
+        prompt: 'Which builtin tool surface should we focus the next preview iteration on?',
+      },
+    },
+  },
+
+  [keyOf('lobe-web-onboarding', 'saveUserQuestion')]: {
+    args: {
+      agentEmoji: '🧪',
+      agentName: 'Devtools Tester',
+      fullName: 'Arvin',
+      interests: ['observability', 'dev-tools', 'agent-runtime'],
+      responseLanguage: 'en-US',
     },
   },
 };

--- a/src/features/DevPanel/RenderGallery/useDevtoolsEntries.ts
+++ b/src/features/DevPanel/RenderGallery/useDevtoolsEntries.ts
@@ -1,0 +1,159 @@
+'use client';
+
+import { listBuiltinInspectorEntries } from '@lobechat/builtin-tools/inspectors';
+import { listBuiltinInterventionEntries } from '@lobechat/builtin-tools/interventions';
+import { listBuiltinPlaceholderEntries } from '@lobechat/builtin-tools/placeholders';
+import { listBuiltinRenderEntries } from '@lobechat/builtin-tools/renders';
+import { listBuiltinStreamingEntries } from '@lobechat/builtin-tools/streamings';
+import type {
+  BuiltinInspector,
+  BuiltinIntervention,
+  BuiltinPlaceholder,
+  BuiltinRender,
+  BuiltinStreaming,
+} from '@lobechat/types';
+import type { MenuProps } from '@lobehub/ui';
+import { useMemo } from 'react';
+
+import {
+  getToolRenderFixture,
+  getToolRenderMeta,
+  type ToolRenderFixture,
+} from './toolRenderFixtures';
+
+export interface ApiEntry {
+  apiName: string;
+  description?: string;
+  fixture: ToolRenderFixture;
+  identifier: string;
+  inspector?: BuiltinInspector;
+  intervention?: BuiltinIntervention;
+  placeholder?: BuiltinPlaceholder;
+  render?: BuiltinRender;
+  streaming?: BuiltinStreaming;
+}
+
+export interface ToolsetEntry {
+  apis: ApiEntry[];
+  identifier: string;
+  toolsetDescription?: string;
+  toolsetName: string;
+}
+
+export interface DevtoolsEntries {
+  defaultToolset?: ToolsetEntry;
+  menuItems: MenuProps['items'];
+  toolsetMap: Map<string, ToolsetEntry>;
+}
+
+export const toToolsetPath = (identifier: string) => `/devtools/${encodeURIComponent(identifier)}`;
+
+export const toApiAnchor = (apiName: string) => `api-${apiName}`;
+
+export const useDevtoolsEntries = (): DevtoolsEntries =>
+  useMemo(() => {
+    const pairKey = (identifier: string, apiName: string) => `${identifier}:${apiName}`;
+
+    const byKey = new Map<
+      string,
+      {
+        apiName: string;
+        identifier: string;
+        inspector?: BuiltinInspector;
+        intervention?: BuiltinIntervention;
+        placeholder?: BuiltinPlaceholder;
+        render?: BuiltinRender;
+        streaming?: BuiltinStreaming;
+      }
+    >();
+
+    const upsert = (
+      identifier: string,
+      apiName: string,
+      patch: Partial<
+        Pick<ApiEntry, 'inspector' | 'intervention' | 'placeholder' | 'render' | 'streaming'>
+      >,
+    ) => {
+      const key = pairKey(identifier, apiName);
+      const existing = byKey.get(key);
+      if (existing) {
+        byKey.set(key, { ...existing, ...patch });
+      } else {
+        byKey.set(key, { apiName, identifier, ...patch });
+      }
+    };
+
+    for (const entry of listBuiltinRenderEntries()) {
+      upsert(entry.identifier, entry.apiName, { render: entry.render });
+    }
+    for (const entry of listBuiltinInspectorEntries()) {
+      upsert(entry.identifier, entry.apiName, { inspector: entry.inspector });
+    }
+    for (const entry of listBuiltinStreamingEntries()) {
+      upsert(entry.identifier, entry.apiName, { streaming: entry.streaming });
+    }
+    for (const entry of listBuiltinPlaceholderEntries()) {
+      upsert(entry.identifier, entry.apiName, { placeholder: entry.placeholder });
+    }
+    for (const entry of listBuiltinInterventionEntries()) {
+      upsert(entry.identifier, entry.apiName, { intervention: entry.intervention });
+    }
+
+    const toolsetMap = new Map<string, ToolsetEntry>();
+
+    for (const {
+      apiName,
+      identifier,
+      inspector,
+      intervention,
+      placeholder,
+      render,
+      streaming,
+    } of byKey.values()) {
+      const meta = getToolRenderMeta(identifier, apiName);
+      const fixture = getToolRenderFixture(identifier, apiName, meta.api);
+
+      const api: ApiEntry = {
+        apiName,
+        description: meta.description,
+        fixture,
+        identifier,
+        inspector,
+        intervention,
+        placeholder,
+        render,
+        streaming,
+      };
+
+      const toolset = toolsetMap.get(identifier);
+      if (toolset) {
+        toolset.apis.push(api);
+      } else {
+        toolsetMap.set(identifier, {
+          apis: [api],
+          identifier,
+          toolsetDescription: meta.toolsetDescription,
+          toolsetName: meta.toolsetName,
+        });
+      }
+    }
+
+    for (const toolset of toolsetMap.values()) {
+      toolset.apis.sort((left, right) => left.apiName.localeCompare(right.apiName));
+    }
+
+    const toolsets = [...toolsetMap.values()].sort((left, right) =>
+      left.toolsetName.localeCompare(right.toolsetName),
+    );
+
+    const menuItems: MenuProps['items'] = toolsets.map((toolset) => ({
+      key: toolset.identifier,
+      label: toolset.toolsetName,
+    }));
+
+    return {
+      defaultToolset: toolsets[0],
+      menuItems,
+      toolsetMap,
+    };
+  }, []);

--- a/src/routes/(main)/devtools/[identifier]/index.tsx
+++ b/src/routes/(main)/devtools/[identifier]/index.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '@/features/DevPanel/RenderGallery/ToolPage';

--- a/src/routes/(main)/devtools/_layout/index.tsx
+++ b/src/routes/(main)/devtools/_layout/index.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '@/features/DevPanel/RenderGallery';

--- a/src/routes/(main)/devtools/index.tsx
+++ b/src/routes/(main)/devtools/index.tsx
@@ -1,3 +1,3 @@
 'use client';
 
-export { default } from '@/features/DevPanel/RenderGallery';
+export { default } from '@/features/DevPanel/RenderGallery/IndexPage';

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -46,7 +46,9 @@ import CommunityListModelLayout from '@/routes/(main)/community/(list)/model/_la
 import CommunityListProviderPage from '@/routes/(main)/community/(list)/provider';
 import CommunityListSkillPage from '@/routes/(main)/community/(list)/skill';
 import CommunityListSkillLayout from '@/routes/(main)/community/(list)/skill/_layout';
-import DevtoolsPage from '@/routes/(main)/devtools';
+import DevtoolsIndexPage from '@/routes/(main)/devtools';
+import DevtoolsLayout from '@/routes/(main)/devtools/_layout';
+import DevtoolsToolPage from '@/routes/(main)/devtools/[identifier]';
 import EvalOverviewPage from '@/routes/(main)/eval';
 import EvalLayout from '@/routes/(main)/eval/_layout';
 import EvalHomeLayout from '@/routes/(main)/eval/(home)/_layout';
@@ -511,15 +513,6 @@ export const desktopRoutes: RouteObject[] = [
         path: 'page',
       },
 
-      ...(isDev
-        ? [
-            {
-              element: <DevtoolsPage />,
-              path: 'devtools',
-            },
-          ]
-        : []),
-
       // Default route - home page (handled by persistent layout)
       {
         index: true,
@@ -548,6 +541,21 @@ export const desktopRoutes: RouteObject[] = [
     element: <ShareTopicLayout />,
     path: '/share/t',
   },
+
+  // Devtools route (outside main layout, dev-only)
+  ...(isDev
+    ? [
+        {
+          children: [
+            { element: <DevtoolsIndexPage />, index: true },
+            { element: <DevtoolsToolPage />, path: ':identifier' },
+          ],
+          element: <DevtoolsLayout />,
+          errorElement: <ErrorBoundary />,
+          path: '/devtools',
+        },
+      ]
+    : []),
 ];
 
 // Desktop onboarding route (Electron only in .desktop.tsx)

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -640,18 +640,6 @@ export const desktopRoutes: RouteObject[] = [
         path: 'page',
       },
 
-      ...(isDev
-        ? [
-            {
-              element: dynamicElement(
-                () => import('@/routes/(main)/devtools'),
-                'Desktop > Devtools',
-              ),
-              path: 'devtools',
-            },
-          ]
-        : []),
-
       // Default route - home page (handled by persistent layout)
       {
         index: true,
@@ -684,6 +672,36 @@ export const desktopRoutes: RouteObject[] = [
     ),
     path: '/share/t',
   },
+
+  // Devtools route (outside main layout, dev-only)
+  ...(isDev
+    ? [
+        {
+          children: [
+            {
+              element: dynamicElement(
+                () => import('@/routes/(main)/devtools'),
+                'Desktop > Devtools > Index',
+              ),
+              index: true,
+            },
+            {
+              element: dynamicElement(
+                () => import('@/routes/(main)/devtools/[identifier]'),
+                'Desktop > Devtools > Toolset',
+              ),
+              path: ':identifier',
+            },
+          ],
+          element: dynamicLayout(
+            () => import('@/routes/(main)/devtools/_layout'),
+            'Desktop > Devtools > Layout',
+          ),
+          errorElement: <ErrorBoundary />,
+          path: '/devtools',
+        },
+      ]
+    : []),
 ];
 
 desktopRoutes.push({


### PR DESCRIPTION
Promote /devtools out of the main layout and break the monolithic gallery into a layout + sidebar + per-tool detail route (/devtools/:identifier). Each builtin-tool category (inspectors, interventions, placeholders, streamings) now exposes a list*Entries registry helper so the sidebar can enumerate them alongside the existing renders.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
