### PR TITLE
🐛 fix(hetero-agent): disable Claude Code AskUserQuestion to avoid auto-decline

### DIFF
--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
@@ -1,22 +1,16 @@
+import { CLAUDE_CODE_BASE_ARGS } from '@lobechat/heterogeneous-agents/spawn';
+
 import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
 
-const CLAUDE_CODE_BASE_ARGS = [
-  '-p',
-  '--input-format',
-  'stream-json',
-  '--output-format',
-  'stream-json',
-  '--verbose',
+// Desktop runs CC as the user (never root, so bypassPermissions is fine) and
+// renders the chat bubble live, so it always wants partial deltas. Compose
+// the shared invariant base args (`@lobechat/heterogeneous-agents/spawn`)
+// with those caller-specific flags.
+const DESKTOP_CLAUDE_CODE_ARGS = [
+  ...CLAUDE_CODE_BASE_ARGS,
   '--include-partial-messages',
   '--permission-mode',
   'bypassPermissions',
-  // CC's built-in `AskUserQuestion` self-injects an `is_error: "Answer questions?"`
-  // tool_result inside the CLI before the host gets a chance to surface the
-  // questions, leaving the model to fall back to plain-text prompting anyway.
-  // Disable it so the model just asks in text. Re-enable once we wire a
-  // local MCP-backed replacement that bridges to LobeHub's intervention UI.
-  '--disallowedTools',
-  'AskUserQuestion',
 ] as const;
 
 export const claudeCodeDriver: HeterogeneousAgentDriver = {
@@ -31,7 +25,7 @@ export const claudeCodeDriver: HeterogeneousAgentDriver = {
 
     return {
       args: [
-        ...CLAUDE_CODE_BASE_ARGS,
+        ...DESKTOP_CLAUDE_CODE_ARGS,
         ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
         ...args,
       ],

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
@@ -10,6 +10,13 @@ const CLAUDE_CODE_BASE_ARGS = [
   '--include-partial-messages',
   '--permission-mode',
   'bypassPermissions',
+  // CC's built-in `AskUserQuestion` self-injects an `is_error: "Answer questions?"`
+  // tool_result inside the CLI before the host gets a chance to surface the
+  // questions, leaving the model to fall back to plain-text prompting anyway.
+  // Disable it so the model just asks in text. Re-enable once we wire a
+  // local MCP-backed replacement that bridges to LobeHub's intervention UI.
+  '--disallowedTools',
+  'AskUserQuestion',
 ] as const;
 
 export const claudeCodeDriver: HeterogeneousAgentDriver = {

--- a/packages/heterogeneous-agents/src/spawn/index.ts
+++ b/packages/heterogeneous-agents/src/spawn/index.ts
@@ -29,6 +29,11 @@ export {
   type NormalizeImageOptions,
 } from './input';
 export { JsonlStreamProcessor } from './jsonlProcessor';
-export { spawnAgent, type SpawnAgentHandle, type SpawnAgentOptions } from './spawnAgent';
+export {
+  CLAUDE_CODE_BASE_ARGS,
+  spawnAgent,
+  type SpawnAgentHandle,
+  type SpawnAgentOptions,
+} from './spawnAgent';
 export { toStreamEvent } from './streamEvent';
 export type { AgentStreamEvent, AgentStreamEventType } from '@lobechat/agent-gateway-client';

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -107,7 +107,14 @@ describe('spawnAgent', () => {
     expect(call.args).toContain('--output-format');
     expect(call.args.filter((a) => a === 'stream-json')).toHaveLength(2);
     expect(call.args).toContain('-p');
-    expect(call.args).toContain('--include-partial-messages');
+    // CC's built-in interactive Q&A is disabled at every spawn site so the
+    // model degrades to plain-text questioning instead of stalling on a
+    // synthetic "Answer questions?" tool_result.
+    const disallowedIdx = call.args.indexOf('--disallowedTools');
+    expect(disallowedIdx).toBeGreaterThan(-1);
+    expect(call.args[disallowedIdx + 1]).toBe('AskUserQuestion');
+    // Partial deltas are opt-in — terminal/sandbox callers want fewer events.
+    expect(call.args).not.toContain('--include-partial-messages');
     // Prompt MUST go through stdin as a stream-json user message — never as argv.
     expect(call.args).not.toContain('do a thing');
     expect(fake.stdinWrites).toHaveLength(1);
@@ -119,6 +126,18 @@ describe('spawnAgent', () => {
     // Events flow through the pipeline (session id extracted by adapter).
     expect(events.length).toBeGreaterThan(0);
     for (const event of events) expect(event.operationId).toBe('op-1');
+  });
+
+  it('passes --include-partial-messages only when includePartialMessages=true', async () => {
+    nextFakeProc = createFakeProc().proc;
+    const { spawnAgent } = await import('./spawnAgent');
+    await spawnAgent({
+      agentType: 'claude-code',
+      includePartialMessages: true,
+      operationId: 'op-1',
+      prompt: 'do a thing',
+    });
+    expect(spawnCalls[0].args).toContain('--include-partial-messages');
   });
 
   it('appends --resume <id> for claude when resuming a session', async () => {

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -23,6 +23,13 @@ export interface SpawnAgentOptions {
   /** Extra CLI arguments appended after the agent's preset flags. */
   extraArgs?: string[];
   /**
+   * (Claude Code only) Pass `--include-partial-messages` so the CLI streams
+   * delta chunks instead of only complete blocks. Off by default — terminal
+   * runs and bulk-ingest flows usually want fewer events. Turn on when a
+   * connected client renders live token streaming.
+   */
+  includePartialMessages?: boolean;
+  /**
    * Image normalization options (URL fetch + on-disk cache + path
    * materialization). Forwarded to `buildAgentInput`. When `prompt` is a
    * plain string this is unused.
@@ -82,19 +89,26 @@ export interface SpawnAgentHandle {
   stderr: NodeJS.ReadableStream;
 }
 
-const CLAUDE_CODE_BASE_ARGS = [
+/**
+ * Invariant Claude Code CLI flags shared by every spawn site (desktop driver,
+ * `lh hetero exec`). Permission mode and `--include-partial-messages` vary by
+ * caller — the desktop UI wants live deltas + user-mode bypassPermissions, the
+ * sandbox CLI may run as root and skip partials — so they're composed on top
+ * of this base.
+ *
+ * `AskUserQuestion` is disabled because CC's CLI self-injects an
+ * `is_error: "Answer questions?"` tool_result in `-p` mode before the host
+ * can surface the questions, so the model falls back to plain-text prompting
+ * anyway. Remove this once a local MCP-backed replacement is wired to
+ * LobeHub's intervention UI.
+ */
+export const CLAUDE_CODE_BASE_ARGS = [
   '-p',
   '--input-format',
   'stream-json',
   '--output-format',
   'stream-json',
   '--verbose',
-  '--include-partial-messages',
-  // CC's built-in `AskUserQuestion` self-injects an `is_error: "Answer questions?"`
-  // tool_result inside the CLI before the host gets a chance to surface the
-  // questions, leaving the model to fall back to plain-text prompting anyway.
-  // Disable it so the model just asks in text. Re-enable once we wire a
-  // local MCP-backed replacement that bridges to LobeHub's intervention UI.
   '--disallowedTools',
   'AskUserQuestion',
 ] as const;
@@ -120,8 +134,10 @@ const buildClaudeCodeArgs = (
   resumeSessionId: string | undefined,
   inputArgs: string[],
   extraArgs: string[],
+  includePartialMessages: boolean,
 ) => [
   ...CLAUDE_CODE_BASE_ARGS,
+  ...(includePartialMessages ? ['--include-partial-messages'] : []),
   ...CLAUDE_CODE_PERMISSION_ARGS(),
   ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
   ...inputArgs,
@@ -142,10 +158,11 @@ const buildSpawnArgs = (
   resumeSessionId: string | undefined,
   inputArgs: string[],
   extraArgs: string[],
+  includePartialMessages: boolean,
 ): string[] => {
   switch (agentType) {
     case 'claude-code': {
-      return buildClaudeCodeArgs(resumeSessionId, inputArgs, extraArgs);
+      return buildClaudeCodeArgs(resumeSessionId, inputArgs, extraArgs, includePartialMessages);
     }
     case 'codex': {
       return buildCodexArgs(resumeSessionId, inputArgs, extraArgs);
@@ -207,6 +224,7 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
     options.resumeSessionId,
     inputPlan.args,
     options.extraArgs ?? [],
+    options.includePartialMessages ?? false,
   );
   const cwd = options.cwd || process.cwd();
 

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -130,12 +130,24 @@ const CLAUDE_CODE_PERMISSION_ARGS = (): string[] =>
 
 const CODEX_REQUIRED_ARGS = ['--json', '--skip-git-repo-check', '--full-auto'] as const;
 
-const buildClaudeCodeArgs = (
-  resumeSessionId: string | undefined,
-  inputArgs: string[],
-  extraArgs: string[],
-  includePartialMessages: boolean,
-) => [
+interface BuildSpawnArgsParams {
+  agentType: string;
+  /** Extra CLI arguments appended after the agent's preset flags. */
+  extraArgs: string[];
+  /** (Claude Code only) Stream `--include-partial-messages` deltas. */
+  includePartialMessages: boolean;
+  /** Per-agent input args produced by `buildAgentInput` (e.g. Codex `--image`). */
+  inputArgs: string[];
+  /** Native session id for resume; undefined for fresh runs. */
+  resumeSessionId: string | undefined;
+}
+
+const buildClaudeCodeArgs = ({
+  extraArgs,
+  includePartialMessages,
+  inputArgs,
+  resumeSessionId,
+}: BuildSpawnArgsParams) => [
   ...CLAUDE_CODE_BASE_ARGS,
   ...(includePartialMessages ? ['--include-partial-messages'] : []),
   ...CLAUDE_CODE_PERMISSION_ARGS(),
@@ -144,31 +156,21 @@ const buildClaudeCodeArgs = (
   ...extraArgs,
 ];
 
-const buildCodexArgs = (
-  resumeSessionId: string | undefined,
-  inputArgs: string[],
-  extraArgs: string[],
-) =>
+const buildCodexArgs = ({ extraArgs, inputArgs, resumeSessionId }: BuildSpawnArgsParams) =>
   resumeSessionId
     ? ['exec', 'resume', ...CODEX_REQUIRED_ARGS, ...inputArgs, ...extraArgs, resumeSessionId, '-']
     : ['exec', ...CODEX_REQUIRED_ARGS, ...inputArgs, ...extraArgs];
 
-const buildSpawnArgs = (
-  agentType: string,
-  resumeSessionId: string | undefined,
-  inputArgs: string[],
-  extraArgs: string[],
-  includePartialMessages: boolean,
-): string[] => {
-  switch (agentType) {
+const buildSpawnArgs = (params: BuildSpawnArgsParams): string[] => {
+  switch (params.agentType) {
     case 'claude-code': {
-      return buildClaudeCodeArgs(resumeSessionId, inputArgs, extraArgs, includePartialMessages);
+      return buildClaudeCodeArgs(params);
     }
     case 'codex': {
-      return buildCodexArgs(resumeSessionId, inputArgs, extraArgs);
+      return buildCodexArgs(params);
     }
     default: {
-      throw new Error(`spawnAgent: unsupported agent type "${agentType}"`);
+      throw new Error(`spawnAgent: unsupported agent type "${params.agentType}"`);
     }
   }
 };
@@ -219,13 +221,13 @@ const killProcessTree = (proc: ChildProcess, signal: NodeJS.Signals): void => {
 export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgentHandle> => {
   const command = options.command || defaultCommand(options.agentType);
   const inputPlan = await buildAgentInput(options.agentType, options.prompt, options.inputOptions);
-  const args = buildSpawnArgs(
-    options.agentType,
-    options.resumeSessionId,
-    inputPlan.args,
-    options.extraArgs ?? [],
-    options.includePartialMessages ?? false,
-  );
+  const args = buildSpawnArgs({
+    agentType: options.agentType,
+    extraArgs: options.extraArgs ?? [],
+    includePartialMessages: options.includePartialMessages ?? false,
+    inputArgs: inputPlan.args,
+    resumeSessionId: options.resumeSessionId,
+  });
   const cwd = options.cwd || process.cwd();
 
   const proc = spawn(command, args, {

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -90,6 +90,13 @@ const CLAUDE_CODE_BASE_ARGS = [
   'stream-json',
   '--verbose',
   '--include-partial-messages',
+  // CC's built-in `AskUserQuestion` self-injects an `is_error: "Answer questions?"`
+  // tool_result inside the CLI before the host gets a chance to surface the
+  // questions, leaving the model to fall back to plain-text prompting anyway.
+  // Disable it so the model just asks in text. Re-enable once we wire a
+  // local MCP-backed replacement that bridges to LobeHub's intervention UI.
+  '--disallowedTools',
+  'AskUserQuestion',
 ] as const;
 
 // bypassPermissions is blocked when running as root (e.g. cloud sandbox).


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When the desktop app (or `lh hetero exec`) drives Claude Code via its `-p --input-format stream-json` non-interactive mode, the CLI auto-rejects any `AskUserQuestion` tool call by self-injecting an `is_error: "Answer questions?"` `tool_result` inside the CLI itself — before the host has any chance to surface the questions.

Reproduced locally with the same flags the desktop driver uses:

```jsonc
// 1. assistant emits tool_use
{"type":"assistant","content":[{"type":"tool_use","name":"AskUserQuestion","input":{"questions":[...]}}]}
// 2. CC CLI synthesizes an error tool_result
{"type":"user","content":[{"type":"tool_result","content":"Answer questions?","is_error":true,"tool_use_id":"..."}]}
// 3. model falls back to plain-text questioning
{"type":"assistant","content":[{"type":"text","text":"I'd be glad to help, but I need more context first..."}]}
```

So the user pays for a wasted assistant turn (191k tokens / 10s in the reported case) and ends up with a stuck-looking tool card and a plain-text question anyway. This is a known upstream limitation — see [anthropics/claude-code#10400](https://github.com/anthropics/claude-code/issues/10400) and [#29733](https://github.com/anthropics/claude-code/issues/29733). Anthropic's recommended fix is the SDK `canUseTool` callback, which the CLI subprocess flow can't reach; the documented CLI workaround is to disable the built-in and replace it with an MCP-backed tool ([oneryalcin/claude-ask-user-demo](https://github.com/oneryalcin/claude-ask-user-demo)).

This PR ships the cheap half: add `--disallowedTools AskUserQuestion` so the model just asks in plain text from the start, no broken tool card. Two spawn sites are patched in lockstep:

- `apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts` — desktop IPC path
- `packages/heterogeneous-agents/src/spawn/spawnAgent.ts` — `lh hetero exec` path

Both carry the same explanatory comment so the flag can be removed when the MCP-backed replacement (which will bridge to LobeHub's existing `lobe-user-interaction` intervention UI) lands.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Repro before the patch (CC 2.1.138):

```bash
echo '{"message":{"content":[{"text":"Use the AskUserQuestion tool right now to ask me what color I want","type":"text"}],"role":"user"},"type":"user"}' \
  | claude -p --input-format stream-json --output-format stream-json --verbose \
    --include-partial-messages --permission-mode bypassPermissions
```

Observe the auto-injected `is_error: "Answer questions?"` `tool_result` immediately after the `tool_use` block.

After the patch (or with `--disallowedTools AskUserQuestion`), the model emits a plain-text question instead and no broken tool card appears.

#### 📝 Additional Information

Follow-up: wire a local MCP server exposing a `lobe_ask_user_question` tool that bridges to the existing `lobe-user-interaction` intervention UI; that brings back structured options and removes the `--disallowedTools` flag.