### PR TITLE
🐛 fix: always recommend task templates regardless of brief count

### DIFF
--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -14,9 +14,6 @@ import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 import { useResolvedInterestKeys } from './useResolvedInterestKeys';
 
-/** Hide the recommend section once the user already has more existing briefs than this. */
-const MAX_EXISTING_BRIEFS_FOR_RECOMMEND = 1;
-
 export type DailyBriefRecommendationsUIState =
   | { mode: 'hidden' }
   | { mode: 'skeleton' }
@@ -30,7 +27,6 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
   const useFetchBriefs = useBriefStore((s) => s.useFetchBriefs);
   useFetchBriefs(isLogin && !!enableAgentTask);
 
-  const briefs = useBriefStore(briefListSelectors.briefs);
   const isInit = useBriefStore(briefListSelectors.isBriefsInit);
 
   const interestKeys = useResolvedInterestKeys();
@@ -78,7 +74,6 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
   useFetchLobehubSkillConnections(requiredSources.has('lobehub'));
 
   if (!swrEnabled) return { mode: 'hidden' };
-  if (isInit && briefs.length > MAX_EXISTING_BRIEFS_FOR_RECOMMEND) return { mode: 'hidden' };
   if (!isInit || isLoading) return { mode: 'skeleton' };
   if (templates.length === 0) return { mode: 'hidden' };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-8624

#### 🔀 Description of Change

Drop the `MAX_EXISTING_BRIEFS_FOR_RECOMMEND = 1` gate in `useDailyBriefRecommendationsUI` so the daily-brief recommendations stay visible even when the user already has multiple unresolved briefs. Hidden mode is now reserved for unauthenticated / disabled-feature / empty-templates cases only.

#### 🧪 How to Test

- [x] Tested locally

Visit `/home` with an account that has more than 1 unresolved brief — task template recommendations should still appear under the briefs section.

#### 📝 Additional Information

The original gate was meant to "not distract users who already have many briefs", but product decision now favors always surfacing recommendations.

The "merged endpoint to avoid skeleton flicker" idea from the original LOBE-8624 description is moved out of scope — that belongs under [LOBE-8597](https://linear.app/lobehub/issue/LOBE-8597) (perf), and merging endpoints does not actually reduce total load time since both fetches were already parallel.