### PR TITLE
💄 style(QueueTray): use visible divider between queued messages

### DIFF
--- a/src/features/Conversation/ChatInput/QueueTray.tsx
+++ b/src/features/Conversation/ChatInput/QueueTray.tsx
@@ -74,7 +74,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 12px 8px;
   `,
   itemDivider: css`
-    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+    border-block-start: 1px solid ${cssVar.colorFillTertiary};
   `,
   text: css`
     overflow: hidden;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

The `QueueTray` divider between stacked queued messages used `colorBorderSecondary`, which renders effectively invisible against `colorBgElevated` in dark themes — visually merging adjacent queued items into one block.

Switched to `colorFillTertiary` so the separator is perceptible while staying lighter than the surrounding container border (`colorFillSecondary`).

#### 🧪 How to Test

1. Run the SPA locally and queue ≥2 follow-up messages while an agent run is in progress.
2. Verify a visible (but subtle) horizontal divider appears between each queued row.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Divider invisible — rows visually merge | Subtle divider separates each queued row |

🤖 Generated with [Claude Code](https://claude.com/claude-code)