### PR TITLE
💄 style(daily-brief): add skeleton loading state

### DIFF
--- a/src/features/DailyBrief/BriefCardSkeleton.tsx
+++ b/src/features/DailyBrief/BriefCardSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Block, Flexbox, Skeleton } from '@lobehub/ui';
+import { Divider } from 'antd';
+import { cssVar } from 'antd-style';
+import { memo } from 'react';
+
+const BriefCardSkeleton = memo(() => {
+  return (
+    <Block
+      gap={12}
+      padding={12}
+      style={{ borderRadius: cssVar.borderRadiusLG }}
+      variant={'outlined'}
+    >
+      <Flexbox horizontal align={'center'} gap={16} justify={'space-between'}>
+        <Flexbox horizontal align={'center'} gap={8} style={{ overflow: 'hidden' }}>
+          <Skeleton.Avatar active shape={'circle'} size={18} style={{ flex: 'none' }} />
+          <Skeleton.Button active style={{ height: 20, width: 200 }} />
+          <Skeleton.Button active style={{ height: 14, width: 60 }} />
+        </Flexbox>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <Skeleton.Avatar active shape={'circle'} size={28} style={{ flex: 'none' }} />
+        </Flexbox>
+      </Flexbox>
+
+      <Divider dashed style={{ marginBlock: 0 }} />
+
+      <Skeleton.Paragraph active fontSize={14} rows={3} style={{ marginBottom: 0 }} />
+
+      <Flexbox horizontal gap={8} style={{ alignSelf: 'flex-end' }}>
+        <Skeleton.Button active style={{ height: 28, width: 100 }} />
+        <Skeleton.Button active style={{ height: 28, width: 80 }} />
+      </Flexbox>
+    </Block>
+  );
+});
+
+export default BriefCardSkeleton;

--- a/src/features/DailyBrief/index.tsx
+++ b/src/features/DailyBrief/index.tsx
@@ -12,6 +12,7 @@ import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 import BriefCard from './BriefCard';
+import BriefCardSkeleton from './BriefCardSkeleton';
 
 const DailyBrief = memo(() => {
   const { t } = useTranslation('home');
@@ -24,7 +25,20 @@ const DailyBrief = memo(() => {
   const briefs = useBriefStore(briefListSelectors.briefs);
   const isInit = useBriefStore(briefListSelectors.isBriefsInit);
 
-  if (!enableAgentTask || !isInit || briefs.length === 0) return null;
+  if (!enableAgentTask || !isLogin) return null;
+
+  if (!isInit) {
+    return (
+      <GroupBlock icon={Newspaper} title={t('brief.title')}>
+        <Flexbox gap={12}>
+          <BriefCardSkeleton />
+          <BriefCardSkeleton />
+        </Flexbox>
+      </GroupBlock>
+    );
+  }
+
+  if (briefs.length === 0) return null;
 
   return (
     <GroupBlock


### PR DESCRIPTION
## Summary
- Add skeleton loading state for the DailyBrief component on the home page
- Previously the component returned `null` while data was loading, leaving a blank gap
- Now shows 2 skeleton cards that mirror the BriefCard layout during initialization
- Fixed a bug where logged-out users with `enableAgentTask` would see an infinite skeleton

## Changes
- **New**: `src/features/DailyBrief/BriefCardSkeleton.tsx` — skeleton card matching BriefCard structure (header, divider, summary, actions)
- **Modified**: `src/features/DailyBrief/index.tsx` — split early-return guard into three stages, render skeleton when `!isInit`

## Key Decisions
- `alignSelf: 'flex-end'` on actions row to work around Block's default `align-items: stretch`
- Added `!isLogin` guard to prevent infinite skeleton when fetch never fires

Closes LOBE-8400

## Test plan
- [ ] Verify skeleton appears briefly on home page before briefs load
- [ ] Verify skeleton disappears once briefs are loaded
- [ ] Verify no skeleton shows when logged out
- [ ] Verify no skeleton shows when `enableAgentTask` is disabled
- [ ] Verify skeleton action buttons are right-aligned, matching the real BriefCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)