### PR TITLE
🐛 fix(model-runtime): scope OpenAI prompt cache key by chat metadata

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -483,7 +483,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe_bv9fvv1ahw1te',
+            prompt_cache_key: 'lobe_agt_1_tpc_1',
           }),
           expect.anything(),
         );
@@ -556,7 +556,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe_10t0z0z1pxx69q',
+            prompt_cache_key: 'lobe_agt_2_tpc_2',
           }),
           expect.anything(),
         );
@@ -1968,7 +1968,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
       expect(instance['client'].responses.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          prompt_cache_key: 'lobe_bv9fvv1ahw1te',
+          prompt_cache_key: 'lobe_agt_1_tpc_1',
         }),
         expect.anything(),
       );
@@ -2267,7 +2267,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe_bv9fvv1ahw1te',
+            prompt_cache_key: 'lobe_agt_1_tpc_1',
           }),
           expect.anything(),
         );

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -461,7 +461,7 @@ describe('LobeOpenAICompatibleFactory', () => {
         );
       });
 
-      it('should add prompt_cache_key for OpenAI chat requests with user', async () => {
+      it('should add prompt_cache_key for OpenAI chat requests with chat metadata', async () => {
         const LobeOpenAIProvider = createOpenAICompatibleRuntime({
           baseURL: 'https://api.openai.com/v1',
           provider: ModelProvider.OpenAI,
@@ -478,12 +478,12 @@ describe('LobeOpenAICompatibleFactory', () => {
             model: 'gpt-4o',
             temperature: 0,
           },
-          { user: 'testUser' },
+          { metadata: { chat: { agentId: 'agt_1', topicId: 'tpc_1' } }, user: 'testUser' },
         );
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe:testUser:gpt-4o',
+            prompt_cache_key: 'lobe_bv9fvv1ahw1te',
           }),
           expect.anything(),
         );
@@ -498,7 +498,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             model: 'llama-3.1-8b-instant',
             temperature: 0,
           },
-          { user: 'testUser' },
+          { metadata: { chat: { agentId: 'agt_1', topicId: 'tpc_1' } }, user: 'testUser' },
         );
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
@@ -509,7 +509,7 @@ describe('LobeOpenAICompatibleFactory', () => {
         );
       });
 
-      it('should not add prompt_cache_key for GPT chat requests without user', async () => {
+      it('should not add prompt_cache_key for GPT chat requests without chat metadata', async () => {
         const LobeOpenAIProvider = createOpenAICompatibleRuntime({
           baseURL: 'https://api.openai.com/v1',
           provider: ModelProvider.OpenAI,
@@ -551,12 +551,12 @@ describe('LobeOpenAICompatibleFactory', () => {
             model: 'gpt-4o-mini',
             temperature: 0,
           },
-          { user: 'testUser' },
+          { metadata: { chat: { agentId: 'agt_2', topicId: 'tpc_2' } }, user: 'testUser' },
         );
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe:testUser:gpt-4o-mini',
+            prompt_cache_key: 'lobe_10t0z0z1pxx69q',
           }),
           expect.anything(),
         );
@@ -587,7 +587,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             model: 'gpt-4o',
             temperature: 0,
           },
-          { user: 'testUser' },
+          { metadata: { chat: { agentId: 'agt_1', topicId: 'tpc_1' } }, user: 'testUser' },
         );
 
         expect(mockCreateMethod).toHaveBeenCalledWith(
@@ -1928,7 +1928,6 @@ describe('LobeOpenAICompatibleFactory', () => {
         {
           input: payload.messages,
           model: payload.model,
-          prompt_cache_key: 'lobe:test-user:gpt-4o',
           // @ts-ignore
           text: { format: { strict: true, type: 'json_schema', ...payload.schema } },
           safety_identifier: options.user,
@@ -1939,7 +1938,7 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toEqual({ status: 'success' });
     });
 
-    it('should add prompt_cache_key for OpenAI generateObject responses requests with user', async () => {
+    it('should add prompt_cache_key for OpenAI generateObject responses requests with chat metadata', async () => {
       const LobeOpenAIProvider = createOpenAICompatibleRuntime({
         baseURL: 'https://api.openai.com/v1',
         provider: ModelProvider.OpenAI,
@@ -1962,11 +1961,14 @@ describe('LobeOpenAICompatibleFactory', () => {
         },
       };
 
-      await instance.generateObject(payload, { user: 'testUser' });
+      await instance.generateObject(payload, {
+        metadata: { chat: { agentId: 'agt_1', topicId: 'tpc_1' } },
+        user: 'testUser',
+      });
 
       expect(instance['client'].responses.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          prompt_cache_key: 'lobe:testUser:gpt-4o',
+          prompt_cache_key: 'lobe_bv9fvv1ahw1te',
         }),
         expect.anything(),
       );
@@ -2218,7 +2220,6 @@ describe('LobeOpenAICompatibleFactory', () => {
           {
             messages: payload.messages,
             model: payload.model,
-            prompt_cache_key: 'lobe:test-user-123:gpt-4o',
             response_format: { json_schema: payload.schema, type: 'json_schema' },
             user: options.user,
           },
@@ -2228,7 +2229,7 @@ describe('LobeOpenAICompatibleFactory', () => {
         expect(result).toEqual({ status: 'completed' });
       });
 
-      it('should add prompt_cache_key for OpenAI generateObject chat completion requests with user', async () => {
+      it('should add prompt_cache_key for OpenAI generateObject chat completion requests with chat metadata', async () => {
         const LobeOpenAIProvider = createOpenAICompatibleRuntime({
           baseURL: 'https://api.openai.com/v1',
           provider: ModelProvider.OpenAI,
@@ -2259,11 +2260,14 @@ describe('LobeOpenAICompatibleFactory', () => {
           },
         };
 
-        await instance.generateObject(payload, { user: 'testUser' });
+        await instance.generateObject(payload, {
+          metadata: { chat: { agentId: 'agt_1', topicId: 'tpc_1' } },
+          user: 'testUser',
+        });
 
         expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
           expect.objectContaining({
-            prompt_cache_key: 'lobe:testUser:gpt-4o',
+            prompt_cache_key: 'lobe_bv9fvv1ahw1te',
           }),
           expect.anything(),
         );

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -80,6 +80,19 @@ type ResponseCreateParamsWithPromptCacheKey = (
   | OpenAI.Responses.ResponseCreateParams
 ) &
   OpenAIExtraParams;
+
+interface PromptCacheScope {
+  agentId: string;
+  topicId: string;
+}
+
+interface ChatRequestMetadata {
+  chat?: {
+    agentId?: unknown;
+    topicId?: unknown;
+  };
+}
+
 export type CreateImageOptions = Omit<ClientOptions, 'apiKey'> & {
   apiKey: string;
   provider: string;
@@ -89,6 +102,44 @@ export type CreateVideoOptions = Omit<ClientOptions, 'apiKey'> & {
   apiKey: string;
   provider: string;
 };
+
+const isPromptCacheSupportedModel = (model?: string) =>
+  model?.startsWith('gpt-') || /^o\d/.test(model || '') || model === 'chat-latest';
+
+const resolvePromptCacheScope = (
+  metadata?: Record<string, unknown>,
+): PromptCacheScope | undefined => {
+  const chat = (metadata as ChatRequestMetadata | undefined)?.chat;
+
+  if (!chat) return;
+
+  const { agentId, topicId } = chat;
+
+  if (typeof agentId !== 'string' || typeof topicId !== 'string') return;
+
+  return { agentId, topicId };
+};
+
+const createStableHash = (value: string) => {
+  let hash1 = 0xdeadbeef ^ value.length;
+  let hash2 = 0x41c6ce57 ^ value.length;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    hash1 = Math.imul(hash1 ^ code, 2654435761);
+    hash2 = Math.imul(hash2 ^ code, 1597334677);
+  }
+
+  hash1 =
+    Math.imul(hash1 ^ (hash1 >>> 16), 2246822507) ^ Math.imul(hash2 ^ (hash2 >>> 13), 3266489909);
+  hash2 =
+    Math.imul(hash2 ^ (hash2 >>> 16), 2246822507) ^ Math.imul(hash1 ^ (hash1 >>> 13), 3266489909);
+
+  return `${(hash2 >>> 0).toString(36)}${(hash1 >>> 0).toString(36)}`;
+};
+
+const createPromptCacheKey = ({ agentId, topicId }: PromptCacheScope) =>
+  `lobe_${createStableHash(JSON.stringify([topicId, agentId]))}`;
 
 export interface CustomClientOptions<T extends Record<string, any> = any> {
   createChatCompletionStream?: (
@@ -352,23 +403,24 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       return false;
     }
 
-    private resolvePromptCacheKey(model?: string, user?: string) {
-      if (!user) return;
+    private resolvePromptCacheKey(model?: string, metadata?: Record<string, unknown>) {
+      if (!isPromptCacheSupportedModel(model)) return;
 
-      // Keep the default key at {userId}:{model}; {agentId} can be added later if a narrower cache bucket is needed.
-      if (model?.startsWith('gpt-') || /^o\d/.test(model || '') || model === 'chat-latest') {
-        return `lobe:${user}:${model}`;
-      }
+      const scope = resolvePromptCacheScope(metadata);
+
+      if (!scope) return;
+
+      return createPromptCacheKey(scope);
     }
 
     private resolvePromptCacheKeyParams(
       model?: string,
-      user?: string,
+      metadata?: Record<string, unknown>,
       existingPromptCacheKey?: string,
     ) {
       if (existingPromptCacheKey !== undefined) return {};
 
-      const promptCacheKey = this.resolvePromptCacheKey(model, user);
+      const promptCacheKey = this.resolvePromptCacheKey(model, metadata);
 
       return promptCacheKey ? { prompt_cache_key: promptCacheKey } : {};
     }
@@ -514,7 +566,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             ...(chatCompletion?.noUserId ? {} : { user: options?.user }),
             ...this.resolvePromptCacheKeyParams(
               cleanedPayload.model,
-              options?.user,
+              options?.metadata,
               cleanedPayload.prompt_cache_key,
             ),
             stream_options:
@@ -779,7 +831,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             {
               messages,
               model,
-              ...this.resolvePromptCacheKeyParams(model, options?.user),
+              ...this.resolvePromptCacheKeyParams(model, options?.metadata),
               tool_choice: { function: { name: tool.function.name }, type: 'function' },
               tools: [tool],
               user: options?.user,
@@ -834,7 +886,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             {
               input: messages,
               model,
-              ...this.resolvePromptCacheKeyParams(model, options?.user),
+              ...this.resolvePromptCacheKeyParams(model, options?.metadata),
               text: { format: { strict: true, type: 'json_schema', ...processedSchema } },
               // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
               safety_identifier: options?.user,
@@ -865,7 +917,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             messages,
             model,
             response_format: { json_schema: processedSchema, type: 'json_schema' },
-            ...this.resolvePromptCacheKeyParams(model, options?.user),
+            ...this.resolvePromptCacheKeyParams(model, options?.metadata),
             user: options?.user,
           },
           { headers: options?.headers, signal: options?.signal },
@@ -1147,7 +1199,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         tools: tools?.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
         ...this.resolvePromptCacheKeyParams(
           res.model,
-          options?.user,
+          options?.metadata,
           (res as OpenAIExtraParams).prompt_cache_key,
         ),
         // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
@@ -1274,7 +1326,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           {
             input,
             model,
-            ...this.resolvePromptCacheKeyParams(model, options?.user),
+            ...this.resolvePromptCacheKeyParams(model, options?.metadata),
             tool_choice: 'required',
             tools: tools!.map((tool) => this.convertChatCompletionToolToResponseTool(tool)),
             // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`
@@ -1316,7 +1368,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         {
           messages: msgs,
           model,
-          ...this.resolvePromptCacheKeyParams(model, options?.user),
+          ...this.resolvePromptCacheKeyParams(model, options?.metadata),
           tool_choice: 'required',
           tools,
           user: options?.user,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -120,26 +120,8 @@ const resolvePromptCacheScope = (
   return { agentId, topicId };
 };
 
-const createStableHash = (value: string) => {
-  let hash1 = 0xdeadbeef ^ value.length;
-  let hash2 = 0x41c6ce57 ^ value.length;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    hash1 = Math.imul(hash1 ^ code, 2654435761);
-    hash2 = Math.imul(hash2 ^ code, 1597334677);
-  }
-
-  hash1 =
-    Math.imul(hash1 ^ (hash1 >>> 16), 2246822507) ^ Math.imul(hash2 ^ (hash2 >>> 13), 3266489909);
-  hash2 =
-    Math.imul(hash2 ^ (hash2 >>> 16), 2246822507) ^ Math.imul(hash1 ^ (hash1 >>> 13), 3266489909);
-
-  return `${(hash2 >>> 0).toString(36)}${(hash1 >>> 0).toString(36)}`;
-};
-
 const createPromptCacheKey = ({ agentId, topicId }: PromptCacheScope) =>
-  `lobe_${createStableHash(JSON.stringify([topicId, agentId]))}`;
+  `lobe_${agentId}_${topicId}`;
 
 export interface CustomClientOptions<T extends Record<string, any> = any> {
   createChatCompletionStream?: (

--- a/src/app/(backend)/webapi/chat/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.test.ts
@@ -106,6 +106,35 @@ describe('POST handler', () => {
       });
     });
 
+    it('should pass chat request metadata from headers', async () => {
+      const mockParams = Promise.resolve({ provider: 'test-provider' });
+      const mockChatPayload = { message: 'Hello, world!' };
+      request = new Request(new URL('https://test.com'), {
+        body: JSON.stringify(mockChatPayload),
+        headers: {
+          'x-agent-id': 'agt_123',
+          'x-topic-id': 'tpc_456',
+        },
+        method: 'POST',
+      });
+
+      const mockChatResponse: any = { success: true, message: 'Reply from agent' };
+      const mockRuntime: LobeRuntimeAI = {
+        baseURL: 'abc',
+        chat: vi.fn().mockResolvedValue(mockChatResponse),
+      };
+
+      vi.mocked(initModelRuntimeFromDB).mockResolvedValue(new ModelRuntime(mockRuntime));
+
+      await POST(request as unknown as Request, { params: mockParams });
+
+      expect(mockRuntime.chat).toHaveBeenCalledWith(mockChatPayload, {
+        metadata: { chat: { agentId: 'agt_123', topicId: 'tpc_456' } },
+        user: 'test-user-id',
+        signal: expect.anything(),
+      });
+    });
+
     it('should return an error response when chat completion fails', async () => {
       const mockParams = Promise.resolve({ provider: 'test-provider' });
       const mockChatPayload = { message: 'Hello, world!' };

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -12,6 +12,15 @@ import { getTracePayload } from '@/utils/trace';
 // this enforce user to enable fluid compute
 export const maxDuration = 300;
 
+const getChatRequestMetadata = (req: Request) => {
+  const agentId = req.headers.get('x-agent-id') || undefined;
+  const topicId = req.headers.get('x-topic-id') || undefined;
+
+  if (!agentId || !topicId) return;
+
+  return { chat: { agentId, topicId } };
+};
+
 export const POST = checkAuth(async (req: Request, { params, userId, serverDB }) => {
   const provider = (await params)!.provider!;
 
@@ -24,6 +33,7 @@ export const POST = checkAuth(async (req: Request, { params, userId, serverDB })
     const data = (await req.json()) as ChatStreamPayload;
 
     const tracePayload = getTracePayload(req);
+    const metadata = getChatRequestMetadata(req);
 
     let traceOptions = {};
     // If user enable trace
@@ -34,6 +44,7 @@ export const POST = checkAuth(async (req: Request, { params, userId, serverDB })
     return await modelRuntime.chat(data, {
       user: userId,
       ...traceOptions,
+      ...(metadata && { metadata }),
       signal: req.signal,
     });
   } catch (e) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
Fixes #14610

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
This PR fixes OpenAI prompt cache key scoping for chat requests.

Previously, OpenAI-compatible requests generated `prompt_cache_key` from only the user and model:

```text
lobe:{userId}:{model}
```

That was too broad for group chat and delegated-agent flows. When multiple agents in the same user session used the same model concurrently, they could share the same prompt cache key even though they represented different chat/agent contexts. This made the cache affinity bucket ambiguous and could cause unrelated agent conversations to be grouped together.

The updated flow scopes the prompt cache key to the actual chat execution context:

1. The web API chat route reads the existing request headers:
   - `x-topic-id`
   - `x-agent-id`

2. It forwards those values through the existing generic model-runtime `metadata` option:

```ts
metadata: {
  chat: {
    topicId,
    agentId,
  },
}
```

3. The OpenAI-compatible runtime derives `prompt_cache_key` internally from that metadata.

4. The final key sent to OpenAI is deterministic and scoped by agent + topic:

```text
lobe_{agentId}_{topicId}
```

Expected behavior after this change:

- Same chat topic + same agent → same `prompt_cache_key`
- Same chat topic + different delegated agent → different `prompt_cache_key`
- Different chat topic → different `prompt_cache_key`
- Calls without chat metadata, such as title generation, do not receive a prompt cache key
- Existing custom `prompt_cache_key` values from provider payload handlers are preserved and not overwritten
- `user` is still used for OpenAI `user` / `safety_identifier`, but no longer determines the prompt cache key

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Ran:

```bash
pnpm exec vitest run --silent='passed-only' 'src/app/(backend)/webapi/chat/[provider]/route.test.ts'
```

```bash
cd packages/model-runtime
pnpm exec vitest run --silent='passed-only' src/core/openaiCompatibleFactory/index.test.ts
```

Manual scenarios to verify with OpenAI debug output:

1. Send multiple messages in the same normal chat with the same agent.
   - The `prompt_cache_key` should stay the same.

2. Send messages in a group chat where the supervisor delegates to another agent.
   - The supervisor and delegated agent should use different `prompt_cache_key` values.

3. Send multiple messages to the same delegated group agent in the same topic.
   - That delegated agent’s `prompt_cache_key` should stay the same.

4. Trigger topic title generation.
   - No `prompt_cache_key` should be sent because the request does not include chat topic/agent metadata.

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
The generated key is deterministic and scoped to the chat topic + agent, so cache affinity remains stable across messages for the same agent in the same topic while avoiding collisions between delegated agents.
