### PR TITLE
✨ feat(model): add GPT-5.5 Pro to LobeHub-hosted OpenAI models

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/openai.ts
@@ -62,6 +62,33 @@ export const openaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_050_000,
     description:
+      'GPT-5.5 Pro uses more compute to think harder and provide the best answers for the hardest problems.',
+    displayName: 'GPT-5.5 Pro',
+    enabled: true,
+    id: 'gpt-5.5-pro',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 180, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-23',
+    settings: {
+      extendParams: ['gpt5_2ProReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
       "GPT-5.4 is OpenAI's latest model for complex professional work and a drop-in replacement for GPT-5.2 and GPT-5.3 Codex.",
     displayName: 'GPT-5.4',
     enabled: true,

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -18,6 +18,9 @@ export const disableStreamModels = new Set([
   */
   'computer-use-preview',
   'computer-use-preview-2025-03-11',
+  // gpt-5.5-pro docs explicitly state "Streaming: Not supported"
+  // (gpt-5-pro / gpt-5.4-pro both document streaming as supported, hence omitted)
+  'gpt-5.5-pro',
 ]);
 
 /**

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -104,7 +104,7 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
 
   const screens = Grid.useBreakpoint();
   const isNarrow = !screens.sm;
-  const gpt52ReasoningEffortDefaultValue = model === 'gpt-5.5' ? 'medium' : 'none';
+  const gpt52ReasoningEffortDefaultValue = model?.startsWith('gpt-5.5') ? 'medium' : 'none';
 
   const descWide = { display: 'inline-block', width: 300 } as const;
   const descNarrow = {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A — newly released OpenAI model.

#### 🔀 Description of Change

Adds GPT-5.5 Pro (released 2026-04-23) to the LobeHub-hosted OpenAI catalog so cloud users can pick it from the model selector.

- New `gpt-5.5-pro` card in `lobehub/chat/openai.ts`
  - 1.05M context, 128K max output, flat $30 / $180 per 1M tokens (no cached-input discount)
  - Vision, function call, reasoning, search abilities
  - `extendParams: ['gpt5_2ProReasoningEffort', 'textVerbosity']` (matches `gpt-5.4-pro`)
  - `searchImpl: 'params'` — built-in OpenAI web search via Responses API tool
- Adds `gpt-5.5-pro` to `responsesAPIModels` so the OpenAI runtime auto-routes it to the Responses API (mirrors `gpt-5.4-pro`)

Notes vs `gpt-5.4-pro`:
- Pricing changed from tiered (272K context tier) to **flat** — both input and output rates apply uniformly.
- Cached input is **not offered** by the upstream API for the Pro variant.
- Streaming is **not supported** by `gpt-5.5-pro` per OpenAI docs; long requests should use background mode. Current runtime sends `stream: payload.stream ?? true`; will monitor and disable in a follow-up if upstream rejects.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual verification:
1. Pick **GPT-5.5 Pro** in the model selector under the LobeHub provider.
2. Send a simple prompt and confirm a successful response.
3. Confirm reasoning effort & verbosity sliders render and modify the request payload.
4. Confirm built-in web search toggle issues a `web_search` tool call.

#### 📝 Additional Information

OpenAI announcement: https://openai.com/index/introducing-gpt-5-5/
API docs: https://developers.openai.com/api/docs/models/gpt-5.5-pro