### PR TITLE
🐛 fix: restore task agent panel toggle

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.test.ts
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRenderTaskAgentPanelToggle } from './taskAgentPanelToggle';
+
+describe('AgentTasksPage', () => {
+  describe('shouldRenderTaskAgentPanelToggle', () => {
+    it('should render the task agent panel toggle on desktop layouts', () => {
+      expect(shouldRenderTaskAgentPanelToggle(false)).toBe(true);
+    });
+
+    it('should hide the task agent panel toggle on mobile layouts', () => {
+      expect(shouldRenderTaskAgentPanelToggle(true)).toBe(false);
+    });
+  });
+});

--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import NavHeader from '@/features/NavHeader';
+import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -28,6 +29,10 @@ const AgentTasksPage = memo(() => {
   const rawViewOptions = useGlobalStore(systemStatusSelectors.taskListViewOptions);
   const viewOptions = useMemo(() => normalizeTaskListViewOptions(rawViewOptions), [rawViewOptions]);
   const inlineCollapsed = useGlobalStore(systemStatusSelectors.taskCreateInlineCollapsed);
+  const [showTaskAgentPanel, toggleTaskAgentPanel] = useGlobalStore((s) => [
+    systemStatusSelectors.showTaskAgentPanel(s),
+    s.toggleTaskAgentPanel,
+  ]);
   const updateSystemStatus = useGlobalStore((s) => s.updateSystemStatus);
   const setViewOptions = useCallback(
     (updater: (prev: TaskListViewOptions) => TaskListViewOptions) => {
@@ -59,6 +64,11 @@ const AgentTasksPage = memo(() => {
               <ActionIcon icon={Plus} size={DESKTOP_HEADER_ICON_SIZE} onClick={handleCreateTask} />
             )}
             <TasksGroupConfig options={viewOptions} setOptions={setViewOptions} />
+            <ToggleRightPanelButton
+              hideWhenExpanded
+              expand={showTaskAgentPanel}
+              onToggle={() => toggleTaskAgentPanel()}
+            />
           </Flexbox>
         }
         styles={{

--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -7,6 +7,7 @@ import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import NavHeader from '@/features/NavHeader';
 import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
 import WideScreenContainer from '@/features/WideScreenContainer';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useTaskStore } from '@/store/task';
@@ -18,11 +19,13 @@ import CreateTaskInlineEntry from './CreateTaskInlineEntry';
 import KanbanBoard from './KanbanBoard';
 import type { TaskListViewOptions } from './listViewOptions';
 import { normalizeTaskListViewOptions } from './listViewOptions';
+import { shouldRenderTaskAgentPanelToggle } from './taskAgentPanelToggle';
 import TaskList from './TaskList';
 import TasksGroupConfig from './TasksGroupConfig';
 
 const AgentTasksPage = memo(() => {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const viewMode = useTaskStore(taskListSelectors.viewMode);
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
   useFetchTaskList({ allAgents: true });
@@ -54,6 +57,8 @@ const AgentTasksPage = memo(() => {
     setViewOptions((prev) => ({ ...prev, hideCompleted: false }));
   }, [setViewOptions]);
 
+  const showTaskAgentPanelToggle = shouldRenderTaskAgentPanelToggle(isMobile);
+
   return (
     <Flexbox flex={1} height={'100%'}>
       <NavHeader
@@ -64,11 +69,13 @@ const AgentTasksPage = memo(() => {
               <ActionIcon icon={Plus} size={DESKTOP_HEADER_ICON_SIZE} onClick={handleCreateTask} />
             )}
             <TasksGroupConfig options={viewOptions} setOptions={setViewOptions} />
-            <ToggleRightPanelButton
-              hideWhenExpanded
-              expand={showTaskAgentPanel}
-              onToggle={() => toggleTaskAgentPanel()}
-            />
+            {showTaskAgentPanelToggle && (
+              <ToggleRightPanelButton
+                hideWhenExpanded
+                expand={showTaskAgentPanel}
+                onToggle={() => toggleTaskAgentPanel()}
+              />
+            )}
           </Flexbox>
         }
         styles={{

--- a/src/features/AgentTasks/AgentTaskList/taskAgentPanelToggle.ts
+++ b/src/features/AgentTasks/AgentTaskList/taskAgentPanelToggle.ts
@@ -1,0 +1,5 @@
+/**
+ * Task routes only mount AgentTaskManager on desktop layouts, so mobile must not
+ * expose a toggle that changes an invisible panel state.
+ */
+export const shouldRenderTaskAgentPanelToggle = (isMobile: boolean) => !isMobile;

--- a/src/hooks/useHotkeys/globalScope.test.ts
+++ b/src/hooks/useHotkeys/globalScope.test.ts
@@ -2,6 +2,8 @@ import { HotkeyEnum } from '@lobechat/const/hotkeys';
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { HotkeyId } from '@/types/hotkey';
+
 import { isTaskPanelRoute, useToggleRightPanelHotkey } from './globalScope';
 
 interface MockGlobalState {
@@ -11,7 +13,7 @@ interface MockGlobalState {
   updateSystemStatus: () => void;
 }
 
-type HotkeyRegistrationArgs = [HotkeyEnum, () => void, ...unknown[]];
+type HotkeyRegistrationArgs = [HotkeyId, () => void, ...unknown[]];
 
 const mocks = vi.hoisted(() => ({
   hotkeyCallback: undefined as (() => void) | undefined,

--- a/src/hooks/useHotkeys/globalScope.test.ts
+++ b/src/hooks/useHotkeys/globalScope.test.ts
@@ -1,0 +1,113 @@
+import { HotkeyEnum } from '@lobechat/const/hotkeys';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isTaskPanelRoute, useToggleRightPanelHotkey } from './globalScope';
+
+interface MockGlobalState {
+  status: { zenMode: boolean };
+  toggleRightPanel: () => void;
+  toggleTaskAgentPanel: () => void;
+  updateSystemStatus: () => void;
+}
+
+type HotkeyRegistrationArgs = [HotkeyEnum, () => void, ...unknown[]];
+
+const mocks = vi.hoisted(() => ({
+  hotkeyCallback: undefined as (() => void) | undefined,
+  pathname: '/',
+  toggleRightPanel: vi.fn(),
+  toggleTaskAgentPanel: vi.fn(),
+  useHotkeyById: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: mocks.pathname }),
+}));
+
+vi.mock('@/hooks/useNavigateToAgent', () => ({
+  useNavigateToAgent: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/usePinnedAgentState', () => ({
+  usePinnedAgentState: () => [undefined, { unpinAgent: vi.fn() }],
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (state: MockGlobalState) => unknown) =>
+    selector({
+      status: { zenMode: false },
+      toggleRightPanel: mocks.toggleRightPanel,
+      toggleTaskAgentPanel: mocks.toggleTaskAgentPanel,
+      updateSystemStatus: vi.fn(),
+    }),
+}));
+
+vi.mock('./useHotkeyById', () => ({
+  useHotkeyById: (...args: HotkeyRegistrationArgs) => mocks.useHotkeyById(...args),
+}));
+
+describe('globalScope hotkeys', () => {
+  beforeEach(() => {
+    mocks.hotkeyCallback = undefined;
+    mocks.pathname = '/';
+    mocks.toggleRightPanel.mockReset();
+    mocks.toggleTaskAgentPanel.mockReset();
+    mocks.useHotkeyById.mockReset();
+    mocks.useHotkeyById.mockImplementation((_, callback) => {
+      mocks.hotkeyCallback = callback;
+      return { id: HotkeyEnum.ToggleRightPanel };
+    });
+  });
+
+  describe('isTaskPanelRoute', () => {
+    it('should match task panel routes only', () => {
+      expect(isTaskPanelRoute('/tasks')).toBe(true);
+      expect(isTaskPanelRoute('/tasks/filter')).toBe(true);
+      expect(isTaskPanelRoute('/task/T-1')).toBe(true);
+      expect(isTaskPanelRoute('/agent/inbox')).toBe(false);
+      expect(isTaskPanelRoute('/task-template')).toBe(false);
+    });
+  });
+
+  describe('useToggleRightPanelHotkey', () => {
+    it('should toggle task agent panel on task routes', () => {
+      mocks.pathname = '/tasks';
+
+      renderHook(() => useToggleRightPanelHotkey());
+
+      act(() => {
+        mocks.hotkeyCallback?.();
+      });
+
+      expect(mocks.toggleTaskAgentPanel).toHaveBeenCalledTimes(1);
+      expect(mocks.toggleRightPanel).not.toHaveBeenCalled();
+    });
+
+    it('should toggle task agent panel on task detail routes', () => {
+      mocks.pathname = '/task/T-1';
+
+      renderHook(() => useToggleRightPanelHotkey());
+
+      act(() => {
+        mocks.hotkeyCallback?.();
+      });
+
+      expect(mocks.toggleTaskAgentPanel).toHaveBeenCalledTimes(1);
+      expect(mocks.toggleRightPanel).not.toHaveBeenCalled();
+    });
+
+    it('should keep toggling the generic right panel on non-task routes', () => {
+      mocks.pathname = '/agent/inbox';
+
+      renderHook(() => useToggleRightPanelHotkey());
+
+      act(() => {
+        mocks.hotkeyCallback?.();
+      });
+
+      expect(mocks.toggleRightPanel).toHaveBeenCalledTimes(1);
+      expect(mocks.toggleTaskAgentPanel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useHotkeys/globalScope.ts
+++ b/src/hooks/useHotkeys/globalScope.ts
@@ -1,11 +1,19 @@
 import { INBOX_SESSION_ID } from '@lobechat/const';
 import { HotkeyEnum } from '@lobechat/const/hotkeys';
+import { useLocation } from 'react-router-dom';
 
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { usePinnedAgentState } from '@/hooks/usePinnedAgentState';
 import { useGlobalStore } from '@/store/global';
 
 import { useHotkeyById } from './useHotkeyById';
+
+/**
+ * Task routes render AgentTaskManager, whose panel status is intentionally
+ * independent from the generic right panel used by chat and page editor routes.
+ */
+export const isTaskPanelRoute = (pathname: string) =>
+  pathname === '/tasks' || pathname.startsWith('/tasks/') || pathname.startsWith('/task/');
 
 // Switch to chat tab (and focus on Lobe AI)
 export const useNavigateToChatHotkey = () => {
@@ -39,13 +47,30 @@ export const useToggleLeftPanelHotkey = () => {
 };
 
 export const useToggleRightPanelHotkey = () => {
+  const { pathname } = useLocation();
   const isZenMode = useGlobalStore((s) => s.status.zenMode);
-  const toggleConfig = useGlobalStore((s) => s.toggleRightPanel);
+  const [toggleRightPanel, toggleTaskAgentPanel] = useGlobalStore((s) => [
+    s.toggleRightPanel,
+    s.toggleTaskAgentPanel,
+  ]);
+  const isTaskRoute = isTaskPanelRoute(pathname);
 
-  return useHotkeyById(HotkeyEnum.ToggleRightPanel, () => toggleConfig(), {
-    enableOnContentEditable: true,
-    enabled: !isZenMode,
-  });
+  return useHotkeyById(
+    HotkeyEnum.ToggleRightPanel,
+    () => {
+      if (isTaskRoute) {
+        toggleTaskAgentPanel();
+        return;
+      }
+
+      toggleRightPanel();
+    },
+    {
+      enableOnContentEditable: true,
+      enabled: !isZenMode,
+    },
+    [isTaskRoute, toggleRightPanel, toggleTaskAgentPanel],
+  );
 };
 
 // CMDK


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - reported from task panel regression review.

#### 🔀 Description of Change

- Route the global right-panel hotkey to the task agent panel on task routes.
- Add the task agent panel toggle button to the all-tasks page header.
- Cover task route hotkey routing with unit tests.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bunx vitest run --silent='passed-only' 'src/hooks/useHotkeys/globalScope.test.ts'
bunx eslint 'src/hooks/useHotkeys/globalScope.ts' 'src/hooks/useHotkeys/globalScope.test.ts' 'src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx'
git diff --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No cloud-specific business logic is included in the open-source submodule changes.