### PR TITLE
feat(mobile): add homeRouter to mobile tRPC router

### DIFF
--- a/src/server/routers/mobile/index.ts
+++ b/src/server/routers/mobile/index.ts
@@ -13,6 +13,7 @@ import { aiProviderRouter } from '../lambda/aiProvider';
 import { chunkRouter } from '../lambda/chunk';
 import { configRouter } from '../lambda/config';
 import { documentRouter } from '../lambda/document';
+import { homeRouter } from '../lambda/home';
 import { fileRouter } from '../lambda/file';
 import { knowledgeBaseRouter } from '../lambda/knowledgeBase';
 import { marketRouter } from '../lambda/market';
@@ -34,6 +35,7 @@ export const mobileRouter = router({
   document: documentRouter,
   file: fileRouter,
   healthcheck: publicProcedure.query(() => "i'm live!"),
+  home: homeRouter,
   knowledgeBase: knowledgeBaseRouter,
   market: marketRouter,
   message: messageRouter,


### PR DESCRIPTION
## Summary
- Add `homeRouter` to the mobile tRPC router, enabling the mobile app to access `home.getSidebarAgentList`, `home.searchAgents`, and `home.updateAgentSessionGroupId`
- This is a prerequisite for migrating the mobile SessionList from sessionId to agentId (LOBE-8401)

## Test plan
- [ ] Verify mobile tRPC client can call `home.getSidebarAgentList`
- [ ] Verify existing mobile endpoints are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)