### PR TITLE
🐛 fix: fix docker build error, missing `.npmrc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ ENV NODE_OPTIONS="--max-old-space-size=8192"
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml ./
-COPY .npmrc ./
 COPY packages ./packages
 COPY patches ./patches
 # bring in desktop workspace manifest so pnpm can resolve it

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,13 +43,14 @@ packageExtensions:
       postcss-styled-syntax: ^0.7.1
 
 allowBuilds:
+  '@google/genai': true
   '@lobehub/editor': true
   '@vercel/speed-insights': true
   core-js: true
   electron: true
   es5-ext: true
   esbuild: true
-  'ffmpeg-static': true
+  ffmpeg-static: true
   protobufjs: true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

1. 移除 `COPY .npmrc ./` 步骤, `.npmrc` 已被删除导致构建错误 1d9b6099bd7ce72d0b656d45936fc81cd8d0ee68
2. 修正 `ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: @google/genai@1.51.0` 错误, `pnpm-workspace.yaml` - `allowBuilds` 缺少 `'@google/genai': true`

---

TODO:
1. Turbopack 构建错误 `We couldn't find the Next.js package (next/package.json) from the project directory: /app/src/app`

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
