### PR TITLE
✨ feat: show original pricing and prioritize DeepSeek

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -48,9 +48,27 @@ export const deepseekChatModels: AIChatModelCard[] = [
     pricing: {
       // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.0003625, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.0435, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.087, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          name: 'textInput_cacheRead',
+          originalRate: 0.0145,
+          rate: 0.0003625,
+          strategy: 'fixed',
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          originalRate: 1.74,
+          rate: 0.0435,
+          strategy: 'fixed',
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          originalRate: 3.48,
+          rate: 0.087,
+          strategy: 'fixed',
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-04-24',

--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -8,38 +8,6 @@ export const deepseekChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
-      'DeepSeek V4 Flash is the cost-efficient member of the V4 family with a 1M context window and hybrid thinking. Toggle thinking via the `thinking` parameter; non-thinking mode targets latency-sensitive workflows while thinking mode enables deeper reasoning.',
-    displayName: 'DeepSeek V4 Flash',
-    enabled: true,
-    id: 'deepseek-v4-flash',
-    maxOutput: 384_000,
-    pricing: {
-      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
-      units: [
-        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
-      ],
-    },
-    releasedAt: '2026-04-24',
-    settings: {
-      extendParamOptions: {
-        enableReasoning: {
-          defaultValue: true,
-          includeBudget: false,
-        },
-      },
-      extendParams: ['enableReasoning', 'deepseekV4ReasoningEffort'],
-    },
-    type: 'chat',
-  },
-  {
-    abilities: {
-      functionCall: true,
-      reasoning: true,
-    },
-    contextWindowTokens: 1_000_000,
-    description:
       'DeepSeek V4 Pro is the flagship of the V4 family, purpose-built for high-intensity reasoning, agent workflows, and long-horizon planning with a 1M context window. Thinking mode is on by default and toggleable via the `thinking` parameter.',
     displayName: 'DeepSeek V4 Pro',
     enabled: true,
@@ -69,6 +37,38 @@ export const deepseekChatModels: AIChatModelCard[] = [
           strategy: 'fixed',
           unit: 'millionTokens',
         },
+      ],
+    },
+    releasedAt: '2026-04-24',
+    settings: {
+      extendParamOptions: {
+        enableReasoning: {
+          defaultValue: true,
+          includeBudget: false,
+        },
+      },
+      extendParams: ['enableReasoning', 'deepseekV4ReasoningEffort'],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
+      'DeepSeek V4 Flash is the cost-efficient member of the V4 family with a 1M context window and hybrid thinking. Toggle thinking via the `thinking` parameter; non-thinking mode targets latency-sensitive workflows while thinking mode enables deeper reasoning.',
+    displayName: 'DeepSeek V4 Flash',
+    enabled: true,
+    id: 'deepseek-v4-flash',
+    maxOutput: 384_000,
+    pricing: {
+      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',

--- a/packages/model-bank/src/aiModels/lobehub/chat/index.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/index.ts
@@ -10,10 +10,10 @@ import { xiaomimimoChatModels } from './xiaomimimo';
 import { zhipuChatModels } from './zhipu';
 
 export const lobehubChatModels: AIChatModelCard[] = [
+  ...deepseekChatModels,
   ...anthropicChatModels,
   ...googleChatModels,
   ...openaiChatModels,
-  ...deepseekChatModels,
   ...xaiChatModels,
   ...moonshotChatModels,
   ...minimaxChatModels,

--- a/packages/model-bank/src/aiModels/lobehub/utils.test.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.test.ts
@@ -7,6 +7,13 @@ import { lobehubImageModels } from './image';
 import { lobehubVideoModels } from './video';
 
 describe('findLobeHubModel', () => {
+  it('prioritizes hosted DeepSeek models in the chat model list', () => {
+    expect(lobehubChatModels.slice(0, 2).map((model) => model.id)).toEqual([
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
+    ]);
+  });
+
   it('returns the model when id exists in chat models', () => {
     const sample = lobehubChatModels[0];
     expect(findLobeHubModel(sample.id)).toMatchObject({ id: sample.id, type: 'chat' });

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -167,6 +167,10 @@ export interface PricingUnitBase {
 }
 
 export interface FixedPricingUnit extends PricingUnitBase {
+  /**
+   * Original display price before discounts. Billing and cost calculation use `rate`.
+   */
+  originalRate?: number;
   rate: number;
   strategy: 'fixed';
 }

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -165,12 +165,25 @@ describe('computeChatPricing', () => {
         expectedUnits: [
           {
             name: 'textInput_cacheRead',
+            originalRate: 0.0145,
             rate: 0.0003625,
             strategy: 'fixed',
             unit: 'millionTokens',
           },
-          { name: 'textInput', rate: 0.0435, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textOutput', rate: 0.087, strategy: 'fixed', unit: 'millionTokens' },
+          {
+            name: 'textInput',
+            originalRate: 1.74,
+            rate: 0.0435,
+            strategy: 'fixed',
+            unit: 'millionTokens',
+          },
+          {
+            name: 'textOutput',
+            originalRate: 3.48,
+            rate: 0.087,
+            strategy: 'fixed',
+            unit: 'millionTokens',
+          },
         ],
         modelId: 'deepseek-v4-pro',
       },

--- a/packages/utils/src/pricing.test.ts
+++ b/packages/utils/src/pricing.test.ts
@@ -6,6 +6,7 @@ import {
   getAudioOutputUnitRate,
   getCachedAudioInputUnitRate,
   getCachedTextInputUnitRate,
+  getOriginalUnitRateByName,
   getTextInputUnitRate,
   getTextOutputUnitRate,
   getUnitRateByName,
@@ -125,6 +126,64 @@ describe('pricing utilities (new)', () => {
       expect(getUnitRateByName(pricing, 'textInput')).toBe(0.001);
       expect(getUnitRateByName(pricing, 'textOutput')).toBe(0.002);
       expect(getUnitRateByName(pricing, 'audioInput')).toBe(0.01);
+    });
+  });
+
+  describe('getOriginalUnitRateByName', () => {
+    it('returns fixed originalRate when it is higher than the current rate', () => {
+      const pricing: Pricing = {
+        units: [
+          {
+            name: 'textInput',
+            originalRate: 0.435,
+            rate: 0.0435,
+            strategy: 'fixed',
+            unit: 'millionTokens',
+          },
+        ],
+      };
+
+      expect(getOriginalUnitRateByName(pricing, 'textInput')).toBe(0.435);
+    });
+
+    it('returns undefined when originalRate is absent or not higher than current rate', () => {
+      const pricing: Pricing = {
+        units: [
+          { name: 'textInput', strategy: 'fixed', unit: 'millionTokens', rate: 0.0435 },
+          {
+            name: 'textOutput',
+            originalRate: 0.087,
+            rate: 0.087,
+            strategy: 'fixed',
+            unit: 'millionTokens',
+          },
+        ],
+      };
+
+      expect(getOriginalUnitRateByName(pricing, 'textInput')).toBeUndefined();
+      expect(getOriginalUnitRateByName(pricing, 'textOutput')).toBeUndefined();
+    });
+
+    it('returns undefined for non-fixed pricing units', () => {
+      const pricing: Pricing = {
+        units: [
+          {
+            name: 'textInput',
+            strategy: 'tiered',
+            tiers: [{ rate: 0.1, upTo: 'infinity' }],
+            unit: 'millionTokens',
+          },
+          {
+            lookup: { prices: { default: 0.2 }, pricingParams: ['quality'] },
+            name: 'textOutput',
+            strategy: 'lookup',
+            unit: 'millionTokens',
+          },
+        ],
+      };
+
+      expect(getOriginalUnitRateByName(pricing, 'textInput')).toBeUndefined();
+      expect(getOriginalUnitRateByName(pricing, 'textOutput')).toBeUndefined();
     });
   });
 

--- a/packages/utils/src/pricing.ts
+++ b/packages/utils/src/pricing.ts
@@ -24,6 +24,12 @@ const getRateFromUnit = (unit: PricingUnit): number | undefined => {
   }
 };
 
+const getOriginalRateFromUnit = (unit: PricingUnit): number | undefined => {
+  if (unit.strategy !== 'fixed') return undefined;
+
+  return unit.originalRate;
+};
+
 /**
  * Get unit rate by unit name, used to deduplicate logic across helpers
  */
@@ -35,6 +41,24 @@ export const getUnitRateByName = (
   const unit = pricing.units.find((u) => u.name === unitName);
   if (!unit) return undefined;
   return getRateFromUnit(unit);
+};
+
+/**
+ * Get fixed unit original rate by unit name when it is higher than the current rate.
+ */
+export const getOriginalUnitRateByName = (
+  pricing?: Pricing,
+  unitName?: PricingUnitName,
+): number | undefined => {
+  if (!pricing?.units || !unitName) return undefined;
+  const unit = pricing.units.find((u) => u.name === unitName);
+  if (!unit) return undefined;
+
+  const originalRate = getOriginalRateFromUnit(unit);
+  const currentRate = getRateFromUnit(unit);
+  if (typeof originalRate !== 'number' || typeof currentRate !== 'number') return undefined;
+
+  return originalRate > currentRate ? originalRate : undefined;
 };
 
 /**

--- a/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
@@ -33,7 +33,12 @@ import type { ModelDetailPanelExpandedKey } from '@/store/global/initialState';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import { formatTokenNumber } from '@/utils/format';
-import { formatPriceByCurrency, getTextInputUnitRate, getTextOutputUnitRate } from '@/utils/index';
+import {
+  formatPriceByCurrency,
+  getOriginalUnitRateByName,
+  getTextInputUnitRate,
+  getTextOutputUnitRate,
+} from '@/utils/index';
 
 import ControlsForm from './ControlsForm';
 
@@ -67,6 +72,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextSecondary};
   `,
+  originalPriceText: css`
+    color: ${cssVar.colorTextTertiary};
+    text-decoration: line-through;
+  `,
+  priceValue: css`
+    display: inline-flex;
+    gap: 4px;
+    align-items: baseline;
+  `,
   titleText: css`
     font-size: 14px;
     font-weight: 400;
@@ -74,21 +88,36 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const getPrice = (pricing: Pricing) => {
-  const inputRate = getTextInputUnitRate(pricing);
-  const outputRate = getTextOutputUnitRate(pricing);
-  const cachedInputRate = getCachedTextInputUnitRate(pricing);
+interface FormattedUnitPrice {
+  current: string;
+  original?: string;
+}
+
+const formatPricingRate = (rate: number | undefined, currency?: ModelPriceCurrency) =>
+  typeof rate === 'number' ? formatPriceByCurrency(rate, currency) : '0';
+
+const getFormattedUnitPrice = (pricing: Pricing, unitName: PricingUnitName): FormattedUnitPrice => {
+  const currency = pricing.currency as ModelPriceCurrency | undefined;
+  const currentRate =
+    unitName === 'textInput'
+      ? getTextInputUnitRate(pricing)
+      : unitName === 'textOutput'
+        ? getTextOutputUnitRate(pricing)
+        : getCachedTextInputUnitRate(pricing);
+  const originalRate = getOriginalUnitRateByName(pricing, unitName);
 
   return {
-    cachedInput: cachedInputRate
-      ? formatPriceByCurrency(cachedInputRate, pricing?.currency as ModelPriceCurrency)
-      : '0',
-    input: inputRate
-      ? formatPriceByCurrency(inputRate, pricing?.currency as ModelPriceCurrency)
-      : '0',
-    output: outputRate
-      ? formatPriceByCurrency(outputRate, pricing?.currency as ModelPriceCurrency)
-      : '0',
+    current: formatPricingRate(currentRate, currency),
+    original:
+      typeof originalRate === 'number' ? formatPriceByCurrency(originalRate, currency) : undefined,
+  };
+};
+
+const getPrice = (pricing: Pricing) => {
+  return {
+    cachedInput: getFormattedUnitPrice(pricing, 'textInput_cacheRead'),
+    input: getFormattedUnitPrice(pricing, 'textInput'),
+    output: getFormattedUnitPrice(pricing, 'textOutput'),
   };
 };
 
@@ -152,23 +181,50 @@ const UNIT_LABEL_MAP: Record<string, string> = {
   second: '/s',
 };
 
-const formatUnitRate = (unit: PricingUnit, currency?: ModelPriceCurrency): string => {
-  const unitLabel = UNIT_LABEL_MAP[unit.unit] || '';
+interface PriceValueProps {
+  prefix?: string;
+  price: FormattedUnitPrice;
+  suffix?: string;
+}
 
+const PriceValue: FC<PriceValueProps> = ({ price, prefix = '', suffix = '' }) => (
+  <span className={styles.priceValue}>
+    {price.original && (
+      <span className={styles.originalPriceText}>
+        {prefix}
+        {price.original}
+        {suffix}
+      </span>
+    )}
+    <span>
+      {prefix}
+      {price.current}
+      {suffix}
+    </span>
+  </span>
+);
+
+const formatUnitRate = (unit: PricingUnit, currency?: ModelPriceCurrency): FormattedUnitPrice => {
   if (unit.strategy === 'fixed') {
-    const price = formatPriceByCurrency((unit as FixedPricingUnit).rate, currency);
-    return `$${price}${unitLabel}`;
+    const fixedUnit = unit as FixedPricingUnit;
+    return {
+      current: formatPriceByCurrency(fixedUnit.rate, currency),
+      original:
+        typeof fixedUnit.originalRate === 'number' && fixedUnit.originalRate > fixedUnit.rate
+          ? formatPriceByCurrency(fixedUnit.originalRate, currency)
+          : undefined,
+    };
   }
 
   if (unit.strategy === 'tiered') {
     const tiers = (unit as TieredPricingUnit).tiers;
     if (tiers.length === 1) {
       const price = formatPriceByCurrency(tiers[0].rate, currency);
-      return `$${price}${unitLabel}`;
+      return { current: price };
     }
     const low = formatPriceByCurrency(tiers[0].rate, currency);
     const high = formatPriceByCurrency(tiers.at(-1)!.rate, currency);
-    return `$${low} ~ $${high}${unitLabel}`;
+    return { current: `${low} ~ $${high}` };
   }
 
   // lookup strategy
@@ -176,15 +232,15 @@ const formatUnitRate = (unit: PricingUnit, currency?: ModelPriceCurrency): strin
     const prices = Object.values(unit.lookup.prices);
     if (prices.length === 1) {
       const price = formatPriceByCurrency(prices[0], currency);
-      return `$${price}${unitLabel}`;
+      return { current: price };
     }
     const sorted = [...prices].sort((a, b) => a - b);
     const low = formatPriceByCurrency(sorted[0], currency);
     const high = formatPriceByCurrency(sorted.at(-1)!, currency);
-    return `$${low} ~ $${high}${unitLabel}`;
+    return { current: `${low} ~ $${high}` };
   }
 
-  return '-';
+  return { current: '-' };
 };
 
 interface PricingGroupData {
@@ -407,33 +463,33 @@ const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(
                       {getCachedTextInputUnitRate(model.pricing!) && (
                         <Tooltip
                           title={t('ModelSwitchPanel.detail.pricing.cachedInput', {
-                            amount: formatPrice!.cachedInput,
+                            amount: formatPrice!.cachedInput.current,
                           })}
                         >
                           <Flexbox horizontal align={'center'} gap={2}>
                             <Icon icon={CircleFadingArrowUp} size={'small'} />
-                            {formatPrice!.cachedInput}
+                            <PriceValue price={formatPrice!.cachedInput} />
                           </Flexbox>
                         </Tooltip>
                       )}
                       <Tooltip
                         title={t('ModelSwitchPanel.detail.pricing.input', {
-                          amount: formatPrice!.input,
+                          amount: formatPrice!.input.current,
                         })}
                       >
                         <Flexbox horizontal align={'center'} gap={2}>
                           <Icon icon={ArrowUpFromDot} size={'small'} />
-                          {formatPrice!.input}
+                          <PriceValue price={formatPrice!.input} />
                         </Flexbox>
                       </Tooltip>
                       <Tooltip
                         title={t('ModelSwitchPanel.detail.pricing.output', {
-                          amount: formatPrice!.output,
+                          amount: formatPrice!.output.current,
                         })}
                       >
                         <Flexbox horizontal align={'center'} gap={2}>
                           <Icon icon={ArrowDownToDot} size={'small'} />
-                          {formatPrice!.output}
+                          <PriceValue price={formatPrice!.output} />
                         </Flexbox>
                       </Tooltip>
                     </Flexbox>
@@ -483,9 +539,14 @@ const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(
                               {t(`ModelSwitchPanel.detail.pricing.unit.${unit.name}` as any)}
                             </span>
                           </Flexbox>
-                          <span>
-                            {formatUnitRate(unit, model.pricing?.currency as ModelPriceCurrency)}
-                          </span>
+                          <PriceValue
+                            prefix="$"
+                            suffix={UNIT_LABEL_MAP[unit.unit] || ''}
+                            price={formatUnitRate(
+                              unit,
+                              model.pricing?.currency as ModelPriceCurrency,
+                            )}
+                          />
                         </Flexbox>
                       ))}
                     </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8386
Related to LOBE-8390

#### 🔀 Description of Change

- Add optional `originalRate` support to fixed pricing units for display-only discounted pricing.
- Show original crossed-out prices alongside current prices in the model switch panel.
- Add DeepSeek V4 Pro original official prices to the LobeHub-hosted model card.
- Prioritize LobeHub-hosted DeepSeek models in the LobeHub model list, with `deepseek-v4-pro` before `deepseek-v4-flash`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/utils && bunx vitest run --silent='passed-only' 'src/pricing.test.ts'
cd packages/model-bank && bunx vitest run --silent='passed-only' 'src/aiModels/lobehub/utils.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

`originalRate` is display-only. Billing and cost calculation continue to use `rate`.
