### PR TITLE
🐛 fix: track visual analysis trigger

### DIFF
--- a/locales/zh-CN/spend.json
+++ b/locales/zh-CN/spend.json
@@ -23,6 +23,7 @@
   "table.columns.trigger.enums.semantic_search": "知识搜索",
   "table.columns.trigger.enums.topic": "话题总结",
   "table.columns.trigger.enums.video": "视频生成",
+  "table.columns.trigger.enums.visual_analysis": "视觉分析",
   "table.columns.trigger.title": "触发方式",
   "table.columns.type.enums.chat": "文本生成",
   "table.columns.type.enums.embedding": "嵌入",

--- a/packages/builtin-tool-lobe-agent/src/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/executor/index.ts
@@ -1,5 +1,5 @@
 import type { BuiltinToolContext, BuiltinToolResult, ChatStreamPayload } from '@lobechat/types';
-import { BaseExecutor } from '@lobechat/types';
+import { BaseExecutor, RequestTrigger } from '@lobechat/types';
 
 import { LobeAgentManifest } from '../manifest';
 import type { AnalyzeVisualMediaParams } from '../types';
@@ -210,6 +210,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       onMessageHandle: (chunk) => {
         if (chunk.type === 'text') content += chunk.text || '';
       },
+      requestTrigger: RequestTrigger.VisualAnalysis,
       signal: abortController.signal,
     });
 
@@ -234,7 +235,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
         files: selectedItems,
         model: config.model,
         provider: config.provider,
-        trigger: 'lobe-agent.analyzeVisualMedia',
+        trigger: RequestTrigger.VisualAnalysis,
         usage,
       },
       success: true,

--- a/packages/const/src/fetch.ts
+++ b/packages/const/src/fetch.ts
@@ -7,6 +7,7 @@ export const USE_AZURE_OPENAI = 'X-use-azure-openai';
 export const AZURE_OPENAI_API_VERSION = 'X-azure-openai-api-version';
 
 export const OAUTH_AUTHORIZED = 'X-oauth-authorized';
+export const REQUEST_TRIGGER_HEADER = 'x-lobechat-request-trigger';
 
 /**
  * @deprecated

--- a/packages/const/src/index.ts
+++ b/packages/const/src/index.ts
@@ -4,6 +4,7 @@ export * from './desktop';
 export * from './desktopGlobalShortcuts';
 export * from './discover';
 export * from './editor';
+export * from './fetch';
 export * from './file';
 export * from './klavis';
 export * from './layoutTokens';

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -10,6 +10,7 @@ export enum RequestTrigger {
   SemanticSearch = 'semantic_search',
   Topic = 'topic',
   Video = 'video',
+  VisualAnalysis = 'visual_analysis',
 }
 
 // ******* Runtime Biz Error ******* //

--- a/src/locales/default/spend.ts
+++ b/src/locales/default/spend.ts
@@ -22,6 +22,7 @@ export default {
   'table.columns.trigger.enums.memory': 'Memory Extraction',
   'table.columns.trigger.enums.semantic_search': 'Knowledge Search',
   'table.columns.trigger.enums.topic': 'Topic Summary',
+  'table.columns.trigger.enums.visual_analysis': 'Visual Analysis',
   'table.columns.trigger.enums.video': 'Video Generation',
   'table.columns.trigger.title': 'Trigger',
   'table.columns.type.enums.chat': 'Text Generation',

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -1,5 +1,5 @@
 import { LobeAgentIdentifier, MAX_VISUAL_MEDIA_URLS } from '@lobechat/builtin-tool-lobe-agent';
-import { createVisualFileRef } from '@lobechat/types';
+import { createVisualFileRef, RequestTrigger } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ToolExecutionContext } from '../../types';
@@ -190,7 +190,11 @@ describe('lobeAgentRuntime', () => {
           }),
         ],
       }),
-      expect.anything(),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          trigger: RequestTrigger.VisualAnalysis,
+        }),
+      }),
     );
   });
 

--- a/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -14,6 +14,7 @@ import type { LobeChatDatabase } from '@lobechat/database';
 import type { ChatStreamPayload } from '@lobechat/model-runtime';
 import { consumeStreamUntilDone } from '@lobechat/model-runtime';
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
+import { RequestTrigger } from '@lobechat/types';
 import { LOBE_DEFAULT_MODEL_LIST } from 'model-bank';
 
 import { MessageModel } from '@/database/models/message';
@@ -248,7 +249,7 @@ class LobeAgentExecutionRuntime {
         },
       },
       metadata: {
-        trigger: 'lobe-agent.analyzeVisualMedia',
+        trigger: RequestTrigger.VisualAnalysis,
       },
     });
 
@@ -260,7 +261,7 @@ class LobeAgentExecutionRuntime {
         files: selectedItems.map(({ ref, id, type, name }) => ({ id, name, ref, type })),
         model,
         provider,
-        trigger: 'lobe-agent.analyzeVisualMedia',
+        trigger: RequestTrigger.VisualAnalysis,
         usage,
       },
       success: true,

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -1,12 +1,8 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
-import {
-  ChatErrorType,
-  type ChatStreamPayload,
-  createVisualFileRef,
-  type LobeTool,
-  type UIChatMessage,
-} from '@lobechat/types';
+import { REQUEST_TRIGGER_HEADER } from '@lobechat/const';
+import type { ChatStreamPayload, LobeTool, UIChatMessage } from '@lobechat/types';
+import { ChatErrorType, createVisualFileRef, RequestTrigger } from '@lobechat/types';
 import { act } from '@testing-library/react';
 import { type EnabledAiModel, ModelProvider } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -46,6 +42,10 @@ vi.hoisted(() => {
     },
   });
 });
+
+const mockCreateHeaderWithAuth = vi.hoisted(() =>
+  vi.fn(async ({ headers }: { headers: Record<string, string> }) => headers),
+);
 
 // Helper to compute expected date content from SystemDateProvider
 const getCurrentDateContent = () => {
@@ -152,7 +152,7 @@ beforeEach(async () => {
 
 // mock auth
 vi.mock('../_auth', () => ({
-  createHeaderWithAuth: vi.fn().mockResolvedValue({}),
+  createHeaderWithAuth: mockCreateHeaderWithAuth,
 }));
 
 // Mock isCanUseFC to control function calling behavior in tests
@@ -1606,6 +1606,7 @@ describe('ChatService', () => {
       const { fetchSSE } = await import('@lobechat/fetch-sse');
       mockFetchSSE = vi.fn().mockResolvedValue(new Response('mock response'));
       vi.mocked(fetchSSE).mockImplementation(mockFetchSSE);
+      mockCreateHeaderWithAuth.mockClear();
     });
 
     it('should make a POST request with the correct payload', async () => {
@@ -1632,6 +1633,29 @@ describe('ChatService', () => {
           method: 'POST',
         }),
       );
+    });
+
+    it('should send request trigger as a header without adding it to the model payload', async () => {
+      const params: Partial<ChatStreamPayload> = {
+        messages: [],
+        model: 'test-model',
+      };
+
+      await chatService.getChatCompletion(params, {
+        requestTrigger: RequestTrigger.VisualAnalysis,
+      });
+
+      expect(mockFetchSSE).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            [REQUEST_TRIGGER_HEADER]: RequestTrigger.VisualAnalysis,
+          }),
+        }),
+      );
+
+      const payload = JSON.parse(mockFetchSSE.mock.calls[0][1].body);
+      expect(payload).not.toHaveProperty('requestTrigger');
     });
 
     it('should make a POST request with chatCompletion apiMode in non-openai provider payload', async () => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -1,15 +1,19 @@
 import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
-import { KLAVIS_SERVER_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
+import {
+  KLAVIS_SERVER_TYPES,
+  LOBEHUB_SKILL_PROVIDERS,
+  REQUEST_TRIGGER_HEADER,
+} from '@lobechat/const';
 import { type OfficialToolItem } from '@lobechat/context-engine';
 import { type FetchSSEOptions } from '@lobechat/fetch-sse';
 import { fetchSSE, standardizeAnimationStyle } from '@lobechat/fetch-sse';
 import type { ChatCompletionErrorPayload } from '@lobechat/model-runtime';
 import { AgentRuntimeError, responsesAPIModels } from '@lobechat/model-runtime';
-import {
-  type RuntimeInitialContext,
-  type RuntimeStepContext,
-  type TracePayload,
-  type UIChatMessage,
+import type {
+  RuntimeInitialContext,
+  RuntimeStepContext,
+  TracePayload,
+  UIChatMessage,
 } from '@lobechat/types';
 import { ChatErrorType, TraceTagMap } from '@lobechat/types';
 import { merge } from 'es-toolkit/compat';
@@ -345,7 +349,7 @@ class ChatService {
   };
 
   getChatCompletion = async (params: Partial<ChatStreamPayload>, options?: FetchOptions) => {
-    const { agentId, signal, responseAnimation, topicId } = options ?? {};
+    const { agentId, requestTrigger, signal, responseAnimation, topicId } = options ?? {};
 
     const { provider = ModelProvider.OpenAI, ...res } = params;
 
@@ -442,6 +446,7 @@ class ChatService {
         'Content-Type': 'application/json',
         ...traceHeader,
         ...(agentId && { 'x-agent-id': agentId }),
+        ...(requestTrigger && { [REQUEST_TRIGGER_HEADER]: requestTrigger }),
         ...(topicId && { 'x-topic-id': topicId }),
       },
       provider,

--- a/src/services/chat/types.ts
+++ b/src/services/chat/types.ts
@@ -1,8 +1,9 @@
-import { type FetchSSEOptions } from '@lobechat/fetch-sse';
-import {
-  type RuntimeInitialContext,
-  type RuntimeStepContext,
-  type TracePayload,
+import type { FetchSSEOptions } from '@lobechat/fetch-sse';
+import type {
+  RequestTrigger,
+  RuntimeInitialContext,
+  RuntimeStepContext,
+  TracePayload,
 } from '@lobechat/types';
 
 export interface FetchOptions extends FetchSSEOptions {
@@ -10,6 +11,7 @@ export interface FetchOptions extends FetchSSEOptions {
   historySummary?: string;
   /** Initial context for page editor (captured at operation start) */
   initialContext?: RuntimeInitialContext;
+  requestTrigger?: RequestTrigger;
   signal?: AbortSignal | undefined;
   /** Step context for page editor (updated each step) */
   stepContext?: RuntimeStepContext;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #14378

#### 🔀 Description of Change

- Add `RequestTrigger.VisualAnalysis` for visual understanding fallback calls.
- Pass the request trigger as transport metadata without adding it to the model payload.
- Move the request trigger header constant into `@lobechat/const` and add usage labels for spend tables.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/services/chat/chat.test.ts'
bunx vitest run --silent='passed-only' 'src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Cloud route validation is implemented in the downstream cloud PR so browser-controlled trigger headers cannot classify ordinary chat requests as visual analysis.
