### PR TITLE
🐛 fix: resolve template variables in server-side (execAgent) context engine

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -10,6 +10,12 @@ import {
   UsageCounter,
 } from '@lobechat/agent-runtime';
 import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
+import { CredsIdentifier, type CredSummary, generateCredsList } from '@lobechat/builtin-tool-creds';
+import {
+  CronIdentifier,
+  type CronJobSummaryForContext,
+  generateCronJobsList,
+} from '@lobechat/builtin-tool-cron';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import {
   AGENT_DOCUMENT_INJECTION_POSITIONS,
@@ -32,8 +38,10 @@ import { type ChatToolPayload, type MessageToolCall, type UIChatMessage } from '
 import { sanitizeToolCallArguments, serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
 
+import { AgentCronJobModel } from '@/database/models/agentCronJob';
 import { type MessageModel, MessageModel as MessageModelClass } from '@/database/models/message';
 import { TopicModel } from '@/database/models/topic';
+import { UserModel } from '@/database/models/user';
 import { type LobeChatDatabase } from '@/database/type';
 import { serverMessagesEngine } from '@/server/modules/Mecha/ContextEngineering';
 import { type EvalContext } from '@/server/modules/Mecha/ContextEngineering/types';
@@ -509,11 +517,103 @@ export const createRuntimeExecutors = (
           topic_title: lobehubSkillTopicTitle,
         };
 
+        // ── Tool-specific template variable resolution ────────────────────
+        // The client-side contextEngineering.ts resolves these via Zustand stores
+        // and lambdaClient. In execAgent (server/bot) mode we must fetch from DB
+        // directly. Each block is gated on the relevant tool being enabled.
+
+        // {{username}} / {{language}} — used by memory, cron, and creds system roles.
+        // Single indexed DB lookup; cheap enough to run on each call_llm step.
+        let serverUsername = '';
+        let serverLanguage = '';
+        if (ctx.serverDB && ctx.userId) {
+          try {
+            const userInfo = await UserModel.getInfoForAIGeneration(ctx.serverDB, ctx.userId);
+            serverUsername = userInfo.userName;
+            serverLanguage = userInfo.responseLanguage;
+          } catch (error) {
+            log('Failed to fetch user info for {{username}}/{{language}} substitution: %O', error);
+          }
+        }
+
+        // {{sandbox_enabled}} — mirrors client-side check for lobe-cloud-sandbox.
+        const sandboxEnabled = String(resolved.enabledToolIds.includes('lobe-cloud-sandbox'));
+
+        // {{memory_effort}} — read from agentConfig chatConfig; no extra query needed.
+        const memoryEffort = String(
+          (state.metadata?.agentConfig as any)?.chatConfig?.memory?.effort ?? '',
+        );
+
+        // {{CREDS_LIST}} — used by lobe-creds system role.
+        // Mirrors client-side: lambdaClient.market.creds.list.query()
+        const isCredsEnabled = resolved.enabledToolIds.includes(CredsIdentifier);
+        let credsListStr = '';
+        if (isCredsEnabled && ctx.userId) {
+          try {
+            const { MarketService } = await import('@/server/services/market');
+            const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
+            const credsResult = await marketService.market.creds.list();
+            const userCreds = (credsResult as any)?.data ?? [];
+            credsListStr = generateCredsList(
+              userCreds.map(
+                (cred: any): CredSummary => ({
+                  description: cred.description,
+                  key: cred.key,
+                  name: cred.name,
+                  type: cred.type,
+                }),
+              ),
+            );
+            log('Fetched %d creds for {{CREDS_LIST}} substitution', userCreds.length);
+          } catch (error) {
+            log('Failed to fetch creds for {{CREDS_LIST}} substitution: %O', error);
+          }
+        }
+
+        // {{CRON_JOBS_LIST}} — used by lobe-cron system role.
+        // Mirrors client-side: lambdaClient.agentCronJob.list.query({ agentId, limit: 4 })
+        const isCronEnabled = resolved.enabledToolIds.includes(CronIdentifier);
+        let cronJobsListStr = '';
+        if (isCronEnabled && lobehubSkillAgentId && ctx.serverDB && ctx.userId) {
+          try {
+            const cronJobModel = new AgentCronJobModel(ctx.serverDB, ctx.userId);
+            const { jobs, total } = await cronJobModel.findWithPagination({
+              agentId: lobehubSkillAgentId,
+              limit: 4,
+            });
+            const summaries: CronJobSummaryForContext[] = jobs.map((job) => ({
+              cronPattern: job.cronPattern,
+              description: job.description ?? undefined,
+              enabled: job.enabled ?? false,
+              id: job.id,
+              lastExecutedAt: job.lastExecutedAt?.toISOString() ?? null,
+              name: job.name ?? null,
+              remainingExecutions: job.remainingExecutions ?? null,
+              timezone: job.timezone ?? 'UTC',
+              totalExecutions: job.totalExecutions ?? 0,
+            }));
+            cronJobsListStr = generateCronJobsList(summaries, total);
+            log('Fetched %d cron jobs for {{CRON_JOBS_LIST}} substitution', jobs.length);
+          } catch (error) {
+            log('Failed to fetch cron jobs for {{CRON_JOBS_LIST}} substitution: %O', error);
+          }
+        }
+
         const contextEngineInput = {
           agentDocuments,
           additionalVariables: {
             ...state.metadata?.deviceSystemInfo,
             ...lobehubSkillVariables,
+            // User identity variables
+            username: serverUsername,
+            language: serverLanguage,
+            // Creds tool variables
+            sandbox_enabled: sandboxEnabled,
+            ...(isCredsEnabled && { CREDS_LIST: credsListStr }),
+            // Memory tool variables
+            memory_effort: memoryEffort,
+            // Cron tool variables
+            ...(isCronEnabled && { CRON_JOBS_LIST: cronJobsListStr }),
           },
           userTimezone: ctx.userTimezone,
           capabilities: {


### PR DESCRIPTION
## Summary

- `{{CREDS_LIST}}`、`{{username}}`、`{{language}}`、`{{sandbox_enabled}}`、`{{memory_effort}}`、`{{CRON_JOBS_LIST}}` 等模板变量在 `execAgent`（服务端/Bot）模式下未被替换，以字面量形式泄露给 LLM
- 根因：客户端 `contextEngineering.ts` 通过 Zustand store + lambdaClient 处理这些变量，但服务端 `RuntimeExecutors.ts` 的 `additionalVariables` 缺失对应逻辑
- 修复：在 `RuntimeExecutors.ts` 构建 `contextEngineInput` 前，直接从 DB/服务获取各变量值

## Changes

- `{{username}}` / `{{language}}`：`UserModel.getInfoForAIGeneration()`
- `{{sandbox_enabled}}`：检查 `lobe-cloud-sandbox` 是否在 enabled tools
- `{{memory_effort}}`：读取 `agentConfig.chatConfig.memory.effort`
- `{{CREDS_LIST}}`：`MarketService.market.creds.list()`（lobe-creds 启用时）
- `{{CRON_JOBS_LIST}}`：`AgentCronJobModel.findWithPagination({ limit: 4 })`（lobe-cron 启用时）

所有 fetch 均 `try/catch` 保护，失败时回退空字符串。

## Test plan

- [ ] Bot 模式下 creds systemRole 中 `{{CREDS_LIST}}` 替换为实际凭据列表
- [ ] memory systemRole 中 `{{username}}`、`{{language}}`、`{{memory_effort}}` 正常替换
- [ ] cron systemRole 中 `{{CRON_JOBS_LIST}}` 替换为实际 cron job 列表
- [ ] creds tool 未启用时 `CREDS_LIST` fetch 不执行（通过 log 确认）

Fixes LOBE-8579

🤖 Generated with [Claude Code](https://claude.com/claude-code)