### PR TITLE
🐛 fix(assistant-group): pass per-segment content overrides to MessageContent

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -26,9 +26,11 @@ const ContentBlock = memo<ContentBlockProps>(
     reasoning,
     error,
     domId,
+    contentOverride,
     assistantId,
     disableEditing,
     disableMarkdownStreaming,
+    hasToolsOverride,
   }) => {
     const errorContent = useErrorContent(error);
     const showImageItems = !!imageList && imageList.length > 0;
@@ -37,7 +39,7 @@ const ContentBlock = memo<ContentBlockProps>(
       s.deleteDBMessage,
       s.continueGeneration,
     ]);
-    const hasTools = tools && tools.length > 0;
+    const hasTools = !!tools?.length;
     const showReasoning =
       (!!reasoning && reasoning.content?.trim() !== '') || (!reasoning && isReasoning);
     const hasContent = !!content && content !== LOADING_FLAT;
@@ -84,7 +86,12 @@ const ContentBlock = memo<ContentBlockProps>(
 
         {showMessageContent && (
           <SafeBoundary variant="alert">
-            <MessageContent disableStreaming={disableMarkdownStreaming} id={id} />
+            <MessageContent
+              contentOverride={contentOverride}
+              disableStreaming={disableMarkdownStreaming}
+              hasToolsOverride={hasToolsOverride}
+              id={id}
+            />
           </SafeBoundary>
         )}
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -41,20 +41,33 @@ vi.mock('./WorkflowCollapse', () => ({
   }: {
     blocks: Array<{
       content: string;
+      contentOverride?: string;
       disableMarkdownStreaming?: boolean;
       domId?: string;
+      hasToolsOverride?: boolean;
       tools?: unknown[];
     }>;
   }) => (
     <div
       data-testid="workflow-segment"
       data-blocks={JSON.stringify(
-        blocks.map(({ content, disableMarkdownStreaming, domId, tools }) => ({
-          content,
-          disableMarkdownStreaming: !!disableMarkdownStreaming,
-          domId,
-          toolCount: tools?.length ?? 0,
-        })),
+        blocks.map(
+          ({
+            content,
+            contentOverride,
+            disableMarkdownStreaming,
+            domId,
+            hasToolsOverride,
+            tools,
+          }) => ({
+            content,
+            contentOverride,
+            disableMarkdownStreaming: !!disableMarkdownStreaming,
+            domId,
+            hasToolsOverride,
+            toolCount: tools?.length ?? 0,
+          }),
+        ),
       )}
     />
   ),
@@ -63,15 +76,19 @@ vi.mock('./WorkflowCollapse', () => ({
 vi.mock('./GroupItem', () => ({
   default: ({
     content,
+    contentOverride,
     disableMarkdownStreaming,
     domId,
+    hasToolsOverride,
     id,
     isFirstBlock,
     tools,
   }: {
     content: string;
+    contentOverride?: string;
     disableMarkdownStreaming?: boolean;
     domId?: string;
+    hasToolsOverride?: boolean;
     id: string;
     isFirstBlock?: boolean;
     tools?: unknown[];
@@ -80,8 +97,10 @@ vi.mock('./GroupItem', () => ({
       data-testid="answer-segment"
       data-block={JSON.stringify({
         content,
+        contentOverride,
         disableMarkdownStreaming: !!disableMarkdownStreaming,
         domId,
+        hasToolsOverride,
         id,
         isFirstBlock: !!isFirstBlock,
         toolCount: tools?.length ?? 0,
@@ -137,16 +156,20 @@ describe('Group', () => {
     expect(parseAnswerSegments()).toEqual([
       {
         content: longContent,
+        contentOverride: longContent,
         disableMarkdownStreaming: true,
         domId: 'block-1__answer',
+        hasToolsOverride: false,
         id: 'block-1',
         isFirstBlock: false,
         toolCount: 0,
       },
       {
         content: '',
+        contentOverride: '',
         disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
+        hasToolsOverride: true,
         id: 'block-1',
         isFirstBlock: false,
         toolCount: 1,
@@ -209,8 +232,10 @@ describe('Group', () => {
     expect(sequence).toEqual(['answer-segment', 'workflow-segment']);
     expect(parseAnswerSegment()).toEqual({
       content: '我先帮你查一下。',
+      contentOverride: '我先帮你查一下。',
       disableMarkdownStreaming: true,
       domId: 'block-1__answer',
+      hasToolsOverride: false,
       id: 'block-1',
       isFirstBlock: false,
       toolCount: 0,
@@ -218,8 +243,10 @@ describe('Group', () => {
     expect(parseWorkflowSegment()).toEqual([
       {
         content: '接下来我会继续整理结果。',
+        contentOverride: '接下来我会继续整理结果。',
         disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
+        hasToolsOverride: true,
         toolCount: 1,
       },
       {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -144,9 +144,14 @@ const createAnswerRenderBlock = (
   block: AssistantContentBlock,
   overrides: Partial<RenderableAssistantContentBlock> = {},
 ): RenderableAssistantContentBlock => {
+  const content = 'content' in overrides ? overrides.content : block.content;
+  const tools = 'tools' in overrides ? overrides.tools : block.tools;
+
   return {
     ...block,
+    contentOverride: content,
     domId: `${block.id}${ANSWER_DOM_ID_SUFFIX}`,
+    hasToolsOverride: !!tools?.length,
     renderKey: `${block.id}${ANSWER_DOM_ID_SUFFIX}`,
     ...overrides,
   };
@@ -156,9 +161,14 @@ const createWorkflowRenderBlock = (
   block: AssistantContentBlock,
   overrides: Partial<RenderableAssistantContentBlock> = {},
 ): RenderableAssistantContentBlock => {
+  const content = 'content' in overrides ? overrides.content : block.content;
+  const tools = 'tools' in overrides ? overrides.tools : block.tools;
+
   return {
     ...block,
+    contentOverride: content,
     domId: `${block.id}${WORKFLOW_DOM_ID_SUFFIX}`,
+    hasToolsOverride: !!tools?.length,
     renderKey: `${block.id}${WORKFLOW_DOM_ID_SUFFIX}`,
     ...overrides,
   };

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import MessageContent from './MessageContent';
+
+let mockStoreContent = 'original full content';
+let mockStoreHasTools = true;
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    pWithTool: 'tool-line',
+  }),
+  cx: (...values: unknown[]) => values.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/features/Conversation/Markdown', () => ({
+  default: ({ children, className }: { children?: ReactNode; className?: string }) => (
+    <div className={className} data-testid="markdown">
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/features/Conversation/Messages/components/ContentLoading', () => ({
+  default: ({ id }: { id: string }) => <div data-testid="loading">{id}</div>,
+}));
+
+vi.mock('../../../store', () => ({
+  dataSelectors: {
+    getBlockContent: () => () => mockStoreContent,
+    getBlockHasTools: () => () => mockStoreHasTools,
+  },
+  useConversationStore: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+vi.mock('../useMarkdown', () => ({
+  useMarkdown: () => ({}),
+}));
+
+describe('MessageContent', () => {
+  afterEach(() => {
+    cleanup();
+    mockStoreContent = 'original full content';
+    mockStoreHasTools = true;
+  });
+
+  it('renders explicit content override instead of the same-id store content', () => {
+    render(
+      <MessageContent contentOverride="lead sentence" hasToolsOverride={false} id="block-1" />,
+    );
+
+    expect(screen.getByTestId('markdown')).toHaveTextContent('lead sentence');
+    expect(screen.queryByText('original full content')).not.toBeInTheDocument();
+  });
+
+  it('keeps the store subscription path when no override is provided', () => {
+    render(<MessageContent id="block-1" />);
+
+    expect(screen.getByTestId('markdown')).toHaveTextContent('original full content');
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -17,36 +17,42 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 interface MessageContentProps {
+  contentOverride?: string;
   disableStreaming?: boolean;
+  hasToolsOverride?: boolean;
   id: string;
 }
 
-const MessageContent = memo<MessageContentProps>(({ disableStreaming, id }) => {
-  // Subscribe to this block's content + hasTools directly so streaming chunks
-  // do not need to flow through ContentBlock's prop chain to reach us.
-  const content = useConversationStore(dataSelectors.getBlockContent(id));
-  const hasTools = useConversationStore(dataSelectors.getBlockHasTools(id));
+const MessageContent = memo<MessageContentProps>(
+  ({ contentOverride, disableStreaming, hasToolsOverride, id }) => {
+    // Subscribe to this block's content + hasTools directly so streaming chunks
+    // do not need to flow through ContentBlock's prop chain to reach us.
+    const storeContent = useConversationStore(dataSelectors.getBlockContent(id));
+    const storeHasTools = useConversationStore(dataSelectors.getBlockHasTools(id));
+    const content = contentOverride ?? storeContent;
+    const hasTools = hasToolsOverride ?? storeHasTools;
 
-  const message = normalizeThinkTags(processWithArtifact(content ?? ''));
-  const markdownProps = useMarkdown(id, disableStreaming);
+    const message = normalizeThinkTags(processWithArtifact(content ?? ''));
+    const markdownProps = useMarkdown(id, disableStreaming);
 
-  if (!content && !hasTools) return <ContentLoading id={id} />;
+    if (!content && !hasTools) return <ContentLoading id={id} />;
 
-  if (content === LOADING_FLAT) {
-    if (hasTools) return null;
-    return <ContentLoading id={id} />;
-  }
+    if (content === LOADING_FLAT) {
+      if (hasTools) return null;
+      return <ContentLoading id={id} />;
+    }
 
-  const isSingleLine = (message || '').split('\n').length <= 2;
-  const isToolSingleLine = hasTools && isSingleLine;
+    const isSingleLine = (message || '').split('\n').length <= 2;
+    const isToolSingleLine = hasTools && isSingleLine;
 
-  return (
-    content && (
-      <MarkdownMessage {...markdownProps} className={cx(isToolSingleLine && styles.pWithTool)}>
-        {message}
-      </MarkdownMessage>
-    )
-  );
-});
+    return (
+      content && (
+        <MarkdownMessage {...markdownProps} className={cx(isToolSingleLine && styles.pWithTool)}>
+          {message}
+        </MarkdownMessage>
+      )
+    );
+  },
+);
 
 export default MessageContent;

--- a/src/features/Conversation/Messages/AssistantGroup/components/types.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/types.ts
@@ -1,7 +1,9 @@
 import type { AssistantContentBlock } from '@/types/index';
 
 export interface RenderableAssistantContentBlock extends AssistantContentBlock {
+  contentOverride?: string;
   disableMarkdownStreaming?: boolean;
   domId?: string;
+  hasToolsOverride?: boolean;
   renderKey?: string;
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [ ] ✨ feat
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When assistant content blocks are split into answer and workflow segments in `Group.tsx`, each segment was previously reading from the same store subscription via `dataSelectors.getBlockContent(id)`. This caused all segments sharing the same block `id` to render identical content, regardless of the override `content`/`tools` passed through `createAnswerRenderBlock` / `createWorkflowRenderBlock`.

This PR introduces two new optional props on `MessageContent` and `ContentBlock`:

- `contentOverride?: string` — explicit content to render instead of store lookup
- `hasToolsOverride?: boolean` — explicit tools flag instead of store lookup

The `Group.tsx` helper functions (`createAnswerRenderBlock`, `createWorkflowRenderBlock`) now compute and attach these overrides, ensuring each split segment displays its own content.

#### 🧪 How to Test

- [x] Added/updated tests
- [ ] Tested locally
- [ ] No tests needed

Run:

```bash
bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx'
bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx'
```

#### 📸 Screenshots / Videos

N/A — no visual change; the fix is in data flow.

#### 📝 Additional Information

| File | Change |
|------|--------|
| `types.ts` | Add `contentOverride`, `hasToolsOverride` to `RenderableAssistantContentBlock` |
| `Group.tsx` | Compute overrides in `createAnswerRenderBlock` / `createWorkflowRenderBlock` |
| `ContentBlock.tsx` | Forward new props to `MessageContent` |
| `MessageContent.tsx` | Use overrides when provided, fall back to store |
| `Group.test.tsx` | Update mocks and assertions for new props |
| `MessageContent.test.tsx` | New tests for override vs store paths |