### PR TITLE
🐛 fix(tasks): scope task completion to terminal result briefs only

### DIFF
--- a/src/server/services/brief/index.test.ts
+++ b/src/server/services/brief/index.test.ts
@@ -186,7 +186,7 @@ describe('BriefService', () => {
       });
     });
 
-    it('should complete the task when force-approving a decision brief', async () => {
+    it('should NOT complete the task when approving a decision brief (mid-execution checkpoint)', async () => {
       const service = new BriefService(db, userId);
       mockBriefModel.resolve.mockResolvedValue({
         id: 'b2',
@@ -196,9 +196,9 @@ describe('BriefService', () => {
 
       await service.resolve('b2', { action: 'approve' });
 
-      expect(mockTaskModel.updateStatus).toHaveBeenCalledWith('task-2', 'completed', {
-        error: null,
-      });
+      // decision briefs are non-terminal checkpoints — approving must not complete
+      // the task or resume/continue flows break.
+      expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
     });
 
     it('should not change task status for non-approve actions', async () => {
@@ -214,7 +214,7 @@ describe('BriefService', () => {
       expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
     });
 
-    it('should not change task status when approving a non-result/decision brief', async () => {
+    it('should not change task status when approving a non-result brief', async () => {
       const service = new BriefService(db, userId);
       mockBriefModel.resolve.mockResolvedValue({
         id: 'b4',

--- a/src/server/services/brief/index.ts
+++ b/src/server/services/brief/index.ts
@@ -63,11 +63,17 @@ export class BriefService {
   /**
    * Resolve a brief and propagate accept signals to the task lifecycle.
    *
-   * 'approve' on a `result` brief is the user-issued accept signal that completes
-   * the task (the agent's result brief alone is only a *proposal* of completion).
-   * 'approve' on a `decision` brief (review max-iterations force-pass) carries the
-   * same semantics. Other actions (feedback / retry / acknowledge) do not transition
-   * task status here — retry triggers re-execution via a separate flow.
+   * Terminal accept rule: `approve` on a `result` brief completes the task. The
+   * `result` type is the only brief that carries terminal-deliverable semantics
+   * — the agent's `result` brief is a *proposal* of completion that the user
+   * accepts here (and the review max-iterations force-pass also surfaces a
+   * `result` brief for the same reason).
+   *
+   * `decision` briefs are non-terminal checkpoints (mid-execution approvals
+   * like "should I proceed with X?") — approving them must NOT move the task to
+   * `completed`, otherwise resume/continue flows break. Other actions
+   * (feedback / retry / acknowledge) likewise do not transition task status
+   * here; retry triggers re-execution via a separate flow.
    */
   async resolve(
     id: string,
@@ -76,11 +82,7 @@ export class BriefService {
     const brief = await this.briefModel.resolve(id, options);
     if (!brief) return null;
 
-    if (
-      options?.action === 'approve' &&
-      brief.taskId &&
-      (brief.type === 'result' || brief.type === 'decision')
-    ) {
+    if (options?.action === 'approve' && brief.taskId && brief.type === 'result') {
       await this.taskModel.updateStatus(brief.taskId, 'completed', { error: null });
     }
 

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -222,14 +222,19 @@ export class TaskLifecycleService {
       });
 
       if (reviewResult.passed) {
+        // Judge is a trusted accept signal — the brief is created already-resolved
+        // (no actionable buttons in the UI) and the task transitions to 'completed'.
+        const now = new Date();
         await this.briefModel.create({
           priority: 'info',
+          resolvedAction: 'auto-judge-pass',
+          resolvedAt: now,
+          readAt: now,
           summary: `Review passed (score: ${reviewResult.overallScore}%, iteration: ${iteration}). ${content.slice(0, 150)}`,
           taskId,
           title: `${taskIdentifier} review passed`,
           type: 'result',
         });
-        // Judge is a trusted accept signal — complete the task directly.
         await this.taskModel.updateStatus(taskId, 'completed', { error: null });
         return true;
       }
@@ -248,7 +253,9 @@ export class TaskLifecycleService {
         return true;
       }
 
-      // Max iterations reached
+      // Max iterations reached — surface the (failed) result for human accept/retry.
+      // Type is `result` so the user's `approve` action is treated as a terminal
+      // accept signal (force-pass) by BriefService.resolve.
       await this.briefModel.create({
         actions: [
           { key: 'retry', label: '🔄 重试', type: 'resolve' as const },
@@ -259,7 +266,7 @@ export class TaskLifecycleService {
         summary: `Review failed after ${iteration} iteration(s) (score: ${reviewResult.overallScore}%). Suggestions: ${reviewResult.suggestions?.join('; ') || 'none'}`,
         taskId,
         title: `${taskIdentifier} review failed — needs attention`,
-        type: 'decision',
+        type: 'result',
       });
       await this.taskModel.updateStatus(taskId, 'paused', { error: null });
       return true;


### PR DESCRIPTION
## Summary

Two follow-ups to the await-review refactor (#14167) flagged in review.

### P1 — `decision` briefs aren't all terminal

`BriefService.resolve` previously completed the task on `approve` of any `decision` brief. But `decision` is also used for non-terminal **mid-execution checkpoints** (e.g. "should I proceed with X?"); approving a routine checkpoint shouldn't end the task or resume/continue flows break.

Fix: limit the accept-signal to `result` briefs only. For the review max-iterations force-pass path, switch the brief type from `decision` → `result` — semantically that brief *is* the final-but-imperfect deliverable awaiting force-pass, so it belongs under the same accept rule.

### P2 — Judge-accepted result briefs render active buttons

When auto-review passed, `runAutoReview` created a `result` brief and transitioned the task to `completed` — but the brief itself was unresolved, so the UI rendered approve/feedback buttons on a task that was already done. This recreated the exact lifecycle/UI mismatch the original refactor was meant to fix, just on a different code path.

Fix: mark the Judge-issued brief as resolved at creation time (`resolvedAction: 'auto-judge-pass'`, `resolvedAt: now`, `readAt: now`).

## Updated accept-signal table

| Brief type | `approve` action | Effect on task |
|---|---|---|
| `result` | terminal accept | → `completed` |
| `decision` | non-terminal checkpoint ack | no change |
| `insight` / `error` | not an accept | no change |

## Changes

- `src/server/services/brief/index.ts` — drop `decision` from the `approve`→`completed` rule; rewrite docstring to capture the terminal-vs-checkpoint distinction
- `src/server/services/taskLifecycle/index.ts`
  - review pass: brief is now created with `resolvedAction: 'auto-judge-pass'` + `resolvedAt` + `readAt`
  - review max-iterations: brief type `decision` → `result` (force-pass becomes a normal terminal accept)
- `src/server/services/brief/index.test.ts` — flip the decision-brief test to assert NO completion happens; rename non-result test

## Test plan

- [x] `bunx vitest run src/server/services/brief/index.test.ts` — 12/12 pass
- [x] `bunx vitest run src/server/routers/lambda/__tests__/integration/task.integration.test.ts` — 19/19 pass
- [x] `bun run type-check` — only the pre-existing `.next/dev/types/validator.ts` error (also on canary)
- [ ] Manual: trigger a mid-execution `decision` checkpoint → click 批准 → verify task stays `paused` and the next topic resumes
- [ ] Manual: enable auto-review with a passing rubric → verify the auto-issued result brief shows no buttons and task is `completed`
- [ ] Manual: enable auto-review that fails to max iterations → verify the surfaced brief is approvable and clicking 强制通过 transitions task to `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)