### PR TITLE
🐛 fix: reset task agent transient state

### DIFF
--- a/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
   };
 
   const chatState = {
+    activeAgentId: undefined as string | undefined,
     activeTopicId: null as string | null | undefined,
     dbMessagesMap: {} as Record<string, unknown[]>,
     replaceMessages: vi.fn(),
@@ -92,6 +93,7 @@ describe('TaskAgentProvider', () => {
   beforeEach(() => {
     mocks.agentState.activeAgentId = undefined;
     mocks.agentState.setActiveAgentId.mockClear();
+    mocks.chatState.activeAgentId = undefined;
     mocks.chatState.activeTopicId = null;
     mocks.chatState.dbMessagesMap = {};
     mocks.chatState.replaceMessages.mockClear();
@@ -160,5 +162,25 @@ describe('TaskAgentProvider', () => {
       expect(mocks.providerContexts.at(-1)?.topicId).toBe('tpc_created');
     });
     expect(mocks.chatState.switchTopic).not.toHaveBeenCalled();
+  });
+
+  it('resets transient state on scoped agent sync even without an active topic', async () => {
+    mocks.agentState.activeAgentId = 'agt_task';
+    mocks.chatState.activeAgentId = 'agt_previous';
+    mocks.chatState.activeTopicId = null;
+
+    render(
+      <TaskAgentProvider>
+        <div>content</div>
+      </TaskAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.chatState.switchTopic).toHaveBeenCalledWith(null, {
+        scope: 'task',
+        skipRefreshMessage: true,
+      });
+    });
+    expect(mocks.chatState.activeAgentId).toBe('agt_task');
   });
 });

--- a/src/features/AgentTaskManager/TaskAgentProvider.tsx
+++ b/src/features/AgentTaskManager/TaskAgentProvider.tsx
@@ -43,6 +43,9 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children }) => 
     }
 
     const chatState = useChatStore.getState();
+    const shouldResetTopic =
+      chatState.activeAgentId !== selectedAgentId || !!chatState.activeTopicId;
+
     if (chatState.activeAgentId !== selectedAgentId) {
       useChatStore.setState({ activeAgentId: selectedAgentId });
     }
@@ -50,7 +53,7 @@ export const TaskAgentProvider = memo<TaskAgentProviderProps>(({ children }) => 
     if (syncedAgentIdRef.current === selectedAgentId) return;
     syncedAgentIdRef.current = selectedAgentId;
 
-    if (chatState.activeTopicId) {
+    if (shouldResetTopic) {
       void chatState.switchTopic(null, { scope: 'task', skipRefreshMessage: true });
     }
   }, [selectedAgentId, setActiveAgentId]);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Reset task agent transient topic state when the scoped active agent changes, even without an existing active topic.
- Keep the one-time scoped reset guard so newly created task agent topics are preserved after the first message.
- Add test coverage for agent sync without an active topic.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/AgentTaskManager/TaskAgentProvider.test.tsx'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This aligns the task agent provider reset behavior with the page agent provider pattern.