### PR TITLE
📝 docs(version-release): add hotfix changelog example and patch scenario [skip ci]

### DIFF
--- a/.agents/skills/version-release/reference/changelog-example/hotfix.md
+++ b/.agents/skills/version-release/reference/changelog-example/hotfix.md
@@ -1,0 +1,21 @@
+# 🚀 LobeHub v2.1.54 (20260427)
+
+**Hotfix Scope:** Agent topic-switching regression — stale chat state on agent change
+
+> Clears residual topic state when navigating between agents and restores blank-canvas behavior on agent switch.
+
+## 🐛 What's Fixed
+
+- **Stale topic on agent switch** — Switching from `/agent/agt_A/tpc_X` to `/agent/agt_B` no longer leaves the previous topic's messages on screen, and _Start new topic_ responds again. (#14231)
+- **Header & sidebar consistency** — Conversation header now shows the active subtopic's title, and the sidebar keeps the parent topic's thread list expanded while a thread is open.
+
+## ⚙️ Upgrade
+
+- Self-hosted: pull the new image and restart. No schema or env changes.
+- Cloud: applied automatically.
+
+## 👥 Owner
+
+@{pr-author}
+
+> **Note for Claude**: Replace `{pr-author}` with the actual PR author. Retrieve via `gh pr view <number> --json author --jq '.author.login'`. Do not hardcode a username.

--- a/.agents/skills/version-release/reference/patch-release-scenarios.md
+++ b/.agents/skills/version-release/reference/patch-release-scenarios.md
@@ -59,7 +59,10 @@ git push -u origin hotfix/v{version}-{short-hash}
 
 2. **Create PR to main** with a gitmoji prefix title (e.g. `🐛 fix: description`)
 
-3. **After merge**: auto-tag-release detects `hotfix/*` branch → auto patch +1.
+3. **Write a short hotfix changelog** — See `changelog-example/hotfix.md`. Keep it minimal: scope line, 1-3 fix bullets (symptom + fix in one sentence), upgrade note, owner. No long root-cause section — that lives in the commit message.
+   - **Hotfix owner**: Use the actual PR author (retrieve via `gh pr view <number> --json author --jq '.author.login'`), never hardcode a username.
+
+4. **After merge**: auto-tag-release detects `hotfix/*` branch → auto patch +1.
 
 ### Script
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A (internal agent skill / release documentation)

#### 🔀 Description of Change

- Adds a **hotfix changelog example** under `version-release` reference material.
- Updates **patch release scenarios** to point at the new example where relevant.

This only touches `.agents/skills/version-release/reference/`; no product code.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A (documentation only)

#### 📝 Additional Information

Branch created from current `canary` and contains a single documentation commit.

Made with [Cursor](https://cursor.com)