### PR TITLE
🐛 fix(builtin-tool-memory): flatten searchUserMemory schema for strict tool validation

### DIFF
--- a/packages/builtin-tool-memory/src/manifest.ts
+++ b/packages/builtin-tool-memory/src/manifest.ts
@@ -34,21 +34,44 @@ const timeIntentSelectorEnum = [
   'range',
 ] as const;
 
-const searchMemoryTimeIntentSchema: JSONSchema7 = {
+const searchMemoryTimeIntentInnerSchema: JSONSchema7 = {
   additionalProperties: false,
   properties: {
     anchor: {
-      description:
-        'Anchor for relativeDay. Supports the legacy string values "today" and "yesterday", or another timeIntent object such as { "selector": "day", "date": "2025-12-15T00:00:00.000Z" }.',
-      oneOf: [
+      description: 'When nested as a relativeDay anchor, only "today" or "yesterday" is allowed.',
+      enum: ['today', 'yesterday'],
+      type: 'string',
+    },
+    date: { format: 'date-time', type: 'string' },
+    end: { format: 'date-time', type: 'string' },
+    month: { maximum: 12, minimum: 1, type: 'integer' },
+    offsetDays: { type: 'integer' },
+    selector: {
+      enum: [...timeIntentSelectorEnum],
+      type: 'string',
+    },
+    start: { format: 'date-time', type: 'string' },
+    year: { maximum: 9999, minimum: 1970, type: 'integer' },
+  },
+  required: ['selector'],
+  type: 'object',
+};
+
+const searchMemoryTimeIntentSchema: JSONSchema7 = {
+  additionalProperties: false,
+  description:
+    'Optional calendar-friendly time selector that the server always resolves into an exact createdAt timeRange. Prefer this for prompts like "December 2025", "last month", or "yesterday".',
+  properties: {
+    anchor: {
+      anyOf: [
         {
           enum: ['today', 'yesterday'],
           type: 'string',
         },
-        {
-          $ref: '#/definitions/searchMemoryTimeIntent',
-        },
+        searchMemoryTimeIntentInnerSchema,
       ],
+      description:
+        'Anchor for relativeDay. Use the string "today"/"yesterday", or a non-recursive timeIntent object such as { "selector": "day", "date": "2025-12-15T00:00:00.000Z" }.',
     },
     date: { format: 'date-time', type: 'string' },
     end: { format: 'date-time', type: 'string' },
@@ -73,9 +96,6 @@ export const MemoryManifest: BuiltinToolManifest = {
       name: MemoryApiName.searchUserMemory,
       parameters: {
         additionalProperties: false,
-        definitions: {
-          searchMemoryTimeIntent: searchMemoryTimeIntentSchema,
-        },
         properties: {
           categories: {
             description: 'Optional memory categories to constrain retrieval.',
@@ -116,11 +136,7 @@ export const MemoryManifest: BuiltinToolManifest = {
             items: { type: 'string' },
             type: 'array',
           },
-          timeIntent: {
-            description:
-              'Optional calendar-friendly time selector that the server always resolves into an exact createdAt timeRange. Prefer this for prompts like "December 2025", "last month", or "yesterday".',
-            allOf: [{ $ref: '#/definitions/searchMemoryTimeIntent' }],
-          },
+          timeIntent: searchMemoryTimeIntentSchema,
           timeRange: {
             additionalProperties: false,
             description:


### PR DESCRIPTION
## Summary

- Inline the `searchUserMemory` parameters JSON Schema so it no longer relies on `definitions` + `$ref` — strict OpenAI-compatible providers (xAI grok-4, etc.) reject these and return 400 before any tokens are spent.
- Bound the recursive `searchMemoryTimeIntent.anchor` self-reference to one level: nested `anchor` falls back to a non-recursive inner schema whose own `anchor` is just the string enum `"today" | "yesterday"`. This preserves the documented use case (`relativeDay` anchored to `{ selector: "day", date: ... }`) while breaking the cycle.
- Switch `oneOf` / `allOf` → `anyOf` for better strict-mode compatibility (OpenAI/xAI only accept `anyOf` in tool schemas).

The runtime Zod validator in `packages/types/src/userMemory/tools.ts` still uses `z.lazy()` and full recursion — only the LLM-facing JSON Schema is bounded. The resolver in `searchParams.ts` continues to handle the supported nesting via `resolveRelativeDayAnchor`.

Closes [LOBE-8224](https://linear.app/lobehub/issue/LOBE-8224).

## Test plan

- [ ] Verify the emitted manifest has no `$ref`, no `definitions`, no `oneOf`/`allOf`:
  ```bash
  bunx tsx -e "import { MemoryManifest } from './packages/builtin-tool-memory/src/manifest'; \
    const s = MemoryManifest.api.find(a => a.name === 'searchUserMemory'); \
    const j = JSON.stringify(s.parameters); \
    console.log({ ref: j.includes('\$ref'), defs: j.includes('\"definitions\"'), oneOf: j.includes('oneOf'), allOf: j.includes('allOf'), anyOf: j.includes('anyOf') });"
  ```
- [ ] Send a chat to grok-4 with `lobe-user-memory` builtin enabled — should no longer 400 on first turn.
- [ ] Smoke-test the `relativeDay` time intent path with a nested anchor (e.g. "3 days after December 15 2025") to confirm 1-level nesting still validates and resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)