### PR TITLE
🐛 fix: render intervention fallback avatar as image

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx
@@ -17,6 +17,9 @@ vi.mock('@lobehub/ui', () => ({
   ActionIcon: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
     <button {...props}>{children}</button>
   ),
+  Avatar: ({ avatar, title }: { avatar?: string; title?: string }) => (
+    <img alt={title} src={avatar} />
+  ),
   Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
     <div {...props}>{children}</div>
   ),
@@ -96,5 +99,24 @@ describe('FallbackIntervention', () => {
     expect(
       screen.getByText('Tools & Skills Activator → Activate Tools (Web Search, Calculator)'),
     ).toBeInTheDocument();
+  });
+
+  it('renders URL avatars as images instead of visible text', () => {
+    const iconUrl = 'https://example.com/icon.png';
+    metaMap.search.avatar = iconUrl;
+
+    render(
+      <FallbackIntervention
+        apiName="search"
+        assistantGroupId="assistant-group-1"
+        id="message-1"
+        identifier="search"
+        requestArgs="{}"
+        toolCallId="tool-call-1"
+      />,
+    );
+
+    expect(screen.queryByText(iconUrl)).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Web Search' })).toHaveAttribute('src', iconUrl);
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lobechat/builtin-tool-activator';
 import { builtinToolIdentifiers } from '@lobechat/builtin-tools/identifiers';
 import { safeParseJSON } from '@lobechat/utils';
-import { ActionIcon, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, Avatar, Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ChevronDown, ChevronRight, Edit3Icon } from 'lucide-react';
@@ -37,10 +37,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     &:hover {
       color: ${cssVar.colorTextSecondary};
     }
-  `,
-  avatar: css`
-    font-size: 16px;
-    line-height: 1;
   `,
   description: css`
     padding-block: 8px;
@@ -153,7 +149,15 @@ const FallbackIntervention = memo<FallbackInterventionProps>(
     return (
       <Flexbox gap={4}>
         <Flexbox horizontal align="center" className={styles.description} gap={6}>
-          {pluginMeta?.avatar && <span className={styles.avatar}>{pluginMeta.avatar}</span>}
+          {pluginMeta?.avatar && (
+            <Avatar
+              avatar={pluginMeta.avatar}
+              shape={'square'}
+              size={16}
+              style={{ flex: 'none' }}
+              title={toolTitle}
+            />
+          )}
           <span>
             {toolTitle} → {actionTitle}
             {actionTitleSuffix}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Fix plugin avatars in tool intervention fallback messages being rendered as plain text when the avatar value is an image URL.

This change renders the plugin avatar through `Avatar`, so URL-based avatars display as images instead of exposing the raw URL in the message description.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Tested with:

```bash
pnpm exec vitest run --silent='passed-only' src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx
```

#### 📸 Screenshots / Videos

The difference is in the icon displayed to the left of the tool ID and name in the warning dialog.


| Before | After |
| ------ | ----- |
| <img width="1273" height="627" alt="a8b339c273c841ef4961f365a24c4cb8" src="https://github.com/user-attachments/assets/d89b1891-80f4-46c8-840e-1558667009c2" /> | <img width="1261" height="595" alt="3674030eed65e454079c8c93e9203781" src="https://github.com/user-attachments/assets/7eaf1540-0fe5-4db8-bcf9-a32c806fbe24" /> |

#### 📝 Additional Information

N/A
