### PR TITLE
🐛 fix: type tag cloud pointer event

### DIFF
--- a/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
+++ b/src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx
@@ -1,4 +1,5 @@
 import { Billboard, Html, OrbitControls, Text } from '@react-three/drei';
+import type { ThreeEvent } from '@react-three/fiber';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { useTheme } from 'antd-style';
 import { memo, Suspense, useEffect, useMemo, useRef, useState } from 'react';
@@ -65,7 +66,7 @@ const Word = memo<WordProps>(
         <Text
           ref={ref}
           onPointerOut={() => setHovered(false)}
-          onPointerOver={(e) => {
+          onPointerOver={(e: ThreeEvent<PointerEvent>) => {
             e.stopPropagation();
             setHovered(true);
           }}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add the explicit `ThreeEvent<PointerEvent>` type for the tag cloud text `onPointerOver` handler.
- Fixes the pnpm 11/cloud `tsc --noEmit` implicit-any failure surfaced by the cloud PR.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Commands run:

- `bunx prettier --write src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx`
- `bunx eslint src/routes/(main)/memory/(home)/features/RoleTagCloud/TagCloudCanvas.tsx`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=12288 npx tsc --noEmit --pretty false` no longer reports the original `TagCloudCanvas.tsx(68,27)` implicit-any error; it still reports unrelated existing type errors in the broader cloud/root type-check context.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is a narrow TypeScript annotation fix for the existing R3F pointer handler.
