### PR TITLE
🐛 fix(space): show document update time

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -848,6 +848,7 @@
   "workingPanel.resources.renameEmpty": "Title cannot be empty",
   "workingPanel.resources.renameError": "Failed to rename document",
   "workingPanel.resources.renameSuccess": "Document renamed",
+  "workingPanel.resources.updatedAt": "Updated {{time}}",
   "workingPanel.resources.viewMode.list": "List view",
   "workingPanel.resources.viewMode.tree": "Tree view",
   "workingPanel.review.binary": "Binary file — diff not shown",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -853,6 +853,7 @@
   "workingPanel.resources.renameEmpty": "标题不能为空",
   "workingPanel.resources.renameError": "重命名失败",
   "workingPanel.resources.renameSuccess": "重命名成功",
+  "workingPanel.resources.updatedAt": "更新于 {{time}}",
   "workingPanel.resources.viewMode.list": "列表视图",
   "workingPanel.resources.viewMode.tree": "树状视图",
   "workingPanel.review.binary": "二进制文件，无法展示 diff",

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -909,6 +909,7 @@ export default {
   'workingPanel.resources.renameEmpty': 'Title cannot be empty',
   'workingPanel.resources.renameError': 'Failed to rename document',
   'workingPanel.resources.renameSuccess': 'Document renamed',
+  'workingPanel.resources.updatedAt': 'Updated {{time}}',
   'workingPanel.resources.viewMode.list': 'List view',
   'workingPanel.resources.viewMode.tree': 'Tree view',
   'workingPanel.review.binary': 'Binary file — diff not shown',

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -52,7 +52,7 @@ vi.mock('@/libs/swr', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) =>
+    t: (key: string, options?: { time?: string }) =>
       (
         ({
           'workingPanel.resources.empty': 'No agent documents yet',
@@ -60,6 +60,7 @@ vi.mock('react-i18next', () => ({
           'workingPanel.resources.filter.all': 'All',
           'workingPanel.resources.filter.documents': 'Documents',
           'workingPanel.resources.filter.web': 'Web',
+          'workingPanel.resources.updatedAt': `Updated ${options?.time}`,
         }) as Record<string, string>
       )[key] || key,
   }),
@@ -129,6 +130,7 @@ describe('AgentDocumentsGroup', () => {
               sourceType: 'file',
               templateId: 'claw',
               title: 'Brief',
+              updatedAt: new Date(),
             },
           ],
           error: undefined,
@@ -142,9 +144,10 @@ describe('AgentDocumentsGroup', () => {
 
     render(<AgentDocumentsGroup />);
 
-    const item = await screen.findByText('Brief');
+    const item = screen.getByText('Brief');
     expect(item).toBeInTheDocument();
     expect(screen.getByText('A short brief')).toBeInTheDocument();
+    expect(screen.getByText('Updated a few seconds ago')).toBeInTheDocument();
 
     fireEvent.click(item);
     expect(openDocument).toHaveBeenCalledWith('doc-content-1');
@@ -162,6 +165,7 @@ describe('AgentDocumentsGroup', () => {
           sourceType: 'file',
           templateId: 'claw',
           title: 'Brief',
+          updatedAt: new Date(),
         },
         {
           createdAt: new Date('2026-04-16T00:00:00Z'),
@@ -172,6 +176,7 @@ describe('AgentDocumentsGroup', () => {
           sourceType: 'web',
           templateId: null,
           title: 'Example',
+          updatedAt: new Date(),
         },
       ],
       error: undefined,
@@ -211,6 +216,7 @@ describe('AgentDocumentsGroup', () => {
           sourceType: 'file',
           templateId: 'claw',
           title: 'Brief',
+          updatedAt: new Date(),
         },
       ],
       error: undefined,

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -116,7 +116,12 @@ const DocumentItem = memo<DocumentItemProps>(({ agentId, document, mutate }) => 
   const description = document.description ?? undefined;
   const isWeb = document.sourceType === 'web';
   const IconComponent: LucideIcon = isWeb ? GlobeIcon : FileTextIcon;
-  const createdAtLabel = document.createdAt ? dayjs(document.createdAt).fromNow() : null;
+  const updatedAtLabel = document.updatedAt
+    ? t('workingPanel.resources.updatedAt', {
+        ns: 'chat',
+        time: dayjs(document.updatedAt).fromNow(),
+      })
+    : null;
 
   const activeDocumentId = pageMatch ? pageMatch.params.docId : portalDocumentId;
   const isActive = activeDocumentId === document.documentId;
@@ -190,7 +195,7 @@ const DocumentItem = memo<DocumentItemProps>(({ agentId, document, mutate }) => 
             {description}
           </Text>
         )}
-        {createdAtLabel && <Text className={styles.meta}>{createdAtLabel}</Text>}
+        {updatedAtLabel && <Text className={styles.meta}>{updatedAtLabel}</Text>}
       </Flexbox>
     </Flexbox>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Show the Space resource card timestamp as the document binding's latest update time instead of its creation time.

This also adds an explicit `Updated {{time}}` label so the relative timestamp is not ambiguous in the agent Space panel.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx'
bunx prettier --check 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx' 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx' src/locales/default/chat.ts locales/en-US/chat.json locales/zh-CN/chat.json
```

Also ran `bun run type-check`; it is currently blocked by existing unrelated repository-wide TypeScript errors outside this change set.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The Space resources list is sorted by `agent_documents.updated_at`, so the visible timestamp now matches that recency behavior.
