### PR TITLE
💄 style(conversation): per-phase workflow expand defaults for heterogeneous agents

### DIFF
--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -13,7 +13,7 @@ import { settingsSelectors } from '@/store/user/selectors';
 import WideScreenContainer from '../../WideScreenContainer';
 import SkeletonList from '../components/SkeletonList';
 import MessageItem from '../Messages';
-import type { WorkflowExpandLevel } from '../Messages/AssistantGroup/components/WorkflowCollapse';
+import type { WorkflowExpandLevelDefault } from '../Messages/AssistantGroup/components/WorkflowCollapse';
 import { MessageActionProvider } from '../Messages/Contexts/MessageActionProvider';
 import { dataSelectors, useConversationStore } from '../store';
 import VirtualizedList from './components/VirtualizedList';
@@ -26,9 +26,10 @@ export interface ChatListProps {
    * - 'collapsed': show summary only
    * - 'semi': constrained scrollable tool list
    * - 'full': all tool details expanded
+   * Pass an object (e.g. `{ streaming: 'full' }`) to override only one phase.
    * Only applies to the default item renderer; ignored when `itemContent` is supplied.
    */
-  defaultWorkflowExpandLevel?: WorkflowExpandLevel;
+  defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   /**
    * Disable the actions bar for all messages (e.g., in share page)
    */

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -17,7 +17,7 @@ import {
 import { CollapsedMessage } from './CollapsedMessage';
 import GroupItem from './GroupItem';
 import type { RenderableAssistantContentBlock } from './types';
-import WorkflowCollapse, { type WorkflowExpandLevel } from './WorkflowCollapse';
+import WorkflowCollapse, { type WorkflowExpandLevelDefault } from './WorkflowCollapse';
 
 const styles = createStaticStyles(({ css }) => {
   return {
@@ -33,7 +33,7 @@ interface GroupChildrenProps {
   blocks: AssistantContentBlock[];
   content?: string;
   contentId?: string;
-  defaultWorkflowExpandLevel?: WorkflowExpandLevel;
+  defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
   id: string;
   messageIndex: number;

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -41,20 +41,36 @@ const WORKFLOW_EXPAND_TOGGLE_TRANSITION = {
 
 export type WorkflowExpandLevel = 'collapsed' | 'semi' | 'full';
 
+/** Per-phase initial level. Pass an object when streaming and completion
+ *  should differ — e.g. heterogeneous agents want full while streaming but
+ *  still collapse once a turn finishes. A plain string applies to both. */
+export type WorkflowExpandLevelDefault =
+  | WorkflowExpandLevel
+  | { completion?: WorkflowExpandLevel; streaming?: WorkflowExpandLevel };
+
 interface WorkflowCollapseProps {
   /** Assistant group message id (for generation state) */
   assistantMessageId: string;
   blocks: RenderableAssistantContentBlock[];
   /**
    * Fixed default expand level. When set, overrides the built-in auto
-   * behavior (expand while streaming, collapse after completion) for both
-   * the initial state and resets. Users can still toggle locally.
+   * behavior (expand while streaming, collapse after completion) for the
+   * initial state and resets. Users can still toggle locally.
+   * Pass an object to override only one phase (e.g. `{ streaming: 'full' }`).
    * Undefined = legacy auto behavior. Pending intervention still forces open.
    */
-  defaultWorkflowExpandLevel?: WorkflowExpandLevel;
+  defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
   workflowChromeComplete?: boolean;
 }
+
+const resolveExpandDefaults = (
+  raw: WorkflowExpandLevelDefault | undefined,
+): { completion?: WorkflowExpandLevel; streaming?: WorkflowExpandLevel } => {
+  if (raw === undefined) return {};
+  if (typeof raw === 'string') return { completion: raw, streaming: raw };
+  return raw;
+};
 
 const collectTools = (blocks: RenderableAssistantContentBlock[]): ChatToolPayloadWithResult[] => {
   return blocks.flatMap((b) => b.tools ?? []);
@@ -152,14 +168,16 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
       [blocks],
     );
     const durationText = totalWorkflowMs > 0 ? formatReasoningDuration(totalWorkflowMs) : undefined;
-    const hasExternalDefault = defaultWorkflowExpandLevel !== undefined;
-    const streamingInitialLevel: WorkflowExpandLevel = defaultWorkflowExpandLevel ?? 'semi';
-    const completionInitialLevel: WorkflowExpandLevel = defaultWorkflowExpandLevel ?? 'collapsed';
+    const { streaming: streamingDefault, completion: completionDefault } = useMemo(
+      () => resolveExpandDefaults(defaultWorkflowExpandLevel),
+      [defaultWorkflowExpandLevel],
+    );
+    const streamingInitialLevel: WorkflowExpandLevel = streamingDefault ?? 'semi';
+    const completionInitialLevel: WorkflowExpandLevel = completionDefault ?? 'collapsed';
 
-    const [expandLevel, setExpandLevel] = useState<WorkflowExpandLevel>(() => {
-      if (hasExternalDefault) return defaultWorkflowExpandLevel;
-      return allComplete ? 'collapsed' : 'semi';
-    });
+    const [expandLevel, setExpandLevel] = useState<WorkflowExpandLevel>(() =>
+      allComplete ? completionInitialLevel : streamingInitialLevel,
+    );
     const userOpenedRef = useRef(false);
     const prevCompleteRef = useRef(allComplete);
 

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -27,7 +27,7 @@ import {
 } from '../Contexts/message-action-context';
 import FileListViewer from '../User/components/FileListViewer';
 import Group from './components/Group';
-import type { WorkflowExpandLevel } from './components/WorkflowCollapse';
+import type { WorkflowExpandLevelDefault } from './components/WorkflowCollapse';
 
 const EditState = dynamic(() => import('./components/EditState'), {
   ssr: false,
@@ -40,7 +40,7 @@ const actionBarHolder = (
   />
 );
 interface GroupMessageProps {
-  defaultWorkflowExpandLevel?: WorkflowExpandLevel;
+  defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
   id: string;
   index: number;

--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -16,7 +16,7 @@ import { dataSelectors, messageStateSelectors, useConversationStore } from '../s
 import AgentCouncilMessage from './AgentCouncil';
 import AssistantMessage from './Assistant';
 import AssistantGroupMessage from './AssistantGroup';
-import type { WorkflowExpandLevel } from './AssistantGroup/components/WorkflowCollapse';
+import type { WorkflowExpandLevelDefault } from './AssistantGroup/components/WorkflowCollapse';
 import CompressedGroupMessage from './CompressedGroup';
 import GroupTasksMessage from './GroupTasks';
 import SupervisorMessage from './Supervisor';
@@ -42,7 +42,7 @@ const styles = createStaticStyles(({ css }) => ({
 
 export interface MessageItemProps {
   className?: string;
-  defaultWorkflowExpandLevel?: WorkflowExpandLevel;
+  defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
   enableHistoryDivider?: boolean;
   endRender?: ReactNode;

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -78,7 +78,10 @@ const Conversation = memo(() => {
           position: 'relative',
         }}
       >
-        <ChatList welcome={<AgentHome />} />
+        <ChatList
+          defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
+          welcome={<AgentHome />}
+        />
       </Flexbox>
       <TodoProgress />
       {isHeterogeneousAgent ? <HeterogeneousChatInput /> : <MainChatInput />}


### PR DESCRIPTION
## Summary

`defaultWorkflowExpandLevel` previously took a single fixed level, which forced callers to choose either streaming-time visibility or completion-time compactness. Heterogeneous agents (Codex, Claude Code) want both: full tool detail while the turn is running, then collapse once it finishes.

Widen the prop to accept an object split by phase, while keeping the plain-string form for callers that want the same level in both phases:

```ts
type WorkflowExpandLevelDefault =
  | WorkflowExpandLevel
  | { streaming?: WorkflowExpandLevel; completion?: WorkflowExpandLevel };
```

`ConversationArea` opts in for heterogeneous agents only:

```tsx
<ChatList
  defaultWorkflowExpandLevel={isHeterogeneousAgent ? { streaming: 'full' } : undefined}
  welcome={<AgentHome />}
/>
```

Undefined (legacy) and plain-string callers behave exactly as before — only the object form is new.

## Changes

- `WorkflowCollapse.tsx` — add `WorkflowExpandLevelDefault` union and `resolveExpandDefaults` helper; replace the `hasExternalDefault` branch with phase-resolved initial level so `useState`'s initializer no longer needs to special-case undefined
- `ChatList/index.tsx`, `Messages/index.tsx`, `AssistantGroup/{index,components/Group}.tsx` — propagate the wider type through the prop chain
- `ConversationArea.tsx` — pass `{ streaming: 'full' }` for heterogeneous agents

## Test plan

- [x] `bun run type-check` — only the pre-existing `.next/dev/types/validator.ts` error (also on canary)
- [ ] Manual: run a Codex agent → verify tools stay fully expanded while streaming, then collapse after the turn finishes
- [ ] Manual: run a Claude Code agent → same as above
- [ ] Manual: run a normal (non-heterogeneous) agent → verify auto behavior is unchanged (semi while streaming, collapsed after)
- [ ] Manual: verify user-toggled expansion is still preserved across re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)