### PR TITLE
✨ feat: add Manifest LLM router as a provider

### DIFF
--- a/docs/self-hosting/environment-variables/model-provider.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.mdx
@@ -843,4 +843,26 @@ NewAPI is a multi-provider model aggregation service that supports automatic mod
 - Default: `-`
 - Example: `-all,+straico-model-1,+straico-model-2=straico-special`
 
+## Manifest
+
+### `MANIFEST_API_KEY`
+
+- Type: Required
+- Description: This is the API key from your [Manifest](https://manifest.build) account. Manifest is an open-source LLM router that cuts inference costs through smart routing across 16+ providers. API keys start with `mnfst_`
+- Default: -
+- Example: `mnfst_xxxxxx...xxxxxx`
+
+### `MANIFEST_PROXY_URL`
+
+- Type: Optional
+- Description: The base URL for the Manifest API. By default this points to Manifest Cloud
+- Default: `https://app.manifest.build/v1`
+- Example: `https://app.manifest.build/v1`
+
+<Callout type={'info'}>
+  Manifest is open-source and can be self-hosted. If you run your own Manifest instance, set this to
+  your local deployment URL, for example `http://localhost:2099/v1`. Self-hosted Manifest can also
+  route to local models for fully private inference.
+</Callout>
+
 [model-list]: /docs/self-hosting/advanced/model-list

--- a/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
@@ -844,4 +844,25 @@ LobeHub 在部署时提供了丰富的模型服务商相关的环境变量，你
 - 默认值：`-`
 - 示例：`-all,+straico-model-1,+straico-model-2=straico-special`
 
+## Manifest
+
+### `MANIFEST_API_KEY`
+
+- 类型：必选
+- 描述：这是你在 [Manifest](https://manifest.build) 中申请的 API 密钥。Manifest 是一个开源 LLM 路由器，通过智能路由在 16+ 个供应商之间降低推理成本。API 密钥以 `mnfst_` 开头
+- 默认值：-
+- 示例：`mnfst_xxxxxx...xxxxxx`
+
+### `MANIFEST_PROXY_URL`
+
+- 类型：可选
+- 描述：Manifest API 的基础 URL，默认指向 Manifest Cloud
+- 默认值：`https://app.manifest.build/v1`
+- 示例：`https://app.manifest.build/v1`
+
+<Callout type={'info'}>
+  Manifest 是开源的，支持自托管部署。如果你运行自己的 Manifest 实例，请将此设置为你的本地部署
+  URL，例如 `http://localhost:2099/v1`。自托管 Manifest 还可以路由到本地模型，实现完全私有的推理。
+</Callout>
+
 [model-list]: /zh/docs/self-hosting/advanced/model-list

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -37,6 +37,7 @@ import { default as kimicodingplan } from './kimiCodingPlan';
 import { default as lmstudio } from './lmstudio';
 import { default as lobehub } from './lobehub/index';
 import { default as longcat } from './longcat';
+import { default as manifest } from './manifest';
 import { default as minimax } from './minimax';
 import { default as minimaxcodingplan } from './minimaxCodingPlan';
 import { default as mistral } from './mistral';
@@ -139,6 +140,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   lmstudio,
   longcat,
   ...(ENABLE_BUSINESS_FEATURES ? { lobehub } : {}),
+  manifest,
   minimax,
   minimaxcodingplan,
   mistral,
@@ -222,6 +224,7 @@ export { default as kimicodingplan } from './kimiCodingPlan';
 export { default as lmstudio } from './lmstudio';
 export { gptImage1Schema, default as lobehub } from './lobehub/index';
 export { default as longcat } from './longcat';
+export { default as manifest } from './manifest';
 export { default as minimax } from './minimax';
 export { default as minimaxcodingplan } from './minimaxCodingPlan';
 export { default as mistral } from './mistral';

--- a/packages/model-bank/src/aiModels/manifest.ts
+++ b/packages/model-bank/src/aiModels/manifest.ts
@@ -1,0 +1,9 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// Manifest - Open-source LLM router
+// Models are fetched dynamically, not predefined
+const manifestChatModels: AIChatModelCard[] = [];
+
+export const allModels = [...manifestChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -34,6 +34,7 @@ export enum ModelProvider {
   KimiCodingPlan = 'kimicodingplan',
   LMStudio = 'lmstudio',
   LobeHub = 'lobehub',
+  Manifest = 'manifest',
   LongCat = 'longcat',
   Minimax = 'minimax',
   MinimaxCodingPlan = 'minimaxcodingplan',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -37,6 +37,7 @@ import JinaProvider from './jina';
 import KimiCodingPlanProvider from './kimiCodingPlan';
 import LMStudioProvider from './lmstudio';
 import LobeHubProvider from './lobehub';
+import ManifestProvider from './manifest';
 import LongCatProvider from './longcat';
 import MinimaxProvider from './minimax';
 import MinimaxCodingPlanProvider from './minimaxCodingPlan';
@@ -157,6 +158,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   AzureAIProvider,
   AiHubMixProvider,
   OpenRouterProvider,
+  ManifestProvider,
   FalProvider,
   OllamaProvider,
   OllamaCloudProvider,
@@ -271,6 +273,7 @@ export { default as KimiCodingPlanProviderCard } from './kimiCodingPlan';
 export { default as LMStudioProviderCard } from './lmstudio';
 export { default as LobeHubProviderCard } from './lobehub';
 export { default as LongCatProviderCard } from './longcat';
+export { default as ManifestProviderCard } from './manifest';
 export { default as MinimaxProviderCard } from './minimax';
 export { default as MinimaxCodingPlanProviderCard } from './minimaxCodingPlan';
 export { default as MistralProviderCard } from './mistral';

--- a/packages/model-bank/src/modelProviders/manifest.ts
+++ b/packages/model-bank/src/modelProviders/manifest.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://manifest.build
+const Manifest: ModelProviderCard = {
+  chatModels: [],
+  description:
+    'Manifest is an open-source LLM router that automatically selects the best model across 16+ providers based on request complexity, with built-in fallback chains.',
+  id: 'manifest',
+  modelList: { showModelFetcher: true },
+  name: 'Manifest',
+  settings: {
+    disableBrowserRequest: true,
+    proxyUrl: {
+      placeholder: 'https://app.manifest.build/v1',
+    },
+    sdkType: 'openai',
+    searchMode: 'params',
+    showModelFetcher: true,
+  },
+  url: 'https://manifest.build',
+};
+
+export default Manifest;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -24,6 +24,7 @@ export { LobeGroq } from './providers/groq';
 export { LobeKimiCodingPlanAI } from './providers/kimiCodingPlan';
 export { LobeHubAI } from './providers/lobehub';
 export { LobeLongCatAI } from './providers/longcat';
+export { LobeManifestAI } from './providers/manifest';
 export { LobeMinimaxAI } from './providers/minimax';
 export { LobeMinimaxCodingPlanAI } from './providers/minimaxCodingPlan';
 export { LobeMistralAI } from './providers/mistral';

--- a/packages/model-runtime/src/providers/manifest/index.ts
+++ b/packages/model-runtime/src/providers/manifest/index.ts
@@ -1,0 +1,14 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+export const params = {
+  baseURL: 'https://app.manifest.build/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_MANIFEST_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Manifest,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeManifestAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -33,6 +33,7 @@ import { LobeJinaAI } from './providers/jina';
 import { LobeKimiCodingPlanAI } from './providers/kimiCodingPlan';
 import { LobeLMStudioAI } from './providers/lmstudio';
 import { LobeHubAI } from './providers/lobehub';
+import { LobeManifestAI } from './providers/manifest';
 import { LobeLongCatAI } from './providers/longcat';
 import { LobeMinimaxAI } from './providers/minimax';
 import { LobeMinimaxCodingPlanAI } from './providers/minimaxCodingPlan';
@@ -115,6 +116,7 @@ export const providerRuntimeMap = {
   kimicodingplan: LobeKimiCodingPlanAI,
   lmstudio: LobeLMStudioAI,
   lobehub: LobeHubAI,
+  manifest: LobeManifestAI,
   longcat: LobeLongCatAI,
   minimax: LobeMinimaxAI,
   minimaxcodingplan: LobeMinimaxCodingPlanAI,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A — new provider integration.

#### 🔀 Description of Change

Add [Manifest](https://manifest.build) as a built-in provider.

Manifest is an open-source, OpenAI-compatible LLM router that automatically selects the best model across 16+ providers based on request complexity, with built-in fallback chains. This PR adds it as a first-class provider following the same pattern as OpenRouter (closest analog, also a router/gateway).

**Files changed:**
- `packages/model-bank/src/const/modelProvider.ts`: add `Manifest` to the `ModelProvider` enum
- `packages/model-bank/src/modelProviders/manifest.ts`:new `ModelProviderCard` with OpenAI SDK type
- `packages/model-bank/src/modelProviders/index.ts`: import, register in `DEFAULT_MODEL_PROVIDER_LIST`, export
- `packages/model-runtime/src/providers/manifest/index.ts`: new runtime using `createOpenAICompatibleRuntime`
- `packages/model-runtime/src/runtimeMap.ts`: register runtime
- `packages/model-runtime/src/index.ts`: export runtime

**Provider details:**
| Property | Value |
|---|---|
| ID | `manifest` |
| SDK type | `openai` |
| Base URL | `https://app.manifest.build/v1` |
| API key prefix | `mnfst_` |
| Model fetcher | enabled (fetches available models dynamically) |
| Browser requests | disabled (server-side proxy only) |

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Go to Settings → Provider → Manifest
2. Enter a Manifest API key (`mnfst_...`)
3. Models should be fetchable from the endpoint
4. Chat should work through the Manifest router

#### 📝 Additional Information

Manifest handles model routing automatically. users can also pick specific models and fallback direclty through Manifest platform. Self-hosted users can override the proxy URL to point to their local instance (e.g. `http://localhost:2099/v1`).