### PR TITLE
fix(xai): strip reasoning_effort for models that do not support it

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
@@ -10,6 +10,57 @@ export const xaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 2_000_000,
     description: 'Intelligent, blazing-fast model that reasons before responding',
+    displayName: 'Grok 4.20',
+    enabled: true,
+    id: 'grok-4.20-0309-reasoning',
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 0.2 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 6, upTo: 0.2 },
+            { rate: 12, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-03-09',
+    settings: {
+      // reasoning_effort is not supported by grok-4.20-0309-reasoning.
+      // Specifying reasoning_effort parameter will get an error response.
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 2_000_000,
+    description: 'Intelligent, blazing-fast model that reasons before responding',
     displayName: 'Grok 4.20 Beta',
     enabled: true,
     id: 'grok-4.20-beta-0309-reasoning',

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -12,6 +12,58 @@ const xaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 2_000_000,
     description: 'Intelligent, blazing-fast model that reasons before responding',
+    displayName: 'Grok 4.20',
+    enabled: true,
+    id: 'grok-4.20-0309-reasoning',
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2, upTo: 0.2 },
+            { rate: 4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 6, upTo: 0.2 },
+            { rate: 12, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-03-09',
+    settings: {
+      // reasoning_effort is not supported by grok-4.20-0309-reasoning.
+      // Specifying reasoning_effort parameter will get an error response.
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 2_000_000,
+    description: 'Intelligent, blazing-fast model that reasons before responding',
     displayName: 'Grok 4.20 Beta',
     enabled: true,
     id: 'grok-4.20-beta-0309-reasoning',

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -120,6 +120,39 @@ describe('LobeXAI - custom features', () => {
       const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
       expect(createCall.tools).toEqual([{ type: 'web_search' }, { type: 'x_search' }]);
     });
+
+    it('should strip reasoning_effort for models that do not support it', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4.20-0309-reasoning',
+        reasoning_effort: 'high',
+      } as any);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.reasoning).toBeUndefined();
+    });
+
+    it('should strip reasoning_effort for grok-4.20-beta-0309-reasoning', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4.20-beta-0309-reasoning',
+        reasoning_effort: 'medium',
+      } as any);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.reasoning).toBeUndefined();
+    });
+
+    it('should preserve reasoning_effort for grok-3-mini', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-3-mini',
+        reasoning_effort: 'low',
+      } as any);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.reasoning).toEqual({ effort: 'low' });
+    });
   });
 
   describe('models', () => {

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -18,17 +18,33 @@ const xaiPenaltySupportedModels = new Set([
   'grok-4-1-fast-non-reasoning',
 ]);
 
-const pruneUnsupportedReasoningParameters = (payload: ChatStreamPayload) => {
-  if (xaiPenaltySupportedModels.has(payload.model)) return payload;
+// Only these models support reasoning_effort via the Responses API reasoning.effort field.
+// All other xAI models reject this parameter with a 400 error.
+// https://docs.x.ai/developers/model-capabilities/text/reasoning
+const xaiReasoningEffortSupportedModels = new Set([
+  'grok-3-mini',
+  'grok-4.20-multi-agent-beta-0309',
+]);
 
-  return {
-    ...payload,
-    // xAI reasoning models reject these parameters:
-    // https://docs.x.ai/developers/model-capabilities/text/reasoning
-    frequency_penalty: undefined,
-    presence_penalty: undefined,
-    stop: undefined,
-  } as ChatStreamPayload;
+const pruneUnsupportedReasoningParameters = (payload: ChatStreamPayload) => {
+  const pruned = xaiPenaltySupportedModels.has(payload.model)
+    ? payload
+    : ({
+        ...payload,
+        // xAI reasoning models reject these parameters:
+        // https://docs.x.ai/developers/model-capabilities/text/reasoning
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+        stop: undefined,
+      } as ChatStreamPayload);
+
+  if (xaiReasoningEffortSupportedModels.has(payload.model)) return pruned;
+
+  // Strip reasoning_effort for models that don't support it to avoid 400 errors.
+  // reasoning_effort may be present when users have it configured in agent params
+  // and switch to a model that does not support it.
+  const { reasoning_effort: _, ...rest } = pruned as any;
+  return rest as ChatStreamPayload;
 };
 
 export const LobeXAI = createOpenAICompatibleRuntime({


### PR DESCRIPTION
Fixes #14175

## Problem

When users configure `reasoning_effort` in their agent params (e.g., after using `grok-3-mini` which supports it) and then switch to an xAI model that does not support the parameter, the request fails with:

```
"Model grok-4.20-0309-reasoning does not support parameter reasoningEffort."
```

This happens because:
1. `reasoning_effort` from agent config params bypasses the model-level `extendParams` check in `modelParamsResolver`
2. The xAI `responses.handlePayload` passed `reasoning_effort` through for all models
3. The factory's Responses API handler converts it to `reasoning.effort` in the request
4. xAI rejects the parameter for models that don't support it

Only `grok-3-mini` and `grok-4.20-multi-agent-beta-0309` support `reasoning.effort` via the xAI Responses API. All other xAI models (including `grok-4`, `grok-4.20-*-reasoning`, `grok-code-fast-1`) reject it with a 400 error.

## Solution

- **Extend `pruneUnsupportedReasoningParameters`** in `packages/model-runtime/src/providers/xai/index.ts` to strip `reasoning_effort` for models not in `xaiReasoningEffortSupportedModels` whitelist (`grok-3-mini`, `grok-4.20-multi-agent-beta-0309`)
- **Add `grok-4.20-0309-reasoning`** to the model bank as the GA (non-beta) version of `grok-4.20-beta-0309-reasoning`, with an explicit comment that `reasoning_effort` is unsupported
- **Add tests** covering the new behavior: `reasoning_effort` is stripped for unsupported models and preserved for `grok-3-mini`

## Testing

All 20 tests in `packages/model-runtime/src/providers/xai/index.test.ts` pass, including 3 new tests:
- `grok-4.20-0309-reasoning` strips `reasoning_effort` → no `reasoning.effort` in request
- `grok-4.20-beta-0309-reasoning` strips `reasoning_effort` → no `reasoning.effort` in request
- `grok-3-mini` preserves `reasoning_effort` → `reasoning.effort` present in request