### PR TITLE
feat(provider): add OfoxAI as a new model provider

### DIFF
--- a/docs/usage/providers/ofoxai.mdx
+++ b/docs/usage/providers/ofoxai.mdx
@@ -1,0 +1,48 @@
+---
+title: Using OfoxAI in LobeHub
+description: >-
+  Learn how to configure and use your OfoxAI API Key in LobeHub to access 100+
+  LLMs through a single unified gateway.
+tags:
+  - LobeHub
+  - OfoxAI
+  - API Key
+  - Web UI
+  - LLM Gateway
+---
+
+# Using OfoxAI in LobeHub
+
+[OfoxAI](https://ofox.ai) is a unified LLM API gateway that provides access to 100+ models — including OpenAI GPT, Anthropic Claude, Google Gemini, DeepSeek, Qwen, Mistral, and Llama — through a single API key. It is wire-compatible with the OpenAI, Anthropic, and Gemini protocols, so you can switch between models without changing your client code.
+
+This guide will walk you through how to use OfoxAI within LobeHub.
+
+<Steps>
+  ### Step 1: Get Your OfoxAI API Key
+
+  - Visit the [OfoxAI Console](https://app.ofox.ai/auth) and create an account or sign in.
+  - Open the **API Keys** section in your dashboard.
+  - Click **Create Key**, then copy and securely store the generated key — you will not be able to view it again.
+
+  ### Step 2: Configure OfoxAI in LobeHub
+
+  - Open the **Settings** panel in LobeHub.
+  - Under **AI Service Provider**, find the **OfoxAI** section.
+  - Enable **OfoxAI** and paste in your API key.
+  - The default API endpoint is `https://api.ofox.ai/v1` — you can leave it as-is unless you have a custom routing setup.
+
+  ### Step 3: Pick a Model and Start Chatting
+
+  - In the model picker, select an OfoxAI model such as `gpt-4o`, `claude-sonnet-4-20250514`, `gemini-2.5-pro`, or `deepseek-v3`.
+  - Start a conversation. Streaming, tool use (where the underlying model supports it), and vision input all work out of the box.
+
+  <Callout type={'info'}>
+    OfoxAI offers a free tier for evaluation and pay-per-token usage afterwards. China users are routed via Hong Kong express by default. See [docs.ofox.ai](https://docs.ofox.ai) for the full model catalog and pricing.
+  </Callout>
+
+  <Callout type={'warning'}>
+    Make sure to store your API key securely. If you lose it, you'll need to generate a new one.
+  </Callout>
+</Steps>
+
+And that's it! You're now ready to use OfoxAI models within LobeHub for conversations and interactions.

--- a/docs/usage/providers/ofoxai.zh-CN.mdx
+++ b/docs/usage/providers/ofoxai.zh-CN.mdx
@@ -1,0 +1,46 @@
+---
+title: 在 LobeHub 中使用 OfoxAI
+description: 学习如何在 LobeHub 中配置和使用您的 OfoxAI API Key，通过统一网关访问 100+ 大模型。
+tags:
+  - LobeHub
+  - OfoxAI
+  - API Key
+  - Web UI
+  - LLM 网关
+---
+
+# 在 LobeHub 中使用 OfoxAI
+
+[OfoxAI](https://ofox.ai) 是一个统一的大语言模型 API 网关，通过单个 API Key 即可访问 100+ 模型——包括 OpenAI GPT、Anthropic Claude、Google Gemini、DeepSeek、Qwen、Mistral 和 Llama 等。它兼容 OpenAI、Anthropic 和 Gemini 协议，无需修改客户端代码即可在不同模型之间切换。
+
+本文将指导您如何在 LobeHub 中使用 OfoxAI。
+
+<Steps>
+  ### 步骤一：获取 OfoxAI API Key
+
+  - 访问 [OfoxAI 控制台](https://app.ofox.ai/auth) 注册或登录账号。
+  - 进入仪表盘的 **API Keys** 页面。
+  - 点击 **Create Key**，复制并妥善保存生成的密钥（仅显示一次）。
+
+  ### 步骤二：在 LobeHub 中配置 OfoxAI
+
+  - 打开 LobeHub 的 **设置** 面板。
+  - 在 **语言模型** 中找到 **OfoxAI** 设置项。
+  - 启用 OfoxAI，并粘贴上一步获取的 API Key。
+  - 默认 API 地址为 `https://api.ofox.ai/v1`，无需修改。
+
+  ### 步骤三：选择模型并开始对话
+
+  - 在模型选择器中选择 OfoxAI 提供的模型，例如 `gpt-4o`、`claude-sonnet-4-20250514`、`gemini-2.5-pro`、`deepseek-v3` 等。
+  - 开始对话。流式输出、工具调用（底层模型支持时）、图片输入均开箱即用。
+
+  <Callout type={'info'}>
+    OfoxAI 提供免费额度可供试用，超出后按 token 计费。中国大陆用户默认通过香港加速线路访问。完整模型列表与价格见 [docs.ofox.ai](https://docs.ofox.ai)。
+  </Callout>
+
+  <Callout type={'warning'}>
+    请妥善保管您的 API Key。一旦丢失只能重新生成。
+  </Callout>
+</Steps>
+
+至此，您已可以在 LobeHub 中使用 OfoxAI 提供的各种模型进行对话与交互。

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -46,6 +46,7 @@ export enum ModelProvider {
   Nvidia = 'nvidia',
   Ollama = 'ollama',
   OllamaCloud = 'ollamacloud',
+  OfoxAI = 'ofoxai',
   OpenAI = 'openai',
   OpenCodeCodingPlan = 'opencodecodingplan',
   OpenCodeZen = 'opencodezen',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -49,6 +49,7 @@ import NovitaProvider from './novita';
 import NvidiaProvider from './nvidia';
 import OllamaProvider from './ollama';
 import OllamaCloudProvider from './ollamacloud';
+import OfoxAIProvider from './ofoxai';
 import OpenAIProvider from './openai';
 import OpenCodeCodingPlanProvider from './opencodeCodingPlan';
 import OpenCodeZenProvider from './opencodeZen';
@@ -88,6 +89,7 @@ import ZhiPuProvider from './zhipu';
  * @deprecated
  */
 export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
+  OfoxAIProvider.chatModels,
   OpenAIProvider.chatModels,
   QwenProvider.chatModels,
   ZhiPuProvider.chatModels,
@@ -146,6 +148,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   GoogleProvider,
   GLMCodingPlanProvider,
   KimiCodingPlanProvider,
+  OfoxAIProvider,
   OpenAIProvider,
   DeepSeekProvider,
   XinferenceProvider,
@@ -282,6 +285,7 @@ export { default as NovitaProviderCard } from './novita';
 export { default as NvidiaProviderCard } from './nvidia';
 export { default as OllamaProviderCard } from './ollama';
 export { default as OllamaCloudProviderCard } from './ollamacloud';
+export { default as OfoxAIProviderCard } from './ofoxai';
 export { default as OpenAIProviderCard } from './openai';
 export { default as OpenCodeCodingPlanProviderCard } from './opencodeCodingPlan';
 export { default as OpenCodeZenProviderCard } from './opencodeZen';

--- a/packages/model-bank/src/modelProviders/ofoxai.ts
+++ b/packages/model-bank/src/modelProviders/ofoxai.ts
@@ -1,0 +1,24 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://docs.ofox.ai
+const OfoxAI: ModelProviderCard = {
+  apiKeyUrl: 'https://app.ofox.ai',
+  chatModels: [],
+  checkModel: 'gpt-4o-mini',
+  description:
+    'OfoxAI is a unified LLM API gateway that provides access to 100+ models — including OpenAI, Anthropic Claude, Google Gemini, DeepSeek, Qwen, Mistral, and Llama — through a single API key. Wire-compatible with the OpenAI, Anthropic, and Gemini protocols.',
+  id: 'ofoxai',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://docs.ofox.ai',
+  name: 'OfoxAI',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.ofox.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://ofox.ai',
+};
+
+export default OfoxAI;

--- a/packages/model-runtime/src/providers/ofoxai/index.ts
+++ b/packages/model-runtime/src/providers/ofoxai/index.ts
@@ -1,0 +1,11 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const LobeOfoxAI = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.ofox.ai/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_OFOXAI_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.OfoxAI,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -48,6 +48,7 @@ import { LobeOllamaCloudAI } from './providers/ollamacloud';
 import { LobeOpenAI } from './providers/openai';
 import { LobeOpenCodeCodingPlanAI } from './providers/opencodeCodingPlan';
 import { LobeOpenCodeZenAI } from './providers/opencodeZen';
+import { LobeOfoxAI } from './providers/ofoxai';
 import { LobeOpenRouterAI } from './providers/openrouter';
 import { LobePerplexityAI } from './providers/perplexity';
 import { LobePPIOAI } from './providers/ppio';
@@ -130,6 +131,7 @@ export const providerRuntimeMap = {
   opencodecodingplan: LobeOpenCodeCodingPlanAI,
   opencodezen: LobeOpenCodeZenAI,
   openai: LobeOpenAI,
+  ofoxai: LobeOfoxAI,
   openrouter: LobeOpenRouterAI,
   perplexity: LobePerplexityAI,
   ppio: LobePPIOAI,


### PR DESCRIPTION
Adds [OfoxAI](https://ofox.ai) as a built-in model provider in LobeChat.

OfoxAI is a unified LLM API gateway that provides access to 100+ models — including OpenAI GPT, Anthropic Claude, Google Gemini, DeepSeek, Qwen, Mistral, and Llama — through a single API key. It is wire-compatible with the OpenAI, Anthropic, and Gemini protocols, so it plugs into LobeChat's existing OpenAI-compatible runtime without any custom adapter logic.

## Changes

- **`packages/model-bank/src/const/modelProvider.ts`**: register `OfoxAI = 'ofoxai'` in the `ModelProvider` enum.
- **`packages/model-bank/src/modelProviders/ofoxai.ts`**: new `ProviderCard` (`sdkType: 'openai'`, base URL `https://api.ofox.ai/v1`, model fetcher enabled).
- **`packages/model-bank/src/modelProviders/index.ts`**: register the new provider in imports, chat-models array, providers list, and re-exports.
- **`packages/model-runtime/src/providers/ofoxai/index.ts`**: new runtime built on `createOpenAICompatibleRuntime` (same minimal pattern as `ai21`).
- **`packages/model-runtime/src/runtimeMap.ts`**: register the runtime.
- **`docs/usage/providers/ofoxai.mdx`** + **`ofoxai.zh-CN.mdx`**: English and Chinese setup guides.

## Notes

- OfoxAI exposes a working `/models` endpoint, so model fetching works out of the box.
- A free tier is available for evaluation, with pay-per-token usage thereafter.
- For users who want native Anthropic prompt caching or Gemini features, OfoxAI also offers `https://api.ofox.ai/anthropic` and `https://api.ofox.ai/gemini` protocol endpoints with the same API key. Left out of this PR to keep it minimal — happy to follow up if maintainers want a `router`-style runtime like AiHubMix.