### PR TITLE
fix(desktop): open settings from tray menu

### DIFF
--- a/apps/desktop/src/main/menus/impls/linux.test.ts
+++ b/apps/desktop/src/main/menus/impls/linux.test.ts
@@ -93,6 +93,10 @@ const createMockApp = () => {
       }),
     },
     browserManager: {
+      getMainWindow: vi.fn(() => ({
+        broadcast: vi.fn(),
+        show: vi.fn(),
+      })),
       showMainWindow: vi.fn(),
       retrieveByIdentifier: vi.fn(() => ({
         show: vi.fn(),
@@ -198,6 +202,19 @@ describe('LinuxMenu', () => {
       expect(template.length).toBeGreaterThan(0);
       expect(template.some((item: any) => item.label?.includes('Open'))).toBe(true);
       expect(template.some((item: any) => item.label === 'Quit')).toBe(true);
+    });
+
+    it('should open settings in the main window from tray menu', () => {
+      linuxMenu.buildTrayMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const preferencesItem = template.find((item: any) => item.label === 'Preferences');
+      preferencesItem.click();
+
+      const mainWindow = (mockApp.browserManager.getMainWindow as any).mock.results[0].value;
+      expect(mockApp.browserManager.retrieveByIdentifier).not.toHaveBeenCalled();
+      expect(mainWindow.show).toHaveBeenCalled();
+      expect(mainWindow.broadcast).toHaveBeenCalledWith('navigate', { path: '/settings' });
     });
   });
 

--- a/apps/desktop/src/main/menus/impls/linux.ts
+++ b/apps/desktop/src/main/menus/impls/linux.ts
@@ -103,7 +103,11 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
           },
           { type: 'separator' },
           {
-            click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+            click: () => {
+              const mainWindow = this.app.browserManager.getMainWindow();
+              mainWindow.show();
+              mainWindow.broadcast('navigate', { path: '/settings' });
+            },
             label: t('file.preferences'),
           },
           {
@@ -465,7 +469,11 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
       },
       { type: 'separator' },
       {
-        click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+        click: () => {
+          const mainWindow = this.app.browserManager.getMainWindow();
+          mainWindow.show();
+          mainWindow.broadcast('navigate', { path: '/settings' });
+        },
         label: t('file.preferences'),
       },
       { type: 'separator' },

--- a/apps/desktop/src/main/menus/impls/windows.test.ts
+++ b/apps/desktop/src/main/menus/impls/windows.test.ts
@@ -181,6 +181,19 @@ describe('WindowsMenu', () => {
       expect(template.some((item: any) => item.label?.includes('Open'))).toBe(true);
       expect(template.some((item: any) => item.label === 'Quit')).toBe(true);
     });
+
+    it('should open settings in the main window from tray menu', () => {
+      windowsMenu.buildTrayMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const settingsItem = template.find((item: any) => item.label === 'Settings');
+      settingsItem.click();
+
+      const mainWindow = (mockApp.browserManager.getMainWindow as any).mock.results[0].value;
+      expect(mockApp.browserManager.retrieveByIdentifier).not.toHaveBeenCalled();
+      expect(mainWindow.show).toHaveBeenCalled();
+      expect(mainWindow.broadcast).toHaveBeenCalledWith('navigate', { path: '/settings' });
+    });
   });
 
   describe('refresh', () => {

--- a/apps/desktop/src/main/menus/impls/windows.ts
+++ b/apps/desktop/src/main/menus/impls/windows.ts
@@ -102,7 +102,11 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
           },
           { type: 'separator' },
           {
-            click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+            click: () => {
+              const mainWindow = this.app.browserManager.getMainWindow();
+              mainWindow.show();
+              mainWindow.broadcast('navigate', { path: '/settings' });
+            },
             label: t('file.preferences'),
           },
           this.getUpdateMenuItem(t),
@@ -472,7 +476,11 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
       },
       { type: 'separator' },
       {
-        click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+        click: () => {
+          const mainWindow = this.app.browserManager.getMainWindow();
+          mainWindow.show();
+          mainWindow.broadcast('navigate', { path: '/settings' });
+        },
         label: t('file.preferences'),
       },
       { type: 'separator' },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #14252

#### 🔀 Description of Change

The Windows and Linux menu handlers were trying to show a `settings` browser identifier, but only the main app and devtools windows are registered. That makes the tray Settings item throw from `retrieveByIdentifier('settings')` in the Electron main process.

Changed the Windows and Linux Settings menu items to mirror macOS: show the main window and navigate it to `/settings`. Added menu tests that exercise the tray Settings click path and verify it no longer asks for a missing `settings` browser.

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verification performed:

- `rg "retrieveByIdentifier\\(['\"]settings['\"]\\)" apps/desktop/src/main/menus/impls` returns no matches.
- Static check confirms both Windows and Linux menu implementations broadcast `navigate` to `/settings`.
- `pnpm exec vitest run apps/desktop/src/main/menus/impls/windows.test.ts apps/desktop/src/main/menus/impls/linux.test.ts` could not run in the fresh checkout because dependencies are not installed (`Command "vitest" not found`).

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Main-process error when clicking Settings from tray/taskbar menu | Settings opens in the main window via `/settings` |

#### 📝 Additional Information

No UI copy or behavior changes beyond routing the existing Settings menu item to the registered main window.
