### PR TITLE
🐛 fix(model-bank): reject lobehub model ids no longer in the bank

### DIFF
--- a/locales/en-US/error.json
+++ b/locales/en-US/error.json
@@ -91,6 +91,7 @@
   "response.InvalidOllamaArgs": "Invalid Ollama configuration, please check Ollama configuration and try again",
   "response.InvalidProviderAPIKey": "{{provider}} API Key is incorrect or empty, please check your {{provider}} API Key and try again",
   "response.InvalidVertexCredentials": "Vertex authentication failed. Please check your credentials and try again.",
+  "response.LobeHubModelDeprecated": "The model \"{{model}}\" is no longer available. Please pick a current model from the model selector.",
   "response.LocationNotSupportError": "We're sorry, your current location does not support this model service. This may be due to regional restrictions or the service not being available. Please confirm if the current location supports using this service, or try using a different location.",
   "response.ModelNotFound": "Sorry, the requested model could not be found. It may not exist or you may not have the necessary access permissions. Please try again after changing the API Key or adjusting your access permissions.",
   "response.NoOpenAIAPIKey": "OpenAI API Key is empty, please add a custom OpenAI API Key",

--- a/locales/zh-CN/error.json
+++ b/locales/zh-CN/error.json
@@ -91,6 +91,7 @@
   "response.InvalidOllamaArgs": "Ollama 配置不正确。请检查配置后重试",
   "response.InvalidProviderAPIKey": "{{provider}} API Key 为空或不正确，请检查 {{provider}} API Key 后重试",
   "response.InvalidVertexCredentials": "Vertex 鉴权失败。请检查凭证后重试",
+  "response.LobeHubModelDeprecated": "模型「{{model}}」已下架，请到模型选择器中重新选择可用模型。",
   "response.LocationNotSupportError": "当前地区暂不支持该模型服务（可能受区域限制或服务未开通）。请切换可用地区或更换模型服务商后重试",
   "response.ModelNotFound": "未找到可用模型或无访问权限。请更换 API Key 或调整权限后重试",
   "response.NoOpenAIAPIKey": "OpenAI API Key 为空或不正确，请添加自定义 OpenAI API Key",

--- a/packages/model-bank/src/aiModels/lobehub/findModel.ts
+++ b/packages/model-bank/src/aiModels/lobehub/findModel.ts
@@ -5,14 +5,14 @@ import { lobehubEmbeddingModels } from './embedding';
 import { lobehubImageModels } from './image';
 import { lobehubVideoModels } from './video';
 
-const lobehubAllModels = [
+export const allModels = [
   ...lobehubChatModels,
   ...lobehubEmbeddingModels,
   ...lobehubImageModels,
   ...lobehubVideoModels,
 ];
 
-export const findLobeHubModel = (id: string) => lobehubAllModels.find((m) => m.id === id);
+export const findLobeHubModel = (id: string) => allModels.find((m) => m.id === id);
 
 export const isLobeHubModelAvailable = (id: string, expectedType: AiModelType) => {
   const model = findLobeHubModel(id);

--- a/packages/model-bank/src/aiModels/lobehub/findModel.ts
+++ b/packages/model-bank/src/aiModels/lobehub/findModel.ts
@@ -1,0 +1,20 @@
+import type { AiModelType } from 'model-bank';
+
+import { lobehubChatModels } from './chat';
+import { lobehubEmbeddingModels } from './embedding';
+import { lobehubImageModels } from './image';
+import { lobehubVideoModels } from './video';
+
+const lobehubAllModels = [
+  ...lobehubChatModels,
+  ...lobehubEmbeddingModels,
+  ...lobehubImageModels,
+  ...lobehubVideoModels,
+];
+
+export const findLobeHubModel = (id: string) => lobehubAllModels.find((m) => m.id === id);
+
+export const isLobeHubModelAvailable = (id: string, expectedType: AiModelType) => {
+  const model = findLobeHubModel(id);
+  return !!model && model.type === expectedType;
+};

--- a/packages/model-bank/src/aiModels/lobehub/index.ts
+++ b/packages/model-bank/src/aiModels/lobehub/index.ts
@@ -5,6 +5,7 @@ import { lobehubVideoModels } from './video';
 
 export { lobehubChatModels } from './chat';
 export { lobehubEmbeddingModels } from './embedding';
+export * from './findModel';
 export { lobehubImageModels } from './image';
 export * from './utils';
 export {

--- a/packages/model-bank/src/aiModels/lobehub/index.ts
+++ b/packages/model-bank/src/aiModels/lobehub/index.ts
@@ -1,7 +1,4 @@
-import { lobehubChatModels } from './chat';
-import { lobehubEmbeddingModels } from './embedding';
-import { lobehubImageModels } from './image';
-import { lobehubVideoModels } from './video';
+import { allModels } from './findModel';
 
 export { lobehubChatModels } from './chat';
 export { lobehubEmbeddingModels } from './embedding';
@@ -14,12 +11,5 @@ export {
   seedance20FastParams,
   seedance20Params,
 } from './video';
-
-export const allModels = [
-  ...lobehubChatModels,
-  ...lobehubEmbeddingModels,
-  ...lobehubImageModels,
-  ...lobehubVideoModels,
-];
 
 export default allModels;

--- a/packages/model-bank/src/aiModels/lobehub/utils.test.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { lobehubChatModels } from './chat';
+import { lobehubEmbeddingModels } from './embedding';
+import { findLobeHubModel, isLobeHubModelAvailable } from './findModel';
+import { lobehubImageModels } from './image';
+import { lobehubVideoModels } from './video';
+
+describe('findLobeHubModel', () => {
+  it('returns the model when id exists in chat models', () => {
+    const sample = lobehubChatModels[0];
+    expect(findLobeHubModel(sample.id)).toMatchObject({ id: sample.id, type: 'chat' });
+  });
+
+  it('returns the model when id exists in image / video / embedding models', () => {
+    if (lobehubImageModels[0]) {
+      expect(findLobeHubModel(lobehubImageModels[0].id)?.type).toBe('image');
+    }
+    if (lobehubVideoModels[0]) {
+      expect(findLobeHubModel(lobehubVideoModels[0].id)?.type).toBe('video');
+    }
+    if (lobehubEmbeddingModels[0]) {
+      expect(findLobeHubModel(lobehubEmbeddingModels[0].id)?.type).toBe('embedding');
+    }
+  });
+
+  it('returns undefined for deprecated/unknown model ids', () => {
+    expect(findLobeHubModel('claude-3-5-sonnet-latest')).toBeUndefined();
+    expect(findLobeHubModel('gpt-3.5-turbo')).toBeUndefined();
+    expect(findLobeHubModel('')).toBeUndefined();
+  });
+});
+
+describe('isLobeHubModelAvailable', () => {
+  it('returns true when id and expected type both match', () => {
+    const sample = lobehubChatModels[0];
+    expect(isLobeHubModelAvailable(sample.id, 'chat')).toBe(true);
+  });
+
+  it('returns false when id matches but type differs', () => {
+    const sample = lobehubChatModels[0];
+    expect(isLobeHubModelAvailable(sample.id, 'image')).toBe(false);
+    expect(isLobeHubModelAvailable(sample.id, 'video')).toBe(false);
+  });
+
+  it('returns false for deprecated/unknown ids regardless of type', () => {
+    expect(isLobeHubModelAvailable('claude-3-5-sonnet-latest', 'chat')).toBe(false);
+    expect(isLobeHubModelAvailable('seedance-2.0-lite', 'video')).toBe(false);
+  });
+});

--- a/packages/types/src/fetch.ts
+++ b/packages/types/src/fetch.ts
@@ -13,6 +13,7 @@ export const ChatErrorType = {
 
   InvalidUserKey: 'InvalidUserKey', // is not valid User key
   CreateMessageError: 'CreateMessageError',
+  LobeHubModelDeprecated: 'LobeHubModelDeprecated', // requested LobeHub model is no longer available
   /**
    * @deprecated
    */

--- a/src/business/client/handleLobeHubModelDeprecatedError.ts
+++ b/src/business/client/handleLobeHubModelDeprecatedError.ts
@@ -1,0 +1,23 @@
+import { TRPCClientError } from '@trpc/client';
+import { t } from 'i18next';
+
+import { message } from '@/components/AntdStaticMethods';
+
+interface LobeHubModelDeprecatedErrorData {
+  modelType?: string;
+  requestedModel?: string;
+}
+
+export const handleLobeHubModelDeprecatedError = (error: unknown) => {
+  if (!(error instanceof TRPCClientError) || error.message !== 'LobeHubModelDeprecated') return;
+
+  const requestedModel = (error.data?.errorData as LobeHubModelDeprecatedErrorData | undefined)
+    ?.requestedModel;
+
+  message.error(
+    t('response.LobeHubModelDeprecated', {
+      model: requestedModel ?? '-',
+      ns: 'error',
+    }),
+  );
+};

--- a/src/business/client/handleLobeHubModelDeprecatedError.ts
+++ b/src/business/client/handleLobeHubModelDeprecatedError.ts
@@ -1,3 +1,4 @@
+import { ChatErrorType } from '@lobechat/types';
 import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
 
@@ -9,7 +10,8 @@ interface LobeHubModelDeprecatedErrorData {
 }
 
 export const handleLobeHubModelDeprecatedError = (error: unknown) => {
-  if (!(error instanceof TRPCClientError) || error.message !== 'LobeHubModelDeprecated') return;
+  if (!(error instanceof TRPCClientError) || error.message !== ChatErrorType.LobeHubModelDeprecated)
+    return;
 
   const requestedModel = (error.data?.errorData as LobeHubModelDeprecatedErrorData | undefined)
     ?.requestedModel;

--- a/src/locales/default/error.ts
+++ b/src/locales/default/error.ts
@@ -217,6 +217,8 @@ export default {
     'Your subscription points have been exhausted, and you cannot use this feature. Please top up credits or configure a custom model API to continue using it.',
   'response.SystemTimeNotMatchError':
     'Sorry, your system time does not match the server. Please check your system time and try again.',
+  'response.LobeHubModelDeprecated':
+    'The model "{{model}}" is no longer available. Please pick a current model from the model selector.',
   'response.UnknownChatFetchError':
     'Sorry, an unknown request error occurred. Please check the information below or try again.',
   'stt.responseError': 'Service request failed, please check the configuration or try again',

--- a/src/server/routers/lambda/__tests__/video.test.ts
+++ b/src/server/routers/lambda/__tests__/video.test.ts
@@ -10,6 +10,7 @@ const {
   mockAfter,
   mockCreateVideo,
   mockProcessBackgroundVideoPolling,
+  mockResolveBusinessModelMapping,
   mockServerDB,
   mockTransaction,
 } = vi.hoisted(() => {
@@ -18,10 +19,12 @@ const {
   const mockCreateVideo = vi.fn();
   const mockAfter = vi.fn((cb: () => void) => cb());
   const mockProcessBackgroundVideoPolling = vi.fn().mockResolvedValue(undefined);
+  const mockResolveBusinessModelMapping = vi.fn();
   return {
     mockAfter,
     mockCreateVideo,
     mockProcessBackgroundVideoPolling,
+    mockResolveBusinessModelMapping,
     mockServerDB,
     mockTransaction,
   };
@@ -46,6 +49,11 @@ vi.mock('@/business/server/video-generation/chargeBeforeGenerate', () => ({
 }));
 vi.mock('@/business/server/video-generation/chargeAfterGenerate', () => ({
   chargeAfterGenerate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
+  ...((await importOriginal()) as any),
+  resolveBusinessModelMapping: (...args: [string, string]) =>
+    mockResolveBusinessModelMapping(...args),
 }));
 vi.mock('@/business/server/video-generation/getVideoFreeQuota', () => ({
   getVideoFreeQuota: vi.fn().mockResolvedValue({ remaining: 10 }),
@@ -127,6 +135,11 @@ describe('videoRouter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockResolveBusinessModelMapping.mockImplementation(
+      async (_provider: string, model: string) => ({
+        resolvedModelId: model,
+      }),
+    );
   });
 
   describe('createVideo - async strategy routing', () => {
@@ -144,6 +157,29 @@ describe('videoRouter', () => {
       });
       // Webhook: should NOT trigger background polling
       expect(mockAfter).not.toHaveBeenCalled();
+    });
+
+    it('should validate mapped model id before rejecting deprecated lobehub video models', async () => {
+      setupMocks();
+      mockResolveBusinessModelMapping.mockResolvedValue({
+        requestedModelId: 'onboarding-video',
+        resolvedModelId: 'dreamina-seedance-2-0-260128',
+      });
+      mockCreateVideo.mockResolvedValue({ inferenceId: 'inf-mapped', useWebhook: true });
+
+      const caller = videoRouter.createCaller(mockCtx);
+      const result = await caller.createVideo({
+        ...defaultInput,
+        model: 'onboarding-video',
+        provider: 'lobehub',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-video');
+      expect(mockCreateVideo).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'dreamina-seedance-2-0-260128' }),
+        expect.any(Object),
+      );
     });
 
     it('should use polling path when response contains only inferenceId', async () => {

--- a/src/server/routers/lambda/image/index.test.ts
+++ b/src/server/routers/lambda/image/index.test.ts
@@ -12,6 +12,7 @@ const {
   mockAsyncTaskModelUpdate,
   mockChargeBeforeGenerate,
   mockCreateAsyncCaller,
+  mockResolveBusinessModelMapping,
 } = vi.hoisted(() => ({
   mockServerDB: {
     transaction: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockAsyncTaskModelUpdate: vi.fn(),
   mockChargeBeforeGenerate: vi.fn(),
   mockCreateAsyncCaller: vi.fn(),
+  mockResolveBusinessModelMapping: vi.fn(),
 }));
 
 // Mock debug
@@ -51,6 +53,12 @@ vi.mock('@/database/models/asyncTask', () => ({
 // Mock chargeBeforeGenerate
 vi.mock('@/business/server/image-generation/chargeBeforeGenerate', () => ({
   chargeBeforeGenerate: (params: any) => mockChargeBeforeGenerate(params),
+}));
+
+vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
+  ...((await importOriginal()) as any),
+  resolveBusinessModelMapping: (...args: [string, string]) =>
+    mockResolveBusinessModelMapping(...args),
 }));
 
 // Mock async caller
@@ -102,6 +110,11 @@ describe('imageRouter', () => {
     vi.clearAllMocks();
 
     // Default mock implementations
+    mockResolveBusinessModelMapping.mockImplementation(
+      async (_provider: string, model: string) => ({
+        resolvedModelId: model,
+      }),
+    );
     mockChargeBeforeGenerate.mockResolvedValue(undefined);
     mockGetKeyFromFullUrl.mockResolvedValue(null);
     mockGetFullFileUrl.mockResolvedValue(null);
@@ -172,6 +185,26 @@ describe('imageRouter', () => {
       expect(result.data.batch.id).toBe('batch-1');
       expect(result.data.generations).toHaveLength(2);
       expect(mockServerDB.transaction).toHaveBeenCalled();
+    });
+
+    it('should validate mapped model id before rejecting deprecated lobehub image models', async () => {
+      mockResolveBusinessModelMapping.mockResolvedValue({
+        requestedModelId: 'onboarding-image',
+        resolvedModelId: 'gpt-image-1',
+      });
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput({
+        model: 'onboarding-image',
+        provider: 'lobehub',
+      });
+
+      const caller = imageRouter.createCaller(ctx);
+      const result = await caller.createImage(input);
+
+      expect(result.success).toBe(true);
+      expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-image');
+      expect(mockCreateAsyncCaller).toHaveBeenCalledWith({ userId: mockUserId });
     });
 
     it('should convert imageUrls to S3 keys for database storage', async () => {

--- a/src/server/routers/lambda/image/index.ts
+++ b/src/server/routers/lambda/image/index.ts
@@ -1,5 +1,8 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
+import { isLobeHubModelAvailable } from 'model-bank/lobehub';
 import { z } from 'zod';
 
 import { chargeBeforeGenerate } from '@/business/server/image-generation/chargeBeforeGenerate';
@@ -58,6 +61,17 @@ export const imageRouter = router({
     const { generationTopicId, provider, model, imageNum, params } = input;
 
     log('Starting image creation process, input: %O', input);
+
+    // Reject lobehub model ids that are no longer in the model bank so callers get a
+    // clear error instead of an opaque downstream failure when the underlying channel
+    // can't serve the requested id.
+    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(model, 'image')) {
+      throw new TRPCError({
+        cause: { data: { modelType: 'image', requestedModel: model } },
+        code: 'BAD_REQUEST',
+        message: 'LobeHubModelDeprecated',
+      });
+    }
 
     // Normalize reference image addresses, store S3 keys uniformly (avoid storing expiring presigned URLs in database)
     let configForDatabase = { ...params };

--- a/src/server/routers/lambda/image/index.ts
+++ b/src/server/routers/lambda/image/index.ts
@@ -1,4 +1,6 @@
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
+import { ChatErrorType } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
@@ -62,14 +64,16 @@ export const imageRouter = router({
 
     log('Starting image creation process, input: %O', input);
 
+    const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
+
     // Reject lobehub model ids that are no longer in the model bank so callers get a
     // clear error instead of an opaque downstream failure when the underlying channel
     // can't serve the requested id.
-    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(model, 'image')) {
+    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(resolvedModelId, 'image')) {
       throw new TRPCError({
         cause: { data: { modelType: 'image', requestedModel: model } },
         code: 'BAD_REQUEST',
-        message: 'LobeHubModelDeprecated',
+        message: ChatErrorType.LobeHubModelDeprecated,
       });
     }
 

--- a/src/server/routers/lambda/video/index.ts
+++ b/src/server/routers/lambda/video/index.ts
@@ -1,12 +1,15 @@
 import { randomBytes } from 'node:crypto';
 
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import {
   buildMappedBusinessModelFields,
   resolveBusinessModelMapping,
 } from '@lobechat/business-model-runtime';
 import { RequestTrigger } from '@lobechat/types';
+import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
+import { isLobeHubModelAvailable } from 'model-bank/lobehub';
 import { after } from 'next/server';
 import { z } from 'zod';
 
@@ -70,6 +73,18 @@ export const videoRouter = router({
   createVideo: videoProcedure.input(createVideoInputSchema).mutation(async ({ input, ctx }) => {
     const { userId, serverDB, asyncTaskModel, fileService } = ctx;
     const { generationTopicId, provider, model, params } = input;
+
+    // Reject lobehub model ids that are no longer in the model bank so callers get a
+    // clear error instead of an opaque downstream failure. Validate against the
+    // user-facing model id (pre-mapping) since that is what the agent record stores.
+    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(model, 'video')) {
+      throw new TRPCError({
+        cause: { data: { modelType: 'video', requestedModel: model } },
+        code: 'BAD_REQUEST',
+        message: 'LobeHubModelDeprecated',
+      });
+    }
+
     const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
 
     log('Starting video creation process, input: %O', input);

--- a/src/server/routers/lambda/video/index.ts
+++ b/src/server/routers/lambda/video/index.ts
@@ -5,7 +5,7 @@ import {
   buildMappedBusinessModelFields,
   resolveBusinessModelMapping,
 } from '@lobechat/business-model-runtime';
-import { RequestTrigger } from '@lobechat/types';
+import { ChatErrorType, RequestTrigger } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
@@ -74,18 +74,18 @@ export const videoRouter = router({
     const { userId, serverDB, asyncTaskModel, fileService } = ctx;
     const { generationTopicId, provider, model, params } = input;
 
+    const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
+
     // Reject lobehub model ids that are no longer in the model bank so callers get a
-    // clear error instead of an opaque downstream failure. Validate against the
-    // user-facing model id (pre-mapping) since that is what the agent record stores.
-    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(model, 'video')) {
+    // clear error instead of an opaque downstream failure when the resolved channel
+    // model is no longer in the model bank.
+    if (provider === BRANDING_PROVIDER && !isLobeHubModelAvailable(resolvedModelId, 'video')) {
       throw new TRPCError({
         cause: { data: { modelType: 'video', requestedModel: model } },
         code: 'BAD_REQUEST',
-        message: 'LobeHubModelDeprecated',
+        message: ChatErrorType.LobeHubModelDeprecated,
       });
     }
-
-    const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
 
     log('Starting video creation process, input: %O', input);
 

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -1,6 +1,7 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 
 import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
+import { handleLobeHubModelDeprecatedError } from '@/business/client/handleLobeHubModelDeprecatedError';
 import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { imageService } from '@/services/image';
 import { type StoreSetter } from '@/store/types';
@@ -108,6 +109,7 @@ export class CreateImageActionImpl {
       );
     } catch (error) {
       handleGenerationPromptModerationError(error);
+      handleLobeHubModelDeprecatedError(error);
       throw error;
     } finally {
       // 8. Reset all creating states
@@ -155,6 +157,7 @@ export class CreateImageActionImpl {
       await store.refreshGenerationBatches();
     } catch (error) {
       handleGenerationPromptModerationError(error);
+      handleLobeHubModelDeprecatedError(error);
       throw error;
     } finally {
       this.#set({ isCreating: false }, false, 'recreateImage/endCreateImage');

--- a/src/store/video/slices/createVideo/action.ts
+++ b/src/store/video/slices/createVideo/action.ts
@@ -2,6 +2,7 @@ import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { t } from 'i18next';
 
 import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
+import { handleLobeHubModelDeprecatedError } from '@/business/client/handleLobeHubModelDeprecatedError';
 import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { message } from '@/components/AntdStaticMethods';
 import { videoService } from '@/services/video';
@@ -120,6 +121,7 @@ export class CreateVideoActionImpl {
       );
     } catch (error) {
       handleGenerationPromptModerationError(error);
+      handleLobeHubModelDeprecatedError(error);
       throw error;
     } finally {
       // 7. Reset all creating states
@@ -160,6 +162,7 @@ export class CreateVideoActionImpl {
       await store.refreshGenerationBatches();
     } catch (error) {
       handleGenerationPromptModerationError(error);
+      handleLobeHubModelDeprecatedError(error);
       throw error;
     } finally {
       this.#set({ isCreating: false }, false, 'recreateVideo/end');

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -30,7 +30,8 @@ const getStatus = (errorType: ILobeAgentRuntimeErrorType | ErrorType) => {
 
     case AgentRuntimeErrorType.ExceededContextWindow:
     case ChatErrorType.SubscriptionKeyMismatch:
-    case ChatErrorType.SystemTimeNotMatchError: {
+    case ChatErrorType.SystemTimeNotMatchError:
+    case ChatErrorType.LobeHubModelDeprecated: {
       return 400;
     }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Internal: LOBE-8263

#### 🔀 Description of Change

When an agent record stores a LobeHub model id that has since been removed from the model bank (e.g. `claude-3-5-sonnet-latest`, `seedance-2.0-lite`), the request currently slips into the runtime and surfaces as an opaque downstream failure. This guards the request entry instead so callers get a clear `LobeHubModelDeprecated` error and the UI can render a dedicated message.

Changes:

- `packages/model-bank/src/aiModels/lobehub/findModel.ts` (new) — `findLobeHubModel(id)` and `isLobeHubModelAvailable(id, type)`. Lives in its own file to avoid circular imports with the existing `utils.ts` (image params schema imports from `utils.ts`).
- `packages/model-bank/src/aiModels/lobehub/utils.test.ts` (new) — 6 cases covering chat / image / video / embedding hits, type mismatch, and unknown ids.
- `packages/types/src/fetch.ts` — add `ChatErrorType.LobeHubModelDeprecated`.
- `src/utils/errorResponse.ts` — map the new error type to HTTP 400.
- `src/server/routers/lambda/{image,video}/index.ts` — validate at the procedure entry when `provider === BRANDING_PROVIDER`, throw `TRPCError({ code: 'BAD_REQUEST', message: 'LobeHubModelDeprecated', cause: { data: { ... } } })` so the existing trpc `errorFormatter` exposes the requested model id under `error.data.errorData`.
- `src/business/client/handleLobeHubModelDeprecatedError.ts` (new) — recognises the trpc error and shows a localized `message.error` toast.
- `src/store/{image,video}/slices/create*/action.ts` — call the handler from the existing catch blocks (alongside `handleGenerationPromptModerationError`) on both create and recreate paths.
- `src/locales/default/error.ts`, `locales/{zh-CN,en-US}/error.json` — `response.LobeHubModelDeprecated` copy.

#### 🧪 How to Test

- [x] Tested locally (unit tests + type-check + diagnostics)
- [x] Added/updated tests
- [ ] No tests needed

End-to-end (run in cloud repo):

1. `bun run dev`
2. Set an agent's `agents.model` to a deprecated id (e.g. `seedance-2.0-lite` for video, an unknown id for image).
3. Trigger generation — expect an antd `message.error` toast with the localized `LobeHubModelDeprecated` copy and no `generation` record created.

#### 📝 Additional Information

- The chat entry guard lives in the cloud repo (`src/app/(backend)/webapi/chat/lobehub/route.ts`) since `chat/lobehub/route.ts` is a cloud-only override.
- Validation runs against the user-facing model id (pre-mapping). If we ever need to revive deprecated ids via runtime model mapping, we'd need to move the guard after the resolver — flagged in the cloud PR as a follow-up consideration.