### PR TITLE
⚡️ perf: refresh home recents periodically and inline task status

### DIFF
--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -63,7 +63,7 @@ describe('RecentModel', () => {
 
       const result = await recentModel.queryRecent();
       expect(result).toHaveLength(1);
-      expect(result[0]).toMatchObject({ id: 'topic-mine', type: 'topic' });
+      expect(result[0]).toMatchObject({ id: 'topic-mine', type: 'topic', status: null });
     });
 
     describe('topics arm', () => {
@@ -242,6 +242,7 @@ describe('RecentModel', () => {
 
         const result = await recentModel.queryRecent();
         expect(result.map((r) => r.id)).toEqual(['doc-api']);
+        expect(result[0].status).toBeNull();
       });
 
       it('excludes file uploads (sourceType "file")', async () => {
@@ -362,7 +363,34 @@ describe('RecentModel', () => {
           title: 'Active Task',
           routeId: 'agent-assignee',
           routeGroupId: null,
+          status: 'running',
         });
+      });
+
+      it('surfaces task status so home can render the icon without a second task.detail call', async () => {
+        await serverDB.insert(tasks).values([
+          {
+            id: 'task-paused',
+            createdByUserId: userId,
+            identifier: 'T-P',
+            status: 'paused',
+            updatedAt: minutesAgo(2),
+            ...baseTaskFields,
+          },
+          {
+            id: 'task-pending',
+            createdByUserId: userId,
+            identifier: 'T-Q',
+            status: 'pending',
+            updatedAt: minutesAgo(1),
+            ...baseTaskFields,
+          },
+        ]);
+
+        const result = await recentModel.queryRecent();
+        const byId = Object.fromEntries(result.map((r) => [r.id, r.status]));
+        expect(byId['task-paused']).toBe('paused');
+        expect(byId['task-pending']).toBe('pending');
       });
 
       it('excludes completed and canceled tasks', async () => {

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -9,6 +9,8 @@ export interface RecentDbItem {
   metadata?: any;
   routeGroupId: string | null;
   routeId: string | null;
+  /** Task lifecycle status when `type === 'task'`; null for topic/document. */
+  status: string | null;
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;
@@ -41,6 +43,7 @@ export class RecentModel {
         metadata: sql<any>`${topics.metadata}`.as('metadata'),
         routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
         routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
+        status: sql<string | null>`NULL`.as('status'),
         title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
         type: sql<RecentDbItem['type']>`'topic'`.as('type'),
         updatedAt: topics.updatedAt,
@@ -65,6 +68,7 @@ export class RecentModel {
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`NULL`.as('route_id'),
+        status: sql<string | null>`NULL`.as('status'),
         title:
           sql<string>`COALESCE(${documents.title}, ${documents.filename}, 'Untitled Document')`.as(
             'title',
@@ -88,6 +92,7 @@ export class RecentModel {
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`${tasks.assigneeAgentId}`.as('route_id'),
+        status: sql<string | null>`${tasks.status}`.as('status'),
         title: sql<string>`COALESCE(${tasks.name}, ${tasks.instruction}, 'Untitled Task')`.as(
           'title',
         ),
@@ -111,6 +116,7 @@ export class RecentModel {
       metadata: row.metadata ?? undefined,
       routeGroupId: row.routeGroupId,
       routeId: row.routeId,
+      status: row.status,
       title: row.title,
       type: row.type,
       updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt as any),

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -1,3 +1,4 @@
+import type { TaskStatus } from '@lobechat/types';
 import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 
@@ -10,7 +11,7 @@ export interface RecentDbItem {
   routeGroupId: string | null;
   routeId: string | null;
   /** Task lifecycle status when `type === 'task'`; null for topic/document. */
-  status: string | null;
+  status: TaskStatus | null;
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;
@@ -43,7 +44,7 @@ export class RecentModel {
         metadata: sql<any>`${topics.metadata}`.as('metadata'),
         routeGroupId: sql<string | null>`${topics.groupId}`.as('route_group_id'),
         routeId: sql<string | null>`${topics.agentId}`.as('route_id'),
-        status: sql<string | null>`NULL`.as('status'),
+        status: sql<TaskStatus | null>`NULL`.as('status'),
         title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
         type: sql<RecentDbItem['type']>`'topic'`.as('type'),
         updatedAt: topics.updatedAt,
@@ -68,7 +69,7 @@ export class RecentModel {
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`NULL`.as('route_id'),
-        status: sql<string | null>`NULL`.as('status'),
+        status: sql<TaskStatus | null>`NULL`.as('status'),
         title:
           sql<string>`COALESCE(${documents.title}, ${documents.filename}, 'Untitled Document')`.as(
             'title',
@@ -92,7 +93,7 @@ export class RecentModel {
         metadata: sql<any>`NULL`.as('metadata'),
         routeGroupId: sql<string | null>`NULL`.as('route_group_id'),
         routeId: sql<string | null>`${tasks.assigneeAgentId}`.as('route_id'),
-        status: sql<string | null>`${tasks.status}`.as('status'),
+        status: sql<TaskStatus | null>`${tasks.status}`.as('status'),
         title: sql<string>`COALESCE(${tasks.name}, ${tasks.instruction}, 'Untitled Task')`.as(
           'title',
         ),

--- a/src/routes/(main)/home/features/Recents/Item.tsx
+++ b/src/routes/(main)/home/features/Recents/Item.tsx
@@ -1,3 +1,4 @@
+import type { TaskStatus } from '@lobechat/types';
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { FileTextIcon, HashIcon, MoreHorizontalIcon } from 'lucide-react';
@@ -19,22 +20,6 @@ const TYPE_ICON_MAP: Partial<Record<'document' | 'task' | 'topic', typeof FileTe
   topic: HashIcon,
 };
 
-type TaskStatus = 'backlog' | 'canceled' | 'completed' | 'failed' | 'paused' | 'running';
-const LEGACY_TASK_STATUS_MAP: Record<string, TaskStatus> = {
-  backlog: 'backlog',
-  canceled: 'canceled',
-  completed: 'completed',
-  failed: 'failed',
-  in_progress: 'running',
-  paused: 'paused',
-  running: 'running',
-  todo: 'backlog',
-};
-const normalizeTaskStatus = (status?: string | null): TaskStatus => {
-  if (!status) return 'backlog';
-  return LEGACY_TASK_STATUS_MAP[status] ?? 'backlog';
-};
-
 const RecentListItem = memo<RecentItem>((item) => {
   const { title, type, agentId, id, metadata, status } = item;
   const IconComponent = TYPE_ICON_MAP[type] || FileTextIcon;
@@ -46,7 +31,7 @@ const RecentListItem = memo<RecentItem>((item) => {
   // the recent.getAll snapshot, so returning from the detail page reflects the
   // latest status without waiting for the next poll.
   const liveTaskStatus = useTaskStore((s) =>
-    taskKey ? s.taskDetailMap[taskKey]?.status : undefined,
+    taskKey ? (s.taskDetailMap[taskKey]?.status as TaskStatus | undefined) : undefined,
   );
   const taskStatus = liveTaskStatus ?? status;
 
@@ -83,7 +68,7 @@ const RecentListItem = memo<RecentItem>((item) => {
         }
         icon={(() => {
           if (type === 'task') {
-            return <TaskStatusIcon size={16} status={normalizeTaskStatus(taskStatus)} />;
+            return <TaskStatusIcon size={16} status={taskStatus ?? 'backlog'} />;
           }
 
           if (type === 'topic' && metadata?.bot?.platform) {

--- a/src/routes/(main)/home/features/Recents/Item.tsx
+++ b/src/routes/(main)/home/features/Recents/Item.tsx
@@ -1,4 +1,3 @@
-import type { TaskStatus } from '@lobechat/types';
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { FileTextIcon, HashIcon, MoreHorizontalIcon } from 'lucide-react';
@@ -11,7 +10,6 @@ import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
 import { usePrefetchPage } from '@/hooks/usePrefetchPage';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { type RecentItem } from '@/server/routers/lambda/recent';
-import { useTaskStore } from '@/store/task';
 
 import { useRecentItemDropdownMenu } from './useDropdownMenu';
 
@@ -26,14 +24,6 @@ const RecentListItem = memo<RecentItem>((item) => {
   const [editing, setEditing] = useState(false);
   const prefetchAgent = usePrefetchAgent();
   const prefetchPage = usePrefetchPage();
-  const taskKey = type === 'task' ? id : undefined;
-  // Prefer the live task store entry (kept fresh by detail-page mutations) over
-  // the recent.getAll snapshot, so returning from the detail page reflects the
-  // latest status without waiting for the next poll.
-  const liveTaskStatus = useTaskStore((s) =>
-    taskKey ? (s.taskDetailMap[taskKey]?.status as TaskStatus | undefined) : undefined,
-  );
-  const taskStatus = liveTaskStatus ?? status;
 
   const toggleEditing = useCallback((visible?: boolean) => {
     setEditing(!!visible);
@@ -68,7 +58,7 @@ const RecentListItem = memo<RecentItem>((item) => {
         }
         icon={(() => {
           if (type === 'task') {
-            return <TaskStatusIcon size={16} status={taskStatus ?? 'backlog'} />;
+            return <TaskStatusIcon size={16} status={status ?? 'backlog'} />;
           }
 
           if (type === 'topic' && metadata?.bot?.platform) {

--- a/src/routes/(main)/home/features/Recents/Item.tsx
+++ b/src/routes/(main)/home/features/Recents/Item.tsx
@@ -36,15 +36,19 @@ const normalizeTaskStatus = (status?: string | null): TaskStatus => {
 };
 
 const RecentListItem = memo<RecentItem>((item) => {
-  const { title, type, agentId, id, metadata } = item;
+  const { title, type, agentId, id, metadata, status } = item;
   const IconComponent = TYPE_ICON_MAP[type] || FileTextIcon;
   const [editing, setEditing] = useState(false);
   const prefetchAgent = usePrefetchAgent();
   const prefetchPage = usePrefetchPage();
-  const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
   const taskKey = type === 'task' ? id : undefined;
-  useFetchTaskDetail(taskKey);
-  const taskStatus = useTaskStore((s) => (taskKey ? s.taskDetailMap[taskKey]?.status : undefined));
+  // Prefer the live task store entry (kept fresh by detail-page mutations) over
+  // the recent.getAll snapshot, so returning from the detail page reflects the
+  // latest status without waiting for the next poll.
+  const liveTaskStatus = useTaskStore((s) =>
+    taskKey ? s.taskDetailMap[taskKey]?.status : undefined,
+  );
+  const taskStatus = liveTaskStatus ?? status;
 
   const toggleEditing = useCallback((visible?: boolean) => {
     setEditing(!!visible);

--- a/src/server/routers/lambda/recent.ts
+++ b/src/server/routers/lambda/recent.ts
@@ -12,6 +12,8 @@ export interface RecentItem {
   id: string;
   metadata?: ChatTopicMetadata;
   routePath: string;
+  /** Task lifecycle status when `type === 'task'`; null/undefined for topic/document. */
+  status?: string | null;
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;
@@ -64,6 +66,7 @@ export const recentRouter = router({
           id: item.id,
           metadata: item.metadata as ChatTopicMetadata | undefined,
           routePath,
+          status: item.status,
           title: item.title,
           type: item.type,
           updatedAt: item.updatedAt,

--- a/src/server/routers/lambda/recent.ts
+++ b/src/server/routers/lambda/recent.ts
@@ -1,3 +1,4 @@
+import type { TaskStatus } from '@lobechat/types';
 import { z } from 'zod';
 
 import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
@@ -12,8 +13,8 @@ export interface RecentItem {
   id: string;
   metadata?: ChatTopicMetadata;
   routePath: string;
-  /** Task lifecycle status when `type === 'task'`; null/undefined for topic/document. */
-  status?: string | null;
+  /** Task lifecycle status when `type === 'task'`; null for topic/document. */
+  status: TaskStatus | null;
   title: string;
   type: 'topic' | 'document' | 'task';
   updatedAt: Date;

--- a/src/store/home/slices/recent/action.ts
+++ b/src/store/home/slices/recent/action.ts
@@ -11,6 +11,11 @@ import { setNamespace } from '@/utils/storeDebug';
 const n = setNamespace('recent');
 
 const FETCH_RECENTS_KEY = 'fetchRecents';
+// Mirror the home Daily Brief / task detail polling cadence so users see new
+// items, status transitions (incl. backlog/paused → running which the per-item
+// task.detail poll never caught) without manual refresh. SWR pauses when the
+// tab is backgrounded.
+const RECENTS_REFRESH_INTERVAL = 10_000;
 /** SWR key prefix for `AllRecentsDrawer` (`['allRecents', open]`) */
 export const ALL_RECENTS_DRAWER_SWR_PREFIX = 'allRecents';
 
@@ -61,6 +66,7 @@ export class RecentActionImpl {
 
           this.#set({ isRecentsInit: true, recents: data }, false, n('useFetchRecents/onData'));
         },
+        refreshInterval: RECENTS_REFRESH_INTERVAL,
       },
     );
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

Related to LOBE-8597

#### 🔀 Description of Change

Two changes that ride together because they cancel out each other's downsides:

1. **`recent.getAll` now polls every 10s** — `useFetchRecents` had no `refreshInterval`, so `/home` only revalidated on focus/reconnect. New tasks/pages/topics created elsewhere wouldn't appear; status transitions like `backlog/paused → running` (which the per-item `task.detail` poll didn't cover) wouldn't surface either. With this poll the home recents stay live. SWR's default `refreshWhenHidden=false` keeps backgrounded tabs quiet.
2. **`tasks.status` is inlined into `recent.getAll`** — every `type='task'` `RecentItem` previously called `useFetchTaskDetail` just to render the status icon, firing a `task.detail` per task on first render and per running task every 10s. With status now part of the recent payload, `Item.tsx` reads `item.status` directly. The store's `taskDetailMap[id]?.status` is still preferred when present so navigating from the detail page back to home reflects updates immediately.

Net effect on home: N `task.detail` calls become 0; in exchange `recent.getAll` itself polls once every 10s. `recent.getAll` was already on the home critical path, so this is a true reduction in request count.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Verification:

- `cd packages/database && bunx vitest run --silent='passed-only' 'src/models/__tests__/recent.test.ts'`
- `bun run type-check`
- Dev (`bun run dev:spa` → Debug Proxy → `/home`):
  - Create a task in another tab → home shows it within 10s
  - In-flight task changes status → home reflects it
  - Background tab → DevTools Network shows no `recent.getAll` traffic
  - Visit task detail page, change state, return to home → status updates immediately

#### 📝 Additional Information

`hasInFlightActivity`'s "topic still in flight" signal in `useFetchTaskDetail` is no longer reachable from home (the per-item poll is gone). This is fine — home's `RecentItem` only renders the task status icon, not topic-level activity, so it doesn't regress what users see on home. The signal is still active for `task.detail` page consumers.