### PR TITLE
✨ feat: support model defaults and DeepSeek pricing

### DIFF
--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -196,6 +196,31 @@ SSRF_ALLOW_IP_ADDRESS_LIST=192.168.1.100,10.0.0.50
 - Default: -
 - Example: `https://cdn.example.com`
 
+## Visual Understanding
+
+### `VISUAL_UNDERSTANDING_PROVIDER`
+
+- Type: Optional
+- Description: Provider ID of the fallback visual understanding model. Configure this together with `VISUAL_UNDERSTANDING_MODEL` to let models without native image or video understanding inspect uploaded visual media through the built-in visual understanding tool.
+- Default: -
+- Example: `openai`, `google`, or `ollama`
+
+### `VISUAL_UNDERSTANDING_MODEL`
+
+- Type: Optional
+- Description: Model ID used by the fallback visual understanding tool. This model should support the visual media types you want to analyze. The feature is enabled only when both `VISUAL_UNDERSTANDING_PROVIDER` and `VISUAL_UNDERSTANDING_MODEL` are configured.
+- Default: -
+- Example: `gpt-4o`, `gemini-2.5-flash`, or your local visual model ID
+
+Configuration example:
+
+```bash
+VISUAL_UNDERSTANDING_PROVIDER=google
+VISUAL_UNDERSTANDING_MODEL=gemini-2.5-flash
+```
+
+When this feature is enabled, users can upload images or videos while using a model that does not have native visual capabilities, as long as the active model supports tool use. File upload still requires the normal file storage configuration for your deployment.
+
 ## AI Image
 
 ### `AI_IMAGE_DEFAULT_IMAGE_NUM`

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -191,6 +191,31 @@ SSRF_ALLOW_IP_ADDRESS_LIST=192.168.1.100,10.0.0.50
 - 默认值：-
 - 示例：`https://cdn.example.com`
 
+## 视觉理解
+
+### `VISUAL_UNDERSTANDING_PROVIDER`
+
+- 类型：可选
+- 描述：兜底视觉理解模型的服务商 ID。与 `VISUAL_UNDERSTANDING_MODEL` 一起配置后，不具备原生图片或视频理解能力的模型可以通过内置视觉理解工具分析上传的视觉媒体。
+- 默认值：-
+- 示例：`openai`、`google` 或 `ollama`
+
+### `VISUAL_UNDERSTANDING_MODEL`
+
+- 类型：可选
+- 描述：内置视觉理解工具使用的模型 ID。该模型应支持你希望分析的视觉媒体类型。仅当 `VISUAL_UNDERSTANDING_PROVIDER` 与 `VISUAL_UNDERSTANDING_MODEL` 同时配置时，此功能才会启用。
+- 默认值：-
+- 示例：`gpt-4o`、`gemini-2.5-flash` 或你的本地视觉模型 ID
+
+配置示例：
+
+```bash
+VISUAL_UNDERSTANDING_PROVIDER=google
+VISUAL_UNDERSTANDING_MODEL=gemini-2.5-flash
+```
+
+启用后，当当前模型没有原生视觉能力但支持工具调用时，用户仍可上传图片或视频，并由兜底视觉理解模型进行分析。文件上传本身仍需要部署中正常配置文件存储能力。
+
 ## AI 图像
 
 ### `AI_IMAGE_DEFAULT_IMAGE_NUM`

--- a/docs/self-hosting/start.mdx
+++ b/docs/self-hosting/start.mdx
@@ -119,6 +119,8 @@ See [AI Provider Configuration](/docs/self-hosting/environment-variables/model-p
 - **Cloudflare R2** — No egress fees
 - **RustFS / MinIO** — Self-hosted S3 alternative (included in Docker Compose)
 
+**Visual understanding fallback** — Optional, but recommended if users will upload images or videos while chatting with models that do not have native visual capabilities. Configure `VISUAL_UNDERSTANDING_PROVIDER` and `VISUAL_UNDERSTANDING_MODEL` with a visual-capable model from one of your enabled AI providers. See [Basic environment variables](/docs/self-hosting/environment-variables/basic#visual-understanding) for details.
+
 **Authentication provider** — For SSO and team features (Google OAuth, GitHub OAuth, Microsoft Azure AD, Auth0, Keycloak). See [Authentication Setup](/docs/self-hosting/auth) for configuration.
 
 ## Security Considerations

--- a/docs/self-hosting/start.zh-CN.mdx
+++ b/docs/self-hosting/start.zh-CN.mdx
@@ -123,6 +123,8 @@ LobeHub 由以下几个关键组件组成：
 - **Cloudflare R2** — 无出口流量费用
 - **RustFS / MinIO** — 自托管 S3 替代方案（Docker Compose 已内置）
 
+**视觉理解兜底模型** — 可选，但如果用户会在没有原生视觉能力的模型中上传图片或视频，建议配置。你可以使用已启用 AI 提供商中的视觉模型配置 `VISUAL_UNDERSTANDING_PROVIDER` 和 `VISUAL_UNDERSTANDING_MODEL`。详见 [基础环境变量](/zh/docs/self-hosting/environment-variables/basic#视觉理解)。
+
 **认证提供商** — 支持 SSO 和团队功能（Google OAuth、GitHub OAuth、Microsoft Azure AD、Auth0、Keycloak）。配置详见 [认证设置](/docs/self-hosting/auth)。
 
 ## 安全注意事项

--- a/packages/business/const/src/llm.ts
+++ b/packages/business/const/src/llm.ts
@@ -1,6 +1,8 @@
 export const DEFAULT_EMBEDDING_PROVIDER = 'openai';
 
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_PROVIDER = 'anthropic';
+export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_MINI_PROVIDER = 'openai';
 
 export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';

--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -1,5 +1,4 @@
-export const DEFAULT_MODEL = 'claude-sonnet-4-6';
-export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
+export { DEFAULT_MINI_MODEL, DEFAULT_MODEL } from '@lobechat/business-const';
 
 export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
 

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -14,11 +14,11 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-flash',
     maxOutput: 384_000,
     pricing: {
-      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
+      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',
@@ -46,12 +46,11 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-pro',
     maxOutput: 384_000,
     pricing: {
-      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
-      // DeepSeek V4 Pro limited-time 75% off discount is valid until 2026-05-05 15:59 UTC.
+      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.003625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.435, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.87, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0003625, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.0435, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.087, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',
@@ -81,11 +80,11 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
-      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
+      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',
@@ -106,11 +105,11 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
-      // Official cache-hit input price is permanently reduced to 1/10 of the launch price.
+      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',

--- a/packages/model-bank/src/modelProviders/lobehub.ts
+++ b/packages/model-bank/src/modelProviders/lobehub.ts
@@ -20,8 +20,8 @@ const LobeHub: ModelProviderCard = {
 export default LobeHub;
 
 export const planCardModels = [
+  'deepseek-v4-pro',
   'claude-sonnet-4-6',
   'gemini-3.1-pro-preview',
   'gpt-5.5',
-  'deepseek-v4-flash',
 ];

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -2,6 +2,7 @@ import type { ModelTokensUsage } from '@lobechat/types';
 import type { Pricing } from 'model-bank';
 import anthropicChatModels from 'model-bank/anthropic';
 import azureChatModels from 'model-bank/azure';
+import deepseekChatModels from 'model-bank/deepseek';
 import googleChatModels from 'model-bank/google';
 import { lobehubChatModels } from 'model-bank/lobehub';
 import openaiChatModels from 'model-bank/openai';
@@ -127,6 +128,116 @@ describe('computeChatPricing', () => {
       // Verify totals match the actual billing log
       expect(totalCredits).toBe(13_132); // 116 + 13016 = 13132
       expect(totalCost).toBeCloseTo(0.013132, 6); // 13132 credits = $0.013132
+    });
+  });
+
+  describe('LobeHub-hosted DeepSeek', () => {
+    const usage: ModelTokensUsage = {
+      inputCacheMissTokens: 1_000_000,
+      inputCachedTokens: 1_000_000,
+      inputTextTokens: 2_000_000,
+      outputTextTokens: 1_000_000,
+      totalInputTokens: 2_000_000,
+      totalOutputTokens: 1_000_000,
+      totalTokens: 3_000_000,
+    };
+
+    it.each([
+      {
+        expectedCredits: {
+          textInput: 14_000,
+          textInput_cacheRead: 280,
+          textOutput: 28_000,
+        },
+        expectedUnits: [
+          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+        modelId: 'deepseek-v4-flash',
+      },
+      {
+        expectedCredits: {
+          textInput: 43_500,
+          textInput_cacheRead: 363,
+          textOutput: 87_000,
+        },
+        expectedUnits: [
+          {
+            name: 'textInput_cacheRead',
+            rate: 0.0003625,
+            strategy: 'fixed',
+            unit: 'millionTokens',
+          },
+          { name: 'textInput', rate: 0.0435, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.087, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+        modelId: 'deepseek-v4-pro',
+      },
+      {
+        expectedCredits: {
+          textInput: 14_000,
+          textInput_cacheRead: 280,
+          textOutput: 28_000,
+        },
+        expectedUnits: [
+          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+        modelId: 'deepseek-chat',
+      },
+      {
+        expectedCredits: {
+          textInput: 14_000,
+          textInput_cacheRead: 280,
+          textOutput: 28_000,
+        },
+        expectedUnits: [
+          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+        modelId: 'deepseek-reasoner',
+      },
+    ])(
+      'applies 10% hosted discount pricing for $modelId',
+      ({ expectedCredits, expectedUnits, modelId }) => {
+        const pricing = lobehubChatModels.find((model) => model.id === modelId)?.pricing;
+        expect(pricing).toBeDefined();
+        expect(pricing?.units).toEqual(expectedUnits);
+
+        const result = computeChatCost(pricing, usage);
+        expect(result).toBeDefined();
+        expect(result?.issues).toHaveLength(0);
+
+        const { breakdown, totalCost, totalCredits } = result!;
+        expect(breakdown).toHaveLength(3);
+
+        for (const [unitName, credits] of Object.entries(expectedCredits)) {
+          const item = breakdown.find((breakdownItem) => breakdownItem.unit.name === unitName);
+          expect(item?.credits).toBe(credits);
+        }
+
+        const expectedTotalCredits = Object.values(expectedCredits).reduce(
+          (sum, credits) => sum + credits,
+          0,
+        );
+        expect(totalCredits).toBe(expectedTotalCredits);
+        expect(totalCost).toBeCloseTo(expectedTotalCredits / 1_000_000, 6);
+      },
+    );
+
+    it('keeps official DeepSeek provider pricing unchanged', () => {
+      const pricing = deepseekChatModels.find((model) => model.id === 'deepseek-v4-flash')?.pricing;
+      expect(pricing).toEqual({
+        currency: 'CNY',
+        units: [
+          { name: 'textInput_cacheRead', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+      });
     });
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8390
Fixes LOBE-8386

#### 🔀 Description of Change

- Move DEFAULT_MODEL and DEFAULT_MINI_MODEL behind @lobechat/business-const so downstream business builds can override model defaults without changing @lobechat/const imports.
- Keep open-source defaults unchanged.
- Promote DeepSeek V4 Pro to the first LobeHub plan card model while retaining Claude, Gemini, and GPT examples.
- Apply the LobeHub-hosted 10% DeepSeek discount to DeepSeek V4 Flash, DeepSeek V4 Pro, and visible DeepSeek aliases without changing the official DeepSeek provider card.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Tested with:

```bash
cd packages/model-bank && bunx vitest run --silent='passed-only' 'src/modelProviders/index.test.ts'
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/usageConverters/utils/computeChatCost.test.ts'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This PR only adds a generic override point for default models. Cloud-specific default model values are set in the cloud repo PR.