### PR TITLE
🐛 fix(agent): refine page switcher and empty topic docs

### DIFF
--- a/src/config/featureFlags/schema.test.ts
+++ b/src/config/featureFlags/schema.test.ts
@@ -108,6 +108,7 @@ describe('mapFeatureFlagsEnvToState', () => {
       knowledge_base: false,
       rag_eval: true,
       agent_onboarding: true,
+      agent_page: true,
       market: true,
       speech_to_text: true,
       changelog: false,
@@ -132,6 +133,7 @@ describe('mapFeatureFlagsEnvToState', () => {
       enableKnowledgeBase: false,
       enableRAGEval: true,
       enableAgentOnboarding: true,
+      enableAgentPage: true,
       showMarket: true,
       enableSTT: true,
       showCloudPromotion: true,
@@ -145,6 +147,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const config = {
       edit_agent: ['user-123', 'user-456'],
       agent_onboarding: ['user-123'],
+      agent_page: ['user-123'],
       create_session: ['user-789'],
       dalle: true,
       knowledge_base: ['user-123'],
@@ -155,6 +158,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     expect(mappedState.isAgentEditable).toBe(true); // user-123 is in allowlist
 
     expect(mappedState.enableAgentOnboarding).toBe(true); // user-123 is in allowlist
+    expect(mappedState.enableAgentPage).toBe(true); // user-123 is in allowlist
     expect(mappedState.enableKnowledgeBase).toBe(true); // user-123 is in allowlist
   });
 
@@ -174,6 +178,7 @@ describe('mapFeatureFlagsEnvToState', () => {
   it('should return false for array flags when no user ID provided', () => {
     const config = {
       agent_onboarding: ['user-1'],
+      agent_page: ['user-1'],
       edit_agent: ['user-123', 'user-456'],
       create_session: true,
     };
@@ -181,6 +186,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const mappedState = mapFeatureFlagsEnvToState(config);
 
     expect(mappedState.enableAgentOnboarding).toBe(false);
+    expect(mappedState.enableAgentPage).toBe(false);
     expect(mappedState.isAgentEditable).toBe(false);
   });
 
@@ -189,6 +195,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const config = {
       edit_agent: ['user-123'],
       agent_onboarding: ['user-123'],
+      agent_page: ['user-123'],
       create_session: true,
       dalle: false,
       ai_image: ['user-456'],
@@ -201,6 +208,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     expect(mappedState.isAgentEditable).toBe(true);
 
     expect(mappedState.enableAgentOnboarding).toBe(true);
+    expect(mappedState.enableAgentPage).toBe(true);
     expect(mappedState.showAiImage).toBe(false);
     expect(mappedState.enableKnowledgeBase).toBe(true);
     expect(mappedState.enableRAGEval).toBe(true);

--- a/src/config/featureFlags/schema.ts
+++ b/src/config/featureFlags/schema.ts
@@ -31,6 +31,7 @@ export const FeatureFlagsSchema = z.object({
 
   // internal flag
   agent_onboarding: FeatureFlagValue.optional(),
+  agent_page: FeatureFlagValue.optional(),
   agent_task: FeatureFlagValue.optional(),
   cloud_promotion: FeatureFlagValue.optional(),
 
@@ -79,6 +80,7 @@ export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
   rag_eval: false,
 
   agent_onboarding: isDev,
+  agent_page: isDev,
   agent_task: isDev,
   cloud_promotion: false,
 
@@ -112,6 +114,7 @@ export const mapFeatureFlagsEnvToState = (config: IFeatureFlags, userId?: string
     enableKnowledgeBase: evaluateFeatureFlag(config.knowledge_base, userId),
     enableRAGEval: evaluateFeatureFlag(config.rag_eval, userId),
     enableAgentOnboarding: evaluateFeatureFlag(config.agent_onboarding, userId),
+    enableAgentPage: evaluateFeatureFlag(config.agent_page, userId),
     enableAgentTask: evaluateFeatureFlag(config.agent_task, userId),
 
     showCloudPromotion: evaluateFeatureFlag(config.cloud_promotion, userId),

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/FolderTag.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/FolderTag.tsx
@@ -13,9 +13,9 @@ const styles = createStaticStyles(({ css }) => ({
     cursor: pointer;
 
     overflow: hidden;
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
 
+    min-width: 0;
     max-width: 200px;
 
     font-size: 13px;
@@ -37,12 +37,11 @@ const FolderTag = memo(() => {
   const topicBoundDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
 
   if (!isDesktop || !topicBoundDirectory) return null;
-
-  const displayName = topicBoundDirectory.split('/').findLast(Boolean) || topicBoundDirectory;
-
   const handleOpen = () => {
     void localFileService.openLocalFolder({ isDirectory: true, path: topicBoundDirectory });
   };
+
+  const displayName = topicBoundDirectory.split('/').findLast(Boolean) || topicBoundDirectory;
 
   return (
     <Tooltip title={`${topicBoundDirectory} · ${t('localFiles.openFolder')}`}>

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
@@ -25,18 +25,10 @@ const TitleTags = memo(() => {
   }
 
   return (
-    <Flexbox
-      allowShrink
-      horizontal
-      align={'center'}
-      gap={8}
-      style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden' }}
-    >
+    <Flexbox allowShrink horizontal align={'center'} gap={8}>
       <span
         style={{
           color: cssVar.colorText,
-          display: 'block',
-          flex: '1 1 auto',
           fontSize: 14,
           fontWeight: 600,
           marginLeft: 8,

--- a/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
@@ -1,14 +1,48 @@
 'use client';
 
-import { Segmented } from '@lobehub/ui';
+import { Flexbox, Segmented } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { FileText, MessageSquareText } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { SESSION_CHAT_TOPIC_PAGE_URL, SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { useChatStore } from '@/store/chat';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 type ViewTab = 'chat' | 'page' | 'task';
+
+const styles = createStaticStyles(({ css }) => ({
+  label: css`
+    justify-content: center;
+    width: 100%;
+    min-width: 0;
+  `,
+  switcher: css`
+    .ant-segmented-item-label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `,
+  icon: css`
+    display: none;
+
+    @container agent-conv-header (max-width: 860px) {
+      display: block;
+    }
+  `,
+  text: css`
+    display: block;
+    text-align: center;
+    white-space: nowrap;
+
+    @container agent-conv-header (max-width: 860px) {
+      display: none;
+    }
+  `,
+}));
 
 const ViewSwitcher = memo(() => {
   const { t } = useTranslation('chat');
@@ -16,6 +50,7 @@ const ViewSwitcher = memo(() => {
   const location = useLocation();
   const params = useParams<{ aid?: string; topicId?: string }>();
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
 
   const aid = params.aid;
   const topicId = params.topicId ?? activeTopicId ?? undefined;
@@ -28,8 +63,34 @@ const ViewSwitcher = memo(() => {
 
   const options = useMemo(
     () => [
-      { label: t('viewSwitcher.chat'), value: 'chat' },
-      { label: t('viewSwitcher.page'), value: 'page' },
+      {
+        label: (
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={styles.label}
+            title={t('viewSwitcher.chat')}
+          >
+            <MessageSquareText className={styles.icon} size={16} />
+            <span className={styles.text}>{t('viewSwitcher.chat')}</span>
+          </Flexbox>
+        ),
+        value: 'chat',
+      },
+      {
+        label: (
+          <Flexbox
+            horizontal
+            align={'center'}
+            className={styles.label}
+            title={t('viewSwitcher.page')}
+          >
+            <FileText className={styles.icon} size={16} />
+            <span className={styles.text}>{t('viewSwitcher.page')}</span>
+          </Flexbox>
+        ),
+        value: 'page',
+      },
       // { label: t('viewSwitcher.task'), value: 'task' },
     ],
     [t],
@@ -54,9 +115,17 @@ const ViewSwitcher = memo(() => {
     }
   };
 
-  if (!topicId) return null;
+  if (!topicId || !enableAgentPage) return null;
 
-  return <Segmented options={options} size={'small'} value={currentTab} onChange={handleChange} />;
+  return (
+    <Segmented
+      className={styles.switcher}
+      options={options}
+      size={'small'}
+      value={currentTab}
+      onChange={handleChange}
+    />
+  );
 });
 
 ViewSwitcher.displayName = 'ViewSwitcher';

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -23,28 +23,14 @@ const headerStyles = createStaticStyles(({ css }) => ({
     flex: 1 1 auto;
     min-width: 0;
   `,
-  slotCenter: css`
-    flex: 0 0 auto !important;
-    align-items: center;
-    justify-content: center;
-    min-width: 0;
-  `,
   slotLeft: css`
     overflow: hidden;
-    flex: 1 1 0;
+    flex: 1 1 auto;
     min-width: 0;
-
-    @container agent-conv-header (max-width: 719px) {
-      flex: 1 1 auto;
-    }
   `,
   slotRight: css`
-    flex: 1 1 0;
+    flex: 0 0 auto;
     min-width: 0;
-
-    @container agent-conv-header (max-width: 719px) {
-      flex: 0 0 auto;
-    }
   `,
 }));
 
@@ -66,19 +52,22 @@ const Header = memo(() => {
           </Flexbox>
         }
         right={
-          <Flexbox horizontal align={'center'} style={{ backgroundColor: cssVar.colorBgContainer }}>
+          <Flexbox
+            horizontal
+            align={'center'}
+            gap={4}
+            style={{ backgroundColor: cssVar.colorBgContainer }}
+          >
+            <ViewSwitcher />
             <ShareButton />
             <WorkingPanelToggle />
           </Flexbox>
         }
         slotClassNames={{
-          center: headerStyles.slotCenter,
           left: headerStyles.slotLeft,
           right: headerStyles.slotRight,
         }}
-      >
-        <ViewSwitcher />
-      </NavHeader>
+      />
     </div>
   );
 });

--- a/src/routes/(main)/agent/features/Page/PageRedirect.test.tsx
+++ b/src/routes/(main)/agent/features/Page/PageRedirect.test.tsx
@@ -9,6 +9,7 @@ import PageRedirect from './PageRedirect';
 const navigateMock = vi.hoisted(() => vi.fn());
 const useAutoCreateTopicDocumentMock = vi.hoisted(() => vi.fn());
 const useParamsMock = vi.hoisted(() => vi.fn());
+const useServerConfigStoreMock = vi.hoisted(() => vi.fn());
 
 vi.mock('react-router-dom', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -29,11 +30,32 @@ vi.mock('@/features/TopicCanvas/useAutoCreateTopicDocument', () => ({
   useAutoCreateTopicDocument: useAutoCreateTopicDocumentMock,
 }));
 
+vi.mock('@/store/serverConfig', () => ({
+  featureFlagsSelectors: (state: { featureFlags: { enableAgentPage: boolean } }) =>
+    state.featureFlags,
+  useServerConfigStore: (selector: (state: unknown) => unknown) =>
+    useServerConfigStoreMock(selector),
+}));
+
 describe('PageRedirect', () => {
   beforeEach(() => {
     navigateMock.mockReset();
     useAutoCreateTopicDocumentMock.mockReset();
     useParamsMock.mockReset();
+    useServerConfigStoreMock.mockReset();
+
+    useAutoCreateTopicDocumentMock.mockReturnValue({
+      document: undefined,
+      documentId: undefined,
+      isLoading: false,
+    });
+
+    useServerConfigStoreMock.mockImplementation((selector) =>
+      selector({
+        featureFlags: { enableAgentPage: true },
+        serverConfigInit: true,
+      }),
+    );
   });
 
   it('redirects to the page created for an empty topic', async () => {
@@ -64,5 +86,24 @@ describe('PageRedirect', () => {
     render(<PageRedirect />);
 
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects back to chat when the agent page feature is disabled', async () => {
+    useParamsMock.mockReturnValue({ aid: 'agt_test', topicId: 'tpc_test' });
+    useServerConfigStoreMock.mockImplementation((selector) =>
+      selector({
+        featureFlags: { enableAgentPage: false },
+        serverConfigInit: true,
+      }),
+    );
+
+    render(<PageRedirect />);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith('/agent/agt_test/tpc_test', {
+        replace: true,
+      }),
+    );
+    expect(useAutoCreateTopicDocumentMock).toHaveBeenCalledWith(undefined, undefined);
   });
 });

--- a/src/routes/(main)/agent/features/Page/PageRedirect.tsx
+++ b/src/routes/(main)/agent/features/Page/PageRedirect.tsx
@@ -4,18 +4,31 @@ import { memo, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import BrandTextLoading from '@/components/Loading/BrandTextLoading';
+import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { useAutoCreateTopicDocument } from '@/features/TopicCanvas/useAutoCreateTopicDocument';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 const PageRedirect = memo(() => {
   const { aid, topicId } = useParams<{ aid?: string; topicId?: string }>();
   const navigate = useNavigate();
+  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
 
-  const { documentId } = useAutoCreateTopicDocument(topicId, aid);
+  const { documentId } = useAutoCreateTopicDocument(
+    enableAgentPage ? topicId : undefined,
+    enableAgentPage ? aid : undefined,
+  );
 
   useEffect(() => {
-    if (!aid || !topicId || !documentId) return;
+    if (!aid || !topicId || !serverConfigInit || enableAgentPage) return;
+
+    navigate(SESSION_CHAT_TOPIC_URL(aid, topicId), { replace: true });
+  }, [aid, topicId, serverConfigInit, enableAgentPage, navigate]);
+
+  useEffect(() => {
+    if (!aid || !topicId || !documentId || !enableAgentPage) return;
     navigate(`/agent/${aid}/${topicId}/page/${documentId}`, { replace: true });
-  }, [aid, topicId, documentId, navigate]);
+  }, [aid, topicId, documentId, enableAgentPage, navigate]);
 
   return <BrandTextLoading debugId={'PageRedirect'} />;
 });

--- a/src/routes/(main)/agent/features/Page/index.test.tsx
+++ b/src/routes/(main)/agent/features/Page/index.test.tsx
@@ -11,6 +11,7 @@ const useParamsMock = vi.hoisted(() => vi.fn());
 const useNavigateMock = vi.hoisted(() => vi.fn());
 const useClientDataSWRMock = vi.hoisted(() => vi.fn());
 const useAutoCreateTopicDocumentMock = vi.hoisted(() => vi.fn());
+const useServerConfigStoreMock = vi.hoisted(() => vi.fn());
 
 vi.mock('react-router-dom', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -54,6 +55,13 @@ vi.mock('@/store/notebook/action', () => ({
 
 vi.mock('@/features/TopicCanvas/useAutoCreateTopicDocument', () => ({
   useAutoCreateTopicDocument: (...args: unknown[]) => useAutoCreateTopicDocumentMock(...args),
+}));
+
+vi.mock('@/store/serverConfig', () => ({
+  featureFlagsSelectors: (state: { featureFlags: { enableAgentPage: boolean } }) =>
+    state.featureFlags,
+  useServerConfigStore: (selector: (state: unknown) => unknown) =>
+    useServerConfigStoreMock(selector),
 }));
 
 vi.mock('@lobehub/ui', () => ({
@@ -118,6 +126,7 @@ describe('Topic page route', () => {
     useAutoCreateTopicDocumentMock.mockReset();
     useNavigateMock.mockReset();
     useParamsMock.mockReset();
+    useServerConfigStoreMock.mockReset();
 
     useClientDataSWRMock.mockReturnValue({ data: null, error: undefined, isLoading: false });
     useAutoCreateTopicDocumentMock.mockReturnValue({
@@ -125,6 +134,12 @@ describe('Topic page route', () => {
       documentId: undefined,
       isLoading: false,
     });
+    useServerConfigStoreMock.mockImplementation((selector) =>
+      selector({
+        featureFlags: { enableAgentPage: true },
+        serverConfigInit: true,
+      }),
+    );
   });
 
   it('renders FloatingChatPanel with route topic context', () => {
@@ -176,6 +191,29 @@ describe('Topic page route', () => {
         replace: true,
       }),
     );
+  });
+
+  it('redirects back to chat when the agent page feature is disabled', async () => {
+    useParamsMock.mockReturnValue({
+      aid: 'agt_test',
+      docId: 'doc_test',
+      topicId: 'tpc_test',
+    });
+    useServerConfigStoreMock.mockImplementation((selector) =>
+      selector({
+        featureFlags: { enableAgentPage: false },
+        serverConfigInit: true,
+      }),
+    );
+
+    render(<TopicPage />);
+
+    await waitFor(() =>
+      expect(useNavigateMock).toHaveBeenCalledWith('/agent/agt_test/tpc_test', {
+        replace: true,
+      }),
+    );
+    expect(useAutoCreateTopicDocumentMock).toHaveBeenCalledWith(undefined, undefined);
   });
 
   it('returns null when aid or topicId is missing', () => {

--- a/src/routes/(main)/agent/features/Page/index.tsx
+++ b/src/routes/(main)/agent/features/Page/index.tsx
@@ -5,6 +5,7 @@ import { debounce } from 'es-toolkit/compat';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { AutoSaveHint } from '@/features/EditorCanvas';
 import FloatingChatPanel from '@/features/FloatingChatPanel';
 import TopicCanvas from '@/features/TopicCanvas';
@@ -14,6 +15,7 @@ import HeaderSlot from '@/routes/(main)/agent/(chat)/_layout/HeaderSlot';
 import { documentService } from '@/services/document';
 import { invalidateDocumentMutation } from '@/services/document/invalidation';
 import { documentSWRKeys } from '@/services/document/swrKeys';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 const MAX_PANEL_WIDTH = 1024;
 const TITLE_SAVE_DEBOUNCE = 500;
@@ -21,8 +23,13 @@ const TITLE_SAVE_DEBOUNCE = 500;
 const TopicPage = memo(() => {
   const { aid, topicId, docId } = useParams<{ aid?: string; docId?: string; topicId?: string }>();
   const navigate = useNavigate();
+  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
 
-  const { documentId: topicDocumentId } = useAutoCreateTopicDocument(topicId, aid);
+  const { documentId: topicDocumentId } = useAutoCreateTopicDocument(
+    enableAgentPage ? topicId : undefined,
+    enableAgentPage ? aid : undefined,
+  );
 
   const [titleDraft, setTitleDraft] = useState<string | undefined>();
 
@@ -37,12 +44,19 @@ const TopicPage = memo(() => {
   const isInvalidDoc = Boolean(docId && !isDocLoading && (documentError || documentMeta == null));
 
   useEffect(() => {
+    if (!aid || !topicId || !serverConfigInit || enableAgentPage) return;
+
+    navigate(SESSION_CHAT_TOPIC_URL(aid, topicId), { replace: true });
+  }, [aid, topicId, serverConfigInit, enableAgentPage, navigate]);
+
+  useEffect(() => {
     if (!aid || !topicId) return;
+    if (!enableAgentPage) return;
     if (!isInvalidDoc) return;
     if (!topicDocumentId) return;
     if (topicDocumentId === docId) return;
     navigate(`/agent/${aid}/${topicId}/page/${topicDocumentId}`, { replace: true });
-  }, [aid, topicId, docId, isInvalidDoc, topicDocumentId, navigate]);
+  }, [aid, topicId, docId, enableAgentPage, isInvalidDoc, topicDocumentId, navigate]);
 
   useEffect(() => {
     setTitleDraft(undefined);

--- a/src/server/services/agentDocuments/headlessEditor.test.ts
+++ b/src/server/services/agentDocuments/headlessEditor.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
 
-import { applyLiteXMLOperations, exportEditorDataSnapshot } from './headlessEditor';
+import { isValidEditorData } from '@/libs/editor/isValidEditorData';
+
+import {
+  applyLiteXMLOperations,
+  createMarkdownEditorSnapshot,
+  exportEditorDataSnapshot,
+} from './headlessEditor';
 
 const hasNodeType = (value: unknown, type: string): boolean => {
   if (!value || typeof value !== 'object') return false;
@@ -25,6 +31,13 @@ const getSpanId = (litexml: string, text: string): string => {
 };
 
 describe('agent document headless editor', () => {
+  it('should create a valid empty snapshot for whitespace-only markdown', async () => {
+    const snapshot = await createMarkdownEditorSnapshot(' \n ');
+
+    expect(snapshot.content).toBe('');
+    expect(isValidEditorData(snapshot.editorData)).toBe(true);
+  });
+
   it('should apply LiteXML operations and persist diff nodes for later human review', async () => {
     const initial = await exportEditorDataSnapshot({
       fallbackContent: 'Original',

--- a/src/server/services/agentDocuments/headlessEditor.ts
+++ b/src/server/services/agentDocuments/headlessEditor.ts
@@ -2,6 +2,7 @@
 import type { HeadlessLiteXMLOperation } from '@lobehub/editor/headless';
 import type { SerializedEditorState, SerializedLexicalNode } from 'lexical';
 
+import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
 import { isValidEditorData } from '@/libs/editor/isValidEditorData';
 
 export type AgentDocumentEditorData = Record<string, any>;
@@ -104,6 +105,22 @@ const exportSnapshot = (
   };
 };
 
+const hydrateMarkdownOrEmptyState = (
+  editor: ReturnType<(typeof import('@lobehub/editor/headless'))['createHeadlessEditor']>,
+  content: string,
+  options?: { keepId?: boolean },
+) => {
+  if (content.trim().length === 0) {
+    editor.hydrateEditorData(
+      EMPTY_EDITOR_STATE as unknown as SerializedEditorState<SerializedLexicalNode>,
+      options,
+    );
+    return;
+  }
+
+  editor.hydrateMarkdown(content, options);
+};
+
 const loadEditorState = (
   editor: ReturnType<(typeof import('@lobehub/editor/headless'))['createHeadlessEditor']>,
   { editorData, fallbackContent = '' }: LoadEditorStateParams,
@@ -118,7 +135,7 @@ const loadEditorState = (
     return;
   }
 
-  editor.hydrateMarkdown(fallbackContent, { keepId: true });
+  hydrateMarkdownOrEmptyState(editor, fallbackContent, { keepId: true });
 };
 
 export const createMarkdownEditorSnapshot = async (
@@ -128,7 +145,7 @@ export const createMarkdownEditorSnapshot = async (
   const editor = createHeadlessEditor();
 
   try {
-    editor.hydrateMarkdown(content);
+    hydrateMarkdownOrEmptyState(editor, content);
     return exportSnapshot(editor);
   } finally {
     editor.destroy();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- move the conversation `ViewSwitcher` from the centered header slot into the right-side action area
- add an `agent_page` feature flag and hide or guard page-specific entry routes when it is disabled
- restore truncation behavior for topic title and folder tag after the header layout change
- make topic page auto-create tolerant of empty initial content by falling back to a valid empty editor state in the headless editor
- add targeted tests for page-route fallback behavior and whitespace-only headless snapshots

#### 🧪 How to Test

- run `bunx vitest run --silent='passed-only' 'src/config/featureFlags/schema.test.ts' 'src/routes/(main)/agent/features/Page/index.test.tsx' 'src/routes/(main)/agent/features/Page/PageRedirect.test.tsx'`
- run `bunx vitest run --silent='passed-only' 'src/server/services/agentDocuments/headlessEditor.test.ts' 'src/server/services/agentDocuments.test.ts'`
- verify in the conversation header that the switcher is right-aligned, uses icon-only on narrow widths, and keeps title/folder ellipsis working

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Header switcher in the centered slot, title/folder truncation regressed on narrow widths | Header switcher moved into the action area and truncation restored |

#### 📝 Additional Information

- no data migration required
- the empty topic document fix is intentionally scoped to whitespace-only markdown initialization on the server headless editor path
