### PR TITLE
✨ feat(desktop): add app tray visibility setting

### DIFF
--- a/apps/desktop/src/main/const/store.ts
+++ b/apps/desktop/src/main/const/store.ts
@@ -26,6 +26,7 @@ export const defaultProxySettings: NetworkProxySettings = {
  * Storage default values
  */
 export const STORE_DEFAULTS: ElectronMainStore = {
+  appTrayVisible: true,
   dataSyncConfig: { storageMode: 'cloud' },
   encryptedTokens: {},
   gatewayDeviceDescription: '',

--- a/apps/desktop/src/main/controllers/TrayMenuCtr.ts
+++ b/apps/desktop/src/main/controllers/TrayMenuCtr.ts
@@ -20,6 +20,26 @@ export default class TrayMenuCtr extends ControllerModule {
   }
 
   /**
+   * Get whether the application tray is visible.
+   */
+  @IpcMethod()
+  getAppTrayVisible(): boolean {
+    return this.app.storeManager.get('appTrayVisible', true);
+  }
+
+  /**
+   * Persist and apply application tray visibility.
+   */
+  @IpcMethod()
+  setAppTrayVisible(visible: boolean) {
+    logger.debug(`Set app tray visibility: ${visible}`);
+    this.app.storeManager.set('appTrayVisible', visible);
+    this.app.trayManager.setAppTrayVisible(visible);
+
+    return { success: true };
+  }
+
+  /**
    * Show tray balloon notification
    * @param options Balloon options
    * @returns Operation result

--- a/apps/desktop/src/main/controllers/__tests__/TrayMenuCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/TrayMenuCtr.test.ts
@@ -40,13 +40,21 @@ const mockDisplayBalloon = vi.fn();
 const mockUpdateIcon = vi.fn();
 const mockUpdateTooltip = vi.fn();
 const mockGetMainTray = vi.fn();
+const mockSetAppTrayVisible = vi.fn();
+const mockStoreGet = vi.fn(() => true);
+const mockStoreSet = vi.fn();
 
 const mockApp = {
   browserManager: {
     getMainWindow: mockGetMainWindow,
   },
+  storeManager: {
+    get: mockStoreGet,
+    set: mockStoreSet,
+  },
   trayManager: {
     getMainTray: mockGetMainTray,
+    setAppTrayVisible: mockSetAppTrayVisible,
   },
 } as unknown as App;
 
@@ -58,7 +66,29 @@ describe('TrayMenuCtr', () => {
     ipcMainHandleMock.mockClear();
     // Reset mockedTray for each test
     mockGetMainTray.mockReset();
+    mockStoreGet.mockReturnValue(true);
     trayMenuCtr = new TrayMenuCtr(mockApp);
+  });
+
+  describe('getAppTrayVisible', () => {
+    it('should return stored app tray visibility', () => {
+      mockStoreGet.mockReturnValue(false);
+
+      const result = trayMenuCtr.getAppTrayVisible();
+
+      expect(mockStoreGet).toHaveBeenCalledWith('appTrayVisible', true);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setAppTrayVisible', () => {
+    it('should persist and apply app tray visibility', () => {
+      const result = trayMenuCtr.setAppTrayVisible(false);
+
+      expect(mockStoreSet).toHaveBeenCalledWith('appTrayVisible', false);
+      expect(mockSetAppTrayVisible).toHaveBeenCalledWith(false);
+      expect(result).toEqual({ success: true });
+    });
   });
 
   // Restore platform settings after all tests complete

--- a/apps/desktop/src/main/core/ui/TrayManager.ts
+++ b/apps/desktop/src/main/core/ui/TrayManager.ts
@@ -39,6 +39,12 @@ export class TrayManager {
   initializeTrays() {
     logger.debug('Initialize application tray');
 
+    if (!this.app.storeManager.get('appTrayVisible', true)) {
+      logger.debug('Application tray is disabled by user settings');
+      this.destroyAll();
+      return;
+    }
+
     // Initialize main tray
     const mainTray = this.initializeMainTray();
 
@@ -56,6 +62,19 @@ export class TrayManager {
    */
   getMainTray() {
     return this.retrieveByIdentifier('main');
+  }
+
+  /**
+   * Toggle the application tray at runtime.
+   */
+  setAppTrayVisible(visible: boolean) {
+    logger.debug(`Set application tray visible: ${visible}`);
+
+    if (visible) {
+      this.initializeTrays();
+    } else {
+      this.destroyAll();
+    }
   }
 
   /**

--- a/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/TrayManager.test.ts
@@ -55,6 +55,9 @@ describe('TrayManager', () => {
       menuManager: {
         buildTrayMenu: vi.fn(() => ({ _mockMenu: true }) as any),
       },
+      storeManager: {
+        get: vi.fn(() => true),
+      },
     } as unknown as App;
 
     // Mock Tray constructor
@@ -92,6 +95,15 @@ describe('TrayManager', () => {
 
       expect(mockApp.menuManager.buildTrayMenu).toHaveBeenCalled();
       expect(mockTray.setMenu).toHaveBeenCalledWith({ _mockMenu: true });
+    });
+
+    it('should skip tray initialization when app tray is disabled', () => {
+      vi.mocked(mockApp.storeManager.get).mockReturnValue(false);
+
+      trayManager.initializeTrays();
+
+      expect(Tray).not.toHaveBeenCalled();
+      expect(trayManager.trays.size).toBe(0);
     });
   });
 
@@ -270,6 +282,24 @@ describe('TrayManager', () => {
 
     it('should not throw when no trays exist', () => {
       expect(() => trayManager.destroyAll()).not.toThrow();
+    });
+  });
+
+  describe('setAppTrayVisible', () => {
+    it('should initialize trays when visible is true', () => {
+      trayManager.setAppTrayVisible(true);
+
+      expect(Tray).toHaveBeenCalled();
+      expect(trayManager.trays.has('main')).toBe(true);
+    });
+
+    it('should destroy all trays when visible is false', () => {
+      trayManager.initializeTrays();
+
+      trayManager.setAppTrayVisible(false);
+
+      expect(mockTray.destroy).toHaveBeenCalled();
+      expect(trayManager.trays.size).toBe(0);
     });
   });
 

--- a/apps/desktop/src/main/locales/default/menu.ts
+++ b/apps/desktop/src/main/locales/default/menu.ts
@@ -75,6 +75,7 @@ const menu = {
   'tray.open': 'Open {{appName}}',
   'tray.quickChat': 'Quick Chat',
   'tray.quit': 'Quit',
+  'tray.settings': 'Settings',
   'tray.show': 'Show {{appName}}',
   'view.forceReload': 'Force Reload',
   'view.reload': 'Reload',

--- a/apps/desktop/src/main/menus/impls/linux.test.ts
+++ b/apps/desktop/src/main/menus/impls/linux.test.ts
@@ -63,7 +63,9 @@ const createMockApp = () => {
       'dev.devPanel': 'Dev Panel',
       'tray.openMiniToolbar': 'Quick Composer',
       'tray.open': `Open ${params?.appName || 'App'}`,
+      'tray.quickChat': 'Quick Chat',
       'tray.quit': 'Quit',
+      'tray.settings': 'Settings',
     };
     return translations[key] || key;
   });
@@ -197,6 +199,7 @@ describe('LinuxMenu', () => {
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
       expect(template.length).toBeGreaterThan(0);
       expect(template.some((item: any) => item.label?.includes('Open'))).toBe(true);
+      expect(template.some((item: any) => item.label === 'Settings')).toBe(true);
       expect(template.some((item: any) => item.label === 'Quit')).toBe(true);
     });
   });

--- a/apps/desktop/src/main/menus/impls/linux.ts
+++ b/apps/desktop/src/main/menus/impls/linux.ts
@@ -466,7 +466,7 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
       { type: 'separator' },
       {
         click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
-        label: t('file.preferences'),
+        label: t('tray.settings'),
       },
       { type: 'separator' },
       { label: t('tray.quit'), role: 'quit' },

--- a/apps/desktop/src/main/menus/impls/macOS.test.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.test.ts
@@ -31,6 +31,19 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('electron-is', () => ({
+  macOS: vi.fn(() => true),
+}));
+
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
 // Mock isDev
 vi.mock('@/const/env', () => ({
   isDev: false,
@@ -177,6 +190,7 @@ describe('MacOSMenu', () => {
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
       expect(template.length).toBeGreaterThan(0);
       expect(template.some((item: any) => item.label?.includes('Show'))).toBe(true);
+      expect(template.some((item: any) => item.label === 'Settings')).toBe(true);
       expect(template.some((item: any) => item.label === 'Quit')).toBe(true);
     });
 

--- a/apps/desktop/src/main/menus/impls/macOS.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.ts
@@ -694,7 +694,7 @@ export class MacOSMenu extends BaseMenuPlatform implements IMenuPlatform {
           mainWindow.show();
           mainWindow.broadcast('navigate', { path: '/settings' });
         },
-        label: t('file.preferences'),
+        label: t('tray.settings'),
       },
       { type: 'separator' },
       { label: t('tray.quit'), role: 'quit' },

--- a/apps/desktop/src/main/menus/impls/windows.test.ts
+++ b/apps/desktop/src/main/menus/impls/windows.test.ts
@@ -58,7 +58,9 @@ const createMockApp = () => {
       'dev.devPanel': 'Dev Panel',
       'tray.openMiniToolbar': 'Quick Composer',
       'tray.open': `Open ${params?.appName || 'App'}`,
+      'tray.quickChat': 'Quick Chat',
       'tray.quit': 'Quit',
+      'tray.settings': 'Settings',
     };
     return translations[key] || key;
   });
@@ -179,6 +181,7 @@ describe('WindowsMenu', () => {
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
       expect(template.length).toBeGreaterThan(0);
       expect(template.some((item: any) => item.label?.includes('Open'))).toBe(true);
+      expect(template.some((item: any) => item.label === 'Settings')).toBe(true);
       expect(template.some((item: any) => item.label === 'Quit')).toBe(true);
     });
   });

--- a/apps/desktop/src/main/menus/impls/windows.ts
+++ b/apps/desktop/src/main/menus/impls/windows.ts
@@ -473,7 +473,7 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
       { type: 'separator' },
       {
         click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
-        label: t('file.preferences'),
+        label: t('tray.settings'),
       },
       { type: 'separator' },
       { label: t('tray.quit'), role: 'quit' },

--- a/apps/desktop/src/main/types/store.ts
+++ b/apps/desktop/src/main/types/store.ts
@@ -5,6 +5,7 @@ import type {
 } from '@lobechat/electron-client-ipc';
 
 export interface ElectronMainStore {
+  appTrayVisible: boolean;
   dataSyncConfig: DataSyncConfig;
   encryptedTokens: {
     accessToken?: string;

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -944,6 +944,10 @@ When I am ___, I need ___
   'tab.about': 'About',
   'tab.advanced': 'Advanced',
   'tab.addAgentSkill': 'Add Agent Skill',
+  'tab.advanced.appTray.desc':
+    'Show the LobeHub tray icon in the desktop system tray or macOS menu bar.',
+  'tab.advanced.appTray.title': 'Show App Tray',
+  'tab.advanced.desktop.title': 'Desktop',
   'tab.advanced.updateChannel.canary': 'Canary',
   'tab.advanced.updateChannel.canaryDesc':
     'Triggered on every PR merge, multiple builds per day. Most unstable.',

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -549,6 +549,9 @@ export default {
   'settingAgent.tag.placeholder': 'Enter tag',
   'settingAgent.tag.title': 'Tag',
   'settingAgent.title': 'Agent info',
+  'settingAppearance.appTray.desc':
+    'Show the LobeHub icon in the system tray or macOS menu bar. Disabling it also removes tray menu access.',
+  'settingAppearance.appTray.title': 'Show App Tray',
   'settingAppearance.animationMode.agile': 'Agile',
   'settingAppearance.animationMode.desc':
     'Select the animation speed for application response actions',
@@ -559,6 +562,7 @@ export default {
   'settingAppearance.contextMenuMode.desc': 'Enable the right-click menu for some list items.',
   'settingAppearance.contextMenuMode.disabled': 'Disabled',
   'settingAppearance.contextMenuMode.title': 'Right-Click Menu Mode',
+  'settingAppearance.desktop.title': 'Desktop',
   'settingAppearance.neutralColor.desc': 'Custom grayscale with different color tendencies',
   'settingAppearance.neutralColor.title': 'Neutral Color',
   'settingAppearance.noAnimation.desc': 'Disable all animation effects in the application',
@@ -944,10 +948,6 @@ When I am ___, I need ___
   'tab.about': 'About',
   'tab.advanced': 'Advanced',
   'tab.addAgentSkill': 'Add Agent Skill',
-  'tab.advanced.appTray.desc':
-    'Show the LobeHub tray icon in the desktop system tray or macOS menu bar.',
-  'tab.advanced.appTray.title': 'Show App Tray',
-  'tab.advanced.desktop.title': 'Desktop',
   'tab.advanced.updateChannel.canary': 'Canary',
   'tab.advanced.updateChannel.canaryDesc':
     'Triggered on every PR merge, multiple builds per day. Most unstable.',

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import { autoUpdateService } from '@/services/electron/autoUpdate';
+import { useElectronStore } from '@/store/electron';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors, preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
@@ -54,6 +55,14 @@ const Page = memo(() => {
   const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
 
   const [channel, setChannel] = useState<UpdateChannelValue>('stable');
+  const [desktopLoading, setDesktopLoading] = useState(false);
+  const [appTrayVisible, setAppTrayVisible, useGetAppTrayVisible] = useElectronStore((s) => [
+    s.appTrayVisible,
+    s.setAppTrayVisible,
+    s.useGetAppTrayVisible,
+  ]);
+
+  useGetAppTrayVisible(isDesktop);
 
   useEffect(() => {
     if (!isDesktop) return;
@@ -101,6 +110,31 @@ const Page = memo(() => {
       },
     ],
     title: t('tab.advanced.updateChannel.title'),
+  };
+
+  const desktopGroup: FormGroupItemType = {
+    children: [
+      {
+        children: (
+          <Switch
+            checked={appTrayVisible}
+            loading={desktopLoading}
+            onChange={async (checked: boolean) => {
+              setDesktopLoading(true);
+              try {
+                await setAppTrayVisible(checked);
+              } finally {
+                setDesktopLoading(false);
+              }
+            }}
+          />
+        ),
+        desc: t('tab.advanced.appTray.desc'),
+        label: t('tab.advanced.appTray.title'),
+        minWidth: undefined,
+      },
+    ],
+    title: t('tab.advanced.desktop.title'),
   };
 
   const labItems: FormItemProps[] = [
@@ -166,7 +200,7 @@ const Page = memo(() => {
   };
 
   const items = isDesktop
-    ? [advancedGroup, updateChannelGroup, labsGroup]
+    ? [advancedGroup, desktopGroup, updateChannelGroup, labsGroup]
     : [advancedGroup, labsGroup];
 
   return (

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from 'react-i18next';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import { autoUpdateService } from '@/services/electron/autoUpdate';
-import { useElectronStore } from '@/store/electron';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors, preferenceSelectors, settingsSelectors } from '@/store/user/selectors';
@@ -55,14 +54,6 @@ const Page = memo(() => {
   const hasGatewayUrl = useServerConfigStore((s) => !!s.serverConfig.agentGatewayUrl);
 
   const [channel, setChannel] = useState<UpdateChannelValue>('stable');
-  const [desktopLoading, setDesktopLoading] = useState(false);
-  const [appTrayVisible, setAppTrayVisible, useGetAppTrayVisible] = useElectronStore((s) => [
-    s.appTrayVisible,
-    s.setAppTrayVisible,
-    s.useGetAppTrayVisible,
-  ]);
-
-  useGetAppTrayVisible(isDesktop);
 
   useEffect(() => {
     if (!isDesktop) return;
@@ -110,31 +101,6 @@ const Page = memo(() => {
       },
     ],
     title: t('tab.advanced.updateChannel.title'),
-  };
-
-  const desktopGroup: FormGroupItemType = {
-    children: [
-      {
-        children: (
-          <Switch
-            checked={appTrayVisible}
-            loading={desktopLoading}
-            onChange={async (checked: boolean) => {
-              setDesktopLoading(true);
-              try {
-                await setAppTrayVisible(checked);
-              } finally {
-                setDesktopLoading(false);
-              }
-            }}
-          />
-        ),
-        desc: t('tab.advanced.appTray.desc'),
-        label: t('tab.advanced.appTray.title'),
-        minWidth: undefined,
-      },
-    ],
-    title: t('tab.advanced.desktop.title'),
   };
 
   const labItems: FormItemProps[] = [
@@ -200,7 +166,7 @@ const Page = memo(() => {
   };
 
   const items = isDesktop
-    ? [advancedGroup, desktopGroup, updateChannelGroup, labsGroup]
+    ? [advancedGroup, updateChannelGroup, labsGroup]
     : [advancedGroup, labsGroup];
 
   return (

--- a/src/routes/(main)/settings/appearance/features/Desktop.tsx
+++ b/src/routes/(main)/settings/appearance/features/Desktop.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { isDesktop } from '@lobechat/const';
+import { type FormGroupItemType } from '@lobehub/ui';
+import { Form } from '@lobehub/ui';
+import { Switch } from '@lobehub/ui/base-ui';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { FORM_STYLE } from '@/const/layoutTokens';
+import { useElectronStore } from '@/store/electron';
+
+const Desktop = memo(() => {
+  const { t } = useTranslation('setting');
+  const [loading, setLoading] = useState(false);
+  const [appTrayVisible, setAppTrayVisible, useGetAppTrayVisible] = useElectronStore((s) => [
+    s.appTrayVisible,
+    s.setAppTrayVisible,
+    s.useGetAppTrayVisible,
+  ]);
+
+  useGetAppTrayVisible(isDesktop);
+
+  if (!isDesktop) return null;
+
+  const desktop: FormGroupItemType = {
+    children: [
+      {
+        children: (
+          <Switch
+            checked={appTrayVisible}
+            loading={loading}
+            onChange={async (checked: boolean) => {
+              setLoading(true);
+              try {
+                await setAppTrayVisible(checked);
+              } finally {
+                setLoading(false);
+              }
+            }}
+          />
+        ),
+        desc: t('settingAppearance.appTray.desc'),
+        label: t('settingAppearance.appTray.title'),
+        minWidth: undefined,
+      },
+    ],
+    title: t('settingAppearance.desktop.title'),
+  };
+
+  return (
+    <Form
+      collapsible={false}
+      items={[desktop]}
+      itemsType={'group'}
+      variant={'filled'}
+      {...FORM_STYLE}
+    />
+  );
+});
+
+export default Desktop;

--- a/src/routes/(main)/settings/appearance/index.tsx
+++ b/src/routes/(main)/settings/appearance/index.tsx
@@ -5,6 +5,7 @@ import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import ChatAppearance from '../chat-appearance/features/ChatAppearance';
 import Appearance from '../common/features/Appearance';
 import Common from '../common/features/Common/Common';
+import Desktop from './features/Desktop';
 
 const Page = () => {
   const { t } = useTranslation('setting');
@@ -13,6 +14,7 @@ const Page = () => {
       <SettingHeader title={t('tab.appearance')} />
       <Common />
       <Appearance />
+      <Desktop />
       <ChatAppearance />
     </>
   );

--- a/src/services/electron/settings.ts
+++ b/src/services/electron/settings.ts
@@ -7,6 +7,13 @@ import { ensureElectronIpc } from '@/utils/electron/ipc';
 
 class DesktopSettingsService {
   /**
+   * Get app tray visibility
+   */
+  getAppTrayVisible = async () => {
+    return ensureElectronIpc().tray.getAppTrayVisible();
+  };
+
+  /**
    * Get proxy settings
    */
   getProxySettings = async () => {
@@ -18,6 +25,13 @@ class DesktopSettingsService {
    */
   setSettings = async (data: Partial<NetworkProxySettings>) => {
     return ensureElectronIpc().networkProxy.setProxySettings(data);
+  };
+
+  /**
+   * Set app tray visibility
+   */
+  setAppTrayVisible = async (visible: boolean) => {
+    return ensureElectronIpc().tray.setAppTrayVisible(visible);
   };
 
   /**

--- a/src/store/electron/actions/settings.ts
+++ b/src/store/electron/actions/settings.ts
@@ -18,6 +18,7 @@ import { type ElectronStore } from '../store';
 
 const ELECTRON_PROXY_SETTINGS_KEY = 'electron:getProxySettings';
 const ELECTRON_DESKTOP_HOTKEYS_KEY = 'electron:getDesktopHotkeys';
+const ELECTRON_APP_TRAY_VISIBLE_KEY = 'electron:getAppTrayVisible';
 
 type Setter = StoreSetter<ElectronStore>;
 export const settingsSlice = (set: Setter, get: () => ElectronStore, _api?: unknown) =>
@@ -37,8 +38,18 @@ export class ElectronSettingsActionImpl {
     await mutate(ELECTRON_DESKTOP_HOTKEYS_KEY);
   };
 
+  refreshAppTrayVisible = async (): Promise<void> => {
+    await mutate(ELECTRON_APP_TRAY_VISIBLE_KEY);
+  };
+
   refreshProxySettings = async (): Promise<void> => {
     await mutate(ELECTRON_PROXY_SETTINGS_KEY);
+  };
+
+  setAppTrayVisible = async (visible: boolean): Promise<void> => {
+    await desktopSettingsService.setAppTrayVisible(visible);
+    this.#set({ appTrayVisible: visible });
+    await this.#get().refreshAppTrayVisible();
   };
 
   setProxySettings = async (values: Partial<NetworkProxySettings>): Promise<void> => {
@@ -74,6 +85,20 @@ export class ElectronSettingsActionImpl {
         onSuccess: (data) => {
           if (!isEqual(data, this.#get().desktopHotkeys)) {
             this.#set({ desktopHotkeys: data, isDesktopHotkeysInit: true });
+          }
+        },
+      },
+    );
+  };
+
+  useGetAppTrayVisible = (enabled = true): SWRResponse => {
+    return useSWR<boolean>(
+      enabled ? ELECTRON_APP_TRAY_VISIBLE_KEY : null,
+      async () => desktopSettingsService.getAppTrayVisible(),
+      {
+        onSuccess: (data) => {
+          if (data !== this.#get().appTrayVisible) {
+            this.#set({ appTrayVisible: data });
           }
         },
       },

--- a/src/store/electron/initialState.ts
+++ b/src/store/electron/initialState.ts
@@ -26,6 +26,7 @@ export const defaultProxySettings: NetworkProxySettings = {
 
 export interface ElectronState extends NavigationHistoryState, RecentPagesState, TabPagesState {
   appState: ElectronAppState;
+  appTrayVisible: boolean;
   dataSyncConfig: DataSyncConfig;
   desktopHotkeys: Record<string, string>;
   gatewayConnectionStatus: GatewayConnectionStatus;
@@ -45,6 +46,7 @@ export const initialState: ElectronState = {
   ...recentPagesInitialState,
   ...tabPagesInitialState,
   appState: {},
+  appTrayVisible: true,
   dataSyncConfig: { storageMode: 'cloud' },
   desktopHotkeys: {},
   gatewayConnectionStatus: 'disconnected',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Add a desktop Appearance setting for showing or hiding the app tray icon.
- Persist the tray visibility preference in the Electron main store and expose tray visibility IPC methods.
- Apply the preference at startup and at runtime by initializing or destroying the tray.
- Rename the app tray context menu item from Preferences to Settings for consistent product copy.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Executed:

\`\`\`bash
bunx vitest run --silent='passed-only' src/main/controllers/__tests__/TrayMenuCtr.test.ts src/main/core/ui/__tests__/TrayManager.test.ts src/main/menus/impls/macOS.test.ts src/main/menus/impls/windows.test.ts src/main/menus/impls/linux.test.ts
\`\`\`

Result: 5 files passed, 149 tests passed.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Not provided | Not provided |

#### 📝 Additional Information

\`pnpm -C apps/desktop type-check\` could not complete in the current local environment because \`apps/desktop/node_modules\` is missing; the command reported unresolved modules such as \`electron\`, \`electron-is\`, and \`electron-store\`.