### PR TITLE
🐛 fix: inject user response language into task summary chains

### DIFF
--- a/packages/prompts/src/chains/generateBrief.ts
+++ b/packages/prompts/src/chains/generateBrief.ts
@@ -25,6 +25,7 @@ export const chainGenerateBrief = (params: {
   artifacts?: BriefArtifacts | null;
   handoff?: TaskTopicHandoff | null;
   lastAssistantContent: string;
+  responseLanguage?: string;
   taskInstruction: string;
   taskName: string;
 }): Partial<ChatStreamPayload> => {
@@ -41,17 +42,21 @@ export const chainGenerateBrief = (params: {
 ${params.artifacts.documents.map((d) => `- ${d.title || '(untitled)'} [id=${d.id}]`).join('\n')}`
     : 'Artifacts: (none)';
 
+  const languageInstruction = params.responseLanguage
+    ? `Output language: ${params.responseLanguage}. Always use this language regardless of the content language.`
+    : "Use the same language as the assistant's content.";
+
   const systemContent = `You are writing the user-facing brief for a topic that has already been judged worth surfacing. Your job is to produce a short delivery report — no skip option, no emit vote. Always return a non-empty title and summary.
 
 Output a JSON object with these fields:
-- "title": string. A non-empty user-facing headline (max 60 chars, same language as the assistant's content). Required.
+- "title": string. A non-empty user-facing headline (max 60 chars). Required.
 - "summary": string. A 2-4 sentence delivery report describing what was produced or observed and why it matters to the user. Required, non-empty.
 
 If the topic has little new activity ("no new tickets today", "no changes since last run"), state that outcome plainly in the summary — that itself is the report. Do not invent activity that did not occur.
 
 Voice and style:
 - Write FOR THE USER, not for the agent or developer.
-- Use the same language as the assistant's content.
+- ${languageInstruction}
 - Lead with the outcome (what changed, what was found, what is unchanged).
 - Do NOT reference internal tool names, operation IDs, topic IDs, or implementation details.
 - Do NOT say "I" or "the agent" — describe the outcome, not the actor.

--- a/packages/prompts/src/chains/taskTopicHandoff.ts
+++ b/packages/prompts/src/chains/taskTopicHandoff.ts
@@ -9,37 +9,44 @@ import type { ChatStreamPayload } from '@lobechat/types';
  */
 export const chainTaskTopicHandoff = (params: {
   lastAssistantContent: string;
+  responseLanguage?: string;
   taskInstruction: string;
   taskName: string;
-}): Partial<ChatStreamPayload> => ({
-  messages: [
-    {
-      content: `You are a task execution summarizer. A topic (one round of agent execution) has just completed within a task. Generate a handoff summary for the next topic to read.
+}): Partial<ChatStreamPayload> => {
+  const languageInstruction = params.responseLanguage
+    ? `Output language: ${params.responseLanguage}. Always use this language for title and summary regardless of the content language.`
+    : 'Use the same language as the content.';
+
+  return {
+    messages: [
+      {
+        content: `You are a task execution summarizer. A topic (one round of agent execution) has just completed within a task. Generate a handoff summary for the next topic to read.
 
 Output a JSON object with these fields:
-- "title": A concise title summarizing what this topic accomplished (max 50 chars, same language as content)
+- "title": A concise title summarizing what this topic accomplished (max 50 chars)
 - "summary": A 1-3 sentence summary of what was done and the key outcome
 - "keyFindings": An array of key findings or decisions made (optional, max 5 items)
 - "nextAction": What the next topic should do (optional, 1 sentence)
 
 Rules:
 - Focus on WHAT WAS ACCOMPLISHED, not what was asked
-- Use the same language as the content
-- Keep title short and specific (e.g. "制定8章书籍大纲" not "完成任务")
+- ${languageInstruction}
+- Keep title short and specific
 - summary should capture the essential outcome a new topic needs to know
 - Output ONLY the JSON object, no markdown fences or explanations`,
-      role: 'system',
-    },
-    {
-      content: `Task: ${params.taskName}
+        role: 'system',
+      },
+      {
+        content: `Task: ${params.taskName}
 Task instruction: ${params.taskInstruction}
 
 Last assistant response:
 ${params.lastAssistantContent}`,
-      role: 'user',
-    },
-  ],
-});
+        role: 'user',
+      },
+    ],
+  };
+};
 
 export const TASK_TOPIC_HANDOFF_SCHEMA = {
   additionalProperties: false,

--- a/src/server/services/systemAgent/index.ts
+++ b/src/server/services/systemAgent/index.ts
@@ -114,7 +114,7 @@ export class SystemAgentService {
   /**
    * Get the user's preferred response language (locale).
    */
-  private async getUserLocale(): Promise<string> {
+  async getUserLocale(): Promise<string> {
     const userInfo = await UserModel.getInfoForAIGeneration(this.db, this.userId);
     return userInfo.responseLanguage || 'en-US';
   }

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -285,12 +285,14 @@ export class TaskLifecycleService {
     currentTask: any,
   ): Promise<void> {
     try {
-      const { model, provider } = await (this.systemAgentService as any).getTaskModelConfig(
-        'topic',
-      );
+      const [{ model, provider }, responseLanguage] = await Promise.all([
+        (this.systemAgentService as any).getTaskModelConfig('topic'),
+        this.systemAgentService.getUserLocale(),
+      ]);
 
       const payload = chainTaskTopicHandoff({
         lastAssistantContent,
+        responseLanguage,
         taskInstruction: currentTask?.instruction || '',
         taskName: currentTask?.name || taskIdentifier,
       });
@@ -378,9 +380,10 @@ export class TaskLifecycleService {
       const artifacts: BriefArtifacts = { documents: pinnedDocs };
       const handoff = (topicLink?.handoff as TaskTopicHandoff | null) ?? null;
 
-      const { model, provider } = await (this.systemAgentService as any).getTaskModelConfig(
-        'topic',
-      );
+      const [{ model, provider }, responseLanguage] = await Promise.all([
+        (this.systemAgentService as any).getTaskModelConfig('topic'),
+        this.systemAgentService.getUserLocale(),
+      ]);
 
       let decision: BriefDecision;
       if (ruleVerdict.emit === 'unknown') {
@@ -442,6 +445,7 @@ export class TaskLifecycleService {
         artifacts,
         handoff,
         lastAssistantContent,
+        responseLanguage,
         taskInstruction: currentTask.instruction || '',
         taskName: currentTask.name || taskIdentifier,
       });


### PR DESCRIPTION
Pass the user's preferred response language (from settings) to chainTaskTopicHandoff and chainGenerateBrief so that task run titles and briefs always output in the user's configured language instead of following the agent's content language.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
