### PR TITLE
🔀 chore: merge main into canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 # Changelog
 
+### [Version 2.1.54](https://github.com/lobehub/lobe-chat/compare/v2.1.53...v2.1.54)
+
+<sup>Released on **2026-04-27**</sup>
+
+#### 🐛 Bug Fixes
+
+- **misc**: clear stale topic when switching agents from a topic route.
+
+<br/>
+
+<details>
+<summary><kbd>Improvements and Fixes</kbd></summary>
+
+#### What's fixed
+
+- **misc**: clear stale topic when switching agents from a topic route, closes [#14231](https://github.com/lobehub/lobe-chat/issues/14231) ([deeb97a](https://github.com/lobehub/lobe-chat/commit/deeb97a))
+
+</details>
+
+<div align="right">
+
+[![](https://img.shields.io/badge/-BACK_TO_TOP-151515?style=flat-square)](#readme-top)
+
+</div>
+
 ### [Version 2.1.52](https://github.com/lobehub/lobe-chat/compare/v2.1.51...v2.1.52)
 
 <sup>Released on **2026-04-20**</sup>

--- a/changelog/v2.json
+++ b/changelog/v2.json
@@ -1,5 +1,12 @@
 [
   {
+    "children": {
+      "fixes": ["clear stale topic when switching agents from a topic route."]
+    },
+    "date": "2026-04-27",
+    "version": "2.1.54"
+  },
+  {
     "children": {},
     "date": "2026-04-20",
     "version": "2.1.52"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.1.53",
+  "version": "2.1.54",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",


### PR DESCRIPTION
## Summary

Merge `main` back into `canary` to sync the latest release commit.

- Includes `🔖 chore(release): release version v2.1.54 [skip ci]`

## Test plan

- [x] No code changes — only changelog/version sync from release