### PR TITLE
🐛 fix(server): Headless editor LiteXML read/patch loses stable node ids

### DIFF
--- a/src/server/services/agentDocuments/headlessEditor.ts
+++ b/src/server/services/agentDocuments/headlessEditor.ts
@@ -92,6 +92,122 @@ interface LoadEditorStateParams {
   fallbackContent?: string;
 }
 
+interface LiteXMLNodeIdRef {
+  id: string;
+  tag: string;
+}
+
+const liteXMLOpeningTagPattern = /<([a-z][\w:-]*)\b([^>]*)>/gi;
+const liteXMLIdAttributePattern = /\sid="([^"]+)"/;
+const liteXMLIdAttributeGlobalPattern = /\sid="([^"]+)"/g;
+
+const extractLiteXMLIdRefs = (litexml?: string): LiteXMLNodeIdRef[] => {
+  if (!litexml) return [];
+
+  return [...litexml.matchAll(liteXMLOpeningTagPattern)].flatMap((match) => {
+    const id = match[2].match(liteXMLIdAttributePattern)?.[1];
+
+    return id ? [{ id, tag: match[1] }] : [];
+  });
+};
+
+const collectEditorDataIds = (node: unknown, ids: string[] = []) => {
+  if (!node || typeof node !== 'object') return ids;
+
+  const record = node as Record<string, unknown>;
+  if (record.root && typeof record.root === 'object') {
+    return collectEditorDataIds(record.root, ids);
+  }
+
+  if (typeof record.id === 'string' && record.type !== 'root') {
+    ids.push(record.id);
+  }
+
+  const children = record.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collectEditorDataIds(child, ids);
+    }
+  }
+
+  return ids;
+};
+
+/**
+ * Normalizes LiteXML ids to stable editorData ids.
+ *
+ * Before:
+ * - `<p id="runtime-a"><span id="runtime-b">Original</span></p>`
+ *
+ * After:
+ * - `<p id="1"><span id="2">Original</span></p>`
+ */
+const normalizeLiteXMLIds = (litexml: string | undefined, editorData: unknown) => {
+  if (!litexml) return litexml;
+
+  const editorDataIds = collectEditorDataIds(editorData);
+  let index = 0;
+
+  return litexml.replaceAll(liteXMLOpeningTagPattern, (match, tag, attributes) => {
+    const stableId = editorDataIds[index];
+    const id = attributes.match(liteXMLIdAttributePattern)?.[1];
+
+    if (!id) return match;
+
+    index += 1;
+
+    return stableId
+      ? `<${tag}${attributes.replaceAll(liteXMLIdAttributeGlobalPattern, ` id="${stableId}"`)}>`
+      : match;
+  });
+};
+
+const createLiteXMLIdMap = (
+  stableLiteXML: string | undefined,
+  runtimeLiteXML: string | undefined,
+) => {
+  const stableRefs = extractLiteXMLIdRefs(stableLiteXML);
+  const runtimeRefs = extractLiteXMLIdRefs(runtimeLiteXML);
+  const idMap = new Map<string, string>();
+
+  for (const [index, stableRef] of stableRefs.entries()) {
+    const runtimeRef = runtimeRefs[index];
+
+    if (!runtimeRef || runtimeRef.tag !== stableRef.tag) continue;
+    idMap.set(stableRef.id, runtimeRef.id);
+  }
+
+  return idMap;
+};
+
+const mapLiteXMLId = (idMap: Map<string, string>, id: string) => idMap.get(id) ?? id;
+
+const remapLiteXMLIds = (idMap: Map<string, string>, litexml: string) =>
+  litexml.replaceAll(/\sid="([^"]+)"/g, (match, id) => ` id="${mapLiteXMLId(idMap, id)}"`);
+
+const remapLiteXMLOperations = (
+  operations: AgentDocumentLiteXMLOperation[],
+  idMap: Map<string, string>,
+): AgentDocumentLiteXMLOperation[] =>
+  operations.map((operation) => {
+    if (operation.action === 'remove') {
+      return { ...operation, id: mapLiteXMLId(idMap, operation.id) };
+    }
+
+    if (operation.action === 'modify') {
+      return {
+        ...operation,
+        litexml: Array.isArray(operation.litexml)
+          ? operation.litexml.map((litexml) => remapLiteXMLIds(idMap, litexml))
+          : remapLiteXMLIds(idMap, operation.litexml),
+      };
+    }
+
+    return 'beforeId' in operation
+      ? { ...operation, beforeId: mapLiteXMLId(idMap, operation.beforeId) }
+      : { ...operation, afterId: mapLiteXMLId(idMap, operation.afterId) };
+  });
+
 const exportSnapshot = (
   editor: ReturnType<(typeof import('@lobehub/editor/headless'))['createHeadlessEditor']>,
   litexml = false,
@@ -101,7 +217,7 @@ const exportSnapshot = (
   return {
     content: snapshot.markdown,
     editorData: snapshot.editorData as SerializedEditorState<SerializedLexicalNode>,
-    litexml: snapshot.litexml,
+    litexml: normalizeLiteXMLIds(snapshot.litexml, snapshot.editorData),
   };
 };
 
@@ -126,12 +242,23 @@ const loadEditorState = (
   { editorData, fallbackContent = '' }: LoadEditorStateParams,
 ) => {
   if (isValidEditorData(editorData)) {
-    editor.hydrateEditorData(
-      editorData as unknown as SerializedEditorState<SerializedLexicalNode>,
-      {
-        keepId: true,
-      },
-    );
+    // NOTICE:
+    // @lobehub/editor@4.9.3 headless JSON hydration breaks when `keepId: true`
+    // is passed for editorData exported by the same headless editor.
+    // Root cause: the editor's JSONDataSource tries to preserve Lexical node ids,
+    // then Lexical 0.42 fails while appending parsed children
+    // (`ElementNode.splice: start + deleteCount > oldSize`) and leaves an empty
+    // document. Instead, this adapter normalizes exported LiteXML ids to stable
+    // editorData ids and remaps them back to runtime ids before applyLiteXML.
+    // Example read-only flow:
+    //   editorData -> hydrate -> export markdown for Context Engine / LLM reads.
+    // Example LiteXML patch flow:
+    //   readDocument exports `<span id="node-1">Original</span>`, then a tool
+    //   sends `<span id="node-1">Updated</span>`. Before applyLiteXML, we map
+    //   stable `node-1` to the runtime id generated by the current hydrate.
+    // Removal condition: @lobehub/editor fixes keepId JSON hydration for
+    // headless editorData round-trips.
+    editor.hydrateEditorData(editorData as unknown as SerializedEditorState<SerializedLexicalNode>);
     return;
   }
 
@@ -178,7 +305,15 @@ export const applyLiteXMLOperations = async ({
 
   try {
     loadEditorState(editor, { editorData, fallbackContent });
-    await editor.applyLiteXML(orderLiteXMLOperations(operations).map(toHeadlessLiteXMLOperation));
+
+    const runtimeSnapshot = editor.export({ litexml: true });
+    const stableLiteXML = normalizeLiteXMLIds(runtimeSnapshot.litexml, editorData);
+    const idMap = createLiteXMLIdMap(stableLiteXML, runtimeSnapshot.litexml);
+    const remappedOperations = remapLiteXMLOperations(operations, idMap);
+
+    await editor.applyLiteXML(
+      orderLiteXMLOperations(remappedOperations).map(toHeadlessLiteXMLOperation),
+    );
     return exportSnapshot(editor, true);
   } finally {
     editor.destroy();


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

**Background**

Agent documents are stored with both:

- `content`: markdown fallback
- `editorData`: Lexical/editor JSON state

When reading a document for tools/LLM context, server code hydrates `editorData` into the headless editor, then exports markdown/LiteXML. LiteXML includes node ids, for example:

```xml
<p id="ll63">
  <span id="lqqe">Original</span>
</p>
```

Tool-side LiteXML patching relies on those ids. A modify operation may later send:

```xml
<span id="lqqe">Updated</span>
```

The server then hydrates the same `editorData` again and applies the patch by id.

**Problem**

`hydrateEditorData(..., { keepId: true })` currently fails in the headless editor path with current dependencies:

- `@lobehub/editor@4.9.3`
- `lexical@0.42.0`

The failure looks like:

```text
ElementNode.splice: start + deleteCount > oldSize
```

After this failure, the headless editor can silently export an empty document or fail to apply LiteXML modifications. This means agent document reads and `modifyNodes` can become unreliable.

**How To Reproduce**

Run:

```bash
cd lobehub
bunx vitest run --silent='passed-only' 'src/server/services/agentDocuments/headlessEditor.test.ts'
```

The failing case is:

```ts
it('should apply LiteXML operations and persist diff nodes for later human review', async () => {
  const initial = await exportEditorDataSnapshot({
    fallbackContent: 'Original',
    litexml: true,
  });

  const textId = getSpanId(initial.litexml!, 'Original');

  const snapshot = await applyLiteXMLOperations({
    editorData: initial.editorData,
    fallbackContent: initial.content,
    operations: [
      {
        action: 'modify',
        litexml: `<span id="${textId}">Updated</span>`,
      },
    ],
  });

  expect(snapshot.content).toBe('Updated\n');
});
```

Observed before fix:

```text
expected 'Original\n' to be 'Updated\n'
```

or earlier:

```text
ElementNode.splice: start + deleteCount > oldSize
```

**Root Cause Hypothesis**

The headless editor JSON data source has a special `keepId` path. That path tries to preserve Lexical node ids while parsing serialized editor data.

In this environment, preserving ids during JSON hydration appears incompatible with Lexical’s current parse/append behavior. The editor throws during child append and leaves the document in an invalid or empty state.

Normal hydration without `keepId` succeeds, but it regenerates runtime LiteXML ids. That breaks patch semantics because the id exported during `readDocument` no longer matches the id available during `modifyNodes`.

**Why This Matters**

Agent document tools expose LiteXML as the precise edit format:

1. `readDocument` exports LiteXML ids.
2. Tool sends `modifyNodes` using those ids.
3. Server applies patch to the same document.

If ids are unstable or hydration fails, tools may:

- fail to update the intended node
- no-op silently
- export empty markdown
- incorrectly report success/failure around document edits

**Proposed Fix**

Do not rely on `hydrateEditorData(..., { keepId: true })`.

Instead:

1. Hydrate editorData normally.
2. Export LiteXML.
3. Normalize exported LiteXML ids to stable ids from `editorData`.
4. Before applying LiteXML operations, hydrate normally again.
5. Export runtime LiteXML for the current hydrate.
6. Build a map from stable ids to runtime ids by document order/tag.
7. Rewrite incoming operations to runtime ids.
8. Apply LiteXML operations.

This preserves the external tool contract while avoiding the broken `keepId` branch.

**Expected Behavior After Fix**

The same round-trip test should pass:

```text
read editorData -> export LiteXML -> patch by exported id -> Updated markdown
```

Expected assertion:

```ts
expect(snapshot.content).toBe('Updated\n');
expect(snapshot.litexml).toContain('Updated');
expect(hasNodeType(snapshot.editorData, 'diff')).toBe(true);
```

**Suggested PR Verification**

```bash
cd lobehub

bunx vitest run --silent='passed-only' \
  'src/server/services/agentDocuments/headlessEditor.test.ts' \
  'src/server/services/agentDocuments/index.test.ts'

bunx eslint --no-warn-ignored \
  src/server/services/agentDocuments/headlessEditor.ts

git diff --check -- src/server/services/agentDocuments/headlessEditor.ts
```

**Notes / Open Questions**

- The proposed fix is an adapter-level workaround, not a root fix in `@lobehub/editor`.
- Longer term, `@lobehub/editor` should make `keepId` hydration safe or provide a first-class stable-id LiteXML API.
- The workaround should include a `NOTICE` comment explaining why `keepId` is avoided and when it can be removed.

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
