### PR TITLE
🐛 fix(model-runtime): preserve reasoning_content for deepseek models in OpenAI-compat layer

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -351,6 +351,111 @@ describe('convertOpenAIMessages', () => {
     expect((result[0] as any).reasoning).toBeUndefined();
     expect((result[0] as any).reasoning_content).toBe('some reasoning content');
   });
+
+  describe('DeepSeek reasoning_content compatibility', () => {
+    it('should derive reasoning_content from reasoning.content for deepseek models', async () => {
+      const messages = [
+        {
+          role: 'assistant',
+          content: 'Answer with tool call',
+          reasoning: { content: 'planned tool invocation', duration: 100 },
+          tool_calls: [
+            { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } },
+          ],
+        },
+      ] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-v4-flash' });
+
+      expect((result[0] as any).reasoning_content).toBe('planned tool invocation');
+      expect((result[0] as any).tool_calls).toHaveLength(1);
+      expect((result[0] as any).reasoning).toBeUndefined();
+    });
+
+    it('should force empty reasoning_content for deepseek-v4 thinking-mode assistant messages without reasoning', async () => {
+      const messages = [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } },
+          ],
+        },
+      ] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-v4-pro' });
+
+      expect((result[0] as any).reasoning_content).toBe('');
+    });
+
+    it('should force empty reasoning_content for deepseek-reasoner', async () => {
+      const messages = [{ role: 'assistant', content: 'Hi' }] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-reasoner' });
+
+      expect((result[0] as any).reasoning_content).toBe('');
+    });
+
+    it('should match provider-prefixed deepseek model ids (e.g. Deepseek/deepseek-v4-pro)', async () => {
+      const messages = [{ role: 'assistant', content: 'Hi' }] as any;
+
+      const result = await convertOpenAIMessages(messages, {
+        model: 'Deepseek/deepseek-v4-pro',
+      });
+
+      expect((result[0] as any).reasoning_content).toBe('');
+    });
+
+    it('should not force reasoning_content for non-thinking deepseek models', async () => {
+      const messages = [{ role: 'assistant', content: 'Hi' }] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-chat' });
+
+      expect((result[0] as any).reasoning_content).toBeUndefined();
+    });
+
+    it('should leave non-deepseek models untouched', async () => {
+      const messages = [
+        {
+          role: 'assistant',
+          content: 'Hi',
+          reasoning: { content: 'unrelated', duration: 10 },
+        },
+      ] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'gpt-4o-mini' });
+
+      expect((result[0] as any).reasoning_content).toBeUndefined();
+      expect((result[0] as any).reasoning).toBeUndefined();
+    });
+
+    it('should not touch non-assistant messages', async () => {
+      const messages = [
+        { role: 'user', content: 'hello' },
+        { role: 'tool', content: '{}', tool_call_id: 'call_1' },
+      ] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-v4-flash' });
+
+      expect((result[0] as any).reasoning_content).toBeUndefined();
+      expect((result[1] as any).reasoning_content).toBeUndefined();
+    });
+
+    it('should preserve existing reasoning_content over reasoning.content', async () => {
+      const messages = [
+        {
+          role: 'assistant',
+          content: 'Hi',
+          reasoning: { content: 'should be ignored', duration: 10 },
+          reasoning_content: 'kept',
+        },
+      ] as any;
+
+      const result = await convertOpenAIMessages(messages, { model: 'deepseek-v4-flash' });
+
+      expect((result[0] as any).reasoning_content).toBe('kept');
+    });
+  });
 });
 
 describe('convertOpenAIResponseInputs', () => {

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -17,7 +17,21 @@ export type ExtendedChatCompletionContentPart = {
 type ConvertMessageContentOptions = {
   forceImageBase64?: boolean;
   forceVideoBase64?: boolean;
+  model?: string;
   strictToolPairing?: boolean;
+};
+
+const isDeepSeekModel = (model: string | undefined) =>
+  typeof model === 'string' && model.toLowerCase().includes('deepseek');
+
+// DeepSeek thinking-mode eligible models require reasoning_content on every
+// assistant history message — otherwise the API rejects follow-up turns with
+// "The reasoning_content in the thinking mode must be passed back to the API."
+// See https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+const isDeepSeekThinkingEligibleModel = (model: string | undefined) => {
+  if (!model) return false;
+  const lower = model.toLowerCase();
+  return lower.includes('deepseek-reasoner') || lower.includes('deepseek-v4');
 };
 
 type OpenAICompatibleContentPart =
@@ -107,6 +121,23 @@ export const convertOpenAIMessages = async (
       if (msg.reasoning_content !== undefined) result.reasoning_content = msg.reasoning_content;
       // MiniMax uses reasoning_details for historical thinking, so forward it unchanged
       if (msg.reasoning_details !== undefined) result.reasoning_details = msg.reasoning_details;
+
+      // For DeepSeek-family models routed via any OpenAI-compatible runtime
+      // (including custom user providers that bypass the dedicated DeepSeek
+      // handlePayload), derive reasoning_content from the structured reasoning
+      // field on assistant messages and force a placeholder when the model is
+      // thinking-mode eligible.
+      if (msg.role === 'assistant' && isDeepSeekModel(options?.model)) {
+        if (result.reasoning_content === undefined && typeof msg.reasoning?.content === 'string') {
+          result.reasoning_content = msg.reasoning.content;
+        }
+        if (
+          result.reasoning_content === undefined &&
+          isDeepSeekThinkingEligibleModel(options?.model)
+        ) {
+          result.reasoning_content = '';
+        }
+      }
 
       return result;
     }),

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -473,6 +473,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         const messages = await convertOpenAIMessages(postPayload.messages, {
           forceImageBase64: chatCompletion?.forceImageBase64,
           forceVideoBase64: chatCompletion?.forceVideoBase64,
+          model: postPayload.model,
         });
 
         let response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;


### PR DESCRIPTION
## Summary

- DeepSeek thinking-mode (`deepseek-reasoner` / `deepseek-v4-*`) rejects follow-up turns when assistant history messages drop `reasoning_content`, surfacing as `Missing reasoning_content field in the assistant message at message index N` or `The reasoning_content in the thinking mode must be passed back to the API`.
- Until now this was only enforced inside `buildDeepSeekOpenAIPayload` on the dedicated DeepSeek runtime. Users routing deepseek model ids through other OpenAI-compatible runtimes (e.g. custom providers, AIhubMix) skipped that transform and hit the 400.
- Move the safety net into `convertOpenAIMessages`: when the model name contains `deepseek`, derive `reasoning_content` from the structured `reasoning.content` for assistant messages, and force an empty placeholder for thinking-mode-eligible models so follow-up tool turns stay valid.

Fixes LOBE-8290
Fixes #12589

Related (also resolved by this change):
- #12294 — DeepSeek V3.2 SubAgent missing reasoning_content
- #11924 — deepseek-reasoner under OpenAI provider cannot reply after calling tools
- #11529 — DeepSeek's reasoning model cannot use web search
- #11288 — deepseek api returns error in multi-assistant broadcast
- #11125 — DeepSeek-Reasoner case (only that branch; GLM/MiniMax in the same report are unrelated)
- #10534 — DeepSeek V3.2 fails to call tools when interleaved thinking is enabled

## Test plan

- [x] `bunx vitest run packages/model-runtime/src/core/contextBuilders/openai.test.ts` — 48 tests pass (7 new deepseek-compat cases)
- [x] `bunx vitest run packages/model-runtime/src/providers/deepseek/index.test.ts` — 43 tests pass (no regression on the dedicated runtime)
- [x] `bunx vitest run packages/model-runtime/src/core/openaiCompatibleFactory` — 129 tests pass
- [x] `bun run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)