### PR TITLE
✨ feat(agent-management): render clickable agent card after createAgent

### DIFF
--- a/packages/builtin-tool-agent-management/package.json
+++ b/packages/builtin-tool-agent-management/package.json
@@ -9,7 +9,10 @@
   },
   "main": "./src/index.ts",
   "dependencies": {
-    "@lobechat/agent-manager-runtime": "workspace:*"
+    "@lobechat/agent-manager-runtime": "workspace:*",
+    "@lobechat/const": "workspace:*",
+    "lucide-react": "*",
+    "react-router-dom": "*"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
@@ -1,13 +1,46 @@
 'use client';
 
+import { SESSION_CHAT_URL } from '@lobechat/const';
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Flexbox,Markdown, Tag  } from '@lobehub/ui';
+import { Avatar, Block, Flexbox, Markdown, Tag } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { memo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import type { CreateAgentParams } from '../../../types';
+import type { CreateAgentParams, CreateAgentState } from '../../../types';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  agentCard: css`
+    cursor: pointer;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+    border-radius: 8px;
+
+    background: ${cssVar.colorFillQuaternary};
+
+    transition: background 0.2s;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  agentDescription: css`
+    overflow: hidden;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  agentTitle: css`
+    font-size: 13px;
+    font-weight: 500;
+  `,
+  arrowIcon: css`
+    color: ${cssVar.colorTextTertiary};
+  `,
   container: css`
     padding: 12px;
     border-radius: 8px;
@@ -31,57 +64,94 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-export const CreateAgentRender = memo<BuiltinRenderProps<CreateAgentParams>>(({ args }) => {
-  const { title, description, systemRole, plugins, model, provider } = args || {};
+export const CreateAgentRender = memo<BuiltinRenderProps<CreateAgentParams, CreateAgentState>>(
+  ({ args, pluginState }) => {
+    const navigate = useNavigate();
+    const { title, description, systemRole, plugins, model, provider, avatar, backgroundColor } =
+      args || {};
 
-  if (!title && !description && !systemRole && !plugins?.length) return null;
+    const handleNavigateToSession = useCallback(() => {
+      const targetId = pluginState?.sessionId ?? pluginState?.agentId;
+      if (!targetId) return;
+      navigate(SESSION_CHAT_URL(targetId));
+    }, [navigate, pluginState?.sessionId, pluginState?.agentId]);
 
-  return (
-    <div className={styles.container}>
-      {title && (
-        <div className={styles.field}>
-          <div className={styles.label}>Title</div>
-          <div className={styles.value}>{title}</div>
-        </div>
-      )}
-      {description && (
-        <div className={styles.field}>
-          <div className={styles.label}>Description</div>
-          <div className={styles.value}>{description}</div>
-        </div>
-      )}
-      {(model || provider) && (
-        <div className={styles.field}>
-          <div className={styles.label}>Model</div>
-          <div className={styles.value}>
-            {provider && `${provider}/`}
-            {model}
-          </div>
-        </div>
-      )}
-      {plugins && plugins.length > 0 && (
-        <div className={styles.field}>
-          <div className={styles.label}>Plugins</div>
-          <Flexbox horizontal gap={4} wrap={'wrap'}>
-            {plugins.map((plugin) => (
-              <Tag key={plugin}>{plugin}</Tag>
-            ))}
+    // After tool execution succeeds, render a clickable agent card
+    if (pluginState?.success && (pluginState.agentId || pluginState.sessionId)) {
+      return (
+        <Flexbox
+          align={'center'}
+          className={styles.agentCard}
+          horizontal
+          gap={12}
+          onClick={handleNavigateToSession}
+        >
+          <Avatar
+            avatar={avatar || '🤖'}
+            background={backgroundColor}
+            shape={'square'}
+            size={36}
+            title={title || undefined}
+          />
+          <Flexbox flex={1} gap={2}>
+            <span className={styles.agentTitle}>{title}</span>
+            {description && <span className={styles.agentDescription}>{description}</span>}
           </Flexbox>
-        </div>
-      )}
-      {systemRole && (
-        <div className={styles.field}>
-          <div className={styles.label}>System Prompt</div>
-          <Block paddingBlock={8} paddingInline={12} variant={'outlined'} width="100%">
-            <Markdown fontSize={13} variant={'chat'}>
-              {systemRole}
-            </Markdown>
-          </Block>
-        </div>
-      )}
-    </div>
-  );
-});
+          <ArrowRight className={styles.arrowIcon} size={16} />
+        </Flexbox>
+      );
+    }
+
+    // While tool is still executing (no pluginState yet), show args preview
+    if (!title && !description && !systemRole && !plugins?.length) return null;
+
+    return (
+      <div className={styles.container}>
+        {title && (
+          <div className={styles.field}>
+            <div className={styles.label}>Title</div>
+            <div className={styles.value}>{title}</div>
+          </div>
+        )}
+        {description && (
+          <div className={styles.field}>
+            <div className={styles.label}>Description</div>
+            <div className={styles.value}>{description}</div>
+          </div>
+        )}
+        {(model || provider) && (
+          <div className={styles.field}>
+            <div className={styles.label}>Model</div>
+            <div className={styles.value}>
+              {provider && `${provider}/`}
+              {model}
+            </div>
+          </div>
+        )}
+        {plugins && plugins.length > 0 && (
+          <div className={styles.field}>
+            <div className={styles.label}>Plugins</div>
+            <Flexbox horizontal gap={4} wrap={'wrap'}>
+              {plugins.map((plugin) => (
+                <Tag key={plugin}>{plugin}</Tag>
+              ))}
+            </Flexbox>
+          </div>
+        )}
+        {systemRole && (
+          <div className={styles.field}>
+            <div className={styles.label}>System Prompt</div>
+            <Block paddingBlock={8} paddingInline={12} variant={'outlined'} width="100%">
+              <Markdown fontSize={13} variant={'chat'}>
+                {systemRole}
+              </Markdown>
+            </Block>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 
 CreateAgentRender.displayName = 'CreateAgentRender';
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When the `createAgent` tool finishes executing, `CreateAgentRender` now renders a clickable agent card instead of just the args preview:

- **During execution** (`pluginState` is empty): shows the existing parameter preview (title, description, model, plugins, system prompt)
- **After execution** (`pluginState.success` is true): renders an `Avatar` + title/description card with an `ArrowRight` icon; clicking navigates to `SESSION_CHAT_URL(sessionId)` (`/agent/{id}`) to open the newly created agent session

The render component now reads both `args` (input params) and `pluginState` (`CreateAgentState` with `agentId`/`sessionId`).

#### 🧪 How to Test

- Trigger the `createAgent` tool via the agent-management builtin tool
- Verify the args preview shows during streaming
- Verify after completion a clickable agent card appears and navigates correctly on click

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Styles use `createStaticStyles` + `cssVar.*` per project conventions.