### PR TITLE
feat(thread): add "Open in Portal" to sidebar thread dropdown menu

### DIFF
--- a/locales/en-US/thread.json
+++ b/locales/en-US/thread.json
@@ -1,5 +1,6 @@
 {
   "actions.confirmRemoveThread": "You are about to delete this subtopic. Once deleted, it cannot be recovered. Please proceed with caution.",
   "newPortalThread.includeContext": "Include topic context",
-  "newPortalThread.title": "Start a new subtopic"
+  "newPortalThread.title": "Start a new subtopic",
+  "openInPortal": "Open in Portal"
 }

--- a/src/locales/default/thread.ts
+++ b/src/locales/default/thread.ts
@@ -3,4 +3,5 @@ export default {
     'You are about to delete this subtopic. Once deleted, it cannot be recovered. Please proceed with caution.',
   'newPortalThread.includeContext': 'Include topic context',
   'newPortalThread.title': 'Start a new subtopic',
+  'openInPortal': 'Open in Portal',
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { PortalViewType } from '@/store/chat/slices/portal/initialState';
+import { createStoreUpdater } from 'zustand-utils';
 import { useChatStore } from '@/store/chat';
 
 interface ThreadItemDropdownMenuProps {
@@ -21,6 +22,7 @@ export const useThreadItemDropdownMenu = ({
   const { modal } = App.useApp();
 
   const [removeThread, pushPortalView] = useChatStore((s) => [s.removeThread, s.pushPortalView]);
+  const updatePortalThreadId = createStoreUpdater(useChatStore, 'portalThreadId');
 
   return useCallback(() => {
     return [
@@ -60,5 +62,5 @@ export const useThreadItemDropdownMenu = ({
         },
       },
     ].filter(Boolean) as MenuProps['items'];
-  }, [id, removeThread, pushPortalView, toggleEditing, t, modal]);
+  }, [id, removeThread, pushPortalView, updatePortalThreadId, toggleEditing, t, modal]);
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -1,10 +1,11 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
 import { App } from 'antd';
-import { PencilLine, Trash } from 'lucide-react';
+import { PanelTop, PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 import { useChatStore } from '@/store/chat';
 
 interface ThreadItemDropdownMenuProps {
@@ -19,7 +20,7 @@ export const useThreadItemDropdownMenu = ({
   const { t } = useTranslation(['thread', 'common']);
   const { modal } = App.useApp();
 
-  const [removeThread] = useChatStore((s) => [s.removeThread]);
+  const [removeThread, pushPortalView] = useChatStore((s) => [s.removeThread, s.pushPortalView]);
 
   return useCallback(() => {
     return [
@@ -29,6 +30,14 @@ export const useThreadItemDropdownMenu = ({
         label: t('rename', { ns: 'common' }),
         onClick: () => {
           toggleEditing(true);
+        },
+      },
+      {
+        icon: <Icon icon={PanelTop} />,
+        key: 'openInPortal',
+        label: t('openInPortal'),
+        onClick: () => {
+          pushPortalView({ threadId: id, type: PortalViewType.Thread });
         },
       },
       {
@@ -51,5 +60,5 @@ export const useThreadItemDropdownMenu = ({
         },
       },
     ].filter(Boolean) as MenuProps['items'];
-  }, [id, removeThread, toggleEditing, t, modal]);
+  }, [id, removeThread, pushPortalView, toggleEditing, t, modal]);
 };


### PR DESCRIPTION
## Summary

Adds an **"Open in Portal"** menu item to the **"..." dropdown** on each sub-topic (thread) in the left sidebar, alongside the existing Rename and Delete options.

## What this does

Clicking "Open in Portal" calls `pushPortalView({ threadId, type: PortalViewType.Thread })`, which opens the thread in the right-side Portal panel in a split (side-by-side) layout.

Because `ThreadHydration.tsx` already binds `portalThreadId` to the `?portalThread=` URL query via `useQueryState`, the side-by-side layout is restorable by simply reloading or bookmarking that URL.

## Why this matters

Previously, the only way to get the split layout was to click the "branch" icon on a message at the moment the sub-topic was first created. Once the page was reloaded, there was **no UI way** to restore it.

This change makes the `?portalThread=` URL feature discoverable from the sidebar — closing a gap in the existing infrastructure.

## Changes

- `src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx` — added `openInPortal` menu item using `pushPortalView`
- `locales/en-US/thread.json` — added `openInPortal` i18n key

## Test plan

1. Create a sub-topic (thread) in a chat
2. Verify the split layout works from the branch icon
3. Reload the page
4. Open the thread from the sidebar "..." menu
5. Click **Open in Portal** — thread should appear in the right-side Portal panel
6. Reload and confirm the URL `?portalThread=` preserves the layout

Fixes lobehub/lobehub#14363.