### PR TITLE
✨ feat(agent-sidebar): move tasks from welcome card to sidebar list

### DIFF
--- a/src/features/AgentHome/index.tsx
+++ b/src/features/AgentHome/index.tsx
@@ -4,7 +4,6 @@ import { Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
-import AgentTaskList from '@/features/AgentTaskList';
 import ToolAuthAlert from '@/routes/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -25,7 +24,6 @@ const AgentHome = memo(() => {
         {extra}
         {openingQuestions.length > 0 && <OpeningQuestions questions={openingQuestions} />}
         <ToolAuthAlert />
-        <AgentTaskList />
       </Flexbox>
     </>
   );

--- a/src/routes/(main)/agent/_layout/Sidebar/Body.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Body.tsx
@@ -2,10 +2,12 @@ import { Accordion, Flexbox } from '@lobehub/ui';
 import React, { memo } from 'react';
 
 import CronTopicList from './Cron';
+import TaskList from './Task';
 import Topic from './Topic';
 
 export enum ChatSidebarKey {
   CronTopics = 'cronTopics',
+  Tasks = 'tasks',
   Topic = 'topic',
 }
 
@@ -13,6 +15,7 @@ const Body = memo(() => {
   return (
     <Flexbox paddingInline={4}>
       <Accordion defaultExpandedKeys={[ChatSidebarKey.Topic]} gap={8}>
+        <TaskList itemKey={ChatSidebarKey.Tasks} />
         <CronTopicList itemKey={ChatSidebarKey.CronTopics} />
         <Topic itemKey={ChatSidebarKey.Topic} />
       </Accordion>

--- a/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { AccordionItem, Center, Flexbox, Icon, Text } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { CircleDashed, CircleDot, HandIcon, type LucideIcon } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
+
+import TaskItem from './TaskItem';
+
+const STATUS_META: Record<string, { color: string; icon: LucideIcon; titleKey: string }> = {
+  backlog: {
+    color: cssVar.colorTextQuaternary,
+    icon: CircleDashed,
+    titleKey: 'taskList.kanban.backlog',
+  },
+  needsInput: {
+    color: cssVar.colorInfo,
+    icon: HandIcon,
+    titleKey: 'taskList.kanban.needsInput',
+  },
+  running: {
+    color: cssVar.colorWarning,
+    icon: CircleDot,
+    titleKey: 'taskList.kanban.running',
+  },
+};
+
+interface StatusGroupProps {
+  group: TaskGroupItem;
+}
+
+const StatusGroup = memo<StatusGroupProps>(({ group }) => {
+  const { t } = useTranslation('chat');
+  const { taskId } = useParams<{ taskId?: string }>();
+  const meta = STATUS_META[group.key];
+  if (!meta) return null;
+
+  return (
+    <AccordionItem
+      itemKey={group.key}
+      paddingBlock={4}
+      paddingInline={4}
+      title={
+        <Flexbox horizontal align="center" gap={8} height={24} style={{ overflow: 'hidden' }}>
+          <Center flex={'none'} height={24} width={24}>
+            <Icon color={meta.color} icon={meta.icon} size={{ size: 14, strokeWidth: 1.75 }} />
+          </Center>
+          <Text ellipsis fontSize={13} style={{ color: cssVar.colorTextSecondary, flex: 1 }}>
+            {t(meta.titleKey as 'taskList.kanban.backlog')}
+          </Text>
+          <Text fontSize={11} type="secondary">
+            {group.tasks.length}
+          </Text>
+        </Flexbox>
+      }
+    >
+      <Flexbox gap={1} paddingBlock={1}>
+        {group.tasks.map((task) => (
+          <TaskItem active={taskId === task.identifier} key={task.id} task={task} />
+        ))}
+      </Flexbox>
+    </AccordionItem>
+  );
+});
+
+export default StatusGroup;

--- a/src/routes/(main)/agent/_layout/Sidebar/Task/TaskItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Task/TaskItem.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Text } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { memo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import NavItem from '@/features/NavPanel/components/NavItem';
+import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
+
+type TaskRow = TaskGroupItem['tasks'][number];
+
+interface TaskItemProps {
+  active?: boolean;
+  task: TaskRow;
+}
+
+const TaskItem = memo<TaskItemProps>(({ task, active }) => {
+  const navigate = useNavigate();
+
+  const handleClick = useCallback(() => {
+    navigate(`/task/${task.identifier}`);
+  }, [navigate, task.identifier]);
+
+  const hasName = Boolean(task.name?.trim());
+  const displayTitle = hasName ? task.name : task.identifier;
+
+  return (
+    <NavItem
+      active={active}
+      title={displayTitle}
+      slots={{
+        titlePrefix: hasName ? (
+          <Text fontSize={12} style={{ color: cssVar.colorTextTertiary, flex: 'none' }}>
+            {task.identifier}
+          </Text>
+        ) : undefined,
+      }}
+      onClick={handleClick}
+    />
+  );
+});
+
+export default TaskItem;

--- a/src/routes/(main)/agent/_layout/Sidebar/Task/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Task/index.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Accordion, AccordionItem, Flexbox, Text } from '@lobehub/ui';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { useClientDataSWR } from '@/libs/swr';
+import { taskService } from '@/services/task';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
+import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
+
+import StatusGroup from './StatusGroup';
+
+const SIDEBAR_GROUPS = [
+  { key: 'needsInput', statuses: ['paused', 'failed'] },
+  { key: 'backlog', statuses: ['backlog'] },
+  { key: 'running', statuses: ['running', 'scheduled'] },
+];
+const STATUS_ORDER = SIDEBAR_GROUPS.map((g) => g.key);
+
+const FETCH_SIDEBAR_TASK_GROUPS_KEY = 'fetchSidebarTaskGroups';
+
+interface TaskListProps {
+  itemKey: string;
+}
+
+const TaskList = memo<TaskListProps>(({ itemKey }) => {
+  const { t } = useTranslation('chat');
+  const agentId = useAgentStore((s) => s.activeAgentId);
+  const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
+  const { enableAgentTask } = useServerConfigStore(featureFlagsSelectors);
+
+  const enabled = !!enableAgentTask && !isHeterogeneous && !!agentId;
+  const { data, isLoading } = useClientDataSWR<{ data: TaskGroupItem[]; success: boolean }>(
+    enabled ? [FETCH_SIDEBAR_TASK_GROUPS_KEY, agentId] : null,
+    async ([, id]: [string, string]) =>
+      taskService.groupList({ assigneeAgentId: id, groups: SIDEBAR_GROUPS }),
+    {
+      fallbackData: { data: [], success: true },
+      revalidateOnFocus: false,
+    },
+  );
+  const taskGroups = data?.data ?? [];
+
+  const orderedGroups = useMemo(() => {
+    const map = new Map(taskGroups.map((g) => [g.key, g]));
+    return STATUS_ORDER.map((key) => map.get(key)).filter(
+      (g): g is NonNullable<typeof g> => !!g && g.tasks.length > 0,
+    );
+  }, [taskGroups]);
+
+  const totalTasks = useMemo(
+    () => orderedGroups.reduce((acc, g) => acc + g.tasks.length, 0),
+    [orderedGroups],
+  );
+
+  if (!enableAgentTask || isHeterogeneous) return null;
+
+  const titleNode = (
+    <Flexbox horizontal align="center" gap={4}>
+      <Text ellipsis fontSize={12} type={'secondary'} weight={500}>
+        {t('tab.tasks')}
+      </Text>
+      {totalTasks > 0 && (
+        <Text fontSize={11} type="secondary">
+          {totalTasks}
+        </Text>
+      )}
+    </Flexbox>
+  );
+
+  if (isLoading && taskGroups.length === 0) {
+    return (
+      <AccordionItem itemKey={itemKey} paddingBlock={4} paddingInline={'8px 4px'} title={titleNode}>
+        <SkeletonList />
+      </AccordionItem>
+    );
+  }
+
+  return (
+    <AccordionItem itemKey={itemKey} paddingBlock={4} paddingInline={'8px 4px'} title={titleNode}>
+      {orderedGroups.length === 0 ? (
+        <Text fontSize={12} style={{ padding: '8px 12px' }} type="secondary">
+          {t('taskList.kanban.emptyColumn')}
+        </Text>
+      ) : (
+        <Accordion defaultExpandedKeys={orderedGroups.map((g) => g.key)} gap={2}>
+          {orderedGroups.map((group) => (
+            <StatusGroup group={group} key={group.key} />
+          ))}
+        </Accordion>
+      )}
+    </AccordionItem>
+  );
+});
+
+export default TaskList;

--- a/src/routes/(main)/agent/features/Conversation/AgentWelcome/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/AgentWelcome/index.tsx
@@ -6,7 +6,6 @@ import React, { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
-import AgentTaskList from '@/features/AgentTaskList';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -66,7 +65,6 @@ const InboxWelcome = memo(() => {
           <OpeningQuestions mobile={mobile} questions={openingQuestions} />
         )}
         <ToolAuthAlert />
-        <AgentTaskList />
       </Flexbox>
     </>
   );


### PR DESCRIPTION
## Summary

- Remove the inline `AgentTaskList` card from the agent welcome (`AgentWelcome`) and inbox/home welcome (`AgentHome`) screens.
- Add a new `Tasks` section in the agent sidebar (under topics / cron jobs) that groups tasks by kanban-status (Pending review / Backlog / In progress) with the canonical icons used by `TaskStatusTag` (HandIcon / CircleDashed / CircleDot).
- Sidebar fetch is scoped to active statuses only — `done` and `canceled` are neither pulled from the server nor rendered. Uses a dedicated SWR cache key (`fetchSidebarTaskGroups`) and does not touch the global `taskGroups` store, so the kanban page (`/tasks`) is unaffected.
- Each task row uses the existing `NavItem` component, navigates to `/task/:identifier`, and shows the task identifier as a tertiary prefix when a name exists.
- Section is gated on `enableAgentTask` and hidden for heterogeneous agents.

## Test plan

- [ ] Open an agent with active tasks → `任务` section appears in the sidebar with `Pending review` / `Backlog` / `In progress` groups.
- [ ] Click a task row → navigates to `/task/:identifier`, row shows active state.
- [ ] Confirm the welcome card (`AgentWelcome` and inbox `AgentHome`) no longer renders the old task list.
- [ ] Verify network tab: sidebar `task.groupList` request body contains only `needsInput`, `backlog`, `running`.
- [ ] Open `/tasks` (kanban) → all 5 columns including done/canceled load correctly; sidebar state remains intact.
- [ ] Disable `enableAgentTask` flag → sidebar section disappears.
- [ ] Open a heterogeneous agent (Claude Code / Codex) → sidebar section is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)