### PR TITLE
🐛 fix: handle unsupported xAI parameters

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -577,6 +577,47 @@ describe('createRouterRuntime', () => {
       expect(mockChatFail).toHaveBeenCalledTimes(1);
     });
 
+    it('should not retry when the upstream rejects an unsupported model parameter', async () => {
+      const unsupportedParameterError = {
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        error: {
+          error: {
+            code: 'bad_response_status_code',
+            message: 'Model grok-4.20-0309-reasoning does not support parameter presencePenalty.',
+            param: '400',
+            type: 'upstream_error',
+          },
+          message: '400 Model grok-4.20-0309-reasoning does not support parameter presencePenalty.',
+        },
+        provider: 'test',
+      };
+
+      const mockChatFail = vi.fn().mockRejectedValue(unsupportedParameterError);
+
+      class FailRuntime implements LobeRuntimeAI {
+        chat = mockChatFail;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: [{ apiKey: 'key-1' }, { apiKey: 'key-2' }],
+            runtime: FailRuntime as any,
+            models: ['gpt-4'],
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+      await expect(
+        runtime.chat({ model: 'gpt-4', messages: [], temperature: 0.7 }),
+      ).rejects.toEqual(unsupportedParameterError);
+
+      expect(mockChatFail).toHaveBeenCalledTimes(1);
+    });
+
     it('should not retry when shouldStopFallback returns true', async () => {
       const moderationError = {
         errorType: AgentRuntimeErrorType.ProviderBizError,

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -28,6 +28,39 @@ describe('LobeXAI - custom features', () => {
     vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(new ReadableStream() as any);
   });
 
+  describe('chatCompletion.handlePayload', () => {
+    it('should remove camelCase penalty parameters for grok-4.20 reasoning variants', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequencyPenalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4.20-beta-0309-reasoning',
+        presencePenalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequencyPenalty).toBeUndefined();
+      expect(createCall.presencePenalty).toBeUndefined();
+      expect(createCall.stream).toBe(true);
+    });
+
+    it('should preserve penalty parameters for legacy non-reasoning models', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequency_penalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-fast-non-reasoning',
+        presence_penalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequency_penalty).toBe(0.4);
+      expect(createCall.presence_penalty).toBe(0.6);
+    });
+  });
+
   describe('responses.handlePayload', () => {
     it('should remove unsupported penalty parameters via Responses API', async () => {
       await instance.chat({
@@ -44,9 +77,22 @@ describe('LobeXAI - custom features', () => {
       expect(createCall.presence_penalty).toBeUndefined();
       expect(createCall.stream).toBe(true);
     });
-  });
 
-  describe('responses.handlePayload', () => {
+    it('should remove camelCase penalty parameters for grok-4.20 reasoning variants', async () => {
+      await instance.chat({
+        apiMode: 'responses',
+        frequencyPenalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4.20-beta-0309-reasoning',
+        presencePenalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequencyPenalty).toBeUndefined();
+      expect(createCall.presencePenalty).toBeUndefined();
+    });
+
     it('should add web_search and x_search tools when enabledSearch is true', async () => {
       await instance.chat({
         enabledSearch: true,

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -45,12 +45,27 @@ describe('LobeXAI - custom features', () => {
       expect(createCall.stream).toBe(true);
     });
 
-    it('should preserve penalty parameters for legacy non-reasoning models', async () => {
+    it('should remove penalty parameters for Grok 4 non-reasoning variants', async () => {
       await instance.chat({
         apiMode: 'chatCompletion',
         frequency_penalty: 0.4,
         messages: [{ content: 'Hello', role: 'user' }],
         model: 'grok-4-fast-non-reasoning',
+        presence_penalty: 0.6,
+      } as any);
+
+      const createCall = (instance['client'].chat.completions.create as Mock).mock.calls[0][0];
+
+      expect(createCall.frequency_penalty).toBeUndefined();
+      expect(createCall.presence_penalty).toBeUndefined();
+    });
+
+    it('should preserve penalty parameters for Grok 3 models', async () => {
+      await instance.chat({
+        apiMode: 'chatCompletion',
+        frequency_penalty: 0.4,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-3',
         presence_penalty: 0.6,
       } as any);
 

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -16,11 +16,7 @@ interface XAIChatStreamPayload extends ChatStreamPayload {
   stop?: string | string[];
 }
 
-const xaiChatCompletionPenaltySupportedModels = new Set([
-  'grok-3',
-  'grok-4-fast-non-reasoning',
-  'grok-4-1-fast-non-reasoning',
-]);
+const supportsChatCompletionPenaltyParameters = (model: string) => model.startsWith('grok-3');
 
 const stripUnsupportedPenaltyParameters = (payload: ChatStreamPayload) => {
   const {
@@ -38,7 +34,7 @@ const stripUnsupportedPenaltyParameters = (payload: ChatStreamPayload) => {
 };
 
 const pruneUnsupportedChatCompletionParameters = (payload: ChatStreamPayload) => {
-  if (xaiChatCompletionPenaltySupportedModels.has(payload.model)) return payload;
+  if (supportsChatCompletionPenaltyParameters(payload.model)) return payload;
 
   return stripUnsupportedPenaltyParameters(payload);
 };

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -1,6 +1,7 @@
 import { ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import type { ChatStreamPayload } from '../../types';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
 import { createXAIImage } from './createImage';
 import { createXAIVideo } from './createVideo';
@@ -9,9 +10,47 @@ export interface XAIModelCard {
   id: string;
 }
 
+interface XAIChatStreamPayload extends ChatStreamPayload {
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  stop?: string | string[];
+}
+
+const xaiChatCompletionPenaltySupportedModels = new Set([
+  'grok-3',
+  'grok-4-fast-non-reasoning',
+  'grok-4-1-fast-non-reasoning',
+]);
+
+const stripUnsupportedPenaltyParameters = (payload: ChatStreamPayload) => {
+  const {
+    frequencyPenalty: _frequencyPenalty,
+    presencePenalty: _presencePenalty,
+    ...rest
+  } = payload as XAIChatStreamPayload;
+
+  return {
+    ...rest,
+    frequency_penalty: undefined,
+    presence_penalty: undefined,
+    stop: undefined,
+  } as ChatStreamPayload;
+};
+
+const pruneUnsupportedChatCompletionParameters = (payload: ChatStreamPayload) => {
+  if (xaiChatCompletionPenaltySupportedModels.has(payload.model)) return payload;
+
+  return stripUnsupportedPenaltyParameters(payload);
+};
+
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
   chatCompletion: {
+    handlePayload: (payload) =>
+      ({
+        ...pruneUnsupportedChatCompletionParameters(payload),
+        stream: payload.stream ?? true,
+      }) as any,
     useResponse: true,
   },
   createImage: createXAIImage,
@@ -36,7 +75,7 @@ export const LobeXAI = createOpenAICompatibleRuntime({
   provider: ModelProvider.XAI,
   responses: {
     handlePayload: (payload) => {
-      const { enabledSearch, tools, ...rest } = payload;
+      const { enabledSearch, tools, ...rest } = stripUnsupportedPenaltyParameters(payload);
 
       const xaiTools = enabledSearch
         ? [...(tools || []), { type: 'web_search' }, { type: 'x_search' }]
@@ -44,8 +83,6 @@ export const LobeXAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
-        frequency_penalty: undefined, // NOT SUPPORTED in Responses API
-        presence_penalty: undefined, // NOT SUPPORTED in Responses API
         tools: xaiTools,
         include: ['reasoning.encrypted_content'],
       } as any;

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
@@ -38,6 +38,23 @@ describe('isNonRetryableRequestError', () => {
     ).toBe(true);
   });
 
+  it('returns true for unsupported model parameter errors', () => {
+    expect(
+      isNonRetryableRequestError({
+        error: {
+          error: {
+            code: 'bad_response_status_code',
+            message: 'Model grok-4.20-0309-reasoning does not support parameter presencePenalty.',
+            param: '400',
+            type: 'upstream_error',
+          },
+          message: '400 Model grok-4.20-0309-reasoning does not support parameter presencePenalty.',
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+      }),
+    ).toBe(true);
+  });
+
   it('returns true for assistant prefill request-shape errors', () => {
     expect(
       isNonRetryableRequestError({

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
@@ -50,6 +50,7 @@ const NON_RETRYABLE_MESSAGE_PATTERNS = [
   'conversation must end with a user message',
   'context length exceeded',
   'context_length_exceeded',
+  'does not support parameter',
   'expected a string',
   'input is too long',
   'input tokens exceed',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to reported xAI upstream 400: `Model grok-4.20-0309-reasoning does not support parameter presencePenalty`.

#### 🔀 Description of Change

- Strip unsupported camelCase xAI penalty parameters before requests reach the upstream.
- Treat explicit unsupported-parameter request errors as non-retryable in RouterRuntime so fallback channels are not retried with the same invalid payload.
- Keep generic bare 4xx errors retryable.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' 'src/providers/xai/index.test.ts'
bunx vitest run --silent='passed-only' 'src/utils/isNonRetryableRequestError.test.ts' 'src/core/RouterRuntime/createRuntime.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The two commits intentionally split provider payload sanitation from RouterRuntime fallback classification.