### PR TITLE
👷 build: disable pnpm gvs for desktop ci

### DIFF
--- a/.github/actions/desktop-build-setup/action.yml
+++ b/.github/actions/desktop-build-setup/action.yml
@@ -17,7 +17,11 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install --node-linker=hoisted --config.enable-global-virtual-store=false
+      env:
+        NODE_OPTIONS: --max-old-space-size=8192
 
     - name: Install deps on Desktop
       shell: bash
       run: npm run install-isolated --prefix=./apps/desktop
+      env:
+        NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/actions/desktop-build-setup/action.yml
+++ b/.github/actions/desktop-build-setup/action.yml
@@ -22,6 +22,6 @@ runs:
 
     - name: Install deps on Desktop
       shell: bash
-      run: npm run install-isolated --prefix=./apps/desktop
+      run: pnpm --dir ./apps/desktop install --node-linker=hoisted --config.enable-global-virtual-store=false
       env:
         NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/actions/desktop-build-setup/action.yml
+++ b/.github/actions/desktop-build-setup/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --node-linker=hoisted
+      run: pnpm install --node-linker=hoisted --config.enable-global-virtual-store=false
 
     - name: Install deps on Desktop
       shell: bash

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm install --config.enable-global-virtual-store=false
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -144,7 +144,9 @@ jobs:
       # Linux 平台构建处理
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: npm run desktop:package:app
+        run: |
+          ulimit -n 65536 || true
+          npm run desktop:package:app
         env:
           # 设置更新通道，PR构建为nightly，否则为stable
           UPDATE_CHANNEL: 'nightly'

--- a/.github/workflows/pr-build-desktop.yml
+++ b/.github/workflows/pr-build-desktop.yml
@@ -144,9 +144,7 @@ jobs:
       # Linux 平台构建处理
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: |
-          ulimit -n 65536 || true
-          npm run desktop:package:app
+        run: npm run desktop:package:app
         env:
           # 设置更新通道，PR构建为nightly，否则为stable
           UPDATE_CHANNEL: 'nightly'

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm install --config.enable-global-virtual-store=false
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -127,9 +127,7 @@ jobs:
       # Linux 构建
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: |
-          ulimit -n 65536 || true
-          npm run desktop:package:app
+        run: npm run desktop:package:app
         env:
           UPDATE_CHANNEL: beta
           APP_URL: http://localhost:3015

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -127,7 +127,9 @@ jobs:
       # Linux 构建
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: npm run desktop:package:app
+        run: |
+          ulimit -n 65536 || true
+          npm run desktop:package:app
         env:
           UPDATE_CHANNEL: beta
           APP_URL: http://localhost:3015

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -200,7 +200,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm install --config.enable-global-virtual-store=false
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -275,7 +275,9 @@ jobs:
       # Linux 构建
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: npm run desktop:package:app
+        run: |
+          ulimit -n 65536 || true
+          npm run desktop:package:app
         env:
           UPDATE_CHANNEL: canary
           UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -275,9 +275,7 @@ jobs:
       # Linux 构建
       - name: Build artifact on Linux
         if: runner.os == 'Linux'
-        run: |
-          ulimit -n 65536 || true
-          npm run desktop:package:app
+        run: npm run desktop:package:app
         env:
           UPDATE_CHANNEL: canary
           UPDATE_SERVER_URL: ${{ secrets.UPDATE_SERVER_URL }}

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -290,7 +290,10 @@ const config = {
       { arch: [arch === 'arm64' ? 'arm64' : 'x64'], target: 'zip' },
     ],
   },
-  npmRebuild: true,
+  // Native dependencies are rebuilt during the isolated desktop install.
+  // Re-running electron-builder's pnpm dependency collector during packaging can
+  // hit EMFILE on Linux runners with pnpm 11.
+  npmRebuild: false,
   nsis: {
     allowToChangeInstallationDirectory: true,
     artifactName: '${productName}-${version}-setup.${ext}',

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -130,6 +130,11 @@ const config = {
     );
     console.info('✅ CLI bundle copied to resources/bin/lobe-cli.js');
   },
+  // Native dependencies are rebuilt during the isolated desktop install and
+  // copied explicitly by the hooks here. Returning false marks node_modules as
+  // externally handled, so electron-builder does not invoke its pnpm collector
+  // during packaging.
+  beforeBuild: () => false,
   /**
    * AfterPack hook for post-processing:
    * 1. Copy native modules to asar.unpacked (resolving pnpm symlinks)
@@ -213,15 +218,6 @@ const config = {
     artifactName: '${productName}-${version}.${ext}',
   },
 
-  // Native modules are copied explicitly by the hooks below. Keeping package
-  // dependencies in the generated app metadata makes electron-builder invoke
-  // its pnpm dependency collector, which can hit EMFILE on Linux runners.
-  extraMetadata: {
-    dependencies: {},
-    devDependencies: {},
-    optionalDependencies: {},
-  },
-
   // Native modules must be unpacked from asar to work correctly
   asarUnpack: getAsarUnpackPatterns(),
 
@@ -299,10 +295,6 @@ const config = {
       { arch: [arch === 'arm64' ? 'arm64' : 'x64'], target: 'zip' },
     ],
   },
-  // Native dependencies are rebuilt during the isolated desktop install.
-  // Re-running electron-builder's pnpm dependency collector during packaging can
-  // hit EMFILE on Linux runners with pnpm 11.
-  npmRebuild: false,
   nsis: {
     allowToChangeInstallationDirectory: true,
     artifactName: '${productName}-${version}-setup.${ext}',

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -213,6 +213,15 @@ const config = {
     artifactName: '${productName}-${version}.${ext}',
   },
 
+  // Native modules are copied explicitly by the hooks below. Keeping package
+  // dependencies in the generated app metadata makes electron-builder invoke
+  // its pnpm dependency collector, which can hit EMFILE on Linux runners.
+  extraMetadata: {
+    dependencies: {},
+    devDependencies: {},
+    optionalDependencies: {},
+  },
+
   // Native modules must be unpacked from asar to work correctly
   asarUnpack: getAsarUnpackPatterns(),
 

--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -40,6 +40,23 @@ export const nativeModules = [
   'node-screenshots',
 ];
 
+const optionalNativePackagePrefixes = new Map([
+  ['@napi-rs/canvas', ['@napi-rs/canvas-']],
+  ['node-screenshots', ['node-screenshots-']],
+]);
+
+function getRuntimeOptionalDependencies(moduleName, optionalDependencies) {
+  const prefixes = optionalNativePackagePrefixes.get(moduleName);
+
+  if (!prefixes) {
+    return [];
+  }
+
+  return Object.keys(optionalDependencies).filter((dep) =>
+    prefixes.some((prefix) => dep.startsWith(prefix)),
+  );
+}
+
 /**
  * Recursively resolve all dependencies of a module
  * @param {string} moduleName - The module to resolve
@@ -77,9 +94,11 @@ function resolveDependencies(
       resolveDependencies(dep, visited, nodeModulesPath);
     }
 
-    // Also resolve optional dependencies (important for native modules like @napi-rs/canvas
-    // which have platform-specific binaries in optional deps)
-    for (const dep of Object.keys(optionalDependencies)) {
+    // Only include optional packages that are runtime native binaries for the
+    // module itself. Native packages can also list install-time toolchains such
+    // as node-gyp or node-pre-gyp as optional deps; those must not be copied or
+    // externalized into the packaged Electron app.
+    for (const dep of getRuntimeOptionalDependencies(moduleName, optionalDependencies)) {
       resolveDependencies(dep, visited, nodeModulesPath);
     }
   } catch {

--- a/apps/desktop/native-deps.config.mjs
+++ b/apps/desktop/native-deps.config.mjs
@@ -45,16 +45,32 @@ const optionalNativePackagePrefixes = new Map([
   ['node-screenshots', ['node-screenshots-']],
 ]);
 
+const runtimeOptionalDependencies = new Map([['get-windows', ['@mapbox/node-pre-gyp']]]);
+
+const runtimeDependencyOverrides = new Map([
+  // get-windows imports @mapbox/node-pre-gyp at runtime only for find().
+  // Keep the narrow find() dependency path and avoid shipping its install,
+  // publish, and CLI dependency tree into app.asar.
+  ['@mapbox/node-pre-gyp', ['detect-libc', 'nopt', 'npmlog', 'semver']],
+]);
+
+function getRuntimeDependencies(moduleName, dependencies) {
+  return runtimeDependencyOverrides.get(moduleName) || Object.keys(dependencies);
+}
+
 function getRuntimeOptionalDependencies(moduleName, optionalDependencies) {
   const prefixes = optionalNativePackagePrefixes.get(moduleName);
+  const dependencies = [...(runtimeOptionalDependencies.get(moduleName) || [])];
 
-  if (!prefixes) {
-    return [];
+  if (prefixes) {
+    dependencies.push(
+      ...Object.keys(optionalDependencies).filter((dep) =>
+        prefixes.some((prefix) => dep.startsWith(prefix)),
+      ),
+    );
   }
 
-  return Object.keys(optionalDependencies).filter((dep) =>
-    prefixes.some((prefix) => dep.startsWith(prefix)),
-  );
+  return dependencies;
 }
 
 /**
@@ -90,7 +106,7 @@ function resolveDependencies(
     const optionalDependencies = packageJson.optionalDependencies || {};
 
     // Resolve regular dependencies
-    for (const dep of Object.keys(dependencies)) {
+    for (const dep of getRuntimeDependencies(moduleName, dependencies)) {
       resolveDependencies(dep, visited, nodeModulesPath);
     }
 


### PR DESCRIPTION
## Summary

- Disable pnpm global virtual store for desktop code quality install jobs
- Apply the same setting to shared desktop build setup and isolated desktop install with hoisted linker
- Increase Node heap for desktop setup install to avoid pnpm 11 lockfile parsing OOM
- Mark desktop native dependencies as externally handled so electron-builder skips the pnpm node module collector that hits EMFILE on Linux

## Verification

- pnpm --dir apps/desktop type-check
- pnpm --dir apps/desktop build:main
- CI=true pnpm install --config.enable-global-virtual-store=false && bun run lint
- git diff --check
- GitHub Desktop PR Build setup passed after the heap change; latest upstream-branch PR run will validate Linux packaging without fork approval

Fixes the failure from https://github.com/lobehub/lobehub/actions/runs/25171952306/job/73793671549
Supersedes #14356, which used a fork branch and required manual workflow approval.