### PR TITLE
🐛 fix(agent-tracing): annotate agent signal event union

### DIFF
--- a/packages/agent-tracing/src/viewer/agentSignal.ts
+++ b/packages/agent-tracing/src/viewer/agentSignal.ts
@@ -109,7 +109,7 @@ const readNumber = (value: Record<string, unknown>, key: string) => {
 const collectStepAgentSignalEvents = (step: StepSnapshot): AgentTracingAgentSignalEvent[] => {
   const stepEvents = step.events ?? [];
 
-  return stepEvents.flatMap((event) => {
+  return stepEvents.flatMap<AgentTracingAgentSignalEvent>((event) => {
     if (!AGENT_SIGNAL_EVENT_TYPES.has(event.type as never)) return [];
     if (!isRecord(event.data)) return [];
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Annotate the `flatMap` result in `collectStepAgentSignalEvents` as `AgentTracingAgentSignalEvent`.

Without the explicit generic, TypeScript can infer the callback result from the first `agent_signal.source` branch and reject other event variants such as `agent_signal.signal` as missing source-only fields.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

```bash
cd packages/agent-tracing
bunx tsc -p tsconfig.json --noEmit --pretty false
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This was exposed by the cloud preview build type-checking the package with `tsc --noEmit`.
