### PR TITLE
🐛 fix: show notification settings in desktop

### DIFF
--- a/src/business/client/BusinessSettingPages/Notification.test.tsx
+++ b/src/business/client/BusinessSettingPages/Notification.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+
+import Notification from './Notification';
+
+vi.mock('@lobechat/const', () => ({
+  isDesktop: true,
+}));
+
+vi.mock('./SubscriptionIframeWrapper', () => ({
+  SubscriptionIframeWrapper: ({ page }: { page: string }) => (
+    <div data-page={page} data-testid="subscription-iframe-wrapper" />
+  ),
+}));
+
+describe('Notification', () => {
+  it('renders the notification embed page on desktop', () => {
+    render(<Notification />);
+
+    expect(screen.getByTestId('subscription-iframe-wrapper')).toHaveAttribute(
+      'data-page',
+      'notification',
+    );
+  });
+});

--- a/src/business/client/BusinessSettingPages/Notification.tsx
+++ b/src/business/client/BusinessSettingPages/Notification.tsx
@@ -1,3 +1,16 @@
-const Notification = () => null;
+'use client';
+
+import { isDesktop } from '@lobechat/const';
+import { memo } from 'react';
+
+import { SubscriptionIframeWrapper } from './SubscriptionIframeWrapper';
+
+const Notification = memo(() => {
+  if (!isDesktop) return null;
+
+  return <SubscriptionIframeWrapper page="notification" />;
+});
+
+Notification.displayName = 'Notification';
 
 export default Notification;

--- a/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx
+++ b/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx
@@ -15,7 +15,7 @@ import { serverConfigSelectors } from '@/store/serverConfig/selectors';
 const PARTITION_ID = 'persist:subscription';
 
 interface SubscriptionIframeWrapperProps {
-  page: 'billing' | 'credits' | 'plans' | 'referral' | 'usage';
+  page: 'billing' | 'credits' | 'notification' | 'plans' | 'referral' | 'usage';
 }
 
 export const SubscriptionIframeWrapper = memo<SubscriptionIframeWrapperProps>(({ page }) => {
@@ -31,7 +31,9 @@ export const SubscriptionIframeWrapper = memo<SubscriptionIframeWrapperProps>(({
   const iframeUrl = useMemo(() => {
     if (!isCloudActive) return null;
 
-    const url = new URL(`/embed/subscription/${page}`, OFFICIAL_URL);
+    const path =
+      page === 'notification' ? '/embed/settings/notification' : `/embed/subscription/${page}`;
+    const url = new URL(path, OFFICIAL_URL);
     // Sync locale to embed page via hl parameter
     if (i18n.language) {
       url.searchParams.set('hl', i18n.language);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A (reported internally)

#### 🔀 Description of Change

- Render the desktop notification settings entry through the existing embedded cloud webview flow instead of returning an empty stub.
- Extend the existing desktop webview wrapper to route notification settings to the cloud embed path.
- Add a regression test for the desktop notification settings entry.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Command:

```bash
bunx vitest run --silent='passed-only' 'src/business/client/BusinessSettingPages/Notification.test.tsx'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Cloud embed route support is added in the paired cloud repo PR.