### PR TITLE
♻️ refactor(tasks): default to await-review on topic done, drive completion via accept signals

### DIFF
--- a/src/server/routers/lambda/brief.ts
+++ b/src/server/routers/lambda/brief.ts
@@ -166,8 +166,8 @@ export const briefRouter = router({
     )
     .mutation(async ({ input, ctx }) => {
       try {
-        const model = new BriefModel(ctx.serverDB, ctx.userId);
-        const brief = await model.resolve(input.id, {
+        const service = new BriefService(ctx.serverDB, ctx.userId);
+        const brief = await service.resolve(input.id, {
           action: input.action,
           comment: input.comment,
         });

--- a/src/server/services/brief/index.test.ts
+++ b/src/server/services/brief/index.test.ts
@@ -31,10 +31,12 @@ describe('BriefService', () => {
   const mockBriefModel = {
     list: vi.fn(),
     listUnresolved: vi.fn(),
+    resolve: vi.fn(),
   };
 
   const mockTaskModel = {
     getTreeAgentIdsForTaskIds: vi.fn(),
+    updateStatus: vi.fn(),
   };
 
   beforeEach(() => {
@@ -163,6 +165,89 @@ describe('BriefService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].agents).toEqual([]);
       expect(mockBriefModel.listUnresolved).toHaveBeenCalled();
+    });
+  });
+
+  describe('resolve', () => {
+    it('should complete the task when approving a result brief', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({
+        id: 'b1',
+        taskId: 'task-1',
+        type: 'result',
+      });
+
+      const brief = await service.resolve('b1', { action: 'approve' });
+
+      expect(brief).toEqual({ id: 'b1', taskId: 'task-1', type: 'result' });
+      expect(mockBriefModel.resolve).toHaveBeenCalledWith('b1', { action: 'approve' });
+      expect(mockTaskModel.updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+        error: null,
+      });
+    });
+
+    it('should complete the task when force-approving a decision brief', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({
+        id: 'b2',
+        taskId: 'task-2',
+        type: 'decision',
+      });
+
+      await service.resolve('b2', { action: 'approve' });
+
+      expect(mockTaskModel.updateStatus).toHaveBeenCalledWith('task-2', 'completed', {
+        error: null,
+      });
+    });
+
+    it('should not change task status for non-approve actions', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({
+        id: 'b3',
+        taskId: 'task-3',
+        type: 'result',
+      });
+
+      await service.resolve('b3', { action: 'feedback', comment: 'tweak the tone' });
+
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('should not change task status when approving a non-result/decision brief', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({
+        id: 'b4',
+        taskId: 'task-4',
+        type: 'insight',
+      });
+
+      await service.resolve('b4', { action: 'approve' });
+
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('should not change task status when brief has no taskId', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({
+        id: 'b5',
+        taskId: null,
+        type: 'result',
+      });
+
+      await service.resolve('b5', { action: 'approve' });
+
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('should return null and skip task update when brief is not found', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(null);
+
+      const result = await service.resolve('missing', { action: 'approve' });
+
+      expect(result).toBeNull();
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/services/brief/index.ts
+++ b/src/server/services/brief/index.ts
@@ -59,4 +59,31 @@ export class BriefService {
     const items = await this.briefModel.listUnresolved();
     return this.enrichBriefsWithAgents(items);
   }
+
+  /**
+   * Resolve a brief and propagate accept signals to the task lifecycle.
+   *
+   * 'approve' on a `result` brief is the user-issued accept signal that completes
+   * the task (the agent's result brief alone is only a *proposal* of completion).
+   * 'approve' on a `decision` brief (review max-iterations force-pass) carries the
+   * same semantics. Other actions (feedback / retry / acknowledge) do not transition
+   * task status here — retry triggers re-execution via a separate flow.
+   */
+  async resolve(
+    id: string,
+    options?: { action?: string; comment?: string },
+  ): Promise<BriefItem | null> {
+    const brief = await this.briefModel.resolve(id, options);
+    if (!brief) return null;
+
+    if (
+      options?.action === 'approve' &&
+      brief.taskId &&
+      (brief.type === 'result' || brief.type === 'decision')
+    ) {
+      await this.taskModel.updateStatus(brief.taskId, 'completed', { error: null });
+    }
+
+    return brief;
+  }
 }

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -75,30 +75,26 @@ export class TaskLifecycleService {
         );
       }
 
-      // 3. Auto-review (if configured)
-      if (currentTask && topicId && lastAssistantContent) {
-        await this.runAutoReview(
-          taskId,
-          taskIdentifier,
-          topicId,
-          lastAssistantContent,
-          currentTask,
-        );
-      }
+      // 3. Auto-review (if configured) — Judge is the trusted accept signal:
+      //    when review passes, runAutoReview itself transitions the task to 'completed'.
+      //    Returns true if it terminated the task (completed/paused for retry/etc.).
+      const reviewTerminated =
+        currentTask && topicId && lastAssistantContent
+          ? await this.runAutoReview(
+              taskId,
+              taskIdentifier,
+              topicId,
+              lastAssistantContent,
+              currentTask,
+            )
+          : false;
 
-      // 4. Check if agent delivered a result brief → auto-complete
-      //    If the latest brief is type 'result' and no review is configured, complete the task
-      const reviewConfig = currentTask ? this.taskModel.getReviewConfig(currentTask) : null;
-      if (!reviewConfig?.enabled) {
-        const briefs = await this.briefModel.findByTaskId(taskId);
-        const latestBrief = briefs[0]; // sorted by createdAt desc
-        if (latestBrief?.type === 'result') {
-          await this.taskModel.updateStatus(taskId, 'completed', { error: null });
-          return;
-        }
-      }
+      if (reviewTerminated) return;
 
-      // 5. Checkpoint — pause for user review
+      // 4. Default: pause for user review.
+      //    A 'result' brief from the agent is a *proposal* of completion — the user
+      //    must explicitly approve via the brief action to transition to 'completed'.
+      //    Auto-complete only happens via the Judge path above.
       if (currentTask && this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
         await this.taskModel.updateStatus(taskId, 'paused', { error: null });
       }
@@ -176,7 +172,13 @@ export class TaskLifecycleService {
 
   /**
    * Run auto-review if configured.
-   * @returns true if auto-retry is in progress (caller should skip pause)
+   *
+   * Acts as a "Judge" accept signal: when review passes the task transitions to
+   * `completed` here; when it fails, the task is paused for retry or human action.
+   *
+   * @returns true if this method terminated the task lifecycle (caller should not
+   *          additionally pause/transition); false if review wasn't configured or
+   *          a non-terminal path was taken.
    */
   private async runAutoReview(
     taskId: string,
@@ -184,9 +186,9 @@ export class TaskLifecycleService {
     topicId: string,
     content: string,
     currentTask: any,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const reviewConfig = this.taskModel.getReviewConfig(currentTask);
-    if (!reviewConfig?.enabled || !reviewConfig.rubrics?.length) return;
+    if (!reviewConfig?.enabled || !reviewConfig.rubrics?.length) return false;
 
     try {
       const topicLinks = await this.taskTopicModel.findByTaskId(taskId);
@@ -227,7 +229,9 @@ export class TaskLifecycleService {
           title: `${taskIdentifier} review passed`,
           type: 'result',
         });
-        return;
+        // Judge is a trusted accept signal — complete the task directly.
+        await this.taskModel.updateStatus(taskId, 'completed', { error: null });
+        return true;
       }
 
       if (reviewConfig.autoRetry && iteration < reviewConfig.maxIterations) {
@@ -241,7 +245,7 @@ export class TaskLifecycleService {
 
         // Pause so the webhook / polling loop can pick up and re-run
         await this.taskModel.updateStatus(taskId, 'paused', { error: null });
-        return;
+        return true;
       }
 
       // Max iterations reached
@@ -257,8 +261,11 @@ export class TaskLifecycleService {
         title: `${taskIdentifier} review failed — needs attention`,
         type: 'decision',
       });
+      await this.taskModel.updateStatus(taskId, 'paused', { error: null });
+      return true;
     } catch (e) {
       console.warn('[TaskLifecycle] auto-review failed:', e);
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Summary

Treat agent-emitted `result` briefs as **proposals**, not completion signals. Tasks now stay `paused` (await-review) when a topic finishes, and only transition to `completed` via an explicit accept signal — either a user-clicked `approve` action on a `result`/`decision` brief, or an auto-review (Judge) pass.

Fixes the screenshot scenario in LOBE-8207 : brief showed a 「批准」 button while the task was already `completed`, leaving the user unsure whether to click it.

Closes LOBE-8223.

## Design

Three concepts decoupled:

| Concept | Meaning | Decided by |
|---|---|---|
| `brief.type` | nature of the deliverable (`result` / `insight` / `decision` / `error`) | agent |
| brief approval | whether the deliverable is accepted | human / Judge / Plan |
| `task.status` | task lifecycle state | **driven by accept signals, not brief existence** |

New state-transition table on `reason === 'done'`:

| Condition | Terminal state |
|---|---|
| `review.enabled` + review pass | `completed` (Judge accept) |
| `review.enabled` + review fail (within `maxIterations`) | `paused` (auto-retry) |
| `review.enabled` + review fail (exhausted) | `paused` + urgent `decision` brief |
| no review, agent emits `result` brief | **`paused`** (await user 「批准」) — was `completed` before |
| `checkpoint.topic.after === false` | continue / schedule next topic |
| anything else | `paused` |

## Changes

- `src/server/services/taskLifecycle/index.ts` — drop the "latest brief is `result` → auto-complete" branch; `runAutoReview` returns `boolean` and now itself transitions the task (`completed` on pass, `paused` at retry / exhaustion)
- `src/server/services/brief/index.ts` — `BriefService.resolve` propagates `approve` on `result` / `decision` briefs to `taskModel.updateStatus(taskId, 'completed')`
- `src/server/routers/lambda/brief.ts` — `brief.resolve` mutation routes through `BriefService` (was direct `BriefModel`)
- `src/server/services/brief/index.test.ts` — 6 new cases covering accept-signal propagation across brief types/actions

UI side (the 批准 button in `BriefCardActions`) already calls `briefService.resolve(briefId, 'approve')`, so the wiring lights up without frontend changes.

## Test plan

- [x] `bunx vitest run src/server/services/brief/index.test.ts` — 12/12 pass
- [x] `bunx vitest run src/server/routers/lambda/__tests__/integration/task.integration.test.ts` — 19/19 pass
- [x] `cd packages/database && bunx vitest run src/models/__tests__/brief.test.ts` — 11/11 pass
- [x] `bunx vitest run src/services/__tests__/brief.test.ts src/features/DailyBrief/__tests__/BriefCardActions.test.tsx` — 12/12 pass
- [x] `bun run type-check` — only pre-existing `.next/dev/types/validator.ts` error (also present on canary)
- [ ] Manual: run a task without review config → verify it stays `paused` after agent emits result brief, and clicking 批准 transitions to `completed`
- [ ] Manual: run a task with `review.enabled = true` and a passing rubric → verify auto-complete still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)