### PR TITLE
🐛 fix: register mobile agent topic route

### DIFF
--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -27,6 +27,13 @@ export const mobileRoutes: RouteObject[] = [
               },
               {
                 element: dynamicElement(
+                  () => import('@/routes/(mobile)/chat'),
+                  'Mobile > Chat > Topic',
+                ),
+                path: ':topicId',
+              },
+              {
+                element: dynamicElement(
                   () => import('@/routes/(mobile)/chat/settings'),
                   'Mobile > Chat > Settings',
                 ),


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #14152

#### 🔀 Description of Change

Register the mobile SPA route for `/agent/:aid/:topicId` so direct navigation to an agent topic renders the mobile chat page instead of falling through to the catch-all redirect.

The existing `ChatHydration` already reads `params.topicId` and syncs it into chat state; this PR adds the missing mobile router entry to reach that code path.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Tried to run the closest existing `ChatHydration` Vitest file, but the local install could not load `vitest.config.mts` because `vite-tsconfig-paths` / `vitest/config` were missing in this environment. Verified the route diff and ran `git diff --check`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This is a router registration only; no component behavior changes.
