### PR TITLE
🐛 fix(skill): skip OAuth redirectUri on desktop to prevent broken app

### DIFF
--- a/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
+++ b/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
@@ -872,8 +872,9 @@ export class AgentManagerRuntime {
     }
 
     // Need OAuth authorization
+    // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
     const redirectUri =
-      typeof window !== 'undefined'
+      typeof window !== 'undefined' && window.location.protocol.startsWith('http')
         ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(identifier)}`
         : undefined;
     const authInfo = await getToolStoreState().getLobehubSkillAuthorizeUrl(identifier, {

--- a/packages/builtin-tool-creds/src/executor/index.ts
+++ b/packages/builtin-tool-creds/src/executor/index.ts
@@ -191,7 +191,11 @@ class CredsExecutor extends BaseExecutor<typeof CredsApiName> {
       }
 
       // Get the authorization URL from the market API
-      const redirectUri = `${typeof window !== 'undefined' ? window.location.origin : ''}/oauth/callback/success?provider=${provider}`;
+      // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+      const redirectUri =
+        typeof window !== 'undefined' && window.location.protocol.startsWith('http')
+          ? `${window.location.origin}/oauth/callback/success?provider=${provider}`
+          : undefined;
       const response = await toolsClient.market.connectGetAuthorizeUrl.query({
         provider,
         redirectUri,

--- a/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/LobehubSkillServerItem.tsx
@@ -201,7 +201,10 @@ const LobehubSkillServerItem = memo<LobehubSkillServerItemProps>(({ provider, la
     setIsConnecting(true);
     try {
       // Use /oauth/callback/success as redirect URI with provider param for auto-enable
-      const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider)}`;
+      // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+      const redirectUri = window.location.protocol.startsWith('http')
+        ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider)}`
+        : undefined;
       const { authorizeUrl } = await getAuthorizeUrl(provider, { redirectUri });
       openOAuthWindow(authorizeUrl);
     } catch (error) {
@@ -277,7 +280,9 @@ const LobehubSkillServerItem = memo<LobehubSkillServerItemProps>(({ provider, la
             onClick={async (e) => {
               e.stopPropagation();
               try {
-                const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider)}`;
+                const redirectUri = window.location.protocol.startsWith('http')
+                  ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider)}`
+                  : undefined;
                 const { authorizeUrl } = await getAuthorizeUrl(provider, { redirectUri });
                 openOAuthWindow(authorizeUrl);
               } catch (error) {

--- a/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.ts
+++ b/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.ts
@@ -178,7 +178,10 @@ export const useSkillConnect = ({ identifier, serverName, type }: UseSkillConnec
       const provider = getLobehubSkillProviderById(identifier);
       if (!provider) return;
 
-      const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(identifier)}`;
+      // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+      const redirectUri = window.location.protocol.startsWith('http')
+        ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(identifier)}`
+        : undefined;
       const { authorizeUrl } = await getAuthorizeUrl(identifier, { redirectUri });
       openOAuthWindow(authorizeUrl, identifier);
     } catch (error) {

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -152,7 +152,10 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
 
     setIsConnecting(true);
     try {
-      const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider.id)}`;
+      // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+      const redirectUri = window.location.protocol.startsWith('http')
+        ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider.id)}`
+        : undefined;
       const { authorizeUrl } = await getAuthorizeUrl(provider.id, { redirectUri });
       openOAuthWindow(authorizeUrl);
     } catch (error) {


### PR DESCRIPTION
…:// navigation

On desktop (Electron), window.location.origin is app://renderer which the system browser cannot navigate to. Skip passing redirectUri so market shows a default success page instead, relying on existing window-close monitoring and fallback polling to detect OAuth completion.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
