### PR TITLE
💄 style(topic): add copy session ID to topic dropdown menu

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Circle,
   ExternalLink,
+  Hash,
   Link2,
   LucideCopy,
   PanelTop,
@@ -162,6 +163,15 @@ export const useTopicItemDropdownMenu = ({
             },
           ]
         : []),
+      {
+        icon: <Icon icon={Hash} />,
+        key: 'copySessionId',
+        label: t('actions.copySessionId'),
+        onClick: () => {
+          navigator.clipboard.writeText(id);
+          message.success(t('actions.copySessionIdSuccess'));
+        },
+      },
       {
         icon: <Icon icon={Link2} />,
         key: 'copyLink',

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Circle,
   ExternalLink,
+  Hash,
   Link2,
   LucideCopy,
   PanelTop,
@@ -128,6 +129,15 @@ export const useTopicItemDropdownMenu = ({
             },
           ]
         : []),
+      {
+        icon: <Icon icon={Hash} />,
+        key: 'copySessionId',
+        label: t('actions.copySessionId'),
+        onClick: () => {
+          navigator.clipboard.writeText(id);
+          message.success(t('actions.copySessionIdSuccess'));
+        },
+      },
       {
         icon: <Icon icon={Link2} />,
         key: 'copyLink',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a "Copy Session ID" action to the topic dropdown menu in both the agent and group sidebars. The action copies the session ID to the clipboard and shows a success toast. i18n keys (`actions.copySessionId` / `actions.copySessionIdSuccess`) already exist in `src/locales/default/topic.ts`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open a topic in either agent or group sidebar, click the dropdown menu, and verify the new "Copy Session ID" entry appears with the Hash icon and copies the ID to clipboard with a success toast.

#### 📸 Screenshots / Videos

UI: a new menu entry between the workspace toggle and "Copy Link", labeled "Copy Session ID" with a Hash icon.

#### 📝 Additional Information

No breaking changes. No migration needed.