### PR TITLE
✨ refactor: agent list reuse to isolate drawer state

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
@@ -5,7 +5,7 @@ import { memo, Suspense, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import List from '@/routes/(main)/home/_layout/Body/Agent/List';
+import AgentListContent from '@/routes/(main)/home/_layout/Body/Agent/List/AgentListContent';
 import { AgentModalProvider } from '@/routes/(main)/home/_layout/Body/Agent/ModalProvider';
 
 const styles = createStaticStyles(({ cssVar, css }) => ({
@@ -31,7 +31,7 @@ const SwitchPanel = memo<PropsWithChildren>(({ children }) => {
               overflowY: 'auto',
             }}
           >
-            <List onMoreClick={() => navigate('/')} />
+            <AgentListContent onMoreClick={() => navigate('/')} />
           </Flexbox>
         </AgentModalProvider>
       </Suspense>

--- a/src/routes/(main)/home/_layout/Body/Agent/AllAgentsDrawer/Content.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/AllAgentsDrawer/Content.tsx
@@ -24,7 +24,10 @@ const Content = memo<ContentProps>(({ searchKeyword }) => {
   const isSearching = trimmedKeyword.length > 0;
 
   // Search agents using homeStore
-  const [useSearchAgents] = useHomeStore((s) => [s.useSearchAgents]);
+  const [closeAllAgentsDrawer, useSearchAgents] = useHomeStore((s) => [
+    s.closeAllAgentsDrawer,
+    s.useSearchAgents,
+  ]);
   const { data: searchResults, isLoading: isSearchLoading } = useSearchAgents(
     isSearching ? trimmedKeyword : undefined,
   );
@@ -36,6 +39,9 @@ const Content = memo<ContentProps>(({ searchKeyword }) => {
   const displayItems = isSearching ? searchResults || [] : allUngroupedAgents;
 
   const count = displayItems.length;
+
+  // Close on navigation because the Home layout stays mounted offscreen across route changes.
+  const handleNavigate = closeAllAgentsDrawer;
 
   // Show loading skeleton when searching
   if (isSearching && (isSearchLoading || !searchResults)) {
@@ -58,7 +64,11 @@ const Content = memo<ContentProps>(({ searchKeyword }) => {
     >
       {displayItems.map((item) => (
         <Flexbox key={item.id} paddingBlock={1} paddingInline={4}>
-          {item.type === 'group' ? <GroupItem item={item} /> : <AgentItem item={item} />}
+          {item.type === 'group' ? (
+            <GroupItem item={item} onNavigate={handleNavigate} />
+          ) : (
+            <AgentItem item={item} onNavigate={handleNavigate} />
+          )}
         </Flexbox>
       ))}
     </VList>

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
@@ -19,10 +19,11 @@ import { useGroupDropdownMenu } from './useDropdownMenu';
 interface GroupItemProps {
   className?: string;
   item: SidebarAgentItem;
+  onNavigate?: () => void;
   style?: CSSProperties;
 }
 
-const GroupItem = memo<GroupItemProps>(({ item, style, className }) => {
+const GroupItem = memo<GroupItemProps>(({ item, style, className, onNavigate }) => {
   const { id, avatar, backgroundColor, title, pinned } = item;
   const { t } = useTranslation('chat');
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
@@ -102,7 +103,7 @@ const GroupItem = memo<GroupItemProps>(({ item, style, className }) => {
   });
 
   return (
-    <Link aria-label={id} ref={setAnchor} to={groupUrl}>
+    <Link aria-label={id} ref={setAnchor} to={groupUrl} onClick={onNavigate}>
       <NavItem
         actions={<Actions dropdownMenu={dropdownMenu} />}
         className={className}

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
@@ -76,10 +76,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 interface AgentItemProps {
   className?: string;
   item: SidebarAgentItem;
+  onNavigate?: () => void;
   style?: CSSProperties;
 }
 
-const AgentItem = memo<AgentItemProps>(({ item, style, className }) => {
+const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) => {
   const { id, avatar, backgroundColor, title, pinned, heterogeneousType } = item;
   const { t } = useTranslation('chat');
   const { openCreateGroupModal } = useAgentModal();
@@ -204,7 +205,13 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className }) => {
   });
 
   return (
-    <Link aria-label={displayTitle} ref={setAnchor} to={agentUrl} onMouseEnter={handleMouseEnter}>
+    <Link
+      aria-label={displayTitle}
+      ref={setAnchor}
+      to={agentUrl}
+      onClick={onNavigate}
+      onMouseEnter={handleMouseEnter}
+    >
       <NavItem
         actions={<Actions dropdownMenu={dropdownMenu} />}
         className={className}

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentListContent.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentListContent.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { memo, useMemo } from 'react';
+
+import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { useFetchAgentList } from '@/hooks/useFetchAgentList';
+import { useHomeStore } from '@/store/home';
+import { homeAgentListSelectors } from '@/store/home/selectors';
+import { SessionDefaultGroup } from '@/types/index';
+
+import Group from './Group';
+import InboxItem from './InboxItem';
+import SessionList from './List';
+import { useAgentList } from './useAgentList';
+
+interface AgentListContentProps {
+  onMoreClick?: () => void;
+}
+
+// Keep this drawer-free so compact switchers can reuse the list without coupling to Home drawer state.
+const AgentListContent = memo<AgentListContentProps>(({ onMoreClick }) => {
+  const isInit = useHomeStore(homeAgentListSelectors.isAgentListInit);
+  const { customList, pinnedList, defaultList } = useAgentList();
+
+  useFetchAgentList();
+
+  // Memoize computed visibility flags to prevent unnecessary recalculations
+  const { showPinned, showCustom, showDefault } = useMemo(() => {
+    const hasPinned = Boolean(pinnedList?.length);
+    const hasCustom = Boolean(customList?.length);
+    const hasDefault = Boolean(defaultList?.length);
+
+    return {
+      showCustom: hasCustom,
+      showDefault: hasDefault,
+      showPinned: hasPinned,
+    };
+  }, [pinnedList?.length, customList?.length, defaultList?.length]);
+
+  if (!isInit) return <SkeletonList rows={6} />;
+
+  return (
+    <>
+      <InboxItem style={{ minHeight: 36 }} />
+      {showPinned && <SessionList dataSource={pinnedList!} />}
+      {showCustom && <Group dataSource={customList!} />}
+      {showDefault && (
+        <SessionList
+          dataSource={defaultList!}
+          groupId={SessionDefaultGroup.Default}
+          onMoreClick={onMoreClick}
+        />
+      )}
+    </>
+  );
+});
+
+AgentListContent.displayName = 'AgentListContent';
+
+export default AgentListContent;

--- a/src/routes/(main)/home/_layout/Body/Agent/List/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/index.tsx
@@ -1,57 +1,22 @@
 'use client';
 
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
-import SkeletonList from '@/features/NavPanel/components/SkeletonList';
-import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { useHomeStore } from '@/store/home';
-import { homeAgentListSelectors } from '@/store/home/selectors';
-import { SessionDefaultGroup } from '@/types/index';
 
 import AllAgentsDrawer from '../AllAgentsDrawer';
-import Group from './Group';
-import InboxItem from './InboxItem';
-import SessionList from './List';
-import { useAgentList } from './useAgentList';
+import AgentListContent from './AgentListContent';
 
+// The Home sidebar owns the all-agents drawer; other surfaces should import AgentListContent directly.
 const AgentList = memo<{ onMoreClick?: () => void }>(({ onMoreClick }) => {
-  const isInit = useHomeStore(homeAgentListSelectors.isAgentListInit);
-  const { customList, pinnedList, defaultList } = useAgentList();
-
   const [allAgentsDrawerOpen, closeAllAgentsDrawer] = useHomeStore((s) => [
     s.allAgentsDrawerOpen,
     s.closeAllAgentsDrawer,
   ]);
 
-  useFetchAgentList();
-
-  // Memoize computed visibility flags to prevent unnecessary recalculations
-  const { showPinned, showCustom, showDefault } = useMemo(() => {
-    const hasPinned = Boolean(pinnedList?.length);
-    const hasCustom = Boolean(customList?.length);
-    const hasDefault = Boolean(defaultList?.length);
-
-    return {
-      showCustom: hasCustom,
-      showDefault: hasDefault,
-      showPinned: hasPinned,
-    };
-  }, [pinnedList?.length, customList?.length, defaultList?.length]);
-
-  if (!isInit) return <SkeletonList rows={6} />;
-
   return (
     <>
-      <InboxItem style={{ minHeight: 36 }} />
-      {showPinned && <SessionList dataSource={pinnedList!} />}
-      {showCustom && <Group dataSource={customList!} />}
-      {showDefault && (
-        <SessionList
-          dataSource={defaultList!}
-          groupId={SessionDefaultGroup.Default}
-          onMoreClick={onMoreClick}
-        />
-      )}
+      <AgentListContent onMoreClick={onMoreClick} />
       <AllAgentsDrawer open={allAgentsDrawerOpen} onClose={closeAllAgentsDrawer} />
     </>
   );


### PR DESCRIPTION
## Summary
- 拆出 `AgentListContent` 作为不挂载 `AllAgentsDrawer` 的纯列表组件，供首页侧边栏和 agent 标题下拉复用
- 保留首页 `AgentList` 作为 drawer 容器，避免下拉场景继承 Home 的抽屉状态
- 让全部 Agents 抽屉内的 Agent/Group 点击后主动关闭抽屉，防止路由切换后状态残留
- 补充注释说明组件职责边界和这次拆分的设计意图

## Testing
- `bunx eslint` 目标文件检查通过
- `bun run type-check` 通过