### PR TITLE
♻️ refactor: move DEFAULT_ONBOARDING_MODEL to business-const

### DIFF
--- a/packages/builtin-agents/src/agents/web-onboarding/index.ts
+++ b/packages/builtin-agents/src/agents/web-onboarding/index.ts
@@ -1,8 +1,7 @@
 import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
 import { GroupAgentBuilderIdentifier } from '@lobechat/builtin-tool-group-agent-builder';
 import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_ONBOARDING_MODEL } from '@lobechat/const';
+import { DEFAULT_ONBOARDING_MODEL, DEFAULT_PROVIDER } from '@lobechat/business-const';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';

--- a/packages/business/const/src/llm.ts
+++ b/packages/business/const/src/llm.ts
@@ -2,3 +2,5 @@ export const DEFAULT_EMBEDDING_PROVIDER = 'openai';
 
 export const DEFAULT_PROVIDER = 'anthropic';
 export const DEFAULT_MINI_PROVIDER = 'openai';
+
+export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';

--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -1,5 +1,4 @@
 export const DEFAULT_MODEL = 'claude-sonnet-4-6';
-export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';
 export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 
 export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';

--- a/src/const/onboarding.ts
+++ b/src/const/onboarding.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
-import { DEFAULT_ONBOARDING_MODEL } from '@lobechat/const';
+import { DEFAULT_ONBOARDING_MODEL, DEFAULT_PROVIDER } from '@lobechat/business-const';
 
 export const ONBOARDING_PRODUCTION_DEFAULT_MODEL = {
   model: DEFAULT_ONBOARDING_MODEL,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A — internal refactor.

#### 🔀 Description of Change

Move `DEFAULT_ONBOARDING_MODEL` from `@lobechat/const` into `@lobechat/business-const`. The OSS default value (`gemini-3-flash-preview`) is unchanged, so self-hosted users are not affected.

This mirrors the existing pattern for `DEFAULT_PROVIDER`, which already lives in `@lobechat/business-const` for the same reason: distributions that ship their own `@cloud/business-const` (e.g. via `pnpm overrides`) can supply a different default without forking this repo.

Files touched:

- `packages/business/const/src/llm.ts` — add `DEFAULT_ONBOARDING_MODEL` (with the existing OSS value).
- `packages/const/src/settings/llm.ts` — drop the constant from here.
- `packages/builtin-agents/src/agents/web-onboarding/index.ts` — change import source.
- `src/const/onboarding.ts` — change import source.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

`bun run type-check` clean. Onboarding agent still resolves `model = 'gemini-3-flash-preview'` for OSS callers; behavior is unchanged.

#### 📝 Additional Information

The motivating downstream change (cloud distribution overriding this default to a virtual model id resolved at runtime) is out of scope for this PR.