### PR TITLE
fix: clear stale agent topic on bare route

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
@@ -15,6 +15,20 @@ const useLocationMock = vi.hoisted(() => vi.fn());
 const useParamsMock = vi.hoisted(() => vi.fn());
 const useSearchParamsMock = vi.hoisted(() => vi.fn());
 
+vi.hoisted(() => {
+  const storage = {
+    clear: vi.fn(),
+    getItem: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+});
+
 vi.mock('react-router-dom', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = (await vi.importActual('react-router-dom')) as typeof import('react-router-dom');
@@ -91,6 +105,32 @@ describe('ChatHydration', () => {
       expect(navigateMock).toHaveBeenCalledWith('/agent/agt_test/tpc_123?thread=thd_456', {
         replace: true,
       });
+    });
+  });
+
+  it('clears stale topic and thread state when the route has no topic or thread', async () => {
+    useChatStore.setState(
+      {
+        activeThreadId: 'thd_previous',
+        activeTopicId: 'tpc_previous',
+      },
+      false,
+    );
+
+    useParamsMock.mockReturnValue({ aid: 'agt_next' });
+    useLocationMock.mockReturnValue({
+      hash: '',
+      pathname: '/agent/agt_next',
+      search: '',
+    });
+    useSearchParamsMock.mockReturnValue([new URLSearchParams(''), setSearchParamsMock]);
+
+    render(<ChatHydration />);
+
+    await waitFor(() => {
+      expect(useChatStore.getState().activeTopicId).toBeNull();
+      expect(useChatStore.getState().activeThreadId).toBeNull();
+      expect(navigateMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -2,11 +2,11 @@
 
 import { memo, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { createStoreUpdater } from 'zustand-utils';
 
 import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@/const/url';
 import { useQueryState } from '@/hooks/useQueryParam';
 import { useChatStore } from '@/store/chat';
+import { createStoreUpdater } from '@/store/utils/createStoreUpdater';
 
 const getSearchSuffix = (searchParams: URLSearchParams) => {
   const search = searchParams.toString();
@@ -25,8 +25,8 @@ const ChatHydration = memo(() => {
   const [thread, setThread] = useQueryState('thread', { history: 'replace', throttleMs: 500 });
   const routeTopicId = params.topicId ?? searchParams.get('topic');
 
-  useStoreUpdater('activeTopicId', routeTopicId ?? undefined);
-  useStoreUpdater('activeThreadId', thread!);
+  useStoreUpdater('activeTopicId', routeTopicId ?? null);
+  useStoreUpdater('activeThreadId', thread ?? null);
 
   const locationRef = useRef(location);
   const paramsRef = useRef(params);
@@ -84,7 +84,7 @@ const ChatHydration = memo(() => {
     const unsubscribeThread = useChatStore.subscribe(
       (s) => s.activeThreadId,
       (state) => {
-        setThread(!state ? null : state);
+        setThread(state || null);
       },
     );
 


### PR DESCRIPTION
## Summary
- clear active topic/thread state when the agent chat URL has no topic/thread params
- use the local store updater wrapper so null route state is written instead of skipped
- add regression coverage for switching to a bare /agent/:aid route after stale topic state

## Tests
- NODE_ENV=test pnpm test-app 'src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx'
- pnpm type-check
- pnpm exec eslint 'src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx' 'src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx'