### PR TITLE
🐛 fix: task breadcrumb title truncation

### DIFF
--- a/src/features/AgentTasks/shared/Breadcrumb.tsx
+++ b/src/features/AgentTasks/shared/Breadcrumb.tsx
@@ -60,17 +60,28 @@ const Breadcrumb = memo<BreadcrumbProps>(({ taskId }) => {
               alignItems: 'center',
               display: 'inline-flex',
               gap: 6,
-              lineHeight: 1,
+              maxWidth: '100%',
               minWidth: 0,
-              overflow: 'hidden',
             }}
           >
             {taskIdentifier && (
-              <Text color={'inherit'} style={{ flexShrink: 0 }} type={'secondary'} weight={500}>
+              <Text
+                as={'span'}
+                color={'inherit'}
+                style={{ flexShrink: 0 }}
+                type={'secondary'}
+                weight={500}
+              >
                 {taskIdentifier}
               </Text>
             )}
-            <Text ellipsis color={'inherit'} style={{ maxWidth: 240 }} weight={500}>
+            <Text
+              ellipsis
+              as={'span'}
+              color={'inherit'}
+              style={{ flex: '1 1 auto', maxWidth: 240, minWidth: 0 }}
+              weight={500}
+            >
               {taskTitle || taskId}
             </Text>
           </span>


### PR DESCRIPTION
## Summary
- 调整 task detail 顶部 breadcrumb 的当前任务标题布局，避免长标题在收缩时把字符下伸部裁掉
- 去掉会强制裁剪内容的 wrapper 样式，让 `Text ellipsis` 自己负责省略显示
- 让任务标识和任务标题都作为可收缩的 inline 内容参与布局，和已有子任务标题修复保持一致

## Testing
- `bunx eslint src/features/AgentTasks/shared/Breadcrumb.tsx`
- `bun run type-check`
- 本地 UI 验证标题较长时的 breadcrumb 显示与截断效果