### PR TITLE
🐛 fix: fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,11 +85,12 @@ RUN set -e && \
     export COREPACK_NPM_REGISTRY=$(npm config get registry | sed 's/\/$//') && \
     npm i -g corepack@latest && \
     corepack enable && \
-    corepack use $(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) && \
+    PACKAGE_MANAGER=$(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json) && \
+    corepack use "${PACKAGE_MANAGER}" && \
     pnpm i && \
     mkdir -p /deps && \
     cd /deps && \
-    pnpm init && \
+    printf '{"private":true,"type":"module","packageManager":"%s"}\n' "${PACKAGE_MANAGER}" > package.json && \
     pnpm add pg drizzle-orm
 
 COPY . .


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

  Fix Docker image build after updating pnpm via Corepack.

  This change reads the `packageManager` value from the root `package.json` once, reuses it when running `corepack use`, and writes the same package manager metadata into the temporary `/deps/package.json`.

  It also replaces `pnpm init` with an explicit minimal `package.json`, avoiding generated package metadata that may not include the expected pnpm/Corepack configuration during Docker builds.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
