### PR TITLE
💄 style: add grok-4.3 to LobeHub-hosted xAI models

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
@@ -4,6 +4,54 @@ export const xaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description: 'The most truth-seeking large language model in the world',
+    displayName: 'Grok 4.3',
+    enabled: true,
+    id: 'grok-4.3',
+    pricing: {
+      units: [
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.4, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1.25, upTo: 0.2 },
+            { rate: 2.5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2.5, upTo: 0.2 },
+            { rate: 5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-05-01',
+    settings: {
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       reasoning: true,
       search: true,
       vision: true,
@@ -109,7 +157,6 @@ export const xaiChatModels: AIChatModelCard[] = [
     description:
       'Our newest and strongest flagship model, excelling in NLP, math, and reasoning—an ideal all-rounder.',
     displayName: 'Grok 4',
-    enabled: true,
     id: 'grok-4',
     pricing: {
       units: [

--- a/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/xai.ts
@@ -18,7 +18,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -27,7 +27,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -36,7 +36,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -67,7 +67,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -76,7 +76,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2, upTo: 0.2 },
+            { rate: 2, upTo: 200_000 },
             { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -85,7 +85,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 6, upTo: 0.2 },
+            { rate: 6, upTo: 200_000 },
             { rate: 12, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -115,7 +115,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -124,7 +124,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2, upTo: 0.2 },
+            { rate: 2, upTo: 200_000 },
             { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -133,7 +133,7 @@ export const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 6, upTo: 0.2 },
+            { rate: 6, upTo: 200_000 },
             { rate: 12, upTo: 'infinity' },
           ],
           unit: 'millionTokens',

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -20,7 +20,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -29,7 +29,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -38,7 +38,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -69,7 +69,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -78,7 +78,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2, upTo: 0.2 },
+            { rate: 2, upTo: 200_000 },
             { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -87,7 +87,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 6, upTo: 0.2 },
+            { rate: 6, upTo: 200_000 },
             { rate: 12, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -119,7 +119,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -128,7 +128,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2, upTo: 0.2 },
+            { rate: 2, upTo: 200_000 },
             { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -137,7 +137,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 6, upTo: 0.2 },
+            { rate: 6, upTo: 200_000 },
             { rate: 12, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -169,7 +169,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -178,7 +178,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2, upTo: 0.2 },
+            { rate: 2, upTo: 200_000 },
             { rate: 4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -187,7 +187,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 6, upTo: 0.2 },
+            { rate: 6, upTo: 200_000 },
             { rate: 12, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -220,7 +220,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.128 },
+            { rate: 0.2, upTo: 128_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -229,7 +229,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.5, upTo: 0.128 },
+            { rate: 0.5, upTo: 128_000 },
             { rate: 1, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -262,7 +262,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.128 },
+            { rate: 0.2, upTo: 128_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -271,7 +271,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.5, upTo: 0.128 },
+            { rate: 0.5, upTo: 128_000 },
             { rate: 1, upTo: 'infinity' },
           ],
           unit: 'millionTokens',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Follow-up to #14382 (which added grok-4.3 to the self-hosted xAI card).

#### 🔀 Description of Change

Add `grok-4.3` to the LobeHub-hosted xAI model list so the new model surfaces on LobeHub Cloud:

- **New card**: `grok-4.3`, 1M context window, tiered pricing — `$1.25 / $2.50` per 1M input/output up to 200K tokens, doubled above (`$2.50 / $5.00`); cached input `$0.20 → $0.40`. abilities: `functionCall`, `search`, `vision` (always-on reasoning, no UI toggle — matches the self-hosted card decision). `searchImpl: 'params'` to align with the existing `grok-4.20-beta-*` cards.
- **Default-disable older generation**: drop `enabled: true` from `grok-4` (now two generations behind 4.3 → 4.20 → 4); the card stays in the bank for users who already opted in.

No runtime / RouterRuntime changes needed: the xAI provider is generic Responses API, and the router's `grok-` prefix already routes 4.3.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Pricing reference: https://docs.x.ai/developers/models