### PR TITLE
✨ feat: add Gemini 3.1 Flash-Lite provider cards

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -307,12 +307,7 @@ const googleChatModels: AIChatModelCard[] = [
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
+        { name: 'textInput_cacheWrite', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -301,11 +301,18 @@ const googleChatModels: AIChatModelCard[] = [
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput_cacheRead', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -94,6 +94,40 @@ export const googleChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
+      "Gemini 3.1 Flash-Lite is Google's most cost-efficient multimodal model, optimized for high-volume agentic tasks, translation, and data processing.",
+    displayName: 'Gemini 3.1 Flash-Lite',
+    enabled: true,
+    id: 'gemini-3.1-flash-lite',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-05-07',
+    settings: {
+      extendParams: ['thinkingLevel5', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
       video: true,
       vision: true,
     },
@@ -145,7 +179,6 @@ export const googleChatModels: AIChatModelCard[] = [
     description:
       "Gemini 3.1 Flash-Lite Preview is Google's most cost-efficient multimodal model, optimized for high-volume agentic tasks, translation, and data processing.",
     displayName: 'Gemini 3.1 Flash-Lite Preview',
-    enabled: true,
     id: 'gemini-3.1-flash-lite-preview',
     maxOutput: 65_536,
     pricing: {

--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -114,12 +114,7 @@ export const googleChatModels: AIChatModelCard[] = [
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
+        { name: 'textInput_cacheWrite', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -108,11 +108,18 @@ export const googleChatModels: AIChatModelCard[] = [
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput_cacheRead', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -147,12 +147,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
-        {
-          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
-          name: 'textInput_cacheWrite',
-          strategy: 'lookup',
-          unit: 'millionTokens',
-        },
+        { name: 'textInput_cacheWrite', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -133,9 +133,42 @@ const vertexaiChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      "Gemini 3.1 Flash-Lite is Google's most cost-efficient multimodal model, optimized for high-volume agentic tasks, translation, and data processing.",
+    displayName: 'Gemini 3.1 Flash-Lite',
+    enabled: true,
+    id: 'gemini-3.1-flash-lite',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-05-07',
+    settings: {
+      extendParams: ['thinkingLevel5', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       "Gemini 3.1 Flash-Lite Preview is Google's most cost-efficient multimodal model, optimized for high-volume agentic tasks, translation, and data processing.",
     displayName: 'Gemini 3.1 Flash-Lite Preview',
-    enabled: true,
     id: 'gemini-3.1-flash-lite-preview',
     maxOutput: 65_536,
     pricing: {

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -141,11 +141,18 @@ const vertexaiChatModels: AIChatModelCard[] = [
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.025, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput_cacheRead', rate: 0.05, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'videoInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'audioInput', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
       ],
     },
     releasedAt: '2026-05-07',

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -6,6 +6,7 @@ import deepseekChatModels from 'model-bank/deepseek';
 import googleChatModels from 'model-bank/google';
 import { lobehubChatModels } from 'model-bank/lobehub';
 import openaiChatModels from 'model-bank/openai';
+import vertexAiModels from 'model-bank/vertexai';
 import { describe, expect, it } from 'vitest';
 
 import { computeChatCost } from './computeChatCost';
@@ -360,6 +361,50 @@ describe('computeChatPricing', () => {
       expect(breakdown.find((item) => item.unit.name === 'videoInput')?.credits).toBe(297);
       expect(breakdown.find((item) => item.unit.name === 'audioInput')?.credits).toBe(222);
       expect(breakdown.find((item) => item.unit.name === 'textOutput')?.credits).toBe(519);
+    });
+
+    it('charges Gemini 3.1 Flash-Lite cached audio and cache writes across Google cards', () => {
+      const modelLists = [googleChatModels, lobehubChatModels, vertexAiModels];
+
+      for (const models of modelLists) {
+        const pricing = models.find(
+          (model: { id: string }) => model.id === 'gemini-3.1-flash-lite',
+        )?.pricing;
+        expect(pricing).toBeDefined();
+
+        const usage: ModelTokensUsage = {
+          inputAudioTokens: 1000,
+          inputCachedAudioTokens: 400,
+          inputCachedTextTokens: 600,
+          inputCachedTokens: 1000,
+          inputTextTokens: 1200,
+          inputWriteCacheTokens: 300,
+          outputTextTokens: 100,
+          totalInputTokens: 2200,
+          totalOutputTokens: 100,
+          totalTokens: 2300,
+        };
+
+        const result = computeChatCost(pricing, usage, { lookupParams: { ttl: '1h' } });
+        expect(result).toBeDefined();
+        expect(result?.issues).toHaveLength(0);
+        expect(result?.totalCredits).toBe(935);
+
+        const { breakdown } = result!;
+        expect(breakdown.find((item) => item.unit.name === 'textInput_cacheRead')?.credits).toBe(
+          15,
+        );
+        expect(breakdown.find((item) => item.unit.name === 'audioInput_cacheRead')?.credits).toBe(
+          20,
+        );
+        expect(breakdown.find((item) => item.unit.name === 'textInput')?.credits).toBe(150);
+        expect(breakdown.find((item) => item.unit.name === 'audioInput')?.credits).toBe(300);
+        expect(breakdown.find((item) => item.unit.name === 'textOutput')?.credits).toBe(150);
+
+        const cacheWrite = breakdown.find((item) => item.unit.name === 'textInput_cacheWrite');
+        expect(cacheWrite?.lookupKey).toBe('1h');
+        expect(cacheWrite?.credits).toBe(300);
+      }
     });
 
     it('charges multimodal input units for LobeHub-hosted Gemini 3 Flash', () => {

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -375,34 +375,39 @@ describe('computeChatPricing', () => {
         const usage: ModelTokensUsage = {
           inputAudioTokens: 1000,
           inputCachedAudioTokens: 400,
+          inputCachedImageTokens: 200,
           inputCachedTextTokens: 600,
-          inputCachedTokens: 1000,
+          inputCachedTokens: 1300,
+          inputCachedVideoTokens: 100,
+          inputImageTokens: 500,
           inputTextTokens: 1200,
+          inputVideoTokens: 300,
           inputWriteCacheTokens: 300,
           outputTextTokens: 100,
-          totalInputTokens: 2200,
+          totalInputTokens: 3000,
           totalOutputTokens: 100,
-          totalTokens: 2300,
+          totalTokens: 3100,
         };
 
-        const result = computeChatCost(pricing, usage, { lookupParams: { ttl: '1h' } });
+        const result = computeChatCost(pricing, usage);
         expect(result).toBeDefined();
         expect(result?.issues).toHaveLength(0);
-        expect(result?.totalCredits).toBe(935);
+        expect(result?.totalCredits).toBe(1068);
 
         const { breakdown } = result!;
         expect(breakdown.find((item) => item.unit.name === 'textInput_cacheRead')?.credits).toBe(
-          15,
+          23,
         );
         expect(breakdown.find((item) => item.unit.name === 'audioInput_cacheRead')?.credits).toBe(
           20,
         );
         expect(breakdown.find((item) => item.unit.name === 'textInput')?.credits).toBe(150);
+        expect(breakdown.find((item) => item.unit.name === 'imageInput')?.credits).toBe(75);
+        expect(breakdown.find((item) => item.unit.name === 'videoInput')?.credits).toBe(50);
         expect(breakdown.find((item) => item.unit.name === 'audioInput')?.credits).toBe(300);
         expect(breakdown.find((item) => item.unit.name === 'textOutput')?.credits).toBe(150);
 
         const cacheWrite = breakdown.find((item) => item.unit.name === 'textInput_cacheWrite');
-        expect(cacheWrite?.lookupKey).toBe('1h');
         expect(cacheWrite?.credits).toBe(300);
       }
     });

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -334,7 +334,7 @@ describe('computeChatPricing', () => {
 
     it('charges Gemini 3.1 Flash-Lite image, video, and audio input tokens', () => {
       const pricing = googleChatModels.find(
-        (model: { id: string }) => model.id === 'gemini-3.1-flash-lite-preview',
+        (model: { id: string }) => model.id === 'gemini-3.1-flash-lite',
       )?.pricing;
       expect(pricing).toBeDefined();
 

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.ts
@@ -53,6 +53,8 @@ export interface PricingComputationResult {
 }
 
 interface UnitQuantityResolverContext {
+  hasDedicatedAudioCacheReadUnit: boolean;
+  hasDedicatedImageCacheReadUnit: boolean;
   hasDedicatedModalityCacheReadUnit: boolean;
 }
 
@@ -108,6 +110,13 @@ const resolveInputVideoTokens = (usage: ModelTokensUsage) => {
   return usage.inputVideoTokens;
 };
 
+const sumDefinedTokens = (...values: Array<number | undefined>) => {
+  const definedValues = values.filter((value): value is number => typeof value === 'number');
+  if (definedValues.length === 0) return undefined;
+
+  return definedValues.reduce((sum, value) => sum + value, 0);
+};
+
 const UNIT_QUANTITY_RESOLVERS: Partial<Record<PricingUnitName, UnitQuantityResolver>> = {
   textInput: (usage) => {
     const toolTokens = usage.inputToolTokens ?? 0;
@@ -143,7 +152,24 @@ const UNIT_QUANTITY_RESOLVERS: Partial<Record<PricingUnitName, UnitQuantityResol
   },
   textInput_cacheRead: (usage, context) => {
     if (hasCachedModalityBreakdown(usage) && context.hasDedicatedModalityCacheReadUnit) {
-      return usage.inputCachedTextTokens;
+      if (typeof usage.inputCachedTokens === 'number') {
+        return Math.max(
+          0,
+          usage.inputCachedTokens -
+            (context.hasDedicatedAudioCacheReadUnit ? (usage.inputCachedAudioTokens ?? 0) : 0) -
+            (context.hasDedicatedImageCacheReadUnit ? (usage.inputCachedImageTokens ?? 0) : 0),
+        );
+      }
+
+      // `textInput_cacheRead` is the fallback bucket for same-price cached modalities.
+      // For Gemini 3.1 Flash-Lite, text/image/video cache reads share one rate while
+      // audio has a dedicated higher rate.
+      return sumDefinedTokens(
+        usage.inputCachedTextTokens,
+        context.hasDedicatedImageCacheReadUnit ? undefined : usage.inputCachedImageTokens,
+        context.hasDedicatedAudioCacheReadUnit ? undefined : usage.inputCachedAudioTokens,
+        usage.inputCachedVideoTokens,
+      );
     }
 
     return usage.inputCachedTokens;
@@ -337,9 +363,13 @@ export const computeChatCost = (
   const currency = pricing.currency || 'USD';
   const usdToCnyRate = options?.usdToCnyRate ?? USD_TO_CNY;
   const pricingUnitNames = new Set(pricing.units.map((unit) => unit.name));
+  const hasDedicatedAudioCacheReadUnit = pricingUnitNames.has('audioInput_cacheRead');
+  const hasDedicatedImageCacheReadUnit = pricingUnitNames.has('imageInput_cacheRead');
   const resolverContext: UnitQuantityResolverContext = {
+    hasDedicatedAudioCacheReadUnit,
+    hasDedicatedImageCacheReadUnit,
     hasDedicatedModalityCacheReadUnit:
-      pricingUnitNames.has('audioInput_cacheRead') || pricingUnitNames.has('imageInput_cacheRead'),
+      hasDedicatedAudioCacheReadUnit || hasDedicatedImageCacheReadUnit,
   };
 
   for (const unit of pricing.units) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - no related issue found.

#### 🔀 Description of Change

- Add `gemini-3.1-flash-lite` to the LobeHub-hosted Google chat model list.
- Add `gemini-3.1-flash-lite` to the Vertex AI model list.
- Keep the deprecated `gemini-3.1-flash-lite-preview` model available but no longer enabled by default.
- Update the Gemini Flash-Lite multimodal pricing test to cover the stable model ID.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx --bun prettier --check packages/model-bank/src/aiModels/lobehub/chat/google.ts packages/model-bank/src/aiModels/vertexai.ts packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/usageConverters/utils/computeChatCost.test.ts' 'src/providers/google/thinkingResolver.test.ts'
```

Also verified the official Google API returns `modelVersion: "gemini-3.1-flash-lite"` for a simple request.

#### 📸 Screenshots / Videos

N/A - model configuration only.

#### 📝 Additional Information

Official references:

- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite
- https://ai.google.dev/gemini-api/docs/pricing
- https://ai.google.dev/gemini-api/docs/deprecations

`gemini-3.1-flash-lite-preview` is scheduled to shut down on May 25, 2026, with `gemini-3.1-flash-lite` listed as the recommended replacement.