### PR TITLE
🐛 fix: localize provider moderation generation errors

### DIFF
--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -268,7 +268,7 @@
   "footer.title": "喜欢我们的产品？",
   "fullscreen": "全屏模式",
   "generation.hero.taglinePrefix": "即刻创作",
-  "generation.promptModeration.blocked": "请求内容可能违反内容政策。请调整提示词后重试",
+  "generation.promptModeration.blocked": "内容安全检查未通过，请调整提示词后重试。",
   "getDesktopApp": "获取桌面应用",
   "historyRange": "历史范围",
   "home.suggestQuestions": "试试这些示例",

--- a/locales/zh-CN/error.json
+++ b/locales/zh-CN/error.json
@@ -111,6 +111,8 @@
   "response.PluginServerError": "技能服务端返回错误，请根据下方信息检查技能描述、配置或服务端实现",
   "response.PluginSettingsInvalid": "该技能需要完成配置后才能使用，请检查技能配置",
   "response.ProviderBizError": "模型服务商返回错误。请根据以下信息排查，或稍后重试",
+  "response.ProviderContentModeration": "内容安全检查未通过，请调整描述后重试。",
+  "response.ProviderContentModerationWarning": "多次触发内容安全限制，继续违规可能导致账号受限。",
   "response.QuotaLimitReached": "Token 用量或请求次数已达配额上限。请提升配额或稍后再试",
   "response.QuotaLimitReachedCloud": "当前模型服务负载较高，请稍后重试或切换其他模型。",
   "response.ServerAgentRuntimeError": "助理运行服务暂不可用。请稍后再试，或邮件联系我们",

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -465,6 +465,57 @@ describe('createRouterRuntime', () => {
       expect(mockChatSuccess).not.toHaveBeenCalled();
     });
 
+    it('should not retry when shouldStopFallback returns true', async () => {
+      const moderationError = {
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        error: { message: 'Content violates usage guidelines' },
+        provider: 'test',
+      };
+
+      const mockChatFail = vi.fn().mockRejectedValue(moderationError);
+      const mockChatSuccess = vi.fn().mockResolvedValue('success');
+      const shouldStopFallback = vi.fn().mockResolvedValue(true);
+
+      class FailRuntime implements LobeRuntimeAI {
+        chat = mockChatFail;
+      }
+
+      class SuccessRuntime implements LobeRuntimeAI {
+        chat = mockChatSuccess;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: [
+              { apiKey: 'key-1', runtime: FailRuntime as any },
+              { apiKey: 'key-2', runtime: SuccessRuntime as any },
+            ],
+            runtime: FailRuntime as any,
+            models: ['gpt-4'],
+          },
+        ],
+        shouldStopFallback,
+      });
+
+      const runtime = new Runtime();
+      await expect(
+        runtime.chat({ model: 'gpt-4', messages: [], temperature: 0.7 }),
+      ).rejects.toEqual(moderationError);
+
+      expect(shouldStopFallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: moderationError,
+          model: 'gpt-4',
+          optionIndex: 0,
+        }),
+      );
+      expect(mockChatFail).toHaveBeenCalledTimes(1);
+      expect(mockChatSuccess).not.toHaveBeenCalled();
+    });
+
     it('should still retry on other error types', async () => {
       const bizError = {
         errorType: AgentRuntimeErrorType.ProviderBizError,

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -164,6 +164,12 @@ export interface CreateRouterRuntimeOptions<T extends Record<string, any> = any>
     ) => ChatStreamPayload;
   };
   routers: Routers;
+  shouldStopFallback?: (params: {
+    error: unknown;
+    metadata?: Record<string, unknown>;
+    model: string;
+    optionIndex: number;
+  }) => boolean | Promise<boolean>;
 }
 
 export const createRouterRuntime = ({
@@ -404,6 +410,25 @@ export const createRouterRuntime = ({
             AgentRuntimeErrorType.ExceededContextWindow
           ) {
             throw error;
+          }
+
+          try {
+            const shouldStopFallback = await params.shouldStopFallback?.({
+              error,
+              metadata,
+              model,
+              optionIndex: index,
+            });
+
+            if (shouldStopFallback) {
+              throw error;
+            }
+          } catch (fallbackError) {
+            if (fallbackError === error) {
+              throw error;
+            }
+
+            log('shouldStopFallback callback error: %O', fallbackError);
           }
 
           if (attempt < totalOptions) {

--- a/packages/types/src/asyncTask.ts
+++ b/packages/types/src/asyncTask.ts
@@ -23,16 +23,17 @@ export enum AsyncTaskErrorType {
   FreePlanLimit = 'FreePlanLimit',
 
   InvalidProviderAPIKey = 'InvalidProviderAPIKey',
-  /* ↑ cloud slot ↑ */
-
   /**
    * Model not found on server
    */
   ModelNotFound = 'ModelNotFound',
+  /* ↑ cloud slot ↑ */
+
   /**
    * the chunk parse result it empty
    */
   NoChunkError = 'NoChunkError',
+  ProviderContentModeration = 'ProviderContentModeration',
   ServerError = 'ServerError',
   /**
    * Subscription plan limit reached (paid users run out of credits)

--- a/src/business/server/getProviderContentPolicyErrorMessage.ts
+++ b/src/business/server/getProviderContentPolicyErrorMessage.ts
@@ -1,0 +1,5 @@
+export const getProviderContentPolicyErrorMessage = async (_params: {
+  error: unknown;
+  provider: string;
+  userId?: string;
+}): Promise<string | undefined> => undefined;

--- a/src/business/server/trackProviderContentPolicyViolation.ts
+++ b/src/business/server/trackProviderContentPolicyViolation.ts
@@ -1,0 +1,11 @@
+export interface TrackProviderContentPolicyViolationParams {
+  error: unknown;
+  model?: string;
+  provider: string;
+  trigger?: string;
+  userId?: string;
+}
+
+export const trackProviderContentPolicyViolation = async (
+  _params: TrackProviderContentPolicyViolationParams,
+): Promise<void> => {};

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -350,8 +350,7 @@ export default {
   'footer.title': 'Like Our Product?',
   'fullscreen': 'Full Screen Mode',
   'generation.hero.taglinePrefix': 'Start Creating with',
-  'generation.promptModeration.blocked':
-    'The request content may violate content policy. Please modify your prompt and try again.',
+  'generation.promptModeration.blocked': 'Content policy check failed. Please revise your prompt.',
   'historyRange': 'History Range',
   'home.suggestQuestions': 'Try these examples',
   'import': 'Import',

--- a/src/locales/default/error.ts
+++ b/src/locales/default/error.ts
@@ -199,6 +199,10 @@ export default {
     'This skill needs to be correctly configured before it can be used. Please check if your configuration is correct',
   'response.ProviderBizError':
     'Error requesting {{provider}} service, please troubleshoot or retry based on the following information',
+  'response.ProviderContentModeration':
+    'Content policy check failed. Revise your prompt and try again.',
+  'response.ProviderContentModerationWarning':
+    'Repeated policy violations detected. Further misuse may restrict your account.',
   'response.QuotaLimitReached':
     "Sorry, the token usage or request count has reached the quota limit for this key. Please increase the key's quota or try again later.",
   'response.ServerAgentRuntimeError':

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ErrorState.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ErrorState.tsx
@@ -7,6 +7,8 @@ import { ImageOffIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { AsyncTaskErrorType } from '@/types/asyncTask';
+
 import { ActionButtons } from './ActionButtons';
 import { styles } from './styles';
 import { type ErrorStateProps } from './types';
@@ -55,7 +57,10 @@ export const ErrorState = memo<ErrorStateProps>(
 
       // Fallback to original error message
       return errorBody || error.name || 'Unknown error';
-    }, [generation.task.error, generationBatch.provider, tError]);
+    }, [generation.task.error, tError]);
+
+    const isProviderContentModerationError =
+      generation.task.error?.name === AsyncTaskErrorType.ProviderContentModeration;
 
     return (
       <Block
@@ -74,9 +79,11 @@ export const ErrorState = memo<ErrorStateProps>(
         <Center gap={8}>
           <Icon color={cssVar.colorTextDescription} icon={ImageOffIcon} size={24} />
           <Text strong align={'center'} type={'secondary'}>
-            {t('generation.status.failed')}
+            {isProviderContentModerationError
+              ? tError('response.ProviderContentModeration')
+              : t('generation.status.failed')}
           </Text>
-          {generation.task.error && (
+          {generation.task.error && !isProviderContentModerationError && (
             <Text
               code
               ellipsis={{ rows: 2 }}

--- a/src/routes/(main)/(create)/video/features/GenerationFeed/VideoErrorItem.tsx
+++ b/src/routes/(main)/(create)/video/features/GenerationFeed/VideoErrorItem.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ActionButtons } from '@/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons';
 import { styles } from '@/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/styles';
+import { AsyncTaskErrorType } from '@/types/asyncTask';
 import type { Generation } from '@/types/generation';
 
 interface VideoErrorItemProps {
@@ -54,6 +55,9 @@ const VideoErrorItem = memo<VideoErrorItemProps>(
       return errorBody || error.name || 'Unknown error';
     }, [generation.task.error, tError]);
 
+    const isProviderContentModerationError =
+      generation.task.error?.name === AsyncTaskErrorType.ProviderContentModeration;
+
     return (
       <Block
         align={'center'}
@@ -72,9 +76,11 @@ const VideoErrorItem = memo<VideoErrorItemProps>(
         <Center gap={8}>
           <Icon color={cssVar.colorTextDescription} icon={VideoOffIcon} size={24} />
           <Text strong type={'secondary'}>
-            {t('generation.status.failed')}
+            {isProviderContentModerationError
+              ? tError('response.ProviderContentModeration')
+              : t('generation.status.failed')}
           </Text>
-          {generation.task.error && (
+          {generation.task.error && !isProviderContentModerationError && (
             <Text
               code
               ellipsis={{ rows: 2 }}

--- a/src/server/routers/async/contentPolicyError.test.ts
+++ b/src/server/routers/async/contentPolicyError.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getContentPolicyErrorMessage } from './contentPolicyError';
+
+describe('getContentPolicyErrorMessage', () => {
+  it('should return a generic message for known content policy codes', () => {
+    expect(getContentPolicyErrorMessage({ code: 'content_policy_violation' })).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+    expect(getContentPolicyErrorMessage({ error: { code: 'moderation_blocked' } })).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+    expect(getContentPolicyErrorMessage({ code: 'InputTextSensitiveContentDetected' })).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+  });
+
+  it('should return a generic message for known content policy text', () => {
+    expect(getContentPolicyErrorMessage({ message: 'Blocked by content policy.' })).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+    expect(
+      getContentPolicyErrorMessage({
+        error: { message: 'Your request was rejected by the safety system.' },
+      }),
+    ).toBe('Content policy check failed. Revise your prompt and try again.');
+    expect(getContentPolicyErrorMessage({ message: 'Input contains sensitive information.' })).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+  });
+
+  it('should return undefined for unrelated provider errors', () => {
+    expect(getContentPolicyErrorMessage({ code: 'rate_limit_exceeded' })).toBeUndefined();
+    expect(getContentPolicyErrorMessage({ message: 'Network timeout' })).toBeUndefined();
+  });
+});

--- a/src/server/routers/async/contentPolicyError.ts
+++ b/src/server/routers/async/contentPolicyError.ts
@@ -1,0 +1,21 @@
+const CONTENT_POLICY_ERROR_MESSAGE =
+  'Content policy check failed. Revise your prompt and try again.';
+
+const getErrorCode = (error: any) => error?.code || error?.error?.code;
+const getErrorMessage = (error: any) => error?.message || error?.error?.message || '';
+
+export const getContentPolicyErrorMessage = (error: any) => {
+  const errorCode = getErrorCode(error);
+  const errorMessage = getErrorMessage(error).toLowerCase();
+
+  if (
+    errorCode === 'InputTextSensitiveContentDetected' ||
+    errorCode === 'content_policy_violation' ||
+    errorCode === 'moderation_blocked' ||
+    errorMessage.includes('content policy') ||
+    errorMessage.includes('safety system') ||
+    errorMessage.includes('sensitive information')
+  ) {
+    return CONTENT_POLICY_ERROR_MESSAGE;
+  }
+};

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -16,6 +16,7 @@ import debug from 'debug';
 import { type RuntimeImageGenParams } from 'model-bank';
 import { z } from 'zod';
 
+import { getProviderContentPolicyErrorMessage } from '@/business/server/getProviderContentPolicyErrorMessage';
 import { chargeAfterGenerate } from '@/business/server/image-generation/chargeAfterGenerate';
 import { notifyImageCompleted } from '@/business/server/image-generation/notifyImageCompleted';
 import { createImageBusinessMiddleware } from '@/business/server/trpc-middlewares/async';
@@ -84,6 +85,7 @@ const categorizeError = (
   error: any,
   isAborted: boolean,
   isEditingImage: boolean,
+  providerContentPolicyMessage?: string,
 ): { errorMessage: string; errorType: AsyncTaskErrorType } => {
   log('🔥🔥🔥 [ASYNC] categorizeError called:', {
     errorMessage: error?.message,
@@ -165,18 +167,9 @@ const categorizeError = (
     };
   }
 
-  // Content moderation / policy violation — return a clean, generic message
-  const errorMsg: string = error.message || error.error?.message || '';
-  const errorCode: string = error.code || error.error?.code || '';
-  if (
-    errorCode === 'InputTextSensitiveContentDetected' ||
-    errorCode === 'content_policy_violation' ||
-    errorMsg.toLowerCase().includes('content policy') ||
-    errorMsg.toLowerCase().includes('sensitive information')
-  ) {
+  if (providerContentPolicyMessage) {
     return {
-      errorMessage:
-        'The request content may violate content policy. Please modify your prompt and try again.',
+      errorMessage: providerContentPolicyMessage,
       errorType: AsyncTaskErrorType.ServerError,
     };
   }
@@ -439,10 +432,16 @@ export const imageRouter = router({
         });
 
         // Improved error categorization logic
+        const providerContentPolicyMessage = await getProviderContentPolicyErrorMessage({
+          error,
+          provider,
+          userId: ctx.userId,
+        });
         const { errorType, errorMessage } = categorizeError(
           error,
           abortController.signal.aborted,
           isEditingImage,
+          providerContentPolicyMessage,
         );
 
         await ctx.asyncTaskModel.update(taskId, {

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -29,27 +29,11 @@ import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { GenerationService } from '@/server/services/generation';
 import { sanitizeFileName } from '@/utils/sanitizeFileName';
 
+import { getContentPolicyErrorMessage } from './contentPolicyError';
+
 const log = debug('lobe-image:async');
 
 const IMAGE_URL_PREVIEW_LENGTH = 100;
-const CONTENT_POLICY_ERROR_MESSAGE =
-  'Content policy check failed. Revise your prompt and try again.';
-
-const getErrorCode = (error: any) => error?.code || error?.error?.code;
-const getErrorMessage = (error: any) => error?.message || error?.error?.message || '';
-const isContentPolicyError = (error: any) => {
-  const errorCode = getErrorCode(error);
-  const errorMessage = getErrorMessage(error).toLowerCase();
-
-  return (
-    errorCode === 'InputTextSensitiveContentDetected' ||
-    errorCode === 'content_policy_violation' ||
-    errorCode === 'moderation_blocked' ||
-    errorMessage.includes('content policy') ||
-    errorMessage.includes('safety system') ||
-    errorMessage.includes('sensitive information')
-  );
-};
 
 const imageProcedure = asyncAuthedProcedure.use(async (opts) => {
   const { ctx } = opts;
@@ -192,9 +176,10 @@ const categorizeError = (
     };
   }
 
-  if (isContentPolicyError(error)) {
+  const fallbackContentPolicyMessage = getContentPolicyErrorMessage(error);
+  if (fallbackContentPolicyMessage) {
     return {
-      errorMessage: CONTENT_POLICY_ERROR_MESSAGE,
+      errorMessage: fallbackContentPolicyMessage,
       errorType: AsyncTaskErrorType.ProviderContentModeration,
     };
   }

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -170,7 +170,7 @@ const categorizeError = (
   if (providerContentPolicyMessage) {
     return {
       errorMessage: providerContentPolicyMessage,
-      errorType: AsyncTaskErrorType.ServerError,
+      errorType: AsyncTaskErrorType.ProviderContentModeration,
     };
   }
 

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -32,6 +32,24 @@ import { sanitizeFileName } from '@/utils/sanitizeFileName';
 const log = debug('lobe-image:async');
 
 const IMAGE_URL_PREVIEW_LENGTH = 100;
+const CONTENT_POLICY_ERROR_MESSAGE =
+  'Content policy check failed. Revise your prompt and try again.';
+
+const getErrorCode = (error: any) => error?.code || error?.error?.code;
+const getErrorMessage = (error: any) => error?.message || error?.error?.message || '';
+const isContentPolicyError = (error: any) => {
+  const errorCode = getErrorCode(error);
+  const errorMessage = getErrorMessage(error).toLowerCase();
+
+  return (
+    errorCode === 'InputTextSensitiveContentDetected' ||
+    errorCode === 'content_policy_violation' ||
+    errorCode === 'moderation_blocked' ||
+    errorMessage.includes('content policy') ||
+    errorMessage.includes('safety system') ||
+    errorMessage.includes('sensitive information')
+  );
+};
 
 const imageProcedure = asyncAuthedProcedure.use(async (opts) => {
   const { ctx } = opts;
@@ -170,6 +188,13 @@ const categorizeError = (
   if (providerContentPolicyMessage) {
     return {
       errorMessage: providerContentPolicyMessage,
+      errorType: AsyncTaskErrorType.ProviderContentModeration,
+    };
+  }
+
+  if (isContentPolicyError(error)) {
+    return {
+      errorMessage: CONTENT_POLICY_ERROR_MESSAGE,
       errorType: AsyncTaskErrorType.ProviderContentModeration,
     };
   }

--- a/src/server/routers/async/video.ts
+++ b/src/server/routers/async/video.ts
@@ -8,6 +8,7 @@ import { AsyncTaskError, AsyncTaskErrorType, AsyncTaskStatus } from '@lobechat/t
 import debug from 'debug';
 import { z } from 'zod';
 
+import { getProviderContentPolicyErrorMessage } from '@/business/server/getProviderContentPolicyErrorMessage';
 import { chargeAfterGenerate } from '@/business/server/video-generation/chargeAfterGenerate';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
@@ -263,11 +264,20 @@ export const videoRouter = router({
         inferenceId,
       });
 
+      const providerContentPolicyMessage = await getProviderContentPolicyErrorMessage({
+        error,
+        provider,
+        userId: ctx.userId,
+      });
+
       await ctx.asyncTaskModel.update(asyncTaskId, {
         error: new AsyncTaskError(
-          AsyncTaskErrorType.ServerError,
-          'Background polling failed: ' +
-            (error instanceof Error ? error.message : 'Unknown error'),
+          providerContentPolicyMessage
+            ? AsyncTaskErrorType.ProviderContentModeration
+            : AsyncTaskErrorType.ServerError,
+          providerContentPolicyMessage ??
+            'Background polling failed: ' +
+              (error instanceof Error ? error.message : 'Unknown error'),
         ),
         status: AsyncTaskStatus.Error,
       });

--- a/src/server/routers/lambda/video/error.test.ts
+++ b/src/server/routers/lambda/video/error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { AsyncTaskErrorType } from '@/types/asyncTask';
+
+import { createVideoTaskSubmitError } from './error';
+
+describe('createVideoTaskSubmitError', () => {
+  it('should use task trigger error for generic submit failures', () => {
+    const error = createVideoTaskSubmitError(new Error('API timeout'));
+
+    expect(error.name).toBe(AsyncTaskErrorType.TaskTriggerError);
+    expect(error.body.detail).toBe('Failed to submit video task: API timeout');
+  });
+
+  it('should use provider moderation type for content policy failures', () => {
+    const error = createVideoTaskSubmitError(
+      new Error('rejected by safety system'),
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+
+    expect(error.name).toBe(AsyncTaskErrorType.ProviderContentModeration);
+    expect(error.body.detail).toBe(
+      'Content policy check failed. Revise your prompt and try again.',
+    );
+  });
+});

--- a/src/server/routers/lambda/video/error.ts
+++ b/src/server/routers/lambda/video/error.ts
@@ -1,0 +1,10 @@
+import { AsyncTaskError, AsyncTaskErrorType } from '@/types/asyncTask';
+
+export const createVideoTaskSubmitError = (error: unknown, providerContentPolicyMessage?: string) =>
+  new AsyncTaskError(
+    providerContentPolicyMessage
+      ? AsyncTaskErrorType.ProviderContentModeration
+      : AsyncTaskErrorType.TaskTriggerError,
+    providerContentPolicyMessage ??
+      'Failed to submit video task: ' + (error instanceof Error ? error.message : 'Unknown error'),
+  );

--- a/src/server/routers/lambda/video/index.ts
+++ b/src/server/routers/lambda/video/index.ts
@@ -29,12 +29,9 @@ import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { FileService } from '@/server/services/file';
 import { processBackgroundVideoPolling } from '@/server/services/generation/videoBackgroundPolling';
-import {
-  AsyncTaskError,
-  AsyncTaskErrorType,
-  AsyncTaskStatus,
-  AsyncTaskType,
-} from '@/types/asyncTask';
+import { AsyncTaskStatus, AsyncTaskType } from '@/types/asyncTask';
+
+import { createVideoTaskSubmitError } from './error';
 
 const log = debug('lobe-video:lambda');
 
@@ -290,13 +287,7 @@ export const videoRouter = router({
         userId,
       });
       await asyncTaskModel.update(asyncTaskId, {
-        error: new AsyncTaskError(
-          providerContentPolicyMessage
-            ? AsyncTaskErrorType.ProviderContentModeration
-            : AsyncTaskErrorType.TaskTriggerError,
-          providerContentPolicyMessage ??
-            'Failed to submit video task: ' + (e instanceof Error ? e.message : 'Unknown error'),
-        ),
+        error: createVideoTaskSubmitError(e, providerContentPolicyMessage),
         status: AsyncTaskStatus.Error,
       });
 

--- a/src/server/routers/lambda/video/index.ts
+++ b/src/server/routers/lambda/video/index.ts
@@ -10,6 +10,7 @@ import { and, eq } from 'drizzle-orm';
 import { after } from 'next/server';
 import { z } from 'zod';
 
+import { getProviderContentPolicyErrorMessage } from '@/business/server/getProviderContentPolicyErrorMessage';
 import { chargeAfterGenerate } from '@/business/server/video-generation/chargeAfterGenerate';
 import { chargeBeforeGenerate } from '@/business/server/video-generation/chargeBeforeGenerate';
 import { getVideoFreeQuota } from '@/business/server/video-generation/getVideoFreeQuota';
@@ -283,10 +284,18 @@ export const videoRouter = router({
     } catch (e) {
       console.error('Failed to submit video generation task:', e);
 
+      const providerContentPolicyMessage = await getProviderContentPolicyErrorMessage({
+        error: e,
+        provider,
+        userId,
+      });
       await asyncTaskModel.update(asyncTaskId, {
         error: new AsyncTaskError(
-          AsyncTaskErrorType.TaskTriggerError,
-          'Failed to submit video task: ' + (e instanceof Error ? e.message : 'Unknown error'),
+          providerContentPolicyMessage
+            ? AsyncTaskErrorType.ServerError
+            : AsyncTaskErrorType.TaskTriggerError,
+          providerContentPolicyMessage ??
+            'Failed to submit video task: ' + (e instanceof Error ? e.message : 'Unknown error'),
         ),
         status: AsyncTaskStatus.Error,
       });

--- a/src/server/routers/lambda/video/index.ts
+++ b/src/server/routers/lambda/video/index.ts
@@ -292,7 +292,7 @@ export const videoRouter = router({
       await asyncTaskModel.update(asyncTaskId, {
         error: new AsyncTaskError(
           providerContentPolicyMessage
-            ? AsyncTaskErrorType.ServerError
+            ? AsyncTaskErrorType.ProviderContentModeration
             : AsyncTaskErrorType.TaskTriggerError,
           providerContentPolicyMessage ??
             'Failed to submit video task: ' + (e instanceof Error ? e.message : 'Unknown error'),

--- a/src/server/services/generation/videoBackgroundPolling.ts
+++ b/src/server/services/generation/videoBackgroundPolling.ts
@@ -127,7 +127,9 @@ export async function processBackgroundVideoPolling(
     }
     await asyncTaskModel.update(asyncTaskId, {
       error: new AsyncTaskError(
-        AsyncTaskErrorType.ServerError,
+        providerContentPolicyMessage
+          ? AsyncTaskErrorType.ProviderContentModeration
+          : AsyncTaskErrorType.ServerError,
         providerContentPolicyMessage ??
           'Background polling failed: ' +
             (error instanceof Error ? error.message : 'Unknown error'),

--- a/src/server/services/generation/videoBackgroundPolling.ts
+++ b/src/server/services/generation/videoBackgroundPolling.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 
 import { getProviderContentPolicyErrorMessage } from '@/business/server/getProviderContentPolicyErrorMessage';
+import { trackProviderContentPolicyViolation } from '@/business/server/trackProviderContentPolicyViolation';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
 import type { LobeChatDatabase } from '@/database/type';
@@ -36,6 +37,7 @@ export async function processBackgroundVideoPolling(
     generationBatchId,
     generationId,
     inferenceId,
+    model,
     provider,
     userId,
   } = params;
@@ -110,6 +112,19 @@ export async function processBackgroundVideoPolling(
       provider,
       userId,
     });
+    if (providerContentPolicyMessage) {
+      try {
+        await trackProviderContentPolicyViolation({
+          error,
+          model,
+          provider,
+          trigger: 'video-polling',
+          userId,
+        });
+      } catch (trackError) {
+        log('Failed to track provider content policy violation: %O', trackError);
+      }
+    }
     await asyncTaskModel.update(asyncTaskId, {
       error: new AsyncTaskError(
         AsyncTaskErrorType.ServerError,

--- a/src/server/services/generation/videoBackgroundPolling.ts
+++ b/src/server/services/generation/videoBackgroundPolling.ts
@@ -1,5 +1,6 @@
 import debug from 'debug';
 
+import { getProviderContentPolicyErrorMessage } from '@/business/server/getProviderContentPolicyErrorMessage';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
 import type { LobeChatDatabase } from '@/database/type';
@@ -34,10 +35,7 @@ export async function processBackgroundVideoPolling(
     asyncTaskId,
     generationBatchId,
     generationId,
-    generationTopicId,
     inferenceId,
-    model,
-    prechargeResult,
     provider,
     userId,
   } = params;
@@ -107,10 +105,17 @@ export async function processBackgroundVideoPolling(
     log('Background video polling error for task: %s', asyncTaskId, error);
 
     const asyncTaskModel = new AsyncTaskModel(db, userId);
+    const providerContentPolicyMessage = await getProviderContentPolicyErrorMessage({
+      error,
+      provider,
+      userId,
+    });
     await asyncTaskModel.update(asyncTaskId, {
       error: new AsyncTaskError(
         AsyncTaskErrorType.ServerError,
-        'Background polling failed: ' + (error instanceof Error ? error.message : 'Unknown error'),
+        providerContentPolicyMessage ??
+          'Background polling failed: ' +
+            (error instanceof Error ? error.message : 'Unknown error'),
       ),
       status: AsyncTaskStatus.Error,
     });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8248

#### 🔀 Description of Change

- Add a dedicated async task error type for provider content moderation failures.
- Localize content policy messages used by generation error UI.
- Show a single actionable message for image and video generation moderation failures instead of raw technical details.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Verified with VS Code diagnostics on modified files.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This keeps provider moderation details generic and does not expose downstream business logic.