### PR TITLE
✨ feat: add monitoring healthcheck hook

### DIFF
--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -8,6 +8,7 @@ export enum RequestTrigger {
   FileEmbedding = 'file_embedding',
   Image = 'image',
   Memory = 'memory',
+  Monitor = 'monitor',
   SemanticSearch = 'semantic_search',
   Topic = 'topic',
   Video = 'video',

--- a/src/business/server/healthcheck.ts
+++ b/src/business/server/healthcheck.ts
@@ -1,0 +1,1 @@
+export async function businessHealthcheck(): Promise<void> {}

--- a/src/server/routers/lambda/__tests__/healthcheck.test.ts
+++ b/src/server/routers/lambda/__tests__/healthcheck.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createContextInner } from '@/libs/trpc/lambda/context';
+
+import { lambdaRouter } from '../index';
+
+const businessHealthcheckMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/server/healthcheck', () => ({
+  businessHealthcheck: businessHealthcheckMock,
+}));
+
+describe('lambdaRouter.healthcheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    businessHealthcheckMock.mockResolvedValue(undefined);
+  });
+
+  it('returns the existing liveness response when dependency checks pass', async () => {
+    const caller = lambdaRouter.createCaller(await createContextInner());
+
+    await expect(caller.healthcheck()).resolves.toBe("i'm live!");
+    expect(businessHealthcheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails the healthcheck when the business dependency check fails', async () => {
+    businessHealthcheckMock.mockRejectedValueOnce(
+      new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Healthcheck failed: redis' }),
+    );
+    const caller = lambdaRouter.createCaller(await createContextInner());
+
+    await expect(caller.healthcheck()).rejects.toThrow('Healthcheck failed: redis');
+  });
+});

--- a/src/server/routers/lambda/index.ts
+++ b/src/server/routers/lambda/index.ts
@@ -1,6 +1,7 @@
 /**
  * This file contains the root router of Lobe Chat tRPC-backend
  */
+import { businessHealthcheck } from '@/business/server/healthcheck';
 import { accountDeletionRouter } from '@/business/server/lambda-routers/accountDeletion';
 import { referralRouter } from '@/business/server/lambda-routers/referral';
 import { spendRouter } from '@/business/server/lambda-routers/spend';
@@ -98,7 +99,11 @@ export const lambdaRouter = router({
   generationBatch: generationBatchRouter,
   generationTopic: generationTopicRouter,
   group: agentGroupRouter,
-  healthcheck: publicProcedure.query(() => "i'm live!"),
+  healthcheck: publicProcedure.query(async () => {
+    await businessHealthcheck();
+
+    return "i'm live!";
+  }),
   home: homeRouter,
   image: imageRouter,
   importer: importerRouter,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - internal monitoring setup.

#### 🔀 Description of Change

- Add a business healthcheck hook used by the lambda healthcheck procedure.
- Keep the default open-source implementation as a no-op.
- Add a monitor request trigger for synthetic monitoring metadata.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed


after running:

```bash
bunx vitest run --silent='passed-only' 'src/server/routers/lambda/__tests__/healthcheck.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR only adds the generic hook surface. Cloud-specific dependency checks are implemented in the cloud repo.
