### PR TITLE
🐛 fix: omit DeepSeek reasoning effort when disabled

### DIFF
--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -259,6 +259,37 @@ describe('LobeDeepSeekAI - custom features', () => {
         });
       });
 
+      it('should remove reasoning_effort when thinking.type is disabled', () => {
+        const payload = {
+          messages: [{ role: 'user', content: 'hi' }],
+          model: 'deepseek-v4-flash',
+          reasoning_effort: 'high',
+          thinking: { type: 'disabled' },
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result).toEqual({
+          messages: [{ role: 'user', content: 'hi' }],
+          model: 'deepseek-v4-flash',
+          stream: true,
+          thinking: { type: 'disabled' },
+        });
+      });
+
+      it('should preserve reasoning_effort when thinking is enabled', () => {
+        const payload = {
+          messages: [{ role: 'user', content: 'hi' }],
+          model: 'deepseek-v4-flash',
+          reasoning_effort: 'high',
+          thinking: { type: 'enabled' },
+        };
+
+        const result = params.chatCompletion!.handlePayload!(payload as any);
+
+        expect(result.reasoning_effort).toBe('high');
+      });
+
       it('should preserve existing reasoning_content on v4 assistant messages', () => {
         const payload = {
           messages: [

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -53,9 +53,13 @@ export const params = {
         return rest;
       });
 
+      // DeepSeek rejects `reasoning_effort` when thinking is explicitly disabled.
+      const { reasoning_effort, ...restPayload } = payload;
+
       return {
-        ...payload,
+        ...restPayload,
         messages,
+        ...(!thinkingExplicitlyDisabled && reasoning_effort && { reasoning_effort }),
         stream: payload.stream ?? true,
       } as any;
     },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #14173

#### 🔀 Description of Change

- Remove `reasoning_effort` from DeepSeek chat payloads when `thinking.type` is explicitly disabled.
- Keep `reasoning_effort` unchanged when DeepSeek thinking is enabled.
- Add regression coverage for both payload shapes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime && bunx vitest run --silent=passed-only src/providers/deepseek/index.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is a provider-level payload compatibility fix. DeepSeek rejects requests that combine disabled thinking with `reasoning_effort`.
