### PR TITLE
🐛 fix: update DeepSeek V4 Pro discount pricing

### DIFF
--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -50,10 +50,11 @@ const deepseekChatModels: AIChatModelCard[] = [
     maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
+      // Official limited-time 75% off discount is valid until 2026-05-05 23:59 Beijing time.
       units: [
-        { name: 'textInput_cacheRead', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 24, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -45,10 +45,11 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-pro',
     maxOutput: 384_000,
     pricing: {
+      // Official limited-time 75% off discount is valid until 2026-05-05 15:59 UTC.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.145, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 1.74, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 3.48, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.03625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.435, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.87, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - follows the official DeepSeek limited-time pricing update.

#### 🔀 Description of Change

- Update `deepseek-v4-pro` pricing to the official limited-time 75% off rates.
- Add comments documenting the discount cutoff in Beijing time and UTC.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx vitest run --silent='passed-only' 'src/exports.test.ts'\nbun run build\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nOfficial pricing reference: https://api-docs.deepseek.com/quick_start/pricing\n