### PR TITLE
💄 fix(chat-input): fix MentionMenu scroll area clipping caused by container padding

### DIFF
--- a/src/features/ChatInput/InputEditor/MentionMenu/style.ts
+++ b/src/features/ChatInput/InputEditor/MentionMenu/style.ts
@@ -136,5 +136,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   scrollArea: css`
     overflow-y: auto;
     flex: 1;
+    margin: -4px;
+    padding: 4px;
   `,
 }));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-7298

#### 🔀 Description of Change

Fix the MentionMenu (@ dropdown) scroll area visual clipping issue. The parent container has `padding: 4px` which caused the scrollable area items to appear clipped at the edges with visible border artifacts.

Apply negative margin with compensating padding (`margin: -4px; padding: 4px`) to the `scrollArea` to counteract the parent padding and ensure smooth scrolling without visual clipping.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open the MentionMenu (type `@` in chat input)
2. Verify scroll area items are not clipped at the edges
3. Verify no double-border visual artifacts on scroll