### PR TITLE
✨ feat: add RecommendTaskTemplates UI and default noop router

### DIFF
--- a/packages/const/src/taskTemplate.ts
+++ b/packages/const/src/taskTemplate.ts
@@ -639,3 +639,5 @@ export const taskTemplates: TaskTemplate[] = [
     optionalSkills: [{ provider: 'notion', source: 'klavis' }],
   },
 ];
+
+export const KNOWN_TASK_TEMPLATE_IDS: ReadonlySet<string> = new Set(taskTemplates.map((t) => t.id));

--- a/src/business/client/DailyBriefRecommendations.tsx
+++ b/src/business/client/DailyBriefRecommendations.tsx
@@ -1,12 +1,1 @@
-import { memo } from 'react';
-
-import type { DailyBriefRecommendationsUIState } from './useDailyBriefRecommendationsUI';
-
-interface DailyBriefRecommendationsProps {
-  state: DailyBriefRecommendationsUIState;
-}
-
-/** Cloud repo overrides this module to render task template recommendations inside Daily brief. */
-export const DailyBriefRecommendations = memo<DailyBriefRecommendationsProps>(() => null);
-
-DailyBriefRecommendations.displayName = 'DailyBriefRecommendations';
+export { DailyBriefRecommendationsView as DailyBriefRecommendations } from '@/features/RecommendTaskTemplates/DailyBriefRecommendationsView';

--- a/src/business/client/RecommendTaskTemplates.tsx
+++ b/src/business/client/RecommendTaskTemplates.tsx
@@ -1,3 +1,1 @@
-import { memo } from 'react';
-
-export const RecommendTaskTemplates = memo(() => null);
+export { RecommendTaskTemplates } from '@/features/RecommendTaskTemplates';

--- a/src/business/client/useDailyBriefRecommendationsUI.ts
+++ b/src/business/client/useDailyBriefRecommendationsUI.ts
@@ -1,24 +1,4 @@
-import type { TaskTemplate } from '@lobechat/const';
-
-export interface DailyBriefRecommendationsUIStateHidden {
-  mode: 'hidden';
-}
-
-export interface DailyBriefRecommendationsUIStateSkeleton {
-  mode: 'skeleton';
-}
-
-export interface DailyBriefRecommendationsUIStateCards {
-  mode: 'cards';
-  onDismiss: (templateId: string) => void;
-  templates: TaskTemplate[];
-}
-
-export type DailyBriefRecommendationsUIState =
-  | DailyBriefRecommendationsUIStateCards
-  | DailyBriefRecommendationsUIStateHidden
-  | DailyBriefRecommendationsUIStateSkeleton;
-
-export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUIState {
-  return { mode: 'hidden' };
-}
+export {
+  type DailyBriefRecommendationsUIState,
+  useDailyBriefRecommendationsUI,
+} from '@/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI';

--- a/src/business/server/lambda-routers/taskTemplate.ts
+++ b/src/business/server/lambda-routers/taskTemplate.ts
@@ -1,3 +1,1 @@
-import { router } from '@/libs/trpc/lambda';
-
-export const taskTemplateRouter = router({});
+export { taskTemplateRouter } from '@/server/routers/lambda/taskTemplate';

--- a/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
+++ b/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
@@ -1,0 +1,35 @@
+import { Flexbox } from '@lobehub/ui';
+import { memo } from 'react';
+
+import { BriefCardSkeleton } from '@/features/DailyBrief/BriefCardSkeleton';
+
+import { TaskTemplateCard } from './TaskTemplateCard';
+import type { DailyBriefRecommendationsUIState } from './useDailyBriefRecommendationsUI';
+
+interface DailyBriefRecommendationsViewProps {
+  state: DailyBriefRecommendationsUIState;
+}
+
+export const DailyBriefRecommendationsView = memo<DailyBriefRecommendationsViewProps>(
+  ({ state }) => {
+    if (state.mode === 'hidden') return null;
+    if (state.mode === 'skeleton') {
+      return (
+        <Flexbox gap={8}>
+          <BriefCardSkeleton />
+          <BriefCardSkeleton />
+        </Flexbox>
+      );
+    }
+
+    return (
+      <Flexbox gap={8}>
+        {state.templates.map((tmpl) => (
+          <TaskTemplateCard key={tmpl.id} template={tmpl} onDismiss={state.onDismiss} />
+        ))}
+      </Flexbox>
+    );
+  },
+);
+
+DailyBriefRecommendationsView.displayName = 'DailyBriefRecommendationsView';

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -200,7 +200,6 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(({ template, onDismi
             <ActionIcon
               icon={Clock}
               size={12}
-              type={'secondary'}
               title={
                 <Center>
                   <span>{scheduleText}</span>

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -1,0 +1,241 @@
+import type { TaskTemplate } from '@lobechat/const';
+import { formatScheduleTime, parseCronPattern, WEEKDAY_I18N_KEYS } from '@lobechat/utils/cron';
+import { ActionIcon, Block, Button, Center, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { App, Divider } from 'antd';
+import { cssVar, cx } from 'antd-style';
+import { Clock, Link2, type LucideIcon, Sparkles, X } from 'lucide-react';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import BriefCardSummary from '@/features/DailyBrief/BriefCardSummary';
+import { styles as briefStyles } from '@/features/DailyBrief/style';
+import { INTEREST_AREAS } from '@/routes/onboarding/config';
+import { agentCronJobService } from '@/services/agentCronJob';
+import { taskTemplateService } from '@/services/taskTemplate';
+import { useAgentStore } from '@/store/agent';
+import { builtinAgentSelectors } from '@/store/agent/selectors';
+
+import { styles } from './style';
+import { SkillConnectionPopupBlockedError, useSkillConnection } from './useSkillConnection';
+
+const INTEREST_ICON_MAP = new Map<string, LucideIcon>(INTEREST_AREAS.map((a) => [a.key, a.icon]));
+
+interface TemplateBriefIconProps {
+  icon: LucideIcon;
+}
+
+/** Same 28×28 tile treatment as {@link BriefIcon} (insight palette). */
+const TemplateBriefIcon = memo<TemplateBriefIconProps>(({ icon }) => (
+  <Block
+    align={'center'}
+    height={28}
+    justify={'center'}
+    style={{ background: cssVar.colorFillSecondary, flexShrink: 0 }}
+    width={28}
+  >
+    <Icon color={cssVar.colorTextSecondary} icon={icon} size={28 * 0.6} />
+  </Block>
+));
+
+TemplateBriefIcon.displayName = 'TemplateBriefIcon';
+
+interface TaskTemplateCardProps {
+  onDismiss: (templateId: string) => void;
+  template: TaskTemplate;
+}
+
+export const TaskTemplateCard = memo<TaskTemplateCardProps>(({ template, onDismiss }) => {
+  const { t } = useTranslation('taskTemplate');
+  const { t: tSetting } = useTranslation('setting');
+  const { message } = App.useApp();
+  const [loading, setLoading] = useState(false);
+  const [created, setCreated] = useState(false);
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+
+  const skillConnection = useSkillConnection(template.requiresSkills);
+  const optionalSkillConnection = useSkillConnection(template.optionalSkills);
+  const showOptionalHint =
+    !skillConnection.needsConnect &&
+    optionalSkillConnection.needsConnect &&
+    !!optionalSkillConnection.nextUnconnected;
+
+  const IconComp = INTEREST_ICON_MAP.get(template.interests[0]) ?? Sparkles;
+  const title = t(`${template.id}.title`, { defaultValue: '' });
+  const description = t(`${template.id}.description`, { defaultValue: '' });
+
+  const scheduleText = useMemo(() => {
+    const parsed = parseCronPattern(template.cronPattern);
+    const time = formatScheduleTime(parsed.triggerHour, parsed.triggerMinute);
+    if (parsed.scheduleType === 'weekly' && parsed.weekdays?.length === 1) {
+      const weekday = tSetting(`agentCronJobs.weekday.${WEEKDAY_I18N_KEYS[parsed.weekdays[0]]}`);
+      return t('schedule.weekly', { time, weekday });
+    }
+    return t('schedule.daily', { time });
+  }, [t, tSetting, template.cronPattern]);
+
+  const handleCreate = useCallback(async () => {
+    if (!inboxAgentId) return;
+    setLoading(true);
+    try {
+      const prompt = t(`${template.id}.prompt`, { defaultValue: '' });
+      await agentCronJobService.create({
+        agentId: inboxAgentId,
+        content: prompt,
+        cronPattern: template.cronPattern,
+        enabled: true,
+        name: title,
+        templateId: template.id,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      });
+      await taskTemplateService.recordCreated(template.id).catch((recordError) => {
+        console.error('[taskTemplate:recordCreated]', recordError);
+      });
+      setCreated(true);
+      message.success(t('action.create.success'));
+    } catch (error) {
+      console.error('[taskTemplate:create]', error);
+      message.error(t('action.create.error'));
+    } finally {
+      setLoading(false);
+    }
+  }, [inboxAgentId, message, t, template.cronPattern, template.id, title]);
+
+  const handleDismiss = useCallback(() => {
+    if (loading || created) return;
+    onDismiss(template.id);
+  }, [created, loading, onDismiss, template.id]);
+
+  const handleConnectError = useCallback(
+    (error: unknown) => {
+      message.error(
+        error instanceof SkillConnectionPopupBlockedError
+          ? t('action.connect.popupBlocked')
+          : t('action.connect.error'),
+      );
+    },
+    [message, t],
+  );
+
+  const handleConnectRequired = useCallback(async () => {
+    try {
+      await skillConnection.connect();
+    } catch (error) {
+      handleConnectError(error);
+    }
+  }, [skillConnection, handleConnectError]);
+
+  const handleConnectOptional = useCallback(async () => {
+    try {
+      await optionalSkillConnection.connect();
+    } catch (error) {
+      handleConnectError(error);
+    }
+  }, [optionalSkillConnection, handleConnectError]);
+
+  const primaryButton =
+    skillConnection.needsConnect && skillConnection.nextUnconnected ? (
+      <Button
+        className={briefStyles.actionBtnPrimary}
+        loading={skillConnection.isConnecting}
+        shape={'round'}
+        variant={'filled'}
+        onClick={handleConnectRequired}
+      >
+        {t('action.connect.button', { provider: skillConnection.nextUnconnected.label })}
+      </Button>
+    ) : (
+      <Button
+        shadow
+        className={briefStyles.actionBtnPrimary}
+        disabled={created || !inboxAgentId}
+        loading={loading}
+        shape={'round'}
+        onClick={handleCreate}
+      >
+        {loading ? t('action.creating') : t('action.createButton')}
+      </Button>
+    );
+
+  const hintNode = showOptionalHint && optionalSkillConnection.nextUnconnected && (
+    <button
+      className={`${styles.meta} ${styles.optionalHintBtn}`}
+      type={'button'}
+      onClick={handleConnectOptional}
+    >
+      <Icon icon={Link2} size={12} />
+      <Text fontSize={12} style={{ color: 'inherit' }}>
+        {t('action.optionalConnect.button', {
+          provider: optionalSkillConnection.nextUnconnected.label,
+        })}
+      </Text>
+    </button>
+  );
+
+  return (
+    <Block
+      className={cx(briefStyles.card, styles.card)}
+      gap={12}
+      padding={12}
+      style={{ borderRadius: cssVar.borderRadiusLG }}
+      variant={'outlined'}
+    >
+      <Flexbox horizontal align={'center'} gap={16} justify={'space-between'}>
+        <Flexbox
+          horizontal
+          align={'center'}
+          gap={8}
+          style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
+        >
+          <TemplateBriefIcon icon={IconComp} />
+          <Flexbox
+            horizontal
+            align={'center'}
+            flex={1}
+            gap={6}
+            style={{ minWidth: 0, overflow: 'hidden' }}
+          >
+            <Text ellipsis fontSize={16} weight={500}>
+              {title}
+            </Text>
+            <ActionIcon
+              icon={Clock}
+              size={12}
+              type={'secondary'}
+              title={
+                <Center>
+                  <span>{scheduleText}</span>
+                  {t('schedule.editableAfterCreateTooltip')}
+                </Center>
+              }
+            />
+          </Flexbox>
+        </Flexbox>
+
+        <Flexbox horizontal align={'center'} gap={8}>
+          <ActionIcon
+            className={`${styles.dismissBtn} task-template-dismiss`}
+            icon={X}
+            size={'small'}
+            title={t('action.dismiss.tooltip')}
+            onClick={handleDismiss}
+          />
+        </Flexbox>
+      </Flexbox>
+      <Divider dashed style={{ marginBlock: 0 }} />
+      {description.trim().length > 0 ? <BriefCardSummary summary={description} /> : null}
+      <Flexbox horizontal align={'center'} gap={8} justify={'space-between'} wrap={'wrap'}>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <Tag size={'small'} variant={'outlined'}>
+            {t('card.templateTag')}
+          </Tag>
+          {hintNode}
+        </Flexbox>
+        <Flexbox horizontal align={'center'} gap={8}>
+          {primaryButton}
+        </Flexbox>
+      </Flexbox>
+    </Block>
+  );
+});
+
+TaskTemplateCard.displayName = 'TaskTemplateCard';

--- a/src/features/RecommendTaskTemplates/index.tsx
+++ b/src/features/RecommendTaskTemplates/index.tsx
@@ -1,0 +1,6 @@
+import { memo } from 'react';
+
+/** @deprecated Recommendations render inside Daily brief via `DailyBriefRecommendations`. */
+export const RecommendTaskTemplates = memo(() => null);
+
+RecommendTaskTemplates.displayName = 'RecommendTaskTemplates';

--- a/src/features/RecommendTaskTemplates/providerMeta.test.ts
+++ b/src/features/RecommendTaskTemplates/providerMeta.test.ts
@@ -1,0 +1,78 @@
+import type { TaskTemplateSkillRequirement } from '@lobechat/const';
+import { describe, expect, it } from 'vitest';
+
+import { findNextUnconnectedSpec, getProviderMeta } from './providerMeta';
+
+describe('getProviderMeta', () => {
+  it('resolves lobehub source via LOBEHUB_SKILL_PROVIDERS', () => {
+    const meta = getProviderMeta({ provider: 'github', source: 'lobehub' });
+    expect(meta).toMatchObject({ label: 'GitHub', provider: 'github', source: 'lobehub' });
+    expect(meta?.icon).toBeDefined();
+  });
+
+  it('resolves klavis source via KLAVIS_SERVER_TYPES', () => {
+    const meta = getProviderMeta({ provider: 'notion', source: 'klavis' });
+    expect(meta).toMatchObject({ label: 'Notion', provider: 'notion', source: 'klavis' });
+    expect(meta?.icon).toBeDefined();
+  });
+
+  it('returns undefined for unknown provider', () => {
+    expect(getProviderMeta({ provider: 'nonexistent-x', source: 'lobehub' })).toBeUndefined();
+    expect(getProviderMeta({ provider: 'nonexistent-x', source: 'klavis' })).toBeUndefined();
+  });
+
+  it('does not cross namespaces (lobehub id under klavis source returns undefined)', () => {
+    // 'github' is a lobehub provider id, not a klavis identifier.
+    expect(getProviderMeta({ provider: 'github', source: 'klavis' })).toBeUndefined();
+  });
+});
+
+describe('findNextUnconnectedSpec', () => {
+  const allConnected = () => true;
+  const noneConnected = () => false;
+
+  it('returns undefined when specs is undefined or empty', () => {
+    expect(findNextUnconnectedSpec(undefined, noneConnected)).toBeUndefined();
+    expect(findNextUnconnectedSpec([], noneConnected)).toBeUndefined();
+  });
+
+  it('returns undefined when all specs are connected', () => {
+    const specs: TaskTemplateSkillRequirement[] = [
+      { provider: 'github', source: 'lobehub' },
+      { provider: 'notion', source: 'klavis' },
+    ];
+    expect(findNextUnconnectedSpec(specs, allConnected)).toBeUndefined();
+  });
+
+  it('returns the first spec when none are connected', () => {
+    const specs: TaskTemplateSkillRequirement[] = [
+      { provider: 'github', source: 'lobehub' },
+      { provider: 'notion', source: 'klavis' },
+    ];
+    const result = findNextUnconnectedSpec(specs, noneConnected);
+    expect(result?.provider).toBe('github');
+    expect(result?.label).toBe('GitHub');
+  });
+
+  it('skips already-connected specs and returns the next missing one in order', () => {
+    const specs: TaskTemplateSkillRequirement[] = [
+      { provider: 'github', source: 'lobehub' },
+      { provider: 'linear', source: 'lobehub' },
+      { provider: 'notion', source: 'klavis' },
+    ];
+    const isConnected = (s: TaskTemplateSkillRequirement) =>
+      s.provider === 'github' || s.provider === 'linear';
+    const result = findNextUnconnectedSpec(specs, isConnected);
+    expect(result?.provider).toBe('notion');
+    expect(result?.source).toBe('klavis');
+  });
+
+  it('skips specs with unknown providers (no meta) and continues searching', () => {
+    const specs: TaskTemplateSkillRequirement[] = [
+      { provider: 'nonexistent-x', source: 'lobehub' },
+      { provider: 'notion', source: 'klavis' },
+    ];
+    const result = findNextUnconnectedSpec(specs, noneConnected);
+    expect(result?.provider).toBe('notion');
+  });
+});

--- a/src/features/RecommendTaskTemplates/providerMeta.ts
+++ b/src/features/RecommendTaskTemplates/providerMeta.ts
@@ -1,0 +1,40 @@
+import type {
+  LobehubSkillProviderType,
+  TaskTemplateSkillRequirement,
+  TaskTemplateSkillSource,
+} from '@lobechat/const';
+import { getKlavisServerByServerIdentifier, getLobehubSkillProviderById } from '@lobechat/const';
+
+export interface SkillProviderMeta {
+  icon: LobehubSkillProviderType['icon'];
+  label: string;
+  provider: string;
+  source: TaskTemplateSkillSource;
+}
+
+export const getProviderMeta = (
+  spec: TaskTemplateSkillRequirement,
+): SkillProviderMeta | undefined => {
+  if (spec.source === 'lobehub') {
+    const p = getLobehubSkillProviderById(spec.provider);
+    if (!p) return undefined;
+    return { icon: p.icon, label: p.label, provider: spec.provider, source: 'lobehub' };
+  }
+  const p = getKlavisServerByServerIdentifier(spec.provider);
+  if (!p) return undefined;
+  return { icon: p.icon, label: p.label, provider: spec.provider, source: 'klavis' };
+};
+
+export const findNextUnconnectedSpec = (
+  specs: TaskTemplateSkillRequirement[] | undefined,
+  isConnected: (spec: TaskTemplateSkillRequirement) => boolean,
+): SkillProviderMeta | undefined => {
+  if (!specs || specs.length === 0) return undefined;
+  for (const spec of specs) {
+    if (isConnected(spec)) continue;
+    const meta = getProviderMeta(spec);
+    if (!meta) continue;
+    return meta;
+  }
+  return undefined;
+};

--- a/src/features/RecommendTaskTemplates/style.ts
+++ b/src/features/RecommendTaskTemplates/style.ts
@@ -1,0 +1,48 @@
+import { createStaticStyles } from 'antd-style';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  card: css`
+    &:hover {
+      border-color: ${cssVar.colorBorder} !important;
+    }
+
+    &:hover .task-template-dismiss {
+      pointer-events: auto;
+      opacity: 1;
+    }
+  `,
+  dismissBtn: css`
+    pointer-events: none;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s;
+  `,
+  meta: css`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  optionalHintBtn: css`
+    cursor: pointer;
+
+    margin: 0;
+    padding: 0;
+    border: none;
+
+    color: ${cssVar.colorTextTertiary};
+    text-decoration: underline;
+
+    background: transparent;
+
+    &:hover {
+      color: ${cssVar.colorText};
+    }
+
+    &:focus-visible {
+      border-radius: ${cssVar.borderRadiusSM};
+      outline: 2px solid ${cssVar.colorPrimary};
+      outline-offset: 2px;
+    }
+  `,
+}));

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -1,0 +1,86 @@
+import type { TaskTemplate, TaskTemplateSkillSource } from '@lobechat/const';
+import { App } from 'antd';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+
+import { taskTemplateService } from '@/services/taskTemplate';
+import { useBriefStore } from '@/store/brief';
+import { briefListSelectors } from '@/store/brief/selectors';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
+import { useToolStore } from '@/store/tool';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/slices/auth/selectors';
+
+import { useResolvedInterestKeys } from './useResolvedInterestKeys';
+
+/** Hide the recommend section once the user already has more existing briefs than this. */
+const MAX_EXISTING_BRIEFS_FOR_RECOMMEND = 1;
+
+export type DailyBriefRecommendationsUIState =
+  | { mode: 'hidden' }
+  | { mode: 'skeleton' }
+  | { mode: 'cards'; onDismiss: (templateId: string) => void; templates: TaskTemplate[] };
+
+export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUIState {
+  const { t } = useTranslation('taskTemplate');
+  const { message } = App.useApp();
+  const isLogin = useUserStore(authSelectors.isLogin);
+  const { enableAgentTask } = useServerConfigStore(featureFlagsSelectors);
+  const useFetchBriefs = useBriefStore((s) => s.useFetchBriefs);
+  useFetchBriefs(isLogin && !!enableAgentTask);
+
+  const briefs = useBriefStore(briefListSelectors.briefs);
+  const isInit = useBriefStore(briefListSelectors.isBriefsInit);
+
+  const interestKeys = useResolvedInterestKeys();
+  const swrKey = interestKeys ? [...interestKeys].sort().join(',') : '';
+  const swrEnabled = isLogin && !!enableAgentTask && interestKeys !== null;
+
+  const { data, isLoading, mutate } = useSWR(
+    swrEnabled ? ['taskTemplate.listDailyRecommend', swrKey] : null,
+    async () => taskTemplateService.listDailyRecommend(interestKeys ?? []),
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  const handleDismiss = useCallback(
+    async (templateId: string) => {
+      mutate(
+        (current) =>
+          current
+            ? { ...current, data: current.data.filter((tmpl) => tmpl.id !== templateId) }
+            : current,
+        { revalidate: false },
+      );
+      try {
+        await taskTemplateService.dismiss(templateId);
+      } catch (error) {
+        console.error('[taskTemplate:dismiss]', error);
+        message.error(t('action.dismiss.error'));
+        mutate();
+      }
+    },
+    [message, mutate, t],
+  );
+
+  const templates = useMemo(() => data?.data ?? [], [data]);
+  const requiredSources = useMemo(() => {
+    const sources = new Set<TaskTemplateSkillSource>();
+    for (const tmpl of templates) {
+      for (const s of tmpl.requiresSkills ?? []) sources.add(s.source);
+      for (const s of tmpl.optionalSkills ?? []) sources.add(s.source);
+    }
+    return sources;
+  }, [templates]);
+  const useFetchUserKlavisServers = useToolStore((s) => s.useFetchUserKlavisServers);
+  const useFetchLobehubSkillConnections = useToolStore((s) => s.useFetchLobehubSkillConnections);
+  useFetchUserKlavisServers(requiredSources.has('klavis'));
+  useFetchLobehubSkillConnections(requiredSources.has('lobehub'));
+
+  if (!swrEnabled) return { mode: 'hidden' };
+  if (isInit && briefs.length > MAX_EXISTING_BRIEFS_FOR_RECOMMEND) return { mode: 'hidden' };
+  if (!isInit || isLoading) return { mode: 'skeleton' };
+  if (templates.length === 0) return { mode: 'hidden' };
+
+  return { mode: 'cards', onDismiss: handleDismiss, templates };
+}

--- a/src/features/RecommendTaskTemplates/useResolvedInterestKeys.ts
+++ b/src/features/RecommendTaskTemplates/useResolvedInterestKeys.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { INTEREST_AREAS } from '@/routes/onboarding/config';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
+/**
+ * onboarding stores localized labels in `user.interests` (e.g. "内容创作",
+ * "Content Creation") plus occasional freeform text. Resolve each entry back
+ * to an INTEREST_AREAS key via the current-locale onboarding translations so
+ * the server can intersection-match against template.interests (which hold
+ * canonical keys). Unresolved entries are lowercased passthroughs — server
+ * treats them as non-matching.
+ *
+ * Returns `null` while the onboarding namespace is still loading (it's lazy-
+ * loaded, not in the startup bundle). Without this gate, the first render
+ * would resolve all localized labels to passthrough strings, fire an SWR
+ * request with the wrong keys, and get back a fallback list — then re-fire
+ * once the namespace lands. Callers should keep SWR disabled while null.
+ */
+export const useResolvedInterestKeys = (): string[] | null => {
+  const userInterests = useUserStore(userProfileSelectors.interests);
+  const { t, ready } = useTranslation('onboarding');
+
+  return useMemo(() => {
+    if (!ready) return null;
+    const labelToKey = new Map<string, string>();
+    for (const area of INTEREST_AREAS) {
+      labelToKey.set(area.key, area.key);
+      const translated = t(`interests.area.${area.key}`, { defaultValue: '' });
+      if (translated) labelToKey.set(translated.trim().toLowerCase(), area.key);
+    }
+    return userInterests.map((raw) => {
+      const k = raw.trim().toLowerCase();
+      return labelToKey.get(k) ?? k;
+    });
+  }, [userInterests, t, ready]);
+};

--- a/src/features/RecommendTaskTemplates/useSkillConnection.ts
+++ b/src/features/RecommendTaskTemplates/useSkillConnection.ts
@@ -241,9 +241,10 @@ export const useSkillConnection = (
     setIsConnecting(true);
     try {
       if (next.source === 'lobehub') {
-        const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(
-          next.provider,
-        )}`;
+        // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+        const redirectUri = window.location.protocol.startsWith('http')
+          ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(next.provider)}`
+          : undefined;
         const { authorizeUrl } = await getLobehubAuth(next.provider, { redirectUri });
         openOAuthWindow(authorizeUrl, next);
         return;

--- a/src/features/RecommendTaskTemplates/useSkillConnection.ts
+++ b/src/features/RecommendTaskTemplates/useSkillConnection.ts
@@ -1,0 +1,292 @@
+import type { TaskTemplateSkillRequirement } from '@lobechat/const';
+import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { LOBEHUB_SKILL_AUTH_SUCCESS_MESSAGE } from '@/const/skillConnection';
+import { useToolStore } from '@/store/tool';
+import { klavisStoreSelectors } from '@/store/tool/slices/klavisStore/selectors';
+import { KlavisServerStatus } from '@/store/tool/slices/klavisStore/types';
+import { lobehubSkillStoreSelectors } from '@/store/tool/slices/lobehubSkillStore/selectors';
+import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
+import { useUserStore } from '@/store/user';
+
+import type { SkillProviderMeta } from './providerMeta';
+import { findNextUnconnectedSpec } from './providerMeta';
+
+// Re-exported for callers that prefer a single import surface for the hook +
+// its types/helpers. The pure helpers themselves live in `./providerMeta` so
+// unit tests can import them without dragging in the store-dependency graph.
+export type { SkillProviderMeta } from './providerMeta';
+export { findNextUnconnectedSpec, getProviderMeta } from './providerMeta';
+
+const POLL_INTERVAL_MS = 1000;
+const POLL_TIMEOUT_MS = 15_000;
+/** Hard cap on how long the OAuth popup-monitor keeps polling — protects against
+ *  users opening the popup, switching away, and never closing it. */
+const OAUTH_OVERALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Thrown when the browser blocks the OAuth popup so callers can surface a clear hint. */
+export class SkillConnectionPopupBlockedError extends Error {
+  constructor() {
+    super('Browser popup blocked');
+    this.name = 'SkillConnectionPopupBlockedError';
+  }
+}
+
+type ConnectTarget = Pick<SkillProviderMeta, 'provider' | 'source'>;
+
+export interface UseSkillConnectionResult {
+  connect: () => Promise<void>;
+  isAllConnected: boolean;
+  isConnecting: boolean;
+  /** True when there is at least one spec and at least one of them is not yet connected. */
+  needsConnect: boolean;
+  /** First spec in input order whose connection is missing. undefined when all connected or specs is empty. */
+  nextUnconnected: SkillProviderMeta | undefined;
+}
+
+export const useSkillConnection = (
+  specs: TaskTemplateSkillRequirement[] | undefined,
+): UseSkillConnectionResult => {
+  const getLobehubAuth = useToolStore((s) => s.getLobehubSkillAuthorizeUrl);
+  const checkLobehubStatus = useToolStore((s) => s.checkLobehubSkillStatus);
+  const createKlavisServer = useToolStore((s) => s.createKlavisServer);
+  const refreshKlavisServerTools = useToolStore((s) => s.refreshKlavisServerTools);
+
+  const lobehubServers = useToolStore(lobehubSkillStoreSelectors.getServers);
+  const klavisServers = useToolStore(klavisStoreSelectors.getServers);
+
+  const isConnectedFor = useCallback(
+    (spec: TaskTemplateSkillRequirement): boolean => {
+      if (spec.source === 'lobehub') {
+        return lobehubServers.some(
+          (s) => s.identifier === spec.provider && s.status === LobehubSkillStatus.CONNECTED,
+        );
+      }
+      return klavisServers.some(
+        (s) => s.identifier === spec.provider && s.status === KlavisServerStatus.CONNECTED,
+      );
+    },
+    [lobehubServers, klavisServers],
+  );
+
+  const nextUnconnected = useMemo(
+    () => findNextUnconnectedSpec(specs, isConnectedFor),
+    [specs, isConnectedFor],
+  );
+
+  const hasSpecs = (specs?.length ?? 0) > 0;
+  const isAllConnected = hasSpecs && !nextUnconnected;
+  const needsConnect = hasSpecs && !!nextUnconnected;
+
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isWaitingAuth, setIsWaitingAuth] = useState(false);
+
+  const oauthWindowRef = useRef<Window | null>(null);
+  const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const windowCheckTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Sync lock against double-click — useState guard would only flip after re-render.
+  const isConnectingRef = useRef(false);
+
+  const cleanup = useCallback(() => {
+    if (windowCheckIntervalRef.current) {
+      clearInterval(windowCheckIntervalRef.current);
+      windowCheckIntervalRef.current = null;
+    }
+    if (windowCheckTimeoutRef.current) {
+      clearTimeout(windowCheckTimeoutRef.current);
+      windowCheckTimeoutRef.current = null;
+    }
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+    if (pollTimeoutRef.current) {
+      clearTimeout(pollTimeoutRef.current);
+      pollTimeoutRef.current = null;
+    }
+    oauthWindowRef.current = null;
+    setIsWaitingAuth(false);
+  }, []);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  useEffect(() => {
+    if (isWaitingAuth && !nextUnconnected) cleanup();
+  }, [isWaitingAuth, nextUnconnected, cleanup]);
+
+  const startFallbackPolling = useCallback(
+    (target: ConnectTarget) => {
+      if (pollIntervalRef.current) return;
+
+      pollIntervalRef.current = setInterval(async () => {
+        try {
+          if (target.source === 'lobehub') {
+            await checkLobehubStatus(target.provider);
+          } else {
+            await refreshKlavisServerTools(target.provider);
+          }
+        } catch {
+          // Polling failure is expected until auth completes — suppress noise.
+        }
+      }, POLL_INTERVAL_MS);
+
+      pollTimeoutRef.current = setTimeout(() => {
+        if (pollIntervalRef.current) {
+          clearInterval(pollIntervalRef.current);
+          pollIntervalRef.current = null;
+        }
+        setIsWaitingAuth(false);
+      }, POLL_TIMEOUT_MS);
+    },
+    [checkLobehubStatus, refreshKlavisServerTools],
+  );
+
+  const startWindowMonitor = useCallback(
+    (oauthWindow: Window, target: ConnectTarget) => {
+      const stopMonitor = () => {
+        if (windowCheckIntervalRef.current) {
+          clearInterval(windowCheckIntervalRef.current);
+          windowCheckIntervalRef.current = null;
+        }
+        if (windowCheckTimeoutRef.current) {
+          clearTimeout(windowCheckTimeoutRef.current);
+          windowCheckTimeoutRef.current = null;
+        }
+      };
+
+      windowCheckIntervalRef.current = setInterval(async () => {
+        try {
+          if (!oauthWindow.closed) return;
+          stopMonitor();
+          oauthWindowRef.current = null;
+          // Refresh status once right after the popup closes so multi-spec flows
+          // can advance to the next provider immediately, instead of waiting up
+          // to 15s for fallback polling to release isWaitingAuth.
+          try {
+            if (target.source === 'lobehub') {
+              await checkLobehubStatus(target.provider);
+            } else {
+              await refreshKlavisServerTools(target.provider);
+            }
+          } catch {
+            // Status check failure isn't actionable; release waiting state regardless.
+          }
+          setIsWaitingAuth(false);
+        } catch {
+          // COOP can block window.closed access — fall back to polling.
+          stopMonitor();
+          startFallbackPolling(target);
+        }
+      }, 500);
+
+      windowCheckTimeoutRef.current = setTimeout(() => {
+        stopMonitor();
+        // Force-close the abandoned popup so a late completion doesn't fire a
+        // postMessage we'd silently drop (oauthWindowRef.current was cleared).
+        try {
+          oauthWindowRef.current?.close();
+        } catch {
+          // Cross-origin restrictions may block .close(); ignore.
+        }
+        oauthWindowRef.current = null;
+        setIsWaitingAuth(false);
+      }, OAUTH_OVERALL_TIMEOUT_MS);
+    },
+    [checkLobehubStatus, refreshKlavisServerTools, startFallbackPolling],
+  );
+
+  const openOAuthWindow = useCallback(
+    (url: string, target: ConnectTarget) => {
+      cleanup();
+      setIsWaitingAuth(true);
+
+      const oauthWindow = window.open(url, '_blank', 'width=600,height=700');
+      if (!oauthWindow) {
+        // Popup blocked — abandon the flow so the caller can surface a clear
+        // error instead of polling forever for an auth that never started.
+        setIsWaitingAuth(false);
+        throw new SkillConnectionPopupBlockedError();
+      }
+      oauthWindowRef.current = oauthWindow;
+      startWindowMonitor(oauthWindow, target);
+    },
+    [cleanup, startWindowMonitor],
+  );
+
+  // Only LobeHub Skill OAuth signals completion via postMessage; Klavis relies on polling.
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      // Reject same-origin iframes / other tabs forging the success event.
+      if (event.source !== oauthWindowRef.current) return;
+      if (event.data?.type !== LOBEHUB_SKILL_AUTH_SUCCESS_MESSAGE) return;
+      const provider = event.data?.provider;
+      if (!provider) return;
+      cleanup();
+      void checkLobehubStatus(provider);
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [checkLobehubStatus, cleanup]);
+
+  const connect = useCallback(async () => {
+    if (isConnectingRef.current || isWaitingAuth) return;
+    const next = nextUnconnected;
+    if (!next) return;
+
+    isConnectingRef.current = true;
+    setIsConnecting(true);
+    try {
+      if (next.source === 'lobehub') {
+        const redirectUri = `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(
+          next.provider,
+        )}`;
+        const { authorizeUrl } = await getLobehubAuth(next.provider, { redirectUri });
+        openOAuthWindow(authorizeUrl, next);
+        return;
+      }
+
+      const userId = useUserStore.getState().user?.id;
+      if (!userId) throw new Error('Sign-in required');
+      const klavisType = KLAVIS_SERVER_TYPES.find((t) => t.identifier === next.provider);
+      if (!klavisType) throw new Error(`Unknown Klavis provider: ${next.provider}`);
+      const newServer = await createKlavisServer({
+        identifier: next.provider,
+        serverName: klavisType.serverName,
+        userId,
+      });
+      if (!newServer) throw new Error('Failed to create Klavis server');
+      if (newServer.isAuthenticated) {
+        await refreshKlavisServerTools(newServer.identifier);
+      } else if (newServer.oauthUrl) {
+        openOAuthWindow(newServer.oauthUrl, next);
+      } else {
+        throw new Error('Klavis server is missing an OAuth URL');
+      }
+    } catch (error) {
+      console.error('[useSkillConnection] Failed to connect:', error);
+      throw error;
+    } finally {
+      isConnectingRef.current = false;
+      setIsConnecting(false);
+    }
+  }, [
+    nextUnconnected,
+    isWaitingAuth,
+    getLobehubAuth,
+    createKlavisServer,
+    refreshKlavisServerTools,
+    openOAuthWindow,
+  ]);
+
+  return {
+    connect,
+    isAllConnected,
+    isConnecting: isConnecting || isWaitingAuth,
+    needsConnect,
+    nextUnconnected,
+  };
+};

--- a/src/server/routers/lambda/taskTemplate.ts
+++ b/src/server/routers/lambda/taskTemplate.ts
@@ -1,0 +1,42 @@
+import { KNOWN_TASK_TEMPLATE_IDS } from '@lobechat/const';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { ENABLED_SKILL_SOURCES, TaskTemplateService } from '@/server/services/taskTemplate';
+
+const listDailyRecommendSchema = z.object({
+  interestKeys: z.array(z.string().max(64)).max(32),
+});
+
+const templateIdSchema = z.object({
+  templateId: z
+    .string()
+    .max(64)
+    .refine((id) => KNOWN_TASK_TEMPLATE_IDS.has(id), { message: 'Unknown task template id' }),
+});
+
+export const taskTemplateRouter = router({
+  dismiss: authedProcedure.input(templateIdSchema).mutation(async () => ({ success: true })),
+
+  listDailyRecommend: authedProcedure
+    .input(listDailyRecommendSchema)
+    .query(async ({ input, ctx }) => {
+      try {
+        const service = new TaskTemplateService(ctx.userId);
+        const data = await service.listDailyRecommend(input.interestKeys, {
+          enabledSkillSources: ENABLED_SKILL_SOURCES,
+        });
+        return { data, success: true };
+      } catch (error) {
+        console.error('[taskTemplate:listDailyRecommend]', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to list recommended task templates',
+        });
+      }
+    }),
+
+  recordCreated: authedProcedure.input(templateIdSchema).mutation(async () => ({ success: true })),
+});

--- a/src/server/services/taskTemplate/index.ts
+++ b/src/server/services/taskTemplate/index.ts
@@ -5,7 +5,19 @@ import {
   type TaskTemplateSkillSource,
 } from '@lobechat/const';
 
+import { klavisEnv } from '@/config/klavis';
+import { appEnv } from '@/envs/app';
+
 export const RECOMMEND_COUNT = 3;
+
+export const ENABLED_SKILL_SOURCES: ReadonlySet<TaskTemplateSkillSource> = (() => {
+  const sources = new Set<TaskTemplateSkillSource>();
+  if (klavisEnv.KLAVIS_API_KEY) sources.add('klavis');
+  if (appEnv.MARKET_TRUSTED_CLIENT_ID && appEnv.MARKET_TRUSTED_CLIENT_SECRET) {
+    sources.add('lobehub');
+  }
+  return sources;
+})();
 
 const hashString = (str: string): number => {
   let hash = 0;

--- a/src/services/taskTemplate.ts
+++ b/src/services/taskTemplate.ts
@@ -1,0 +1,17 @@
+import { lambdaClient } from '@/libs/trpc/client/lambda';
+
+class TaskTemplateService {
+  dismiss = async (templateId: string) => {
+    return lambdaClient.taskTemplate.dismiss.mutate({ templateId });
+  };
+
+  listDailyRecommend = async (interestKeys: string[]) => {
+    return lambdaClient.taskTemplate.listDailyRecommend.query({ interestKeys });
+  };
+
+  recordCreated = async (templateId: string) => {
+    return lambdaClient.taskTemplate.recordCreated.mutate({ templateId });
+  };
+}
+
+export const taskTemplateService = new TaskTemplateService();


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Cloud counterpart: lobehub-biz/lobehub-cloud#TBD

#### 🔀 Description of Change

Bring the home **Try these tasks** recommendation cards into the open-source build so desktop and self-hosted users see them too. Previously the entire feature lived in the closed-source cloud repo and the OSS build only had `() => null` stubs, leaving the recommendation slot inside Daily Brief permanently empty for desktop users.

What moves into the submodule:

- `src/features/RecommendTaskTemplates/` — the full feature (cards, view, hook, OAuth-aware skill connection helper, provider meta + tests, styles)
- `src/services/taskTemplate.ts` — TRPC client wrapper
- `src/server/routers/lambda/taskTemplate.ts` — **default noop lambda router**:
  - `listDailyRecommend` returns recommendations from the catalog using the same `TaskTemplateService` already in this repo, with no per-user dismiss history
  - `dismiss` / `recordCreated` accept the call (so the UI works) and immediately return `{ success: true }` without persisting anything
- The three `business/client/*` slot stubs and the `business/server/lambda-routers/taskTemplate.ts` stub now re-export the real implementations

Supporting changes:

- `packages/const/src/taskTemplate.ts` exports a derived `KNOWN_TASK_TEMPLATE_IDS` set so both default and override routers can validate `templateId` inputs against the catalog
- `src/server/services/taskTemplate/index.ts` exposes a module-level `ENABLED_SKILL_SOURCES` set computed once from `klavisEnv` / `appEnv`, replacing the equivalent IIFE that used to live in cloud's router

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

1. `bunx vitest run src/features/RecommendTaskTemplates/providerMeta` — 9/9 passing.
2. Run `bun run dev:spa`, sign in, open home; the recommendation cards render based on the catalog. Dismissing a card removes it from the current view; refreshing brings it back (expected for the default noop router — overrides persist this).

#### 📝 Additional Information

The cloud repo continues to override `business/server/lambda-routers/taskTemplate.ts` with the cloudDB-backed router (real `dismiss` / `recordCreated` persistence and `excludeIds` plumbed through to the service). The default router here intentionally has the same input schemas and output shapes so the override stays type-compatible.