### PR TITLE
🐛 fix(conversation): inline single-tool assistant group and promote leading sentence

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -96,6 +96,11 @@ const blk = (p: Partial<AssistantContentBlock> & { id: string }): AssistantConte
 const parseAnswerSegment = () =>
   JSON.parse(screen.getByTestId('answer-segment').getAttribute('data-block') || '{}');
 
+const parseAnswerSegments = () =>
+  screen
+    .queryAllByTestId('answer-segment')
+    .map((node) => JSON.parse(node.getAttribute('data-block') || '{}'));
+
 const parseWorkflowSegment = () =>
   JSON.parse(screen.getByTestId('workflow-segment').getAttribute('data-blocks') || '[]');
 
@@ -106,7 +111,7 @@ describe('Group', () => {
     mockIsGenerating = false;
   });
 
-  it('keeps long structured mixed content visible and moves only tools into workflow', () => {
+  it('keeps long structured mixed content visible and renders the single tool inline', () => {
     const longContent =
       '后宫番 + 实际项目中的状态管理问题，这个组合挺有意思的！\n\n对于实际项目中的状态管理，你目前遇到的具体问题是什么？比如：\n- 不知道什么时候该用 useState，什么时候该用 Context\n- 组件间状态传递变得混乱\n- 性能问题（不必要的重渲染）';
 
@@ -128,27 +133,28 @@ describe('Group', () => {
       node.getAttribute('data-testid'),
     );
 
-    expect(sequence).toEqual(['answer-segment', 'workflow-segment']);
-
-    expect(parseAnswerSegment()).toEqual({
-      content: longContent,
-      disableMarkdownStreaming: true,
-      domId: 'block-1__answer',
-      id: 'block-1',
-      isFirstBlock: false,
-      toolCount: 0,
-    });
-    expect(parseWorkflowSegment()).toEqual([
+    expect(sequence).toEqual(['answer-segment', 'answer-segment']);
+    expect(parseAnswerSegments()).toEqual([
+      {
+        content: longContent,
+        disableMarkdownStreaming: true,
+        domId: 'block-1__answer',
+        id: 'block-1',
+        isFirstBlock: false,
+        toolCount: 0,
+      },
       {
         content: '',
         disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
+        id: 'block-1',
+        isFirstBlock: false,
         toolCount: 1,
       },
     ]);
   });
 
-  it('keeps short mixed status text inside workflow', () => {
+  it('keeps a short mixed status block inline when there is only one tool call', () => {
     render(
       <Group
         id="assistant-1"
@@ -163,12 +169,91 @@ describe('Group', () => {
       />,
     );
 
-    expect(screen.queryByTestId('answer-segment')).not.toBeInTheDocument();
-    expect(parseWorkflowSegment()).toEqual([
+    expect(screen.queryByTestId('workflow-segment')).not.toBeInTheDocument();
+    expect(parseAnswerSegments()).toEqual([
       {
         content: '现在我来搜索资料。',
         disableMarkdownStreaming: true,
         domId: undefined,
+        id: 'block-1',
+        isFirstBlock: false,
+        toolCount: 1,
+      },
+    ]);
+  });
+
+  it('promotes the first sentence before folding a multi-tool workflow', () => {
+    const { container } = render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '我先帮你查一下。接下来我会继续整理结果。',
+            id: 'block-1',
+            tools: [{ apiName: 'search', id: 'tool-1' } as any],
+          }),
+          blk({
+            content: '',
+            id: 'block-2',
+            tools: [{ apiName: 'readFile', id: 'tool-2' } as any],
+          }),
+        ]}
+      />,
+    );
+
+    const sequence = Array.from(container.querySelectorAll('[data-testid]')).map((node) =>
+      node.getAttribute('data-testid'),
+    );
+
+    expect(sequence).toEqual(['answer-segment', 'workflow-segment']);
+    expect(parseAnswerSegment()).toEqual({
+      content: '我先帮你查一下。',
+      disableMarkdownStreaming: true,
+      domId: 'block-1__answer',
+      id: 'block-1',
+      isFirstBlock: false,
+      toolCount: 0,
+    });
+    expect(parseWorkflowSegment()).toEqual([
+      {
+        content: '接下来我会继续整理结果。',
+        disableMarkdownStreaming: true,
+        domId: 'block-1__workflow',
+        toolCount: 1,
+      },
+      {
+        content: '',
+        disableMarkdownStreaming: false,
+        domId: undefined,
+        toolCount: 1,
+      },
+    ]);
+  });
+
+  it('renders a single tool call inline instead of folding it', () => {
+    render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'search', id: 'tool-1' } as any],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('workflow-segment')).not.toBeInTheDocument();
+    expect(parseAnswerSegments()).toEqual([
+      {
+        content: '',
+        disableMarkdownStreaming: true,
+        domId: undefined,
+        id: 'block-1',
+        isFirstBlock: false,
         toolCount: 1,
       },
     ]);

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -57,6 +57,11 @@ interface PartitionedBlocks {
   segments: GroupRenderSegment[];
 }
 
+interface LeadingSentenceSplit {
+  lead: string;
+  remainder: string;
+}
+
 const ANSWER_DOM_ID_SUFFIX = '__answer';
 const WORKFLOW_DOM_ID_SUFFIX = '__workflow';
 
@@ -80,6 +85,55 @@ const hasSubstantiveContent = (block: AssistantContentBlock): boolean => {
 
 const hasReasoningContent = (block: AssistantContentBlock): boolean => {
   return !!block.reasoning?.content?.trim();
+};
+
+const isSentenceBoundary = (content: string, index: number): boolean => {
+  const char = content[index];
+  if (!char) return false;
+  if (char === '。' || char === '！' || char === '？' || char === '!' || char === '?') return true;
+  if (char !== '.') return false;
+
+  const prev = content[index - 1] ?? '';
+  const next = content[index + 1] ?? '';
+  if (/[a-z\d]/i.test(prev) && /[a-z\d]/i.test(next)) return false;
+  if (/\d/.test(prev) && /\d/.test(next)) return false;
+
+  return true;
+};
+
+const extractLeadingSentenceSplit = (block: AssistantContentBlock): LeadingSentenceSplit | null => {
+  const content = block.content ?? '';
+  const trimmed = content.trim();
+
+  if (!trimmed || trimmed === LOADING_FLAT) return null;
+
+  let splitIndex = -1;
+
+  for (let i = 0; i < content.length; i++) {
+    if (!isSentenceBoundary(content, i)) continue;
+    splitIndex = i + 1;
+    break;
+  }
+
+  if (splitIndex === -1) {
+    const paragraphBreak = content.search(/\n\s*\n/);
+    if (paragraphBreak >= 0) splitIndex = paragraphBreak;
+  }
+
+  if (splitIndex === -1) {
+    const firstLineBreak = content.indexOf('\n');
+    if (firstLineBreak >= 0) splitIndex = firstLineBreak;
+  }
+
+  if (splitIndex === -1) return null;
+
+  const lead = content.slice(0, splitIndex).trim();
+  const remainder = content.slice(splitIndex).trimStart();
+
+  if (!lead) return null;
+  if (!remainder && !hasTools(block) && !hasReasoningContent(block) && !block.error) return null;
+
+  return { lead, remainder };
 };
 
 const isTrailingReasoningCandidate = (block: AssistantContentBlock): boolean => {
@@ -140,8 +194,37 @@ const shouldPromoteMixedBlockContent = (block: AssistantContentBlock): boolean =
   );
 };
 
-const appendWorkflowRangeBlock = (segments: GroupRenderSegment[], block: AssistantContentBlock) => {
+const appendWorkflowRangeBlock = (
+  segments: GroupRenderSegment[],
+  block: AssistantContentBlock,
+  allowLeadingSentencePromotion = false,
+) => {
   if (!shouldPromoteMixedBlockContent(block)) {
+    const leadingSentenceSplit =
+      allowLeadingSentencePromotion && segments.length === 0 && hasTools(block)
+        ? extractLeadingSentenceSplit(block)
+        : null;
+
+    if (leadingSentenceSplit) {
+      appendAnswerBlock(
+        segments,
+        createAnswerRenderBlock(block, {
+          content: leadingSentenceSplit.lead,
+          error: undefined,
+          imageList: undefined,
+          reasoning: undefined,
+          tools: undefined,
+        }),
+      );
+      appendWorkflowBlock(
+        segments,
+        createWorkflowRenderBlock(block, {
+          content: leadingSentenceSplit.remainder,
+        }),
+      );
+      return;
+    }
+
     appendWorkflowBlock(segments, block);
     return;
   }
@@ -230,6 +313,8 @@ const partitionBlocks = (
     }
   }
 
+  const totalToolCount = blocks.reduce((sum, block) => sum + (block.tools?.length ?? 0), 0);
+
   for (const block of blocks.slice(0, firstToolIndex)) {
     appendAnswerBlock(segments, block);
   }
@@ -248,7 +333,7 @@ const partitionBlocks = (
     }
 
     for (const block of blocks.slice(firstToolIndex, workingEndExclusive)) {
-      appendWorkflowRangeBlock(segments, block);
+      appendWorkflowRangeBlock(segments, block, totalToolCount > 1);
     }
 
     for (const block of blocks.slice(workingEndExclusive)) {
@@ -262,7 +347,7 @@ const partitionBlocks = (
   }
 
   for (const block of blocks.slice(firstToolIndex, lastToolIndex + 1)) {
-    appendWorkflowRangeBlock(segments, block);
+    appendWorkflowRangeBlock(segments, block, totalToolCount > 1);
   }
 
   appendPostToolBlocks(segments, blocks.slice(lastToolIndex + 1));
@@ -280,6 +365,17 @@ const withMarkdownStreamingState = (
   ...block,
   disableMarkdownStreaming: block.disableMarkdownStreaming || block.id === firstBlockId,
 });
+
+const shouldInlineWorkflowSegment = (blocks: RenderableAssistantContentBlock[]): boolean => {
+  let toolCount = 0;
+
+  for (const block of blocks) {
+    toolCount += block.tools?.length ?? 0;
+    if (toolCount > 1) return false;
+  }
+
+  return toolCount === 1;
+};
 
 const Group = memo<GroupChildrenProps>(
   ({
@@ -321,6 +417,24 @@ const Group = memo<GroupChildrenProps>(
           {segments.map((segment, index) => {
             if (segment.kind === 'workflow') {
               if (segment.blocks.length === 0) return null;
+
+              if (shouldInlineWorkflowSegment(segment.blocks)) {
+                return segment.blocks.map((block, blockIndex) => {
+                  const item = withMarkdownStreamingState(block, firstBlockId);
+                  if (!isGenerating && isEmptyBlock(item)) return null;
+
+                  return (
+                    <GroupItem
+                      {...item}
+                      assistantId={id}
+                      contentId={contentId}
+                      disableEditing={disableEditing}
+                      key={item.renderKey ?? `${id}.workflow-inline.${index}.${blockIndex}`}
+                      messageIndex={messageIndex}
+                    />
+                  );
+                });
+              }
 
               return (
                 <WorkflowCollapse


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — no matching GitHub issue found.

#### 🔀 Description of Change

- Renders a single tool call inline in the assistant message group instead of folding it into the workflow collapse.
- When multiple tools are present, promotes the first sentence (CJK/English boundaries + paragraph/line breaks) into the answer segment so status text stays visible before the workflow block.
- Removes a useless `totalToolCount` initializer to satisfy lint.

#### 🧪 How to Test

- `bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx'`
- Manually: send assistant replies with one tool vs several tools and mixed Chinese/English status text; confirm layout matches expectations.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A — layout behavior covered by unit tests.

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

None.

Made with [Cursor](https://cursor.com)