### PR TITLE
✨ feat: add user activity business hook

### DIFF
--- a/packages/database/src/models/__tests__/user.test.ts
+++ b/packages/database/src/models/__tests__/user.test.ts
@@ -1,5 +1,5 @@
 import type { UserPreference } from '@lobechat/types';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -203,23 +203,43 @@ describe('UserModel', () => {
     });
   });
 
-  describe('updateLastActiveAtIfUnchanged', () => {
-    it('should only advance lastActiveAt when the expected previous value still matches', async () => {
+  describe('advanceLastActiveAt', () => {
+    it('should advance lastActiveAt and return the previous activity state', async () => {
       const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
       const currentTime = new Date('2026-05-01T00:00:00.000Z');
-      const staleCurrentTime = new Date('2026-05-02T00:00:00.000Z');
 
       await serverDB
         .update(users)
         .set({ lastActiveAt: previousLastActiveAt })
         .where(eq(users.id, userId));
 
-      await expect(
-        userModel.updateLastActiveAtIfUnchanged(currentTime, previousLastActiveAt),
-      ).resolves.toBe(true);
-      await expect(
-        userModel.updateLastActiveAtIfUnchanged(staleCurrentTime, previousLastActiveAt),
-      ).resolves.toBe(false);
+      await expect(userModel.advanceLastActiveAt(currentTime)).resolves.toMatchObject({
+        previousLastActiveAt,
+      });
+
+      const updated = await serverDB.query.users.findFirst({
+        where: eq(users.id, userId),
+      });
+
+      expect(updated?.lastActiveAt.getTime()).toBe(currentTime.getTime());
+    });
+
+    it('should advance lastActiveAt when the previous DB value has microsecond precision', async () => {
+      const currentTime = new Date('2026-05-01T00:00:00.000Z');
+
+      await serverDB.execute(sql`
+        UPDATE ${users}
+        SET last_active_at = '2026-03-01T00:00:00.123456Z'::timestamptz
+        WHERE id = ${userId}
+      `);
+
+      const user = await UserModel.findById(serverDB, userId);
+
+      expect(user?.lastActiveAt.getTime()).toBe(new Date('2026-03-01T00:00:00.123Z').getTime());
+
+      await expect(userModel.advanceLastActiveAt(currentTime)).resolves.toMatchObject({
+        previousLastActiveAt: new Date('2026-03-01T00:00:00.123Z'),
+      });
 
       const updated = await serverDB.query.users.findFirst({
         where: eq(users.id, userId),

--- a/packages/database/src/models/__tests__/user.test.ts
+++ b/packages/database/src/models/__tests__/user.test.ts
@@ -203,6 +203,32 @@ describe('UserModel', () => {
     });
   });
 
+  describe('updateLastActiveAtIfUnchanged', () => {
+    it('should only advance lastActiveAt when the expected previous value still matches', async () => {
+      const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
+      const currentTime = new Date('2026-05-01T00:00:00.000Z');
+      const staleCurrentTime = new Date('2026-05-02T00:00:00.000Z');
+
+      await serverDB
+        .update(users)
+        .set({ lastActiveAt: previousLastActiveAt })
+        .where(eq(users.id, userId));
+
+      await expect(
+        userModel.updateLastActiveAtIfUnchanged(currentTime, previousLastActiveAt),
+      ).resolves.toBe(true);
+      await expect(
+        userModel.updateLastActiveAtIfUnchanged(staleCurrentTime, previousLastActiveAt),
+      ).resolves.toBe(false);
+
+      const updated = await serverDB.query.users.findFirst({
+        where: eq(users.id, userId),
+      });
+
+      expect(updated?.lastActiveAt.getTime()).toBe(currentTime.getTime());
+    });
+  });
+
   describe('deleteSetting', () => {
     it('should delete user settings', async () => {
       await serverDB.insert(userSettings).values({

--- a/packages/database/src/models/user.ts
+++ b/packages/database/src/models/user.ts
@@ -198,6 +198,21 @@ export class UserModel {
       .where(eq(users.id, this.userId));
   };
 
+  /**
+   * Advances `lastActiveAt` only if no concurrent request has already moved it.
+   * Callers can use the boolean result to run transition hooks exactly once for
+   * the observed previous timestamp.
+   */
+  updateLastActiveAtIfUnchanged = async (currentTime: Date, previousLastActiveAt: Date) => {
+    const [updated] = await this.db
+      .update(users)
+      .set({ lastActiveAt: currentTime, updatedAt: currentTime })
+      .where(and(eq(users.id, this.userId), eq(users.lastActiveAt, previousLastActiveAt)))
+      .returning({ id: users.id });
+
+    return updated !== undefined;
+  };
+
   deleteSetting = async () => {
     return this.db.delete(userSettings).where(eq(userSettings.id, this.userId));
   };

--- a/packages/database/src/models/user.ts
+++ b/packages/database/src/models/user.ts
@@ -47,6 +47,11 @@ export interface UserInfoForAIGeneration {
   userName: string;
 }
 
+interface LastActiveAtTransition {
+  previousLastActiveAt: Date;
+  userCreatedAt: Date;
+}
+
 export class UserModel {
   private userId: string;
   private db: LobeChatDatabase;
@@ -199,18 +204,42 @@ export class UserModel {
   };
 
   /**
-   * Advances `lastActiveAt` only if no concurrent request has already moved it.
-   * Callers can use the boolean result to run transition hooks exactly once for
-   * the observed previous timestamp.
+   * Atomically advances `lastActiveAt` and returns the previous DB value.
+   *
+   * The previous timestamp must stay inside the SQL statement because Postgres
+   * keeps microseconds while JS `Date` rounds to milliseconds. For example,
+   * `2026-03-01T00:00:00.123456Z` is read as `...123Z`, so comparing the JS
+   * value back against `last_active_at` can miss the row.
    */
-  updateLastActiveAtIfUnchanged = async (currentTime: Date, previousLastActiveAt: Date) => {
-    const [updated] = await this.db
-      .update(users)
-      .set({ lastActiveAt: currentTime, updatedAt: currentTime })
-      .where(and(eq(users.id, this.userId), eq(users.lastActiveAt, previousLastActiveAt)))
-      .returning({ id: users.id });
+  advanceLastActiveAt = async (currentTime: Date): Promise<LastActiveAtTransition | undefined> => {
+    const result = await this.db.execute(sql`
+      WITH previous_user AS MATERIALIZED (
+        SELECT id, created_at, last_active_at
+        FROM ${users}
+        WHERE id = ${this.userId}
+      ),
+      updated_user AS (
+        UPDATE ${users}
+        SET last_active_at = ${currentTime}, updated_at = ${currentTime}
+        FROM previous_user
+        WHERE ${users.id} = previous_user.id
+          AND ${users.lastActiveAt} = previous_user.last_active_at
+        RETURNING
+          previous_user.created_at AS "userCreatedAt",
+          previous_user.last_active_at AS "previousLastActiveAt"
+      )
+      SELECT "userCreatedAt", "previousLastActiveAt" FROM updated_user
+    `);
 
-    return updated !== undefined;
+    const row = result.rows[0] as
+      | { previousLastActiveAt: Date | string; userCreatedAt: Date | string }
+      | undefined;
+    if (!row) return;
+
+    return {
+      previousLastActiveAt: new Date(row.previousLastActiveAt),
+      userCreatedAt: new Date(row.userCreatedAt),
+    };
   };
 
   deleteSetting = async () => {

--- a/src/business/server/user.ts
+++ b/src/business/server/user.ts
@@ -1,6 +1,13 @@
 /* eslint-disable unused-imports/no-unused-vars */
-import { type ReferralStatusString } from '@lobechat/types';
+import type { ReferralStatusString } from '@lobechat/types';
 import { Plans } from '@lobechat/types';
+
+export interface OnUserActivityForBusinessParams {
+  currentTime: Date;
+  previousLastActiveAt: Date;
+  userCreatedAt: Date;
+  userId: string;
+}
 
 export async function getReferralStatus(userId: string): Promise<ReferralStatusString | undefined> {
   return undefined;
@@ -13,4 +20,8 @@ export async function getSubscriptionPlan(userId: string): Promise<Plans> {
 export async function initNewUserForBusiness(
   userId: string,
   createdAt: Date | null | undefined,
+): Promise<void> {}
+
+export async function onUserActivityForBusiness(
+  params: OnUserActivityForBusinessParams,
 ): Promise<void> {}

--- a/src/server/routers/lambda/__tests__/user.test.ts
+++ b/src/server/routers/lambda/__tests__/user.test.ts
@@ -111,6 +111,7 @@ describe('userRouter', () => {
       vi.mocked(UserModel).mockImplementation(
         () =>
           ({
+            advanceLastActiveAt: vi.fn().mockResolvedValue(undefined),
             getUserState: vi.fn().mockResolvedValue(mockState),
             updateUser: vi.fn().mockResolvedValue({ rowCount: 1 }),
           }) as any,
@@ -146,7 +147,10 @@ describe('userRouter', () => {
     it('should invoke the user activity hook after winning the lastActiveAt update', async () => {
       const createdAt = new Date('2026-01-01T00:00:00.000Z');
       const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
-      const updateLastActiveAtIfUnchanged = vi.fn().mockResolvedValue(true);
+      const advanceLastActiveAt = vi.fn().mockResolvedValue({
+        previousLastActiveAt,
+        userCreatedAt: createdAt,
+      });
       const mockState = {
         isOnboarded: true,
         preference: {},
@@ -154,15 +158,11 @@ describe('userRouter', () => {
         userId: mockUserId,
       };
 
-      vi.mocked(UserModel.findById).mockResolvedValue({
-        createdAt,
-        lastActiveAt: previousLastActiveAt,
-      } as any);
       vi.mocked(UserModel).mockImplementation(
         () =>
           ({
+            advanceLastActiveAt,
             getUserState: vi.fn().mockResolvedValue(mockState),
-            updateLastActiveAtIfUnchanged,
           }) as any,
       );
       vi.mocked(MessageModel).mockImplementation(
@@ -181,10 +181,7 @@ describe('userRouter', () => {
       await userRouter.createCaller({ ...mockCtx }).getUserState();
       await flushAfterTasks();
 
-      expect(updateLastActiveAtIfUnchanged).toHaveBeenCalledWith(
-        expect.any(Date),
-        previousLastActiveAt,
-      );
+      expect(advanceLastActiveAt).toHaveBeenCalledWith(expect.any(Date));
       expect(onUserActivityForBusiness).toHaveBeenCalledWith({
         currentTime: expect.any(Date),
         previousLastActiveAt,
@@ -194,8 +191,7 @@ describe('userRouter', () => {
     });
 
     it('should skip the user activity hook when a concurrent request already updated lastActiveAt', async () => {
-      const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
-      const updateLastActiveAtIfUnchanged = vi.fn().mockResolvedValue(false);
+      const advanceLastActiveAt = vi.fn().mockResolvedValue(undefined);
       const mockState = {
         isOnboarded: true,
         preference: {},
@@ -203,15 +199,11 @@ describe('userRouter', () => {
         userId: mockUserId,
       };
 
-      vi.mocked(UserModel.findById).mockResolvedValue({
-        createdAt: new Date('2026-01-01T00:00:00.000Z'),
-        lastActiveAt: previousLastActiveAt,
-      } as any);
       vi.mocked(UserModel).mockImplementation(
         () =>
           ({
+            advanceLastActiveAt,
             getUserState: vi.fn().mockResolvedValue(mockState),
-            updateLastActiveAtIfUnchanged,
           }) as any,
       );
       vi.mocked(MessageModel).mockImplementation(
@@ -230,10 +222,7 @@ describe('userRouter', () => {
       await userRouter.createCaller({ ...mockCtx }).getUserState();
       await flushAfterTasks();
 
-      expect(updateLastActiveAtIfUnchanged).toHaveBeenCalledWith(
-        expect.any(Date),
-        previousLastActiveAt,
-      );
+      expect(advanceLastActiveAt).toHaveBeenCalledWith(expect.any(Date));
       expect(onUserActivityForBusiness).not.toHaveBeenCalled();
     });
   });

--- a/src/server/routers/lambda/__tests__/user.test.ts
+++ b/src/server/routers/lambda/__tests__/user.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  getReferralStatus,
+  getSubscriptionPlan,
+  onUserActivityForBusiness,
+} from '@/business/server/user';
 import { MessageModel } from '@/database/models/message';
 import { SessionModel } from '@/database/models/session';
 import { UserModel } from '@/database/models/user';
@@ -9,7 +14,21 @@ import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 
 import { userRouter } from '../user';
 
+const mockAfterTasks = vi.hoisted((): Promise<void>[] => []);
+
 // Mock modules
+vi.mock('next/server', () => ({
+  after: (callback: () => Promise<void> | void) => {
+    mockAfterTasks.push(Promise.resolve(callback()));
+  },
+}));
+
+vi.mock('@/business/server/user', () => ({
+  getReferralStatus: vi.fn(),
+  getSubscriptionPlan: vi.fn(),
+  onUserActivityForBusiness: vi.fn(),
+}));
+
 vi.mock('@/database/server', () => ({
   serverDB: {},
 }));
@@ -27,8 +46,16 @@ describe('userRouter', () => {
     userId: mockUserId,
   };
 
+  const flushAfterTasks = async () => {
+    await Promise.all(mockAfterTasks.splice(0));
+  };
+
   beforeEach(() => {
+    mockAfterTasks.length = 0;
     vi.clearAllMocks();
+    vi.mocked(getReferralStatus).mockResolvedValue(undefined);
+    vi.mocked(getSubscriptionPlan).mockResolvedValue(undefined);
+    vi.mocked(onUserActivityForBusiness).mockResolvedValue(undefined);
   });
 
   describe('getUserRegistrationDuration', () => {
@@ -114,6 +141,100 @@ describe('userRouter', () => {
         canEnableTrace: true,
         userId: mockUserId,
       });
+    });
+
+    it('should invoke the user activity hook after winning the lastActiveAt update', async () => {
+      const createdAt = new Date('2026-01-01T00:00:00.000Z');
+      const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
+      const updateLastActiveAtIfUnchanged = vi.fn().mockResolvedValue(true);
+      const mockState = {
+        isOnboarded: true,
+        preference: {},
+        settings: {},
+        userId: mockUserId,
+      };
+
+      vi.mocked(UserModel.findById).mockResolvedValue({
+        createdAt,
+        lastActiveAt: previousLastActiveAt,
+      } as any);
+      vi.mocked(UserModel).mockImplementation(
+        () =>
+          ({
+            getUserState: vi.fn().mockResolvedValue(mockState),
+            updateLastActiveAtIfUnchanged,
+          }) as any,
+      );
+      vi.mocked(MessageModel).mockImplementation(
+        () =>
+          ({
+            countUpTo: vi.fn().mockResolvedValue(0),
+          }) as any,
+      );
+      vi.mocked(SessionModel).mockImplementation(
+        () =>
+          ({
+            hasMoreThanN: vi.fn().mockResolvedValue(false),
+          }) as any,
+      );
+
+      await userRouter.createCaller({ ...mockCtx }).getUserState();
+      await flushAfterTasks();
+
+      expect(updateLastActiveAtIfUnchanged).toHaveBeenCalledWith(
+        expect.any(Date),
+        previousLastActiveAt,
+      );
+      expect(onUserActivityForBusiness).toHaveBeenCalledWith({
+        currentTime: expect.any(Date),
+        previousLastActiveAt,
+        userCreatedAt: createdAt,
+        userId: mockUserId,
+      });
+    });
+
+    it('should skip the user activity hook when a concurrent request already updated lastActiveAt', async () => {
+      const previousLastActiveAt = new Date('2026-03-01T00:00:00.000Z');
+      const updateLastActiveAtIfUnchanged = vi.fn().mockResolvedValue(false);
+      const mockState = {
+        isOnboarded: true,
+        preference: {},
+        settings: {},
+        userId: mockUserId,
+      };
+
+      vi.mocked(UserModel.findById).mockResolvedValue({
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        lastActiveAt: previousLastActiveAt,
+      } as any);
+      vi.mocked(UserModel).mockImplementation(
+        () =>
+          ({
+            getUserState: vi.fn().mockResolvedValue(mockState),
+            updateLastActiveAtIfUnchanged,
+          }) as any,
+      );
+      vi.mocked(MessageModel).mockImplementation(
+        () =>
+          ({
+            countUpTo: vi.fn().mockResolvedValue(0),
+          }) as any,
+      );
+      vi.mocked(SessionModel).mockImplementation(
+        () =>
+          ({
+            hasMoreThanN: vi.fn().mockResolvedValue(false),
+          }) as any,
+      );
+
+      await userRouter.createCaller({ ...mockCtx }).getUserState();
+      await flushAfterTasks();
+
+      expect(updateLastActiveAtIfUnchanged).toHaveBeenCalledWith(
+        expect.any(Date),
+        previousLastActiveAt,
+      );
+      expect(onUserActivityForBusiness).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routers/lambda/__tests__/user.test.ts
+++ b/src/server/routers/lambda/__tests__/user.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Plans } from '@lobechat/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -54,7 +55,7 @@ describe('userRouter', () => {
     mockAfterTasks.length = 0;
     vi.clearAllMocks();
     vi.mocked(getReferralStatus).mockResolvedValue(undefined);
-    vi.mocked(getSubscriptionPlan).mockResolvedValue(undefined);
+    vi.mocked(getSubscriptionPlan).mockResolvedValue(Plans.Free);
     vi.mocked(onUserActivityForBusiness).mockResolvedValue(undefined);
   });
 

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -23,7 +23,11 @@ import { after } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
-import { getReferralStatus, getSubscriptionPlan } from '@/business/server/user';
+import {
+  getReferralStatus,
+  getSubscriptionPlan,
+  onUserActivityForBusiness,
+} from '@/business/server/user';
 import { MessageModel } from '@/database/models/message';
 import { SessionModel } from '@/database/models/session';
 import { UserModel } from '@/database/models/user';
@@ -90,7 +94,23 @@ export const userRouter = router({
     try {
       after(async () => {
         try {
-          await ctx.userModel.updateUser({ lastActiveAt: new Date() });
+          const currentTime = new Date();
+          const user = await UserModel.findById(ctx.serverDB, ctx.userId);
+
+          await ctx.userModel.updateUser({ lastActiveAt: currentTime });
+
+          if (user?.createdAt && user.lastActiveAt) {
+            try {
+              await onUserActivityForBusiness({
+                currentTime,
+                previousLastActiveAt: user.lastActiveAt,
+                userCreatedAt: user.createdAt,
+                userId: ctx.userId,
+              });
+            } catch (err) {
+              console.error('user activity hook failed, error:', err);
+            }
+          }
         } catch (err) {
           console.error('update lastActiveAt failed, error:', err);
         }

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -95,20 +95,14 @@ export const userRouter = router({
       after(async () => {
         try {
           const currentTime = new Date();
-          const user = await UserModel.findById(ctx.serverDB, ctx.userId);
+          const transition = await ctx.userModel.advanceLastActiveAt(currentTime);
 
-          if (user?.createdAt && user.lastActiveAt) {
-            const lastActiveAtUpdated = await ctx.userModel.updateLastActiveAtIfUnchanged(
-              currentTime,
-              user.lastActiveAt,
-            );
-            if (!lastActiveAtUpdated) return;
-
+          if (transition) {
             try {
               await onUserActivityForBusiness({
                 currentTime,
-                previousLastActiveAt: user.lastActiveAt,
-                userCreatedAt: user.createdAt,
+                previousLastActiveAt: transition.previousLastActiveAt,
+                userCreatedAt: transition.userCreatedAt,
                 userId: ctx.userId,
               });
             } catch (err) {

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -97,9 +97,13 @@ export const userRouter = router({
           const currentTime = new Date();
           const user = await UserModel.findById(ctx.serverDB, ctx.userId);
 
-          await ctx.userModel.updateUser({ lastActiveAt: currentTime });
-
           if (user?.createdAt && user.lastActiveAt) {
+            const lastActiveAtUpdated = await ctx.userModel.updateLastActiveAtIfUnchanged(
+              currentTime,
+              user.lastActiveAt,
+            );
+            if (!lastActiveAtUpdated) return;
+
             try {
               await onUserActivityForBusiness({
                 currentTime,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-8700

#### 🔀 Description of Change

- Add a generic user activity business hook contract.
- Invoke the hook after updating user activity state, while preserving the previous activity timestamp for downstream business handling.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with VSCode diagnostics on changed files and pre-commit hooks.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR only exposes a generic business slot. Cloud-specific inactive-user freeze and budget restore logic stays in the cloud repo.