### PR TITLE
✨ feat: add task template tracking

### DIFF
--- a/packages/const/src/taskTemplate.ts
+++ b/packages/const/src/taskTemplate.ts
@@ -28,6 +28,15 @@ export interface TaskTemplate {
   requiresSkills?: TaskTemplateSkillRequirement[];
 }
 
+export type TaskTemplateRecommendationSource = 'matched' | 'fallback';
+
+export type TaskTemplateFallbackPool = 'preferred_category' | 'all_candidates';
+
+export interface RecommendedTaskTemplate extends TaskTemplate {
+  fallbackPool?: TaskTemplateFallbackPool;
+  source: TaskTemplateRecommendationSource;
+}
+
 export interface TaskTemplateSkillRequirement {
   /** Short identifier from `LOBEHUB_SKILL_PROVIDERS[i].id` or `KLAVIS_SERVER_TYPES[i].identifier`. */
   provider: string;

--- a/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
+++ b/src/features/RecommendTaskTemplates/DailyBriefRecommendationsView.tsx
@@ -24,8 +24,16 @@ export const DailyBriefRecommendationsView = memo<DailyBriefRecommendationsViewP
 
     return (
       <Flexbox gap={8}>
-        {state.templates.map((tmpl) => (
-          <TaskTemplateCard key={tmpl.id} template={tmpl} onDismiss={state.onDismiss} />
+        {state.templates.map((tmpl, index) => (
+          <TaskTemplateCard
+            key={tmpl.id}
+            position={index}
+            recommendationBatchId={state.recommendationBatchId}
+            template={tmpl}
+            userInterestCount={state.userInterestCount}
+            onCreated={state.onCreated}
+            onDismiss={state.onDismiss}
+          />
         ))}
       </Flexbox>
     );

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.test.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.test.tsx
@@ -1,0 +1,396 @@
+import type { RecommendedTaskTemplate } from '@lobechat/const';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SkillConnectionResult, UseSkillConnectionResult } from './useSkillConnection';
+
+const mocks = vi.hoisted(() => ({
+  analyticsTrack: vi.fn(() => Promise.resolve()),
+  createCronJob: vi.fn(),
+  errorMessage: vi.fn(),
+  inboxAgentId: 'inbox-agent-1' as string | undefined,
+  intersectionCallback: undefined as IntersectionObserverCallback | undefined,
+  optionalConnectOptions: undefined as
+    | { onConnectResult?: (result: SkillConnectionResult) => void }
+    | undefined,
+  optionalConnection: undefined as UseSkillConnectionResult | undefined,
+  recordCreated: vi.fn(),
+  requiredConnectOptions: undefined as
+    | { onConnectResult?: (result: SkillConnectionResult) => void }
+    | undefined,
+  requiredConnection: undefined as UseSkillConnectionResult | undefined,
+  successMessage: vi.fn(),
+  userId: 'user-1' as string | undefined,
+}));
+
+vi.mock('antd-style', () => {
+  const cssVar = {
+    borderRadiusLG: '8px',
+    borderRadiusSM: '4px',
+    colorBorder: '#ddd',
+    colorFillSecondary: '#f5f5f5',
+    colorPrimary: '#1677ff',
+    colorText: '#111',
+    colorTextSecondary: '#666',
+    colorTextTertiary: '#999',
+  };
+
+  return {
+    createStaticStyles: (factory: (helpers: { css: () => string; cssVar: typeof cssVar }) => any) =>
+      factory({ css: () => 'mock-class', cssVar }),
+    cssVar,
+    cx: (...classes: Array<string | undefined>) => classes.filter(Boolean).join(' '),
+  };
+});
+
+vi.mock('@lobehub/ui', () => {
+  const Div = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+
+  return {
+    ActionIcon: ({ icon: _icon, title, ...props }: any) => (
+      <button aria-label={typeof title === 'string' ? title : undefined} type="button" {...props}>
+        {typeof title === 'string' ? title : 'icon'}
+      </button>
+    ),
+    Block: ({ children, ref, ...props }: any) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    ),
+    Button: ({ children, loading, ...props }: any) => (
+      <button disabled={props.disabled || loading} type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Center: Div,
+    Flexbox: Div,
+    Icon: () => <span data-testid="icon" />,
+    Tag: Div,
+    Text: Div,
+  };
+});
+
+vi.mock('antd', () => ({
+  App: {
+    useApp: () => ({
+      message: {
+        error: mocks.errorMessage,
+        success: mocks.successMessage,
+      },
+    }),
+  },
+  Divider: () => <hr />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        'action.connect.button': `Connect ${options?.provider}`,
+        'action.connect.error': 'Connect failed',
+        'action.connect.popupBlocked': 'Popup blocked',
+        'action.create.error': 'Create failed',
+        'action.create.success': 'Created',
+        'action.createButton': 'Create',
+        'action.creating': 'Creating',
+        'action.dismiss.tooltip': 'Not interested',
+        'action.optionalConnect.button': `Connect ${options?.provider}`,
+        'card.templateTag': 'Template',
+        'schedule.daily': 'Daily',
+        'template-a.description': 'Template description',
+        'template-a.prompt': 'Template prompt',
+        'template-a.title': 'Template A',
+      };
+
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/features/DailyBrief/BriefCardSummary', () => ({
+  default: ({ summary }: { summary: string }) => <div>{summary}</div>,
+}));
+
+vi.mock('@/services/agentCronJob', () => ({
+  agentCronJobService: {
+    create: mocks.createCronJob,
+  },
+}));
+
+vi.mock('@/services/taskTemplate', () => ({
+  taskTemplateService: {
+    recordCreated: mocks.recordCreated,
+  },
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: Record<string, unknown>) => unknown) => selector({}),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  builtinAgentSelectors: {
+    inboxAgentId: () => mocks.inboxAgentId,
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: { user?: { id?: string } }) => unknown) =>
+    selector({ user: { id: mocks.userId } }),
+}));
+
+vi.mock('@lobehub/analytics/react', () => ({
+  useAnalytics: () => ({
+    analytics: {
+      track: mocks.analyticsTrack,
+    },
+  }),
+}));
+
+vi.mock('./useSkillConnection', () => {
+  class SkillConnectionPopupBlockedError extends Error {
+    constructor() {
+      super('Browser popup blocked');
+      this.name = 'SkillConnectionPopupBlockedError';
+    }
+  }
+
+  return {
+    SkillConnectionPopupBlockedError,
+    useSkillConnection: (
+      specs: Array<{ provider: string; source: 'klavis' | 'lobehub' }> | undefined,
+      options?: { onConnectResult?: (result: SkillConnectionResult) => void },
+    ) => {
+      const provider = specs?.[0]?.provider;
+      if (provider === 'github') {
+        mocks.requiredConnectOptions = options;
+        return mocks.requiredConnection!;
+      }
+      if (provider === 'notion') {
+        mocks.optionalConnectOptions = options;
+        return mocks.optionalConnection!;
+      }
+
+      return {
+        connect: vi.fn(),
+        isAllConnected: false,
+        isConnecting: false,
+        needsConnect: false,
+        nextUnconnected: undefined,
+      };
+    },
+  };
+});
+
+const { TaskTemplateCard } = await import('./TaskTemplateCard');
+
+const makeConnection = (
+  overrides: Partial<UseSkillConnectionResult> = {},
+): UseSkillConnectionResult => ({
+  connect: vi.fn(),
+  isAllConnected: false,
+  isConnecting: false,
+  needsConnect: false,
+  nextUnconnected: undefined,
+  ...overrides,
+});
+
+const makeTemplate = (
+  overrides: Partial<RecommendedTaskTemplate> = {},
+): RecommendedTaskTemplate => ({
+  category: 'engineering',
+  cronPattern: '0 9 * * *',
+  id: 'template-a',
+  interests: ['coding'],
+  source: 'matched',
+  ...overrides,
+});
+
+const renderCard = (template = makeTemplate()) => {
+  const onCreated = vi.fn();
+  const onDismiss = vi.fn();
+
+  render(
+    <TaskTemplateCard
+      position={0}
+      recommendationBatchId="batch-1"
+      template={template}
+      userInterestCount={1}
+      onCreated={onCreated}
+      onDismiss={onDismiss}
+    />,
+  );
+
+  return { onCreated, onDismiss };
+};
+
+const triggerIntersection = () => {
+  mocks.intersectionCallback?.(
+    [{ isIntersecting: true } as IntersectionObserverEntry],
+    {} as IntersectionObserver,
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  mocks.inboxAgentId = 'inbox-agent-1';
+  mocks.userId = 'user-1';
+  mocks.requiredConnection = makeConnection();
+  mocks.optionalConnection = makeConnection();
+  mocks.requiredConnectOptions = undefined;
+  mocks.optionalConnectOptions = undefined;
+  mocks.createCronJob.mockResolvedValue({ id: 'cron-1' });
+  mocks.recordCreated.mockResolvedValue({ success: true });
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback: IntersectionObserverCallback) {
+        mocks.intersectionCallback = callback;
+      }
+      disconnect = vi.fn();
+      observe = vi.fn();
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('TaskTemplateCard analytics', () => {
+  it('tracks a card impression once per session storage key', () => {
+    renderCard();
+
+    triggerIntersection();
+    triggerIntersection();
+
+    expect(mocks.analyticsTrack).toHaveBeenCalledTimes(1);
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_card_impression',
+      properties: expect.objectContaining({
+        position: 0,
+        primary_action: 'create',
+        recommendation_batch_id: 'batch-1',
+        source: 'matched',
+        spm: 'home.task_templates.card_impression',
+        template_id: 'template-a',
+        user_interest_count: 1,
+      }),
+    });
+  });
+
+  it('tracks create success and removes the created template from the current list', async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mocks.createCronJob).toHaveBeenCalled());
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_create_clicked',
+      properties: expect.objectContaining({
+        spm: 'home.task_templates.create_clicked',
+        template_id: 'template-a',
+      }),
+    });
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_create_result',
+      properties: expect.objectContaining({
+        error_type: null,
+        result: 'success',
+        spm: 'home.task_templates.create_result',
+      }),
+    });
+    expect(onCreated).toHaveBeenCalledWith('template-a');
+  });
+
+  it('tracks create failure without removing the template', async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderCard();
+    mocks.createCronJob.mockRejectedValueOnce(new Error('network'));
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+        name: 'task_template_create_result',
+        properties: expect.objectContaining({
+          error_type: 'Error',
+          result: 'fail',
+          spm: 'home.task_templates.create_result',
+        }),
+      }),
+    );
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it('tracks dismiss with impression timing state', async () => {
+    const user = userEvent.setup();
+    const { onDismiss } = renderCard();
+    triggerIntersection();
+
+    await user.click(screen.getByRole('button', { name: 'Not interested' }));
+
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_dismissed',
+      properties: expect.objectContaining({
+        spm: 'home.task_templates.dismissed',
+        template_id: 'template-a',
+        was_impressed: true,
+      }),
+    });
+    expect(onDismiss).toHaveBeenCalledWith('template-a');
+  });
+
+  it('tracks required skill connect clicked and result events', async () => {
+    const user = userEvent.setup();
+    const connect = vi.fn(async () => {
+      mocks.requiredConnectOptions?.onConnectResult?.({
+        durationMs: 123,
+        provider: 'github',
+        result: 'success',
+        source: 'lobehub',
+      });
+    });
+    mocks.requiredConnection = makeConnection({
+      connect,
+      needsConnect: true,
+      nextUnconnected: {
+        icon: 'github',
+        label: 'GitHub',
+        provider: 'github',
+        source: 'lobehub',
+      },
+    });
+
+    renderCard(
+      makeTemplate({
+        requiresSkills: [{ provider: 'github', source: 'lobehub' }],
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Connect GitHub' }));
+
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_skill_connect_clicked',
+      properties: expect.objectContaining({
+        requirement_type: 'required',
+        skill_provider: 'github',
+        skill_source: 'lobehub',
+        spm: 'home.task_templates.skill_connect_clicked',
+      }),
+    });
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_skill_connect_result',
+      properties: expect.objectContaining({
+        duration_ms: 123,
+        requirement_type: 'required',
+        result: 'success',
+        skill_provider: 'github',
+        skill_source: 'lobehub',
+        spm: 'home.task_templates.skill_connect_result',
+      }),
+    });
+  });
+});

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.test.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SkillConnectionResult, UseSkillConnectionResult } from './useSkillConnection';
 
 const mocks = vi.hoisted(() => ({
+  analyticsEnabled: true,
   analyticsTrack: vi.fn(() => Promise.resolve()),
   createCronJob: vi.fn(),
   errorMessage: vi.fn(),
@@ -141,9 +142,11 @@ vi.mock('@/store/user', () => ({
 
 vi.mock('@lobehub/analytics/react', () => ({
   useAnalytics: () => ({
-    analytics: {
-      track: mocks.analyticsTrack,
-    },
+    analytics: mocks.analyticsEnabled
+      ? {
+          track: mocks.analyticsTrack,
+        }
+      : undefined,
   }),
 }));
 
@@ -234,7 +237,9 @@ const triggerIntersection = () => {
 beforeEach(() => {
   vi.clearAllMocks();
   sessionStorage.clear();
+  mocks.analyticsEnabled = true;
   mocks.inboxAgentId = 'inbox-agent-1';
+  mocks.intersectionCallback = undefined;
   mocks.userId = 'user-1';
   mocks.requiredConnection = makeConnection();
   mocks.optionalConnection = makeConnection();
@@ -259,6 +264,47 @@ afterEach(() => {
 });
 
 describe('TaskTemplateCard analytics', () => {
+  it('does not mark an impression as tracked before analytics is ready', () => {
+    mocks.analyticsEnabled = false;
+    const { rerender } = render(
+      <TaskTemplateCard
+        position={0}
+        recommendationBatchId="batch-1"
+        template={makeTemplate()}
+        userInterestCount={1}
+        onCreated={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(mocks.intersectionCallback).toBeUndefined();
+    expect(
+      Object.keys(sessionStorage).some((key) => key.startsWith('task-template-impression:')),
+    ).toBe(false);
+
+    mocks.analyticsEnabled = true;
+    rerender(
+      <TaskTemplateCard
+        position={0}
+        recommendationBatchId="batch-1"
+        template={makeTemplate()}
+        userInterestCount={1}
+        onCreated={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    triggerIntersection();
+
+    expect(mocks.analyticsTrack).toHaveBeenCalledWith({
+      name: 'task_template_card_impression',
+      properties: expect.objectContaining({
+        spm: 'home.task_templates.card_impression',
+        template_id: 'template-a',
+      }),
+    });
+  });
+
   it('tracks a card impression once per session storage key', () => {
     renderCard();
 

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -1,10 +1,12 @@
-import type { TaskTemplate } from '@lobechat/const';
+import type { RecommendedTaskTemplate } from '@lobechat/const';
 import { formatScheduleTime, parseCronPattern, WEEKDAY_I18N_KEYS } from '@lobechat/utils/cron';
+import { useAnalytics } from '@lobehub/analytics/react';
 import { ActionIcon, Block, Button, Center, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
 import { App, Divider } from 'antd';
 import { cssVar, cx } from 'antd-style';
-import { Clock, Link2, type LucideIcon, Sparkles, X } from 'lucide-react';
-import { memo, useCallback, useMemo, useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Clock, Link2, Sparkles, X } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import BriefCardSummary from '@/features/DailyBrief/BriefCardSummary';
@@ -14,8 +16,18 @@ import { agentCronJobService } from '@/services/agentCronJob';
 import { taskTemplateService } from '@/services/taskTemplate';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { useUserStore } from '@/store/user';
 
+import {
+  getTaskTemplateCardStateProperties,
+  getTaskTemplateCommonAnalyticsProperties,
+  getTaskTemplateImpressionStorageKey,
+  hasTrackedTaskTemplateImpression,
+  markTaskTemplateImpressionTracked,
+  resolveTaskTemplateErrorType,
+} from './analytics';
 import { styles } from './style';
+import type { SkillConnectionResult } from './useSkillConnection';
 import { SkillConnectionPopupBlockedError, useSkillConnection } from './useSkillConnection';
 
 const INTEREST_ICON_MAP = new Map<string, LucideIcon>(INTEREST_AREAS.map((a) => [a.key, a.icon]));
@@ -40,201 +52,368 @@ const TemplateBriefIcon = memo<TemplateBriefIconProps>(({ icon }) => (
 TemplateBriefIcon.displayName = 'TemplateBriefIcon';
 
 interface TaskTemplateCardProps {
+  onCreated: (templateId: string) => void;
   onDismiss: (templateId: string) => void;
-  template: TaskTemplate;
+  position: number;
+  recommendationBatchId: string;
+  template: RecommendedTaskTemplate;
+  userInterestCount: number;
 }
 
-export const TaskTemplateCard = memo<TaskTemplateCardProps>(({ template, onDismiss }) => {
-  const { t } = useTranslation('taskTemplate');
-  const { t: tSetting } = useTranslation('setting');
-  const { message } = App.useApp();
-  const [loading, setLoading] = useState(false);
-  const [created, setCreated] = useState(false);
-  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+export const TaskTemplateCard = memo<TaskTemplateCardProps>(
+  ({ onCreated, onDismiss, position, recommendationBatchId, template, userInterestCount }) => {
+    const { t } = useTranslation('taskTemplate');
+    const { t: tSetting } = useTranslation('setting');
+    const { analytics } = useAnalytics();
+    const { message } = App.useApp();
+    const [loading, setLoading] = useState(false);
+    const [created, setCreated] = useState(false);
+    const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+    const userId = useUserStore((s) => s.user?.id);
+    const cardRef = useRef<HTMLDivElement>(null);
+    const impressedAtRef = useRef<number | undefined>(undefined);
 
-  const skillConnection = useSkillConnection(template.requiresSkills);
-  const optionalSkillConnection = useSkillConnection(template.optionalSkills);
-  const showOptionalHint =
-    !skillConnection.needsConnect &&
-    optionalSkillConnection.needsConnect &&
-    !!optionalSkillConnection.nextUnconnected;
-
-  const IconComp = INTEREST_ICON_MAP.get(template.interests[0]) ?? Sparkles;
-  const title = t(`${template.id}.title`, { defaultValue: '' });
-  const description = t(`${template.id}.description`, { defaultValue: '' });
-
-  const scheduleText = useMemo(() => {
-    const parsed = parseCronPattern(template.cronPattern);
-    const time = formatScheduleTime(parsed.triggerHour, parsed.triggerMinute);
-    if (parsed.scheduleType === 'weekly' && parsed.weekdays?.length === 1) {
-      const weekday = tSetting(`agentCronJobs.weekday.${WEEKDAY_I18N_KEYS[parsed.weekdays[0]]}`);
-      return t('schedule.weekly', { time, weekday });
-    }
-    return t('schedule.daily', { time });
-  }, [t, tSetting, template.cronPattern]);
-
-  const handleCreate = useCallback(async () => {
-    if (!inboxAgentId) return;
-    setLoading(true);
-    try {
-      const prompt = t(`${template.id}.prompt`, { defaultValue: '' });
-      await agentCronJobService.create({
-        agentId: inboxAgentId,
-        content: prompt,
-        cronPattern: template.cronPattern,
-        enabled: true,
-        name: title,
-        templateId: template.id,
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      });
-      await taskTemplateService.recordCreated(template.id).catch((recordError) => {
-        console.error('[taskTemplate:recordCreated]', recordError);
-      });
-      setCreated(true);
-      message.success(t('action.create.success'));
-    } catch (error) {
-      console.error('[taskTemplate:create]', error);
-      message.error(t('action.create.error'));
-    } finally {
-      setLoading(false);
-    }
-  }, [inboxAgentId, message, t, template.cronPattern, template.id, title]);
-
-  const handleDismiss = useCallback(() => {
-    if (loading || created) return;
-    onDismiss(template.id);
-  }, [created, loading, onDismiss, template.id]);
-
-  const handleConnectError = useCallback(
-    (error: unknown) => {
-      message.error(
-        error instanceof SkillConnectionPopupBlockedError
-          ? t('action.connect.popupBlocked')
-          : t('action.connect.error'),
-      );
-    },
-    [message, t],
-  );
-
-  const handleConnectRequired = useCallback(async () => {
-    try {
-      await skillConnection.connect();
-    } catch (error) {
-      handleConnectError(error);
-    }
-  }, [skillConnection, handleConnectError]);
-
-  const handleConnectOptional = useCallback(async () => {
-    try {
-      await optionalSkillConnection.connect();
-    } catch (error) {
-      handleConnectError(error);
-    }
-  }, [optionalSkillConnection, handleConnectError]);
-
-  const primaryButton =
-    skillConnection.needsConnect && skillConnection.nextUnconnected ? (
-      <Button
-        className={briefStyles.actionBtnPrimary}
-        loading={skillConnection.isConnecting}
-        shape={'round'}
-        variant={'filled'}
-        onClick={handleConnectRequired}
-      >
-        {t('action.connect.button', { provider: skillConnection.nextUnconnected.label })}
-      </Button>
-    ) : (
-      <Button
-        shadow
-        className={briefStyles.actionBtnPrimary}
-        disabled={created || !inboxAgentId}
-        loading={loading}
-        shape={'round'}
-        onClick={handleCreate}
-      >
-        {loading ? t('action.creating') : t('action.createButton')}
-      </Button>
+    const analyticsContext = useMemo(
+      () => ({ position, recommendationBatchId, template, userInterestCount }),
+      [position, recommendationBatchId, template, userInterestCount],
     );
 
-  const hintNode = showOptionalHint && optionalSkillConnection.nextUnconnected && (
-    <button
-      className={`${styles.meta} ${styles.optionalHintBtn}`}
-      type={'button'}
-      onClick={handleConnectOptional}
-    >
-      <Icon icon={Link2} size={12} />
-      <Text fontSize={12} style={{ color: 'inherit' }}>
-        {t('action.optionalConnect.button', {
-          provider: optionalSkillConnection.nextUnconnected.label,
-        })}
-      </Text>
-    </button>
-  );
+    const trackCardEvent = useCallback(
+      (name: string, spm: string, properties: Record<string, unknown> = {}) => {
+        void analytics?.track({
+          name,
+          properties: {
+            ...getTaskTemplateCommonAnalyticsProperties(analyticsContext, spm),
+            ...properties,
+          },
+        });
+      },
+      [analytics, analyticsContext],
+    );
 
-  return (
-    <Block
-      className={cx(briefStyles.card, styles.card)}
-      gap={12}
-      padding={12}
-      style={{ borderRadius: cssVar.borderRadiusLG }}
-      variant={'outlined'}
-    >
-      <Flexbox horizontal align={'center'} gap={16} justify={'space-between'}>
-        <Flexbox
-          horizontal
-          align={'center'}
-          gap={8}
-          style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
+    const handleRequiredConnectResult = useCallback(
+      (result: SkillConnectionResult) => {
+        trackCardEvent(
+          'task_template_skill_connect_result',
+          'home.task_templates.skill_connect_result',
+          {
+            duration_ms: result.durationMs,
+            requirement_type: 'required',
+            result: result.result,
+            skill_provider: result.provider,
+            skill_source: result.source,
+          },
+        );
+      },
+      [trackCardEvent],
+    );
+
+    const handleOptionalConnectResult = useCallback(
+      (result: SkillConnectionResult) => {
+        trackCardEvent(
+          'task_template_skill_connect_result',
+          'home.task_templates.skill_connect_result',
+          {
+            duration_ms: result.durationMs,
+            requirement_type: 'optional',
+            result: result.result,
+            skill_provider: result.provider,
+            skill_source: result.source,
+          },
+        );
+      },
+      [trackCardEvent],
+    );
+
+    const skillConnection = useSkillConnection(template.requiresSkills, {
+      onConnectResult: handleRequiredConnectResult,
+    });
+    const optionalSkillConnection = useSkillConnection(template.optionalSkills, {
+      onConnectResult: handleOptionalConnectResult,
+    });
+    const showOptionalHint =
+      !skillConnection.needsConnect &&
+      optionalSkillConnection.needsConnect &&
+      !!optionalSkillConnection.nextUnconnected;
+
+    const IconComp = INTEREST_ICON_MAP.get(template.interests[0]) ?? Sparkles;
+    const title = t(`${template.id}.title`, { defaultValue: '' });
+    const description = t(`${template.id}.description`, { defaultValue: '' });
+
+    const getCurrentCardStateProperties = useCallback(
+      () =>
+        getTaskTemplateCardStateProperties({
+          missingRequiredSkill: skillConnection.nextUnconnected,
+          showOptionalHint,
+          template,
+        }),
+      [showOptionalHint, skillConnection.nextUnconnected, template],
+    );
+
+    const trackSkillConnectClicked = useCallback(
+      (
+        requirementType: 'optional' | 'required',
+        target: Pick<SkillConnectionResult, 'provider' | 'source'> | undefined,
+      ) => {
+        if (!target) return;
+
+        trackCardEvent(
+          'task_template_skill_connect_clicked',
+          'home.task_templates.skill_connect_clicked',
+          {
+            requirement_type: requirementType,
+            skill_provider: target.provider,
+            skill_source: target.source,
+          },
+        );
+      },
+      [trackCardEvent],
+    );
+
+    useEffect(() => {
+      const node = cardRef.current;
+      if (!node) return;
+
+      const storageKey = getTaskTemplateImpressionStorageKey({
+        templateId: template.id,
+        userId,
+      });
+      if (hasTrackedTaskTemplateImpression(storageKey)) return;
+
+      const trackImpression = () => {
+        if (hasTrackedTaskTemplateImpression(storageKey)) return;
+        markTaskTemplateImpressionTracked(storageKey);
+        impressedAtRef.current = Date.now();
+        trackCardEvent(
+          'task_template_card_impression',
+          'home.task_templates.card_impression',
+          getCurrentCardStateProperties(),
+        );
+      };
+
+      if (typeof IntersectionObserver === 'undefined') {
+        trackImpression();
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (!entries.some((entry) => entry.isIntersecting)) return;
+          trackImpression();
+          observer.disconnect();
+        },
+        { threshold: 0.5 },
+      );
+
+      observer.observe(node);
+
+      return () => observer.disconnect();
+    }, [getCurrentCardStateProperties, template.id, trackCardEvent, userId]);
+
+    const scheduleText = useMemo(() => {
+      const parsed = parseCronPattern(template.cronPattern);
+      const time = formatScheduleTime(parsed.triggerHour, parsed.triggerMinute);
+      if (parsed.scheduleType === 'weekly' && parsed.weekdays?.length === 1) {
+        const weekday = tSetting(`agentCronJobs.weekday.${WEEKDAY_I18N_KEYS[parsed.weekdays[0]]}`);
+        return t('schedule.weekly', { time, weekday });
+      }
+      return t('schedule.daily', { time });
+    }, [t, tSetting, template.cronPattern]);
+
+    const handleCreate = useCallback(async () => {
+      if (!inboxAgentId) return;
+      const startedAt = Date.now();
+      trackCardEvent('task_template_create_clicked', 'home.task_templates.create_clicked');
+      setLoading(true);
+      try {
+        const prompt = t(`${template.id}.prompt`, { defaultValue: '' });
+        await agentCronJobService.create({
+          agentId: inboxAgentId,
+          content: prompt,
+          cronPattern: template.cronPattern,
+          enabled: true,
+          name: title,
+          templateId: template.id,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+        trackCardEvent('task_template_create_result', 'home.task_templates.create_result', {
+          duration_ms: Date.now() - startedAt,
+          error_type: null,
+          result: 'success',
+        });
+        await taskTemplateService.recordCreated(template.id).catch((recordError) => {
+          console.error('[taskTemplate:recordCreated]', recordError);
+        });
+        setCreated(true);
+        onCreated(template.id);
+        message.success(t('action.create.success'));
+      } catch (error) {
+        trackCardEvent('task_template_create_result', 'home.task_templates.create_result', {
+          duration_ms: Date.now() - startedAt,
+          error_type: resolveTaskTemplateErrorType(error),
+          result: 'fail',
+        });
+        console.error('[taskTemplate:create]', error);
+        message.error(t('action.create.error'));
+      } finally {
+        setLoading(false);
+      }
+    }, [
+      inboxAgentId,
+      message,
+      onCreated,
+      t,
+      template.cronPattern,
+      template.id,
+      title,
+      trackCardEvent,
+    ]);
+
+    const handleDismiss = useCallback(() => {
+      if (loading || created) return;
+      trackCardEvent('task_template_dismissed', 'home.task_templates.dismissed', {
+        time_since_impression_ms: impressedAtRef.current
+          ? Date.now() - impressedAtRef.current
+          : null,
+        was_impressed: !!impressedAtRef.current,
+      });
+      onDismiss(template.id);
+    }, [created, loading, onDismiss, template.id, trackCardEvent]);
+
+    const handleConnectError = useCallback(
+      (error: unknown) => {
+        message.error(
+          error instanceof SkillConnectionPopupBlockedError
+            ? t('action.connect.popupBlocked')
+            : t('action.connect.error'),
+        );
+      },
+      [message, t],
+    );
+
+    const handleConnectRequired = useCallback(async () => {
+      trackSkillConnectClicked('required', skillConnection.nextUnconnected);
+      try {
+        await skillConnection.connect();
+      } catch (error) {
+        handleConnectError(error);
+      }
+    }, [handleConnectError, skillConnection, trackSkillConnectClicked]);
+
+    const handleConnectOptional = useCallback(async () => {
+      trackSkillConnectClicked('optional', optionalSkillConnection.nextUnconnected);
+      try {
+        await optionalSkillConnection.connect();
+      } catch (error) {
+        handleConnectError(error);
+      }
+    }, [handleConnectError, optionalSkillConnection, trackSkillConnectClicked]);
+
+    const primaryButton =
+      skillConnection.needsConnect && skillConnection.nextUnconnected ? (
+        <Button
+          className={briefStyles.actionBtnPrimary}
+          loading={skillConnection.isConnecting}
+          shape={'round'}
+          variant={'filled'}
+          onClick={handleConnectRequired}
         >
-          <TemplateBriefIcon icon={IconComp} />
+          {t('action.connect.button', { provider: skillConnection.nextUnconnected.label })}
+        </Button>
+      ) : (
+        <Button
+          shadow
+          className={briefStyles.actionBtnPrimary}
+          disabled={created || !inboxAgentId}
+          loading={loading}
+          shape={'round'}
+          onClick={handleCreate}
+        >
+          {loading ? t('action.creating') : t('action.createButton')}
+        </Button>
+      );
+
+    const hintNode = showOptionalHint && optionalSkillConnection.nextUnconnected && (
+      <button
+        className={`${styles.meta} ${styles.optionalHintBtn}`}
+        type={'button'}
+        onClick={handleConnectOptional}
+      >
+        <Icon icon={Link2} size={12} />
+        <Text fontSize={12} style={{ color: 'inherit' }}>
+          {t('action.optionalConnect.button', {
+            provider: optionalSkillConnection.nextUnconnected.label,
+          })}
+        </Text>
+      </button>
+    );
+
+    return (
+      <Block
+        className={cx(briefStyles.card, styles.card)}
+        gap={12}
+        padding={12}
+        ref={cardRef}
+        style={{ borderRadius: cssVar.borderRadiusLG }}
+        variant={'outlined'}
+      >
+        <Flexbox horizontal align={'center'} gap={16} justify={'space-between'}>
           <Flexbox
             horizontal
             align={'center'}
-            flex={1}
-            gap={6}
-            style={{ minWidth: 0, overflow: 'hidden' }}
+            gap={8}
+            style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}
           >
-            <Text ellipsis fontSize={16} weight={500}>
-              {title}
-            </Text>
+            <TemplateBriefIcon icon={IconComp} />
+            <Flexbox
+              horizontal
+              align={'center'}
+              flex={1}
+              gap={6}
+              style={{ minWidth: 0, overflow: 'hidden' }}
+            >
+              <Text ellipsis fontSize={16} weight={500}>
+                {title}
+              </Text>
+              <ActionIcon
+                icon={Clock}
+                size={12}
+                title={
+                  <Center>
+                    <span>{scheduleText}</span>
+                    {t('schedule.editableAfterCreateTooltip')}
+                  </Center>
+                }
+              />
+            </Flexbox>
+          </Flexbox>
+
+          <Flexbox horizontal align={'center'} gap={8}>
             <ActionIcon
-              icon={Clock}
-              size={12}
-              title={
-                <Center>
-                  <span>{scheduleText}</span>
-                  {t('schedule.editableAfterCreateTooltip')}
-                </Center>
-              }
+              className={`${styles.dismissBtn} task-template-dismiss`}
+              icon={X}
+              size={'small'}
+              title={t('action.dismiss.tooltip')}
+              onClick={handleDismiss}
             />
           </Flexbox>
         </Flexbox>
-
-        <Flexbox horizontal align={'center'} gap={8}>
-          <ActionIcon
-            className={`${styles.dismissBtn} task-template-dismiss`}
-            icon={X}
-            size={'small'}
-            title={t('action.dismiss.tooltip')}
-            onClick={handleDismiss}
-          />
+        <Divider dashed style={{ marginBlock: 0 }} />
+        {description.trim().length > 0 ? <BriefCardSummary summary={description} /> : null}
+        <Flexbox horizontal align={'center'} gap={8} justify={'space-between'} wrap={'wrap'}>
+          <Flexbox horizontal align={'center'} gap={8}>
+            <Tag size={'small'} variant={'outlined'}>
+              {t('card.templateTag')}
+            </Tag>
+            {hintNode}
+          </Flexbox>
+          <Flexbox horizontal align={'center'} gap={8}>
+            {primaryButton}
+          </Flexbox>
         </Flexbox>
-      </Flexbox>
-      <Divider dashed style={{ marginBlock: 0 }} />
-      {description.trim().length > 0 ? <BriefCardSummary summary={description} /> : null}
-      <Flexbox horizontal align={'center'} gap={8} justify={'space-between'} wrap={'wrap'}>
-        <Flexbox horizontal align={'center'} gap={8}>
-          <Tag size={'small'} variant={'outlined'}>
-            {t('card.templateTag')}
-          </Tag>
-          {hintNode}
-        </Flexbox>
-        <Flexbox horizontal align={'center'} gap={8}>
-          {primaryButton}
-        </Flexbox>
-      </Flexbox>
-    </Block>
-  );
-});
+      </Block>
+    );
+  },
+);
 
 TaskTemplateCard.displayName = 'TaskTemplateCard';

--- a/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateCard.tsx
@@ -171,6 +171,8 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
     );
 
     useEffect(() => {
+      if (!analytics) return;
+
       const node = cardRef.current;
       if (!node) return;
 
@@ -208,7 +210,7 @@ export const TaskTemplateCard = memo<TaskTemplateCardProps>(
       observer.observe(node);
 
       return () => observer.disconnect();
-    }, [getCurrentCardStateProperties, template.id, trackCardEvent, userId]);
+    }, [analytics, getCurrentCardStateProperties, template.id, trackCardEvent, userId]);
 
     const scheduleText = useMemo(() => {
       const parsed = parseCronPattern(template.cronPattern);

--- a/src/features/RecommendTaskTemplates/analytics.test.ts
+++ b/src/features/RecommendTaskTemplates/analytics.test.ts
@@ -1,0 +1,105 @@
+import type { RecommendedTaskTemplate } from '@lobechat/const';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getTaskTemplateCardStateProperties,
+  getTaskTemplateCommonAnalyticsProperties,
+  getTaskTemplateImpressionStorageKey,
+  getTaskTemplateListServedProperties,
+} from './analytics';
+
+const makeTemplate = (overrides: Partial<RecommendedTaskTemplate>): RecommendedTaskTemplate => ({
+  category: 'engineering',
+  cronPattern: '0 9 * * *',
+  id: 'template-a',
+  interests: ['coding'],
+  source: 'matched',
+  ...overrides,
+});
+
+describe('task template analytics helpers', () => {
+  it('builds list served properties for matched and fallback recommendations', () => {
+    const properties = getTaskTemplateListServedProperties({
+      recommendationBatchId: 'batch-1',
+      templates: [
+        makeTemplate({ id: 'matched', source: 'matched' }),
+        makeTemplate({
+          fallbackPool: 'preferred_category',
+          id: 'fallback',
+          source: 'fallback',
+        }),
+      ],
+      userInterestCount: 2,
+    });
+
+    expect(properties).toEqual({
+      all_candidates_fallback_count: 0,
+      fallback_count: 1,
+      matched_count: 1,
+      preferred_category_fallback_count: 1,
+      recommendation_batch_id: 'batch-1',
+      spm: 'home.task_templates.list_served',
+      template_count: 2,
+      user_interest_count: 2,
+    });
+  });
+
+  it('builds common per-card properties without leaking interest values', () => {
+    const properties = getTaskTemplateCommonAnalyticsProperties(
+      {
+        position: 1,
+        recommendationBatchId: 'batch-1',
+        template: makeTemplate({
+          fallbackPool: 'all_candidates',
+          optionalSkills: [{ provider: 'notion', source: 'klavis' }],
+          requiresSkills: [{ provider: 'github', source: 'lobehub' }],
+          source: 'fallback',
+        }),
+        userInterestCount: 3,
+      },
+      'home.task_templates.card_impression',
+    );
+
+    expect(properties).toMatchObject({
+      fallback_pool: 'all_candidates',
+      position: 1,
+      recommendation_batch_id: 'batch-1',
+      requires_skills: true,
+      skill_sources: ['lobehub', 'klavis'],
+      source: 'fallback',
+      spm: 'home.task_templates.card_impression',
+      template_category: 'engineering',
+      template_id: 'template-a',
+      user_interest_count: 3,
+    });
+  });
+
+  it('resolves card state properties for connect-blocked cards', () => {
+    expect(
+      getTaskTemplateCardStateProperties({
+        missingRequiredSkill: { provider: 'github', source: 'lobehub' },
+        showOptionalHint: false,
+        template: makeTemplate({
+          requiresSkills: [{ provider: 'github', source: 'lobehub' }],
+        }),
+      }),
+    ).toEqual({
+      has_optional_connect_hint: false,
+      has_optional_skills: false,
+      has_required_skills: true,
+      missing_required_skill_provider: 'github',
+      missing_required_skill_source: 'lobehub',
+      primary_action: 'connect_required',
+    });
+  });
+
+  it('scopes impression de-duplication by user, UTC date, and template', () => {
+    expect(
+      getTaskTemplateImpressionStorageKey({
+        date: new Date('2026-05-08T23:59:00Z'),
+        templateId: 'template-a',
+        userId: 'user-1',
+      }),
+    ).toBe('task-template-impression:user-1:2026-05-08:template-a');
+  });
+});

--- a/src/features/RecommendTaskTemplates/analytics.ts
+++ b/src/features/RecommendTaskTemplates/analytics.ts
@@ -1,0 +1,141 @@
+import type {
+  RecommendedTaskTemplate,
+  TaskTemplateSkillRequirement,
+  TaskTemplateSkillSource,
+} from '@lobechat/const';
+
+export type TaskTemplateSkillConnectResult =
+  | 'cancel'
+  | 'fail'
+  | 'popup_blocked'
+  | 'success'
+  | 'timeout';
+
+export type TaskTemplateSkillRequirementType = 'optional' | 'required';
+
+export interface TaskTemplateAnalyticsContext {
+  position: number;
+  recommendationBatchId: string;
+  template: RecommendedTaskTemplate;
+  userInterestCount: number;
+}
+
+export interface TaskTemplateCardStateProperties extends Record<string, unknown> {
+  has_optional_connect_hint: boolean;
+  has_optional_skills: boolean;
+  has_required_skills: boolean;
+  missing_required_skill_provider: null | string;
+  missing_required_skill_source: null | TaskTemplateSkillSource;
+  primary_action: 'connect_required' | 'create';
+}
+
+const TASK_TEMPLATE_ANALYTICS_ERROR_PREFIX = '[taskTemplate:analytics]';
+
+const getSkillSources = (template: RecommendedTaskTemplate): null | TaskTemplateSkillSource[] => {
+  const sources = new Set<TaskTemplateSkillSource>();
+
+  for (const skill of template.requiresSkills ?? []) sources.add(skill.source);
+  for (const skill of template.optionalSkills ?? []) sources.add(skill.source);
+
+  return sources.size > 0 ? [...sources] : null;
+};
+
+export const createRecommendationBatchId = () =>
+  `tt_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+
+export const getTaskTemplateCommonAnalyticsProperties = (
+  context: TaskTemplateAnalyticsContext,
+  spm: string,
+) => ({
+  fallback_pool: context.template.fallbackPool ?? null,
+  position: context.position,
+  recommendation_batch_id: context.recommendationBatchId,
+  requires_skills: (context.template.requiresSkills?.length ?? 0) > 0,
+  skill_sources: getSkillSources(context.template),
+  source: context.template.source,
+  spm,
+  template_category: context.template.category,
+  template_id: context.template.id,
+  user_interest_count: context.userInterestCount,
+});
+
+export const getTaskTemplateListServedProperties = ({
+  recommendationBatchId,
+  templates,
+  userInterestCount,
+}: {
+  recommendationBatchId: string;
+  templates: RecommendedTaskTemplate[];
+  userInterestCount: number;
+}) => {
+  const matchedCount = templates.filter((template) => template.source === 'matched').length;
+  const preferredCategoryFallbackCount = templates.filter(
+    (template) => template.fallbackPool === 'preferred_category',
+  ).length;
+  const allCandidatesFallbackCount = templates.filter(
+    (template) => template.fallbackPool === 'all_candidates',
+  ).length;
+
+  return {
+    all_candidates_fallback_count: allCandidatesFallbackCount,
+    fallback_count: templates.length - matchedCount,
+    matched_count: matchedCount,
+    preferred_category_fallback_count: preferredCategoryFallbackCount,
+    recommendation_batch_id: recommendationBatchId,
+    spm: 'home.task_templates.list_served',
+    template_count: templates.length,
+    user_interest_count: userInterestCount,
+  };
+};
+
+export const getTaskTemplateCardStateProperties = ({
+  missingRequiredSkill,
+  showOptionalHint,
+  template,
+}: {
+  missingRequiredSkill?: Pick<TaskTemplateSkillRequirement, 'provider' | 'source'>;
+  showOptionalHint: boolean;
+  template: RecommendedTaskTemplate;
+}): TaskTemplateCardStateProperties => ({
+  has_optional_connect_hint: showOptionalHint,
+  has_optional_skills: (template.optionalSkills?.length ?? 0) > 0,
+  has_required_skills: (template.requiresSkills?.length ?? 0) > 0,
+  missing_required_skill_provider: missingRequiredSkill?.provider ?? null,
+  missing_required_skill_source: missingRequiredSkill?.source ?? null,
+  primary_action: missingRequiredSkill ? 'connect_required' : 'create',
+});
+
+export const getTaskTemplateImpressionStorageKey = ({
+  date = new Date(),
+  templateId,
+  userId,
+}: {
+  date?: Date;
+  templateId: string;
+  userId?: string;
+}) => {
+  const userSegment = userId || 'anonymous';
+  return `task-template-impression:${userSegment}:${date.toISOString().slice(0, 10)}:${templateId}`;
+};
+
+export const hasTrackedTaskTemplateImpression = (key: string) => {
+  try {
+    return globalThis.sessionStorage?.getItem(key) === '1';
+  } catch (error) {
+    console.error(`${TASK_TEMPLATE_ANALYTICS_ERROR_PREFIX} Failed to read impression key`, error);
+    return false;
+  }
+};
+
+export const markTaskTemplateImpressionTracked = (key: string) => {
+  try {
+    globalThis.sessionStorage?.setItem(key, '1');
+  } catch (error) {
+    console.error(`${TASK_TEMPLATE_ANALYTICS_ERROR_PREFIX} Failed to write impression key`, error);
+  }
+};
+
+export const resolveTaskTemplateErrorType = (error: unknown) => {
+  if (error instanceof Error) return error.name || 'Error';
+  return typeof error;
+};

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -1,6 +1,7 @@
-import type { TaskTemplate, TaskTemplateSkillSource } from '@lobechat/const';
+import type { RecommendedTaskTemplate, TaskTemplateSkillSource } from '@lobechat/const';
+import { useAnalytics } from '@lobehub/analytics/react';
 import { App } from 'antd';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
@@ -12,15 +13,24 @@ import { useToolStore } from '@/store/tool';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
+import { createRecommendationBatchId, getTaskTemplateListServedProperties } from './analytics';
 import { useResolvedInterestKeys } from './useResolvedInterestKeys';
 
 export type DailyBriefRecommendationsUIState =
   | { mode: 'hidden' }
   | { mode: 'skeleton' }
-  | { mode: 'cards'; onDismiss: (templateId: string) => void; templates: TaskTemplate[] };
+  | {
+      mode: 'cards';
+      onCreated: (templateId: string) => void;
+      onDismiss: (templateId: string) => void;
+      recommendationBatchId: string;
+      templates: RecommendedTaskTemplate[];
+      userInterestCount: number;
+    };
 
 export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUIState {
   const { t } = useTranslation('taskTemplate');
+  const { analytics } = useAnalytics();
   const { message } = App.useApp();
   const isLogin = useUserStore(authSelectors.isLogin);
   const { enableAgentTask } = useServerConfigStore(featureFlagsSelectors);
@@ -32,6 +42,14 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
   const interestKeys = useResolvedInterestKeys();
   const swrKey = interestKeys ? [...interestKeys].sort().join(',') : '';
   const swrEnabled = isLogin && !!enableAgentTask && interestKeys !== null;
+  const batchRef = useRef<
+    | {
+        id: string;
+        served: boolean;
+        swrKey: string;
+      }
+    | undefined
+  >(undefined);
 
   const { data, isLoading, mutate } = useSWR(
     swrEnabled ? ['taskTemplate.listDailyRecommend', swrKey] : null,
@@ -39,8 +57,36 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
     { revalidateOnFocus: false, revalidateOnReconnect: false },
   );
 
-  const handleDismiss = useCallback(
-    async (templateId: string) => {
+  const templates = useMemo(() => data?.data ?? [], [data]);
+
+  if (templates.length > 0 && batchRef.current?.swrKey !== swrKey) {
+    batchRef.current = {
+      id: createRecommendationBatchId(),
+      served: false,
+      swrKey,
+    };
+  }
+
+  const recommendationBatchId = batchRef.current?.id;
+  const userInterestCount = interestKeys?.length ?? 0;
+
+  useEffect(() => {
+    const batch = batchRef.current;
+    if (!analytics || !batch || batch.served || templates.length === 0) return;
+
+    void analytics.track({
+      name: 'task_template_list_served',
+      properties: getTaskTemplateListServedProperties({
+        recommendationBatchId: batch.id,
+        templates,
+        userInterestCount,
+      }),
+    });
+    batch.served = true;
+  }, [analytics, templates, userInterestCount]);
+
+  const removeTemplateFromList = useCallback(
+    (templateId: string) => {
       mutate(
         (current) =>
           current
@@ -48,6 +94,20 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
             : current,
         { revalidate: false },
       );
+    },
+    [mutate],
+  );
+
+  const handleCreated = useCallback(
+    (templateId: string) => {
+      removeTemplateFromList(templateId);
+    },
+    [removeTemplateFromList],
+  );
+
+  const handleDismiss = useCallback(
+    async (templateId: string) => {
+      removeTemplateFromList(templateId);
       try {
         await taskTemplateService.dismiss(templateId);
       } catch (error) {
@@ -56,10 +116,9 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
         mutate();
       }
     },
-    [message, mutate, t],
+    [message, mutate, removeTemplateFromList, t],
   );
 
-  const templates = useMemo(() => data?.data ?? [], [data]);
   const requiredSources = useMemo(() => {
     const sources = new Set<TaskTemplateSkillSource>();
     for (const tmpl of templates) {
@@ -77,5 +136,12 @@ export function useDailyBriefRecommendationsUI(): DailyBriefRecommendationsUISta
   if (!isInit || isLoading) return { mode: 'skeleton' };
   if (templates.length === 0) return { mode: 'hidden' };
 
-  return { mode: 'cards', onDismiss: handleDismiss, templates };
+  return {
+    mode: 'cards',
+    onCreated: handleCreated,
+    onDismiss: handleDismiss,
+    recommendationBatchId: recommendationBatchId ?? createRecommendationBatchId(),
+    templates,
+    userInterestCount,
+  };
 }

--- a/src/features/RecommendTaskTemplates/useSkillConnection.ts
+++ b/src/features/RecommendTaskTemplates/useSkillConnection.ts
@@ -35,6 +35,24 @@ export class SkillConnectionPopupBlockedError extends Error {
 
 type ConnectTarget = Pick<SkillProviderMeta, 'provider' | 'source'>;
 
+export type SkillConnectionResultStatus =
+  | 'cancel'
+  | 'fail'
+  | 'popup_blocked'
+  | 'success'
+  | 'timeout';
+
+export interface SkillConnectionResult {
+  durationMs: number;
+  provider: string;
+  result: SkillConnectionResultStatus;
+  source: ConnectTarget['source'];
+}
+
+export interface UseSkillConnectionOptions {
+  onConnectResult?: (result: SkillConnectionResult) => void;
+}
+
 export interface UseSkillConnectionResult {
   connect: () => Promise<void>;
   isAllConnected: boolean;
@@ -47,7 +65,9 @@ export interface UseSkillConnectionResult {
 
 export const useSkillConnection = (
   specs: TaskTemplateSkillRequirement[] | undefined,
+  options: UseSkillConnectionOptions = {},
 ): UseSkillConnectionResult => {
+  const { onConnectResult } = options;
   const getLobehubAuth = useToolStore((s) => s.getLobehubSkillAuthorizeUrl);
   const checkLobehubStatus = useToolStore((s) => s.checkLobehubSkillStatus);
   const createKlavisServer = useToolStore((s) => s.createKlavisServer);
@@ -89,6 +109,14 @@ export const useSkillConnection = (
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Sync lock against double-click — useState guard would only flip after re-render.
   const isConnectingRef = useRef(false);
+  const activeConnectionRef = useRef<
+    | {
+        resultReported: boolean;
+        startedAt: number;
+        target: ConnectTarget;
+      }
+    | undefined
+  >(undefined);
 
   const cleanup = useCallback(() => {
     if (windowCheckIntervalRef.current) {
@@ -111,11 +139,70 @@ export const useSkillConnection = (
     setIsWaitingAuth(false);
   }, []);
 
+  const reportConnectResult = useCallback(
+    (result: SkillConnectionResultStatus, target?: ConnectTarget) => {
+      const activeConnection = activeConnectionRef.current;
+      const resolvedTarget = target ?? activeConnection?.target;
+
+      if (!activeConnection || !resolvedTarget || activeConnection.resultReported) return;
+
+      activeConnectionRef.current = {
+        ...activeConnection,
+        resultReported: true,
+      };
+      onConnectResult?.({
+        durationMs: Date.now() - activeConnection.startedAt,
+        provider: resolvedTarget.provider,
+        result,
+        source: resolvedTarget.source,
+      });
+    },
+    [onConnectResult],
+  );
+
+  const finishConnection = useCallback(
+    (result: SkillConnectionResultStatus, target?: ConnectTarget) => {
+      reportConnectResult(result, target);
+      cleanup();
+    },
+    [cleanup, reportConnectResult],
+  );
+
+  const isTargetConnected = useCallback((target: ConnectTarget): boolean => {
+    const state = useToolStore.getState();
+
+    if (target.source === 'lobehub') {
+      return state.lobehubSkillServers.some(
+        (server) =>
+          server.identifier === target.provider && server.status === LobehubSkillStatus.CONNECTED,
+      );
+    }
+
+    return state.servers.some(
+      (server) =>
+        server.identifier === target.provider && server.status === KlavisServerStatus.CONNECTED,
+    );
+  }, []);
+
+  const refreshTargetStatus = useCallback(
+    async (target: ConnectTarget): Promise<boolean> => {
+      if (target.source === 'lobehub') {
+        const server = await checkLobehubStatus(target.provider);
+        return server?.status === LobehubSkillStatus.CONNECTED;
+      }
+
+      await refreshKlavisServerTools(target.provider);
+      return isTargetConnected(target);
+    },
+    [checkLobehubStatus, isTargetConnected, refreshKlavisServerTools],
+  );
+
   useEffect(() => () => cleanup(), [cleanup]);
 
   useEffect(() => {
-    if (isWaitingAuth && !nextUnconnected) cleanup();
-  }, [isWaitingAuth, nextUnconnected, cleanup]);
+    if (!isWaitingAuth || nextUnconnected) return;
+    finishConnection('success');
+  }, [finishConnection, isWaitingAuth, nextUnconnected]);
 
   const startFallbackPolling = useCallback(
     (target: ConnectTarget) => {
@@ -123,25 +210,20 @@ export const useSkillConnection = (
 
       pollIntervalRef.current = setInterval(async () => {
         try {
-          if (target.source === 'lobehub') {
-            await checkLobehubStatus(target.provider);
-          } else {
-            await refreshKlavisServerTools(target.provider);
-          }
-        } catch {
-          // Polling failure is expected until auth completes — suppress noise.
+          const connected = await refreshTargetStatus(target);
+          if (connected) finishConnection('success', target);
+        } catch (error) {
+          // Polling failure is expected until auth completes, but keep it visible
+          // in local debugging because it can otherwise mask a broken OAuth route.
+          console.error('[useSkillConnection] Failed to poll auth status:', error);
         }
       }, POLL_INTERVAL_MS);
 
       pollTimeoutRef.current = setTimeout(() => {
-        if (pollIntervalRef.current) {
-          clearInterval(pollIntervalRef.current);
-          pollIntervalRef.current = null;
-        }
-        setIsWaitingAuth(false);
+        finishConnection('timeout', target);
       }, POLL_TIMEOUT_MS);
     },
-    [checkLobehubStatus, refreshKlavisServerTools],
+    [finishConnection, refreshTargetStatus],
   );
 
   const startWindowMonitor = useCallback(
@@ -165,16 +247,11 @@ export const useSkillConnection = (
           // Refresh status once right after the popup closes so multi-spec flows
           // can advance to the next provider immediately, instead of waiting up
           // to 15s for fallback polling to release isWaitingAuth.
-          try {
-            if (target.source === 'lobehub') {
-              await checkLobehubStatus(target.provider);
-            } else {
-              await refreshKlavisServerTools(target.provider);
-            }
-          } catch {
-            // Status check failure isn't actionable; release waiting state regardless.
-          }
-          setIsWaitingAuth(false);
+          const connected = await refreshTargetStatus(target).catch((error) => {
+            console.error('[useSkillConnection] Failed to refresh auth status:', error);
+            return false;
+          });
+          finishConnection(connected ? 'success' : 'cancel', target);
         } catch {
           // COOP can block window.closed access — fall back to polling.
           stopMonitor();
@@ -192,10 +269,10 @@ export const useSkillConnection = (
           // Cross-origin restrictions may block .close(); ignore.
         }
         oauthWindowRef.current = null;
-        setIsWaitingAuth(false);
+        finishConnection('timeout', target);
       }, OAUTH_OVERALL_TIMEOUT_MS);
     },
-    [checkLobehubStatus, refreshKlavisServerTools, startFallbackPolling],
+    [finishConnection, refreshTargetStatus, startFallbackPolling],
   );
 
   const openOAuthWindow = useCallback(
@@ -208,12 +285,13 @@ export const useSkillConnection = (
         // Popup blocked — abandon the flow so the caller can surface a clear
         // error instead of polling forever for an auth that never started.
         setIsWaitingAuth(false);
+        reportConnectResult('popup_blocked', target);
         throw new SkillConnectionPopupBlockedError();
       }
       oauthWindowRef.current = oauthWindow;
       startWindowMonitor(oauthWindow, target);
     },
-    [cleanup, startWindowMonitor],
+    [cleanup, reportConnectResult, startWindowMonitor],
   );
 
   // Only LobeHub Skill OAuth signals completion via postMessage; Klavis relies on polling.
@@ -225,12 +303,16 @@ export const useSkillConnection = (
       if (event.data?.type !== LOBEHUB_SKILL_AUTH_SUCCESS_MESSAGE) return;
       const provider = event.data?.provider;
       if (!provider) return;
-      cleanup();
-      void checkLobehubStatus(provider);
+      void checkLobehubStatus(provider).then((server) => {
+        finishConnection(server?.status === LobehubSkillStatus.CONNECTED ? 'success' : 'fail', {
+          provider,
+          source: 'lobehub',
+        });
+      });
     };
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [checkLobehubStatus, cleanup]);
+  }, [checkLobehubStatus, finishConnection]);
 
   const connect = useCallback(async () => {
     if (isConnectingRef.current || isWaitingAuth) return;
@@ -238,6 +320,11 @@ export const useSkillConnection = (
     if (!next) return;
 
     isConnectingRef.current = true;
+    activeConnectionRef.current = {
+      resultReported: false,
+      startedAt: Date.now(),
+      target: next,
+    };
     setIsConnecting(true);
     try {
       if (next.source === 'lobehub') {
@@ -262,6 +349,7 @@ export const useSkillConnection = (
       if (!newServer) throw new Error('Failed to create Klavis server');
       if (newServer.isAuthenticated) {
         await refreshKlavisServerTools(newServer.identifier);
+        reportConnectResult(isTargetConnected(next) ? 'success' : 'fail', next);
       } else if (newServer.oauthUrl) {
         openOAuthWindow(newServer.oauthUrl, next);
       } else {
@@ -269,6 +357,11 @@ export const useSkillConnection = (
       }
     } catch (error) {
       console.error('[useSkillConnection] Failed to connect:', error);
+      if (error instanceof SkillConnectionPopupBlockedError) {
+        reportConnectResult('popup_blocked', next);
+      } else {
+        reportConnectResult('fail', next);
+      }
       throw error;
     } finally {
       isConnectingRef.current = false;
@@ -281,6 +374,8 @@ export const useSkillConnection = (
     createKlavisServer,
     refreshKlavisServerTools,
     openOAuthWindow,
+    isTargetConnected,
+    reportConnectResult,
   ]);
 
   return {

--- a/src/server/services/taskTemplate/index.test.ts
+++ b/src/server/services/taskTemplate/index.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
-import { type TaskTemplate, taskTemplates } from '@lobechat/const';
+import type { TaskTemplate } from '@lobechat/const';
+import { TASK_TEMPLATE_FALLBACK_CATEGORIES, taskTemplates } from '@lobechat/const';
 import { describe, expect, it } from 'vitest';
 
 import { isTemplateSkillSourceEligible, RECOMMEND_COUNT, TaskTemplateService } from './index';
@@ -21,6 +22,7 @@ describe('TaskTemplateService.listDailyRecommend', () => {
     const picked = await service.listDailyRecommend(['coding'], { now: UTC_DAY_1 });
 
     expect(picked).toHaveLength(RECOMMEND_COUNT);
+    expect(picked.every((p) => p.source === 'matched')).toBe(true);
     const codingMatches = taskTemplates.filter((t) => t.interests.includes('coding'));
     expect(picked.some((p) => codingMatches.some((m) => m.id === p.id))).toBe(true);
   });
@@ -65,7 +67,25 @@ describe('TaskTemplateService.listDailyRecommend', () => {
     expect(picked).toHaveLength(RECOMMEND_COUNT);
     for (const p of picked) {
       expect(taskTemplates.some((t) => t.id === p.id)).toBe(true);
+      expect(p.source).toBe('fallback');
+      expect(p.fallbackPool).toBe('preferred_category');
     }
+  });
+
+  it('marks all-candidate fallback when preferred fallback categories are exhausted', async () => {
+    const service = new TaskTemplateService('user-1');
+    const fallbackCategoryIds = taskTemplates
+      .filter((t) => TASK_TEMPLATE_FALLBACK_CATEGORIES.includes(t.category))
+      .map((t) => t.id);
+
+    const picked = await service.listDailyRecommend([], {
+      excludeIds: fallbackCategoryIds,
+      now: UTC_DAY_1,
+    });
+
+    expect(picked).toHaveLength(RECOMMEND_COUNT);
+    expect(picked.every((p) => p.source === 'fallback')).toBe(true);
+    expect(picked.every((p) => p.fallbackPool === 'all_candidates')).toBe(true);
   });
 
   it('intersection is case-insensitive and trims whitespace', async () => {

--- a/src/server/services/taskTemplate/index.ts
+++ b/src/server/services/taskTemplate/index.ts
@@ -1,9 +1,11 @@
-import {
-  TASK_TEMPLATE_FALLBACK_CATEGORIES,
-  type TaskTemplate,
-  taskTemplates,
-  type TaskTemplateSkillSource,
+import type {
+  RecommendedTaskTemplate,
+  TaskTemplate,
+  TaskTemplateFallbackPool,
+  TaskTemplateRecommendationSource,
+  TaskTemplateSkillSource,
 } from '@lobechat/const';
+import { TASK_TEMPLATE_FALLBACK_CATEGORIES, taskTemplates } from '@lobechat/const';
 
 import { klavisEnv } from '@/config/klavis';
 import { appEnv } from '@/envs/app';
@@ -58,6 +60,16 @@ const hasIntersection = (template: TaskTemplate, userInterests: string[]): boole
 
 const getUtcDateStr = (now: Date): string => now.toISOString().slice(0, 10);
 
+const toRecommendedTemplate = (
+  template: TaskTemplate,
+  source: TaskTemplateRecommendationSource,
+  fallbackPool?: TaskTemplateFallbackPool,
+): RecommendedTaskTemplate => ({
+  ...template,
+  ...(fallbackPool ? { fallbackPool } : {}),
+  source,
+});
+
 /**
  * A template is eligible only if every `requiresSkills[].source` is enabled
  * server-side. When a template declares no skill requirement, it is always
@@ -87,7 +99,7 @@ export class TaskTemplateService {
       excludeIds?: string[];
       now?: Date;
     } = {},
-  ): Promise<TaskTemplate[]> {
+  ): Promise<RecommendedTaskTemplate[]> {
     const { enabledSkillSources, excludeIds, now = new Date() } = options;
     const excluded = new Set(excludeIds ?? []);
     const seed = hashString(`${this.userId}:${getUtcDateStr(now)}`);
@@ -96,17 +108,26 @@ export class TaskTemplateService {
       (t) => !excluded.has(t.id) && isTemplateSkillSourceEligible(t, enabledSkillSources),
     );
     const matched = candidates.filter((t) => hasIntersection(t, interestKeys));
-    const result: TaskTemplate[] = seededShuffle(matched, seed).slice(0, RECOMMEND_COUNT);
+    const result: RecommendedTaskTemplate[] = seededShuffle(matched, seed)
+      .slice(0, RECOMMEND_COUNT)
+      .map((t) => toRecommendedTemplate(t, 'matched'));
 
-    const takeFrom = (pool: TaskTemplate[]) => {
+    const takeFrom = (pool: TaskTemplate[], fallbackPool: TaskTemplateFallbackPool) => {
       if (result.length >= RECOMMEND_COUNT) return;
       const seen = new Set(result.map((t) => t.id));
       const remaining = pool.filter((t) => !seen.has(t.id));
-      result.push(...seededShuffle(remaining, seed).slice(0, RECOMMEND_COUNT - result.length));
+      result.push(
+        ...seededShuffle(remaining, seed)
+          .slice(0, RECOMMEND_COUNT - result.length)
+          .map((t) => toRecommendedTemplate(t, 'fallback', fallbackPool)),
+      );
     };
 
-    takeFrom(candidates.filter((t) => TASK_TEMPLATE_FALLBACK_CATEGORIES.includes(t.category)));
-    takeFrom(candidates);
+    takeFrom(
+      candidates.filter((t) => TASK_TEMPLATE_FALLBACK_CATEGORIES.includes(t.category)),
+      'preferred_category',
+    );
+    takeFrom(candidates, 'all_candidates');
 
     return result;
   }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8190

#### 🔀 Description of Change

Adds client-side analytics for the Task Template recommendation funnel:

- Marks recommended templates as `matched` or `fallback`, with fallback pool metadata.
- Tracks list served, card impression, skill connect click/result, create click/result, and dismiss events.
- Adds recommendation batch IDs and per-card metadata for PostHog funnel breakdowns.
- Removes a template from the current recommendation list after successful creation.
- Captures skill connection outcomes including success, fail, cancel, timeout, and popup blocked.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/RecommendTaskTemplates/analytics.test.ts' 'src/features/RecommendTaskTemplates/TaskTemplateCard.test.tsx' 'src/server/services/taskTemplate/index.test.ts'
```

Result: 26 tests passed.

#### 📸 Screenshots / Videos

N/A. Analytics-only behavior change.

#### 📝 Additional Information

PostHog does not need event pre-registration by default. After deployment, verify new events in Live Events before creating the recommendation, skill connection, and dismiss funnels.
