### PR TITLE
♻️ refactor(agent): reuse task flag for page agent

### DIFF
--- a/src/config/featureFlags/schema.test.ts
+++ b/src/config/featureFlags/schema.test.ts
@@ -108,7 +108,7 @@ describe('mapFeatureFlagsEnvToState', () => {
       knowledge_base: false,
       rag_eval: true,
       agent_onboarding: true,
-      agent_page: true,
+      agent_task: true,
       market: true,
       speech_to_text: true,
       changelog: false,
@@ -133,7 +133,7 @@ describe('mapFeatureFlagsEnvToState', () => {
       enableKnowledgeBase: false,
       enableRAGEval: true,
       enableAgentOnboarding: true,
-      enableAgentPage: true,
+      enableAgentTask: true,
       showMarket: true,
       enableSTT: true,
       showCloudPromotion: true,
@@ -147,7 +147,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const config = {
       edit_agent: ['user-123', 'user-456'],
       agent_onboarding: ['user-123'],
-      agent_page: ['user-123'],
+      agent_task: ['user-123'],
       create_session: ['user-789'],
       dalle: true,
       knowledge_base: ['user-123'],
@@ -158,7 +158,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     expect(mappedState.isAgentEditable).toBe(true); // user-123 is in allowlist
 
     expect(mappedState.enableAgentOnboarding).toBe(true); // user-123 is in allowlist
-    expect(mappedState.enableAgentPage).toBe(true); // user-123 is in allowlist
+    expect(mappedState.enableAgentTask).toBe(true); // user-123 is in allowlist
     expect(mappedState.enableKnowledgeBase).toBe(true); // user-123 is in allowlist
   });
 
@@ -178,7 +178,7 @@ describe('mapFeatureFlagsEnvToState', () => {
   it('should return false for array flags when no user ID provided', () => {
     const config = {
       agent_onboarding: ['user-1'],
-      agent_page: ['user-1'],
+      agent_task: ['user-1'],
       edit_agent: ['user-123', 'user-456'],
       create_session: true,
     };
@@ -186,7 +186,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const mappedState = mapFeatureFlagsEnvToState(config);
 
     expect(mappedState.enableAgentOnboarding).toBe(false);
-    expect(mappedState.enableAgentPage).toBe(false);
+    expect(mappedState.enableAgentTask).toBe(false);
     expect(mappedState.isAgentEditable).toBe(false);
   });
 
@@ -195,7 +195,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     const config = {
       edit_agent: ['user-123'],
       agent_onboarding: ['user-123'],
-      agent_page: ['user-123'],
+      agent_task: ['user-123'],
       create_session: true,
       dalle: false,
       ai_image: ['user-456'],
@@ -208,7 +208,7 @@ describe('mapFeatureFlagsEnvToState', () => {
     expect(mappedState.isAgentEditable).toBe(true);
 
     expect(mappedState.enableAgentOnboarding).toBe(true);
-    expect(mappedState.enableAgentPage).toBe(true);
+    expect(mappedState.enableAgentTask).toBe(true);
     expect(mappedState.showAiImage).toBe(false);
     expect(mappedState.enableKnowledgeBase).toBe(true);
     expect(mappedState.enableRAGEval).toBe(true);

--- a/src/config/featureFlags/schema.ts
+++ b/src/config/featureFlags/schema.ts
@@ -31,7 +31,6 @@ export const FeatureFlagsSchema = z.object({
 
   // internal flag
   agent_onboarding: FeatureFlagValue.optional(),
-  agent_page: FeatureFlagValue.optional(),
   agent_task: FeatureFlagValue.optional(),
   cloud_promotion: FeatureFlagValue.optional(),
 
@@ -80,7 +79,6 @@ export const DEFAULT_FEATURE_FLAGS: IFeatureFlags = {
   rag_eval: false,
 
   agent_onboarding: isDev,
-  agent_page: isDev,
   agent_task: isDev,
   cloud_promotion: false,
 
@@ -114,7 +112,6 @@ export const mapFeatureFlagsEnvToState = (config: IFeatureFlags, userId?: string
     enableKnowledgeBase: evaluateFeatureFlag(config.knowledge_base, userId),
     enableRAGEval: evaluateFeatureFlag(config.rag_eval, userId),
     enableAgentOnboarding: evaluateFeatureFlag(config.agent_onboarding, userId),
-    enableAgentPage: evaluateFeatureFlag(config.agent_page, userId),
     enableAgentTask: evaluateFeatureFlag(config.agent_task, userId),
 
     showCloudPromotion: evaluateFeatureFlag(config.cloud_promotion, userId),

--- a/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
@@ -50,7 +50,7 @@ const ViewSwitcher = memo(() => {
   const location = useLocation();
   const params = useParams<{ aid?: string; topicId?: string }>();
   const activeTopicId = useChatStore((s) => s.activeTopicId);
-  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
+  const enableAgentTask = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentTask);
 
   const aid = params.aid;
   const topicId = params.topicId ?? activeTopicId ?? undefined;
@@ -115,7 +115,7 @@ const ViewSwitcher = memo(() => {
     }
   };
 
-  if (!topicId || !enableAgentPage) return null;
+  if (!topicId || !enableAgentTask) return null;
 
   return (
     <Segmented

--- a/src/routes/(main)/agent/features/Page/PageRedirect.test.tsx
+++ b/src/routes/(main)/agent/features/Page/PageRedirect.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@/features/TopicCanvas/useAutoCreateTopicDocument', () => ({
 }));
 
 vi.mock('@/store/serverConfig', () => ({
-  featureFlagsSelectors: (state: { featureFlags: { enableAgentPage: boolean } }) =>
+  featureFlagsSelectors: (state: { featureFlags: { enableAgentTask: boolean } }) =>
     state.featureFlags,
   useServerConfigStore: (selector: (state: unknown) => unknown) =>
     useServerConfigStoreMock(selector),
@@ -52,7 +52,7 @@ describe('PageRedirect', () => {
 
     useServerConfigStoreMock.mockImplementation((selector) =>
       selector({
-        featureFlags: { enableAgentPage: true },
+        featureFlags: { enableAgentTask: true },
         serverConfigInit: true,
       }),
     );
@@ -88,11 +88,11 @@ describe('PageRedirect', () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it('redirects back to chat when the agent page feature is disabled', async () => {
+  it('redirects back to chat when the agent task feature is disabled', async () => {
     useParamsMock.mockReturnValue({ aid: 'agt_test', topicId: 'tpc_test' });
     useServerConfigStoreMock.mockImplementation((selector) =>
       selector({
-        featureFlags: { enableAgentPage: false },
+        featureFlags: { enableAgentTask: false },
         serverConfigInit: true,
       }),
     );

--- a/src/routes/(main)/agent/features/Page/PageRedirect.tsx
+++ b/src/routes/(main)/agent/features/Page/PageRedirect.tsx
@@ -11,24 +11,24 @@ import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfi
 const PageRedirect = memo(() => {
   const { aid, topicId } = useParams<{ aid?: string; topicId?: string }>();
   const navigate = useNavigate();
-  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
+  const enableAgentTask = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentTask);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
 
   const { documentId } = useAutoCreateTopicDocument(
-    enableAgentPage ? topicId : undefined,
-    enableAgentPage ? aid : undefined,
+    enableAgentTask ? topicId : undefined,
+    enableAgentTask ? aid : undefined,
   );
 
   useEffect(() => {
-    if (!aid || !topicId || !serverConfigInit || enableAgentPage) return;
+    if (!aid || !topicId || !serverConfigInit || enableAgentTask) return;
 
     navigate(SESSION_CHAT_TOPIC_URL(aid, topicId), { replace: true });
-  }, [aid, topicId, serverConfigInit, enableAgentPage, navigate]);
+  }, [aid, topicId, serverConfigInit, enableAgentTask, navigate]);
 
   useEffect(() => {
-    if (!aid || !topicId || !documentId || !enableAgentPage) return;
+    if (!aid || !topicId || !documentId || !enableAgentTask) return;
     navigate(`/agent/${aid}/${topicId}/page/${documentId}`, { replace: true });
-  }, [aid, topicId, documentId, enableAgentPage, navigate]);
+  }, [aid, topicId, documentId, enableAgentTask, navigate]);
 
   return <BrandTextLoading debugId={'PageRedirect'} />;
 });

--- a/src/routes/(main)/agent/features/Page/index.test.tsx
+++ b/src/routes/(main)/agent/features/Page/index.test.tsx
@@ -58,7 +58,7 @@ vi.mock('@/features/TopicCanvas/useAutoCreateTopicDocument', () => ({
 }));
 
 vi.mock('@/store/serverConfig', () => ({
-  featureFlagsSelectors: (state: { featureFlags: { enableAgentPage: boolean } }) =>
+  featureFlagsSelectors: (state: { featureFlags: { enableAgentTask: boolean } }) =>
     state.featureFlags,
   useServerConfigStore: (selector: (state: unknown) => unknown) =>
     useServerConfigStoreMock(selector),
@@ -136,7 +136,7 @@ describe('Topic page route', () => {
     });
     useServerConfigStoreMock.mockImplementation((selector) =>
       selector({
-        featureFlags: { enableAgentPage: true },
+        featureFlags: { enableAgentTask: true },
         serverConfigInit: true,
       }),
     );
@@ -193,7 +193,7 @@ describe('Topic page route', () => {
     );
   });
 
-  it('redirects back to chat when the agent page feature is disabled', async () => {
+  it('redirects back to chat when the agent task feature is disabled', async () => {
     useParamsMock.mockReturnValue({
       aid: 'agt_test',
       docId: 'doc_test',
@@ -201,7 +201,7 @@ describe('Topic page route', () => {
     });
     useServerConfigStoreMock.mockImplementation((selector) =>
       selector({
-        featureFlags: { enableAgentPage: false },
+        featureFlags: { enableAgentTask: false },
         serverConfigInit: true,
       }),
     );

--- a/src/routes/(main)/agent/features/Page/index.tsx
+++ b/src/routes/(main)/agent/features/Page/index.tsx
@@ -23,12 +23,12 @@ const TITLE_SAVE_DEBOUNCE = 500;
 const TopicPage = memo(() => {
   const { aid, topicId, docId } = useParams<{ aid?: string; docId?: string; topicId?: string }>();
   const navigate = useNavigate();
-  const enableAgentPage = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentPage);
+  const enableAgentTask = useServerConfigStore((s) => featureFlagsSelectors(s).enableAgentTask);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
 
   const { documentId: topicDocumentId } = useAutoCreateTopicDocument(
-    enableAgentPage ? topicId : undefined,
-    enableAgentPage ? aid : undefined,
+    enableAgentTask ? topicId : undefined,
+    enableAgentTask ? aid : undefined,
   );
 
   const [titleDraft, setTitleDraft] = useState<string | undefined>();
@@ -44,19 +44,19 @@ const TopicPage = memo(() => {
   const isInvalidDoc = Boolean(docId && !isDocLoading && (documentError || documentMeta == null));
 
   useEffect(() => {
-    if (!aid || !topicId || !serverConfigInit || enableAgentPage) return;
+    if (!aid || !topicId || !serverConfigInit || enableAgentTask) return;
 
     navigate(SESSION_CHAT_TOPIC_URL(aid, topicId), { replace: true });
-  }, [aid, topicId, serverConfigInit, enableAgentPage, navigate]);
+  }, [aid, topicId, serverConfigInit, enableAgentTask, navigate]);
 
   useEffect(() => {
     if (!aid || !topicId) return;
-    if (!enableAgentPage) return;
+    if (!enableAgentTask) return;
     if (!isInvalidDoc) return;
     if (!topicDocumentId) return;
     if (topicDocumentId === docId) return;
     navigate(`/agent/${aid}/${topicId}/page/${topicDocumentId}`, { replace: true });
-  }, [aid, topicId, docId, enableAgentPage, isInvalidDoc, topicDocumentId, navigate]);
+  }, [aid, topicId, docId, enableAgentTask, isInvalidDoc, topicDocumentId, navigate]);
 
   useEffect(() => {
     setTitleDraft(undefined);


### PR DESCRIPTION
## Summary
- remove the standalone agent_page feature flag mapping
- gate Page Agent routes, redirects, and view switcher with enableAgentTask
- update feature flag and page route tests to use enableAgentTask

## Tests
- rg -n "agent_page|enableAgentPage" src packages --glob '!**/node_modules/**' -S
- git diff --check
- vitest run src/config/featureFlags/schema.test.ts