### PR TITLE
🐛 fix: sync DEFAULT_MODEL into desktop business-const stub

### DIFF
--- a/apps/desktop/stubs/business-const/src/index.ts
+++ b/apps/desktop/stubs/business-const/src/index.ts
@@ -1,7 +1,9 @@
 export const BRANDING_LOGO_URL = '';
 export const BRANDING_NAME = 'LobeHub';
 export const DEFAULT_EMBEDDING_PROVIDER = 'openai';
+export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_MINI_PROVIDER = 'openai';
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_ONBOARDING_MODEL = 'gemini-3-flash-preview';
 export const DEFAULT_PROVIDER = 'openai';
 export const ORG_NAME = 'LobeHub';


### PR DESCRIPTION
## Summary

- #14379 moved `DEFAULT_MODEL` / `DEFAULT_MINI_MODEL` from `packages/const/src/settings/llm.ts` to `@lobechat/business-const`, leaving `packages/const/src/settings/llm.ts` as a re-export.
- The desktop workspace resolves `@lobechat/business-const` to `apps/desktop/stubs/business-const` (see `apps/desktop/pnpm-workspace.yaml`), but that stub was not updated, so the desktop SPA build fails with 12 `MISSING_EXPORT: "DEFAULT_MODEL" is not exported by "../../packages/const/src/index.ts"` errors during `vite build`.
- Adds `DEFAULT_MODEL = 'claude-sonnet-4-6'` and `DEFAULT_MINI_MODEL = 'gpt-5.4-mini'` to the stub, matching the canonical values in `packages/business/const/src/llm.ts`.

## Test plan

- [ ] Run the desktop production build and confirm vite no longer errors with `MISSING_EXPORT` for `DEFAULT_MODEL`
- [ ] CI desktop build job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)