### PR TITLE
💄 style(brief): use Footprints icon and hide view-run until card hover

### DIFF
--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -1,7 +1,7 @@
 import { type BriefAction, DEFAULT_BRIEF_ACTIONS } from '@lobechat/types';
 import { Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { Check, MessageSquareText, SquarePen } from 'lucide-react';
+import { Check, Footprints, SquarePen } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
@@ -71,7 +71,8 @@ const BriefCardActions = memo<BriefCardActionsProps>(
     }, [openTopicDrawer, setActiveTaskId, taskId, topicId]);
     const viewRunButton = showViewRun ? (
       <Button
-        icon={MessageSquareText}
+        className={'brief-view-run-btn'}
+        icon={Footprints}
         size={'small'}
         style={{ color: cssVar.colorTextSecondary }}
         type={'text'}

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -1,7 +1,7 @@
 import { type BriefAction, DEFAULT_BRIEF_ACTIONS } from '@lobechat/types';
 import { Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { Check, Footprints, SquarePen } from 'lucide-react';
+import { Check, SquarePen, Workflow } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
@@ -72,7 +72,7 @@ const BriefCardActions = memo<BriefCardActionsProps>(
     const viewRunButton = showViewRun ? (
       <Button
         className={'brief-view-run-btn'}
-        icon={Footprints}
+        icon={Workflow}
         size={'small'}
         style={{ color: cssVar.colorTextSecondary }}
         type={'text'}

--- a/src/features/DailyBrief/style.ts
+++ b/src/features/DailyBrief/style.ts
@@ -23,14 +23,16 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextQuaternary};
   `,
   card: css`
-    .brief-comment-btn {
+    .brief-comment-btn,
+    .brief-view-run-btn {
       opacity: 0;
     }
 
     &:hover {
       border-color: ${cssVar.colorBorder} !important;
 
-      .brief-comment-btn {
+      .brief-comment-btn,
+      .brief-view-run-btn {
         opacity: 1;
       }
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔀 Description of Change

Refines the **View run** action introduced in #14340:

- Switches the icon from \`MessageSquareText\` to \`Footprints\` so it visually reads as a run trace / 轨迹 rather than a generic chat icon.
- Hides the button by default and reveals it on card hover (same pattern as \`brief-comment-btn\`), so the brief card stays visually clean until the user actually wants the shortcut.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual:
1. From home, daily brief cards should not show the "View run" button until you hover over the card.
2. Hover a brief card with both \`taskId\` and \`topicId\` — the Footprints button fades in next to the existing edit hover-action.
3. Click it — the topic drawer opens as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)