### PR TITLE
💄 style(intervention): polish confirmation bar layout

### DIFF
--- a/packages/builtin-tool-user-interaction/src/client/Intervention/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Intervention/AskUserQuestion/index.tsx
@@ -133,6 +133,7 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
     }, [escapeActive]);
 
     const isFreeform = !question.fields || question.fields.length === 0;
+    const shouldShowEscapeAction = !isFreeform;
 
     const isSubmitDisabled = escapeActive
       ? !escapeText.trim()
@@ -207,7 +208,7 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
         )}
         <Flexbox horizontal gap={8} justify={'space-between'}>
           <Flexbox horizontal gap={8} justify="flex-start">
-            {escapeActive ? (
+            {escapeActive && shouldShowEscapeAction ? (
               <Text className={styles.escapeLink} type="secondary" onClick={handleEscapeToggle}>
                 <Icon icon={ArrowLeft} /> {t('form.otherBack')}
               </Text>
@@ -216,9 +217,11 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
                 <Text className={styles.escapeLink} type="secondary" onClick={handleSkip}>
                   {t('form.skip')}
                 </Text>
-                <Text className={styles.escapeLink} type="secondary" onClick={handleEscapeToggle}>
-                  {t('form.other')} <Icon icon={PenLine} />
-                </Text>
+                {shouldShowEscapeAction && (
+                  <Text className={styles.escapeLink} type="secondary" onClick={handleEscapeToggle}>
+                    {t('form.other')} <Icon icon={PenLine} />
+                  </Text>
+                )}
               </>
             )}
           </Flexbox>

--- a/src/features/Conversation/InterventionBar/style.ts
+++ b/src/features/Conversation/InterventionBar/style.ts
@@ -2,35 +2,40 @@ import { createStaticStyles } from 'antd-style';
 
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   actions: css`
-    padding-block: 8px;
-    padding-inline: 16px;
+    padding-block: 8px 10px;
+    padding-inline: 10px;
     border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+    background: color-mix(in srgb, ${cssVar.colorBgElevated} 92%, ${cssVar.colorFillSecondary});
 
     &:empty {
       display: none;
     }
   `,
   container: css`
+    overflow: hidden;
     margin-block-end: 12px;
   `,
   content: css`
     overflow-y: auto;
     flex: 1;
     min-height: 0;
-    padding-block: 8px 12px;
+    padding-block: 6px 8px;
   `,
   tab: css`
     cursor: pointer;
 
-    padding-block: 6px;
-    padding-inline: 14px;
+    padding-block: 5px;
+    padding-inline: 10px;
     border-block-end: 2px solid transparent;
 
     font-size: 12px;
     color: ${cssVar.colorTextSecondary};
     white-space: nowrap;
 
-    transition: all 0.2s;
+    transition:
+      border-color 0.2s,
+      color 0.2s,
+      background 0.2s;
 
     &:hover {
       color: ${cssVar.colorText};
@@ -49,8 +54,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   tabCounter: css`
     margin-inline-start: auto;
-    padding-block: 6px;
-    padding-inline: 14px;
+    padding-block: 5px;
+    padding-inline: 10px;
 
     font-size: 11px;
     color: ${cssVar.colorTextTertiary};

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/ApprovalActions.tsx
@@ -34,7 +34,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   footer: css`
     display: flex;
     justify-content: flex-end;
-    margin-block-start: 12px;
+    margin-block-start: 8px;
   `,
   number: css`
     flex-shrink: 0;
@@ -49,9 +49,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 8px;
     align-items: center;
 
-    padding-block: 8px;
-    padding-inline: 12px;
-    border-radius: 8px;
+    min-height: 40px;
+    padding-block: 7px;
+    padding-inline: 16px;
+    border-radius: calc(${cssVar.borderRadiusLG} - 2px);
 
     color: ${cssVar.colorTextSecondary};
 
@@ -120,6 +121,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     margin-inline-start: 6px;
     color: ${cssVar.colorTextTertiary};
+  `,
+  submitButton: css`
+    &.ant-btn {
+      min-width: 88px;
+      height: 36px;
+      border-radius: calc(${cssVar.borderRadiusLG} - 2px);
+    }
   `,
 }));
 
@@ -290,9 +298,9 @@ const ApprovalActions = memo<ApprovalActionsProps>(
 
         <div className={styles.footer}>
           <Button
+            className={styles.submitButton}
             disabled={isMessageCreating}
             loading={loading}
-            shape={'round'}
             size={'middle'}
             type={'primary'}
             onClick={handleSubmit}

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
@@ -29,7 +29,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     user-select: none;
 
     padding-block: 6px;
-    padding-inline: 16px;
+    padding-inline: 10px;
 
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
@@ -41,7 +41,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   description: css`
     padding-block: 8px;
     padding-inline: 16px;
+
     font-size: 14px;
+    font-weight: 600;
     color: ${cssVar.colorText};
   `,
 }));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None found.

#### 🔀 Description of Change

- Tighten the intervention bar spacing and render its footer as a docked action area.
- Align confirmation option rows and submit button radius so the nested surfaces match the outer card.
- Remove the redundant freeform escape action from `askUserQuestion` when the question is already a single freeform input.
- Make the fallback intervention title semibold for clearer hierarchy.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validation performed:

- `git diff --check`
- `bunx eslint packages/builtin-tool-user-interaction/src/client/Intervention/AskUserQuestion/index.tsx src/features/Conversation/InterventionBar/style.ts src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/ApprovalActions.tsx src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx --quiet`
- `bunx vitest run --silent='passed-only' src/ExecutionRuntime/index.test.ts` in `packages/builtin-tool-user-interaction`

Note: the final clean worktree based on latest `origin/canary` did not have local workspace dependencies installed, so eslint/vitest were verified in the original prepared worktree before cherry-picking the commit onto the clean PR branch. The clean PR branch was additionally verified with `git diff --check origin/canary..HEAD`.

Manual scenarios:

- Trigger `lobe-user-interaction____askUserQuestion` with freeform mode and verify only skip/send actions are shown.
- Trigger a generic intervention approval card and verify the footer action bar and submit button radius align with the outer card.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Existing intervention card had looser spacing and pill-shaped submit button | Submit action now sits in a docked footer with matching nested radii |

#### 📝 Additional Information

The PR intentionally excludes unrelated local edits under `src/features/Conversation/Messages/AssistantGroup/components/*`.
