### PR TITLE
🐛 fix: propagate groupId through all compression paths for group chat

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -220,6 +220,7 @@ export interface RuntimeExecutorContext {
   toolExecutionService: ToolExecutionService;
   topicId?: string;
   userId?: string;
+  groupId?: string;
   userTimezone?: string;
 }
 
@@ -1246,6 +1247,7 @@ export const createRuntimeExecutors = (
         {
           agentId: state.metadata?.agentId,
           threadId: state.metadata?.threadId,
+          groupId: ctx.groupId,
           topicId,
         },
         { postProcessUrl: buildPostProcessUrl(ctx) },
@@ -1286,6 +1288,7 @@ export const createRuntimeExecutors = (
       const messageService = new MessageService(ctx.serverDB, ctx.userId);
       const compressionResult = await messageService.createCompressionGroup(topicId, messageIds, {
         agentId: state.metadata?.agentId,
+        groupId: ctx.groupId,
         threadId: state.metadata?.threadId,
         topicId,
       });
@@ -2318,6 +2321,7 @@ export const createRuntimeExecutors = (
       {
         agentId: state.metadata?.agentId,
         threadId: state.metadata?.threadId,
+        groupId: ctx.groupId,
         topicId: state.metadata?.topicId,
       },
       { postProcessUrl: buildPostProcessUrl(ctx) },

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -1474,6 +1474,7 @@ export class AgentRuntimeService {
       streamManager: this.streamManager,
       toolExecutionService: this.toolExecutionService,
       topicId: metadata?.topicId,
+      groupId: metadata?.groupId,
       userId: metadata?.userId,
     };
 

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -2728,7 +2728,9 @@ export const createAgentExecutors = (context: {
         // 1. Create compression group with placeholder content
         const result = await messageService.createCompressionGroup({
           agentId,
+          groupId: opContext.groupId,
           messageIds,
+          threadId: opContext.threadId,
           topicId,
         });
         const { messageGroupId, messages: initialCompressedMessages, messagesToSummarize } = result;

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -1261,7 +1261,9 @@ export class ConversationLifecycleActionImpl {
       // 1. Create compression group on server
       const result = await messageService.createCompressionGroup({
         agentId,
+        groupId: context.groupId,
         messageIds,
+        threadId: context.threadId,
         topicId,
       });
       const { messageGroupId, messages: serverMessages, messagesToSummarize } = result;


### PR DESCRIPTION
### Summary

Follow-up to #14320 / #14236.

PR #14320 wired `groupId` into two `messageModel.query` call sites inside the `compress_context` and `call_tools_batch` executors. Context compression in **group chats** still failed though, because `groupId` gets dropped in five other places along the compression pipeline, and the DB query inside `MessageService.createCompressionGroup` re-scopes to `topicId` alone, producing an empty `messagesToSummarize` array. The upstream compression LLM then either returns a polite "no history to compress" reply, or — with smaller models — hallucinates a fake summary.

This PR threads `groupId` (and `threadId` on the frontend) through every compression code path.

### Changes (9 lines across 4 files)

**Backend**
- `src/server/modules/AgentRuntime/RuntimeExecutors.ts`
  - `RuntimeExecutorContext` interface: add `groupId?: string`
  - `messageService.createCompressionGroup(...)` call inside `compress_context`: pass `groupId: ctx.groupId` so its internal `messageModel.query` stays scoped to the group
- `src/server/services/agentRuntime/AgentRuntimeService.ts`
  - `createAgentRuntime`: forward `groupId: metadata?.groupId` into `executorContext`

**Frontend (tRPC call sites that previously lost groupId entirely)**
- `src/store/chat/slices/aiChat/actions/conversationLifecycle.ts` — manual `/compact` path (`executeCompression`)
- `src/store/chat/agents/createAgentExecutors.ts` — client-side auto-compression path

Both frontend call sites now pass `groupId` and `threadId` through to the already-accepting tRPC input schema at `src/server/routers/lambda/message.ts:121`.

### Verification

End-to-end verified on a self-hosted deployment (canary HEAD `f35e2d84` + this patch, built as a local Docker image):

1. Before patch: clicking "Compress history" in a group chat yielded summaries like *"User provided a placeholder `<chat_history>` with no actual conversation content. No information to compress."* confirming empty input to the LLM.
2. After patch: the same action on the same group produced a faithful structured summary of the real conversation (Context / Key Information / Decisions & Conclusions / Action Items / Code & Technical all populated correctly from the actual messages).

### Related

- Follow-up to #14320
- Refs #14236
