### PR TITLE
💄 style(builtin-tools): add UI render for github marketplace tool

### DIFF
--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/ExportFile/index.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { FilePathDisplay } from '@lobechat/shared-tool-ui/components';
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { Icon } from '@lobehub/ui';
+import { cssVar, cx } from 'antd-style';
+import { Check, X } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ExportFileState } from '../../../types';
+
+interface ExportFileArgs {
+  path?: string;
+}
+
+export const ExportFileInspector = memo<BuiltinInspectorProps<ExportFileArgs, ExportFileState>>(
+  ({ args, partialArgs, isArgumentsStreaming, pluginState, isLoading }) => {
+    const { t } = useTranslation('plugin');
+
+    const filePath = args?.path || partialArgs?.path || '';
+    const showShiny = isArgumentsStreaming || isLoading;
+
+    return (
+      <div className={cx(inspectorTextStyles.root, showShiny && shinyTextStyles.shinyText)}>
+        <span style={{ marginInlineEnd: 6 }}>
+          {t('builtins.lobe-cloud-sandbox.apiName.exportFile')}:
+        </span>
+        {filePath && <FilePathDisplay filePath={filePath} />}
+        {!isLoading && pluginState !== undefined && (
+          <span style={{ marginInlineStart: 4 }}>
+            {pluginState.success ? (
+              <Icon color={cssVar.colorSuccess} icon={Check} size={14} />
+            ) : (
+              <Icon color={cssVar.colorError} icon={X} size={14} />
+            )}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+
+ExportFileInspector.displayName = 'ExportFileInspector';

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/MoveLocalFiles/index.tsx
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/MoveLocalFiles/index.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { createMoveLocalFilesInspector } from '@lobechat/shared-tool-ui/inspectors';
+
+export const MoveLocalFilesInspector = createMoveLocalFilesInspector(
+  'builtins.lobe-cloud-sandbox.apiName.moveLocalFiles',
+);

--- a/packages/builtin-tool-cloud-sandbox/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/client/Inspector/index.ts
@@ -1,9 +1,11 @@
 import { CloudSandboxApiName } from '../../types';
 import { EditLocalFileInspector } from './EditLocalFile';
 import { ExecuteCodeInspector } from './ExecuteCode';
+import { ExportFileInspector } from './ExportFile';
 import { GlobLocalFilesInspector } from './GlobLocalFiles';
 import { GrepContentInspector } from './GrepContent';
 import { ListLocalFilesInspector } from './ListLocalFiles';
+import { MoveLocalFilesInspector } from './MoveLocalFiles';
 import { ReadLocalFileInspector } from './ReadLocalFile';
 import { RunCommandInspector } from './RunCommand';
 import { SearchLocalFilesInspector } from './SearchLocalFiles';
@@ -15,9 +17,11 @@ import { WriteLocalFileInspector } from './WriteLocalFile';
 export const CloudSandboxInspectors = {
   [CloudSandboxApiName.editLocalFile]: EditLocalFileInspector,
   [CloudSandboxApiName.executeCode]: ExecuteCodeInspector,
+  [CloudSandboxApiName.exportFile]: ExportFileInspector,
   [CloudSandboxApiName.globLocalFiles]: GlobLocalFilesInspector,
   [CloudSandboxApiName.grepContent]: GrepContentInspector,
   [CloudSandboxApiName.listLocalFiles]: ListLocalFilesInspector,
+  [CloudSandboxApiName.moveLocalFiles]: MoveLocalFilesInspector,
   [CloudSandboxApiName.readLocalFile]: ReadLocalFileInspector,
   [CloudSandboxApiName.runCommand]: RunCommandInspector,
   [CloudSandboxApiName.searchLocalFiles]: SearchLocalFilesInspector,

--- a/packages/builtin-tool-local-system/src/client/Inspector/MoveLocalFiles/index.tsx
+++ b/packages/builtin-tool-local-system/src/client/Inspector/MoveLocalFiles/index.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { createMoveLocalFilesInspector } from '@lobechat/shared-tool-ui/inspectors';
+
+export const MoveLocalFilesInspector = createMoveLocalFilesInspector(
+  'builtins.lobe-local-system.apiName.moveLocalFiles',
+);

--- a/packages/builtin-tool-local-system/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-local-system/src/client/Inspector/index.ts
@@ -3,6 +3,7 @@ import { EditLocalFileInspector } from './EditLocalFile';
 import { GlobLocalFilesInspector } from './GlobLocalFiles';
 import { GrepContentInspector } from './GrepContent';
 import { ListLocalFilesInspector } from './ListLocalFiles';
+import { MoveLocalFilesInspector } from './MoveLocalFiles';
 import { ReadLocalFileInspector } from './ReadLocalFile';
 import { RenameLocalFileInspector } from './RenameLocalFile';
 import { RunCommandInspector } from './RunCommand';
@@ -17,6 +18,7 @@ export const LocalSystemInspectors = {
   [LocalSystemApiName.globLocalFiles]: GlobLocalFilesInspector,
   [LocalSystemApiName.grepContent]: GrepContentInspector,
   [LocalSystemApiName.listLocalFiles]: ListLocalFilesInspector,
+  [LocalSystemApiName.moveLocalFiles]: MoveLocalFilesInspector,
   [LocalSystemApiName.readLocalFile]: ReadLocalFileInspector,
   [LocalSystemApiName.renameLocalFile]: RenameLocalFileInspector,
   [LocalSystemApiName.runCommand]: RunCommandInspector,

--- a/packages/builtin-tools/package.json
+++ b/packages/builtin-tools/package.json
@@ -46,7 +46,8 @@
     "@lobechat/builtin-tool-user-interaction": "workspace:*",
     "@lobechat/builtin-tool-web-browsing": "workspace:*",
     "@lobechat/builtin-tool-web-onboarding": "workspace:*",
-    "@lobechat/const": "workspace:*"
+    "@lobechat/const": "workspace:*",
+    "@lobehub/icons": "^5.4.0"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*",

--- a/packages/builtin-tools/src/github/RunCommandInspector.tsx
+++ b/packages/builtin-tools/src/github/RunCommandInspector.tsx
@@ -43,6 +43,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   icon: css`
     flex-shrink: 0;
+    margin-inline: 6px;
     color: ${cssVar.colorTextDescription};
   `,
   statusIcon: css`
@@ -62,11 +63,13 @@ const GithubRunCommandInspector = memo<
 
   return (
     <div className={cx(inspectorTextStyles.root, pulse && shinyTextStyles.shinyText)}>
-      <span className={styles.chip}>
-        <Github className={styles.icon} size={14} />
-        <span className={styles.ghPrefix}>gh</span>
-        {subcommand && <span className={styles.command}>{subcommand}</span>}
-      </span>
+      <span className={styles.ghPrefix}>gh</span>
+      <Github className={styles.icon} size={14} />
+      {subcommand && (
+        <span className={styles.chip}>
+          <span className={styles.command}>{subcommand}</span>
+        </span>
+      )}
       {hasResult ? (
         isSuccess ? (
           <Check className={styles.statusIcon} color={cssVar.colorSuccess} size={14} />

--- a/packages/builtin-tools/src/github/RunCommandInspector.tsx
+++ b/packages/builtin-tools/src/github/RunCommandInspector.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { Github } from '@lobehub/icons';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { Check, X } from 'lucide-react';
+import { memo } from 'react';
+
+import { getGhSubcommand, type GithubRunCommandArgs, type GithubRunCommandState } from './utils';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    gap: 6px;
+    align-items: center;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    padding-block: 2px;
+    padding-inline: 10px;
+    border-radius: 999px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  command: css`
+    overflow: hidden;
+
+    min-width: 0;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  ghPrefix: css`
+    flex-shrink: 0;
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  icon: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextDescription};
+  `,
+  statusIcon: css`
+    margin-inline-start: 4px;
+  `,
+}));
+
+const GithubRunCommandInspector = memo<
+  BuiltinInspectorProps<GithubRunCommandArgs, GithubRunCommandState>
+>(({ args, partialArgs, isArgumentsStreaming, isLoading, pluginState }) => {
+  const command = args?.command || partialArgs?.command || '';
+  const subcommand = getGhSubcommand(command);
+
+  const pulse = isArgumentsStreaming || isLoading;
+
+  if (isArgumentsStreaming && !subcommand) {
+    return (
+      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
+        <span>GitHub</span>
+      </div>
+    );
+  }
+
+  const isSuccess = pluginState?.success ?? pluginState?.exitCode === 0;
+  const hasResult = !pulse && pluginState && pluginState.success !== undefined;
+
+  return (
+    <div className={cx(inspectorTextStyles.root, pulse && shinyTextStyles.shinyText)}>
+      <span>GitHub:</span>
+      {subcommand && (
+        <span className={styles.chip}>
+          <Github className={styles.icon} size={14} />
+          <span className={styles.ghPrefix}>gh</span>
+          <span className={styles.command}>{subcommand}</span>
+        </span>
+      )}
+      {hasResult ? (
+        isSuccess ? (
+          <Check className={styles.statusIcon} color={cssVar.colorSuccess} size={14} />
+        ) : (
+          <X className={styles.statusIcon} color={cssVar.colorError} size={14} />
+        )
+      ) : null}
+    </div>
+  );
+});
+
+GithubRunCommandInspector.displayName = 'GithubRunCommandInspector';
+
+export default GithubRunCommandInspector;

--- a/packages/builtin-tools/src/github/RunCommandInspector.tsx
+++ b/packages/builtin-tools/src/github/RunCommandInspector.tsx
@@ -37,13 +37,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   ghPrefix: css`
     flex-shrink: 0;
+
+    margin-inline-end: 6px;
+
     font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
     color: ${cssVar.colorTextDescription};
   `,
   icon: css`
     flex-shrink: 0;
-    margin-inline: 6px;
+    margin-inline-end: 6px;
     color: ${cssVar.colorTextDescription};
   `,
   statusIcon: css`
@@ -63,8 +66,8 @@ const GithubRunCommandInspector = memo<
 
   return (
     <div className={cx(inspectorTextStyles.root, pulse && shinyTextStyles.shinyText)}>
-      <span className={styles.ghPrefix}>gh</span>
       <Github className={styles.icon} size={14} />
+      <span className={styles.ghPrefix}>gh</span>
       {subcommand && (
         <span className={styles.chip}>
           <span className={styles.command}>{subcommand}</span>

--- a/packages/builtin-tools/src/github/RunCommandInspector.tsx
+++ b/packages/builtin-tools/src/github/RunCommandInspector.tsx
@@ -18,7 +18,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    margin-inline-start: 6px;
     padding-block: 2px;
     padding-inline: 10px;
     border-radius: 999px;
@@ -58,28 +57,16 @@ const GithubRunCommandInspector = memo<
   const subcommand = getGhSubcommand(command);
 
   const pulse = isArgumentsStreaming || isLoading;
-
-  if (isArgumentsStreaming && !subcommand) {
-    return (
-      <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>
-        <span>GitHub</span>
-      </div>
-    );
-  }
-
   const isSuccess = pluginState?.success ?? pluginState?.exitCode === 0;
   const hasResult = !pulse && pluginState && pluginState.success !== undefined;
 
   return (
     <div className={cx(inspectorTextStyles.root, pulse && shinyTextStyles.shinyText)}>
-      <span>GitHub:</span>
-      {subcommand && (
-        <span className={styles.chip}>
-          <Github className={styles.icon} size={14} />
-          <span className={styles.ghPrefix}>gh</span>
-          <span className={styles.command}>{subcommand}</span>
-        </span>
-      )}
+      <span className={styles.chip}>
+        <Github className={styles.icon} size={14} />
+        <span className={styles.ghPrefix}>gh</span>
+        {subcommand && <span className={styles.command}>{subcommand}</span>}
+      </span>
       {hasResult ? (
         isSuccess ? (
           <Check className={styles.statusIcon} color={cssVar.colorSuccess} size={14} />

--- a/packages/builtin-tools/src/github/RunCommandRender.tsx
+++ b/packages/builtin-tools/src/github/RunCommandRender.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { ToolResultCard } from '@lobechat/shared-tool-ui/components';
+import type { BuiltinRenderProps } from '@lobechat/types';
+import { Flexbox, Highlighter, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { GitBranch } from 'lucide-react';
+import { memo, useMemo } from 'react';
+
+import {
+  getGhSubcommand,
+  getGithubOutput,
+  type GithubRunCommandArgs,
+  type GithubRunCommandState,
+  normalizeGhCommand,
+  tryParseJson,
+} from './utils';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  exitCode: css`
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+  `,
+  exitCodeError: css`
+    color: ${cssVar.colorError};
+  `,
+  exitCodeSuccess: css`
+    color: ${cssVar.colorSuccess};
+  `,
+  ghPrefix: css`
+    flex-shrink: 0;
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  headerCommand: css`
+    overflow: hidden;
+    flex: 1 1 auto;
+
+    min-width: 0;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 13px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  headerRow: css`
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    min-width: 0;
+  `,
+  sectionLabel: css`
+    margin-block-end: 4px;
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+}));
+
+const GithubRunCommandRender = memo<
+  BuiltinRenderProps<GithubRunCommandArgs, GithubRunCommandState>
+>(({ args, content, pluginState }) => {
+  const rawCommand = args?.command || '';
+  const normalized = normalizeGhCommand(rawCommand);
+  const subcommand = getGhSubcommand(rawCommand);
+
+  const output = getGithubOutput(pluginState, content);
+  const stderr = pluginState?.stderr || '';
+  const exitCode = pluginState?.exitCode;
+  const success = pluginState?.success ?? (exitCode === undefined ? undefined : exitCode === 0);
+
+  const { language: outputLanguage, body: outputBody } = useMemo(() => {
+    const parsed = tryParseJson(output);
+    if (parsed !== undefined) {
+      return { body: JSON.stringify(parsed, null, 2), language: 'json' as const };
+    }
+    return { body: output, language: 'text' as const };
+  }, [output]);
+
+  if (!normalized && !output && !stderr) return null;
+
+  return (
+    <ToolResultCard
+      wrapHeader
+      icon={GitBranch}
+      header={
+        <Flexbox horizontal align={'center'} className={styles.headerRow} wrap={'wrap'}>
+          <span className={styles.ghPrefix}>gh</span>
+          <span className={styles.headerCommand}>{subcommand || normalized || 'command'}</span>
+          {success !== undefined && (
+            <span
+              className={`${styles.exitCode} ${
+                success ? styles.exitCodeSuccess : styles.exitCodeError
+              }`}
+            >
+              exit {exitCode ?? (success ? 0 : 1)}
+            </span>
+          )}
+        </Flexbox>
+      }
+    >
+      <Flexbox gap={12}>
+        {normalized && (
+          <div>
+            <Text className={styles.sectionLabel}>Command</Text>
+            <Highlighter
+              wrap
+              language={'sh'}
+              showLanguage={false}
+              style={{ maxHeight: 160, overflow: 'auto', paddingInline: 8 }}
+              variant={'outlined'}
+            >
+              {`gh ${normalized}`}
+            </Highlighter>
+          </div>
+        )}
+        {outputBody && (
+          <div>
+            <Text className={styles.sectionLabel}>Output</Text>
+            <Highlighter
+              wrap
+              language={outputLanguage}
+              showLanguage={outputLanguage === 'json'}
+              style={{ maxHeight: 360, overflow: 'auto', paddingInline: 8 }}
+              variant={'filled'}
+            >
+              {outputBody}
+            </Highlighter>
+          </div>
+        )}
+        {stderr && (
+          <div>
+            <Text className={styles.sectionLabel} style={{ color: cssVar.colorError }}>
+              Stderr
+            </Text>
+            <Highlighter
+              wrap
+              language={'text'}
+              showLanguage={false}
+              style={{ maxHeight: 200, overflow: 'auto', paddingInline: 8 }}
+              variant={'filled'}
+            >
+              {stderr}
+            </Highlighter>
+          </div>
+        )}
+      </Flexbox>
+    </ToolResultCard>
+  );
+});
+
+GithubRunCommandRender.displayName = 'GithubRunCommandRender';
+
+export default GithubRunCommandRender;

--- a/packages/builtin-tools/src/github/index.ts
+++ b/packages/builtin-tools/src/github/index.ts
@@ -1,0 +1,18 @@
+import { type BuiltinInspector, type BuiltinRender } from '@lobechat/types';
+
+import GithubRunCommandInspector from './RunCommandInspector';
+import GithubRunCommandRender from './RunCommandRender';
+
+export const GithubIdentifier = 'github';
+
+export const GithubApiName = {
+  runCommand: 'run_command',
+} as const;
+
+export const GithubInspectors: Record<string, BuiltinInspector> = {
+  [GithubApiName.runCommand]: GithubRunCommandInspector as BuiltinInspector,
+};
+
+export const GithubRenders: Record<string, BuiltinRender> = {
+  [GithubApiName.runCommand]: GithubRunCommandRender as BuiltinRender,
+};

--- a/packages/builtin-tools/src/github/utils.ts
+++ b/packages/builtin-tools/src/github/utils.ts
@@ -1,0 +1,63 @@
+'use client';
+
+export interface GithubRunCommandArgs {
+  command?: string;
+}
+
+export interface GithubRunCommandState {
+  exitCode?: number;
+  output?: string;
+  stderr?: string;
+  stdout?: string;
+  success?: boolean;
+}
+
+/**
+ * Normalize a gh command string by stripping a leading `gh ` prefix if present.
+ * The tool's manifest accepts both `gh repo list` and `repo list`.
+ */
+export const normalizeGhCommand = (command?: string): string => {
+  const trimmed = (command || '').trim();
+  if (!trimmed) return '';
+  if (trimmed === 'gh') return '';
+  return trimmed.startsWith('gh ') ? trimmed.slice(3).trimStart() : trimmed;
+};
+
+/**
+ * Extract the gh subcommand path (e.g. "repo list", "api /repos/...", "issue create")
+ * for compact display. Stops at the first flag (token starting with `-`).
+ */
+export const getGhSubcommand = (command?: string): string => {
+  const normalized = normalizeGhCommand(command);
+  if (!normalized) return '';
+
+  const tokens = normalized.split(/\s+/);
+  const subcommandTokens: string[] = [];
+  for (const token of tokens) {
+    if (token.startsWith('-')) break;
+    subcommandTokens.push(token);
+    // Most gh commands are 2-3 tokens deep; cap to keep the chip short.
+    if (subcommandTokens.length >= 3) break;
+  }
+  return subcommandTokens.join(' ');
+};
+
+/**
+ * Best-effort: detect whether a string is JSON so the render can syntax-highlight
+ * the output of `gh api` or `gh ... --json` calls.
+ */
+export const tryParseJson = (value?: string): unknown | undefined => {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const first = trimmed[0];
+  if (first !== '{' && first !== '[') return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+};
+
+export const getGithubOutput = (state?: GithubRunCommandState, fallbackContent?: string): string =>
+  state?.output || state?.stdout || fallbackContent || '';

--- a/packages/builtin-tools/src/inspectors.ts
+++ b/packages/builtin-tools/src/inspectors.ts
@@ -57,6 +57,7 @@ import { createRunCommandInspector } from '@lobechat/shared-tool-ui/inspectors';
 import { type BuiltinInspector } from '@lobechat/types';
 
 import { CodexInspectors } from './codex';
+import { GithubIdentifier, GithubInspectors } from './github';
 
 /**
  * Builtin tools inspector registry
@@ -100,6 +101,7 @@ const BuiltinToolInspectors: Record<string, Record<string, BuiltinInspector>> = 
     ...CodexInspectors,
     command_execution: createRunCommandInspector('Run') as BuiltinInspector,
   },
+  [GithubIdentifier]: GithubInspectors,
 };
 
 export interface BuiltinInspectorRegistryEntry {

--- a/packages/builtin-tools/src/renders.ts
+++ b/packages/builtin-tools/src/renders.ts
@@ -38,6 +38,7 @@ import { RunCommandRender } from '@lobechat/shared-tool-ui/renders';
 import { type BuiltinRender } from '@lobechat/types';
 
 import { CodexRenders } from './codex';
+import { GithubIdentifier, GithubRenders } from './github';
 
 export interface BuiltinRenderRegistryEntry {
   apiName: string;
@@ -74,6 +75,7 @@ const BuiltinToolsRenders: Record<string, Record<string, BuiltinRender>> = {
     ...CodexRenders,
     command_execution: RunCommandRender as BuiltinRender,
   },
+  [GithubIdentifier]: GithubRenders,
 };
 
 export const listBuiltinRenderEntries = (): BuiltinRenderRegistryEntry[] =>

--- a/packages/shared-tool-ui/src/Inspector/MoveLocalFiles/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/MoveLocalFiles/index.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { MoveFilesState } from '@lobechat/tool-runtime';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { Icon, Text } from '@lobehub/ui';
+import { cssVar, cx } from 'antd-style';
+import { Check, X } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { inspectorTextStyles, shinyTextStyles } from '../../styles';
+
+interface MoveFilesArgs {
+  items?: Array<{ newPath?: string; oldPath?: string }>;
+  operations?: Array<{ destination?: string; source?: string }>;
+}
+
+export const createMoveLocalFilesInspector = (translationKey: string) => {
+  const Inspector = memo<BuiltinInspectorProps<MoveFilesArgs, MoveFilesState>>(
+    ({ args, partialArgs, isArgumentsStreaming, pluginState, isLoading }) => {
+      const { t } = useTranslation('plugin');
+
+      const sourceArgs = args || partialArgs || {};
+      const itemsCount = sourceArgs.operations?.length ?? sourceArgs.items?.length ?? 0;
+
+      const totalCount = pluginState?.totalCount ?? itemsCount;
+      const successCount = pluginState?.successCount;
+      const allSucceeded =
+        successCount !== undefined && totalCount > 0 && successCount === totalCount;
+
+      const showShiny = isArgumentsStreaming || isLoading;
+
+      return (
+        <div className={cx(inspectorTextStyles.root, showShiny && shinyTextStyles.shinyText)}>
+          <span style={{ marginInlineEnd: 6 }}>{t(translationKey as any)}</span>
+          {totalCount > 0 && (
+            <Text code as={'span'} fontSize={12}>
+              {successCount === undefined ? totalCount : `${successCount}/${totalCount}`}
+            </Text>
+          )}
+          {!isLoading && successCount !== undefined && (
+            <span style={{ marginInlineStart: 4 }}>
+              {allSucceeded ? (
+                <Icon color={cssVar.colorSuccess} icon={Check} size={14} />
+              ) : (
+                <Icon color={cssVar.colorError} icon={X} size={14} />
+              )}
+            </span>
+          )}
+        </div>
+      );
+    },
+  );
+  Inspector.displayName = 'MoveLocalFilesInspector';
+  return Inspector;
+};

--- a/packages/shared-tool-ui/src/Inspector/index.ts
+++ b/packages/shared-tool-ui/src/Inspector/index.ts
@@ -2,6 +2,7 @@ export { createEditLocalFileInspector } from './EditLocalFile';
 export { createGlobLocalFilesInspector } from './GlobLocalFiles';
 export { createGrepContentInspector } from './GrepContent';
 export { createListLocalFilesInspector } from './ListLocalFiles';
+export { createMoveLocalFilesInspector } from './MoveLocalFiles';
 export { createReadLocalFileInspector } from './ReadLocalFile';
 export { createRunCommandInspector, RunCommandInspector } from './RunCommand';
 export { createSearchLocalFilesInspector } from './SearchLocalFiles';

--- a/src/features/DevPanel/RenderGallery/toolRenderFixtures.ts
+++ b/src/features/DevPanel/RenderGallery/toolRenderFixtures.ts
@@ -1222,6 +1222,17 @@ const toolRenderFixtures: Record<string, ToolRenderFixture> = {
       responseLanguage: 'en-US',
     },
   },
+
+  [keyOf('github', 'run_command')]: {
+    args: {
+      command: 'gh api /repos/lobehub/lobe-chat/issues?state=open',
+    },
+    pluginState: {
+      command: 'gh api /repos/lobehub/lobe-chat/issues?state=open',
+      exitCode: 0,
+      success: true,
+    },
+  },
 };
 
 export const getToolRenderFixture = (


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds an Inspector + Render for the marketplace `github` MCP tool — a single-API tool whose only argument is a `gh` CLI command string.

Mirrors the existing `codex` non-builtin pattern under `packages/builtin-tools/src/github/`, registered in the central registries under identifier `github`, apiName `run_command`. No new builtin tool package, no manifest, no executor — only UI surfaces, since the tool is provided by the marketplace at runtime.

- **Inspector** — header chip showing the GitHub brand icon + parsed `gh <subcommand>` (e.g. `gh repo list`, `gh api`), pulses while args stream / executor runs, and shows ✓/✗ once the call resolves.
- **Render** — `ToolResultCard` with a `gh <subcommand>` header and exit code, plus three sections: the full `gh` command (`sh`-highlighted), the output (auto-detected as JSON for `gh api` / `--json` calls, otherwise plain text), and a stderr section when present.
- **Utils** — strips an optional leading `gh ` prefix (the manifest accepts both `gh repo list` and `repo list`), extracts the first 1–3 non-flag tokens for the chip, and best-effort detects JSON output.

The Render relies on `BuiltinRenderProps`'s `pluginState` (`success`, `exitCode`, `output`/`stdout`, `stderr`) and falls back to `content` when the marketplace tool only returns a string.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

`bun run type-check` passes. End-to-end visual verification requires a chat session that calls the marketplace `github` tool — I have not exercised that path, so the live render should be sanity-checked once the tool is available in a dev environment.

Two open assumptions:

1. **API name** — registered as `run_command`. If the marketplace tool's apiName is different (e.g. `gh`, `runCommand`), update `GithubApiName` in `packages/builtin-tools/src/github/index.ts`.
2. **No i18n key** — Inspector hardcodes the `"GitHub:"` label; marketplace tools aren't tracked in `src/locales/default/plugin.ts`. Easy to add if needed.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Falls back to generic argument render | GitHub brand chip + parsed gh subcommand in header; ToolResultCard with the gh command and JSON-aware output below |

#### 📝 Additional Information

No breaking changes. Adds `@lobehub/icons` as a direct dep of `@lobechat/builtin-tools` (already present transitively elsewhere; no lockfile churn).