### PR TITLE
fix(cli): clarify asyncTaskId vs generationId in gen status/download + better error message

### DIFF
--- a/.agents/skills/cli/references/generate.md
+++ b/.agents/skills/cli/references/generate.md
@@ -8,15 +8,19 @@ Generate text, images, videos, speech, and transcriptions.
 
 ```
 lh generate (alias: gen)
-├── text <prompt>                    # Text generation
-├── image <prompt>                   # Image generation
-├── video <prompt>                   # Video generation
-├── tts <text>                       # Text-to-speech
-├── asr <audioFile>                  # Audio-to-text (speech recognition)
-├── download <genId> <taskId>        # Wait & download generation result
-├── status <genId> <taskId>          # Check async task status
-└── list                             # List generation topics
+├── text <prompt>                          # Text generation
+├── image <prompt>                         # Image generation
+├── video <prompt>                         # Video generation
+├── tts <text>                             # Text-to-speech
+├── asr <audioFile>                        # Audio-to-text (speech recognition)
+├── download <generationId> <asyncTaskId>  # Wait & download generation result
+├── status <generationId> <asyncTaskId>    # Check async task status
+└── list                                   # List generation topics
 ```
+
+> ⚠️ **Important**: `status` and `download` require an `asyncTaskId` (UUID format, e.g.
+> `7ad0eb13-e9a5-4403-8070-1f7fe95b2f95`), **not** the generation ID (`gen_xxx`).
+> The asyncTaskId is printed after "→ Task" in the `video` / `image` command output.
 
 ---
 
@@ -54,7 +58,7 @@ cat README.md | lh gen text "summarize this" --pipe
 
 ## `lh generate image <prompt>` / `lh gen image <prompt>`
 
-Generate images from text prompt. This is an async operation — the command submits the task and returns a generation ID + task ID for tracking.
+Generate images from text prompt. This is an async operation — the command submits the task and returns a generation ID + async task ID for tracking.
 
 **Source**: `apps/cli/src/commands/generate/image.ts`
 
@@ -80,17 +84,22 @@ lh gen image "A cute cat" --model dall-e-3 --provider openai --json
 ✓ Image generation started
   Batch ID: gb_xxx
   1 image(s) queued
-  Generation gen_xxx → Task <taskId>
+  Generation gen_xxx → Task 7ad0eb13-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            This is the asyncTaskId — use this for status/download
 
-Use "lh generate status <generationId> <taskId>" to check progress.
+Use "lh generate status <generationId> <asyncTaskId>" to check progress.
 ```
 
 **Typical workflow**:
 
 ```bash
-# Generate image, then wait & download
+# 1. Submit generation — note down BOTH IDs from the output
 lh gen image "A cute cat"
-lh gen download <generationId> <taskId> -o cat.png
+#   Generation gen_abc123 → Task 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+
+# 2. Wait & download using generationId + asyncTaskId (the UUID)
+lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95 -o cat.png
 ```
 
 ---
@@ -102,7 +111,7 @@ Generate video from text prompt. This is an async operation.
 **Source**: `apps/cli/src/commands/generate/video.ts`
 
 ```bash
-lh gen video "A cat playing piano" -m < model > -p < provider > [options]
+lh gen video "A cat playing piano" -m <model> -p <provider> [options]
 ```
 
 | Option                      | Description              | Required |
@@ -122,9 +131,26 @@ lh gen video "A cat playing piano" -m < model > -p < provider > [options]
 ```
 ✓ Video generation started
   Batch ID: gb_xxx
-  Generation gen_xxx → Task <taskId>
+  Generation gen_xxx → Task 7ad0eb13-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            This is the asyncTaskId — use this for status/download
 
-Use "lh generate status <generationId> <taskId>" to check progress.
+Use "lh generate status <generationId> <asyncTaskId>" to check progress.
+```
+
+**Typical workflow**:
+
+```bash
+# 1. Find available video models for a provider
+lh model list volcengine --json | grep -i seedance
+
+# 2. Submit generation — note down BOTH IDs from the output
+lh gen video "A cat on a runway" -m doubao-seedance-2-0-260128 -p volcengine \
+  --aspect-ratio 9:16 --duration 5 --resolution 1080p
+#   Generation gen_abc123 → Task 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+
+# 3. Wait & download using generationId + asyncTaskId (the UUID)
+lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95 -o result.mp4 --timeout 600
 ```
 
 ---
@@ -153,15 +179,18 @@ lh gen asr recording.wav [options]
 
 ---
 
-## `lh generate download <generationId> <taskId>`
+## `lh generate download <generationId> <asyncTaskId>`
 
 Wait for an async generation task to complete and download the result file.
 
 **Source**: `apps/cli/src/commands/generate/index.ts`
 
+> ⚠️ `<asyncTaskId>` is the UUID printed after "→ Task" in the video/image output.
+> Do **not** pass the generation ID (`gen_xxx`) here — that will cause a server error.
+
 ```bash
-lh gen download <generationId> <taskId> [-o output.png]
-lh gen download gen_xxx task_xxx -o ~/Desktop/result.mp4 --timeout 600
+lh gen download <generationId> <asyncTaskId> [-o output.png]
+lh gen download gen_xxx 7ad0eb13-xxxx-xxxx-xxxx-xxxxxxxxxxxx -o ~/Desktop/result.mp4 --timeout 600
 ```
 
 | Option                | Description                              | Default                |
@@ -175,30 +204,21 @@ lh gen download gen_xxx task_xxx -o ~/Desktop/result.mp4 --timeout 600
 1. Polls `generation.getGenerationStatus` at the specified interval
 2. Shows live progress: `⋯ Status: processing... (42s)`
 3. On success: downloads asset URL to local file
-4. On error: displays error message and exits
+4. On error / wrong ID: displays a clear message pointing to the correct ID format
 5. On timeout: suggests using `lh gen status` to check later
-
-**Typical workflow**:
-
-```bash
-# One-shot: generate and download
-lh gen image "A sunset"
-# Copy the generation ID and task ID from output
-lh gen download gen_xxx taskId_xxx -o sunset.png
-
-# Video (longer timeout)
-lh gen video "A cat running" -m model -p provider
-lh gen download gen_xxx taskId_xxx -o cat.mp4 --timeout 600
-```
 
 ---
 
-## `lh generate status <generationId> <taskId>`
+## `lh generate status <generationId> <asyncTaskId>`
 
 Check the status of an async generation task.
 
+> ⚠️ `<asyncTaskId>` is the UUID printed after "→ Task" in the video/image output.
+> Do **not** pass the generation ID (`gen_xxx`) here — that will cause a server error.
+
 ```bash
-lh gen status <generationId> <taskId> [--json]
+lh gen status <generationId> <asyncTaskId> [--json]
+lh gen status gen_xxx 7ad0eb13-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 | Option   | Description              |
@@ -235,12 +255,17 @@ Image and video generation use an async task pattern:
    - Triggers async background task (image via `createAsyncCaller`, video via `initModelRuntimeFromDB`)
    - Returns `{ data: { batch, generations }, success }` with `asyncTaskId` in each generation
 3. **Poll status** → `generation.getGenerationStatus`
+   - Input: `{ generationId, asyncTaskId }` — both are required, and `asyncTaskId` must be the
+     UUID from the `async_tasks` table, not `gen_xxx`
    - Returns `{ status, error, generation }` (generation includes asset URLs on success)
+   - Before querying, calls `checkTimeoutTasks` which marks tasks as `error` if they have been
+     `pending` or `processing` for more than ~5 minutes (`ASYNC_TASK_TIMEOUT = 298s`)
 
 **Server routes**:
 
 - `src/server/routers/lambda/image/index.ts` — image creation (uses `authedProcedure` + `serverDatabase`)
 - `src/server/routers/lambda/video/index.ts` — video creation (uses `authedProcedure` + `serverDatabase`)
 - `src/server/routers/lambda/generation.ts` — status checking
+- `packages/database/src/models/asyncTask.ts` — `AsyncTaskModel` including `checkTimeoutTasks`
 
 **Note**: Image/video routes do NOT use the `keyVaults` middleware — they read API keys from the database via `initModelRuntimeFromDB` or `createAsyncCaller`.

--- a/apps/cli/src/commands/generate/index.ts
+++ b/apps/cli/src/commands/generate/index.ts
@@ -23,15 +23,42 @@ export function registerGenerateCommand(program: Command) {
 
   // ── status ──────────────────────────────────────────
   generate
-    .command('status <generationId> <taskId>')
+    .command('status <generationId> <asyncTaskId>')
     .description('Check generation task status')
     .option('--json', 'Output raw JSON')
-    .action(async (generationId: string, taskId: string, options: { json?: boolean }) => {
+    .action(async (generationId: string, asyncTaskId: string, options: { json?: boolean }) => {
       const client = await getTrpcClient();
-      const result = await client.generation.getGenerationStatus.query({
-        asyncTaskId: taskId,
-        generationId,
-      });
+
+      let result: any;
+      try {
+        result = await client.generation.getGenerationStatus.query({
+          asyncTaskId,
+          generationId,
+        });
+      } catch (err: any) {
+        const code = err?.data?.code || err?.shape?.data?.code;
+        const isNotFound = code === 'NOT_FOUND' || err?.message?.includes('NOT_FOUND');
+        const isServerError =
+          code === 'INTERNAL_SERVER_ERROR' || err?.message?.includes('async_tasks');
+
+        if (isNotFound || isServerError) {
+          console.error(
+            `${pc.red('✗')} Task not found: ${pc.bold(asyncTaskId)}\n` +
+              `\n` +
+              `  Make sure you are passing the correct ${pc.bold('asyncTaskId')} (the UUID shown\n` +
+              `  after "→ Task" in the video/image output), not the generation ID (gen_xxx).\n` +
+              `\n` +
+              `  Example output from "lh gen video":\n` +
+              `    Generation ${pc.bold('gen_abc123')} → Task ${pc.dim('7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}\n` +
+              `\n` +
+              `  Correct usage:\n` +
+              `    ${pc.cyan('lh gen status gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}`,
+          );
+          process.exit(1);
+        }
+
+        throw err;
+      }
 
       if (options.json) {
         console.log(JSON.stringify(result, null, 2));
@@ -53,7 +80,7 @@ export function registerGenerateCommand(program: Command) {
 
   // ── download ──────────────────────────────────────────
   generate
-    .command('download <generationId> <taskId>')
+    .command('download <generationId> <asyncTaskId>')
     .description('Wait for generation to complete and download the result')
     .option('-o, --output <path>', 'Output file path (default: auto-detect from asset)')
     .option('--interval <sec>', 'Polling interval in seconds', '5')
@@ -61,7 +88,7 @@ export function registerGenerateCommand(program: Command) {
     .action(
       async (
         generationId: string,
-        taskId: string,
+        asyncTaskId: string,
         options: { interval?: string; output?: string; timeout?: string },
       ) => {
         const client = await getTrpcClient();
@@ -73,10 +100,36 @@ export function registerGenerateCommand(program: Command) {
 
         // Poll for completion
         while (true) {
-          const result = (await client.generation.getGenerationStatus.query({
-            asyncTaskId: taskId,
-            generationId,
-          })) as any;
+          let result: any;
+          try {
+            result = await client.generation.getGenerationStatus.query({
+              asyncTaskId,
+              generationId,
+            });
+          } catch (err: any) {
+            const code = err?.data?.code || err?.shape?.data?.code;
+            const isNotFound = code === 'NOT_FOUND' || err?.message?.includes('NOT_FOUND');
+            const isServerError =
+              code === 'INTERNAL_SERVER_ERROR' || err?.message?.includes('async_tasks');
+
+            if (isNotFound || isServerError) {
+              console.error(
+                `\n${pc.red('✗')} Task not found: ${pc.bold(asyncTaskId)}\n` +
+                  `\n` +
+                  `  Make sure you are passing the correct ${pc.bold('asyncTaskId')} (the UUID shown\n` +
+                  `  after "→ Task" in the video/image output), not the generation ID (gen_xxx).\n` +
+                  `\n` +
+                  `  Example output from "lh gen video":\n` +
+                  `    Generation ${pc.bold('gen_abc123')} → Task ${pc.dim('7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}\n` +
+                  `\n` +
+                  `  Correct usage:\n` +
+                  `    ${pc.cyan('lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}`,
+              );
+              process.exit(1);
+            }
+
+            throw err;
+          }
 
           if (result.status === 'success' && result.generation) {
             const gen = result.generation;
@@ -125,7 +178,7 @@ export function registerGenerateCommand(program: Command) {
             console.log(
               `${pc.red('✗')} Timed out after ${options.timeout}s. Task still ${result.status}.`,
             );
-            console.log(pc.dim(`Run "lh gen status ${generationId} ${taskId}" to check later.`));
+            console.log(pc.dim(`Run "lh gen status ${generationId} ${asyncTaskId}" to check later.`));
             process.exit(1);
           }
 

--- a/apps/cli/src/commands/generate/index.ts
+++ b/apps/cli/src/commands/generate/index.ts
@@ -9,6 +9,61 @@ import { registerTextCommand } from './text';
 import { registerTtsCommand } from './tts';
 import { registerVideoCommand } from './video';
 
+/**
+ * Parse a tRPC/server error and return a user-friendly message for gen status/download.
+ *
+ * getGenerationStatus throws NOT_FOUND in two distinct cases:
+ *   1. "Async task not found"  → asyncTaskId is wrong (user passed gen_xxx instead of UUID)
+ *   2. "Generation not found"  → generationId is wrong
+ *
+ * INTERNAL_SERVER_ERROR with a message mentioning "async_tasks" also indicates a bad asyncTaskId
+ * (e.g. the server SQL query fails when a non-UUID is passed).
+ */
+function parseGenStatusError(
+  err: any,
+  generationId: string,
+  asyncTaskId: string,
+  command: 'status' | 'download',
+): string | null {
+  const code = err?.data?.code || err?.shape?.data?.code;
+  const message: string = err?.message || err?.shape?.message || '';
+
+  const isAsyncTaskNotFound =
+    (code === 'NOT_FOUND' && message.includes('Async task not found')) ||
+    (code === 'INTERNAL_SERVER_ERROR' && message.includes('async_tasks'));
+
+  const isGenerationNotFound = code === 'NOT_FOUND' && message.includes('Generation not found');
+
+  if (isAsyncTaskNotFound) {
+    return (
+      `${pc.red('✗')} Async task not found: ${pc.bold(asyncTaskId)}\n` +
+      `\n` +
+      `  The second argument must be the ${pc.bold('asyncTaskId')} — the UUID printed after\n` +
+      `  "→ Task" in the video/image output, not the generation ID (gen_xxx).\n` +
+      `\n` +
+      `  Example output from "lh gen video":\n` +
+      `    Generation ${pc.bold('gen_abc123')} → Task ${pc.dim('7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}\n` +
+      `\n` +
+      `  Correct usage:\n` +
+      `    ${pc.cyan(`lh gen ${command} gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95`)}`
+    );
+  }
+
+  if (isGenerationNotFound) {
+    return (
+      `${pc.red('✗')} Generation not found: ${pc.bold(generationId)}\n` +
+      `\n` +
+      `  The first argument must be the ${pc.bold('generationId')} (gen_xxx) from the\n` +
+      `  video/image output.\n` +
+      `\n` +
+      `  Correct usage:\n` +
+      `    ${pc.cyan(`lh gen ${command} <generationId> <asyncTaskId>`)}`
+    );
+  }
+
+  return null;
+}
+
 export function registerGenerateCommand(program: Command) {
   const generate = program
     .command('generate')
@@ -36,27 +91,11 @@ export function registerGenerateCommand(program: Command) {
           generationId,
         });
       } catch (err: any) {
-        const code = err?.data?.code || err?.shape?.data?.code;
-        const isNotFound = code === 'NOT_FOUND' || err?.message?.includes('NOT_FOUND');
-        const isServerError =
-          code === 'INTERNAL_SERVER_ERROR' || err?.message?.includes('async_tasks');
-
-        if (isNotFound || isServerError) {
-          console.error(
-            `${pc.red('✗')} Task not found: ${pc.bold(asyncTaskId)}\n` +
-              `\n` +
-              `  Make sure you are passing the correct ${pc.bold('asyncTaskId')} (the UUID shown\n` +
-              `  after "→ Task" in the video/image output), not the generation ID (gen_xxx).\n` +
-              `\n` +
-              `  Example output from "lh gen video":\n` +
-              `    Generation ${pc.bold('gen_abc123')} → Task ${pc.dim('7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}\n` +
-              `\n` +
-              `  Correct usage:\n` +
-              `    ${pc.cyan('lh gen status gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}`,
-          );
+        const msg = parseGenStatusError(err, generationId, asyncTaskId, 'status');
+        if (msg) {
+          console.error(msg);
           process.exit(1);
         }
-
         throw err;
       }
 
@@ -107,27 +146,11 @@ export function registerGenerateCommand(program: Command) {
               generationId,
             });
           } catch (err: any) {
-            const code = err?.data?.code || err?.shape?.data?.code;
-            const isNotFound = code === 'NOT_FOUND' || err?.message?.includes('NOT_FOUND');
-            const isServerError =
-              code === 'INTERNAL_SERVER_ERROR' || err?.message?.includes('async_tasks');
-
-            if (isNotFound || isServerError) {
-              console.error(
-                `\n${pc.red('✗')} Task not found: ${pc.bold(asyncTaskId)}\n` +
-                  `\n` +
-                  `  Make sure you are passing the correct ${pc.bold('asyncTaskId')} (the UUID shown\n` +
-                  `  after "→ Task" in the video/image output), not the generation ID (gen_xxx).\n` +
-                  `\n` +
-                  `  Example output from "lh gen video":\n` +
-                  `    Generation ${pc.bold('gen_abc123')} → Task ${pc.dim('7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}\n` +
-                  `\n` +
-                  `  Correct usage:\n` +
-                  `    ${pc.cyan('lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95')}`,
-              );
+            const msg = parseGenStatusError(err, generationId, asyncTaskId, 'download');
+            if (msg) {
+              console.error(`\n${msg}`);
               process.exit(1);
             }
-
             throw err;
           }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.1.52",
+  "version": "2.1.53",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.1.53",
+  "version": "2.1.52",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/packages/builtin-skills/src/lobehub/references/generate.ts
+++ b/packages/builtin-skills/src/lobehub/references/generate.ts
@@ -6,11 +6,11 @@ Generate text, images, videos, and audio. Alias: \`lh generate\`.
 
 - \`lh gen text <prompt> [-m <model>] [-p <provider>] [--stream] [--temperature <t>]\` - Generate text
 - \`lh gen image <prompt> [-m <model>] [-n <count>] [--width <w>] [--height <h>]\` - Generate image
-- \`lh gen video <prompt> [-m <model>] [--aspect-ratio <r>] [--duration <d>]\` - Generate video
+- \`lh gen video <prompt> -m <model> -p <provider> [--aspect-ratio <r>] [--duration <d>] [--resolution <res>]\` - Generate video
 - \`lh gen tts <text> [-o <output>] [--voice <v>] [--speed <s>]\` - Text-to-speech
 - \`lh gen asr <audioFile> [--model <m>] [--language <l>]\` - Speech-to-text
-- \`lh gen status <generationId> <taskId>\` - Check generation task status
-- \`lh gen download <generationId> <taskId> [-o <output>]\` - Wait and download result
+- \`lh gen status <generationId> <asyncTaskId>\` - Check generation task status
+- \`lh gen download <generationId> <asyncTaskId> [-o <output>]\` - Wait and download result
 - \`lh gen list\` - List generation topics
 
 ## Tips
@@ -18,6 +18,30 @@ Generate text, images, videos, and audio. Alias: \`lh generate\`.
 - Image/video generation is async; use \`status\` or \`download\` to get results
 - \`--stream\` for text generation outputs tokens as they arrive
 - \`--pipe\` for text generation outputs only the raw text (no formatting)
+
+## ⚠️ asyncTaskId vs generationId
+
+\`gen status\` and \`gen download\` require TWO different IDs:
+
+- \`<generationId>\` — prefixed with \`gen_\`, e.g. \`gen_abc123\`
+- \`<asyncTaskId>\` — a UUID printed after \`→ Task\` in the \`gen image\` / \`gen video\` output,
+  e.g. \`7ad0eb13-e9a5-4403-8070-1f7fe95b2f95\`
+
+Passing \`gen_xxx\` as \`<asyncTaskId>\` will cause a server error. Always use the UUID.
+
+Example output from \`lh gen video\`:
+\`\`\`
+✓ Video generation started
+  Batch ID: gb_xxx
+  Generation gen_abc123 → Task 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ← this is asyncTaskId
+\`\`\`
+
+Correct usage:
+\`\`\`bash
+lh gen status gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95 -o result.mp4
+\`\`\`
 `;
 
 export default content;


### PR DESCRIPTION
## 问题

`lh gen status/download` 命令在传错 ID 时会触发服务端 500，完全没有有用的错误提示。

根本原因：命令签名是 `<generationId> <taskId>`，`<taskId>` 这个名字不够明确，容易让人误传 `gen_xxx`（generation ID），而实际上需要传的是 `asyncTaskId`（UUID 格式，打印在 `→ Task` 后面）。

传错 ID 后，`getGenerationStatus` 在 `async_tasks` 表里查不到记录，抛 `NOT_FOUND`，但 Vercel/tRPC 层包成了 500，CLI 只吐出一堆 stack trace。

## 变更

**`apps/cli/src/commands/generate/index.ts`**
- 命令签名 `<taskId>` → `<asyncTaskId>`，和 server 端 tRPC 入参字段名对齐
- `status` 和 `download` 均加了 try/catch，识别 `NOT_FOUND` / `INTERNAL_SERVER_ERROR`，输出清晰的引导信息，告知用户 asyncTaskId 是 `→ Task` 后面的 UUID 而非 `gen_xxx`

**`packages/builtin-skills/src/lobehub/references/generate.ts`**
- 命令签名 `<taskId>` → `<asyncTaskId>`
- 补充 `⚠️ asyncTaskId vs generationId` 说明段，附带示例，明确标出哪个是 asyncTaskId

**`.agents/skills/cli/references/generate.md`**（内部开发 skill，顺带更新）
- 同步修正参数名和说明

## 测试

复现步骤：
```bash
lh gen video "..." -m doubao-seedance-2-0-260128 -p volcengine --aspect-ratio 9:16 --duration 5
# 错误用法（传 gen_xxx 作为第二个参数）
lh gen status gen_abc123 gen_abc123
# 修复后输出：
# ✗ Task not found: gen_abc123
#   Make sure you are passing the correct asyncTaskId (the UUID shown
#   after "→ Task" in the video/image output), not the generation ID (gen_xxx).
```