### PR TITLE
🐛 fix: preserve user fields on better-auth session refetch

### DIFF
--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
@@ -68,6 +68,39 @@ describe('UserUpdater', () => {
     expect(useUserStore.getState().user?.latestName).toBe('lice');
   });
 
+  it('drops the previous user profile fields when the session switches to a different account', () => {
+    // Simulate user A is signed in with profile fields populated.
+    useUserStore.setState({
+      user: {
+        id: 'userA',
+        email: 'a@b.com',
+        fullName: 'Alice',
+        username: 'alice',
+        avatar: 'avatar-a',
+        interests: ['内容创作', '编程'],
+        firstName: 'A',
+        latestName: 'lice',
+      },
+    });
+
+    // Better-Auth refetch returns a different account directly (e.g. another
+    // tab signed in as user B with the same cookie jar). No intermediate
+    // signed-out state here.
+    useSessionMock.mockReturnValue(
+      sampleSession({ id: 'userB', email: 'b@c.com', name: 'Bob', username: 'bob' }),
+    );
+    render(<UserUpdater />);
+
+    // Profile fields tied to user A must NOT leak to user B's store entry.
+    const user = useUserStore.getState().user;
+    expect(user?.id).toBe('userB');
+    expect(user?.email).toBe('b@c.com');
+    expect(user?.interests).toBeUndefined();
+    expect(user?.firstName).toBeUndefined();
+    expect(user?.latestName).toBeUndefined();
+    expect(user?.avatar).toBe('');
+  });
+
   it('clears the user when the session goes away', () => {
     useUserStore.setState({
       user: { id: 'u1', email: 'a@b.com', interests: ['x'] },

--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserStore } from '@/store/user';
+
+import UserUpdater from './UserUpdater';
+
+const useSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/libs/better-auth/auth-client', () => ({
+  useSession: useSessionMock,
+}));
+
+const sampleSession = (overrides?: Record<string, unknown>) => ({
+  data: {
+    user: {
+      id: 'u1',
+      email: 'a@b.com',
+      name: 'Alice',
+      username: 'alice',
+      ...overrides,
+    },
+  },
+  isPending: false,
+  error: null,
+});
+
+describe('UserUpdater', () => {
+  beforeEach(() => {
+    useSessionMock.mockReset();
+    useUserStore.setState({ user: undefined, isSignedIn: false, isLoaded: false });
+  });
+
+  afterEach(() => {
+    useUserStore.setState({ user: undefined, isSignedIn: false, isLoaded: false });
+  });
+
+  it('preserves user fields populated by useInitUserState (e.g. interests) when better-auth re-emits the session on tab focus', () => {
+    // Simulate the post-init state: useInitUserState has loaded interests etc.
+    useUserStore.setState({
+      user: {
+        id: 'u1',
+        email: 'a@b.com',
+        fullName: 'Alice',
+        username: 'alice',
+        interests: ['内容创作', '编程'],
+        firstName: 'A',
+        latestName: 'lice',
+      },
+    });
+
+    useSessionMock.mockReturnValue(sampleSession());
+    const { rerender } = render(<UserUpdater />);
+
+    expect(useUserStore.getState().user?.interests).toEqual(['内容创作', '编程']);
+    expect(useUserStore.getState().user?.firstName).toBe('A');
+
+    // Simulate better-auth refetching on visibilitychange: same logical user,
+    // but `data` (and therefore `user`) is a fresh object reference.
+    useSessionMock.mockReturnValue(sampleSession());
+    rerender(<UserUpdater />);
+
+    // Regression: interests / firstName / latestName must NOT be wiped by the
+    // session sync. (LOBE-8597 — wiped interests caused the home daily-brief
+    // recommendation SWR key to reset and refetch with empty interestKeys.)
+    expect(useUserStore.getState().user?.interests).toEqual(['内容创作', '编程']);
+    expect(useUserStore.getState().user?.firstName).toBe('A');
+    expect(useUserStore.getState().user?.latestName).toBe('lice');
+  });
+
+  it('clears the user when the session goes away', () => {
+    useUserStore.setState({
+      user: { id: 'u1', email: 'a@b.com', interests: ['x'] },
+    });
+
+    useSessionMock.mockReturnValue({ data: null, isPending: false, error: null });
+    render(<UserUpdater />);
+
+    expect(useUserStore.getState().user).toBeUndefined();
+  });
+});

--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
@@ -30,19 +30,29 @@ const UserUpdater = memo(() => {
   // populated by `useInitUserState` (one-shot SWR) and would otherwise be
   // wiped on every focus, breaking downstream selectors (e.g. the daily-brief
   // recommendation SWR key resets to empty interests and refetches). LOBE-8597.
+  //
+  // Guard the merge by user id: if the session switches to a different
+  // account (e.g. another tab signed in as a different user, focus refetch
+  // returns the new session here without an intermediate signed-out state),
+  // drop the previous user's profile fields so they don't leak across
+  // accounts. `useInitUserState` is `useOnlyFetchOnceSWR` with a constant
+  // key, so it won't re-fetch profile data for the new user on its own.
   useEffect(() => {
     if (betterAuthUser) {
-      useUserStore.setState((state) => ({
-        user: {
-          ...state.user,
-          // Preserve avatar from settings, don't override with auth provider value
-          avatar: state.user?.avatar || '',
-          email: betterAuthUser.email,
-          fullName: betterAuthUser.name,
-          id: betterAuthUser.id,
-          username: betterAuthUser.username,
-        } as LobeUser,
-      }));
+      useUserStore.setState((state) => {
+        const baseUser = state.user?.id === betterAuthUser.id ? state.user : undefined;
+        return {
+          user: {
+            ...baseUser,
+            // Preserve avatar from settings, don't override with auth provider value
+            avatar: baseUser?.avatar || '',
+            email: betterAuthUser.email,
+            fullName: betterAuthUser.name,
+            id: betterAuthUser.id,
+            username: betterAuthUser.username,
+          } as LobeUser,
+        };
+      });
       return;
     }
 

--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
@@ -22,22 +22,27 @@ const UserUpdater = memo(() => {
   useStoreUpdater('isLoaded', isLoaded);
   useStoreUpdater('isSignedIn', isSignedIn);
 
-  // Sync user data from Better-Auth session to Zustand store
+  // Sync user data from Better-Auth session to Zustand store.
+  // Better-Auth refetches the session on tab focus (visibilitychange), which
+  // gives us a new `betterAuthUser` reference each time even when the
+  // underlying user is unchanged. We must merge into the existing user rather
+  // than replace it — fields like `interests`, `firstName`, `latestName` are
+  // populated by `useInitUserState` (one-shot SWR) and would otherwise be
+  // wiped on every focus, breaking downstream selectors (e.g. the daily-brief
+  // recommendation SWR key resets to empty interests and refetches). LOBE-8597.
   useEffect(() => {
     if (betterAuthUser) {
-      const userAvatar = useUserStore.getState().user?.avatar;
-
-      const lobeUser = {
-        // Preserve avatar from settings, don't override with auth provider value
-        avatar: userAvatar || '',
-        email: betterAuthUser.email,
-        fullName: betterAuthUser.name,
-        id: betterAuthUser.id,
-        username: betterAuthUser.username,
-      } as LobeUser;
-
-      // Update user data in store
-      useUserStore.setState({ user: lobeUser });
+      useUserStore.setState((state) => ({
+        user: {
+          ...state.user,
+          // Preserve avatar from settings, don't override with auth provider value
+          avatar: state.user?.avatar || '',
+          email: betterAuthUser.email,
+          fullName: betterAuthUser.name,
+          id: betterAuthUser.id,
+          username: betterAuthUser.username,
+        } as LobeUser,
+      }));
       return;
     }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

LOBE-8597 (second item: "template SWR seems to refresh frequently").

#### 🔀 Description of Change

Better-Auth's \`useSession\` refetches the session on tab focus (\`visibilitychange\`, rate-limited to 5s). Each refetch yields a new \`session.user\` reference even when the underlying user is unchanged.

\`UserUpdater\` previously **replaced** the entire \`user\` object in the Zustand store with only the auth-derived fields (\`avatar\`, \`email\`, \`fullName\`, \`id\`, \`username\`), wiping fields populated elsewhere — most importantly \`interests\`, \`firstName\`, \`latestName\`, all written by \`useInitUserState\` (a one-shot SWR that does not re-fire on focus).

After every focus refetch:

1. \`useUserStore.user.interests\` silently flips to \`undefined\`
2. \`userProfileSelectors.interests\` returns \`[]\`
3. \`useResolvedInterestKeys\` recomputes \`null/[]\`
4. \`swrKey\` for \`taskTemplate.listDailyRecommend\` changes
5. The home daily-brief recommendation list refetches with \`interestKeys: []\`
6. Cards visually "flash" on every tab return — easy to reproduce if your account has interests set; invisible on fresh dev accounts where \`interests\` is already empty

The fix switches the \`useEffect\` to a setter-form \`setState\` that **merges** the auth-derived fields into the existing user, preserving everything else.

#### 🧪 How to Test

- [x] Tested locally (verified Network: \`taskTemplate.listDailyRecommend\` no longer fires on tab focus)
- [x] Added/updated tests — new \`UserUpdater.test.tsx\` regression test, fails before this change, passes after

\`\`\`
bunx vitest run src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
\`\`\`

#### 📝 Additional Information

Side benefit: removes one redundant trpc round-trip plus the server-side enrichment work on every tab focus, which compounds with the brief-side trimming in #14516.