### PR TITLE
✨ feat(devtools): add dev-only feature flag override panel

### DIFF
--- a/src/features/DevFeatureFlagPanel/Fab.tsx
+++ b/src/features/DevFeatureFlagPanel/Fab.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Tooltip } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { FlagIcon } from 'lucide-react';
+import { memo } from 'react';
+
+import { useServerConfigStore } from '@/store/serverConfig';
+
+const styles = createStaticStyles(({ css }) => ({
+  badge: css`
+    pointer-events: none;
+
+    position: absolute;
+    inset-block-start: -4px;
+    inset-inline-end: -4px;
+
+    min-width: 16px;
+    height: 16px;
+    padding-inline: 4px;
+    border: 1.5px solid ${cssVar.colorBgContainer};
+    border-radius: 8px;
+
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 13px;
+    color: ${cssVar.colorBgContainer};
+    text-align: center;
+
+    background: ${cssVar.colorWarning};
+  `,
+  fab: css`
+    cursor: pointer;
+    user-select: none;
+
+    position: fixed;
+    z-index: 1100;
+    inset-block-end: 64px;
+    inset-inline-end: 16px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 36px;
+    height: 36px;
+    border: 1px solid transparent;
+    border-radius: 50%;
+
+    color: ${cssVar.colorBgContainer};
+
+    background: ${cssVar.colorText};
+    box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+
+    transition:
+      transform 160ms ease,
+      background 160ms ease,
+      color 160ms ease,
+      border-color 160ms ease;
+
+    &:hover {
+      transform: scale(1.04);
+    }
+  `,
+  fabActive: css`
+    border-color: ${cssVar.colorBorder};
+    color: ${cssVar.colorText};
+    background: ${cssVar.colorFillSecondary};
+  `,
+}));
+
+interface FabProps {
+  active: boolean;
+  onToggle: () => void;
+}
+
+const Fab = memo<FabProps>(({ active, onToggle }) => {
+  const overrideCount = useServerConfigStore((s) => Object.keys(s._featureFlagOverrides).length);
+
+  return (
+    <Tooltip placement={'left'} title={'Feature Flag Overrides (dev only)'}>
+      <div
+        className={`${styles.fab} ${active ? styles.fabActive : ''}`}
+        role={'button'}
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+      >
+        <FlagIcon size={18} />
+        {overrideCount > 0 && <span className={styles.badge}>{overrideCount}</span>}
+      </div>
+    </Tooltip>
+  );
+});
+
+Fab.displayName = 'DevFeatureFlagPanel/Fab';
+
+export default Fab;

--- a/src/features/DevFeatureFlagPanel/FlagRow.tsx
+++ b/src/features/DevFeatureFlagPanel/FlagRow.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Flexbox, Segmented, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { snakeCase } from 'es-toolkit/compat';
+import { memo, useMemo } from 'react';
+
+import { useServerConfigStore } from '@/store/serverConfig';
+import { type FeatureFlagKey } from '@/store/serverConfig/slices/featureFlagOverride/action';
+
+type SegmentedValue = 'true' | 'false' | 'inherit';
+
+const styles = createStaticStyles(({ css }) => ({
+  meta: css`
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 10px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  name: css`
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+  `,
+  row: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+
+    margin-block: 2px;
+    margin-inline: 4px;
+    padding-block: 6px;
+    padding-inline: 8px;
+    border-inline-start: 2px solid transparent;
+    border-radius: 6px;
+
+    transition: background 120ms ease;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  rowOverridden: css`
+    border-inline-start-color: ${cssVar.colorWarning};
+    background: ${cssVar.colorWarningBg};
+
+    &:hover {
+      background: ${cssVar.colorWarningBgHover};
+    }
+  `,
+}));
+
+const segmentOptions = [
+  { label: 'true', value: 'true' as const },
+  { label: 'false', value: 'false' as const },
+  { label: 'inherit', value: 'inherit' as const },
+];
+
+interface FlagRowProps {
+  flagKey: FeatureFlagKey;
+}
+
+const FlagRow = memo<FlagRowProps>(({ flagKey }) => {
+  const original = useServerConfigStore((s) => s._originalFeatureFlags?.[flagKey]);
+  const overrideValue = useServerConfigStore(
+    (s) => s._featureFlagOverrides[flagKey] as boolean | undefined,
+  );
+  const setFlagOverride = useServerConfigStore((s) => s.setFlagOverride);
+
+  const isOverridden = overrideValue !== undefined;
+
+  const value: SegmentedValue = useMemo(() => {
+    if (overrideValue === true) return 'true';
+    if (overrideValue === false) return 'false';
+    return 'inherit';
+  }, [overrideValue]);
+
+  const handleChange = (next: SegmentedValue) => {
+    if (next === 'inherit') {
+      setFlagOverride(flagKey, undefined);
+      return;
+    }
+    setFlagOverride(flagKey, next === 'true');
+  };
+
+  return (
+    <div className={`${styles.row} ${isOverridden ? styles.rowOverridden : ''}`}>
+      <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
+        <Text ellipsis className={styles.name}>
+          {snakeCase(flagKey as string)}
+        </Text>
+        <span className={styles.meta}>server: {String(original)}</span>
+      </Flexbox>
+      <Segmented
+        options={segmentOptions}
+        size={'small'}
+        value={value}
+        onChange={(v) => handleChange(v as SegmentedValue)}
+      />
+    </div>
+  );
+});
+
+FlagRow.displayName = 'DevFeatureFlagPanel/FlagRow';
+
+export default FlagRow;

--- a/src/features/DevFeatureFlagPanel/Hydrator.tsx
+++ b/src/features/DevFeatureFlagPanel/Hydrator.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { memo, useEffect } from 'react';
+
+import { useServerConfigStore } from '@/store/serverConfig';
+
+const isDevEnv = process.env.NODE_ENV === 'development';
+
+const DevFlagOverrideHydrator = memo(() => {
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
+  const syncDevFlagOverrides = useServerConfigStore((s) => s.syncDevFlagOverrides);
+
+  useEffect(() => {
+    if (!isDevEnv) return;
+    syncDevFlagOverrides();
+  }, [serverConfigInit, syncDevFlagOverrides]);
+
+  return null;
+});
+
+DevFlagOverrideHydrator.displayName = 'DevFlagOverrideHydrator';
+
+export default DevFlagOverrideHydrator;

--- a/src/features/DevFeatureFlagPanel/Panel.tsx
+++ b/src/features/DevFeatureFlagPanel/Panel.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { ActionIcon, Button, Flexbox, Input, Text } from '@lobehub/ui';
+import { Switch } from 'antd';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { snakeCase } from 'es-toolkit/compat';
+import { ListRestartIcon, XIcon } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+
+import { useServerConfigStore } from '@/store/serverConfig';
+import { type FeatureFlagKey } from '@/store/serverConfig/slices/featureFlagOverride/action';
+
+import FlagRow from './FlagRow';
+
+const styles = createStaticStyles(({ css }) => ({
+  body: css`
+    overflow: auto;
+    flex: 1;
+    padding-block: 4px;
+    padding-inline: 4px;
+  `,
+  container: css`
+    position: fixed;
+    z-index: 1099;
+    inset-block-end: 112px;
+    inset-inline-end: 16px;
+
+    display: flex;
+    flex-direction: column;
+
+    width: 380px;
+    height: min(70vh, 600px);
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 12px;
+
+    background: ${cssVar.colorBgElevated};
+    box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+  `,
+  empty: css`
+    padding-block: 32px;
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+    text-align: center;
+  `,
+  footer: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    padding-block: 8px;
+    padding-inline: 12px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  header: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  toolbar: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    padding-block: 8px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+}));
+
+interface PanelProps {
+  onClose: () => void;
+}
+
+const Panel = memo<PanelProps>(({ onClose }) => {
+  const originalFlags = useServerConfigStore((s) => s._originalFeatureFlags);
+  const overrideCount = useServerConfigStore((s) => Object.keys(s._featureFlagOverrides).length);
+  const overrides = useServerConfigStore((s) => s._featureFlagOverrides);
+  const resetFlagOverrides = useServerConfigStore((s) => s.resetFlagOverrides);
+
+  const [search, setSearch] = useState('');
+  const [overriddenOnly, setOverriddenOnly] = useState(false);
+
+  const flagKeys = useMemo<FeatureFlagKey[]>(() => {
+    if (!originalFlags) return [];
+    return (Object.keys(originalFlags) as FeatureFlagKey[]).sort();
+  }, [originalFlags]);
+
+  const visibleKeys = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return flagKeys.filter((key) => {
+      if (overriddenOnly && overrides[key] === undefined) return false;
+      if (!term) return true;
+      return snakeCase(key as string).includes(term);
+    });
+  }, [flagKeys, overrides, overriddenOnly, search]);
+
+  if (!originalFlags) return null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Flexbox gap={2}>
+          <Text strong style={{ fontSize: 13 }}>
+            Feature Flag Overrides
+          </Text>
+          <Text style={{ fontSize: 11 }} type={'secondary'}>
+            dev only · client-side · localStorage persisted
+          </Text>
+        </Flexbox>
+        <ActionIcon icon={XIcon} size={'small'} onClick={onClose} />
+      </div>
+
+      <div className={styles.toolbar}>
+        <Input
+          allowClear
+          placeholder={'Search flag name…'}
+          size={'small'}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <Flexbox horizontal align={'center'} gap={6}>
+          <Switch checked={overriddenOnly} size={'small'} onChange={setOverriddenOnly} />
+          <Text style={{ fontSize: 12 }} type={'secondary'}>
+            overridden only
+          </Text>
+        </Flexbox>
+      </div>
+
+      <div className={styles.body}>
+        {visibleKeys.length === 0 ? (
+          <div className={styles.empty}>No flags match</div>
+        ) : (
+          visibleKeys.map((key) => <FlagRow flagKey={key} key={key} />)
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <Text style={{ fontSize: 11 }} type={'secondary'}>
+          {overrideCount} active override{overrideCount === 1 ? '' : 's'}
+        </Text>
+        <Button
+          disabled={overrideCount === 0}
+          icon={ListRestartIcon}
+          size={'small'}
+          onClick={resetFlagOverrides}
+        >
+          Reset all
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+Panel.displayName = 'DevFeatureFlagPanel/Panel';
+
+export default Panel;

--- a/src/features/DevFeatureFlagPanel/index.tsx
+++ b/src/features/DevFeatureFlagPanel/index.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { lazy, memo, Suspense, useEffect, useState } from 'react';
+
+import { useServerConfigStore } from '@/store/serverConfig';
+
+import Fab from './Fab';
+import Hydrator from './Hydrator';
+
+const Panel = lazy(() => import('./Panel'));
+
+const isDevEnv = process.env.NODE_ENV === 'development';
+const STORAGE_KEY = 'LOBE_DEV_FEATURE_FLAG_PANEL_ENABLED';
+
+const useDevPanelEnabled = (): boolean => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (!isDevEnv) return;
+    setEnabled(window.localStorage.getItem(STORAGE_KEY) === '1');
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setEnabled(e.newValue === '1');
+    };
+    window.addEventListener('storage', onStorage);
+
+    if (!window.localStorage.getItem(STORAGE_KEY)) {
+      console.info(
+        `[DevFeatureFlagPanel] Dev tool available. Enable with: localStorage.${STORAGE_KEY} = "1"`,
+      );
+    }
+
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  return enabled;
+};
+
+const DevFeatureFlagPanel = memo(() => {
+  const enabled = useDevPanelEnabled();
+  const [open, setOpen] = useState(false);
+  const originalFlags = useServerConfigStore((s) => s._originalFeatureFlags);
+
+  if (!isDevEnv || !enabled) return null;
+
+  return (
+    <>
+      <Hydrator />
+      {originalFlags && <Fab active={open} onToggle={() => setOpen((v) => !v)} />}
+      {open && (
+        <Suspense fallback={null}>
+          <Panel onClose={() => setOpen(false)} />
+        </Suspense>
+      )}
+    </>
+  );
+});
+
+DevFeatureFlagPanel.displayName = 'DevFeatureFlagPanel';
+
+export default DevFeatureFlagPanel;

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -9,6 +9,7 @@ import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyti
 import { DragUploadProvider } from '@/components/DragUploadZone/DragUploadProvider';
 import { isDesktop } from '@/const/version';
 import AgentMockDevtools from '@/features/AgentMockDevtools';
+import DevFeatureFlagPanel from '@/features/DevFeatureFlagPanel';
 import AuthProvider from '@/layout/AuthProvider';
 import AppTheme from '@/layout/GlobalProvider/AppTheme';
 import DynamicFavicon from '@/layout/GlobalProvider/DynamicFavicon';
@@ -83,7 +84,12 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
             <Suspense>
               <ImportSettings />
               {/* DevPanel disabled in SPA: depends on node:fs */}
-              {__DEV__ && <AgentMockDevtools />}
+              {__DEV__ && (
+                <>
+                  <AgentMockDevtools />
+                  <DevFeatureFlagPanel />
+                </>
+              )}
             </Suspense>
           </ServerConfigStoreProvider>
         </AppTheme>

--- a/src/store/serverConfig/slices/featureFlagOverride/action.test.ts
+++ b/src/store/serverConfig/slices/featureFlagOverride/action.test.ts
@@ -1,0 +1,211 @@
+import { act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_FEATURE_FLAGS, mapFeatureFlagsEnvToState } from '@/config/featureFlags';
+
+import { initServerConfigStore } from '../../store';
+import { DEV_FLAG_OVERRIDE_SCHEMA_VERSION, DEV_FLAG_OVERRIDE_STORAGE_KEY } from './constants';
+
+const baseFeatureFlags = mapFeatureFlagsEnvToState(DEFAULT_FEATURE_FLAGS);
+
+const createStore = () => initServerConfigStore({ featureFlags: { ...baseFeatureFlags } });
+
+const writeStorage = (overrides: Record<string, boolean>) => {
+  window.localStorage.setItem(
+    DEV_FLAG_OVERRIDE_STORAGE_KEY,
+    JSON.stringify({ version: DEV_FLAG_OVERRIDE_SCHEMA_VERSION, overrides }),
+  );
+};
+
+const readStorage = () => {
+  const raw = window.localStorage.getItem(DEV_FLAG_OVERRIDE_STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+};
+
+beforeEach(() => {
+  vi.stubEnv('NODE_ENV', 'development');
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('featureFlagOverride slice', () => {
+  describe('syncDevFlagOverrides', () => {
+    it('snapshots current featureFlags as _originalFeatureFlags', () => {
+      const store = createStore();
+
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._originalFeatureFlags).toEqual(baseFeatureFlags);
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+    });
+
+    it('merges valid persisted overrides into featureFlags after snapshot', () => {
+      writeStorage({ enableAgentOnboarding: true, showMarket: false });
+
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState().featureFlags.enableAgentOnboarding).toBe(true);
+      expect(store.getState().featureFlags.showMarket).toBe(false);
+      expect(store.getState()._featureFlagOverrides).toEqual({
+        enableAgentOnboarding: true,
+        showMarket: false,
+      });
+      // original snapshot stays untouched by the override merge
+      expect(store.getState()._originalFeatureFlags?.showMarket).toBe(true);
+    });
+
+    it('drops unknown keys from persisted overrides with a warning', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      writeStorage({ enableAgentOnboarding: true, somethingObsolete: true });
+
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides).toEqual({ enableAgentOnboarding: true });
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('drops non-boolean values from persisted overrides', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      writeStorage({ enableAgentOnboarding: true, showMarket: 'yes' as unknown as boolean });
+
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides).toEqual({ enableAgentOnboarding: true });
+    });
+
+    it('drops all persisted overrides on schema version mismatch', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      window.localStorage.setItem(
+        DEV_FLAG_OVERRIDE_STORAGE_KEY,
+        JSON.stringify({ version: 999, overrides: { enableAgentOnboarding: true } }),
+      );
+
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+      expect(window.localStorage.getItem(DEV_FLAG_OVERRIDE_STORAGE_KEY)).toBeNull();
+    });
+
+    it('survives corrupt JSON in localStorage', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      window.localStorage.setItem(DEV_FLAG_OVERRIDE_STORAGE_KEY, '{not-json');
+
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+      expect(store.getState()._originalFeatureFlags).toEqual(baseFeatureFlags);
+    });
+
+    it('re-snapshots when called again with fresh server flags', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      const fresher = { ...baseFeatureFlags, showMarket: false } as typeof baseFeatureFlags;
+      act(() => store.setState({ featureFlags: fresher }));
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._originalFeatureFlags?.showMarket).toBe(false);
+      // Override still applied on top of new server truth
+      expect(store.getState()._featureFlagOverrides.showMarket).toBe(false);
+    });
+
+    it('is a no-op outside development', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      const store = createStore();
+
+      act(() => store.getState().syncDevFlagOverrides());
+
+      expect(store.getState()._originalFeatureFlags).toBeNull();
+    });
+  });
+
+  describe('setFlagOverride', () => {
+    it('writes a true override and mutates featureFlags', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      act(() => store.getState().setFlagOverride('enableAgentOnboarding', true));
+
+      expect(store.getState()._featureFlagOverrides.enableAgentOnboarding).toBe(true);
+      expect(store.getState().featureFlags.enableAgentOnboarding).toBe(true);
+      expect(readStorage().overrides).toEqual({ enableAgentOnboarding: true });
+    });
+
+    it('writes a false override and mutates featureFlags', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      expect(store.getState()._featureFlagOverrides.showMarket).toBe(false);
+      expect(store.getState().featureFlags.showMarket).toBe(false);
+    });
+
+    it('clears an override and restores featureFlags from snapshot', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      act(() => store.getState().setFlagOverride('showMarket', undefined));
+
+      expect(store.getState()._featureFlagOverrides.showMarket).toBeUndefined();
+      expect(store.getState().featureFlags.showMarket).toBe(baseFeatureFlags.showMarket);
+      expect(readStorage()).toBeNull();
+    });
+
+    it('is a no-op before sync (original snapshot missing)', () => {
+      const store = createStore();
+
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+      expect(readStorage()).toBeNull();
+    });
+
+    it('is a no-op outside development', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+
+      vi.stubEnv('NODE_ENV', 'production');
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+    });
+  });
+
+  describe('resetFlagOverrides', () => {
+    it('clears overrides and restores featureFlags from snapshot', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+      act(() => store.getState().setFlagOverride('showMarket', false));
+      act(() => store.getState().setFlagOverride('enableAgentOnboarding', true));
+
+      act(() => store.getState().resetFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides).toEqual({});
+      expect(store.getState().featureFlags).toEqual(baseFeatureFlags);
+      expect(readStorage()).toBeNull();
+    });
+
+    it('is a no-op outside development', () => {
+      const store = createStore();
+      act(() => store.getState().syncDevFlagOverrides());
+      act(() => store.getState().setFlagOverride('showMarket', false));
+
+      vi.stubEnv('NODE_ENV', 'production');
+      act(() => store.getState().resetFlagOverrides());
+
+      expect(store.getState()._featureFlagOverrides.showMarket).toBe(false);
+    });
+  });
+});

--- a/src/store/serverConfig/slices/featureFlagOverride/action.ts
+++ b/src/store/serverConfig/slices/featureFlagOverride/action.ts
@@ -1,0 +1,107 @@
+import { type IFeatureFlagsState } from '@/config/featureFlags';
+import { type StoreSetter } from '@/store/types';
+
+import { type ServerConfigStore } from '../../store';
+import {
+  clearPersistedOverrides,
+  readPersistedOverrides,
+  writePersistedOverrides,
+} from './storage';
+
+const isDevEnv = () => process.env.NODE_ENV === 'development';
+
+export type FeatureFlagKey = keyof IFeatureFlagsState;
+
+type Setter = StoreSetter<ServerConfigStore>;
+
+export interface FeatureFlagOverrideAction {
+  /** dev panel: clear all overrides and restore featureFlags from snapshot */
+  resetFlagOverrides: () => void;
+  /** dev panel: write override (true|false) or clear override (undefined) for a single flag */
+  setFlagOverride: (key: FeatureFlagKey, value: boolean | undefined) => void;
+  /** Hydrator: snapshot current featureFlags as original, then merge persisted overrides */
+  syncDevFlagOverrides: () => void;
+}
+
+export const createFeatureFlagOverrideSlice = (
+  set: Setter,
+  get: () => ServerConfigStore,
+  _api?: unknown,
+) => new FeatureFlagOverrideActionImpl(set, get, _api);
+
+class FeatureFlagOverrideActionImpl implements FeatureFlagOverrideAction {
+  readonly #set: Setter;
+  readonly #get: () => ServerConfigStore;
+
+  constructor(set: Setter, get: () => ServerConfigStore, _api?: unknown) {
+    void _api;
+    this.#set = set;
+    this.#get = get;
+  }
+
+  syncDevFlagOverrides = () => {
+    if (!isDevEnv()) return;
+
+    const { featureFlags } = this.#get();
+    const original = { ...featureFlags } as IFeatureFlagsState;
+
+    const knownKeys = new Set<string>(Object.keys(original));
+    const persisted = readPersistedOverrides(knownKeys) as Partial<IFeatureFlagsState>;
+
+    const merged = { ...original, ...persisted } as IFeatureFlagsState;
+
+    this.#set(
+      {
+        _featureFlagOverrides: persisted,
+        _originalFeatureFlags: original,
+        featureFlags: merged,
+      },
+      false,
+      'syncDevFlagOverrides',
+    );
+  };
+
+  setFlagOverride = (key: FeatureFlagKey, value: boolean | undefined) => {
+    if (!isDevEnv()) return;
+
+    const state = this.#get();
+    const original = state._originalFeatureFlags;
+    if (!original) return;
+
+    const nextOverrides = { ...state._featureFlagOverrides } as Partial<IFeatureFlagsState>;
+    const nextFlags = { ...state.featureFlags } as IFeatureFlagsState;
+
+    if (value === undefined) {
+      delete nextOverrides[key];
+      (nextFlags as Record<string, unknown>)[key] = (original as Record<string, unknown>)[key];
+    } else {
+      (nextOverrides as Record<string, boolean>)[key] = value;
+      (nextFlags as Record<string, unknown>)[key] = value;
+    }
+
+    writePersistedOverrides(nextOverrides as Record<string, boolean>);
+
+    this.#set(
+      { _featureFlagOverrides: nextOverrides, featureFlags: nextFlags },
+      false,
+      'setFlagOverride',
+    );
+  };
+
+  resetFlagOverrides = () => {
+    if (!isDevEnv()) return;
+
+    const original = this.#get()._originalFeatureFlags;
+    if (!original) return;
+
+    clearPersistedOverrides();
+
+    this.#set(
+      { _featureFlagOverrides: {}, featureFlags: { ...original } },
+      false,
+      'resetFlagOverrides',
+    );
+  };
+}
+
+export type { FeatureFlagOverrideActionImpl };

--- a/src/store/serverConfig/slices/featureFlagOverride/constants.ts
+++ b/src/store/serverConfig/slices/featureFlagOverride/constants.ts
@@ -1,0 +1,7 @@
+export const DEV_FLAG_OVERRIDE_STORAGE_KEY = 'LOBE_DEV_FEATURE_FLAG_OVERRIDES';
+export const DEV_FLAG_OVERRIDE_SCHEMA_VERSION = 1;
+
+export interface PersistedDevFlagOverrides {
+  overrides: Record<string, boolean>;
+  version: number;
+}

--- a/src/store/serverConfig/slices/featureFlagOverride/storage.ts
+++ b/src/store/serverConfig/slices/featureFlagOverride/storage.ts
@@ -1,0 +1,80 @@
+import {
+  DEV_FLAG_OVERRIDE_SCHEMA_VERSION,
+  DEV_FLAG_OVERRIDE_STORAGE_KEY,
+  type PersistedDevFlagOverrides,
+} from './constants';
+
+const isDevEnv = () => process.env.NODE_ENV === 'development';
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const sanitizeOverrides = (
+  raw: unknown,
+  knownKeys: ReadonlySet<string>,
+): Record<string, boolean> => {
+  if (typeof raw !== 'object' || raw === null) return {};
+
+  const result: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!knownKeys.has(key)) {
+      console.warn(`[DevFlagOverride] dropping unknown override key: ${key}`);
+      continue;
+    }
+    if (typeof value !== 'boolean') {
+      console.warn(`[DevFlagOverride] dropping non-boolean override for: ${key}`);
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+};
+
+export const readPersistedOverrides = (knownKeys: ReadonlySet<string>): Record<string, boolean> => {
+  if (!isDevEnv() || !isBrowser()) return {};
+
+  try {
+    const raw = window.localStorage.getItem(DEV_FLAG_OVERRIDE_STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw) as Partial<PersistedDevFlagOverrides>;
+    if (parsed?.version !== DEV_FLAG_OVERRIDE_SCHEMA_VERSION) {
+      console.warn('[DevFlagOverride] schema version mismatch, dropping persisted overrides');
+      window.localStorage.removeItem(DEV_FLAG_OVERRIDE_STORAGE_KEY);
+      return {};
+    }
+
+    return sanitizeOverrides(parsed.overrides, knownKeys);
+  } catch (error) {
+    console.warn('[DevFlagOverride] failed to read persisted overrides', error);
+    return {};
+  }
+};
+
+export const writePersistedOverrides = (overrides: Record<string, boolean>) => {
+  if (!isDevEnv() || !isBrowser()) return;
+
+  try {
+    if (Object.keys(overrides).length === 0) {
+      window.localStorage.removeItem(DEV_FLAG_OVERRIDE_STORAGE_KEY);
+      return;
+    }
+
+    const payload: PersistedDevFlagOverrides = {
+      overrides,
+      version: DEV_FLAG_OVERRIDE_SCHEMA_VERSION,
+    };
+    window.localStorage.setItem(DEV_FLAG_OVERRIDE_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('[DevFlagOverride] failed to persist overrides', error);
+  }
+};
+
+export const clearPersistedOverrides = () => {
+  if (!isDevEnv() || !isBrowser()) return;
+
+  try {
+    window.localStorage.removeItem(DEV_FLAG_OVERRIDE_STORAGE_KEY);
+  } catch (error) {
+    console.warn('[DevFlagOverride] failed to clear persisted overrides', error);
+  }
+};

--- a/src/store/serverConfig/store.ts
+++ b/src/store/serverConfig/store.ts
@@ -15,8 +15,16 @@ import { merge } from '@/utils/merge';
 import { flattenActions } from '../utils/flattenActions';
 import { type ServerConfigAction } from './action';
 import { createServerConfigSlice } from './action';
+import {
+  createFeatureFlagOverrideSlice,
+  type FeatureFlagOverrideAction,
+} from './slices/featureFlagOverride/action';
 
 interface ServerConfigState {
+  /** dev-only: pending overrides keyed by mapped flag name; empty in prod */
+  _featureFlagOverrides: Partial<IFeatureFlagsState>;
+  /** dev-only: snapshot of server-provided featureFlags before any override; null until hydrated */
+  _originalFeatureFlags: IFeatureFlagsState | null;
   billboard?: GlobalBillboard | null;
   featureFlags: IFeatureFlagsState;
   isMobile?: boolean;
@@ -26,6 +34,8 @@ interface ServerConfigState {
 }
 
 const initialState: ServerConfigState = {
+  _featureFlagOverrides: {},
+  _originalFeatureFlags: null,
   billboard: null,
   featureFlags: mapFeatureFlagsEnvToState(DEFAULT_FEATURE_FLAGS),
   segmentVariants: '',
@@ -35,9 +45,10 @@ const initialState: ServerConfigState = {
 
 //  ===============  Aggregate createStoreFn ============ //
 
-export interface ServerConfigStore extends ServerConfigState, ServerConfigAction {}
+export interface ServerConfigStore
+  extends ServerConfigState, ServerConfigAction, FeatureFlagOverrideAction {}
 
-type ServerConfigStoreAction = ServerConfigAction;
+type ServerConfigStoreAction = ServerConfigAction & FeatureFlagOverrideAction;
 
 type CreateStore = (
   initState: Partial<ServerConfigStore>,
@@ -47,7 +58,10 @@ const createStore: CreateStore =
   (runtimeState: any) =>
   (...params) => ({
     ...merge(initialState, runtimeState),
-    ...flattenActions<ServerConfigStoreAction>([createServerConfigSlice(...params)]),
+    ...flattenActions<ServerConfigStoreAction>([
+      createServerConfigSlice(...params),
+      createFeatureFlagOverrideSlice(...params),
+    ]),
   });
 
 //  ===============  Implement useStore ============ //


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add a client-side feature flag override panel for development workflows. Lets devs flip any mapped `featureFlags.*` value at runtime without env-var fiddling or backend round-trips.

**How it works**

- New slice `serverConfig/slices/featureFlagOverride` adds `_originalFeatureFlags` (snapshot) and `_featureFlagOverrides` (active overrides) plus three actions: `syncDevFlagOverrides`, `setFlagOverride(key, value | undefined)`, `resetFlagOverrides`.
- On mount, a `Hydrator` snapshots the server-issued flags as the original truth and merges any persisted overrides into `featureFlags`. Existing `useServerConfigStore((s) => s.featureFlags.x)` consumers see the merged value with **zero callsite changes**.
- Overrides are persisted in `localStorage` under `LOBE_DEV_FEATURE_FLAG_OVERRIDES` with a schema version. Drift guards drop unknown keys, non-boolean values, and version mismatches.
- A floating FAB + panel UI (built with `createStaticStyles`, no backdrop blur) lets you search/filter flags and toggle each between `true` / `false` / `inherit` (= remove override). Reset-all is one click.

**Triple gating against prod leakage**

1. Mount: `process.env.NODE_ENV === 'development'` in `SPAGlobalProvider`
2. Action body: each action no-ops when not dev
3. Storage I/O: read/write/clear all guarded
4. Visibility: even in dev, FAB only renders when `localStorage.LOBE_DEV_FEATURE_FLAG_PANEL_ENABLED === '1'` (mirrors `AgentMockDevtools` opt-in pattern)

Webpack's static replacement of `process.env.NODE_ENV` lets prod builds tree-shake the entire feature.

**Scope note**

Override is purely **client-side**. Server-rendered flag decisions (e.g. SSR routes that read flags before the SPA hydrates) are unaffected. Documented for future readers.

#### 🧪 How to Test

1. Start dev server (`bun run dev:spa`).
2. In DevTools console: `localStorage.LOBE_DEV_FEATURE_FLAG_PANEL_ENABLED = '1'`, then reload.
3. A flag icon FAB appears bottom-right (above AgentMock FAB).
4. Click → panel opens. Try toggling any flag (e.g. `enable_agent_onboarding`) between `true`/`false`/`inherit`.
5. Verify dependent UI reacts (e.g. mode switch on onboarding shows/hides).
6. Reload — overrides persist.
7. Click `Reset all` — overrides clear, flags restore.
8. Set `localStorage.LOBE_DEV_FEATURE_FLAG_PANEL_ENABLED = '0'` and reload — FAB disappears, persisted overrides are not applied.

Unit tests cover slice behavior, schema drift, prod gating, and storage error paths (15 cases, all green).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| no runtime way to flip flags client-side | floating FAB + panel with per-flag tri-state and reset |

#### 📝 Additional Information

- No production bundle impact (NODE_ENV-gated, tree-shakable).
- No server changes; existing `getMergedFeatureFlags` runtime-config infra untouched.
- Follows the `AgentMockDevtools` opt-in pattern for consistency.