### PR TITLE
fix(security): add max pagination limits to tRPC endpoints

### DIFF
--- a/src/server/routers/lambda/agent.ts
+++ b/src/server/routers/lambda/agent.ts
@@ -276,7 +276,7 @@ export const agentRouter = router({
       z
         .object({
           keyword: z.string().optional(),
-          limit: z.number().optional(),
+          limit: z.number().optional().max(100),
           offset: z.number().optional(),
         })
         .optional(),

--- a/src/server/routers/lambda/document.ts
+++ b/src/server/routers/lambda/document.ts
@@ -229,7 +229,7 @@ export const documentRouter = router({
         .object({
           current: z.number().optional(),
           fileTypes: z.array(z.string()).optional(),
-          pageSize: z.number().optional(),
+          pageSize: z.number().optional().max(100),
           sourceTypes: z.array(z.string()).optional(),
         })
         .optional(),

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -423,7 +423,7 @@ export const fileRouter = router({
     }),
 
   recentFiles: fileProcedure
-    .input(z.object({ limit: z.number().optional() }).optional())
+    .input(z.object({ limit: z.number().optional().max(50) }).optional())
     .query(async ({ ctx, input }) => {
       const limit = input?.limit ?? 12;
       // Query recent items and filter for files only (exclude documents/pages)
@@ -483,7 +483,7 @@ export const fileRouter = router({
     }),
 
   recentPages: fileProcedure
-    .input(z.object({ limit: z.number().optional() }).optional())
+    .input(z.object({ limit: z.number().optional().max(50) }).optional())
     .query(async ({ ctx, input }) => {
       const limit = input?.limit ?? 12;
       // Query recent items and filter for pages (documents) only, exclude folders

--- a/src/server/routers/lambda/session.ts
+++ b/src/server/routers/lambda/session.ts
@@ -138,7 +138,7 @@ export const sessionRouter = router({
     .input(
       z.object({
         current: z.number().optional(),
-        pageSize: z.number().optional(),
+        pageSize: z.number().optional().max(100),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -147,7 +147,7 @@ export const sessionRouter = router({
       return ctx.sessionModel.query({ current, pageSize });
     }),
 
-  rankSessions: sessionProcedure.input(z.number().optional()).query(async ({ ctx, input }) => {
+  rankSessions: sessionProcedure.input(z.number().optional().max(50)).query(async ({ ctx, input }) => {
     return ctx.sessionModel.rank(input);
   }),
 

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -240,7 +240,7 @@ export const topicRouter = router({
         groupId: z.string().nullable().optional(),
         includeTriggers: z.array(z.string()).optional(),
         isInbox: z.boolean().optional(),
-        pageSize: z.number().optional(),
+        pageSize: z.number().optional().max(100),
         sessionId: z.string().nullable().optional(),
         triggers: z.array(z.string()).optional(),
       }),
@@ -340,12 +340,12 @@ export const topicRouter = router({
       return result;
     }),
 
-  rankTopics: topicProcedure.input(z.number().optional()).query(async ({ ctx, input }) => {
+  rankTopics: topicProcedure.input(z.number().optional().max(50)).query(async ({ ctx, input }) => {
     return ctx.topicModel.rank(input);
   }),
 
   recentTopics: topicProcedure
-    .input(z.object({ limit: z.number().optional() }).optional())
+    .input(z.object({ limit: z.number().optional().max(50) }).optional())
     .query(async ({ ctx, input }): Promise<RecentTopic[]> => {
       const recentTopics = await ctx.topicModel.queryRecent(input?.limit ?? 12);
 


### PR DESCRIPTION
## Summary

Fixes **GHSA-jr3g-w7rp-fhm9** — Unbounded Pagination Limits Across Multiple tRPC Endpoints Allow Authenticated Resource Exhaustion.

**CVSS:** 4.3 (Medium) | **Severity:** Medium

## Problem

Seven tRPC endpoints accepted user-controlled `limit`/`pageSize` parameters with no upper bound in their Zod schemas. An authenticated user could supply extremely large values (e.g., `999999999`) causing the database to attempt returning arbitrarily large result sets, leading to memory exhaustion and degraded service availability.

## Changes

Added `.max()` constraints to all seven affected Zod schemas:

| File | Endpoint | Parameter | Max |
|------|----------|-----------|-----|
| `lambda/file.ts` | `file.recentFiles` | `limit` | 50 |
| `lambda/file.ts` | `file.recentPages` | `limit` | 50 |
| `lambda/topic.ts` | `topic.getTopics` | `pageSize` | 100 |
| `lambda/topic.ts` | `topic.rankTopics` | input | 50 |
| `lambda/topic.ts` | `topic.recentTopics` | `limit` | 50 |
| `lambda/session.ts` | `session.getSessions` | `pageSize` | 100 |
| `lambda/session.ts` | `session.rankSessions` | input | 50 |
| `lambda/agent.ts` | `agent.queryAgents` | `limit` | 100 |
| `lambda/document.ts` | `document.queryDocuments` | `pageSize` | 100 |

## Verification

The fix is purely at the Zod schema validation layer — no changes to business logic or DB query structure. Existing callers using the default values (12–50 items) are unaffected.

## References

- Security Advisory: GHSA-jr3g-w7rp-fhm9
