### PR TITLE
🐛 fix: update DeepSeek cache hit pricing

### DIFF
--- a/packages/model-bank/src/aiModels/deepseek.ts
+++ b/packages/model-bank/src/aiModels/deepseek.ts
@@ -17,8 +17,9 @@ const deepseekChatModels: AIChatModelCard[] = [
     maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -50,9 +51,10 @@ const deepseekChatModels: AIChatModelCard[] = [
     maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
-      // Official limited-time 75% off discount is valid until 2026-05-05 23:59 Beijing time.
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
+      // DeepSeek V4 Pro limited-time 75% off discount is valid until 2026-05-05 23:59 Beijing time.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -86,8 +88,9 @@ const deepseekChatModels: AIChatModelCard[] = [
     maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -111,8 +114,9 @@ const deepseekChatModels: AIChatModelCard[] = [
     maxOutput: 384_000,
     pricing: {
       currency: 'CNY',
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
       ],

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -14,8 +14,9 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-flash',
     maxOutput: 384_000,
     pricing: {
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -45,9 +46,10 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-pro',
     maxOutput: 384_000,
     pricing: {
-      // Official limited-time 75% off discount is valid until 2026-05-05 15:59 UTC.
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
+      // DeepSeek V4 Pro limited-time 75% off discount is valid until 2026-05-05 15:59 UTC.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.03625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.003625, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.435, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.87, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -79,8 +81,9 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
@@ -103,8 +106,9 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
+      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Update DeepSeek V4 Flash and compatibility alias cache-hit input pricing to the official 1/10 launch price.
- Update DeepSeek V4 Pro cache-hit input pricing while preserving the active limited-time 75% discount for non-cache input and output pricing.
- Add pricing comments for the permanent cache-hit reduction and the V4 Pro promotion cutoff.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/exports.test.ts'\nbun run build\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nPricing source: https://api-docs.deepseek.com/quick_start/pricing/