### PR TITLE
Fix Review panel gating to use effective working directory

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.test.tsx
@@ -13,7 +13,7 @@ import AgentWorkingSidebar from './index';
 const mocks = vi.hoisted(() => ({
   agentStoreState: {
     activeAgentId: 'agent-1',
-    agentWorkingDirectory: undefined as string | undefined,
+    agentWorkingDirectoryById: {} as Record<string, string | undefined>,
   },
   repoType: undefined as 'git' | 'github' | undefined,
   topicWorkingDirectory: undefined as string | undefined,
@@ -149,9 +149,11 @@ vi.mock('@/store/agent', () => ({
 }));
 
 vi.mock('@/store/agent/selectors', () => ({
-  agentSelectors: {
-    currentAgentWorkingDirectory: (state: { agentWorkingDirectory?: string }) =>
-      state.agentWorkingDirectory,
+  agentByIdSelectors: {
+    getAgentWorkingDirectoryById:
+      (agentId: string) =>
+      (state: { agentWorkingDirectoryById?: Record<string, string | undefined> }) =>
+        state.agentWorkingDirectoryById?.[agentId],
   },
 }));
 
@@ -177,7 +179,7 @@ vi.mock('@/store/chat/selectors', () => ({
 
 beforeEach(() => {
   mocks.agentStoreState.activeAgentId = 'agent-1';
-  mocks.agentStoreState.agentWorkingDirectory = undefined;
+  mocks.agentStoreState.agentWorkingDirectoryById = {};
   mocks.repoType = undefined;
   mocks.topicWorkingDirectory = undefined;
   vi.mocked(swr.useClientDataSWR).mockImplementation((() => ({
@@ -222,7 +224,7 @@ describe('AgentWorkingSidebar', () => {
   });
 
   it('shows review when the agent has a git working directory but the topic does not', () => {
-    mocks.agentStoreState.agentWorkingDirectory = '/Users/hai/LobeHub/lobehub';
+    mocks.agentStoreState.agentWorkingDirectoryById['agent-1'] = '/Users/hai/LobeHub/lobehub';
     mocks.repoType = 'git';
     useGlobalStore.setState({
       status: {

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.test.tsx
@@ -10,10 +10,29 @@ import { initialState as initialUserState } from '@/store/user/initialState';
 
 import AgentWorkingSidebar from './index';
 
+const mocks = vi.hoisted(() => ({
+  agentStoreState: {
+    activeAgentId: 'agent-1',
+    agentWorkingDirectory: undefined as string | undefined,
+  },
+  repoType: undefined as 'git' | 'github' | undefined,
+  topicWorkingDirectory: undefined as string | undefined,
+}));
+
 vi.mock('@/libs/swr', async (importOriginal) => {
   const actual = await importOriginal<typeof swr>();
   return { ...actual, useClientDataSWR: vi.fn() };
 });
+
+vi.mock('./Review', () => ({
+  default: ({ workingDirectory }: { workingDirectory: string }) => (
+    <div data-testid="review-panel">{workingDirectory}</div>
+  ),
+}));
+
+vi.mock('@/features/ChatInput/RuntimeConfig/useRepoType', () => ({
+  useRepoType: (path?: string) => (path ? mocks.repoType : undefined),
+}));
 
 vi.mock('@lobehub/ui', () => ({
   Accordion: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
@@ -117,6 +136,7 @@ vi.mock('react-i18next', () => ({
       (
         ({
           'workingPanel.resources.empty': 'No agent documents yet',
+          'workingPanel.review.title': 'Review',
           'workingPanel.space': 'Space',
         }) as Record<string, string>
       )[key] || key,
@@ -125,9 +145,14 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/store/agent', () => ({
   useAgentStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector?.({
-      activeAgentId: 'agent-1',
-    }),
+    selector?.(mocks.agentStoreState),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    currentAgentWorkingDirectory: (state: { agentWorkingDirectory?: string }) =>
+      state.agentWorkingDirectory,
+  },
 }));
 
 vi.mock('@/store/chat', () => ({
@@ -146,11 +171,15 @@ vi.mock('@/store/chat/selectors', () => ({
     portalDocumentId: () => null,
   },
   topicSelectors: {
-    currentTopicWorkingDirectory: () => undefined,
+    currentTopicWorkingDirectory: () => mocks.topicWorkingDirectory,
   },
 }));
 
 beforeEach(() => {
+  mocks.agentStoreState.activeAgentId = 'agent-1';
+  mocks.agentStoreState.agentWorkingDirectory = undefined;
+  mocks.repoType = undefined;
+  mocks.topicWorkingDirectory = undefined;
   vi.mocked(swr.useClientDataSWR).mockImplementation((() => ({
     data: [],
     error: undefined,
@@ -190,5 +219,21 @@ describe('AgentWorkingSidebar', () => {
 
     expect(screen.getByTestId('right-panel')).toBeInTheDocument();
     expect(screen.getByTestId('right-panel')).toHaveAttribute('data-stable-layout', 'true');
+  });
+
+  it('shows review when the agent has a git working directory but the topic does not', () => {
+    mocks.agentStoreState.agentWorkingDirectory = '/Users/hai/LobeHub/lobehub';
+    mocks.repoType = 'git';
+    useGlobalStore.setState({
+      status: {
+        ...useGlobalStore.getState().status,
+        workingSidebarTab: 'review',
+      },
+    });
+
+    render(<AgentWorkingSidebar />);
+
+    expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
+    expect(screen.getByTestId('review-panel')).toHaveTextContent('/Users/hai/LobeHub/lobehub');
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -8,7 +8,7 @@ import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useRepoType } from '@/features/ChatInput/RuntimeConfig/useRepoType';
 import RightPanel from '@/features/RightPanel';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -74,7 +74,10 @@ const AgentWorkingSidebar = memo(() => {
   const setWorkingSidebarTab = useGlobalStore((s) => s.setWorkingSidebarTab);
   const storedTab = useGlobalStore((s) => s.status.workingSidebarTab);
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
-  const agentWorkingDirectory = useAgentStore(agentSelectors.currentAgentWorkingDirectory);
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const agentWorkingDirectory = useAgentStore((s) =>
+    activeAgentId ? agentByIdSelectors.getAgentWorkingDirectoryById(activeAgentId)(s) : undefined,
+  );
   const workingDirectory = topicWorkingDirectory || agentWorkingDirectory;
   const repoType = useRepoType(workingDirectory);
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -5,7 +5,10 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+import { useRepoType } from '@/features/ChatInput/RuntimeConfig/useRepoType';
 import RightPanel from '@/features/RightPanel';
+import { useAgentStore } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -70,12 +73,14 @@ const AgentWorkingSidebar = memo(() => {
   const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
   const setWorkingSidebarTab = useGlobalStore((s) => s.setWorkingSidebarTab);
   const storedTab = useGlobalStore((s) => s.status.workingSidebarTab);
-  const workingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+  const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+  const agentWorkingDirectory = useAgentStore(agentSelectors.currentAgentWorkingDirectory);
+  const workingDirectory = topicWorkingDirectory || agentWorkingDirectory;
+  const repoType = useRepoType(workingDirectory);
 
-  const reviewAvailable = !!workingDirectory;
-  // When the topic has a working directory we lead with Review — that's why
-  // the sidebar is open in agent-coding flows. Otherwise no tab strip at all,
-  // we just show the resources view as before.
+  const reviewAvailable = !!workingDirectory && !!repoType;
+  // Topic metadata is preferred for resuming a coding session, but Review is
+  // project-scoped and should also work before a topic has bound metadata.
   const activeTab: Tab = reviewAvailable ? (storedTab ?? 'review') : 'resources';
 
   return (


### PR DESCRIPTION
## Summary
- Align the right-side Review panel with the same effective working directory used by the git status bar
- Allow Review to open when the topic has no bound `workingDirectory` but the agent does, while still requiring a git/github repo
- Add a test covering the agent-level fallback case

## Testing
- `bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.test.tsx'`