### PR TITLE
📝 docs(version-release): enforce git-derived PR refs and metrics

### DIFF
--- a/.agents/skills/version-release/SKILL.md
+++ b/.agents/skills/version-release/SKILL.md
@@ -146,7 +146,7 @@ Before creating the release branch, verify the source branch:
 
 Choose workflow by scenario (see `reference/patch-release-scenarios.md`):
 
-- **Weekly Release**: create `release/weekly-{YYYYMMDD}` from canary; use `git log main..canary` for release note inputs; title like `🚀 release: 20260222`
+- **Weekly Release**: create `release/weekly-{YYYYMMDD}` from canary; derive release note inputs from `$PREV_TAG..origin/release/weekly-<YYYYMMDD>` per **Computing Inputs (Hard Rules)** below (where `$PREV_TAG` is the latest semver tag on main) — using a hand-picked previous-weekly tag will silently miss hotfixes shipped between weeklies; title like `🚀 release: 20260222`
 - **Bug Hotfix**: create `hotfix/` from main; use gitmoji prefix title (e.g. `🐛 fix: ...`)
 - **New Model Launch**: community PRs trigger automatically via title prefix (`feat` / `style`)
 - **DB Migration**: create `release/db-migration-{name}` from main; cherry-pick migration commits; include dedicated migration notes
@@ -184,6 +184,88 @@ Collect these inputs first:
 5. Known risks / migrations / rollout notes (if any)
 
 If metrics cannot be reliably computed, omit unknown numbers instead of guessing.
+
+### Computing Inputs (Hard Rules — Verify, Never Guess)
+
+> Hallucinated PR numbers and wrong "Since v..." bases are the #1 failure mode of this skill. Every number and every `(#XXXX)` must come from `git`, never from memory or inference.
+
+#### 1. Compare base = latest semver tag on `main`
+
+Do **not** eyeball the tag list or pick the "last weekly" PR. Compute it:
+
+```bash
+git fetch origin main canary --tags
+PREV_TAG=$(git describe --tags --abbrev=0 origin/main --match 'v*.*.*' --exclude '*-canary*' --exclude '*-nightly*')
+echo "$PREV_TAG"
+```
+
+Sanity check that the tag is reachable from the release branch:
+
+```bash
+git merge-base --is-ancestor "$PREV_TAG" origin/release/weekly-<YYYYMMDD> && echo OK
+```
+
+If the check fails, stop and ask the user — the release branch is based on the wrong source.
+
+> **Why not "the last weekly release PR"?** Hotfixes (`v2.1.54`, `v2.1.55`, …) merge directly into main between weeklies. They get back-merged via `sync-main-to-canary`, so the latest semver tag on main _is_ the correct previous release for both weekly and minor flows. Picking the previous weekly's tag will silently undercount and put a stale version in "Since v…".
+
+#### 2. PR refs must come from commit subjects — never from descriptions
+
+Compute the canonical set:
+
+```bash
+git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" \
+  --pretty=format:'%s' --no-merges \
+  | grep -oE '\(#[0-9]+\)$' \
+  | sort -u > /tmp/release_prs.txt
+```
+
+Hard rules:
+
+- Every `(#XXXX)` you write in the body **must** appear in `/tmp/release_prs.txt`. No exceptions.
+- Never infer a PR number from a feature description. If you remember "the KB BM25 PR was around #14501", that memory is wrong about half the time. Look up the commit hash by feature keyword and read its actual subject.
+- If your terminal truncates long subjects (any wrapper that compresses output, e.g. `rtk`), bypass it. With `rtk` use `rtk proxy git log …`. Verify with `wc -l /tmp/release_prs.txt` — the count must match `git log $PREV_TAG..HEAD --no-merges --pretty=format:'%h' | wc -l` minus the few commits without a PR ref. A mismatch of >5% means subjects are being silently truncated.
+
+#### 3. Metrics must come from git counts
+
+```bash
+PR_COUNT=$(wc -l < /tmp/release_prs.txt | tr -d ' ')
+
+COMMIT_COUNT=$(git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" --no-merges --pretty=format:'%h' | wc -l | tr -d ' ')
+
+CONTRIBUTOR_COUNT=$(git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" --no-merges --pretty=format:'%an' \
+  | sort -u \
+  | grep -viE '^(lobehubbot|LobeHub Bot|renovate\[bot\])$' \
+  | wc -l | tr -d ' ')
+```
+
+If a number cannot be confidently derived, omit it — never guess.
+
+#### 4. Author-to-handle resolution
+
+Git `%an` is the commit author display name, not the GitHub handle. For each author you mention, confirm the handle:
+
+```bash
+gh pr view lobehub/lobe-chat --json author --jq '.author.login' < some-pr-by-them > --repo
+```
+
+Use the result for `@handle`. Then classify each author per the `LobeHub team roster` below; community first, team after.
+
+#### 5. Pre-publish verification (mandatory)
+
+Before `gh pr create` / `gh pr edit --body-file`, diff body PR refs against the canonical set:
+
+```bash
+grep -oE '#[0-9]+' release_body.md | sort -u > /tmp/body_prs.txt
+sed 's/[()]//g' /tmp/release_prs.txt > /tmp/release_prs_clean.txt
+
+echo "=== In body but NOT in actual range (must be EMPTY) ==="
+comm -23 /tmp/body_prs.txt /tmp/release_prs_clean.txt
+```
+
+Empty diff = OK. Any output = the body cites a PR that wasn't merged in this range. Stop and fix before publishing.
+
+Also verify the metrics line in the body matches the computed values (`PR_COUNT`, `CONTRIBUTOR_COUNT`) and that `**Full Changelog**` uses `$PREV_TAG`, not some older tag.
 
 ### Canonical Structure
 
@@ -251,9 +333,10 @@ Render contributors as a **single flat list** (no separate "Community" / "Core T
 - @Neko
 - @Rdmclin2
 - @AmAzing129
-- @sudongyuer
-- @rivertwilight
+- @sudongyuer (commit author name: Tsuki)
+- @rivertwilight (commit author name: René Wang)
 - @CanisMinor
+- @cy948 (commit author name: Rylan Cai)
 
 > **Resolving handles** — git author names (e.g. `YuTengjing`) are not always the GitHub handle. Verify via `gh pr view <PR> --json author` or `gh api search/users -f q='<email>'` before listing.
 
@@ -330,6 +413,11 @@ Plus @lobehubbot and renovate[bot] for maintenance.
 
 ### Quick Checklist
 
+- [ ] `PREV_TAG` is `git describe --tags --abbrev=0 origin/main` (latest semver), not the last weekly's tag
+- [ ] Every `(#XXXX)` in the body appears in `/tmp/release_prs.txt` (verified via `comm -23`)
+- [ ] `Since v…` line uses `$PREV_TAG`; PR / contributor counts match `wc -l` on the computed sets
+- [ ] `**Full Changelog**` uses `$PREV_TAG...release/weekly-<YYYYMMDD>` (or `…v{x.y.z}` for minor)
+- [ ] Author handles resolved via `gh pr view --json author`, not assumed from `%an`
 - [ ] Uses top metadata and a clear release thesis
 - [ ] Includes `Highlights` plus domain-grouped sections
 - [ ] Every major bullet states both change and user/operator impact

--- a/.agents/skills/version-release/SKILL.md
+++ b/.agents/skills/version-release/SKILL.md
@@ -5,6 +5,8 @@ description: "Version release workflow. Use when the user mentions 'release', 'h
 
 # Version Release Workflow
 
+This skill is a router. The detailed steps live in `reference/`.
+
 ## Scope Boundary (Important)
 
 This skill is only for:
@@ -28,68 +30,12 @@ The primary development branch is **canary**. All day-to-day development happens
 
 Only two release types are used in practice (major releases are extremely rare and can be ignored):
 
-| Type  | Use Case                                       | Frequency             | Source Branch  | PR Title Format                      | Version       |
-| ----- | ---------------------------------------------- | --------------------- | -------------- | ------------------------------------ | ------------- |
-| Minor | Feature iteration release                      | \~Every 4 weeks       | canary         | `🚀 release: v{x.y.0}`               | Manually set  |
-| Patch | Weekly release / hotfix / model / DB migration | \~Weekly or as needed | canary or main | Custom (e.g. `🚀 release: 20260222`) | Auto patch +1 |
+| Type  | Use Case                                       | Frequency             | Source Branch  | PR Title Format                      | Version       | Reference                              |
+| ----- | ---------------------------------------------- | --------------------- | -------------- | ------------------------------------ | ------------- | -------------------------------------- |
+| Minor | Feature iteration release                      | \~Every 4 weeks       | canary         | `🚀 release: v{x.y.0}`               | Manually set  | `reference/minor-release.md`           |
+| Patch | Weekly release / hotfix / model / DB migration | \~Weekly or as needed | canary or main | Custom (e.g. `🚀 release: 20260222`) | Auto patch +1 | `reference/patch-release-scenarios.md` |
 
-## Minor Release Workflow
-
-Used to publish a new minor version (e.g. `v2.2.0`), roughly every 4 weeks.
-
-### Steps
-
-1. **Create a release branch from canary**
-
-```bash
-git checkout canary
-git pull origin canary
-git checkout -b release/v{version}
-git push -u origin release/v{version}
-```
-
-2. **Determine the version number** — Read the current version from `package.json` and compute the next minor version (e.g. 2.1.x -> 2.2.0)
-
-3. **Create a PR to main**
-
-```bash
-gh pr create \
-  --title "🚀 release: v{version}" \
-  --base main \
-  --head release/v{version} \
-  --body "## 📦 Release v{version} ..."
-```
-
-> \[!IMPORTANT]
-> The PR title must strictly match the `🚀 release: v{x.y.z}` format. CI uses a regex on this title to determine the exact version number.
-
-4. **Automatic trigger after merge**: `auto-tag-release` detects the title format and uses the version number from the title to complete the release.
-
-### Scripts
-
-```bash
-bun run release:branch         # Interactive
-bun run release:branch --minor # Directly specify minor
-```
-
-## Patch Release Workflow
-
-Version number is automatically bumped by patch +1. There are 4 common scenarios:
-
-| Scenario            | Source Branch | Branch Naming                 | Description                                      |
-| ------------------- | ------------- | ----------------------------- | ------------------------------------------------ |
-| Weekly Release      | canary        | `release/weekly-{YYYYMMDD}`   | Weekly release train, canary -> main             |
-| Bug Hotfix          | main          | `hotfix/v{version}-{hash}`    | Emergency bug fix                                |
-| New Model Launch    | canary        | Community PR merged directly  | New model launch, triggered by PR title prefix   |
-| DB Schema Migration | main          | `release/db-migration-{name}` | Database migration, requires dedicated changelog |
-
-All scenarios auto-bump patch +1. Patch PR titles do not need a version number. See `reference/patch-release-scenarios.md` for detailed steps per scenario.
-
-### Scripts
-
-```bash
-bun run hotfix:branch # Hotfix scenario
-```
+For writing the release-note body (any release type), see `reference/release-notes-style.md`.
 
 ## Auto-Release Trigger Rules (`auto-tag-release.yml`)
 
@@ -127,7 +73,7 @@ PRs that don't match any conditions above (e.g. `docs`, `chore`, `ci`, `test`) w
 
 When the user requests a release:
 
-### Precheck
+### Precheck (applies to all release types)
 
 Before creating the release branch, verify the source branch:
 
@@ -135,292 +81,18 @@ Before creating the release branch, verify the source branch:
 - **All other release/hotfix branches**: must branch from `main`; run `git merge-base --is-ancestor main <branch> && echo OK`
 - If the branch is based on the wrong source, recreate from the correct base
 
-### Minor Release
+### Routing
 
-1. Read `package.json` to get the current version and compute the next minor version
-2. Create a `release/v{version}` branch from canary
-3. Push and create PR — **title must be `🚀 release: v{version}`**
-4. Inform the user that merge will auto-trigger release
+Pick the right reference and follow it end-to-end:
 
-### Patch Release
+- **Minor release** → `reference/minor-release.md`
+- **Patch release** (weekly / hotfix / model launch / DB migration) → `reference/patch-release-scenarios.md`
+- **Writing the PR body / release notes** (any release type) → `reference/release-notes-style.md`
 
-Choose workflow by scenario (see `reference/patch-release-scenarios.md`):
+### Hard Rules (apply to every release type)
 
-- **Weekly Release**: create `release/weekly-{YYYYMMDD}` from canary; derive release note inputs from `$PREV_TAG..origin/release/weekly-<YYYYMMDD>` per **Computing Inputs (Hard Rules)** below (where `$PREV_TAG` is the latest semver tag on main) — using a hand-picked previous-weekly tag will silently miss hotfixes shipped between weeklies; title like `🚀 release: 20260222`
-- **Bug Hotfix**: create `hotfix/` from main; use gitmoji prefix title (e.g. `🐛 fix: ...`)
-- **New Model Launch**: community PRs trigger automatically via title prefix (`feat` / `style`)
-- **DB Migration**: create `release/db-migration-{name}` from main; cherry-pick migration commits; include dedicated migration notes
-
-### Hard Rules
-
-- **Do NOT** manually modify `package.json` version
-- **Do NOT** manually create tags
-- Minor PR title format is strict
-- Patch PRs do not need explicit version number
-- Keep release facts accurate; do not invent metrics or availability statements
-
-## GitHub Release Changelog Standard (Long-Form Style)
-
-Use this section for writing **GitHub Release notes** (or release PR body when the PR body is intended to become release notes).\
-Do not use this as `docs/changelog` page guidance.
-
-### Positioning
-
-This release-note style is:
-
-1. **Data-backed at the top** (date, range, key metrics)
-2. **Narrative first, then structured detail**
-3. **Deep but scannable** (clear sectioning + compact bullets)
-4. **Contributor-forward** (credits are part of the release story)
-
-### Required Inputs Before Writing
-
-Collect these inputs first:
-
-1. Compare range (`<prev_tag>...<current_tag>`)
-2. Release metrics (commits, merged PRs, resolved issues, contributors, optional files/insertions/deletions)
-3. High-impact changes by domain (core loop, platform/gateway, UX, tooling, security, reliability)
-4. Contributor list (with standout contributions if known)
-5. Known risks / migrations / rollout notes (if any)
-
-If metrics cannot be reliably computed, omit unknown numbers instead of guessing.
-
-### Computing Inputs (Hard Rules — Verify, Never Guess)
-
-> Hallucinated PR numbers and wrong "Since v..." bases are the #1 failure mode of this skill. Every number and every `(#XXXX)` must come from `git`, never from memory or inference.
-
-#### 1. Compare base = latest semver tag on `main`
-
-Do **not** eyeball the tag list or pick the "last weekly" PR. Compute it:
-
-```bash
-git fetch origin main canary --tags
-PREV_TAG=$(git describe --tags --abbrev=0 origin/main --match 'v*.*.*' --exclude '*-canary*' --exclude '*-nightly*')
-echo "$PREV_TAG"
-```
-
-Sanity check that the tag is reachable from the release branch:
-
-```bash
-git merge-base --is-ancestor "$PREV_TAG" origin/release/weekly-<YYYYMMDD> && echo OK
-```
-
-If the check fails, stop and ask the user — the release branch is based on the wrong source.
-
-> **Why not "the last weekly release PR"?** Hotfixes (`v2.1.54`, `v2.1.55`, …) merge directly into main between weeklies. They get back-merged via `sync-main-to-canary`, so the latest semver tag on main _is_ the correct previous release for both weekly and minor flows. Picking the previous weekly's tag will silently undercount and put a stale version in "Since v…".
-
-#### 2. PR refs must come from commit subjects — never from descriptions
-
-Compute the canonical set:
-
-```bash
-git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" \
-  --pretty=format:'%s' --no-merges \
-  | grep -oE '\(#[0-9]+\)$' \
-  | sort -u > /tmp/release_prs.txt
-```
-
-Hard rules:
-
-- Every `(#XXXX)` you write in the body **must** appear in `/tmp/release_prs.txt`. No exceptions.
-- Never infer a PR number from a feature description. If you remember "the KB BM25 PR was around #14501", that memory is wrong about half the time. Look up the commit hash by feature keyword and read its actual subject.
-- If your terminal truncates long subjects (any wrapper that compresses output, e.g. `rtk`), bypass it. With `rtk` use `rtk proxy git log …`. Verify with `wc -l /tmp/release_prs.txt` — the count must match `git log $PREV_TAG..HEAD --no-merges --pretty=format:'%h' | wc -l` minus the few commits without a PR ref. A mismatch of >5% means subjects are being silently truncated.
-
-#### 3. Metrics must come from git counts
-
-```bash
-PR_COUNT=$(wc -l < /tmp/release_prs.txt | tr -d ' ')
-
-COMMIT_COUNT=$(git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" --no-merges --pretty=format:'%h' | wc -l | tr -d ' ')
-
-CONTRIBUTOR_COUNT=$(git log "$PREV_TAG..origin/release/weekly-<YYYYMMDD>" --no-merges --pretty=format:'%an' \
-  | sort -u \
-  | grep -viE '^(lobehubbot|LobeHub Bot|renovate\[bot\])$' \
-  | wc -l | tr -d ' ')
-```
-
-If a number cannot be confidently derived, omit it — never guess.
-
-#### 4. Author-to-handle resolution
-
-Git `%an` is the commit author display name, not the GitHub handle. For each author you mention, confirm the handle:
-
-```bash
-gh pr view lobehub/lobe-chat --json author --jq '.author.login' < some-pr-by-them > --repo
-```
-
-Use the result for `@handle`. Then classify each author per the `LobeHub team roster` below; community first, team after.
-
-#### 5. Pre-publish verification (mandatory)
-
-Before `gh pr create` / `gh pr edit --body-file`, diff body PR refs against the canonical set:
-
-```bash
-grep -oE '#[0-9]+' release_body.md | sort -u > /tmp/body_prs.txt
-sed 's/[()]//g' /tmp/release_prs.txt > /tmp/release_prs_clean.txt
-
-echo "=== In body but NOT in actual range (must be EMPTY) ==="
-comm -23 /tmp/body_prs.txt /tmp/release_prs_clean.txt
-```
-
-Empty diff = OK. Any output = the body cites a PR that wasn't merged in this range. Stop and fix before publishing.
-
-Also verify the metrics line in the body matches the computed values (`PR_COUNT`, `CONTRIBUTOR_COUNT`) and that `**Full Changelog**` uses `$PREV_TAG`, not some older tag.
-
-### Canonical Structure
-
-Follow this section order unless the user asks otherwise:
-
-1. `# 🚀 LobeHub Release (<YYYYMMDD>)`
-2. Metadata lines:
-   - `Release Date`
-   - `Since <Previous Version>` metrics
-3. One quoted release thesis (single paragraph, 1-2 lines)
-4. `## ✨ Highlights` (6-12 bullets for major releases; 3-8 for weekly)
-5. Domain blocks with optional `###` subsections:
-   - `## 🏗️ Core Agent & Architecture` (or equivalent product core)
-   - `## 📱 Platforms / Integrations`
-   - `## 🖥️ CLI & User Experience`
-   - `## 🔧 Tooling`
-   - `## 🔒 Security & Reliability`
-   - `## 📚 Documentation` (optional if meaningful)
-6. `## 👥 Contributors`
-7. `**Full Changelog**: <prev>...<current>`
-
-Use `---` separators between major blocks for long releases.
-
-### Writing Rules (Hard)
-
-1. **No fabricated metrics**: all numbers must be traceable.
-2. **No vague headline bullets**: each bullet must include capability + impact.
-3. **No internal-only framing**: phrase from user/operator perspective.
-4. **Security must be explicit** when security-sensitive fixes are present.
-5. **PR/issue linkage**: use `(#1234)` when IDs are available.
-6. **Terminology consistency**: same feature/provider name across sections.
-7. **Do not bury migration or breaking changes**: elevate to dedicated section or callout.
-
-### Style Rules (Long-Form)
-
-1. Start with an "everyday use" framing, not implementation internals.
-2. Mix narrative sentence + evidence bullets.
-3. Keep bullets compact but informative:
-   - Good: `**Fast Mode (`/fast`)** — Priority routing for OpenAI and Anthropic, reducing latency on supported models. (#6875, #6960)`
-4. Use bold only for capability names, not for whole sentences.
-5. Keep heading depth <= 3 levels.
-
-### Release Size Heuristics
-
-- **Minor / major milestone release**
-  - Include full structure with multiple domain blocks.
-  - `Highlights` usually 8-12 bullets.
-- **Weekly patch release**
-  - Keep full skeleton but reduce subsection count.
-  - `Highlights` usually 4-8 bullets.
-- **DB migration release**
-  - Keep concise.
-  - Must include `Migration overview`, operator impact, and rollback/backup note.
-
-### Contributor Ordering
-
-Render contributors as a **single flat list** (no separate "Community" / "Core Team" subsections). Order: **community contributors first, team members after**. Within each group, sort by PR count desc. Bots (`@lobehubbot`, `renovate[bot]`) go on a separate "maintenance" line.
-
-**LobeHub team roster** — anyone in this list is a team member; anyone not in this list is a community contributor:
-
-- @arvinxx
-- @Innei
-- @tjx666 (commit author name: YuTengjing)
-- @LiJian
-- @Neko
-- @Rdmclin2
-- @AmAzing129
-- @sudongyuer (commit author name: Tsuki)
-- @rivertwilight (commit author name: René Wang)
-- @CanisMinor
-- @cy948 (commit author name: Rylan Cai)
-
-> **Resolving handles** — git author names (e.g. `YuTengjing`) are not always the GitHub handle. Verify via `gh pr view <PR> --json author` or `gh api search/users -f q='<email>'` before listing.
-
-If a new contributor appears who is not on this list, treat them as community by default and ask the user whether to add them to the roster.
-
-### GitHub Release Changelog Template
-
-```md
-# 🚀 LobeHub Release (<YYYYMMDD>)
-
-**Release Date:** <Month DD, YYYY>  
-**Since <Previous Version>:** <N merged PRs> · <N resolved issues> · <N contributors>
-
-> <One release thesis sentence: what this release unlocks in practice.>
-
----
-
-## ✨ Highlights
-
-- **<Capability A>** — <What changed and why it matters>. (#1234)
-- **<Capability B>** — <What changed and why it matters>. (#2345)
-- **<Capability C>** — <What changed and why it matters>. (#3456)
-
----
-
-## 🏗️ Core Product & Architecture
-
-### <Subdomain>
-
-- <Concrete change + impact>. (#...)
-- <Concrete change + impact>. (#...)
-
----
-
-## 📱 Platforms / Integrations
-
-- <Platform update + impact>. (#...)
-- <Compatibility/reliability fix + impact>. (#...)
-
----
-
-## 🖥️ CLI & User Experience
-
-- <User-facing workflow improvement>. (#...)
-- <Quality-of-life fix>. (#...)
-
----
-
-## 🔧 Tooling
-
-- <Tool/runtime improvement>. (#...)
-
----
-
-## 🔒 Security & Reliability
-
-- **Security:** <hardening or vulnerability fix>. (#...)
-- **Reliability:** <stability/performance behavior improvement>. (#...)
-
----
-
-## 👥 Contributors
-
-Huge thanks to **<N contributors>** who shipped **<N merged PRs>** this cycle.
-
-@<community-handle> · @<community-handle> · @<team-handle> · @<team-handle>
-
-Plus @lobehubbot and renovate[bot] for maintenance.
-
----
-
-**Full Changelog**: <previous_tag>...<current_tag>
-```
-
-### Quick Checklist
-
-- [ ] `PREV_TAG` is `git describe --tags --abbrev=0 origin/main` (latest semver), not the last weekly's tag
-- [ ] Every `(#XXXX)` in the body appears in `/tmp/release_prs.txt` (verified via `comm -23`)
-- [ ] `Since v…` line uses `$PREV_TAG`; PR / contributor counts match `wc -l` on the computed sets
-- [ ] `**Full Changelog**` uses `$PREV_TAG...release/weekly-<YYYYMMDD>` (or `…v{x.y.z}` for minor)
-- [ ] Author handles resolved via `gh pr view --json author`, not assumed from `%an`
-- [ ] Uses top metadata and a clear release thesis
-- [ ] Includes `Highlights` plus domain-grouped sections
-- [ ] Every major bullet states both change and user/operator impact
-- [ ] Security and reliability updates are explicitly surfaced (when present)
-- [ ] Contributor credits and compare range are included
-- [ ] All numbers and claims are verifiable
+- **Do NOT** manually modify `package.json` version — CI handles it.
+- **Do NOT** manually create tags — CI handles them.
+- Minor PR title format is strict (`🚀 release: v{x.y.z}`).
+- Patch PRs do not need an explicit version number.
+- Keep release facts accurate; do not invent metrics or availability statements. Release-note inputs (compare base, PR refs, contributor list) **must be derived from `git`** per `reference/release-notes-style.md` § Computing Inputs — never from memory or descriptions.

--- a/.agents/skills/version-release/reference/minor-release.md
+++ b/.agents/skills/version-release/reference/minor-release.md
@@ -1,0 +1,47 @@
+# Minor Release Workflow
+
+Used to publish a new minor version (e.g. `v2.2.0`), roughly every 4 weeks. The PR title carries the exact version number; CI parses it to drive the rest of the release.
+
+## Steps
+
+1. **Create a release branch from canary**
+
+   ```bash
+   git checkout canary
+   git pull origin canary
+   git checkout -b release/v{version}
+   git push -u origin release/v{version}
+   ```
+
+2. **Determine the version number** — Read the current version from `package.json` and compute the next minor version (e.g. `2.1.x` → `2.2.0`).
+
+3. **Create a PR to main**
+
+   ```bash
+   gh pr create \
+     --title "🚀 release: v{version}" \
+     --base main \
+     --head release/v{version} \
+     --body-file release_body.md
+   ```
+
+   > \[!IMPORTANT]
+   > The PR title must strictly match the `🚀 release: v{x.y.z}` format. CI uses a regex on this title to determine the exact version number.
+
+4. **Write the PR body as release notes** — Follow `release-notes-style.md`. Compare base is the latest semver tag on main (`git describe --tags --abbrev=0 origin/main`).
+
+5. **Automatic trigger after merge** — `auto-tag-release` detects the title format, uses the version number from the title, bumps `package.json`, tags `v{x.y.z}`, creates the GitHub Release, and dispatches `sync-main-to-canary`.
+
+## Scripts
+
+```bash
+bun run release:branch         # Interactive
+bun run release:branch --minor # Directly specify minor
+```
+
+## Hard Rules (specific to Minor)
+
+- PR title format is **strict**: `🚀 release: v{x.y.z}`. Any deviation falls through to patch detection.
+- Do **NOT** manually modify `package.json` version — CI will bump it.
+- Do **NOT** manually create the tag — CI will tag.
+- Highlights bullet count is usually 8–12 (see `release-notes-style.md` size heuristics).

--- a/.agents/skills/version-release/reference/patch-release-scenarios.md
+++ b/.agents/skills/version-release/reference/patch-release-scenarios.md
@@ -21,12 +21,16 @@ git push -u origin release/weekly-{YYYYMMDD}
 
 2. **Scan changes and write changelog**
 
+Compute the previous tag from main first — never reuse the last weekly's tag, since hotfixes published in between will be missed:
+
 ```bash
-git log main..canary --oneline
-git diff main...canary --stat
+git fetch origin main canary --tags
+PREV_TAG=$(git describe --tags --abbrev=0 origin/main --match 'v*.*.*' --exclude '*-canary*' --exclude '*-nightly*')
+git log "$PREV_TAG..origin/release/weekly-{YYYYMMDD}" --oneline --no-merges
+git diff "$PREV_TAG...origin/release/weekly-{YYYYMMDD}" --stat
 ```
 
-Write a user-facing changelog following the format in `patch-release-changelog-example.md`.
+Then follow the **Computing Inputs (Hard Rules)** section in `../SKILL.md` to derive PR refs, metrics, and contributors. Every `(#XXXX)` in the body must come from actual commit subjects in this range — never inferred from descriptions.
 
 3. **Create PR to main** with the changelog as the PR body
 

--- a/.agents/skills/version-release/reference/patch-release-scenarios.md
+++ b/.agents/skills/version-release/reference/patch-release-scenarios.md
@@ -30,7 +30,7 @@ git log "$PREV_TAG..origin/release/weekly-{YYYYMMDD}" --oneline --no-merges
 git diff "$PREV_TAG...origin/release/weekly-{YYYYMMDD}" --stat
 ```
 
-Then follow the **Computing Inputs (Hard Rules)** section in `../SKILL.md` to derive PR refs, metrics, and contributors. Every `(#XXXX)` in the body must come from actual commit subjects in this range — never inferred from descriptions.
+Then follow `./release-notes-style.md` § **Computing Inputs (Hard Rules)** to derive PR refs, metrics, and contributors. Every `(#XXXX)` in the body must come from actual commit subjects in this range — never inferred from descriptions.
 
 3. **Create PR to main** with the changelog as the PR body
 

--- a/.agents/skills/version-release/reference/release-notes-style.md
+++ b/.agents/skills/version-release/reference/release-notes-style.md
@@ -1,0 +1,264 @@
+# GitHub Release Changelog Standard (Long-Form Style)
+
+Use this guide for **GitHub Release notes** — the body of a release PR that becomes the GitHub Release after merge. Do **not** use it for `docs/changelog/*.mdx` website pages (load `../../docs-changelog/SKILL.md` instead).
+
+## Positioning
+
+This release-note style is:
+
+1. **Data-backed at the top** (date, range, key metrics)
+2. **Narrative first, then structured detail**
+3. **Deep but scannable** (clear sectioning + compact bullets)
+4. **Contributor-forward** (credits are part of the release story)
+
+## Required Inputs Before Writing
+
+Collect these inputs first:
+
+1. Compare range (`<prev_tag>...<current_tag>`)
+2. Release metrics (commits, merged PRs, resolved issues, contributors, optional files/insertions/deletions)
+3. High-impact changes by domain (core loop, platform/gateway, UX, tooling, security, reliability)
+4. Contributor list (with standout contributions if known)
+5. Known risks / migrations / rollout notes (if any)
+
+If metrics cannot be reliably computed, omit unknown numbers instead of guessing.
+
+## Computing Inputs (Hard Rules — Verify, Never Guess)
+
+> Hallucinated PR numbers and wrong "Since v..." bases are the #1 failure mode of this skill. Every number and every `(#XXXX)` must come from `git`, never from memory or inference.
+
+### 1. Compare base = latest semver tag on `main`
+
+Do **not** eyeball the tag list or pick the "last weekly" PR. Compute it:
+
+```bash
+git fetch origin main canary --tags
+PREV_TAG=$(git describe --tags --abbrev=0 origin/main --match 'v*.*.*' --exclude '*-canary*' --exclude '*-nightly*')
+echo "$PREV_TAG"
+```
+
+Sanity check that the tag is reachable from the release branch:
+
+```bash
+git merge-base --is-ancestor "$PREV_TAG" origin/release/weekly-{YYYYMMDD} && echo OK
+```
+
+If the check fails, stop and ask the user — the release branch is based on the wrong source.
+
+> **Why not "the last weekly release PR"?** Hotfixes (`v2.1.54`, `v2.1.55`, …) merge directly into main between weeklies. They get back-merged via `sync-main-to-canary`, so the latest semver tag on main _is_ the correct previous release for both weekly and minor flows. Picking the previous weekly's tag will silently undercount and put a stale version in "Since v…".
+
+### 2. PR refs must come from commit subjects — never from descriptions
+
+Compute the canonical set:
+
+```bash
+git log "$PREV_TAG..origin/release/weekly-{YYYYMMDD}" \
+  --pretty=format:'%s' --no-merges \
+  | grep -oE '\(#[0-9]+\)$' \
+  | sort -u > /tmp/release_prs.txt
+```
+
+Hard rules:
+
+- Every `(#XXXX)` you write in the body **must** appear in `/tmp/release_prs.txt`. No exceptions.
+- Never infer a PR number from a feature description. If you remember "the KB BM25 PR was around #14501", that memory is wrong about half the time. Look up the commit hash by feature keyword and read its actual subject.
+- If your terminal truncates long subjects (any wrapper that compresses output, e.g. `rtk`), bypass it. With `rtk` use `rtk proxy git log …`. Verify with `wc -l /tmp/release_prs.txt` — the count must match `git log $PREV_TAG..HEAD --no-merges --pretty=format:'%h' | wc -l` minus the few commits without a PR ref. A mismatch of >5% means subjects are being silently truncated.
+
+### 3. Metrics must come from git counts
+
+```bash
+PR_COUNT=$(wc -l < /tmp/release_prs.txt | tr -d ' ')
+
+COMMIT_COUNT=$(git log "$PREV_TAG..origin/release/weekly-{YYYYMMDD}" --no-merges --pretty=format:'%h' | wc -l | tr -d ' ')
+
+CONTRIBUTOR_COUNT=$(git log "$PREV_TAG..origin/release/weekly-{YYYYMMDD}" --no-merges --pretty=format:'%an' \
+  | sort -u \
+  | grep -viE '^(lobehubbot|LobeHub Bot|renovate\[bot\])$' \
+  | wc -l | tr -d ' ')
+```
+
+If a number cannot be confidently derived, omit it — never guess.
+
+### 4. Author-to-handle resolution
+
+Git `%an` is the commit author display name, not the GitHub handle. For each author you mention, confirm the handle:
+
+```bash
+gh pr view "$PR_NUMBER" --repo lobehub/lobe-chat --json author --jq '.author.login'
+```
+
+Use the result for `@handle`. Then classify each author per the `LobeHub team roster` below; community first, team after.
+
+### 5. Pre-publish verification (mandatory)
+
+Before `gh pr create` / `gh pr edit --body-file`, diff body PR refs against the canonical set:
+
+```bash
+grep -oE '#[0-9]+' release_body.md | sort -u > /tmp/body_prs.txt
+sed 's/[()]//g' /tmp/release_prs.txt > /tmp/release_prs_clean.txt
+
+echo "=== In body but NOT in actual range (must be EMPTY) ==="
+comm -23 /tmp/body_prs.txt /tmp/release_prs_clean.txt
+```
+
+Empty diff = OK. Any output = the body cites a PR that wasn't merged in this range. Stop and fix before publishing.
+
+Also verify the metrics line in the body matches the computed values (`PR_COUNT`, `CONTRIBUTOR_COUNT`) and that `**Full Changelog**` uses `$PREV_TAG`, not some older tag.
+
+## Canonical Structure
+
+Follow this section order unless the user asks otherwise:
+
+1. `# 🚀 LobeHub Release (<YYYYMMDD>)`
+2. Metadata lines:
+   - `Release Date`
+   - `Since <Previous Version>` metrics
+3. One quoted release thesis (single paragraph, 1-2 lines)
+4. `## ✨ Highlights` (6-12 bullets for major releases; 3-8 for weekly)
+5. Domain blocks with optional `###` subsections:
+   - `## 🏗️ Core Agent & Architecture` (or equivalent product core)
+   - `## 📱 Platforms / Integrations`
+   - `## 🖥️ CLI & User Experience`
+   - `## 🔧 Tooling`
+   - `## 🔒 Security & Reliability`
+   - `## 📚 Documentation` (optional if meaningful)
+6. `## 👥 Contributors`
+7. `**Full Changelog**: <prev>...<current>`
+
+Use `---` separators between major blocks for long releases.
+
+## Writing Rules (Hard)
+
+1. **No fabricated metrics**: all numbers must be traceable.
+2. **No vague headline bullets**: each bullet must include capability + impact.
+3. **No internal-only framing**: phrase from user/operator perspective.
+4. **Security must be explicit** when security-sensitive fixes are present.
+5. **PR/issue linkage**: use `(#1234)` when IDs are available.
+6. **Terminology consistency**: same feature/provider name across sections.
+7. **Do not bury migration or breaking changes**: elevate to dedicated section or callout.
+
+## Style Rules (Long-Form)
+
+1. Start with an "everyday use" framing, not implementation internals.
+2. Mix narrative sentence + evidence bullets.
+3. Keep bullets compact but informative:
+   - Good: `**Fast Mode (`/fast`)** — Priority routing for OpenAI and Anthropic, reducing latency on supported models. (#6875, #6960)`
+4. Use bold only for capability names, not for whole sentences.
+5. Keep heading depth ≤ 3 levels.
+
+## Release Size Heuristics
+
+- **Minor / major milestone release**
+  - Include full structure with multiple domain blocks.
+  - `Highlights` usually 8-12 bullets.
+- **Weekly patch release**
+  - Keep full skeleton but reduce subsection count.
+  - `Highlights` usually 4-8 bullets.
+- **DB migration release**
+  - Keep concise.
+  - Must include `Migration overview`, operator impact, and rollback/backup note.
+
+## Contributor Ordering
+
+Render contributors as a **single flat list** (no separate "Community" / "Core Team" subsections). Order: **community contributors first, team members after**. Within each group, sort by PR count desc. Bots (`@lobehubbot`, `renovate[bot]`) go on a separate "maintenance" line.
+
+**LobeHub team roster** — anyone in this list is a team member; anyone not in this list is a community contributor:
+
+- @arvinxx
+- @Innei
+- @tjx666 (commit author name: YuTengjing)
+- @LiJian
+- @Neko
+- @Rdmclin2
+- @AmAzing129
+- @sudongyuer (commit author name: Tsuki)
+- @rivertwilight (commit author name: René Wang)
+- @CanisMinor
+- @cy948 (commit author name: Rylan Cai)
+
+> **Resolving handles** — git author names (e.g. `YuTengjing`) are not always the GitHub handle. Verify via `gh pr view "$PR" --json author` or `gh api search/users -f q='<email>'` before listing.
+
+If a new contributor appears who is not on this list, treat them as community by default and ask the user whether to add them to the roster.
+
+## Template
+
+```md
+# 🚀 LobeHub Release (<YYYYMMDD>)
+
+**Release Date:** <Month DD, YYYY>  
+**Since <Previous Version>:** <N merged PRs> · <N resolved issues> · <N contributors>
+
+> <One release thesis sentence: what this release unlocks in practice.>
+
+---
+
+## ✨ Highlights
+
+- **<Capability A>** — <What changed and why it matters>. (#1234)
+- **<Capability B>** — <What changed and why it matters>. (#2345)
+- **<Capability C>** — <What changed and why it matters>. (#3456)
+
+---
+
+## 🏗️ Core Product & Architecture
+
+### <Subdomain>
+
+- <Concrete change + impact>. (#...)
+- <Concrete change + impact>. (#...)
+
+---
+
+## 📱 Platforms / Integrations
+
+- <Platform update + impact>. (#...)
+- <Compatibility/reliability fix + impact>. (#...)
+
+---
+
+## 🖥️ CLI & User Experience
+
+- <User-facing workflow improvement>. (#...)
+- <Quality-of-life fix>. (#...)
+
+---
+
+## 🔧 Tooling
+
+- <Tool/runtime improvement>. (#...)
+
+---
+
+## 🔒 Security & Reliability
+
+- **Security:** <hardening or vulnerability fix>. (#...)
+- **Reliability:** <stability/performance behavior improvement>. (#...)
+
+---
+
+## 👥 Contributors
+
+Huge thanks to **<N contributors>** who shipped **<N merged PRs>** this cycle.
+
+@<community-handle> · @<community-handle> · @<team-handle> · @<team-handle>
+
+Plus @lobehubbot and renovate[bot] for maintenance.
+
+---
+
+**Full Changelog**: <previous_tag>...<current_tag>
+```
+
+## Quick Checklist
+
+- [ ] `PREV_TAG` is `git describe --tags --abbrev=0 origin/main` (latest semver), not the last weekly's tag
+- [ ] Every `(#XXXX)` in the body appears in `/tmp/release_prs.txt` (verified via `comm -23`)
+- [ ] `Since v…` line uses `$PREV_TAG`; PR / contributor counts match `wc -l` on the computed sets
+- [ ] `**Full Changelog**` uses `$PREV_TAG...release/weekly-<YYYYMMDD>` (or `…v{x.y.z}` for minor)
+- [ ] Author handles resolved via `gh pr view --json author`, not assumed from `%an`
+- [ ] Uses top metadata and a clear release thesis
+- [ ] Includes `Highlights` plus domain-grouped sections
+- [ ] Every major bullet states both change and user/operator impact
+- [ ] Security and reliability updates are explicitly surfaced (when present)
+- [ ] Contributor credits and compare range are included
+- [ ] All numbers and claims are verifiable

--- a/.agents/skills/version-release/reference/release-notes-style.md
+++ b/.agents/skills/version-release/reference/release-notes-style.md
@@ -105,9 +105,9 @@ Empty diff = OK. Any output = the body cites a PR that wasn't merged in this ran
 
 Also verify the metrics line in the body matches the computed values (`PR_COUNT`, `CONTRIBUTOR_COUNT`) and that `**Full Changelog**` uses `$PREV_TAG`, not some older tag.
 
-## Canonical Structure
+## Canonical Structure (Long-Form: Minor / Weekly)
 
-Follow this section order unless the user asks otherwise:
+Follow this section order for **Minor** and **Weekly** releases unless the user asks otherwise. For **Hotfix** and **DB Migration**, see § Variants for Shorter Releases below — the canonical structure does not apply.
 
 1. `# 🚀 LobeHub Release (<YYYYMMDD>)`
 2. Metadata lines:
@@ -126,6 +126,44 @@ Follow this section order unless the user asks otherwise:
 7. `**Full Changelog**: <prev>...<current>`
 
 Use `---` separators between major blocks for long releases.
+
+## Variants for Shorter Releases
+
+The Canonical Structure above is for **long-form** (Minor / Weekly). Two short-form variants override it.
+
+### Hotfix Variant
+
+A hotfix targets one regression and ships fast. The body is short and operator-focused — no Highlights, no domain blocks, no Contributors line.
+
+Required sections, in order:
+
+1. `# 🚀 LobeHub Release (<YYYYMMDD>)`
+2. `**Hotfix Scope:**` — one line summarizing the regression scope (e.g. `Agent topic-switching regression — stale chat state on agent change`). Replaces the long-form `Release Date` / `Since vX.Y.Z` metrics.
+3. One quoted thesis (single paragraph, 1-2 lines) describing what is now restored.
+4. `## 🐛 What's Fixed` — 1-3 bullets, each `**<symptom>** — <fix in one sentence>. (#PR)`. No root-cause prose; that lives in the commit message.
+5. `## ⚙️ Upgrade` — short notes for self-hosted (pull image / restart, schema or env changes) and cloud (usually "applied automatically").
+6. `## 👥 Owner` — single `@handle` for the PR author, resolved via `gh pr view "$PR" --json author --jq '.author.login'`. Never hardcoded.
+
+Hard rules specific to hotfix:
+
+- **No Highlights / domain blocks / Contributors / Full Changelog** — these add noise to a one-shot fix.
+- **No metric line** — `Since vX.Y.Z` doesn't apply; the body cites the single PR (or 1-3 PRs) directly.
+- **Owner ≠ Contributors** — one author, listed under § Owner. Not a flat handle list.
+- See `changelog-example/hotfix.md` for the canonical template.
+
+### DB Migration Variant
+
+Database schema changes that need to be released independently. Operator impact is the headline.
+
+Required sections, in order:
+
+1. `# 🚀 LobeHub Release (<YYYYMMDD>)` + scope line
+2. **Migration overview** — what tables / columns are added, modified, or removed
+3. **Operator impact** — backwards-compatible? required actions for self-hosted?
+4. **Rollback / backup note** — how to recover
+5. `## 👥 Owner` — single PR author, resolved via `gh pr view`
+
+See `changelog-example/db-migration.md` for the canonical template.
 
 ## Writing Rules (Hard)
 
@@ -149,13 +187,16 @@ Use `---` separators between major blocks for long releases.
 ## Release Size Heuristics
 
 - **Minor / major milestone release**
-  - Include full structure with multiple domain blocks.
+  - Long-form structure with multiple domain blocks.
   - `Highlights` usually 8-12 bullets.
 - **Weekly patch release**
-  - Keep full skeleton but reduce subsection count.
+  - Long-form skeleton with reduced subsection count.
   - `Highlights` usually 4-8 bullets.
+- **Hotfix release**
+  - Short-form (see § Variants → Hotfix). No Highlights, no domain blocks, no Contributors.
+  - 1-3 fix bullets. Body should fit on one screen.
 - **DB migration release**
-  - Keep concise.
+  - Short-form (see § Variants → DB Migration).
   - Must include `Migration overview`, operator impact, and rollback/backup note.
 
 ## Contributor Ordering
@@ -251,6 +292,8 @@ Plus @lobehubbot and renovate[bot] for maintenance.
 
 ## Quick Checklist
 
+### Long-Form (Minor / Weekly)
+
 - [ ] `PREV_TAG` is `git describe --tags --abbrev=0 origin/main` (latest semver), not the last weekly's tag
 - [ ] Every `(#XXXX)` in the body appears in `/tmp/release_prs.txt` (verified via `comm -23`)
 - [ ] `Since v…` line uses `$PREV_TAG`; PR / contributor counts match `wc -l` on the computed sets
@@ -262,3 +305,12 @@ Plus @lobehubbot and renovate[bot] for maintenance.
 - [ ] Security and reliability updates are explicitly surfaced (when present)
 - [ ] Contributor credits and compare range are included
 - [ ] All numbers and claims are verifiable
+
+### Hotfix
+
+- [ ] `**Hotfix Scope:**` line replaces metrics line
+- [ ] Single quoted thesis describes what is restored (operator-facing, not internal)
+- [ ] `## 🐛 What's Fixed` has 1-3 bullets, each `**<symptom>** — <fix>. (#PR)` with PR ref verified to exist and be merged
+- [ ] `## ⚙️ Upgrade` notes self-hosted action and cloud auto-apply
+- [ ] `## 👥 Owner` is a single `@handle` resolved via `gh pr view "$PR" --json author`
+- [ ] No Highlights / domain blocks / Contributors / Full Changelog included


### PR DESCRIPTION
## Summary

Hardens the **version-release** skill so release-note drafting derives every fact from `git`, then splits the resulting 426-line file into a router + per-flow references.

Motivated by #14563, where the body cited 7 unmerged/non-existent PRs, 9 PR numbers had drifted off the underlying commits, and the "Since v…" base was set to v2.1.53 while main was already at v2.1.56.

### Hard-rules (commit 1)

- New *Computing Inputs (Verify, Never Guess)* section codifies:
  - `$PREV_TAG = git describe --tags --abbrev=0 origin/main --match 'v*.*.*' …` — the only correct compare base; picking the previous weekly's tag silently drops hotfixes.
  - Every `(#XXXX)` in the body must come from `git log "$PREV_TAG..HEAD" --pretty='%s' --no-merges | grep -oE '\(#[0-9]+\)$'`. Inferring PR numbers from feature descriptions is banned.
  - Metrics (`PR_COUNT`, `COMMIT_COUNT`, `CONTRIBUTOR_COUNT`) come from `wc -l` on the computed sets.
  - Author handles must be resolved via `gh pr view --json author`, not assumed from `%an`.
  - Pre-publish `comm -23 body_prs actual_prs` must be empty before `gh pr edit`.
  - Notes terminal-truncation pitfall (e.g. token-saving wrappers) and how to detect it.
- Quick Checklist prepended with the five verification gates.
- Patch action guide updated to use `$PREV_TAG..weekly` instead of `main..canary` for changelog inputs.
- Team roster adds @cy948, plus commit-author-name aliases for @sudongyuer (Tsuki) and @rivertwilight (René Wang).

### Split into router + references (commit 2)

`SKILL.md` was 426 lines covering three distinct flows. Each flow now lives next to its own checklist:

| File | Role | Lines |
|---|---|---|
| `SKILL.md` | Router: scope, overview, CI triggers, post-release automation, precheck, shared hard rules, routing pointers | 98 |
| `reference/minor-release.md` | Minor flow (lifted from `SKILL.md`) | 47 |
| `reference/patch-release-scenarios.md` | Patch flows (weekly / hotfix / model / DB migration) | 127 |
| `reference/release-notes-style.md` | Long-form changelog standard, template, and Computing Inputs hard rules (lifted from `SKILL.md`) | 264 |

Cross-links replace previous in-file jumps. Also fixes a prettier-mangled placeholder (`< some-pr-by-them >` was being parsed as shell redirect) by using `$PR_NUMBER` instead of an angle-bracket placeholder.

### Why this matters

Both failure modes in #14563 were one verification command away from being caught at draft time. Encoding those commands as hard rules in the skill turns "the writer remembered to check" into "the skill can't be followed without checking." The split keeps `SKILL.md` short enough to be the entry point an agent actually reads end-to-end, with deep details paged in only for the active flow.

## Test plan

- [ ] Re-run the verification commands against #14563 with this skill loaded — `comm -23` should be empty, metrics should match
- [ ] Use the skill on the next weekly release and confirm `$PREV_TAG` resolves to the latest semver tag (not the previous weekly)
- [ ] Confirm contributor classification handles new community contributors not in the roster (default to community + ask)