### PR TITLE
💄 style(tasks): drop custom actions on result briefs & show trigger tag in subtasks

### DIFF
--- a/packages/builtin-tool-brief/src/manifest.ts
+++ b/packages/builtin-tool-brief/src/manifest.ts
@@ -15,7 +15,7 @@ export const BriefManifest: BuiltinToolManifest = {
         properties: {
           actions: {
             description:
-              'Custom action buttons for the user. If omitted, defaults are generated based on type. Each action has key (identifier), label (display text), and type ("resolve" to close, "comment" to prompt feedback).',
+              'Custom action buttons for the user. Ignored when type is "result" (result briefs render a fixed approve button). For other types, if omitted, defaults are generated based on type. Each action has key (identifier), label (display text), and type ("resolve" to close, "comment" to prompt feedback).',
             items: {
               properties: {
                 key: { description: 'Action identifier, e.g. "approve", "split"', type: 'string' },

--- a/packages/types/src/brief/index.ts
+++ b/packages/types/src/brief/index.ts
@@ -14,7 +14,13 @@ export interface BriefAction {
   url?: string;
 }
 
-/** Default actions by brief type */
+/**
+ * Default actions by brief type.
+ *
+ * Note: `result` briefs intentionally have no defaults — they are terminal and
+ * render a fixed single-button UI (approve → completes the task). Custom
+ * actions on result briefs are dropped at creation time.
+ */
 export const DEFAULT_BRIEF_ACTIONS: Record<string, BriefAction[]> = {
   decision: [
     { key: 'approve', label: '✅ 确认', type: 'resolve' },
@@ -25,10 +31,6 @@ export const DEFAULT_BRIEF_ACTIONS: Record<string, BriefAction[]> = {
     { key: 'feedback', label: '💬 反馈', type: 'comment' },
   ],
   insight: [{ key: 'acknowledge', label: '👍 知悉', type: 'resolve' }],
-  result: [
-    { key: 'approve', label: '✅ 通过', type: 'resolve' },
-    { key: 'feedback', label: '💬 修改意见', type: 'comment' },
-  ],
 };
 
 /** Brief type — must match DEFAULT_BRIEF_ACTIONS keys and DB schema comment */

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -162,11 +162,14 @@ export interface TaskDetailSubtaskAssignee {
 
 export interface TaskDetailSubtask {
   assignee?: TaskDetailSubtaskAssignee | null;
+  automationMode?: TaskAutomationMode | null;
   blockedBy?: string;
   children?: TaskDetailSubtask[];
+  heartbeat?: { interval?: number | null };
   identifier: string;
   name?: string | null;
   priority?: number | null;
+  schedule?: { pattern?: string | null; timezone?: string | null };
   status: string;
 }
 

--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
@@ -17,6 +17,7 @@ import AssigneeAvatar from '../features/AssigneeAvatar';
 import TaskPriorityTag from '../features/TaskPriorityTag';
 import TaskStatusTag from '../features/TaskStatusTag';
 import TaskSubtaskProgressTag from '../features/TaskSubtaskProgressTag';
+import TaskTriggerTag from '../features/TaskTriggerTag';
 import { useTaskItemContextMenu } from '../features/useTaskItemContextMenu';
 import { styles } from '../shared/style';
 
@@ -88,6 +89,7 @@ const SubtaskTitle = memo<{ task: TaskDetailSubtask }>(({ task }) => {
         horizontal
         align="center"
         gap={8}
+        justify="space-between"
         style={{ lineHeight: 1, minWidth: 0, overflow: 'hidden', width: '100%' }}
       >
         <span
@@ -105,6 +107,18 @@ const SubtaskTitle = memo<{ task: TaskDetailSubtask }>(({ task }) => {
         <Text ellipsis fontSize={13} style={{ flex: 1, minWidth: 0 }}>
           {task.name || task.identifier}
         </Text>
+        {task.automationMode ? (
+          <span
+            style={{ alignItems: 'center', display: 'inline-flex', flex: 'none' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <TaskTriggerTag
+              heartbeatInterval={task.heartbeat?.interval}
+              schedulePattern={task.schedule?.pattern}
+              scheduleTimezone={task.schedule?.timezone}
+            />
+          </span>
+        ) : null}
         <AssigneeAgentSelector
           currentAgentId={task.assignee?.id ?? null}
           disabled={isRunning}

--- a/src/features/AgentTasks/shared/style.ts
+++ b/src/features/AgentTasks/shared/style.ts
@@ -61,12 +61,20 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
       overflow: hidden;
       display: flex;
+      flex: 1;
       gap: 4px;
       align-items: center;
 
+      min-width: 0;
       min-height: 36px;
 
       color: ${cssVar.colorTextSecondary};
+    }
+
+    .ant-tree-title {
+      overflow: hidden;
+      flex: 1;
+      min-width: 0;
     }
 
     .ant-tree-switcher {

--- a/src/features/Conversation/ChatInput/QueueTray.tsx
+++ b/src/features/Conversation/ChatInput/QueueTray.tsx
@@ -2,7 +2,7 @@
 
 import { ActionIcon, Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { ListEnd, Pencil, SendHorizontal, Trash2 } from 'lucide-react';
+import { ArrowUp, ListEnd, Pencil, Trash2 } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -124,7 +124,7 @@ const QueueTray = memo(() => {
             onClick={() => handleEdit(msg.id, msg.content)}
           />
           <ActionIcon
-            icon={SendHorizontal}
+            icon={ArrowUp}
             size="small"
             title={t('inputQueue.sendNow')}
             onClick={() => handleSendNow(msg)}

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -117,11 +117,16 @@ export class TaskService {
                 },
               }
             : {}),
+          automationMode: s.automationMode,
           blockedBy: depMap.get(s.id),
           children: buildSubtaskTree(s.id),
+          ...(s.heartbeatInterval != null ? { heartbeat: { interval: s.heartbeatInterval } } : {}),
           identifier: s.identifier,
           name: s.name,
           priority: s.priority,
+          ...(s.schedulePattern || s.scheduleTimezone
+            ? { schedule: { pattern: s.schedulePattern, timezone: s.scheduleTimezone } }
+            : {}),
           status: s.status,
         };
       });

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -354,13 +354,9 @@ export class TaskLifecycleService {
 
       // Max iterations reached — surface the (failed) result for human accept/retry.
       // Type is `result` so the user's `approve` action is treated as a terminal
-      // accept signal (force-pass) by BriefService.resolve.
+      // accept signal (force-pass) by BriefService.resolve. Result briefs render
+      // a fixed single-button UI, so no custom actions are persisted.
       await this.briefModel.create({
-        actions: [
-          { key: 'retry', label: '🔄 重试', type: 'resolve' as const },
-          { key: 'approve', label: '✅ 强制通过', type: 'resolve' as const },
-          { key: 'feedback', label: '💬 修改意见', type: 'comment' as const },
-        ],
         priority: 'urgent',
         summary: `Review failed after ${iteration} iteration(s) (score: ${reviewResult.overallScore}%). Suggestions: ${reviewResult.suggestions?.join('; ') || 'none'}`,
         taskId,

--- a/src/server/services/toolExecution/serverRuntimes/brief.ts
+++ b/src/server/services/toolExecution/serverRuntimes/brief.ts
@@ -23,7 +23,11 @@ const createBriefRuntime = ({
     title: string;
     type: string;
   }) => {
-    const actions = args.actions || DEFAULT_BRIEF_ACTIONS[args.type] || [];
+    // 'result' briefs are terminal — the UI hardcodes a single approve action
+    // and routes it through BriefService.resolve to complete the task. Custom
+    // actions on result briefs would be ignored, so reject them at the source.
+    const actions =
+      args.type === 'result' ? null : args.actions || DEFAULT_BRIEF_ACTIONS[args.type] || [];
 
     const brief = await briefModel.create({
       actions,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #14208.

#### 🔀 Description of Change

- **Result briefs are terminal — no custom actions.** The result brief UI hardcodes a single approve button that routes through `BriefService.resolve` to complete the task, so any `actions` array on a result brief was silently ignored. Reject them at the source: drop the `result` entry from `DEFAULT_BRIEF_ACTIONS`, force `actions = null` in the server runtime when `type === 'result'`, and remove the now-dead custom action list from the lifecycle's max-iteration brief. The tool manifest description now calls out this constraint so the agent stops emitting actions it never gets credit for.
- **Surface automation trigger on subtask rows.** Threaded `automationMode` / `heartbeat.interval` / `schedule.{pattern,timezone}` through `TaskService → TaskDetailSubtask` and rendered `TaskTriggerTag` next to the subtask name when the subtask runs in heartbeat / schedule mode. Tree title now flexes/overflows correctly so long names truncate without pushing the tag offscreen.
- **Polish.** `QueueTray` send icon swapped to `ArrowUp` for consistency with the main composer.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Trigger an auto-review with `maxIterations` reached → confirm the urgent result brief renders the fixed approve button only (no retry/feedback custom actions).
- Have an agent emit a `briefCreate` with `type: 'result'` and a custom `actions` array → confirm the brief is created with `actions = null` in DB.
- Open a task with subtasks running in heartbeat or schedule mode → confirm `TaskTriggerTag` shows next to each subtask name and long names truncate cleanly.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

No DB migration. No breaking change for existing briefs (`actions` column already nullable).