### PR TITLE
🐛 fix: consume visual content parts in server runtime

### DIFF
--- a/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -172,6 +172,7 @@ describe('lobeAgentRuntime', () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.content).toBe('visual answer');
     expect(mockMessageModelQueryByIds).not.toHaveBeenCalled();
     expect(result.state).toMatchObject({
       files: [{ name: 'generated.png', ref: 'url_1', type: 'image' }],
@@ -196,6 +197,33 @@ describe('lobeAgentRuntime', () => {
         }),
       }),
     );
+  });
+
+  it('should accumulate text content_part chunks from the visual model', async () => {
+    mockChat.mockImplementationOnce(async (_payload, options) => {
+      options?.callback?.onContentPart?.({
+        content: 'visual answer from content part',
+        mimeType: 'text/plain',
+        partType: 'text',
+      });
+      options?.callback?.onContentPart?.({
+        content: 'base64-image-data',
+        mimeType: 'image/png',
+        partType: 'image',
+      });
+      options?.callback?.onCompletion?.({ usage: { totalTokens: 12 } });
+
+      return new Response('ok');
+    });
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeVisualMedia({
+      question: 'what is this?',
+      urls: ['https://example.com/generated.png'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('visual answer from content part');
   });
 
   it('should reject unsupported direct media url protocols', async () => {

--- a/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/src/server/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -244,6 +244,9 @@ class LobeAgentExecutionRuntime {
         onCompletion: (data) => {
           usage = data.usage;
         },
+        onContentPart: (part) => {
+          if (part.partType === 'text') content += part.content;
+        },
         onText: (text) => {
           content += text;
         },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8726

#### 🔀 Description of Change

- Consume text `content_part` events in the server-side Lobe Agent visual analysis runtime.
- Keep non-text content parts out of the returned tool result string.
- Add regression coverage for visual models that emit `content_part` text without `text` events, while preserving the existing `onText` path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/server/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This fixes the server bot path for visual fallback results from Gemini-style multimodal output streams.