### PR TITLE
🐛 fix: recover hetero persistence state across Vercel replicas

### DIFF
--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -73,12 +73,13 @@ export interface ChatTopicMetadata {
    */
   cronJobId?: string;
   /**
-   * ID of the currently active assistant message for a running heterogeneous
-   * agent operation. Updated on every step boundary so a new server replica
-   * can reconstruct `currentAssistantMessageId` from topic metadata rather
-   * than falling back to the stale initial placeholder.
+   * Scoped pointer to the currently active assistant message for a running
+   * heterogeneous agent operation. Includes `operationId` so cold-start
+   * replicas only use the value when it belongs to the current operation —
+   * preventing a stale pointer from a previous run from corrupting a new one.
+   * Updated on every step boundary.
    */
-  heteroCurrentMsgId?: string;
+  heteroCurrentMsgId?: { msgId: string; operationId: string };
   /**
    * Persistent session id for a heterogeneous agent.
    * Saved after each turn so the next message in the same topic can resume

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -73,6 +73,13 @@ export interface ChatTopicMetadata {
    */
   cronJobId?: string;
   /**
+   * ID of the currently active assistant message for a running heterogeneous
+   * agent operation. Updated on every step boundary so a new server replica
+   * can reconstruct `currentAssistantMessageId` from topic metadata rather
+   * than falling back to the stale initial placeholder.
+   */
+  heteroCurrentMsgId?: string;
+  /**
    * Persistent session id for a heterogeneous agent.
    * Saved after each turn so the next message in the same topic can resume
    * the conversation (e.g. Claude Code CLI uses `--resume <sessionId>`).

--- a/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -332,8 +332,14 @@ export class HeterogeneousPersistenceHandler {
     // Prefer the latest step's assistant message id (written by handleStepStart)
     // over the initial placeholder — so a new replica after a step boundary uses
     // the correct message rather than the stale initial one.
+    // Guard: only use heteroCurrentMsgId when it belongs to THIS operation.
+    // A stale value from a previous run must not override the new operation's
+    // seeded assistantMessageId (P1 fix).
+    const stored = topic.metadata?.heteroCurrentMsgId;
     const currentAssistantMessageId =
-      (topic.metadata?.heteroCurrentMsgId as string | undefined) ?? running.assistantMessageId;
+      stored?.operationId === running.operationId
+        ? (stored.msgId ?? running.assistantMessageId)
+        : running.assistantMessageId;
 
     // Restore toolMsgIdByCallId from the DB so tool_results that arrive on a
     // different replica than their tool_use can still be matched and persisted.
@@ -460,18 +466,21 @@ export class HeterogeneousPersistenceHandler {
       role: 'assistant',
       topicId: state.topicId,
     });
-    state.currentAssistantMessageId = newMsg.id;
 
+    // Persist BEFORE advancing in-memory state (P2 fix). If this write fails
+    // transiently and the event is retried, state is still at the previous step
+    // so handleStepStart re-creates the new message with the correct parent
+    // rather than chaining off the partially-created one. The first attempt's
+    // empty message becomes an orphan but does not corrupt the turn chain.
+    await this.deps.topicModel.updateMetadata(state.topicId, {
+      heteroCurrentMsgId: { msgId: newMsg.id, operationId: state.operationId },
+    });
+
+    // Advance state only after the DB write lands.
+    state.currentAssistantMessageId = newMsg.id;
     state.accumulatedContent = '';
     state.accumulatedReasoning = '';
     state.toolState = { payloads: [], persistedIds: new Set() };
-
-    // Persist the new assistant message id so a subsequent replica can
-    // reconstruct `currentAssistantMessageId` from topic metadata instead of
-    // falling back to the stale initial placeholder.
-    await this.deps.topicModel.updateMetadata(state.topicId, {
-      heteroCurrentMsgId: newMsg.id,
-    });
   }
 
   private async handleStreamChunk(state: OperationState, event: AgentStreamEvent) {

--- a/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -253,6 +253,11 @@ export class HeterogeneousPersistenceHandler {
       await this.handleEvent(state, event);
       state.processedKeys.add(key);
     }
+
+    // Flush accumulated content after every batch so a subsequent replica
+    // picking up this operation always sees the latest content in the DB,
+    // even if it never processes a step boundary or terminal event.
+    await this.flushBatchContent(state);
   }
 
   /**
@@ -324,22 +329,42 @@ export class HeterogeneousPersistenceHandler {
       throw new Error(`runningOperation on topic ${topicId} is missing assistantMessageId`);
     }
 
+    // Prefer the latest step's assistant message id (written by handleStepStart)
+    // over the initial placeholder — so a new replica after a step boundary uses
+    // the correct message rather than the stale initial one.
+    const currentAssistantMessageId =
+      (topic.metadata?.heteroCurrentMsgId as string | undefined) ?? running.assistantMessageId;
+
+    // Restore toolMsgIdByCallId from the DB so tool_results that arrive on a
+    // different replica than their tool_use can still be matched and persisted.
+    const toolPlugins = await this.deps.messageModel.listMessagePluginsByTopic(topicId);
+    const toolMsgIdByCallId = new Map<string, string>();
+    for (const plugin of toolPlugins) {
+      if (plugin.toolCallId) toolMsgIdByCallId.set(plugin.toolCallId, plugin.id);
+    }
+
     state = {
       accumulatedContent: '',
       accumulatedReasoning: '',
       agentId: topic.agentId ?? null,
-      currentAssistantMessageId: running.assistantMessageId,
+      currentAssistantMessageId,
       lastModel: undefined,
       lastProvider: undefined,
       operationId,
       processedKeys: new Set(),
       subagentRuns: new Map(),
-      toolMsgIdByCallId: new Map(),
+      toolMsgIdByCallId,
       toolState: { payloads: [], persistedIds: new Set() },
       topicId,
     };
     operationStates.set(operationId, state);
-    log('created state for operation %s on topic %s', operationId, topicId);
+    log(
+      'created state for operation %s on topic %s msgId=%s tools=%d',
+      operationId,
+      topicId,
+      currentAssistantMessageId,
+      toolMsgIdByCallId.size,
+    );
     return state;
   }
 
@@ -440,6 +465,13 @@ export class HeterogeneousPersistenceHandler {
     state.accumulatedContent = '';
     state.accumulatedReasoning = '';
     state.toolState = { payloads: [], persistedIds: new Set() };
+
+    // Persist the new assistant message id so a subsequent replica can
+    // reconstruct `currentAssistantMessageId` from topic metadata instead of
+    // falling back to the stale initial placeholder.
+    await this.deps.topicModel.updateMetadata(state.topicId, {
+      heteroCurrentMsgId: newMsg.id,
+    });
   }
 
   private async handleStreamChunk(state: OperationState, event: AgentStreamEvent) {
@@ -575,6 +607,20 @@ export class HeterogeneousPersistenceHandler {
     if (Object.keys(updateValue).length > 0) {
       await this.deps.messageModel.update(state.currentAssistantMessageId, updateValue);
     }
+  }
+
+  /**
+   * Write accumulated content/reasoning to DB after every ingest batch.
+   * This ensures a subsequent replica always finds the latest text in the DB
+   * even if the current replica never processes a step-boundary or terminal
+   * event (which are the normal flush triggers).
+   */
+  private async flushBatchContent(state: OperationState): Promise<void> {
+    if (!state.accumulatedContent && !state.accumulatedReasoning) return;
+    const update: Record<string, any> = {};
+    if (state.accumulatedContent) update.content = state.accumulatedContent;
+    if (state.accumulatedReasoning) update.reasoning = { content: state.accumulatedReasoning };
+    await this.deps.messageModel.update(state.currentAssistantMessageId, update);
   }
 
   private toChatMessageError(data: unknown): ChatMessageError {

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
@@ -121,6 +121,7 @@ const createHarness = (
         return { success: true };
       },
     ),
+    listMessagePluginsByTopic: vi.fn(async (_topicId: string) => []),
   };
 
   const threadModel = {
@@ -149,6 +150,7 @@ const createHarness = (
       id: topicId,
       metadata: { runningOperation: { assistantMessageId, operationId } },
     })),
+    updateMetadata: vi.fn(async (_topicId: string, _patch: any) => {}),
   };
 
   const handler = new HeterogeneousPersistenceHandler({
@@ -306,8 +308,10 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
         buildEvent('stream_chunk', 1, { chunkType: 'text', content: 'there' }),
       ]);
 
-      // No update yet — text is held in accumulator
-      expect(h.messageModel.update).not.toHaveBeenCalled();
+      // Text is flushed to DB at end of each batch (multi-replica fix)
+      expect(h.messageModel.update).toHaveBeenCalledWith(h.assistantMessageId, {
+        content: 'hi there',
+      });
     });
 
     it('main-side reasoning accumulates separately from text', async () => {

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.fixture.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.fixture.test.ts
@@ -181,6 +181,7 @@ const createHarness = () => {
       });
       return { success: true };
     }),
+    listMessagePluginsByTopic: vi.fn(async (_topicId: string) => []),
   };
 
   const threadModel = {
@@ -202,6 +203,7 @@ const createHarness = () => {
         runningOperation: { assistantMessageId: 'asst-fixture', operationId: 'op-fixture' },
       },
     })),
+    updateMetadata: vi.fn(async (_topicId: string, _patch: any) => {}),
   };
 
   const handler = new HeterogeneousPersistenceHandler({

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -101,6 +101,7 @@ const createHarness = (params: {
         return { success: true };
       },
     ),
+    listMessagePluginsByTopic: vi.fn(async (_topicId: string) => []),
   };
 
   const threadModel = {
@@ -138,6 +139,7 @@ const createHarness = (params: {
         },
       };
     }),
+    updateMetadata: vi.fn(async (_topicId: string, _patch: any) => {}),
   };
 
   const handler = new HeterogeneousPersistenceHandler({
@@ -190,8 +192,8 @@ describe('HeterogeneousPersistenceHandler', () => {
       });
 
       expect(h.topicModel.findById).toHaveBeenCalledWith('topic-1');
-      // Text chunks accumulate; nothing flushed until step boundary or finish
-      expect(h.messageModel.update).not.toHaveBeenCalled();
+      // Text chunks accumulate; flushed to DB at end of each batch (multi-replica fix)
+      expect(h.messageModel.update).toHaveBeenCalledWith('asst-seeded', { content: 'hello world' });
     });
 
     it('throws when the topic has no matching runningOperation', async () => {
@@ -394,8 +396,8 @@ describe('HeterogeneousPersistenceHandler', () => {
         topicId: 'topic-1',
       });
 
-      // Phase 1 (update-asst) → Phase 2 (create-tool) → Phase 3 (update-asst)
-      expect(order).toEqual(['update-asst', 'create-tool', 'update-asst']);
+      // Phase 1 (update-asst) → Phase 2 (create-tool) → Phase 3 (update-asst) → batch flush (update-asst)
+      expect(order).toEqual(['update-asst', 'create-tool', 'update-asst', 'update-asst']);
 
       // Tool message exists with content from tool_result + correct tool_call_id
       const toolMsg = [...h.messages.values()].find((m) => m.role === 'tool');

--- a/src/server/services/heterogeneousAgent/__tests__/sessionResume.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/sessionResume.test.ts
@@ -31,7 +31,10 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
 
       // Real handler so we exercise the persistSessionId path end-to-end
       const handler = new HeterogeneousPersistenceHandler({
-        messageModel: { update: vi.fn(async () => ({ success: true })) } as any,
+        messageModel: {
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
         threadModel: {} as any,
         topicModel: { findById, updateMetadata } as any,
       });
@@ -83,7 +86,10 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       }));
 
       const handler = new HeterogeneousPersistenceHandler({
-        messageModel: { update: vi.fn(async () => ({ success: true })) } as any,
+        messageModel: {
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
         threadModel: {} as any,
         topicModel: { findById, updateMetadata } as any,
       });
@@ -131,7 +137,10 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       }));
 
       const handler = new HeterogeneousPersistenceHandler({
-        messageModel: { update: vi.fn(async () => ({ success: true })) } as any,
+        messageModel: {
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
         threadModel: {} as any,
         topicModel: { findById, updateMetadata } as any,
       });
@@ -186,7 +195,10 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       }));
 
       const handler = new HeterogeneousPersistenceHandler({
-        messageModel: { update: vi.fn(async () => ({ success: true })) } as any,
+        messageModel: {
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
         threadModel: {} as any,
         topicModel: { findById, updateMetadata } as any,
       });
@@ -244,7 +256,10 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
       }));
 
       const handler = new HeterogeneousPersistenceHandler({
-        messageModel: { update: vi.fn(async () => ({ success: true })) } as any,
+        messageModel: {
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
         threadModel: {} as any,
         topicModel: { findById, updateMetadata } as any,
       });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-8516 (cloud hetero agent pipeline)

#### 🔀 Description of Change

Fixes message fragmentation and orphaned tool calls caused by Vercel serverless routing the same operation's `heteroIngest` batches to different Node.js instances.

**Root cause**: `HeterogeneousPersistenceHandler` keeps `operationStates` in process memory. When consecutive batches land on different replicas, the second replica starts with a blank state — wrong `currentAssistantMessageId`, empty `toolMsgIdByCallId`, and lost accumulated text.

**Three-part fix** (no Redis, no new infra):

1. **Flush content after every batch** — `ingest()` now writes `accumulatedContent`/`accumulatedReasoning` to DB at the end of each call, so a replica switch mid-stream doesn't discard buffered text (fixes isolated single-character messages like "我").

2. **Persist `heteroCurrentMsgId` on step boundaries** — `handleStepStart` now writes the new assistant message id to `topic.metadata.heteroCurrentMsgId`. A fresh replica reads this field instead of falling back to the stale initial placeholder, so new content lands on the correct message.

3. **Restore `toolMsgIdByCallId` from DB on state creation** — `loadOrCreateState` now queries `listMessagePluginsByTopic` to rebuild the tool call → tool message mapping, so `tool_result` events on a new replica can still find and update their counterpart rows.

**Desktop unaffected**: `HeterogeneousPersistenceHandler` is only invoked via `heteroIngest`/`heteroFinish` tRPC. Desktop hetero agent uses the renderer-side IPC path and never touches this handler.

#### 🧪 How to Test

- Deploy to Vercel (multi-instance) and run a multi-step Claude Code task
- Verify no isolated text fragments or orphaned tool call warnings in the conversation

#### 📝 Additional Information

The in-memory singleton remains for same-replica fast-path. The DB reads in `loadOrCreateState` are only triggered on a cold state (first batch per replica per operation), so the overhead is bounded to one `listMessagePluginsByTopic` query per replica cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)