### PR TITLE
🐛 fix: handle Claude assistant prefill errors

### DIFF
--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -139,6 +139,7 @@ export const shouldOmitSamplingParams = (model: string): boolean => {
 
 export const assistantPrefillUnsupportedModelPatterns: RegExp[] = [
   /^claude-(opus|sonnet)-4-(6|7)(\b|-)/,
+  /anthropic\.claude-(opus|sonnet)-4-(6|7)(\b|-)/,
 ];
 
 export const shouldDropUnsupportedClaudeAssistantPrefill = (model: string): boolean => {

--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -136,3 +136,11 @@ export const omitSamplingParamsModelPatterns: RegExp[] = [
 export const shouldOmitSamplingParams = (model: string): boolean => {
   return omitSamplingParamsModelPatterns.some((pattern) => pattern.test(model));
 };
+
+export const assistantPrefillUnsupportedModelPatterns: RegExp[] = [
+  /^claude-(opus|sonnet)-4-(6|7)(\b|-)/,
+];
+
+export const shouldDropUnsupportedClaudeAssistantPrefill = (model: string): boolean => {
+  return assistantPrefillUnsupportedModelPatterns.some((pattern) => pattern.test(model));
+};

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -5,6 +5,7 @@ import type { ChatModelCard } from '@lobechat/types';
 import debug from 'debug';
 import type { Pricing } from 'model-bank';
 
+import { shouldDropUnsupportedClaudeAssistantPrefill } from '../../const/models';
 import type {
   ChatCompletionErrorPayload,
   ChatMethodOptions,
@@ -159,8 +160,10 @@ export const buildDefaultAnthropicPayload = async (
 
   const postMessages = await buildAnthropicMessages(userMessages, { enabledContextCaching });
 
-  // Claude 4.6 models do not support assistant turn prefill
-  if (model.includes('-4-6') && postMessages.at(-1)?.role === 'assistant') {
+  if (
+    shouldDropUnsupportedClaudeAssistantPrefill(model) &&
+    postMessages.at(-1)?.role === 'assistant'
+  ) {
     postMessages.pop();
   }
 

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -824,6 +824,25 @@ describe('LobeAnthropicAI', () => {
         });
       });
 
+      it('should drop assistant prefill for Claude Opus 4.7', async () => {
+        const payload: ChatStreamPayload = {
+          messages: [
+            { content: 'Continue this answer', role: 'user' },
+            { content: 'Partial assistant draft', role: 'assistant' },
+          ],
+          model: 'claude-opus-4-7',
+        };
+
+        const result = await buildDefaultAnthropicPayload(payload);
+
+        expect(result.messages).toEqual([
+          {
+            content: 'Continue this answer',
+            role: 'user',
+          },
+        ]);
+      });
+
       it('should respect max_tokens in thinking mode when provided', async () => {
         const payload: ChatStreamPayload = {
           max_tokens: 1000,

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -193,6 +193,34 @@ describe('LobeBedrockAI', () => {
         expect(result).toBeInstanceOf(Response);
       });
 
+      it('should drop assistant prefill for Claude Opus 4.7', async () => {
+        const mockStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue('Hello, world!');
+            controller.close();
+          },
+        });
+        (instance['client'].send as Mock).mockResolvedValue(Promise.resolve(mockStream));
+
+        await instance.chat({
+          messages: [
+            { content: 'Continue this answer', role: 'user' },
+            { content: 'Partial assistant draft', role: 'assistant' },
+          ],
+          model: 'claude-opus-4-7',
+        });
+
+        const commandInput = (InvokeModelWithResponseStreamCommand as Mock).mock.calls[0][0];
+        const body = JSON.parse(commandInput.body);
+
+        expect(body.messages).toEqual([
+          {
+            content: 'Continue this answer',
+            role: 'user',
+          },
+        ]);
+      });
+
       it('should handle system prompt correctly', async () => {
         // Arrange
         const mockStream = new ReadableStream({

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -210,7 +210,8 @@ describe('LobeBedrockAI', () => {
           model: 'global.anthropic.claude-opus-4-7',
         });
 
-        const commandInput = (InvokeModelWithResponseStreamCommand as Mock).mock.calls[0][0];
+        const commandInput = (InvokeModelWithResponseStreamCommand as unknown as Mock).mock
+          .calls[0][0];
         const body = JSON.parse(commandInput.body);
 
         expect(body.messages).toEqual([

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -207,7 +207,7 @@ describe('LobeBedrockAI', () => {
             { content: 'Continue this answer', role: 'user' },
             { content: 'Partial assistant draft', role: 'assistant' },
           ],
-          model: 'claude-opus-4-7',
+          model: 'global.anthropic.claude-opus-4-7',
         });
 
         const commandInput = (InvokeModelWithResponseStreamCommand as Mock).mock.calls[0][0];

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -7,6 +7,7 @@ import {
 import { cloudModelIdMapping } from '@lobechat/business-const';
 import { ModelProvider } from 'model-bank';
 
+import { shouldDropUnsupportedClaudeAssistantPrefill } from '../../const/models';
 import { resolveCacheTTL } from '../../core/anthropicCompatibleFactory/resolveCacheTTL';
 import { resolveMaxTokens } from '../../core/anthropicCompatibleFactory/resolveMaxTokens';
 import type { LobeRuntimeAI } from '../../core/BaseAI';
@@ -204,8 +205,10 @@ export class LobeBedrockAI implements LobeRuntimeAI {
 
     const postMessages = await buildAnthropicMessages(user_messages, { enabledContextCaching });
 
-    // Claude 4.6 models do not support assistant turn prefill
-    if (model.includes('-4-6') && postMessages.at(-1)?.role === 'assistant') {
+    if (
+      shouldDropUnsupportedClaudeAssistantPrefill(model) &&
+      postMessages.at(-1)?.role === 'assistant'
+    ) {
       postMessages.pop();
     }
 

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
@@ -38,6 +38,20 @@ describe('isNonRetryableRequestError', () => {
     ).toBe(true);
   });
 
+  it('returns true for assistant prefill request-shape errors', () => {
+    expect(
+      isNonRetryableRequestError({
+        error: {
+          body: { httpStatusCode: 400 },
+          message:
+            'This model does not support assistant message prefill. The conversation must end with a user message.',
+          type: 'ValidationException',
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+      }),
+    ).toBe(true);
+  });
+
   it('returns false for bare 400/413/422 request errors', () => {
     expect(isNonRetryableRequestError({ errorType: 'ProviderBizError', status: 400 })).toBe(false);
     expect(isNonRetryableRequestError({ errorType: 'ProviderBizError', status: 413 })).toBe(false);

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
@@ -46,6 +46,8 @@ const RETRYABLE_MESSAGE_PATTERNS = [
 ];
 
 const NON_RETRYABLE_MESSAGE_PATTERNS = [
+  'assistant message prefill',
+  'conversation must end with a user message',
   'context length exceeded',
   'context_length_exceeded',
   'expected a string',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 💄 style
- [ ] ♻️ refactor
- [ ] ⚡ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore
- [ ] 🌐 i18n
- [ ] 🐳 docker
- [ ] 🔒 security
- [ ] 🤖 workflow

#### 🔗 Related Issue

No related issue.

#### 🔀 Description of Change

- Drop unsupported assistant prefill tails for Claude Opus/Sonnet 4.6 and 4.7 in Anthropic-compatible and Bedrock payload builders.
- Treat assistant-prefill request-shape validation errors as non-retryable to avoid channel fallback on deterministic payload failures.
- Add regression coverage for Anthropic-compatible payloads, Bedrock payloads, and fallback classification.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run --silent='passed-only' 'src/providers/anthropic/index.test.ts'`\n\n`bunx vitest run --silent='passed-only' 'src/providers/bedrock/index.test.ts'`\n\n`bunx vitest run --silent='passed-only' 'src/utils/isNonRetryableRequestError.test.ts'`\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThis prevents Claude 4.7 assistant prefill validation errors from retrying the same invalid request on fallback channels.