### PR TITLE
🐛 fix(onboarding): guard skip/mode-switch footer with feature flag, desktop & init checks

### DIFF
--- a/src/routes/onboarding/_layout/index.test.tsx
+++ b/src/routes/onboarding/_layout/index.test.tsx
@@ -1,16 +1,35 @@
 import type * as BusinessConst from '@lobechat/business-const';
-import { render, screen } from '@testing-library/react';
+import type * as Const from '@lobechat/const';
+import { cleanup, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import OnBoardingContainer from './index';
 
+const mocks = vi.hoisted(() => ({
+  AGENT_ONBOARDING_ENABLED: true,
+  enableAgentOnboarding: true as boolean | undefined,
+  isDesktop: false,
+  serverConfigInit: true,
+}));
+
 vi.mock('@lobechat/business-const', async (importOriginal) => {
   const actual = (await importOriginal()) as typeof BusinessConst;
-
   return {
     ...actual,
-    AGENT_ONBOARDING_ENABLED: true,
+    get AGENT_ONBOARDING_ENABLED() {
+      return mocks.AGENT_ONBOARDING_ENABLED;
+    },
+  };
+});
+
+vi.mock('@lobechat/const', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof Const;
+  return {
+    ...actual,
+    get isDesktop() {
+      return mocks.isDesktop;
+    },
   };
 });
 
@@ -38,34 +57,78 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('@/store/serverConfig', () => ({
+  useServerConfigStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      featureFlags: { enableAgentOnboarding: mocks.enableAgentOnboarding },
+      serverConfigInit: mocks.serverConfigInit,
+    }),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ finishOnboarding: vi.fn() }),
+}));
+
+const renderAt = (initialPath: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <OnBoardingContainer>
+        <div>Onboarding Content</div>
+      </OnBoardingContainer>
+    </MemoryRouter>,
+  );
+
+const hasSkipFooter = () =>
+  screen.queryByText((content) => content.includes('agent.layout.skip')) !== null;
+
+beforeEach(() => {
+  mocks.AGENT_ONBOARDING_ENABLED = true;
+  mocks.enableAgentOnboarding = true;
+  mocks.isDesktop = false;
+  mocks.serverConfigInit = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
 describe('OnBoardingContainer', () => {
-  it('renders onboarding content without footer copyright', () => {
-    render(
-      <MemoryRouter>
-        <OnBoardingContainer>
-          <div>Onboarding Content</div>
-        </OnBoardingContainer>
-      </MemoryRouter>,
-    );
+  it('renders onboarding content without footer on the shared-prefix /onboarding path', () => {
+    renderAt('/onboarding');
 
     expect(screen.getByText('Lang Button')).toBeInTheDocument();
     expect(screen.getByText('Theme Button')).toBeInTheDocument();
     expect(screen.getByText('Onboarding Content')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'agent.skipOnboarding' })).not.toBeInTheDocument();
-    expect(screen.queryByText('© 2026 LobeHub. All rights reserved.')).not.toBeInTheDocument();
+    expect(hasSkipFooter()).toBe(false);
   });
 
-  it('shows skip onboarding on agent onboarding route', () => {
-    render(
-      <MemoryRouter initialEntries={['/onboarding/agent']}>
-        <OnBoardingContainer>
-          <div>Onboarding Content</div>
-        </OnBoardingContainer>
-      </MemoryRouter>,
-    );
+  it('shows skip-and-switch footer on /onboarding/agent when agent flow is reachable', () => {
+    renderAt('/onboarding/agent');
+    expect(hasSkipFooter()).toBe(true);
+  });
 
-    expect(
-      screen.getByText((content) => content.includes('agent.layout.skip')),
-    ).toBeInTheDocument();
+  it('hides footer when AGENT_ONBOARDING_ENABLED master switch is off', () => {
+    mocks.AGENT_ONBOARDING_ENABLED = false;
+    renderAt('/onboarding/agent');
+    expect(hasSkipFooter()).toBe(false);
+  });
+
+  it('hides footer on desktop, where agent flow is unreachable', () => {
+    mocks.isDesktop = true;
+    renderAt('/onboarding/agent');
+    expect(hasSkipFooter()).toBe(false);
+  });
+
+  it('hides footer when runtime feature flag enableAgentOnboarding is off', () => {
+    mocks.enableAgentOnboarding = false;
+    renderAt('/onboarding/agent');
+    expect(hasSkipFooter()).toBe(false);
+  });
+
+  it('hides footer until server config has initialized', () => {
+    mocks.serverConfigInit = false;
+    renderAt('/onboarding/agent');
+    expect(hasSkipFooter()).toBe(false);
   });
 });

--- a/src/routes/onboarding/_layout/index.tsx
+++ b/src/routes/onboarding/_layout/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AGENT_ONBOARDING_ENABLED } from '@lobechat/business-const';
+import { isDesktop } from '@lobechat/const';
 import { Center, Flexbox, FluentEmoji, Text } from '@lobehub/ui';
 import { Divider, Popconfirm } from 'antd';
 import { cx, useTheme } from 'antd-style';
@@ -12,6 +13,7 @@ import { ProductLogo } from '@/components/Branding';
 import LangButton from '@/features/User/UserPanel/LangButton';
 import ThemeButton from '@/features/User/UserPanel/ThemeButton';
 import { useIsDark } from '@/hooks/useIsDark';
+import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 
 import { styles } from './style';
@@ -23,17 +25,24 @@ const OnBoardingContainer: FC<PropsWithChildren> = ({ children }) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const finishOnboarding = useUserStore((s) => s.finishOnboarding);
+  const enableAgentOnboarding = useServerConfigStore((s) => s.featureFlags.enableAgentOnboarding);
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
   const isAgentOnboarding = pathname.startsWith('/onboarding/agent');
   const isBranchOnboarding = isAgentOnboarding || pathname.startsWith('/onboarding/classic');
 
-  const showModeSwitchAndSkipFooter = AGENT_ONBOARDING_ENABLED && isBranchOnboarding;
+  const showModeSwitchAndSkipFooter =
+    AGENT_ONBOARDING_ENABLED &&
+    !isDesktop &&
+    serverConfigInit &&
+    !!enableAgentOnboarding &&
+    isBranchOnboarding;
 
   const handleConfirmSkip = useCallback(() => {
     finishOnboarding();
     navigate('/');
   }, [finishOnboarding, navigate]);
 
-  const swichMode = useCallback(
+  const switchMode = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
       e.preventDefault();
@@ -79,7 +88,7 @@ const OnBoardingContainer: FC<PropsWithChildren> = ({ children }) => {
                   modeLink: (
                     <a
                       href={isAgentOnboarding ? '/onboarding/classic' : '/onboarding/agent'}
-                      onClick={swichMode}
+                      onClick={switchMode}
                     />
                   ),
                   modeText: <Text as={'span'} />,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

The skip-and-switch footer on onboarding pages was visible whenever `AGENT_ONBOARDING_ENABLED` was true and the path matched a branch route. This could show the footer in inappropriate contexts (desktop, before server config loaded, or when the runtime feature flag was disabled).

Changes:
- **Guard footer visibility** with additional runtime checks: `!isDesktop`, `serverConfigInit`, and `enableAgentOnboarding` feature flag
- **Fix typo**: `swichMode` → `switchMode`
- **Expand tests**: Add hoisted mocks and 6 test cases covering each visibility condition (agent path, master switch off, desktop, feature flag off, server config not initialized)

#### 🧪 How to Test

- [x] Added/updated tests
- [ ] Tested locally

#### 📝 Additional Information

The footer now only appears when all conditions are met: `AGENT_ONBOARDING_ENABLED && !isDesktop && serverConfigInit && enableAgentOnboarding && isBranchOnboarding`.