### PR TITLE
🎨 Refine Agent Signal receipt cards

### DIFF
--- a/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
+++ b/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
@@ -101,7 +101,7 @@ describe('AgentSignalReceiptList', () => {
     );
 
     expect(screen.getByText('Future reply preference')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
     expect(screen.queryByText('agentSignal.receipts.recentActivity')).not.toBeInTheDocument();
   });
 
@@ -131,7 +131,7 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('button', { name: /GitHub PR review workflow/ }));
 
     expect(mocks.openDocument).toHaveBeenCalledWith('document-1');
   });
@@ -159,7 +159,8 @@ describe('AgentSignalReceiptList', () => {
 
     fireEvent.click(screen.getByText('Self-review completed'));
 
-    expect(screen.queryByRole('button', { name: 'Open' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
     expect(
       screen.getByText('Reviewed recent activity and found no follow-up action.'),
     ).toBeInTheDocument();
@@ -226,7 +227,7 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('button', { name: /GitHub PR review workflow/ }));
 
     expect(mocks.openDocument).toHaveBeenCalledWith('index-document-1');
   });
@@ -256,7 +257,7 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('button', { name: /Decision-first PR review preference/ }));
 
     expect(mocks.navigate).toHaveBeenCalledWith('/memory');
   });

--- a/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
+++ b/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
@@ -74,10 +74,9 @@ describe('AgentSignalReceiptList', () => {
     expect(screen.getByText('Skill updated')).toBeInTheDocument();
   });
 
-  it('collapses recent activity receipts from the label', () => {
+  it('renders receipt cards without the recent activity label', () => {
     render(
       <AgentSignalReceiptList
-        showRecentLabel
         receipts={[
           {
             agentId: 'agent-1',
@@ -101,9 +100,9 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'agentSignal.receipts.recentActivity' }));
-
-    expect(screen.queryByText('Future reply preference')).not.toBeInTheDocument();
+    expect(screen.getByText('Future reply preference')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+    expect(screen.queryByText('agentSignal.receipts.recentActivity')).not.toBeInTheDocument();
   });
 
   it('opens skill target documents from a receipt item', () => {
@@ -132,7 +131,69 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /GitHub PR review workflow/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(mocks.openDocument).toHaveBeenCalledWith('document-1');
+  });
+
+  it('renders receipts without openable targets as non-clickable status cards', () => {
+    render(
+      <AgentSignalReceiptList
+        receipts={[
+          {
+            agentId: 'agent-1',
+            createdAt: 1,
+            detail: 'Reviewed recent activity and found no follow-up action.',
+            id: 'receipt-1',
+            kind: 'review',
+            sourceId: 'source-1',
+            sourceType: 'agent.signal.review',
+            status: 'completed',
+            title: 'Self-review completed',
+            topicId: 'topic-1',
+            userId: 'user-1',
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Self-review completed'));
+
+    expect(screen.queryByRole('button', { name: 'Open' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Reviewed recent activity and found no follow-up action.'),
+    ).toBeInTheDocument();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.openDocument).not.toHaveBeenCalled();
+  });
+
+  it('opens skill targets when clicking the receipt card content', () => {
+    render(
+      <AgentSignalReceiptList
+        receipts={[
+          {
+            agentId: 'agent-1',
+            createdAt: 1,
+            detail: 'Improved how this assistant handles similar requests',
+            id: 'receipt-1',
+            kind: 'skill',
+            sourceId: 'source-1',
+            sourceType: 'client.gateway.runtime_end',
+            status: 'updated',
+            target: {
+              id: 'document-1',
+              title: 'GitHub PR review workflow',
+              type: 'skill',
+            },
+            title: 'Skill updated',
+            topicId: 'topic-1',
+            userId: 'user-1',
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('GitHub PR review workflow'));
 
     expect(mocks.openDocument).toHaveBeenCalledWith('document-1');
   });
@@ -165,7 +226,7 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /GitHub PR review workflow/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
 
     expect(mocks.openDocument).toHaveBeenCalledWith('index-document-1');
   });
@@ -195,7 +256,7 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Decision-first PR review preference/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
 
     expect(mocks.navigate).toHaveBeenCalledWith('/memory');
   });

--- a/src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx
+++ b/src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { Block, Flexbox, Icon, Tooltip } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
-import { Activity, CheckCircle, ChevronRight, Sparkles } from 'lucide-react';
-import { AnimatePresence, m as motion } from 'motion/react';
-import { memo, useCallback, useState } from 'react';
+import { createStaticStyles } from 'antd-style';
+import type { LucideIcon } from 'lucide-react';
+import { Brain, ClipboardCheck, FileText, Wrench } from 'lucide-react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import PortalResourceCard from '@/features/Conversation/components/PortalResourceCard';
 import { useStableNavigate } from '@/hooks/useStableNavigate';
 import { useChatStore } from '@/store/chat';
 
@@ -14,87 +14,26 @@ import type { AgentSignalReceiptView } from '../hooks/useAgentSignalReceipts';
 
 const PAGE_ROUTE_PATTERN = /^\/agent\/([^/]+)\/([^/]+)\/page(?:\/[^/?#]+)?/;
 
-const useStyles = createStyles(({ css, token }) => ({
-  content: css`
-    overflow: hidden;
-  `,
-  item: css`
-    width: 100%;
-    padding-block: 6px;
-    padding-inline: 8px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: 8px;
-
-    font-size: 12px;
-    line-height: 1.45;
-    color: ${token.colorTextSecondary};
-
-    background: ${token.colorFillQuaternary};
-  `,
-  itemButton: css`
-    cursor: pointer;
-
+const styles = createStaticStyles(({ css }) => ({
+  list: css`
     display: flex;
+    flex-direction: column;
     gap: 8px;
-    align-items: center;
 
     width: 100%;
-    padding: 0;
-    border: 0;
-
-    color: inherit;
-    text-align: start;
-
-    background: transparent;
-  `,
-  label: css`
-    cursor: pointer;
-
-    display: flex;
-    gap: 6px;
-    align-items: center;
-
-    width: fit-content;
-    max-width: min(520px, 100%);
-    margin-block-start: 4px;
-    padding: 0;
-    border: 0;
-
-    font-size: 12px;
-    line-height: 1.45;
-    color: ${token.colorTextTertiary};
-
-    background: transparent;
-  `,
-  labelText: css`
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `,
-  labelIcon: css`
-    transition: transform 120ms ease;
-  `,
-  labelIconOpen: css`
-    transform: rotate(90deg);
-  `,
-  title: css`
-    font-weight: 500;
-    color: ${token.colorText};
-  `,
-  titleGroup: css`
-    overflow: hidden;
-    min-width: 0;
+    margin-block-start: 8px;
   `,
 }));
 
-const collapseTransition = {
-  duration: 0.16,
-  ease: [0.4, 0, 0.2, 1],
-} as const;
+const RECEIPT_ICON_BY_KIND = {
+  maintenance: Wrench,
+  memory: Brain,
+  review: ClipboardCheck,
+  skill: FileText,
+} satisfies Record<AgentSignalReceiptView['kind'], LucideIcon>;
 
 interface AgentSignalReceiptListProps {
   receipts: AgentSignalReceiptView[];
-  showRecentLabel?: boolean;
 }
 
 interface AgentSignalReceiptItemProps {
@@ -102,17 +41,19 @@ interface AgentSignalReceiptItemProps {
 }
 
 const AgentSignalReceiptItem = memo<AgentSignalReceiptItemProps>(({ receipt }) => {
-  const { styles } = useStyles();
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const navigate = useStableNavigate();
   const openDocument = useChatStore((s) => s.openDocument);
-  const ReceiptIcon = receipt.kind === 'memory' ? CheckCircle : Sparkles;
+  const ReceiptIcon = RECEIPT_ICON_BY_KIND[receipt.kind];
   const fallbackTitle = t(`agentSignal.receipts.${receipt.kind}.title`, receipt.title);
-  const title = receipt.target?.title ?? fallbackTitle;
   const detail = t(`agentSignal.receipts.${receipt.kind}.detail`, receipt.detail);
+  const title = receipt.target?.title ?? fallbackTitle;
+  const description = receipt.target ? fallbackTitle : detail;
   const summary = receipt.target?.summary ?? detail;
   const tooltip = `${fallbackTitle}: ${summary}`;
   const target = receipt.target;
+  const documentId = target?.type === 'skill' ? (target.documentId ?? target.id) : undefined;
+  const canOpen = target?.type === 'memory' || Boolean(documentId);
   const handleOpen = useCallback(() => {
     if (target?.type === 'memory') {
       navigate('/memory');
@@ -120,7 +61,6 @@ const AgentSignalReceiptItem = memo<AgentSignalReceiptItemProps>(({ receipt }) =
     }
 
     if (target?.type !== 'skill') return;
-    const documentId = target.documentId ?? target.id;
     if (!documentId) return;
 
     const pathname = globalThis.location?.pathname ?? '';
@@ -132,91 +72,35 @@ const AgentSignalReceiptItem = memo<AgentSignalReceiptItemProps>(({ receipt }) =
     }
 
     openDocument(documentId);
-  }, [navigate, openDocument, target]);
+  }, [documentId, navigate, openDocument, target]);
 
   return (
-    <div className={styles.item}>
-      <Tooltip placement={'topLeft'} title={tooltip}>
-        <button
-          className={styles.itemButton}
-          type={'button'}
-          // TODO: Replace memory fallback with category/id-aware routes when Agent Signal receipts expose them.
-          onClick={handleOpen}
-        >
-          <Block
-            horizontal
-            align={'center'}
-            flex={'none'}
-            height={24}
-            justify={'center'}
-            style={{ fontSize: 12 }}
-            variant={'outlined'}
-            width={24}
-          >
-            <Icon icon={ReceiptIcon} />
-          </Block>
-          <Flexbox className={styles.titleGroup}>
-            <span className={styles.title}>{title}</span>
-            <span className={styles.labelText}>{fallbackTitle}</span>
-          </Flexbox>
-        </button>
-      </Tooltip>
-    </div>
+    <PortalResourceCard
+      description={description}
+      icon={ReceiptIcon}
+      openLabel={canOpen ? t('common:cmdk.toOpen', 'Open') : undefined}
+      title={title}
+      tooltip={tooltip}
+      // TODO: Replace memory fallback with category/id-aware routes when Agent Signal receipts expose them.
+      onOpen={canOpen ? handleOpen : undefined}
+    />
   );
 });
 
 AgentSignalReceiptItem.displayName = 'AgentSignalReceiptItem';
 
-const AgentSignalReceiptList = memo<AgentSignalReceiptListProps>(
-  ({ receipts, showRecentLabel }) => {
-    const { styles } = useStyles();
-    const { t } = useTranslation('chat');
-    const [open, setOpen] = useState(true);
+const AgentSignalReceiptList = memo<AgentSignalReceiptListProps>(({ receipts }) => {
+  if (receipts.length === 0) return null;
 
-    if (receipts.length === 0) return null;
-
-    // TODO: Migrate this temporary receipt UI into the final Agent Signal feedback surface.
-    return (
-      <Flexbox gap={4}>
-        {showRecentLabel && (
-          <button className={styles.label} type={'button'} onClick={() => setOpen(!open)}>
-            <Block
-              horizontal
-              align={'center'}
-              flex={'none'}
-              height={24}
-              justify={'center'}
-              style={{ fontSize: 12 }}
-              variant={'outlined'}
-              width={24}
-            >
-              <Icon icon={Activity} />
-            </Block>
-            <span className={styles.labelText}>{t('agentSignal.receipts.recentActivity')}</span>
-            <Icon className={open ? styles.labelIconOpen : styles.labelIcon} icon={ChevronRight} />
-          </button>
-        )}
-        <AnimatePresence initial={false}>
-          {(!showRecentLabel || open) && (
-            <motion.div
-              animate={{ height: 'auto', opacity: 1 }}
-              className={styles.content}
-              exit={{ height: 0, opacity: 0 }}
-              initial={{ height: 0, opacity: 0 }}
-              transition={collapseTransition}
-            >
-              <Flexbox gap={4}>
-                {receipts.map((receipt) => (
-                  <AgentSignalReceiptItem key={receipt.id} receipt={receipt} />
-                ))}
-              </Flexbox>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </Flexbox>
-    );
-  },
-);
+  // TODO: Migrate this temporary receipt UI into the final Agent Signal feedback surface.
+  return (
+    <div className={styles.list}>
+      {receipts.map((receipt) => (
+        <AgentSignalReceiptItem key={receipt.id} receipt={receipt} />
+      ))}
+    </div>
+  );
+});
 
 AgentSignalReceiptList.displayName = 'AgentSignalReceiptList';
 

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -97,14 +97,14 @@ const ChatList = memo<ChatListProps>(
           anchoredReceipts.length > 0 || latestUnanchoredReceipts.length > 0 ? (
             <>
               <AgentSignalReceiptList receipts={anchoredReceipts} />
-              <AgentSignalReceiptList showRecentLabel receipts={latestUnanchoredReceipts} />
+              <AgentSignalReceiptList receipts={latestUnanchoredReceipts} />
             </>
           ) : undefined;
 
         return (
           <MessageItem
             defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
-            endRender={receiptRender}
+            footerRender={receiptRender}
             id={id}
             index={index}
             isLatestItem={isLatestItem}

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -2,7 +2,7 @@
 
 import { LOADING_FLAT } from '@lobechat/const';
 import isEqual from 'fast-deep-equal';
-import { type MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 import { memo, useCallback } from 'react';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
@@ -29,117 +29,123 @@ const actionBarHolder = (
 
 interface AssistantMessageProps {
   disableEditing?: boolean;
+  footerRender?: ReactNode;
   id: string;
   index: number;
   isLatestItem?: boolean;
 }
 
-const AssistantMessage = memo<AssistantMessageProps>(({ id, index, disableEditing }) => {
-  // Get message and actionsConfig from ConversationStore
-  const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual)!;
+const AssistantMessage = memo<AssistantMessageProps>(
+  ({ id, index, disableEditing, footerRender }) => {
+    // Get message and actionsConfig from ConversationStore
+    const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual)!;
 
-  const {
-    agentId,
-    branch,
-    error,
-    role,
-    content,
-    createdAt,
-    tools,
-    extra,
-    model,
-    provider,
-    performance,
-    usage,
-    metadata,
-  } = item;
+    const {
+      agentId,
+      branch,
+      error,
+      role,
+      content,
+      createdAt,
+      tools,
+      extra,
+      model,
+      provider,
+      performance,
+      usage,
+      metadata,
+    } = item;
 
-  const avatar = useAgentMeta(agentId);
+    const avatar = useAgentMeta(agentId);
 
-  // Get editing, generating, creating, and interrupted state from ConversationStore
-  const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
-  const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
-  const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
-  const interrupted = useConversationStore(messageStateSelectors.isMessageInterrupted(id));
+    // Get editing, generating, creating, and interrupted state from ConversationStore
+    const editing = useConversationStore(messageStateSelectors.isMessageEditing(id));
+    const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
+    const isCreating = useConversationStore(messageStateSelectors.isMessageCreating(id));
+    const interrupted = useConversationStore(messageStateSelectors.isMessageInterrupted(id));
 
-  const errorContent = useErrorContent(error);
+    const errorContent = useErrorContent(error);
 
-  const shouldForceShowError =
-    error?.type === 'ProviderBizError' &&
-    (error?.body as any)?.provider === 'google' &&
-    !!(
-      (error?.body as any)?.context?.promptFeedback?.blockReason ||
-      (error?.body as any)?.context?.finishReason
+    const shouldForceShowError =
+      error?.type === 'ProviderBizError' &&
+      (error?.body as any)?.provider === 'google' &&
+      !!(
+        (error?.body as any)?.context?.promptFeedback?.blockReason ||
+        (error?.body as any)?.context?.finishReason
+      );
+
+    // remove line breaks in artifact tag to make the ast transform easier
+    const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
+
+    const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
+    const setMessageItemActionElementPortialContext =
+      useSetMessageItemActionElementPortialContext();
+    const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
+
+    const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
+
+    const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
+      (e) => {
+        setMessageItemActionElementPortialContext(e.currentTarget);
+        setMessageItemActionTypeContext({ id, index, type: 'assistant' });
+      },
+      [id, index, setMessageItemActionElementPortialContext, setMessageItemActionTypeContext],
     );
 
-  // remove line breaks in artifact tag to make the ast transform easier
-  const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
-
-  const onDoubleClick = useDoubleClickEdit({ disableEditing, error, id, role });
-  const setMessageItemActionElementPortialContext = useSetMessageItemActionElementPortialContext();
-  const setMessageItemActionTypeContext = useSetMessageItemActionTypeContext();
-
-  const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
-
-  const onMouseEnter: MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
-      setMessageItemActionElementPortialContext(e.currentTarget);
-      setMessageItemActionTypeContext({ id, index, type: 'assistant' });
-    },
-    [id, index, setMessageItemActionElementPortialContext, setMessageItemActionTypeContext],
-  );
-
-  return (
-    <ChatItem
-      showTitle
-      aboveMessage={null}
-      avatar={avatar}
-      customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
-      editing={editing}
-      id={id}
-      loading={generating || isCreating}
-      message={message}
-      placement={'left'}
-      time={createdAt}
-      actions={
-        <>
-          {isDevMode && branch && (
-            <MessageBranch
-              activeBranchIndex={branch.activeBranchIndex}
-              count={branch.count}
-              messageId={id}
+    return (
+      <ChatItem
+        showTitle
+        aboveMessage={null}
+        avatar={avatar}
+        customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
+        editing={editing}
+        id={id}
+        loading={generating || isCreating}
+        message={message}
+        placement={'left'}
+        time={createdAt}
+        actions={
+          <>
+            {isDevMode && branch && (
+              <MessageBranch
+                activeBranchIndex={branch.activeBranchIndex}
+                count={branch.count}
+                messageId={id}
+              />
+            )}
+            {!disableEditing && actionBarHolder}
+          </>
+        }
+        error={
+          errorContent && error && (message === LOADING_FLAT || !message || shouldForceShowError)
+            ? errorContent
+            : undefined
+        }
+        messageExtra={
+          <>
+            {interrupted && <InterruptedHint />}
+            <AssistantMessageExtra
+              content={content}
+              extra={extra}
+              id={id}
+              model={model!}
+              performance={performance! || metadata}
+              provider={provider!}
+              tools={tools}
+              usage={usage! || metadata}
             />
-          )}
-          {!disableEditing && actionBarHolder}
-        </>
-      }
-      error={
-        errorContent && error && (message === LOADING_FLAT || !message || shouldForceShowError)
-          ? errorContent
-          : undefined
-      }
-      messageExtra={
-        <>
-          {interrupted && <InterruptedHint />}
-          <AssistantMessageExtra
-            content={content}
-            extra={extra}
-            id={id}
-            model={model!}
-            performance={performance! || metadata}
-            provider={provider!}
-            tools={tools}
-            usage={usage! || metadata}
-          />
-        </>
-      }
-      onDoubleClick={onDoubleClick}
-      onMouseEnter={onMouseEnter}
-    >
-      <MessageContent {...item} />
-    </ChatItem>
-  );
-}, isEqual);
+          </>
+        }
+        onDoubleClick={onDoubleClick}
+        onMouseEnter={onMouseEnter}
+      >
+        <MessageContent {...item} />
+        {footerRender}
+      </ChatItem>
+    );
+  },
+  isEqual,
+);
 
 AssistantMessage.displayName = 'AssistantMessage';
 

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -92,11 +92,18 @@ const AssistantMessage = memo<AssistantMessageProps>(
       [id, index, setMessageItemActionElementPortialContext, setMessageItemActionTypeContext],
     );
 
+    const hasEmptyErrorMessage = Boolean(
+      errorContent &&
+      error &&
+      (message === LOADING_FLAT || !message || String(message).trim() === ''),
+    );
+
     return (
       <ChatItem
         showTitle
         aboveMessage={null}
         avatar={avatar}
+        belowMessage={hasEmptyErrorMessage ? footerRender : undefined}
         customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
         editing={editing}
         id={id}
@@ -123,6 +130,7 @@ const AssistantMessage = memo<AssistantMessageProps>(
         }
         messageExtra={
           <>
+            {footerRender}
             {interrupted && <InterruptedHint />}
             <AssistantMessageExtra
               content={content}
@@ -140,7 +148,6 @@ const AssistantMessage = memo<AssistantMessageProps>(
         onMouseEnter={onMouseEnter}
       >
         <MessageContent {...item} />
-        {footerRender}
       </ChatItem>
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -2,7 +2,7 @@
 
 import type { AssistantContentBlock, EmojiReaction } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
-import type { MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 import { memo, Suspense, useCallback, useMemo } from 'react';
 
 import { MESSAGE_ACTION_BAR_PORTAL_ATTRIBUTES } from '@/const/messageActionPortal';
@@ -42,13 +42,14 @@ const actionBarHolder = (
 interface GroupMessageProps {
   defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
+  footerRender?: ReactNode;
   id: string;
   index: number;
   isLatestItem?: boolean;
 }
 
 const GroupMessage = memo<GroupMessageProps>(
-  ({ defaultWorkflowExpandLevel, id, index, disableEditing }) => {
+  ({ defaultWorkflowExpandLevel, id, index, disableEditing, footerRender }) => {
     // Get message and actionsConfig from ConversationStore
     const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual)!;
 
@@ -178,6 +179,7 @@ const GroupMessage = memo<GroupMessageProps>(
           </div>
         )}
         {interrupted && <InterruptedHint />}
+        {footerRender}
         {isDevMode && model && (
           <Usage model={model} performance={performance} provider={provider!} usage={usage} />
         )}

--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -46,6 +46,7 @@ export interface MessageItemProps {
   disableEditing?: boolean;
   enableHistoryDivider?: boolean;
   endRender?: ReactNode;
+  footerRender?: ReactNode;
   id: string;
   index: number;
   inPortalThread?: boolean;
@@ -59,6 +60,7 @@ const MessageItem = memo<MessageItemProps>(
     enableHistoryDivider,
     id,
     endRender,
+    footerRender,
     disableEditing,
     inPortalThread = false,
     index,
@@ -81,6 +83,7 @@ const MessageItem = memo<MessageItemProps>(
       inPortalThread,
       topic,
     });
+    const shouldInjectFooter = role === 'assistant' || role === 'assistantGroup';
 
     const onContextMenu = useCallback(
       async (event: MouseEvent<HTMLDivElement>) => {
@@ -122,6 +125,7 @@ const MessageItem = memo<MessageItemProps>(
           return (
             <AssistantMessage
               disableEditing={disableEditing}
+              footerRender={footerRender}
               id={id}
               index={index}
               isLatestItem={isLatestItem}
@@ -134,6 +138,7 @@ const MessageItem = memo<MessageItemProps>(
             <AssistantGroupMessage
               defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
               disableEditing={disableEditing}
+              footerRender={footerRender}
               id={id}
               index={index}
               isLatestItem={isLatestItem}
@@ -184,7 +189,7 @@ const MessageItem = memo<MessageItemProps>(
       }
 
       return null;
-    }, [role, defaultWorkflowExpandLevel, disableEditing, id, index, isLatestItem]);
+    }, [role, defaultWorkflowExpandLevel, disableEditing, footerRender, id, index, isLatestItem]);
 
     if (!role) return;
 
@@ -199,6 +204,7 @@ const MessageItem = memo<MessageItemProps>(
           <SafeBoundary variant="alert">
             <Suspense fallback={<BubblesLoading />}>{renderContent()}</Suspense>
           </SafeBoundary>
+          {!shouldInjectFooter && footerRender}
           {endRender}
         </Flexbox>
       </>

--- a/src/features/Conversation/components/PortalResourceCard/index.tsx
+++ b/src/features/Conversation/components/PortalResourceCard/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { Button, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import type { LucideIcon } from 'lucide-react';
+import { FileText } from 'lucide-react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { memo } from 'react';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  actionable: css`
+    cursor: pointer;
+
+    &:hover {
+      background: ${cssVar.colorFillQuaternary};
+    }
+
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimary};
+      outline-offset: 2px;
+    }
+  `,
+  avatar: css`
+    flex: none;
+    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  button: css`
+    height: 28px;
+    padding-inline: 12px;
+    font-size: 13px;
+  `,
+  container: css`
+    width: 100%;
+    min-height: 48px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 6px;
+
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  content: css`
+    overflow: hidden;
+    min-width: 0;
+  `,
+  desc: css`
+    font-size: 12px;
+    line-height: 1.3;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  title: css`
+    font-weight: 500;
+    line-height: 1.35;
+  `,
+}));
+
+export interface PortalResourceCardProps {
+  className?: string;
+  description?: ReactNode;
+  icon?: LucideIcon;
+  onOpen?: () => void;
+  openLabel?: ReactNode;
+  title: ReactNode;
+  tooltip?: ReactNode;
+}
+
+const PortalResourceCard = memo<PortalResourceCardProps>(
+  ({ className, description, icon = FileText, openLabel, title, tooltip, onOpen }) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!onOpen) return;
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+
+      event.preventDefault();
+      onOpen();
+    };
+
+    // Mirrors the inline artifact card shell, while keeping portal-open behavior owned by callers.
+    const card = (
+      <Flexbox
+        horizontal
+        align={'center'}
+        className={cx(styles.container, onOpen && styles.actionable, className)}
+        role={onOpen ? 'button' : undefined}
+        tabIndex={onOpen ? 0 : undefined}
+        onClick={onOpen}
+        onKeyDown={onOpen ? handleKeyDown : undefined}
+      >
+        <Center horizontal className={styles.avatar} height={48} width={48}>
+          <Icon icon={icon} size={22} />
+        </Center>
+        <Flexbox className={styles.content} flex={1} gap={2} paddingBlock={6} paddingInline={10}>
+          <Text ellipsis className={styles.title}>
+            {title}
+          </Text>
+          {description && (
+            <Text ellipsis className={styles.desc}>
+              {description}
+            </Text>
+          )}
+        </Flexbox>
+        {onOpen && openLabel && (
+          <Flexbox flex={'none'} style={{ paddingInlineEnd: 10 }}>
+            <Button
+              className={styles.button}
+              size={'small'}
+              variant={'outlined'}
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpen();
+              }}
+            >
+              {openLabel}
+            </Button>
+          </Flexbox>
+        )}
+      </Flexbox>
+    );
+
+    return tooltip ? (
+      <Tooltip placement={'topLeft'} title={tooltip}>
+        {card}
+      </Tooltip>
+    ) : (
+      card
+    );
+  },
+);
+
+PortalResourceCard.displayName = 'PortalResourceCard';
+
+export default PortalResourceCard;

--- a/src/features/Conversation/components/PortalResourceCard/index.tsx
+++ b/src/features/Conversation/components/PortalResourceCard/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
 import { FileText } from 'lucide-react';
@@ -25,10 +25,21 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
     background: ${cssVar.colorFillQuaternary};
   `,
-  button: css`
+  openLabel: css`
+    display: flex;
+    align-items: center;
+
     height: 28px;
     padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorder};
+    border-radius: 6px;
+
     font-size: 13px;
+    line-height: 1;
+    color: ${cssVar.colorText};
+    white-space: nowrap;
+
+    background: ${cssVar.colorBgContainer};
   `,
   container: css`
     width: 100%;
@@ -101,17 +112,9 @@ const PortalResourceCard = memo<PortalResourceCardProps>(
         </Flexbox>
         {onOpen && openLabel && (
           <Flexbox flex={'none'} style={{ paddingInlineEnd: 10 }}>
-            <Button
-              className={styles.button}
-              size={'small'}
-              variant={'outlined'}
-              onClick={(event) => {
-                event.stopPropagation();
-                onOpen();
-              }}
-            >
+            <div aria-hidden className={styles.openLabel}>
               {openLabel}
-            </Button>
+            </div>
           </Flexbox>
         )}
       </Flexbox>


### PR DESCRIPTION
## Summary
- 将 Agent Signal receipt 统一抽成可复用的 `PortalResourceCard`，并按 `kind` 区分 icon 与描述
- 仅在存在可打开 `target` 时才显示 `Open`，并让整张卡可点击；无目标时降级为纯状态卡
- 继续沿用对话尾部的 receipt 展示位置，同时保留 anchored / unanchored 的现有渲染链路
- 补充 receipt 卡片交互与无目标状态的测试

## Testing
- `bunx vitest run --silent='passed-only' src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx`
- `bun run type-check`
- 本地浏览器预览确认 receipt 卡片样式与点击行为