### PR TITLE
🐛 fix: revoke sessions after password reset

### DIFF
--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  betterAuth: vi.fn((options) => options),
+}));
+
+vi.mock('@better-auth/expo', () => ({
+  expo: vi.fn(() => ({ id: 'expo' })),
+}));
+
+vi.mock('@better-auth/passkey', () => ({
+  passkey: vi.fn(() => ({ id: 'passkey' })),
+}));
+
+vi.mock('@lobechat/business-const', () => ({
+  ENABLE_BUSINESS_FEATURES: false,
+}));
+
+vi.mock('@lobechat/database', () => ({
+  createNanoId: vi.fn(() => vi.fn(() => 'generated-id')),
+  idGenerator: vi.fn(() => 'generated-user-id'),
+  serverDB: {},
+}));
+
+vi.mock('@lobechat/database/schemas', () => ({}));
+
+vi.mock('bcryptjs', () => ({
+  default: {
+    compare: vi.fn(),
+  },
+}));
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: vi.fn(() => ({ id: 'drizzle-adapter' })),
+}));
+
+vi.mock('better-auth/crypto', () => ({
+  verifyPassword: vi.fn(),
+}));
+
+vi.mock('better-auth/minimal', () => ({
+  betterAuth: mocks.betterAuth,
+}));
+
+vi.mock('better-auth/plugins', () => ({
+  admin: vi.fn(() => ({ id: 'admin' })),
+  emailOTP: vi.fn(() => ({ id: 'email-otp' })),
+  genericOAuth: vi.fn(() => ({ id: 'generic-oauth' })),
+  magicLink: vi.fn(() => ({ id: 'magic-link' })),
+}));
+
+vi.mock('better-auth-harmony', () => ({
+  emailHarmony: vi.fn(() => ({ id: 'email-harmony' })),
+}));
+
+vi.mock('better-auth-harmony/email', () => ({
+  validateEmail: vi.fn(),
+}));
+
+vi.mock('undici', () => ({
+  ProxyAgent: vi.fn(),
+  setGlobalDispatcher: vi.fn(),
+}));
+
+vi.mock('@/business/server/better-auth', () => ({
+  businessEmailValidator: vi.fn(),
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: {
+    APP_URL: 'https://example.com',
+  },
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    AUTH_DISABLE_EMAIL_PASSWORD: false,
+    AUTH_EMAIL_VERIFICATION: true,
+    AUTH_ENABLE_MAGIC_LINK: false,
+    AUTH_SECRET: 'test-secret',
+    AUTH_SSO_PROVIDERS: '',
+  },
+}));
+
+vi.mock('@/libs/better-auth/email-templates', () => ({
+  getChangeEmailVerificationTemplate: vi.fn(() => ({})),
+  getMagicLinkEmailTemplate: vi.fn(() => ({})),
+  getResetPasswordEmailTemplate: vi.fn(() => ({})),
+  getVerificationEmailTemplate: vi.fn(() => ({})),
+  getVerificationOTPEmailTemplate: vi.fn(() => ({})),
+}));
+
+vi.mock('@/libs/better-auth/plugins/email-whitelist', () => ({
+  emailWhitelist: vi.fn(() => ({ id: 'email-whitelist' })),
+}));
+
+vi.mock('@/libs/better-auth/sso', () => ({
+  initBetterAuthSSOProviders: vi.fn(() => ({
+    genericOAuthProviders: [],
+    socialProviders: {},
+  })),
+}));
+
+vi.mock('@/libs/better-auth/utils/config', () => ({
+  createSecondaryStorage: vi.fn(() => ({ id: 'secondary-storage' })),
+  getTrustedOrigins: vi.fn(() => ['https://example.com']),
+}));
+
+vi.mock('@/libs/better-auth/utils/server', () => ({
+  parseSSOProviders: vi.fn(() => []),
+}));
+
+vi.mock('@/server/services/email', () => ({
+  EmailService: vi.fn(),
+}));
+
+vi.mock('@/server/services/user', () => ({
+  UserService: vi.fn(),
+}));
+
+describe('defineConfig', () => {
+  it('should revoke existing sessions after password reset by default', async () => {
+    const { defineConfig } = await import('./define-config');
+
+    defineConfig({ plugins: [] });
+
+    expect(mocks.betterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: expect.objectContaining({
+          revokeSessionsOnPasswordReset: true,
+        }),
+      }),
+    );
+  });
+});

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -113,6 +113,7 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       maxPasswordLength: 64,
       minPasswordLength: 8,
       requireEmailVerification: authEnv.AUTH_EMAIL_VERIFICATION,
+      revokeSessionsOnPasswordReset: true,
 
       // Compatible with bcrypt password hashes migrated from Clerk; after login, you can re-hash in the backend using BetterAuth's default scrypt.
       password: {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - user-reported account security behavior.

#### 🔀 Description of Change

Enable Better Auth `revokeSessionsOnPasswordReset` by default so existing sessions are invalidated after a successful password reset.

This prevents already signed-in devices from retaining access after the account owner resets their password.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/libs/better-auth/define-config.test.ts'\n```\n\n#### 📸 Screenshots / Videos\n\nN/A - no UI changes.\n\n#### 📝 Additional Information\n\nThis only changes the shared Better Auth default configuration.