### PR TITLE
fix: pass groupId to messageModel.query in compress_context

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -226,6 +226,7 @@ export interface RuntimeExecutorContext {
   streamManager: IStreamEventManager;
   toolExecutionService: ToolExecutionService;
   topicId?: string;
+  groupId?: string;
   userId?: string;
   userTimezone?: string;
 }
@@ -1061,6 +1062,7 @@ export const createRuntimeExecutors = (
         agentId: state.metadata?.agentId,
         threadId: state.metadata?.threadId,
         topicId,
+        groupId: ctx.groupId,
       });
 
       const messageIds = dbMessages
@@ -1786,6 +1788,7 @@ export const createRuntimeExecutors = (
       agentId: state.metadata?.agentId,
       threadId: state.metadata?.threadId,
       topicId: state.metadata?.topicId,
+      groupId: ctx.groupId,
     });
 
     // Use conversation-flow parse to resolve branching into linear flat list

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -1458,6 +1458,7 @@ export class AgentRuntimeService {
       streamManager: this.streamManager,
       toolExecutionService: this.toolExecutionService,
       topicId: metadata?.topicId,
+      groupId: metadata?.groupId,
       userId: metadata?.userId,
     };
 


### PR DESCRIPTION
## Summary

Fixes issue where context compression fails in Group Chat with error: 'No conversation history provided to compress'

## Root Cause

The server-side `compress_context` and `call_tools_batch` executors in RuntimeExecutors didn't pass `groupId` when querying messages via `messageModel.query()`. In Group Chat scenarios, the message query requires `groupId` to correctly scope messages - without it, the query returns empty results even when messages exist.

## Changes

1. **RuntimeExecutorContext interface** (`src/server/modules/AgentRuntime/RuntimeExecutors.ts`):
   - Added optional `groupId?: string` field

2. **createAgentRuntime** (`src/server/services/agentRuntime/AgentRuntimeService.ts`):
   - Added `groupId: metadata?.groupId` to executorContext

3. **compress_context executor**:
   - Added `groupId: ctx.groupId` to `messageModel.query()` call

4. **call_tools_batch executor**:
   - Added `groupId: ctx.groupId` to `messageModel.query()` call

## Testing

This fix ensures that when context compression is triggered in Group Chat:
- The message query correctly includes `groupId` in its filter conditions
- Messages are properly retrieved and compression succeeds
- The 'No conversation history' error no longer occurs

Fixes #14236