### PR TITLE
🐛 fix: preserve nested router runtime id

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -1159,5 +1159,45 @@ describe('createRouterRuntime', () => {
 
       expect(constructorOptions[0].apiKey).toBe('default-api-key');
     });
+
+    it('should preserve inherited runtime id across nested router runtimes', async () => {
+      const constructorOptions: any[] = [];
+
+      class LeafRuntime implements LobeRuntimeAI {
+        constructor(options: any) {
+          constructorOptions.push(options);
+        }
+        chat = vi.fn().mockResolvedValue('response');
+      }
+
+      const InnerRuntime = createRouterRuntime({
+        id: 'deepseek',
+        routers: [
+          {
+            apiType: 'deepseek',
+            models: ['deepseek-v4-pro'],
+            options: {},
+            runtime: LeafRuntime as any,
+          },
+        ],
+      });
+
+      const OuterRuntime = createRouterRuntime({
+        id: 'lobehub',
+        routers: [
+          {
+            apiType: 'deepseek',
+            models: ['deepseek-v4-pro'],
+            options: {},
+            runtime: InnerRuntime as any,
+          },
+        ],
+      });
+
+      const runtime = new OuterRuntime();
+      await runtime.chat({ messages: [], model: 'deepseek-v4-pro', temperature: 0.7 });
+
+      expect(constructorOptions[0]).toEqual(expect.objectContaining({ id: 'lobehub' }));
+    });
   });
 });

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -196,7 +196,7 @@ export const createRouterRuntime = ({
       // Save configuration without creating runtimes
       this._routers = routers;
       this._params = params;
-      this._id = id;
+      this._id = options.id ?? id;
     }
 
     /**


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Preserve an inherited runtime `id` when a RouterRuntime creates another RouterRuntime as its child runtime.

This keeps nested router chains such as LobeHub -> DeepSeek -> Anthropic-compatible runtime using the outer billing/provider id, so pricing lookup remains provider-scoped instead of falling back to the nested provider id.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd lobehub/packages/model-runtime
bunx vitest run --silent='passed-only' 'src/core/RouterRuntime/createRuntime.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.