### PR TITLE
Fix task subtitle and assignee trigger layout

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
@@ -59,7 +59,7 @@ const SubtaskTitle = memo<{ task: TaskDetailSubtask }>(({ task }) => {
       align="center"
       gap={8}
       justify="space-between"
-      style={{ lineHeight: 1, minWidth: 0, overflow: 'hidden', width: '100%' }}
+      style={{ minWidth: 0, width: '100%' }}
     >
       <span
         style={{ alignItems: 'center', display: 'inline-flex', flex: 'none' }}

--- a/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
+++ b/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
@@ -1,17 +1,8 @@
 import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { Flexbox, Popover, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import {
-  type KeyboardEvent,
-  memo,
-  type ReactNode,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
+import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
@@ -51,6 +42,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
 }));
+
+const triggerStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'inline-flex',
+  justifyContent: 'center',
+  lineHeight: 1,
+};
 
 const AssigneeAgentSelector = memo<AssigneeAgentSelectorProps>(
   ({ children, currentAgentId, disabled, onChange, taskIdentifier }) => {
@@ -152,12 +150,17 @@ const AssigneeAgentSelector = memo<AssigneeAgentSelectorProps>(
 
     const trigger = disabled ? (
       <Tooltip title={t('taskDetail.reassignDisabled', { ns: 'chat' })}>
-        <div style={{ cursor: 'not-allowed', opacity: 0.5 }} onClick={(e) => e.stopPropagation()}>
+        <div
+          style={{ ...triggerStyle, cursor: 'not-allowed', opacity: 0.5 }}
+          onClick={(e) => e.stopPropagation()}
+        >
           <span style={{ pointerEvents: 'none' }}>{children}</span>
         </div>
       </Tooltip>
     ) : (
-      <div onClick={(e) => e.stopPropagation()}>{children}</div>
+      <div style={triggerStyle} onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
     );
 
     return (


### PR DESCRIPTION
## Summary
- Remove the extra overflow/line-height styling from task subtask titles so they lay out naturally
- Reuse a shared inline-flex trigger style for the assignee selector, including the disabled state
- Keep the reassign trigger centered and consistent across enabled and disabled modes

## Testing
- Not run (not requested)