### PR TITLE
♻️ refactor(taskTemplate): use string icon identifiers

### DIFF
--- a/packages/const/src/taskTemplate.ts
+++ b/packages/const/src/taskTemplate.ts
@@ -1,7 +1,3 @@
-import type { IconType } from '@icons-pack/react-simple-icons';
-import { SiGithub } from '@icons-pack/react-simple-icons';
-import type { LucideIcon } from 'lucide-react';
-
 /**
  * Task Template catalog used by home "Try following tasks" recommendation.
  * I18n keys: `taskTemplate:${id}.title|description|prompt`.
@@ -9,11 +5,21 @@ import type { LucideIcon } from 'lucide-react';
  * `interests` values must be keys from `INTEREST_AREAS` in
  * `src/routes/onboarding/config.ts` — that's what `users.interests` stores.
  */
+
+/**
+ * Identifier for a per-template icon override. The renderer maps each value to
+ * a concrete icon component; keep this union small and stable so consumers can
+ * exhaustively type their registries.
+ */
+export const TASK_TEMPLATE_ICONS = ['github'] as const;
+
+export type TaskTemplateIcon = (typeof TASK_TEMPLATE_ICONS)[number];
+
 export interface TaskTemplate {
   category: TaskTemplateCategory;
   cronPattern: string;
-  /** Per-template icon override. Falls back to a category-level default when omitted. */
-  icon?: IconType | LucideIcon;
+  /** Optional icon identifier; consumers resolve it to a component. */
+  icon?: TaskTemplateIcon;
   id: string;
   interests: string[];
   /** Skills that enrich the brief but are not required to run it. */
@@ -114,7 +120,7 @@ export const taskTemplates: TaskTemplate[] = [
     id: 'oss-intel-daily',
     category: 'engineering',
     cronPattern: '0 9 * * *',
-    icon: SiGithub,
+    icon: 'github',
     interests: ['coding'],
   },
   {

--- a/src/business/client/RecommendTaskTemplates.tsx
+++ b/src/business/client/RecommendTaskTemplates.tsx
@@ -1,5 +1,3 @@
 import { memo } from 'react';
 
-const RecommendTaskTemplates = memo(() => null);
-
-export default RecommendTaskTemplates;
+export const RecommendTaskTemplates = memo(() => null);

--- a/src/routes/(main)/home/features/index.tsx
+++ b/src/routes/(main)/home/features/index.tsx
@@ -3,7 +3,7 @@
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
-import RecommendTaskTemplates from '@/business/client/RecommendTaskTemplates';
+import { RecommendTaskTemplates } from '@/business/client/RecommendTaskTemplates';
 import DailyBrief from '@/features/DailyBrief';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A — follow-up to a runtime regression on the home page where icon serialization broke recommendation rendering.

#### 🔀 Description of Change

\`TaskTemplate.icon\` was previously typed as \`IconType | LucideIcon\` and assigned a real React component reference (\`SiGithub\`). React \`forwardRef\` components are not JSON-serializable — they reach the renderer as \`{}\` over tRPC, slip past nullish-coalescing fallbacks, and crash \`<Icon icon={...}>\`.

This refactor:

- Adds a \`TASK_TEMPLATE_ICONS\` const + \`TaskTemplateIcon\` string union as the new shape of \`icon\`.
- Replaces \`icon: SiGithub\` on \`oss-intel-daily\` with \`icon: 'github'\`.
- Drops the \`@icons-pack/react-simple-icons\` and \`lucide-react\` imports from \`packages/const/src/taskTemplate.ts\`.
- Flips \`RecommendTaskTemplates\` (the open-source stub) and its consumer to a named export, satisfying the workspace's no-default-export lint.

The wire shape is now fully JSON-safe; consumers register components against the union and TS exhaustiveness flags missing entries.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

\`packages/const\` and \`src/server/services/taskTemplate\` test suites still pass:

\`\`\`
✓ packages/const/src/taskTemplate.test.ts (8/8)
✓ src/server/services/taskTemplate/index.test.ts (16/16)
\`\`\`

#### 📝 Additional Information

Cloud-side counterpart will register \`'github' → SiGithub\` in its renderer and bump the submodule hash in the same flow.