### PR TITLE
🐛 fix: support provider sdk type routing

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -2,8 +2,8 @@
  * @see https://github.com/lobehub/lobe-chat/discussions/6563
  */
 import type { GoogleGenAIOptions } from '@google/genai';
-import { AgentRuntimeErrorType } from '@lobechat/types';
 import type { ChatModelCard } from '@lobechat/types';
+import { AgentRuntimeErrorType } from '@lobechat/types';
 import debug from 'debug';
 import type { ClientOptions } from 'openai';
 import type OpenAI from 'openai';
@@ -54,6 +54,7 @@ interface ProviderIniOptions extends Record<string, any> {
   baseURLOrAccountID?: string;
   dangerouslyAllowBrowser?: boolean;
   region?: string;
+  sdkType?: string;
   sessionToken?: string;
 }
 

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -17,13 +17,38 @@ const anthropicBaseURL = 'https://api.deepseek.com/anthropic';
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
 describe('LobeDeepSeekAI', () => {
-  const resolveRouter = async (baseURL?: string) => {
-    const runtime = new LobeDeepSeekAI({
+  const createRuntime = ({
+    baseURL,
+    sdkType,
+  }: {
+    baseURL?: string;
+    sdkType?: string;
+  } = {}) =>
+    new LobeDeepSeekAI({
       apiKey: 'test',
       ...(baseURL ? { baseURL } : {}),
+      ...(sdkType ? { sdkType } : {}),
     });
 
+  const resolveRouter = async (baseURL?: string, sdkType?: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
+
     return (runtime as any).resolveMatchedRouter('deepseek-v4-pro');
+  };
+
+  const resolveFirstRuntime = async (baseURL: string, sdkType: string) => {
+    const runtime = new LobeDeepSeekAI({
+      apiKey: 'test',
+      baseURL,
+      sdkType,
+    });
+    const router = await (runtime as any).resolveMatchedRouter('deepseek-v4-pro');
+    const routerOptions = (runtime as any).normalizeRouterOptions(router);
+
+    return {
+      router,
+      runtime: (await (runtime as any).createRuntimeFromOption(router, routerOptions[0])).runtime,
+    };
   };
 
   describe('RouterRuntime baseURL routing', () => {
@@ -60,6 +85,46 @@ describe('LobeDeepSeekAI', () => {
 
       expect(router.apiType).toBe('deepseek');
       expect(router.id).toBe('openai-compatible');
+    });
+
+    it('should route to Anthropic format when sdkType is anthropic', async () => {
+      const router = await resolveRouter('https://aihubmix.com/v1/messages', 'anthropic');
+
+      expect(router.apiType).toBe('deepseek');
+      expect(router.id).toBe('anthropic-compatible');
+    });
+
+    it('should normalize /v1/messages before creating an Anthropic SDK runtime', async () => {
+      const { runtime } = await resolveFirstRuntime(
+        'https://aihubmix.com/v1/messages',
+        'anthropic',
+      );
+
+      expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
+      expect((runtime as any).baseURL).toBe('https://aihubmix.com');
+    });
+
+    it('should normalize /anthropic/v1/messages before creating an Anthropic SDK runtime', async () => {
+      const { runtime } = await resolveFirstRuntime(
+        'https://api.deepseek.com/anthropic/v1/messages',
+        'anthropic',
+      );
+
+      expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
+      expect((runtime as any).baseURL).toBe(anthropicBaseURL);
+    });
+
+    it('should let sdkType override legacy baseURL suffix routing', async () => {
+      const router = await resolveRouter(anthropicBaseURL, 'openai');
+
+      expect(router.apiType).toBe('deepseek');
+      expect(router.id).toBe('openai-compatible');
+    });
+
+    it('should reject unsupported sdkType values', async () => {
+      await expect(resolveRouter(defaultOpenAIBaseURL, 'invalid')).rejects.toThrow(
+        'Unsupported DeepSeek sdkType: invalid',
+      );
     });
   });
 });

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -36,18 +36,14 @@ describe('LobeDeepSeekAI', () => {
     return (runtime as any).resolveMatchedRouter('deepseek-v4-pro');
   };
 
-  const resolveFirstRuntime = async (baseURL: string, sdkType: string) => {
-    const runtime = new LobeDeepSeekAI({
-      apiKey: 'test',
-      baseURL,
-      sdkType,
-    });
+  const resolveFirstRouterOption = async (baseURL: string, sdkType: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
     const router = await (runtime as any).resolveMatchedRouter('deepseek-v4-pro');
     const routerOptions = (runtime as any).normalizeRouterOptions(router);
 
     return {
+      option: routerOptions[0],
       router,
-      runtime: (await (runtime as any).createRuntimeFromOption(router, routerOptions[0])).runtime,
     };
   };
 
@@ -95,21 +91,25 @@ describe('LobeDeepSeekAI', () => {
     });
 
     it('should normalize /v1/messages before creating an Anthropic SDK runtime', async () => {
-      const { runtime } = await resolveFirstRuntime(
+      const { option } = await resolveFirstRouterOption(
         'https://aihubmix.com/v1/messages',
         'anthropic',
       );
+      const runtime = new LobeDeepSeekAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
 
+      expect(option.baseURL).toBe('https://aihubmix.com');
       expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
       expect((runtime as any).baseURL).toBe('https://aihubmix.com');
     });
 
     it('should normalize /anthropic/v1/messages before creating an Anthropic SDK runtime', async () => {
-      const { runtime } = await resolveFirstRuntime(
+      const { option } = await resolveFirstRouterOption(
         'https://api.deepseek.com/anthropic/v1/messages',
         'anthropic',
       );
+      const runtime = new LobeDeepSeekAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
 
+      expect(option.baseURL).toBe(anthropicBaseURL);
       expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
       expect((runtime as any).baseURL).toBe(anthropicBaseURL);
     });

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -42,7 +42,7 @@ const toContentArray = (content: any) =>
     ? content
     : [{ text: isEmptyContent(content) ? ' ' : content, type: 'text' as const }];
 
-const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string) =>
+const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
 
 /**

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -22,6 +22,10 @@ export interface DeepSeekModelCard {
 
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
+const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
+
+type DeepSeekSDKType = 'anthropic' | 'openai';
 
 const isDeepSeekV4Model = (model: string) => model.startsWith('deepseek-v4');
 const isEmptyContent = (content: unknown) =>
@@ -37,6 +41,20 @@ const toContentArray = (content: any) =>
   Array.isArray(content)
     ? content
     : [{ text: isEmptyContent(content) ? ' ' : content, type: 'text' as const }];
+
+const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string) =>
+  baseURL?.replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
+
+/**
+ * `sdkType` explicitly selects the DeepSeek SDK wrapper for router-runtime channels.
+ * Legacy baseURL suffix matching is only kept for existing configs that have not set it.
+ */
+const resolveDeepSeekSDKType = (sdkType: unknown): DeepSeekSDKType | undefined => {
+  if (sdkType === undefined || sdkType === null || sdkType === '') return undefined;
+  if (sdkType === 'anthropic' || sdkType === 'openai') return sdkType;
+
+  throw new Error(`Unsupported DeepSeek sdkType: ${String(sdkType)}`);
+};
 
 const shouldEnableDeepSeekThinking = (payload: ChatStreamPayload) => {
   if (payload.model === 'deepseek-reasoner') return true;
@@ -246,25 +264,54 @@ export const openAIParams = {
 
 export const LobeDeepSeekOpenAI = createOpenAICompatibleRuntime(openAIParams);
 
+const createOpenAIRouter = (baseURLPattern?: RegExp) => ({
+  apiType: 'deepseek' as const,
+  ...(baseURLPattern ? { baseURLPattern } : {}),
+  id: 'openai-compatible',
+  options: { remark: 'openai-compatible' },
+  runtime: LobeDeepSeekOpenAI,
+});
+
+const createAnthropicRouter = ({
+  baseURL,
+  baseURLPattern,
+}: {
+  baseURL?: string;
+  baseURLPattern?: RegExp;
+} = {}) => ({
+  apiType: 'deepseek' as const,
+  ...(baseURLPattern ? { baseURLPattern } : {}),
+  id: 'anthropic-compatible',
+  options: {
+    ...(baseURL ? { baseURL } : {}),
+    remark: 'anthropic-compatible',
+  },
+  runtime: LobeDeepSeekAnthropicAI,
+});
+
 export const params: CreateRouterRuntimeOptions = {
   id: ModelProvider.DeepSeek,
   models: fetchDeepSeekModels,
-  routers: [
-    {
-      apiType: 'deepseek',
-      baseURLPattern: /^(?!.*\/anthropic\/?$).+$/,
-      id: 'openai-compatible',
-      options: { remark: 'openai-compatible' },
-      runtime: LobeDeepSeekOpenAI,
-    },
-    {
-      apiType: 'deepseek',
-      baseURLPattern: /\/anthropic\/?$/,
-      id: 'anthropic-compatible',
-      options: { remark: 'anthropic-compatible' },
-      runtime: LobeDeepSeekAnthropicAI,
-    },
-  ],
+  routers: (options) => {
+    const sdkType = resolveDeepSeekSDKType(options.sdkType);
+
+    if (sdkType === 'anthropic') {
+      return [
+        createAnthropicRouter({
+          baseURL: normalizeDeepSeekAnthropicBaseURL(options.baseURL),
+        }),
+      ];
+    }
+
+    if (sdkType === 'openai') {
+      return [createOpenAIRouter()];
+    }
+
+    return [
+      createOpenAIRouter(/^(?!.*\/anthropic\/?$).+$/),
+      createAnthropicRouter({ baseURLPattern: DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN }),
+    ];
+  },
 };
 
 export const LobeDeepSeekAI = createRouterRuntime(params);

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -19,34 +19,107 @@ vi.spyOn(console, 'error').mockImplementation(() => {});
 vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 describe('LobeMoonshotAI', () => {
+  const createRuntime = ({
+    baseURL,
+    sdkType,
+  }: {
+    baseURL?: string;
+    sdkType?: string;
+  } = {}) =>
+    new LobeMoonshotAI({
+      apiKey: 'test',
+      ...(baseURL ? { baseURL } : {}),
+      ...(sdkType ? { sdkType } : {}),
+    });
+
+  const resolveRouter = async (baseURL?: string, sdkType?: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
+
+    return (runtime as any).resolveMatchedRouter('moonshot-v1-8k');
+  };
+
+  const resolveFirstRouterOption = async (baseURL: string, sdkType: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
+    const router = await (runtime as any).resolveMatchedRouter('moonshot-v1-8k');
+    const routerOptions = (runtime as any).normalizeRouterOptions(router);
+
+    return {
+      option: routerOptions[0],
+      router,
+    };
+  };
+
   describe('RouterRuntime baseURL routing', () => {
     it('should route to OpenAI format by default', async () => {
-      const runtime = new LobeMoonshotAI({ apiKey: 'test' });
-      expect(runtime).toBeInstanceOf(LobeMoonshotAI);
+      const router = await resolveRouter();
+
+      expect(router.apiType).toBe('openai');
+      expect(router.runtime).toBe(LobeMoonshotOpenAI);
     });
 
     it('should route to OpenAI format when baseURL ends with /v1', async () => {
-      const runtime = new LobeMoonshotAI({
-        apiKey: 'test',
-        baseURL: 'https://api.moonshot.cn/v1',
-      });
-      expect(runtime).toBeInstanceOf(LobeMoonshotAI);
+      const router = await resolveRouter(defaultOpenAIBaseURL);
+
+      expect(router.apiType).toBe('openai');
+      expect(router.runtime).toBe(LobeMoonshotOpenAI);
     });
 
     it('should route to Anthropic format when baseURL ends with /anthropic', async () => {
-      const runtime = new LobeMoonshotAI({
-        apiKey: 'test',
-        baseURL: 'https://api.moonshot.cn/anthropic',
-      });
-      expect(runtime).toBeInstanceOf(LobeMoonshotAI);
+      const router = await resolveRouter(anthropicBaseURL);
+
+      expect(router.apiType).toBe('anthropic');
+      expect(router.runtime).toBe(LobeMoonshotAnthropicAI);
     });
 
     it('should route to Anthropic format when baseURL ends with /anthropic/', async () => {
-      const runtime = new LobeMoonshotAI({
-        apiKey: 'test',
-        baseURL: 'https://api.moonshot.cn/anthropic/',
-      });
-      expect(runtime).toBeInstanceOf(LobeMoonshotAI);
+      const router = await resolveRouter(`${anthropicBaseURL}/`);
+
+      expect(router.apiType).toBe('anthropic');
+      expect(router.runtime).toBe(LobeMoonshotAnthropicAI);
+    });
+
+    it('should route to Anthropic format when sdkType is anthropic', async () => {
+      const router = await resolveRouter('https://aihubmix.com/v1/messages', 'anthropic');
+
+      expect(router.apiType).toBe('anthropic');
+      expect(router.runtime).toBe(LobeMoonshotAnthropicAI);
+    });
+
+    it('should normalize /v1/messages before creating an Anthropic SDK runtime', async () => {
+      const { option } = await resolveFirstRouterOption(
+        'https://aihubmix.com/v1/messages',
+        'anthropic',
+      );
+      const runtime = new LobeMoonshotAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
+
+      expect(option.baseURL).toBe('https://aihubmix.com');
+      expect(runtime).toBeInstanceOf(LobeMoonshotAnthropicAI);
+      expect((runtime as any).baseURL).toBe('https://aihubmix.com');
+    });
+
+    it('should normalize /anthropic/v1/messages before creating an Anthropic SDK runtime', async () => {
+      const { option } = await resolveFirstRouterOption(
+        'https://api.moonshot.cn/anthropic/v1/messages',
+        'anthropic',
+      );
+      const runtime = new LobeMoonshotAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
+
+      expect(option.baseURL).toBe(anthropicBaseURL);
+      expect(runtime).toBeInstanceOf(LobeMoonshotAnthropicAI);
+      expect((runtime as any).baseURL).toBe(anthropicBaseURL);
+    });
+
+    it('should let sdkType override legacy baseURL suffix routing', async () => {
+      const router = await resolveRouter(anthropicBaseURL, 'openai');
+
+      expect(router.apiType).toBe('openai');
+      expect(router.runtime).toBe(LobeMoonshotOpenAI);
+    });
+
+    it('should reject unsupported sdkType values', async () => {
+      await expect(resolveRouter(defaultOpenAIBaseURL, 'invalid')).rejects.toThrow(
+        'Unsupported Moonshot sdkType: invalid',
+      );
     });
   });
 

--- a/packages/model-runtime/src/providers/moonshot/index.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.ts
@@ -23,6 +23,10 @@ export interface MoonshotModelCard {
 
 const DEFAULT_MOONSHOT_BASE_URL = 'https://api.moonshot.cn/v1';
 const DEFAULT_MOONSHOT_ANTHROPIC_BASE_URL = 'https://api.moonshot.cn/anthropic';
+const MOONSHOT_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const MOONSHOT_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
+
+type MoonshotSDKType = 'anthropic' | 'openai';
 
 // Shared constants and helpers
 const MOONSHOT_SEARCH_TOOL = { function: { name: '$web_search' }, type: 'builtin_function' } as any;
@@ -37,6 +41,20 @@ const isKimiNativeThinkingModel = (model: string) => model.startsWith('kimi-k2-t
 const isEmptyContent = (content: any) =>
   content === '' || content === null || content === undefined;
 const hasValidReasoning = (reasoning: any) => reasoning?.content && !reasoning?.signature;
+
+const normalizeMoonshotAnthropicBaseURL = (baseURL?: string | null) =>
+  baseURL?.replace(MOONSHOT_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
+
+/**
+ * `sdkType` explicitly selects the Moonshot SDK wrapper for router-runtime channels.
+ * Legacy baseURL suffix matching is only kept for existing configs that have not set it.
+ */
+const resolveMoonshotSDKType = (sdkType: unknown): MoonshotSDKType | undefined => {
+  if (sdkType === undefined || sdkType === null || sdkType === '') return undefined;
+  if (sdkType === 'anthropic' || sdkType === 'openai') return sdkType;
+
+  throw new Error(`Unsupported Moonshot sdkType: ${String(sdkType)}`);
+};
 
 const getKimiThinkingToggleParams = (isThinkingEnabled: boolean) => ({
   temperature: isThinkingEnabled ? 1 : 0.6,
@@ -253,24 +271,54 @@ export const LobeMoonshotOpenAI = createOpenAICompatibleRuntime({
 
 /**
  * RouterRuntime configuration for Moonshot
- * Routes to Anthropic format for /anthropic URLs, otherwise uses OpenAI format
+ * Routes to Anthropic format for /anthropic URLs, otherwise uses OpenAI format.
+ * `sdkType` can explicitly select the format when a gateway URL does not expose
+ * the legacy /anthropic suffix, such as an Anthropic-compatible /v1/messages URL.
  */
+const createAnthropicRouter = ({
+  baseURL,
+  baseURLPattern,
+}: {
+  baseURL?: string;
+  baseURLPattern?: RegExp;
+} = {}) => ({
+  apiType: 'anthropic' as const,
+  ...(baseURLPattern ? { baseURLPattern } : {}),
+  options: {
+    ...(baseURL ? { baseURL } : {}),
+  },
+  runtime: LobeMoonshotAnthropicAI,
+});
+
+const createOpenAIRouter = () => ({
+  apiType: 'openai' as const,
+  options: {},
+  runtime: LobeMoonshotOpenAI,
+});
+
 export const params: CreateRouterRuntimeOptions = {
   id: ModelProvider.Moonshot,
   models: fetchMoonshotModels,
-  routers: [
-    {
-      apiType: 'anthropic',
-      baseURLPattern: /\/anthropic\/?$/,
-      options: {},
-      runtime: LobeMoonshotAnthropicAI,
-    },
-    {
-      apiType: 'openai',
-      options: {},
-      runtime: LobeMoonshotOpenAI,
-    },
-  ],
+  routers: (options) => {
+    const sdkType = resolveMoonshotSDKType(options.sdkType);
+
+    if (sdkType === 'anthropic') {
+      return [
+        createAnthropicRouter({
+          baseURL: normalizeMoonshotAnthropicBaseURL(options.baseURL),
+        }),
+      ];
+    }
+
+    if (sdkType === 'openai') {
+      return [createOpenAIRouter()];
+    }
+
+    return [
+      createAnthropicRouter({ baseURLPattern: MOONSHOT_ANTHROPIC_BASE_URL_PATTERN }),
+      createOpenAIRouter(),
+    ];
+  },
 };
 
 export const LobeMoonshotAI = createRouterRuntime(params);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8634

#### 🔀 Description of Change

- Add a generic router-runtime option field, `sdkType`, so provider channels can explicitly select an SDK wrapper.
- Make the DeepSeek and Moonshot providers use `sdkType: 'anthropic' | 'openai'` before falling back to legacy baseURL suffix routing.
- Normalize trailing `/v1/messages` for Anthropic-compatible SDK clients so endpoints such as `https://aihubmix.com/v1/messages` are passed to the SDK as `https://aihubmix.com`.
- Keep model-family gateway providers unchanged because their runtime selection is model-based, not a single-channel SDK format choice.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/moonshot/index.test.ts' 'src/providers/deepseek/index.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.
