### PR TITLE
🐛 fix(agent): clear stale topic when switching agents from a topic route

### DIFF
--- a/src/features/Conversation/ConversationProvider.test.tsx
+++ b/src/features/Conversation/ConversationProvider.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ConversationContext, UIChatMessage } from '@lobechat/types';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+
+import { ConversationProvider } from './ConversationProvider';
+import { dataSelectors, useConversationStore } from './store';
+
+const oldContext = {
+  agentId: 'agt_old',
+  threadId: null,
+  topicId: 'tpc_old',
+} satisfies ConversationContext;
+
+const nextContext = {
+  agentId: 'agt_next',
+  threadId: null,
+  topicId: null,
+} satisfies ConversationContext;
+
+const oldMessages = [
+  {
+    content: 'old message',
+    createdAt: 1,
+    id: 'msg_old',
+    role: 'user',
+    updatedAt: 1,
+  },
+] as UIChatMessage[];
+
+interface Snapshot {
+  actualContextKey: string;
+  displayMessageIds: string[];
+  expectedContextKey: string;
+}
+
+const Probe = ({
+  expectedContext,
+  snapshots,
+}: {
+  expectedContext: ConversationContext;
+  snapshots: Snapshot[];
+}) => {
+  const context = useConversationStore((s) => s.context);
+  const displayMessageIds = useConversationStore(dataSelectors.displayMessageIds);
+
+  snapshots.push({
+    actualContextKey: messageMapKey(context),
+    displayMessageIds,
+    expectedContextKey: messageMapKey(expectedContext),
+  });
+
+  return null;
+};
+
+describe('ConversationProvider', () => {
+  it('does not expose the previous local conversation store after context changes', () => {
+    const snapshots: Snapshot[] = [];
+
+    const { rerender } = render(
+      <ConversationProvider hasInitMessages context={oldContext} messages={oldMessages}>
+        <Probe expectedContext={oldContext} snapshots={snapshots} />
+      </ConversationProvider>,
+    );
+
+    rerender(
+      <ConversationProvider context={nextContext} hasInitMessages={false}>
+        <Probe expectedContext={nextContext} snapshots={snapshots} />
+      </ConversationProvider>,
+    );
+
+    const mismatchedNextContextSnapshots = snapshots.filter(
+      (snapshot) =>
+        snapshot.expectedContextKey === messageMapKey(nextContext) &&
+        snapshot.actualContextKey !== snapshot.expectedContextKey,
+    );
+
+    expect(mismatchedNextContextSnapshots).toEqual([]);
+  });
+});

--- a/src/features/Conversation/ConversationProvider.tsx
+++ b/src/features/Conversation/ConversationProvider.tsx
@@ -92,7 +92,7 @@ export const ConversationProvider = memo<ConversationProviderProps>(
     );
 
     return (
-      <Provider createStore={() => createStore({ context, hooks, skipFetch })}>
+      <Provider createStore={() => createStore({ context, hooks, skipFetch })} key={contextKey}>
         <StoreUpdater
           actionsBar={actionsBar}
           context={context}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -107,7 +107,9 @@ vi.mock('./useDropdownMenu', () => ({
   useTopicItemDropdownMenu: () => ({ dropdownMenu: [] }),
 }));
 vi.mock('../../TopicListContent/ThreadList', () => ({
-  default: () => <div data-testid="topic-thread-list" />,
+  default: ({ topicId }: { topicId: string }) => (
+    <div data-testid="topic-thread-list" data-topic-id={topicId} />
+  ),
 }));
 
 describe('TopicItem active state', () => {
@@ -117,12 +119,13 @@ describe('TopicItem active state', () => {
       isInTopicContextRoute: true,
       navigateToTopic: vi.fn(),
       routeTopicId: 'tpc_test',
+      urlTopicId: 'tpc_test',
     });
 
     render(<TopicItem active={false} id="tpc_test" title="Topic" />);
 
     expect(screen.getByTestId('nav-item')).toHaveAttribute('data-active', 'true');
-    expect(screen.getByTestId('topic-thread-list')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-thread-list')).toHaveAttribute('data-topic-id', 'tpc_test');
   });
 
   it('does not highlight a stale topic while visiting non-topic agent sub-routes', () => {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -117,7 +117,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
   const isTopicActive = Boolean(
     (active || isRouteTopicActive) && !threadId && (!isInAgentSubRoute || isRouteTopicActive),
   );
-
+  // ThreadList visibility must not depend on whether a thread is currently
+  // selected — when a thread is open we still want the parent topic's thread
+  // list expanded so the user can see context and switch threads.
+  const shouldShowThreadList = Boolean(
+    (active || isRouteTopicActive) && (!isInAgentSubRoute || isRouteTopicActive),
+  );
   const toggleEditing = useCallback(
     (visible?: boolean) => {
       useChatStore.setState({ topicRenamingId: visible && id ? id : '' });
@@ -252,7 +257,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
         onDoubleClick={() => void handleDoubleClick()}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />
-      {isTopicActive && (
+      {shouldShowThreadList && (
         <Suspense
           fallback={
             <Flexbox gap={8} paddingBlock={8} paddingInline={24} width={'100%'}>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -112,17 +112,15 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
     isInAgentSubRoute,
     isInTopicContextRoute,
     routeTopicId,
+    urlTopicId,
   } = useTopicNavigation();
   const isRouteTopicActive = Boolean(id && routeTopicId === id && isInTopicContextRoute);
   const isTopicActive = Boolean(
     (active || isRouteTopicActive) && !threadId && (!isInAgentSubRoute || isRouteTopicActive),
   );
-  // ThreadList visibility must not depend on whether a thread is currently
-  // selected — when a thread is open we still want the parent topic's thread
-  // list expanded so the user can see context and switch threads.
-  const shouldShowThreadList = Boolean(
-    (active || isRouteTopicActive) && (!isInAgentSubRoute || isRouteTopicActive),
-  );
+
+  const shouldShowThreadList = Boolean(id && id === urlTopicId);
+
   const toggleEditing = useCallback(
     (visible?: boolean) => {
       useChatStore.setState({ topicRenamingId: visible && id ? id : '' });
@@ -266,7 +264,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
             </Flexbox>
           }
         >
-          <ThreadList />
+          <ThreadList topicId={id} />
         </Suspense>
       )}
     </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -9,6 +9,7 @@ import ThreadItem from './ThreadItem';
 
 const ThreadList = memo(() => {
   const [id] = useChatStore((s) => [s.activeTopicId]);
+
   const threads = useChatStore(threadSelectors.getThreadsByTopic(id));
 
   useFetchThreads(id);

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -7,12 +7,10 @@ import { threadSelectors } from '@/store/chat/selectors';
 
 import ThreadItem from './ThreadItem';
 
-const ThreadList = memo(() => {
-  const [id] = useChatStore((s) => [s.activeTopicId]);
+const ThreadList = memo(({ topicId }: { topicId: string }) => {
+  const threads = useChatStore(threadSelectors.getThreadsByTopic(topicId));
 
-  const threads = useChatStore(threadSelectors.getThreadsByTopic(id));
-
-  useFetchThreads(id);
+  useFetchThreads(topicId);
 
   if (!threads || threads.length === 0) return;
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
@@ -24,11 +24,14 @@ export const useTopicNavigation = () => {
   const toggleConfig = useGlobalStore((s) => s.toggleMobileTopic);
   const switchTopic = useChatStore((s) => s.switchTopic);
   const routeAgentId = params.aid ?? activeAgentId;
+  // URL is the source of truth. Sidebar mounts at `/agent/:aid` so `params.topicId`
+  // is undefined here — fall back to parsing pathname directly so consumers can compare
+  // their item id against the URL's topic id without waiting for store hydration.
+  const urlTopicId = params.topicId;
   const routeTopicId = params.topicId ?? activeTopicId ?? undefined;
   const topicBasePath =
     routeAgentId && routeTopicId ? SESSION_CHAT_TOPIC_URL(routeAgentId, routeTopicId) : undefined;
-  // URL-derived topic path (no store fallback) — used for sub-route detection so a cached
-  // activeTopicId cannot mask a non-topic page like /agent/:aid/profile.
+
   const urlTopicBasePath =
     routeAgentId && params.topicId
       ? SESSION_CHAT_TOPIC_URL(routeAgentId, params.topicId)
@@ -87,5 +90,6 @@ export const useTopicNavigation = () => {
     isInTopicContextRoute: isInTopicContextRoute(),
     navigateToTopic,
     routeTopicId,
+    urlTopicId,
   };
 };

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
@@ -15,6 +15,20 @@ const useLocationMock = vi.hoisted(() => vi.fn());
 const useParamsMock = vi.hoisted(() => vi.fn());
 const useSearchParamsMock = vi.hoisted(() => vi.fn());
 
+vi.hoisted(() => {
+  const storage = {
+    clear: vi.fn(),
+    getItem: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+});
+
 vi.mock('react-router-dom', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = (await vi.importActual('react-router-dom')) as typeof import('react-router-dom');
@@ -91,6 +105,32 @@ describe('ChatHydration', () => {
       expect(navigateMock).toHaveBeenCalledWith('/agent/agt_test/tpc_123?thread=thd_456', {
         replace: true,
       });
+    });
+  });
+
+  it('clears stale topic and thread state when the route has no topic or thread', async () => {
+    useChatStore.setState(
+      {
+        activeThreadId: 'thd_previous',
+        activeTopicId: 'tpc_previous',
+      },
+      false,
+    );
+
+    useParamsMock.mockReturnValue({ aid: 'agt_next' });
+    useLocationMock.mockReturnValue({
+      hash: '',
+      pathname: '/agent/agt_next',
+      search: '',
+    });
+    useSearchParamsMock.mockReturnValue([new URLSearchParams(''), setSearchParamsMock]);
+
+    render(<ChatHydration />);
+
+    await waitFor(() => {
+      expect(useChatStore.getState().activeTopicId).toBeNull();
+      expect(useChatStore.getState().activeThreadId).toBeNull();
+      expect(navigateMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.test.tsx
@@ -61,7 +61,7 @@ describe('ChatHydration', () => {
     );
   });
 
-  it('hydrates legacy topic query params into the store and rewrites them to the topic path', async () => {
+  it('ignores topic query params and only hydrates thread from search params', async () => {
     useParamsMock.mockReturnValue({ aid: 'agt_test' });
     useLocationMock.mockReturnValue({
       hash: '#msg_1',
@@ -76,16 +76,13 @@ describe('ChatHydration', () => {
     render(<ChatHydration />);
 
     await waitFor(() => {
-      expect(useChatStore.getState().activeTopicId).toBe('tpc_123');
+      expect(useChatStore.getState().activeTopicId).toBeNull();
       expect(useChatStore.getState().activeThreadId).toBe('thd_456');
-      expect(navigateMock).toHaveBeenCalledWith(
-        '/agent/agt_test/tpc_123?thread=thd_456&mode=single#msg_1',
-        { replace: true },
-      );
+      expect(navigateMock).not.toHaveBeenCalled();
     });
   });
 
-  it('removes duplicate legacy topic query params when the path already carries topicId', async () => {
+  it('hydrates topic from the path even when a stale topic query param exists', async () => {
     useParamsMock.mockReturnValue({ aid: 'agt_test', topicId: 'tpc_123' });
     useLocationMock.mockReturnValue({
       hash: '',
@@ -102,9 +99,7 @@ describe('ChatHydration', () => {
     await waitFor(() => {
       expect(useChatStore.getState().activeTopicId).toBe('tpc_123');
       expect(useChatStore.getState().activeThreadId).toBe('thd_456');
-      expect(navigateMock).toHaveBeenCalledWith('/agent/agt_test/tpc_123?thread=thd_456', {
-        replace: true,
-      });
+      expect(navigateMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { createStoreUpdater } from 'zustand-utils';
 
 import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@/const/url';
 import { useQueryState } from '@/hooks/useQueryParam';
@@ -16,7 +15,6 @@ const getSearchSuffix = (searchParams: URLSearchParams) => {
 
 // sync outside state to useChatStore
 const ChatHydration = memo(() => {
-  const useStoreUpdater = createStoreUpdater(useChatStore);
   const location = useLocation();
   const navigate = useNavigate();
   const params = useParams<{ aid?: string; topicId?: string }>();
@@ -25,8 +23,23 @@ const ChatHydration = memo(() => {
   const [thread, setThread] = useQueryState('thread', { history: 'replace', throttleMs: 500 });
   const routeTopicId = params.topicId ?? searchParams.get('topic');
 
-  useStoreUpdater('activeTopicId', routeTopicId ?? undefined);
-  useStoreUpdater('activeThreadId', thread!);
+  // Sync URL → store synchronously (before paint) so the store never carries
+  // a stale topic/thread id from a previous agent. A useEffect-based
+  // updater here would let Conversation paint one frame against the prior
+  // agent's `activeTopicId` after switching agents.
+  useLayoutEffect(() => {
+    const target = routeTopicId ?? null;
+    if (useChatStore.getState().activeTopicId !== target) {
+      useChatStore.setState({ activeTopicId: target }, false, 'ChatHydration/syncTopicFromUrl');
+    }
+  }, [routeTopicId]);
+
+  useLayoutEffect(() => {
+    const target = thread ?? null;
+    if (useChatStore.getState().activeThreadId !== target) {
+      useChatStore.setState({ activeThreadId: target }, false, 'ChatHydration/syncThreadFromUrl');
+    }
+  }, [thread]);
 
   const locationRef = useRef(location);
   const paramsRef = useRef(params);
@@ -84,7 +97,7 @@ const ChatHydration = memo(() => {
     const unsubscribeThread = useChatStore.subscribe(
       (s) => s.activeThreadId,
       (state) => {
-        setThread(!state ? null : state);
+        setThread(state || null);
       },
     );
 

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -21,23 +21,19 @@ const ChatHydration = memo(() => {
   const [searchParams] = useSearchParams();
 
   const [thread, setThread] = useQueryState('thread', { history: 'replace', throttleMs: 500 });
-  const routeTopicId = params.topicId ?? searchParams.get('topic');
+  const routeTopicId = params.topicId;
 
-  // Sync URL → store synchronously (before paint) so the store never carries
-  // a stale topic/thread id from a previous agent. A useEffect-based
-  // updater here would let Conversation paint one frame against the prior
-  // agent's `activeTopicId` after switching agents.
   useLayoutEffect(() => {
     const target = routeTopicId ?? null;
     if (useChatStore.getState().activeTopicId !== target) {
-      useChatStore.setState({ activeTopicId: target }, false, 'ChatHydration/syncTopicFromUrl');
+      useChatStore.setState({ activeTopicId: target! }, false, 'ChatHydration/syncTopicFromUrl');
     }
   }, [routeTopicId]);
 
   useLayoutEffect(() => {
     const target = thread ?? null;
     if (useChatStore.getState().activeThreadId !== target) {
-      useChatStore.setState({ activeThreadId: target }, false, 'ChatHydration/syncThreadFromUrl');
+      useChatStore.setState({ activeThreadId: target! }, false, 'ChatHydration/syncThreadFromUrl');
     }
   }, [thread]);
 
@@ -48,31 +44,6 @@ const ChatHydration = memo(() => {
   locationRef.current = location;
   paramsRef.current = params;
   searchParamsRef.current = searchParams;
-
-  useLayoutEffect(() => {
-    const legacyTopicId = searchParams.get('topic');
-
-    if (!params.aid || !legacyTopicId) return;
-
-    const normalizedTopicId = params.topicId ?? legacyTopicId;
-    const nextSearchParams = new URLSearchParams(searchParams);
-    nextSearchParams.delete('topic');
-
-    const nextUrl = `${SESSION_CHAT_TOPIC_URL(params.aid, normalizedTopicId)}${getSearchSuffix(nextSearchParams)}${location.hash}`;
-    const currentUrl = `${location.pathname}${location.search}${location.hash}`;
-
-    if (currentUrl !== nextUrl) {
-      navigate(nextUrl, { replace: true });
-    }
-  }, [
-    location.hash,
-    location.pathname,
-    location.search,
-    navigate,
-    params.aid,
-    params.topicId,
-    searchParams,
-  ]);
 
   useLayoutEffect(() => {
     const unsubscribeTopic = useChatStore.subscribe(

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -41,6 +41,7 @@ const Conversation = memo(() => {
   );
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
+
   log('contextKey %s: %o', chatKey, messages);
 
   // Get operation state from ChatStore for reactive updates

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/index.tsx
@@ -12,7 +12,13 @@ import FolderTag from './FolderTag';
 import MemberCountTag from './MemberCountTag';
 
 const TitleTags = memo(() => {
-  const { t } = useTranslation('topic');
+  const { t } = useTranslation(['topic', 'chat']);
+  const activeThreadId = useChatStore((s) => s.activeThreadId);
+  const threadTitle = useChatStore((s) =>
+    s.activeThreadId && s.activeTopicId
+      ? s.threadMaps[s.activeTopicId]?.find((thread) => thread.id === s.activeThreadId)?.title
+      : undefined,
+  );
   const topicTitle = useChatStore((s) => topicSelectors.currentActiveTopic(s)?.title);
   const isGroupSession = useSessionStore(sessionSelectors.isCurrentSessionGroupSession);
 
@@ -23,6 +29,10 @@ const TitleTags = memo(() => {
       </Flexbox>
     );
   }
+
+  const displayTitle = activeThreadId
+    ? threadTitle || t('thread.title', { ns: 'chat' })
+    : topicTitle || t('newTopic');
 
   return (
     <Flexbox allowShrink horizontal align={'center'} gap={8}>
@@ -38,7 +48,7 @@ const TitleTags = memo(() => {
           whiteSpace: 'nowrap',
         }}
       >
-        {topicTitle || t('newTopic')}
+        {displayTitle}
       </span>
       <FolderTag />
     </Flexbox>

--- a/src/routes/(main)/agent/features/Conversation/useAgentContext.ts
+++ b/src/routes/(main)/agent/features/Conversation/useAgentContext.ts
@@ -17,6 +17,7 @@ export function useAgentContext(): ConversationContext {
     s.activeTopicId ?? null,
     s.activeThreadId ?? null,
   ]);
+
   const activeTopicDocumentId = useDocumentStore((s) => {
     if (!topicId || threadId) return undefined;
 

--- a/src/routes/(main)/agent/index.desktop.tsx
+++ b/src/routes/(main)/agent/index.desktop.tsx
@@ -2,6 +2,7 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
+import { useParams } from 'react-router-dom';
 
 import TopicInPopupGuard from '@/features/TopicPopupGuard';
 import { useTopicInPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
@@ -10,22 +11,21 @@ import { useChatStore } from '@/store/chat';
 import Conversation from './features/Conversation';
 import ChatHydration from './features/Conversation/ChatHydration';
 import PageTitle from './features/PageTitle';
-import Portal from './features/Portal';
 import TelemetryNotification from './features/TelemetryNotification';
 
 const ChatPage = memo(() => {
+  const { topicId: urlTopicId } = useParams<{ topicId?: string }>();
   const activeAgentId = useChatStore((s) => s.activeAgentId);
-  const activeTopicId = useChatStore((s) => s.activeTopicId);
   const popup = useTopicInPopup({
     agentId: activeAgentId,
-    topicId: activeTopicId ?? '',
+    topicId: urlTopicId ?? '',
   });
 
   // When the same topic is already hosted in a popup window, avoid
   // rendering a second (out-of-sync) instance here — guide the user back
   // to the popup instead.
   const pageContent =
-    activeTopicId && popup ? (
+    urlTopicId && popup ? (
       <>
         <PageTitle />
         <TopicInPopupGuard popup={popup} />
@@ -40,7 +40,6 @@ const ChatPage = memo(() => {
           width={'100%'}
         >
           <Conversation />
-          <Portal />
         </Flexbox>
         <TelemetryNotification mobile={false} />
       </>


### PR DESCRIPTION
**Hotfix Scope:** Agent topic / thread navigation regression — stale chat state on agent switch

> Clears residual topic state when navigating between agents, restores the active subtopic's title in the header, and keeps the sidebar's thread list expanded while a thread is open.

## 🐛 What's Fixed

- **Stale topic on agent switch** — `ChatHydration` syncs `activeTopicId` / `activeThreadId` from the URL via `useLayoutEffect` and writes `null` (not `undefined`) so `/agent/agt_A/tpc_X` → `/agent/agt_B` no longer carries over the previous topic; *Start new topic* responds again.
- **Conversation context isolation** — `ConversationProvider` keys its inner store on `contextKey`, so consumers don't read stale values for one render after agent / topic / thread identity changes.
- **Sidebar thread list visibility** — `<ThreadList />` visibility is now driven by `urlTopicId` and accepts `topicId` as a prop, so the parent topic's thread list stays expanded while viewing a subtopic.
- **Header thread title** — Header `Tags` reads the active thread's title from `s.threadMaps[s.activeTopicId]` when `activeThreadId` is set, falling back to `chat:thread.title` for unnamed threads.