### PR TITLE
fix: add server runtime for lobe-agent-management (LOBE-8434)

### DIFF
--- a/src/server/services/toolExecution/serverRuntimes/agentManagement.ts
+++ b/src/server/services/toolExecution/serverRuntimes/agentManagement.ts
@@ -1,0 +1,318 @@
+import {
+  AgentManagementIdentifier,
+  type CallAgentParams,
+  type CreateAgentParams,
+  type DeleteAgentParams,
+  type DuplicateAgentParams,
+  type GetAgentDetailParams,
+  type InstallPluginParams,
+  type SearchAgentParams,
+  type UpdateAgentParams,
+  type UpdatePromptParams,
+} from '@lobechat/builtin-tool-agent-management';
+
+import { AgentModel } from '@/database/models/agent';
+import { DiscoverService } from '@/server/services/discover';
+
+import { type ToolExecutionContext, type ToolExecutionResult } from '../types';
+import { type ServerRuntimeRegistration } from './types';
+
+const handleError = (error: unknown, message: string): ToolExecutionResult => {
+  const err = error as Error;
+  return { content: `${message}: ${err.message}`, success: false };
+};
+
+export const agentManagementRuntime: ServerRuntimeRegistration = {
+  factory: (context) => {
+    if (!context.userId || !context.serverDB) {
+      throw new Error('userId and serverDB are required for Agent Management execution');
+    }
+
+    const agentModel = new AgentModel(context.serverDB, context.userId);
+    const discoverService = new DiscoverService();
+
+    return {
+      callAgent: async (
+        params: CallAgentParams,
+        ctx: ToolExecutionContext,
+      ): Promise<ToolExecutionResult> => {
+        const { agentId, instruction, runAsTask, taskTitle, timeout } = params;
+
+        if (runAsTask) {
+          return {
+            content: `🚀 Triggered async task to call agent "${agentId}"${taskTitle ? `: ${taskTitle}` : ''}`,
+            state: {
+              parentMessageId: ctx.messageId,
+              task: {
+                description: taskTitle || `Call agent ${agentId}`,
+                instruction,
+                targetAgentId: agentId,
+                timeout: timeout || 1_800_000,
+              },
+              type: 'execTask',
+            },
+            success: true,
+          };
+        }
+
+        return {
+          content: `Agent "${agentId}" has been called. Execution will proceed asynchronously.`,
+          state: { agentId, instruction, mode: 'speak' },
+          success: true,
+        };
+      },
+
+      createAgent: async (params: CreateAgentParams): Promise<ToolExecutionResult> => {
+        try {
+          const agent = await agentModel.create({
+            avatar: params.avatar,
+            backgroundColor: params.backgroundColor,
+            description: params.description,
+            model: params.model,
+            openingMessage: params.openingMessage,
+            openingQuestions: params.openingQuestions,
+            plugins: params.plugins,
+            provider: params.provider,
+            systemRole: params.systemRole,
+            tags: params.tags,
+            title: params.title,
+          });
+
+          return {
+            content: `Successfully created agent "${params.title}" with ID: ${agent.id}`,
+            state: { agentId: agent.id, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to create agent');
+        }
+      },
+
+      deleteAgent: async (params: DeleteAgentParams): Promise<ToolExecutionResult> => {
+        try {
+          await agentModel.delete(params.agentId);
+          return {
+            content: `Successfully deleted agent ${params.agentId}`,
+            state: { agentId: params.agentId, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to delete agent');
+        }
+      },
+
+      duplicateAgent: async (params: DuplicateAgentParams): Promise<ToolExecutionResult> => {
+        try {
+          const result = await agentModel.duplicate(params.agentId, params.newTitle);
+          if (!result) {
+            return { content: `Agent "${params.agentId}" not found.`, success: false };
+          }
+          return {
+            content: `Successfully duplicated agent. New agent ID: ${result.agentId}${params.newTitle ? ` with title "${params.newTitle}"` : ''}`,
+            state: { newAgentId: result.agentId, sourceAgentId: params.agentId, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to duplicate agent');
+        }
+      },
+
+      getAgentDetail: async (params: GetAgentDetailParams): Promise<ToolExecutionResult> => {
+        try {
+          const agent = await agentModel.getAgentConfigById(params.agentId);
+          if (!agent) {
+            return { content: `Agent "${params.agentId}" not found.`, success: false };
+          }
+
+          const detail = {
+            config: {
+              model: agent.model,
+              openingMessage: agent.openingMessage,
+              openingQuestions: agent.openingQuestions,
+              plugins: agent.plugins,
+              provider: agent.provider,
+              systemRole: agent.systemRole,
+            },
+            meta: {
+              avatar: agent.avatar,
+              backgroundColor: agent.backgroundColor,
+              description: agent.description,
+              tags: agent.tags,
+              title: agent.title,
+            },
+          };
+
+          const parts: string[] = [];
+          if (detail.meta.title) parts.push(`**${detail.meta.title}**`);
+          if (detail.meta.description) parts.push(detail.meta.description);
+          if (detail.config.model)
+            parts.push(`Model: ${detail.config.provider || ''}/${detail.config.model}`);
+          if (detail.config.plugins?.length)
+            parts.push(`Plugins: ${detail.config.plugins.join(', ')}`);
+          if (detail.config.systemRole) parts.push(`System Prompt: ${detail.config.systemRole}`);
+
+          return {
+            content:
+              parts.length > 0 ? parts.join('\n') : `Agent "${params.agentId}" found.`,
+            state: { agentId: params.agentId, ...detail, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to get agent detail');
+        }
+      },
+
+      installPlugin: async (params: InstallPluginParams): Promise<ToolExecutionResult> => {
+        try {
+          const { agentId, identifier } = params;
+          const agent = await agentModel.getAgentConfigById(agentId);
+          if (!agent) {
+            return { content: `Agent "${agentId}" not found.`, success: false };
+          }
+
+          const currentPlugins = (agent.plugins as string[] | null) || [];
+          if (!currentPlugins.includes(identifier)) {
+            await agentModel.updateConfig(agentId, {
+              plugins: [...currentPlugins, identifier],
+            });
+          }
+
+          return {
+            content: `Successfully enabled plugin "${identifier}" for agent "${agentId}"`,
+            state: { installed: true, pluginId: identifier, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to install plugin');
+        }
+      },
+
+      searchAgent: async (params: SearchAgentParams): Promise<ToolExecutionResult> => {
+        try {
+          const source = params.source || 'all';
+          const limit = Math.min(params.limit || 10, 20);
+          const results: Array<{
+            avatar?: string | null;
+            backgroundColor?: string | null;
+            description?: string | null;
+            id: string;
+            isMarket?: boolean;
+            title?: string | null;
+          }> = [];
+
+          if (source === 'user' || source === 'all') {
+            const userAgents = await agentModel.queryAgents({ keyword: params.keyword, limit });
+            results.push(...userAgents.map((a) => ({ ...a, isMarket: false })));
+          }
+
+          if (source === 'market' || source === 'all') {
+            const marketResult = await discoverService.getAssistantList({
+              pageSize: limit,
+              q: params.keyword,
+              ...(params.category && { category: params.category }),
+            });
+            results.push(
+              ...marketResult.items.map((a) => ({
+                avatar: a.avatar,
+                backgroundColor: a.backgroundColor,
+                description: a.description,
+                id: a.identifier,
+                isMarket: true,
+                title: a.title,
+              })),
+            );
+          }
+
+          const sliced = results.slice(0, limit);
+          const list = sliced
+            .map((a) => `- ${a.title || 'Untitled'} (${a.id})${a.isMarket ? ' [Market]' : ''}`)
+            .join('\n');
+
+          return {
+            content:
+              sliced.length > 0
+                ? `Found ${sliced.length} agents:\n${list}`
+                : 'No agents found matching your search criteria.',
+            state: {
+              agents: sliced,
+              keyword: params.keyword,
+              source,
+              totalCount: sliced.length,
+            },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to search agents');
+        }
+      },
+
+      updateAgent: async (params: UpdateAgentParams): Promise<ToolExecutionResult> => {
+        try {
+          const { agentId } = params;
+          let { config, meta } = params;
+
+          // Guard against LLM double-encoding: parse strings if needed
+          if (typeof config === 'string') {
+            try {
+              config = JSON.parse(config as string);
+            } catch {
+              config = undefined;
+            }
+          }
+          if (typeof meta === 'string') {
+            try {
+              meta = JSON.parse(meta as string);
+            } catch {
+              meta = undefined;
+            }
+          }
+
+          const updatedParts: string[] = [];
+
+          if (config && Object.keys(config).length > 0) {
+            await agentModel.updateConfig(agentId, config as Record<string, unknown>);
+            updatedParts.push(`config: ${Object.keys(config).join(', ')}`);
+          }
+
+          if (meta && Object.keys(meta).length > 0) {
+            await agentModel.update(agentId, meta as Record<string, unknown>);
+            updatedParts.push(`meta: ${Object.keys(meta).join(', ')}`);
+          }
+
+          if (updatedParts.length === 0) {
+            return { content: 'No fields to update.', state: { success: true }, success: true };
+          }
+
+          return {
+            content: `Successfully updated agent. Updated ${updatedParts.join('; ')}`,
+            state: { agentId, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to update agent');
+        }
+      },
+
+      updatePrompt: async (params: UpdatePromptParams): Promise<ToolExecutionResult> => {
+        try {
+          const { agentId, prompt } = params;
+          await agentModel.update(agentId, { editorData: null, systemRole: prompt } as Record<
+            string,
+            unknown
+          >);
+
+          return {
+            content: prompt
+              ? `Successfully updated system prompt (${prompt.length} characters)`
+              : 'Successfully cleared system prompt',
+            state: { newPrompt: prompt, success: true },
+            success: true,
+          };
+        } catch (error) {
+          return handleError(error, 'Failed to update prompt');
+        }
+      },
+    };
+  },
+  identifier: AgentManagementIdentifier,
+};

--- a/src/server/services/toolExecution/serverRuntimes/index.ts
+++ b/src/server/services/toolExecution/serverRuntimes/index.ts
@@ -9,6 +9,7 @@
 import { type ToolExecutionContext } from '../types';
 import { activatorRuntime } from './activator';
 import { agentDocumentsRuntime } from './agentDocuments';
+import { agentManagementRuntime } from './agentManagement';
 import { agentMarketplaceRuntime } from './agentMarketplace';
 import { briefRuntime } from './brief';
 import { calculatorRuntime } from './calculator';
@@ -50,6 +51,7 @@ registerRuntimes([
   cloudSandboxRuntime,
   calculatorRuntime,
   agentDocumentsRuntime,
+  agentManagementRuntime,
   notebookRuntime,
   skillStoreRuntime,
   skillsRuntime,


### PR DESCRIPTION
## Summary

- Add missing server-side runtime for `lobe-agent-management` builtin tool
- Register `lobe-agent-management` in the server runtime registry

## Problem

When executing Agent Tasks, any call to `lobe-agent-management` APIs throws:
```
Builtin tool "lobe-agent-management" is not implemented
```

Root cause: The tool has a client-side executor but no server-side runtime registered in `serverRuntimeFactories`. Normal chat uses the client executor (works fine), but Task execution routes through the server `BuiltinToolsExecutor` → `hasServerRuntime()` returns false → error.

## Changes

- **Add** `src/server/services/toolExecution/serverRuntimes/agentManagement.ts`
  - Implements all 9 API methods using `AgentModel` and `DiscoverService`
  - `createAgent`, `updateAgent`, `deleteAgent`, `getAgentDetail`, `duplicateAgent`, `updatePrompt` — direct DB operations via `AgentModel`
  - `installPlugin` — updates agent's plugins array in DB
  - `searchAgent` — queries user agents + marketplace via `DiscoverService`
  - `callAgent` — returns `execTask` state for task system when `runAsTask: true`
- **Update** `src/server/services/toolExecution/serverRuntimes/index.ts` — register runtime

## Test Plan

- [ ] Agent Task calling `createAgent` no longer throws "not implemented"
- [ ] Agent Task calling `searchAgent` returns results from user agents + marketplace
- [ ] Agent Task calling `callAgent` with `runAsTask: true` triggers sub-task correctly
- [ ] Normal chat (client executor path) unaffected

Fixes LOBE-8434
