### PR TITLE
Persist model detail panel expansion state

### DIFF
--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -116,11 +116,7 @@ const ModelSwitch = memo(() => {
                   </Flexbox>
                 }
               >
-                <ModelDetailPanel
-                  defaultExpandedKeys={['pricing', 'config']}
-                  model={model}
-                  provider={provider}
-                />
+                <ModelDetailPanel model={model} provider={provider} />
               </Suspense>
             ),
             maxWidth: 400,

--- a/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
@@ -23,11 +23,14 @@ import {
   type TieredPricingUnit,
 } from 'model-bank';
 import { type FC } from 'react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { useGlobalStore } from '@/store/global';
+import type { ModelDetailPanelExpandedKey } from '@/store/global/initialState';
+import { systemStatusSelectors } from '@/store/global/selectors';
 import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import { formatTokenNumber } from '@/utils/format';
 import { formatPriceByCurrency, getTextInputUnitRate, getTextOutputUnitRate } from '@/utils/index';
@@ -220,7 +223,6 @@ const ABILITY_CONFIG: AbilityItem[] = [
 export type PricingMode = 'image' | 'video';
 
 interface ModelDetailPanelProps {
-  defaultExpandedKeys?: string[];
   enabledList?: EnabledProviderWithModels[];
   model?: string;
   pricingMode?: PricingMode;
@@ -228,13 +230,7 @@ interface ModelDetailPanelProps {
 }
 
 const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(
-  ({
-    defaultExpandedKeys = ['pricing'],
-    model: modelId,
-    provider,
-    enabledList: enabledListProp,
-    pricingMode,
-  }) => {
+  ({ model: modelId, provider, enabledList: enabledListProp, pricingMode }) => {
     const { t } = useTranslation('components');
 
     const enabledListFromHook = useEnabledChatModels();
@@ -249,7 +245,8 @@ const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(
       aiModelSelectors.isModelHasExtendParams(modelId ?? '', provider ?? ''),
     );
 
-    const [expandedKeys, setExpandedKeys] = useState<string[]>(defaultExpandedKeys);
+    const expandedKeys = useGlobalStore(systemStatusSelectors.modelDetailPanelExpandedKeys);
+    const updateExpandedKeys = useGlobalStore((s) => s.updateModelDetailPanelExpandedKeys);
 
     const hasPricing = !!model?.pricing;
     const formatPrice = hasPricing ? getPrice(model!.pricing!) : null;
@@ -294,7 +291,7 @@ const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(
           <Accordion
             expandedKeys={expandedKeys}
             gap={8}
-            onExpandedChange={(keys) => setExpandedKeys(keys as string[])}
+            onExpandedChange={(keys) => updateExpandedKeys(keys as ModelDetailPanelExpandedKey[])}
           >
             {/* Context Length */}
             {hasContext && (

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -2,8 +2,9 @@ import { produce } from 'immer';
 
 import { INBOX_SESSION_ID } from '@/const/session';
 import { SESSION_CHAT_URL } from '@/const/url';
-import { type GlobalStore } from '@/store/global';
-import { type StoreSetter } from '@/store/types';
+import type { GlobalStore } from '@/store/global';
+import type { ModelDetailPanelExpandedKey } from '@/store/global/initialState';
+import type { StoreSetter } from '@/store/types';
 import { getStableNavigate } from '@/utils/stableNavigate';
 import { setNamespace } from '@/utils/storeDebug';
 
@@ -134,6 +135,13 @@ export class GlobalWorkspacePaneActionImpl {
     const nextZenMode = !status.zenMode;
 
     this.#get().updateSystemStatus({ zenMode: nextZenMode }, n('toggleZenMode'));
+  };
+
+  updateModelDetailPanelExpandedKeys = (keys: ModelDetailPanelExpandedKey[]): void => {
+    this.#get().updateSystemStatus(
+      { modelDetailPanelExpandedKeys: keys },
+      n('updateModelDetailPanelExpandedKeys', keys),
+    );
   };
 }
 

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -88,6 +88,19 @@ export enum ProfileTabs {
   Usage = 'usage',
 }
 
+export const MODEL_DETAIL_PANEL_EXPANDED_KEYS = [
+  'context',
+  'abilities',
+  'pricing',
+  'config',
+] as const;
+
+export type ModelDetailPanelExpandedKey = (typeof MODEL_DETAIL_PANEL_EXPANDED_KEYS)[number];
+
+export const DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS = [
+  'pricing',
+] as const satisfies readonly ModelDetailPanelExpandedKey[];
+
 export interface SystemStatus {
   /**
    * Agent Builder panel width
@@ -152,6 +165,12 @@ export interface SystemStatus {
   leftPanelWidth: number;
   mobileShowPortal?: boolean;
   mobileShowTopic?: boolean;
+  /**
+   * Persisted expanded keys of the ModelDetailPanel Accordion
+   * (Pricing / Context / Abilities / Model Config). Single shared preference
+   * across all entries (model picker submenu, ChatInput extend-params popover).
+   */
+  modelDetailPanelExpandedKeys?: ModelDetailPanelExpandedKey[];
   /**
    * ModelSwitchPanel grouping mode
    */
@@ -318,6 +337,7 @@ export const INITIAL_STATUS = {
   knowledgeBaseModalViewMode: 'list' as const,
   leftPanelWidth: 320,
   mobileShowTopic: false,
+  modelDetailPanelExpandedKeys: [...DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS],
   modelSwitchPanelGroupMode: 'byProvider',
   modelSwitchPanelWidth: 460,
   noWideScreen: true,

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -99,6 +99,7 @@ export type ModelDetailPanelExpandedKey = (typeof MODEL_DETAIL_PANEL_EXPANDED_KE
 
 export const DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS = [
   'pricing',
+  'config',
 ] as const satisfies readonly ModelDetailPanelExpandedKey[];
 
 export interface SystemStatus {

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { merge } from '@/utils/merge';
 
-import { type GlobalState } from '../initialState';
-import { INITIAL_STATUS, initialState } from '../initialState';
+import type { GlobalState } from '../initialState';
+import {
+  DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS,
+  INITIAL_STATUS,
+  initialState,
+} from '../initialState';
 import { DEFAULT_SIDEBAR_ITEMS, reorderSidebarItems, systemStatusSelectors } from './systemStatus';
 
 // Mock version constants
@@ -86,6 +90,32 @@ describe('systemStatusSelectors', () => {
         status: { portalWidth: undefined },
       });
       expect(systemStatusSelectors.portalWidth(noPortalWidth)).toBe(400);
+    });
+  });
+
+  describe('modelDetailPanelExpandedKeys', () => {
+    it('should expand pricing and config by default', () => {
+      const s: GlobalState = {
+        ...initialState,
+        status: {
+          ...initialState.status,
+          modelDetailPanelExpandedKeys: undefined,
+        },
+      };
+
+      expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(
+        DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS,
+      );
+    });
+
+    it('should return stored user preference when set', () => {
+      const s: GlobalState = merge(initialState, {
+        status: {
+          modelDetailPanelExpandedKeys: ['pricing'],
+        },
+      });
+
+      expect(systemStatusSelectors.modelDetailPanelExpandedKeys(s)).toEqual(['pricing']);
     });
   });
 

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -1,5 +1,5 @@
-import { type GlobalState } from '../initialState';
-import { INITIAL_STATUS } from '../initialState';
+import type { GlobalState, ModelDetailPanelExpandedKey } from '../initialState';
+import { DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS, INITIAL_STATUS } from '../initialState';
 
 export const systemStatus = (s: GlobalState) => s.status;
 
@@ -175,6 +175,8 @@ const showImageTopicPanel = (s: GlobalState) => s.status.showImageTopicPanel;
 const hidePWAInstaller = (s: GlobalState) => s.status.hidePWAInstaller;
 const isShowCredit = (s: GlobalState) => s.status.isShowCredit;
 const language = (s: GlobalState) => s.status.language || 'auto';
+const modelDetailPanelExpandedKeys = (s: GlobalState): ModelDetailPanelExpandedKey[] =>
+  s.status.modelDetailPanelExpandedKeys ?? [...DEFAULT_MODEL_DETAIL_PANEL_EXPANDED_KEYS];
 const modelSwitchPanelGroupMode = (s: GlobalState) =>
   s.status.modelSwitchPanelGroupMode || 'byProvider';
 const modelSwitchPanelWidth = (s: GlobalState) => s.status.modelSwitchPanelWidth || 460;
@@ -256,6 +258,7 @@ export const systemStatusSelectors = {
   leftPanelWidth,
   mobileShowPortal,
   mobileShowTopic,
+  modelDetailPanelExpandedKeys,
   modelSwitchPanelGroupMode,
   modelSwitchPanelWidth,
   pageAgentPanelWidth,


### PR DESCRIPTION
## Summary
- Persist `ModelDetailPanel` accordion expansion state in global system status
- Share the saved expansion keys across model picker and chat input detail popovers
- Keep the detail panel default initialized from the persisted store state

## Testing
- Not run (not requested)