### PR TITLE
✨ feat: add generation error business hook

### DIFF
--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -268,6 +268,7 @@
   "footer.title": "喜欢我们的产品？",
   "fullscreen": "全屏模式",
   "generation.hero.taglinePrefix": "即刻创作",
+  "generation.promptModeration.blocked": "请求内容可能违反内容政策。请调整提示词后重试",
   "getDesktopApp": "获取桌面应用",
   "historyRange": "历史范围",
   "home.suggestQuestions": "试试这些示例",

--- a/src/business/client/handleGenerationPromptModerationError.ts
+++ b/src/business/client/handleGenerationPromptModerationError.ts
@@ -1,0 +1,1 @@
+export const handleGenerationPromptModerationError = (_error: unknown) => {};

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -350,6 +350,8 @@ export default {
   'footer.title': 'Like Our Product?',
   'fullscreen': 'Full Screen Mode',
   'generation.hero.taglinePrefix': 'Start Creating with',
+  'generation.promptModeration.blocked':
+    'The request content may violate content policy. Please modify your prompt and try again.',
   'historyRange': 'History Range',
   'home.suggestQuestions': 'Try these examples',
   'import': 'Import',

--- a/src/store/image/slices/createImage/action.test.ts
+++ b/src/store/image/slices/createImage/action.test.ts
@@ -235,11 +235,15 @@ describe('CreateImageAction', () => {
         });
       });
 
-      await expect(
-        act(async () => {
+      let caught: unknown;
+      await act(async () => {
+        try {
           await result.current.createImage();
-        }),
-      ).rejects.toThrow('Service error');
+        } catch (e) {
+          caught = e;
+        }
+      });
+      expect((caught as Error)?.message).toBe('Service error');
 
       // Verify topic was created before the error
       expect(mockCreateGenerationTopic).toHaveBeenCalled();
@@ -352,11 +356,15 @@ describe('CreateImageAction', () => {
         });
       });
 
-      await expect(
-        act(async () => {
+      let caught: unknown;
+      await act(async () => {
+        try {
           await result.current.recreateImage('batch-id');
-        }),
-      ).rejects.toThrow('Service error');
+        } catch (e) {
+          caught = e;
+        }
+      });
+      expect((caught as Error)?.message).toBe('Service error');
 
       // Verify batch was removed before the error
       expect(mockRemoveGenerationBatch).toHaveBeenCalledWith('batch-id', 'active-topic-id');

--- a/src/store/image/slices/createImage/action.test.ts
+++ b/src/store/image/slices/createImage/action.test.ts
@@ -4,7 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { imageService } from '@/services/image';
 import { useImageStore } from '@/store/image';
 
+const { handleGenerationPromptModerationErrorMock } = vi.hoisted(() => ({
+  handleGenerationPromptModerationErrorMock: vi.fn(),
+}));
+
 // Mock external dependencies
+vi.mock('@/business/client/handleGenerationPromptModerationError', () => ({
+  handleGenerationPromptModerationError: handleGenerationPromptModerationErrorMock,
+}));
+
 vi.mock('@/services/image', () => ({
   imageService: {
     createImage: vi.fn().mockResolvedValue({
@@ -202,6 +210,7 @@ describe('CreateImageAction', () => {
 
       // The service should have been called before the error
       expect(mockImageService.createImage).toHaveBeenCalled();
+      expect(handleGenerationPromptModerationErrorMock).toHaveBeenCalledWith(error);
 
       // Verify prompt is NOT cleared when error occurs
       expect(result.current.parameters?.prompt).toBe('test prompt');
@@ -235,6 +244,7 @@ describe('CreateImageAction', () => {
       // Verify topic was created before the error
       expect(mockCreateGenerationTopic).toHaveBeenCalled();
       expect(mockSwitchGenerationTopic).toHaveBeenCalled();
+      expect(handleGenerationPromptModerationErrorMock).toHaveBeenCalledWith(error);
 
       // Verify prompt is NOT cleared when error occurs
       expect(result.current.parameters?.prompt).toBe('test prompt');
@@ -350,6 +360,7 @@ describe('CreateImageAction', () => {
 
       // Verify batch was removed before the error
       expect(mockRemoveGenerationBatch).toHaveBeenCalledWith('batch-id', 'active-topic-id');
+      expect(handleGenerationPromptModerationErrorMock).toHaveBeenCalledWith(error);
     });
 
     it('should handle batch removal error', async () => {

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -1,5 +1,6 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 
+import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
 import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { imageService } from '@/services/image';
 import { type StoreSetter } from '@/store/types';
@@ -105,6 +106,9 @@ export class CreateImageActionImpl {
         false,
         'createImage/clearPrompt',
       );
+    } catch (error) {
+      handleGenerationPromptModerationError(error);
+      throw error;
     } finally {
       // 8. Reset all creating states
       if (isNewTopic) {
@@ -149,6 +153,9 @@ export class CreateImageActionImpl {
 
       // 3. Refresh generation batches to show the real data
       await store.refreshGenerationBatches();
+    } catch (error) {
+      handleGenerationPromptModerationError(error);
+      throw error;
     } finally {
       this.#set({ isCreating: false }, false, 'recreateImage/endCreateImage');
     }

--- a/src/store/video/slices/createVideo/action.ts
+++ b/src/store/video/slices/createVideo/action.ts
@@ -1,6 +1,7 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { t } from 'i18next';
 
+import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
 import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { message } from '@/components/AntdStaticMethods';
 import { videoService } from '@/services/video';
@@ -117,6 +118,9 @@ export class CreateVideoActionImpl {
         false,
         'createVideo/clearPrompt',
       );
+    } catch (error) {
+      handleGenerationPromptModerationError(error);
+      throw error;
     } finally {
       // 7. Reset all creating states
       if (isNewTopic) {
@@ -154,6 +158,9 @@ export class CreateVideoActionImpl {
       });
 
       await store.refreshGenerationBatches();
+    } catch (error) {
+      handleGenerationPromptModerationError(error);
+      throw error;
     } finally {
       this.#set({ isCreating: false }, false, 'recreateVideo/end');
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8248

#### 🔀 Description of Change

- Add a minimal business hook for generation prompt moderation errors.
- Call the hook when image or video generation creation fails, while keeping the default implementation as a no-op.
- Cover image create/recreate error paths with hook invocation assertions.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `bunx eslint --fix src/business/client/handleGenerationPromptModerationError.ts src/store/image/slices/createImage/action.ts src/store/image/slices/createImage/action.test.ts src/store/video/slices/createVideo/action.ts`
- VS Code diagnostics: clean for modified files

Note: running `bunx vitest run --silent=passed-only src/store/image/slices/createImage/action.test.ts` in this local checkout currently fails during test bootstrap with `localStorage.getItem is not a function` before collecting tests.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The new submodule hook is intentionally generic and contains no cloud-specific implementation details.