### PR TITLE
✨ feat(activator): require activation reason

### DIFF
--- a/packages/builtin-tool-activator/src/manifest.ts
+++ b/packages/builtin-tool-activator/src/manifest.ts
@@ -20,8 +20,13 @@ export const LobeActivatorManifest: BuiltinToolManifest = {
             },
             type: 'array',
           },
+          reason: {
+            description:
+              'A concise explanation shown to the user for why these tools need to be activated.',
+            type: 'string',
+          },
         },
-        required: ['identifiers'],
+        required: ['identifiers', 'reason'],
         type: 'object',
       },
     },

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -6,13 +6,15 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 3. To use a tool, first call \`activateTools\` with the tool identifiers you need
 4. After activation, the tool's full API schemas become available as native function calls in subsequent turns
 5. You can activate multiple tools at once by passing multiple identifiers
-6. To activate a skill, use the \`activateSkill\` tool from lobe-skills — it returns instructions to follow
+6. Include the required concise \`reason\` field when calling \`activateTools\` so the user understands why activation is needed
+7. To activate a skill, use the \`activateSkill\` tool from lobe-skills — it returns instructions to follow
 </how_it_works>
 
 <tool_selection_guidelines>
 - **activateTools**: Call this when you need to use a tool that isn't yet activated
   - Review the \`<available_tools>\` list to find relevant tools for the user's task
   - Provide an array of tool identifiers to activate
+  - Provide the required concise \`reason\` field explaining why those tools are needed for the current task
   - After activation, the tools' APIs will be available for you to call directly
   - Tools that are already active will be noted in the response
   - If an identifier is not found, it will be reported in the response

--- a/packages/builtin-tool-activator/src/types.ts
+++ b/packages/builtin-tool-activator/src/types.ts
@@ -7,6 +7,7 @@ export const ActivatorApiName = {
 
 export interface ActivateToolsParams {
   identifiers: string[];
+  reason: string;
 }
 
 export interface ActivatedToolInfo {

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx
@@ -101,6 +101,23 @@ describe('FallbackIntervention', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the activation reason for activateTools interventions', () => {
+    const reason = 'I need GTD tools to create and manage the requested task list.';
+
+    render(
+      <FallbackIntervention
+        apiName="activateTools"
+        assistantGroupId="assistant-group-1"
+        id="message-1"
+        identifier="lobe-activator"
+        requestArgs={JSON.stringify({ identifiers: ['search'], reason })}
+        toolCallId="tool-call-1"
+      />,
+    );
+
+    expect(screen.getByText(reason)).toBeInTheDocument();
+  });
+
   it('renders URL avatars as images instead of visible text', () => {
     const iconUrl = 'https://example.com/icon.png';
     metaMap.search.avatar = iconUrl;

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
@@ -42,9 +42,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-block: 8px;
     padding-inline: 16px;
 
-    font-size: 14px;
+    font-size: ${cssVar.fontSize};
     font-weight: 600;
     color: ${cssVar.colorText};
+  `,
+  reason: css`
+    margin-block-start: -4px;
+    padding-block-end: 8px;
+    padding-inline: 16px;
+    font-size: ${cssVar.fontSizeSM};
+    line-height: 1.45;
+    color: ${cssVar.colorTextSecondary};
   `,
 }));
 
@@ -79,10 +87,10 @@ const FallbackIntervention = memo<FallbackInterventionProps>(
 
     const parsedArgs = useMemo(() => safeParseJSON(requestArgs || '') ?? {}, [requestArgs]);
     const argCount = typeof parsedArgs === 'object' ? Object.keys(parsedArgs).length : 0;
+    const isActivateToolsIntervention =
+      identifier === LobeActivatorIdentifier && apiName === ActivatorApiName.activateTools;
     const requestedToolIdentifiers = useMemo(() => {
-      if (identifier !== LobeActivatorIdentifier || apiName !== ActivatorApiName.activateTools) {
-        return [];
-      }
+      if (!isActivateToolsIntervention) return [];
 
       const identifiers = (parsedArgs as ActivateToolsParams | undefined)?.identifiers;
       if (!Array.isArray(identifiers)) return [];
@@ -90,7 +98,14 @@ const FallbackIntervention = memo<FallbackInterventionProps>(
       return identifiers.filter(
         (item): item is string => typeof item === 'string' && !!item.trim(),
       );
-    }, [apiName, identifier, parsedArgs]);
+    }, [isActivateToolsIntervention, parsedArgs]);
+    const activationReason = useMemo(() => {
+      if (!isActivateToolsIntervention) return;
+
+      const reason = (parsedArgs as ActivateToolsParams | undefined)?.reason;
+
+      return typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+    }, [isActivateToolsIntervention, parsedArgs]);
     const requestedToolNames = useToolStore(
       (s) =>
         requestedToolIdentifiers.map((toolIdentifier) => {
@@ -165,6 +180,8 @@ const FallbackIntervention = memo<FallbackInterventionProps>(
             {actionTitleSuffix}
           </span>
         </Flexbox>
+
+        {activationReason && <div className={styles.reason}>{activationReason}</div>}
 
         {argCount > 0 && (
           <>

--- a/src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts
@@ -60,7 +60,10 @@ describe('lobe-activator executor discovery allowlist', () => {
 
     const result = await activatorExecutor.invoke(
       'activateTools',
-      { identifiers: ['web-browsing', 'internal-admin'] },
+      {
+        identifiers: ['web-browsing', 'internal-admin'],
+        reason: 'Use web browsing to answer the current request.',
+      },
       { messageId: 'msg-1', operationId: 'op-1' },
     );
 
@@ -85,7 +88,10 @@ describe('lobe-activator executor discovery allowlist', () => {
 
     const result = await activatorExecutor.invoke(
       'activateTools',
-      { identifiers: ['secret-tool'] },
+      {
+        identifiers: ['secret-tool'],
+        reason: 'Use the secret tool to answer the current request.',
+      },
       { messageId: 'msg-1', operationId: 'op-1' },
     );
 
@@ -110,7 +116,10 @@ describe('lobe-activator executor discovery allowlist', () => {
 
     const result = await activatorExecutor.invoke(
       'activateTools',
-      { identifiers: ['community-plugin'] },
+      {
+        identifiers: ['community-plugin'],
+        reason: 'Use the plugin to answer the current request.',
+      },
       { messageId: 'msg-1', operationId: 'op-1' },
     );
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8701

#### 🔀 Description of Change

- Add a required `reason` field to `lobe-activator.activateTools` so the model must explain why activation is needed.
- Surface the activation reason in the human intervention prompt for `activateTools` calls.
- Update activator executor and intervention tests for the new argument contract.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts
bunx eslint packages/builtin-tool-activator/src/types.ts packages/builtin-tool-activator/src/manifest.ts packages/builtin-tool-activator/src/systemRole.ts src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.test.tsx src/store/tool/slices/builtin/executors/__tests__/lobe-activator.test.ts --quiet
git diff --check origin/canary..HEAD
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Verified that the generated `activateTools` schema now includes `reason` in `required`.
