### PR TITLE
✨ feat(mobile-router): add task and brief routers

### DIFF
--- a/src/server/routers/mobile/index.ts
+++ b/src/server/routers/mobile/index.ts
@@ -10,6 +10,7 @@ import { aiAgentRouter } from '../lambda/aiAgent';
 import { aiChatRouter } from '../lambda/aiChat';
 import { aiModelRouter } from '../lambda/aiModel';
 import { aiProviderRouter } from '../lambda/aiProvider';
+import { briefRouter } from '../lambda/brief';
 import { chunkRouter } from '../lambda/chunk';
 import { configRouter } from '../lambda/config';
 import { documentRouter } from '../lambda/document';
@@ -19,6 +20,7 @@ import { marketRouter } from '../lambda/market';
 import { messageRouter } from '../lambda/message';
 import { sessionRouter } from '../lambda/session';
 import { sessionGroupRouter } from '../lambda/sessionGroup';
+import { taskRouter } from '../lambda/task';
 import { topicRouter } from '../lambda/topic';
 import { uploadRouter } from '../lambda/upload';
 import { userRouter } from '../lambda/user';
@@ -27,6 +29,7 @@ export const mobileRouter = router({
   agent: agentRouter,
   aiAgent: aiAgentRouter,
   aiChat: aiChatRouter,
+  brief: briefRouter,
   aiModel: aiModelRouter,
   aiProvider: aiProviderRouter,
   chunk: chunkRouter,
@@ -40,6 +43,7 @@ export const mobileRouter = router({
   session: sessionRouter,
   sessionGroup: sessionGroupRouter,
   subscription: mobileSubscriptionRouter,
+  task: taskRouter,
   topic: topicRouter,
   upload: uploadRouter,
   user: userRouter,


### PR DESCRIPTION
## Summary
- Add `taskRouter` and `briefRouter` to the mobile tRPC router
- Enables the React Native mobile app to access task management and daily brief endpoints
- No new server code — reuses existing lambda routers

## Test plan
- [ ] Verify `trpcClient.task.*` and `trpcClient.brief.*` calls work from mobile client
- [ ] Verify no regression on existing mobile endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)