### PR TITLE
🐛 fix(conversation): disable first assistant block markdown streaming

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -18,7 +18,18 @@ interface ContentBlockProps extends RenderableAssistantContentBlock {
   disableEditing?: boolean;
 }
 const ContentBlock = memo<ContentBlockProps>(
-  ({ id, tools, content, imageList, reasoning, error, domId, assistantId, disableEditing }) => {
+  ({
+    id,
+    tools,
+    content,
+    imageList,
+    reasoning,
+    error,
+    domId,
+    assistantId,
+    disableEditing,
+    disableMarkdownStreaming,
+  }) => {
     const errorContent = useErrorContent(error);
     const showImageItems = !!imageList && imageList.length > 0;
     const [isReasoning, deleteMessage, continueGeneration] = useConversationStore((s) => [
@@ -73,7 +84,12 @@ const ContentBlock = memo<ContentBlockProps>(
 
         {showMessageContent && (
           <SafeBoundary variant="alert">
-            <MessageContent content={content} hasTools={hasTools} id={id} />
+            <MessageContent
+              content={content}
+              disableStreaming={disableMarkdownStreaming}
+              hasTools={hasTools}
+              id={id}
+            />
           </SafeBoundary>
         )}
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ContentBlocksScroll from './ContentBlocksScroll';
+import type { RenderableAssistantContentBlock } from './types';
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ScrollShadow: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    scrollTask: 'scroll-task',
+    scrollWorkflow: 'scroll-workflow',
+  }),
+}));
+
+vi.mock('./ContentBlock', () => ({
+  default: ({ disableMarkdownStreaming, id }: RenderableAssistantContentBlock) => (
+    <div
+      data-block-id={id}
+      data-disable-markdown-streaming={String(!!disableMarkdownStreaming)}
+      data-testid="content-block"
+    />
+  ),
+}));
+
+describe('ContentBlocksScroll', () => {
+  it('does not disable markdown streaming for the first block of a workflow subset', () => {
+    render(
+      <ContentBlocksScroll
+        assistantId="assistant-1"
+        blocks={[{ content: 'workflow block', id: 'block-2' }]}
+        scroll={false}
+        variant="workflow"
+      />,
+    );
+
+    expect(screen.getByTestId('content-block')).toHaveAttribute(
+      'data-disable-markdown-streaming',
+      'false',
+    );
+  });
+
+  it('preserves precomputed markdown streaming disable flag', () => {
+    render(
+      <ContentBlocksScroll
+        assistantId="assistant-1"
+        blocks={[{ content: 'first group block', disableMarkdownStreaming: true, id: 'block-1' }]}
+        scroll={false}
+        variant="workflow"
+      />,
+    );
+
+    expect(screen.getByTestId('content-block')).toHaveAttribute(
+      'data-disable-markdown-streaming',
+      'true',
+    );
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -62,8 +62,6 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
     };
   }, [assistantIdFromProps, blocksFromProps, messagesList]);
 
-  const firstBlockId = blocks[0]?.id;
-
   const list = (
     <Flexbox gap={8}>
       {blocks.map((block) => (
@@ -72,7 +70,6 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
           {...block}
           assistantId={assistantId}
           disableEditing={disableEditing}
-          disableMarkdownStreaming={block.disableMarkdownStreaming || block.id === firstBlockId}
         />
       ))}
     </Flexbox>

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -62,6 +62,8 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
     };
   }, [assistantIdFromProps, blocksFromProps, messagesList]);
 
+  const firstBlockId = blocks[0]?.id;
+
   const list = (
     <Flexbox gap={8}>
       {blocks.map((block) => (
@@ -70,6 +72,7 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
           {...block}
           assistantId={assistantId}
           disableEditing={disableEditing}
+          disableMarkdownStreaming={block.disableMarkdownStreaming || block.id === firstBlockId}
         />
       ))}
     </Flexbox>

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -38,13 +38,19 @@ vi.mock('./WorkflowCollapse', () => ({
   default: ({
     blocks,
   }: {
-    blocks: Array<{ content: string; domId?: string; tools?: unknown[] }>;
+    blocks: Array<{
+      content: string;
+      disableMarkdownStreaming?: boolean;
+      domId?: string;
+      tools?: unknown[];
+    }>;
   }) => (
     <div
       data-testid="workflow-segment"
       data-blocks={JSON.stringify(
-        blocks.map(({ content, domId, tools }) => ({
+        blocks.map(({ content, disableMarkdownStreaming, domId, tools }) => ({
           content,
+          disableMarkdownStreaming: !!disableMarkdownStreaming,
           domId,
           toolCount: tools?.length ?? 0,
         })),
@@ -56,12 +62,14 @@ vi.mock('./WorkflowCollapse', () => ({
 vi.mock('./GroupItem', () => ({
   default: ({
     content,
+    disableMarkdownStreaming,
     domId,
     id,
     isFirstBlock,
     tools,
   }: {
     content: string;
+    disableMarkdownStreaming?: boolean;
     domId?: string;
     id: string;
     isFirstBlock?: boolean;
@@ -71,6 +79,7 @@ vi.mock('./GroupItem', () => ({
       data-testid="answer-segment"
       data-block={JSON.stringify({
         content,
+        disableMarkdownStreaming: !!disableMarkdownStreaming,
         domId,
         id,
         isFirstBlock: !!isFirstBlock,
@@ -122,6 +131,7 @@ describe('Group', () => {
 
     expect(parseAnswerSegment()).toEqual({
       content: longContent,
+      disableMarkdownStreaming: true,
       domId: 'block-1__answer',
       id: 'block-1',
       isFirstBlock: false,
@@ -130,6 +140,7 @@ describe('Group', () => {
     expect(parseWorkflowSegment()).toEqual([
       {
         content: '',
+        disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
         toolCount: 1,
       },
@@ -155,6 +166,7 @@ describe('Group', () => {
     expect(parseWorkflowSegment()).toEqual([
       {
         content: '现在我来搜索资料。',
+        disableMarkdownStreaming: true,
         domId: undefined,
         toolCount: 1,
       },

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -24,6 +24,7 @@ vi.mock('antd-style', () => ({
 
 vi.mock('../../../store', () => ({
   messageStateSelectors: {
+    isAssistantGroupItemGenerating: () => () => mockIsGenerating,
     isMessageCollapsed: () => () => mockIsCollapsed,
     isMessageGenerating: () => () => mockIsGenerating,
   },

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -293,7 +293,7 @@ const Group = memo<GroupChildrenProps>(
   }) => {
     const [isCollapsed, isGenerating] = useConversationStore((s) => [
       messageStateSelectors.isMessageCollapsed(id)(s),
-      messageStateSelectors.isMessageGenerating(id)(s),
+      messageStateSelectors.isAssistantGroupItemGenerating(id)(s),
     ]);
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
     const firstBlockId = blocks[0]?.id;

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -273,6 +273,14 @@ const partitionBlocks = (
   };
 };
 
+const withMarkdownStreamingState = (
+  block: RenderableAssistantContentBlock,
+  firstBlockId: string | undefined,
+): RenderableAssistantContentBlock => ({
+  ...block,
+  disableMarkdownStreaming: block.disableMarkdownStreaming || block.id === firstBlockId,
+});
+
 const Group = memo<GroupChildrenProps>(
   ({
     blocks,
@@ -288,6 +296,7 @@ const Group = memo<GroupChildrenProps>(
       messageStateSelectors.isMessageGenerating(id)(s),
     ]);
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
+    const firstBlockId = blocks[0]?.id;
 
     const { segments, postToolTailPromoted } = useMemo(
       () => partitionBlocks(blocks, isGenerating),
@@ -316,11 +325,13 @@ const Group = memo<GroupChildrenProps>(
               return (
                 <WorkflowCollapse
                   assistantMessageId={id}
-                  blocks={segment.blocks}
                   defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
                   disableEditing={disableEditing}
                   key={segment.blocks[0]?.renderKey ?? `${id}.workflow.${index}`}
                   workflowChromeComplete={workflowChromeComplete}
+                  blocks={segment.blocks.map((block) =>
+                    withMarkdownStreamingState(block, firstBlockId),
+                  )}
                 />
               );
             }
@@ -330,7 +341,7 @@ const Group = memo<GroupChildrenProps>(
 
             return (
               <GroupItem
-                {...item}
+                {...withMarkdownStreamingState(item, firstBlockId)}
                 assistantId={id}
                 contentId={contentId}
                 disableEditing={disableEditing}

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -17,13 +17,14 @@ const styles = createStaticStyles(({ css, cssVar }) => {
 });
 interface ContentBlockProps {
   content: string;
+  disableStreaming?: boolean;
   hasTools?: boolean;
   id: string;
 }
 
-const MessageContent = memo<ContentBlockProps>(({ content, hasTools, id }) => {
+const MessageContent = memo<ContentBlockProps>(({ content, disableStreaming, hasTools, id }) => {
   const message = normalizeThinkTags(processWithArtifact(content));
-  const markdownProps = useMarkdown(id);
+  const markdownProps = useMarkdown(id, disableStreaming);
 
   if (!content && !hasTools) return <ContentLoading id={id} />;
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -112,6 +112,7 @@ vi.mock('@/styles', () => ({
 
 vi.mock('../../../store', () => ({
   messageStateSelectors: {
+    isAssistantGroupItemGenerating: () => () => mockIsGenerating,
     isMessageGenerating: () => () => mockIsGenerating,
   },
   useConversationStore: (selector: (state: unknown) => unknown) => selector({}),

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -148,7 +148,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
     const toolsPhaseComplete = areWorkflowToolsComplete(allTools);
     const pendingInterventionPresent = useMemo(() => hasPendingIntervention(allTools), [allTools]);
     const isGenerating = useConversationStore(
-      messageStateSelectors.isMessageGenerating(assistantMessageId),
+      messageStateSelectors.isAssistantGroupItemGenerating(assistantMessageId),
     );
     /** Earliest op startTime for this message — anchors the working timer so
      *  it reflects wall-clock since the op began, not since the component mounted. */

--- a/src/features/Conversation/Messages/AssistantGroup/components/types.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/types.ts
@@ -1,6 +1,7 @@
 import type { AssistantContentBlock } from '@/types/index';
 
 export interface RenderableAssistantContentBlock extends AssistantContentBlock {
+  disableMarkdownStreaming?: boolean;
   domId?: string;
   renderKey?: string;
 }

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -17,7 +17,7 @@ const remarkPlugins = markdownElements
 
 export const useMarkdown = (id: string, disableStreaming = false): Partial<MarkdownProps> => {
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
-  const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
+  const generating = useConversationStore(messageStateSelectors.isAssistantGroupItemGenerating(id));
 
   const enableStream = !disableStreaming;
   const animated = enableStream && transitionMode === 'fadeIn' && generating;

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -15,11 +15,12 @@ const remarkPlugins = markdownElements
   .map((element: MarkdownElement) => element.remarkPlugin)
   .filter(Boolean);
 
-export const useMarkdown = (id: string): Partial<MarkdownProps> => {
+export const useMarkdown = (id: string, disableStreaming = false): Partial<MarkdownProps> => {
   const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
   const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
-  const animated = transitionMode === 'fadeIn' && generating;
+  const enableStream = !disableStreaming;
+  const animated = enableStream && transitionMode === 'fadeIn' && generating;
 
   const components = useMemo(
     () =>
@@ -38,10 +39,10 @@ export const useMarkdown = (id: string): Partial<MarkdownProps> => {
         animated,
         components,
         enableCustomFootnotes: true,
-        enableStream: true,
+        enableStream,
         rehypePlugins,
         remarkPlugins,
       }) satisfies Partial<MarkdownProps>,
-    [animated, components],
+    [animated, components, enableStream],
   );
 };

--- a/src/features/Conversation/store/selectors.test.ts
+++ b/src/features/Conversation/store/selectors.test.ts
@@ -234,6 +234,33 @@ describe('conversationSelectors', () => {
 
   describe('Message State Selectors', () => {
     describe('isMessageGenerating', () => {
+      it('only checks the requested message id', () => {
+        const store = createMockState({
+          displayMessages: [
+            {
+              children: [
+                { content: 'first', id: 'block-1' },
+                { content: 'second', id: 'block-2' },
+              ],
+              content: '',
+              id: 'group-1',
+              role: 'assistantGroup',
+            } as any,
+          ],
+          operationState: {
+            ...DEFAULT_OPERATION_STATE,
+            getMessageOperationState: (messageId) => ({
+              ...DEFAULT_MESSAGE_OPERATION_STATE,
+              isGenerating: messageId === 'block-2',
+            }),
+          },
+        });
+
+        expect(conversationSelectors.isMessageGenerating('group-1')(store)).toBe(false);
+      });
+    });
+
+    describe('isAssistantGroupItemGenerating', () => {
       it('returns true for an assistantGroup when any child block is generating', () => {
         const store = createMockState({
           displayMessages: [
@@ -256,7 +283,7 @@ describe('conversationSelectors', () => {
           },
         });
 
-        expect(conversationSelectors.isMessageGenerating('group-1')(store)).toBe(true);
+        expect(conversationSelectors.isAssistantGroupItemGenerating('group-1')(store)).toBe(true);
       });
 
       it('returns true for a child block when its assistantGroup is generating', () => {
@@ -281,7 +308,7 @@ describe('conversationSelectors', () => {
           },
         });
 
-        expect(conversationSelectors.isMessageGenerating('block-2')(store)).toBe(true);
+        expect(conversationSelectors.isAssistantGroupItemGenerating('block-2')(store)).toBe(true);
       });
     });
   });

--- a/src/features/Conversation/store/selectors.test.ts
+++ b/src/features/Conversation/store/selectors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_OPERATION_STATE } from '../types/operation';
+import { DEFAULT_MESSAGE_OPERATION_STATE, DEFAULT_OPERATION_STATE } from '../types/operation';
 import { type State } from './initialState';
 import { conversationSelectors } from './selectors';
 
@@ -228,6 +228,60 @@ describe('conversationSelectors', () => {
 
         const hookSelector = conversationSelectors.hook('onBeforeSendMessage');
         expect(hookSelector(store)).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Message State Selectors', () => {
+    describe('isMessageGenerating', () => {
+      it('returns true for an assistantGroup when any child block is generating', () => {
+        const store = createMockState({
+          displayMessages: [
+            {
+              children: [
+                { content: 'first', id: 'block-1' },
+                { content: 'second', id: 'block-2' },
+              ],
+              content: '',
+              id: 'group-1',
+              role: 'assistantGroup',
+            } as any,
+          ],
+          operationState: {
+            ...DEFAULT_OPERATION_STATE,
+            getMessageOperationState: (messageId) => ({
+              ...DEFAULT_MESSAGE_OPERATION_STATE,
+              isGenerating: messageId === 'block-2',
+            }),
+          },
+        });
+
+        expect(conversationSelectors.isMessageGenerating('group-1')(store)).toBe(true);
+      });
+
+      it('returns true for a child block when its assistantGroup is generating', () => {
+        const store = createMockState({
+          displayMessages: [
+            {
+              children: [
+                { content: 'first', id: 'block-1' },
+                { content: 'second', id: 'block-2' },
+              ],
+              content: '',
+              id: 'group-1',
+              role: 'assistantGroup',
+            } as any,
+          ],
+          operationState: {
+            ...DEFAULT_OPERATION_STATE,
+            getMessageOperationState: (messageId) => ({
+              ...DEFAULT_MESSAGE_OPERATION_STATE,
+              isGenerating: messageId === 'group-1',
+            }),
+          },
+        });
+
+        expect(conversationSelectors.isMessageGenerating('block-2')(store)).toBe(true);
       });
     });
   });

--- a/src/features/Conversation/store/slices/messageState/selectors.ts
+++ b/src/features/Conversation/store/slices/messageState/selectors.ts
@@ -60,20 +60,28 @@ const isMessageCreating = (id: string) => (s: State) =>
 /**
  * Check if a message is being generated (streaming response)
  */
-const isMessageGenerating = (id: string) => (s: State) => {
-  const isGenerating = (messageId: string) =>
-    s.operationState.getMessageOperationState(messageId).isGenerating;
+const isMessageGenerating = (id: string) => (s: State) =>
+  s.operationState.getMessageOperationState(id).isGenerating;
 
-  if (isGenerating(id)) return true;
+/**
+ * Check if an AssistantGroup root or child block is generating.
+ * A group is generating when itself or any child block has a running generation operation.
+ * A child block is generating when itself or its parent group has a running generation operation.
+ */
+const isAssistantGroupItemGenerating = (id: string) => (s: State) => {
+  if (isMessageGenerating(id)(s)) return true;
 
-  const displayMessage = s.displayMessages.find((message) => message.id === id);
-  if (displayMessage?.children?.some((block) => isGenerating(block.id))) return true;
+  const message = s.displayMessages.find((item) => item.id === id);
+  if (message?.role === 'assistantGroup') {
+    return message.children?.some((block) => isMessageGenerating(block.id)(s)) ?? false;
+  }
 
-  const parentMessage = s.displayMessages.find((message) =>
-    message.children?.some((block) => block.id === id),
+  const parentMessage = s.displayMessages.find(
+    (message) =>
+      message.role === 'assistantGroup' && message.children?.some((block) => block.id === id),
   );
 
-  return parentMessage ? isGenerating(parentMessage.id) : false;
+  return parentMessage ? isMessageGenerating(parentMessage.id)(s) : false;
 };
 
 /**
@@ -162,6 +170,7 @@ const isThreadMode = (_s: State) => {
 export const messageStateSelectors = {
   hasThreadBySourceMsgId,
   isAIGenerating,
+  isAssistantGroupItemGenerating,
   isInputLoading,
   isMessageCollapsed,
   isMessageContinuing,

--- a/src/features/Conversation/store/slices/messageState/selectors.ts
+++ b/src/features/Conversation/store/slices/messageState/selectors.ts
@@ -60,8 +60,21 @@ const isMessageCreating = (id: string) => (s: State) =>
 /**
  * Check if a message is being generated (streaming response)
  */
-const isMessageGenerating = (id: string) => (s: State) =>
-  s.operationState.getMessageOperationState(id).isGenerating;
+const isMessageGenerating = (id: string) => (s: State) => {
+  const isGenerating = (messageId: string) =>
+    s.operationState.getMessageOperationState(messageId).isGenerating;
+
+  if (isGenerating(id)) return true;
+
+  const displayMessage = s.displayMessages.find((message) => message.id === id);
+  if (displayMessage?.children?.some((block) => isGenerating(block.id))) return true;
+
+  const parentMessage = s.displayMessages.find((message) =>
+    message.children?.some((block) => block.id === id),
+  );
+
+  return parentMessage ? isGenerating(parentMessage.id) : false;
+};
 
 /**
  * Check if a message is being regenerated


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- None

#### 🔀 Description of Change

- Disable markdown streaming for the first assistant-group block so the initial content does not replay stream/fade animation when grouped blocks remount around workflow segments.
- Propagate generating state across assistant-group parents and child blocks so markdown animation decisions follow the active generating message.
- Update focused tests for assistant-group segmentation and message generating selectors.

#### 🧪 How to Test

- `bunx vitest run --silent='passed-only' src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx`
- `bunx vitest run --silent='passed-only' src/features/Conversation/store/selectors.test.ts` currently fails in isolation because the existing test environment lacks a browser-like `localStorage` implementation.
- `bun run type-check` currently fails because of unrelated pre-existing workspace type errors.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

- No related GitHub or Linear issue was identified for this scope.
