### PR TITLE
🐛 fix: Docker build compatibility with pnpm v11 global virtual store

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm i --config.enable-global-virtual-store=false
 
       - name: Install Playwright browsers (with system deps)
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm i --config.enable-global-virtual-store=false
 
       - name: Test packages with coverage
         run: |
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm i --config.enable-global-virtual-store=false
 
       - name: Run tests
         run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/3
@@ -134,7 +134,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm i --config.enable-global-virtual-store=false
 
       - name: Download blob reports
         uses: actions/download-artifact@v7
@@ -167,7 +167,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install deps
-        run: pnpm install
+        run: pnpm i --config.enable-global-virtual-store=false
         working-directory: apps/desktop
         env:
           NODE_OPTIONS: --max-old-space-size=8192

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ ENV NODE_OPTIONS="--max-old-space-size=8192"
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml ./
-COPY .npmrc ./
 COPY packages ./packages
 COPY patches ./patches
 # bring in desktop workspace manifest so pnpm can resolve it
@@ -80,13 +79,19 @@ RUN set -e && \
     if [ "${USE_CN_MIRROR:-false}" = "true" ]; then \
         export SENTRYCLI_CDNURL="https://npmmirror.com/mirrors/sentry-cli"; \
         npm config set registry "https://registry.npmmirror.com/"; \
-        echo 'canvas_binary_host_mirror=https://npmmirror.com/mirrors/canvas' >> .npmrc; \
+        echo 'canvas_binary_host_mirror=https://npmmirror.com/mirrors/canvas' > .npmrc; \
     fi && \
     export COREPACK_NPM_REGISTRY=$(npm config get registry | sed 's/\/$//') && \
-    npm i -g corepack@latest && \
-    corepack enable && \
-    corepack use $(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) && \
+    rm -rf /usr/local/lib/node_modules/corepack /usr/local/bin/corepack /usr/local/bin/pnpm /usr/local/bin/pnpx \
+           /root/.local/share/pnpm/.tools && \
+    npm i -g pnpm@10.33.2 && \
+    sed -i '/"packageManager"/d' package.json && \
+    sed -i '/enableGlobalVirtualStore/d' pnpm-workspace.yaml && \
+    echo 'shamefully-hoist=true' >> .npmrc && \
+    pnpm --version && \
     pnpm i && \
+    rm -rf /root/.local/share/pnpm/.tools && \
+    readlink -f node_modules/next/package.json && \
     mkdir -p /deps && \
     cd /deps && \
     pnpm init && \
@@ -95,11 +100,19 @@ RUN set -e && \
 COPY . .
 
 # Prebuild: env checks (checkDeprecatedAuth, checkRequiredEnvVars, printEnvInfo) then remove desktop-only code
-RUN pnpm exec tsx scripts/dockerPrebuild.mts
+RUN CI=true npx tsx scripts/dockerPrebuild.mts
 RUN rm -rf src/app/desktop "src/app/(backend)/trpc/desktop"
 
 # run build standalone for docker version
-RUN npm run build:docker
+# Inline build commands to avoid pnpm run (which uses pnpm v11 global virtual store)
+RUN export PATH="/app/node_modules/.bin:${PATH}" && \
+    export CI=true && \
+    export NODE_OPTIONS="--max-old-space-size=8192" && \
+    rm -rf public/_spa && vite build && \
+    MOBILE=true vite build && \
+    tsx scripts/copySpaBuild.mts && tsx scripts/generateSpaTemplates.mts && \
+    export DOCKER=true && next build && \
+    tsx ./scripts/buildSitemapIndex/index.ts
 
 ## Application image, copy all the files for production
 FROM busybox:latest AS app

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ packageExtensions:
       postcss-styled-syntax: ^0.7.1
 
 allowBuilds:
+  '@google/genai': true
   '@lobehub/editor': true
   '@vercel/speed-insights': true
   core-js: true

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, relative, resolve, sep } from 'node:path';
 
@@ -30,9 +30,29 @@ const getCommonDirectory = (paths: string[]) => {
 };
 
 const getTurbopackRoot = () => {
-  const nextPackageDirectory = dirname(require.resolve('next/package.json'));
+  // Resolve 'next' without following symlinks (important for pnpm v11 global virtual store).
+  // require.resolve + realpathSync follows symlinks to the global store, making the common
+  // directory resolve to '/' which breaks Turbopack.
+  let current = process.cwd();
 
-  return getCommonDirectory([realpathSync(process.cwd()), realpathSync(nextPackageDirectory)]);
+  while (true) {
+    const candidate = resolve(current, 'node_modules', 'next', 'package.json');
+
+    if (existsSync(candidate)) {
+      return current;
+    }
+
+    const parent = resolve(current, '..');
+
+    if (parent === current) break;
+
+    current = parent;
+  }
+
+  // Fallback: original behaviour (may fail with pnpm v11 global virtual store)
+  const nextPackageDirectory = dirname(require.resolve('next/package.json'));
+  const root = getCommonDirectory([process.cwd(), nextPackageDirectory]);
+  return root;
 };
 
 const resolvePackageDirectory = (packageName: string) => {
@@ -40,6 +60,26 @@ const resolvePackageDirectory = (packageName: string) => {
     resolve(process.cwd(), 'node_modules', packageName),
     resolve(process.cwd(), 'node_modules/.pnpm/node_modules', packageName),
   ];
+
+  // Also check pnpm v11 global virtual store entries (e.g. node_modules/.pnpm/<name>@<version>_.../node_modules/<name>)
+  const pnpmDir = resolve(process.cwd(), 'node_modules/.pnpm');
+
+  if (existsSync(pnpmDir)) {
+    try {
+      const { readdirSync } = require('node:fs');
+
+      for (const entry of readdirSync(pnpmDir)) {
+        if (
+          entry.startsWith(`${packageName.replace('/', '+')}@`) ||
+          entry.startsWith(`${packageName.replace('/', '+')}@`)
+        ) {
+          candidateDirectories.push(resolve(pnpmDir, entry, 'node_modules', packageName));
+        }
+      }
+    } catch {
+      // ignore directory read errors
+    }
+  }
 
   return candidateDirectories.find((directory) => existsSync(resolve(directory, 'package.json')));
 };


### PR DESCRIPTION
## Summary

- 修复 pnpm v11 `enableGlobalVirtualStore` 导致 Docker 构建失败的问题
- pnpm v11 的全局虚拟存储在 `/root/.local/share/pnpm/store/v11/links/...` 创建 symlink，导致 Turbopack 无法从 `/app/src/app` 推断 workspace root，同时 Rolldown 无法解析 pnpm symlink 结构下的依赖
- Dockerfile 改用 pnpm v10.33.2 + `shamefully-hoist=true`，内联构建命令避免 `pnpm run` 触发 v11 重下载
- `define-config.ts` 的 `getTurbopackRoot()` 改为不跟随 symlink 解析，同时增强 `resolvePackageDirectory()` 支持 pnpm v11 全局存储路径

## Changes

### Dockerfile
- 移除 `COPY .npmrc ./`（pnpm v11 已删除此文件）
- 移除 corepack，直接安装 pnpm@10.33.2
- 删除 `packageManager` 字段（防止 pnpm v10 自动切换到 v11）
- 从 `pnpm-workspace.yaml` 移除 `enableGlobalVirtualStore`
- 添加 `shamefully-hoist=true` 解决 Rolldown symlink 解析问题
- 内联 `build:docker` 的构建命令，避免 `pnpm run` 使用 pnpm v11

### src/libs/next/config/define-config.ts
- `getTurbopackRoot()`: 改用从 cwd 向上查找 `node_modules/next/package.json`，不跟随 symlink
- `resolvePackageDirectory()`: 增加 pnpm v11 `.pnpm` 目录扫描
- 移除未使用的 `realpathSync` 导入

## Test plan

- [x] `docker build` 成功通过，镜像 1.4GB