### PR TITLE
🐛 fix(home): restore welcome typewriter stability

### DIFF
--- a/src/routes/(main)/home/features/WelcomeText/index.tsx
+++ b/src/routes/(main)/home/features/WelcomeText/index.tsx
@@ -1,14 +1,18 @@
 import { Center } from '@lobehub/ui';
-import { sample } from 'es-toolkit/compat';
+import { TypewriterEffect } from '@lobehub/ui/awesome';
+import { LoadingDots } from '@lobehub/ui/chat';
+import { cssVar } from 'antd-style';
+import { shuffle } from 'es-toolkit/compat';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const WelcomeText = memo(() => {
-  const { t } = useTranslation('welcome');
+  const { t, i18n } = useTranslation('welcome');
+  const locale = i18n.language;
 
-  const sentence = useMemo(() => {
+  const sentences = useMemo(() => {
     const messages = t('welcomeMessages', { returnObjects: true }) as Record<string, string>;
-    return sample(Object.values(messages));
+    return shuffle(Object.values(messages));
   }, [t]);
 
   return (
@@ -19,7 +23,17 @@ const WelcomeText = memo(() => {
         marginBlock: '36px 24px',
       }}
     >
-      {sentence}
+      <TypewriterEffect
+        cursorCharacter={<LoadingDots color={cssVar.colorText} size={20} variant={'pulse'} />}
+        cursorFade={false}
+        deletePauseDuration={1000}
+        deletingSpeed={32}
+        hideCursorWhileTyping={'afterTyping'}
+        key={locale}
+        pauseDuration={16_000}
+        sentences={sentences}
+        typingSpeed={64}
+      />
     </Center>
   );
 });

--- a/src/routes/(main)/home/features/index.tsx
+++ b/src/routes/(main)/home/features/index.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
+import { memo } from 'react';
 
 import DailyBrief from '@/features/DailyBrief';
 import { useHomeStore } from '@/store/home';
@@ -15,7 +14,6 @@ import InputArea from './InputArea';
 import WelcomeText from './WelcomeText';
 
 const Home = memo(() => {
-  const { i18n } = useTranslation();
   const isLogin = useUserStore(authSelectors.isLogin);
   const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
   const inputActiveMode = useHomeStore((s) => s.inputActiveMode);
@@ -23,12 +21,9 @@ const Home = memo(() => {
   // Hide other modules when a starter mode is active
   const hideOtherModules = inputActiveMode && ['agent', 'group', 'write'].includes(inputActiveMode);
 
-  // eslint-disable-next-line @eslint-react/no-nested-component-definitions
-  const Welcome = useCallback(() => <WelcomeText />, [i18n.language]);
-
   return (
     <Flexbox gap={40}>
-      <Welcome />
+      <WelcomeText />
       <InputArea />
       {isLogin && (
         <Flexbox style={{ display: hideOtherModules ? 'none' : undefined }}>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Restore the home welcome text to use the TypewriterEffect-based welcome message carousel.
- Render WelcomeText directly from the home page instead of wrapping it in a nested component keyed by i18n.language, preventing extra remounts during first-screen language initialization.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

```bash
bunx eslint 'src/routes/(main)/home/features/index.tsx' 'src/routes/(main)/home/features/WelcomeText/index.tsx' --fix
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Only the home welcome text files are included in this PR. Other local workspace changes were left untouched.