### PR TITLE
🐛 fix(docker): replace pnpm init with static package.json in /deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN set -e && \
     pnpm i && \
     mkdir -p /deps && \
     cd /deps && \
-    pnpm init && \
+    echo '{"name":"deps","private":true}' > package.json && \
     pnpm add pg drizzle-orm
 
 COPY . .


### PR DESCRIPTION
## Summary

Docker PR Build (#14563 run [25597803295](https://github.com/lobehub/lobehub/actions/runs/25597803295/job/75150788402?pr=14563)) was failing at the `[builder 7/11]` step:

```
Invalid package manager specification in package.json (pnpm@^11.0.9); expected a semver version
```

Root cause: `pnpm init` (pnpm 10.33) writes a `devEngines.packageManager: { version: "^11.0.9" }` field into the generated `package.json`. The next command (`pnpm add pg drizzle-orm`) triggers `corepack@latest` to validate that field — it rejects ranges and aborts.

Fix: skip `pnpm init` and write a minimal static `package.json` so corepack has nothing to validate.

## Test plan

- [ ] Docker PR Build passes on this branch
- [ ] After merge into `release/weekly-20260509`, Docker PR Build #14563 turns green