### PR TITLE
✨ feat: add visual understanding tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "@lobechat/builtin-tool-group-management": "workspace:*",
     "@lobechat/builtin-tool-gtd": "workspace:*",
     "@lobechat/builtin-tool-knowledge-base": "workspace:*",
+    "@lobechat/builtin-tool-lobe-agent": "workspace:*",
     "@lobechat/builtin-tool-local-system": "workspace:*",
     "@lobechat/builtin-tool-memory": "workspace:*",
     "@lobechat/builtin-tool-message": "workspace:*",

--- a/packages/builtin-tool-lobe-agent/package.json
+++ b/packages/builtin-tool-lobe-agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@lobechat/builtin-tool-lobe-agent",
+  "version": "1.0.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./executor": "./src/executor/index.ts"
+  },
+  "main": "./src/index.ts",
+  "devDependencies": {
+    "@lobechat/types": "workspace:*"
+  }
+}

--- a/packages/builtin-tool-lobe-agent/src/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/executor/index.ts
@@ -1,0 +1,239 @@
+import type {
+  BuiltinToolContext,
+  BuiltinToolResult,
+  ChatImageItem,
+  ChatVideoItem,
+} from '@lobechat/types';
+import { BaseExecutor } from '@lobechat/types';
+
+import { LobeAgentManifest } from '../manifest';
+import type { AnalyzeVisualMediaParams } from '../types';
+import { LobeAgentApiName } from '../types';
+
+interface VisualFileItem {
+  description: string;
+  name: string;
+  ref: string;
+  type: 'image' | 'video';
+  uri: string;
+}
+
+const getVisualUnderstandingConfig = () =>
+  typeof window === 'undefined'
+    ? undefined
+    : window.global_serverConfigStore?.getState().serverConfig.visualUnderstanding;
+
+const createAbortController = (signal?: AbortSignal) => {
+  const abortController = new AbortController();
+
+  if (signal?.aborted) {
+    abortController.abort();
+    return abortController;
+  }
+
+  signal?.addEventListener('abort', () => abortController.abort(), { once: true });
+
+  return abortController;
+};
+
+const toVisualFileItems = (
+  images: ChatImageItem[] = [],
+  videos: ChatVideoItem[] = [],
+): VisualFileItem[] => [
+  ...images.map((image, index) => ({
+    description: image.alt || `Image ${index + 1}`,
+    name: image.alt || image.id,
+    ref: `image_${index + 1}`,
+    type: 'image' as const,
+    uri: image.url,
+  })),
+  ...videos.map((video, index) => ({
+    description: video.alt || `Video ${index + 1}`,
+    name: video.alt || video.id,
+    ref: `video_${index + 1}`,
+    type: 'video' as const,
+    uri: video.url,
+  })),
+];
+
+const selectFiles = (items: VisualFileItem[], refs?: string[]) => {
+  if (!refs || refs.length === 0) return { selected: items };
+
+  const selected = refs
+    .map((ref) => items.find((item) => item.ref === ref))
+    .filter((item): item is VisualFileItem => !!item);
+  const invalidRefs = refs.filter((ref) => !items.some((item) => item.ref === ref));
+
+  return { invalidRefs, selected };
+};
+
+const hasVisualFiles = (message?: {
+  imageList?: unknown[];
+  role?: string;
+  videoList?: unknown[];
+}) =>
+  message?.role === 'user' &&
+  ((message.imageList?.length ?? 0) > 0 || (message.videoList?.length ?? 0) > 0);
+
+class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
+  readonly identifier = LobeAgentManifest.identifier;
+  protected readonly apiEnum = LobeAgentApiName;
+
+  analyzeVisualMedia = async (
+    params: AnalyzeVisualMediaParams,
+    ctx: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    const config = getVisualUnderstandingConfig();
+
+    if (!config?.provider || !config.model) {
+      return {
+        error: {
+          message: 'Visual understanding model is not configured',
+          type: 'PluginSettingsInvalid',
+        },
+        success: false,
+      };
+    }
+
+    if (!params.question?.trim()) {
+      return {
+        error: { message: '`question` is required', type: 'InvalidToolArguments' },
+        success: false,
+      };
+    }
+
+    const [{ chatService }, { getChatStoreState }, { dbMessageSelectors }] = await Promise.all([
+      import('@/services/chat'),
+      import('@/store/chat'),
+      import('@/store/chat/selectors'),
+    ]);
+
+    const chatState = getChatStoreState();
+    const sourceCandidate =
+      ctx.sourceMessageId && dbMessageSelectors.getDbMessageById(ctx.sourceMessageId)(chatState);
+    const toolMessage = dbMessageSelectors.getDbMessageById(ctx.messageId)(chatState);
+    const assistantMessage =
+      toolMessage?.parentId && dbMessageSelectors.getDbMessageById(toolMessage.parentId)(chatState);
+    const parentUserMessage =
+      assistantMessage?.parentId &&
+      dbMessageSelectors.getDbMessageById(assistantMessage.parentId)(chatState);
+    const sourceMessage = hasVisualFiles(sourceCandidate)
+      ? sourceCandidate
+      : hasVisualFiles(parentUserMessage)
+        ? parentUserMessage
+        : dbMessageSelectors.latestUserMessage(chatState);
+    const files = toVisualFileItems(sourceMessage?.imageList, sourceMessage?.videoList);
+
+    if (files.length === 0) {
+      return {
+        error: {
+          message: 'No visual files are available in the current message',
+          type: 'VisualFilesNotFound',
+        },
+        success: false,
+      };
+    }
+
+    const { invalidRefs, selected } = selectFiles(files, params.files);
+    if (invalidRefs?.length) {
+      return {
+        content: `Unknown file refs: ${invalidRefs.join(', ')}. Available refs: ${files
+          .map((file) => file.ref)
+          .join(', ')}`,
+        error: { message: 'Unknown visual file refs', type: 'InvalidToolArguments' },
+        state: { availableFiles: files, invalidRefs },
+        success: false,
+      };
+    }
+
+    if (selected.length === 0) {
+      return {
+        error: { message: 'No visual files selected', type: 'InvalidToolArguments' },
+        success: false,
+      };
+    }
+
+    let content = '';
+    let error: { message?: string } | undefined;
+    let usage: unknown;
+    const abortController = createAbortController(ctx.signal);
+    const fileSummary = selected
+      .map((file) => `- ${file.ref}: ${file.name} (${file.type})`)
+      .join('\n');
+
+    await chatService.getChatCompletion(
+      {
+        max_tokens: 2000,
+        messages: [
+          {
+            content: [
+              {
+                text: [
+                  'Analyze the attached visual media and answer the user question.',
+                  'Do not mention that you are a fallback tool unless it is relevant.',
+                  '',
+                  'Files:',
+                  fileSummary,
+                  '',
+                  `Question: ${params.question}`,
+                ].join('\n'),
+                type: 'text',
+              },
+              ...selected.map((file) =>
+                file.type === 'image'
+                  ? { image_url: { detail: 'auto', url: file.uri }, type: 'image_url' as const }
+                  : { type: 'video_url' as const, video_url: { url: file.uri } },
+              ),
+            ],
+            role: 'user',
+          },
+        ] as any,
+        model: config.model,
+        provider: config.provider,
+        stream: true,
+      },
+      {
+        onFinish: (output, metadata) => {
+          content = output || content;
+          usage = metadata.usage;
+        },
+        onErrorHandle: (err) => {
+          error = err;
+        },
+        onMessageHandle: (chunk) => {
+          if (chunk.type === 'text') content += chunk.text || '';
+        },
+        signal: abortController.signal,
+      },
+    );
+
+    if (abortController.signal.aborted) {
+      return { stop: true, success: false };
+    }
+
+    if (error) {
+      return {
+        error: {
+          body: error,
+          message: error.message ?? 'Visual understanding request failed',
+          type: 'PluginServerError',
+        },
+        success: false,
+      };
+    }
+
+    return {
+      content,
+      state: {
+        files: selected,
+        model: config.model,
+        provider: config.provider,
+        trigger: 'lobe-agent.analyzeVisualMedia',
+        usage,
+      },
+      success: true,
+    };
+  };
+}
+
+export const lobeAgentExecutor = new LobeAgentExecutor();

--- a/packages/builtin-tool-lobe-agent/src/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/executor/index.ts
@@ -18,6 +18,13 @@ interface VisualFileItem {
   uri: string;
 }
 
+interface VisualSourceMessage {
+  imageList?: ChatImageItem[];
+  parentId?: string;
+  role?: string;
+  videoList?: ChatVideoItem[];
+}
+
 const getVisualUnderstandingConfig = () =>
   typeof window === 'undefined'
     ? undefined
@@ -67,12 +74,12 @@ const selectFiles = (items: VisualFileItem[], refs?: string[]) => {
   return { invalidRefs, selected };
 };
 
-const hasVisualFiles = (message?: {
-  imageList?: unknown[];
-  role?: string;
-  videoList?: unknown[];
-}) =>
-  message?.role === 'user' &&
+const isVisualSourceMessage = (message: unknown): message is VisualSourceMessage =>
+  !!message && typeof message === 'object';
+
+const hasVisualFiles = (message: unknown): message is VisualSourceMessage =>
+  isVisualSourceMessage(message) &&
+  message.role === 'user' &&
   ((message.imageList?.length ?? 0) > 0 || (message.videoList?.length ?? 0) > 0);
 
 class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
@@ -113,9 +120,12 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       ctx.sourceMessageId && dbMessageSelectors.getDbMessageById(ctx.sourceMessageId)(chatState);
     const toolMessage = dbMessageSelectors.getDbMessageById(ctx.messageId)(chatState);
     const assistantMessage =
-      toolMessage?.parentId && dbMessageSelectors.getDbMessageById(toolMessage.parentId)(chatState);
+      isVisualSourceMessage(toolMessage) &&
+      toolMessage.parentId &&
+      dbMessageSelectors.getDbMessageById(toolMessage.parentId)(chatState);
     const parentUserMessage =
-      assistantMessage?.parentId &&
+      isVisualSourceMessage(assistantMessage) &&
+      assistantMessage.parentId &&
       dbMessageSelectors.getDbMessageById(assistantMessage.parentId)(chatState);
     const sourceMessage = hasVisualFiles(sourceCandidate)
       ? sourceCandidate
@@ -193,7 +203,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
         stream: true,
       },
       {
-        onFinish: (output, metadata) => {
+        onFinish: async (output, metadata) => {
           content = output || content;
           usage = metadata.usage;
         },

--- a/packages/builtin-tool-lobe-agent/src/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/index.ts
@@ -1,0 +1,3 @@
+export * from './manifest';
+export * from './systemRole';
+export * from './types';

--- a/packages/builtin-tool-lobe-agent/src/manifest.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.ts
@@ -1,0 +1,43 @@
+import type { BuiltinToolManifest } from '@lobechat/types';
+
+import { systemPrompt } from './systemRole';
+import { LobeAgentApiName, LobeAgentIdentifier } from './types';
+
+export const LobeAgentManifest: BuiltinToolManifest = {
+  api: [
+    {
+      description:
+        'Analyze the images or videos attached to the current user message and answer a visual question. Use this only when the current model cannot inspect the visual media directly.',
+      name: LobeAgentApiName.analyzeVisualMedia,
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          files: {
+            description:
+              'Optional visual file refs from the current message, such as image_1 or video_1. Omit this field to analyze all current visual files.',
+            items: {
+              type: 'string',
+            },
+            type: 'array',
+          },
+          question: {
+            description: 'The visual question or task to answer.',
+            type: 'string',
+          },
+        },
+        required: ['question'],
+        type: 'object',
+      },
+    },
+  ],
+  identifier: LobeAgentIdentifier,
+  meta: {
+    avatar: '👁️',
+    description: 'Run built-in agent capabilities, including visual media analysis.',
+    readme:
+      'Analyze visual media from the current user message when the active chat model cannot directly inspect images or videos.',
+    title: 'Lobe Agent',
+  },
+  systemRole: systemPrompt,
+  type: 'builtin',
+};

--- a/packages/builtin-tool-lobe-agent/src/systemRole.ts
+++ b/packages/builtin-tool-lobe-agent/src/systemRole.ts
@@ -1,0 +1,6 @@
+export const systemPrompt = `Use Lobe Agent capabilities when the active model needs built-in assistance. The currently available capability analyzes uploaded images or videos when the current model cannot inspect visual content directly.
+
+Rules:
+- Use the refs shown in <files_info>, such as image_1 or video_1.
+- Omit files to analyze all visual files from the current user message.
+- Do not copy or pass attachment URLs manually.`;

--- a/packages/builtin-tool-lobe-agent/src/types.ts
+++ b/packages/builtin-tool-lobe-agent/src/types.ts
@@ -1,0 +1,12 @@
+export const LobeAgentIdentifier = 'lobe-agent';
+
+export const LobeAgentApiName = {
+  analyzeVisualMedia: 'analyzeVisualMedia',
+} as const;
+
+export type LobeAgentApiNameType = (typeof LobeAgentApiName)[keyof typeof LobeAgentApiName];
+
+export interface AnalyzeVisualMediaParams {
+  files?: string[];
+  question: string;
+}

--- a/packages/builtin-tools/package.json
+++ b/packages/builtin-tools/package.json
@@ -31,6 +31,7 @@
     "@lobechat/builtin-tool-group-management": "workspace:*",
     "@lobechat/builtin-tool-gtd": "workspace:*",
     "@lobechat/builtin-tool-knowledge-base": "workspace:*",
+    "@lobechat/builtin-tool-lobe-agent": "workspace:*",
     "@lobechat/builtin-tool-local-system": "workspace:*",
     "@lobechat/builtin-tool-memory": "workspace:*",
     "@lobechat/builtin-tool-message": "workspace:*",

--- a/packages/builtin-tools/src/identifiers.ts
+++ b/packages/builtin-tools/src/identifiers.ts
@@ -10,6 +10,7 @@ import { GroupAgentBuilderManifest } from '@lobechat/builtin-tool-group-agent-bu
 import { GroupManagementManifest } from '@lobechat/builtin-tool-group-management';
 import { GTDManifest } from '@lobechat/builtin-tool-gtd';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { NotebookManifest } from '@lobechat/builtin-tool-notebook';
@@ -43,5 +44,6 @@ export const builtinToolIdentifiers: string[] = [
   LobeActivatorManifest.identifier,
   WebBrowsingManifest.identifier,
   UserInteractionManifest.identifier,
+  LobeAgentManifest.identifier,
   WebOnboardingManifest.identifier,
 ];

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -12,6 +12,7 @@ import { GroupAgentBuilderManifest } from '@lobechat/builtin-tool-group-agent-bu
 import { GroupManagementManifest } from '@lobechat/builtin-tool-group-management';
 import { GTDManifest } from '@lobechat/builtin-tool-gtd';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { MessageManifest } from '@lobechat/builtin-tool-message';
@@ -45,6 +46,7 @@ export const defaultToolIds = [
   AgentDocumentsManifest.identifier,
   GTDManifest.identifier,
   TaskManifest.identifier,
+  LobeAgentManifest.identifier,
 ];
 
 /**
@@ -87,6 +89,7 @@ export const runtimeManagedToolIds = [
   LocalSystemManifest.identifier,
   MemoryManifest.identifier,
   RemoteDeviceManifest.identifier,
+  LobeAgentManifest.identifier,
   WebBrowsingManifest.identifier,
 ];
 
@@ -259,6 +262,13 @@ export const builtinTools: LobeBuiltinTool[] = [
     hidden: true,
     identifier: BriefManifest.identifier,
     manifest: BriefManifest,
+    type: 'builtin',
+  },
+  {
+    discoverable: false,
+    hidden: true,
+    identifier: LobeAgentManifest.identifier,
+    manifest: LobeAgentManifest,
     type: 'builtin',
   },
 ];

--- a/packages/prompts/src/prompts/files/image.ts
+++ b/packages/prompts/src/prompts/files/image.ts
@@ -1,16 +1,16 @@
 import type { ChatImageItem } from '@lobechat/types';
 
-const imagePrompt = (item: ChatImageItem, attachUrl: boolean) =>
+const imagePrompt = (item: ChatImageItem, attachUrl: boolean, index: number) =>
   attachUrl
-    ? `<image name="${item.alt}" url="${item.url}"></image>`
-    : `<image name="${item.alt}"></image>`;
+    ? `<image ref="image_${index + 1}" name="${item.alt}" url="${item.url}"></image>`
+    : `<image ref="image_${index + 1}" name="${item.alt}"></image>`;
 
 export const imagesPrompts = (imageList: ChatImageItem[], attachUrl: boolean) => {
   if (imageList.length === 0) return '';
 
   const prompt = `<images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-${imageList.map((item) => imagePrompt(item, attachUrl)).join('\n')}
+${imageList.map((item, index) => imagePrompt(item, attachUrl, index)).join('\n')}
 </images>`;
 
   return prompt.trim();

--- a/packages/prompts/src/prompts/files/index.test.ts
+++ b/packages/prompts/src/prompts/files/index.test.ts
@@ -41,7 +41,7 @@ describe('filesPrompts', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="test image" url="https://example.com/image.jpg"></image>
+<image ref="image_1" name="test image" url="https://example.com/image.jpg"></image>
 </images>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -87,7 +87,7 @@ describe('filesPrompts', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="test image" url="https://example.com/image.jpg"></image>
+<image ref="image_1" name="test image" url="https://example.com/image.jpg"></image>
 </images>
 <files>
 <files_docstring>here are user upload files you can refer to</files_docstring>
@@ -135,8 +135,8 @@ describe('filesPrompts', () => {
 
     expect(result).toContain('second image');
     expect(result).toContain('document.docx');
-    expect(result).toMatch(/<image.*?>.*<image.*?>/s); // Check for multiple image tags
-    expect(result).toMatch(/<file.*?>.*<file.*?>/s); // Check for multiple file tags
+    expect(result.match(/<image\b/g)).toHaveLength(2);
+    expect(result.match(/<file\b/g)).toHaveLength(2);
   });
 
   it('should handle without url', () => {
@@ -176,8 +176,8 @@ describe('filesPrompts', () => {
       <files_info>
       <images>
       <images_docstring>here are user upload images you can refer to</images_docstring>
-      <image name="test image"></image>
-      <image name="second image"></image>
+      <image ref="image_1" name="test image"></image>
+      <image ref="image_2" name="second image"></image>
       </images>
       <files>
       <files_docstring>here are user upload files you can refer to</files_docstring>
@@ -205,7 +205,7 @@ describe('filesPrompts', () => {
 <files_info>
 <videos>
 <videos_docstring>here are user upload videos you can refer to</videos_docstring>
-<video name="test video" url="https://example.com/video.mp4"></video>
+<video ref="video_1" name="test video" url="https://example.com/video.mp4"></video>
 </videos>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -228,11 +228,11 @@ describe('filesPrompts', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="test image" url="https://example.com/image.jpg"></image>
+<image ref="image_1" name="test image" url="https://example.com/image.jpg"></image>
 </images>
 <videos>
 <videos_docstring>here are user upload videos you can refer to</videos_docstring>
-<video name="test video" url="https://example.com/video.mp4"></video>
+<video ref="video_1" name="test video" url="https://example.com/video.mp4"></video>
 </videos>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -256,7 +256,7 @@ describe('filesPrompts', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="test image" url="https://example.com/image.jpg"></image>
+<image ref="image_1" name="test image" url="https://example.com/image.jpg"></image>
 </images>
 <files>
 <files_docstring>here are user upload files you can refer to</files_docstring>
@@ -264,7 +264,7 @@ describe('filesPrompts', () => {
 </files>
 <videos>
 <videos_docstring>here are user upload videos you can refer to</videos_docstring>
-<video name="test video" url="https://example.com/video.mp4"></video>
+<video ref="video_1" name="test video" url="https://example.com/video.mp4"></video>
 </videos>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -287,7 +287,7 @@ describe('filesPrompts', () => {
 
       expect(result).toContain('test video');
       expect(result).toContain('second video');
-      expect(result).toMatch(/<video.*?>.*<video.*?>/s); // Check for multiple video tags
+      expect(result.match(/<video\b/g)).toHaveLength(2);
     });
 
     it('should handle videos without url when addUrl is false', () => {
@@ -306,7 +306,7 @@ describe('filesPrompts', () => {
         <files_info>
         <videos>
         <videos_docstring>here are user upload videos you can refer to</videos_docstring>
-        <video name="test video"></video>
+        <video ref="video_1" name="test video"></video>
         </videos>
         </files_info>
         <!-- END SYSTEM CONTEXT -->"

--- a/packages/prompts/src/prompts/files/video.ts
+++ b/packages/prompts/src/prompts/files/video.ts
@@ -1,16 +1,16 @@
 import type { ChatVideoItem } from '@lobechat/types';
 
-const videoPrompt = (item: ChatVideoItem, attachUrl: boolean) =>
+const videoPrompt = (item: ChatVideoItem, attachUrl: boolean, index: number) =>
   attachUrl
-    ? `<video name="${item.alt}" url="${item.url}"></video>`
-    : `<video name="${item.alt}"></video>`;
+    ? `<video ref="video_${index + 1}" name="${item.alt}" url="${item.url}"></video>`
+    : `<video ref="video_${index + 1}" name="${item.alt}"></video>`;
 
 export const videosPrompts = (videoList: ChatVideoItem[], addUrl: boolean = true) => {
   if (videoList.length === 0) return '';
 
   const prompt = `<videos>
 <videos_docstring>here are user upload videos you can refer to</videos_docstring>
-${videoList.map((item) => videoPrompt(item, addUrl)).join('\n')}
+${videoList.map((item, index) => videoPrompt(item, addUrl, index)).join('\n')}
 </videos>`;
 
   return prompt.trim();

--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -34,6 +34,11 @@ export interface GlobalMemoryConfig {
   userMemory?: GlobalMemoryExtractionConfig;
 }
 
+export interface VisualUnderstandingConfig {
+  model: string;
+  provider: string;
+}
+
 export interface ServerModelProviderConfig {
   enabled?: boolean;
   enabledModels?: string[];
@@ -67,6 +72,7 @@ export interface GlobalServerConfig {
   enableMagicLink?: boolean;
   enableMarketTrustedClient?: boolean;
   enableUploadFileToServer?: boolean;
+  enableVisualUnderstanding?: boolean;
   image?: PartialDeep<UserImageConfig>;
   memory?: GlobalMemoryConfig;
   oAuthSSOProviders?: string[];
@@ -74,6 +80,7 @@ export interface GlobalServerConfig {
   telemetry: {
     langfuse?: boolean;
   };
+  visualUnderstanding?: VisualUnderstandingConfig;
 }
 
 export interface GlobalBillboardItemLocaleFields {

--- a/packages/types/src/tool/builtin.ts
+++ b/packages/types/src/tool/builtin.ts
@@ -463,6 +463,11 @@ export interface BuiltinToolContext {
   signal?: AbortSignal;
 
   /**
+   * The source user message ID for tools that need to inspect the current turn.
+   */
+  sourceMessageId?: string;
+
+  /**
    * Step context computed at the beginning of each step
    * Contains dynamic state like GTD todos that changes between steps
    * Computed by AgentRuntime and passed to Tool Executors

--- a/src/components/DragUpload/useDragUpload.test.tsx
+++ b/src/components/DragUpload/useDragUpload.test.tsx
@@ -4,14 +4,14 @@ import { App } from 'antd';
 import { type Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { useVisualMediaUploadAbility } from '@/hooks/useVisualMediaUploadAbility';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { getContainer, useDragUpload } from './useDragUpload';
 
 // Mock the hooks and components
-vi.mock('@/hooks/useModelSupportVision');
+vi.mock('@/hooks/useVisualMediaUploadAbility');
 vi.mock('@/store/agent');
 vi.mock('antd', async () => {
   const actual = await vi.importActual<typeof AntdModule>('antd');
@@ -32,16 +32,17 @@ vi.mock('antd', async () => {
 
 describe('useDragUpload', () => {
   let mockOnUploadFiles: Mock;
-  let mockMessage: { warning: Mock };
 
   beforeEach(() => {
     mockOnUploadFiles = vi.fn();
-    mockMessage = { warning: vi.fn() };
     vi.useFakeTimers();
     document.body.innerHTML = '';
 
     // Mock the hooks
-    (useModelSupportVision as Mock).mockReturnValue(false);
+    (useVisualMediaUploadAbility as Mock).mockReturnValue({
+      canUploadImage: false,
+      canUploadVideo: false,
+    });
     (useAgentStore as unknown as Mock).mockImplementation((selector) => {
       if (selector === agentSelectors.currentAgentModel) return 'test-model';
       if (selector === agentSelectors.currentAgentModelProvider) return 'test-provider';
@@ -206,7 +207,10 @@ describe('useDragUpload', () => {
   });
 
   it('should allow image files when vision is supported', async () => {
-    (useModelSupportVision as Mock).mockReturnValue(true);
+    (useVisualMediaUploadAbility as Mock).mockReturnValue({
+      canUploadImage: true,
+      canUploadVideo: false,
+    });
 
     renderHook(() => useDragUpload(mockOnUploadFiles));
 
@@ -230,6 +234,36 @@ describe('useDragUpload', () => {
 
     await act(async () => {
       window.dispatchEvent(dropEvent);
+    });
+
+    expect(mockOnUploadFiles).toHaveBeenCalledWith([mockImageFile]);
+    expect(App.useApp().message.warning).not.toHaveBeenCalled();
+  });
+
+  it('should allow image files when visual understanding fallback is enabled', async () => {
+    (useVisualMediaUploadAbility as Mock).mockReturnValue({
+      canUploadImage: true,
+      canUploadVideo: true,
+    });
+
+    renderHook(() => useDragUpload(mockOnUploadFiles));
+
+    const mockImageFile = new File([''], 'test.png', { type: 'image/png' });
+    const pasteEvent = new Event('paste') as ClipboardEvent;
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [
+          {
+            kind: 'file',
+            getAsFile: () => mockImageFile,
+            webkitGetAsEntry: () => null,
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      window.dispatchEvent(pasteEvent);
     });
 
     expect(mockOnUploadFiles).toHaveBeenCalledWith([mockImageFile]);

--- a/src/components/DragUpload/useDragUpload.tsx
+++ b/src/components/DragUpload/useDragUpload.tsx
@@ -1,9 +1,8 @@
- 
 import { App } from 'antd';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { useVisualMediaUploadAbility } from '@/hooks/useVisualMediaUploadAbility';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
@@ -78,9 +77,9 @@ export const useDragUpload = (onUploadFiles: (files: File[]) => Promise<void>) =
 
   const model = useAgentStore(agentSelectors.currentAgentModel);
   const provider = useAgentStore(agentSelectors.currentAgentModelProvider);
-  const supportVision = useModelSupportVision(model, provider);
+  const { canUploadImage, canUploadVideo } = useVisualMediaUploadAbility(model, provider);
 
-  const handleDragEnter = (e: DragEvent) => {
+  const handleDragEnter = useCallback((e: DragEvent) => {
     if (!e.dataTransfer?.items || e.dataTransfer.items.length === 0) return;
 
     const isFile = e.dataTransfer.types.includes('Files');
@@ -89,9 +88,9 @@ export const useDragUpload = (onUploadFiles: (files: File[]) => Promise<void>) =
       e.preventDefault();
       setIsDragging(true);
     }
-  };
+  }, []);
 
-  const handleDragLeave = (e: DragEvent) => {
+  const handleDragLeave = useCallback((e: DragEvent) => {
     if (!e.dataTransfer?.items || e.dataTransfer.items.length === 0) return;
 
     const isFile = e.dataTransfer.types.includes('Files');
@@ -105,54 +104,62 @@ export const useDragUpload = (onUploadFiles: (files: File[]) => Promise<void>) =
         setIsDragging(false);
       }
     }
-  };
+  }, []);
 
-  const handleDrop = async (e: DragEvent) => {
-    if (!e.dataTransfer?.items || e.dataTransfer.items.length === 0) return;
+  const handleDrop = useCallback(
+    async (e: DragEvent) => {
+      if (!e.dataTransfer?.items || e.dataTransfer.items.length === 0) return;
 
-    const isFile = e.dataTransfer.types.includes('Files');
-    if (!isFile) return;
+      const isFile = e.dataTransfer.types.includes('Files');
+      if (!isFile) return;
 
-    e.preventDefault();
+      e.preventDefault();
 
-    // reset counter
-    dragCounter.current = 0;
+      // reset counter
+      dragCounter.current = 0;
 
-    setIsDragging(false);
-    const items = Array.from(e.dataTransfer?.items);
+      setIsDragging(false);
+      const items = Array.from(e.dataTransfer?.items);
 
-    const files = await getFileListFromDataTransferItems(items);
+      const files = await getFileListFromDataTransferItems(items);
 
-    if (files.length === 0) return;
+      if (files.length === 0) return;
 
-    // Check if there are image files and the model does not support vision
-    const hasImageFiles = files.some((file) => file.type.startsWith('image/'));
-    if (hasImageFiles && !supportVision) {
-      message.warning(t('upload.clientMode.visionNotSupported'));
-      return;
-    }
+      // Check if there are visual files and the current model cannot receive them directly or via fallback.
+      const hasImageFiles = files.some((file) => file.type.startsWith('image/'));
+      const hasVideoFiles = files.some((file) => file.type.startsWith('video/'));
+      if ((hasImageFiles && !canUploadImage) || (hasVideoFiles && !canUploadVideo)) {
+        message.warning(t('upload.clientMode.visionNotSupported'));
+        return;
+      }
 
-    // upload files
-    onUploadFiles(files);
-  };
+      // upload files
+      onUploadFiles(files);
+    },
+    [canUploadImage, canUploadVideo, message, onUploadFiles, t],
+  );
 
-  const handlePaste = async (event: ClipboardEvent) => {
-    // get files from clipboard
-    if (!event.clipboardData) return;
-    const items = Array.from(event.clipboardData?.items);
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent) => {
+      // get files from clipboard
+      if (!event.clipboardData) return;
+      const items = Array.from(event.clipboardData?.items);
 
-    const files = await getFileListFromDataTransferItems(items);
-    if (files.length === 0) return;
+      const files = await getFileListFromDataTransferItems(items);
+      if (files.length === 0) return;
 
-    // Check if there are image files and the model does not support vision
-    const hasImageFiles = files.some((file) => file.type.startsWith('image/'));
-    if (hasImageFiles && !supportVision) {
-      message.warning(t('upload.clientMode.visionNotSupported'));
-      return;
-    }
+      // Check if there are visual files and the current model cannot receive them directly or via fallback.
+      const hasImageFiles = files.some((file) => file.type.startsWith('image/'));
+      const hasVideoFiles = files.some((file) => file.type.startsWith('video/'));
+      if ((hasImageFiles && !canUploadImage) || (hasVideoFiles && !canUploadVideo)) {
+        message.warning(t('upload.clientMode.visionNotSupported'));
+        return;
+      }
 
-    onUploadFiles(files);
-  };
+      onUploadFiles(files);
+    },
+    [canUploadImage, canUploadVideo, message, onUploadFiles, t],
+  );
 
   useEffect(() => {
     if (getContainer()) return;
@@ -179,7 +186,7 @@ export const useDragUpload = (onUploadFiles: (files: File[]) => Promise<void>) =
       window.removeEventListener('drop', handleDrop);
       window.removeEventListener('paste', handlePaste);
     };
-  }, [handleDragEnter, handleDragOver, handleDragLeave, handleDrop, handlePaste]);
+  }, [handleDragEnter, handleDragLeave, handleDrop, handlePaste]);
 
   return isDragging;
 };

--- a/src/components/DragUploadZone/useUploadFiles.ts
+++ b/src/components/DragUploadZone/useUploadFiles.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { useVisualMediaUploadAbility } from '@/hooks/useVisualMediaUploadAbility';
 import { useFileStore } from '@/store/file';
 
 interface UseUploadFilesOptions {
@@ -9,8 +9,8 @@ interface UseUploadFilesOptions {
 }
 
 /**
- * Hook to handle file uploads with vision support filtering.
- * Filters out image files if the model does not support vision.
+ * Hook to handle file uploads with visual media support filtering.
+ * Filters out image/video files if the model cannot receive them directly or via fallback.
  *
  * @param options - The model and provider to check for vision support
  * @returns handleUploadFiles - Callback to handle file uploads
@@ -18,23 +18,24 @@ interface UseUploadFilesOptions {
 export const useUploadFiles = (options: UseUploadFilesOptions = {}) => {
   const { model = '', provider = '' } = options;
 
-  const canUploadImage = useModelSupportVision(model, provider);
+  const { canUploadImage, canUploadVideo } = useVisualMediaUploadAbility(model, provider);
   const uploadFiles = useFileStore((s) => s.uploadChatFiles);
 
   const handleUploadFiles = useCallback(
     async (files: File[]) => {
-      // Filter out image files if the model does not support vision
+      // Filter out visual files if the model cannot receive them directly or via fallback.
       const filteredFiles = files.filter((file) => {
-        if (canUploadImage) return true;
-        return !file.type.startsWith('image');
+        if (file.type.startsWith('image')) return canUploadImage;
+        if (file.type.startsWith('video')) return canUploadVideo;
+        return true;
       });
 
       if (filteredFiles.length > 0) {
         uploadFiles(filteredFiles);
       }
     },
-    [canUploadImage, uploadFiles],
+    [canUploadImage, canUploadVideo, uploadFiles],
   );
 
-  return { canUploadImage, handleUploadFiles };
+  return { canUploadImage, canUploadVideo, handleUploadFiles };
 };

--- a/src/envs/tools.ts
+++ b/src/envs/tools.ts
@@ -15,6 +15,8 @@ export const getToolsConfig = () => {
       CRAWLER_IMPLS: process.env.CRAWLER_IMPLS,
       SEARCH_PROVIDERS: process.env.SEARCH_PROVIDERS,
       SEARXNG_URL: process.env.SEARXNG_URL,
+      VISUAL_UNDERSTANDING_MODEL: process.env.VISUAL_UNDERSTANDING_MODEL,
+      VISUAL_UNDERSTANDING_PROVIDER: process.env.VISUAL_UNDERSTANDING_PROVIDER,
     },
 
     server: {
@@ -23,6 +25,8 @@ export const getToolsConfig = () => {
       CRAWLER_IMPLS: z.string().optional(),
       SEARCH_PROVIDERS: z.string().optional(),
       SEARXNG_URL: z.string().url().optional(),
+      VISUAL_UNDERSTANDING_MODEL: z.string().optional(),
+      VISUAL_UNDERSTANDING_PROVIDER: z.string().optional(),
     },
   });
 };

--- a/src/features/ChatInput/ActionBar/Upload/index.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/index.tsx
@@ -13,7 +13,7 @@ import FileIcon from '@/components/FileIcon';
 import RepoIcon from '@/components/LibIcon';
 import TipGuide from '@/components/TipGuide';
 import { openAttachKnowledgeModal } from '@/features/LibraryModal';
-import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { useVisualMediaUploadAbility } from '@/hooks/useVisualMediaUploadAbility';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useFileStore } from '@/store/file';
@@ -48,7 +48,7 @@ const FileUpload = memo(() => {
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
   const provider = useAgentStore((s) => agentByIdSelectors.getAgentModelProviderById(agentId)(s));
 
-  const canUploadImage = useModelSupportVision(model, provider);
+  const { canUploadImage, canUploadVideo } = useVisualMediaUploadAbility(model, provider);
 
   const [showTip, updateGuideState] = useUserStore((s) => [
     preferenceSelectors.showUploadFileInKnowledgeBaseTip(s),
@@ -105,7 +105,10 @@ const FileUpload = memo(() => {
           multiple
           showUploadList={false}
           beforeUpload={async (file) => {
-            if (!canUploadImage && (file.type.startsWith('image') || file.type.startsWith('video')))
+            if (
+              (file.type.startsWith('image') && !canUploadImage) ||
+              (file.type.startsWith('video') && !canUploadVideo)
+            )
               return false;
 
             // Validate video file size
@@ -139,7 +142,10 @@ const FileUpload = memo(() => {
           multiple={true}
           showUploadList={false}
           beforeUpload={async (file) => {
-            if (!canUploadImage && (file.type.startsWith('image') || file.type.startsWith('video')))
+            if (
+              (file.type.startsWith('image') && !canUploadImage) ||
+              (file.type.startsWith('video') && !canUploadVideo)
+            )
               return false;
 
             // Validate video file size

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -59,6 +59,35 @@ vi.mock('@/store/tool', () => ({
         } as unknown as ToolManifest,
         type: 'builtin' as const,
       },
+      {
+        identifier: 'lobe-agent',
+        manifest: {
+          api: [
+            {
+              description: 'Analyze visual media',
+              name: 'analyzeVisualMedia',
+              parameters: {
+                properties: {
+                  files: {
+                    items: { type: 'string' },
+                    type: 'array',
+                  },
+                  question: { type: 'string' },
+                },
+                required: ['question'],
+                type: 'object',
+              },
+            },
+          ],
+          identifier: 'lobe-agent',
+          meta: {
+            title: 'Lobe Agent',
+            avatar: 'V',
+          },
+          type: 'builtin',
+        } as unknown as ToolManifest,
+        type: 'builtin' as const,
+      },
     ],
   }),
 }));
@@ -128,7 +157,17 @@ describe('toolEngineering', () => {
     mockInstalledPluginManifestList = () => [];
     mockUseApplicationBuiltinSearchTool = true;
     mockCurrentAgentPlugins = [];
+    Reflect.deleteProperty(window, 'global_serverConfigStore');
   });
+
+  const setVisualUnderstandingConfig = (enabled: boolean) => {
+    Object.defineProperty(window, 'global_serverConfigStore', {
+      configurable: true,
+      value: {
+        getState: () => ({ serverConfig: { enableVisualUnderstanding: enabled } }),
+      },
+    });
+  };
 
   describe('createToolsEngine', () => {
     it('should generate tools array for enabled plugins', () => {
@@ -217,6 +256,41 @@ describe('toolEngineering', () => {
 
       expect(result.enabledToolIds).toEqual(['search', 'lobe-web-browsing']);
       expect(result.enabledToolIds).toHaveLength(2);
+    });
+
+    it('should enable visual understanding when explicitly requested for the current turn', () => {
+      setVisualUnderstandingConfig(true);
+
+      const toolsEngine = createAgentToolsEngine(
+        { model: 'deepseek-chat', provider: 'deepseek' },
+        undefined,
+        { enableVisualUnderstanding: true },
+      );
+
+      const result = toolsEngine.generateToolsDetailed({
+        model: 'deepseek-chat',
+        provider: 'deepseek',
+        toolIds: [],
+      });
+
+      expect(result.enabledToolIds).toContain('lobe-agent');
+    });
+
+    it('should not enable visual understanding by default', () => {
+      setVisualUnderstandingConfig(true);
+
+      const toolsEngine = createAgentToolsEngine({
+        model: 'deepseek-chat',
+        provider: 'deepseek',
+      });
+
+      const result = toolsEngine.generateToolsDetailed({
+        model: 'deepseek-chat',
+        provider: 'deepseek',
+        toolIds: [],
+      });
+
+      expect(result.enabledToolIds).not.toContain('lobe-agent');
     });
   });
 

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -3,6 +3,7 @@
  */
 import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
@@ -36,6 +37,14 @@ export interface ToolsEngineConfig {
   defaultToolIds?: string[];
   /** Custom enable checker for plugins */
   enableChecker?: PluginEnableChecker;
+}
+
+export interface AgentToolsEngineOptions {
+  /**
+   * Enable the visual understanding fallback tool for turns with visual attachments.
+   * Callers should opt in only after checking the current message and model abilities.
+   */
+  enableVisualUnderstanding?: boolean;
 }
 
 /**
@@ -121,10 +130,16 @@ export const createAgentToolsEngine = (
   workingModel: WorkingModel,
   /** Runtime-resolved plugin IDs (from agentConfigResolver), may include tools beyond the active agent */
   pluginIds?: string[],
+  options: AgentToolsEngineOptions = {},
 ) => {
   const searchConfig = getSearchConfig(workingModel.model, workingModel.provider);
   const agentState = getAgentStoreState();
   const userPlugins = agentSelectors.currentAgentPlugins(agentState);
+  const visualUnderstandingConfigured =
+    typeof window !== 'undefined' &&
+    !!window.global_serverConfigStore?.getState().serverConfig.enableVisualUnderstanding;
+  const shouldEnableVisualUnderstanding =
+    !!options.enableVisualUnderstanding && visualUnderstandingConfigured;
 
   return createToolsEngine({
     defaultToolIds,
@@ -160,6 +175,7 @@ export const createAgentToolsEngine = (
         [MemoryManifest.identifier]:
           agentChatConfigSelectors.currentChatConfig(agentState).memory?.enabled ??
           settingsSelectors.memoryEnabled(useUserStore.getState()),
+        [LobeAgentManifest.identifier]: shouldEnableVisualUnderstanding,
         [WebBrowsingManifest.identifier]: searchConfig.useApplicationBuiltinSearchTool,
       },
     }),

--- a/src/hooks/useVisualMediaUploadAbility.test.ts
+++ b/src/hooks/useVisualMediaUploadAbility.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
+import { useModelSupportVideo } from '@/hooks/useModelSupportVideo';
+import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { useServerConfigStore } from '@/store/serverConfig';
+
+import { useVisualMediaUploadAbility } from './useVisualMediaUploadAbility';
+
+vi.mock('@/hooks/useModelSupportToolUse');
+vi.mock('@/hooks/useModelSupportVideo');
+vi.mock('@/hooks/useModelSupportVision');
+vi.mock('@/store/serverConfig', () => ({
+  serverConfigSelectors: {
+    enableVisualUnderstanding: (s: { enableVisualUnderstanding: boolean }) =>
+      s.enableVisualUnderstanding,
+    visualUnderstanding: (s: { visualUnderstanding?: { model: string; provider: string } }) =>
+      s.visualUnderstanding,
+  },
+  useServerConfigStore: vi.fn(),
+}));
+
+const mockedUseModelSupportToolUse = vi.mocked(useModelSupportToolUse);
+const mockedUseModelSupportVideo = vi.mocked(useModelSupportVideo);
+const mockedUseModelSupportVision = vi.mocked(useModelSupportVision);
+const mockedUseServerConfigStore = vi.mocked(useServerConfigStore);
+
+describe('useVisualMediaUploadAbility', () => {
+  beforeEach(() => {
+    mockedUseModelSupportVision.mockReturnValue(false);
+    mockedUseModelSupportVideo.mockReturnValue(false);
+    mockedUseModelSupportToolUse.mockReturnValue(false);
+    mockedUseServerConfigStore.mockImplementation((selector) =>
+      selector({ enableVisualUnderstanding: false, visualUnderstanding: undefined } as any),
+    );
+  });
+
+  it('should allow native visual upload without tool use', () => {
+    mockedUseModelSupportVision.mockImplementation((id) => id === 'model');
+
+    const { result } = renderHook(() => useVisualMediaUploadAbility('model', 'provider'));
+
+    expect(result.current.canUploadImage).toBe(true);
+    expect(result.current.canUploadVideo).toBe(false);
+  });
+
+  it('should allow fallback visual upload only when tool use is supported', () => {
+    mockedUseModelSupportToolUse.mockReturnValue(true);
+    mockedUseModelSupportVision.mockImplementation((id) => id === 'fallback-model');
+    mockedUseModelSupportVideo.mockImplementation((id) => id === 'fallback-model');
+    mockedUseServerConfigStore.mockImplementation((selector) =>
+      selector({
+        enableVisualUnderstanding: true,
+        visualUnderstanding: { model: 'fallback-model', provider: 'fallback-provider' },
+      } as any),
+    );
+
+    const { result } = renderHook(() => useVisualMediaUploadAbility('model', 'provider'));
+
+    expect(result.current.canUploadImage).toBe(true);
+    expect(result.current.canUploadVideo).toBe(true);
+  });
+
+  it('should reject fallback visual upload when tool use is unsupported', () => {
+    mockedUseModelSupportVision.mockImplementation((id) => id === 'fallback-model');
+    mockedUseModelSupportVideo.mockImplementation((id) => id === 'fallback-model');
+    mockedUseServerConfigStore.mockImplementation((selector) =>
+      selector({
+        enableVisualUnderstanding: true,
+        visualUnderstanding: { model: 'fallback-model', provider: 'fallback-provider' },
+      } as any),
+    );
+
+    const { result } = renderHook(() => useVisualMediaUploadAbility('model', 'provider'));
+
+    expect(result.current.canUploadImage).toBe(false);
+    expect(result.current.canUploadVideo).toBe(false);
+  });
+
+  it('should respect fallback model media abilities separately', () => {
+    mockedUseModelSupportToolUse.mockReturnValue(true);
+    mockedUseModelSupportVision.mockImplementation((id) => id === 'fallback-model');
+    mockedUseModelSupportVideo.mockReturnValue(false);
+    mockedUseServerConfigStore.mockImplementation((selector) =>
+      selector({
+        enableVisualUnderstanding: true,
+        visualUnderstanding: { model: 'fallback-model', provider: 'fallback-provider' },
+      } as any),
+    );
+
+    const { result } = renderHook(() => useVisualMediaUploadAbility('model', 'provider'));
+
+    expect(result.current.canUploadImage).toBe(true);
+    expect(result.current.canUploadVideo).toBe(false);
+  });
+});

--- a/src/hooks/useVisualMediaUploadAbility.ts
+++ b/src/hooks/useVisualMediaUploadAbility.ts
@@ -1,0 +1,28 @@
+import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
+import { useModelSupportVideo } from '@/hooks/useModelSupportVideo';
+import { useModelSupportVision } from '@/hooks/useModelSupportVision';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
+
+export const useVisualMediaUploadAbility = (model: string, provider: string) => {
+  const supportVision = useModelSupportVision(model, provider);
+  const supportVideo = useModelSupportVideo(model, provider);
+  const supportToolUse = useModelSupportToolUse(model, provider);
+  const enableVisualUnderstanding = useServerConfigStore(
+    serverConfigSelectors.enableVisualUnderstanding,
+  );
+  const visualUnderstanding = useServerConfigStore(serverConfigSelectors.visualUnderstanding);
+  const fallbackSupportVision = useModelSupportVision(
+    visualUnderstanding?.model ?? '',
+    visualUnderstanding?.provider ?? '',
+  );
+  const fallbackSupportVideo = useModelSupportVideo(
+    visualUnderstanding?.model ?? '',
+    visualUnderstanding?.provider ?? '',
+  );
+  const canUseVisualUnderstanding = enableVisualUnderstanding && supportToolUse;
+
+  return {
+    canUploadImage: supportVision || (canUseVisualUnderstanding && fallbackSupportVision),
+    canUploadVideo: supportVideo || (canUseVisualUnderstanding && fallbackSupportVideo),
+  };
+};

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -8,6 +8,7 @@ import { fileEnv } from '@/envs/file';
 import { imageEnv } from '@/envs/image';
 import { knowledgeEnv } from '@/envs/knowledge';
 import { langfuseEnv } from '@/envs/langfuse';
+import { toolsEnv } from '@/envs/tools';
 import { parseSSOProviders } from '@/libs/better-auth/utils/server';
 import { parseSystemAgent } from '@/server/globalConfig/parseSystemAgent';
 import { type GlobalServerConfig } from '@/types/serverConfig';
@@ -84,6 +85,17 @@ export const getServerGlobalConfig = async () => {
       appEnv.MARKET_TRUSTED_CLIENT_SECRET && appEnv.MARKET_TRUSTED_CLIENT_ID
     ),
     enableUploadFileToServer: !!fileEnv.S3_SECRET_ACCESS_KEY,
+    enableVisualUnderstanding: !!(
+      toolsEnv.VISUAL_UNDERSTANDING_PROVIDER && toolsEnv.VISUAL_UNDERSTANDING_MODEL
+    ),
+    ...(toolsEnv.VISUAL_UNDERSTANDING_PROVIDER && toolsEnv.VISUAL_UNDERSTANDING_MODEL
+      ? {
+          visualUnderstanding: {
+            model: toolsEnv.VISUAL_UNDERSTANDING_MODEL,
+            provider: toolsEnv.VISUAL_UNDERSTANDING_PROVIDER,
+          },
+        }
+      : undefined),
 
     // Expose Agent Gateway URL to client when queue-based agent runtime is enabled
     ...(appEnv.enableQueueAgentRuntime && appEnv.AGENT_GATEWAY_URL

--- a/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -1,12 +1,15 @@
 // @vitest-environment node
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { RemoteDeviceManifest } from '@lobechat/builtin-tool-remote-device';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { builtinTools } from '@lobechat/builtin-tools';
 import { ToolsEngine } from '@lobechat/context-engine';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { toolsEnv } from '@/envs/tools';
 
 import { createServerAgentToolsEngine, createServerToolsEngine } from '../index';
 import { type InstalledPlugin, type ServerAgentToolsContext } from '../types';
@@ -142,6 +145,16 @@ describe('createServerToolsEngine', () => {
 });
 
 describe('createServerAgentToolsEngine', () => {
+  beforeEach(() => {
+    (toolsEnv as any).VISUAL_UNDERSTANDING_PROVIDER = undefined;
+    (toolsEnv as any).VISUAL_UNDERSTANDING_MODEL = undefined;
+  });
+
+  afterEach(() => {
+    (toolsEnv as any).VISUAL_UNDERSTANDING_PROVIDER = undefined;
+    (toolsEnv as any).VISUAL_UNDERSTANDING_MODEL = undefined;
+  });
+
   it('should return a ToolsEngine instance', () => {
     const context = createMockContext();
     const engine = createServerAgentToolsEngine(context, {
@@ -209,6 +222,42 @@ describe('createServerAgentToolsEngine', () => {
     });
 
     expect(result.enabledToolIds).not.toContain(WebBrowsingManifest.identifier);
+  });
+
+  it('should enable VisualUnderstanding for non-vision models when configured', () => {
+    (toolsEnv as any).VISUAL_UNDERSTANDING_PROVIDER = 'test-provider';
+    (toolsEnv as any).VISUAL_UNDERSTANDING_MODEL = 'vision-model';
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: { plugins: [] },
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+    });
+
+    const result = engine.generateToolsDetailed({
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+      toolIds: [],
+    });
+
+    expect(result.enabledToolIds).toContain(LobeAgentManifest.identifier);
+  });
+
+  it('should not enable VisualUnderstanding when visual model is not configured', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: { plugins: [] },
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+    });
+
+    const result = engine.generateToolsDetailed({
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+      toolIds: [],
+    });
+
+    expect(result.enabledToolIds).not.toContain(LobeAgentManifest.identifier);
   });
 
   it('should enable KnowledgeBase when hasEnabledKnowledgeBases is true', () => {

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -12,6 +12,7 @@
 import { AgentDocumentsManifest } from '@lobechat/builtin-tool-agent-documents';
 import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MemoryManifest } from '@lobechat/builtin-tool-memory';
 import { MessageManifest } from '@lobechat/builtin-tool-message';
@@ -22,6 +23,9 @@ import { createEnableChecker, type LobeToolManifest } from '@lobechat/context-en
 import { ToolsEngine } from '@lobechat/context-engine';
 import { type RuntimeEnvMode, type RuntimePlatform } from '@lobechat/types';
 import debug from 'debug';
+import { LOBE_DEFAULT_MODEL_LIST } from 'model-bank';
+
+import { toolsEnv } from '@/envs/tools';
 
 import {
   type ServerAgentToolsContext,
@@ -37,6 +41,13 @@ export type {
 } from './types';
 
 const log = debug('lobe-server:agent-tools-engine');
+
+const getModelAbilities = (model: string, provider: string) => {
+  return (
+    LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model && item.providerId === provider) ??
+    LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model)
+  )?.abilities;
+};
 
 /**
  * Initialize ToolsEngine with server-side context
@@ -136,6 +147,12 @@ export const createServerAgentToolsEngine = (
 
   const searchMode = agentConfig.chatConfig?.searchMode ?? 'auto';
   const isSearchEnabled = searchMode !== 'off';
+  const modelAbilities = getModelAbilities(model, provider);
+  const visualUnderstandingConfigured = !!(
+    toolsEnv.VISUAL_UNDERSTANDING_PROVIDER && toolsEnv.VISUAL_UNDERSTANDING_MODEL
+  );
+  const shouldEnableVisualUnderstanding =
+    visualUnderstandingConfigured && (!modelAbilities?.vision || !modelAbilities?.video);
 
   log(
     'Creating agent tools engine model=%s provider=%s searchMode=%s platform=%s runtimeMode=%s additionalManifests=%d hasClientExecutor=%s hasDeviceProxy=%s',
@@ -199,6 +216,7 @@ export const createServerAgentToolsEngine = (
           !isBotConversation,
         [AgentDocumentsManifest.identifier]: hasAgentDocuments,
         [WebBrowsingManifest.identifier]: isSearchEnabled,
+        [LobeAgentManifest.identifier]: shouldEnableVisualUnderstanding,
       },
     }),
   });

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
 import { BUILTIN_AGENT_SLUGS, getAgentRuntimeConfig } from '@lobechat/builtin-agents';
 import { builtinSkills } from '@lobechat/builtin-skills';
+import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MessageToolIdentifier } from '@lobechat/builtin-tool-message';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
@@ -49,6 +50,7 @@ import { ThreadModel } from '@/database/models/thread';
 import { TopicModel } from '@/database/models/topic';
 import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
+import { toolsEnv } from '@/envs/tools';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
 import { signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import {
@@ -1377,6 +1379,33 @@ export class AiAgentService {
       role: 'user' as const,
       videoList,
     };
+
+    if (toolsResult.enabledToolIds.includes(LobeAgentManifest.identifier)) {
+      const modelAbilities =
+        LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model && item.providerId === provider)
+          ?.abilities ?? LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model)?.abilities;
+      const needsImageUnderstanding = !!imageList?.length && !modelAbilities?.vision;
+      const needsVideoUnderstanding = !!videoList?.length && !modelAbilities?.video;
+      const shouldKeepVisualUnderstanding =
+        !!toolsEnv.VISUAL_UNDERSTANDING_PROVIDER &&
+        !!toolsEnv.VISUAL_UNDERSTANDING_MODEL &&
+        (needsImageUnderstanding || needsVideoUnderstanding);
+
+      if (!shouldKeepVisualUnderstanding) {
+        const visualToolNamePrefix = `${LobeAgentManifest.identifier}____`;
+        tools = tools?.filter((tool) => !tool.function.name.startsWith(visualToolNamePrefix));
+        toolsResult = {
+          ...toolsResult,
+          enabledToolIds: toolsResult.enabledToolIds.filter(
+            (id) => id !== LobeAgentManifest.identifier,
+          ),
+          tools,
+        };
+        delete toolManifestMap[LobeAgentManifest.identifier];
+        delete toolSourceMap[LobeAgentManifest.identifier];
+        delete toolExecutorMap[LobeAgentManifest.identifier];
+      }
+    }
 
     // Combine history messages with user message
     const allMessages = effectiveResume ? historyMessages : [...historyMessages, userMessage];

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -1,0 +1,201 @@
+import { LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ToolExecutionContext } from '../../types';
+
+const mockToolsEnv = vi.hoisted(() => ({
+  VISUAL_UNDERSTANDING_MODEL: undefined as string | undefined,
+  VISUAL_UNDERSTANDING_PROVIDER: undefined as string | undefined,
+}));
+const mockMessageModelQueryByIds = vi.hoisted(() => vi.fn());
+const mockChat = vi.hoisted(() => vi.fn());
+const mockInitModelRuntimeFromDB = vi.hoisted(() => vi.fn());
+const mockConsumeStreamUntilDone = vi.hoisted(() => vi.fn());
+
+vi.mock('@/envs/tools', () => ({
+  toolsEnv: mockToolsEnv,
+}));
+
+vi.mock('@/database/models/message', () => ({
+  MessageModel: vi.fn().mockImplementation(() => ({
+    queryByIds: (...args: any[]) => mockMessageModelQueryByIds(...args),
+  })),
+}));
+
+vi.mock('@/server/services/file', () => ({
+  FileService: vi.fn().mockImplementation(() => ({
+    getFullFileUrl: (path: string | null) => Promise.resolve(path || ''),
+  })),
+}));
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeFromDB: (...args: any[]) => mockInitModelRuntimeFromDB(...args),
+}));
+
+vi.mock('@lobechat/model-runtime', () => ({
+  consumeStreamUntilDone: (...args: any[]) => mockConsumeStreamUntilDone(...args),
+}));
+
+vi.mock('model-bank', () => ({
+  LOBE_DEFAULT_MODEL_LIST: [
+    {
+      abilities: { video: true, vision: true },
+      id: 'vision-model',
+      providerId: 'test-provider',
+    },
+    {
+      abilities: { video: false, vision: true },
+      id: 'image-only-model',
+      providerId: 'test-provider',
+    },
+  ],
+}));
+
+const { lobeAgentRuntime } = await import('../lobeAgent');
+
+describe('lobeAgentRuntime', () => {
+  const baseContext: ToolExecutionContext = {
+    messageId: 'msg-1',
+    serverDB: {} as any,
+    toolManifestMap: {},
+    userId: 'user-1',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToolsEnv.VISUAL_UNDERSTANDING_MODEL = 'vision-model';
+    mockToolsEnv.VISUAL_UNDERSTANDING_PROVIDER = 'test-provider';
+    mockChat.mockImplementation(async (_payload, options) => {
+      options?.callback?.onText?.('visual answer');
+      options?.callback?.onCompletion?.({ usage: { totalTokens: 12 } });
+      return new Response('ok');
+    });
+    mockInitModelRuntimeFromDB.mockResolvedValue({ chat: mockChat });
+    mockConsumeStreamUntilDone.mockResolvedValue(undefined);
+  });
+
+  it('should have the correct identifier', () => {
+    expect(lobeAgentRuntime.identifier).toBe(LobeAgentIdentifier);
+  });
+
+  it('should require serverDB, userId and messageId', () => {
+    expect(() => lobeAgentRuntime.factory({ toolManifestMap: {}, userId: 'user-1' })).toThrow(
+      'serverDB is required for LobeAgent execution',
+    );
+
+    expect(() => lobeAgentRuntime.factory({ serverDB: {} as any, toolManifestMap: {} })).toThrow(
+      'userId is required for LobeAgent execution',
+    );
+
+    expect(() =>
+      lobeAgentRuntime.factory({
+        serverDB: {} as any,
+        toolManifestMap: {},
+        userId: 'user-1',
+      }),
+    ).toThrow('messageId is required for LobeAgent execution');
+  });
+
+  it('should return a configuration error when visual model env is missing', async () => {
+    mockToolsEnv.VISUAL_UNDERSTANDING_MODEL = undefined;
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({ question: 'what is this?' });
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe('VISUAL_UNDERSTANDING_NOT_CONFIGURED');
+  });
+
+  it('should return an error when the source message has no visual files', async () => {
+    mockMessageModelQueryByIds.mockResolvedValue([{ id: 'msg-1' }]);
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({ question: 'what is this?' });
+
+    expect(result).toMatchObject({
+      error: { code: 'NO_VISUAL_FILES' },
+      success: false,
+    });
+  });
+
+  it('should validate requested visual file refs', async () => {
+    mockMessageModelQueryByIds.mockResolvedValue([
+      {
+        id: 'msg-1',
+        imageList: [{ alt: 'image.png', id: 'file-image', url: 'https://example.com/image.png' }],
+      },
+    ]);
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({
+      files: ['image_2'],
+      question: 'what is this?',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.content).toContain('Available refs: image_1');
+  });
+
+  it('should analyze all visual files when files is omitted', async () => {
+    mockMessageModelQueryByIds.mockResolvedValue([
+      {
+        id: 'msg-1',
+        imageList: [{ alt: 'image.png', id: 'file-image', url: 'https://example.com/image.png' }],
+        videoList: [{ alt: 'video.mp4', id: 'file-video', url: 'https://example.com/video.mp4' }],
+      },
+    ]);
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({ question: 'what is this?' });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('visual answer');
+    expect(result.state).toMatchObject({
+      files: [
+        { id: 'file-image', name: 'image.png', ref: 'image_1', type: 'image' },
+        { id: 'file-video', name: 'video.mp4', ref: 'video_1', type: 'video' },
+      ],
+      model: 'vision-model',
+      provider: 'test-provider',
+      trigger: 'lobe-agent.analyzeVisualMedia',
+      usage: { totalTokens: 12 },
+    });
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: [
+              expect.objectContaining({ type: 'text' }),
+              expect.objectContaining({ type: 'image_url' }),
+              expect.objectContaining({ type: 'video_url' }),
+            ],
+          }),
+        ],
+        model: 'vision-model',
+        stream: false,
+      }),
+      expect.objectContaining({
+        metadata: { trigger: 'lobe-agent.analyzeVisualMedia' },
+      }),
+    );
+  });
+
+  it('should reject video files when the configured model lacks video support', async () => {
+    mockToolsEnv.VISUAL_UNDERSTANDING_MODEL = 'image-only-model';
+    mockMessageModelQueryByIds.mockResolvedValue([
+      {
+        id: 'msg-1',
+        videoList: [{ alt: 'video.mp4', id: 'file-video', url: 'https://example.com/video.mp4' }],
+      },
+    ]);
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({ question: 'what is in the video?' });
+
+    expect(result).toMatchObject({
+      error: { code: 'VISUAL_MODEL_VIDEO_UNSUPPORTED' },
+      success: false,
+    });
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/toolExecution/serverRuntimes/index.ts
+++ b/src/server/services/toolExecution/serverRuntimes/index.ts
@@ -16,6 +16,7 @@ import { cloudSandboxRuntime } from './cloudSandbox';
 import { credsRuntime } from './creds';
 import { cronRuntime } from './cron';
 import { gtdRuntime } from './gtd';
+import { lobeAgentRuntime } from './lobeAgent';
 import { localSystemRuntime } from './localSystem';
 import { memoryRuntime } from './memory';
 import { messageRuntime } from './message';
@@ -67,6 +68,7 @@ registerRuntimes([
   gtdRuntime,
   webOnboardingRuntime,
   agentMarketplaceRuntime,
+  lobeAgentRuntime,
 ]);
 
 // ==================== Registry API ====================

--- a/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -1,0 +1,232 @@
+import { LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
+import type { LobeChatDatabase } from '@lobechat/database';
+import { consumeStreamUntilDone } from '@lobechat/model-runtime';
+import type { BuiltinServerRuntimeOutput, ChatImageItem, ChatVideoItem } from '@lobechat/types';
+import { LOBE_DEFAULT_MODEL_LIST } from 'model-bank';
+
+import { MessageModel } from '@/database/models/message';
+import { toolsEnv } from '@/envs/tools';
+import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { FileService } from '@/server/services/file';
+
+import type { ServerRuntimeRegistration } from './types';
+
+interface AnalyzeVisualMediaParams {
+  files?: string[];
+  question: string;
+}
+
+interface VisualFileItem {
+  id: string;
+  mimeType?: string;
+  name?: string;
+  ref: string;
+  type: 'image' | 'video';
+  url: string;
+}
+
+interface LobeAgentRuntimeContext {
+  messageId: string;
+  serverDB: LobeChatDatabase;
+  userId: string;
+}
+
+const buildError = (content: string, code: string): BuiltinServerRuntimeOutput => ({
+  content,
+  error: { code, message: content },
+  success: false,
+});
+
+const getModelAbilities = (model: string, provider: string) => {
+  return (
+    LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model && item.providerId === provider) ??
+    LOBE_DEFAULT_MODEL_LIST.find((item) => item.id === model)
+  )?.abilities;
+};
+
+const buildVisualItems = (message: {
+  imageList?: ChatImageItem[];
+  videoList?: ChatVideoItem[];
+}): VisualFileItem[] => {
+  const images: VisualFileItem[] = (message.imageList ?? []).map((item, index) => ({
+    id: item.id,
+    name: item.alt,
+    ref: `image_${index + 1}`,
+    type: 'image',
+    url: item.url,
+  }));
+
+  const videos: VisualFileItem[] = (message.videoList ?? []).map((item, index) => ({
+    id: item.id,
+    name: item.alt,
+    ref: `video_${index + 1}`,
+    type: 'video',
+    url: item.url,
+  }));
+
+  return [...images, ...videos];
+};
+
+class LobeAgentExecutionRuntime {
+  private db: LobeChatDatabase;
+  private userId: string;
+  private messageId: string;
+
+  constructor(context: LobeAgentRuntimeContext) {
+    this.db = context.serverDB;
+    this.messageId = context.messageId;
+    this.userId = context.userId;
+  }
+
+  analyzeVisualMedia = async (
+    params: AnalyzeVisualMediaParams,
+  ): Promise<BuiltinServerRuntimeOutput> => {
+    const provider = toolsEnv.VISUAL_UNDERSTANDING_PROVIDER;
+    const model = toolsEnv.VISUAL_UNDERSTANDING_MODEL;
+
+    if (!provider || !model) {
+      return buildError(
+        'Visual understanding is not configured. Set VISUAL_UNDERSTANDING_PROVIDER and VISUAL_UNDERSTANDING_MODEL.',
+        'VISUAL_UNDERSTANDING_NOT_CONFIGURED',
+      );
+    }
+
+    if (!params.question || typeof params.question !== 'string') {
+      return buildError('question is required.', 'INVALID_ARGUMENTS');
+    }
+
+    const fileService = new FileService(this.db, this.userId);
+    const messageModel = new MessageModel(this.db, this.userId);
+    const [sourceMessage] = await messageModel.queryByIds([this.messageId], {
+      postProcessUrl: (path) => fileService.getFullFileUrl(path),
+    });
+
+    if (!sourceMessage) {
+      return buildError(`Source message not found: ${this.messageId}`, 'SOURCE_MESSAGE_NOT_FOUND');
+    }
+
+    const visualItems = buildVisualItems(sourceMessage);
+
+    if (visualItems.length === 0) {
+      return buildError('No visual files are attached to the current message.', 'NO_VISUAL_FILES');
+    }
+
+    const availableRefs = visualItems.map((item) => item.ref);
+    const requestedRefs = params.files?.filter(Boolean);
+    const unknownRefs = requestedRefs?.filter((ref) => !availableRefs.includes(ref)) ?? [];
+
+    if (unknownRefs.length > 0) {
+      return buildError(
+        `Unknown visual file refs: ${unknownRefs.join(', ')}. Available refs: ${availableRefs.join(', ')}.`,
+        'UNKNOWN_VISUAL_FILE_REFS',
+      );
+    }
+
+    const selectedItems =
+      requestedRefs && requestedRefs.length > 0
+        ? visualItems.filter((item) => requestedRefs.includes(item.ref))
+        : visualItems;
+
+    const abilities = getModelAbilities(model, provider);
+    const hasImages = selectedItems.some((item) => item.type === 'image');
+    const hasVideos = selectedItems.some((item) => item.type === 'video');
+
+    if (hasImages && abilities?.vision === false) {
+      return buildError(
+        `Configured visual understanding model "${provider}/${model}" does not support image vision.`,
+        'VISUAL_MODEL_IMAGE_UNSUPPORTED',
+      );
+    }
+
+    if (hasVideos && abilities?.video === false) {
+      return buildError(
+        `Configured visual understanding model "${provider}/${model}" does not support video understanding.`,
+        'VISUAL_MODEL_VIDEO_UNSUPPORTED',
+      );
+    }
+
+    let content = '';
+    let usage: unknown;
+    const runtime = await initModelRuntimeFromDB(this.db, this.userId, provider);
+    const response = await runtime.chat(
+      {
+        messages: [
+          {
+            content: [
+              {
+                text: [
+                  'Analyze the attached visual media and answer the user question.',
+                  '',
+                  `Question: ${params.question}`,
+                ].join('\n'),
+                type: 'text',
+              },
+              ...selectedItems.map((item) =>
+                item.type === 'image'
+                  ? {
+                      image_url: { detail: 'auto', url: item.url },
+                      type: 'image_url',
+                    }
+                  : {
+                      type: 'video_url',
+                      video_url: { url: item.url },
+                    },
+              ),
+            ],
+            role: 'user',
+          },
+        ],
+        model,
+        stream: false,
+      } as any,
+      {
+        callback: {
+          onCompletion: (data) => {
+            usage = data.usage;
+          },
+          onText: (text) => {
+            content += text;
+          },
+        },
+        metadata: {
+          trigger: 'lobe-agent.analyzeVisualMedia',
+        },
+      },
+    );
+
+    await consumeStreamUntilDone(response);
+
+    return {
+      content: content.trim(),
+      state: {
+        files: selectedItems.map(({ ref, id, type, name }) => ({ id, name, ref, type })),
+        model,
+        provider,
+        trigger: 'lobe-agent.analyzeVisualMedia',
+        usage,
+      },
+      success: true,
+    };
+  };
+}
+
+export const lobeAgentRuntime: ServerRuntimeRegistration = {
+  factory: (context) => {
+    if (!context.serverDB) {
+      throw new Error('serverDB is required for LobeAgent execution');
+    }
+    if (!context.userId) {
+      throw new Error('userId is required for LobeAgent execution');
+    }
+    if (!context.messageId) {
+      throw new Error('messageId is required for LobeAgent execution');
+    }
+
+    return new LobeAgentExecutionRuntime({
+      messageId: context.messageId,
+      serverDB: context.serverDB,
+      userId: context.userId,
+    });
+  },
+  identifier: LobeAgentIdentifier,
+};

--- a/src/services/agentRuntime/__tests__/index.test.ts
+++ b/src/services/agentRuntime/__tests__/index.test.ts
@@ -8,11 +8,15 @@ const {
   createOperationMutateMock,
   createAgentToolsEngineMock,
   getAgentStoreStateMock,
+  isCanUseVideoMock,
+  isCanUseVisionMock,
 } = vi.hoisted(() => ({
   contextEngineeringMock: vi.fn(),
   createAgentToolsEngineMock: vi.fn(),
   createOperationMutateMock: vi.fn(),
   getAgentStoreStateMock: vi.fn(),
+  isCanUseVideoMock: vi.fn(),
+  isCanUseVisionMock: vi.fn(),
 }));
 
 vi.mock('@/helpers/toolEngineering', () => ({
@@ -37,6 +41,11 @@ vi.mock('@/libs/trpc/client', () => ({
 
 vi.mock('@/services/chat/mecha', () => ({
   contextEngineering: contextEngineeringMock,
+}));
+
+vi.mock('@/services/chat/helper', () => ({
+  isCanUseVideo: isCanUseVideoMock,
+  isCanUseVision: isCanUseVisionMock,
 }));
 
 vi.mock('@/store/agent', () => ({
@@ -75,6 +84,8 @@ describe('AgentRuntimeService', () => {
 
     contextEngineeringMock.mockResolvedValue([{ content: 'compiled', role: 'system' }]);
     createOperationMutateMock.mockResolvedValue({ operationId: 'op-1' });
+    isCanUseVideoMock.mockReturnValue(true);
+    isCanUseVisionMock.mockReturnValue(true);
   });
 
   it('should keep agent documents optional when hydration returns undefined', async () => {
@@ -102,6 +113,43 @@ describe('AgentRuntimeService', () => {
       expect.objectContaining({
         messages: [{ content: 'compiled', role: 'system' }],
       }),
+    );
+  });
+
+  it('should opt into visual understanding for image messages when the model cannot see images', async () => {
+    isCanUseVisionMock.mockReturnValue(false);
+    getAgentStoreStateMock.mockReturnValue({
+      activeAgentId: 'agent-1',
+    });
+
+    await agentRuntimeService.createOperation({
+      messages: [{ id: 'msg-1', imageList: [{ id: 'file-1' }], role: 'user' }] as UIChatMessage[],
+      userMessageId: 'msg-1',
+    });
+
+    expect(createAgentToolsEngineMock).toHaveBeenCalledWith(
+      { model: 'gpt-4o', provider: 'openai' },
+      undefined,
+      { enableVisualUnderstanding: true },
+    );
+  });
+
+  it('should not opt into visual understanding when the current message has no visual attachments', async () => {
+    isCanUseVisionMock.mockReturnValue(false);
+    isCanUseVideoMock.mockReturnValue(false);
+    getAgentStoreStateMock.mockReturnValue({
+      activeAgentId: 'agent-1',
+    });
+
+    await agentRuntimeService.createOperation({
+      messages: [{ id: 'msg-1', content: 'Hello', role: 'user' }] as UIChatMessage[],
+      userMessageId: 'msg-1',
+    });
+
+    expect(createAgentToolsEngineMock).toHaveBeenCalledWith(
+      { model: 'gpt-4o', provider: 'openai' },
+      undefined,
+      { enableVisualUnderstanding: false },
     );
   });
 });

--- a/src/services/agentRuntime/index.ts
+++ b/src/services/agentRuntime/index.ts
@@ -4,6 +4,7 @@ import { type UIChatMessage } from '@lobechat/types';
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
 import { lambdaClient } from '@/libs/trpc/client';
 import { type HumanInterventionRequest } from '@/services/agentRuntime/type';
+import { isCanUseVideo, isCanUseVision } from '@/services/chat/helper';
 import { contextEngineering } from '@/services/chat/mecha';
 import { getAgentStoreState } from '@/store/agent';
 import { agentChatConfigSelectors, agentSelectors } from '@/store/agent/selectors';
@@ -41,10 +42,15 @@ class AgentRuntimeService {
       model: agentConfig.model,
       provider: agentConfig.provider!,
     };
+    const currentUserMessage = data.messages.find((message) => message.id === data.userMessageId);
+    const enableVisualUnderstanding =
+      (!!currentUserMessage?.imageList?.length &&
+        !isCanUseVision(modelRuntimeConfig.model, modelRuntimeConfig.provider)) ||
+      (!!currentUserMessage?.videoList?.length &&
+        !isCanUseVideo(modelRuntimeConfig.model, modelRuntimeConfig.provider));
 
-    const toolsEngine = createAgentToolsEngine({
-      model: agentConfig.model,
-      provider: agentConfig.provider!,
+    const toolsEngine = createAgentToolsEngine(modelRuntimeConfig, undefined, {
+      enableVisualUnderstanding,
     });
 
     const { tools, enabledToolIds } = toolsEngine.generateToolsDetailed({

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -20,6 +20,28 @@ import { chatService } from './index';
 import * as mechaModule from './mecha';
 import { type ResolvedAgentConfig } from './mecha';
 
+vi.hoisted(() => {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      get length() {
+        return storage.size;
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    },
+  });
+});
+
 // Helper to compute expected date content from SystemDateProvider
 const getCurrentDateContent = () => {
   const tz = 'UTC';
@@ -557,7 +579,7 @@ describe('ChatService', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="abc.png" url="http://example.com/image.jpg"></image>
+<image ref="image_1" name="abc.png" url="http://example.com/image.jpg"></image>
 </images>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -683,7 +705,7 @@ describe('ChatService', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="local-image.png" url="http://127.0.0.1:3000/uploads/image.png"></image>
+<image ref="image_1" name="local-image.png" url="http://127.0.0.1:3000/uploads/image.png"></image>
 </images>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -779,7 +801,7 @@ describe('ChatService', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="remote-image.jpg" url="https://example.com/remote-image.jpg"></image>
+<image ref="image_1" name="remote-image.jpg" url="https://example.com/remote-image.jpg"></image>
 </images>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,
@@ -1707,23 +1729,21 @@ describe('ChatService', () => {
 
     it('should handle successful chat completion response', async () => {
       // Mock getChatCompletion to simulate successful completion
-      const getChatCompletionSpy = vi
-        .spyOn(chatService, 'getChatCompletion')
-        .mockImplementation(async (params, options) => {
-          // Simulate successful response
-          if (options?.onFinish) {
-            options.onFinish('AI response', {
-              type: 'done',
-              observationId: null,
-              toolCalls: undefined,
-              traceId: null,
-            });
-          }
-          if (options?.onMessageHandle) {
-            options.onMessageHandle({ type: 'text', text: 'AI response' });
-          }
-          return new Response('');
-        });
+      vi.spyOn(chatService, 'getChatCompletion').mockImplementation(async (params, options) => {
+        // Simulate successful response
+        if (options?.onFinish) {
+          options.onFinish('AI response', {
+            type: 'done',
+            observationId: null,
+            toolCalls: undefined,
+            traceId: null,
+          });
+        }
+        if (options?.onMessageHandle) {
+          options.onMessageHandle({ type: 'text', text: 'AI response' });
+        }
+        return new Response('');
+      });
 
       const params = {
         messages: [{ content: 'Hello', role: 'user' as const }],
@@ -1762,15 +1782,13 @@ describe('ChatService', () => {
 
     it('should handle error in chat completion', async () => {
       // Mock getChatCompletion to simulate error
-      const getChatCompletionSpy = vi
-        .spyOn(chatService, 'getChatCompletion')
-        .mockImplementation(async (params, options) => {
-          // Simulate error response
-          if (options?.onErrorHandle) {
-            options.onErrorHandle({ message: 'translated_response.404', type: 404 });
-          }
-          return new Response('');
-        });
+      vi.spyOn(chatService, 'getChatCompletion').mockImplementation(async (params, options) => {
+        // Simulate error response
+        if (options?.onErrorHandle) {
+          options.onErrorHandle({ message: 'translated_response.404', type: 404 });
+        }
+        return new Response('');
+      });
 
       const params = {
         messages: [{ content: 'Hello', role: 'user' as const }],

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -8,6 +8,28 @@ import * as helpers from '../helper';
 import { contextEngineering } from './contextEngineering';
 import * as memoryManager from './memoryManager';
 
+vi.hoisted(() => {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      get length() {
+        return storage.size;
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    },
+  });
+});
+
 // Mock VARIABLE_GENERATORS
 vi.mock('@/helpers/parserPlaceholder', () => ({
   VARIABLE_GENERATORS: {
@@ -159,7 +181,7 @@ describe('contextEngineering', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="ttt.png" url="http://example.com/xxx0asd-dsd.png"></image>
+<image ref="image_1" name="ttt.png" url="http://example.com/xxx0asd-dsd.png"></image>
 </images>
 <files>
 <files_docstring>here are user upload files you can refer to</files_docstring>
@@ -232,7 +254,7 @@ describe('contextEngineering', () => {
 <files_info>
 <images>
 <images_docstring>here are user upload images you can refer to</images_docstring>
-<image name="abc.png" url="http://example.com/image.jpg"></image>
+<image ref="image_1" name="abc.png" url="http://example.com/image.jpg"></image>
 </images>
 </files_info>
 <!-- END SYSTEM CONTEXT -->`,

--- a/src/store/chat/slices/aiChat/actions/clientToolExecution.ts
+++ b/src/store/chat/slices/aiChat/actions/clientToolExecution.ts
@@ -102,6 +102,7 @@ export class ClientToolExecutionActionImpl {
           operationId,
           scope: operation?.context?.scope,
           signal: operation?.abortController?.signal,
+          sourceMessageId: operation?.context?.messageId,
           topicId: operation?.context?.topicId ?? undefined,
         };
 

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -21,6 +21,7 @@ import debug from 'debug';
 import { t } from 'i18next';
 
 import { createAgentToolsEngine } from '@/helpers/toolEngineering';
+import { isCanUseVideo, isCanUseVision } from '@/services/chat/helper';
 import { type ResolvedAgentConfig } from '@/services/chat/mecha';
 import { composeEnabledTools, resolveAgentConfig } from '@/services/chat/mecha';
 import { localFileService } from '@/services/electron/localFileService';
@@ -177,6 +178,18 @@ export class StreamingExecutorActionImpl {
     const effectivePluginIds = hasTopicReference
       ? [...(pluginIds || []), 'lobe-topic-reference']
       : pluginIds;
+    let currentUserMessage: UIChatMessage | undefined;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index].role === 'user') {
+        currentUserMessage = messages[index];
+        break;
+      }
+    }
+    const enableVisualUnderstanding =
+      (!!currentUserMessage?.imageList?.length &&
+        !isCanUseVision(agentConfigData.model, agentConfigData.provider!)) ||
+      (!!currentUserMessage?.videoList?.length &&
+        !isCanUseVideo(agentConfigData.model, agentConfigData.provider!));
 
     log(
       '[internal_createAgentState] resolved plugins=%o, isSubTask=%s, disableTools=%s, hasTopicReference=%s',
@@ -191,6 +204,7 @@ export class StreamingExecutorActionImpl {
     const toolsEngine = createAgentToolsEngine(
       { model: agentConfigData.model, provider: agentConfigData.provider! },
       effectivePluginIds,
+      { enableVisualUnderstanding },
     );
     // When skillActivateMode is 'manual':
     // Exclude only discovery tools (activator, skill-store) so runtime-managed defaults

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -156,6 +156,7 @@ export class PluginTypesActionImpl {
           registerAfterCompletion,
           scope,
           signal: operation?.abortController?.signal,
+          sourceMessageId: rootRuntimeOperationContext?.messageId,
           stepContext,
           taskId,
           topicId,

--- a/src/store/serverConfig/selectors.ts
+++ b/src/store/serverConfig/selectors.ts
@@ -13,7 +13,10 @@ export const serverConfigSelectors = {
   enableMarketTrustedClient: (s: ServerConfigStore) =>
     s.serverConfig.enableMarketTrustedClient || false,
   enableUploadFileToServer: (s: ServerConfigStore) => s.serverConfig.enableUploadFileToServer,
+  enableVisualUnderstanding: (s: ServerConfigStore) =>
+    s.serverConfig.enableVisualUnderstanding || false,
   enabledTelemetryChat: (s: ServerConfigStore) => s.serverConfig.telemetry.langfuse || false,
   isMobile: (s: ServerConfigStore) => s.isMobile || false,
   oAuthSSOProviders: (s: ServerConfigStore) => s.serverConfig.oAuthSSOProviders,
+  visualUnderstanding: (s: ServerConfigStore) => s.serverConfig.visualUnderstanding,
 };

--- a/src/store/tool/slices/builtin/executors/index.test.ts
+++ b/src/store/tool/slices/builtin/executors/index.test.ts
@@ -1,10 +1,33 @@
+import { LobeAgentApiName, LobeAgentIdentifier } from '@lobechat/builtin-tool-lobe-agent';
 import {
   WebOnboardingApiName,
   WebOnboardingIdentifier,
 } from '@lobechat/builtin-tool-web-onboarding';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { getApiNamesForIdentifier, hasExecutor } from './index';
+
+vi.hoisted(() => {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      get length() {
+        return storage.size;
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    },
+  });
+});
 
 describe('builtin executor registry', () => {
   it('registers web onboarding executor APIs', () => {
@@ -13,5 +36,9 @@ describe('builtin executor registry', () => {
     expect(getApiNamesForIdentifier(WebOnboardingIdentifier)).toEqual(
       Object.values(WebOnboardingApiName),
     );
+  });
+
+  it('registers visual understanding executor APIs', () => {
+    expect(hasExecutor(LobeAgentIdentifier, LobeAgentApiName.analyzeVisualMedia)).toBe(true);
   });
 });

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -14,6 +14,7 @@ import { groupAgentBuilderExecutor } from '@lobechat/builtin-tool-group-agent-bu
 import { groupManagementExecutor } from '@lobechat/builtin-tool-group-management/executor';
 import { gtdExecutor } from '@lobechat/builtin-tool-gtd/executor';
 import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/executor';
+import { lobeAgentExecutor } from '@lobechat/builtin-tool-lobe-agent/executor';
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
 import { taskExecutor } from '@lobechat/builtin-tool-task/executor';
@@ -157,6 +158,7 @@ registerExecutors([
   activatorExecutor,
   topicReferenceExecutor,
   userInteractionExecutor,
+  lobeAgentExecutor,
   webOnboardingExecutor,
   webBrowsing,
 ]);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8387

#### 🔀 Description of Change

- Add the @lobechat/builtin-tool-lobe-agent package with the lobe-agent identifier.
- Move visual media fallback execution into the Lobe Agent tool as analyzeVisualMedia.
- Wire the client/server tool runtimes so non-visual models can use a configured visual model for image and video attachments.
- Keep VISUAL_UNDERSTANDING_* env and server config names scoped to the visual capability.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bunx vitest run --silent='passed-only' 'src/store/tool/slices/builtin/executors/index.test.ts' 'src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts' 'src/helpers/toolEngineering/index.test.ts' 'src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts' 'src/services/agentRuntime/__tests__/index.test.ts' 'src/components/DragUpload/useDragUpload.test.tsx' 'src/hooks/useVisualMediaUploadAbility.test.ts'
cd packages/prompts && bunx vitest run --silent='passed-only' 'src/prompts/files/index.test.ts'
bunx vitest run --silent='passed-only' 'src/services/chat/chat.test.ts' 'src/services/chat/mecha/contextEngineering.test.ts'
bunx eslint packages/builtin-tool-lobe-agent/src packages/builtin-tools/src/index.ts packages/builtin-tools/src/identifiers.ts packages/prompts/src/prompts/files/index.test.ts src/store/tool/slices/builtin/executors/index.ts src/store/tool/slices/builtin/executors/index.test.ts src/server/services/toolExecution/serverRuntimes/index.ts src/server/services/toolExecution/serverRuntimes/lobeAgent.ts src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts src/helpers/toolEngineering/index.ts src/helpers/toolEngineering/index.test.ts src/server/modules/Mecha/AgentToolsEngine/index.ts src/server/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts src/server/services/aiAgent/index.ts src/services/chat/chat.test.ts src/services/chat/mecha/contextEngineering.test.ts --max-warnings=0
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Security review: checked the submodule diff for cloud/business/billing-specific implementation details; no new cloud-specific logic is exposed.