### PR TITLE
🐛 fix: sanitize assistant media in Responses input

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -779,6 +779,55 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
+  it('should drop assistant image content for Responses API input', async () => {
+    const messages: OpenAIChatMessage[] = [
+      {
+        content: [
+          {
+            image_url: { url: 'data:image/jpeg;base64,abc123' },
+            type: 'image_url',
+          },
+        ],
+        role: 'assistant',
+      },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should keep assistant text and drop unsupported assistant media for Responses API input', async () => {
+    const messages: OpenAIChatMessage[] = [
+      {
+        content: [
+          {
+            text: 'Here is the generated image.',
+            type: 'text',
+          },
+          {
+            image_url: { url: 'data:image/jpeg;base64,abc123' },
+            type: 'image_url',
+          },
+          {
+            video_url: { url: 'data:video/mp4;base64,def456' },
+            type: 'video_url',
+          },
+        ],
+        role: 'assistant',
+      },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result).toEqual([
+      {
+        content: [{ text: 'Here is the generated image.', type: 'output_text' }],
+        role: 'assistant',
+      },
+    ]);
+  });
+
   it('should pass forceVideoBase64 to convertMessageContent in video_url branch', async () => {
     process.env.LLM_VISION_VIDEO_USE_BASE64 = undefined;
 

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -213,6 +213,13 @@ export const convertOpenAIResponseInputs = async (
                   }
                   return { ...c, type: 'input_text' };
                 }
+
+                // Responses API only accepts output_text/refusal inside assistant history.
+                // Multimodal parts are valid as model inputs, not as previous assistant outputs.
+                if (message.role === 'assistant') {
+                  return undefined;
+                }
+
                 if (c.type === 'video_url') {
                   const video = await convertMessageContent(c, options);
                   if (!('video_url' in video) || !video.video_url?.url) {
@@ -237,12 +244,18 @@ export const convertOpenAIResponseInputs = async (
               }),
             );
 
+      const content =
+        typeof processedContent === 'string'
+          ? processedContent
+          : processedContent.filter((m) => m !== undefined);
+
+      if (message.role === 'assistant' && Array.isArray(content) && content.length === 0) {
+        return items;
+      }
+
       const item = {
         ...message,
-        content:
-          typeof processedContent === 'string'
-            ? processedContent
-            : processedContent.filter((m) => m !== undefined),
+        content,
       } as OpenAI.Responses.ResponseInputItem;
 
       // remove reasoning field from the message item


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #13075

#### 🔀 Description of Change

- Drop unsupported assistant-side image and video content parts when building Responses API input history.
- Keep assistant text parts as `output_text` and skip assistant history items that become empty after filtering.
- Add regression coverage for assistant media-only and mixed text/media history.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/contextBuilders/openai.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This prevents Responses-compatible providers from receiving invalid assistant history content such as `input_image` / `input_video`, which is only valid for user input content.
