### PR TITLE
💄 style(electron): refine desktop tab bar dark theme surface

### DIFF
--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -75,6 +75,15 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     &:hover {
       background-color: ${cssVar.colorBgElevated};
     }
+
+    html.desktop[data-theme='dark'] & {
+      background-color: ${cssVar.colorFillSecondary};
+      box-shadow: inset 0 0 0 1px ${cssVar.colorBorderSecondary};
+
+      &:hover {
+        background-color: ${cssVar.colorFillSecondary};
+      }
+    }
   `,
   tabIcon: css`
     flex-shrink: 0;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds explicit dark-theme surface styling for the Electron desktop title bar tab strip: secondary fill background, a subtle inset border using design tokens, and a stable hover state so tabs read clearly against the dark chrome.

#### 🧪 How to Test

1. Run the desktop app and switch to dark theme.
2. Inspect the tab bar area: tabs should use the secondary fill with a light border ring; hover should not flash to an unintended color.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| (default token stacking) | Secondary fill + inset border in dark theme |

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)