### PR TITLE
🐛 fix: gateway client-tool pluginState + drop redundant `Exit code: 0` tail

### DIFF
--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -52,19 +52,17 @@ describe('formatCommandResult', () => {
     expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
   });
 
-  it('should include the Exit code line for non-zero exit codes', () => {
+  it('should treat a non-zero exit code as failure even when envelope success is true', () => {
     const result = formatCommandResult({
       exitCode: 137,
       stdout: 'partial output',
       success: true,
     });
     expect(result).toMatchInlineSnapshot(`
-      "Command completed successfully.
+      "Command failed with exit code 137
 
       Output:
-      partial output
-
-      Exit code: 137"
+      partial output"
     `);
   });
 
@@ -85,15 +83,13 @@ describe('formatCommandResult', () => {
       success: false,
     });
     expect(result).toMatchInlineSnapshot(`
-      "Command failed: Command error
+      "Command failed with exit code 1: Command error
 
       Output:
       Some output
 
       Stderr:
-      Error occurred
-
-      Exit code: 1"
+      Error occurred"
     `);
   });
 });

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -44,15 +44,27 @@ describe('formatCommandResult', () => {
     `);
   });
 
-  it('should format successful command with exit code', () => {
+  it('should suppress the Exit code line when exitCode is 0', () => {
     const result = formatCommandResult({
       exitCode: 0,
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+  });
+
+  it('should include the Exit code line for non-zero exit codes', () => {
+    const result = formatCommandResult({
+      exitCode: 137,
+      stdout: 'partial output',
       success: true,
     });
     expect(result).toMatchInlineSnapshot(`
       "Command completed successfully.
 
-      Exit code: 0"
+      Output:
+      partial output
+
+      Exit code: 137"
     `);
   });
 

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -17,22 +17,25 @@ export const formatCommandResult = ({
 }: FormatCommandResultParams): string => {
   const parts: string[] = [];
 
-  if (success) {
-    if (shellId) {
-      parts.push(`Command started in background with shell_id: ${shellId}`);
-    } else {
-      parts.push('Command completed successfully.');
-    }
+  // `success` is the envelope ("service responded"); `exitCode` is the command
+  // itself. Treat a non-zero exit as failure regardless of envelope success,
+  // so we never render "Command completed successfully." over a 137/130/etc.
+  const hasNonZeroExit = exitCode !== undefined && exitCode !== 0;
+  const failed = !success || hasNonZeroExit;
+
+  if (failed) {
+    let header = 'Command failed';
+    if (hasNonZeroExit) header += ` with exit code ${exitCode}`;
+    if (error) header += `: ${error}`;
+    parts.push(header);
+  } else if (shellId) {
+    parts.push(`Command started in background with shell_id: ${shellId}`);
   } else {
-    parts.push(`Command failed: ${error}`);
+    parts.push('Command completed successfully.');
   }
 
   if (stdout) parts.push(`Output:\n${stdout}`);
   if (stderr) parts.push(`Stderr:\n${stderr}`);
-  // Suppress the redundant `Exit code: 0` tail — "Command completed successfully."
-  // already conveys the same signal. Non-zero codes stay because they carry
-  // diagnostic info the LLM may need (e.g. 137=OOM, 130=SIGINT).
-  if (exitCode !== undefined && exitCode !== 0) parts.push(`Exit code: ${exitCode}`);
 
   return parts.join('\n\n');
 };

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -29,7 +29,10 @@ export const formatCommandResult = ({
 
   if (stdout) parts.push(`Output:\n${stdout}`);
   if (stderr) parts.push(`Stderr:\n${stderr}`);
-  if (exitCode !== undefined) parts.push(`Exit code: ${exitCode}`);
+  // Suppress the redundant `Exit code: 0` tail — "Command completed successfully."
+  // already conveys the same signal. Non-zero codes stay because they carry
+  // diagnostic info the LLM may need (e.g. 137=OOM, 130=SIGINT).
+  if (exitCode !== undefined && exitCode !== 0) parts.push(`Exit code: ${exitCode}`);
 
   return parts.join('\n\n');
 };

--- a/src/server/agent-hono/handlers/__tests__/toolResult.test.ts
+++ b/src/server/agent-hono/handlers/__tests__/toolResult.test.ts
@@ -96,6 +96,19 @@ describe('toolResult handler', () => {
     expect(mockPipelineExec).toHaveBeenCalled();
   });
 
+  it('preserves the optional state field through validation and into the LPUSHed payload', async () => {
+    const bodyWithState = {
+      ...validBody,
+      state: { cwd: '/Users/x', cursor: 12 },
+    };
+    const { ctx } = buildContext(bodyWithState);
+    const res = await toolResult(ctx);
+    expect(res.status).toBe(204);
+    const args = mockLpush.mock.calls[0] as unknown as [string, string];
+    const persisted = JSON.parse(args[1]);
+    expect(persisted.state).toEqual({ cwd: '/Users/x', cursor: 12 });
+  });
+
   it('returns 503 when Redis pipeline exec throws', async () => {
     mockPipelineExec.mockRejectedValueOnce(new Error('redis down'));
     const { ctx } = buildContext(validBody);

--- a/src/server/agent-hono/handlers/toolResult.ts
+++ b/src/server/agent-hono/handlers/toolResult.ts
@@ -16,6 +16,7 @@ const ToolResultBodySchema = z.object({
       type: z.string().optional(),
     })
     .optional(),
+  state: z.record(z.string(), z.any()).optional(),
   success: z.boolean(),
   toolCallId: z.string().min(1),
 });

--- a/src/server/modules/AgentRuntime/ToolResultWaiter.ts
+++ b/src/server/modules/AgentRuntime/ToolResultWaiter.ts
@@ -9,6 +9,7 @@ export interface ToolResultPayload {
     message: string;
     type?: string;
   };
+  state?: Record<string, any>;
   success: boolean;
   toolCallId: string;
 }

--- a/src/server/modules/AgentRuntime/__tests__/dispatchClientTool.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/dispatchClientTool.test.ts
@@ -128,6 +128,29 @@ describe('dispatchClientTool', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
+  it('forwards pluginState (state field) from the BLPOP payload to the execution result', async () => {
+    const sendToolExecute = vi.fn().mockResolvedValue(undefined);
+    const streamManager = makeStreamManager(sendToolExecute);
+
+    const state = { cursor: 7, mode: 'preview' };
+    mockBlpop.mockResolvedValue([
+      'tool_result:call-1',
+      JSON.stringify({
+        content: 'file contents',
+        state,
+        success: true,
+        toolCallId: 'call-1',
+      }),
+    ]);
+
+    const result = await dispatchClientTool(makePayload(), {
+      operationId: 'op-1',
+      streamManager,
+    });
+
+    expect(result.state).toEqual(state);
+  });
+
   it('returns a timeout result and still disconnects when BLPOP times out', async () => {
     const sendToolExecute = vi.fn().mockResolvedValue(undefined);
     const streamManager = makeStreamManager(sendToolExecute);

--- a/src/server/modules/AgentRuntime/dispatchClientTool.ts
+++ b/src/server/modules/AgentRuntime/dispatchClientTool.ts
@@ -139,6 +139,7 @@ function projectToExecutionResult(
     content: payload.content ?? '',
     error: payload.error,
     executionTime,
+    state: payload.state,
     success: payload.success,
   };
 }


### PR DESCRIPTION
## Summary

Three related fixes for noisy / lossy / dishonest tool-result rendering in the agent loop:

### 1. Forward `pluginState` through gateway client tool result

Gateway-mode client tool results lost the `state` field (the UI's "技能状态" / `pluginState`) at three points along the chain, so the tab was always empty even though the client sent `state` correctly and non-gateway paths persist it fine:

- `src/server/agent-hono/handlers/toolResult.ts` — Zod `ToolResultBodySchema` didn't declare `state`, so `safeParse` silently dropped it before the LPUSH.
- `src/server/modules/AgentRuntime/ToolResultWaiter.ts` — `ToolResultPayload` had no `state` field, so even if Redis carried it, the parsed type wouldn't.
- `src/server/modules/AgentRuntime/dispatchClientTool.ts` — `projectToExecutionResult` didn't forward `state` into the `ToolExecutionResultResponse`.

`RuntimeExecutors` was already calling `updateToolMessage({ pluginState: executionResult.state })` on the gateway path; it just always saw `undefined`.

### 2. Treat non-zero exit code as command failure

`formatCommandResult` was driving the header off the `success` flag alone, but `success` is envelope-level ("the service returned a result") while `exitCode` is the command's own status. With `success: true` + `exitCode: 137` we were rendering `Command completed successfully.` on top of a SIGKILL/OOM, lying to the LLM.

Now the header is derived from both — any non-zero exit folds into the failure branch as `Command failed with exit code N[: error]`.

### 3. Drop the trailing `Exit code: N` line

Now redundant with the new failure header (and was always redundant for success runs). Successful commands no longer carry an `Exit code: 0` tail; failed ones surface the exit code in the header.

### Before / after

`{ success: true, exitCode: 137, stdout: 'partial output' }`

Before:
```
Command completed successfully.

Output:
partial output

Exit code: 137
```

After:
```
Command failed with exit code 137

Output:
partial output
```

## Test plan

- [x] `bunx vitest run src/server/agent-hono/handlers/__tests__/toolResult.test.ts` — added a case asserting `state` survives Zod validation and lands in the LPUSHed payload
- [x] `bunx vitest run src/server/modules/AgentRuntime/__tests__/dispatchClientTool.test.ts` — added a case asserting BLPOP'd `state` is forwarded onto `ToolExecutionResultResponse`
- [x] `bunx vitest run src/server/modules/AgentRuntime/__tests__/ToolResultWaiter.test.ts` — still green
- [x] `cd packages/prompts && bunx vitest run src/prompts/fileSystem/formatCommandResult.test.ts` — updated snapshots; added a non-zero-exit-with-success case asserting the failure header
- [x] `bun run type-check`
- [ ] Local gateway run: dispatch a client tool with non-trivial state, confirm the "技能状态" tab is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)