### PR TITLE
♻️ refactor(agent): remove working sidebar from desktop chat page

### DIFF
--- a/src/routes/(main)/agent/index.desktop.tsx
+++ b/src/routes/(main)/agent/index.desktop.tsx
@@ -9,7 +9,6 @@ import { useChatStore } from '@/store/chat';
 
 import Conversation from './features/Conversation';
 import ChatHydration from './features/Conversation/ChatHydration';
-import AgentWorkingSidebar from './features/Conversation/WorkingSidebar';
 import PageTitle from './features/PageTitle';
 import Portal from './features/Portal';
 import TelemetryNotification from './features/TelemetryNotification';
@@ -42,7 +41,6 @@ const ChatPage = memo(() => {
         >
           <Conversation />
           <Portal />
-          <AgentWorkingSidebar />
         </Flexbox>
         <TelemetryNotification mobile={false} />
       </>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Removes `AgentWorkingSidebar` from the desktop agent chat page (`src/routes/(main)/agent/index.desktop.tsx`), simplifying the layout by no longer rendering the working sidebar in that route.

#### 🧪 How to Test

- Open the desktop app (or desktop route) and navigate to the agent chat view; confirm the working sidebar is no longer shown and the rest of the page behaves as expected.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A (layout change; optional before/after if desired)

#### 📝 Additional Information

None

Made with [Cursor](https://cursor.com)