### PR TITLE
🐛 fix: inject skill instruction into tool system role

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "@lobehub/desktop-ipc-typings": "workspace:*",
     "@lobehub/editor": "^4.9.3",
     "@lobehub/icons": "^5.0.0",
-    "@lobehub/market-sdk": "0.32.2",
+    "@lobehub/market-sdk": "0.33.3",
     "@lobehub/tts": "^5.1.2",
     "@lobehub/ui": "^5.9.6",
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@lobechat/python-interpreter": "workspace:*",
     "@lobechat/web-crawler": "workspace:*",
-    "@lobehub/market-sdk": "0.32.2",
+    "@lobehub/market-sdk": "0.33.3",
     "@lobehub/market-types": "^1.12.3",
     "model-bank": "workspace:*",
     "type-fest": "^4.41.0",

--- a/src/server/services/market/index.ts
+++ b/src/server/services/market/index.ts
@@ -547,7 +547,7 @@ export class MarketService {
           };
           const providerLabel = PROVIDER_LABELS[providerId] || providerId;
 
-          const { tools } = await this.market.skills.listTools(providerId);
+          const { tools, instruction } = await this.market.skills.listTools(providerId);
           if (!tools || tools.length === 0) continue;
 
           const manifest: LobeToolManifest = {
@@ -563,6 +563,7 @@ export class MarketService {
               tags: ['lobehub-skill', providerId],
               title: providerLabel,
             },
+            systemRole: instruction || undefined,
             type: 'builtin',
           };
 


### PR DESCRIPTION
Consume the `instruction` field from market SDK's `listTools` response and pass it as `systemRole` on the tool manifest, so the LLM receives skill-level guidance documentation via `<tool.instructions>` in the system prompt.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
