### PR TITLE
✨ feat: polish task list & detail, expose topic operation ID

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -725,7 +725,8 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     prompt: string,
     imageList: HeterogeneousAgentImageAttachment[] = [],
   ): Promise<string> {
-    const content: any[] = [{ text: prompt, type: 'text' }];
+    const content: any[] = [];
+    if (prompt && prompt.length > 0) content.push({ text: prompt, type: 'text' });
 
     for (const image of imageList) {
       try {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -185,6 +185,7 @@ describe('HeterogeneousAgentCtr', () => {
       prompt: string,
       sessionOverrides: Record<string, any> = {},
       stdoutLines: string[] = [],
+      sendPromptOverrides: Partial<{ imageList: Array<{ id: string; url: string }> }> = {},
     ) => {
       const { proc, writes } = createFakeProc({ stdoutLines });
       nextFakeProc = proc;
@@ -198,7 +199,7 @@ describe('HeterogeneousAgentCtr', () => {
         command: 'claude',
         ...sessionOverrides,
       });
-      await ctr.sendPrompt({ prompt, sessionId });
+      await ctr.sendPrompt({ prompt, sessionId, ...sendPromptOverrides });
 
       const { args: cliArgs, command, options } = spawnCalls[0];
       return { cliArgs, command, ctr, options, sessionId, writes };
@@ -259,6 +260,23 @@ describe('HeterogeneousAgentCtr', () => {
       const { options } = await runSendPrompt('hello', { cwd: explicitCwd });
 
       expect(options.cwd).toBe(explicitCwd);
+    });
+
+    it('omits the empty text block when only images are attached', async () => {
+      const { writes } = await runSendPrompt('', {}, [], {
+        imageList: [{ id: 'image-1', url: 'data:image/png;base64,UE5HX1RFU1Q=' }],
+      });
+
+      expect(writes).toHaveLength(1);
+      const msg = JSON.parse(writes[0].trimEnd());
+      // Anthropic rejects `{ text: '', type: 'text' }` with
+      // "messages: text content blocks must be non-empty".
+      expect(msg.message.content).toEqual([
+        {
+          source: { data: 'UE5HX1RFU1Q=', media_type: 'image/png', type: 'base64' },
+          type: 'image',
+        },
+      ]);
     });
 
     it('captures the Claude Code session id from stream-json init events', async () => {

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -214,6 +214,7 @@ export class TaskTopicModel {
         createdAt: taskTopics.createdAt,
         handoff: taskTopics.handoff,
         metadata: topics.metadata,
+        operationId: taskTopics.operationId,
         seq: taskTopics.seq,
         status: taskTopics.status,
         title: topics.title,

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -223,6 +223,13 @@ export interface TaskDetailActivity {
   createdAt?: string;
   cronJobId?: string | null;
   id?: string;
+  /**
+   * Topic-only: persisted Gateway operation ID for the task topic, sourced
+   * from `task_topics.operationId`. Survives across runs (created on add,
+   * updated on resume) so it remains available after the topic completes —
+   * unlike `runningOperation`, which is cleared when the run terminates.
+   */
+  operationId?: string | null;
   priority?: string | null;
   readAt?: string | null;
   resolvedAction?: string | null;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -75,7 +75,7 @@ const TaskBriefCard = memo<TaskBriefCardProps>(
         variant={'outlined'}
       >
         <Flexbox horizontal align={'center'} gap={8} style={{ overflow: 'hidden' }}>
-          <BriefIcon size={24} type={brief.type} />
+          <BriefIcon muted={isResolved} size={24} type={brief.type} />
           <Text ellipsis style={{ flex: 1 }} weight={500}>
             {brief.title}
           </Text>

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -64,6 +64,10 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
     if (activity.id) void navigator.clipboard.writeText(activity.id);
   }, [activity.id]);
 
+  const handleCopyOperationId = useCallback(() => {
+    if (activity.operationId) void navigator.clipboard.writeText(activity.operationId);
+  }, [activity.operationId]);
+
   const startedAt = activity.time ? dayjs(activity.time).fromNow() : '';
   const durationText = isRunning
     ? formatDuration(elapsed)
@@ -84,6 +88,13 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
       key: 'copy',
       label: t('taskDetail.topicMenu.copyId', { defaultValue: 'Copy topic ID' }),
       onClick: handleCopyId,
+    },
+    {
+      disabled: !activity.operationId,
+      icon: Copy,
+      key: 'copyOperationId',
+      label: t('taskDetail.topicMenu.copyOperationId', { defaultValue: 'Copy operation ID' }),
+      onClick: handleCopyOperationId,
     },
   ];
 

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -1,21 +1,36 @@
 'use client';
 
 import { type ConversationContext } from '@lobechat/types';
-import { Drawer, Flexbox, Text } from '@lobehub/ui';
+import {
+  ActionIcon,
+  copyToClipboard,
+  Drawer,
+  type DropdownItem,
+  DropdownMenu,
+  Flexbox,
+  Text,
+} from '@lobehub/ui';
 import { cssVar } from 'antd-style';
+import { Copy, MoreHorizontal, Share2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ChatList, ConversationProvider, MessageItem } from '@/features/Conversation';
 import { TaskCardScopeProvider } from '@/features/Conversation/Markdown/plugins/Task';
+import { useShareModal } from '@/features/ShareModal';
 import { useGatewayReconnect } from '@/hooks/useGatewayReconnect';
 import { useOperationState } from '@/hooks/useOperationState';
 import { useChatStore } from '@/store/chat';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { useServerConfigStore } from '@/store/serverConfig';
+import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 import { useTaskStore } from '@/store/task';
 import { taskActivitySelectors, taskDetailSelectors } from '@/store/task/selectors';
 
 import TopicStatusIcon from '../TopicStatusIcon';
+
+const SharePopover = dynamic(() => import('@/features/SharePopover'));
 
 interface TopicChatDrawerBodyProps {
   agentId: string;
@@ -78,14 +93,49 @@ const TopicChatDrawerBody = memo<TopicChatDrawerBodyProps>(({ agentId, topicId }
 TopicChatDrawerBody.displayName = 'TopicChatDrawerBody';
 
 const TopicChatDrawer = memo(() => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const topicId = useTaskStore(taskDetailSelectors.activeTopicDrawerTopicId);
   const agentId = useTaskStore(taskDetailSelectors.activeTaskAgentId);
   const activity = useTaskStore(taskActivitySelectors.activeDrawerTopicActivity);
   const closeTopicDrawer = useTaskStore((s) => s.closeTopicDrawer);
+  const enableTopicLinkShare = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   const open = !!topicId && !!agentId;
   const status = activity?.status;
+
+  const shareContext = useMemo<Partial<ConversationContext>>(
+    () => ({ agentId: agentId ?? undefined, topicId: topicId ?? undefined }),
+    [agentId, topicId],
+  );
+  const { openShareModal } = useShareModal({ context: shareContext });
+
+  const handleCopyTopicId = useCallback(() => {
+    if (topicId) void copyToClipboard(topicId);
+  }, [topicId]);
+
+  const handleCopyOperationId = useCallback(() => {
+    if (activity?.operationId) void copyToClipboard(activity.operationId);
+  }, [activity?.operationId]);
+
+  const menuItems = useMemo<DropdownItem[]>(
+    () => [
+      {
+        disabled: !topicId,
+        icon: Copy,
+        key: 'copyTopicId',
+        label: t('taskDetail.topicMenu.copyId', { defaultValue: 'Copy topic ID' }),
+        onClick: handleCopyTopicId,
+      },
+      {
+        disabled: !activity?.operationId,
+        icon: Copy,
+        key: 'copyOperationId',
+        label: t('taskDetail.topicMenu.copyOperationId', { defaultValue: 'Copy operation ID' }),
+        onClick: handleCopyOperationId,
+      },
+    ],
+    [t, topicId, activity?.operationId, handleCopyTopicId, handleCopyOperationId],
+  );
 
   const title = (
     <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
@@ -98,13 +148,37 @@ const TopicChatDrawer = memo(() => {
           #{activity.seq}
         </Text>
       )}
+      <DropdownMenu items={menuItems}>
+        <ActionIcon icon={MoreHorizontal} size={'small'} />
+      </DropdownMenu>
     </Flexbox>
   );
+
+  const shareIcon = (
+    <ActionIcon
+      icon={Share2}
+      size={'small'}
+      title={t('share', { ns: 'common' })}
+      onClick={enableTopicLinkShare ? undefined : openShareModal}
+    />
+  );
+
+  const extra = topicId ? (
+    enableTopicLinkShare ? (
+      <SharePopover topicId={topicId} onOpenModal={openShareModal}>
+        {shareIcon}
+      </SharePopover>
+    ) : (
+      shareIcon
+    )
+  ) : null;
 
   return (
     <Drawer
       destroyOnHidden
       containerMaxWidth={'auto'}
+      extra={extra}
+      getContainer={false}
       mask={false}
       open={open}
       placement={'right'}

--- a/src/features/AgentTasks/features/AgentTaskItem.tsx
+++ b/src/features/AgentTasks/features/AgentTaskItem.tsx
@@ -7,7 +7,6 @@ import { useNavigate } from 'react-router-dom';
 import { useTaskStore } from '@/store/task';
 import type { TaskListItem } from '@/store/task/slices/list/initialState';
 
-import TaskScheduleConfig from '../AgentTaskDetail/TaskScheduleConfig';
 import AssigneeAgentSelector from './AssigneeAgentSelector';
 import AssigneeAvatar from './AssigneeAvatar';
 import { formatTaskItemDate } from './formatTaskItemDate';
@@ -120,17 +119,12 @@ const AgentTaskItem = memo<TaskItemProps>(({ task, variant = 'default' }) => {
   );
 
   const scheduleNode = task.automationMode ? (
-    <TaskScheduleConfig
-      currentInterval={taskDetail?.heartbeat?.interval ?? 0}
-      taskId={task.identifier}
-    >
-      <TaskTriggerTag
-        automationMode={task.automationMode}
-        heartbeatInterval={taskDetail?.heartbeat?.interval}
-        schedulePattern={task.schedulePattern}
-        scheduleTimezone={task.scheduleTimezone}
-      />
-    </TaskScheduleConfig>
+    <TaskTriggerTag
+      automationMode={task.automationMode}
+      heartbeatInterval={taskDetail?.heartbeat?.interval}
+      schedulePattern={task.schedulePattern}
+      scheduleTimezone={task.scheduleTimezone}
+    />
   ) : null;
 
   const timeNode = time ? (

--- a/src/features/Conversation/Markdown/plugins/Task/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Task/Render.tsx
@@ -1,5 +1,5 @@
 import type { TaskStatus } from '@lobechat/types';
-import { Block, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ClipboardList } from 'lucide-react';
 import { memo, useMemo } from 'react';
@@ -21,11 +21,6 @@ const KNOWN_STATUSES: TaskStatus[] = [
 ];
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  container: css`
-    overflow: hidden;
-    border-radius: 12px;
-    box-shadow: ${cssVar.boxShadowTertiary};
-  `,
   divider: css`
     inline-size: 100%;
     block-size: 1px;
@@ -65,11 +60,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     inline-size: 32px;
     block-size: 32px;
-    border-radius: 8px;
 
-    color: ${cssVar.colorPrimary};
-
-    background: ${cssVar.colorPrimaryBg};
+    color: ${cssVar.colorTextSecondary};
   `,
   identifier: css`
     flex: none;
@@ -165,13 +157,7 @@ const Render = memo<TaskRenderProps>(({ children }) => {
   const titleText = parsed.name || parsed.identifier || '';
 
   return (
-    <Block
-      className={styles.container}
-      gap={12}
-      paddingBlock={14}
-      paddingInline={16}
-      variant={'outlined'}
-    >
+    <Flexbox gap={12}>
       <Flexbox horizontal align={'center'} gap={12}>
         <span className={styles.headerIcon}>
           <ClipboardList size={16} />
@@ -248,7 +234,7 @@ const Render = memo<TaskRenderProps>(({ children }) => {
           <RawSection items={parsed.reviewRubrics ?? []} label="Review rubrics" />
         </Flexbox>
       )}
-    </Block>
+    </Flexbox>
   );
 });
 

--- a/src/features/DailyBrief/BriefIcon.tsx
+++ b/src/features/DailyBrief/BriefIcon.tsx
@@ -27,24 +27,18 @@ const BRIEF_TYPE_COLOR_BG: Record<BriefType, string | undefined> = {
 } as const;
 
 interface BriefIconProps {
+  muted?: boolean;
   size?: number;
   type: BriefType;
 }
 
-const BriefIcon = memo<BriefIconProps>(({ size = 28, type }) => {
+const BriefIcon = memo<BriefIconProps>(({ size = 28, type, muted = false }) => {
   const icon = BRIEF_TYPE_ICON[type] || Lightbulb;
-  const color = BRIEF_TYPE_COLOR[type] || cssVar.colorPrimary;
+  const color = muted ? cssVar.colorTextQuaternary : BRIEF_TYPE_COLOR[type] || cssVar.colorPrimary;
+  const background = muted ? cssVar.colorFillQuaternary : BRIEF_TYPE_COLOR_BG[type];
 
   return (
-    <Block
-      align={'center'}
-      height={size}
-      justify={'center'}
-      width={size}
-      style={{
-        background: BRIEF_TYPE_COLOR_BG[type],
-      }}
-    >
+    <Block align={'center'} height={size} justify={'center'} style={{ background }} width={size}>
       <Icon color={color} icon={icon} size={size * 0.6} />
     </Block>
   );

--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -31,9 +31,10 @@ type Visibility = 'private' | 'link';
 
 interface SharePopoverContentProps {
   onOpenModal?: () => void;
+  topicId?: string;
 }
 
-const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal }) => {
+const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topicId }) => {
   const { t } = useTranslation('chat');
   const { message, modal } = App.useApp();
   const [updating, setUpdating] = useState(false);
@@ -41,7 +42,8 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal }) => 
   const containerRef = useRef<HTMLDivElement>(null);
   const appOrigin = useAppOrigin();
 
-  const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const chatActiveTopicId = useChatStore((s) => s.activeTopicId);
+  const activeTopicId = topicId ?? chatActiveTopicId;
   const [hideTopicSharePrivacyWarning, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.systemStatus(s).hideTopicSharePrivacyWarning ?? false,
     s.updateSystemStatus,
@@ -240,15 +242,16 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal }) => 
 interface SharePopoverProps {
   children?: ReactNode;
   onOpenModal?: () => void;
+  topicId?: string;
 }
 
-const SharePopover = memo<SharePopoverProps>(({ children, onOpenModal }) => {
+const SharePopover = memo<SharePopoverProps>(({ children, onOpenModal, topicId }) => {
   const isMobile = useIsMobile();
 
   return (
     <Popover
       arrow={false}
-      content={<SharePopoverContent onOpenModal={onOpenModal} />}
+      content={<SharePopoverContent topicId={topicId} onOpenModal={onOpenModal} />}
       placement={isMobile ? 'top' : 'bottomRight'}
       trigger={['click']}
       styles={{

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -217,6 +217,7 @@ export class TaskService {
           author: task.assigneeAgentId ? authorMap.get(task.assigneeAgentId) : undefined,
           completedAt: toISO(t.completedAt),
           id: t.topicId ?? undefined,
+          operationId: t.operationId ?? null,
           runningOperation: t.metadata?.runningOperation ?? null,
           seq: t.seq,
           status: t.status,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor
- [x] 💄 style
- [x] ✨ new feature

#### 🔀 Description of Change

Bundle of task list / detail UX polish that piled up on this branch:

1. **Task list row stays purely informational.** Removed the `TaskScheduleConfig` popover wrapper from `AgentTaskItem`'s trigger tag — clicking it no longer opens an inline schedule popup that overlaid neighboring rows and sometimes rendered stale state (it read `automationMode` / schedule fields from `activeTaskId`, not the row's own `taskId`). Configuration of automation mode / schedule remains available on the task detail page via `TaskProperties` → `TaskScheduleConfig`.

2. **BriefIcon muted when the task is resolved.** Visual signal that the brief no longer needs attention.

3. **Flattened task markdown card.** Dropped the container background and padding so the markdown body integrates with the surrounding activity feed.

4. **Surface topic operation ID on the topic card menu.** Added "Copy operation ID" alongside the existing "Open run" / "Copy topic ID" entries. Plumbed `task_topics.operationId` through `findWithHandoff` → task service → `TaskDetailActivity`, so the persisted Gateway operation ID is available even after the run terminates (unlike `runningOperation`, which is cleared on completion). Useful for grepping debug traces by operation ID.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Task list: click the schedule trigger tag on a scheduled item — should not open a popup. Open task detail → properties panel → schedule config popup still works.
2. Resolve a brief and confirm the brief icon goes muted.
3. Open a task detail with a markdown reply → card should sit flush with the feed (no extra padding/background).
4. On the topic card `…` menu, click **Copy operation ID** — clipboard should hold the topic's persisted Gateway operation ID. The item is disabled if no operation ID exists.