### PR TITLE
🐛 fix: remove signin captcha flow

### DIFF
--- a/src/app/[variants]/(auth)/signin/SignInEmailStep.tsx
+++ b/src/app/[variants]/(auth)/signin/SignInEmailStep.tsx
@@ -24,7 +24,6 @@ export const EMAIL_REGEX = /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/;
 export const USERNAME_REGEX = /^\w+$/;
 
 export interface SignInEmailStepProps {
-  businessElement?: React.ReactNode;
   disableEmailPassword?: boolean;
   form: FormInstance<{ email: string }>;
   isSocialOnly: boolean;
@@ -39,7 +38,6 @@ export interface SignInEmailStepProps {
 }
 
 export const SignInEmailStep = ({
-  businessElement,
   disableEmailPassword,
   form,
   isSocialOnly,
@@ -157,7 +155,6 @@ export const SignInEmailStep = ({
               button
             );
           })}
-          {businessElement}
           {!disableEmailPassword && divider}
         </Flexbox>
       )}

--- a/src/app/[variants]/(auth)/signin/page.tsx
+++ b/src/app/[variants]/(auth)/signin/page.tsx
@@ -10,7 +10,6 @@ import { useSignIn } from './useSignIn';
 
 const SignInPage = () => {
   const {
-    businessElement,
     disableEmailPassword,
     email,
     form,
@@ -32,7 +31,6 @@ const SignInPage = () => {
     <Suspense fallback={<Loading debugId={'Signin'} />}>
       {step === 'email' ? (
         <SignInEmailStep
-          businessElement={businessElement}
           disableEmailPassword={disableEmailPassword}
           form={form as any}
           isSocialOnly={isSocialOnly}

--- a/src/app/[variants]/(auth)/signin/useSignIn.test.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.test.ts
@@ -14,7 +14,16 @@ const mockSignInOauth2 = vi.hoisted(() => vi.fn());
 const mockSignInEmail = vi.hoisted(() => vi.fn());
 const mockSignInMagicLink = vi.hoisted(() => vi.fn());
 const mockRequestPasswordReset = vi.hoisted(() => vi.fn());
-const mockGetCaptchaTokenOnError = vi.hoisted(() => vi.fn());
+const mockLocalStorage = vi.hoisted(() => {
+  const store = new Map<string, string>();
+
+  return {
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    removeItem: (key: string) => store.delete(key),
+    setItem: (key: string, value: string) => store.set(key, value),
+  };
+});
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
@@ -47,10 +56,7 @@ vi.mock('@lobechat/business-const', () => ({
 
 vi.mock('@/business/client/hooks/useBusinessSignin', () => ({
   useBusinessSignin: () => ({
-    businessElement: null,
     getAdditionalData: async () => ({}),
-    getCaptchaTokenOnError: mockGetCaptchaTokenOnError,
-    getFetchOptions: async () => undefined,
     preSocialSigninCheck: async () => true,
     ssoProviders: [],
   }),
@@ -94,12 +100,13 @@ vi.mock('antd', async () => {
 // Mock global fetch
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
+vi.stubGlobal('localStorage', mockLocalStorage);
 
 describe('useSignIn', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocalStorage.clear();
     mockSearchParamsGet.mockReturnValue(null);
-    mockGetCaptchaTokenOnError.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -349,32 +356,7 @@ describe('useSignIn', () => {
       expect(mockMessageError).toHaveBeenCalled();
     });
 
-    it('should retry social sign in with captcha token when captcha is required', async () => {
-      mockGetCaptchaTokenOnError.mockResolvedValue('captcha-token');
-      mockSignInSocial
-        .mockResolvedValueOnce({
-          error: { code: 'CAPTCHA_REQUIRED', message: 'Missing CAPTCHA response', status: 400 },
-        })
-        .mockResolvedValueOnce({ url: 'https://google.com/auth' });
-
-      const { result } = renderHook(() => useSignIn());
-
-      await act(async () => {
-        await result.current.handleSocialSignIn('google');
-      });
-
-      expect(mockSignInSocial).toHaveBeenCalledTimes(2);
-      expect(mockSignInSocial).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          fetchOptions: { headers: { 'x-captcha-response': 'captcha-token' } },
-          provider: 'google',
-        }),
-      );
-      expect(mockMessageError).not.toHaveBeenCalled();
-    });
-
-    it('should stop social sign in when captcha modal is cancelled', async () => {
-      mockGetCaptchaTokenOnError.mockResolvedValue(null);
+    it('should not retry social sign in when captcha is returned unexpectedly', async () => {
       mockSignInSocial.mockResolvedValue({
         error: { code: 'CAPTCHA_REQUIRED', message: 'Missing CAPTCHA response', status: 400 },
       });
@@ -386,7 +368,7 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInSocial).toHaveBeenCalledTimes(1);
-      expect(mockMessageError).not.toHaveBeenCalled();
+      expect(mockMessageError).toHaveBeenCalled();
     });
 
     it('should save last auth provider to localStorage', async () => {

--- a/src/app/[variants]/(auth)/signin/useSignIn.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.ts
@@ -13,8 +13,6 @@ import { requestPasswordReset, signIn } from '@/libs/better-auth/auth-client';
 import { isBuiltinProvider, normalizeProviderId } from '@/libs/better-auth/utils/client';
 
 import { useAuthServerConfigStore } from '../_layout/AuthServerConfigProvider';
-import type { AuthFetchOptions } from '../utils/authFetchOptions';
-import { withCaptchaToken } from '../utils/authFetchOptions';
 import { EMAIL_REGEX, USERNAME_REGEX } from './SignInEmailStep';
 
 const LAST_AUTH_PROVIDER_KEY = 'lobehub:auth:last-provider:v1';
@@ -54,14 +52,7 @@ export const useSignIn = () => {
   });
   const serverConfigInit = useAuthServerConfigStore((s) => s.serverConfigInit);
   const oAuthSSOProviders = useAuthServerConfigStore((s) => s.serverConfig.oAuthSSOProviders) || [];
-  const {
-    businessElement,
-    ssoProviders,
-    preSocialSigninCheck,
-    getAdditionalData,
-    getCaptchaTokenOnError,
-    getFetchOptions,
-  } = useBusinessSignin();
+  const { getAdditionalData, preSocialSigninCheck, ssoProviders } = useBusinessSignin();
 
   useEffect(() => {
     const emailParam = searchParams.get('email');
@@ -230,30 +221,20 @@ export const useSignIn = () => {
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
       const additionalData = await getAdditionalData();
-      const fetchOptions = await getFetchOptions();
-      const signInWithFetchOptions = async (nextFetchOptions?: AuthFetchOptions) =>
+      const signInWithAdditionalData = async () =>
         isBuiltinProvider(normalizedProvider)
           ? await signIn.social({
               additionalData,
               callbackURL: callbackUrl,
-              fetchOptions: nextFetchOptions,
               provider: normalizedProvider,
             })
           : await signIn.oauth2({
               additionalData,
               callbackURL: callbackUrl,
-              fetchOptions: nextFetchOptions,
               providerId: normalizedProvider,
             });
 
-      let result = await signInWithFetchOptions(fetchOptions);
-      if (result && 'error' in result && result.error) {
-        const captchaToken = await getCaptchaTokenOnError(result.error);
-        if (captchaToken === null) return;
-        if (captchaToken) {
-          result = await signInWithFetchOptions(withCaptchaToken(fetchOptions, captchaToken));
-        }
-      }
+      const result = await signInWithAdditionalData();
 
       if (result && 'error' in result && result.error) throw result.error;
     } catch (error) {
@@ -303,7 +284,6 @@ export const useSignIn = () => {
     : resolvedProviders;
 
   return {
-    businessElement,
     disableEmailPassword,
     email,
     form,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] 📝 docs
- [ ] ♻️ refactor
- [ ] ✅ test
- [ ] 🌐 style
- [ ] 🧹 chore
- [ ] 🚀 perf
- [ ] 🤖 workflow

#### 🔗 Related Issue

N/A - no matching GitHub issue found for "captcha signin".

#### 🔀 Description of Change

- Removes the unused CAPTCHA widget wiring from the sign-in email step.
- Stops social sign-in from retrying with `x-captcha-response` when CAPTCHA errors are returned unexpectedly.
- Keeps auth CAPTCHA handling scoped to sign-up flows owned by cloud.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run --silent='passed-only' 'src/app/[variants]/(auth)/signin/useSignIn.test.ts'`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No cloud-specific business logic is exposed in this open-source change.
