### PR TITLE
🐛 fix(agent-runtime): tighten isCanUseVision default and add aggregator fallback

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -532,10 +532,14 @@ export const createRuntimeExecutors = (
               return info?.abilities?.video ?? false;
             },
             isCanUseVision: (m: string, p: string) => {
-              const info = LOBE_DEFAULT_MODEL_LIST.find(
-                (item) => item.id === m && item.providerId === p,
-              );
-              return info?.abilities?.vision ?? true;
+              // Aggregator providers (e.g. lobehub) route to upstream model cards
+              // that live under the original provider's id in the registry, so
+              // fall back to a cross-provider lookup by model id when the
+              // (model, provider) pair has no direct entry.
+              const info =
+                LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === m && item.providerId === p) ??
+                LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === m);
+              return info?.abilities?.vision ?? false;
             },
           },
           botPlatformContext: ctx.botPlatformContext,

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1175,10 +1175,15 @@ describe('RuntimeExecutors', () => {
         expect(callArgs.capabilities.isCanUseVision('no-tools-model', 'test-provider')).toBe(false);
         expect(callArgs.capabilities.isCanUseVideo('no-tools-model', 'test-provider')).toBe(false);
 
-        // Unknown model defaults: functionCall=true, vision=true, video=false
+        // Unknown model defaults: functionCall=true, vision=false, video=false
         expect(callArgs.capabilities.isCanUseFC('unknown', 'unknown')).toBe(true);
-        expect(callArgs.capabilities.isCanUseVision('unknown', 'unknown')).toBe(true);
+        expect(callArgs.capabilities.isCanUseVision('unknown', 'unknown')).toBe(false);
         expect(callArgs.capabilities.isCanUseVideo('unknown', 'unknown')).toBe(false);
+
+        // Aggregator (e.g. lobehub) routes a known model id under a different
+        // provider — vision flag falls back to the upstream model card.
+        expect(callArgs.capabilities.isCanUseVision('gpt-4', 'lobehub')).toBe(true);
+        expect(callArgs.capabilities.isCanUseVision('no-tools-model', 'lobehub')).toBe(false);
       });
 
       it('should filter disabled files and knowledgeBases from agentConfig', async () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

Follow-up to LOBE-7214 — the original downgrade processor was correct, but the runtime capability probe was too permissive and prevented it from triggering for two real production cases.

#### 🔀 Description of Change

`createRuntimeExecutors` in `RuntimeExecutors.ts` builds `isCanUseVision` by looking up the model card and returning `info?.abilities?.vision ?? true`. The `?? true` fallback silently treated any model whose card omits the `vision` ability key as vision-capable, which neutralised the LOBE-7214 image-history downgrade for two clusters observed on the agent-gateway error dashboard:

1. **Models present in the registry without an explicit `vision: true`** (e.g. the new `deepseek-v4-pro` card lists `functionCall / reasoning / structuredOutput` but no `vision`). `info.abilities.vision` is `undefined`, falls through to `?? true`, and the harness happily forwards `image_url` content blocks to a text-only DeepSeek endpoint.
2. **Models routed via aggregator providers like `lobehub`**, where the lookup `(id, providerId)` finds nothing because the registry only has the model under its upstream provider id (e.g. `(deepseek-v4-pro, deepseek)`). Same fallthrough.

Both surfaces produce the same upstream error:

```
ProviderBizError — Failed to deserialize the JSON body into the target type:
messages[N]: unknown variant `image_url`, expected `text`
```

This PR:

- Switches the default to `false`, matching the existing `isCanUseVideo` convention. Models must explicitly opt in via `abilities.vision = true` to be treated as vision-capable.
- Adds a cross-provider fallback so aggregator-routed model ids still resolve to their upstream model card (e.g. `(claude-haiku-4-5, lobehub)` falls back to the `(claude-haiku-4-5, anthropic)` entry).

#### 🧪 How to Test

- [x] Added/updated tests

`src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts`:

- Updated `(unknown, unknown)` expectation from `true` → `false` to match new default.
- Added two cases for aggregator fallback: `('gpt-4', 'lobehub')` resolves to `true` via the openai card, `('no-tools-model', 'lobehub')` resolves to `false`.

#### 📝 Additional Information

Production trace evidence (8 errors on 2026-04-25, all `deepseek-v4-pro`):

- 2 via `provider=lobehub` — fall-through to default-true (case 2)
- 6 via `provider=deepseek` — registry hit, but ability key missing (case 1)

After this fix:
- `(deepseek-v4-pro, deepseek)` → registry hit, `vision` undefined, returns `false` ✅
- `(deepseek-v4-pro, lobehub)` → no direct hit, fallback to deepseek card, returns `false` ✅
- `(claude-haiku-4-5, lobehub)` → no direct hit, fallback to anthropic card with `vision: true`, returns `true` ✅ (no regression for vision models routed via aggregators)