### PR TITLE
🐛 fix: flatten visual analysis tool schema

### DIFF
--- a/packages/builtin-tool-lobe-agent/src/manifest.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.test.ts
@@ -20,4 +20,14 @@ describe('LobeAgentManifest', () => {
     expect(apiDescription).toContain('Use only stable refs');
     expect(apiDescription).toContain('answer the user directly with the result');
   });
+
+  it('should keep visual analysis parameters compatible with strict tool schema validators', () => {
+    const parameters = LobeAgentManifest.api[0].parameters;
+
+    expect(parameters).not.toHaveProperty('oneOf');
+    expect(parameters).not.toHaveProperty('allOf');
+    expect(parameters).not.toHaveProperty('anyOf');
+    expect(parameters.properties.refs.description).toContain('Provide either refs or urls');
+    expect(parameters.properties.urls.description).toContain('Provide either refs or urls');
+  });
 });

--- a/packages/builtin-tool-lobe-agent/src/manifest.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.test.ts
@@ -16,8 +16,10 @@ describe('LobeAgentManifest', () => {
 
     expect(apiDescription).toContain('native multimodal capability');
     expect(apiDescription).toContain('use this tool only as a fallback');
+    expect(apiDescription).toContain('Provide either refs or urls');
+    expect(apiDescription).toContain('Prefer refs when stable refs are available');
     expect(apiDescription).toContain('msg_xxx.image_1');
-    expect(apiDescription).toContain('Use only stable refs');
+    expect(apiDescription).toContain('use urls only for direct media URLs');
     expect(apiDescription).toContain('answer the user directly with the result');
   });
 
@@ -27,7 +29,5 @@ describe('LobeAgentManifest', () => {
     expect(parameters).not.toHaveProperty('oneOf');
     expect(parameters).not.toHaveProperty('allOf');
     expect(parameters).not.toHaveProperty('anyOf');
-    expect(parameters.properties.refs.description).toContain('Provide either refs or urls');
-    expect(parameters.properties.urls.description).toContain('Provide either refs or urls');
   });
 });

--- a/packages/builtin-tool-lobe-agent/src/manifest.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.ts
@@ -7,7 +7,7 @@ export const LobeAgentManifest: BuiltinToolManifest = {
   api: [
     {
       description:
-        "Analyze images or videos selected by visual file refs or direct media URLs and answer a visual question. Prefer the active model's native multimodal capability when it can inspect the visual media directly; use this tool only as a fallback when the active model cannot inspect the requested images or videos. Use only stable refs shown in <files_info>, such as msg_xxx.image_1 or msg_xxx.video_1. Pass refs for message attachments, or urls for direct media URLs that are not available as message refs. After this tool returns, answer the user directly with the result.",
+        "Analyze images or videos selected by visual file refs or direct media URLs and answer a visual question. Prefer the active model's native multimodal capability when it can inspect the visual media directly; use this tool only as a fallback when the active model cannot inspect the requested images or videos. Provide either refs or urls; at least one is required. Prefer refs when stable refs are available in <files_info>, such as msg_xxx.image_1 or msg_xxx.video_1, and use urls only for direct media URLs that are not available as message refs. After this tool returns, answer the user directly with the result.",
       name: LobeAgentApiName.analyzeVisualMedia,
       parameters: {
         additionalProperties: false,
@@ -18,7 +18,7 @@ export const LobeAgentManifest: BuiltinToolManifest = {
           },
           refs: {
             description:
-              'Stable visual file ref strings to analyze, such as ["msg_xxx.image_1"] or ["msg_xxx.video_1"]. Provide either refs or urls; at least one is required.',
+              'Stable visual file ref strings to analyze, such as ["msg_xxx.image_1"] or ["msg_xxx.video_1"].',
             items: {
               type: 'string',
             },
@@ -26,8 +26,7 @@ export const LobeAgentManifest: BuiltinToolManifest = {
             type: 'array',
           },
           urls: {
-            description:
-              'Direct image or video URLs to analyze when no message file ref exists. Provide either refs or urls; at least one is required.',
+            description: 'Direct image or video URLs to analyze when no message file ref exists.',
             items: {
               type: 'string',
             },

--- a/packages/builtin-tool-lobe-agent/src/manifest.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.ts
@@ -11,7 +11,6 @@ export const LobeAgentManifest: BuiltinToolManifest = {
       name: LobeAgentApiName.analyzeVisualMedia,
       parameters: {
         additionalProperties: false,
-        anyOf: [{ required: ['refs'] }, { required: ['urls'] }],
         properties: {
           question: {
             description: 'The visual question or task to answer.',
@@ -19,7 +18,7 @@ export const LobeAgentManifest: BuiltinToolManifest = {
           },
           refs: {
             description:
-              'Stable visual file ref strings to analyze, such as ["msg_xxx.image_1"] or ["msg_xxx.video_1"].',
+              'Stable visual file ref strings to analyze, such as ["msg_xxx.image_1"] or ["msg_xxx.video_1"]. Provide either refs or urls; at least one is required.',
             items: {
               type: 'string',
             },
@@ -27,7 +26,8 @@ export const LobeAgentManifest: BuiltinToolManifest = {
             type: 'array',
           },
           urls: {
-            description: 'Direct image or video URLs to analyze when no message file ref exists.',
+            description:
+              'Direct image or video URLs to analyze when no message file ref exists. Provide either refs or urls; at least one is required.',
             items: {
               type: 'string',
             },

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -67,7 +67,6 @@ vi.mock('@/store/tool', () => ({
               description: 'Analyze visual media',
               name: 'analyzeVisualMedia',
               parameters: {
-                anyOf: [{ required: ['refs'] }, { required: ['urls'] }],
                 properties: {
                   question: { type: 'string' },
                   refs: {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #14544
Fixes LOBE-8669
Related to LOBE-8538

#### 🔀 Description of Change

Flatten the visual analysis built-in tool input schema by removing the top-level `anyOf` guard from `analyzeVisualMedia`.

Strict tool schema validators such as Claude on Bedrock reject schemas with top-level composition keywords before the tool can run, so the manifest now keeps `refs` and `urls` as flat optional arrays. The cross-field rule is documented in the tool description: provide either `refs` or `urls`, prefer stable `refs` from `<files_info>` when available, and use `urls` only when the media is not available as a message ref. Runtime validation in the executor still rejects calls without media input.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/builtin-tool-lobe-agent && bunx vitest run --silent='passed-only' 'src/manifest.test.ts'
bunx vitest run --silent='passed-only' 'src/helpers/toolEngineering/index.test.ts'
git diff --check -- packages/builtin-tool-lobe-agent/src/manifest.ts packages/builtin-tool-lobe-agent/src/manifest.test.ts src/helpers/toolEngineering/index.test.ts
```

Also checked the modified files with VS Code diagnostics: no errors or warnings.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This keeps the hotfix scoped to the source manifest so all providers receive a Bedrock-compatible schema without adding provider-specific schema rewriting. The broader provider-side schema normalization follow-up remains tracked by LOBE-8538.
