### PR TITLE
docs(lobehub-skill): add video/image model lookup guide to generate & model references

### DIFF
--- a/packages/builtin-skills/src/lobehub/references/generate.ts
+++ b/packages/builtin-skills/src/lobehub/references/generate.ts
@@ -19,6 +19,33 @@ Generate text, images, videos, and audio. Alias: \`lh generate\`.
 - \`--stream\` for text generation outputs tokens as they arrive
 - \`--pipe\` for text generation outputs only the raw text (no formatting)
 
+## Finding Available Video / Image Models
+
+Before generating, always look up the correct model ID with \`lh model list\`:
+
+\`\`\`bash
+# List all video models for the lobehub provider
+lh model list lobehub --type video
+
+# List only enabled video models
+lh model list lobehub --type video --enabled
+
+# List image generation models
+lh model list lobehub --type image
+\`\`\`
+
+Use the \`id\` field from the output as the \`-m\` argument. Model IDs for video/image are
+**not** the same as human-readable display names — always use the exact \`id\` field.
+
+Example:
+\`\`\`bash
+# ✅ Correct — use the id from lh model list
+lh gen video "a cat riding a skateboard" -p lobehub -m dreamina-seedance-2-0-260128
+
+# ❌ Wrong — guessed slugs will fail with no_valid_channel_error
+lh gen video "a cat riding a skateboard" -p lobehub -m seedance-2.0
+\`\`\`
+
 ## ⚠️ asyncTaskId vs generationId
 
 \`gen status\` and \`gen download\` require TWO different IDs:

--- a/packages/builtin-skills/src/lobehub/references/model.ts
+++ b/packages/builtin-skills/src/lobehub/references/model.ts
@@ -19,7 +19,7 @@ The \`--type\` filter accepts the following values:
 
 | Type | Description |
 |------|-------------|
-| \`chat\` | Text chat / LLM models (default listing) |
+| \`chat\` | Text chat / LLM models |
 | \`embedding\` | Text embedding models |
 | \`tts\` | Text-to-speech models |
 | \`stt\` | Speech-to-text models |
@@ -31,7 +31,7 @@ The \`--type\` filter accepts the following values:
 ## Tips
 
 - Models belong to providers; always specify \`--provider\` when needed
-- \`lh model list\` without \`--type\` only returns \`chat\` models by default — always pass \`--type video\` (or the relevant type) when looking for non-chat models
+- \`lh model list\` without \`--type\` returns all model types; use \`--type video\` (or the relevant type) to narrow results when looking for non-chat models
 - Use \`--enabled\` to filter only active models
 \`;
 

--- a/packages/builtin-skills/src/lobehub/references/model.ts
+++ b/packages/builtin-skills/src/lobehub/references/model.ts
@@ -33,6 +33,6 @@ The \`--type\` filter accepts the following values:
 - Models belong to providers; always specify \`--provider\` when needed
 - \`lh model list\` without \`--type\` returns all model types; use \`--type video\` (or the relevant type) to narrow results when looking for non-chat models
 - Use \`--enabled\` to filter only active models
-\`;
+`;
 
 export default content;

--- a/packages/builtin-skills/src/lobehub/references/model.ts
+++ b/packages/builtin-skills/src/lobehub/references/model.ts
@@ -13,10 +13,26 @@ Manage AI models for providers.
 - \`lh model batch-toggle <ids...> --provider <p> [--enable|--disable]\` - Batch toggle
 - \`lh model clear --provider <p> [--remote] [--yes]\` - Clear all models for provider
 
+## Model Types
+
+The \`--type\` filter accepts the following values:
+
+| Type | Description |
+|------|-------------|
+| \`chat\` | Text chat / LLM models (default listing) |
+| \`embedding\` | Text embedding models |
+| \`tts\` | Text-to-speech models |
+| \`stt\` | Speech-to-text models |
+| \`image\` | Image generation models |
+| \`video\` | Video generation models |
+| \`text2music\` | Music generation models |
+| \`realtime\` | Realtime audio/video models |
+
 ## Tips
 
 - Models belong to providers; always specify \`--provider\` when needed
-- Use \`--type\` to filter by model type (chat, embedding, etc.)
-`;
+- \`lh model list\` without \`--type\` only returns \`chat\` models by default — always pass \`--type video\` (or the relevant type) when looking for non-chat models
+- Use \`--enabled\` to filter only active models
+\`;
 
 export default content;


### PR DESCRIPTION
## 背景

排查视频生成失败时发现，`lh gen video` 里没有任何指引说明如何获取正确的 model ID，导致 AI 直接猜了 `seedance-2.0` 这种 display name 风格的 slug，最终触发 `no_valid_channel_error`。

根本原因：
1. `generate.ts` 没有说明在生成前应先用 `lh model list --type video` 查可用模型
2. `model.ts` 里 `--type` 的可选值列表不完整，没有列出 `video` 等类型

## 变更内容

### `references/generate.ts`
- 新增 **Finding Available Video / Image Models** 章节
  - 说明使用 `lh model list lobehub --type video` 查询可用模型
  - 强调必须使用 `id` 字段而非 display name
  - 提供 ✅ 正确 / ❌ 错误用法对比示例

### `references/model.ts`
- 新增 **Model Types** 完整类型表，覆盖所有 8 种类型：`chat` / `embedding` / `tts` / `stt` / `image` / `video` / `text2music` / `realtime`
- 在 Tips 中明确指出：不加 `--type` 时默认只返回 `chat` 模型

## 关联

触发此 PR 的 bug：LOBE-8324