### PR TITLE
🐛 fix(agent-runtime): scope pending-approval check to current assistant turn

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -305,6 +305,41 @@ export class GeneralChatAgent implements Agent {
   }
 
   /**
+   * Pending-tool scope guard for the main loop.
+   *
+   * The pending-approval check must only count tool messages produced by the
+   * **current** assistant turn. Stale `pluginIntervention.status === 'pending'`
+   * rows from a previous turn (e.g. an abandoned approval flow whose user
+   * never clicked approve/reject) get loaded back into `state.messages` via
+   * `historyMessages` and would otherwise hijack every subsequent
+   * `tool_result` / `tools_batch_result` phase, parking the loop in
+   * `waiting_for_human` forever.
+   *
+   * "Current turn" = the most recent assistant message that emitted
+   * `tool_calls`. All pending tool messages legitimately belonging to this
+   * turn have `parentId === currentAssistantId`.
+   */
+  private getCurrentTurnPendingToolMessages(state: AgentState): any[] {
+    let currentAssistantId: string | undefined;
+    for (let i = state.messages.length - 1; i >= 0; i--) {
+      const m = state.messages[i] as any;
+      if (m.role === 'assistant' && m.tool_calls?.length > 0) {
+        currentAssistantId = m.id;
+        break;
+      }
+    }
+
+    if (!currentAssistantId) return [];
+
+    return state.messages.filter(
+      (m: any) =>
+        m.role === 'tool' &&
+        m.pluginIntervention?.status === 'pending' &&
+        m.parentId === currentAssistantId,
+    );
+  }
+
+  /**
    * Find existing compression summary from messages
    * Looks for MessageGroup with type 'compression' and extracts its content
    */
@@ -543,10 +578,9 @@ export class GeneralChatAgent implements Agent {
           }
         }
 
-        // Check if there are still pending tool messages waiting for approval
-        const pendingToolMessages = state.messages.filter(
-          (m: any) => m.role === 'tool' && m.pluginIntervention?.status === 'pending',
-        );
+        // Scope pending check to the current assistant turn so stale
+        // `pending` rows from prior turns can never block the loop.
+        const pendingToolMessages = this.getCurrentTurnPendingToolMessages(state);
 
         // If there are pending tools, wait for human approval
         if (pendingToolMessages.length > 0) {
@@ -577,10 +611,9 @@ export class GeneralChatAgent implements Agent {
       case 'tools_batch_result': {
         const { parentMessageId } = context.payload as GeneralAgentCallToolResultPayload;
 
-        // Check if there are still pending tool messages waiting for approval
-        const pendingToolMessages = state.messages.filter(
-          (m: any) => m.role === 'tool' && m.pluginIntervention?.status === 'pending',
-        );
+        // Scope pending check to the current assistant turn so stale
+        // `pending` rows from prior turns can never block the loop.
+        const pendingToolMessages = this.getCurrentTurnPendingToolMessages(state);
 
         // If there are pending tools, wait for human approval
         if (pendingToolMessages.length > 0) {

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -315,15 +315,16 @@ export class GeneralChatAgent implements Agent {
    * `tool_result` / `tools_batch_result` phase, parking the loop in
    * `waiting_for_human` forever.
    *
-   * "Current turn" = the most recent assistant message that emitted
-   * `tool_calls`. All pending tool messages legitimately belonging to this
-   * turn have `parentId === currentAssistantId`.
+   * "Current turn" = the most recent assistant message that emitted tool calls,
+   * stored as either model-native `tool_calls` or persisted `tools`. All pending
+   * tool messages legitimately belonging to this turn have
+   * `parentId === currentAssistantId`.
    */
   private getCurrentTurnPendingToolMessages(state: AgentState): any[] {
     let currentAssistantId: string | undefined;
     for (let i = state.messages.length - 1; i >= 0; i--) {
       const m = state.messages[i] as any;
-      if (m.role === 'assistant' && m.tool_calls?.length > 0) {
+      if (m.role === 'assistant' && (m.tool_calls?.length > 0 || m.tools?.length > 0)) {
         currentAssistantId = m.id;
         break;
       }

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -667,12 +667,32 @@ describe('GeneralChatAgent', () => {
         type: 'default',
       };
 
+      // Pending tool messages must hang off the *current* assistant turn for
+      // the runner to treat them as live (otherwise they're treated as stale
+      // history). Mirror the real persisted shape: assistant carries
+      // `tool_calls`, pending tool message carries `parentId`.
       const state = createMockState({
         messages: [
           { role: 'user', content: 'Hello' },
-          { role: 'assistant', content: '', tools: [] },
-          { role: 'tool', content: 'Result', tool_call_id: 'call-1' },
           {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              { id: 'call-1', function: { name: 'plugin-1', arguments: '{}' }, type: 'function' },
+              { id: 'call-2', function: { name: 'plugin-2', arguments: '{}' }, type: 'function' },
+            ],
+          },
+          {
+            id: 'tool-1',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result',
+            tool_call_id: 'call-1',
+          },
+          {
+            id: 'tool-2',
+            parentId: 'assistant-1',
             role: 'tool',
             content: '',
             tool_call_id: 'call-2',
@@ -694,6 +714,85 @@ describe('GeneralChatAgent', () => {
         reason: 'Some tools still pending approval',
         skipCreateToolMessage: true,
       });
+    });
+
+    it('should ignore stale pending tool messages from a previous assistant turn', async () => {
+      // Regression: before scoping, a previous turn's never-resolved
+      // `pluginIntervention.status === 'pending'` row would be loaded back
+      // into state.messages via historyMessages and hijack every subsequent
+      // tool_result phase, parking the loop in waiting_for_human forever.
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const stalePendingPlugin: ChatToolPayload = {
+        id: 'old-call-1',
+        identifier: 'plugin-old',
+        apiName: 'api-old',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        messages: [
+          // Previous turn — abandoned, leaves a pending tool message behind.
+          { role: 'user', content: 'old prompt' },
+          {
+            id: 'old-assistant',
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'old-call-1',
+                function: { name: 'plugin-old', arguments: '{}' },
+                type: 'function',
+              },
+            ],
+          },
+          {
+            id: 'old-tool-1',
+            parentId: 'old-assistant',
+            role: 'tool',
+            content: '',
+            tool_call_id: 'old-call-1',
+            plugin: stalePendingPlugin,
+            pluginIntervention: { status: 'pending' },
+          },
+          // Current turn — assistant called a different tool and it succeeded.
+          { role: 'user', content: 'new prompt' },
+          {
+            id: 'current-assistant',
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'new-call-1',
+                function: { name: 'plugin-new', arguments: '{}' },
+                type: 'function',
+              },
+            ],
+          },
+          {
+            id: 'current-tool-1',
+            parentId: 'current-assistant',
+            role: 'tool',
+            content: 'OK',
+            tool_call_id: 'new-call-1',
+          },
+        ] as any,
+      });
+
+      const context = createMockContext('tool_result', {
+        parentMessageId: 'current-tool-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      // The loop must continue with another LLM call, NOT get hijacked into
+      // request_human_approve by the stale pending row from the prior turn.
+      expect((result as any).type).toBe('call_llm');
     });
   });
 
@@ -747,13 +846,40 @@ describe('GeneralChatAgent', () => {
         type: 'default',
       };
 
+      // Pending tool messages must hang off the *current* assistant turn for
+      // the runner to treat them as live (otherwise they're treated as stale
+      // history). Mirror the real persisted shape: assistant carries
+      // `tool_calls`, pending tool message carries `parentId`.
       const state = createMockState({
         messages: [
           { role: 'user', content: 'Hello' },
-          { role: 'assistant', content: '', tools: [] },
-          { role: 'tool', content: 'Result 1', tool_call_id: 'call-1' },
-          { role: 'tool', content: 'Result 2', tool_call_id: 'call-2' },
           {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              { id: 'call-1', function: { name: 'plugin-1', arguments: '{}' }, type: 'function' },
+              { id: 'call-2', function: { name: 'plugin-2', arguments: '{}' }, type: 'function' },
+              { id: 'call-3', function: { name: 'plugin-3', arguments: '{}' }, type: 'function' },
+            ],
+          },
+          {
+            id: 'tool-1',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result 1',
+            tool_call_id: 'call-1',
+          },
+          {
+            id: 'tool-2',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result 2',
+            tool_call_id: 'call-2',
+          },
+          {
+            id: 'tool-3',
+            parentId: 'assistant-1',
             role: 'tool',
             content: '',
             tool_call_id: 'call-3',

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -716,6 +716,72 @@ describe('GeneralChatAgent', () => {
       });
     });
 
+    it('should return request_human_approve when current assistant turn stores calls in tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const pendingPlugin: ChatToolPayload = {
+        id: 'call-2',
+        identifier: 'plugin-2',
+        apiName: 'api-2',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: '',
+            tools: [
+              {
+                apiName: 'api-1',
+                arguments: '{}',
+                id: 'call-1',
+                identifier: 'plugin-1',
+                type: 'default',
+              },
+              pendingPlugin,
+            ],
+          },
+          {
+            id: 'tool-1',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result',
+            tool_call_id: 'call-1',
+          },
+          {
+            id: 'tool-2',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: '',
+            tool_call_id: 'call-2',
+            plugin: pendingPlugin,
+            pluginIntervention: { status: 'pending' },
+          },
+        ] as any,
+      });
+
+      const context = createMockContext('tool_result', {
+        parentMessageId: 'tool-msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'request_human_approve',
+        pendingToolsCalling: [pendingPlugin],
+        reason: 'Some tools still pending approval',
+        skipCreateToolMessage: true,
+      });
+    });
+
     it('should ignore stale pending tool messages from a previous assistant turn', async () => {
       // Regression: before scoping, a previous turn's never-resolved
       // `pluginIntervention.status === 'pending'` row would be loaded back
@@ -861,6 +927,86 @@ describe('GeneralChatAgent', () => {
               { id: 'call-1', function: { name: 'plugin-1', arguments: '{}' }, type: 'function' },
               { id: 'call-2', function: { name: 'plugin-2', arguments: '{}' }, type: 'function' },
               { id: 'call-3', function: { name: 'plugin-3', arguments: '{}' }, type: 'function' },
+            ],
+          },
+          {
+            id: 'tool-1',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result 1',
+            tool_call_id: 'call-1',
+          },
+          {
+            id: 'tool-2',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: 'Result 2',
+            tool_call_id: 'call-2',
+          },
+          {
+            id: 'tool-3',
+            parentId: 'assistant-1',
+            role: 'tool',
+            content: '',
+            tool_call_id: 'call-3',
+            plugin: pendingPlugin,
+            pluginIntervention: { status: 'pending' },
+          },
+        ] as any,
+      });
+
+      const context = createMockContext('tools_batch_result', {
+        parentMessageId: 'tool-msg-2',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'request_human_approve',
+        pendingToolsCalling: [pendingPlugin],
+        reason: 'Some tools still pending approval',
+        skipCreateToolMessage: true,
+      });
+    });
+
+    it('should return request_human_approve when batch current assistant turn stores calls in tools', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const pendingPlugin: ChatToolPayload = {
+        id: 'call-3',
+        identifier: 'plugin-3',
+        apiName: 'api-3',
+        arguments: '{}',
+        type: 'default',
+      };
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: '',
+            tools: [
+              {
+                apiName: 'api-1',
+                arguments: '{}',
+                id: 'call-1',
+                identifier: 'plugin-1',
+                type: 'default',
+              },
+              {
+                apiName: 'api-2',
+                arguments: '{}',
+                id: 'call-2',
+                identifier: 'plugin-2',
+                type: 'default',
+              },
+              pendingPlugin,
             ],
           },
           {


### PR DESCRIPTION
## Summary

A stale `pluginIntervention.status === 'pending'` row from a prior turn (e.g. an abandoned approval flow whose user never clicked approve/reject) gets loaded back into `state.messages` via `historyMessages`, hijacks every subsequent `tool_result` / `tools_batch_result` phase in `GeneralChatAgent.runner`, and parks the loop in `waiting_for_human` forever — so after a tool call succeeds, the next LLM call is never scheduled and the conversation appears frozen.

- Add `getCurrentTurnPendingToolMessages` helper that resolves the **current** assistant turn (most recent assistant with `tool_calls`) and only returns pending tool messages whose `parentId` matches that assistant.
- Use the helper in `case 'tool_result'` and `case 'tools_batch_result'`. Stale pending rows from earlier turns are now ignored, so the loop continues to the next `call_llm` as intended.
- `extractAbortInfo` (abort path) is intentionally left unchanged — it's a different correctness contract and out of scope for this fix.

## Test plan
- [x] `bunx vitest run packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts` (64 / 64 passing)
- [x] Updated existing `should return request_human_approve when there are pending tools` fixtures (both phases) to mirror the real persisted shape — assistant carries `tool_calls`, tool message carries `parentId`. Without these, the new scope guard would treat them as stale.
- [x] New regression test: `should ignore stale pending tool messages from a previous assistant turn` — constructs a previous abandoned turn's pending tool plus a current turn's successful tool result, asserts the runner returns `call_llm`, not `request_human_approve`.

## Repro context
Was hit while developing on `feat/agent-marketplace-picker`: after `lobe-web-onboarding/updateDocument` succeeded, the loop never issued the follow-up LLM call. Server logs (added temporary tracing during diagnosis) showed `tool_result -> request_human_approve (pending=1)` with the pending row's `id` pointing at a tool message from a prior turn.