### PR TITLE
✨ feat(aihubmix): add gpt-image-2 and Grok 4.20 models

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -1,6 +1,7 @@
-import { type AIChatModelCard } from '../types/aiModel';
+import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import { gptImage2Schema } from './lobehub';
 
-const aihubmixModels: AIChatModelCard[] = [
+const aihubmixChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
@@ -802,6 +803,87 @@ const aihubmixModels: AIChatModelCard[] = [
         { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
       ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 2_000_000,
+    description: 'A non-reasoning variant for simple use cases',
+    displayName: 'Grok 4.20 (Non-Reasoning)',
+    enabled: true,
+    id: 'grok-4-20-non-reasoning',
+    maxOutput: 2_000_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-09',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 2_000_000,
+    description: 'Intelligent, blazing-fast model that reasons before responding',
+    displayName: 'Grok 4.20',
+    enabled: true,
+    id: 'grok-4-20-reasoning',
+    maxOutput: 2_000_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-09',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 2_000_000,
+    description:
+      'A team of 4 or 16 agents, Excels at research use cases, Does not currently support client-side tools. Only supports xAI server side tools (eg X Search, Web Search tools) and remote MCP tools.',
+    displayName: 'Grok 4.20 Multi-Agent',
+    enabled: true,
+    id: 'grok-4.20-multi-agent-0309',
+    maxOutput: 2_000_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-09',
+    settings: {
+      extendParams: ['grok4_20ReasoningEffort'],
+      searchImpl: 'params',
     },
     type: 'chat',
   },
@@ -1830,4 +1912,30 @@ const aihubmixModels: AIChatModelCard[] = [
   },
 ];
 
-export default aihubmixModels;
+const aihubmixImageModels: AIImageModelCard[] = [
+  {
+    description:
+      "OpenAI's next-generation multimodal image model with native reasoning, up to 4K resolution, near-perfect text rendering, and high-fidelity multilingual support.",
+    displayName: 'GPT Image 2',
+    enabled: true,
+    id: 'gpt-image-2',
+    parameters: gptImage2Schema,
+    pricing: {
+      // Medium quality at 1024x1024: ~1767 output tokens * $30/M = $0.053 per image.
+      // Source: https://aihubmix.com/model/gpt-image-2
+      approximatePricePerImage: 0.053,
+      units: [
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 8, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-04-21',
+    type: 'image',
+  },
+];
+
+export const allModels = [...aihubmixChatModels, ...aihubmixImageModels];
+
+export default allModels;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Closes #14221
Related to #13839 (the Seedance 2.0 video models are tracked separately — they need additional runtime support beyond model card registration)

#### 🔀 Description of Change

Surface the latest AiHubMix-hosted models that landed on aihubmix.com but were not yet registered in the model bank.

**Chat (xAI Grok 4.20 family)**:
- `grok-4-20-non-reasoning`
- `grok-4-20-reasoning`
- `grok-4.20-multi-agent-0309`

**Image (OpenAI)**:
- `gpt-image-2`

**Notes**:
- Model IDs match what AiHubMix actually exposes (verified against `https://aihubmix.com/model/<id>`). Note that the non-reasoning / reasoning variants use `grok-4-20-...` rather than xAI's official `grok-4.20-0309-...` — AiHubMix renames those two but keeps `grok-4.20-multi-agent-0309` as-is.
- Pricing reflects AiHubMix's flat single-tier rate ($2 in / $6 out / $0.20 cache per M tokens for Grok 4.20; $5 textIn / $10 textOut / $8 imageIn / $30 imageOut per M tokens for gpt-image-2). xAI's official tiered pricing does not apply on AiHubMix.
- The aihubmix model bank previously declared only `AIChatModelCard[]`. Restructured to mirror the `fal.ts` / `replicate.ts` mixed pattern (`aihubmixChatModels` + `aihubmixImageModels`, exported via `allModels`).

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed (pure data registration)

`bunx vitest run --silent='passed-only'` from `packages/model-bank` passes (34/34).

#### 📝 Additional Information

`gpt-image-2` lives in `openai.ts` and so it routes via the existing `apiType: 'openai'` fallback in the AiHubMix runtime. Grok 4.20 IDs all contain `grok` so `detectModelProvider` classifies them as `xai` and routes through the existing `apiType: 'xai'` router. No runtime changes required.