### PR TITLE
🐛 fix(utils): keep tiny prices visible in formatPrice

### DIFF
--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -191,6 +191,13 @@ describe('format', () => {
       expect(formatPrice(0.0001)).toBe('0.0001');
       expect(formatPrice(0)).toBe('0.00');
     });
+
+    it('should not throw RangeError for sub-1e-100 prices', () => {
+      // Number.prototype.toFixed accepts digits in [0, 100]; without a clamp
+      // Math.ceil(-Math.log10(price)) can exceed that and throw RangeError.
+      expect(() => formatPrice(1e-101)).not.toThrow();
+      expect(() => formatPrice(Number.MIN_VALUE)).not.toThrow();
+    });
   });
 
   describe('formatPriceByCurrency', () => {

--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -185,6 +185,12 @@ describe('format', () => {
       expect(formatPrice(0.99)).toBe('0.99');
       expect(formatPrice(1000000.01, 0)).toBe('1,000,000');
     });
+
+    it('should expand precision when a positive price would round to zero', () => {
+      expect(formatPrice(0.003625)).toBe('0.004');
+      expect(formatPrice(0.0001)).toBe('0.0001');
+      expect(formatPrice(0)).toBe('0.00');
+    });
   });
 
   describe('formatPriceByCurrency', () => {

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -104,9 +104,10 @@ export const formatPrice = (price: number, fractionDigits: number = 2) => {
 
   // Expand precision when a positive price would round to zero at the requested
   // precision (e.g. $0.003625 → "0.00"), so users can tell it isn't actually free.
+  // Cap at 100 because Number.prototype.toFixed throws RangeError beyond that.
   let digits = fractionDigits;
   if (price > 0 && Number(price.toFixed(fractionDigits)) === 0) {
-    digits = Math.ceil(-Math.log10(price));
+    digits = Math.min(100, Math.ceil(-Math.log10(price)));
   }
 
   const [a, b] = price.toFixed(digits).split('.');

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -25,26 +25,10 @@ export const formatSize = (bytes: number, fractionDigits: number = 1): string =>
 export const formatSpeed = (byte: number, fractionDigits = 2) => {
   if (!byte && byte !== 0) return '--';
 
-  let word = '';
-
-  // Byte
-  if (byte <= 1000) {
-    word = byte.toFixed(fractionDigits) + ' Byte/s';
-  }
-  // KB
-  else if (byte / 1024 <= 1000) {
-    word = (byte / 1024).toFixed(fractionDigits) + ' KB/s';
-  }
-  // MB
-  else if (byte / 1024 / 1024 <= 1000) {
-    word = (byte / 1024 / 1024).toFixed(fractionDigits) + ' MB/s';
-  }
-  // GB
-  else {
-    word = (byte / 1024 / 1024 / 1024).toFixed(fractionDigits) + ' GB/s';
-  }
-
-  return word;
+  if (byte <= 1000) return byte.toFixed(fractionDigits) + ' Byte/s';
+  if (byte / 1024 <= 1000) return (byte / 1024).toFixed(fractionDigits) + ' KB/s';
+  if (byte / 1024 / 1024 <= 1000) return (byte / 1024 / 1024).toFixed(fractionDigits) + ' MB/s';
+  return (byte / 1024 / 1024 / 1024).toFixed(fractionDigits) + ' GB/s';
 };
 
 export const formatTime = (timeInSeconds: number): string => {
@@ -118,7 +102,14 @@ export const formatPrice = (price: number, fractionDigits: number = 2) => {
 
   if (fractionDigits === 0) return numeral(price).format('0,0');
 
-  const [a, b] = price.toFixed(fractionDigits).split('.');
+  // Expand precision when a positive price would round to zero at the requested
+  // precision (e.g. $0.003625 → "0.00"), so users can tell it isn't actually free.
+  let digits = fractionDigits;
+  if (price > 0 && Number(price.toFixed(fractionDigits)) === 0) {
+    digits = Math.ceil(-Math.log10(price));
+  }
+
+  const [a, b] = price.toFixed(digits).split('.');
   return `${numeral(a).format('0,0')}.${b}`;
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — surfaced while reviewing DeepSeek V4 Pro's cache-hit input price card.

#### 🔀 Description of Change

`formatPrice` always rounds to `fractionDigits` (default `2`) via `toFixed`, so any positive price under `$0.005` collapses to `\"0.00\"`. The model detail panel hits this for any model whose cache-hit price is less than half a cent — DeepSeek V4 Pro's cache-hit input rate (`$0.003625 / M tokens`) renders as `\$0.00 / M tokens`, which reads as \"free\" and is misleading.

Fix: when the price is positive but rounds to zero at the requested precision, expand precision to `Math.ceil(-Math.log10(price))` so at least one significant digit is visible:

- `0.003625` → `\"0.004\"`
- `0.0001` → `\"0.0001\"`
- `0` → `\"0.00\"` (unchanged)
- `0.99` / `1234.56` / `1,000,000.01` (unchanged)

Also collapsed `formatSpeed` early-returns to silence a long-standing `let word = ''` ESLint warning that lit up while editing the file.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

\`\`\`
cd packages/utils && bunx vitest run --silent='passed-only' src/format.test.ts
\`\`\`

#### 📝 Additional Information

Pure display-layer change. \`formatPrice\` is not on any server-side billing path (CostService / spend log / Stripe all consume raw \`pricing.units[].rate\` numbers); the only non-UI caller in cloud (\`subscription/selectors.ts\`) feeds dollars-scale values that never trip the new branch.