### PR TITLE
♻️ refactor: remove model extend param options

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/mapping.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/mapping.ts
@@ -9,12 +9,6 @@ export const mappingChatModels: AIChatModelCard[] = [
     enabled: true,
     id: 'lobehub-onboarding-v1',
     settings: {
-      extendParamOptions: {
-        enableReasoning: {
-          defaultValue: true,
-          includeBudget: false,
-        },
-      },
       extendParams: ['enableReasoning'],
     },
     type: 'chat',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -286,15 +286,6 @@ export type ExtendParamsType =
 
 export type DisabledParamType = 'temperature' | 'top_p' | 'frequency_penalty' | 'presence_penalty';
 
-export interface EnableReasoningExtendParamOptions {
-  defaultValue?: boolean;
-  includeBudget?: boolean;
-}
-
-export interface ExtendParamOptions {
-  enableReasoning?: EnableReasoningExtendParamOptions;
-}
-
 export interface AiModelSettings {
   /**
    * Chat params that should be hidden from the agent config UI and stripped from
@@ -302,7 +293,6 @@ export interface AiModelSettings {
    * params (e.g. Claude Opus 4.7 returns 400 on any non-default temperature / top_p).
    */
   disabledParams?: DisabledParamType[];
-  extendParamOptions?: ExtendParamOptions;
   extendParams?: ExtendParamsType[];
   /**
    * How the model layer implements search
@@ -353,18 +343,8 @@ export const DisabledParamTypeSchema = z.enum([
   'presence_penalty',
 ]);
 
-export const EnableReasoningExtendParamOptionsSchema = z.object({
-  defaultValue: z.boolean().optional(),
-  includeBudget: z.boolean().optional(),
-});
-
-export const ExtendParamOptionsSchema = z.object({
-  enableReasoning: EnableReasoningExtendParamOptionsSchema.optional(),
-});
-
 export const AiModelSettingsSchema = z.object({
   disabledParams: z.array(DisabledParamTypeSchema).optional(),
-  extendParamOptions: ExtendParamOptionsSchema.optional(),
   extendParams: z.array(ExtendParamsTypeSchema).optional(),
   searchImpl: ModelSearchImplementTypeSchema.optional(),
   searchProvider: z.string().optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -50,16 +50,13 @@ interface ControlsFormProps {
  * Users may still have only `thinking: 'disabled'`; treating that as unset would
  * show the model default and could persist the opposite value on unrelated edits.
  */
-const resolveEnableReasoningInitialValue = (
-  config: LobeAgentChatConfig,
-  defaultValue?: boolean,
-) => {
+const resolveEnableReasoningInitialValue = (config: LobeAgentChatConfig) => {
   if (Object.hasOwn(config, 'enableReasoning')) return config.enableReasoning;
 
   if (config.thinking === 'enabled') return true;
   if (config.thinking === 'disabled') return false;
 
-  return defaultValue;
+  return undefined;
 };
 
 const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: providerProp }) => {
@@ -80,20 +77,14 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
   );
 
   const modelExtendParams = useAiInfraStore(aiModelSelectors.modelExtendParams(model, provider));
-  const modelExtendParamOptions = useAiInfraStore(
-    aiModelSelectors.modelExtendParamOptions(model, provider),
-  );
   const initialValues = useMemo(() => {
-    const enableReasoningInitialValue = resolveEnableReasoningInitialValue(
-      config,
-      modelExtendParamOptions?.enableReasoning?.defaultValue,
-    );
+    const enableReasoningInitialValue = resolveEnableReasoningInitialValue(config);
 
     return {
       ...config,
       enableReasoning: enableReasoningInitialValue,
     };
-  }, [config, modelExtendParamOptions?.enableReasoning?.defaultValue]);
+  }, [config]);
 
   useEffect(() => {
     form.setFieldsValue(initialValues);
@@ -101,7 +92,6 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
 
   const enableReasoningValue =
     AntdForm.useWatch(['enableReasoning'], form) ?? initialValues.enableReasoning;
-  const includeReasoningBudget = modelExtendParamOptions?.enableReasoning?.includeBudget !== false;
 
   const screens = Grid.useBreakpoint();
   const isNarrow = !screens.sm;
@@ -163,8 +153,7 @@ const ControlsForm = memo<ControlsFormProps>(({ model: modelProp, provider: prov
       minWidth: undefined,
       name: 'enableAdaptiveThinking',
     },
-    ((enableReasoningValue && includeReasoningBudget) ||
-      modelExtendParams?.includes('reasoningBudgetToken')) && {
+    (enableReasoningValue || modelExtendParams?.includes('reasoningBudgetToken')) && {
       children: <ReasoningTokenSlider />,
       label: t('extendParams.reasoningBudgetToken.title'),
       layout: 'vertical',

--- a/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
@@ -11,12 +11,6 @@ interface TestAgentState {
 }
 
 interface TestAiState {
-  extendParamOptions?: {
-    enableReasoning?: {
-      defaultValue?: boolean;
-      includeBudget?: boolean;
-    };
-  };
   extendParams: string[];
 }
 
@@ -27,7 +21,6 @@ const testState = vi.hoisted(() => ({
     provider: 'openai',
   } as TestAgentState,
   aiState: {
-    extendParamOptions: undefined,
     extendParams: ['enableReasoning'],
   } as TestAiState,
   setFieldsValue: vi.fn(),
@@ -80,7 +73,6 @@ vi.mock('@/store/agent/selectors', () => ({
 
 vi.mock('@/store/aiInfra', () => ({
   aiModelSelectors: {
-    modelExtendParamOptions: () => (state: TestAiState) => state.extendParamOptions,
     modelExtendParams: () => (state: TestAiState) => state.extendParams,
   },
   useAiInfraStore: <T,>(selector: (state: TestAiState) => T) => selector(testState.aiState),
@@ -95,30 +87,35 @@ describe('ControlsForm', () => {
       provider: 'openai',
     };
     testState.aiState = {
-      extendParamOptions: undefined,
       extendParams: ['enableReasoning'],
     };
   });
 
-  it('should sync model default values into mounted form without persisting them', () => {
-    const { rerender } = render(<ControlsForm model="gpt-4" provider="openai" />);
-
-    expect(testState.setFieldsValue).toHaveBeenLastCalledWith({ enableReasoning: undefined });
-    expect(testState.updateAgentChatConfig).not.toHaveBeenCalled();
-
-    testState.aiState = {
-      extendParamOptions: {
-        enableReasoning: {
-          defaultValue: true,
-          includeBudget: false,
-        },
-      },
-      extendParams: ['enableReasoning'],
+  it('should sync legacy thinking values into mounted form without persisting them', () => {
+    testState.agentState.config = {
+      thinking: 'disabled',
     };
 
-    rerender(<ControlsForm model="deepseek-v4-flash" provider="deepseek" />);
+    const { unmount } = render(<ControlsForm model="gpt-4" provider="openai" />);
 
-    expect(testState.setFieldsValue).toHaveBeenLastCalledWith({ enableReasoning: true });
+    expect(testState.setFieldsValue).toHaveBeenLastCalledWith({
+      enableReasoning: false,
+      thinking: 'disabled',
+    });
+    expect(testState.updateAgentChatConfig).not.toHaveBeenCalled();
+
+    unmount();
+
+    testState.agentState.config = {
+      thinking: 'enabled',
+    };
+
+    render(<ControlsForm model="gpt-4" provider="openai" />);
+
+    expect(testState.setFieldsValue).toHaveBeenLastCalledWith({
+      enableReasoning: true,
+      thinking: 'enabled',
+    });
     expect(testState.updateAgentChatConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -130,60 +130,7 @@ describe('resolveModelExtendParams', () => {
         });
       });
 
-      it('should use model default for enableReasoning when chat config is unset', () => {
-        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParamOptions').mockReturnValue(
-          () => ({
-            enableReasoning: {
-              defaultValue: true,
-              includeBudget: false,
-            },
-          }),
-        );
-
-        const result = resolveModelExtendParams({
-          chatConfig: createChatConfig(),
-          model: 'deepseek-v4-flash',
-          provider: 'deepseek',
-        });
-
-        expect(result.thinking).toEqual({
-          type: 'enabled',
-        });
-      });
-
-      it('should allow explicit chat config to override model enableReasoning default', () => {
-        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParamOptions').mockReturnValue(
-          () => ({
-            enableReasoning: {
-              defaultValue: true,
-              includeBudget: false,
-            },
-          }),
-        );
-
-        const result = resolveModelExtendParams({
-          chatConfig: createChatConfig({
-            enableReasoning: false,
-          }),
-          model: 'deepseek-v4-flash',
-          provider: 'deepseek',
-        });
-
-        expect(result.thinking).toEqual({
-          type: 'disabled',
-        });
-      });
-
       it('should preserve legacy thinking disabled when enableReasoning is unset', () => {
-        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParamOptions').mockReturnValue(
-          () => ({
-            enableReasoning: {
-              defaultValue: true,
-              includeBudget: false,
-            },
-          }),
-        );
-
         const result = resolveModelExtendParams({
           chatConfig: createChatConfig({
             thinking: 'disabled',
@@ -193,20 +140,12 @@ describe('resolveModelExtendParams', () => {
         });
 
         expect(result.thinking).toEqual({
+          budget_tokens: 0,
           type: 'disabled',
         });
       });
 
       it('should preserve legacy thinking enabled when enableReasoning is unset', () => {
-        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParamOptions').mockReturnValue(
-          () => ({
-            enableReasoning: {
-              defaultValue: false,
-              includeBudget: false,
-            },
-          }),
-        );
-
         const result = resolveModelExtendParams({
           chatConfig: createChatConfig({
             thinking: 'enabled',
@@ -216,6 +155,7 @@ describe('resolveModelExtendParams', () => {
         });
 
         expect(result.thinking).toEqual({
+          budget_tokens: 1024,
           type: 'enabled',
         });
       });

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -50,19 +50,16 @@ const THINKING_LEVEL_PARAM_TO_CONFIG_KEY = {
 
 /**
  * Preserves legacy `thinking` preferences for users created before `enableReasoning`.
- * Without this fallback, an old `thinking: 'disabled'` setting would be treated as unset
- * and could be overwritten by a model-level default such as DeepSeek V4 reasoning enabled.
+ * Without this fallback, an old `thinking: 'enabled'` or `thinking: 'disabled'`
+ * setting would be treated as unset by models that now expose the `enableReasoning` switch.
  */
-const resolveEnableReasoningValue = (
-  chatConfig: LobeAgentChatConfig,
-  defaultValue?: boolean,
-): boolean | undefined => {
+const resolveEnableReasoningValue = (chatConfig: LobeAgentChatConfig): boolean | undefined => {
   if (Object.hasOwn(chatConfig, 'enableReasoning')) return chatConfig.enableReasoning;
 
   if (chatConfig.thinking === 'enabled') return true;
   if (chatConfig.thinking === 'disabled') return false;
 
-  return defaultValue;
+  return undefined;
 };
 
 /**
@@ -92,50 +89,32 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     return extendParams;
   }
 
-  const modelExtendParamOptions = aiModelSelectors.modelExtendParamOptions(
-    model,
-    provider,
-  )(aiInfraStoreState);
-
   // Reasoning configuration
   if (modelExtendParams.includes('enableReasoning')) {
-    const enableReasoningOptions = modelExtendParamOptions?.enableReasoning;
-    const enableReasoning = resolveEnableReasoningValue(
-      chatConfig,
-      enableReasoningOptions?.defaultValue,
-    );
-    const includeBudget = enableReasoningOptions?.includeBudget !== false;
+    const enableReasoning = resolveEnableReasoningValue(chatConfig);
 
     if (enableReasoning) {
       const thinking: NonNullable<ModelExtendParams['thinking']> = {
         type: 'enabled',
       };
 
-      if (includeBudget) {
-        // Determine which budget field to use based on model support
-        let budgetTokens: number | undefined;
-        if (modelExtendParams.includes('reasoningBudgetToken32k')) {
-          budgetTokens = chatConfig.reasoningBudgetToken32k || 1024;
-        } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
-          budgetTokens = chatConfig.reasoningBudgetToken80k || 1024;
-        } else {
-          budgetTokens = chatConfig.reasoningBudgetToken || 1024;
-        }
-
-        thinking.budget_tokens = budgetTokens;
+      // Determine which budget field to use based on model support
+      let budgetTokens: number | undefined;
+      if (modelExtendParams.includes('reasoningBudgetToken32k')) {
+        budgetTokens = chatConfig.reasoningBudgetToken32k || 1024;
+      } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
+        budgetTokens = chatConfig.reasoningBudgetToken80k || 1024;
+      } else {
+        budgetTokens = chatConfig.reasoningBudgetToken || 1024;
       }
 
+      thinking.budget_tokens = budgetTokens;
       extendParams.thinking = thinking;
     } else {
-      const thinking: NonNullable<ModelExtendParams['thinking']> = {
+      extendParams.thinking = {
+        budget_tokens: 0,
         type: 'disabled',
       };
-
-      if (includeBudget) {
-        thinking.budget_tokens = 0;
-      }
-
-      extendParams.thinking = thinking;
     }
   } else if (modelExtendParams.includes('reasoningBudgetToken32k')) {
     // For models that only have reasoningBudgetToken32k without enableReasoning

--- a/src/store/aiInfra/slices/aiModel/selectors.test.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.test.ts
@@ -50,12 +50,6 @@ describe('aiModelSelectors', () => {
         contextWindowTokens: 4000,
         settings: {
           disabledParams: ['temperature', 'top_p'],
-          extendParamOptions: {
-            enableReasoning: {
-              defaultValue: true,
-              includeBudget: false,
-            },
-          },
         },
         type: 'chat',
       },
@@ -270,23 +264,6 @@ describe('aiModelSelectors', () => {
     it('should return undefined for an unknown model', () => {
       expect(
         aiModelSelectors.modelDisabledParams('missing', 'provider1')(mockState),
-      ).toBeUndefined();
-    });
-  });
-
-  describe('modelExtendParamOptions', () => {
-    it('should return extendParamOptions when declared on the model card', () => {
-      expect(aiModelSelectors.modelExtendParamOptions('model1', 'provider1')(mockState)).toEqual({
-        enableReasoning: {
-          defaultValue: true,
-          includeBudget: false,
-        },
-      });
-    });
-
-    it('should return undefined when the model has no settings', () => {
-      expect(
-        aiModelSelectors.modelExtendParamOptions('model4', 'provider2')(mockState),
       ).toBeUndefined();
     });
   });

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -99,12 +99,6 @@ const modelExtendParams = (id: string, provider: string) => (s: AIProviderStoreS
   return model?.settings?.extendParams;
 };
 
-const modelExtendParamOptions = (id: string, provider: string) => (s: AIProviderStoreState) => {
-  const model = getEnabledModelById(id, provider)(s);
-
-  return model?.settings?.extendParamOptions;
-};
-
 const modelDisabledParams = (id: string, provider: string) => (s: AIProviderStoreState) => {
   const model = getEnabledModelById(id, provider)(s);
 
@@ -175,7 +169,6 @@ export const aiModelSelectors = {
   modelBuiltinSearchImpl,
   modelContextWindowTokens,
   modelDisabledParams,
-  modelExtendParamOptions,
   modelExtendParams,
   totalAiProviderModelList,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #14110
Related to #14173

#### 🔀 Description of Change

- Remove the generic `extendParamOptions` model setting and schema support.
- Remove the `modelExtendParamOptions` selector and model-level `enableReasoning` default handling in the controls form and model params resolver.
- Keep the legacy `thinking` to `enableReasoning` fallback so older configs still render and resolve consistently.
- Keep DeepSeek V4 on the dedicated `deepseekV4ReasoningEffort` tri-state control introduced by #14110.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/services/chat/mecha/modelParamsResolver.test.ts' 'src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx' 'src/store/aiInfra/slices/aiModel/selectors.test.ts'
bunx --bun prettier -c 'packages/model-bank/src/types/aiModel.ts' 'packages/model-bank/src/aiModels/lobehub/chat/mapping.ts' 'src/store/aiInfra/slices/aiModel/selectors.ts' 'src/store/aiInfra/slices/aiModel/selectors.test.ts' 'src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx' 'src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx' 'src/services/chat/mecha/modelParamsResolver.ts' 'src/services/chat/mecha/modelParamsResolver.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This follows the DeepSeek V4 reasoning config migration path after #14110. The generic model-level options are no longer needed because DeepSeek V4 now uses `deepseekV4ReasoningEffort: none | high | max` directly.
