### PR TITLE
🔨 chore(release-template): clean up changelog templates (drop Highlights from db-migration, drop version numbers everywhere)

### DIFF
--- a/.agents/skills/version-release/SKILL.md
+++ b/.agents/skills/version-release/SKILL.md
@@ -189,7 +189,7 @@ If metrics cannot be reliably computed, omit unknown numbers instead of guessing
 
 Follow this section order unless the user asks otherwise:
 
-1. `# 🚀 LobeHub v<x.y.z> (<YYYYMMDD>)`
+1. `# 🚀 LobeHub Release (<YYYYMMDD>)`
 2. Metadata lines:
    - `Release Date`
    - `Since <Previous Version>` metrics
@@ -262,7 +262,7 @@ If a new contributor appears who is not on this list, treat them as community by
 ### GitHub Release Changelog Template
 
 ```md
-# 🚀 LobeHub v<x.y.z> (<YYYYMMDD>)
+# 🚀 LobeHub Release (<YYYYMMDD>)
 
 **Release Date:** <Month DD, YYYY>  
 **Since <Previous Version>:** <N merged PRs> · <N resolved issues> · <N contributors>

--- a/.agents/skills/version-release/reference/changelog-example/db-migration.md
+++ b/.agents/skills/version-release/reference/changelog-example/db-migration.md
@@ -1,4 +1,4 @@
-# 🚀 LobeHub v2.1.50 (20260416)
+# 🚀 LobeHub Release (20260416)
 
 **Release Date:** April 20, 2026\
 **Migration Scope:** Agent benchmark data model bootstrap (5 new tables, 2 new indexes)

--- a/.agents/skills/version-release/reference/changelog-example/db-migration.md
+++ b/.agents/skills/version-release/reference/changelog-example/db-migration.md
@@ -7,14 +7,6 @@
 
 ---
 
-## ✨ Highlights
-
-- **Benchmark Lifecycle Schema** — Added a relational model that tracks benchmark setup, runs, per-topic execution, and record outputs end-to-end.
-- **Queryability Upgrade** — Added indexes for run status and benchmark-topic joins, improving operational queries in dashboard and debugging workflows.
-- **Safer Operator Rollout** — Migration is startup-driven and backward-compatible with existing non-benchmark chat workflows.
-
----
-
 ## 🗄️ Migration Overview
 
 Added tables:

--- a/.agents/skills/version-release/reference/changelog-example/hotfix.md
+++ b/.agents/skills/version-release/reference/changelog-example/hotfix.md
@@ -1,4 +1,4 @@
-# 🚀 LobeHub v2.1.54 (20260427)
+# 🚀 LobeHub Release (20260427)
 
 **Hotfix Scope:** Agent topic-switching regression — stale chat state on agent change
 

--- a/.agents/skills/version-release/reference/changelog-example/weekly-release.md
+++ b/.agents/skills/version-release/reference/changelog-example/weekly-release.md
@@ -1,7 +1,7 @@
-# 🚀 LobeHub v2.1.50 (20260420)
+# 🚀 LobeHub Release (20260420)
 
 **Release Date:** April 20, 2026\
-**Since v2026.04.13:** 96 commits · 58 merged PRs · 31 resolved issues · 17 contributors
+**Since previous release:** 96 commits · 58 merged PRs · 31 resolved issues · 17 contributors
 
 > This weekly release focuses on reducing friction in everyday agent work: faster model routing, smoother gateway behavior, stronger task continuity, and clearer operator diagnostics when something goes wrong.
 
@@ -77,4 +77,4 @@
 
 ---
 
-**Full Changelog**: v2026.04.13...v2026.04.20
+**Full Changelog**: <previous-tag>...<current-tag>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

Two cleanups to the changelog templates under `.agents/skills/version-release/`:

**1. Drop `## ✨ Highlights` from the DB-migration template**

DB-migration releases are narrow in scope — a single schema change with operator-facing impact — so the migration overview, operator notes, and reliability/risk sections already cover everything a self-hosted operator needs. The Highlights block ends up restating the same facts in a different shape. The hotfix template already follows this leaner structure; this change brings db-migration in line.

After this change, DB-migration changelogs flow: thesis quote → Migration Overview → Operator Notes → Reliability & Risk → Owner.

**2. Drop hard-coded version numbers from all changelog templates**

Patch releases auto-bump on merge (`auto-tag-release.yml`), so the version isn't known at the time the changelog body is authored. Hard-coding `v2.1.50` etc. in the example templates encouraged Claude/agents to invent or guess a version number when filling in a real PR body.

Specifically:

- `# 🚀 LobeHub v<x.y.z> (YYYYMMDD)` → `# 🚀 LobeHub Release (YYYYMMDD)` in all 3 examples (`db-migration.md`, `hotfix.md`, `weekly-release.md`) and the GitHub Release Changelog Template inside `SKILL.md`.
- `weekly-release.md`: `Since v2026.04.13:` → `Since previous release:`, and `Full Changelog: v2026.04.13...v2026.04.20` → `Full Changelog: <previous-tag>...<current-tag>` (the placeholder form already used by the SKILL.md template).

**Out of scope (intentionally kept):**

- Workflow text in `SKILL.md` describing PR title format `🚀 release: v{x.y.z}` — this is regex-required by `auto-tag-release.yml` for minor releases.
- Branch-name conventions like `release/v{version}` and `hotfix/v{version}-{hash}` — these are operational naming, not "version numbers in templates".

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Template-only doc change; no runtime impact.

#### 📝 Additional Information

These templates are consumed by the `version-release` skill when authoring release PR bodies (e.g. lobehub/lobehub#14354).