### PR TITLE
🐛 fix: add signOperationJwt with 4h expiry for hetero-agent operations

### DIFF
--- a/src/libs/trpc/utils/internalJwt.test.ts
+++ b/src/libs/trpc/utils/internalJwt.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    JWKS_KEY: JSON.stringify({
+      keys: [
+        {
+          alg: 'RS256',
+          e: 'AQAB',
+          kid: 'test-kid',
+          kty: 'RSA',
+          n: 'test-modulus',
+          use: 'sig',
+        },
+      ],
+    }),
+    INTERNAL_JWT_EXPIRATION: '30s',
+  },
+}));
+
+// Track SignJWT constructor payload and chain calls
+let capturedPayload: Record<string, unknown> | undefined;
+let capturedProtectedHeader: Record<string, unknown> | undefined;
+let capturedSubject: string | undefined;
+let capturedExpirationTime: string | undefined;
+
+const signMock = vi.fn().mockResolvedValue('signed-jwt-token');
+
+const SignJWT = vi.fn(function (this: Record<string, unknown>, payload: Record<string, unknown>) {
+  capturedPayload = payload;
+  this.setProtectedHeader = vi.fn(function (
+    this: Record<string, unknown>,
+    header: Record<string, unknown>,
+  ) {
+    capturedProtectedHeader = header;
+    return this;
+  });
+  this.setSubject = vi.fn(function (this: Record<string, unknown>, sub: string) {
+    capturedSubject = sub;
+    return this;
+  });
+  this.setIssuedAt = vi.fn(function (this: Record<string, unknown>) {
+    return this;
+  });
+  this.setExpirationTime = vi.fn(function (this: Record<string, unknown>, exp: string) {
+    capturedExpirationTime = exp;
+    return this;
+  });
+  this.sign = signMock;
+  return this;
+});
+
+const importJWKMock = vi.fn().mockResolvedValue('mock-crypto-key');
+
+vi.mock('jose', () => ({
+  importJWK: (...args: unknown[]) => importJWKMock(...args),
+  SignJWT,
+}));
+
+// Dynamically import the module under test after mocks are set up
+const loadModule = async () => {
+  return await import('./internalJwt');
+};
+
+describe('signUserJWT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedPayload = undefined;
+    capturedProtectedHeader = undefined;
+    capturedSubject = undefined;
+    capturedExpirationTime = undefined;
+  });
+
+  it('should produce a JWT with 5-minute expiry', async () => {
+    const { signUserJWT } = await loadModule();
+
+    const token = await signUserJWT('user-123');
+
+    expect(token).toBe('signed-jwt-token');
+    expect(capturedExpirationTime).toBe('5m');
+    expect(capturedSubject).toBe('user-123');
+    expect(capturedPayload).toEqual({ purpose: 'cli-sandbox' });
+    expect(capturedProtectedHeader).toEqual({ alg: 'RS256', kid: 'test-kid' });
+    expect(signMock).toHaveBeenCalledWith('mock-crypto-key');
+  });
+
+  it('should set the purpose to cli-sandbox', async () => {
+    const { signUserJWT } = await loadModule();
+
+    await signUserJWT('user-abc');
+
+    expect(capturedPayload).toEqual({ purpose: 'cli-sandbox' });
+  });
+
+  it('should pass the userId as the subject claim', async () => {
+    const { signUserJWT } = await loadModule();
+
+    await signUserJWT('specific-user-id');
+
+    expect(capturedSubject).toBe('specific-user-id');
+  });
+
+  it('should import the JWK as RS256', async () => {
+    const { signUserJWT } = await loadModule();
+
+    await signUserJWT('user-123');
+
+    expect(importJWKMock).toHaveBeenCalled();
+    const [firstArg, secondArg] = importJWKMock.mock.calls[0];
+    expect(firstArg).toHaveProperty('alg', 'RS256');
+    expect(firstArg).toHaveProperty('kty', 'RSA');
+    expect(secondArg).toBe('RS256');
+  });
+});
+
+describe('signOperationJwt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedPayload = undefined;
+    capturedProtectedHeader = undefined;
+    capturedSubject = undefined;
+    capturedExpirationTime = undefined;
+  });
+
+  it('should produce a JWT with 4-hour expiry', async () => {
+    const { signOperationJwt } = await loadModule();
+
+    const token = await signOperationJwt('user-456');
+
+    expect(token).toBe('signed-jwt-token');
+    expect(capturedExpirationTime).toBe('4h');
+  });
+
+  it('should set the purpose to hetero-operation', async () => {
+    const { signOperationJwt } = await loadModule();
+
+    await signOperationJwt('user-789');
+
+    expect(capturedPayload).toEqual({ purpose: 'hetero-operation' });
+  });
+
+  it('should pass the userId as the subject claim', async () => {
+    const { signOperationJwt } = await loadModule();
+
+    await signOperationJwt('hetero-user');
+
+    expect(capturedSubject).toBe('hetero-user');
+  });
+
+  it('should use RS256 algorithm with correct kid', async () => {
+    const { signOperationJwt } = await loadModule();
+
+    await signOperationJwt('user-abc');
+
+    expect(capturedProtectedHeader).toEqual({ alg: 'RS256', kid: 'test-kid' });
+  });
+
+  it('should sign with the imported crypto key', async () => {
+    const { signOperationJwt } = await loadModule();
+
+    await signOperationJwt('user-xyz');
+
+    expect(signMock).toHaveBeenCalledWith('mock-crypto-key');
+  });
+});
+
+describe('expiry contrast between signUserJWT and signOperationJwt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedPayload = undefined;
+    capturedProtectedHeader = undefined;
+    capturedSubject = undefined;
+    capturedExpirationTime = undefined;
+  });
+
+  it('signUserJWT should expire in 5m, signOperationJwt in 4h', async () => {
+    const { signUserJWT, signOperationJwt } = await loadModule();
+
+    // Reset tracked state between calls
+    await signUserJWT('user-1');
+    const userJwtExpiry = capturedExpirationTime;
+
+    await signOperationJwt('user-1');
+    const operationJwtExpiry = capturedExpirationTime;
+
+    expect(userJwtExpiry).toBe('5m');
+    expect(operationJwtExpiry).toBe('4h');
+  });
+
+  it('signUserJWT purpose should be cli-sandbox, signOperationJwt purpose should be hetero-operation', async () => {
+    const { signUserJWT, signOperationJwt } = await loadModule();
+
+    await signUserJWT('user-2');
+    const userPurpose = capturedPayload;
+
+    await signOperationJwt('user-2');
+    const operationPurpose = capturedPayload;
+
+    expect(userPurpose).toEqual({ purpose: 'cli-sandbox' });
+    expect(operationPurpose).toEqual({ purpose: 'hetero-operation' });
+  });
+});
+
+describe('signInternalJWT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedPayload = undefined;
+    capturedProtectedHeader = undefined;
+    capturedSubject = undefined;
+    capturedExpirationTime = undefined;
+  });
+
+  it('should use INTERNAL_JWT_EXPIRATION from env (30s default)', async () => {
+    const { signInternalJWT } = await loadModule();
+
+    await signInternalJWT();
+
+    expect(capturedExpirationTime).toBe('30s');
+  });
+
+  it('should set purpose to lobe-internal-call', async () => {
+    const { signInternalJWT } = await loadModule();
+
+    await signInternalJWT();
+
+    expect(capturedPayload).toEqual({ purpose: 'lobe-internal-call' });
+  });
+
+  it('should NOT set a subject (internal calls are userless)', async () => {
+    const { signInternalJWT } = await loadModule();
+
+    await signInternalJWT();
+
+    expect(capturedSubject).toBeUndefined();
+  });
+});

--- a/src/libs/trpc/utils/internalJwt.ts
+++ b/src/libs/trpc/utils/internalJwt.ts
@@ -83,6 +83,10 @@ export const signInternalJWT = async (): Promise<string> => {
  * Sign a short-lived OIDC-compatible JWT for a given user.
  * Used by server-side sandbox execution to authenticate CLI commands.
  * The token contains `sub: userId` and passes standard OIDC JWT validation.
+ *
+ * ⚠️ 5-minute expiry is intentionally short: this token is for gateway
+ * WebSocket auth and quick CLI operations — NOT for long-running jobs.
+ * For hetero-agent operations (Claude Code / Codex), use signOperationJwt().
  */
 export const signUserJWT = async (userId: string): Promise<string> => {
   const { key, kid } = await getSigningKey();
@@ -92,6 +96,29 @@ export const signUserJWT = async (userId: string): Promise<string> => {
     .setSubject(userId)
     .setIssuedAt()
     .setExpirationTime('5m')
+    .sign(key);
+};
+
+/**
+ * Sign a long-lived operation-scoped JWT for hetero-agent execution.
+ *
+ * Unlike signUserJWT (5-minute expiry for gateway / quick CLI auth), this
+ * produces a token valid for 4 hours — enough for a Claude Code or Codex
+ * session to run multiple tool calls without 401 errors on heteroIngest /
+ * heteroFinish.
+ *
+ * The token contains `sub: userId` and `purpose: 'hetero-operation'` so
+ * the validation middleware can distinguish operation tokens from short-lived
+ * gateway tokens when minimum-scope enforcement is needed.
+ */
+export const signOperationJwt = async (userId: string): Promise<string> => {
+  const { key, kid } = await getSigningKey();
+
+  return new SignJWT({ purpose: 'hetero-operation' })
+    .setProtectedHeader({ alg: 'RS256', kid })
+    .setSubject(userId)
+    .setIssuedAt()
+    .setExpirationTime('4h')
     .sign(key);
 };
 

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -53,7 +53,7 @@ import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { toolsEnv } from '@/envs/tools';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
-import { signUserJWT } from '@/libs/trpc/utils/internalJwt';
+import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import type { EvalContext, ServerAgentToolsContext } from '@/server/modules/Mecha';
 import { createServerAgentToolsEngine } from '@/server/modules/Mecha';
 import type { ServerUserMemoryConfig } from '@/server/modules/Mecha/ContextEngineering/types';
@@ -666,9 +666,11 @@ export class AiAgentService {
       const resumeSessionId = await heteroService.getHeterogeneousResumeSessionId(topicId);
       // Sign an operation-scoped JWT so the CLI can authenticate against
       // heteroIngest / heteroFinish without full user credentials.
+      // Uses 4h expiry (signOperationJwt) — a Claude Code task may exceed the
+      // default 5m signUserJWT lifetime, causing heteroIngest 401 mid-task.
       let operationJwt: string;
       try {
-        operationJwt = await signUserJWT(this.userId);
+        operationJwt = await signOperationJwt(this.userId);
       } catch (err) {
         log('execAgent: failed to sign operation JWT for hetero run: %O', err);
         throw new Error('Failed to sign operation JWT for hetero agent', { cause: err });


### PR DESCRIPTION
## 💻 Change Type
🐛 fix

## 🔗 Related Issue
Closes LOBE-8649 (subtask T-13: operation JWT 4h expiry)

## 🔀 Description of Change

Hetero-agent operations (Claude Code / Codex) currently use `signUserJWT` which defaults to **5-minute expiry**. Long-running tasks exceeding 5 minutes cause `heteroIngest` / `heteroFinish` to return 401 mid-execution.

### Changes
- **`src/libs/trpc/utils/internalJwt.ts`**: Add `signOperationJwt(userId)` with **4-hour** expiry and `purpose: 'hetero-operation'`
- **`src/server/services/aiAgent/index.ts`**: Update `execAgent` to call `signOperationJwt` for the hetero operation JWT (injected as `LOBEHUB_JWT`)

### What stays unchanged
- `signUserJWT` remains 5m — used for gateway WebSocket auth and quick CLI operations
- `gatewayToken` (x2) in `execAgent` still uses `signUserJWT`
- `preprocessLhCommand.ts` still uses `signUserJWT`
- `refreshGatewayToken` router still uses `signUserJWT`

## 🧪 How to Test
- [ ] Verify `signOperationJwt` produces a JWT with 4h expiry and `purpose: 'hetero-operation'`
- [ ] Verify a Claude Code task running > 5 minutes does not get 401 on `heteroIngest` / `heteroFinish`
- [ ] Verify `gatewayToken` (WebSocket auth) still has 5m expiry
- [ ] TypeScript type-check passes (`pnpm type-check:tsc`)