### PR TITLE
✨ feat: add lobeAgents markdown tag for inline agent card rendering

### DIFF
--- a/packages/builtin-tool-agent-management/src/systemRole.ts
+++ b/packages/builtin-tool-agent-management/src/systemRole.ts
@@ -275,6 +275,38 @@ The agent will work in the background and return results upon completion.
 3. Call the agent with instructions that leverage the installed plugins
 </workflow_patterns>
 
+<agent_card_rendering>
+## Rendering Agent Cards
+
+After successfully creating, duplicating, or finding an agent, render a clickable agent card by outputting a \`<lobeAgents>\` tag. This card appears inline in the conversation and lets the user navigate directly to the agent.
+
+**Format:**
+\`\`\`
+<lobeAgents identifier="{sessionId or agentId}" title="{title}" description="{description}" avatar="{avatar}" backgroundColor="{backgroundColor}" />
+\`\`\`
+
+**Attribute rules:**
+- **identifier** (required): Use \`sessionId\` from the tool result if available, otherwise use \`agentId\`
+- **title** (required): The agent's display name
+- **description** (optional): Brief description of the agent
+- **avatar** (optional): Emoji or image URL used for the agent
+- **backgroundColor** (optional): The agent's background color
+
+**When to render:**
+- After **createAgent** succeeds → render a card for the newly created agent
+- After **duplicateAgent** succeeds → render a card for the duplicated agent
+- After **searchAgent** returns results → render a card for each relevant agent found (up to 5)
+
+**Example — after createAgent:**
+\`\`\`
+I've created your coding assistant agent.
+
+<lobeAgents identifier="session-abc123" title="Coding Assistant" description="Expert in TypeScript and React" avatar="💻" backgroundColor="#3B82F6" />
+\`\`\`
+
+Do NOT render a card when calling \`getAgentDetail\`, \`updateAgent\`, \`updatePrompt\`, \`deleteAgent\`, or \`installPlugin\`.
+</agent_card_rendering>
+
 <best_practices>
 ## Best Practices
 

--- a/packages/const/src/plugin.ts
+++ b/packages/const/src/plugin.ts
@@ -19,3 +19,6 @@ export const ARTIFACT_THINKING_TAG_REGEX = /<lobeThinking\b[^>]*>([\S\s]*?)(?:<\
 export const THINKING_TAG_REGEX = /<think\b[^>]*>([\S\s]*?)(?:<\/think>|$)/;
 
 export const MENTION_TAG_REGEX = /<mention\b[^>]*>([\S\s]*?)(?:<\/mention>|$)/;
+
+export const AGENTS_TAG = 'lobeAgents';
+export const AGENTS_TAG_REGEX = /<lobeAgents\b[^>]*(?:\/>|>([\S\s]*?)(?:<\/lobeAgents>|$))/;

--- a/src/features/Conversation/Markdown/plugins/LobeAgents/Render/index.tsx
+++ b/src/features/Conversation/Markdown/plugins/LobeAgents/Render/index.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { SESSION_CHAT_URL } from '@lobechat/const';
+import { Avatar, Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { ArrowRight } from 'lucide-react';
+import { memo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { type MarkdownElementProps } from '../../type';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  arrowIcon: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  card: css`
+    cursor: pointer;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+    border-radius: 8px;
+
+    background: ${cssVar.colorFillQuaternary};
+
+    transition: background 0.15s;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  description: css`
+    overflow: hidden;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  title: css`
+    font-size: 13px;
+    font-weight: 500;
+  `,
+}));
+
+interface LobeAgentsProps extends MarkdownElementProps {
+  avatar?: string;
+  backgroundColor?: string;
+  description?: string;
+  identifier: string;
+  title: string;
+}
+
+const Render = memo<LobeAgentsProps>(
+  ({ identifier, title, description, avatar, backgroundColor }) => {
+    const navigate = useNavigate();
+
+    const handleClick = useCallback(() => {
+      if (!identifier) return;
+      navigate(SESSION_CHAT_URL(identifier));
+    }, [navigate, identifier]);
+
+    if (!identifier) return null;
+
+    return (
+      <Flexbox
+        align={'center'}
+        className={styles.card}
+        gap={12}
+        horizontal
+        onClick={handleClick}
+      >
+        <Avatar
+          avatar={avatar || '🤖'}
+          background={backgroundColor}
+          shape={'square'}
+          size={36}
+          title={title || undefined}
+        />
+        <Flexbox flex={1} gap={2}>
+          <span className={styles.title}>{title || identifier}</span>
+          {description && <span className={styles.description}>{description}</span>}
+        </Flexbox>
+        <ArrowRight className={styles.arrowIcon} size={16} />
+      </Flexbox>
+    );
+  },
+);
+
+Render.displayName = 'LobeAgentsRender';
+
+export default Render;

--- a/src/features/Conversation/Markdown/plugins/LobeAgents/index.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeAgents/index.ts
@@ -1,0 +1,16 @@
+import { type FC } from 'react';
+
+import { AGENTS_TAG } from '@/const/plugin';
+
+import { type MarkdownElement, type MarkdownElementProps } from '../type';
+import rehypePlugin from './rehypePlugin';
+import Component from './Render';
+
+const LobeAgentsElement: MarkdownElement = {
+  Component: Component as unknown as FC<MarkdownElementProps>,
+  rehypePlugin,
+  scope: 'assistant',
+  tag: AGENTS_TAG,
+};
+
+export default LobeAgentsElement;

--- a/src/features/Conversation/Markdown/plugins/LobeAgents/rehypePlugin.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeAgents/rehypePlugin.ts
@@ -2,43 +2,51 @@ import { SKIP, visit } from 'unist-util-visit';
 
 import { AGENTS_TAG } from '@/const/plugin';
 
+const attributeRegex = /(\w+)=["']([^"']*)["']/g;
+
+function parseAttributes(raw: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  let match;
+  attributeRegex.lastIndex = 0;
+  while ((match = attributeRegex.exec(raw)) !== null) {
+    attributes[match[1]] = match[2];
+  }
+  return attributes;
+}
+
 function rehypeLobeAgents() {
   return (tree: any) => {
     visit(tree, (node, index, parent) => {
-      // Handle <lobeAgents .../> or <lobeAgents ...> wrapped inside a <p> element
+      // Handle <lobeAgents .../> wrapped inside a <p> element
       if (node.type === 'element' && node.tagName === 'p' && node.children.length > 0) {
         const firstChild = node.children[0];
         if (firstChild.type === 'raw' && firstChild.value.startsWith(`<${AGENTS_TAG}`)) {
-          const attributes: Record<string, string> = {};
-          const attributeRegex = /(\w+)="([^"]*)"/g;
-          let match;
-          while ((match = attributeRegex.exec(firstChild.value)) !== null) {
-            attributes[match[1]] = match[2];
-          }
-
           const newNode = {
             children: [],
-            properties: attributes,
+            properties: parseAttributes(firstChild.value),
             tagName: AGENTS_TAG,
             type: 'element',
           };
 
-          parent.children.splice(index, 1, newNode);
+          // P1 fix: preserve any trailing siblings in the paragraph
+          const remainingChildren = node.children.slice(1).filter(
+            (c: any) => !(c.type === 'raw' && c.value.startsWith('</')),
+          );
+
+          if (remainingChildren.length > 0) {
+            const remainingP = { ...node, children: remainingChildren };
+            parent.children.splice(index, 1, newNode, remainingP);
+          } else {
+            parent.children.splice(index, 1, newNode);
+          }
           return [SKIP, index];
         }
       }
       // Handle bare <lobeAgents .../> raw node (self-closing or opening tag)
       else if (node.type === 'raw' && node.value.startsWith(`<${AGENTS_TAG}`)) {
-        const attributes: Record<string, string> = {};
-        const attributeRegex = /(\w+)="([^"]*)"/g;
-        let match;
-        while ((match = attributeRegex.exec(node.value)) !== null) {
-          attributes[match[1]] = match[2];
-        }
-
         const newNode = {
           children: [],
-          properties: attributes,
+          properties: parseAttributes(node.value),
           tagName: AGENTS_TAG,
           type: 'element',
         };

--- a/src/features/Conversation/Markdown/plugins/LobeAgents/rehypePlugin.ts
+++ b/src/features/Conversation/Markdown/plugins/LobeAgents/rehypePlugin.ts
@@ -1,0 +1,53 @@
+import { SKIP, visit } from 'unist-util-visit';
+
+import { AGENTS_TAG } from '@/const/plugin';
+
+function rehypeLobeAgents() {
+  return (tree: any) => {
+    visit(tree, (node, index, parent) => {
+      // Handle <lobeAgents .../> or <lobeAgents ...> wrapped inside a <p> element
+      if (node.type === 'element' && node.tagName === 'p' && node.children.length > 0) {
+        const firstChild = node.children[0];
+        if (firstChild.type === 'raw' && firstChild.value.startsWith(`<${AGENTS_TAG}`)) {
+          const attributes: Record<string, string> = {};
+          const attributeRegex = /(\w+)="([^"]*)"/g;
+          let match;
+          while ((match = attributeRegex.exec(firstChild.value)) !== null) {
+            attributes[match[1]] = match[2];
+          }
+
+          const newNode = {
+            children: [],
+            properties: attributes,
+            tagName: AGENTS_TAG,
+            type: 'element',
+          };
+
+          parent.children.splice(index, 1, newNode);
+          return [SKIP, index];
+        }
+      }
+      // Handle bare <lobeAgents .../> raw node (self-closing or opening tag)
+      else if (node.type === 'raw' && node.value.startsWith(`<${AGENTS_TAG}`)) {
+        const attributes: Record<string, string> = {};
+        const attributeRegex = /(\w+)="([^"]*)"/g;
+        let match;
+        while ((match = attributeRegex.exec(node.value)) !== null) {
+          attributes[match[1]] = match[2];
+        }
+
+        const newNode = {
+          children: [],
+          properties: attributes,
+          tagName: AGENTS_TAG,
+          type: 'element',
+        };
+
+        parent.children.splice(index, 1, newNode);
+        return [SKIP, index];
+      }
+    });
+  };
+}
+
+export default rehypeLobeAgents;

--- a/src/features/Conversation/Markdown/plugins/index.ts
+++ b/src/features/Conversation/Markdown/plugins/index.ts
@@ -1,4 +1,5 @@
 import ImageSearchRef from './ImageSearchRef';
+import LobeAgents from './LobeAgents';
 import LobeArtifact from './LobeArtifact';
 import LobeThinking from './LobeThinking';
 import LocalFile from './LocalFile';
@@ -17,4 +18,5 @@ export const markdownElements: MarkdownElement[] = [
   Mention,
   Task,
   ImageSearchRef,
+  LobeAgents,
 ];

--- a/src/features/Conversation/utils/markdown.ts
+++ b/src/features/Conversation/utils/markdown.ts
@@ -3,6 +3,8 @@ import { ARTIFACT_THINKING_TAG_REGEX } from '@lobechat/const';
 const ARTIFACT_TAG_REGEX_GLOBAL =
   /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/g;
 
+const AGENTS_TAG_REGEX_GLOBAL = /<lobeAgents\b[^>]*(?:\/>|>([\S\s]*?)(?:<\/lobeAgents>|$))/g;
+
 /**
  * Replace all line breaks in the matched `lobeArtifact` tag with an empty string
  */
@@ -62,6 +64,11 @@ export const processWithArtifact = (input: string = '') => {
   if (regex.test(output)) {
     output = output.replace(regex, '<lobeArtifact>');
   }
+
+  // Strip newlines inside lobeAgents tags (self-closing or wrapping)
+  output = output.replaceAll(AGENTS_TAG_REGEX_GLOBAL, (match) =>
+    match.replaceAll(/\r?\n|\r/g, ''),
+  );
 
   return output;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a new `<lobeAgents>` XML tag that LLMs can output in markdown responses to render a clickable inline agent card. Follows the same pipeline as `<lobeArtifact>`:

- **`packages/const/src/plugin.ts`** — `AGENTS_TAG` + `AGENTS_TAG_REGEX` constants
- **`Markdown/plugins/LobeAgents/rehypePlugin.ts`** — parses `<lobeAgents identifier="..." title="..." />` into element node with properties
- **`Markdown/plugins/LobeAgents/Render/index.tsx`** — inline agent card (Avatar + title + description + ArrowRight), clicking navigates to `SESSION_CHAT_URL(identifier)`
- **`Markdown/plugins/LobeAgents/index.ts`** — `MarkdownElement` definition (`scope: 'assistant'`)
- **`Markdown/plugins/index.ts`** — registered in `markdownElements` array
- **`utils/markdown.ts`** — `processWithArtifact` strips newlines inside `<lobeAgents>` tags

**LLM output format:**
```
<lobeAgents identifier="session-xxx" title="My Agent" description="..." avatar="🤖" />
```

No Portal/sidebar needed — card navigates inline on click.

#### 🧪 How to Test

- Trigger LLM to output `<lobeAgents identifier="..." title="..." />` in a message
- Verify the agent card renders inline with avatar, title, description, and arrow icon
- Verify clicking navigates to the correct agent session

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed