### PR TITLE
🐛 fix(context-engine): normalize tool parameters required to []

### DIFF
--- a/packages/context-engine/src/engine/tools/ToolsEngine.ts
+++ b/packages/context-engine/src/engine/tools/ToolsEngine.ts
@@ -10,7 +10,7 @@ import type {
   ToolsGenerationResult,
   UniformTool,
 } from './types';
-import { generateToolName } from './utils';
+import { generateToolName, normalizeToolParameters } from './utils';
 
 const log = debug('context-engine:tools-engine');
 
@@ -267,7 +267,7 @@ export class ToolsEngine {
         function: {
           description: api.description,
           name: this.generateToolName(manifest.identifier, api.name, manifest.type),
-          parameters: api.parameters,
+          parameters: normalizeToolParameters(api.parameters),
         },
         type: 'function' as const,
       })),

--- a/packages/context-engine/src/engine/tools/__tests__/ToolsEngine.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/ToolsEngine.test.ts
@@ -168,6 +168,55 @@ describe('ToolsEngine', () => {
       });
     });
 
+    it('should default object-typed parameters required to [] when omitted', () => {
+      const allOptionalManifest: LobeToolManifest = {
+        api: [
+          {
+            description: 'Search with all-optional params',
+            name: 'search',
+            parameters: {
+              type: 'object',
+              properties: {
+                q: { type: 'string', description: 'optional query' },
+              },
+            },
+          },
+        ],
+        identifier: 'lobe-all-optional',
+        meta: { title: 'All Optional', description: '' },
+        type: 'builtin',
+      };
+
+      const engine = new ToolsEngine({
+        manifestSchemas: [allOptionalManifest],
+        enableChecker: () => true,
+        functionCallChecker: () => true,
+      });
+
+      const result = engine.generateTools({
+        toolIds: ['lobe-all-optional'],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'lobe-all-optional____search____builtin',
+            description: 'Search with all-optional params',
+            parameters: {
+              type: 'object',
+              properties: {
+                q: { type: 'string', description: 'optional query' },
+              },
+              required: [],
+            },
+          },
+        },
+      ]);
+    });
+
     it('should handle non-existent plugins gracefully', () => {
       const engine = new ToolsEngine({
         manifestSchemas: [mockWebBrowsingManifest],
@@ -742,6 +791,7 @@ describe('ToolsEngine', () => {
                 type: 'string',
               },
             },
+            required: [],
             type: 'object',
           },
         });
@@ -764,6 +814,7 @@ describe('ToolsEngine', () => {
         expect(func.parameters).toEqual({
           type: 'object',
           properties: { a: { type: 'string' } },
+          required: [],
         });
       });
     });

--- a/packages/context-engine/src/engine/tools/__tests__/utils.test.ts
+++ b/packages/context-engine/src/engine/tools/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { LobeToolManifest } from '../types';
-import { filterValidManifests, validateManifest } from '../utils';
+import { filterValidManifests, normalizeToolParameters, validateManifest } from '../utils';
 
 // Mock manifest schemas
 const mockBuiltinManifest: LobeToolManifest = {
@@ -66,6 +66,54 @@ describe('utils', () => {
 
       expect(result.valid).toEqual([validManifest]);
       expect(result.invalid).toEqual([invalidManifest]);
+    });
+  });
+
+  describe('normalizeToolParameters', () => {
+    it('should add required: [] when missing on object schemas', () => {
+      const result = normalizeToolParameters({
+        type: 'object',
+        properties: { q: { type: 'string' } },
+      });
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: [],
+      });
+    });
+
+    it('should preserve existing required array', () => {
+      const parameters = {
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: ['q'],
+      };
+
+      expect(normalizeToolParameters(parameters)).toEqual(parameters);
+    });
+
+    it('should overwrite non-array required with []', () => {
+      const result = normalizeToolParameters({
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: null as any,
+      });
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: [],
+      });
+    });
+
+    it('should leave non-object schemas untouched', () => {
+      const stringSchema = { type: 'string' };
+      expect(normalizeToolParameters(stringSchema)).toBe(stringSchema);
+    });
+
+    it('should pass through undefined', () => {
+      expect(normalizeToolParameters(undefined)).toBeUndefined();
     });
   });
 });

--- a/packages/context-engine/src/engine/tools/utils.ts
+++ b/packages/context-engine/src/engine/tools/utils.ts
@@ -17,6 +17,22 @@ export const generateToolName = (
 };
 
 /**
+ * Ensure object-typed tool parameters carry an explicit `required` array.
+ *
+ * Why: JSON Schema permits omitting `required` when nothing is required, but
+ * some OpenAI-compatible upstreams (bailian, glm/zhipu) reject the field when
+ * it arrives as `null` after intermediate proxies normalize the missing key.
+ * Emitting `required: []` keeps the wire format consistent for strict providers.
+ */
+export const normalizeToolParameters = (
+  parameters: Record<string, any> | undefined,
+): Record<string, any> | undefined => {
+  if (!parameters || parameters.type !== 'object') return parameters;
+  if (Array.isArray(parameters.required)) return parameters;
+  return { ...parameters, required: [] };
+};
+
+/**
  * Convert a tool manifest into LLM-compatible UniformTool definitions
  */
 export function generateToolsFromManifest(manifest: LobeToolManifest): UniformTool[] {
@@ -24,7 +40,7 @@ export function generateToolsFromManifest(manifest: LobeToolManifest): UniformTo
     function: {
       description: api.description,
       name: new ToolNameResolver().generate(manifest.identifier, api.name, manifest.type),
-      parameters: api.parameters,
+      parameters: normalizeToolParameters(api.parameters),
     },
     type: 'function' as const,
   }));


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

close LOBE-8203

#### 🔀 Description of Change

When a tool's JSON Schema parameters has all-optional fields, the manifest legitimately omits `required` (per JSON Schema spec). However, strict OpenAI-compatible upstreams (bailian, glm/zhipu, and similar) reject the request when intermediate proxies normalize the missing key to `null`:

```
400 - {"error":{"code":"invalid_argument","message":"at '/required': got null, want array"}}
```

Verified via agent-tracing that 4 tools (`searchUserMemory`, `queryTaxonomyOptions`, `searchSkill`, `listOnlineDevices`) consistently lack `required` because every parameter is optional, triggering the failure on `glm-5.1` through user-configured pinche proxy.

Fix at the tool generation boundary in `ToolsEngine.convertManifestsToTools` (and `generateToolsFromManifest`): if `parameters.type === 'object'` and `required` is missing or non-array, emit `required: []`. Single-point fix that covers builtin / MCP / user-defined tools.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added `normalizeToolParameters` unit tests in `utils.test.ts` plus an integration test in `ToolsEngine.test.ts` that asserts an all-optional manifest produces `required: []`.

```bash
cd packages/context-engine && bunx vitest run --silent='passed-only' 'src/engine/tools/__tests__/'
# 8 files / 170 tests, all green
```

#### 📝 Additional Information

JSON Schema regards `required` as optional, so this is a defensive normalization rather than a spec compliance change. Existing tools that already declare `required: [...]` are passed through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)