### PR TITLE
🔨 chore: support key vault secret rotation fallback

### DIFF
--- a/packages/database/src/models/__tests__/apiKey.test.ts
+++ b/packages/database/src/models/__tests__/apiKey.test.ts
@@ -2,7 +2,7 @@
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { hashApiKey } from '@/utils/server/apiKeyHash';
+import { hashApiKey, hashApiKeyWithSecret } from '@/utils/server/apiKeyHash';
 
 import { getTestDB } from '../../core/getTestDB';
 import { apiKeys, users } from '../../schemas';
@@ -12,14 +12,18 @@ import { ApiKeyModel } from '../apiKey';
 const serverDB: LobeChatDatabase = await getTestDB();
 
 const userId = 'api-key-model-test-user-id';
+const legacyKeyVaultsSecret = 'Q10pwdq00KXUu9R+c8A8p4PSlIRWi7KwgUophBtkHVk=';
 const validKeyVaultsSecret = 'ofQiJCXLF8mYemwfMWLOHoHimlPu91YmLfU7YZ4lreQ=';
 
 let apiKeyModel: ApiKeyModel;
+let originalLegacyKeyVaultsSecret: string | undefined;
 let originalKeyVaultsSecret: string | undefined;
 
 beforeEach(async () => {
   originalKeyVaultsSecret = process.env.KEY_VAULTS_SECRET;
+  originalLegacyKeyVaultsSecret = process.env.LEGACY_KEY_VAULTS_SECRET;
   process.env.KEY_VAULTS_SECRET = validKeyVaultsSecret;
+  delete process.env.LEGACY_KEY_VAULTS_SECRET;
   apiKeyModel = new ApiKeyModel(serverDB, userId);
   await serverDB.delete(users);
   await serverDB.insert(users).values([{ id: userId }, { id: 'user2' }]);
@@ -29,6 +33,11 @@ afterEach(async () => {
   await serverDB.delete(users).where(eq(users.id, userId));
   await serverDB.delete(apiKeys).where(eq(apiKeys.userId, userId));
   process.env.KEY_VAULTS_SECRET = originalKeyVaultsSecret;
+  if (originalLegacyKeyVaultsSecret) {
+    process.env.LEGACY_KEY_VAULTS_SECRET = originalLegacyKeyVaultsSecret;
+  } else {
+    delete process.env.LEGACY_KEY_VAULTS_SECRET;
+  }
 });
 
 describe('ApiKeyModel', () => {
@@ -200,6 +209,24 @@ describe('ApiKeyModel', () => {
       expect(found).toBeDefined();
       expect(found?.key).toBe(validKey);
       expect(found?.name).toBe('Test Key');
+    });
+
+    it('should find API key by legacy key hash fallback', async () => {
+      const validKey = 'sk-lh-abcdef0123456789';
+      await serverDB.insert(apiKeys).values({
+        enabled: true,
+        key: validKey,
+        keyHash: hashApiKeyWithSecret(validKey, legacyKeyVaultsSecret),
+        name: 'Legacy Key',
+        userId,
+      });
+      process.env.LEGACY_KEY_VAULTS_SECRET = legacyKeyVaultsSecret;
+
+      const found = await apiKeyModel.findByKey(validKey);
+
+      expect(found).toBeDefined();
+      expect(found?.keyHash).toBe(hashApiKeyWithSecret(validKey, legacyKeyVaultsSecret));
+      expect(found?.name).toBe('Legacy Key');
     });
 
     it('should return null for invalid key format', async () => {

--- a/packages/database/src/models/apiKey.ts
+++ b/packages/database/src/models/apiKey.ts
@@ -1,5 +1,5 @@
 import { generateApiKey, isApiKeyExpired, validateApiKeyFormat } from '@lobechat/utils/apiKey';
-import { hashApiKey } from '@lobechat/utils/server';
+import { hashApiKey, hashApiKeyWithLegacySecret } from '@lobechat/utils/server';
 import { and, desc, eq } from 'drizzle-orm';
 
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
@@ -15,8 +15,17 @@ export class ApiKeyModel {
     }
     const keyHash = hashApiKey(key);
 
-    return db.query.apiKeys.findFirst({
+    const apiKey = await db.query.apiKeys.findFirst({
       where: eq(apiKeys.keyHash, keyHash),
+    });
+
+    if (apiKey) return apiKey;
+
+    const legacyKeyHash = hashApiKeyWithLegacySecret(key);
+    if (!legacyKeyHash) return;
+
+    return db.query.apiKeys.findFirst({
+      where: eq(apiKeys.keyHash, legacyKeyHash),
     });
   };
 

--- a/packages/utils/src/server/apiKeyHash.ts
+++ b/packages/utils/src/server/apiKeyHash.ts
@@ -2,6 +2,11 @@ import { createHmac } from 'node:crypto';
 
 const getApiKeyHashSecret = () => process.env.KEY_VAULTS_SECRET;
 
+const getLegacyApiKeyHashSecret = () => process.env.LEGACY_KEY_VAULTS_SECRET;
+
+export const hashApiKeyWithSecret = (apiKey: string, secret: string): string =>
+  createHmac('sha256', secret).update(apiKey).digest('hex');
+
 export const hashApiKey = (apiKey: string): string => {
   const secret = getApiKeyHashSecret();
 
@@ -9,5 +14,14 @@ export const hashApiKey = (apiKey: string): string => {
     throw new Error('`KEY_VAULTS_SECRET` is required for API key hash calculation.');
   }
 
-  return createHmac('sha256', secret).update(apiKey).digest('hex');
+  return hashApiKeyWithSecret(apiKey, secret);
+};
+
+export const hashApiKeyWithLegacySecret = (apiKey: string): string | undefined => {
+  const primarySecret = getApiKeyHashSecret();
+  const legacySecret = getLegacyApiKeyHashSecret();
+
+  if (!legacySecret || legacySecret.trim() === '' || legacySecret === primarySecret) return;
+
+  return hashApiKeyWithSecret(apiKey, legacySecret);
 };

--- a/src/app/(backend)/api/agent/gateway/start/route.ts
+++ b/src/app/(backend)/api/agent/gateway/start/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from 'next/server';
 
-import { getServerDBConfig } from '@/config/db';
+import { isKeyVaultsSecretBearerToken } from '@/server/modules/KeyVaultsEncrypt';
 import { GatewayService } from '@/server/services/gateway';
 
 export const POST = async (req: Request): Promise<Response> => {
-  const { KEY_VAULTS_SECRET } = getServerDBConfig();
-
   const authHeader = req.headers.get('authorization');
-  if (authHeader !== `Bearer ${KEY_VAULTS_SECRET}`) {
+  if (!isKeyVaultsSecretBearerToken(authHeader)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/(backend)/webapi/create-image/comfyui/route.ts
+++ b/src/app/(backend)/webapi/create-image/comfyui/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { checkAuth } from '@/app/(backend)/middleware/auth';
 import { getServerDBConfig } from '@/config/db';
 import { createCallerFactory } from '@/libs/trpc/lambda';
+import { isKeyVaultsSecretBearerToken } from '@/server/modules/KeyVaultsEncrypt';
 import { lambdaRouter } from '@/server/routers/lambda';
 
 export const maxDuration = 300;
@@ -83,7 +84,7 @@ export const POST = async (req: Request) => {
     const authorization = req.headers.get('Authorization');
 
     // If request has internal service token, bypass regular auth
-    if (authorization === `Bearer ${serverDBEnv.KEY_VAULTS_SECRET}`) {
+    if (isKeyVaultsSecretBearerToken(authorization)) {
       // Internal service call from ComfyUI provider
       // Pass a system user ID for internal service calls
       return handler(req, { jwtPayload: { userId: 'INTERNAL_SERVICE' } });

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -9,6 +9,7 @@ export const getServerDBConfig = () => {
       DATABASE_URL: process.env.DATABASE_URL,
 
       KEY_VAULTS_SECRET: process.env.KEY_VAULTS_SECRET,
+      LEGACY_KEY_VAULTS_SECRET: process.env.LEGACY_KEY_VAULTS_SECRET,
 
       REMOVE_GLOBAL_FILE: process.env.DISABLE_REMOVE_GLOBAL_FILE !== '0',
     },
@@ -18,6 +19,7 @@ export const getServerDBConfig = () => {
       DATABASE_URL: z.string().optional(),
 
       KEY_VAULTS_SECRET: z.string().optional(),
+      LEGACY_KEY_VAULTS_SECRET: z.string().optional(),
 
       REMOVE_GLOBAL_FILE: z.boolean().optional(),
     },

--- a/src/libs/oidc-provider/provider.test.ts
+++ b/src/libs/oidc-provider/provider.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/envs/app', () => ({
 vi.mock('@/config/db', () => ({
   serverDBEnv: {
     KEY_VAULTS_SECRET: 'test-secret-key',
+    LEGACY_KEY_VAULTS_SECRET: undefined,
   },
 }));
 
@@ -85,6 +86,21 @@ describe('OIDC Provider - Market Client Integration', () => {
       expect(typeof module.createOIDCProvider).toBe('function');
 
       vi.doUnmock('@/envs/app');
+    }, 10000);
+
+    it('should put primary cookie key before legacy cookie key', async () => {
+      vi.doMock('@/config/db', () => ({
+        serverDBEnv: {
+          KEY_VAULTS_SECRET: 'primary-secret-key',
+          LEGACY_KEY_VAULTS_SECRET: 'legacy-secret-key',
+        },
+      }));
+
+      const module = await import('./provider');
+
+      expect(module.getCookieKeys()).toEqual(['primary-secret-key', 'legacy-secret-key']);
+
+      vi.doUnmock('@/config/db');
     }, 10000);
   });
 

--- a/src/libs/oidc-provider/provider.ts
+++ b/src/libs/oidc-provider/provider.ts
@@ -21,11 +21,15 @@ export const API_AUDIENCE = 'urn:lobehub:chat';
 /**
  * Get cookie keys using KEY_VAULTS_SECRET
  */
-const getCookieKeys = () => {
+export const getCookieKeys = () => {
   const key = serverDBEnv.KEY_VAULTS_SECRET;
   if (!key) {
     throw new Error('KEY_VAULTS_SECRET is required for OIDC Provider cookie encryption');
   }
+
+  const legacyKey = serverDBEnv.LEGACY_KEY_VAULTS_SECRET;
+  if (legacyKey && legacyKey !== key) return [key, legacyKey];
+
   return [key];
 };
 

--- a/src/server/modules/KeyVaultsEncrypt/index.test.ts
+++ b/src/server/modules/KeyVaultsEncrypt/index.test.ts
@@ -1,22 +1,32 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { KeyVaultsGateKeeper } from './index';
+import { isKeyVaultsSecretBearerToken, KeyVaultsGateKeeper } from './index';
 
 describe('KeyVaultsGateKeeper', () => {
+  const legacySecret = 'ofQiJCXLF8mYemwfMWLOHoHimlPu91YmLfU7YZ4lreQ=';
+  const primarySecret = 'Q10pwdq00KXUu9R+c8A8p4PSlIRWi7KwgUophBtkHVk=';
   let gateKeeper: KeyVaultsGateKeeper;
+  let originalLegacySecret: string | undefined;
   let originalSecret: string | undefined;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     originalSecret = process.env.KEY_VAULTS_SECRET;
-    process.env.KEY_VAULTS_SECRET = 'Q10pwdq00KXUu9R+c8A8p4PSlIRWi7KwgUophBtkHVk=';
+    originalLegacySecret = process.env.LEGACY_KEY_VAULTS_SECRET;
+    process.env.KEY_VAULTS_SECRET = primarySecret;
+    delete process.env.LEGACY_KEY_VAULTS_SECRET;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
   });
 
   afterEach(() => {
     process.env.KEY_VAULTS_SECRET = originalSecret;
+    if (originalLegacySecret) {
+      process.env.LEGACY_KEY_VAULTS_SECRET = originalLegacySecret;
+    } else {
+      delete process.env.LEGACY_KEY_VAULTS_SECRET;
+    }
     consoleErrorSpy.mockRestore();
   });
 
@@ -56,10 +66,49 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
     );
   });
 
+  it('should throw an error if LEGACY_KEY_VAULTS_SECRET decodes to an unsupported length', async () => {
+    process.env.LEGACY_KEY_VAULTS_SECRET = Buffer.from('short').toString('base64');
+
+    await expect(KeyVaultsGateKeeper.initWithEnvKey()).rejects.toThrow(
+      '`LEGACY_KEY_VAULTS_SECRET` must be 16, 24, or 32 bytes',
+    );
+  });
+
+  it('should throw an error if LEGACY_KEY_VAULTS_SECRET equals KEY_VAULTS_SECRET', async () => {
+    process.env.LEGACY_KEY_VAULTS_SECRET = primarySecret;
+
+    await expect(KeyVaultsGateKeeper.initWithEnvKey()).rejects.toThrow(
+      '`LEGACY_KEY_VAULTS_SECRET` must be different from `KEY_VAULTS_SECRET`.',
+    );
+  });
+
   it('should throw an error for invalid encrypted data format', async () => {
     await expect(gateKeeper.decrypt('invalid-format')).rejects.toThrow(
       'Invalid encrypted data format',
     );
+  });
+
+  it('should decrypt data encrypted with LEGACY_KEY_VAULTS_SECRET fallback', async () => {
+    process.env.KEY_VAULTS_SECRET = legacySecret;
+    const legacyGateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
+    const encrypted = await legacyGateKeeper.encrypt('legacy data');
+
+    process.env.KEY_VAULTS_SECRET = primarySecret;
+    process.env.LEGACY_KEY_VAULTS_SECRET = legacySecret;
+    const rotatingGateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
+
+    await expect(rotatingGateKeeper.decrypt(encrypted)).resolves.toEqual({
+      plaintext: 'legacy data',
+      wasAuthentic: true,
+    });
+  });
+
+  it('should accept primary and legacy bearer tokens for internal service auth', () => {
+    process.env.LEGACY_KEY_VAULTS_SECRET = legacySecret;
+
+    expect(isKeyVaultsSecretBearerToken(`Bearer ${primarySecret}`)).toBe(true);
+    expect(isKeyVaultsSecretBearerToken(`Bearer ${legacySecret}`)).toBe(true);
+    expect(isKeyVaultsSecretBearerToken('Bearer invalid')).toBe(false);
   });
 
   describe('getUserKeyVaults', () => {

--- a/src/server/modules/KeyVaultsEncrypt/index.ts
+++ b/src/server/modules/KeyVaultsEncrypt/index.ts
@@ -6,39 +6,96 @@ interface DecryptionResult {
   wasAuthentic: boolean;
 }
 
-export class KeyVaultsGateKeeper {
-  private aesKey: CryptoKey;
+interface KeyVaultSecretConfig {
+  legacy?: string;
+  primary: string;
+}
 
-  constructor(aesKey: CryptoKey) {
-    this.aesKey = aesKey;
-  }
+const getConfiguredKeyVaultSecrets = () => {
+  const { KEY_VAULTS_SECRET, LEGACY_KEY_VAULTS_SECRET } = getServerDBConfig();
 
-  static initWithEnvKey = async () => {
-    const { KEY_VAULTS_SECRET } = getServerDBConfig();
-    if (!KEY_VAULTS_SECRET)
-      throw new Error(` \`KEY_VAULTS_SECRET\` is not set, please set it in your environment variables.
+  return [KEY_VAULTS_SECRET, LEGACY_KEY_VAULTS_SECRET].filter(
+    (secret): secret is string => !!secret && secret.trim() !== '',
+  );
+};
+
+const getKeyVaultSecretConfig = (): KeyVaultSecretConfig => {
+  const { KEY_VAULTS_SECRET, LEGACY_KEY_VAULTS_SECRET } = getServerDBConfig();
+  const legacySecret = LEGACY_KEY_VAULTS_SECRET?.trim() ? LEGACY_KEY_VAULTS_SECRET : undefined;
+
+  if (!KEY_VAULTS_SECRET)
+    throw new Error(` \`KEY_VAULTS_SECRET\` is not set, please set it in your environment variables.
 
 If you don't have it, please run \`openssl rand -base64 32\` to create one.
 `);
 
-    const rawKey = Buffer.from(KEY_VAULTS_SECRET, 'base64');
+  if (legacySecret && legacySecret === KEY_VAULTS_SECRET) {
+    throw new Error('`LEGACY_KEY_VAULTS_SECRET` must be different from `KEY_VAULTS_SECRET`.');
+  }
 
-    // Validate key length - AES-GCM supports 128, 192, and 256 bit keys (16, 24, or 32 bytes)
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/AesKeyGenParams#length
-    if (![16, 24, 32].includes(rawKey.length)) {
-      throw new Error(
-        `\`KEY_VAULTS_SECRET\` must be 16, 24, or 32 bytes (128, 192, or 256 bits) when base64 decoded, got ${rawKey.length} bytes. ` +
-          'Please run `openssl rand -base64 32` to create a valid key.',
-      );
-    }
-    const aesKey = await crypto.subtle.importKey(
-      'raw',
-      rawKey,
-      { length: 256, name: 'AES-GCM' },
-      false,
-      ['encrypt', 'decrypt'],
+  return legacySecret
+    ? {
+        legacy: legacySecret,
+        primary: KEY_VAULTS_SECRET,
+      }
+    : { primary: KEY_VAULTS_SECRET };
+};
+
+const importAesKey = async (secret: string, label: string) => {
+  const rawKey = Buffer.from(secret, 'base64');
+
+  if (![16, 24, 32].includes(rawKey.length)) {
+    throw new Error(
+      `\`${label}\` must be 16, 24, or 32 bytes (128, 192, or 256 bits) when base64 decoded, got ${rawKey.length} bytes. ` +
+        'Please run `openssl rand -base64 32` to create a valid key.',
     );
-    return new KeyVaultsGateKeeper(aesKey);
+  }
+
+  return crypto.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+};
+
+export const isKeyVaultsSecretBearerToken = (authorization: string | null) =>
+  getConfiguredKeyVaultSecrets().some((secret) => authorization === `Bearer ${secret}`);
+
+export class KeyVaultsGateKeeper {
+  private legacyAesKey?: CryptoKey;
+  private primaryAesKey: CryptoKey;
+
+  constructor(primaryAesKey: CryptoKey, legacyAesKey?: CryptoKey) {
+    this.primaryAesKey = primaryAesKey;
+    this.legacyAesKey = legacyAesKey;
+  }
+
+  static initWithEnvKey = async () => {
+    const { legacy, primary } = getKeyVaultSecretConfig();
+    const primaryAesKey = await importAesKey(primary, 'KEY_VAULTS_SECRET');
+    const legacyAesKey = legacy
+      ? await importAesKey(legacy, 'LEGACY_KEY_VAULTS_SECRET')
+      : undefined;
+
+    return new KeyVaultsGateKeeper(primaryAesKey, legacyAesKey);
+  };
+
+  private decryptWithKey = async (encryptedData: string, aesKey: CryptoKey) => {
+    const parts = encryptedData.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Invalid encrypted data format');
+    }
+
+    const iv = Buffer.from(parts[0], 'hex');
+    const authTag = Buffer.from(parts[1], 'hex');
+    const encrypted = Buffer.from(parts[2], 'hex');
+
+    const decryptedBuffer = await crypto.subtle.decrypt(
+      {
+        iv,
+        name: 'AES-GCM',
+      },
+      aesKey,
+      Buffer.concat([encrypted, authTag]),
+    );
+
+    return new TextDecoder().decode(decryptedBuffer);
   };
 
   /**
@@ -53,7 +110,7 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
         iv,
         name: 'AES-GCM',
       },
-      this.aesKey,
+      this.primaryAesKey,
       encodedKeyVault,
     );
 
@@ -66,34 +123,29 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
 
   // Assuming key and encrypted data are obtained from external sources
   decrypt = async (encryptedData: string): Promise<DecryptionResult> => {
-    const parts = encryptedData.split(':');
-    if (parts.length !== 3) {
+    if (encryptedData.split(':').length !== 3) {
       throw new Error('Invalid encrypted data format');
     }
 
-    const iv = Buffer.from(parts[0], 'hex');
-    const authTag = Buffer.from(parts[1], 'hex');
-    const encrypted = Buffer.from(parts[2], 'hex');
-
-    // Combine encrypted data and authentication tag
-    const combined = Buffer.concat([encrypted, authTag]);
-
     try {
-      const decryptedBuffer = await crypto.subtle.decrypt(
-        {
-          iv,
-          name: 'AES-GCM',
-        },
-        this.aesKey,
-        combined,
-      );
-
-      const decrypted = new TextDecoder().decode(decryptedBuffer);
+      const decrypted = await this.decryptWithKey(encryptedData, this.primaryAesKey);
       return {
         plaintext: decrypted,
         wasAuthentic: true,
       };
     } catch {
+      if (this.legacyAesKey) {
+        try {
+          const decrypted = await this.decryptWithKey(encryptedData, this.legacyAesKey);
+          return {
+            plaintext: decrypted,
+            wasAuthentic: true,
+          };
+        } catch {
+          // Fall through to unauthentic result when neither rotation key can decrypt.
+        }
+      }
+
       return {
         plaintext: '',
         wasAuthentic: false,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-7627

#### 🔀 Description of Change

- Add optional `LEGACY_KEY_VAULTS_SECRET` support for key vault secret rotation.
- Keep new encryption and API key hashes on `KEY_VAULTS_SECRET`, while allowing legacy fallback for existing encrypted data and API key lookup during rotation.
- Allow OIDC cookie verification and internal key-vault bearer auth to accept the legacy secret during the transition window.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/server/modules/KeyVaultsEncrypt/index.test.ts' 'src/libs/oidc-provider/provider.test.ts'
cd packages/database && bunx vitest run --silent='passed-only' 'src/models/__tests__/apiKey.test.ts'
cd .. && cd .. && bun run type-check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is a preparation change for rotating `KEY_VAULTS_SECRET`. Runtime fallback is intended to be temporary until the encrypted database fields and API key hashes are migrated.
