### PR TITLE
🐛 fix(prompts): suppress redundant `Exit code: 0` tail in command result

### DIFF
--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -44,15 +44,27 @@ describe('formatCommandResult', () => {
     `);
   });
 
-  it('should format successful command with exit code', () => {
+  it('should suppress the Exit code line when exitCode is 0', () => {
     const result = formatCommandResult({
       exitCode: 0,
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+  });
+
+  it('should include the Exit code line for non-zero exit codes', () => {
+    const result = formatCommandResult({
+      exitCode: 137,
+      stdout: 'partial output',
       success: true,
     });
     expect(result).toMatchInlineSnapshot(`
       "Command completed successfully.
 
-      Exit code: 0"
+      Output:
+      partial output
+
+      Exit code: 137"
     `);
   });
 

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -29,7 +29,10 @@ export const formatCommandResult = ({
 
   if (stdout) parts.push(`Output:\n${stdout}`);
   if (stderr) parts.push(`Stderr:\n${stderr}`);
-  if (exitCode !== undefined) parts.push(`Exit code: ${exitCode}`);
+  // Suppress the redundant `Exit code: 0` tail — "Command completed successfully."
+  // already conveys the same signal. Non-zero codes stay because they carry
+  // diagnostic info the LLM may need (e.g. 137=OOM, 130=SIGINT).
+  if (exitCode !== undefined && exitCode !== 0) parts.push(`Exit code: ${exitCode}`);
 
   return parts.join('\n\n');
 };


### PR DESCRIPTION
## Summary

When a shell tool runs successfully, `formatCommandResult` was appending `Exit code: 0` after `Command completed successfully.`, sending the LLM the same signal twice and wasting tokens on noise.

Now: skip the line when `exitCode === 0`. Non-zero exit codes (e.g. 130 SIGINT, 137 OOM, anything an `npm run` / `vercel` invocation can come back with) still print, since they carry diagnostic info the LLM may need to act on.

Before:
```
Command completed successfully.

Output:
928 /tmp/vercel_errors_full.log

Exit code: 0
```

After:
```
Command completed successfully.

Output:
928 /tmp/vercel_errors_full.log
```

## Test plan

- [x] `bunx vitest run packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts` — replaced the `exitCode: 0` snapshot with one asserting suppression; added a new case for `exitCode: 137 + success: true` confirming non-zero codes still print
- [x] `bun run type-check`
- [x] No other test files snapshot `Exit code:` (grep confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)