### PR TITLE
🐛 fix(onboarding): guard injectors with finished flag to stop false finishOnboarding signals (#14310)

### DIFF
--- a/packages/context-engine/src/providers/OnboardingActionHintInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingActionHintInjector.ts
@@ -27,6 +27,10 @@ export class OnboardingActionHintInjector extends BaseVirtualLastUserContentProv
       log('Disabled or no phaseGuidance configured, skipping');
       return true;
     }
+    if (this.config.onboardingContext.finished) {
+      log('Onboarding is complete, skipping action hint injection');
+      return true;
+    }
     return false;
   }
 

--- a/packages/context-engine/src/providers/OnboardingContextInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingContextInjector.ts
@@ -12,6 +12,8 @@ export interface OnboardingContext {
   phaseGuidance: string;
   /** SOUL.md document content */
   soulContent?: string | null;
+  /** Whether onboarding is complete. When true, injectors must not fire. */
+  finished?: boolean;
 }
 
 export interface OnboardingContextInjectorConfig {
@@ -80,4 +82,6 @@ const numberLines = (source: string): string => {
   const lines = normalized === '' ? [''] : normalized.split('\n');
   const width = Math.max(String(lines.length).length, 2);
   return lines.map((line, i) => `${String(i + 1).padStart(width, ' ')}→${line}`).join('\n');
+  /** Whether onboarding is complete. When true, injectors must not fire. */
+  finished?: boolean;
 };

--- a/packages/context-engine/src/providers/OnboardingSyntheticStateInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingSyntheticStateInjector.ts
@@ -35,6 +35,10 @@ export class OnboardingSyntheticStateInjector extends BaseProcessor {
       log('Disabled or no phaseGuidance, skipping');
       return this.markAsExecuted(context);
     }
+    if (this.config.onboardingContext.finished) {
+      log('Onboarding is complete, skipping synthetic state injection');
+      return this.markAsExecuted(context);
+    }
 
     const ctx = this.config.onboardingContext;
 

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -694,7 +694,7 @@ export const contextEngineering = async ({
         // Ignore — document may not exist yet
       }
 
-      onboardingContext = { personaContent, phaseGuidance, soulContent };
+      onboardingContext = { personaContent, phaseGuidance, soulContent, finished: state.finished };
       log('Built onboarding context, phase: %s', state.phase);
     } catch (error) {
       log('Failed to build onboarding context: %O', error);


### PR DESCRIPTION
## Summary

Fixes #14310 —  injects `<next_actions>` after completion, triggers false `finishOnboarding` signals.

## Root Cause

The state injectors (`OnboardingActionHintInjector`, `OnboardingSyntheticStateInjector`) have no awareness of the `finished` state. When `getOnboardingState` returns `phase=PREVIEW` after onboarding is complete, the `phaseGuidance` guard alone never blocks injection.

## Fix (defense-in-depth across 4 files)

| File | Change |
|---|---|
| `OnboardingContextInjector.ts` | Add `finished?: boolean` to `OnboardingContext` interface |
| `contextEngineering.ts` | Pass `finished: state.finished` to context |
| `OnboardingActionHintInjector.ts` | Guard `shouldSkip()` on `config.onboardingContext.finished` |
| `OnboardingSyntheticStateInjector.ts` | Guard `doProcess()` on `config.onboardingContext.finished` |

When `finished=true`, both injectors log and skip, preventing false `finishOnboarding` signals.

## Testing

- [ ] Verify onboarding completes without `<next_actions>` in subsequent turns
- [ ] Verify onboarding still works normally when `finished=false`
- [ ] Verify phase guidance still injects during active onboarding