### PR TITLE
🔥 chore(web-crawler): remove WeChat URL rules

### DIFF
--- a/packages/web-crawler/src/__tests__/urlRules.test.ts
+++ b/packages/web-crawler/src/__tests__/urlRules.test.ts
@@ -31,15 +31,6 @@ describe('urlRules', () => {
   });
 
   describe('specific URL patterns', () => {
-    it('should match WeChat Sogou links', () => {
-      const wechatRule = crawUrlRules.find(
-        (rule) => rule.urlPattern === 'https://weixin.sogou.com/link(.*)',
-      );
-
-      expect(wechatRule).toBeDefined();
-      expect(wechatRule?.impls).toEqual(['search1api']);
-    });
-
     it('should match Sogou links', () => {
       const sogouRule = crawUrlRules.find(
         (rule) => rule.urlPattern === 'https://sogou.com/link(.*)',
@@ -65,15 +56,6 @@ describe('urlRules', () => {
 
       expect(redditRule).toBeDefined();
       expect(redditRule?.impls).toEqual(['search1api']);
-    });
-
-    it('should match WeChat public account links', () => {
-      const wechatPublicRule = crawUrlRules.find(
-        (rule) => rule.urlPattern === 'https://mp.weixin.qq.com(.*)',
-      );
-
-      expect(wechatPublicRule).toBeDefined();
-      expect(wechatPublicRule?.impls).toEqual(['search1api', 'jina']);
     });
 
     it('should match GitHub blob links with URL transformation', () => {
@@ -250,7 +232,6 @@ describe('urlRules', () => {
       const patterns = crawUrlRules.map((rule) => rule.urlPattern);
 
       // Check for Chinese platforms
-      expect(patterns.some((p) => p.includes('weixin.sogou.com'))).toBe(true);
       expect(patterns.some((p) => p.includes('xiaohongshu.com'))).toBe(true);
       expect(patterns.some((p) => p.includes('feishu.cn'))).toBe(true);
     });

--- a/packages/web-crawler/src/urlRules.ts
+++ b/packages/web-crawler/src/urlRules.ts
@@ -1,11 +1,6 @@
 import type { CrawlUrlRule } from './type';
 
 export const crawUrlRules: CrawlUrlRule[] = [
-  // Sogou WeChat links, use search1api
-  {
-    impls: ['search1api'],
-    urlPattern: 'https://weixin.sogou.com/link(.*)',
-  },
   // Sogou links, use search1api
   {
     impls: ['search1api'],
@@ -20,11 +15,6 @@ export const crawUrlRules: CrawlUrlRule[] = [
   {
     impls: ['search1api'],
     urlPattern: 'https://www.reddit.com/r/(.*)/comments/(.*)',
-  },
-  // WeChat official accounts have crawler protection, use search1api first, jina as fallback (currently jina crawling may be blocked)
-  {
-    impls: ['search1api', 'jina'],
-    urlPattern: 'https://mp.weixin.qq.com(.*)',
   },
   // GitHub source code parsing
   {


### PR DESCRIPTION
## Summary

- Remove the `weixin.sogou.com` (Sogou WeChat search redirect) and `mp.weixin.qq.com` (WeChat official accounts) entries from `crawUrlRules`.
- Remove the corresponding cases in `urlRules.test.ts` and the WeChat assertion in the "Chinese platforms" coverage check.

These rules previously routed WeChat URLs to `search1api` / `jina`; both impls handle these URLs out of the box now and the dedicated rules are no longer needed.

## Test plan

- [x] `bunx vitest run --silent='passed-only' packages/web-crawler/src/__tests__/urlRules.test.ts` (22/22 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)