### PR TITLE
💄 style(brief): open run topic drawer from daily brief card

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -22,6 +22,7 @@
   "brief.resolved": "Marked as resolved",
   "brief.title": "Daily brief",
   "brief.viewAllTasks": "View all tasks",
+  "brief.viewRun": "View run",
   "project.create": "New project",
   "project.deleteConfirm": "This project will be deleted and can't be recovered. Confirm to continue.",
   "starter.createAgent": "Create Agent",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -22,6 +22,7 @@
   "brief.resolved": "已标记为已解决",
   "brief.title": "每日简报",
   "brief.viewAllTasks": "查看全部任务",
+  "brief.viewRun": "查看执行",
   "project.create": "新建项目",
   "project.deleteConfirm": "此项目将被删除且无法恢复。确认继续操作。",
   "starter.createAgent": "创建助理",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -22,7 +22,7 @@
   "brief.resolved": "已标记为已解决",
   "brief.title": "每日简报",
   "brief.viewAllTasks": "查看全部任务",
-  "brief.viewRun": "查看执行",
+  "brief.viewRun": "查看运行轨迹",
   "project.create": "新建项目",
   "project.deleteConfirm": "此项目将被删除且无法恢复。确认继续操作。",
   "starter.createAgent": "创建助理",

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -109,6 +109,7 @@ const TaskBriefCard = memo<TaskBriefCardProps>(
               briefType={brief.type}
               resolvedAction={brief.resolvedAction}
               taskId={brief.taskId}
+              topicId={brief.topicId}
               onAfterAddComment={onAfterAddComment}
               onAfterResolve={onAfterResolve}
             />

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
     activeTaskId: 'T-1',
     activeTopicDrawerTopicId: 'topic-1',
     closeTopicDrawer: vi.fn(),
+    useFetchTaskDetail: vi.fn(),
     taskDetailMap: {
       'T-1': {
         activities: [

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -96,10 +96,16 @@ TopicChatDrawerBody.displayName = 'TopicChatDrawerBody';
 const TopicChatDrawer = memo(() => {
   const { t } = useTranslation(['chat', 'common']);
   const topicId = useTaskStore(taskDetailSelectors.activeTopicDrawerTopicId);
+  const activeTaskId = useTaskStore((s) => s.activeTaskId);
   const agentId = useTaskStore(taskDetailSelectors.activeTaskAgentId);
   const activity = useTaskStore(taskActivitySelectors.activeDrawerTopicActivity);
   const closeTopicDrawer = useTaskStore((s) => s.closeTopicDrawer);
+  const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
   const enableTopicLinkShare = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
+
+  // Hydrate task detail when the drawer is opened outside of TaskDetailPage
+  // (e.g. from a brief on home) so the header has agentId / status / seq.
+  useFetchTaskDetail(topicId ? activeTaskId : undefined);
 
   const open = !!topicId && !!agentId;
   const status = activity?.status;

--- a/src/features/DailyBrief/BriefCard.tsx
+++ b/src/features/DailyBrief/BriefCard.tsx
@@ -117,6 +117,7 @@ const BriefCard = memo<BriefCardProps>(
               briefType={brief.type}
               resolvedAction={brief.resolvedAction}
               taskId={brief.taskId}
+              topicId={brief.topicId}
               onAfterAddComment={onAfterAddComment}
               onAfterResolve={onAfterResolve}
             />

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -1,12 +1,13 @@
 import { type BriefAction, DEFAULT_BRIEF_ACTIONS } from '@lobechat/types';
 import { Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { Check, SquarePen } from 'lucide-react';
+import { Check, MessageSquareText, SquarePen } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
 import { useBriefStore } from '@/store/brief';
+import { useTaskStore } from '@/store/task';
 
 import CommentInput from './CommentInput';
 import { styles } from './style';
@@ -22,6 +23,8 @@ export interface BriefCardActionsProps {
   onAfterResolve?: () => void | Promise<void>;
   resolvedAction?: string | null;
   taskId?: string | null;
+  /** When set together with taskId, renders a "View run" shortcut to the topic drawer. */
+  topicId?: string | null;
 }
 
 type CommentMode = { type: 'feedback' } | { key: string; type: 'comment' };
@@ -42,6 +45,7 @@ const BriefCardActions = memo<BriefCardActionsProps>(
     onAfterResolve,
     resolvedAction,
     taskId,
+    topicId,
   }) => {
     const { t } = useTranslation('home');
     const [commentMode, setCommentMode] = useState<CommentMode | null>(null);
@@ -50,6 +54,32 @@ const BriefCardActions = memo<BriefCardActionsProps>(
       (s) => ({ resolveBrief: s.resolveBrief, submitFeedback: s.submitFeedback }),
       shallow,
     );
+    const { setActiveTaskId, openTopicDrawer } = useTaskStore(
+      (s) => ({ openTopicDrawer: s.openTopicDrawer, setActiveTaskId: s.setActiveTaskId }),
+      shallow,
+    );
+
+    const showViewRun = !!taskId && !!topicId;
+    const handleViewRun = useCallback(() => {
+      if (!taskId || !topicId) return;
+      // setActiveTaskId hydrates `activeTaskId` so the drawer can resolve the
+      // task's agentId / activity metadata (and clears any prior drawer topic
+      // when switching tasks). openTopicDrawer must come after — setActiveTaskId
+      // resets activeTopicDrawerTopicId on task changes.
+      setActiveTaskId(taskId);
+      openTopicDrawer(topicId);
+    }, [openTopicDrawer, setActiveTaskId, taskId, topicId]);
+    const viewRunButton = showViewRun ? (
+      <Button
+        icon={MessageSquareText}
+        size={'small'}
+        style={{ color: cssVar.colorTextSecondary }}
+        type={'text'}
+        onClick={handleViewRun}
+      >
+        {t('brief.viewRun')}
+      </Button>
+    ) : null;
 
     const isResult = briefType === 'result';
 
@@ -114,7 +144,15 @@ const BriefCardActions = memo<BriefCardActionsProps>(
       ],
     );
 
-    if (resolvedAction) return <SuccessTag label={t('brief.resolved')} />;
+    if (resolvedAction) {
+      if (!showViewRun) return <SuccessTag label={t('brief.resolved')} />;
+      return (
+        <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
+          {viewRunButton}
+          <SuccessTag label={t('brief.resolved')} />
+        </Flexbox>
+      );
+    }
     if (commentMode) {
       return <CommentInput onCancel={() => setCommentMode(null)} onSubmit={handleCommentSubmit} />;
     }
@@ -133,7 +171,8 @@ const BriefCardActions = memo<BriefCardActionsProps>(
         : t('brief.addFeedback');
 
     return (
-      <Flexbox horizontal align={'center'} gap={8} justify={'flex-end'} wrap={'wrap'}>
+      <Flexbox horizontal align={'center'} gap={8} justify={'space-between'} wrap={'wrap'}>
+        {viewRunButton ?? <span />}
         <Flexbox horizontal align={'center'} gap={8}>
           {showEditButton && (
             <Tooltip title={editTooltip}>

--- a/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
+++ b/src/features/DailyBrief/__tests__/BriefCardActions.test.tsx
@@ -1,10 +1,14 @@
 import type { BriefAction } from '@lobechat/types';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useBriefStore } from '@/store/brief';
 
 import BriefCardActions from '../BriefCardActions';
+
+const renderWithRouter = (ui: ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
 // Mock i18n
 vi.mock('react-i18next', () => ({
@@ -17,6 +21,7 @@ vi.mock('react-i18next', () => ({
         'brief.commentSubmit': 'Submit feedback',
         'brief.action.confirmDone': 'Confirm complete',
         'brief.editResult': 'Edit',
+        'brief.viewRun': 'View run',
       };
       return map[key] || key;
     },
@@ -39,12 +44,14 @@ beforeEach(() => {
 
 describe('BriefCardActions', () => {
   it('should render resolve action buttons from actions prop', () => {
-    render(<BriefCardActions actions={sampleActions} briefId="brief-1" briefType="decision" />);
+    renderWithRouter(
+      <BriefCardActions actions={sampleActions} briefId="brief-1" briefType="decision" />,
+    );
     expect(screen.getByText('Approve')).toBeInTheDocument();
   });
 
   it('should render comment action button', () => {
-    const { container } = render(
+    const { container } = renderWithRouter(
       <BriefCardActions
         actions={sampleActions}
         briefId="brief-1"
@@ -59,7 +66,7 @@ describe('BriefCardActions', () => {
   it('should call resolveBrief and onAfterResolve on resolve button click', async () => {
     mockResolveBrief.mockResolvedValueOnce(undefined);
     const onAfterResolve = vi.fn();
-    render(
+    renderWithRouter(
       <BriefCardActions
         actions={sampleActions}
         briefId="brief-1"
@@ -76,7 +83,7 @@ describe('BriefCardActions', () => {
   });
 
   it('should hide action buttons when comment button clicked', () => {
-    const { container } = render(
+    const { container } = renderWithRouter(
       <BriefCardActions
         actions={sampleActions}
         briefId="brief-1"
@@ -95,7 +102,7 @@ describe('BriefCardActions', () => {
   });
 
   it('should show resolved state when resolvedAction is set', () => {
-    render(
+    renderWithRouter(
       <BriefCardActions
         actions={sampleActions}
         briefId="brief-1"
@@ -109,13 +116,13 @@ describe('BriefCardActions', () => {
   });
 
   it('should fallback to DEFAULT_BRIEF_ACTIONS when actions prop is null', () => {
-    render(<BriefCardActions actions={null} briefId="brief-2" briefType="decision" />);
+    renderWithRouter(<BriefCardActions actions={null} briefId="brief-2" briefType="decision" />);
 
     expect(screen.getByText('✅ 确认')).toBeInTheDocument();
   });
 
   it('should hardcode primary action label to "Confirm complete" for result briefs', () => {
-    render(
+    renderWithRouter(
       <BriefCardActions
         actions={[{ key: 'approve', label: '✅ Custom approve', type: 'resolve' }]}
         briefId="brief-3"
@@ -128,7 +135,7 @@ describe('BriefCardActions', () => {
   });
 
   it('should always show the Edit button for result briefs when taskId is set', () => {
-    const { container } = render(
+    const { container } = renderWithRouter(
       <BriefCardActions
         actions={[{ key: 'approve', label: '✅ Custom', type: 'resolve' }]}
         briefId="brief-4"
@@ -138,5 +145,30 @@ describe('BriefCardActions', () => {
     );
 
     expect(container.querySelector('.brief-comment-btn')).toBeInTheDocument();
+  });
+
+  it('should render the View run button when taskId and topicId are both set', () => {
+    renderWithRouter(
+      <BriefCardActions
+        actions={sampleActions}
+        briefId="brief-5"
+        briefType="decision"
+        taskId="task-5"
+        topicId="topic-5"
+      />,
+    );
+    expect(screen.getByText('View run')).toBeInTheDocument();
+  });
+
+  it('should not render the View run button when topicId is missing', () => {
+    renderWithRouter(
+      <BriefCardActions
+        actions={sampleActions}
+        briefId="brief-6"
+        briefType="decision"
+        taskId="task-6"
+      />,
+    );
+    expect(screen.queryByText('View run')).not.toBeInTheDocument();
   });
 });

--- a/src/features/DailyBrief/index.tsx
+++ b/src/features/DailyBrief/index.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
+import TopicChatDrawer from '@/features/AgentTasks/AgentTaskDetail/TopicChatDrawer';
 import DocumentPreviewModal from '@/features/DocumentModal/Preview';
 import GroupBlock from '@/routes/(main)/home/features/components/GroupBlock';
 import { useBriefStore } from '@/store/brief';
@@ -58,6 +59,7 @@ const DailyBrief = memo(() => {
         ))}
       </Flexbox>
       <DocumentPreviewModal />
+      <TopicChatDrawer />
     </GroupBlock>
   );
 });

--- a/src/locales/default/home.ts
+++ b/src/locales/default/home.ts
@@ -22,6 +22,7 @@ export default {
   'brief.resolved': 'Marked as resolved',
   'brief.title': 'Daily brief',
   'brief.viewAllTasks': 'View all tasks',
+  'brief.viewRun': 'View run',
   'project.create': 'New project',
   'project.deleteConfirm':
     "This project will be deleted and can't be recovered. Confirm to continue.",


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Adds a one-click **View run** shortcut to each daily brief card so the user can inspect the agent's actual run without leaving the home page.

- A new \`MessageSquareText\` button appears on the left of the brief card's actions row whenever both \`taskId\` and \`topicId\` are set.
- Clicking it calls \`setActiveTaskId(brief.taskId)\` then \`openTopicDrawer(brief.topicId)\`. The order matters — \`setActiveTaskId\` clears \`activeTopicDrawerTopicId\` on task switches, so \`openTopicDrawer\` must run after.
- \`<TopicChatDrawer />\` is now rendered inside \`DailyBrief\` so the drawer can mount inline on the home page (it stays where it was on the task detail page).
- \`TopicChatDrawer\` self-hydrates via \`useFetchTaskDetail(activeTaskId)\` when open, so the header has agentId / status / seq even when not driven by \`TaskDetailPage\`.

i18n: \`brief.viewRun\` → "View run" / "查看执行".

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Manual:
1. From home, find a brief card with a topic id.
2. Click **View run** — the topic drawer should slide in over the home page with the conversation.
3. Repeat with a different brief from a different task — the drawer should swap to the new topic.
4. From a task detail page, behavior is unchanged.

Automated: \`bunx vitest run 'src/features/DailyBrief' 'src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer'\` — 14 tests pass, including 2 new cases for the View run button visibility.

#### 📸 Screenshots / Videos

| Before                                            | After                                      |
| ------------------------------------------------- | ------------------------------------------ |
| Brief card had no shortcut to the run conversation | Inline drawer opens from the brief card    |

🤖 Generated with [Claude Code](https://claude.com/claude-code)