### PR TITLE
🐛 fix: use runtime config to hide LobeHub provider toggle

### DIFF
--- a/src/features/ChatInput/ActionBar/STT/index.tsx
+++ b/src/features/ChatInput/ActionBar/STT/index.tsx
@@ -1,8 +1,11 @@
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
-import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
+import {
+  featureFlagsSelectors,
+  serverConfigSelectors,
+  useServerConfigStore,
+} from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 
@@ -12,10 +15,11 @@ import OpenaiSTT from './openai';
 const STT = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { sttServer } = useUserStore(settingsSelectors.currentTTS, isEqual);
   const { enableSTT } = useServerConfigStore(featureFlagsSelectors);
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   if (!enableSTT) return;
 
-  if (ENABLE_BUSINESS_FEATURES) {
+  if (enableBusinessFeatures) {
     return <BrowserSTT mobile={mobile} />;
   }
   switch (sttServer) {

--- a/src/features/CommandMenu/ContextCommands.tsx
+++ b/src/features/CommandMenu/ContextCommands.tsx
@@ -3,10 +3,12 @@ import { ChevronRight } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
+
 import { useCommandMenuContext } from './CommandMenuContext';
 import { CommandItem } from './components';
 import { useCommandMenu } from './useCommandMenu';
-import { CONTEXT_COMMANDS, getContextCommands } from './utils/contextCommands';
+import { buildContextCommands, getContextCommands } from './utils/contextCommands';
 
 const ContextCommands = memo(() => {
   const { t } = useTranslation('setting');
@@ -15,6 +17,7 @@ const ContextCommands = memo(() => {
   const { t: tCommon } = useTranslation('common');
   const { handleNavigate } = useCommandMenu();
   const { menuContext, pathname } = useCommandMenuContext();
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   // Extract subPath from pathname
   const subPath = useMemo(() => {
@@ -22,13 +25,13 @@ const ContextCommands = memo(() => {
     return pathParts && pathParts.length > 1 ? pathParts[1] : undefined;
   }, [pathname]);
 
-  const commands = getContextCommands(menuContext, subPath);
+  const commands = getContextCommands(menuContext, subPath, { enableBusinessFeatures });
 
   // Get settings commands to show globally (when not in settings context)
   const globalSettingsCommands = useMemo(() => {
     if (menuContext === 'settings') return [];
-    return CONTEXT_COMMANDS.settings;
-  }, [menuContext]);
+    return buildContextCommands({ enableBusinessFeatures }).settings;
+  }, [menuContext, enableBusinessFeatures]);
 
   const hasCommands = commands.length > 0 || globalSettingsCommands.length > 0;
 

--- a/src/features/CommandMenu/utils/contextCommands.ts
+++ b/src/features/CommandMenu/utils/contextCommands.ts
@@ -1,4 +1,3 @@
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { isDesktop } from '@lobechat/const';
 import { type LucideIcon } from 'lucide-react';
 import {
@@ -31,8 +30,62 @@ export interface ContextCommand {
   subPath: string;
 }
 
+const BUSINESS_SETTINGS_COMMANDS: ContextCommand[] = [
+  {
+    icon: Map,
+    keywords: ['subscription', 'plan', 'upgrade', 'pricing'],
+    keywordsKey: 'cmdk.keywords.plans',
+    label: 'Subscription Plans',
+    labelKey: 'tab.plans',
+    labelNamespace: 'subscription',
+    path: '/settings/plans',
+    subPath: 'plans',
+  },
+  {
+    icon: Coins,
+    keywords: ['credits', 'balance', 'credit', 'money'],
+    keywordsKey: 'cmdk.keywords.credits',
+    label: 'Credits',
+    labelKey: 'tab.credits',
+    labelNamespace: 'subscription',
+    path: '/settings/credits',
+    subPath: 'credits',
+  },
+  {
+    icon: PieChart,
+    keywords: ['usage', 'statistics', 'consumption', 'quota'],
+    keywordsKey: 'cmdk.keywords.usage',
+    label: 'Usage',
+    labelKey: 'tab.usage',
+    labelNamespace: 'subscription',
+    path: '/settings/usage',
+    subPath: 'usage',
+  },
+  {
+    icon: CreditCard,
+    keywords: ['billing', 'payment', 'invoice', 'transaction'],
+    keywordsKey: 'cmdk.keywords.billing',
+    label: 'Billing',
+    labelKey: 'tab.billing',
+    labelNamespace: 'subscription',
+    path: '/settings/billing',
+    subPath: 'billing',
+  },
+  {
+    icon: Gift,
+    keywords: ['referral', 'rewards', 'invite', 'bonus'],
+    keywordsKey: 'cmdk.keywords.referral',
+    label: 'Referral Rewards',
+    labelKey: 'tab.referral',
+    labelNamespace: 'subscription',
+    path: '/settings/referral',
+    subPath: 'referral',
+  },
+];
+
 /**
- * Map of context types to their available commands
+ * Map of context types to their core (non-business) commands.
+ * Business commands are appended at runtime via {@link buildContextCommands}.
  */
 export const CONTEXT_COMMANDS: Record<ContextType, ContextCommand[]> = {
   agent: [],
@@ -136,62 +189,24 @@ export const CONTEXT_COMMANDS: Record<ContextType, ContextCommand[]> = {
       path: '/settings/about',
       subPath: 'about',
     },
-    ...(ENABLE_BUSINESS_FEATURES
-      ? [
-          {
-            icon: Map,
-            keywords: ['subscription', 'plan', 'upgrade', 'pricing'],
-            keywordsKey: 'cmdk.keywords.plans',
-            label: 'Subscription Plans',
-            labelKey: 'tab.plans',
-            labelNamespace: 'subscription' as const,
-            path: '/settings/plans',
-            subPath: 'plans',
-          },
-          {
-            icon: Coins,
-            keywords: ['credits', 'balance', 'credit', 'money'],
-            keywordsKey: 'cmdk.keywords.credits',
-            label: 'Credits',
-            labelKey: 'tab.credits',
-            labelNamespace: 'subscription' as const,
-            path: '/settings/credits',
-            subPath: 'credits',
-          },
-          {
-            icon: PieChart,
-            keywords: ['usage', 'statistics', 'consumption', 'quota'],
-            keywordsKey: 'cmdk.keywords.usage',
-            label: 'Usage',
-            labelKey: 'tab.usage',
-            labelNamespace: 'subscription' as const,
-            path: '/settings/usage',
-            subPath: 'usage',
-          },
-          {
-            icon: CreditCard,
-            keywords: ['billing', 'payment', 'invoice', 'transaction'],
-            keywordsKey: 'cmdk.keywords.billing',
-            label: 'Billing',
-            labelKey: 'tab.billing',
-            labelNamespace: 'subscription' as const,
-            path: '/settings/billing',
-            subPath: 'billing',
-          },
-          {
-            icon: Gift,
-            keywords: ['referral', 'rewards', 'invite', 'bonus'],
-            keywordsKey: 'cmdk.keywords.referral',
-            label: 'Referral Rewards',
-            labelKey: 'tab.referral',
-            labelNamespace: 'subscription' as const,
-            path: '/settings/referral',
-            subPath: 'referral',
-          },
-        ]
-      : []),
   ],
 };
+
+interface BuildContextCommandsOptions {
+  enableBusinessFeatures: boolean;
+}
+
+/**
+ * Build the full command map, optionally appending business-only entries.
+ */
+export const buildContextCommands = ({
+  enableBusinessFeatures,
+}: BuildContextCommandsOptions): Record<ContextType, ContextCommand[]> => ({
+  ...CONTEXT_COMMANDS,
+  settings: enableBusinessFeatures
+    ? [...CONTEXT_COMMANDS.settings, ...BUSINESS_SETTINGS_COMMANDS]
+    : CONTEXT_COMMANDS.settings,
+});
 
 /**
  * Get context-specific commands based on context type and current sub-path
@@ -199,9 +214,10 @@ export const CONTEXT_COMMANDS: Record<ContextType, ContextCommand[]> = {
  */
 export const getContextCommands = (
   contextType: MenuContext,
-  currentSubPath?: string,
+  currentSubPath: string | undefined,
+  options: BuildContextCommandsOptions,
 ): ContextCommand[] => {
-  const commands = CONTEXT_COMMANDS[contextType as ContextType] || [];
+  const commands = buildContextCommands(options)[contextType as ContextType] || [];
 
   // Filter out the current page
   return commands.filter((cmd) => cmd.subPath !== currentSubPath);

--- a/src/features/Conversation/Error/index.test.tsx
+++ b/src/features/Conversation/Error/index.test.tsx
@@ -103,6 +103,13 @@ vi.mock('@/libs/next/dynamic', () => ({
   default: () => () => <div>dynamic</div>,
 }));
 
+vi.mock('@/store/serverConfig', () => ({
+  serverConfigSelectors: {
+    enableBusinessFeatures: () => false,
+  },
+  useServerConfigStore: (selector: (s: unknown) => unknown) => selector({}),
+}));
+
 describe('ErrorMessageExtra', () => {
   it('renders the auth guide when the refreshed error is missing type but still carries session code', () => {
     render(

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -1,4 +1,3 @@
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { HeterogeneousAgentSessionErrorCode } from '@lobechat/electron-client-ipc';
 import { type ILobeAgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
@@ -17,6 +16,7 @@ import ErrorContent from '@/features/Conversation/ChatItem/components/ErrorConte
 import HeterogeneousAgentStatusGuide from '@/features/Electron/HeterogeneousAgent/StatusGuide';
 import { useProviderName } from '@/hooks/useProviderName';
 import dynamic from '@/libs/next/dynamic';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 import ChatInvalidAPIKey from './ChatInvalidApiKey';
 
@@ -156,13 +156,13 @@ const ErrorMessageExtra = memo<ErrorExtraProps>(({ error: alertError, data }) =>
   const error = data.error;
   const navigate = useNavigate();
   const businessChatErrorMessageExtra = useRenderBusinessChatErrorMessageExtra(error, data.id);
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
   const sessionErrorCode = error?.body?.code;
   const sessionAgentType = error?.body?.agentType;
   const sessionErrorBody = error?.body;
   const rawErrorMessage = getRawErrorMessage(error) || alertError?.message;
 
-  if (ENABLE_BUSINESS_FEATURES && businessChatErrorMessageExtra)
-    return businessChatErrorMessageExtra;
+  if (enableBusinessFeatures && businessChatErrorMessageExtra) return businessChatErrorMessageExtra;
 
   if (
     (error?.type === AgentRuntimeErrorType.AgentRuntimeError || !error?.type) &&

--- a/src/features/FileSidePanel/index.tsx
+++ b/src/features/FileSidePanel/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { type DraggablePanelProps } from '@lobehub/ui';
 import { DraggablePanel, DraggablePanelContainer } from '@lobehub/ui';
 import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
@@ -12,6 +11,7 @@ import UsageFooter from '@/business/client/features/FileSidePanel/UsageFooter';
 import { FOLDER_WIDTH } from '@/const/layoutTokens';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 export const styles = createStaticStyles(({ css }) => ({
   panel: css`
@@ -27,6 +27,7 @@ const FileSidePanel = memo<PropsWithChildren>(({ children }) => {
     systemStatusSelectors.showFilePanel(s),
     s.updateSystemStatus,
   ]);
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
 
   const [tmpWidth, setWidth] = useState(filePanelWidth);
   if (tmpWidth !== filePanelWidth) setWidth(filePanelWidth);
@@ -73,7 +74,7 @@ const FileSidePanel = memo<PropsWithChildren>(({ children }) => {
         }}
       >
         {children}
-        {ENABLE_BUSINESS_FEATURES && <UsageFooter />}
+        {enableBusinessFeatures && <UsageFooter />}
       </DraggablePanelContainer>
     </DraggablePanel>
   );

--- a/src/features/User/UserPanel/PanelContent.tsx
+++ b/src/features/User/UserPanel/PanelContent.tsx
@@ -1,4 +1,3 @@
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { Flexbox } from '@lobehub/ui';
 import { type FC } from 'react';
 import { Link } from 'react-router-dom';
@@ -9,6 +8,7 @@ import { isDesktop } from '@/const/version';
 import UserInfo from '@/features/User/UserInfo';
 import { navigateToDesktopOnboarding } from '@/routes/(desktop)/desktop-onboarding/navigation';
 import { DesktopOnboardingScreen } from '@/routes/(desktop)/desktop-onboarding/types';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
@@ -20,6 +20,7 @@ import { useMenu } from './useMenu';
 const PanelContent: FC<{ closePopover: () => void }> = ({ closePopover }) => {
   const isLoginWithAuth = useUserStore(authSelectors.isLoginWithAuth);
   const [openSignIn, signOut] = useUserStore((s) => [s.openLogin, s.logout]);
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
   const { mainItems, logoutItems } = useMenu();
 
   const handleSignIn = () => {
@@ -55,7 +56,7 @@ const PanelContent: FC<{ closePopover: () => void }> = ({ closePopover }) => {
           <Link style={{ color: 'inherit' }} to={'/settings/stats'}>
             <DataStatistics />
           </Link>
-          {ENABLE_BUSINESS_FEATURES && <BusinessPanelContent />}
+          {enableBusinessFeatures && <BusinessPanelContent />}
         </>
       ) : (
         <UserLoginOrSignup onClick={handleSignIn} />

--- a/src/features/User/__tests__/PanelContent.test.tsx
+++ b/src/features/User/__tests__/PanelContent.test.tsx
@@ -63,6 +63,13 @@ vi.mock('@/const/version', () => ({
   isDesktop: false,
 }));
 
+vi.mock('@/store/serverConfig', () => ({
+  serverConfigSelectors: {
+    enableBusinessFeatures: () => false,
+  },
+  useServerConfigStore: (selector: (s: unknown) => unknown) => selector({}),
+}));
+
 describe('PanelContent', () => {
   const closePopover = vi.fn();
 

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,4 +1,3 @@
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import {
   type EdgeSpeechOptions,
   type MicrosoftSpeechOptions,
@@ -15,6 +14,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 import { type TTSServer } from '@/types/agent';
@@ -31,6 +31,7 @@ export const useTTS = (content: string, config?: TTSConfig) => {
   const lang = useGlobalStore(globalGeneralSelectors.currentLanguage);
   const voice = useAgentStore(agentSelectors.currentAgentTTSVoice(lang));
   const businessTTSProvider = useBusinessTTSProvider();
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
   let useSelectedTTS;
   let options: any = {};
   switch (config?.server || ttsAgentSettings.ttsService) {
@@ -39,7 +40,7 @@ export const useTTS = (content: string, config?: TTSConfig) => {
       options = {
         api: {
           headers: createHeaderWithOpenAI(),
-          serviceUrl: API_ENDPOINTS.tts(ENABLE_BUSINESS_FEATURES ? businessTTSProvider : 'openai'),
+          serviceUrl: API_ENDPOINTS.tts(enableBusinessFeatures ? businessTTSProvider : 'openai'),
         },
         options: {
           model: ttsSettings.openAI.ttsModel,

--- a/src/routes/(main)/(create)/image/features/ConfigPanel/components/ImageNum.tsx
+++ b/src/routes/(main)/(create)/image/features/ConfigPanel/components/ImageNum.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { ActionIcon, Flexbox, InputNumber, Segmented } from '@lobehub/ui';
 import { Check, Plus, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useImageStore } from '@/store/image';
 import { imageGenerationConfigSelectors } from '@/store/image/selectors';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 
-const DEFAULT_IMAGE_NUM_MAX = ENABLE_BUSINESS_FEATURES ? 8 : 50;
 const CUSTOM_VALUE = '__custom__';
 
 interface ImageNumSelectorProps {
@@ -19,9 +18,13 @@ interface ImageNumSelectorProps {
 }
 
 const ImageNum = memo<ImageNumSelectorProps>(
-  ({ presetCounts = [1, 2, 4, 8], min = 1, max = DEFAULT_IMAGE_NUM_MAX, disabled = false }) => {
+  ({ presetCounts = [1, 2, 4, 8], min = 1, max, disabled = false }) => {
     const imageNum = useImageStore(imageGenerationConfigSelectors.imageNum);
     const setImageNum = useImageStore((s) => s.setImageNum);
+    const enableBusinessFeatures = useServerConfigStore(
+      serverConfigSelectors.enableBusinessFeatures,
+    );
+    const resolvedMax = max ?? (enableBusinessFeatures ? 8 : 50);
     const [isEditing, setIsEditing] = useState(false);
     const [customCount, setCustomCount] = useState<number | null>(null);
     const customCountRef = useRef<number | null>(null);
@@ -75,8 +78,8 @@ const ImageNum = memo<ImageNumSelectorProps>(
         return;
       }
 
-      if (count > max) {
-        count = max;
+      if (count > resolvedMax) {
+        count = resolvedMax;
       } else if (count < min) {
         count = min;
       }
@@ -84,7 +87,7 @@ const ImageNum = memo<ImageNumSelectorProps>(
       setImageNum(count);
       setIsEditing(false);
       setCustomCount(null);
-    }, [min, max, setImageNum]);
+    }, [min, resolvedMax, setImageNum]);
 
     const handleCustomCancel = useCallback(() => {
       setIsEditing(false);
@@ -123,9 +126,9 @@ const ImageNum = memo<ImageNumSelectorProps>(
       return (
         <Flexbox horizontal gap={8} style={{ width: '100%' }}>
           <InputNumber
-            max={max}
+            max={resolvedMax}
             min={min}
-            placeholder={`${min}-${max}`}
+            placeholder={`${min}-${resolvedMax}`}
             ref={inputRef}
             size="small"
             style={{ flex: 1 }}

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { AES_GCM_URL, BASE_PROVIDER_DOC_URL, FORM_STYLE } from '@lobechat/const';
 import { ProviderCombine } from '@lobehub/icons';
 import { type FormGroupItemType, type FormItemProps } from '@lobehub/ui';
@@ -28,6 +28,7 @@ import { FormInput, FormPassword } from '@/components/FormInput';
 import { SkeletonInput, SkeletonSwitch } from '@/components/Skeleton';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { type AiProviderDetailItem, type AiProviderSourceType } from '@/types/aiProvider';
 import { AiProviderSourceEnum } from '@/types/aiProvider';
 
@@ -170,6 +171,9 @@ const ProviderConfig = memo<ProviderConfigProps>(
       aiProviderSelectors.isProviderConfigUpdating(id)(s),
       aiProviderSelectors.providerConfigById(id)(s),
     ]);
+    const enableBusinessFeatures = useServerConfigStore(
+      serverConfigSelectors.enableBusinessFeatures,
+    );
 
     // Watch form values in real-time to show/hide switches immediately
     // Watch nested form values for endpoints
@@ -470,7 +474,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
       <Flexbox horizontal align={'center'} gap={8}>
         {extra}
         {isCustom && <UpdateProviderInfo />}
-        {canDeactivate && !(ENABLE_BUSINESS_FEATURES && id === 'lobehub') && (
+        {canDeactivate && !(enableBusinessFeatures && id === BRANDING_PROVIDER) && (
           <EnableSwitch id={id} key={id} />
         )}
       </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The enable switch for the LobeHub built-in provider (under Settings → AI Providers → LobeHub) was previously gated by the build-time `ENABLE_BUSINESS_FEATURES` constant from `@lobechat/business-const`. In the open-source build that constant is hard-coded to `false`, so the guard `!(ENABLE_BUSINESS_FEATURES && id === 'lobehub')` always evaluated to `true` and the toggle stayed visible on every build derived from this bundle (e.g. desktop). Users could end up flipping the LobeHub provider off even though the platform manages it for them.

This PR switches the gate to the runtime `serverConfigSelectors.enableBusinessFeatures` value so visibility follows the connected backend rather than the bundle, and replaces the hard-coded `'lobehub'` literal with the existing `BRANDING_PROVIDER` constant.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Repro path: open the desktop app → Settings → AI Providers → select **LobeHub**. Before this change the enable switch is rendered in the top-right; after the change the switch is hidden whenever the server reports `enableBusinessFeatures: true`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| LobeHub provider header shows an enable toggle | Toggle hidden when `enableBusinessFeatures` is true at runtime |

#### 📝 Additional Information

No breaking changes. The visible-on-self-hosted behaviour is unchanged: when `enableBusinessFeatures` is `false` the LobeHub provider is not registered in the default provider list anyway, so the toggle is irrelevant there.