### PR TITLE
chore: Refine homepage banner copy for channels and skills

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -29,7 +29,7 @@
   "batchDelete": "Batch Delete",
   "blog": "Product Blog",
   "botIntegrationBanner.dismiss": "Dismiss",
-  "botIntegrationBanner.title": "Add Channels to Lobe AI",
+  "botIntegrationBanner.title": "Talk to Lobe AI on your favorite messaging apps.",
   "branching": "Create Subtopic",
   "branchingDisable": "The \"Sub-topic\" feature is unavailable in the current mode. To use this feature, please switch to Postgres/Pglite DB mode or use LobeHub Cloud.",
   "branchingRequiresSavedTopic": "Current topic is not saved, please save it first to use subtopic feature",

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -681,7 +681,7 @@
   "skillDetail.tools": "Tools",
   "skillDetail.trustWarning": "Only use connectors from developers you trust. LobeHub does not control which tools developers make available and cannot verify that they will work as intended or that they won't change.",
   "skillInstallBanner.dismiss": "Dismiss",
-  "skillInstallBanner.title": "Add skills to Lobe AI",
+  "skillInstallBanner.title": "Connect your favorite apps to Lobe AI.",
   "store.actions.cancel": "Cancel",
   "store.actions.configure": "Configure",
   "store.actions.confirmUninstall": "Uninstalling will clear Skill config. Continue?",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -29,7 +29,7 @@
   "batchDelete": "批量删除",
   "blog": "产品博客",
   "botIntegrationBanner.dismiss": "关闭",
-  "botIntegrationBanner.title": "为 LobeAI 添加渠道",
+  "botIntegrationBanner.title": "在你喜爱的聊天应用中，与 Lobe AI 畅聊。",
   "branching": "创建子话题",
   "branchingDisable": "「子话题」功能在当前模式下不可用。如需该功能，请切换到 Postgres/Pglite DB 模式或使用 LobeHub Cloud",
   "branchingRequiresSavedTopic": "当前话题未保存。保存后即可使用子话题",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -681,7 +681,7 @@
   "skillDetail.tools": "工具",
   "skillDetail.trustWarning": "请仅使用您信任的开发者提供的连接器。LobeHub 无法控制开发者提供哪些工具，也无法验证这些工具是否按预期工作或是否会发生变化。",
   "skillInstallBanner.dismiss": "关闭",
-  "skillInstallBanner.title": "为 Lobe AI 添加技能",
+  "skillInstallBanner.title": "将你的常用软件连接到 Lobe AI.",
   "store.actions.cancel": "取消安装",
   "store.actions.configure": "配置",
   "store.actions.confirmUninstall": "即将卸载该技能，卸载后将清除该技能配置，请确认你的操作",

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -32,7 +32,7 @@ export default {
   'batchDelete': 'Batch Delete',
   'blog': 'Product Blog',
   'botIntegrationBanner.dismiss': 'Dismiss',
-  'botIntegrationBanner.title': 'Add Channels to Lobe AI',
+  'botIntegrationBanner.title': 'Talk to Lobe AI on your favorite messaging apps.',
   'branching': 'Create Subtopic',
   'branchingDisable':
     'The "Sub-topic" feature is unavailable in the current mode. To use this feature, please switch to Postgres/Pglite DB mode or use LobeHub Cloud.',

--- a/src/locales/default/plugin.ts
+++ b/src/locales/default/plugin.ts
@@ -697,7 +697,7 @@ export default {
   'skillDetail.trustWarning':
     "Only use connectors from developers you trust. LobeHub does not control which tools developers make available and cannot verify that they will work as intended or that they won't change.",
   'skillInstallBanner.dismiss': 'Dismiss',
-  'skillInstallBanner.title': 'Add skills to Lobe AI',
+  'skillInstallBanner.title': 'Connect your favorite apps to Lobe AI.',
   'store.actions.cancel': 'Cancel',
   'store.actions.configure': 'Configure',
   'store.actions.confirmUninstall': 'Uninstalling will clear Skill config. Continue?',


### PR DESCRIPTION
## Summary
- Updated the homepage banner titles for the channel and skill dialogs with the new English copy.
- Synced the `en-US` and `zh-CN` locale files so both previews reflect the revised wording.

## Testing
- Not run (not requested).