### PR TITLE
🐛 fix(model-runtime): preserve LLM finishReason through callbacks transformer

### DIFF
--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -615,6 +615,44 @@ describe('createCallbacksTransformer', () => {
     expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ finishReason: 'RECITATION' }));
   });
 
+  it('should keep the first finishReason when multiple stop chunks are emitted', async () => {
+    // Anthropic emits message_delta (carrying real stop_reason) followed by a
+    // message_stop sentinel — the meaningful reason must not be clobbered.
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+
+    const chunks = [
+      'event: stop\n',
+      `data: ${JSON.stringify('max_tokens')}\n\n`,
+      'event: stop\n',
+      `data: ${JSON.stringify('message_stop')}\n\n`,
+    ];
+
+    await processChunks(transformer, chunks);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ finishReason: 'max_tokens' }),
+    );
+  });
+
+  it('should fall back to a later stop chunk when the first one is empty', async () => {
+    const onCompletion = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion });
+
+    const chunks = [
+      'event: stop\n',
+      `data: ${JSON.stringify('')}\n\n`,
+      'event: stop\n',
+      `data: ${JSON.stringify('end_turn')}\n\n`,
+    ];
+
+    await processChunks(transformer, chunks);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ finishReason: 'end_turn' }),
+    );
+  });
+
   it('should leave finishReason undefined when no stop chunk is received', async () => {
     const onFinal = vi.fn();
     const transformer = createCallbacksTransformer({ onFinal });

--- a/packages/model-runtime/src/core/streams/protocol.test.ts
+++ b/packages/model-runtime/src/core/streams/protocol.test.ts
@@ -592,6 +592,40 @@ describe('createCallbacksTransformer', () => {
     expect(onFinal).toHaveBeenCalledWith(expectedData);
   });
 
+  it('should capture finishReason from stop chunks and include in final data', async () => {
+    const onCompletion = vi.fn();
+    const onFinal = vi.fn();
+    const transformer = createCallbacksTransformer({ onCompletion, onFinal });
+
+    // Simulates the Gemini "soft interrupt" path: empty content + non-STOP finishReason
+    // (e.g. RECITATION / MAX_TOKENS) — we MUST capture the reason so downstream
+    // tracing/UI can surface it instead of silently rendering empty.
+    const chunks = [
+      'event: stop\n',
+      `data: ${JSON.stringify('RECITATION')}\n\n`,
+      'event: usage\n',
+      `data: ${JSON.stringify({ totalTokens: 10 })}\n\n`,
+    ];
+
+    await processChunks(transformer, chunks);
+
+    expect(onCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ finishReason: 'RECITATION' }),
+    );
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ finishReason: 'RECITATION' }));
+  });
+
+  it('should leave finishReason undefined when no stop chunk is received', async () => {
+    const onFinal = vi.fn();
+    const transformer = createCallbacksTransformer({ onFinal });
+
+    const chunks = ['event: text\n', 'data: "Hi"\n\n'];
+
+    await processChunks(transformer, chunks);
+
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ finishReason: undefined }));
+  });
+
   it('should handle speed chunks and include in final data', async () => {
     const onFinal = vi.fn();
     const transformer = createCallbacksTransformer({ onFinal });

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -268,6 +268,7 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
   let grounding: any;
   let toolsCalling: any;
   let streamError: any;
+  let finishReason: string | undefined;
   // Track base64 images for accumulation
   const base64Images: Array<{ data: string; id: string }> = [];
 
@@ -278,6 +279,7 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
     async flush(): Promise<void> {
       const data = {
         error: streamError,
+        finishReason,
         grounding,
         speed,
         text: aggregatedText,
@@ -388,6 +390,16 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
             toolsCalling = parseToolCalls(toolsCalling, data);
 
             await callbacks.onToolsCalling?.({ chunk: data, toolsCalling });
+            break;
+          }
+
+          case 'stop': {
+            // Provider's terminal finishReason (e.g. Google's RECITATION / MAX_TOKENS,
+            // OpenAI's length, Anthropic's end_turn). Capture so downstream consumers
+            // can detect soft interrupts where content is empty but tokens were billed.
+            if (typeof data === 'string') {
+              finishReason = data;
+            }
             break;
           }
 

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -397,7 +397,13 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
             // Provider's terminal finishReason (e.g. Google's RECITATION / MAX_TOKENS,
             // OpenAI's length, Anthropic's end_turn). Capture so downstream consumers
             // can detect soft interrupts where content is empty but tokens were billed.
-            if (typeof data === 'string') {
+            //
+            // Some providers emit multiple stop chunks per stream — Anthropic sends
+            // `message_delta` (carrying the real `stop_reason` like `end_turn` /
+            // `max_tokens` / `tool_use`) followed by a `message_stop` sentinel.
+            // Keep the FIRST non-empty value so the meaningful reason is not
+            // clobbered by the trailing sentinel.
+            if (typeof data === 'string' && data && !finishReason) {
               finishReason = data;
             }
             break;

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -225,6 +225,13 @@ export interface ChatCompletionTool {
 
 export interface OnFinishData {
   error?: any;
+  /**
+   * The terminal finishReason emitted by the provider in the `stop` SSE chunk
+   * (e.g. Google: STOP / SAFETY / RECITATION / MAX_TOKENS; OpenAI: stop / length;
+   * Anthropic: end_turn / max_tokens / tool_use). Used to detect "soft interrupts"
+   * where the provider returns empty content with a non-normal finishReason.
+   */
+  finishReason?: string;
   grounding?: any;
   speed?: ModelPerformance;
   text: string;

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -690,6 +690,7 @@ export const createRuntimeExecutors = (
         const imageList: any[] = [];
         let grounding: any = null;
         let currentStepUsage: any = undefined;
+        let currentStepFinishReason: string | undefined = undefined;
         let streamError: any = undefined;
         const contentParts: ContentPart[] = [];
         const reasoningParts: ContentPart[] = [];
@@ -730,6 +731,12 @@ export const createRuntimeExecutors = (
                 // Capture usage (may or may not include cost)
                 if (data.usage) {
                   currentStepUsage = data.usage;
+                }
+                // Capture provider's terminal finishReason so soft interrupts
+                // (e.g. Gemini RECITATION / MAX_TOKENS with empty content)
+                // are visible in tracing instead of being silently swallowed.
+                if (data.finishReason) {
+                  currentStepFinishReason = data.finishReason;
                 }
               },
               onGrounding: async (groundingData) => {
@@ -869,7 +876,13 @@ export const createRuntimeExecutors = (
 
           // Add a complete llm_stream event (including all streaming chunks)
           events.push({
-            result: { content, reasoning: thinkingContent, tool_calls, usage: currentStepUsage },
+            result: {
+              content,
+              finishReason: currentStepFinishReason,
+              reasoning: thinkingContent,
+              tool_calls,
+              usage: currentStepUsage,
+            },
             type: 'llm_result',
           });
 


### PR DESCRIPTION
## Summary

- Provider soft-interrupts (Gemini `RECITATION` / `MAX_TOKENS` / `SAFETY`, etc.) emit a `type: 'stop'` SSE chunk with the finishReason string, but `createCallbacksTransformer` only used it as a terminal-event flag and never aggregated the value — so `OnFinishData` (and everything downstream) lost it.
- Result: agent harness silently treated empty-content responses as `completionReason: done` even though the model returned no text and the user got billed (e.g. `op_xxxx` — 922 output text tokens, `$0.062`, content `""`).
- Fix:
  - `OnFinishData` gets a `finishReason?: string` field.
  - `createCallbacksTransformer` captures the string from the `'stop'` SSE chunk and writes it into the aggregator that feeds `onCompletion` / `onFinal`.
  - `RuntimeExecutors` reads `data.finishReason` in `onCompletion` and writes it into the `llm_result` tracing event so we can diagnose future soft interrupts.

This is the minimal fix (Layer 1-4 from the issue). Layer 5 — actually classifying non-`STOP` reasons as errors and surfacing a user-facing message — is left for a follow-up so we can pick the legal-value whitelist from real traces.

Fixes LOBE-8403

## Test plan

- [x] `bunx vitest run packages/model-runtime/src/core/streams/protocol.test.ts` — 34/34 pass (2 new: RECITATION captured, undefined when no stop chunk)
- [x] `bun run type-check` — no new errors in changed files (pre-existing failures in `agentSignal/run.ts` and `builtin-tool-agent-marketplace` are unrelated, present on `canary` before this branch)
- [ ] Re-run the failing op once deployed and confirm the new tracing event includes `result.finishReason: "RECITATION"` (or whatever Gemini returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)