### PR TITLE
docs(lobehub-skill): add video/image model lookup guide to generate & model references

### DIFF
--- a/packages/builtin-skills/src/lobehub/references/generate.ts
+++ b/packages/builtin-skills/src/lobehub/references/generate.ts
@@ -5,12 +5,12 @@ Generate text, images, videos, and audio. Alias: \`lh generate\`.
 ## Subcommands
 
 - \`lh gen text <prompt> [-m <model>] [-p <provider>] [--stream] [--temperature <t>]\` - Generate text
-- \`lh gen image <prompt> [-m <model>] [-n <count>] [--width <w>] [--height <h>]\` - Generate image
-- \`lh gen video <prompt> [-m <model>] [--aspect-ratio <r>] [--duration <d>]\` - Generate video
+- \`lh gen image <prompt> [-m <model>] [-n <count>] [--width <w>] [--height <h=]\` - Generate image
+- \`lh gen video <prompt> -m <model> -p <provider> [--aspect-ratio <r>] [--duration <d>] [--resolution <res>]\` - Generate video
 - \`lh gen tts <text> [-o <output>] [--voice <v>] [--speed <s>]\` - Text-to-speech
 - \`lh gen asr <audioFile> [--model <m>] [--language <l>]\` - Speech-to-text
-- \`lh gen status <generationId> <taskId>\` - Check generation task status
-- \`lh gen download <generationId> <taskId> [-o <output>]\` - Wait and download result
+- \`lh gen status <generationId> <asyncTaskId>\` - Check generation task status
+- \`lh gen download <generationId> <asyncTaskId> [-o <output>]\` - Wait and download result
 - \`lh gen list\` - List generation topics
 
 ## Tips
@@ -18,6 +18,57 @@ Generate text, images, videos, and audio. Alias: \`lh generate\`.
 - Image/video generation is async; use \`status\` or \`download\` to get results
 - \`--stream\` for text generation outputs tokens as they arrive
 - \`--pipe\` for text generation outputs only the raw text (no formatting)
+
+## Finding Available Video / Image Models
+
+Before generating, always look up the correct model ID with \`lh model list\`:
+
+\`\`\`bash
+# List all video models for the lobehub provider
+lh model list lobehub --type video
+
+# List only enabled video models
+lh model list lobehub --type video --enabled
+
+# List image generation models
+lh model list lobehub --type image
+\`\`\`
+
+Use the \`id\` field from the output as the \`-m\` argument. Model IDs for video/image are
+**not** the same as human-readable display names — always use the exact \`id\` field.
+
+Example:
+\`\`\`bash
+# ✅ Correct — use the id from lh model list
+lh gen video "a cat riding a skateboard" -p lobehub -m dreamina-seedance-2-0-260128
+
+# ❌ Wrong — guessed slugs will fail with no_valid_channel_error
+lh gen video "a cat riding a skateboard" -p lobehub -m seedance-2.0
+\`\`\`
+
+## ⚠️ asyncTaskId vs generationId
+
+\`gen status\` and \`gen download\` require TWO different IDs:
+
+- \`<generationId>\` — prefixed with \`gen_\`, e.g. \`gen_abc123\`
+- \`<asyncTaskId>\` — a UUID printed after \`→ Task\` in the \`gen image\` / \`gen video\` output,
+  e.g. \`7ad0eb13-e9a5-4403-8070-1f7fe95b2f95\`
+
+Passing \`gen_xxx\` as \`<asyncTaskId>\` will cause a server error. Always use the UUID.
+
+Example output from \`lh gen video\`:
+\`\`\`
+✓ Video generation started
+  Batch ID: gb_xxx
+  Generation gen_abc123 → Task 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ← this is asyncTaskId
+\`\`\`
+
+Correct usage:
+\`\`\`bash
+lh gen status gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95
+lh gen download gen_abc123 7ad0eb13-e9a5-4403-8070-1f7fe95b2f95 -o result.mp4
+\`\`\`
 `;
 
 export default content;

--- a/packages/builtin-skills/src/lobehub/references/model.ts
+++ b/packages/builtin-skills/src/lobehub/references/model.ts
@@ -13,10 +13,26 @@ Manage AI models for providers.
 - \`lh model batch-toggle <ids...> --provider <p> [--enable|--disable]\` - Batch toggle
 - \`lh model clear --provider <p> [--remote] [--yes]\` - Clear all models for provider
 
+## Model Types
+
+The \`--type\` filter accepts the following values:
+
+| Type | Description |
+|------|-------------|
+| \`chat\` | Text chat / LLM models (default listing) |
+| \`embedding\` | Text embedding models |
+| \`tts\` | Text-to-speech models |
+| \`stt\` | Speech-to-text models |
+| \`image\` | Image generation models |
+| \`video\` | Video generation models |
+| \`text2music\` | Music generation models |
+| \`realtime\` | Realtime audio/video models |
+
 ## Tips
 
 - Models belong to providers; always specify \`--provider\` when needed
-- Use \`--type\` to filter by model type (chat, embedding, etc.)
-`;
+- \`lh model list\` without \`--type\` only returns \`chat\` models by default — always pass \`--type video\` (or the relevant type) when looking for non-chat models
+- Use \`--enabled\` to filter only active models
+\`;
 
 export default content;


### PR DESCRIPTION
## 背景

排查视频生成失败时发现，`lh gen video` 里没有任何指引说明如何获取正确的 model ID，导致 AI 直接猜了 `seedance-2.0` 这种 display name 风格的 slug，最终触发 `no_valid_channel_error`。

根本原因：
1. `generate.ts` 没有说明在生成前应先用 `lh model list --type video` 查可用模型
2. `model.ts` 里 `--type` 的可选值列表不完整，只有 `chat`/`embedding` 举例，没有列出 `video` 等类型

## 变更内容

### `references/generate.ts`
- 新增 **Finding Available Video / Image Models** 章节
  - 说明使用 `lh model list lobehub --type video` 查询可用模型
  - 强调必须使用 `id` 字段而非 display name
  - 提供 ✅ 正确 / ❌ 错误用法示例对比

### `references/model.ts`
- 新增 **Model Types** 完整类型表，覆盖所有 8 种类型：`chat` / `embedding` / `tts` / `stt` / `image` / `video` / `text2music` / `realtime`
- 在 Tips 中明确指出：不加 `--type` 时默认只返回 `chat` 模型

## 关联

触发此 PR 的 bug：LOBE-8324