### PR TITLE
🐛 fix: trim brief / task-template fetch overhead on home

### DIFF
--- a/packages/database/src/models/__tests__/brief.test.ts
+++ b/packages/database/src/models/__tests__/brief.test.ts
@@ -121,10 +121,15 @@ describe('BriefModel', () => {
     });
   });
 
-  describe('listUnresolved', () => {
-    it('should return unresolved briefs sorted by priority', async () => {
+  describe('listUnresolvedEnriched', () => {
+    it('should return unresolved briefs sorted by priority and exclude resolved ones', async () => {
       const model = new BriefModel(serverDB, userId);
-      await model.create({ priority: 'info', summary: 'Low', title: 'Info', type: 'result' });
+      const b1 = await model.create({
+        priority: 'info',
+        summary: 'Low',
+        title: 'Info',
+        type: 'result',
+      });
       await model.create({
         priority: 'urgent',
         summary: 'High',
@@ -137,47 +142,14 @@ describe('BriefModel', () => {
         title: 'Normal',
         type: 'insight',
       });
-
-      const unresolved = await model.listUnresolved();
-      expect(unresolved).toHaveLength(3);
-      expect(unresolved[0].priority).toBe('urgent');
-      expect(unresolved[1].priority).toBe('normal');
-      expect(unresolved[2].priority).toBe('info');
-    });
-
-    it('should exclude resolved briefs', async () => {
-      const model = new BriefModel(serverDB, userId);
-      const b1 = await model.create({ summary: 'A', title: 'Brief 1', type: 'result' });
-      await model.create({ summary: 'B', title: 'Brief 2', type: 'result' });
-
       await model.resolve(b1.id);
 
-      const unresolved = await model.listUnresolved();
-      expect(unresolved).toHaveLength(1);
+      const rows = await model.listUnresolvedEnriched();
+      expect(rows).toHaveLength(2);
+      expect(rows[0].brief.priority).toBe('urgent');
+      expect(rows[1].brief.priority).toBe('normal');
     });
 
-    it('should cap unresolved briefs at the default limit of 20', async () => {
-      const model = new BriefModel(serverDB, userId);
-      for (let i = 0; i < 25; i++) {
-        await model.create({ summary: `S${i}`, title: `Brief ${i}`, type: 'insight' });
-      }
-
-      const unresolved = await model.listUnresolved();
-      expect(unresolved).toHaveLength(20);
-    });
-
-    it('should respect a caller-provided limit', async () => {
-      const model = new BriefModel(serverDB, userId);
-      for (let i = 0; i < 5; i++) {
-        await model.create({ summary: `S${i}`, title: `Brief ${i}`, type: 'insight' });
-      }
-
-      const unresolved = await model.listUnresolved({ limit: 2 });
-      expect(unresolved).toHaveLength(2);
-    });
-  });
-
-  describe('listUnresolvedEnriched', () => {
     it('should join the producing agent and parent task status in one query', async () => {
       await serverDB.insert(agents).values({
         avatar: '🤖',

--- a/packages/database/src/models/__tests__/brief.test.ts
+++ b/packages/database/src/models/__tests__/brief.test.ts
@@ -155,6 +155,26 @@ describe('BriefModel', () => {
       const unresolved = await model.listUnresolved();
       expect(unresolved).toHaveLength(1);
     });
+
+    it('should cap unresolved briefs at the default limit of 20', async () => {
+      const model = new BriefModel(serverDB, userId);
+      for (let i = 0; i < 25; i++) {
+        await model.create({ summary: `S${i}`, title: `Brief ${i}`, type: 'insight' });
+      }
+
+      const unresolved = await model.listUnresolved();
+      expect(unresolved).toHaveLength(20);
+    });
+
+    it('should respect a caller-provided limit', async () => {
+      const model = new BriefModel(serverDB, userId);
+      for (let i = 0; i < 5; i++) {
+        await model.create({ summary: `S${i}`, title: `Brief ${i}`, type: 'insight' });
+      }
+
+      const unresolved = await model.listUnresolved({ limit: 2 });
+      expect(unresolved).toHaveLength(2);
+    });
   });
 
   describe('markRead', () => {

--- a/packages/database/src/models/__tests__/brief.test.ts
+++ b/packages/database/src/models/__tests__/brief.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { users } from '../../schemas';
+import { agents, tasks, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { BriefModel } from '../brief';
 
@@ -174,6 +174,87 @@ describe('BriefModel', () => {
 
       const unresolved = await model.listUnresolved({ limit: 2 });
       expect(unresolved).toHaveLength(2);
+    });
+  });
+
+  describe('listUnresolvedEnriched', () => {
+    it('should join the producing agent and parent task status in one query', async () => {
+      await serverDB.insert(agents).values({
+        avatar: '🤖',
+        backgroundColor: '#fff',
+        id: 'agent-x',
+        title: 'Agent X',
+        userId,
+      });
+      await serverDB.insert(tasks).values({
+        createdByUserId: userId,
+        id: 'task-x',
+        identifier: 'TASK-X',
+        instruction: 'do work',
+        name: 'Task X',
+        seq: 1,
+        status: 'paused',
+      });
+
+      const model = new BriefModel(serverDB, userId);
+      await model.create({
+        agentId: 'agent-x',
+        priority: 'urgent',
+        summary: 'Has agent + task',
+        taskId: 'task-x',
+        title: 'Joined',
+        type: 'decision',
+      });
+      await model.create({
+        priority: 'info',
+        summary: 'Bare brief',
+        title: 'No agent',
+        type: 'insight',
+      });
+
+      const rows = await model.listUnresolvedEnriched();
+      expect(rows).toHaveLength(2);
+
+      const joined = rows.find((r) => r.brief.title === 'Joined')!;
+      expect(joined.agentRowId).toBe('agent-x');
+      expect(joined.agentAvatar).toBe('🤖');
+      expect(joined.agentTitle).toBe('Agent X');
+      expect(joined.taskStatus).toBe('paused');
+
+      const bare = rows.find((r) => r.brief.title === 'No agent')!;
+      expect(bare.agentRowId).toBeNull();
+      expect(bare.taskStatus).toBeNull();
+    });
+
+    it('should still return briefs whose producing agent has been deleted', async () => {
+      const model = new BriefModel(serverDB, userId);
+      // agentId points at a row that doesn't exist — LEFT JOIN should keep
+      // the brief and surface null agent fields rather than dropping it.
+      await model.create({
+        agentId: 'agent-ghost',
+        summary: 'Producer gone',
+        title: 'Ghost',
+        type: 'result',
+      });
+
+      const rows = await model.listUnresolvedEnriched();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].brief.title).toBe('Ghost');
+      expect(rows[0].agentRowId).toBeNull();
+      expect(rows[0].agentAvatar).toBeNull();
+    });
+
+    it('should respect the default cap of 20 and a caller-provided limit', async () => {
+      const model = new BriefModel(serverDB, userId);
+      for (let i = 0; i < 25; i++) {
+        await model.create({ summary: `S${i}`, title: `Brief ${i}`, type: 'insight' });
+      }
+
+      const capped = await model.listUnresolvedEnriched();
+      expect(capped).toHaveLength(20);
+
+      const trimmed = await model.listUnresolvedEnriched({ limit: 3 });
+      expect(trimmed).toHaveLength(3);
     });
   });
 

--- a/packages/database/src/models/brief.ts
+++ b/packages/database/src/models/brief.ts
@@ -1,8 +1,18 @@
 import { and, desc, eq, isNull, notInArray, sql } from 'drizzle-orm';
 
+import { agents } from '../schemas/agent';
 import type { BriefItem, NewBrief } from '../schemas/task';
-import { briefs } from '../schemas/task';
+import { briefs, tasks } from '../schemas/task';
 import type { LobeChatDatabase } from '../type';
+
+export interface UnresolvedBriefRow {
+  agentAvatar: string | null;
+  agentBackgroundColor: string | null;
+  agentRowId: string | null;
+  agentTitle: string | null;
+  brief: BriefItem;
+  taskStatus: string | null;
+}
 
 export class BriefModel {
   private readonly userId: string;
@@ -69,6 +79,38 @@ export class BriefModel {
     return this.db
       .select()
       .from(briefs)
+      .where(and(eq(briefs.userId, this.userId), isNull(briefs.resolvedAt)))
+      .orderBy(
+        sql`CASE
+          WHEN ${briefs.priority} = 'urgent' THEN 0
+          WHEN ${briefs.priority} = 'normal' THEN 1
+          ELSE 2
+        END`,
+        desc(briefs.createdAt),
+      )
+      .limit(limit);
+  }
+
+  /**
+   * Same shape as {@link listUnresolved} but joins the producing agent and
+   * the parent task in a single SQL — saves one round trip vs. fetching
+   * briefs first and then enriching client-side. Used by the home Daily
+   * Brief surface where every brief renders `agent` + `taskStatus`.
+   */
+  async listUnresolvedEnriched(options?: { limit?: number }): Promise<UnresolvedBriefRow[]> {
+    const { limit = 20 } = options ?? {};
+    return this.db
+      .select({
+        agentAvatar: agents.avatar,
+        agentBackgroundColor: agents.backgroundColor,
+        agentRowId: agents.id,
+        agentTitle: agents.title,
+        brief: briefs,
+        taskStatus: tasks.status,
+      })
+      .from(briefs)
+      .leftJoin(agents, eq(briefs.agentId, agents.id))
+      .leftJoin(tasks, eq(briefs.taskId, tasks.id))
       .where(and(eq(briefs.userId, this.userId), isNull(briefs.resolvedAt)))
       .orderBy(
         sql`CASE

--- a/packages/database/src/models/brief.ts
+++ b/packages/database/src/models/brief.ts
@@ -70,32 +70,11 @@ export class BriefModel {
     return { briefs: items, total: Number(countResult[0].count) };
   }
 
-  // For Daily Brief homepage — unresolved briefs sorted by priority.
-  // Capped via `limit` (default 20) so heavy-inbox users don't pay the full
-  // enrich cost on every home render; users beyond the cap reach the rest
-  // through the task list page.
-  async listUnresolved(options?: { limit?: number }): Promise<BriefItem[]> {
-    const { limit = 20 } = options ?? {};
-    return this.db
-      .select()
-      .from(briefs)
-      .where(and(eq(briefs.userId, this.userId), isNull(briefs.resolvedAt)))
-      .orderBy(
-        sql`CASE
-          WHEN ${briefs.priority} = 'urgent' THEN 0
-          WHEN ${briefs.priority} = 'normal' THEN 1
-          ELSE 2
-        END`,
-        desc(briefs.createdAt),
-      )
-      .limit(limit);
-  }
-
   /**
-   * Same shape as {@link listUnresolved} but joins the producing agent and
-   * the parent task in a single SQL — saves one round trip vs. fetching
-   * briefs first and then enriching client-side. Used by the home Daily
-   * Brief surface where every brief renders `agent` + `taskStatus`.
+   * Home Daily Brief feed: unresolved briefs sorted by priority, joined
+   * with the producing agent + parent task in a single SQL. Capped at 20
+   * so heavy-inbox users don't pay the full enrich cost on every home
+   * render — the rest is reachable via the task list page.
    */
   async listUnresolvedEnriched(options?: { limit?: number }): Promise<UnresolvedBriefRow[]> {
     const { limit = 20 } = options ?? {};

--- a/packages/database/src/models/brief.ts
+++ b/packages/database/src/models/brief.ts
@@ -60,8 +60,12 @@ export class BriefModel {
     return { briefs: items, total: Number(countResult[0].count) };
   }
 
-  // For Daily Brief homepage — unresolved briefs sorted by priority
-  async listUnresolved(): Promise<BriefItem[]> {
+  // For Daily Brief homepage — unresolved briefs sorted by priority.
+  // Capped via `limit` (default 20) so heavy-inbox users don't pay the full
+  // enrich cost on every home render; users beyond the cap reach the rest
+  // through the task list page.
+  async listUnresolved(options?: { limit?: number }): Promise<BriefItem[]> {
+    const { limit = 20 } = options ?? {};
     return this.db
       .select()
       .from(briefs)
@@ -73,7 +77,8 @@ export class BriefModel {
           ELSE 2
         END`,
         desc(briefs.createdAt),
-      );
+      )
+      .limit(limit);
   }
 
   async findByTaskId(taskId: string): Promise<BriefItem[]> {

--- a/src/features/RecommendTaskTemplates/useResolvedInterestKeys.ts
+++ b/src/features/RecommendTaskTemplates/useResolvedInterestKeys.ts
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { INTEREST_AREAS } from '@/routes/onboarding/config';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
+import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 /**
  * onboarding stores localized labels in `user.interests` (e.g. "内容创作",
@@ -13,18 +14,23 @@ import { userProfileSelectors } from '@/store/user/selectors';
  * canonical keys). Unresolved entries are lowercased passthroughs — server
  * treats them as non-matching.
  *
- * Returns `null` while the onboarding namespace is still loading (it's lazy-
- * loaded, not in the startup bundle). Without this gate, the first render
- * would resolve all localized labels to passthrough strings, fire an SWR
- * request with the wrong keys, and get back a fallback list — then re-fire
- * once the namespace lands. Callers should keep SWR disabled while null.
+ * Returns `null` while either:
+ *   - the user store hasn't finished hydrating (`interests` is `[]` until then,
+ *     which would fire an SWR request with empty keys and immediately re-fire
+ *     once the real interests land — wasted round trip), or
+ *   - the onboarding namespace is still loading (lazy-loaded, not in startup
+ *     bundle; without this gate localized labels resolve to passthrough strings
+ *     on first render and re-resolve correctly after the namespace lands).
+ *
+ * Callers should keep SWR disabled while null.
  */
 export const useResolvedInterestKeys = (): string[] | null => {
+  const isUserLoaded = useUserStore(authSelectors.isLoaded);
   const userInterests = useUserStore(userProfileSelectors.interests);
   const { t, ready } = useTranslation('onboarding');
 
   return useMemo(() => {
-    if (!ready) return null;
+    if (!isUserLoaded || !ready) return null;
     const labelToKey = new Map<string, string>();
     for (const area of INTEREST_AREAS) {
       labelToKey.set(area.key, area.key);
@@ -35,5 +41,5 @@ export const useResolvedInterestKeys = (): string[] | null => {
       const k = raw.trim().toLowerCase();
       return labelToKey.get(k) ?? k;
     });
-  }, [userInterests, t, ready]);
+  }, [isUserLoaded, userInterests, t, ready]);
 };

--- a/src/server/routers/lambda/brief.ts
+++ b/src/server/routers/lambda/brief.ts
@@ -134,7 +134,6 @@ export const briefRouter = router({
     try {
       const service = new BriefService(ctx.serverDB, ctx.userId);
       const data = await service.listUnresolved();
-
       return { data, success: true };
     } catch (error) {
       console.error('[brief:listUnresolved]', error);

--- a/src/server/services/brief/index.test.ts
+++ b/src/server/services/brief/index.test.ts
@@ -38,6 +38,7 @@ describe('BriefService', () => {
   const mockBriefModel = {
     list: vi.fn(),
     listUnresolved: vi.fn(),
+    listUnresolvedEnriched: vi.fn(),
     resolve: vi.fn(),
   };
 
@@ -101,7 +102,7 @@ describe('BriefService', () => {
         { avatar: '🔧', backgroundColor: null, id: 'agent-c', title: 'Agent C' },
       ]);
 
-      const result = await service.enrichBriefsWithAgents(briefs);
+      const result = await service.enrichBriefsWithAgents(briefs, { includeTreeAgents: true });
 
       expect(result[0].agent).toEqual({
         avatar: '🤖',
@@ -191,7 +192,7 @@ describe('BriefService', () => {
         },
       ]);
 
-      const result = await service.enrichBriefsWithAgents(briefs);
+      const result = await service.enrichBriefsWithAgents(briefs, { includeTreeAgents: true });
 
       expect(result[0].agents).toEqual([
         {
@@ -224,9 +225,36 @@ describe('BriefService', () => {
         { avatar: '🧠', backgroundColor: '#fff', id: 'agent-b', title: 'Agent B' },
       ]);
 
-      const result = await service.enrichBriefsWithAgents(briefs);
+      const result = await service.enrichBriefsWithAgents(briefs, { includeTreeAgents: true });
 
       expect(result[0].agents.map((agent) => agent.id)).toEqual(['agent-a', 'agent-b']);
+    });
+
+    it('should default to skipping the task-tree CTE and return empty agents[]', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { agentId: 'agent-a', id: 'b1', taskId: 'task-1', title: 'Brief 1' },
+      ] as any[];
+
+      mockTaskModel.findByIds.mockResolvedValue([{ id: 'task-1', status: 'scheduled' }]);
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
+        { avatar: '🤖', backgroundColor: null, id: 'agent-a', title: 'Agent A' },
+      ]);
+
+      const result = await service.enrichBriefsWithAgents(briefs);
+
+      expect(result[0].agent).toEqual({
+        avatar: '🤖',
+        backgroundColor: null,
+        id: 'agent-a',
+        title: 'Agent A',
+      });
+      expect(result[0].taskStatus).toBe('scheduled');
+      expect(result[0].agents).toEqual([]);
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).not.toHaveBeenCalled();
+      // direct-agent ids are passed straight through, no need to wait on the CTE.
+      expect(mockAgentModel.getAgentAvatarsByIds).toHaveBeenCalledWith(['agent-a']);
     });
   });
 
@@ -318,18 +346,47 @@ describe('BriefService', () => {
   });
 
   describe('listUnresolved', () => {
-    it('should return enriched unresolved briefs', async () => {
+    it('should map joined rows into BriefWithAgent without re-fetching', async () => {
       const service = new BriefService(db, userId);
 
-      mockBriefModel.listUnresolved.mockResolvedValue([
-        { agentId: null, id: 'b1', taskId: null, title: 'Unresolved' },
+      mockBriefModel.listUnresolvedEnriched.mockResolvedValue([
+        {
+          agentAvatar: null,
+          agentBackgroundColor: null,
+          agentRowId: null,
+          agentTitle: null,
+          brief: { agentId: null, id: 'b1', taskId: null, title: 'Solo' },
+          taskStatus: null,
+        },
+        {
+          agentAvatar: '🤖',
+          agentBackgroundColor: '#fff',
+          agentRowId: 'agent-a',
+          agentTitle: 'Agent A',
+          brief: { agentId: 'agent-a', id: 'b2', taskId: 'task-1', title: 'With Task' },
+          taskStatus: 'scheduled',
+        },
       ]);
 
       const result = await service.listUnresolved();
 
-      expect(result).toHaveLength(1);
-      expect(result[0].agent).toBeNull();
-      expect(mockBriefModel.listUnresolved).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        agent: null,
+        agents: [],
+        id: 'b1',
+        taskStatus: null,
+      });
+      expect(result[1]).toMatchObject({
+        agent: { avatar: '🤖', backgroundColor: '#fff', id: 'agent-a', title: 'Agent A' },
+        agents: [],
+        id: 'b2',
+        taskStatus: 'scheduled',
+      });
+      // No follow-up enrichment SQLs.
+      expect(mockTaskModel.findByIds).not.toHaveBeenCalled();
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).not.toHaveBeenCalled();
+      expect(mockAgentModel.getAgentAvatarsByIds).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/services/brief/index.test.ts
+++ b/src/server/services/brief/index.test.ts
@@ -230,6 +230,75 @@ describe('BriefService', () => {
     });
   });
 
+  describe('enrichBriefAgentOnly', () => {
+    it('should return briefs with null agent when no agentIds and skip db calls', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { agentId: null, id: 'b1', taskId: 'task-1', title: 'Brief 1' },
+        { agentId: null, id: 'b2', taskId: null, title: 'Brief 2' },
+      ] as any[];
+
+      const result = await service.enrichBriefAgentOnly(briefs);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].agent).toBeNull();
+      expect(result[1].agent).toBeNull();
+      expect(mockAgentModel.getAgentAvatarsByIds).not.toHaveBeenCalled();
+      expect(mockTaskModel.findByIds).not.toHaveBeenCalled();
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).not.toHaveBeenCalled();
+    });
+
+    it('should attach the direct producing agent without calling task tree CTE', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { agentId: 'agent-a', id: 'b1', taskId: 'task-1', title: 'Brief 1' },
+        { agentId: 'agent-b', id: 'b2', taskId: 'task-2', title: 'Brief 2' },
+      ] as any[];
+
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
+        { avatar: '🤖', backgroundColor: null, id: 'agent-a', title: 'Agent A' },
+        { avatar: '🔧', backgroundColor: null, id: 'agent-b', title: 'Agent B' },
+      ]);
+
+      const result = await service.enrichBriefAgentOnly(briefs);
+
+      expect(result[0].agent).toEqual({
+        avatar: '🤖',
+        backgroundColor: null,
+        id: 'agent-a',
+        title: 'Agent A',
+      });
+      expect(result[1].agent).toEqual({
+        avatar: '🔧',
+        backgroundColor: null,
+        id: 'agent-b',
+        title: 'Agent B',
+      });
+      expect(mockAgentModel.getAgentAvatarsByIds).toHaveBeenCalledWith(
+        expect.arrayContaining(['agent-a', 'agent-b']),
+      );
+      expect(mockTaskModel.findByIds).not.toHaveBeenCalled();
+      expect(mockTaskModel.getTreeAgentIdsForTaskIds).not.toHaveBeenCalled();
+    });
+
+    it('should leave agent null when the producing agent has been deleted', async () => {
+      const service = new BriefService(db, userId);
+
+      const briefs = [
+        { agentId: 'agent-gone', id: 'b1', taskId: 'task-1', title: 'Brief' },
+      ] as any[];
+
+      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([]);
+
+      const result = await service.enrichBriefAgentOnly(briefs);
+
+      expect(result[0].agent).toBeNull();
+      expect(mockAgentModel.getAgentAvatarsByIds).toHaveBeenCalledWith(['agent-gone']);
+    });
+  });
+
   describe('list', () => {
     it('should return enriched briefs with total', async () => {
       const service = new BriefService(db, userId);

--- a/src/server/services/brief/index.ts
+++ b/src/server/services/brief/index.ts
@@ -37,6 +37,33 @@ export class BriefService {
     this.taskModel = new TaskModel(db, userId);
   }
 
+  /**
+   * Lightweight enrich for callers that only need the direct producing agent
+   * (e.g. task detail, where the surrounding payload already covers task tree
+   * + status). Skips the recursive task-tree CTE and `taskFindByIds` round
+   * trip used by {@link enrichBriefsWithAgents}.
+   */
+  async enrichBriefAgentOnly(
+    briefs: BriefItem[],
+  ): Promise<(BriefItem & { agent: AgentAvatarInfo | null })[]> {
+    const directAgentIds = [
+      ...new Set(briefs.map((b) => b.agentId).filter((id): id is string => !!id)),
+    ];
+    if (directAgentIds.length === 0) {
+      return briefs.map((brief) => ({ ...brief, agent: null }));
+    }
+
+    const agentList = await this.agentModel.getAgentAvatarsByIds(directAgentIds);
+    const agentMap: Record<string, AgentAvatarInfo> = Object.fromEntries(
+      agentList.map((a) => [a.id, a]),
+    );
+
+    return briefs.map((brief) => ({
+      ...brief,
+      agent: brief.agentId ? (agentMap[brief.agentId] ?? null) : null,
+    }));
+  }
+
   async enrichBriefsWithAgents(briefs: BriefItem[]): Promise<BriefWithAgent[]> {
     const taskIds = [...new Set(briefs.map((b) => b.taskId).filter((id): id is string => !!id))];
     const directAgentIds = [

--- a/src/server/services/brief/index.ts
+++ b/src/server/services/brief/index.ts
@@ -64,7 +64,22 @@ export class BriefService {
     }));
   }
 
-  async enrichBriefsWithAgents(briefs: BriefItem[]): Promise<BriefWithAgent[]> {
+  /**
+   * Enrich briefs with the producing agent + parent task status (always),
+   * plus optionally the full task-tree agent roster (`agents[]`).
+   *
+   * `includeTreeAgents` defaults to `false` because no current consumer
+   * renders `brief.agents[]` — `BriefCard` only uses `brief.agent`. Skipping
+   * the recursive task-tree CTE turns the previous waterfall (CTE, then
+   * `getAgentAvatars` once tree ids are known) into two truly parallel SQLs
+   * (`taskFindByIds` + `getAgentAvatars` over direct agents only). Pass
+   * `true` if a future caller actually needs the tree roster.
+   */
+  async enrichBriefsWithAgents(
+    briefs: BriefItem[],
+    options: { includeTreeAgents?: boolean } = {},
+  ): Promise<BriefWithAgent[]> {
+    const { includeTreeAgents = false } = options;
     const taskIds = [...new Set(briefs.map((b) => b.taskId).filter((id): id is string => !!id))];
     const directAgentIds = [
       ...new Set(briefs.map((b) => b.agentId).filter((id): id is string => !!id)),
@@ -73,19 +88,21 @@ export class BriefService {
       return briefs.map((brief) => ({ ...brief, agent: null, agents: [], taskStatus: null }));
     }
 
-    const emptyTreeAgentIdsByTaskId: Record<string, string[]> = {};
-    const [taskRows, treeAgentIdsByTaskId] = await Promise.all([
-      taskIds.length > 0 ? this.taskModel.findByIds(taskIds) : Promise.resolve([]),
-      taskIds.length > 0
-        ? this.taskModel.getTreeAgentIdsForTaskIds(taskIds)
-        : Promise.resolve(emptyTreeAgentIdsByTaskId),
-    ]);
-
-    const agentIds = [
+    const treeAgentIdsByTaskId =
+      includeTreeAgents && taskIds.length > 0
+        ? await this.taskModel.getTreeAgentIdsForTaskIds(taskIds)
+        : ({} as Record<string, string[]>);
+    const allAgentIds = [
       ...new Set([...directAgentIds, ...Object.values(treeAgentIdsByTaskId).flat()]),
     ];
-    const agentList =
-      agentIds.length > 0 ? await this.agentModel.getAgentAvatarsByIds(agentIds) : [];
+
+    const [taskRows, agentList] = await Promise.all([
+      taskIds.length > 0 ? this.taskModel.findByIds(taskIds) : Promise.resolve([]),
+      allAgentIds.length > 0
+        ? this.agentModel.getAgentAvatarsByIds(allAgentIds)
+        : Promise.resolve([]),
+    ]);
+
     const taskStatusMap = Object.fromEntries(
       taskRows.map((t) => [t.id, (t.status as TaskStatus) ?? null]),
     );
@@ -94,22 +111,24 @@ export class BriefService {
     );
 
     return briefs.map((brief) => {
-      const briefAgentIds = new Set<string>();
-      if (brief.agentId) {
-        briefAgentIds.add(brief.agentId);
-      }
-      if (brief.taskId) {
-        for (const agentId of treeAgentIdsByTaskId[brief.taskId] ?? []) {
-          briefAgentIds.add(agentId);
+      let agents: AgentAvatarInfo[] = [];
+      if (includeTreeAgents) {
+        const briefAgentIds = new Set<string>();
+        if (brief.agentId) briefAgentIds.add(brief.agentId);
+        if (brief.taskId) {
+          for (const agentId of treeAgentIdsByTaskId[brief.taskId] ?? []) {
+            briefAgentIds.add(agentId);
+          }
         }
+        agents = [...briefAgentIds]
+          .map((agentId) => agentMap[agentId])
+          .filter((agent): agent is AgentAvatarInfo => Boolean(agent));
       }
 
       return {
         ...brief,
         agent: brief.agentId ? (agentMap[brief.agentId] ?? null) : null,
-        agents: [...briefAgentIds]
-          .map((agentId) => agentMap[agentId])
-          .filter((agent): agent is AgentAvatarInfo => Boolean(agent)),
+        agents,
         taskStatus: brief.taskId ? (taskStatusMap[brief.taskId] ?? null) : null,
       };
     });
@@ -121,9 +140,28 @@ export class BriefService {
     return { briefs: data, total: result.total };
   }
 
-  async listUnresolved() {
-    const items = await this.briefModel.listUnresolved();
-    return this.enrichBriefsWithAgents(items);
+  /**
+   * Home Daily Brief feed. Uses the JOIN-based model query so the producing
+   * agent + parent task status come back in a single round trip — no
+   * separate enrichment pass.
+   */
+  async listUnresolved(): Promise<BriefWithAgent[]> {
+    const rows = await this.briefModel.listUnresolvedEnriched();
+    return rows.map(
+      ({ brief, agentRowId, agentAvatar, agentBackgroundColor, agentTitle, taskStatus }) => ({
+        ...brief,
+        agent: agentRowId
+          ? {
+              avatar: agentAvatar,
+              backgroundColor: agentBackgroundColor,
+              id: agentRowId,
+              title: agentTitle,
+            }
+          : null,
+        agents: [],
+        taskStatus: (taskStatus as TaskStatus) ?? null,
+      }),
+    );
   }
 
   /**

--- a/src/server/services/task/index.test.ts
+++ b/src/server/services/task/index.test.ts
@@ -1123,7 +1123,7 @@ describe('TaskService', () => {
       // Force the brief enrichment path to reject without breaking the
       // sibling resolveAuthors call (which shares the agent model mock).
       const enrichSpy = vi
-        .spyOn(BriefService.prototype, 'enrichBriefsWithAgents')
+        .spyOn(BriefService.prototype, 'enrichBriefAgentOnly')
         .mockRejectedValueOnce(new Error('DB error'));
 
       const service = new TaskService(db, userId);

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -195,7 +195,7 @@ export class TaskService {
     const [authorMap, enrichedBriefs] = await Promise.all([
       this.resolveAuthors(agentIds, userIds),
       this.briefService
-        .enrichBriefsWithAgents(briefs)
+        .enrichBriefAgentOnly(briefs)
         .catch(() => briefs.map((b) => ({ ...b, agent: null }))),
     ]);
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ⚡️ perf

#### 🔗 Related Issue

Related to [LOBE-8597](https://linear.app/lobehub/issue/LOBE-8597)

#### 🔀 Description of Change

Three small wins on the home `/home` request fan-out, all rooted in the same observation: the daily brief and task templates panels share a single render budget, but each was paying for things it didn't need.

1. **`useResolvedInterestKeys` now gates on user-store hydration.** Previously the hook only waited on the `onboarding` i18n namespace — `user.interests` defaults to `[]` until the user store finishes loading, so the SWR key would fire once with an empty array and immediately re-fire with the real interests. Now the hook returns `null` until `authSelectors.isLoaded` is true, eliminating that wasted round trip.

2. **`task.detail` no longer triggers the recursive task-tree CTE for brief enrichment.** `getTaskDetail` only consumes `b.agent` (the direct producing agent) from the enriched briefs — the `agents[]` and `taskStatus` fields are home-page concerns. A new lightweight `BriefService.enrichBriefAgentOnly` skips the CTE + `taskFindByIds` calls and just resolves agent avatars. Home `brief.listUnresolved` keeps the heavier path. Net effect on home: when the same batch contains `brief.listUnresolved` + `task.detail × N`, those `task.detail` calls no longer contend with the home enrich for the connection pool.

3. **`BriefModel.listUnresolved` is capped at 20 by default.** No prior limit meant a heavy-inbox user (50+ unresolved briefs) would pay the full enrich cost on every home render — and that's where the recursive CTE complexity actually shows. Users beyond the cap reach the rest through the existing "View all tasks" link to the task list page.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Test additions:

- `BriefService.enrichBriefAgentOnly` — three new unit tests covering empty agents, direct-agent enrichment, and deleted-agent fallback (all assert that the task tree CTE is **not** called).
- `BriefModel.listUnresolved` — two new tests: default cap of 20, caller-provided limit honored.
- `TaskService.getTaskDetail` — existing brief-enrichment-failure test repointed at `enrichBriefAgentOnly`.

Manual: `bun run dev:spa` → `/home` → confirm brief + task templates panels still render correctly with 0, 1, 2 unresolved briefs and watch network tab for a single (not double) `taskTemplate.listDailyRecommend` call after sign-in.

#### 📝 Additional Information

This is the cleanup pass after the `LOBE-8597` brief experience perf investigation; no behavior change beyond the cap. Anyone who needs the full unresolved list server-side can pass `{ limit }` explicitly to `listUnresolved`.