### PR TITLE
📝 docs: add intro and screenshot to task scheduler changelog

### DIFF
--- a/docs/.cdn.cache.json
+++ b/docs/.cdn.cache.json
@@ -1,5 +1,6 @@
 {
   "https://file.rene.wang/540830955-0fe626a3-0ddc-4f67-b595-3c5b3f1701e0.png": "/blog/assetsa8e504275f2cd891fabecca985998de0.webp",
+  "https://file.rene.wang/Changelog-Seedance.png": "/blog/assetsb2bf4ddf0a45ff887a993c18cb7ab983.webp",
   "https://file.rene.wang/changlog-04-14.png": "/blog/assets300abe7e259d293da6c5ed4f642a1be6.webp",
   "https://file.rene.wang/clipboard-1768907980491-9cc0669fc3a38.png": "/blog/assets8be3a46c8f9c5d3b61bc541f44b7f245.webp",
   "https://file.rene.wang/clipboard-1768908081787-ed9eb1cb78bdb.png": "/blog/assetsab009b79dd794f02aec24b7607f342e8.webp",
@@ -53,6 +54,8 @@
   "https://file.rene.wang/clipboard-1774923001079-89ce6aa271a62.png": "/blog/assets53e6ec9cf72554dbc1f8224fc0550a03.webp",
   "https://file.rene.wang/clipboard-1775701725582-123f8f8cf73f8.png": "/blog/assets7ea204859aeb5aa9be5810a20ba1669a.webp",
   "https://file.rene.wang/clipboard-1776909505252-94b051f3ea0a7.png": "/blog/assetsdfda32866c4bc59af0526e52f31d1da2.webp",
+  "https://file.rene.wang/clipboard-1777343750668-9b3dcb0dfff86.png": "/blog/assetsfa267a02f20bc5ba6f1273bcf27b7c9f.webp",
+  "https://file.rene.wang/clipboard-1778331942656-f33b41b2dc439.png": "/blog/assets71fe5959cbc6f0a89243d7262f48fafc.webp",
   "https://file.rene.wang/lobehub/467951f5-ad65-498d-aea9-fca8f35a4314.png": "/blog/assets907ea775d228958baca38e2dbb65939a.webp",
   "https://file.rene.wang/lobehub/58d91528-373a-4a42-b520-cf6cb1f8ce1e.png": "/blog/assets7dccdd4df55aede71001da649639437f.webp",
   "https://file.rene.wang/lobehub/ee700103-3c08-41dc-9ddf-c7705bb7bc6a.png": "/blog/assets196d679bc7071abbf71f2a8566f05aa3.webp",
@@ -468,7 +471,5 @@
   "https://github.com/user-attachments/assets/fa8fab19-ace2-4f85-8428-a3a0e28845bb": "/blog/assets/2d678631c55369ba7d753c3ffcb73782.webp",
   "https://github.com/user-attachments/assets/facdc83c-e789-4649-8060-7f7a10a1b1dd": "/blog/assets05b20e40c03ced0ec8707fed2e8e0f25.webp",
   "https://github.com/user-attachments/assets/fcdfb9c5-819a-488f-b28d-0857fe861219": "/blog/assets8477415ecec1f37e38ab38ff1217d0a7.webp",
-  "https://github.com/user-attachments/assets/fd60ab55-ead2-4930-ad00-fdf77662f5a0": "/blog/assets276a4e8748e9bd300b30dcd9d0e24980.webp",
-  "https://file.rene.wang/clipboard-1777343750668-9b3dcb0dfff86.png": "/blog/assetsfa267a02f20bc5ba6f1273bcf27b7c9f.webp",
-  "https://file.rene.wang/Changelog-Seedance.png": "/blog/assetsb2bf4ddf0a45ff887a993c18cb7ab983.webp"
+  "https://github.com/user-attachments/assets/fd60ab55-ead2-4930-ad00-fdf77662f5a0": "/blog/assets276a4e8748e9bd300b30dcd9d0e24980.webp"
 }

--- a/docs/changelog/2026-05-04-task-scheduler.mdx
+++ b/docs/changelog/2026-05-04-task-scheduler.mdx
@@ -1,9 +1,8 @@
 ---
-title: 'Delegate Claude Code and Codex'
+title: Delegate Claude Code and Codex
 description: >-
-  Delegate Claude Code and Codex from inside LobeHub, with a redesigned home, a Review tab for bulk git diffs, visual understanding, and a wave of new models.
-
-
+  Delegate Claude Code and Codex from inside LobeHub, with a redesigned home, a
+  Review tab for bulk git diffs, visual understanding, and a wave of new models.
 tags:
   - Coding agent
   - Claude Code
@@ -14,9 +13,12 @@ tags:
 
 # Delegate Claude Code and Codex
 
+Now you can control coding agents in LobeHub. Simply click `Create Agent` and choose your coding agent. This feature is only available on desktop app.
+
+![](/blog/assets71fe5959cbc6f0a89243d7262f48fafc.webp)
+
 ## Features
 
-- New: Delegate Claude Code and Codex in LobeHub
 - Agent-specific topic grouping: switch the topic list to group by agent, with a friendlier empty state
 - Review tab: a new tab that aggregates bulk git diffs across a tree, \~9× faster on large repos
 - Local file mention snapshots: drag a file into chat and a snapshot is captured for the model to reason over

--- a/docs/changelog/2026-05-04-task-scheduler.zh-CN.mdx
+++ b/docs/changelog/2026-05-04-task-scheduler.zh-CN.mdx
@@ -1,6 +1,8 @@
 ---
 title: 在 LobeHub 中调度 Claude Code 与 Codex
-description: 在 LobeHub 中直接调度 Claude Code 与 Codex，全新首页、批量 git diff 的 Review 标签页、视觉理解工具，以及一批新模型。
+description: >-
+  在 LobeHub 中直接调度 Claude Code 与 Codex，全新首页、批量 git diff 的 Review
+  标签页、视觉理解工具，以及一批新模型。
 tags:
   - 编程 Agent
   - Claude Code
@@ -10,6 +12,10 @@ tags:
 ---
 
 # 在 LobeHub 中调度 Claude Code 与 Codex
+
+现在你可以在 LobeHub 内使用 Coding Agents。新建助手时选择你最喜欢的 Coding Agent 即可。此功能仅在桌面端可用。
+
+![](/blog/assets71fe5959cbc6f0a89243d7262f48fafc.webp)
 
 ## 新功能
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔀 Description of Change

Polish the `2026-05-04-task-scheduler` changelog entry:

- Add a short intro paragraph explaining that coding agents (Claude Code, Codex) can now be created from `Create Agent`, with a note that the feature is desktop-only (EN + zh-CN).
- Embed a screenshot illustrating the new entry point.
- Drop the redundant `Delegate Claude Code and Codex in LobeHub` bullet from the Features list (already covered by the new intro and the H1).
- Frontmatter is reformatted by remark/prettier (no semantic change), and `docs/.cdn.cache.json` picks up the cached webp for the new image.

#### 🧪 How to Test

- [x] No tests needed

Render the changelog locally / in preview and confirm the new intro paragraph and image appear in both English and zh-CN versions.

#### 📸 Screenshots / Videos

The new image is referenced from the changelog itself: `/blog/assets71fe5959cbc6f0a89243d7262f48fafc.webp`.