### PR TITLE
♻️ refactor(recent): rewrite queryRecent in Drizzle, exclude web-tool scrapes

### DIFF
--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -1,0 +1,477 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import { agents, chatGroups, documents, knowledgeBases, tasks, topics, users } from '../../schemas';
+import type { LobeChatDatabase } from '../../type';
+import { RecentModel } from '../recent';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+
+const userId = 'recent-model-test-user';
+const otherUserId = 'recent-model-test-other-user';
+
+const recentModel = new RecentModel(serverDB, userId);
+
+const now = () => new Date();
+const minutesAgo = (n: number) => new Date(Date.now() - n * 60 * 1000);
+
+const baseDocFields = {
+  fileType: 'markdown',
+  source: 'document',
+  totalCharCount: 100,
+  totalLineCount: 5,
+} as const;
+
+const baseTaskFields = {
+  instruction: 'do the thing',
+  seq: 1,
+} as const;
+
+describe('RecentModel', () => {
+  beforeEach(async () => {
+    await serverDB.delete(users);
+    await serverDB.insert(users).values([{ id: userId }, { id: otherUserId }]);
+  });
+
+  afterEach(async () => {
+    await serverDB.delete(users);
+  });
+
+  describe('queryRecent', () => {
+    it('returns empty array when user has no recent items', async () => {
+      const result = await recentModel.queryRecent();
+      expect(result).toEqual([]);
+    });
+
+    it('only returns rows for the calling user', async () => {
+      await serverDB.insert(agents).values({ id: 'agent-mine', userId, slug: 'inbox' });
+      await serverDB
+        .insert(agents)
+        .values({ id: 'agent-other', userId: otherUserId, slug: 'inbox' });
+
+      await serverDB.insert(topics).values([
+        { id: 'topic-mine', userId, agentId: 'agent-mine', title: 'mine', updatedAt: now() },
+        {
+          id: 'topic-other',
+          userId: otherUserId,
+          agentId: 'agent-other',
+          title: 'other',
+          updatedAt: now(),
+        },
+      ]);
+
+      const result = await recentModel.queryRecent();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ id: 'topic-mine', type: 'topic' });
+    });
+
+    describe('topics arm', () => {
+      it('includes inbox-agent topics and group topics', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(chatGroups).values({ id: 'group-1', userId });
+
+        await serverDB.insert(topics).values([
+          {
+            id: 'topic-inbox',
+            userId,
+            agentId: 'agent-inbox',
+            title: 'inbox topic',
+            updatedAt: minutesAgo(5),
+          },
+          {
+            id: 'topic-group',
+            userId,
+            groupId: 'group-1',
+            title: 'group topic',
+            updatedAt: minutesAgo(2),
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        expect(result.map((r) => r.id)).toEqual(['topic-group', 'topic-inbox']);
+        expect(result[0]).toMatchObject({
+          id: 'topic-group',
+          type: 'topic',
+          routeId: null,
+          routeGroupId: 'group-1',
+        });
+        expect(result[1]).toMatchObject({
+          id: 'topic-inbox',
+          type: 'topic',
+          routeId: 'agent-inbox',
+          routeGroupId: null,
+        });
+      });
+
+      it('includes topics on non-virtual non-group agents', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-real', userId, virtual: false });
+
+        await serverDB.insert(topics).values({
+          id: 'topic-real',
+          userId,
+          agentId: 'agent-real',
+          title: 'real',
+          updatedAt: now(),
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('topic-real');
+      });
+
+      it('excludes topics on virtual agents that are not in a group', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-virtual', userId, virtual: true });
+
+        await serverDB.insert(topics).values({
+          id: 'topic-virtual',
+          userId,
+          agentId: 'agent-virtual',
+          title: 'virtual',
+          updatedAt: now(),
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toEqual([]);
+      });
+
+      it('excludes topics with system triggers', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+
+        await serverDB.insert(topics).values([
+          { id: 'topic-cron', userId, agentId: 'agent-inbox', trigger: 'cron', updatedAt: now() },
+          { id: 'topic-eval', userId, agentId: 'agent-inbox', trigger: 'eval', updatedAt: now() },
+          {
+            id: 'topic-task',
+            userId,
+            agentId: 'agent-inbox',
+            trigger: 'task_manager',
+            updatedAt: now(),
+          },
+          {
+            id: 'topic-task2',
+            userId,
+            agentId: 'agent-inbox',
+            trigger: 'task',
+            updatedAt: now(),
+          },
+          {
+            id: 'topic-chat',
+            userId,
+            agentId: 'agent-inbox',
+            trigger: 'chat',
+            updatedAt: now(),
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        expect(result.map((r) => r.id)).toEqual(['topic-chat']);
+      });
+
+      it('falls back to "Untitled Topic" when title is null', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values({
+          id: 'topic-untitled',
+          userId,
+          agentId: 'agent-inbox',
+          title: null,
+          updatedAt: now(),
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result[0].title).toBe('Untitled Topic');
+      });
+
+      it('returns topic metadata when present', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values({
+          id: 'topic-with-meta',
+          userId,
+          agentId: 'agent-inbox',
+          metadata: { bot: { platform: 'slack' } } as any,
+          updatedAt: now(),
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result[0].metadata).toEqual({ bot: { platform: 'slack' } });
+      });
+    });
+
+    describe('documents arm', () => {
+      it('includes user-authored "api" pages', async () => {
+        await serverDB.insert(documents).values({
+          id: 'doc-api',
+          userId,
+          title: 'My Page',
+          sourceType: 'api',
+          updatedAt: now(),
+          ...baseDocFields,
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          id: 'doc-api',
+          type: 'document',
+          title: 'My Page',
+          routeId: null,
+          routeGroupId: null,
+          metadata: undefined,
+        });
+      });
+
+      it('excludes web-browsing scraped pages (sourceType "web")', async () => {
+        await serverDB.insert(documents).values([
+          {
+            id: 'doc-api',
+            userId,
+            title: 'Real Page',
+            sourceType: 'api',
+            updatedAt: minutesAgo(1),
+            ...baseDocFields,
+          },
+          {
+            id: 'doc-web',
+            userId,
+            title: 'XAU USD | Gold Spot US Dollar',
+            sourceType: 'web',
+            updatedAt: now(),
+            ...baseDocFields,
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        expect(result.map((r) => r.id)).toEqual(['doc-api']);
+      });
+
+      it('excludes file uploads (sourceType "file")', async () => {
+        await serverDB.insert(documents).values({
+          id: 'doc-file',
+          userId,
+          sourceType: 'file',
+          updatedAt: now(),
+          ...baseDocFields,
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toEqual([]);
+      });
+
+      it('excludes documents inside a knowledge base', async () => {
+        await serverDB.insert(knowledgeBases).values({ id: 'kb-1', userId, name: 'kb' });
+        await serverDB.insert(documents).values({
+          id: 'doc-kb',
+          userId,
+          title: 'kb doc',
+          sourceType: 'api',
+          knowledgeBaseId: 'kb-1',
+          updatedAt: now(),
+          ...baseDocFields,
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toEqual([]);
+      });
+
+      it('excludes folder documents', async () => {
+        await serverDB.insert(documents).values({
+          id: 'doc-folder',
+          userId,
+          title: 'Folder',
+          sourceType: 'api',
+          updatedAt: now(),
+          ...baseDocFields,
+          fileType: 'custom/folder',
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toEqual([]);
+      });
+
+      it('falls back to filename then "Untitled Document" when title is null', async () => {
+        await serverDB.insert(documents).values([
+          {
+            id: 'doc-fallback-filename',
+            userId,
+            title: null,
+            filename: 'notes.md',
+            sourceType: 'api',
+            updatedAt: minutesAgo(1),
+            ...baseDocFields,
+          },
+          {
+            id: 'doc-untitled',
+            userId,
+            title: null,
+            filename: null,
+            sourceType: 'api',
+            updatedAt: now(),
+            ...baseDocFields,
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        const byId = Object.fromEntries(result.map((r) => [r.id, r.title]));
+        expect(byId['doc-fallback-filename']).toBe('notes.md');
+        expect(byId['doc-untitled']).toBe('Untitled Document');
+      });
+    });
+
+    describe('tasks arm', () => {
+      it('includes active tasks and surfaces assigneeAgentId as routeId', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-assignee', userId });
+
+        await serverDB.insert(tasks).values({
+          id: 'task-active',
+          createdByUserId: userId,
+          assigneeAgentId: 'agent-assignee',
+          identifier: 'T-1',
+          name: 'Active Task',
+          status: 'running',
+          updatedAt: now(),
+          ...baseTaskFields,
+        });
+
+        const result = await recentModel.queryRecent();
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          id: 'task-active',
+          type: 'task',
+          title: 'Active Task',
+          routeId: 'agent-assignee',
+          routeGroupId: null,
+        });
+      });
+
+      it('excludes completed and canceled tasks', async () => {
+        await serverDB.insert(tasks).values([
+          {
+            id: 'task-done',
+            createdByUserId: userId,
+            identifier: 'T-2',
+            status: 'completed',
+            updatedAt: now(),
+            ...baseTaskFields,
+          },
+          {
+            id: 'task-canceled',
+            createdByUserId: userId,
+            identifier: 'T-3',
+            status: 'canceled',
+            updatedAt: now(),
+            ...baseTaskFields,
+          },
+          {
+            id: 'task-running',
+            createdByUserId: userId,
+            identifier: 'T-4',
+            status: 'running',
+            updatedAt: now(),
+            ...baseTaskFields,
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        expect(result.map((r) => r.id)).toEqual(['task-running']);
+      });
+
+      it('falls back from name → instruction → "Untitled Task"', async () => {
+        await serverDB.insert(tasks).values([
+          {
+            id: 'task-named',
+            createdByUserId: userId,
+            identifier: 'T-A',
+            name: 'Named',
+            instruction: 'do A',
+            seq: 1,
+            status: 'running',
+            updatedAt: minutesAgo(2),
+          },
+          {
+            id: 'task-instruction',
+            createdByUserId: userId,
+            identifier: 'T-B',
+            name: null,
+            instruction: 'fallback to instruction',
+            seq: 2,
+            status: 'running',
+            updatedAt: minutesAgo(1),
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        const byId = Object.fromEntries(result.map((r) => [r.id, r.title]));
+        expect(byId['task-named']).toBe('Named');
+        expect(byId['task-instruction']).toBe('fallback to instruction');
+      });
+    });
+
+    describe('combined results', () => {
+      it('orders all three types by updatedAt desc and applies the limit', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+
+        await serverDB.insert(topics).values({
+          id: 'topic-1',
+          userId,
+          agentId: 'agent-inbox',
+          title: 'topic',
+          updatedAt: minutesAgo(10),
+        });
+        await serverDB.insert(documents).values({
+          id: 'doc-1',
+          userId,
+          title: 'doc',
+          sourceType: 'api',
+          updatedAt: minutesAgo(5),
+          ...baseDocFields,
+        });
+        await serverDB.insert(tasks).values({
+          id: 'task-1',
+          createdByUserId: userId,
+          identifier: 'T-1',
+          name: 'task',
+          status: 'running',
+          updatedAt: minutesAgo(1),
+          ...baseTaskFields,
+        });
+
+        const result = await recentModel.queryRecent(10);
+        expect(result.map((r) => `${r.type}:${r.id}`)).toEqual([
+          'task:task-1',
+          'document:doc-1',
+          'topic:topic-1',
+        ]);
+      });
+
+      it('respects the limit parameter', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values(
+          Array.from({ length: 5 }, (_, i) => ({
+            id: `topic-${i}`,
+            userId,
+            agentId: 'agent-inbox',
+            title: `t${i}`,
+            updatedAt: minutesAgo(i),
+          })),
+        );
+
+        const result = await recentModel.queryRecent(2);
+        expect(result).toHaveLength(2);
+        expect(result.map((r) => r.id)).toEqual(['topic-0', 'topic-1']);
+      });
+
+      it('returns Date objects for updatedAt', async () => {
+        await serverDB.insert(agents).values({ id: 'agent-inbox', userId, slug: 'inbox' });
+        await serverDB.insert(topics).values({
+          id: 'topic-date',
+          userId,
+          agentId: 'agent-inbox',
+          updatedAt: now(),
+        });
+
+        const [row] = await recentModel.queryRecent();
+        expect(row.updatedAt).toBeInstanceOf(Date);
+      });
+    });
+  });
+});

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -1,4 +1,5 @@
-import { sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
+import { unionAll } from 'drizzle-orm/pg-core';
 
 import { agents, DOCUMENT_FOLDER_TYPE, documents, tasks, topics } from '../schemas';
 import type { LobeChatDatabase } from '../type';
@@ -13,6 +14,17 @@ export interface RecentDbItem {
   updatedAt: Date;
 }
 
+// Mirrors `MAIN_SIDEBAR_EXCLUDE_TRIGGERS` in `src/const/topic.ts`. System-trigger
+// topics live in their own surfaces (Task Manager, cron, eval, task runs) and
+// would clutter the main "Recent" list.
+const SYSTEM_TOPIC_TRIGGERS = ['cron', 'eval', 'task_manager', 'task'];
+
+// Excluded so file uploads and web-browsing tool scrapes don't surface as
+// "recent docs"; only user-authored pages ('api') and legacy 'topic' rows remain.
+const TOOL_DOCUMENT_SOURCE_TYPES = ['file', 'web'];
+
+const TASK_FINAL_STATUSES = ['completed', 'canceled'];
+
 export class RecentModel {
   private userId: string;
   private db: LobeChatDatabase;
@@ -23,76 +35,85 @@ export class RecentModel {
   }
 
   queryRecent = async (limit: number = 10): Promise<RecentDbItem[]> => {
-    // System-trigger topics live in their own surfaces (Task Manager, cron,
-    // eval, task runs) and would clutter the main "Recent" sidebar. Mirrors
-    // `MAIN_SIDEBAR_EXCLUDE_TRIGGERS` in `src/const/topic.ts`.
-    const query = sql`
-      SELECT * FROM (
-        SELECT
-          ${topics.id} as id,
-          COALESCE(${topics.title}, 'Untitled Topic') as title,
-          'topic' as type,
-          ${topics.agentId} as route_id,
-          ${topics.groupId} as route_group_id,
-          ${topics.updatedAt} as updated_at,
-          ${topics.metadata} as metadata
-        FROM ${topics}
-        LEFT JOIN ${agents} ON ${topics.agentId} = ${agents.id}
-        WHERE ${topics.userId} = ${this.userId}
-          AND (
-            ${topics.groupId} IS NOT NULL
-            OR ${agents.slug} = 'inbox'
-            OR (${topics.groupId} IS NULL AND ${agents.virtual} != true)
-          )
-          AND (
-            ${topics.trigger} IS NULL
-            OR ${topics.trigger} NOT IN ('cron', 'eval', 'task_manager', 'task')
-          )
+    const topicArm = this.db
+      .select({
+        id: topics.id,
+        metadata: sql<any>`${topics.metadata}`.as('metadata'),
+        routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
+        routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
+        title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
+        type: sql<RecentDbItem['type']>`'topic'`.as('type'),
+        updatedAt: topics.updatedAt,
+      })
+      .from(topics)
+      .leftJoin(agents, eq(topics.agentId, agents.id))
+      .where(
+        and(
+          eq(topics.userId, this.userId),
+          or(
+            isNotNull(topics.groupId),
+            eq(agents.slug, 'inbox'),
+            and(isNull(topics.groupId), ne(agents.virtual, true)),
+          ),
+          or(isNull(topics.trigger), not(inArray(topics.trigger, SYSTEM_TOPIC_TRIGGERS))),
+        ),
+      );
 
-        UNION ALL
+    const documentArm = this.db
+      .select({
+        id: documents.id,
+        metadata: sql<any>`NULL`.as('metadata'),
+        routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
+        routeId: sql<string | null>`NULL`.as('route_id'),
+        title:
+          sql<string>`COALESCE(${documents.title}, ${documents.filename}, 'Untitled Document')`.as(
+            'title',
+          ),
+        type: sql<RecentDbItem['type']>`'document'`.as('type'),
+        updatedAt: documents.updatedAt,
+      })
+      .from(documents)
+      .where(
+        and(
+          eq(documents.userId, this.userId),
+          not(inArray(documents.sourceType, TOOL_DOCUMENT_SOURCE_TYPES)),
+          isNull(documents.knowledgeBaseId),
+          ne(documents.fileType, DOCUMENT_FOLDER_TYPE),
+        ),
+      );
 
-        SELECT
-          ${documents.id} as id,
-          COALESCE(${documents.title}, ${documents.filename}, 'Untitled Document') as title,
-          'document' as type,
-          NULL as route_id,
-          NULL as route_group_id,
-          ${documents.updatedAt} as updated_at,
-          NULL as metadata
-        FROM ${documents}
-        WHERE ${documents.userId} = ${this.userId}
-          AND ${documents.sourceType} != 'file'
-          AND ${documents.knowledgeBaseId} IS NULL
-          AND ${documents.fileType} != ${DOCUMENT_FOLDER_TYPE}
+    const taskArm = this.db
+      .select({
+        id: tasks.id,
+        metadata: sql<any>`NULL`.as('metadata'),
+        routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
+        routeId: sql<string | null>`${tasks.assigneeAgentId}`.as('route_id'),
+        title: sql<string>`COALESCE(${tasks.name}, ${tasks.instruction}, 'Untitled Task')`.as(
+          'title',
+        ),
+        type: sql<RecentDbItem['type']>`'task'`.as('type'),
+        updatedAt: tasks.updatedAt,
+      })
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.createdByUserId, this.userId),
+          not(inArray(tasks.status, TASK_FINAL_STATUSES)),
+        ),
+      );
 
-        UNION ALL
+    const rows = await unionAll(topicArm, documentArm, taskArm)
+      .orderBy(desc(sql`updated_at`))
+      .limit(limit);
 
-        SELECT
-          ${tasks.id} as id,
-          COALESCE(${tasks.name}, ${tasks.instruction}, 'Untitled Task') as title,
-          'task' as type,
-          ${tasks.assigneeAgentId} as route_id,
-          NULL as route_group_id,
-          ${tasks.updatedAt} as updated_at,
-          NULL as metadata
-        FROM ${tasks}
-        WHERE ${tasks.createdByUserId} = ${this.userId}
-          AND ${tasks.status} NOT IN ('completed', 'canceled')
-      ) AS combined
-      ORDER BY updated_at DESC
-      LIMIT ${limit}
-    `;
-
-    const result = await this.db.execute(query);
-
-    return result.rows.map((row: any) => ({
+    return rows.map((row) => ({
       id: row.id,
       metadata: row.metadata ?? undefined,
-      routeGroupId: row.route_group_id,
-      routeId: row.route_id,
+      routeGroupId: row.routeGroupId,
+      routeId: row.routeId,
       title: row.title,
-      type: row.type as RecentDbItem['type'],
-      updatedAt: new Date(row.updated_at),
+      type: row.type,
+      updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt as any),
     }));
   };
 }

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -21,7 +21,7 @@ const SYSTEM_TOPIC_TRIGGERS = ['cron', 'eval', 'task_manager', 'task'];
 
 // Excluded so file uploads and web-browsing tool scrapes don't surface as
 // "recent docs"; only user-authored pages ('api') and legacy 'topic' rows remain.
-const TOOL_DOCUMENT_SOURCE_TYPES = ['file', 'web'];
+const TOOL_DOCUMENT_SOURCE_TYPES = ['file', 'web'] as const;
 
 const TASK_FINAL_STATUSES = ['completed', 'canceled'];
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

Rewrites `RecentModel.queryRecent` and tightens its filters.

- Replace the raw SQL UNION with Drizzle's typed `unionAll` (`topicArm` / `documentArm` / `taskArm`), so the query is type-checked end-to-end and the result mapping no longer goes through `db.execute().rows`.
- Hoist the filter lists into named module-level constants (`SYSTEM_TOPIC_TRIGGERS`, `TOOL_DOCUMENT_SOURCE_TYPES`, `TASK_FINAL_STATUSES`) to make the intent self-documenting at the call sites.
- Exclude documents whose `sourceType` is in `('file', 'web')`. Previously only `'file'` was excluded, so web-browsing tool scrapes (`sourceType = 'web'`) were leaking into the Recent list. Only user-authored pages (`'api'`) and legacy `'topic'` rows now surface.
- Adds a `RecentModel` test suite covering topic/document/task arms, the new exclusion, system-trigger filtering, and ordering/limit.

No schema changes. Output shape unchanged.

#### 🧪 How to Test

- [x] Added/updated tests

```bash
cd packages/database && bunx vitest run --silent='passed-only' src/models/__tests__/recent.test.ts
```

Manual check: in a workspace with web-tool browsing history, the Recent list should no longer include scraped web pages — only your own pages, topics, and active tasks.