### PR TITLE
🐛 fix(editor-runtime): add mutation handlers for post-save synchronization

### DIFF
--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -27,6 +27,13 @@ interface InspectableEditor {
   pluginsInstances?: unknown[];
 }
 
+interface LiteXMLNodeMatch {
+  attributes: string;
+  content: string;
+  id: string;
+  tagName: string;
+}
+
 export type EditorMutationApiName = 'editTitle' | 'initPage' | 'modifyNodes' | 'replaceText';
 
 export interface EditorMutationContext {
@@ -497,23 +504,21 @@ export class EditorRuntime {
 
   /**
    * Extract all element nodes with their IDs and content from LiteXML
-   * Returns an array of { id, tagName, fullMatch, content } objects
+   * Returns an array of { id, tagName, attributes, content } objects
    */
-  private extractNodesFromLiteXML(
-    litexml: string,
-  ): Array<{ content: string; fullMatch: string; id: string; tagName: string }> {
-    const nodes: Array<{ content: string; fullMatch: string; id: string; tagName: string }> = [];
+  private extractNodesFromLiteXML(litexml: string): LiteXMLNodeMatch[] {
+    const nodes: LiteXMLNodeMatch[] = [];
 
     // Match elements with id attributes and their content
     // Pattern: <tagName id="nodeId" ...>content</tagName>
-    const elementRegex = /<(\w+)\s[^>]*id="([^"]+)"[^>]*>([\s\S]*?)<\/\1>/g;
+    const elementRegex = /<(\w+)(\s[^>]*id="([^"]+)"[^>]*)>([\s\S]*?)<\/\1>/g;
     let match;
 
     while ((match = elementRegex.exec(litexml)) !== null) {
       nodes.push({
-        content: match[3],
-        fullMatch: match[0],
-        id: match[2],
+        attributes: match[2].trim(),
+        content: match[4],
+        id: match[3],
         tagName: match[1],
       });
     }
@@ -681,6 +686,7 @@ export class EditorRuntime {
     const pageXML = editor.getDocument('litexml') as unknown as string;
 
     if (!pageXML) {
+      console.error('[EditorRuntime] replaceText:failed — pageXML is empty');
       throw new Error('Document is empty or not initialized');
     }
 
@@ -698,6 +704,8 @@ export class EditorRuntime {
 
     // Extract nodes from LiteXML
     const nodes = this.extractNodesFromLiteXML(pageXML);
+    const allNodeIds = nodes.map((n) => n.id);
+
     log('Found nodes:', nodes.length);
 
     // Filter nodes if nodeIds is specified and non-empty
@@ -706,12 +714,7 @@ export class EditorRuntime {
     const targetNodes = hasNodeFilter ? nodes.filter((node) => nodeIds.includes(node.id)) : nodes;
 
     if (hasNodeFilter && targetNodes.length === 0) {
-      log(
-        '[replaceText] Node IDs requested:',
-        nodeIds,
-        'Available IDs:',
-        nodes.map((n) => n.id),
-      );
+      log('[replaceText] Node IDs requested:', nodeIds, 'Available IDs:', allNodeIds);
       throw new Error(`None of the specified nodes were found: ${nodeIds.join(', ')}`);
     }
 
@@ -728,7 +731,9 @@ export class EditorRuntime {
           ? node.content.includes(searchPattern)
           : searchPattern.test(node.content);
 
-      if (!hasMatch) continue;
+      if (!hasMatch) {
+        continue;
+      }
 
       // Reset regex lastIndex if using regex
       if (searchPattern instanceof RegExp) {
@@ -748,12 +753,7 @@ export class EditorRuntime {
         modifiedNodeIds.push(node.id);
 
         // Build the updated LiteXML for this node
-        // Extract attributes from the original fullMatch
-        const firstSpace = node.fullMatch.indexOf(' ');
-        const attributes =
-          firstSpace > 0 ? node.fullMatch.slice(firstSpace + 1, -1) : `id="${node.id}"`;
-
-        const updatedLitexml = `<${node.tagName} ${attributes}>${newContent}</${node.tagName}>`;
+        const updatedLitexml = `<${node.tagName} ${node.attributes}>${newContent}</${node.tagName}>`;
         litexmlUpdates.push(updatedLitexml);
 
         log('Updated node:', node.id, 'count:', count);
@@ -766,20 +766,18 @@ export class EditorRuntime {
     }
 
     // Apply updates if any replacements were made
+
     if (litexmlUpdates.length > 0) {
       log('Applying updates:', litexmlUpdates.length);
+      if (!hasDataSource(editor as InspectableEditor, 'litexml')) {
+        throw new Error('replaceText failed: LiteXML data source is not ready.');
+      }
+
       const dispatchSuccess = editor.dispatchCommand(LITEXML_APPLY_COMMAND, {
         litexml: litexmlUpdates,
       });
-      log('Command dispatched, success:', dispatchSuccess);
 
-      if (!dispatchSuccess) {
-        throw new Error(
-          `replaceText failed: editor.dispatchCommand returned false. ` +
-            `Replacement count: ${totalReplacementCount}, ` +
-            `Modified nodes: ${modifiedNodeIds.join(', ')}.`,
-        );
-      }
+      log('Command dispatched, success:', dispatchSuccess);
     }
 
     const result = { modifiedNodeIds, replacementCount: totalReplacementCount };

--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -27,6 +27,12 @@ interface InspectableEditor {
   pluginsInstances?: unknown[];
 }
 
+export type EditorMutationApiName = 'editTitle' | 'initPage' | 'modifyNodes' | 'replaceText';
+
+export interface EditorMutationContext {
+  apiName: EditorMutationApiName;
+}
+
 export interface EditorRuntimeDebugSnapshot {
   currentDocId?: string;
   dataSourceTypes: string[];
@@ -66,7 +72,8 @@ export class EditorRuntime {
   private titleGetter: (() => string) | null = null;
   private currentDocId: string | undefined = undefined;
   private afterMutateHandler: (() => void | Promise<void>) | null = null;
-  private beforeMutateHandler: (() => void | Promise<void>) | null = null;
+  private beforeMutateHandler: ((context: EditorMutationContext) => void | Promise<void>) | null =
+    null;
 
   /**
    * Set the current editor instance
@@ -96,7 +103,9 @@ export class EditorRuntime {
    * Set a handler to be called before any mutating operation.
    * This can be used to save history or perform other pre-mutation tasks.
    */
-  setBeforeMutateHandler(handler: (() => void | Promise<void>) | null) {
+  setBeforeMutateHandler(
+    handler: ((context: EditorMutationContext) => void | Promise<void>) | null,
+  ) {
     this.beforeMutateHandler = handler;
     log('[EditorRuntime] setBeforeMutateHandler', this.getDebugSnapshot());
   }
@@ -178,9 +187,9 @@ export class EditorRuntime {
     return { getter: this.titleGetter, setter: this.titleSetter };
   }
 
-  private async runBeforeMutate() {
+  private async runBeforeMutate(apiName: EditorMutationApiName) {
     try {
-      await this.beforeMutateHandler?.();
+      await this.beforeMutateHandler?.({ apiName });
     } catch {
       /* ignore pre-mutation errors */
     }
@@ -211,7 +220,7 @@ export class EditorRuntime {
       throw new Error('initPage failed: markdown content is empty.');
     }
 
-    await this.runBeforeMutate();
+    await this.runBeforeMutate('initPage');
     const editor = this.getEditor();
 
     let markdown = args.markdown;
@@ -287,7 +296,7 @@ export class EditorRuntime {
       titleLength: args.title.length,
     });
 
-    await this.runBeforeMutate();
+    await this.runBeforeMutate('editTitle');
     const { setter, getter } = this.getTitleHandlers();
     const previousTitle = getter();
 
@@ -380,11 +389,7 @@ export class EditorRuntime {
       snapshot: this.getDebugSnapshot(),
     });
 
-    try {
-      await this.beforeMutateHandler?.();
-    } catch {
-      /* ignore pre-mutation errors */
-    }
+    await this.runBeforeMutate('modifyNodes');
     const editor = this.getEditor();
     let { operations } = args;
 
@@ -660,7 +665,7 @@ export class EditorRuntime {
    * @returns Raw result with modifiedNodeIds and replacementCount
    */
   async replaceText(args: ReplaceTextArgs): Promise<ReplaceTextRuntimeResult> {
-    await this.runBeforeMutate();
+    await this.runBeforeMutate('replaceText');
     const editor = this.getEditor();
     const { searchText, newText, useRegex = false, replaceAll = true, nodeIds } = args;
 

--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -30,6 +30,7 @@ interface InspectableEditor {
 export interface EditorRuntimeDebugSnapshot {
   currentDocId?: string;
   dataSourceTypes: string[];
+  hasAfterMutateHandler: boolean;
   hasBeforeMutateHandler: boolean;
   hasEditor: boolean;
   hasLexicalEditor: boolean;
@@ -64,6 +65,7 @@ export class EditorRuntime {
   private titleSetter: ((title: string) => void) | null = null;
   private titleGetter: (() => string) | null = null;
   private currentDocId: string | undefined = undefined;
+  private afterMutateHandler: (() => void | Promise<void>) | null = null;
   private beforeMutateHandler: (() => void | Promise<void>) | null = null;
 
   /**
@@ -100,6 +102,15 @@ export class EditorRuntime {
   }
 
   /**
+   * Set a handler to be called after any successful mutating operation.
+   * This can be used to synchronize editor changes into the host persistence layer.
+   */
+  setAfterMutateHandler(handler: (() => void | Promise<void>) | null) {
+    this.afterMutateHandler = handler;
+    log('[EditorRuntime] setAfterMutateHandler', this.getDebugSnapshot());
+  }
+
+  /**
    * Set the title setter and getter functions
    */
   setTitleHandlers(setter: ((title: string) => void) | null, getter: (() => string) | null) {
@@ -125,6 +136,7 @@ export class EditorRuntime {
     return {
       currentDocId: this.currentDocId,
       dataSourceTypes: inspectableEditor ? getDataSourceTypes(inspectableEditor) : [],
+      hasAfterMutateHandler: !!this.afterMutateHandler,
       hasBeforeMutateHandler: !!this.beforeMutateHandler,
       hasEditor: !!this.editor,
       hasLexicalEditor,
@@ -166,6 +178,22 @@ export class EditorRuntime {
     return { getter: this.titleGetter, setter: this.titleSetter };
   }
 
+  private async runBeforeMutate() {
+    try {
+      await this.beforeMutateHandler?.();
+    } catch {
+      /* ignore pre-mutation errors */
+    }
+  }
+
+  private async runAfterMutate() {
+    try {
+      await this.afterMutateHandler?.();
+    } catch {
+      /* ignore post-mutation errors */
+    }
+  }
+
   // ==================== Initialize ====================
 
   /**
@@ -175,14 +203,15 @@ export class EditorRuntime {
   async initPage(args: InitDocumentArgs): Promise<InitPageRuntimeResult> {
     log('[EditorRuntime] initPage:start', {
       markdownLength: args.markdown.length,
+
       snapshot: this.getDebugSnapshot(),
     });
 
-    try {
-      await this.beforeMutateHandler?.();
-    } catch {
-      /* ignore pre-mutation errors */
+    if (!args.markdown || args.markdown.trim().length === 0) {
+      throw new Error('initPage failed: markdown content is empty.');
     }
+
+    await this.runBeforeMutate();
     const editor = this.getEditor();
 
     let markdown = args.markdown;
@@ -196,6 +225,11 @@ export class EditorRuntime {
       // Remove the title line from markdown
       markdown = markdown.slice(titleLine.length).trimStart();
 
+      log('[EditorRuntime] initPage:titleExtracted', {
+        extractedTitle,
+        remainingMarkdownLength: markdown.length,
+      });
+
       // Set the title separately if title handlers are available
       if (this.titleSetter) {
         this.titleSetter(extractedTitle);
@@ -203,11 +237,31 @@ export class EditorRuntime {
     }
 
     // Set markdown content directly - the editor will convert it internally
+
     editor.setDocument('markdown', markdown, { keepId: true });
 
     // Get the resulting document to count nodes
+    // Lexical getDocument('json') returns { root: { children: [...] } }
+    // where 'root' wraps the top-level block elements
     const jsonState = editor.getDocument('json') as any;
-    const nodeCount = jsonState?.children?.length || 0;
+    const root = jsonState?.root ?? jsonState;
+    const nodeCount = root?.children?.length || 0;
+
+    log('[EditorRuntime] initPage:afterSetDocument', {
+      nodeCount,
+      jsonStateKeys: jsonState ? Object.keys(jsonState) : null,
+      rootKeys: root ? Object.keys(root) : null,
+    });
+
+    if (nodeCount === 0) {
+      throw new Error(
+        `initPage failed: setDocument produced 0 nodes. ` +
+          `Input markdown length: ${args.markdown.length}, ` +
+          `after title-stripping: ${markdown.length}. ` +
+          `jsonState keys: ${jsonState ? JSON.stringify(Object.keys(jsonState)) : 'null'}, ` +
+          `root keys: ${root ? JSON.stringify(Object.keys(root)) : 'null'}.`,
+      );
+    }
 
     const result = { extractedTitle, nodeCount };
     log('[EditorRuntime] initPage:success', {
@@ -215,6 +269,8 @@ export class EditorRuntime {
       snapshot: this.getDebugSnapshot(),
       titleExtracted: !!extractedTitle,
     });
+
+    await this.runAfterMutate();
 
     return result;
   }
@@ -231,11 +287,7 @@ export class EditorRuntime {
       titleLength: args.title.length,
     });
 
-    try {
-      await this.beforeMutateHandler?.();
-    } catch {
-      /* ignore pre-mutation errors */
-    }
+    await this.runBeforeMutate();
     const { setter, getter } = this.getTitleHandlers();
     const previousTitle = getter();
 
@@ -247,6 +299,8 @@ export class EditorRuntime {
       snapshot: this.getDebugSnapshot(),
       titleLength: args.title.length,
     });
+
+    await this.runAfterMutate();
 
     return result;
   }
@@ -373,6 +427,10 @@ export class EditorRuntime {
                 afterId: op.afterId,
                 litexml: op.litexml,
               });
+            } else {
+              throw new Error(
+                `Insert operation requires either 'beforeId' or 'afterId'. Got: ${JSON.stringify(Object.keys(op))}.`,
+              );
             }
             results.push({ action: 'insert', success: true });
             break;
@@ -405,8 +463,15 @@ export class EditorRuntime {
 
     // Dispatch all operations at once
     log('Dispatching LITEXML_MODIFY_COMMAND with payload:', commandPayload);
-    const success = editor.dispatchCommand(LITEXML_MODIFY_COMMAND, commandPayload);
-    log('Command dispatched, success:', success);
+    const dispatchSuccess = editor.dispatchCommand(LITEXML_MODIFY_COMMAND, commandPayload);
+    log('Command dispatched, success:', dispatchSuccess);
+
+    if (!dispatchSuccess && commandPayload.length > 0) {
+      throw new Error(
+        `modifyNodes failed: editor.dispatchCommand returned false. ` +
+          `Operations attempted: ${commandPayload.map((p) => p.action).join(', ')}.`,
+      );
+    }
 
     const successCount = results.filter((r) => r.success).length;
     const totalCount = results.length;
@@ -417,6 +482,8 @@ export class EditorRuntime {
       successCount,
       totalCount,
     });
+
+    await this.runAfterMutate();
 
     return result;
   }
@@ -593,11 +660,7 @@ export class EditorRuntime {
    * @returns Raw result with modifiedNodeIds and replacementCount
    */
   async replaceText(args: ReplaceTextArgs): Promise<ReplaceTextRuntimeResult> {
-    try {
-      await this.beforeMutateHandler?.();
-    } catch {
-      /* ignore pre-mutation errors */
-    }
+    await this.runBeforeMutate();
     const editor = this.getEditor();
     const { searchText, newText, useRegex = false, replaceAll = true, nodeIds } = args;
 
@@ -700,12 +763,24 @@ export class EditorRuntime {
     // Apply updates if any replacements were made
     if (litexmlUpdates.length > 0) {
       log('Applying updates:', litexmlUpdates.length);
-      const success = editor.dispatchCommand(LITEXML_APPLY_COMMAND, {
+      const dispatchSuccess = editor.dispatchCommand(LITEXML_APPLY_COMMAND, {
         litexml: litexmlUpdates,
       });
-      log('Command dispatched, success:', success);
+      log('Command dispatched, success:', dispatchSuccess);
+
+      if (!dispatchSuccess) {
+        throw new Error(
+          `replaceText failed: editor.dispatchCommand returned false. ` +
+            `Replacement count: ${totalReplacementCount}, ` +
+            `Modified nodes: ${modifiedNodeIds.join(', ')}.`,
+        );
+      }
     }
 
-    return { modifiedNodeIds, replacementCount: totalReplacementCount };
+    const result = { modifiedNodeIds, replacementCount: totalReplacementCount };
+
+    await this.runAfterMutate();
+
+    return result;
   }
 }

--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -57,6 +57,9 @@ const getDataSourceTypes = (editor: InspectableEditor): string[] => {
   return Object.keys(dataTypeMap).sort();
 };
 
+const hasDataSource = (editor: InspectableEditor, type: string) =>
+  getDataSourceTypes(editor).includes(type);
+
 /**
  * Editor Execution Runtime
  * Handles the execution logic for editor operations including:
@@ -466,17 +469,14 @@ export class EditorRuntime {
       }
     }
 
-    // Dispatch all operations at once
-    log('Dispatching LITEXML_MODIFY_COMMAND with payload:', commandPayload);
-    const dispatchSuccess = editor.dispatchCommand(LITEXML_MODIFY_COMMAND, commandPayload);
-    log('Command dispatched, success:', dispatchSuccess);
-
-    if (!dispatchSuccess && commandPayload.length > 0) {
-      throw new Error(
-        `modifyNodes failed: editor.dispatchCommand returned false. ` +
-          `Operations attempted: ${commandPayload.map((p) => p.action).join(', ')}.`,
-      );
+    if (!hasDataSource(editor as InspectableEditor, 'litexml')) {
+      throw new Error('modifyNodes failed: LiteXML data source is not ready.');
     }
+
+    // Dispatch all operations at once. The LiteXML command handler returns false
+    // even after handling the command, so the return value is not a failure signal.
+    log('Dispatching LITEXML_MODIFY_COMMAND with payload:', commandPayload);
+    editor.dispatchCommand(LITEXML_MODIFY_COMMAND, commandPayload);
 
     const successCount = results.filter((r) => r.success).length;
     const totalCount = results.length;

--- a/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
+++ b/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
@@ -531,7 +531,7 @@ describe('EditorRuntime', () => {
       await runtime.initPage({ markdown: 'Test content' });
       await moment();
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ apiName: 'initPage' });
     });
 
     it('should call beforeMutateHandler before editTitle', async () => {
@@ -540,7 +540,7 @@ describe('EditorRuntime', () => {
 
       await runtime.editTitle({ title: 'New Title' });
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ apiName: 'editTitle' });
     });
 
     it('should call beforeMutateHandler before modifyNodes', async () => {
@@ -551,7 +551,7 @@ describe('EditorRuntime', () => {
         operations: [{ action: 'insert', afterId: 'root', litexml: '<p>Test</p>' }],
       });
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ apiName: 'modifyNodes' });
     });
 
     it('should call beforeMutateHandler before replaceText', async () => {
@@ -560,7 +560,7 @@ describe('EditorRuntime', () => {
 
       await runtime.replaceText({ searchText: 'old', newText: 'new' });
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ apiName: 'replaceText' });
     });
 
     it('should still proceed when beforeMutateHandler is not set', async () => {

--- a/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
+++ b/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
@@ -583,6 +583,40 @@ describe('EditorRuntime', () => {
     });
   });
 
+  describe('afterMutateHandler', () => {
+    it('should call afterMutateHandler after initPage succeeds', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      runtime.setAfterMutateHandler(handler);
+
+      await runtime.initPage({ markdown: 'Test content' });
+      await moment();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call afterMutateHandler when initPage fails before mutation', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      runtime.setAfterMutateHandler(handler);
+
+      await expect(runtime.initPage({ markdown: '' })).rejects.toThrow(
+        'initPage failed: markdown content is empty.',
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should still proceed when afterMutateHandler throws', async () => {
+      const handler = vi.fn().mockRejectedValue(new Error('Handler failed'));
+      runtime.setAfterMutateHandler(handler);
+
+      const result = await runtime.initPage({ markdown: 'Test content' });
+      await moment();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(result.nodeCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
   describe('getPageContentContext', () => {
     beforeEach(async () => {
       await runtime.initPage({ markdown: 'Test content for context' });

--- a/src/features/AgentMockDevtools/index.tsx
+++ b/src/features/AgentMockDevtools/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useState } from 'react';
+import { useMatches } from 'react-router-dom';
 
 import { Fab } from './Fab';
 import { Modal } from './Modal';
@@ -26,9 +27,17 @@ const useDevtoolsEnabled = (): boolean => {
   return enabled;
 };
 
+const useIsAgentTopicRoute = (): boolean => {
+  const matches = useMatches();
+  // Check if any resolved route segment has a topicId param
+  // This correctly distinguishes /agent/:topicId from /agent/page, /agent/profile, etc.
+  return matches.some((m) => 'topicId' in m.params);
+};
+
 const AgentMockDevtools = memo(() => {
   const enabled = useDevtoolsEnabled();
-  if (!isDevEnv || !enabled) return null;
+  const isAgentTopicRoute = useIsAgentTopicRoute();
+  if (!isDevEnv || !enabled || !isAgentTopicRoute) return null;
   return (
     <>
       <Fab />

--- a/src/features/PageEditor/StoreUpdater.tsx
+++ b/src/features/PageEditor/StoreUpdater.tsx
@@ -3,6 +3,7 @@
 import { memo, useEffect } from 'react';
 import { createStoreUpdater } from 'zustand-utils';
 
+import { hasMeaningfulEditorContent } from '@/libs/editor/hasMeaningfulEditorContent';
 import { documentHistoryQueueService } from '@/services/documentHistoryQueue';
 import { useDocumentStore } from '@/store/document';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
@@ -78,9 +79,16 @@ const StoreUpdater = memo<StoreUpdaterProps>(
       pageAgentRuntime.setCurrentDocId(pageId);
       pageAgentRuntime.setTitleHandlers(storeApi.getState().setTitle, titleGetter);
       pageAgentRuntime.setBeforeMutateHandler(() => {
+        const editor = storeApi.getState().editor;
+        const editorData = editor?.getDocument('json');
+
+        if (!hasMeaningfulEditorContent(editorData)) {
+          return;
+        }
+
         documentHistoryQueueService.enqueueEditorSnapshot({
           documentId: pageId,
-          editor: storeApi.getState().editor,
+          editor,
         });
       });
       pageAgentRuntime.setAfterMutateHandler(async () => {

--- a/src/features/PageEditor/StoreUpdater.tsx
+++ b/src/features/PageEditor/StoreUpdater.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect } from 'react';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { documentHistoryQueueService } from '@/services/documentHistoryQueue';
+import { useDocumentStore } from '@/store/document';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 
 import { type PublicState } from './store';
@@ -82,9 +83,15 @@ const StoreUpdater = memo<StoreUpdaterProps>(
           editor: storeApi.getState().editor,
         });
       });
+      pageAgentRuntime.setAfterMutateHandler(async () => {
+        if (!pageId) return;
+
+        await useDocumentStore.getState().commitEditorMutation(pageId, { saveSource: 'llm_call' });
+      });
 
       return () => {
         pageAgentRuntime.setCurrentDocId(undefined);
+        pageAgentRuntime.setAfterMutateHandler(null);
         pageAgentRuntime.setTitleHandlers(null, null);
         pageAgentRuntime.setBeforeMutateHandler(null);
         void documentHistoryQueueService.flush();

--- a/src/features/TopicCanvas/index.test.tsx
+++ b/src/features/TopicCanvas/index.test.tsx
@@ -14,7 +14,7 @@ const mockEditor = {
     ['markdown', {}],
   ]),
   focus: vi.fn(),
-  getDocument: vi.fn(() => ({ root: true })),
+  getDocument: vi.fn((): unknown => ({ root: true })),
   getLexicalEditor: vi.fn(() => ({})),
 } as const;
 
@@ -144,8 +144,8 @@ describe('TopicCanvas', () => {
 
     const beforeMutateHandler = runtimeSpies.setBeforeMutateHandler.mock.calls.find(
       ([handler]) => typeof handler === 'function',
-    )?.[0] as (() => void) | undefined;
-    beforeMutateHandler?.();
+    )?.[0] as ((context: { apiName: 'modifyNodes' }) => void) | undefined;
+    beforeMutateHandler?.({ apiName: 'modifyNodes' });
 
     expect(documentHistoryQueueService.enqueueEditorSnapshot).toHaveBeenCalledWith({
       documentId: 'doc-1',
@@ -168,5 +168,32 @@ describe('TopicCanvas', () => {
     expect(runtimeSpies.setTitleHandlers).toHaveBeenLastCalledWith(null, null);
     expect(runtimeSpies.setBeforeMutateHandler).toHaveBeenLastCalledWith(null);
     expect(runtimeSpies.setEditor).toHaveBeenLastCalledWith(null);
+  });
+
+  it('does not save a history snapshot for an empty editor state', async () => {
+    const { unmount } = render(
+      <TopicCanvas documentId="doc-1" title="Topic Title" onTitleChange={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(runtimeSpies.setBeforeMutateHandler).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    const beforeMutateHandler = runtimeSpies.setBeforeMutateHandler.mock.calls.find(
+      ([handler]) => typeof handler === 'function',
+    )?.[0] as ((context: { apiName: 'modifyNodes' }) => void) | undefined;
+
+    mockEditor.getDocument.mockReturnValueOnce({
+      root: {
+        children: [{ children: [], type: 'paragraph' }],
+        type: 'root',
+      },
+    });
+
+    beforeMutateHandler?.({ apiName: 'modifyNodes' });
+
+    expect(documentHistoryQueueService.enqueueEditorSnapshot).not.toHaveBeenCalled();
+
+    unmount();
   });
 });

--- a/src/features/TopicCanvas/index.test.tsx
+++ b/src/features/TopicCanvas/index.test.tsx
@@ -19,6 +19,7 @@ const mockEditor = {
 } as const;
 
 const runtimeSpies = vi.hoisted(() => ({
+  setAfterMutateHandler: vi.fn(),
   setBeforeMutateHandler: vi.fn(),
   setCurrentDocId: vi.fn(),
   setEditor: vi.fn(),
@@ -26,6 +27,9 @@ const runtimeSpies = vi.hoisted(() => ({
 }));
 
 const useEditorMock = vi.hoisted(() => vi.fn(() => mockEditor));
+const documentStoreMock = vi.hoisted(() => ({
+  commitEditorMutation: vi.fn(),
+}));
 
 vi.mock('@lobehub/editor/react', () => ({
   EditorProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -106,6 +110,12 @@ vi.mock('@/services/documentHistoryQueue', () => ({
   },
 }));
 
+vi.mock('@/store/document', () => ({
+  useDocumentStore: {
+    getState: () => documentStoreMock,
+  },
+}));
+
 vi.mock('@/store/tool/slices/builtin/executors/lobe-page-agent', () => ({
   pageAgentRuntime: runtimeSpies,
 }));
@@ -129,6 +139,7 @@ describe('TopicCanvas', () => {
       expect(runtimeSpies.setCurrentDocId).toHaveBeenCalledWith('doc-1');
       expect(runtimeSpies.setTitleHandlers).toHaveBeenCalledTimes(1);
       expect(runtimeSpies.setBeforeMutateHandler).toHaveBeenCalledWith(expect.any(Function));
+      expect(runtimeSpies.setAfterMutateHandler).toHaveBeenCalledWith(expect.any(Function));
     });
 
     const beforeMutateHandler = runtimeSpies.setBeforeMutateHandler.mock.calls.find(
@@ -141,9 +152,19 @@ describe('TopicCanvas', () => {
       editor: mockEditor,
     });
 
+    const afterMutateHandler = runtimeSpies.setAfterMutateHandler.mock.calls.find(
+      ([handler]) => typeof handler === 'function',
+    )?.[0] as (() => Promise<void>) | undefined;
+    await afterMutateHandler?.();
+
+    expect(documentStoreMock.commitEditorMutation).toHaveBeenCalledWith('doc-1', {
+      saveSource: 'llm_call',
+    });
+
     unmount();
 
     expect(runtimeSpies.setCurrentDocId).toHaveBeenLastCalledWith(undefined);
+    expect(runtimeSpies.setAfterMutateHandler).toHaveBeenLastCalledWith(null);
     expect(runtimeSpies.setTitleHandlers).toHaveBeenLastCalledWith(null, null);
     expect(runtimeSpies.setBeforeMutateHandler).toHaveBeenLastCalledWith(null);
     expect(runtimeSpies.setEditor).toHaveBeenLastCalledWith(null);

--- a/src/features/TopicCanvas/index.tsx
+++ b/src/features/TopicCanvas/index.tsx
@@ -12,6 +12,7 @@ import { DiffAllToolbar, EditorCanvas as SharedEditorCanvas } from '@/features/E
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useRegisterFilesHotkeys } from '@/hooks/useHotkeys';
 import { documentHistoryQueueService } from '@/services/documentHistoryQueue';
+import { useDocumentStore } from '@/store/document';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { StyleSheet } from '@/utils/styles';
 
@@ -147,10 +148,18 @@ const TopicCanvasPageAgentBridge = memo<
       });
       documentHistoryQueueService.enqueueEditorSnapshot({ documentId, editor });
     });
+    pageAgentRuntime.setAfterMutateHandler(async () => {
+      if (!documentId) return;
+
+      await useDocumentStore
+        .getState()
+        .commitEditorMutation(documentId, { saveSource: 'llm_call' });
+    });
 
     return () => {
       log('[TopicCanvas/PageAgentBridge] clearDocumentContext', { documentId });
       pageAgentRuntime.setCurrentDocId(undefined);
+      pageAgentRuntime.setAfterMutateHandler(null);
       pageAgentRuntime.setTitleHandlers(null, null);
       pageAgentRuntime.setBeforeMutateHandler(null);
       void documentHistoryQueueService.flush();

--- a/src/features/TopicCanvas/index.tsx
+++ b/src/features/TopicCanvas/index.tsx
@@ -11,6 +11,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { DiffAllToolbar, EditorCanvas as SharedEditorCanvas } from '@/features/EditorCanvas';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import { useRegisterFilesHotkeys } from '@/hooks/useHotkeys';
+import { hasMeaningfulEditorContent } from '@/libs/editor/hasMeaningfulEditorContent';
 import { documentHistoryQueueService } from '@/services/documentHistoryQueue';
 import { useDocumentStore } from '@/store/document';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
@@ -140,12 +141,21 @@ const TopicCanvasPageAgentBridge = memo<
       },
       () => titleRef.current,
     );
-    pageAgentRuntime.setBeforeMutateHandler(() => {
+    pageAgentRuntime.setBeforeMutateHandler(({ apiName }) => {
+      const editorData = editor?.getDocument('json');
+      const hasHistorySnapshot = hasMeaningfulEditorContent(editorData);
+
       log('[TopicCanvas/PageAgentBridge] beforeMutate', {
+        apiName,
         dataSourceTypes: getPageAgentEditorSnapshot(editor).dataSourceTypes,
         documentId,
         hasEditor: !!editor,
+        hasHistorySnapshot,
       });
+      if (!hasHistorySnapshot) {
+        return;
+      }
+
       documentHistoryQueueService.enqueueEditorSnapshot({ documentId, editor });
     });
     pageAgentRuntime.setAfterMutateHandler(async () => {

--- a/src/libs/editor/hasMeaningfulEditorContent.test.ts
+++ b/src/libs/editor/hasMeaningfulEditorContent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasMeaningfulEditorContent } from './hasMeaningfulEditorContent';
+
+describe('hasMeaningfulEditorContent', () => {
+  it('should reject an empty paragraph editor state', () => {
+    expect(
+      hasMeaningfulEditorContent({
+        root: {
+          children: [
+            {
+              children: [],
+              type: 'paragraph',
+            },
+          ],
+          type: 'root',
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('should accept text content', () => {
+    expect(
+      hasMeaningfulEditorContent({
+        root: {
+          children: [
+            {
+              children: [{ text: 'content', type: 'text' }],
+              type: 'paragraph',
+            },
+          ],
+          type: 'root',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('should accept non-text structural content', () => {
+    expect(
+      hasMeaningfulEditorContent({
+        root: {
+          children: [{ type: 'horizontalrule' }],
+          type: 'root',
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/libs/editor/hasMeaningfulEditorContent.ts
+++ b/src/libs/editor/hasMeaningfulEditorContent.ts
@@ -1,0 +1,30 @@
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const hasMeaningfulEditorContent = (editorData: unknown): boolean => {
+  if (!isRecord(editorData)) return false;
+
+  const root = editorData.root;
+
+  // Unknown shapes are treated as meaningful so callers do not drop data they
+  // cannot safely classify.
+  if (!isRecord(root) || !Array.isArray(root.children)) return true;
+
+  const walk = (node: unknown): boolean => {
+    if (!isRecord(node)) return false;
+
+    if (typeof node.text === 'string' && node.text.trim().length > 0) return true;
+
+    const type = node.type;
+    if (typeof type === 'string' && !['paragraph', 'root', 'text'].includes(type)) {
+      return true;
+    }
+
+    const children = node.children;
+    if (!Array.isArray(children)) return false;
+
+    return children.some(walk);
+  };
+
+  return root.children.some(walk);
+};

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -5,7 +5,8 @@ import {
   type Cost,
   type Usage,
 } from '@lobechat/agent-runtime';
-import { AgentRuntime, computeStepContext, GeneralChatAgent } from '@lobechat/agent-runtime';
+import { AgentRuntime, computeStepContext } from '@lobechat/agent-runtime';
+import * as agentRuntimeModule from '@lobechat/agent-runtime';
 import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { createPathScopeAudit } from '@lobechat/builtin-tool-local-system';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
@@ -541,7 +542,7 @@ export class StreamingExecutorActionImpl {
       provider!,
     )(getAiInfraStoreState());
 
-    const agent = new GeneralChatAgent({
+    const agent = new agentRuntimeModule.GeneralChatAgent({
       agentConfig: { maxSteps: 1000 },
       compressionConfig: {
         enabled: agentConfigData.chatConfig?.enableContextCompression ?? true, // Default to enabled

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -5,8 +5,7 @@ import {
   type Cost,
   type Usage,
 } from '@lobechat/agent-runtime';
-import { AgentRuntime, computeStepContext } from '@lobechat/agent-runtime';
-import * as agentRuntimeModule from '@lobechat/agent-runtime';
+import { AgentRuntime, computeStepContext, GeneralChatAgent } from '@lobechat/agent-runtime';
 import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { createPathScopeAudit } from '@lobechat/builtin-tool-local-system';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
@@ -542,7 +541,7 @@ export class StreamingExecutorActionImpl {
       provider!,
     )(getAiInfraStoreState());
 
-    const agent = new agentRuntimeModule.GeneralChatAgent({
+    const agent = new GeneralChatAgent({
       agentConfig: { maxSteps: 1000 },
       compressionConfig: {
         enabled: agentConfigData.chatConfig?.enableContextCompression ?? true, // Default to enabled

--- a/src/store/document/slices/editor/action.test.ts
+++ b/src/store/document/slices/editor/action.test.ts
@@ -367,6 +367,55 @@ describe('DocumentStore - Editor Actions', () => {
     });
   });
 
+  describe('commitEditorMutation', () => {
+    it('syncs current editor content and immediately saves through the document manager', async () => {
+      const { result } = renderHook(() => useDocumentStore());
+      const editorData = {
+        root: { children: [{ children: [], type: 'paragraph' }], type: 'root' },
+      };
+      const mockEditor = {
+        getDocument: vi.fn((type: string) => {
+          if (type === 'markdown') return '# Updated';
+          if (type === 'json') return editorData;
+          return null;
+        }),
+        setDocument: vi.fn(),
+      } as any;
+
+      act(() => {
+        result.current.initDocumentWithEditor({
+          content: '# Initial',
+          documentId: 'doc-1',
+          editor: mockEditor,
+          editorData: {
+            root: { children: [{ children: [], type: 'paragraph' }], type: 'root' },
+          },
+          sourceType: 'page',
+        });
+      });
+
+      await act(async () => {
+        await result.current.commitEditorMutation('doc-1', { saveSource: 'llm_call' });
+      });
+
+      expect(documentService.updateDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '# Updated',
+          editorData: JSON.stringify(editorData),
+          id: 'doc-1',
+          saveSource: 'llm_call',
+        }),
+      );
+      expect(result.current.documents['doc-1']).toMatchObject({
+        content: '# Updated',
+        editorData,
+        isDirty: false,
+        lastSavedContent: '# Updated',
+        lastSavedEditorData: editorData,
+      });
+    });
+  });
+
   describe('setEditorState', () => {
     it('should set editor state', () => {
       const { result } = renderHook(() => useDocumentStore());

--- a/src/store/document/slices/editor/action.ts
+++ b/src/store/document/slices/editor/action.ts
@@ -57,13 +57,17 @@ export class EditorActionImpl {
     }
   };
 
-  handleContentChange = (): void => {
+  private syncEditorContent = (
+    documentId?: string,
+    options: { triggerAutoSave?: boolean } = {},
+  ): boolean => {
     const { editor, activeDocumentId, documents, internal_dispatchDocument } = this.#get();
+    const id = documentId || activeDocumentId;
 
-    if (!editor || !activeDocumentId) return;
+    if (!editor || !id) return false;
 
-    const doc = documents[activeDocumentId];
-    if (!doc) return;
+    const doc = documents[id];
+    if (!doc) return false;
 
     try {
       const markdown = (editor.getDocument('markdown') as unknown as string) || '';
@@ -75,7 +79,7 @@ export class EditorActionImpl {
 
       internal_dispatchDocument(
         {
-          id: activeDocumentId,
+          id,
           type: 'updateDocument',
           value: { content: markdown, editorData, isDirty: contentChanged },
         },
@@ -83,12 +87,30 @@ export class EditorActionImpl {
       );
 
       // Only trigger auto-save if content actually changed AND autoSave is enabled
-      if (contentChanged && doc.autoSave !== false) {
-        this.#get().triggerDebouncedSave(activeDocumentId);
+      if (options.triggerAutoSave !== false && contentChanged && doc.autoSave !== false) {
+        this.#get().triggerDebouncedSave(id);
       }
+
+      return contentChanged;
     } catch (error) {
       console.error('[DocumentStore] Failed to update content:', error);
+      return false;
     }
+  };
+
+  commitEditorMutation = async (
+    documentId?: string,
+    options?: SaveExecutionOptions,
+  ): Promise<void> => {
+    const id = documentId || this.#get().activeDocumentId;
+    if (!id) return;
+
+    this.syncEditorContent(id, { triggerAutoSave: false });
+    await this.performSave(id, undefined, options);
+  };
+
+  handleContentChange = (): void => {
+    this.syncEditorContent(undefined, { triggerAutoSave: true });
   };
 
   internal_dispatchDocument = (payload: DocumentDispatch, action?: string): void => {

--- a/src/store/file/slices/document/action.test.ts
+++ b/src/store/file/slices/document/action.test.ts
@@ -233,6 +233,65 @@ describe('DocumentAction', () => {
     expect(useStore.getState().resourceMap.get('doc-1')?._optimistic).toBeUndefined();
   });
 
+  it('does not send content or editorData when Page Agent editTitle follows initPage', async () => {
+    const { result } = renderHook(() => useStore());
+    const initializedEditorData = {
+      root: {
+        children: [{ children: [], type: 'paragraph', version: 1 }],
+        type: 'root',
+        version: 1,
+      },
+    };
+
+    vi.mocked(documentService.updateDocument).mockResolvedValue({
+      historyAppended: false,
+      id: 'doc-1',
+    });
+
+    act(() => {
+      useStore.setState(
+        {
+          documents: [
+            createDocumentFixture({
+              content: '',
+              editorData: {},
+            }),
+          ],
+        },
+        false,
+      );
+    });
+
+    await act(async () => {
+      await result.current.updateDocumentOptimistically('doc-1', {
+        content: 'Body written by page agent.',
+        editorData: initializedEditorData,
+      });
+    });
+
+    await act(async () => {
+      await result.current.updateDocumentOptimistically('doc-1', {
+        metadata: { emoji: 'page' },
+        title: 'Final title',
+      });
+    });
+
+    expect(documentService.updateDocument).toHaveBeenNthCalledWith(1, {
+      content: 'Body written by page agent.',
+      editorData: JSON.stringify(initializedEditorData),
+      id: 'doc-1',
+      metadata: {},
+      parentId: undefined,
+      title: 'Old title',
+    });
+    expect(documentService.updateDocument).toHaveBeenNthCalledWith(2, {
+      id: 'doc-1',
+      metadata: { emoji: 'page' },
+      parentId: undefined,
+      title: 'Final title',
+    });
+  });
+
   it('reverts optimistic resource updates when the sync fails', async () => {
     const { result } = renderHook(() => useStore());
     const existingDocument = createDocumentFixture();

--- a/src/store/file/slices/document/action.ts
+++ b/src/store/file/slices/document/action.ts
@@ -683,15 +683,19 @@ export class DocumentActionImpl {
     // Queue background sync to DB
     try {
       await documentService.updateDocument({
-        content: updatedPage.content || '',
-        editorData:
-          typeof updatedPage.editorData === 'string'
-            ? updatedPage.editorData
-            : JSON.stringify(updatedPage.editorData || {}),
         id: documentId,
         metadata: updatedPage.metadata || {},
         parentId: updatedPage.parentId !== undefined ? updatedPage.parentId : undefined,
         title: updatedPage.title || updatedPage.filename,
+        ...(updates.content === undefined ? {} : { content: updatedPage.content ?? '' }),
+        ...(updates.editorData === undefined
+          ? {}
+          : {
+              editorData:
+                typeof updatedPage.editorData === 'string'
+                  ? updatedPage.editorData
+                  : JSON.stringify(updatedPage.editorData || {}),
+            }),
       });
       if (existingResource) {
         this.#syncResourceItem(this.#createResourceItem(updatedPage, existingResource));

--- a/src/store/page/slices/crud/action.ts
+++ b/src/store/page/slices/crud/action.ts
@@ -326,11 +326,6 @@ export class CrudActionImpl {
     // Queue background sync to DB
     try {
       await documentService.updateDocument({
-        content: updatedPage.content || '',
-        editorData:
-          typeof updatedPage.editorData === 'string'
-            ? updatedPage.editorData
-            : JSON.stringify(updatedPage.editorData || {}),
         id: pageId,
         metadata: updatedPage.metadata || {},
         parentId: updatedPage.parentId || undefined,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,7 +109,7 @@ export default defineConfig({
   },
   define: sharedRendererDefine({ isMobile, isElectron: false }),
   experimental: {
-    bundledDev: true,
+    bundledDev: false,
   },
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue



#### 🔀 Description of Change

This PR reduces unnecessary re-renders of the assistant message subtree during streaming by addressing two root causes:

1. **Reference instability after `parse()`**: The `parse()` function from `@lobechat/conversation-flow` rebuilds the entire `displayMessages` tree on every dispatch (including streaming chunks), giving every message/block/tool/result a fresh reference. This defeats `memo` and `useStore(selector, isEqual)` for unchanged subtrees. Added a `stabilizeReferences` utility that recursively walks old vs new trees and pins unchanged subtrees back to their previous reference identity, so React and Zustand can bail out as designed.

2. **Prop drilling of tool data**: Tool components received all their data (arguments, result, intervention, etc.) as props from the parent `ContentBlock`, meaning any streaming chunk that changes one tool would cause the entire tools array to change reference and cascade re-renders to all sibling tools. Refactored `Tool`, `Tools`, and `MessageContent` to self-subscribe to their own data via new store selectors (`findBlockById`, `getToolsInBlock`, `getToolInBlock`, `getBlockContent`, `getBlockHasTools`), so only the component whose data actually changed will re-render.

3. **Unstable Accordion callbacks**: `WorkflowCollapse` passed new function/array references on every render to the `Accordion` component, causing all nested `AccordionItem` components (one per tool) to re-render due to context changes. Wrapped `handleExpandedChange` in `useCallback` and derived `expandedKeys` with `useMemo`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified with React DevTools Profiler that during streaming:
- Only the tool whose args/result changed re-renders, not sibling tools
- Content blocks that did not change are skipped by React.memo
- `stabilizeReferences` preserves reference identity for unchanged subtrees (covered by unit tests in `stabilizeReferences.test.ts`)

#### 📝 Additional Information

- This is a rendering performance fix with no behavioral changes
- The `stabilizeReferences` utility is generic and could be reused elsewhere if similar reference instability issues arise