### PR TITLE
🐛 fix: preserve visual refs for bot uploads

### DIFF
--- a/src/server/services/aiAgent/__tests__/execAgent.files.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.files.test.ts
@@ -243,6 +243,7 @@ describe('AiAgentService.execAgent - file upload handling', () => {
 
       expect(lastMessage).toMatchObject({
         content: 'Describe this screenshot',
+        id: 'msg-1',
         role: 'user',
       });
       expect(lastMessage.imageList).toEqual([

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1472,6 +1472,7 @@ export class AiAgentService {
     const userMessage = {
       content: prompt,
       fileList,
+      id: userMessageRecord?.id,
       imageList,
       role: 'user' as const,
       videoList,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #14378

#### 🔀 Description of Change

- Preserve the newly created user message id in the server-side `execAgent` initial messages.
- Keep visual media refs stable for bot-uploaded image and video attachments, so `analyzeVisualMedia` can resolve the same refs that are shown to the model.
- Add a regression assertion for uploaded image messages carrying the message id.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/server/services/aiAgent/__tests__/execAgent.files.test.ts'
bunx vitest run --silent='passed-only' 'src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts'
bunx vitest run --silent='passed-only' 'src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts'
```

Manual scenario:

- Send an image to a Discord bot backed by a non-vision model and ask it to inspect the image through the visual fallback tool.
- Verify the visual tool can resolve the image ref and returns analysis instead of reporting missing visual files.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This fixes a follow-up issue in the server-side path used by bot uploads. The Discord adapter already forwards image attachments into `execAgent`; the missing piece was preserving the current message id before context engineering builds visual refs.
