### PR TITLE
🐛 fix: include all properties in task_topic_handoff response_format required

### DIFF
--- a/packages/prompts/src/chains/taskTopicHandoff.ts
+++ b/packages/prompts/src/chains/taskTopicHandoff.ts
@@ -52,6 +52,6 @@ export const TASK_TOPIC_HANDOFF_SCHEMA = {
     summary: { type: 'string' },
     title: { type: 'string' },
   },
-  required: ['title', 'summary'],
+  required: ['title', 'summary', 'keyFindings', 'nextAction'],
   type: 'object' as const,
 };


### PR DESCRIPTION
## Summary

- `TASK_TOPIC_HANDOFF_SCHEMA` only listed `title` and `summary` in `required`, so OpenAI/Azure strict structured outputs rejected every `generateHandoff` call with `400 Invalid schema for response_format 'task_topic_handoff': 'required' is required to be supplied and to be an array including every key in properties. Missing 'keyFindings'`.
- Added `keyFindings` and `nextAction` to `required` so the schema satisfies strict mode. Downstream code in `src/server/services/taskLifecycle/index.ts` already treats both as optional (`keyFindings?`, `nextAction?`) and the title is only written when truthy, so behavior is unchanged when the model returns empty values.

## Impact

- Affected azure-ai handoffs (24h: 36× 400 errors across 2 users). Other providers may have been silently lenient but the schema was technically wrong everywhere.
- No DB / API surface changes; just the schema literal.

## Test plan

- [ ] `bun run type-check` (passing locally)
- [ ] Manually trigger a topic completion on azure-ai and confirm `task_topic_handoff` now succeeds and the topic title + handoff fields populate
- [ ] Sanity-check a non-azure provider (e.g. openai) still returns valid handoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)