### PR TITLE
♻️ refactor(web-crawler): remove zhihu-specific crawl rules

### DIFF
--- a/packages/web-crawler/src/urlRules.ts
+++ b/packages/web-crawler/src/urlRules.ts
@@ -53,15 +53,6 @@ export const crawUrlRules: CrawlUrlRule[] = [
     impls: ['jina'],
     urlPattern: 'https://arxiv.org/pdf/(.*)',
   },
-  // Zhihu has crawler protection, use jina
-  {
-    impls: ['jina'],
-    urlPattern: 'https://zhuanlan.zhihu.com(.*)',
-  },
-  {
-    impls: ['jina'],
-    urlPattern: 'https://zhihu.com(.*)',
-  },
   {
     // Convert Medium articles to Scribe.rip
     urlPattern: 'https://medium.com/(.*)',


### PR DESCRIPTION
## Summary

Remove zhihu-specific crawl rules that relied solely on Jina, which is now blocked by Zhihu.

## What changed

- Removed two URL rules targeting `zhuanlan.zhihu.com` and `zhihu.com`
- Both rules only specified `impls: ['jina']` with no fallback

## Why

Jina (r.jina.ai) is being blocked by Zhihu. Since the zhihu rules only used jina as the sole implementation, all Zhihu crawling fails.

By removing these rules, Zhihu URLs will now fall through to the default implementation chain:

```
jina → naive → search1api → browserless
```

This allows other implementations to be tried when jina fails.

## File changes

- `packages/web-crawler/src/urlRules.ts` — 9 lines removed