### PR TITLE
💄 style(tasks): detail polish round + heartbeat webhook fix + notif deep-link

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -155,6 +155,9 @@ export default class NotificationCtr extends ControllerModule {
         const mainWindow = this.app.browserManager.getMainWindow();
         mainWindow.show();
         mainWindow.browserWindow.focus();
+        if (params.navigate?.path) {
+          mainWindow.broadcast('navigate', params.navigate);
+        }
       });
 
       notification.on('close', () => {

--- a/packages/electron-client-ipc/src/types/notification.ts
+++ b/packages/electron-client-ipc/src/types/notification.ts
@@ -1,6 +1,12 @@
 export interface ShowDesktopNotificationParams {
   body: string;
   force?: boolean;
+  /**
+   * SPA path to navigate to when the user clicks the notification.
+   * Reuses the existing `navigate` main-broadcast pipeline, so it requires
+   * `DesktopNavigationBridge` to be mounted on the renderer side.
+   */
+  navigate?: { path: string; replace?: boolean };
   requestAttention?: boolean;
   silent?: boolean;
   title: string;

--- a/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
@@ -98,7 +98,8 @@ const CommentCard = memo<CommentCardProps>(({ activity }) => {
     <Block
       className={styles.commentCard}
       gap={8}
-      padding={12}
+      paddingBlock={12}
+      paddingInline={8}
       style={{ borderRadius: cssVar.borderRadiusLG }}
       variant={'outlined'}
     >

--- a/src/features/AgentTasks/AgentTaskDetail/TaskActivities.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskActivities.tsx
@@ -8,7 +8,6 @@ import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
-import BriefCard from '@/features/DailyBrief/BriefCard';
 import type { BriefItem } from '@/features/DailyBrief/types';
 import { useTaskStore } from '@/store/task';
 import { taskActivitySelectors, taskDetailSelectors } from '@/store/task/selectors';
@@ -16,6 +15,7 @@ import { taskActivitySelectors, taskDetailSelectors } from '@/store/task/selecto
 import { styles } from '../shared/style';
 import CommentCard from './CommentCard';
 import CommentInput from './CommentInput';
+import TaskBriefCard from './TaskBriefCard';
 import TopicCard from './TopicCard';
 
 const ROW_TYPE_ICON = {
@@ -164,9 +164,8 @@ const TaskActivities = memo(() => {
             items.map(({ activity, brief, key }) => {
               if (brief) {
                 return (
-                  <BriefCard
+                  <TaskBriefCard
                     brief={brief}
-                    enableNavigation={false}
                     key={key}
                     onAfterAddComment={refreshActiveTask}
                     onAfterResolve={refreshActiveTask}

--- a/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
@@ -1,0 +1,118 @@
+import type { TaskDetailWorkspaceNode } from '@lobechat/types';
+import { Block, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { ConfigProvider, Tree } from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { cssVar } from 'antd-style';
+import { ChevronDown, FileText, FolderClosed, Package } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useTaskStore } from '@/store/task';
+import { taskDetailSelectors } from '@/store/task/selectors';
+
+import { styles } from '../shared/style';
+
+const formatSize = (size?: number | null): string | undefined => {
+  if (size == null) return undefined;
+  if (size < 1000) return `${size} chars`;
+  return `${(size / 1000).toFixed(1)}k chars`;
+};
+
+const ArtifactTitle = memo<{ node: TaskDetailWorkspaceNode }>(({ node }) => {
+  const isFolder = (node.children?.length ?? 0) > 0;
+  const sizeLabel = formatSize(node.size);
+
+  return (
+    <Flexbox
+      horizontal
+      align="center"
+      gap={8}
+      style={{ lineHeight: 1, minWidth: 0, overflow: 'hidden', width: '100%' }}
+    >
+      <Icon
+        color={cssVar.colorTextDescription}
+        icon={isFolder ? FolderClosed : FileText}
+        size={14}
+        style={{ flex: 'none' }}
+      />
+      <Text ellipsis fontSize={13} style={{ flex: 1, minWidth: 0 }}>
+        {node.title || 'Untitled'}
+      </Text>
+      {sizeLabel && (
+        <Text style={{ color: cssVar.colorTextQuaternary, flex: 'none', fontSize: 12 }}>
+          {sizeLabel}
+        </Text>
+      )}
+      {node.sourceTaskIdentifier && (
+        <Tag size="small" style={{ flexShrink: 0 }}>
+          {node.sourceTaskIdentifier}
+        </Tag>
+      )}
+    </Flexbox>
+  );
+});
+
+const toTreeData = (nodes: TaskDetailWorkspaceNode[]): DataNode[] =>
+  nodes.map((node) => ({
+    children: node.children?.length ? toTreeData(node.children) : undefined,
+    key: node.documentId,
+    title: <ArtifactTitle node={node} />,
+  }));
+
+const TaskArtifacts = memo(() => {
+  const { t } = useTranslation('chat');
+  const workspace = useTaskStore(taskDetailSelectors.activeTaskWorkspace);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const treeData = useMemo(() => toTreeData(workspace), [workspace]);
+
+  if (workspace.length === 0) return null;
+
+  return (
+    <Flexbox gap={8}>
+      <Flexbox horizontal align="center" justify="space-between">
+        <Block
+          clickable
+          horizontal
+          align="center"
+          gap={8}
+          paddingBlock={4}
+          paddingInline={8}
+          style={{ cursor: 'pointer', width: 'fit-content' }}
+          variant="borderless"
+          onClick={() => setIsExpanded((prev) => !prev)}
+        >
+          <Icon color={cssVar.colorTextDescription} icon={Package} size={16} />
+          <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
+            {t('taskDetail.artifacts')}
+          </Text>
+          <Tag size="small">{workspace.length}</Tag>
+          <Icon
+            color={cssVar.colorTextDescription}
+            icon={ChevronDown}
+            size={14}
+            style={{
+              transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+              transition: 'transform 200ms',
+            }}
+          />
+        </Block>
+      </Flexbox>
+      {isExpanded && (
+        <ConfigProvider theme={{ components: { Tree: { titleHeight: 32 } } }}>
+          <Tree
+            blockNode
+            defaultExpandAll
+            showLine
+            className={styles.subtaskTree}
+            selectable={false}
+            switcherIcon={<Icon icon={ChevronDown} size={14} />}
+            treeData={treeData}
+          />
+        </ConfigProvider>
+      )}
+    </Flexbox>
+  );
+});
+
+export default TaskArtifacts;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -1,0 +1,48 @@
+import { Block, Flexbox, Text } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { memo } from 'react';
+
+import BriefCardActions from '@/features/DailyBrief/BriefCardActions';
+import BriefCardSummary from '@/features/DailyBrief/BriefCardSummary';
+import BriefIcon from '@/features/DailyBrief/BriefIcon';
+import { styles as briefStyles } from '@/features/DailyBrief/style';
+import type { BriefItem } from '@/features/DailyBrief/types';
+import Time from '@/routes/(main)/home/features/components/Time';
+
+interface TaskBriefCardProps {
+  brief: BriefItem;
+  onAfterAddComment?: () => void | Promise<void>;
+  onAfterResolve?: () => void | Promise<void>;
+}
+
+const TaskBriefCard = memo<TaskBriefCardProps>(({ brief, onAfterResolve, onAfterAddComment }) => {
+  return (
+    <Block
+      className={briefStyles.card}
+      gap={12}
+      padding={12}
+      style={{ borderRadius: cssVar.borderRadiusLG }}
+      variant={'outlined'}
+    >
+      <Flexbox horizontal align={'center'} gap={8} style={{ overflow: 'hidden' }}>
+        <BriefIcon size={20} type={brief.type} />
+        <Text ellipsis style={{ flex: 1 }} weight={500}>
+          {brief.title}
+        </Text>
+        <Time date={brief.createdAt} />
+      </Flexbox>
+      <BriefCardSummary summary={brief.summary} />
+      <BriefCardActions
+        actions={brief.actions}
+        briefId={brief.id}
+        briefType={brief.type}
+        resolvedAction={brief.resolvedAction}
+        taskId={brief.taskId}
+        onAfterAddComment={onAfterAddComment}
+        onAfterResolve={onAfterResolve}
+      />
+    </Block>
+  );
+});
+
+export default TaskBriefCard;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
@@ -12,6 +12,7 @@ import { taskDetailSelectors } from '@/store/task/selectors';
 
 import Breadcrumb from '../shared/Breadcrumb';
 import TaskActivities from './TaskActivities';
+import TaskArtifacts from './TaskArtifacts';
 import TaskDetailAssignee from './TaskDetailAssignee';
 import TaskDetailHeaderActions from './TaskDetailHeaderActions';
 import TaskDetailRunPauseAction from './TaskDetailRunPauseAction';
@@ -95,6 +96,7 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ agentId, taskId }) => {
               <Flexbox gap={24} style={{ paddingBottom: 120 }}>
                 <TaskInstruction />
                 <TaskSubtasks />
+                <TaskArtifacts />
                 <TaskActivities />
               </Flexbox>
             </>

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -6,17 +6,18 @@ import {
   type DropdownItem,
   DropdownMenu,
   Flexbox,
-  Icon,
   Text,
 } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import dayjs from 'dayjs';
-import { CalendarDays, Copy, ExternalLink, MoreHorizontal } from 'lucide-react';
+import { CircleDot, Copy, ExternalLink, MoreHorizontal } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
 import { useTaskStore } from '@/store/task';
 
+import { styles } from '../shared/style';
 import TopicStatusIcon from './TopicStatusIcon';
 
 const formatDuration = (ms: number): string => {
@@ -76,17 +77,39 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
     },
   ];
 
+  const isAgent = activity.author?.type === 'agent';
+
+  const avatarNode = activity.author?.avatar ? (
+    <Avatar avatar={activity.author.avatar} size={24} />
+  ) : (
+    <div className={styles.activityAvatar}>
+      <CircleDot size={12} />
+    </div>
+  );
+
   return (
     <Block
       clickable={!!activity.id}
       gap={8}
-      padding={12}
+      paddingBlock={8}
+      paddingInline={8}
       style={{ borderRadius: cssVar.borderRadiusLG }}
       variant={'outlined'}
       onClick={activity.id ? handleOpen : undefined}
     >
-      <Flexbox horizontal align={'center'} gap={12} justify={'space-between'}>
+      <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
         <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0, overflow: 'hidden' }}>
+          {isAgent && activity.author?.id ? (
+            <AgentProfilePopup
+              agent={{ avatar: activity.author.avatar, title: activity.author.name }}
+              agentId={activity.author.id}
+              trigger={'hover'}
+            >
+              {avatarNode}
+            </AgentProfilePopup>
+          ) : (
+            avatarNode
+          )}
           <TopicStatusIcon size={16} status={activity.status} />
           <Text ellipsis weight={500}>
             {activity.title}
@@ -104,21 +127,10 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
         </Flexbox>
 
         <Flexbox horizontal align={'center'} flex={'none'} gap={8}>
-          {activity.author && (
-            <Flexbox horizontal align={'center'} gap={6}>
-              {activity.author.avatar && <Avatar avatar={activity.author.avatar} size={20} />}
-              <Text fontSize={12} type={'secondary'}>
-                {activity.author.name}
-              </Text>
-            </Flexbox>
-          )}
           {startedAt && (
-            <Flexbox horizontal align={'center'} gap={4}>
-              <Icon color={cssVar.colorTextTertiary} icon={CalendarDays} size={12} />
-              <Text fontSize={12} type={'secondary'}>
-                {startedAt}
-              </Text>
-            </Flexbox>
+            <Text fontSize={12} type={'secondary'}>
+              {startedAt}
+            </Text>
           )}
           <DropdownMenu items={menuItems}>
             <ActionIcon

--- a/src/features/AgentTasks/shared/style.ts
+++ b/src/features/AgentTasks/shared/style.ts
@@ -144,16 +144,22 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   commentInputCard: css`
     padding-block: 4px;
     padding-inline: 8px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
+    border: 1px solid transparent;
     border-radius: ${cssVar.borderRadiusLG};
 
-    background: ${cssVar.colorBgElevated};
+    background: ${cssVar.colorFillTertiary};
 
-    transition: border-color 0.15s ease;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
 
-    &:hover,
+    &:hover {
+      background: ${cssVar.colorFillSecondary};
+    }
+
     &:focus-within {
       border-color: ${cssVar.colorBorder};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
 }));

--- a/src/features/DailyBrief/BriefCard.tsx
+++ b/src/features/DailyBrief/BriefCard.tsx
@@ -1,5 +1,6 @@
 import { DEFAULT_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
 import { Avatar, Block, Flexbox, Text } from '@lobehub/ui';
+import { Divider } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -80,6 +81,7 @@ const BriefCard = memo<BriefCardProps>(
           </Flexbox>
           {brief.agents.length > 0 && <AgentAvatars agents={brief.agents} />}
         </Flexbox>
+        <Divider dashed style={{ marginBlock: 0 }} />
         <BriefCardSummary summary={brief.summary} />
         <BriefCardActions
           actions={brief.actions}

--- a/src/features/DailyBrief/BriefCardSummary.tsx
+++ b/src/features/DailyBrief/BriefCardSummary.tsx
@@ -1,6 +1,5 @@
 import { Button, Flexbox, Markdown, MaskShadow } from '@lobehub/ui';
 import { useSize } from 'ahooks';
-import { Divider } from 'antd';
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from 'lucide-react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -33,7 +32,6 @@ const BriefCardSummary = memo<BriefCardSummaryProps>(({ summary }) => {
 
   return (
     <Flexbox gap={4}>
-      <Divider dashed style={{ marginTop: 0, marginBottom: 8 }} />
       {isOverflow && !expanded ? (
         <MaskShadow
           size={32}

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -531,6 +531,7 @@ export default {
   'taskSchedule.title': 'Schedule',
   'taskDetail.activities': 'Activities',
   'taskDetail.activitiesEmpty': 'No activity yet',
+  'taskDetail.artifacts': 'Artifacts',
   'taskDetail.activities.agentTag': 'Agent',
   'taskDetail.activities.fallback.brief': 'posted a brief',
   'taskDetail.activities.fallback.comment': 'left a comment',

--- a/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
@@ -25,6 +25,11 @@ const styles = createStaticStyles(({ css }) => ({
       align-items: center;
       justify-content: center;
     }
+
+    .ant-segmented-item,
+    .ant-segmented-thumb {
+      border-radius: 999px;
+    }
   `,
   icon: css`
     display: none;
@@ -121,6 +126,7 @@ const ViewSwitcher = memo(() => {
     <Segmented
       className={styles.switcher}
       options={options}
+      shape={'round'}
       size={'small'}
       value={currentTab}
       onChange={handleChange}

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Flexbox, Icon, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDown, ChevronUp, CircleArrowRight } from 'lucide-react';
-import { memo, useMemo, useState } from 'react';
+import { type KeyboardEvent, memo, useCallback, useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
@@ -18,7 +18,8 @@ const RING_CIRCUM = 2 * Math.PI * RING_RADIUS;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   collapsed: css`
-    max-height: 0;
+    grid-template-rows: 0fr;
+
     margin-block-start: 0 !important;
     padding-block: 0 !important;
     border-block-start: none !important;
@@ -26,9 +27,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     opacity: 0;
   `,
   container: css`
-    cursor: pointer;
-    user-select: none;
-
     margin-block-start: 4px;
     margin-inline: 16px;
     padding-block: 8px 10px;
@@ -46,7 +44,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextSecondary};
   `,
   expanded: css`
-    max-height: 600px;
+    grid-template-rows: 1fr;
     opacity: 1;
   `,
   header: css`
@@ -57,6 +55,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorText};
     text-overflow: ellipsis;
     white-space: nowrap;
+  `,
+  headerRow: css`
+    cursor: pointer;
+    user-select: none;
+    border-radius: 4px;
+
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimaryBorder};
+      outline-offset: 2px;
+    }
   `,
   itemRow: css`
     padding-block: 6px;
@@ -69,16 +77,21 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   listContainer: css`
-    overflow: hidden;
+    display: grid;
 
     margin-block-start: 8px;
     padding-block: 4px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
 
     transition:
-      max-height 0.25s ${cssVar.motionEaseInOut},
+      grid-template-rows 0.25s ${cssVar.motionEaseInOut},
       opacity 0.2s ${cssVar.motionEaseInOut},
+      margin-block-start 0.2s ${cssVar.motionEaseInOut},
       padding 0.2s ${cssVar.motionEaseInOut};
+  `,
+  listInner: css`
+    overflow: hidden;
+    min-height: 0;
   `,
   processingRow: css`
     display: flex;
@@ -115,6 +128,7 @@ const ProgressSection = memo(() => {
   const context = useAgentContext();
   const chatKey = messageMapKey(context);
   const dbMessages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+  const listId = useId();
 
   const progress = useMemo(
     () => normalizeTaskProgress(selectCurrentTurnTodosFromMessages(dbMessages || [])),
@@ -125,17 +139,38 @@ const ProgressSection = memo(() => {
   const total = items.length;
   const completed = items.filter((item) => item.status === 'completed').length;
 
+  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
+  const handleHeaderKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleExpanded();
+      }
+    },
+    [toggleExpanded],
+  );
+
   if (total === 0) return null;
 
   const allDone = completed === total;
   const ringColor = allDone ? cssVar.colorSuccess : cssVar.colorInfo;
   const ringOffset = RING_CIRCUM * (1 - progress.completionPercent / 100);
 
-  const toggleExpanded = () => setExpanded((prev) => !prev);
-
   return (
-    <div className={styles.container} data-testid="workspace-progress" onClick={toggleExpanded}>
-      <Flexbox horizontal align="center" gap={8} justify="space-between">
+    <div className={styles.container} data-testid="workspace-progress">
+      <Flexbox
+        horizontal
+        align="center"
+        aria-controls={listId}
+        aria-expanded={expanded}
+        className={styles.headerRow}
+        gap={8}
+        justify="space-between"
+        role="button"
+        tabIndex={0}
+        onClick={toggleExpanded}
+        onKeyDown={handleHeaderKeyDown}
+      >
         <Flexbox horizontal align="center" gap={8} style={{ flex: 1, minWidth: 0 }}>
           <svg className={styles.ring} height={RING_SIZE} width={RING_SIZE}>
             <circle
@@ -173,43 +208,48 @@ const ProgressSection = memo(() => {
         />
       </Flexbox>
 
-      <div className={cx(styles.listContainer, expanded ? styles.expanded : styles.collapsed)}>
-        {items.map((item, index) => {
-          const isCompleted = item.status === 'completed';
-          const isProcessing = item.status === 'processing';
+      <div
+        className={cx(styles.listContainer, expanded ? styles.expanded : styles.collapsed)}
+        id={listId}
+      >
+        <div className={styles.listInner}>
+          {items.map((item, index) => {
+            const isCompleted = item.status === 'completed';
+            const isProcessing = item.status === 'processing';
 
-          if (isProcessing) {
+            if (isProcessing) {
+              return (
+                <div className={cx(styles.itemRow, styles.processingRow)} key={item.id ?? index}>
+                  <Icon
+                    icon={CircleArrowRight}
+                    size={17}
+                    style={{ color: cssVar.colorTextSecondary }}
+                  />
+                  <span className={styles.textProcessing}>{item.text}</span>
+                </div>
+              );
+            }
+
             return (
-              <div className={cx(styles.itemRow, styles.processingRow)} key={item.id ?? index}>
-                <Icon
-                  icon={CircleArrowRight}
-                  size={17}
-                  style={{ color: cssVar.colorTextSecondary }}
-                />
-                <span className={styles.textProcessing}>{item.text}</span>
-              </div>
+              <Checkbox
+                backgroundColor={cssVar.colorSuccess}
+                checked={isCompleted}
+                key={item.id ?? index}
+                shape="circle"
+                style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
+                classNames={{
+                  text: cx(styles.textTodo, isCompleted && styles.textCompleted),
+                  wrapper: styles.itemRow,
+                }}
+                textProps={{
+                  type: isCompleted ? 'secondary' : undefined,
+                }}
+              >
+                {item.text}
+              </Checkbox>
             );
-          }
-
-          return (
-            <Checkbox
-              backgroundColor={cssVar.colorSuccess}
-              checked={isCompleted}
-              key={item.id ?? index}
-              shape="circle"
-              style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
-              classNames={{
-                text: cx(styles.textTodo, isCompleted && styles.textCompleted),
-                wrapper: styles.itemRow,
-              }}
-              textProps={{
-                type: isCompleted ? 'secondary' : undefined,
-              }}
-            >
-              {item.text}
-            </Checkbox>
-          );
-        })}
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ProgressSection/index.tsx
@@ -1,174 +1,217 @@
-import type { StepContextTodoStatus } from '@lobechat/types';
-import { Accordion, AccordionItem, Checkbox, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
-import { Progress } from 'antd';
+import { Checkbox, Flexbox, Icon, Tag } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { CircleArrowRight } from 'lucide-react';
-import { memo, type ReactNode, useMemo } from 'react';
+import { ChevronDown, ChevronUp, CircleArrowRight } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useIsDark } from '@/hooks/useIsDark';
 import { useChatStore } from '@/store/chat';
-import { selectTodosFromMessages } from '@/store/chat/slices/message/selectors/dbMessage';
+import { selectCurrentTurnTodosFromMessages } from '@/store/chat/slices/message/selectors/dbMessage';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { useAgentContext } from '../../useAgentContext';
 import { normalizeTaskProgress } from './taskProgressAdapter';
 
-const styles = createStaticStyles(({ css }) => ({
-  barWrap: css`
-    margin-block-end: 2px;
-    margin-inline: -16px;
+const RING_SIZE = 14;
+const RING_STROKE = 2;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUM = 2 * Math.PI * RING_RADIUS;
 
-    :where(.ant-progress-line) .ant-progress-rail {
-      border-radius: 0;
-    }
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  collapsed: css`
+    max-height: 0;
+    margin-block-start: 0 !important;
+    padding-block: 0 !important;
+    border-block-start: none !important;
+
+    opacity: 0;
   `,
-  chevron: css`
-    color: ${cssVar.colorTextQuaternary};
+  container: css`
+    cursor: pointer;
+    user-select: none;
+
+    margin-block-start: 4px;
+    margin-inline: 16px;
+    padding-block: 8px 10px;
+    padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 12px;
+
+    background: ${cssVar.colorBgElevated};
+
+    transition: all 0.2s ${cssVar.motionEaseInOut};
   `,
-  progressBadge: css`
-    color: ${cssVar.colorTextLightSolid};
-  `,
-  progressBadge_dark: css`
-    color: ${cssVar.colorBgBase};
-  `,
-  progressBadge_neutral: css`
+  count: css`
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
     color: ${cssVar.colorTextSecondary};
   `,
-  sectionTitle: css`
-    color: ${cssVar.colorTextSecondary};
+  expanded: css`
+    max-height: 600px;
+    opacity: 1;
+  `,
+  header: css`
+    overflow: hidden;
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
   `,
   itemRow: css`
     padding-block: 6px;
-    padding-inline: 0;
+    padding-inline: 4px;
+    border-block-end: 1px dashed ${cssVar.colorBorderSecondary};
+    font-size: 13px;
+
+    &:last-child {
+      border-block-end: none;
+    }
+  `,
+  listContainer: css`
+    overflow: hidden;
+
+    margin-block-start: 8px;
+    padding-block: 4px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+
+    transition:
+      max-height 0.25s ${cssVar.motionEaseInOut},
+      opacity 0.2s ${cssVar.motionEaseInOut},
+      padding 0.2s ${cssVar.motionEaseInOut};
   `,
   processingRow: css`
     display: flex;
-    gap: 7px;
+    gap: 6px;
     align-items: center;
   `,
+  ring: css`
+    transform: rotate(-90deg);
+    flex-shrink: 0;
+  `,
+  ringProgress: css`
+    transition:
+      stroke-dashoffset 240ms ease,
+      stroke 240ms ease;
+  `,
+  ringTrack: css`
+    stroke: ${cssVar.colorFillSecondary};
+  `,
   textCompleted: css`
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorTextQuaternary};
+    text-decoration: line-through;
   `,
   textProcessing: css`
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   textTodo: css`
     color: ${cssVar.colorTextSecondary};
   `,
 }));
 
-interface ReadOnlyTodoItemProps {
-  status: StepContextTodoStatus;
-  text: ReactNode;
-}
-
-const ReadOnlyTodoItem = memo<ReadOnlyTodoItemProps>(({ status, text }) => {
-  const isCompleted = status === 'completed';
-  const isProcessing = status === 'processing';
-
-  if (isProcessing) {
-    return (
-      <div className={cx(styles.itemRow, styles.processingRow)}>
-        <Icon icon={CircleArrowRight} size={17} style={{ color: cssVar.colorTextSecondary }} />
-        <span className={styles.textProcessing}>{text}</span>
-      </div>
-    );
-  }
-
-  return (
-    <Checkbox
-      backgroundColor={cssVar.colorSuccess}
-      checked={isCompleted}
-      shape={'circle'}
-      style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
-      classNames={{
-        text: cx(styles.textTodo, isCompleted && styles.textCompleted),
-        wrapper: styles.itemRow,
-      }}
-      textProps={{
-        type: isCompleted ? 'secondary' : undefined,
-      }}
-    >
-      {text}
-    </Checkbox>
-  );
-});
-
-ReadOnlyTodoItem.displayName = 'ReadOnlyTodoItem';
-
 const ProgressSection = memo(() => {
   const { t } = useTranslation('chat');
-  const isDarkMode = useIsDark();
+  const [expanded, setExpanded] = useState(true);
   const context = useAgentContext();
   const chatKey = messageMapKey(context);
   const dbMessages = useChatStore((s) => s.dbMessagesMap[chatKey]);
 
   const progress = useMemo(
-    () => normalizeTaskProgress(selectTodosFromMessages(dbMessages || [])),
+    () => normalizeTaskProgress(selectCurrentTurnTodosFromMessages(dbMessages || [])),
     [dbMessages],
   );
-  const hasTasks = progress.items.length > 0;
 
-  if (!hasTasks) return null;
+  const items = progress.items;
+  const total = items.length;
+  const completed = items.filter((item) => item.status === 'completed').length;
+
+  if (total === 0) return null;
+
+  const allDone = completed === total;
+  const ringColor = allDone ? cssVar.colorSuccess : cssVar.colorInfo;
+  const ringOffset = RING_CIRCUM * (1 - progress.completionPercent / 100);
+
+  const toggleExpanded = () => setExpanded((prev) => !prev);
 
   return (
-    <>
-      <div className={styles.barWrap}>
-        <Progress
-          percent={progress.completionPercent}
-          railColor={cssVar.colorFillTertiary}
-          showInfo={false}
-          strokeColor={cssVar.colorSuccess}
-          strokeWidth={4}
-        />
-      </div>
-      <Flexbox data-testid="workspace-progress" padding={16}>
-        <Flexbox horizontal gap={8}>
-          <Accordion defaultExpandedKeys={['progress']} gap={0}>
-            <AccordionItem
-              itemKey={'progress'}
-              paddingBlock={2}
-              paddingInline={6}
-              title={<Text strong>{t('workingPanel.progress')}</Text>}
-              styles={{
-                header: {
-                  width: 'fit-content',
-                },
-              }}
-            >
-              <div style={{ paddingTop: 2 }}>
-                {progress.items.map((item, index) => (
-                  <ReadOnlyTodoItem key={index} status={item.status} text={item.text} />
-                ))}
-              </div>
-            </AccordionItem>
-          </Accordion>
-          <Tag
-            size={'small'}
-            variant={'filled'}
-            style={{
-              background: hasTasks ? cssVar.colorSuccess : cssVar.colorFillTertiary,
-              borderRadius: 999,
-              flexShrink: 0,
-              minWidth: 42,
-              paddingInline: 8,
-              textAlign: 'center',
-            }}
-          >
-            <span
-              className={
-                hasTasks
-                  ? cx(styles.progressBadge, isDarkMode && styles.progressBadge_dark)
-                  : styles.progressBadge_neutral
-              }
-            >
-              {progress.completionPercent}%
+    <div className={styles.container} data-testid="workspace-progress" onClick={toggleExpanded}>
+      <Flexbox horizontal align="center" gap={8} justify="space-between">
+        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, minWidth: 0 }}>
+          <svg className={styles.ring} height={RING_SIZE} width={RING_SIZE}>
+            <circle
+              className={styles.ringTrack}
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              fill="none"
+              r={RING_RADIUS}
+              strokeWidth={RING_STROKE}
+            />
+            <circle
+              className={styles.ringProgress}
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              fill="none"
+              r={RING_RADIUS}
+              stroke={ringColor}
+              strokeDasharray={RING_CIRCUM}
+              strokeDashoffset={ringOffset}
+              strokeLinecap="round"
+              strokeWidth={RING_STROKE}
+            />
+          </svg>
+          <span className={styles.header}>{t('workingPanel.progress')}</span>
+          <Tag size="small" style={{ flexShrink: 0 }}>
+            <span className={styles.count}>
+              {completed}/{total}
             </span>
           </Tag>
         </Flexbox>
+        <Icon
+          icon={expanded ? ChevronUp : ChevronDown}
+          size={16}
+          style={{ color: cssVar.colorTextTertiary, flexShrink: 0 }}
+        />
       </Flexbox>
-    </>
+
+      <div className={cx(styles.listContainer, expanded ? styles.expanded : styles.collapsed)}>
+        {items.map((item, index) => {
+          const isCompleted = item.status === 'completed';
+          const isProcessing = item.status === 'processing';
+
+          if (isProcessing) {
+            return (
+              <div className={cx(styles.itemRow, styles.processingRow)} key={item.id ?? index}>
+                <Icon
+                  icon={CircleArrowRight}
+                  size={17}
+                  style={{ color: cssVar.colorTextSecondary }}
+                />
+                <span className={styles.textProcessing}>{item.text}</span>
+              </div>
+            );
+          }
+
+          return (
+            <Checkbox
+              backgroundColor={cssVar.colorSuccess}
+              checked={isCompleted}
+              key={item.id ?? index}
+              shape="circle"
+              style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
+              classNames={{
+                text: cx(styles.textTodo, isCompleted && styles.textCompleted),
+                wrapper: styles.itemRow,
+              }}
+              textProps={{
+                type: isCompleted ? 'secondary' : undefined,
+              }}
+            >
+              {item.text}
+            </Checkbox>
+          );
+        })}
+      </div>
+    </div>
   );
 });
 

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -49,7 +49,6 @@ interface SidebarItemConfig {
 
 const ALL_SIDEBAR_ITEMS: SidebarItemConfig[] = [
   { id: 'pages', labelKey: 'tab.pages', routeId: 'page' },
-  { id: 'tasks', labelKey: 'tab.tasks', routeId: 'tasks' },
   { id: 'recents', labelKey: 'recents' },
   { alwaysVisible: true, id: 'agent', labelKey: 'navPanel.agent' },
   { id: 'community', labelKey: 'tab.community', routeId: 'community' },

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -48,6 +48,7 @@ interface SidebarItemConfig {
 }
 
 const ALL_SIDEBAR_ITEMS: SidebarItemConfig[] = [
+  { id: 'tasks', labelKey: 'tab.tasks', routeId: 'tasks' },
   { id: 'pages', labelKey: 'tab.pages', routeId: 'page' },
   { id: 'recents', labelKey: 'recents' },
   { alwaysVisible: true, id: 'agent', labelKey: 'navPanel.agent' },

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -31,7 +31,7 @@ const ACCORDION_KEYS = new Set<string>([GroupKey.Recents, GroupKey.Agent]);
 
 /** Keys rendered in the header — must be excluded from the body to avoid duplicates
  * when migrating users whose persisted sidebarItems still include them. */
-const HEADER_KEYS = new Set<string>(['home', 'search', 'tasks']);
+const HEADER_KEYS = new Set<string>(['home', 'search']);
 
 const accordionComponents: Record<string, (key: string) => ReactElement> = {
   [GroupKey.Agent]: (key) => <Agent itemKey={key} key={key} />,

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -29,6 +29,10 @@ export enum GroupKey {
 
 const ACCORDION_KEYS = new Set<string>([GroupKey.Recents, GroupKey.Agent]);
 
+/** Keys rendered in the header — must be excluded from the body to avoid duplicates
+ * when migrating users whose persisted sidebarItems still include them. */
+const HEADER_KEYS = new Set<string>(['home', 'search', 'tasks']);
+
 const accordionComponents: Record<string, (key: string) => ReactElement> = {
   [GroupKey.Agent]: (key) => <Agent itemKey={key} key={key} />,
   [GroupKey.Recents]: (key) => <Recents itemKey={key} key={key} />,
@@ -83,7 +87,10 @@ const Body = memo(() => {
     [hiddenSections],
   );
 
-  const visibleKeys = useMemo(() => sidebarItems.filter(isVisible), [sidebarItems, isVisible]);
+  const visibleKeys = useMemo(
+    () => sidebarItems.filter((k) => !HEADER_KEYS.has(k) && isVisible(k)),
+    [sidebarItems, isVisible],
+  );
 
   const renderNavLink = useCallback(
     (key: string) => {

--- a/src/routes/(main)/home/_layout/Header/components/Nav.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/Nav.tsx
@@ -13,7 +13,7 @@ import { isModifierClick } from '@/utils/navigation';
 import { prefetchRoute } from '@/utils/router';
 
 /** Keys that are rendered in the header; all others are managed by Body via sidebarSectionOrder */
-const HEADER_KEYS = new Set(['home', 'search']);
+const HEADER_KEYS = new Set(['home', 'search', 'tasks']);
 
 const Nav = memo(() => {
   const tab = useActiveTabKey();
@@ -30,7 +30,7 @@ const Nav = memo(() => {
   return (
     <Flexbox gap={1} paddingInline={4}>
       {items
-        .filter((item) => HEADER_KEYS.has(item.key))
+        .filter((item) => HEADER_KEYS.has(item.key) && !item.hidden)
         .map((item) => {
           const extra = item.isNew ? newBadge : undefined;
 

--- a/src/routes/(main)/home/_layout/Header/components/Nav.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/Nav.tsx
@@ -13,7 +13,7 @@ import { isModifierClick } from '@/utils/navigation';
 import { prefetchRoute } from '@/utils/router';
 
 /** Keys that are rendered in the header; all others are managed by Body via sidebarSectionOrder */
-const HEADER_KEYS = new Set(['home', 'search', 'tasks']);
+const HEADER_KEYS = new Set(['home', 'search']);
 
 const Nav = memo(() => {
   const tab = useActiveTabKey();

--- a/src/server/services/agentEvalRun/__tests__/trajectoryMethods.test.ts
+++ b/src/server/services/agentEvalRun/__tests__/trajectoryMethods.test.ts
@@ -197,6 +197,7 @@ describe('AgentEvalRunService', () => {
               type: 'onComplete',
               webhook: {
                 body: { runId: run.id, testCaseId: testCase.id, userId },
+                delivery: 'qstash',
                 url: '/api/workflows/agent-eval-run/on-trajectory-complete',
               },
             }),

--- a/src/server/services/agentEvalRun/index.ts
+++ b/src/server/services/agentEvalRun/index.ts
@@ -567,6 +567,7 @@ export class AgentEvalRunService {
             type: 'onComplete' as const,
             webhook: {
               body: { runId, testCaseId, userId },
+              delivery: 'qstash' as const,
               url: webhookUrl,
             },
           },
@@ -708,6 +709,7 @@ export class AgentEvalRunService {
             type: 'onComplete' as const,
             webhook: {
               body: { runId, testCaseId, threadId, topicId, userId },
+              delivery: 'qstash' as const,
               url: webhookUrl,
             },
           },
@@ -987,6 +989,7 @@ export class AgentEvalRunService {
             type: 'onComplete' as const,
             webhook: {
               body: { runId, testCaseId, userId },
+              delivery: 'qstash' as const,
               url: webhookUrl,
             },
           },
@@ -1143,6 +1146,7 @@ export class AgentEvalRunService {
             type: 'onComplete' as const,
             webhook: {
               body: { runId, testCaseId, threadId, topicId, userId },
+              delivery: 'qstash' as const,
               url: webhookUrl,
             },
           },

--- a/src/server/services/taskRunner/index.ts
+++ b/src/server/services/taskRunner/index.ts
@@ -163,6 +163,7 @@ export class TaskRunnerService {
             type: 'onComplete' as const,
             webhook: {
               body: { taskId, taskIdentifier, userId },
+              delivery: 'qstash' as const,
               url: '/api/workflows/task/on-topic-complete',
             },
           },

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
@@ -1,9 +1,13 @@
 import { AgentDocumentsExecutionRuntime } from '@lobechat/builtin-tool-agent-documents/executionRuntime';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskModel } from '@/database/models/task';
+import { AgentDocumentsService } from '@/server/services/agentDocuments';
 
 import { agentDocumentsRuntime } from '../agentDocuments';
 
 vi.mock('@/server/services/agentDocuments');
+vi.mock('@/database/models/task');
 
 describe('agentDocumentsRuntime', () => {
   it('should have correct identifier', () => {
@@ -20,6 +24,101 @@ describe('agentDocumentsRuntime', () => {
     expect(() => agentDocumentsRuntime.factory({ toolManifestMap: {}, userId: 'user-1' })).toThrow(
       'userId and serverDB are required for Agent Documents execution',
     );
+  });
+});
+
+describe('agentDocumentsRuntime auto-pin to task', () => {
+  const newDoc = {
+    documentId: 'documents-row-id',
+    filename: 'daily-brief',
+    id: 'agent-doc-assoc-id',
+    title: 'Daily Brief',
+  };
+
+  let serviceImpl: {
+    copyDocumentById: ReturnType<typeof vi.fn>;
+    createDocument: ReturnType<typeof vi.fn>;
+    createForTopic: ReturnType<typeof vi.fn>;
+    upsertDocumentByFilename: ReturnType<typeof vi.fn>;
+  };
+  let pinDocument: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    serviceImpl = {
+      copyDocumentById: vi.fn().mockResolvedValue(newDoc),
+      createDocument: vi.fn().mockResolvedValue(newDoc),
+      createForTopic: vi.fn().mockResolvedValue(newDoc),
+      upsertDocumentByFilename: vi.fn().mockResolvedValue(newDoc),
+    };
+    pinDocument = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(AgentDocumentsService).mockImplementation(() => serviceImpl as any);
+    vi.mocked(TaskModel).mockImplementation(() => ({ pinDocument }) as any);
+  });
+
+  const buildContext = (taskId?: string) => ({
+    serverDB: {} as never,
+    taskId,
+    toolManifestMap: {},
+    userId: 'user-1',
+  });
+
+  it('pins newly created document when taskId is in context', async () => {
+    const runtime = agentDocumentsRuntime.factory(buildContext('task-1'));
+
+    await runtime.createDocument({ content: 'body', title: 'Daily Brief' }, { agentId: 'agent-1' });
+
+    expect(pinDocument).toHaveBeenCalledWith('task-1', 'documents-row-id', 'agent');
+  });
+
+  it('skips pin when no taskId is provided', async () => {
+    const runtime = agentDocumentsRuntime.factory(buildContext());
+
+    await runtime.createDocument({ content: 'body', title: 'Daily Brief' }, { agentId: 'agent-1' });
+
+    expect(pinDocument).not.toHaveBeenCalled();
+  });
+
+  it('pins documents created via createTopicDocument', async () => {
+    const runtime = agentDocumentsRuntime.factory(buildContext('task-1'));
+
+    await runtime.createDocument(
+      { content: 'body', target: 'currentTopic', title: 'Topic Note' },
+      { agentId: 'agent-1', topicId: 'topic-1' },
+    );
+
+    expect(pinDocument).toHaveBeenCalledWith('task-1', 'documents-row-id', 'agent');
+  });
+
+  it('pins documents produced by copyDocument', async () => {
+    const runtime = agentDocumentsRuntime.factory(buildContext('task-1'));
+
+    await runtime.copyDocument(
+      { id: 'agent-doc-assoc-id', newTitle: 'Copy' },
+      { agentId: 'agent-1' },
+    );
+
+    expect(pinDocument).toHaveBeenCalledWith('task-1', 'documents-row-id', 'agent');
+  });
+
+  it('pins documents produced by upsertDocumentByFilename', async () => {
+    const runtime = agentDocumentsRuntime.factory(buildContext('task-1'));
+
+    await runtime.upsertDocumentByFilename(
+      { content: 'body', filename: 'daily-brief.md' },
+      { agentId: 'agent-1' },
+    );
+
+    expect(pinDocument).toHaveBeenCalledWith('task-1', 'documents-row-id', 'agent');
+  });
+
+  it('does not pin when service returns undefined (e.g. copy of missing doc)', async () => {
+    serviceImpl.copyDocumentById.mockResolvedValue(undefined);
+    const runtime = agentDocumentsRuntime.factory(buildContext('task-1'));
+
+    await runtime.copyDocument({ id: 'missing' }, { agentId: 'agent-1' });
+
+    expect(pinDocument).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/toolExecution/serverRuntimes/agentDocuments.ts
+++ b/src/server/services/toolExecution/serverRuntimes/agentDocuments.ts
@@ -2,6 +2,7 @@ import type { DocumentLoadRule } from '@lobechat/agent-templates';
 import { AgentDocumentsIdentifier } from '@lobechat/builtin-tool-agent-documents';
 import { AgentDocumentsExecutionRuntime } from '@lobechat/builtin-tool-agent-documents/executionRuntime';
 
+import { TaskModel } from '@/database/models/task';
 import { AgentDocumentsService } from '@/server/services/agentDocuments';
 
 import { type ServerRuntimeRegistration } from './types';
@@ -13,13 +14,23 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
     }
 
     const service = new AgentDocumentsService(context.serverDB, context.userId);
+    const taskModel = new TaskModel(context.serverDB, context.userId);
+    const { taskId } = context;
+
+    const pinToTask = async <T extends { documentId?: string } | undefined>(doc: T): Promise<T> => {
+      if (taskId && doc?.documentId) {
+        await taskModel.pinDocument(taskId, doc.documentId, 'agent');
+      }
+      return doc;
+    };
 
     return new AgentDocumentsExecutionRuntime({
-      copyDocument: ({ agentId, id, newTitle }) => service.copyDocumentById(id, newTitle, agentId),
-      createDocument: ({ agentId, content, title }) =>
-        service.createDocument(agentId, title, content),
-      createTopicDocument: ({ agentId, content, title, topicId }) =>
-        service.createForTopic(agentId, title, content, topicId),
+      copyDocument: async ({ agentId, id, newTitle }) =>
+        pinToTask(await service.copyDocumentById(id, newTitle, agentId)),
+      createDocument: async ({ agentId, content, title }) =>
+        pinToTask(await service.createDocument(agentId, title, content)),
+      createTopicDocument: async ({ agentId, content, title, topicId }) =>
+        pinToTask(await service.createForTopic(agentId, title, content, topicId)),
       editDocument: ({ agentId, content, id }) => service.editDocumentById(id, content, agentId),
       listDocuments: async ({ agentId }) => {
         const docs = await service.listDocuments(agentId);
@@ -53,8 +64,8 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
           { ...rule, rule: rule.rule as DocumentLoadRule | undefined },
           agentId,
         ),
-      upsertDocumentByFilename: ({ agentId, content, filename }) =>
-        service.upsertDocumentByFilename({ agentId, content, filename }),
+      upsertDocumentByFilename: async ({ agentId, content, filename }) =>
+        pinToTask(await service.upsertDocumentByFilename({ agentId, content, filename })),
     });
   },
   identifier: AgentDocumentsIdentifier,

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -29,6 +29,7 @@ import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgen
 import { messageService } from '@/services/message';
 import { threadService } from '@/services/thread';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
+import { resolveNotificationNavigatePath } from '@/store/chat/utils/desktopNotification';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { messageMapKey } from '../../../utils/messageMapKey';
@@ -43,12 +44,21 @@ const generateThreadId = () => `thd_${createNanoId(16)()}`;
  * Notification only shows when the window is hidden (enforced in main); the
  * badge is always set so a minimized/backgrounded app still signals completion.
  */
-const notifyCompletion = async (title: string, body: string) => {
+const notifyCompletion = async (title: string, body: string, context: ConversationContext) => {
   if (!isDesktop) return;
   try {
     const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
+    const navigatePath = resolveNotificationNavigatePath({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      topicId: context.topicId,
+    });
     await Promise.allSettled([
-      desktopNotificationService.showNotification({ body, title }),
+      desktopNotificationService.showNotification({
+        body,
+        navigate: navigatePath ? { path: navigatePath } : undefined,
+        title,
+      }),
       desktopNotificationService.setBadgeCount(1),
     ]);
   } catch (error) {
@@ -1719,7 +1729,11 @@ export const executeHeterogeneousAgent = async (
           const body = accumulatedContent
             ? markdownToTxt(accumulatedContent)
             : t('notification.finishChatGeneration', { ns: 'electron' });
-          notifyCompletion(t('notification.finishChatGeneration', { ns: 'electron' }), body);
+          notifyCompletion(
+            t('notification.finishChatGeneration', { ns: 'electron' }),
+            body,
+            context,
+          );
         }
       },
 

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -30,7 +30,10 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { createAgentExecutors } from '@/store/chat/agents/createAgentExecutors';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/aiChat/actions/agentSignalBridge';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
-import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
+import {
+  notifyDesktopHumanApprovalRequired,
+  resolveNotificationNavigatePath,
+} from '@/store/chat/utils/desktopNotification';
 import { getTaskStoreState } from '@/store/task';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { type StoreSetter } from '@/store/types';
@@ -846,8 +849,11 @@ export class StreamingExecutorActionImpl {
             if (agentMeta?.title) notificationTitle = agentMeta.title;
           }
 
+          const navigatePath = resolveNotificationNavigatePath({ agentId, groupId, topicId });
+
           await desktopNotificationService.showNotification({
             body: markdownToTxt(lastAssistant.content),
+            navigate: navigatePath ? { path: navigatePath } : undefined,
             title: notificationTitle,
           });
         }

--- a/src/store/chat/utils/desktopNotification.ts
+++ b/src/store/chat/utils/desktopNotification.ts
@@ -1,4 +1,9 @@
-import { isDesktop } from '@lobechat/const';
+import {
+  GROUP_CHAT_URL,
+  isDesktop,
+  SESSION_CHAT_TOPIC_URL,
+  SESSION_CHAT_URL,
+} from '@lobechat/const';
 import type { ConversationContext } from '@lobechat/types';
 import { t } from 'i18next';
 
@@ -8,11 +13,28 @@ import type { ChatStore } from '@/store/chat/store';
 
 import { topicMapKey } from './topicMapKey';
 
-interface DesktopNotificationContext {
+export interface DesktopNotificationContext {
   agentId?: ConversationContext['agentId'];
   groupId?: ConversationContext['groupId'];
   topicId?: ConversationContext['topicId'];
 }
+
+/**
+ * Resolve the SPA path that should be opened when the user clicks a desktop
+ * notification, based on the conversation context. Group chats land on the
+ * group root (topic is selected from store), 1:1 chats deep-link to the
+ * specific topic.
+ */
+export const resolveNotificationNavigatePath = (
+  context: DesktopNotificationContext,
+): string | undefined => {
+  if (context.groupId) return GROUP_CHAT_URL(context.groupId);
+  if (context.agentId && context.topicId) {
+    return SESSION_CHAT_TOPIC_URL(context.agentId, context.topicId);
+  }
+  if (context.agentId) return SESSION_CHAT_URL(context.agentId);
+  return undefined;
+};
 
 const resolveNotificationTitle = (
   get: () => ChatStore,
@@ -47,11 +69,14 @@ export const notifyDesktopHumanApprovalRequired = async (
     const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
     const title = resolveNotificationTitle(get, context);
 
+    const navigatePath = resolveNotificationNavigatePath(context);
+
     await Promise.allSettled([
       desktopNotificationService.setBadgeCount(1),
       desktopNotificationService.showNotification({
         body: t('desktopNotification.humanApprovalRequired.body', { ns: 'chat' }),
         force: true,
+        navigate: navigatePath ? { path: navigatePath } : undefined,
         requestAttention: true,
         title,
       }),

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -122,15 +122,7 @@ describe('systemStatusSelectors', () => {
       });
       const items = systemStatusSelectors.sidebarItems(s);
       // accordion slot in the default list now uses the user's legacy order
-      expect(items).toEqual([
-        'pages',
-        'tasks',
-        'agent',
-        'recents',
-        'community',
-        'resource',
-        'memory',
-      ]);
+      expect(items).toEqual(['pages', 'agent', 'recents', 'community', 'resource', 'memory']);
     });
 
     it('should fall back to default when legacy `sidebarSectionOrder` is the default order', () => {

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -122,7 +122,15 @@ describe('systemStatusSelectors', () => {
       });
       const items = systemStatusSelectors.sidebarItems(s);
       // accordion slot in the default list now uses the user's legacy order
-      expect(items).toEqual(['pages', 'agent', 'recents', 'community', 'resource', 'memory']);
+      expect(items).toEqual([
+        'tasks',
+        'pages',
+        'agent',
+        'recents',
+        'community',
+        'resource',
+        'memory',
+      ]);
     });
 
     it('should fall back to default when legacy `sidebarSectionOrder` is the default order', () => {

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -45,7 +45,6 @@ const hiddenSidebarSections = (s: GlobalState): string[] =>
 
 export const DEFAULT_SIDEBAR_ITEMS: string[] = [
   'pages',
-  'tasks',
   'recents',
   'agent',
   'community',

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -44,6 +44,7 @@ const hiddenSidebarSections = (s: GlobalState): string[] =>
   s.status.hiddenSidebarSections ?? DEFAULT_HIDDEN_SECTIONS;
 
 export const DEFAULT_SIDEBAR_ITEMS: string[] = [
+  'tasks',
   'pages',
   'recents',
   'agent',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 💄 style
- [x] 🐛 fix
- [x] ♿ a11y

#### 🔗 Related Issue

- LOBE-8303 (heartbeat onTopicComplete webhook silently rejected by qstashAuth)

#### 🔀 Description of Change

Bundle of 11 commits on the task detail / progress UI plus two adjacent fixes that surfaced along the way. Roughly grouped:

**Tasks detail page**

- ✨ Render the task workspace as a collapsible artifact tree (`TaskArtifacts`).
- ✨ Auto-pin agent-created documents to the current task via `agentDocumentsRuntime` → `taskDocuments`. Idempotent via existing unique constraint.
- 💄 Split a dedicated `TaskBriefCard` for the detail timeline so brief styling there can diverge from the daily-brief card without conditionals.
- 💄 Promote the agent avatar (with profile popup) to the `TopicCard` header, drop the redundant author chip and calendar icon next to the timestamp.
- 💄 Move the dashed divider from `BriefCardSummary` into `BriefCard` so any consumer of the summary block doesn't get an unexpected leading rule.
- 💄 Tighten `CommentCard` / `TopicCard` padding to align with the timeline rhythm.
- 💄 Switch the comment input from a bordered card on `colorBgElevated` (which read as outline-only in light mode) to `colorFillTertiary` filled card.

**Workspace progress alignment**

- ✨ Switch the right-side `ProgressSection` to `selectCurrentTurnTodosFromMessages` so it appears / disappears in lockstep with the `TodoProgress` bar above `ChatInput`, instead of lingering on stale historical todos.
- ♿ Restore keyboard toggle (role=button, tabIndex, aria-expanded, Enter/Space) and replace the `max-height: 600px` cap with the `grid-template-rows: 0fr → 1fr` pattern so long todo plans aren't clipped.

**Sidebar placement**

- 💄 Move the `tasks` tab back into the customizable body sidebar (reverts the earlier header-promotion in this same branch — gives users control over placement / visibility).

**Other surfaces**

- ✨ Desktop notification deep-link: resolve the SPA path (group / 1:1 topic / agent root) from the conversation context, forward through the existing main-broadcast `navigate` pipeline so clicking the notification brings the user back to the originating chat instead of just focusing the window.
- 💄 Round the `ant-segmented-item` corners in the agent header `ViewSwitcher`.

**🐛 LOBE-8303 fix**

The `onTopicComplete` hook in `taskRunner` was registered without `delivery: 'qstash'`, defaulting to plain fetch. The target route `/api/workflows/task/on-topic-complete` is mounted under `qstashAuth()`, which rejects unsigned requests with 401 in production. `HookDispatcher.fetchDeliver` only logs failures, so the webhook silently failed — leaving `task_topic.status` stuck at `'running'` forever for every heartbeat (and regular) task in production.

Verified against production DB via `lobehub-analysis-cli`: agent reached the finish executor (cleared `runningOperation`) but `tasks.last_heartbeat_at` was never updated past startup and `tasks.context` remained empty — proving `onTopicComplete` was never invoked.

Local dev / Electron never reproduced because `QSTASH_CURRENT_SIGNING_KEY` is unset → `qstashAuth` middleware skips the check.

Same fix mirrored to all four `agentEvalRun` webhook registrations for consistency (those routes are currently unauth, so they were never broken — the change just unifies the pattern).

#### 🧪 How to Test

- [x] Tested locally (UI polish, notification deep-link, sidebar placement)
- [x] Added/updated tests (`agentEvalRun/__tests__/trajectoryMethods.test.ts` updated for the new `delivery` field)
- [ ] No tests needed for the rest

Steps:

1. **Workspace progress** — trigger an agent turn that produces todos. Both the chat-input progress bar and the right-side resources progress should appear together; sending a new user message should clear both in lockstep.
2. **Artifacts panel** — open a task detail with workspace docs; collapse / expand the new tree.
3. **Docs auto-pin** — have an agent create a document inside a task; confirm it shows up in the artifacts tree without manual pinning.
4. **Heartbeat lifecycle** (after merge to canary, in cloud env): create a task with `automationMode: 'heartbeat'`, run a topic. Verify `task_topics.status` transitions to `'completed'` after the agent finishes and `tasks.last_heartbeat_at` gets refreshed past the agent completion timestamp.
5. **Notification deep-link** — trigger a finished-chat notification while the desktop window is hidden / minimized. Click it; window should focus AND navigate to the source topic / group / agent.
6. **Sidebar tasks tab** — verify the tasks entry shows in the customizable body sidebar by default, and can be hidden / reordered via `CustomizeSidebarModal`.

#### 📝 Additional Information

- No schema or API changes.
- Heartbeat fix is a single line in `taskRunner/index.ts` (+ 4 mirrored lines in `agentEvalRun/index.ts`); minimal blast radius.
- Follow-up items tracked on LOBE-8303: `HookDispatcher.fetchDeliver` should warn / retry on non-2xx instead of silently logging; `taskLifecycle.onTopicComplete` should add reason fallback for `interrupted / waiting_for_human / max_steps / cost_limit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)