### PR TITLE
🐛 fix: fix PDF chunking logic to prevent vectorization failure

### DIFF
--- a/src/libs/document-loaders/loaders/pdf/index.ts
+++ b/src/libs/document-loaders/loaders/pdf/index.ts
@@ -1,4 +1,6 @@
+import { splitPdf } from '../../splitter';
 import { type DocumentChunk } from '../../types';
+import { loaderConfig } from '../config';
 
 export const PdfLoader = async (fileBlob: Blob): Promise<DocumentChunk[]> => {
   const pdfParse = (await import('pdf-parse')).default;
@@ -6,15 +8,7 @@ export const PdfLoader = async (fileBlob: Blob): Promise<DocumentChunk[]> => {
   const buffer = Buffer.from(await fileBlob.arrayBuffer());
   const data = await pdfParse(buffer);
 
-  // Split by pages using form feed character, or treat as single page
-  const pages: string[] = data.text
-    ? data.text.split(/\f/).filter((page: string) => page.trim().length > 0)
-    : [];
-
-  return pages.map((pageContent: string, index: number) => ({
-    metadata: {
-      loc: { pageNumber: index + 1 },
-    },
-    pageContent: pageContent.trim(),
-  }));
+  // Split into physical pages using form feed (\f),
+  // then recursively chunk each page's text while preserving page numbers.
+  return splitPdf(data.text, loaderConfig);
 };

--- a/src/libs/document-loaders/splitter/index.ts
+++ b/src/libs/document-loaders/splitter/index.ts
@@ -183,6 +183,21 @@ export function splitLatex(text: string, config: SplitterConfig): DocumentChunk[
   return createDocuments(text, LATEX_SEPARATORS, config);
 }
 
+export function splitPdf(text: string, config: SplitterConfig): DocumentChunk[] {
+  const pages: string[] = text
+    ? text.split(/\f/).filter((page: string) => page.trim().length > 0)
+    : [];
+  return pages.flatMap((pageContent: string, index: number) => {
+    const stringChunks = splitTextWithSeparators(pageContent, DEFAULT_SEPARATORS, config);
+    return stringChunks.map((chunkContent: string) => ({
+      metadata: {
+        loc: { pageNumber: index + 1 },
+      },
+      pageContent: chunkContent.trim(),
+    }));
+  });
+}
+
 export function splitCode(
   text: string,
   language: SupportedLanguage,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->
close https://github.com/lobehub/lobehub/issues/14325
<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

Fixed the PDF loader chunking logic to support recursive text splitting while strictly preserving the original `pageNumber` metadata structure. 

Previously, parsing entire pages as single chunks could lead to exceeding token limits. This update uses a two-step approach:
1. Splits the PDF into physical pages using the form feed character (`\f`).
2. Recursively chunks the text within each page using `splitTextWithSeparators` and uses `flatMap` to return a 1D array. 

This ensures that downstream systems relying on the exact `metadata: { loc: { pageNumber: X } }` format will not break, avoiding the introduction of incompatible fields like `lines`.
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->
1. Upload a large multi-page PDF document.
2. Verify that the document is successfully chunked and vectorized.
<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
