### PR TITLE
✨ feat(hetero-agent): support AskUserQuestion tools for claude code

### DIFF
--- a/.agents/skills/local-testing/scripts/electron-dev.sh
+++ b/.agents/skills/local-testing/scripts/electron-dev.sh
@@ -76,7 +76,9 @@ find_project_pids() {
   port_pid=$(lsof -ti tcp:"$CDP_PORT" -sTCP:LISTEN 2>/dev/null || true)
   pids="$pids $port_pid"
 
-  echo "$pids" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' '
+  # `|| true` because `grep -v '^$'` exits 1 when input has no non-empty
+  # lines, which (with pipefail + set -e) silently kills the caller.
+  echo "$pids" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ' || true
 }
 
 # Wait for the CDP HTTP endpoint to respond, with a deadline + early bail-out
@@ -146,7 +148,7 @@ do_stop() {
   for pid in $seed_pids; do
     all_pids="$all_pids $(expand_descendants "$pid")"
   done
-  all_pids=$(echo "$all_pids" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
+  all_pids=$(echo "$all_pids" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ' || true)
 
   if [ -z "$all_pids" ]; then
     echo "[electron-dev] No project Electron/vite processes found."
@@ -270,10 +272,17 @@ do_start() {
   # Launch in a new session (setsid) so the whole process tree shares a PGID
   # we can later signal in one shot. `setsid bash -c '... exec ...' &` keeps
   # the bash shell as the session leader; its PID is what we save.
-  setsid bash -c "
+  # macOS doesn't ship setsid by default — fall back to plain bash; cleanup
+  # still works via `expand_descendants` walking the process tree.
+  local launch_cmd="
     cd '$PROJECT_ROOT/apps/desktop'
     exec npx electron-vite dev -- --remote-debugging-port=$CDP_PORT
-  " >> "$ELECTRON_LOG" 2>&1 < /dev/null &
+  "
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash -c "$launch_cmd" >> "$ELECTRON_LOG" 2>&1 < /dev/null &
+  else
+    bash -c "$launch_cmd" >> "$ELECTRON_LOG" 2>&1 < /dev/null &
+  fi
   local launcher_pid=$!
   echo "$launcher_pid" > "$PIDFILE"
   echo "[electron-dev] Launcher PID (session leader): $launcher_pid"

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { unlinkSync } from 'node:fs';
 import { access, appendFile, mkdir, unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -1150,10 +1151,30 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   }
 
   /**
-   * Cleanup on app quit.
+   * Synchronously unlink every pending intervention's temp `mcp.json`. The
+   * async exit-handler cleanup loses to Electron's main-process teardown
+   * often enough that we'd leak `lobe-cc-mcp-<opId>.json` files into
+   * `os.tmpdir()` on real shutdowns; sync unlink here is the only reliable
+   * guarantee. Safe to call multiple times.
+   */
+  private unlinkPendingInterventionConfigsSync = (): void => {
+    for (const [, intervention] of this.opIdToIntervention) {
+      try {
+        unlinkSync(intervention.tmpConfigPath);
+      } catch {
+        /* file may already be gone — fine */
+      }
+    }
+  };
+
+  /**
+   * Cleanup on app quit. `before-quit` covers the user-driven Cmd+Q /
+   * `app.quit()` path; SIGTERM / SIGINT cover external kills (test
+   * harnesses, OS shutdown) where Electron's lifecycle events never fire.
    */
   afterAppReady() {
     electronApp.on('before-quit', () => {
+      this.unlinkPendingInterventionConfigsSync();
       for (const [, session] of this.sessions) {
         if (session.process && !session.process.killed) {
           session.cancelledByUs = true;
@@ -1169,5 +1190,20 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
         logger.warn('AskUserQuestion MCP server stop error:', err);
       });
     });
+
+    const onSignal = (signal: NodeJS.Signals) => {
+      this.unlinkPendingInterventionConfigsSync();
+      // Defer to Electron's normal quit flow so the rest of the app gets a
+      // chance to tear down. The `before-quit` handler above is idempotent.
+      try {
+        electronApp.quit();
+      } catch {
+        /* during late shutdown app.quit may throw — fine */
+      }
+      // Last-resort exit if Electron is wedged and won't quit on its own.
+      setTimeout(() => process.exit(signal === 'SIGINT' ? 130 : 143), 1000).unref();
+    };
+    process.on('SIGTERM', onSignal);
+    process.on('SIGINT', onSignal);
   }
 }

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1,7 +1,8 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { access, appendFile, mkdir, writeFile } from 'node:fs/promises';
+import { access, appendFile, mkdir, unlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 import { finished as streamFinished } from 'node:stream/promises';
@@ -14,6 +15,8 @@ import {
   CODEX_CLI_INSTALL_DOCS_URL,
   HeterogeneousAgentSessionErrorCode,
 } from '@lobechat/electron-client-ipc';
+import type { AskUserBridge } from '@lobechat/heterogeneous-agents/askUser';
+import { AskUserMcpServer } from '@lobechat/heterogeneous-agents/askUser';
 import type { AgentContentBlock } from '@lobechat/heterogeneous-agents/spawn';
 import {
   AgentStreamPipeline,
@@ -99,6 +102,18 @@ interface CancelSessionParams {
   sessionId: string;
 }
 
+interface SubmitInterventionParams {
+  cancelled?: boolean;
+  /** When set, signals user-cancelled or timeout — the bridge resolves with isError. */
+  cancelReason?: 'timeout' | 'user_cancelled';
+  /** Operation id stamped on the request the renderer is responding to. */
+  operationId: string;
+  /** Structured user answer; ignored when `cancelled` is true. */
+  result?: unknown;
+  /** Correlation key carried on the original `agent_intervention_request`. */
+  toolCallId: string;
+}
+
 interface StopSessionParams {
   sessionId: string;
 }
@@ -150,10 +165,28 @@ interface CliTraceSession {
  *
  * Lifecycle: startSession → sendPrompt → (heteroAgentEvent broadcasts) → stopSession
  */
+interface InterventionSlot {
+  bridge: AskUserBridge;
+  /** Resolves once bridge.events() iterator ends (after `cancelAll`). */
+  pumpDone: Promise<void>;
+  /** Path to the per-op temp `mcp.json` we wrote for `--mcp-config`. */
+  tmpConfigPath: string;
+}
+
 export default class HeterogeneousAgentCtr extends ControllerModule {
   static override readonly groupName = 'heterogeneousAgent';
 
   private sessions = new Map<string, AgentSession>();
+  /**
+   * Per-operation AskUserQuestion bridge state. Keyed by `operationId` so the
+   * `submitIntervention` IPC can route an answer to the right pending MCP
+   * handler regardless of which `sessionId` it belongs to (one session can
+   * fire many ops over its lifetime).
+   */
+  private opIdToIntervention = new Map<string, InterventionSlot>();
+  /** Lazy single MCP server, started on first claude-code prompt. */
+  private askUserMcpServer?: AskUserMcpServer;
+  private askUserMcpStartPromise?: Promise<AskUserMcpServer>;
 
   private resolveSessionCommand(session: AgentSession): string {
     const resolvedCommand = session.command.trim();
@@ -567,6 +600,92 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     }
   }
 
+  // ─── AskUserQuestion MCP server (LOBE-8725) ───
+
+  /**
+   * Lazy single-instance MCP server for CC's AskUserQuestion replacement.
+   * First claude-code prompt triggers `start()`; subsequent prompts reuse
+   * the same listener. Concurrent first-callers de-dupe via the in-flight
+   * promise so we don't bind two ports.
+   */
+  private async ensureAskUserMcpServerStarted(): Promise<AskUserMcpServer> {
+    if (this.askUserMcpServer) return this.askUserMcpServer;
+    if (!this.askUserMcpStartPromise) {
+      this.askUserMcpStartPromise = (async () => {
+        const server = new AskUserMcpServer();
+        await server.start();
+        this.askUserMcpServer = server;
+        logger.info('AskUserQuestion MCP server started:', server.url);
+        return server;
+      })().catch((err) => {
+        // Reset so a later sendPrompt can retry; surface the error.
+        this.askUserMcpStartPromise = undefined;
+        logger.error('Failed to start AskUserQuestion MCP server:', err);
+        throw err;
+      });
+    }
+    return this.askUserMcpStartPromise;
+  }
+
+  /**
+   * Register a per-op AskUserQuestion bridge, write its temp `mcp.json`,
+   * and start pumping the bridge's outbound events into the regular
+   * `heteroAgentEvent` broadcast. Caller must invoke the returned cleanup
+   * after the spawn finishes (success, error, or cancel) to remove the
+   * temp file and tear down the bridge.
+   *
+   * Pump errors are logged but never thrown — they don't fail the spawn.
+   */
+  private async setupInterventionForOp(
+    operationId: string,
+    sessionId: string,
+  ): Promise<{ cleanup: () => Promise<void>; tmpConfigPath: string }> {
+    const server = await this.ensureAskUserMcpServerStarted();
+    const bridge = server.registerOperation(operationId);
+    const tmpConfigPath = path.join(os.tmpdir(), `lobe-cc-mcp-${operationId}.json`);
+
+    // `alwaysLoad: true` is the undocumented CC flag that promotes our
+    // server's tool out of the deferred set so the model calls it directly
+    // (no ToolSearch hop). See LOBE-8725 spike notes — falls back to the
+    // 2-hop ToolSearch path if a future CC drops the flag, no breakage.
+    const config = {
+      mcpServers: {
+        lobe_cc: {
+          alwaysLoad: true,
+          type: 'http' as const,
+          url: server.urlForOperation(operationId),
+        },
+      },
+    };
+    await writeFile(tmpConfigPath, JSON.stringify(config), 'utf8');
+
+    // Pump bridge.events() into the `heteroAgentEvent` broadcast. The
+    // iterator only ends after `cancelAll()`, so `pumpDone` resolves at
+    // cleanup time and gates teardown.
+    const pumpDone = (async () => {
+      for await (const event of bridge.events()) {
+        this.broadcast('heteroAgentEvent', { event, sessionId });
+      }
+    })().catch((err) => {
+      logger.warn('AskUserQuestion bridge pump error:', err);
+    });
+
+    this.opIdToIntervention.set(operationId, { bridge, pumpDone, tmpConfigPath });
+
+    const cleanup = async () => {
+      // Unregistering on the server cancels all bridge pendings AND closes
+      // the events iterator (cancelAll fires from within unregisterOperation).
+      this.askUserMcpServer?.unregisterOperation(operationId);
+      await pumpDone;
+      this.opIdToIntervention.delete(operationId);
+      await unlink(tmpConfigPath).catch(() => {
+        /* file may already be gone if app crashed mid-prompt */
+      });
+    };
+
+    return { cleanup, tmpConfigPath };
+  }
+
   // ─── File cache ───
 
   private get fileCacheDir(): string {
@@ -697,31 +816,57 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       throw new Error(preflightError.message);
     }
 
-    const driver = getHeterogeneousAgentDriver(session.agentType);
-    const spawnPlan = await driver.buildSpawnPlan({
-      args: session.args,
-      helpers: {
-        buildClaudeStreamJsonInput: (prompt, imageList) =>
-          this.buildStreamJsonInput(prompt, imageList),
-        resolveCliImagePaths: (imageList) => this.resolveCliImagePaths(imageList),
-      },
-      imageList: params.imageList ?? [],
-      prompt: params.prompt,
-      resumeSessionId: session.agentSessionId,
-    });
+    // Stand up the AskUserQuestion MCP bridge for claude-code prompts BEFORE
+    // building the spawn plan so the driver can wire the temp config path
+    // into `--mcp-config`. Codex / future agents skip this entirely.
+    const intervention =
+      session.agentType === 'claude-code'
+        ? await this.setupInterventionForOp(params.operationId, session.sessionId).catch((err) => {
+            logger.warn('Failed to set up AskUserQuestion bridge — proceeding without it:', err);
+            return undefined;
+          })
+        : undefined;
+
+    let spawnPlan;
+    let traceSession;
+    let cwd: string;
+    try {
+      const driver = getHeterogeneousAgentDriver(session.agentType);
+      spawnPlan = await driver.buildSpawnPlan({
+        args: session.args,
+        helpers: {
+          buildClaudeStreamJsonInput: (prompt, imageList) =>
+            this.buildStreamJsonInput(prompt, imageList),
+          resolveCliImagePaths: (imageList) => this.resolveCliImagePaths(imageList),
+        },
+        imageList: params.imageList ?? [],
+        mcpConfigPath: intervention?.tmpConfigPath,
+        prompt: params.prompt,
+        resumeSessionId: session.agentSessionId,
+      });
+
+      // Fall back to the user's Desktop so the process never inherits
+      // the Electron parent's cwd (which is `/` when launched from Finder).
+      cwd = session.cwd || electronApp.getPath('desktop');
+      traceSession = await this.createCliTraceSession({
+        cliArgs: spawnPlan.args,
+        cwd,
+        imageList: params.imageList ?? [],
+        session,
+        stdinPayload: spawnPlan.stdinPayload,
+      });
+    } catch (err) {
+      // We never made it to spawn — the `proc.on('exit')` cleanup path
+      // won't run, so tear the intervention bridge down right here.
+      if (intervention) {
+        await intervention.cleanup().catch((cleanupErr) => {
+          logger.warn('AskUserQuestion cleanup error during pre-spawn failure:', cleanupErr);
+        });
+      }
+      throw err;
+    }
     const useStdin = spawnPlan.stdinPayload !== undefined;
     const cliArgs = spawnPlan.args;
-
-    // Fall back to the user's Desktop so the process never inherits
-    // the Electron parent's cwd (which is `/` when launched from Finder).
-    const cwd = session.cwd || electronApp.getPath('desktop');
-    const traceSession = await this.createCliTraceSession({
-      cliArgs,
-      cwd,
-      imageList: params.imageList ?? [],
-      session,
-      stdinPayload: spawnPlan.stdinPayload,
-    });
 
     return new Promise<void>((resolve, reject) => {
       logger.info('Spawning agent:', session.command, cliArgs.join(' '), `(cwd: ${cwd})`);
@@ -838,6 +983,15 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
         void stdoutDrained
           .then(() => stdoutBroadcastQueue)
           .finally(async () => {
+            // Tear down the AskUserQuestion bridge / temp `mcp.json` for this
+            // op. Pending MCP handlers get a `session_ended` cancellation so
+            // they return cleanly even if CC was killed mid-tool-call.
+            if (intervention) {
+              await intervention.cleanup().catch((err) => {
+                logger.warn('AskUserQuestion cleanup error:', err);
+              });
+            }
+
             void this.writeCliTraceJson(traceSession, 'exit.json', {
               code,
               finishedAt: new Date().toISOString(),
@@ -972,6 +1126,30 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   }
 
   /**
+   * Renderer → main: deliver the user's answer to a pending CC AskUserQuestion
+   * (or signal cancellation). The matching bridge resolves its blocked
+   * `pending()` Promise, the local MCP handler returns to CC, and CC's
+   * `tool_result` flows back through the normal stream pipeline.
+   *
+   * Idempotent — late submissions for already-resolved tool calls are no-ops.
+   * No-op when called for an unknown opId; the bridge may have been cleaned
+   * up already (op finished / cancelled).
+   */
+  @IpcMethod()
+  async submitIntervention(params: SubmitInterventionParams): Promise<void> {
+    const slot = this.opIdToIntervention.get(params.operationId);
+    if (!slot) {
+      logger.warn('submitIntervention: no active intervention for operationId', params.operationId);
+      return;
+    }
+    slot.bridge.resolve(params.toolCallId, {
+      cancelReason: params.cancelled ? (params.cancelReason ?? 'user_cancelled') : undefined,
+      cancelled: params.cancelled,
+      result: params.result,
+    });
+  }
+
+  /**
    * Cleanup on app quit.
    */
   afterAppReady() {
@@ -983,6 +1161,13 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
         }
       }
       this.sessions.clear();
+      // The exit handlers will tear each per-op intervention down, but if
+      // CC's stdio close races shutdown we'd leave the MCP server bound to
+      // a port. Stopping it here cancels every still-pending bridge with
+      // `session_ended` and closes the listener.
+      void this.askUserMcpServer?.stop().catch((err) => {
+        logger.warn('AskUserQuestion MCP server stop error:', err);
+      });
     });
   }
 }

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -802,4 +802,131 @@ describe('HeterogeneousAgentCtr', () => {
       expect(toolEnds.length).toBeGreaterThan(0);
     });
   });
+
+  describe('app-quit cleanup of AskUserQuestion temp configs (LOBE-8725)', () => {
+    // The async exit-handler cleanup races Electron's main-process teardown
+    // and used to leak `lobe-cc-mcp-<opId>.json` files in `os.tmpdir()` on
+    // every quit. The controller now unlinks pending intervention temp
+    // configs *synchronously* from `before-quit` AND from process signal
+    // handlers (SIGTERM / SIGINT — `before-quit` doesn't fire on external
+    // kills). These tests exercise both paths against real files.
+
+    /**
+     * Drop a temp `lobe-cc-mcp-<id>.json` and stash it on the controller's
+     * `opIdToIntervention` map under the same key, so the quit hook treats
+     * it like a real pending intervention and tries to unlink it.
+     */
+    const seedPendingIntervention = async (ctr: HeterogeneousAgentCtr, opId: string) => {
+      const tmpConfigPath = path.join(tmpdir(), `lobe-cc-mcp-test-${opId}.json`);
+      await writeFile(tmpConfigPath, '{"mcpServers":{}}');
+      const slot = {
+        bridge: {} as any,
+        pumpDone: Promise.resolve(),
+        tmpConfigPath,
+      };
+      (ctr as any).opIdToIntervention.set(opId, slot);
+      return tmpConfigPath;
+    };
+
+    const captureRegisteredHandler = (
+      registerSpy: ReturnType<typeof vi.fn> | ReturnType<typeof vi.spyOn>,
+      eventName: string,
+    ): (() => void) => {
+      const calls = (registerSpy as any).mock.calls as Array<[string, () => void]>;
+      const match = calls.findLast(([evt]) => evt === eventName);
+      if (!match) throw new Error(`no handler registered for "${eventName}"`);
+      return match[1];
+    };
+
+    it('before-quit synchronously unlinks every pending intervention temp config', async () => {
+      const electron = (await import('electron')) as any;
+      electron.app.on.mockClear();
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+
+      const fileA = await seedPendingIntervention(ctr, 'opA');
+      const fileB = await seedPendingIntervention(ctr, 'opB');
+
+      ctr.afterAppReady();
+      const beforeQuit = captureRegisteredHandler(electron.app.on, 'before-quit');
+      beforeQuit();
+
+      await expect(access(fileA)).rejects.toThrow();
+      await expect(access(fileB)).rejects.toThrow();
+    });
+
+    it('SIGTERM handler unlinks pending intervention temp configs (external-kill path)', async () => {
+      // External kills (test harness, OS shutdown) skip Electron's lifecycle
+      // events entirely — `before-quit` never fires, so the controller has to
+      // hook the raw process signal too. Stub `process.on` so the handler is
+      // *recorded* but never actually attached to the test runner's process
+      // (otherwise the test leaks a SIGTERM listener that survives the test).
+      // Same for `process.exit` — the controller's fail-safe shouldn't get a
+      // chance to actually exit the worker if its `setTimeout(...).unref()`
+      // ever fires before mockRestore.
+      const electron = (await import('electron')) as any;
+      electron.app.on.mockClear();
+      const processOnSpy = vi.spyOn(process, 'on').mockImplementation(() => process);
+      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const file = await seedPendingIntervention(ctr, 'opSigterm');
+
+      ctr.afterAppReady();
+      const sigterm = captureRegisteredHandler(processOnSpy, 'SIGTERM');
+      sigterm();
+
+      await expect(access(file)).rejects.toThrow();
+
+      processOnSpy.mockRestore();
+      processExitSpy.mockRestore();
+    });
+
+    it('SIGINT handler unlinks pending intervention temp configs (Ctrl-C path)', async () => {
+      const electron = (await import('electron')) as any;
+      electron.app.on.mockClear();
+      const processOnSpy = vi.spyOn(process, 'on').mockImplementation(() => process);
+      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const file = await seedPendingIntervention(ctr, 'opSigint');
+
+      ctr.afterAppReady();
+      const sigint = captureRegisteredHandler(processOnSpy, 'SIGINT');
+      sigint();
+
+      await expect(access(file)).rejects.toThrow();
+
+      processOnSpy.mockRestore();
+      processExitSpy.mockRestore();
+    });
+
+    it('cleanup is idempotent — already-deleted files do not throw', async () => {
+      const electron = (await import('electron')) as any;
+      electron.app.on.mockClear();
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+      } as any);
+      const file = await seedPendingIntervention(ctr, 'opIdempotent');
+
+      // Pre-delete the file out from under the controller — simulates a
+      // partial cleanup race where the async exit handler beat us to it.
+      await unlink(file);
+
+      ctr.afterAppReady();
+      const beforeQuit = captureRegisteredHandler(electron.app.on, 'before-quit');
+      expect(() => beforeQuit()).not.toThrow();
+    });
+  });
 });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  HeterogeneousAgentBuildPlanHelpers,
+  HeterogeneousAgentBuildPlanParams,
+} from '../types';
+import { claudeCodeDriver } from './claudeCode';
+
+const stubHelpers: HeterogeneousAgentBuildPlanHelpers = {
+  buildClaudeStreamJsonInput: async () => '{"type":"user","message":{}}\n',
+  resolveCliImagePaths: async () => [],
+};
+
+const buildParams = (
+  overrides: Partial<HeterogeneousAgentBuildPlanParams> = {},
+): HeterogeneousAgentBuildPlanParams => ({
+  args: [],
+  helpers: stubHelpers,
+  imageList: [],
+  prompt: 'hi',
+  ...overrides,
+});
+
+describe('claudeCodeDriver', () => {
+  it('omits --mcp-config when mcpConfigPath is undefined', async () => {
+    const { args } = await claudeCodeDriver.buildSpawnPlan(buildParams());
+    expect(args).not.toContain('--mcp-config');
+  });
+
+  it('appends --mcp-config <path> when mcpConfigPath is provided', async () => {
+    const { args } = await claudeCodeDriver.buildSpawnPlan(
+      buildParams({ mcpConfigPath: '/tmp/lobe-cc-mcp-op-1.json' }),
+    );
+    const idx = args.indexOf('--mcp-config');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('/tmp/lobe-cc-mcp-op-1.json');
+  });
+
+  it('still pins --disallowedTools AskUserQuestion alongside --mcp-config', async () => {
+    // Even with our local MCP replacement available, CC's built-in stays
+    // disabled — leaving both visible would let the model double-register
+    // the same name and pick the broken one.
+    const { args } = await claudeCodeDriver.buildSpawnPlan(
+      buildParams({ mcpConfigPath: '/tmp/x.json' }),
+    );
+    const disallowedIdx = args.indexOf('--disallowedTools');
+    expect(disallowedIdx).toBeGreaterThan(-1);
+    expect(args[disallowedIdx + 1]).toBe('AskUserQuestion');
+  });
+
+  it('--mcp-config goes before --resume so user --args can still override the resume id', async () => {
+    const { args } = await claudeCodeDriver.buildSpawnPlan(
+      buildParams({ mcpConfigPath: '/tmp/x.json', resumeSessionId: 'cc-prev-1' }),
+    );
+    const mcpIdx = args.indexOf('--mcp-config');
+    const resumeIdx = args.indexOf('--resume');
+    expect(mcpIdx).toBeGreaterThan(-1);
+    expect(resumeIdx).toBeGreaterThan(-1);
+    expect(mcpIdx).toBeLessThan(resumeIdx);
+    expect(args[resumeIdx + 1]).toBe('cc-prev-1');
+  });
+});

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/claudeCode.ts
@@ -18,6 +18,7 @@ export const claudeCodeDriver: HeterogeneousAgentDriver = {
     args,
     helpers,
     imageList,
+    mcpConfigPath,
     prompt,
     resumeSessionId,
   }: HeterogeneousAgentBuildPlanParams) {
@@ -26,6 +27,10 @@ export const claudeCodeDriver: HeterogeneousAgentDriver = {
     return {
       args: [
         ...DESKTOP_CLAUDE_CODE_ARGS,
+        // Wire the controller-managed temp mcp.json (AskUserQuestion server,
+        // see LOBE-8725) when present. Path-based config is required — CC
+        // does not accept inline JSON for `--mcp-config`.
+        ...(mcpConfigPath ? ['--mcp-config', mcpConfigPath] : []),
         ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
         ...args,
       ],

--- a/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/types.ts
@@ -20,6 +20,12 @@ export interface HeterogeneousAgentBuildPlanParams {
   args: string[];
   helpers: HeterogeneousAgentBuildPlanHelpers;
   imageList: HeterogeneousAgentImageAttachment[];
+  /**
+   * Optional path to an MCP config JSON written by the controller (e.g. for
+   * the local `lobe_cc` AskUserQuestion server). Drivers that recognize the
+   * field append `--mcp-config <path>`; others ignore it.
+   */
+  mcpConfigPath?: string;
   prompt: string;
   resumeSessionId?: string;
 }

--- a/packages/agent-gateway-client/src/index.ts
+++ b/packages/agent-gateway-client/src/index.ts
@@ -1,5 +1,7 @@
 export { AgentStreamClient } from './client';
 export type {
+  AgentInterventionRequestData,
+  AgentInterventionResponseData,
   AgentStreamClientEvents,
   AgentStreamClientOptions,
   AgentStreamEvent,

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -16,6 +16,23 @@ export type AgentStreamEventType =
    * wire union so consumers can pattern-match without casting.
    */
   | 'tool_result'
+  /**
+   * Producer needs structured input from the user mid-run (e.g. CC's
+   * AskUserQuestion delivered via a local MCP server). Distinct from
+   * `tool_execute` — that one means "client, please run this tool"; this
+   * one means "user, please answer these questions". Renderer surfaces a
+   * dedicated UI; the producer's MCP handler stays pending until the
+   * paired `agent_intervention_response` resolves it (or the deadline
+   * passes / the op is cancelled).
+   */
+  | 'agent_intervention_request'
+  /**
+   * The user's answer to a prior `agent_intervention_request`. Flows back
+   * to the producer (Electron main → MCP handler resolve, sandbox →
+   * server bus → CLI). Carries either a structured `result` or a
+   * cancellation marker.
+   */
+  | 'agent_intervention_response'
   | 'step_start'
   | 'step_complete'
   | 'error';
@@ -76,6 +93,39 @@ export interface StepCompleteData {
   phase: string;
   reason?: string;
   reasonDetail?: string;
+}
+
+/**
+ * Producer → consumer: structured-input request the user must answer
+ * directly (no tool execution involved). The producer's tool handler stays
+ * blocked until a matching `agent_intervention_response` (correlated by
+ * `toolCallId`) flows back, or the `deadline` is reached.
+ */
+export interface AgentInterventionRequestData {
+  /** Tool API name (e.g. `'askUserQuestion'`). */
+  apiName: string;
+  /** JSON-encoded payload the UI renders (e.g. `{ questions: [...] }`). */
+  arguments: string;
+  /** Unix-ms wall-clock at which the producer will give up waiting. */
+  deadline: number;
+  /** Tool plugin identifier (e.g. `'claude-code'`). */
+  identifier: string;
+  /** Correlation key. Stable for the lifetime of the intervention. */
+  toolCallId: string;
+}
+
+/**
+ * Consumer → producer: the user's answer to a prior intervention request.
+ * Either `result` (success) or `cancelled: true` (timeout / user cancel).
+ */
+export interface AgentInterventionResponseData {
+  /** Set when the user cancelled or the deadline elapsed. */
+  cancelled?: boolean;
+  /** When `cancelled`, optional reason for telemetry/logging. */
+  cancelReason?: 'timeout' | 'user_cancelled' | 'session_ended';
+  /** User-supplied answer (JSON-serializable). Absent when cancelled. */
+  result?: unknown;
+  toolCallId: string;
 }
 
 /**

--- a/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/AskUserQuestion.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type AskUserQuestionArgs, ClaudeCodeApiName } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    padding-block: 2px;
+    padding-inline: 10px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+}));
+
+export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuestionArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.AskUserQuestion as any);
+    const questions = args?.questions ?? partialArgs?.questions ?? [];
+    const summary =
+      questions.length === 0
+        ? undefined
+        : questions.length === 1
+          ? questions[0]?.header || questions[0]?.question
+          : `${questions[0]?.header || questions[0]?.question} +${questions.length - 1}`;
+
+    if (isArgumentsStreaming && !summary) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    return (
+      <div
+        className={cx(
+          inspectorTextStyles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <span>{label}</span>
+        {summary && <span className={styles.chip}>{summary}</span>}
+      </div>
+    );
+  },
+);
+
+AskUserQuestionInspector.displayName = 'ClaudeCodeAskUserQuestionInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
@@ -8,6 +8,7 @@ import {
 
 import { ClaudeCodeApiName } from '../../types';
 import { AgentInspector } from './Agent';
+import { AskUserQuestionInspector } from './AskUserQuestion';
 import { EditInspector } from './Edit';
 import { ReadInspector } from './Read';
 import { ScheduleWakeupInspector } from './ScheduleWakeup';
@@ -28,6 +29,7 @@ import { WriteInspector } from './Write';
 // state for diff stats), so they live in their own sibling files.
 export const ClaudeCodeInspectors = {
   [ClaudeCodeApiName.Agent]: AgentInspector,
+  [ClaudeCodeApiName.AskUserQuestion]: AskUserQuestionInspector,
   [ClaudeCodeApiName.Bash]: createRunCommandInspector(ClaudeCodeApiName.Bash),
   [ClaudeCodeApiName.Edit]: EditInspector,
   [ClaudeCodeApiName.Glob]: createGlobLocalFilesInspector(ClaudeCodeApiName.Glob),

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import type { BuiltinInterventionProps } from '@lobechat/types';
+import { Block, Button, CheckboxGroup, Flexbox, Select, Text } from '@lobehub/ui';
+import { Send, X } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { AskUserQuestionArgs, AskUserQuestionItem } from '../../types';
+
+/**
+ * Server-side bridge timeout (matches `AskUserMcpServer.pendingTimeoutMs`).
+ * Not strictly synchronized — server is authoritative — but keeps the on-screen
+ * countdown close to reality without plumbing a deadline through every layer.
+ */
+const COUNTDOWN_MS = 5 * 60 * 1000;
+
+const formatRemaining = (msLeft: number): string => {
+  const totalSec = Math.max(0, Math.floor(msLeft / 1000));
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${sec.toString().padStart(2, '0')}`;
+};
+
+const optionsForSelect = (q: AskUserQuestionItem) =>
+  q.options.map((opt) => ({
+    label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
+    value: opt.label,
+  }));
+
+/**
+ * CC AskUserQuestion intervention component.
+ *
+ * Pure form — `onInteractionAction` ({type:'submit'|'skip'|'cancel'}) is the
+ * only side effect. The framework's `handleInteractionAction` (or the hetero
+ * branch the chat conversation wires up) is responsible for marking
+ * `pluginIntervention.status` and forwarding the answer to CC over IPC.
+ *
+ * Renders one Select per question (multi-select uses CheckboxGroup) plus a
+ * countdown that ticks once a second. Submit stays disabled until every
+ * question has at least one answer; Skip is always enabled.
+ */
+const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestionArgs>>(
+  ({ args, onInteractionAction }) => {
+    const questions = args?.questions ?? [];
+
+    // Question text → selected label(s); single-select stores a string,
+    // multi-select stores a string[].
+    const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+    const [submitting, setSubmitting] = useState(false);
+
+    // Mounted-time deadline; server has its own clock and will return
+    // isError if it expires first. Drift of a few seconds is fine.
+    const deadline = useMemo(() => Date.now() + COUNTDOWN_MS, []);
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+      const id = setInterval(() => setNow(Date.now()), 1000);
+      return () => clearInterval(id);
+    }, []);
+    const expired = now >= deadline;
+
+    const handleSelect = useCallback((questionText: string, value: string | string[]) => {
+      setAnswers((prev) => ({ ...prev, [questionText]: value }));
+    }, []);
+
+    const handleSubmit = useCallback(async () => {
+      if (!onInteractionAction || submitting) return;
+      setSubmitting(true);
+      try {
+        await onInteractionAction({ payload: answers, type: 'submit' });
+      } catch (err) {
+        console.error('[AskUserQuestion] submit failed:', err);
+        setSubmitting(false);
+      }
+    }, [answers, onInteractionAction, submitting]);
+
+    const handleSkip = useCallback(async () => {
+      if (!onInteractionAction || submitting) return;
+      setSubmitting(true);
+      try {
+        await onInteractionAction({ type: 'skip' });
+      } catch (err) {
+        console.error('[AskUserQuestion] skip failed:', err);
+        setSubmitting(false);
+      }
+    }, [onInteractionAction, submitting]);
+
+    const allAnswered = useMemo(
+      () =>
+        questions.every((q) => {
+          const a = answers[q.question];
+          return q.multiSelect ? Array.isArray(a) && a.length > 0 : !!a;
+        }),
+      [answers, questions],
+    );
+
+    return (
+      <Block padding={16} variant="outlined" width="100%">
+        <Flexbox gap={16}>
+          {questions.map((q, qIdx) => (
+            <Flexbox gap={8} key={`${q.question}-${qIdx}`}>
+              <Flexbox horizontal align="center" justify="space-between">
+                <Text strong>{q.question}</Text>
+                {q.header && <Text type="secondary">{q.header}</Text>}
+              </Flexbox>
+
+              {q.multiSelect ? (
+                <CheckboxGroup
+                  disabled={expired || submitting}
+                  options={optionsForSelect(q)}
+                  value={(answers[q.question] as string[] | undefined) ?? []}
+                  onChange={(vals) => handleSelect(q.question, vals as string[])}
+                />
+              ) : (
+                <Select
+                  disabled={expired || submitting}
+                  options={optionsForSelect(q)}
+                  placeholder="Select an option"
+                  style={{ width: '100%' }}
+                  value={(answers[q.question] as string | undefined) ?? undefined}
+                  onChange={(val) => handleSelect(q.question, val as string)}
+                />
+              )}
+            </Flexbox>
+          ))}
+
+          <Flexbox horizontal align="center" gap={8} justify="space-between">
+            <Text fontSize={12} type="secondary">
+              {expired
+                ? 'Time expired — answer is no longer accepted.'
+                : `Time remaining: ${formatRemaining(deadline - now)}`}
+            </Text>
+            <Flexbox horizontal gap={8}>
+              <Button disabled={submitting} icon={X} size="small" onClick={handleSkip}>
+                Skip
+              </Button>
+              <Button
+                disabled={!allAnswered || expired || submitting}
+                icon={Send}
+                loading={submitting}
+                size="small"
+                type="primary"
+                onClick={handleSubmit}
+              >
+                Submit
+              </Button>
+            </Flexbox>
+          </Flexbox>
+        </Flexbox>
+      </Block>
+    );
+  },
+);
+
+AskUserQuestionIntervention.displayName = 'CCAskUserQuestionIntervention';
+
+export default AskUserQuestionIntervention;

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { BuiltinInterventionProps } from '@lobechat/types';
-import { Block, Button, CheckboxGroup, Flexbox, Select, Text } from '@lobehub/ui';
+import { Block, Button, Flexbox, Tag, Text } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
 import { Send, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -21,30 +22,135 @@ const formatRemaining = (msLeft: number): string => {
   return `${min}:${sec.toString().padStart(2, '0')}`;
 };
 
-const optionsForSelect = (q: AskUserQuestionItem) =>
-  q.options.map((opt) => ({
-    label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
-    value: opt.label,
-  }));
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  // Numbered option card. Outlined by default, primary tinted when selected.
+  // Hover gets a subtle fill so the card reads as clickable even before pick.
+  option: css`
+    cursor: pointer;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorder};
+    border-radius: 8px;
+
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: ${cssVar.colorFillQuaternary};
+    }
+  `,
+  optionDescription: css`
+    font-size: 12px;
+    line-height: 1.45;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  // 1/2/3/4 chip — small enough to sit alongside the label without crowding.
+  optionIndex: css`
+    flex-shrink: 0;
+
+    box-sizing: border-box;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 22px;
+    color: ${cssVar.colorTextSecondary};
+    text-align: center;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  optionIndexSelected: css`
+    color: ${cssVar.colorTextLightSolid};
+    background: ${cssVar.colorPrimary};
+  `,
+  optionLabel: css`
+    font-weight: 500;
+  `,
+  optionSelected: css`
+    border-color: ${cssVar.colorPrimary};
+    background: ${cssVar.colorPrimaryBg};
+
+    &:hover {
+      background: ${cssVar.colorPrimaryBgHover};
+    }
+  `,
+  // Visual gutter between consecutive questions; first question has no top
+  // margin/border so the form starts clean.
+  questionBlock: css`
+    &:not(:first-of-type) {
+      margin-block-start: 8px;
+      padding-block-start: 16px;
+      border-block-start: 1px dashed ${cssVar.colorBorderSecondary};
+    }
+  `,
+}));
+
+interface OptionCardProps {
+  description?: string;
+  disabled?: boolean;
+  index: number;
+  label: string;
+  onToggle: () => void;
+  selected: boolean;
+}
+
+/**
+ * One numbered option in a question. Whole card is the click target so the
+ * label, description, and number all act as one selectable unit. Selected
+ * state lights up with `colorPrimary` for both the index chip and the
+ * outline — gives the form a clear "you picked this" signal that survives
+ * keyboard / screen-reader enumeration as well as visual scan.
+ */
+const OptionCard = memo<OptionCardProps>(
+  ({ index, label, description, selected, disabled, onToggle }) => (
+    <Flexbox
+      horizontal
+      align="flex-start"
+      aria-selected={selected}
+      className={cx(styles.option, selected && styles.optionSelected)}
+      gap={12}
+      role="option"
+      onClick={() => {
+        if (!disabled) onToggle();
+      }}
+    >
+      <span className={cx(styles.optionIndex, selected && styles.optionIndexSelected)}>
+        {index}
+      </span>
+      <Flexbox flex={1} gap={2}>
+        <Text className={styles.optionLabel}>{label}</Text>
+        {description && <span className={styles.optionDescription}>{description}</span>}
+      </Flexbox>
+    </Flexbox>
+  ),
+);
+
+OptionCard.displayName = 'CCAskUserQuestionOption';
 
 /**
  * CC AskUserQuestion intervention component.
  *
- * Pure form — `onInteractionAction` ({type:'submit'|'skip'|'cancel'}) is the
- * only side effect. The framework's `handleInteractionAction` (or the hetero
+ * Pure form — `onInteractionAction` ({type:'submit'|'skip'}) is the only
+ * side effect. The framework's `handleInteractionAction` (or the hetero
  * branch the chat conversation wires up) is responsible for marking
  * `pluginIntervention.status` and forwarding the answer to CC over IPC.
  *
- * Renders one Select per question (multi-select uses CheckboxGroup) plus a
- * countdown that ticks once a second. Submit stays disabled until every
- * question has at least one answer; Skip is always enabled.
+ * Each question renders as a stack of numbered option cards (1/2/3/4 — CC
+ * caps options at 4). Multi-select questions accept any subset; single-
+ * select replaces. Multiple questions are stacked with a dashed divider
+ * and a `Q1/N` tag so the user always knows where they are. Submit stays
+ * disabled until every question has at least one pick; Skip is always on.
  */
 const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestionArgs>>(
   ({ args, onInteractionAction }) => {
     const questions = args?.questions ?? [];
 
     // Question text → selected label(s); single-select stores a string,
-    // multi-select stores a string[].
+    // multi-select stores a string[]. Question text is unique per call by
+    // CC's contract, so it's safe to use as the dictionary key.
     const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
     const [submitting, setSubmitting] = useState(false);
 
@@ -58,8 +164,26 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
     }, []);
     const expired = now >= deadline;
 
-    const handleSelect = useCallback((questionText: string, value: string | string[]) => {
-      setAnswers((prev) => ({ ...prev, [questionText]: value }));
+    const isOptionSelected = useCallback(
+      (q: AskUserQuestionItem, label: string): boolean => {
+        const a = answers[q.question];
+        if (q.multiSelect) return Array.isArray(a) && a.includes(label);
+        return a === label;
+      },
+      [answers],
+    );
+
+    const handleToggle = useCallback((q: AskUserQuestionItem, label: string) => {
+      setAnswers((prev) => {
+        if (q.multiSelect) {
+          const current = (prev[q.question] as string[] | undefined) ?? [];
+          const next = current.includes(label)
+            ? current.filter((x) => x !== label)
+            : [...current, label];
+          return { ...prev, [q.question]: next };
+        }
+        return { ...prev, [q.question]: label };
+      });
     }, []);
 
     const handleSubmit = useCallback(async () => {
@@ -97,29 +221,35 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
       <Block padding={16} variant="outlined" width="100%">
         <Flexbox gap={16}>
           {questions.map((q, qIdx) => (
-            <Flexbox gap={8} key={`${q.question}-${qIdx}`}>
-              <Flexbox horizontal align="center" justify="space-between">
-                <Text strong>{q.question}</Text>
+            <Flexbox className={styles.questionBlock} gap={10} key={`${q.question}-${qIdx}`}>
+              <Flexbox horizontal align="center" gap={8}>
+                {questions.length > 1 && (
+                  <Tag bordered={false}>
+                    Q{qIdx + 1}/{questions.length}
+                  </Tag>
+                )}
                 {q.header && <Text type="secondary">{q.header}</Text>}
+                {q.multiSelect && (
+                  <Text fontSize={12} type="secondary">
+                    (multi-select)
+                  </Text>
+                )}
               </Flexbox>
+              <Text strong>{q.question}</Text>
 
-              {q.multiSelect ? (
-                <CheckboxGroup
-                  disabled={expired || submitting}
-                  options={optionsForSelect(q)}
-                  value={(answers[q.question] as string[] | undefined) ?? []}
-                  onChange={(vals) => handleSelect(q.question, vals as string[])}
-                />
-              ) : (
-                <Select
-                  disabled={expired || submitting}
-                  options={optionsForSelect(q)}
-                  placeholder="Select an option"
-                  style={{ width: '100%' }}
-                  value={(answers[q.question] as string | undefined) ?? undefined}
-                  onChange={(val) => handleSelect(q.question, val as string)}
-                />
-              )}
+              <Flexbox gap={6} role="listbox">
+                {q.options.map((opt, optIdx) => (
+                  <OptionCard
+                    description={opt.description}
+                    disabled={expired || submitting}
+                    index={optIdx + 1}
+                    key={opt.label}
+                    label={opt.label}
+                    selected={isOptionSelected(q, opt.label)}
+                    onToggle={() => handleToggle(q, opt.label)}
+                  />
+                ))}
+              </Flexbox>
             </Flexbox>
           ))}
 

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import type { BuiltinInterventionProps } from '@lobechat/types';
-import { Block, Button, Flexbox, Tag, Text } from '@lobehub/ui';
+import { Button, Flexbox, Icon, Tabs, Text } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
-import { Send, X } from 'lucide-react';
+import { Check, Send, X } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useConversationStore } from '@/features/Conversation/store';
+import { dataSelectors } from '@/features/Conversation/store/slices/data/selectors';
+import { useChatStore } from '@/store/chat';
 
 import type { AskUserQuestionArgs, AskUserQuestionItem } from '../../types';
 
@@ -15,6 +19,9 @@ import type { AskUserQuestionArgs, AskUserQuestionItem } from '../../types';
  */
 const COUNTDOWN_MS = 5 * 60 * 1000;
 
+/** Key under tool message `pluginState` where in-progress draft answers live. */
+const DRAFT_PLUGIN_STATE_KEY = 'askUserDraft';
+
 const formatRemaining = (msLeft: number): string => {
   const totalSec = Math.max(0, Math.floor(msLeft / 1000));
   const min = Math.floor(totalSec / 60);
@@ -23,28 +30,33 @@ const formatRemaining = (msLeft: number): string => {
 };
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  // Numbered option card. Outlined by default, primary tinted when selected.
-  // Hover gets a subtle fill so the card reads as clickable even before pick.
+  // Card sits inline with the chat — no surrounding panel chrome. Hover
+  // tints the row so the stack reads as clickable; selection swaps to a
+  // filled `colorPrimaryBg` so the pick is visually weighty.
   option: css`
     cursor: pointer;
 
     padding-block: 10px;
     padding-inline: 12px;
-    border: 1px solid ${cssVar.colorBorder};
     border-radius: 8px;
 
-    transition: all 0.15s ease;
+    transition: background 0.12s ease;
 
     &:hover {
       background: ${cssVar.colorFillQuaternary};
     }
+  `,
+  optionCheck: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorPrimary};
   `,
   optionDescription: css`
     font-size: 12px;
     line-height: 1.45;
     color: ${cssVar.colorTextSecondary};
   `,
-  // 1/2/3/4 chip — small enough to sit alongside the label without crowding.
+  // Neutral 1/2/3/4 chip — stays the same colour whether selected or not so
+  // the selection signal lives on the filled background + checkmark.
   optionIndex: css`
     flex-shrink: 0;
 
@@ -62,28 +74,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorFillTertiary};
   `,
-  optionIndexSelected: css`
-    color: ${cssVar.colorTextLightSolid};
-    background: ${cssVar.colorPrimary};
-  `,
   optionLabel: css`
     font-weight: 500;
   `,
   optionSelected: css`
-    border-color: ${cssVar.colorPrimary};
     background: ${cssVar.colorPrimaryBg};
 
     &:hover {
       background: ${cssVar.colorPrimaryBgHover};
-    }
-  `,
-  // Visual gutter between consecutive questions; first question has no top
-  // margin/border so the form starts clean.
-  questionBlock: css`
-    &:not(:first-of-type) {
-      margin-block-start: 8px;
-      padding-block-start: 16px;
-      border-block-start: 1px dashed ${cssVar.colorBorderSecondary};
     }
   `,
 }));
@@ -98,17 +96,15 @@ interface OptionCardProps {
 }
 
 /**
- * One numbered option in a question. Whole card is the click target so the
- * label, description, and number all act as one selectable unit. Selected
- * state lights up with `colorPrimary` for both the index chip and the
- * outline — gives the form a clear "you picked this" signal that survives
- * keyboard / screen-reader enumeration as well as visual scan.
+ * One numbered option in a question. Outlined when picked, neutral otherwise;
+ * a right-side checkmark seals the selection so the state reads cleanly even
+ * with the number chip kept neutral.
  */
 const OptionCard = memo<OptionCardProps>(
   ({ index, label, description, selected, disabled, onToggle }) => (
     <Flexbox
       horizontal
-      align="flex-start"
+      align="center"
       aria-selected={selected}
       className={cx(styles.option, selected && styles.optionSelected)}
       gap={12}
@@ -117,42 +113,109 @@ const OptionCard = memo<OptionCardProps>(
         if (!disabled) onToggle();
       }}
     >
-      <span className={cx(styles.optionIndex, selected && styles.optionIndexSelected)}>
-        {index}
-      </span>
+      <span className={styles.optionIndex}>{index}</span>
       <Flexbox flex={1} gap={2}>
         <Text className={styles.optionLabel}>{label}</Text>
         {description && <span className={styles.optionDescription}>{description}</span>}
       </Flexbox>
+      {selected && <Icon className={styles.optionCheck} icon={Check} size={16} />}
     </Flexbox>
   ),
 );
 
 OptionCard.displayName = 'CCAskUserQuestionOption';
 
+interface QuestionPanelProps {
+  answer: string | string[] | undefined;
+  disabled: boolean;
+  onToggle: (q: AskUserQuestionItem, label: string) => void;
+  question: AskUserQuestionItem;
+}
+
+const QuestionPanel = memo<QuestionPanelProps>(({ question, answer, disabled, onToggle }) => {
+  const isOptionSelected = (label: string): boolean =>
+    question.multiSelect ? Array.isArray(answer) && answer.includes(label) : answer === label;
+
+  return (
+    <Flexbox gap={10}>
+      <Flexbox horizontal align="center" gap={8}>
+        {question.header && <Text type="secondary">{question.header}</Text>}
+        {question.multiSelect && (
+          <Text fontSize={12} type="secondary">
+            (multi-select)
+          </Text>
+        )}
+      </Flexbox>
+      <Text strong>{question.question}</Text>
+
+      <Flexbox gap={4} role="listbox">
+        {question.options.map((opt, optIdx) => (
+          <OptionCard
+            description={opt.description}
+            disabled={disabled}
+            index={optIdx + 1}
+            key={opt.label}
+            label={opt.label}
+            selected={isOptionSelected(opt.label)}
+            onToggle={() => onToggle(question, opt.label)}
+          />
+        ))}
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+QuestionPanel.displayName = 'CCAskUserQuestionPanel';
+
 /**
  * CC AskUserQuestion intervention component.
  *
  * Pure form — `onInteractionAction` ({type:'submit'|'skip'}) is the only
- * side effect. The framework's `handleInteractionAction` (or the hetero
- * branch the chat conversation wires up) is responsible for marking
+ * outbound side effect. The framework's `handleInteractionAction` (or the
+ * hetero branch the chat conversation wires up) is responsible for marking
  * `pluginIntervention.status` and forwarding the answer to CC over IPC.
  *
- * Each question renders as a stack of numbered option cards (1/2/3/4 — CC
- * caps options at 4). Multi-select questions accept any subset; single-
- * select replaces. Multiple questions are stacked with a dashed divider
- * and a `Q1/N` tag so the user always knows where they are. Submit stays
- * disabled until every question has at least one pick; Skip is always on.
+ * Layout
+ * - One question → renders the question + options directly, no tab strip.
+ * - Multiple questions → top tab bar (Q1, Q2, …), one panel visible at a
+ *   time. Picking an answer auto-advances to the next unanswered question
+ *   so the user sweeps through without re-clicking the tabs.
+ *
+ * Draft persistence
+ * - Per-message state lives on the tool message's `pluginState.askUserDraft`
+ *   (see `setInterventionDraft` in the chat store). HMR reloads, store
+ *   re-mounts, and tab switches all keep the partial answers around — only
+ *   a fresh `tool_use` (different toolCallId / messageId) starts blank.
  */
 const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestionArgs>>(
-  ({ args, onInteractionAction }) => {
+  ({ args, messageId, onInteractionAction }) => {
     const questions = args?.questions ?? [];
 
-    // Question text → selected label(s); single-select stores a string,
-    // multi-select stores a string[]. Question text is unique per call by
-    // CC's contract, so it's safe to use as the dictionary key.
-    const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+    // Persisted draft (survives unmount / HMR / refresh) — read from the tool
+    // message's pluginState so the form stays where the user left it.
+    const persistedDraft = useConversationStore((s) => {
+      const msg = dataSelectors.getDbMessageById(messageId)(s);
+      return (
+        msg?.pluginState as { [DRAFT_PLUGIN_STATE_KEY]?: Record<string, string | string[]> }
+      )?.[DRAFT_PLUGIN_STATE_KEY];
+    });
+    const setInterventionDraft = useChatStore((s) => s.setInterventionDraft);
+
+    const [answers, setAnswers] = useState<Record<string, string | string[]>>(
+      () => persistedDraft ?? {},
+    );
     const [submitting, setSubmitting] = useState(false);
+    const [activeTab, setActiveTab] = useState<string>(() => {
+      // Resume on the first unanswered question so coming back lands the user
+      // where they left off rather than always at Q1.
+      const initial = persistedDraft ?? {};
+      const firstUnanswered = questions.findIndex((q) => {
+        const a = initial[q.question];
+        return q.multiSelect ? !Array.isArray(a) || a.length === 0 : !a;
+      });
+      const idx = firstUnanswered >= 0 ? firstUnanswered : 0;
+      return String(idx);
+    });
 
     // Mounted-time deadline; server has its own clock and will return
     // isError if it expires first. Drift of a few seconds is fine.
@@ -164,38 +227,60 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
     }, []);
     const expired = now >= deadline;
 
-    const isOptionSelected = useCallback(
-      (q: AskUserQuestionItem, label: string): boolean => {
-        const a = answers[q.question];
-        if (q.multiSelect) return Array.isArray(a) && a.includes(label);
-        return a === label;
+    const handleToggle = useCallback(
+      (q: AskUserQuestionItem, label: string) => {
+        setAnswers((prev) => {
+          let next: Record<string, string | string[]>;
+          if (q.multiSelect) {
+            const current = (prev[q.question] as string[] | undefined) ?? [];
+            const updated = current.includes(label)
+              ? current.filter((x) => x !== label)
+              : [...current, label];
+            next = { ...prev, [q.question]: updated };
+          } else {
+            next = { ...prev, [q.question]: label };
+          }
+          // Persist to pluginState so the picks survive remount / refresh.
+          setInterventionDraft(messageId, next);
+
+          // Single-select auto-advance: if there's a next unanswered question,
+          // jump to it. Multi-select stays on the same panel so the user can
+          // toggle additional options.
+          if (!q.multiSelect && questions.length > 1) {
+            const nextUnanswered = questions.findIndex((qq, idx) => {
+              if (qq.question === q.question) return false;
+              const a = next[qq.question];
+              if (idx < 0) return false;
+              return qq.multiSelect ? !Array.isArray(a) || a.length === 0 : !a;
+            });
+            if (nextUnanswered >= 0) setActiveTab(String(nextUnanswered));
+          }
+          return next;
+        });
       },
-      [answers],
+      [messageId, questions, setInterventionDraft],
     );
 
-    const handleToggle = useCallback((q: AskUserQuestionItem, label: string) => {
-      setAnswers((prev) => {
-        if (q.multiSelect) {
-          const current = (prev[q.question] as string[] | undefined) ?? [];
-          const next = current.includes(label)
-            ? current.filter((x) => x !== label)
-            : [...current, label];
-          return { ...prev, [q.question]: next };
+    /**
+     * Submit `payload` exactly as given. Used by both the explicit "Submit"
+     * button (with whatever the user picked) and the timeout fallback (with
+     * option 1 of each unanswered question merged in).
+     */
+    const submitWith = useCallback(
+      async (payload: Record<string, string | string[]>) => {
+        if (!onInteractionAction || submitting) return;
+        setSubmitting(true);
+        try {
+          await onInteractionAction({ payload, type: 'submit' });
+        } catch (err) {
+          console.error('[AskUserQuestion] submit failed:', err);
+          setSubmitting(false);
         }
-        return { ...prev, [q.question]: label };
-      });
-    }, []);
+      },
+      [onInteractionAction, submitting],
+    );
 
-    const handleSubmit = useCallback(async () => {
-      if (!onInteractionAction || submitting) return;
-      setSubmitting(true);
-      try {
-        await onInteractionAction({ payload: answers, type: 'submit' });
-      } catch (err) {
-        console.error('[AskUserQuestion] submit failed:', err);
-        setSubmitting(false);
-      }
-    }, [answers, onInteractionAction, submitting]);
+    const handleSubmit = useCallback(() => submitWith(answers), [answers, submitWith]);
 
     const handleSkip = useCallback(async () => {
       if (!onInteractionAction || submitting) return;
@@ -217,66 +302,83 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
       [answers, questions],
     );
 
+    // Timeout fallback: when the countdown hits zero and the user hasn't
+    // submitted, fill in option 1 of each unanswered question and submit.
+    // Beats letting the server-side bridge time out into a `cancelled`
+    // result — the model gets a structured answer it can act on instead of
+    // a "user didn't respond" isError. Single-shot via `submitting` guard.
+    useEffect(() => {
+      if (!expired || submitting || questions.length === 0) return;
+      const fallback: Record<string, string | string[]> = { ...answers };
+      for (const q of questions) {
+        const a = fallback[q.question];
+        const unanswered = q.multiSelect ? !Array.isArray(a) || a.length === 0 : !a;
+        if (unanswered && q.options.length > 0) {
+          const first = q.options[0].label;
+          fallback[q.question] = q.multiSelect ? [first] : first;
+        }
+      }
+      void submitWith(fallback);
+    }, [expired, submitting, questions, answers, submitWith]);
+
+    const isMulti = questions.length > 1;
+    const activeQuestion = questions[Number(activeTab)] ?? questions[0];
+
     return (
-      <Block padding={16} variant="outlined" width="100%">
-        <Flexbox gap={16}>
-          {questions.map((q, qIdx) => (
-            <Flexbox className={styles.questionBlock} gap={10} key={`${q.question}-${qIdx}`}>
-              <Flexbox horizontal align="center" gap={8}>
-                {questions.length > 1 && (
-                  <Tag bordered={false}>
-                    Q{qIdx + 1}/{questions.length}
-                  </Tag>
-                )}
-                {q.header && <Text type="secondary">{q.header}</Text>}
-                {q.multiSelect && (
-                  <Text fontSize={12} type="secondary">
-                    (multi-select)
-                  </Text>
-                )}
-              </Flexbox>
-              <Text strong>{q.question}</Text>
+      <Flexbox gap={12}>
+        {isMulti && (
+          <Tabs
+            compact
+            activeKey={activeTab}
+            items={questions.map((q, idx) => {
+              const a = answers[q.question];
+              const done = q.multiSelect ? Array.isArray(a) && a.length > 0 : !!a;
+              return {
+                key: String(idx),
+                label: (
+                  <Flexbox horizontal align="center" gap={6}>
+                    <Text>Q{idx + 1}</Text>
+                    {done && <Icon icon={Check} size={12} />}
+                  </Flexbox>
+                ),
+              };
+            })}
+            onChange={(key) => setActiveTab(key as string)}
+          />
+        )}
 
-              <Flexbox gap={6} role="listbox">
-                {q.options.map((opt, optIdx) => (
-                  <OptionCard
-                    description={opt.description}
-                    disabled={expired || submitting}
-                    index={optIdx + 1}
-                    key={opt.label}
-                    label={opt.label}
-                    selected={isOptionSelected(q, opt.label)}
-                    onToggle={() => handleToggle(q, opt.label)}
-                  />
-                ))}
-              </Flexbox>
-            </Flexbox>
-          ))}
+        {activeQuestion && (
+          <QuestionPanel
+            answer={answers[activeQuestion.question]}
+            disabled={expired || submitting}
+            question={activeQuestion}
+            onToggle={handleToggle}
+          />
+        )}
 
-          <Flexbox horizontal align="center" gap={8} justify="space-between">
-            <Text fontSize={12} type="secondary">
-              {expired
-                ? 'Time expired — answer is no longer accepted.'
-                : `Time remaining: ${formatRemaining(deadline - now)}`}
-            </Text>
-            <Flexbox horizontal gap={8}>
-              <Button disabled={submitting} icon={X} size="small" onClick={handleSkip}>
-                Skip
-              </Button>
-              <Button
-                disabled={!allAnswered || expired || submitting}
-                icon={Send}
-                loading={submitting}
-                size="small"
-                type="primary"
-                onClick={handleSubmit}
-              >
-                Submit
-              </Button>
-            </Flexbox>
+        <Flexbox horizontal align="center" gap={8} justify="space-between">
+          <Text fontSize={12} type="secondary">
+            {expired
+              ? 'Time expired — using option 1 of each question.'
+              : `Time remaining: ${formatRemaining(deadline - now)} · ` +
+                'unanswered questions default to option 1 on timeout.'}
+          </Text>
+          <Flexbox horizontal gap={8}>
+            <Button disabled={submitting} icon={X} onClick={handleSkip}>
+              Skip
+            </Button>
+            <Button
+              disabled={!allAnswered || expired || submitting}
+              icon={Send}
+              loading={submitting}
+              type="primary"
+              onClick={handleSubmit}
+            >
+              Submit
+            </Button>
           </Flexbox>
         </Flexbox>
-      </Block>
+      </Flexbox>
     );
   },
 );

--- a/packages/builtin-tool-claude-code/src/client/Intervention/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/index.ts
@@ -1,0 +1,14 @@
+import type { BuiltinIntervention } from '@lobechat/types';
+
+import { ClaudeCodeApiName } from '../../types';
+import AskUserQuestionIntervention from './AskUserQuestion';
+
+/**
+ * Claude Code Intervention components.
+ *
+ * Currently only `askUserQuestion` (CC's clarifying-question MCP tool) needs
+ * one. Approval / file-picker etc. would slot in alongside.
+ */
+export const ClaudeCodeInterventions: Record<string, BuiltinIntervention> = {
+  [ClaudeCodeApiName.AskUserQuestion]: AskUserQuestionIntervention as BuiltinIntervention,
+};

--- a/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
@@ -1,10 +1,98 @@
 'use client';
 
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { Check } from 'lucide-react';
 import { memo } from 'react';
 
-import type { AskUserQuestionArgs } from '../../../types';
+import type { AskUserQuestionArgs, AskUserQuestionItem } from '../../../types';
+
+/** Persisted draft + answer shape stored on `pluginState`. */
+interface AskUserQuestionState {
+  askUserAnswers?: Record<string, string | string[]>;
+  askUserDraft?: Record<string, string | string[]>;
+}
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  answer: css`
+    color: ${cssVar.colorText};
+  `,
+  answerRow: css`
+    padding-block: 6px;
+    padding-inline: 10px;
+    border-radius: 6px;
+    background: ${cssVar.colorBgContainer};
+  `,
+  check: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorPrimary};
+  `,
+  container: css`
+    padding: 12px;
+    border-radius: ${cssVar.borderRadiusLG};
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  header: css`
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  question: css`
+    font-weight: 500;
+  `,
+}));
+
+interface QABlockProps {
+  answer?: string | string[];
+  question: AskUserQuestionItem;
+}
+
+/**
+ * One question/answer pair for the completed Render. The original question
+ * stays visible (header + body); the answer renders as one card per picked
+ * option (multi-select fans out into multiple rows). When `answer` is
+ * absent — older messages persisted before LOBE-8725 added structured
+ * storage — we show a `—` placeholder so the layout stays uniform.
+ */
+const QABlock = memo<QABlockProps>(({ question, answer }) => {
+  const labels: string[] = Array.isArray(answer) ? answer : answer ? [answer] : [];
+  const optionByLabel = new Map(question.options.map((o) => [o.label, o]));
+
+  return (
+    <Flexbox gap={6}>
+      {question.header && <span className={styles.header}>{question.header}</span>}
+      <Text className={styles.question}>{question.question}</Text>
+      {labels.length > 0 ? (
+        <Flexbox gap={4}>
+          {labels.map((label) => {
+            const opt = optionByLabel.get(label);
+            return (
+              <Flexbox
+                horizontal
+                align="center"
+                className={cx(styles.answerRow)}
+                gap={8}
+                key={label}
+              >
+                <Icon className={styles.check} icon={Check} size={14} />
+                <Flexbox flex={1} gap={2}>
+                  <Text className={styles.answer}>{label}</Text>
+                  {opt?.description && opt.description !== label && (
+                    <span className={styles.header}>{opt.description}</span>
+                  )}
+                </Flexbox>
+              </Flexbox>
+            );
+          })}
+        </Flexbox>
+      ) : (
+        <Text type="secondary">—</Text>
+      )}
+    </Flexbox>
+  );
+});
+
+QABlock.displayName = 'CCAskUserQuestionQABlock';
 
 /**
  * CC `askUserQuestion` Render — answered / aborted state only.
@@ -12,30 +100,31 @@ import type { AskUserQuestionArgs } from '../../../types';
  * The pending form lives on the canonical Intervention surface
  * (`BuiltinToolInterventions['claude-code']['askUserQuestion']`) — the
  * framework hides this Render while `pluginIntervention.status === 'pending'`,
- * then yields to it once the user submits / skips and a `tool_result` arrives
- * with the formatted answer text in `content`.
+ * then yields to it once the user submits / skips and a `tool_result` arrives.
+ *
+ * Structured rendering reads `pluginState.askUserAnswers`, written by
+ * `setInterventionAnswers` in `conversationControl` at submit time. If the
+ * key is missing (older messages, or skipped/cancelled flows where there's
+ * nothing to show), we fall back to the question list with a status hint.
  */
-const AskUserQuestion = memo<BuiltinRenderProps<AskUserQuestionArgs, unknown, unknown>>(
-  ({ args, content, pluginError }) => {
-    const text = typeof content === 'string' ? content : '';
-    const isError = !!pluginError;
-    return (
-      <Block padding={12} variant="outlined" width="100%">
-        <Flexbox gap={8}>
-          {(args?.questions ?? []).map((q, idx) => (
-            <Text key={idx} type="secondary">
-              {q.question}
-            </Text>
-          ))}
-          {text && <Text>{text}</Text>}
-          {isError && (
-            <Text type="warning">(No answer received — model continued without their input.)</Text>
-          )}
-        </Flexbox>
-      </Block>
-    );
-  },
-);
+const AskUserQuestion = memo<
+  BuiltinRenderProps<AskUserQuestionArgs, AskUserQuestionState, unknown>
+>(({ args, pluginError, pluginState }) => {
+  const questions = args?.questions ?? [];
+  const answers = pluginState?.askUserAnswers;
+  const isError = !!pluginError;
+
+  return (
+    <Flexbox className={styles.container} gap={12}>
+      {questions.map((q, idx) => (
+        <QABlock answer={answers?.[q.question]} key={`${q.question}-${idx}`} question={q} />
+      ))}
+      {isError && (
+        <Text type="warning">(No answer received — model continued without their input.)</Text>
+      )}
+    </Flexbox>
+  );
+});
 
 AskUserQuestion.displayName = 'CCAskUserQuestion';
 

--- a/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import type { BuiltinRenderProps } from '@lobechat/types';
+import { Block, Button, CheckboxGroup, Flexbox, Select, Text } from '@lobehub/ui';
+import { Send, X } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgent';
+import { useChatStore } from '@/store/chat';
+
+import type {
+  AskUserQuestionArgs,
+  AskUserQuestionItem,
+  AskUserQuestionPluginState,
+} from '../../../types';
+
+interface AskUserQuestionState {
+  askUserQuestion?: AskUserQuestionPluginState;
+}
+
+const formatRemaining = (deadlineMs: number, nowMs: number): string => {
+  const remainingMs = Math.max(0, deadlineMs - nowMs);
+  const totalSec = Math.floor(remainingMs / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${sec.toString().padStart(2, '0')}`;
+};
+
+const optionsForSelect = (q: AskUserQuestionItem) =>
+  q.options.map((opt) => ({
+    label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
+    value: opt.label,
+  }));
+
+interface PendingFormProps {
+  deadline: number;
+  messageId: string;
+  questions: AskUserQuestionItem[];
+  toolCallId: string;
+}
+
+const PendingForm = memo<PendingFormProps>(({ questions, deadline, toolCallId, messageId }) => {
+  // question text → selected label(s); single-select stores a string,
+  // multi-select stores a string[].
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Tick every second so the countdown updates.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const operationId = useChatStore((s) => s.messageOperationMap?.[messageId]);
+  const expired = now >= deadline;
+
+  const handleSelect = useCallback((questionText: string, value: string | string[]) => {
+    setAnswers((prev) => ({ ...prev, [questionText]: value }));
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!operationId || submitting) return;
+    setSubmitting(true);
+    try {
+      await heterogeneousAgentService.submitIntervention({
+        operationId,
+        result: answers,
+        toolCallId,
+      });
+    } catch (err) {
+      console.error('[AskUserQuestion] submit failed:', err);
+      setSubmitting(false);
+    }
+  }, [answers, operationId, submitting, toolCallId]);
+
+  const handleCancel = useCallback(async () => {
+    if (!operationId || submitting) return;
+    setSubmitting(true);
+    try {
+      await heterogeneousAgentService.submitIntervention({
+        cancelReason: 'user_cancelled',
+        cancelled: true,
+        operationId,
+        toolCallId,
+      });
+    } catch (err) {
+      console.error('[AskUserQuestion] cancel failed:', err);
+      setSubmitting(false);
+    }
+  }, [operationId, submitting, toolCallId]);
+
+  const allAnswered = useMemo(
+    () =>
+      questions.every((q) => {
+        const a = answers[q.question];
+        return q.multiSelect ? Array.isArray(a) && a.length > 0 : !!a;
+      }),
+    [answers, questions],
+  );
+
+  return (
+    <Block padding={16} variant="outlined" width="100%">
+      <Flexbox gap={16}>
+        {questions.map((q, qIdx) => (
+          <Flexbox gap={8} key={`${q.question}-${qIdx}`}>
+            <Flexbox horizontal align="center" justify="space-between">
+              <Text strong>{q.question}</Text>
+              {q.header && <Text type="secondary">{q.header}</Text>}
+            </Flexbox>
+
+            {q.multiSelect ? (
+              <CheckboxGroup
+                disabled={expired || submitting}
+                options={optionsForSelect(q)}
+                value={(answers[q.question] as string[] | undefined) ?? []}
+                onChange={(vals) => handleSelect(q.question, vals as string[])}
+              />
+            ) : (
+              <Select
+                disabled={expired || submitting}
+                options={optionsForSelect(q)}
+                placeholder="Select an option"
+                style={{ width: '100%' }}
+                value={(answers[q.question] as string | undefined) ?? undefined}
+                onChange={(val) => handleSelect(q.question, val as string)}
+              />
+            )}
+          </Flexbox>
+        ))}
+
+        <Flexbox horizontal align="center" gap={8} justify="space-between">
+          <Text fontSize={12} type="secondary">
+            {expired
+              ? 'Time expired — answer is no longer accepted.'
+              : `Time remaining: ${formatRemaining(deadline, now)}`}
+          </Text>
+          <Flexbox horizontal gap={8}>
+            <Button disabled={submitting} icon={X} size="small" onClick={handleCancel}>
+              Skip
+            </Button>
+            <Button
+              disabled={!allAnswered || expired || submitting || !operationId}
+              icon={Send}
+              loading={submitting}
+              size="small"
+              type="primary"
+              onClick={handleSubmit}
+            >
+              Submit
+            </Button>
+          </Flexbox>
+        </Flexbox>
+      </Flexbox>
+    </Block>
+  );
+});
+
+PendingForm.displayName = 'CCAskUserQuestionPendingForm';
+
+const AnsweredView = memo<{
+  args: AskUserQuestionArgs;
+  content?: unknown;
+  isError: boolean;
+}>(({ args, content, isError }) => {
+  const text = typeof content === 'string' ? content : '';
+  return (
+    <Block padding={12} variant="outlined" width="100%">
+      <Flexbox gap={8}>
+        {(args?.questions ?? []).map((q, idx) => (
+          <Text key={idx} type="secondary">
+            {q.question}
+          </Text>
+        ))}
+        {text && <Text>{text}</Text>}
+        {isError && (
+          <Text type="warning">
+            (User did not answer — model will continue without their input.)
+          </Text>
+        )}
+      </Flexbox>
+    </Block>
+  );
+});
+
+AnsweredView.displayName = 'CCAskUserQuestionAnsweredView';
+
+const AskUserQuestion = memo<
+  BuiltinRenderProps<AskUserQuestionArgs, AskUserQuestionState, unknown>
+>(({ args, content, messageId, pluginError, pluginState }) => {
+  const intervention = pluginState?.askUserQuestion;
+  if (intervention?.status === 'pending') {
+    return (
+      <PendingForm
+        deadline={intervention.deadline}
+        messageId={messageId}
+        questions={intervention.questions ?? args?.questions ?? []}
+        toolCallId={intervention.toolCallId}
+      />
+    );
+  }
+  return <AnsweredView args={args} content={content} isError={!!pluginError} />;
+});
+
+AskUserQuestion.displayName = 'CCAskUserQuestion';
+
+export default AskUserQuestion;

--- a/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/AskUserQuestion/index.tsx
@@ -1,206 +1,41 @@
 'use client';
 
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { Block, Button, CheckboxGroup, Flexbox, Select, Text } from '@lobehub/ui';
-import { Send, X } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Block, Flexbox, Text } from '@lobehub/ui';
+import { memo } from 'react';
 
-import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgent';
-import { useChatStore } from '@/store/chat';
+import type { AskUserQuestionArgs } from '../../../types';
 
-import type {
-  AskUserQuestionArgs,
-  AskUserQuestionItem,
-  AskUserQuestionPluginState,
-} from '../../../types';
-
-interface AskUserQuestionState {
-  askUserQuestion?: AskUserQuestionPluginState;
-}
-
-const formatRemaining = (deadlineMs: number, nowMs: number): string => {
-  const remainingMs = Math.max(0, deadlineMs - nowMs);
-  const totalSec = Math.floor(remainingMs / 1000);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  return `${min}:${sec.toString().padStart(2, '0')}`;
-};
-
-const optionsForSelect = (q: AskUserQuestionItem) =>
-  q.options.map((opt) => ({
-    label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
-    value: opt.label,
-  }));
-
-interface PendingFormProps {
-  deadline: number;
-  messageId: string;
-  questions: AskUserQuestionItem[];
-  toolCallId: string;
-}
-
-const PendingForm = memo<PendingFormProps>(({ questions, deadline, toolCallId, messageId }) => {
-  // question text → selected label(s); single-select stores a string,
-  // multi-select stores a string[].
-  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [now, setNow] = useState(() => Date.now());
-
-  // Tick every second so the countdown updates.
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  const operationId = useChatStore((s) => s.messageOperationMap?.[messageId]);
-  const expired = now >= deadline;
-
-  const handleSelect = useCallback((questionText: string, value: string | string[]) => {
-    setAnswers((prev) => ({ ...prev, [questionText]: value }));
-  }, []);
-
-  const handleSubmit = useCallback(async () => {
-    if (!operationId || submitting) return;
-    setSubmitting(true);
-    try {
-      await heterogeneousAgentService.submitIntervention({
-        operationId,
-        result: answers,
-        toolCallId,
-      });
-    } catch (err) {
-      console.error('[AskUserQuestion] submit failed:', err);
-      setSubmitting(false);
-    }
-  }, [answers, operationId, submitting, toolCallId]);
-
-  const handleCancel = useCallback(async () => {
-    if (!operationId || submitting) return;
-    setSubmitting(true);
-    try {
-      await heterogeneousAgentService.submitIntervention({
-        cancelReason: 'user_cancelled',
-        cancelled: true,
-        operationId,
-        toolCallId,
-      });
-    } catch (err) {
-      console.error('[AskUserQuestion] cancel failed:', err);
-      setSubmitting(false);
-    }
-  }, [operationId, submitting, toolCallId]);
-
-  const allAnswered = useMemo(
-    () =>
-      questions.every((q) => {
-        const a = answers[q.question];
-        return q.multiSelect ? Array.isArray(a) && a.length > 0 : !!a;
-      }),
-    [answers, questions],
-  );
-
-  return (
-    <Block padding={16} variant="outlined" width="100%">
-      <Flexbox gap={16}>
-        {questions.map((q, qIdx) => (
-          <Flexbox gap={8} key={`${q.question}-${qIdx}`}>
-            <Flexbox horizontal align="center" justify="space-between">
-              <Text strong>{q.question}</Text>
-              {q.header && <Text type="secondary">{q.header}</Text>}
-            </Flexbox>
-
-            {q.multiSelect ? (
-              <CheckboxGroup
-                disabled={expired || submitting}
-                options={optionsForSelect(q)}
-                value={(answers[q.question] as string[] | undefined) ?? []}
-                onChange={(vals) => handleSelect(q.question, vals as string[])}
-              />
-            ) : (
-              <Select
-                disabled={expired || submitting}
-                options={optionsForSelect(q)}
-                placeholder="Select an option"
-                style={{ width: '100%' }}
-                value={(answers[q.question] as string | undefined) ?? undefined}
-                onChange={(val) => handleSelect(q.question, val as string)}
-              />
-            )}
-          </Flexbox>
-        ))}
-
-        <Flexbox horizontal align="center" gap={8} justify="space-between">
-          <Text fontSize={12} type="secondary">
-            {expired
-              ? 'Time expired — answer is no longer accepted.'
-              : `Time remaining: ${formatRemaining(deadline, now)}`}
-          </Text>
-          <Flexbox horizontal gap={8}>
-            <Button disabled={submitting} icon={X} size="small" onClick={handleCancel}>
-              Skip
-            </Button>
-            <Button
-              disabled={!allAnswered || expired || submitting || !operationId}
-              icon={Send}
-              loading={submitting}
-              size="small"
-              type="primary"
-              onClick={handleSubmit}
-            >
-              Submit
-            </Button>
-          </Flexbox>
-        </Flexbox>
-      </Flexbox>
-    </Block>
-  );
-});
-
-PendingForm.displayName = 'CCAskUserQuestionPendingForm';
-
-const AnsweredView = memo<{
-  args: AskUserQuestionArgs;
-  content?: unknown;
-  isError: boolean;
-}>(({ args, content, isError }) => {
-  const text = typeof content === 'string' ? content : '';
-  return (
-    <Block padding={12} variant="outlined" width="100%">
-      <Flexbox gap={8}>
-        {(args?.questions ?? []).map((q, idx) => (
-          <Text key={idx} type="secondary">
-            {q.question}
-          </Text>
-        ))}
-        {text && <Text>{text}</Text>}
-        {isError && (
-          <Text type="warning">
-            (User did not answer — model will continue without their input.)
-          </Text>
-        )}
-      </Flexbox>
-    </Block>
-  );
-});
-
-AnsweredView.displayName = 'CCAskUserQuestionAnsweredView';
-
-const AskUserQuestion = memo<
-  BuiltinRenderProps<AskUserQuestionArgs, AskUserQuestionState, unknown>
->(({ args, content, messageId, pluginError, pluginState }) => {
-  const intervention = pluginState?.askUserQuestion;
-  if (intervention?.status === 'pending') {
+/**
+ * CC `askUserQuestion` Render — answered / aborted state only.
+ *
+ * The pending form lives on the canonical Intervention surface
+ * (`BuiltinToolInterventions['claude-code']['askUserQuestion']`) — the
+ * framework hides this Render while `pluginIntervention.status === 'pending'`,
+ * then yields to it once the user submits / skips and a `tool_result` arrives
+ * with the formatted answer text in `content`.
+ */
+const AskUserQuestion = memo<BuiltinRenderProps<AskUserQuestionArgs, unknown, unknown>>(
+  ({ args, content, pluginError }) => {
+    const text = typeof content === 'string' ? content : '';
+    const isError = !!pluginError;
     return (
-      <PendingForm
-        deadline={intervention.deadline}
-        messageId={messageId}
-        questions={intervention.questions ?? args?.questions ?? []}
-        toolCallId={intervention.toolCallId}
-      />
+      <Block padding={12} variant="outlined" width="100%">
+        <Flexbox gap={8}>
+          {(args?.questions ?? []).map((q, idx) => (
+            <Text key={idx} type="secondary">
+              {q.question}
+            </Text>
+          ))}
+          {text && <Text>{text}</Text>}
+          {isError && (
+            <Text type="warning">(No answer received — model continued without their input.)</Text>
+          )}
+        </Flexbox>
+      </Block>
     );
-  }
-  return <AnsweredView args={args} content={content} isError={!!pluginError} />;
-});
+  },
+);
 
 AskUserQuestion.displayName = 'CCAskUserQuestion';
 

--- a/packages/builtin-tool-claude-code/src/client/Render/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Render/index.ts
@@ -3,6 +3,7 @@ import type { RenderDisplayControl } from '@lobechat/types';
 
 import { ClaudeCodeApiName } from '../../types';
 import Agent from './Agent';
+import AskUserQuestion from './AskUserQuestion';
 import Edit from './Edit';
 import Glob from './Glob';
 import Grep from './Grep';
@@ -19,6 +20,7 @@ import Write from './Write';
  */
 export const ClaudeCodeRenders = {
   [ClaudeCodeApiName.Agent]: Agent,
+  [ClaudeCodeApiName.AskUserQuestion]: AskUserQuestion,
   // RunCommand already renders `args.command` + combined output the way CC emits —
   // use the shared component directly instead of wrapping it in a re-export file.
   [ClaudeCodeApiName.Bash]: RunCommandRender,

--- a/packages/builtin-tool-claude-code/src/client/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/index.ts
@@ -1,5 +1,6 @@
 export { ClaudeCodeApiName, ClaudeCodeIdentifier } from '../types';
 export { ClaudeCodeInspectors } from './Inspector';
+export { ClaudeCodeInterventions } from './Intervention';
 export { ClaudeCodeRenderDisplayControls, ClaudeCodeRenders } from './Render';
 export { ClaudeCodeStreamings } from './Streaming';
 export { CC_SUBAGENT_TYPES, type CCSubagentTypeInfo, resolveCCSubagentType } from './subagentTypes';

--- a/packages/builtin-tool-claude-code/src/index.ts
+++ b/packages/builtin-tool-claude-code/src/index.ts
@@ -1,5 +1,9 @@
 export {
   type AgentArgs,
+  type AskUserQuestionArgs,
+  type AskUserQuestionItem,
+  type AskUserQuestionOption,
+  type AskUserQuestionPluginState,
   ClaudeCodeApiName,
   ClaudeCodeIdentifier,
   type ClaudeCodeTodoItem,

--- a/packages/builtin-tool-claude-code/src/index.ts
+++ b/packages/builtin-tool-claude-code/src/index.ts
@@ -3,7 +3,6 @@ export {
   type AskUserQuestionArgs,
   type AskUserQuestionItem,
   type AskUserQuestionOption,
-  type AskUserQuestionPluginState,
   ClaudeCodeApiName,
   ClaudeCodeIdentifier,
   type ClaudeCodeTodoItem,

--- a/packages/builtin-tool-claude-code/src/types.ts
+++ b/packages/builtin-tool-claude-code/src/types.ts
@@ -23,6 +23,13 @@ export enum ClaudeCodeApiName {
    * different concept.
    */
   Agent = 'Agent',
+  /**
+   * Synthetic apiName the adapter rewrites the local
+   * `mcp__lobe_cc__ask_user_question` MCP tool to. Routes the dedicated
+   * intervention UI for CC's clarifying-question flow (LOBE-8725); not
+   * something CC's CLI emits directly.
+   */
+  AskUserQuestion = 'askUserQuestion',
   Bash = 'Bash',
   Edit = 'Edit',
   Glob = 'Glob',
@@ -116,4 +123,47 @@ export interface TaskOutputArgs {
 export interface TaskStopArgs {
   shell_id?: string;
   task_id?: string;
+}
+
+/**
+ * One option on an AskUserQuestion question — `label` is what the user picks,
+ * `description` is the supporting text shown alongside.
+ */
+export interface AskUserQuestionOption {
+  description: string;
+  label: string;
+}
+
+/**
+ * One question in an `AskUserQuestion` invocation — header is short (≤12
+ * chars per CC's contract), `options` is 2-4 entries, `multiSelect` is opt-in.
+ */
+export interface AskUserQuestionItem {
+  header: string;
+  multiSelect?: boolean;
+  options: AskUserQuestionOption[];
+  question: string;
+}
+
+/**
+ * `AskUserQuestion` tool arguments — mirrors CC's own schema verbatim so the
+ * model's existing prompts work unchanged. 1-4 questions per call.
+ */
+export interface AskUserQuestionArgs {
+  questions: AskUserQuestionItem[];
+}
+
+/**
+ * `pluginState.askUserQuestion` shape stamped by the renderer when an
+ * `agent_intervention_request` arrives. The intervention UI consumes it to
+ * render the form and run the deadline countdown.
+ */
+export interface AskUserQuestionPluginState {
+  apiName: string;
+  /** Unix-ms wall-clock at which the producer will give up waiting. */
+  deadline: number;
+  identifier: string;
+  questions?: AskUserQuestionItem[];
+  status: 'pending';
+  toolCallId: string;
 }

--- a/packages/builtin-tool-claude-code/src/types.ts
+++ b/packages/builtin-tool-claude-code/src/types.ts
@@ -152,18 +152,3 @@ export interface AskUserQuestionItem {
 export interface AskUserQuestionArgs {
   questions: AskUserQuestionItem[];
 }
-
-/**
- * `pluginState.askUserQuestion` shape stamped by the renderer when an
- * `agent_intervention_request` arrives. The intervention UI consumes it to
- * render the form and run the deadline countdown.
- */
-export interface AskUserQuestionPluginState {
-  apiName: string;
-  /** Unix-ms wall-clock at which the producer will give up waiting. */
-  deadline: number;
-  identifier: string;
-  questions?: AskUserQuestionItem[];
-  status: 'pending';
-  toolCallId: string;
-}

--- a/packages/builtin-tools/src/interventions.ts
+++ b/packages/builtin-tools/src/interventions.ts
@@ -2,6 +2,10 @@ import {
   AgentBuilderInterventions,
   AgentBuilderManifest,
 } from '@lobechat/builtin-tool-agent-builder/client';
+import {
+  ClaudeCodeIdentifier,
+  ClaudeCodeInterventions,
+} from '@lobechat/builtin-tool-claude-code/client';
 import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { CloudSandboxInterventions } from '@lobechat/builtin-tool-cloud-sandbox/client';
 import {
@@ -37,6 +41,7 @@ import { type BuiltinIntervention } from '@lobechat/types';
 export const BuiltinToolInterventions: Record<string, Record<string, any>> = {
   [AgentBuilderManifest.identifier]: AgentBuilderInterventions,
   [AgentMarketplaceManifest.identifier]: AgentMarketplaceInterventions,
+  [ClaudeCodeIdentifier]: ClaudeCodeInterventions,
   [CloudSandboxManifest.identifier]: CloudSandboxInterventions,
   [GroupManagementManifest.identifier]: GroupManagementInterventions,
   [GTDManifest.identifier]: GTDInterventions,

--- a/packages/heterogeneous-agents/package.json
+++ b/packages/heterogeneous-agents/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
+    "./askUser": "./src/askUser/index.ts",
     "./client": "./src/client/index.ts",
     "./spawn": "./src/spawn/index.ts"
   },
@@ -15,7 +16,9 @@
   "dependencies": {
     "@lobechat/agent-gateway-client": "workspace:*",
     "@lobehub/icons": "^5.4.0",
-    "diff": "^8.0.4"
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "diff": "^8.0.4",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -158,6 +158,53 @@ describe('ClaudeCodeAdapter', () => {
       const toolStart = events.find((e) => e.type === 'tool_start');
       expect(toolStart).toBeDefined();
     });
+
+    it('rewrites mcp__lobe_cc__ask_user_question to apiName=askUserQuestion', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt({ subtype: 'init', type: 'system' });
+
+      const askInput = {
+        questions: [
+          {
+            header: 'Color',
+            options: [
+              { description: 'Red', label: 'Red' },
+              { description: 'Blue', label: 'Blue' },
+            ],
+            question: 'Pick a color?',
+          },
+        ],
+      };
+
+      const events = adapter.adapt({
+        message: {
+          id: 'msg_1',
+          content: [
+            {
+              id: 'tu_aq_1',
+              input: askInput,
+              name: 'mcp__lobe_cc__ask_user_question',
+              type: 'tool_use',
+            },
+          ],
+        },
+        type: 'assistant',
+      });
+
+      const chunk = events.find(
+        (e) => e.type === 'stream_chunk' && e.data.chunkType === 'tools_calling',
+      );
+      expect(chunk!.data.toolsCalling).toEqual([
+        {
+          // Wire-prefixed name is rewritten to the stable domain key.
+          apiName: 'askUserQuestion',
+          arguments: JSON.stringify(askInput),
+          id: 'tu_aq_1',
+          identifier: 'claude-code',
+          type: 'default',
+        },
+      ]);
+    });
   });
 
   describe('tool_result in user events', () => {

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -61,6 +61,22 @@ import type {
  */
 const CC_TODO_WRITE_TOOL_NAME = 'TodoWrite';
 
+/**
+ * Tool name CC sees for the LobeHub-hosted MCP `ask_user_question` server.
+ * Source of truth lives in `../askUser/constants.ts`; replicated here as a
+ * literal so the adapter compiles in browser bundles without dragging in
+ * any of the askUser package's runtime (node:http, MCP SDK, etc.) by
+ * accident. Keep in sync.
+ */
+const ASK_USER_MCP_TOOL_NAME = 'mcp__lobe_cc__ask_user_question';
+
+/**
+ * apiName the adapter rewrites the MCP tool to so the renderer routes on
+ * a stable key, not the wire-prefixed MCP name. Source of truth same as
+ * above.
+ */
+const ASK_USER_API_NAME = 'askUserQuestion';
+
 /** Status of a single todo item in CC's `TodoWrite` tool_use. */
 type ClaudeCodeTodoStatus = 'pending' | 'in_progress' | 'completed';
 
@@ -414,8 +430,13 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           break;
         }
         case 'tool_use': {
+          // Rewrite our local MCP `ask_user_question` tool to a stable
+          // apiName so the renderer routes on `askUserQuestion` (clean,
+          // domain-named) instead of the wire-prefixed MCP form. Identifier
+          // stays `claude-code` because this remains a CC-side tool.
+          const apiName = block.name === ASK_USER_MCP_TOOL_NAME ? ASK_USER_API_NAME : block.name;
           newToolCalls.push({
-            apiName: block.name,
+            apiName,
             arguments: JSON.stringify(block.input || {}),
             id: block.id,
             identifier: 'claude-code',
@@ -507,8 +528,13 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           break;
         }
         case 'tool_use': {
+          // Rewrite our local MCP `ask_user_question` tool to a stable
+          // apiName so the renderer routes on `askUserQuestion` (clean,
+          // domain-named) instead of the wire-prefixed MCP form. Identifier
+          // stays `claude-code` because this remains a CC-side tool.
+          const apiName = block.name === ASK_USER_MCP_TOOL_NAME ? ASK_USER_API_NAME : block.name;
           newToolCalls.push({
-            apiName: block.name,
+            apiName,
             arguments: JSON.stringify(block.input || {}),
             id: block.id,
             identifier: 'claude-code',

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
@@ -39,6 +39,32 @@ describe('AskUserBridge', () => {
       await expect(pending).resolves.toEqual({ result: { foo: 'bar' } });
     });
 
+    it('uses caller-supplied toolCallId as the wire correlation key', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({
+        arguments: { questions: [] },
+        toolCallId: 'cc-tool-use-abc',
+      });
+      const event = await drain.firstEvent;
+      expect(event.data.toolCallId).toBe('cc-tool-use-abc');
+
+      bridge.resolve('cc-tool-use-abc', { result: { picked: 'red' } });
+      await expect(pending).resolves.toEqual({ result: { picked: 'red' } });
+      drain.stop();
+    });
+
+    it('rejects pending() when the same toolCallId is already in flight', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      void bridge.pending({ arguments: {}, toolCallId: 'dup' });
+      await expect(bridge.pending({ arguments: {}, toolCallId: 'dup' })).rejects.toThrow(
+        /duplicate toolCallId/,
+      );
+      bridge.cancelAll();
+      drain.stop();
+    });
+
     it('ignores resolve() for unknown toolCallId', async () => {
       const bridge = new AskUserBridge('op-1');
       // Drain emitted events into the void so pending() can run.

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AskUserBridge } from './AskUserBridge';
+
+describe('AskUserBridge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('pending() → resolve()', () => {
+    it('emits an agent_intervention_request and resolves with the user-supplied result', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const events: any[] = [];
+      const iter = bridge.events()[Symbol.asyncIterator]();
+
+      // Pump events asynchronously into the array.
+      const pumped = (async () => {
+        const e = await iter.next();
+        if (!e.done) events.push(e.value);
+      })();
+
+      const pending = bridge.pending({ arguments: { questions: [{ q: 'foo' }] } });
+      await pumped;
+
+      expect(events).toHaveLength(1);
+      const req = events[0];
+      expect(req.type).toBe('agent_intervention_request');
+      expect(req.operationId).toBe('op-1');
+      expect(req.data.identifier).toBe('claude-code');
+      expect(req.data.apiName).toBe('askUserQuestion');
+      expect(req.data.toolCallId).toMatch(/^[\da-f-]{36}$/);
+      expect(JSON.parse(req.data.arguments)).toEqual({ questions: [{ q: 'foo' }] });
+
+      bridge.resolve(req.data.toolCallId, { result: { foo: 'bar' } });
+      await expect(pending).resolves.toEqual({ result: { foo: 'bar' } });
+    });
+
+    it('ignores resolve() for unknown toolCallId', async () => {
+      const bridge = new AskUserBridge('op-1');
+      // Drain emitted events into the void so pending() can run.
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({ arguments: {} });
+
+      bridge.resolve('not-a-real-id', { result: 'x' });
+
+      // Promise should still be unresolved — fast-forward past timeout to confirm.
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      const answer = await pending;
+      expect(answer.cancelled).toBe(true);
+      expect(answer.cancelReason).toBe('timeout');
+      drain.stop();
+    });
+  });
+
+  describe('cancellation paths', () => {
+    it('resolves with cancelled=true on user_cancelled via cancel()', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({ arguments: {} });
+      const toolCallId = (await drain.firstEvent).data.toolCallId;
+
+      bridge.cancel(toolCallId);
+
+      const answer = await pending;
+      expect(answer).toEqual({ cancelReason: 'user_cancelled', cancelled: true });
+      drain.stop();
+    });
+
+    it('resolves with cancelled=true on session_ended via cancelAll()', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({ arguments: {} });
+      await drain.firstEvent;
+
+      bridge.cancelAll('session_ended');
+
+      const answer = await pending;
+      expect(answer).toEqual({ cancelReason: 'session_ended', cancelled: true });
+      drain.stop();
+    });
+
+    it('resolves with cancelled=true on timeout (default 5 min)', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({ arguments: {} });
+
+      vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+      const stillPending = await Promise.race([pending, Promise.resolve('not-yet')]);
+      expect(stillPending).toBe('not-yet');
+
+      vi.advanceTimersByTime(2);
+      const answer = await pending;
+      expect(answer).toEqual({ cancelReason: 'timeout', cancelled: true });
+      drain.stop();
+    });
+
+    it('honors a custom timeoutMs', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const pending = bridge.pending({ arguments: {} }, { timeoutMs: 1000 });
+
+      vi.advanceTimersByTime(1001);
+      const answer = await pending;
+      expect(answer.cancelled).toBe(true);
+      drain.stop();
+    });
+
+    it('cancelAll() rejects future pending() calls', async () => {
+      const bridge = new AskUserBridge('op-1');
+      bridge.cancelAll();
+      await expect(bridge.pending({ arguments: {} })).rejects.toThrow(/closed/);
+    });
+  });
+
+  describe('progress notifications (keepalive)', () => {
+    it('calls onProgress at the configured interval until resolved', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      const onProgress = vi.fn();
+      const pending = bridge.pending(
+        { arguments: {} },
+        { onProgress, progressIntervalMs: 100, timeoutMs: 1000 },
+      );
+      const toolCallId = (await drain.firstEvent).data.toolCallId;
+
+      vi.advanceTimersByTime(350);
+      // Three ticks elapsed (100, 200, 300) — Node's setInterval fires
+      // exactly at multiples, so 3 calls with monotonically increasing
+      // elapsed values.
+      expect(onProgress).toHaveBeenCalledTimes(3);
+      expect(onProgress.mock.calls[0][0]).toBeGreaterThanOrEqual(100);
+      expect(onProgress.mock.calls[2][0]).toBeGreaterThanOrEqual(300);
+      expect(onProgress.mock.calls[0][1]).toBe(1000);
+
+      bridge.resolve(toolCallId, { result: 'done' });
+      await pending;
+
+      // After resolve, no further ticks even after more time passes.
+      vi.advanceTimersByTime(500);
+      expect(onProgress).toHaveBeenCalledTimes(3);
+      drain.stop();
+    });
+
+    it('skips onProgress entirely when not provided', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+      // No onProgress — just verify timeout still works without it.
+      const pending = bridge.pending({ arguments: {} }, { timeoutMs: 50 });
+      vi.advanceTimersByTime(60);
+      await expect(pending).resolves.toMatchObject({ cancelled: true });
+      drain.stop();
+    });
+  });
+
+  describe('event stream', () => {
+    it('emits one request event per pending() call', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const drain = drainEvents(bridge);
+
+      bridge.pending({ arguments: { q: 1 } });
+      bridge.pending({ arguments: { q: 2 } });
+      bridge.pending({ arguments: { q: 3 } });
+
+      // Advance timers so the resolved-via-cancellation cleanup paths don't
+      // interfere with the assertion below.
+      const events = await Promise.all([
+        drain.firstEvent,
+        drain.events.next(),
+        drain.events.next(),
+      ]);
+      // first 3 events are all intervention requests
+      const types = events.map((e: any) => e.value?.type ?? e.type);
+      expect(types.every((t) => t === 'agent_intervention_request')).toBe(true);
+
+      bridge.cancelAll();
+      drain.stop();
+    });
+
+    it('stamps stepIndex via the configured getter', async () => {
+      let step = 7;
+      const bridge = new AskUserBridge('op-1', { getStepIndex: () => step });
+      const drain = drainEvents(bridge);
+
+      bridge.pending({ arguments: {} });
+      const e1 = await drain.firstEvent;
+      expect(e1.stepIndex).toBe(7);
+
+      step = 11;
+      bridge.pending({ arguments: {} });
+      const e2 = await drain.events.next();
+      expect((e2.value as any).stepIndex).toBe(11);
+
+      bridge.cancelAll();
+    });
+
+    it('iterator ends after cancelAll()', async () => {
+      const bridge = new AskUserBridge('op-1');
+      const iter = bridge.events()[Symbol.asyncIterator]();
+      const next = iter.next();
+      bridge.cancelAll();
+      await expect(next).resolves.toMatchObject({ done: true });
+    });
+  });
+});
+
+// Helper: drain events from a bridge in the background, exposing the first
+// emitted event as a promise and a way to call iter.next() on demand.
+const drainEvents = (bridge: AskUserBridge) => {
+  const events = bridge.events()[Symbol.asyncIterator]();
+  const firstEvent = events.next().then((r) => {
+    if (r.done) throw new Error('stream ended before first event');
+    return r.value as any;
+  });
+  let stopped = false;
+  return {
+    events,
+    firstEvent,
+    stop: () => {
+      stopped = true;
+    },
+    get stopped() {
+      return stopped;
+    },
+  };
+};

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  AgentInterventionRequestData,
+  AgentStreamEvent,
+} from '@lobechat/agent-gateway-client';
+
+/**
+ * What the MCP handler gets back from `bridge.pending()`.
+ *
+ * `result` carries the user's structured answer when they submit; `cancelled`
+ * with a reason when the deadline elapses, the user cancels, or the producer
+ * tears the session down. Mutually exclusive — exactly one of `result` /
+ * `cancelled` is set.
+ */
+export interface InterventionAnswer {
+  cancelled?: boolean;
+  cancelReason?: 'timeout' | 'user_cancelled' | 'session_ended';
+  result?: unknown;
+}
+
+export interface PendingArgs {
+  /** Whatever the MCP tool's input schema accepted (e.g. `{ questions: [...] }`). */
+  arguments: unknown;
+  /**
+   * CC's own toolUseId for this call, if known (forwarded from the MCP
+   * `_meta.claudecode/toolUseId`). Only used for telemetry/correlation in
+   * traces — the bridge's own `toolCallId` is the wire correlation key.
+   */
+  ccToolUseId?: string;
+}
+
+export interface PendingOptions {
+  /**
+   * Called every `progressIntervalMs` while the call is pending. Use it to
+   * push MCP `notifications/progress` to keep the SSE channel from timing
+   * out (CC's HTTP transport drops at ~5min without keepalive).
+   *
+   * `elapsedMs` is the wall-clock millis since `pending()` was called.
+   */
+  onProgress?: (elapsedMs: number, totalMs: number) => void | Promise<void>;
+  /** How often to call `onProgress`. Default: 30 000 (30s). */
+  progressIntervalMs?: number;
+  /**
+   * Absolute deadline (`Date.now() + timeoutMs`). When it elapses, the
+   * pending promise resolves with `{ cancelled: true, cancelReason: 'timeout' }`.
+   * Default: 5 minutes.
+   */
+  timeoutMs?: number;
+}
+
+interface PendingEntry {
+  cleanup: () => void;
+  reject: (err: unknown) => void;
+  resolve: (answer: InterventionAnswer) => void;
+}
+
+interface BridgeOptions {
+  /**
+   * Stamps `stepIndex` on emitted events. The bridge has no visibility into
+   * the CC adapter's own step counter, so the producer (which owns the
+   * merged stream) provides it. Defaults to a constant `0` — fine for unit
+   * tests, but real producers should plug in their adapter's current value.
+   */
+  getStepIndex?: () => number;
+}
+
+/**
+ * Per-operation channel between an MCP tool handler (which awaits the user)
+ * and the producer's outbound stream (which carries the request to UI and
+ * receives the user's answer back).
+ *
+ * Lifecycle:
+ * 1. Producer constructs a bridge for an `operationId`.
+ * 2. The MCP handler calls `pending(args, opts)` — gets a Promise.
+ * 3. Bridge synthesizes a `toolCallId`, emits an
+ *    `agent_intervention_request` AgentStreamEvent on `events()` for the
+ *    producer to forward.
+ * 4. Producer eventually calls `resolve(toolCallId, payload)` (from the
+ *    consumer's `agent_intervention_response`) — Promise resolves.
+ * 5. Or: deadline / `cancelAll()` rejects the pending Promise with a
+ *    `{ cancelled: true, cancelReason }` answer (no exception thrown).
+ *
+ * Errors only surface from `pending()` if the bridge itself is misused
+ * (e.g. emitting after `cancelAll`). Cancellation/timeout is normal flow,
+ * not an exception.
+ */
+export class AskUserBridge {
+  private readonly pending_ = new Map<string, PendingEntry>();
+  private readonly outboundQueue: AgentStreamEvent[] = [];
+  private readonly outboundWaiters: Array<(value: IteratorResult<AgentStreamEvent>) => void> = [];
+  private readonly getStepIndex: () => number;
+  private closed = false;
+
+  constructor(
+    public readonly operationId: string,
+    options: BridgeOptions = {},
+  ) {
+    this.getStepIndex = options.getStepIndex ?? (() => 0);
+  }
+
+  /** Currently-blocked MCP handler count. Useful for telemetry / shutdown gates. */
+  get pendingCount(): number {
+    return this.pending_.size;
+  }
+
+  /**
+   * Block the caller until the consumer answers (or the deadline / cancel
+   * fires). Always resolves; never throws unless the bridge is already
+   * closed (programming error).
+   */
+  pending(args: PendingArgs, options: PendingOptions = {}): Promise<InterventionAnswer> {
+    if (this.closed) {
+      return Promise.reject(new Error('AskUserBridge is closed; cannot accept new pending calls'));
+    }
+
+    const toolCallId = randomUUID();
+    const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+    const progressIntervalMs = options.progressIntervalMs ?? 30_000;
+    const startedAt = Date.now();
+    const deadline = startedAt + timeoutMs;
+
+    return new Promise<InterventionAnswer>((resolve, reject) => {
+      const timeoutTimer = setTimeout(() => {
+        this.pending_.delete(toolCallId);
+        clearInterval(progressTimer);
+        resolve({ cancelled: true, cancelReason: 'timeout' });
+      }, timeoutMs);
+
+      const progressTimer: ReturnType<typeof setInterval> | undefined = options.onProgress
+        ? setInterval(() => {
+            const elapsed = Date.now() - startedAt;
+            // Fire-and-forget; consumer-side errors are logged by caller.
+            void Promise.resolve(options.onProgress!(elapsed, timeoutMs)).catch(() => {});
+          }, progressIntervalMs)
+        : undefined;
+
+      const cleanup = () => {
+        clearTimeout(timeoutTimer);
+        if (progressTimer) clearInterval(progressTimer);
+      };
+
+      this.pending_.set(toolCallId, { cleanup, reject, resolve });
+
+      // Emit the intervention request AFTER setting up the pending entry,
+      // so any synchronous resolve from a test fixture finds the slot.
+      // Hardcoded to AskUserQuestion for now — the only intervention shape
+      // we support. Take an explicit `apiName` in PendingArgs when adding
+      // more (e.g. CC approval, file picker).
+      const data: AgentInterventionRequestData = {
+        apiName: 'askUserQuestion',
+        arguments: JSON.stringify(args.arguments ?? {}),
+        deadline,
+        identifier: 'claude-code',
+        toolCallId,
+      };
+      this.emit({
+        data,
+        operationId: this.operationId,
+        stepIndex: this.getStepIndex(),
+        timestamp: startedAt,
+        type: 'agent_intervention_request',
+      });
+    });
+  }
+
+  /**
+   * Producer-side: called when an `agent_intervention_response` arrives
+   * from the consumer. No-op if the toolCallId is unknown (already
+   * timed out, cancelled, or a stale duplicate).
+   */
+  resolve(
+    toolCallId: string,
+    payload: {
+      cancelled?: boolean;
+      cancelReason?: InterventionAnswer['cancelReason'];
+      result?: unknown;
+    },
+  ): void {
+    const entry = this.pending_.get(toolCallId);
+    if (!entry) return;
+    this.pending_.delete(toolCallId);
+    entry.cleanup();
+    entry.resolve(
+      payload.cancelled
+        ? { cancelReason: payload.cancelReason ?? 'user_cancelled', cancelled: true }
+        : { result: payload.result },
+    );
+  }
+
+  /**
+   * Cancel a single pending call. Used when the consumer explicitly aborts
+   * one intervention without ending the whole op.
+   */
+  cancel(toolCallId: string, reason: InterventionAnswer['cancelReason'] = 'user_cancelled'): void {
+    this.resolve(toolCallId, { cancelReason: reason, cancelled: true });
+  }
+
+  /**
+   * Tear down the bridge. Every pending handler is resolved with
+   * `cancelled: true, reason='session_ended'` (so its MCP tool returns
+   * cleanly to CC), the outbound event stream closes, and subsequent
+   * `pending()` calls reject.
+   */
+  cancelAll(reason: InterventionAnswer['cancelReason'] = 'session_ended'): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const entry of this.pending_.values()) {
+      entry.cleanup();
+      entry.resolve({ cancelReason: reason, cancelled: true });
+    }
+    this.pending_.clear();
+    // Drain any waiters with a "done" so consumers can break their loop.
+    while (this.outboundWaiters.length > 0) {
+      const waiter = this.outboundWaiters.shift()!;
+      waiter({ done: true, value: undefined as any });
+    }
+  }
+
+  /**
+   * Async iterable over outbound events the producer should forward to the
+   * consumer. One iterator per bridge — multi-consumer fan-out is the
+   * producer's job. Iterator ends after `cancelAll()`.
+   */
+  events(): AsyncIterable<AgentStreamEvent> {
+    return {
+      [Symbol.asyncIterator]: () => this.makeIterator(),
+    };
+  }
+
+  private makeIterator(): AsyncIterator<AgentStreamEvent> {
+    return {
+      next: () => {
+        const buffered = this.outboundQueue.shift();
+        if (buffered) {
+          return Promise.resolve({ done: false, value: buffered });
+        }
+        if (this.closed) {
+          return Promise.resolve({ done: true, value: undefined as any });
+        }
+        return new Promise((resolveWaiter) => {
+          this.outboundWaiters.push(resolveWaiter);
+        });
+      },
+      return: () => Promise.resolve({ done: true, value: undefined as any }),
+    };
+  }
+
+  private emit(event: AgentStreamEvent): void {
+    const waiter = this.outboundWaiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: event });
+    } else {
+      this.outboundQueue.push(event);
+    }
+  }
+}

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
@@ -23,11 +23,19 @@ export interface PendingArgs {
   /** Whatever the MCP tool's input schema accepted (e.g. `{ questions: [...] }`). */
   arguments: unknown;
   /**
-   * CC's own toolUseId for this call, if known (forwarded from the MCP
-   * `_meta.claudecode/toolUseId`). Only used for telemetry/correlation in
-   * traces — the bridge's own `toolCallId` is the wire correlation key.
+   * Wire correlation key for this intervention. Used as the `toolCallId`
+   * on outbound `agent_intervention_request` events and looked up by
+   * `resolve()` / `cancel()` when the user submits an answer.
+   *
+   * For CC, the producer should pass `extra._meta['claudecode/toolUseId']`
+   * here so it equals the existing tool message id on the renderer side
+   * (the assistant `tool_use` for `mcp__lobe_cc__ask_user_question` and
+   * the intervention request both reference the same tool bubble).
+   *
+   * If omitted, the bridge synthesizes a random UUID — fine for
+   * stand-alone tests, but the renderer won't be able to correlate.
    */
-  ccToolUseId?: string;
+  toolCallId?: string;
 }
 
 export interface PendingOptions {
@@ -114,7 +122,14 @@ export class AskUserBridge {
       return Promise.reject(new Error('AskUserBridge is closed; cannot accept new pending calls'));
     }
 
-    const toolCallId = randomUUID();
+    const toolCallId = args.toolCallId ?? randomUUID();
+    if (this.pending_.has(toolCallId)) {
+      // Two pendings on the same key would clobber each other. Caller bug;
+      // surface it loudly rather than silently lose one resolve.
+      return Promise.reject(
+        new Error(`AskUserBridge: duplicate toolCallId in flight: ${toolCallId}`),
+      );
+    }
     const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
     const progressIntervalMs = options.progressIntervalMs ?? 30_000;
     const startedAt = Date.now();

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.test.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.test.ts
@@ -198,6 +198,54 @@ describe('AskUserMcpServer', () => {
       }
       await producerLoop;
     });
+
+    /**
+     * Regression: a single shared `StreamableHTTPServerTransport` rejects the
+     * second `initialize` with `Server already initialized`, breaking every
+     * op after the first. Ensures we mint one transport+McpServer per session.
+     */
+    it('handles sequential ops on independent sessions', async () => {
+      server = new AskUserMcpServer({ pendingTimeoutMs: 30_000, progressIntervalMs: 1000 });
+      await server.start();
+
+      for (const opId of ['op-seq-1', 'op-seq-2', 'op-seq-3']) {
+        const bridge = server.registerOperation(opId);
+        const producerLoop = (async () => {
+          for await (const e of bridge.events()) {
+            if (e.type === 'agent_intervention_request') {
+              bridge.resolve(e.data.toolCallId, { result: { pick: 'A' } });
+              break;
+            }
+          }
+        })();
+
+        const client = await connectClient(server.urlForOperation(opId));
+        try {
+          const callResult = (await client.callTool({
+            arguments: {
+              questions: [
+                {
+                  header: opId,
+                  options: [
+                    { description: 'a', label: 'A' },
+                    { description: 'b', label: 'B' },
+                  ],
+                  question: 'pick',
+                },
+              ],
+            },
+            name: ASK_USER_TOOL_NAME,
+          })) as { content: Array<{ text: string }>; isError?: boolean };
+
+          expect(callResult.isError).toBeFalsy();
+          expect(callResult.content[0].text).toContain('pick: A');
+        } finally {
+          await client.close();
+        }
+        await producerLoop;
+        server.unregisterOperation(opId);
+      }
+    });
   });
 });
 

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.test.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.test.ts
@@ -1,0 +1,209 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AskUserBridge } from './AskUserBridge';
+import { AskUserMcpServer } from './AskUserMcpServer';
+import { ASK_USER_MCP_SERVER_NAME, ASK_USER_TOOL_FULL_NAME, ASK_USER_TOOL_NAME } from './constants';
+
+let server: AskUserMcpServer;
+
+afterEach(async () => {
+  await server?.stop();
+});
+
+describe('AskUserMcpServer', () => {
+  describe('lifecycle', () => {
+    it('starts on port=0 (auto-assigned), exposes a localhost URL, stops cleanly', async () => {
+      server = new AskUserMcpServer();
+      const { port, url } = await server.start();
+      expect(port).toBeGreaterThan(0);
+      expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+
+      await server.stop();
+      // After stop, calling .url throws — server is no longer listening.
+      expect(() => server.url).toThrow();
+    });
+
+    it('start() is idempotent', async () => {
+      server = new AskUserMcpServer();
+      const a = await server.start();
+      const b = await server.start();
+      expect(a.port).toBe(b.port);
+    });
+  });
+
+  describe('per-op routing', () => {
+    it('hasOperation / operationCount track register / unregister', async () => {
+      server = new AskUserMcpServer();
+      await server.start();
+
+      expect(server.operationCount).toBe(0);
+      const bridge1 = server.registerOperation('op-1');
+      const bridge2 = server.registerOperation('op-2');
+      expect(server.operationCount).toBe(2);
+      expect(server.hasOperation('op-1')).toBe(true);
+      expect(server.hasOperation('op-3')).toBe(false);
+      expect(bridge1).toBeInstanceOf(AskUserBridge);
+      expect(bridge2).toBeInstanceOf(AskUserBridge);
+      expect(bridge1).not.toBe(bridge2);
+
+      server.unregisterOperation('op-1');
+      expect(server.operationCount).toBe(1);
+      expect(server.hasOperation('op-1')).toBe(false);
+    });
+
+    it('rejects double-registering the same op id', async () => {
+      server = new AskUserMcpServer();
+      await server.start();
+      server.registerOperation('op-1');
+      expect(() => server.registerOperation('op-1')).toThrow(/already registered/);
+    });
+
+    it('urlForOperation appends ?op=<id> to the base url', async () => {
+      server = new AskUserMcpServer();
+      await server.start();
+      server.registerOperation('op-7');
+      const url = server.urlForOperation('op-7');
+      expect(url).toContain('/mcp');
+      expect(new URL(url).searchParams.get('op')).toBe('op-7');
+    });
+
+    it('unregisterOperation cancels pending bridges', async () => {
+      server = new AskUserMcpServer();
+      await server.start();
+      const bridge = server.registerOperation('op-1');
+
+      const pending = bridge.pending({ arguments: { questions: [{ q: 'foo' }] } });
+      // Drain the request event so the iterator's queue doesn't deadlock.
+      void bridge.events()[Symbol.asyncIterator]().next();
+
+      server.unregisterOperation('op-1');
+      const answer = await pending;
+      expect(answer).toEqual({ cancelReason: 'session_ended', cancelled: true });
+    });
+
+    it('publishes the canonical mcp__lobe_cc__ask_user_question tool', async () => {
+      server = new AskUserMcpServer();
+      await server.start();
+      server.registerOperation('probe-op');
+
+      const client = await connectClient(server.urlForOperation('probe-op'));
+      try {
+        const list = await client.listTools();
+        expect(list.tools).toHaveLength(1);
+        expect(list.tools[0].name).toBe(ASK_USER_TOOL_NAME);
+        expect(ASK_USER_TOOL_FULL_NAME).toBe(
+          `mcp__${ASK_USER_MCP_SERVER_NAME}__${ASK_USER_TOOL_NAME}`,
+        );
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe('end-to-end tool call', () => {
+    it('routes a tools/call to the right per-op bridge and returns the user answer', async () => {
+      server = new AskUserMcpServer({ pendingTimeoutMs: 30_000, progressIntervalMs: 1000 });
+      await server.start();
+      const bridge = server.registerOperation('op-A');
+
+      // Producer-side: when an intervention_request shows up on bridge.events,
+      // resolve it with a fake user answer.
+      let interventionRequestSeen: any;
+      const producerLoop = (async () => {
+        for await (const e of bridge.events()) {
+          if (e.type === 'agent_intervention_request') {
+            interventionRequestSeen = e;
+            bridge.resolve(e.data.toolCallId, {
+              result: { 'What color do you want?': 'Red' },
+            });
+            break;
+          }
+        }
+      })();
+
+      // Client-side: behave like CC — initialize, list, call.
+      const client = await connectClient(server.urlForOperation('op-A'));
+      try {
+        const list = await client.listTools();
+        expect(list.tools[0].name).toBe(ASK_USER_TOOL_NAME);
+
+        const callResult = (await client.callTool({
+          arguments: {
+            questions: [
+              {
+                header: 'Color',
+                options: [
+                  { description: 'Red color', label: 'Red' },
+                  { description: 'Blue color', label: 'Blue' },
+                ],
+                question: 'What color do you want?',
+              },
+            ],
+          },
+          name: ASK_USER_TOOL_NAME,
+        })) as { content: Array<{ text: string; type: string }>; isError?: boolean };
+
+        expect(callResult.isError).toBeFalsy();
+        expect(callResult.content[0].text).toContain('User answers');
+        expect(callResult.content[0].text).toContain('What color do you want?: Red');
+      } finally {
+        await client.close();
+      }
+
+      await producerLoop;
+      expect(interventionRequestSeen).toBeDefined();
+      expect(interventionRequestSeen.operationId).toBe('op-A');
+      expect(interventionRequestSeen.data.identifier).toBe('claude-code');
+      expect(interventionRequestSeen.data.apiName).toBe('askUserQuestion');
+    });
+
+    it('returns an isError tool result when the user cancels', async () => {
+      server = new AskUserMcpServer({ pendingTimeoutMs: 30_000, progressIntervalMs: 1000 });
+      await server.start();
+      const bridge = server.registerOperation('op-cancel');
+
+      const producerLoop = (async () => {
+        for await (const e of bridge.events()) {
+          if (e.type === 'agent_intervention_request') {
+            bridge.resolve(e.data.toolCallId, { cancelled: true, cancelReason: 'user_cancelled' });
+            break;
+          }
+        }
+      })();
+
+      const client = await connectClient(server.urlForOperation('op-cancel'));
+      try {
+        const callResult = (await client.callTool({
+          arguments: {
+            questions: [
+              {
+                header: 'X',
+                options: [
+                  { description: 'a', label: 'A' },
+                  { description: 'b', label: 'B' },
+                ],
+                question: 'pick',
+              },
+            ],
+          },
+          name: ASK_USER_TOOL_NAME,
+        })) as { content: Array<{ text: string; type: string }>; isError?: boolean };
+
+        expect(callResult.isError).toBe(true);
+        expect(callResult.content[0].text.toLowerCase()).toContain('cancel');
+      } finally {
+        await client.close();
+      }
+      await producerLoop;
+    });
+  });
+});
+
+const connectClient = async (url: string): Promise<Client> => {
+  const transport = new StreamableHTTPClientTransport(new URL(url));
+  const client = new Client({ name: 'unit-test', version: '0' }, { capabilities: {} });
+  await client.connect(transport);
+  return client;
+};

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from 'node:net';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import type { InterventionAnswer } from './AskUserBridge';
@@ -69,6 +70,11 @@ interface RegisteredOperation {
   bridge: AskUserBridge;
 }
 
+interface SessionEntry {
+  mcp: McpServer;
+  transport: StreamableHTTPServerTransport;
+}
+
 /**
  * Process-wide MCP server that exposes a single `ask_user_question` tool to
  * CC over HTTP/SSE. One server, many concurrent operations — each spawn
@@ -82,11 +88,21 @@ interface RegisteredOperation {
  *   ...spawn CC pointing at server.url + ?op=opId...
  *   server.unregisterOperation(opId)    // releases bridge resources
  *   server.stop()                       // on app shutdown
+ *
+ * ## Per-session transport
+ *
+ * Each MCP `initialize` from a new CC subprocess gets its own
+ * `StreamableHTTPServerTransport` + `McpServer` pair. The SDK's transport
+ * stores `_initialized=true` and a `sessionId` per instance, so reusing a
+ * single transport across sequential ops makes the second `initialize` fail
+ * with `Invalid Request: Server already initialized`. Subsequent requests
+ * from the same CC subprocess (carrying `mcp-session-id`) route back to the
+ * matching transport via `sessionTransports` lookup.
  */
 export class AskUserMcpServer {
   private httpServer?: http.Server;
-  private readonly transport: StreamableHTTPServerTransport;
-  private readonly mcp: McpServer;
+  /** sessionId → transport+mcp pair. Populated on initialize, removed on session close. */
+  private readonly sessionTransports = new Map<string, SessionEntry>();
   private readonly operations = new Map<string, RegisteredOperation>();
   /**
    * MCP session id → operationId. Populated when a CC initialize POST
@@ -104,25 +120,6 @@ export class AskUserMcpServer {
   constructor(private readonly options: AskUserMcpServerOptions = {}) {
     this.pendingTimeoutMs = options.pendingTimeoutMs ?? 5 * 60 * 1000;
     this.progressIntervalMs = options.progressIntervalMs ?? 30_000;
-
-    this.mcp = new McpServer(
-      { name: ASK_USER_MCP_SERVER_NAME, version: '1.0.0' },
-      { capabilities: { tools: {} } },
-    );
-
-    // Stateful session id is required — empirically CC rejects the
-    // stateless mode (no session id returned on initialize → all
-    // subsequent requests fail). The session→op binding is set the moment
-    // the SDK generates a fresh sessionId for an initialize request.
-    this.transport = new StreamableHTTPServerTransport({
-      onsessioninitialized: (sessionId: string) => {
-        const opId = this.opIdContext.getStore();
-        if (opId) this.sessionIdToOpId.set(sessionId, opId);
-      },
-      sessionIdGenerator: () => randomUUID(),
-    });
-
-    this.registerAskUserTool();
   }
 
   /** URL only valid after `start()` resolves. */
@@ -138,8 +135,6 @@ export class AskUserMcpServer {
       // idempotent — repeat calls return the existing started state.
       return { port: (this.httpServer.address() as AddressInfo).port, url: this.url };
     }
-
-    await this.mcp.connect(this.transport);
 
     const httpServer = http.createServer(async (req, res) => {
       // Only the `/mcp` path is part of our contract. Anything else is
@@ -166,7 +161,22 @@ export class AskUserMcpServer {
 
       await this.opIdContext.run(opId, async () => {
         try {
-          await this.transport.handleRequest(req, res, body);
+          const transport = await this.resolveTransport(req, body);
+          if (!transport) {
+            res.writeHead(400, { 'content-type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                error: {
+                  code: -32_000,
+                  message: 'Bad Request: no session and no initialize request',
+                },
+                id: null,
+                jsonrpc: '2.0',
+              }),
+            );
+            return;
+          }
+          await transport.handleRequest(req, res, body);
         } catch (err) {
           if (!res.headersSent) {
             res.writeHead(500, { 'content-type': 'text/plain' });
@@ -193,7 +203,12 @@ export class AskUserMcpServer {
   async stop(): Promise<void> {
     // Close all bridges first so pending MCP handlers return quickly.
     for (const [opId] of this.operations) this.unregisterOperation(opId);
-    await this.transport.close().catch(() => {});
+    // Tear down every per-session transport + MCP server pair.
+    for (const [, entry] of this.sessionTransports) {
+      await entry.transport.close().catch(() => {});
+      await entry.mcp.close().catch(() => {});
+    }
+    this.sessionTransports.clear();
     await new Promise<void>((resolve) => {
       if (!this.httpServer) {
         resolve();
@@ -247,8 +262,76 @@ export class AskUserMcpServer {
     return this.operations.size;
   }
 
-  private registerAskUserTool() {
-    this.mcp.registerTool(
+  /** Active MCP session count (initialize succeeded, not yet closed). */
+  get sessionCount(): number {
+    return this.sessionTransports.size;
+  }
+
+  /**
+   * Locate (or build) the transport that should handle this request.
+   *
+   * - Existing session id (header) → matching stored transport
+   * - No session id + initialize body → fresh transport+mcp pair, registered
+   *   on `onsessioninitialized` so the very next message from this client
+   *   finds its session
+   * - Anything else → null (caller responds with 400)
+   */
+  private async resolveTransport(
+    req: http.IncomingMessage,
+    body: unknown,
+  ): Promise<StreamableHTTPServerTransport | undefined> {
+    const sessionId = (req.headers['mcp-session-id'] as string | undefined) ?? undefined;
+    if (sessionId) {
+      const entry = this.sessionTransports.get(sessionId);
+      if (entry) return entry.transport;
+      // Unknown session id — let the SDK respond 404; we still return the
+      // transport-less response below.
+      return undefined;
+    }
+
+    if (body && isInitializeRequest(body)) {
+      return this.createSessionTransport();
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Build a fresh `StreamableHTTPServerTransport` + `McpServer` pair for a
+   * new MCP session. The pair is registered into `sessionTransports` from
+   * the `onsessioninitialized` callback, so every subsequent request
+   * tagged with that sessionId routes back here without reconstruction.
+   */
+  private createSessionTransport(): StreamableHTTPServerTransport {
+    const mcp = new McpServer(
+      { name: ASK_USER_MCP_SERVER_NAME, version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+    this.registerAskUserTool(mcp);
+
+    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+      onsessionclosed: (sessionId: string) => {
+        this.sessionTransports.delete(sessionId);
+        this.sessionIdToOpId.delete(sessionId);
+      },
+      onsessioninitialized: (sessionId: string) => {
+        this.sessionTransports.set(sessionId, { mcp, transport });
+        const opId = this.opIdContext.getStore();
+        if (opId) this.sessionIdToOpId.set(sessionId, opId);
+      },
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    // Connect synchronously so the first request's body can be processed
+    // by the same transport we just built. `mcp.connect(transport)` is
+    // idempotent at this stage and resolves before `handleRequest` is
+    // called by the caller.
+    void mcp.connect(transport);
+    return transport;
+  }
+
+  private registerAskUserTool(mcp: McpServer) {
+    mcp.registerTool(
       ASK_USER_TOOL_NAME,
       {
         description: ASK_USER_TOOL_DESCRIPTION,

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
@@ -275,6 +275,11 @@ export class AskUserMcpServer {
         ];
         const progressToken = (extra?._meta as { progressToken?: string | number } | undefined)
           ?.progressToken;
+        // Use CC's own tool_use id as the bridge correlation key so the
+        // outbound `agent_intervention_request` shares an id with the
+        // existing tool message on the renderer side. Without this the
+        // renderer can't tie the intervention card to its tool bubble.
+        const toolCallId = ccToolUseId;
 
         // SSE keepalive: every progressIntervalMs send a progress
         // notification so CC's transport doesn't time out on long waits.
@@ -301,7 +306,7 @@ export class AskUserMcpServer {
             : undefined;
 
         const answer = await op.bridge.pending(
-          { arguments: args, ccToolUseId },
+          { arguments: args, toolCallId },
           {
             onProgress,
             progressIntervalMs: this.progressIntervalMs,

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
@@ -1,0 +1,360 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+import type { InterventionAnswer } from './AskUserBridge';
+import { AskUserBridge } from './AskUserBridge';
+import { ASK_USER_MCP_SERVER_NAME, ASK_USER_TOOL_NAME } from './constants';
+
+/**
+ * Mirrors CC's built-in `AskUserQuestion` schema. CC's schema:
+ *   - 1-4 questions
+ *   - each: header (≤12 chars), question, options (2-4), multiSelect?
+ *   - each option: label, description
+ * We replicate it so the model can call our tool with the exact shape CC
+ * trained on.
+ */
+const askUserOptionShape = z.object({
+  description: z.string(),
+  label: z.string(),
+});
+
+const askUserQuestionShape = z.object({
+  header: z.string(),
+  multiSelect: z.boolean().optional(),
+  options: z.array(askUserOptionShape).min(2).max(4),
+  question: z.string(),
+});
+
+const askUserInputShape = {
+  questions: z.array(askUserQuestionShape).min(1).max(4),
+};
+
+/** Tool description seen by the model. Kept terse — full schema lives in `inputSchema`. */
+const ASK_USER_TOOL_DESCRIPTION =
+  'Ask the user one or more clarifying questions with multiple-choice options. ' +
+  "Use this whenever the user's intent is ambiguous and you need them to pick.";
+
+export interface StartedServer {
+  /** Effective listen port (auto-assigned when constructed with port=0). */
+  port: number;
+  /** Base URL the producer hands to CC via `--mcp-config`. */
+  url: string;
+}
+
+export interface AskUserMcpServerOptions {
+  /**
+   * Per-call timeout passed to `bridge.pending()`. Default 5 minutes —
+   * matches the issue's UX requirement and the tested CC keepalive ceiling.
+   */
+  pendingTimeoutMs?: number;
+  /**
+   * Port to bind. `0` (default) lets the OS pick a free one.
+   */
+  port?: number;
+  /**
+   * Progress notification cadence. Default 30s. CC's HTTP transport drops
+   * SSE around 5min idle without a wire-level message — `notifications/progress`
+   * counts as a wire-level message.
+   */
+  progressIntervalMs?: number;
+}
+
+interface RegisteredOperation {
+  bridge: AskUserBridge;
+}
+
+/**
+ * Process-wide MCP server that exposes a single `ask_user_question` tool to
+ * CC over HTTP/SSE. One server, many concurrent operations — each spawn
+ * registers a per-op `AskUserBridge` and gets back a URL with `?op=<opId>`
+ * that CC's `--mcp-config` points at. Tool invocations route to the matching
+ * bridge by query param.
+ *
+ * Lifecycle:
+ *   server.start()                      // once per process
+ *   bridge = server.registerOperation(opId)
+ *   ...spawn CC pointing at server.url + ?op=opId...
+ *   server.unregisterOperation(opId)    // releases bridge resources
+ *   server.stop()                       // on app shutdown
+ */
+export class AskUserMcpServer {
+  private httpServer?: http.Server;
+  private readonly transport: StreamableHTTPServerTransport;
+  private readonly mcp: McpServer;
+  private readonly operations = new Map<string, RegisteredOperation>();
+  /**
+   * MCP session id → operationId. Populated when a CC initialize POST
+   * arrives at `/mcp?op=<opId>`; the URL's `op` is captured via
+   * `AsyncLocalStorage`, the SDK's `onsessioninitialized` hook reads it
+   * at session-create time, and tool handler lookups use `extra.sessionId`.
+   */
+  private readonly sessionIdToOpId = new Map<string, string>();
+  /** Per-request op id, populated for the duration of `handleRequest`. */
+  private readonly opIdContext = new AsyncLocalStorage<string | undefined>();
+  private startedUrl?: string;
+  private readonly pendingTimeoutMs: number;
+  private readonly progressIntervalMs: number;
+
+  constructor(private readonly options: AskUserMcpServerOptions = {}) {
+    this.pendingTimeoutMs = options.pendingTimeoutMs ?? 5 * 60 * 1000;
+    this.progressIntervalMs = options.progressIntervalMs ?? 30_000;
+
+    this.mcp = new McpServer(
+      { name: ASK_USER_MCP_SERVER_NAME, version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+
+    // Stateful session id is required — empirically CC rejects the
+    // stateless mode (no session id returned on initialize → all
+    // subsequent requests fail). The session→op binding is set the moment
+    // the SDK generates a fresh sessionId for an initialize request.
+    this.transport = new StreamableHTTPServerTransport({
+      onsessioninitialized: (sessionId: string) => {
+        const opId = this.opIdContext.getStore();
+        if (opId) this.sessionIdToOpId.set(sessionId, opId);
+      },
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    this.registerAskUserTool();
+  }
+
+  /** URL only valid after `start()` resolves. */
+  get url(): string {
+    if (!this.startedUrl) {
+      throw new Error('AskUserMcpServer not started yet — call start() first');
+    }
+    return this.startedUrl;
+  }
+
+  async start(): Promise<StartedServer> {
+    if (this.httpServer) {
+      // idempotent — repeat calls return the existing started state.
+      return { port: (this.httpServer.address() as AddressInfo).port, url: this.url };
+    }
+
+    await this.mcp.connect(this.transport);
+
+    const httpServer = http.createServer(async (req, res) => {
+      // Only the `/mcp` path is part of our contract. Anything else is
+      // either a misroute or a probe — answer with 404 so it's loud.
+      if (!req.url || !req.url.startsWith('/mcp')) {
+        res.writeHead(404, { 'content-type': 'text/plain' });
+        res.end('Not Found');
+        return;
+      }
+
+      // Producer encodes operationId as `?op=<opId>` on the URL it hands
+      // to CC. Capture it now so `onsessioninitialized` can bind it to the
+      // generated sessionId. AsyncLocalStorage keeps interleaved requests
+      // from clobbering each other.
+      const parsed = new URL(req.url, 'http://127.0.0.1');
+      const opId = parsed.searchParams.get('op') ?? undefined;
+
+      // The MCP transport reads from req directly. We only need to extract
+      // the JSON body for POST requests so it can be passed in.
+      let body: unknown;
+      if (req.method === 'POST') {
+        body = await readJsonBody(req).catch(() => undefined);
+      }
+
+      await this.opIdContext.run(opId, async () => {
+        try {
+          await this.transport.handleRequest(req, res, body);
+        } catch (err) {
+          if (!res.headersSent) {
+            res.writeHead(500, { 'content-type': 'text/plain' });
+            res.end(String((err as Error)?.message ?? err));
+          }
+        }
+      });
+    });
+
+    this.httpServer = httpServer;
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(this.options.port ?? 0, '127.0.0.1', () => {
+        httpServer.off('error', reject);
+        resolve();
+      });
+    });
+
+    const port = (httpServer.address() as AddressInfo).port;
+    this.startedUrl = `http://127.0.0.1:${port}/mcp`;
+    return { port, url: this.startedUrl };
+  }
+
+  async stop(): Promise<void> {
+    // Close all bridges first so pending MCP handlers return quickly.
+    for (const [opId] of this.operations) this.unregisterOperation(opId);
+    await this.transport.close().catch(() => {});
+    await new Promise<void>((resolve) => {
+      if (!this.httpServer) {
+        resolve();
+        return;
+      }
+      this.httpServer.close(() => resolve());
+    });
+    this.httpServer = undefined;
+    this.startedUrl = undefined;
+  }
+
+  /**
+   * Allocate a bridge for a new operation and return the
+   * `--mcp-config`-ready URL. The caller spawns CC pointing at this URL
+   * and merges `bridge.events()` into the producer's outbound stream.
+   */
+  registerOperation(operationId: string, bridge?: AskUserBridge): AskUserBridge {
+    if (this.operations.has(operationId)) {
+      throw new Error(`AskUserMcpServer: operation already registered: ${operationId}`);
+    }
+    const created = bridge ?? new AskUserBridge(operationId);
+    this.operations.set(operationId, { bridge: created });
+    return created;
+  }
+
+  unregisterOperation(operationId: string): void {
+    const entry = this.operations.get(operationId);
+    if (!entry) return;
+    entry.bridge.cancelAll('session_ended');
+    this.operations.delete(operationId);
+    // Drop the reverse mapping for any sessions that were bound to this op.
+    for (const [sid, oid] of this.sessionIdToOpId) {
+      if (oid === operationId) this.sessionIdToOpId.delete(sid);
+    }
+  }
+
+  /** Build the per-op URL the producer writes into the temp `mcp-config` JSON. */
+  urlForOperation(operationId: string): string {
+    const base = new URL(this.url);
+    base.searchParams.set('op', operationId);
+    return base.toString();
+  }
+
+  /** Test/inspection helper. */
+  hasOperation(operationId: string): boolean {
+    return this.operations.has(operationId);
+  }
+
+  /** Currently-registered operation count. */
+  get operationCount(): number {
+    return this.operations.size;
+  }
+
+  private registerAskUserTool() {
+    this.mcp.registerTool(
+      ASK_USER_TOOL_NAME,
+      {
+        description: ASK_USER_TOOL_DESCRIPTION,
+        inputSchema: askUserInputShape,
+        title: 'Ask User Question',
+      },
+      async (args, extra) => {
+        const sessionId = (extra as { sessionId?: string } | undefined)?.sessionId;
+        const operationId = sessionId ? this.sessionIdToOpId.get(sessionId) : undefined;
+        if (!operationId) {
+          return errorResult(
+            "Missing 'op' query parameter on MCP server URL — producer should append ?op=<operationId>",
+          );
+        }
+        const op = this.operations.get(operationId);
+        if (!op) {
+          return errorResult(
+            `No active operation for id '${operationId}'. The op may have ended before the tool call landed.`,
+          );
+        }
+
+        const ccToolUseId = (extra?._meta as { 'claudecode/toolUseId'?: string } | undefined)?.[
+          'claudecode/toolUseId'
+        ];
+        const progressToken = (extra?._meta as { progressToken?: string | number } | undefined)
+          ?.progressToken;
+
+        // SSE keepalive: every progressIntervalMs send a progress
+        // notification so CC's transport doesn't time out on long waits.
+        // Empirically required for >~5min — we cap at 5min anyway, but
+        // tick from the start so even 4-minute pendings get periodic life.
+        const onProgress =
+          progressToken !== undefined && extra?.sendNotification
+            ? async (elapsedMs: number, totalMs: number) => {
+                try {
+                  await extra.sendNotification!({
+                    method: 'notifications/progress',
+                    params: {
+                      message: `Waiting for user (${Math.round(elapsedMs / 1000)}s)`,
+                      progress: elapsedMs,
+                      progressToken,
+                      total: totalMs,
+                    },
+                  });
+                } catch {
+                  // Non-fatal — the underlying transport may be torn down
+                  // mid-flight; the next setInterval tick will skip too.
+                }
+              }
+            : undefined;
+
+        const answer = await op.bridge.pending(
+          { arguments: args, ccToolUseId },
+          {
+            onProgress,
+            progressIntervalMs: this.progressIntervalMs,
+            timeoutMs: this.pendingTimeoutMs,
+          },
+        );
+
+        return formatAnswerForCC(answer, args);
+      },
+    );
+  }
+}
+
+const readJsonBody = async (req: http.IncomingMessage): Promise<unknown> => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  if (chunks.length === 0) return undefined;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+};
+
+const errorResult = (message: string) => ({
+  content: [{ text: message, type: 'text' as const }],
+  isError: true,
+});
+
+const formatAnswerForCC = (answer: InterventionAnswer, args: unknown) => {
+  if (answer.cancelled) {
+    const reasonText =
+      answer.cancelReason === 'timeout'
+        ? 'No answer received within the wait window; the user did not respond. Continue without their input or ask in plain text.'
+        : answer.cancelReason === 'session_ended'
+          ? 'The session was ended before the user could respond.'
+          : 'The user cancelled the question.';
+    return {
+      content: [{ text: reasonText, type: 'text' as const }],
+      isError: true,
+    };
+  }
+
+  // Success: format the structured answer back as text. CC's built-in
+  // AskUserQuestion returns "User answers:\n- <q>: <a>" style — match it
+  // so the model handles our payload identically.
+  const answerObj = (answer.result ?? {}) as Record<string, unknown>;
+  const questions = (args as { questions?: Array<{ question: string }> }).questions ?? [];
+  const lines = ['User answers:'];
+  for (const q of questions) {
+    const a = answerObj[q.question];
+    const formatted = Array.isArray(a) ? a.join(', ') : a == null ? '(no answer)' : String(a);
+    lines.push(`- ${q.question}: ${formatted}`);
+  }
+  return {
+    content: [{ text: lines.join('\n'), type: 'text' as const }],
+  };
+};

--- a/packages/heterogeneous-agents/src/askUser/constants.ts
+++ b/packages/heterogeneous-agents/src/askUser/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Public constants shared between the producer-side MCP server (Node-only)
+ * and the consumer-side adapter / renderer (browser-safe). Kept in a
+ * dependency-free module so importers don't accidentally pull node:http
+ * etc. into the renderer bundle.
+ */
+
+/** MCP server name as it appears in the tool name prefix. */
+export const ASK_USER_MCP_SERVER_NAME = 'lobe_cc';
+
+/** MCP tool name (without the `mcp__lobe_cc__` prefix). */
+export const ASK_USER_TOOL_NAME = 'ask_user_question';
+
+/** Full tool name as the CC model sees it on the wire. */
+export const ASK_USER_TOOL_FULL_NAME = `mcp__${ASK_USER_MCP_SERVER_NAME}__${ASK_USER_TOOL_NAME}`;
+
+/**
+ * Stable apiName the adapter rewrites the MCP tool to so that downstream
+ * UI / persistence routes on a clean key, not the wire-prefixed MCP name.
+ */
+export const ASK_USER_API_NAME = 'askUserQuestion';

--- a/packages/heterogeneous-agents/src/askUser/index.ts
+++ b/packages/heterogeneous-agents/src/askUser/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Producer-side MCP server + per-op bridge for Claude Code's AskUserQuestion
+ * via local HTTP MCP. See `LOBE-8725` for the full design.
+ *
+ * Used by:
+ *   - Electron main (`HeterogeneousAgentCtr`) — local app
+ *   - Sandbox CLI (`lh hetero exec`) — phase 2; for now the CLI doesn't
+ *     register a server and CC falls back to text questions
+ *
+ * Consumer (renderer / web client) talks to the producer via the existing
+ * `AgentStreamEvent` pipeline — `agent_intervention_request` flows out,
+ * `agent_intervention_response` flows back.
+ */
+export {
+  AskUserBridge,
+  type InterventionAnswer,
+  type PendingArgs,
+  type PendingOptions,
+} from './AskUserBridge';
+export {
+  AskUserMcpServer,
+  type AskUserMcpServerOptions,
+  type StartedServer,
+} from './AskUserMcpServer';
+export {
+  ASK_USER_API_NAME,
+  ASK_USER_MCP_SERVER_NAME,
+  ASK_USER_TOOL_FULL_NAME,
+  ASK_USER_TOOL_NAME,
+} from './constants';

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/customInteractionHandlers.ts
@@ -1,3 +1,4 @@
+import { ClaudeCodeIdentifier } from '@lobechat/builtin-tool-claude-code';
 import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
 import {
   AgentMarketplaceIdentifier,
@@ -117,8 +118,22 @@ const customInteractionSubmitHandlers = new Map<string, CustomInteractionSubmitH
   [AgentMarketplaceIdentifier, handleAgentMarketplaceSubmit],
 ]);
 
+/**
+ * Identifiers whose intervention component renders inline as a form (with
+ * `onInteractionAction` callbacks) rather than the default approve / reject
+ * approval UI. Hetero CLIs (CC AskUserQuestion etc.) need this surface
+ * because the answer ships back through IPC, not through a synthetic user
+ * turn.
+ */
+const HETERO_CUSTOM_INTERACTION_IDENTIFIERS = new Set<string>([ClaudeCodeIdentifier]);
+
+export const isHeteroInteractionIdentifier = (identifier: string) =>
+  HETERO_CUSTOM_INTERACTION_IDENTIFIERS.has(identifier);
+
 export const isCustomInteractionIdentifier = (identifier: string) =>
-  identifier === UserInteractionIdentifier || customInteractionSubmitHandlers.has(identifier);
+  identifier === UserInteractionIdentifier ||
+  isHeteroInteractionIdentifier(identifier) ||
+  customInteractionSubmitHandlers.has(identifier);
 
 export const prepareCustomInteractionSubmit = async (
   identifier: string,

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/index.tsx
@@ -4,6 +4,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { toolInterventionSelectors } from '@/store/user/selectors';
 
@@ -12,6 +13,7 @@ import Arguments from '../Arguments';
 import ApprovalActions from './ApprovalActions';
 import {
   isCustomInteractionIdentifier,
+  isHeteroInteractionIdentifier,
   prepareCustomInteractionSubmit,
   recordCustomInteractionResolution,
 } from './customInteractionHandlers';
@@ -98,6 +100,11 @@ const Intervention = memo<InterventionProps>(
     const submitToolInteraction = useConversationStore((s) => s.submitToolInteraction);
     const skipToolInteraction = useConversationStore((s) => s.skipToolInteraction);
     const cancelToolInteraction = useConversationStore((s) => s.cancelToolInteraction);
+    // Hetero (CC / Codex) interventions ship the answer back through IPC to a
+    // running CLI subprocess instead of starting a fresh `executeClientAgent`
+    // turn. Pull the chat-store action lazily so non-hetero interactions stay
+    // on the existing path with no behavior change.
+    const submitHeteroIntervention = useChatStore((s) => s.submitHeteroIntervention);
 
     const handleInteractionAction = useCallback(
       async (
@@ -106,6 +113,10 @@ const Intervention = memo<InterventionProps>(
           | { type: 'skip'; payload?: Record<string, unknown>; reason?: string }
           | { type: 'cancel'; payload?: Record<string, unknown> },
       ) => {
+        if (isHeteroInteractionIdentifier(identifier)) {
+          await submitHeteroIntervention(id, action.type, action.payload);
+          return;
+        }
         switch (action.type) {
           case 'submit': {
             const { payload, options } = await prepareCustomInteractionSubmit(
@@ -149,6 +160,7 @@ const Intervention = memo<InterventionProps>(
         identifier,
         parsedArgs,
         skipToolInteraction,
+        submitHeteroIntervention,
         submitToolInteraction,
         topicId,
       ],

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/index.tsx
@@ -1,4 +1,3 @@
-import { getBuiltinRender } from '@lobechat/builtin-tools/renders';
 import { getBuiltinStreaming } from '@lobechat/builtin-tools/streamings';
 import { type ChatToolResult, type ToolIntervention } from '@lobechat/types';
 import { safeParsePartialJSON } from '@lobechat/utils';
@@ -97,40 +96,6 @@ const Render = memo<RenderProps>(
         toolCallId={toolCallId}
       />
     );
-
-    // Some tool calls need user input mid-flight (e.g. CC's AskUserQuestion
-    // delivered through the local MCP server, LOBE-8725). The producer
-    // stamps `pluginState.askUserQuestion.status = 'pending'` on the tool
-    // message, but the wider framework intervention plumbing isn't engaged
-    // (no `intervention` field on the tool payload). Reach the registered
-    // custom render directly so the UI can collect the answer rather than
-    // showing the loading placeholder for the whole timeout window.
-    const askUserPending =
-      isToolCalling &&
-      identifier === 'claude-code' &&
-      apiName === 'askUserQuestion' &&
-      (result?.state as { askUserQuestion?: { status?: string } } | undefined)?.askUserQuestion
-        ?.status === 'pending';
-    if (askUserPending) {
-      const InlineRender = getBuiltinRender(identifier, apiName);
-      if (InlineRender) {
-        return (
-          <Suspense fallback={placeholder}>
-            <Flexbox gap={8}>
-              <InlineRender
-                apiName={apiName}
-                args={safeParsePartialJSON(requestArgs)}
-                content={result?.content || ''}
-                identifier={identifier}
-                messageId={toolMessageId || messageId}
-                pluginState={result?.state}
-                toolCallId={toolCallId}
-              />
-            </Flexbox>
-          </Suspense>
-        );
-      }
-    }
 
     if (isToolCalling) return placeholder;
 

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/index.tsx
@@ -1,3 +1,4 @@
+import { getBuiltinRender } from '@lobechat/builtin-tools/renders';
 import { getBuiltinStreaming } from '@lobechat/builtin-tools/streamings';
 import { type ChatToolResult, type ToolIntervention } from '@lobechat/types';
 import { safeParsePartialJSON } from '@lobechat/utils';
@@ -96,6 +97,40 @@ const Render = memo<RenderProps>(
         toolCallId={toolCallId}
       />
     );
+
+    // Some tool calls need user input mid-flight (e.g. CC's AskUserQuestion
+    // delivered through the local MCP server, LOBE-8725). The producer
+    // stamps `pluginState.askUserQuestion.status = 'pending'` on the tool
+    // message, but the wider framework intervention plumbing isn't engaged
+    // (no `intervention` field on the tool payload). Reach the registered
+    // custom render directly so the UI can collect the answer rather than
+    // showing the loading placeholder for the whole timeout window.
+    const askUserPending =
+      isToolCalling &&
+      identifier === 'claude-code' &&
+      apiName === 'askUserQuestion' &&
+      (result?.state as { askUserQuestion?: { status?: string } } | undefined)?.askUserQuestion
+        ?.status === 'pending';
+    if (askUserPending) {
+      const InlineRender = getBuiltinRender(identifier, apiName);
+      if (InlineRender) {
+        return (
+          <Suspense fallback={placeholder}>
+            <Flexbox gap={8}>
+              <InlineRender
+                apiName={apiName}
+                args={safeParsePartialJSON(requestArgs)}
+                content={result?.content || ''}
+                identifier={identifier}
+                messageId={toolMessageId || messageId}
+                pluginState={result?.state}
+                toolCallId={toolCallId}
+              />
+            </Flexbox>
+          </Suspense>
+        );
+      }
+    }
 
     if (isToolCalling) return placeholder;
 

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -1,16 +1,23 @@
 import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
+import { LOADING_FLAT } from '@lobechat/const';
+import type { ConversationContext, HeterogeneousProviderConfig } from '@lobechat/types';
+import { t } from 'i18next';
 import { type StateCreator } from 'zustand';
 
+import { message as antdMessage } from '@/components/AntdStaticMethods';
 import { MESSAGE_CANCEL_FLAT } from '@/const/index';
+import { messageService } from '@/services/message';
 import { getAgentStoreState } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 import { selectRuntimeType } from '@/store/chat/slices/aiChat/actions/agentDispatcher';
 import {
   parseMentionedAgentsFromEditorData,
   parseSelectedSkillsFromEditorData,
   parseSelectedToolsFromEditorData,
 } from '@/store/chat/slices/aiChat/actions/commandBus';
+import { resolveHeteroResume } from '@/store/chat/slices/aiChat/actions/heteroResume';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { INPUT_LOADING_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 import {
@@ -47,6 +54,91 @@ const buildRetryInitialContext = (editorData: Record<string, any> | null | undef
     },
     phase: 'init' as const,
   };
+};
+
+/**
+ * Branch a hetero (Claude Code / Codex) turn off an existing user message.
+ *
+ * Used by regenerate (parent = user msg, prompt = original user content).
+ * Pre-creates the assistant row so `executeHeterogeneousAgent` has a stable
+ * `assistantMessageId` to stream into, then runs an `execHeterogeneousAgent`
+ * op as a child of the caller's parent op so Stop cancels the executor
+ * without killing the parent op early.
+ */
+const runHeterogeneousFromExistingMessage = async (
+  chatStore: ReturnType<typeof useChatStore.getState>,
+  params: {
+    context: ConversationContext;
+    heterogeneousProvider: HeterogeneousProviderConfig;
+    parentMessageId: string;
+    parentOperationId: string;
+    prompt: string;
+  },
+): Promise<string> => {
+  const { context, heterogeneousProvider, parentMessageId, parentOperationId, prompt } = params;
+  const agentId = context.agentId;
+  if (!agentId) throw new Error('agentId is required for heterogeneous agent');
+
+  // Resolve workingDirectory: topic-level pin (set when bound to a project)
+  // wins over the agent-level default. Mirrors the sendMessage hetero branch
+  // so regenerate stays on the same project as the original turn.
+  const topic = context.topicId
+    ? topicSelectors.getTopicById(context.topicId)(chatStore)
+    : undefined;
+  const agentWorkingDirectory =
+    agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(getAgentStoreState());
+  const workingDirectory = topic?.metadata?.workingDirectory || agentWorkingDirectory;
+
+  // Drops the saved sessionId when its bound cwd disagrees with the current
+  // one — without this CC emits "No conversation found with session ID".
+  const { cwdChanged, resumeSessionId } = resolveHeteroResume(topic?.metadata, workingDirectory);
+  if (cwdChanged) antdMessage.info(t('heteroAgent.resumeReset.cwdChanged', { ns: 'chat' }));
+
+  const assistantMsg = await messageService.createMessage({
+    agentId,
+    content: LOADING_FLAT,
+    parentId: parentMessageId,
+    // External CLIs own model selection; persist only the runtime provider up
+    // front. The adapter backfills the actual model later if the CLI reports it.
+    provider: heterogeneousProvider.type,
+    role: 'assistant',
+    threadId: context.threadId ?? undefined,
+    topicId: context.topicId ?? undefined,
+  });
+
+  // Pull the new row into the store so the loading bubble is visible while
+  // the executor runs (the executor only dispatches updates, not creates).
+  await chatStore.refreshMessages();
+
+  if (context.topicId) chatStore.internal_updateTopicLoading(context.topicId, true);
+
+  const { operationId: heteroOpId } = chatStore.startOperation({
+    context,
+    label: 'Heterogeneous Agent Execution',
+    metadata: { heterogeneousType: heterogeneousProvider.type },
+    parentOperationId,
+    type: 'execHeterogeneousAgent',
+  });
+  chatStore.associateMessageWithOperation(assistantMsg.id, heteroOpId);
+
+  try {
+    const { executeHeterogeneousAgent } =
+      await import('@/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor');
+    await executeHeterogeneousAgent(() => useChatStore.getState(), {
+      assistantMessageId: assistantMsg.id,
+      context,
+      heterogeneousProvider,
+      message: prompt,
+      operationId: heteroOpId,
+      resumeSessionId,
+      workingDirectory,
+    });
+  } finally {
+    if (context.topicId)
+      useChatStore.getState().internal_updateTopicLoading(context.topicId, false);
+  }
+
+  return assistantMsg.id;
 };
 
 /**
@@ -223,15 +315,11 @@ export const generationSlice: StateCreator<
       isGatewayMode: chatStore.isGatewayModeEnabled(),
     });
 
-    // TODO(LOBE-8519 follow-up): continue is currently only wired for the client
-    // runtime. Gateway / hetero continue both fall through to the client path
-    // here; a proper implementation needs runtime-specific resume semantics.
-    if (runtimeType !== 'client') {
-      console.warn(
-        `[continueGenerationMessage] runtime=${runtimeType} not yet supported; ` +
-          'falling through to client mode',
-      );
-    }
+    // Hetero CLIs (CC / Codex) have no "continue a cut-off response" primitive
+    // — each prompt is a fresh user turn from their perspective. Bail out
+    // rather than synthesize a fake "please continue" turn that would pollute
+    // the session and confuse the model. The button is a no-op in this mode.
+    if (runtimeType === 'hetero') return;
 
     // Create continue operation with ConversationStore context (includes groupId)
     const { operationId } = chatStore.startOperation({
@@ -240,7 +328,24 @@ export const generationSlice: StateCreator<
     });
 
     try {
-      // Execute agent runtime with full context from ConversationStore
+      // ── Gateway mode: branch a server-side run from the cut-off message ──
+      // `parentMessageId` triggers `resume: true` on the router, so the server
+      // skips user-message creation and continues from the existing chain.
+      // Empty prompt is intentional and matches the approve/reject resume path.
+      if (runtimeType === 'gateway') {
+        await chatStore.executeGatewayAgent({
+          context,
+          message: '',
+          onComplete: () => {
+            chatStore.completeOperation(operationId);
+            if (hooks.onContinueComplete) hooks.onContinueComplete(displayMessageId);
+          },
+          parentMessageId: dbMessageId,
+        });
+        return;
+      }
+
+      // ── Client mode: run agent locally ──
       await chatStore.executeClientAgent({
         context,
         messages: displayMessages,
@@ -381,8 +486,9 @@ export const generationSlice: StateCreator<
       });
 
       const agentConfig = agentSelectors.getAgentConfigById(context.agentId)(getAgentStoreState());
+      const heterogeneousProvider = agentConfig?.agencyConfig?.heterogeneousProvider;
       const runtimeType = selectRuntimeType({
-        heterogeneousProvider: agentConfig?.agencyConfig?.heterogeneousProvider,
+        heterogeneousProvider,
         isGatewayMode: chatStore.isGatewayModeEnabled(),
       });
 
@@ -405,13 +511,25 @@ export const generationSlice: StateCreator<
         return;
       }
 
-      // ── Client mode: run agent locally ──
-      // TODO(LOBE-8519 follow-up): hetero regenerate is not yet implemented and
-      // currently falls through to client mode (silently uses the agent's underlying
-      // LLM instead of routing back through the heterogeneous CLI). Implementing it
-      // requires the same persistence + executeHeterogeneousAgent setup as
-      // sendMessage's hetero branch.
+      // ── Hetero mode: re-run the local CLI against the original user prompt ──
+      // Creates a fresh assistant row branched off the existing user message so
+      // the CC / Codex turn replaces the previous attempt without rewriting
+      // history, and resumes the same session id (when the cwd still matches)
+      // so prior context is preserved.
+      if (runtimeType === 'hetero' && heterogeneousProvider) {
+        await runHeterogeneousFromExistingMessage(chatStore, {
+          context,
+          heterogeneousProvider,
+          parentMessageId: messageId,
+          parentOperationId: operationId,
+          prompt: item.content,
+        });
+        chatStore.completeOperation(operationId);
+        if (hooks.onRegenerateComplete) hooks.onRegenerateComplete(messageId);
+        return;
+      }
 
+      // ── Client mode: run agent locally ──
       // Execute agent runtime with full context from ConversationStore
       await chatStore.executeClientAgent({
         context,

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -357,6 +357,8 @@ const AgentStreamEventSchema = z.object({
     'tool_end',
     'tool_execute',
     'tool_result',
+    'agent_intervention_request',
+    'agent_intervention_response',
     'step_start',
     'step_complete',
     'error',

--- a/src/services/electron/heterogeneousAgent.ts
+++ b/src/services/electron/heterogeneousAgent.ts
@@ -39,6 +39,21 @@ class HeterogeneousAgentService {
   async getSessionInfo(sessionId: string) {
     return this.ipc.heterogeneousAgent.getSessionInfo({ sessionId });
   }
+
+  /**
+   * Submit the user's answer (or cancellation) for a pending CC
+   * AskUserQuestion intervention. The main process routes it to the
+   * matching MCP bridge so the blocked tool handler can return to CC.
+   */
+  async submitIntervention(params: {
+    cancelReason?: 'timeout' | 'user_cancelled';
+    cancelled?: boolean;
+    operationId: string;
+    result?: unknown;
+    toolCallId: string;
+  }) {
+    return this.ipc.heterogeneousAgent.submitIntervention(params);
+  }
 }
 
 export const heterogeneousAgentService = new HeterogeneousAgentService();

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -631,6 +631,115 @@ export class ConversationControlActionImpl {
     completeOperation(operationId);
   };
 
+  /**
+   * Resolve a heterogeneous-runtime intervention (CC AskUserQuestion, …).
+   *
+   * Why this action exists separately from `submitToolInteraction`:
+   * - The CC subprocess is already running and blocked on an MCP call —
+   *   we need to feed the answer back through the IPC bridge, not spawn
+   *   a fresh `executeClientAgent` turn.
+   * - Once the answer ships, CC's existing stream emits `tool_result` and
+   *   keeps going on its own; no synthetic user message, no new op.
+   *
+   * The framework's intervention surface still drives the UI: we just
+   * stamp `pluginIntervention.status` and the eventual `tool_result`
+   * content via the same optimistic primitives, so the InterventionBar /
+   * inline tool body update synchronously and the answered Render takes
+   * over once `pluginIntervention.status === 'approved' | 'rejected'`.
+   *
+   * `actionType`:
+   *   - `'submit'` → mark approved, ship `payload` as the answer
+   *   - `'skip' | 'cancel'` → mark rejected, ship `cancelled: true` so the
+   *     bridge resolves with `cancelReason` and CC sees an isError result
+   *     (it'll fall back to plain-text questioning)
+   */
+  submitHeteroIntervention = async (
+    toolMessageId: string,
+    actionType: 'submit' | 'skip' | 'cancel',
+    payload?: Record<string, unknown>,
+    context?: ConversationContext,
+  ): Promise<void> => {
+    const toolMessage = dbMessageSelectors.getDbMessageById(toolMessageId)(this.#get());
+    if (!toolMessage) return;
+
+    const toolCallId = toolMessage.tool_call_id;
+    if (!toolCallId) {
+      console.warn('[submitHeteroIntervention] tool message has no tool_call_id', toolMessageId);
+      return;
+    }
+
+    // Walk up to the assistant that owns this tool — its operation is the
+    // running CC stream we need to address. Falls through to the tool
+    // message id itself if a producer ever associated it directly.
+    const { messageOperationMap } = this.#get();
+    const operationId =
+      (toolMessage.parentId && messageOperationMap?.[toolMessage.parentId]) ??
+      messageOperationMap?.[toolMessageId];
+
+    if (!operationId) {
+      console.warn('[submitHeteroIntervention] no operationId for', toolMessageId);
+      return;
+    }
+
+    const effectiveContext: ConversationContext = context ?? {
+      agentId: this.#get().activeAgentId,
+      topicId: this.#get().activeTopicId,
+      threadId: this.#get().activeThreadId,
+    };
+    const optimisticContext: OptimisticUpdateContext = { operationId };
+
+    if (actionType === 'submit') {
+      await this.#get().optimisticUpdateMessagePlugin(
+        toolMessageId,
+        { intervention: { status: 'approved' } },
+        optimisticContext,
+      );
+      // Bridge formats its own "User answers:" string for CC, so the eventual
+      // tool_result re-rewrites this content. The optimistic write is just
+      // for the brief gap between Submit and CC echoing the result back.
+      const summary = `User submitted: ${JSON.stringify(payload ?? {})}`;
+      await this.#get().optimisticUpdateMessageContent(
+        toolMessageId,
+        summary,
+        undefined,
+        optimisticContext,
+      );
+    } else {
+      const reason = actionType === 'skip' ? 'User skipped' : 'User cancelled';
+      await this.#get().optimisticUpdateMessagePlugin(
+        toolMessageId,
+        { intervention: { rejectedReason: reason, status: 'rejected' } },
+        optimisticContext,
+      );
+      await this.#get().optimisticUpdateMessageContent(
+        toolMessageId,
+        `${reason} this interaction.`,
+        undefined,
+        optimisticContext,
+      );
+    }
+
+    // Forward to the producer (Electron main → bridge.resolve). Dynamic
+    // import keeps `@/services/electron/*` out of non-Electron bundles.
+    try {
+      const { heterogeneousAgentService } = await import('@/services/electron/heterogeneousAgent');
+      await heterogeneousAgentService.submitIntervention(
+        actionType === 'submit'
+          ? { operationId, result: payload ?? {}, toolCallId }
+          : {
+              cancelReason: actionType === 'skip' ? 'user_cancelled' : 'user_cancelled',
+              cancelled: true,
+              operationId,
+              toolCallId,
+            },
+      );
+    } catch (err) {
+      console.error('[submitHeteroIntervention] IPC submitIntervention failed:', err);
+    }
+
+    void effectiveContext;
+  };
+
   rejectToolCalling = async (
     messageId: string,
     reason?: string,

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -694,6 +694,11 @@ export class ConversationControlActionImpl {
         { intervention: { status: 'approved' } },
         optimisticContext,
       );
+      // Persist the structured `{ [questionText]: selectedLabel(s) }` answers
+      // to `pluginState.askUserAnswers` so the Render component can show
+      // Q&A pairs instead of parsing the bridge's prose `User answers:`
+      // dump out of `content`. Best-effort — never block the IPC submit.
+      await this.setInterventionAnswers(toolMessageId, payload ?? {}, optimisticContext);
       // Bridge formats its own "User answers:" string for CC, so the eventual
       // tool_result re-rewrites this content. The optimistic write is just
       // for the brief gap between Submit and CC echoing the result back.
@@ -747,9 +752,9 @@ export class ConversationControlActionImpl {
    * intervention is pending (5 min cap), and the canonical pluginState
    * mirror is enough to survive HMR / panel re-mounts.
    *
-   * On the eventual `tool_result`, the executor's `persistToolResult`
-   * overwrites pluginState with whatever the tool returned (typically the
-   * formatted answer text), so stale drafts naturally evaporate.
+   * `askUserDraft` is irrelevant after submit (the form unmounts), so we
+   * don't bother clearing it — it stays buried under `askUserAnswers` in
+   * `pluginState` and never affects the completed Render.
    */
   setInterventionDraft = (toolMessageId: string, draft: Record<string, unknown>): void => {
     this.#get().internal_dispatchMessage({
@@ -758,6 +763,45 @@ export class ConversationControlActionImpl {
       type: 'updatePluginState',
       value: draft,
     });
+  };
+
+  /**
+   * Persist the structured intervention answers (`{ questionText:
+   * selectedLabel | selectedLabel[] }`) to the tool message's
+   * `pluginState.askUserAnswers`. Drives structured Q&A rendering on the
+   * `Render` component without re-parsing the bridge's prose tool_result.
+   *
+   * Both writes are merge-style by key — the in-memory `updatePluginState`
+   * reducer (`message/reducer.ts:142`) and the DB
+   * `messageModel.updatePluginState` shallow-merge so co-existing keys
+   * (`askUserDraft` etc.) survive. DB write is best-effort: a slow lambda
+   * must not strand the IPC submit that follows.
+   */
+  setInterventionAnswers = async (
+    toolMessageId: string,
+    answers: Record<string, unknown>,
+    context?: OptimisticUpdateContext,
+  ): Promise<void> => {
+    this.#get().internal_dispatchMessage(
+      {
+        id: toolMessageId,
+        key: 'askUserAnswers',
+        type: 'updatePluginState',
+        value: answers,
+      },
+      context,
+    );
+    try {
+      const { messageService } = await import('@/services/message');
+      const ctx = this.#get().internal_getConversationContext(context);
+      await messageService.updateMessagePluginState(
+        toolMessageId,
+        { askUserAnswers: answers },
+        ctx,
+      );
+    } catch (err) {
+      console.warn('[setInterventionAnswers] persist failed:', err);
+    }
   };
 
   rejectToolCalling = async (

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -740,6 +740,26 @@ export class ConversationControlActionImpl {
     void effectiveContext;
   };
 
+  /**
+   * In-memory draft store for an intervention form. Backs the renderer's
+   * "remember what I'd partially answered" behaviour without paying for a
+   * DB round-trip on every keystroke — drafts only matter while the
+   * intervention is pending (5 min cap), and the canonical pluginState
+   * mirror is enough to survive HMR / panel re-mounts.
+   *
+   * On the eventual `tool_result`, the executor's `persistToolResult`
+   * overwrites pluginState with whatever the tool returned (typically the
+   * formatted answer text), so stale drafts naturally evaporate.
+   */
+  setInterventionDraft = (toolMessageId: string, draft: Record<string, unknown>): void => {
+    this.#get().internal_dispatchMessage({
+      id: toolMessageId,
+      key: 'askUserDraft',
+      type: 'updatePluginState',
+      value: draft,
+    });
+  };
+
   rejectToolCalling = async (
     messageId: string,
     reason?: string,

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -1016,61 +1016,6 @@ const persistToolResult = async (
 };
 
 /**
- * Persist a CC AskUserQuestion intervention request: stamp the existing
- * tool message's `pluginState.askUserQuestion` with the questions array
- * and the wall-clock deadline so the UI can render the intervention card
- * and a countdown.
- *
- * Runs only after `persistToolBatch` has populated `toolMsgIdByCallId` for
- * the matching toolCallId. The MCP server uses CC's tool_use id as the
- * correlation key (via `_meta.claudecode/toolUseId`) so the lookup hits
- * the same message that the assistant `tool_use` created. Eventual
- * `tool_result` clears `pluginState` and reveals the final answer.
- */
-const persistInterventionRequest = async (
-  data: AgentInterventionRequestData,
-  toolMsgIdByCallId: Map<string, string>,
-  context: ConversationContext,
-) => {
-  const toolMsgId = toolMsgIdByCallId.get(data.toolCallId);
-  if (!toolMsgId) {
-    console.warn(
-      '[HeterogeneousAgent] intervention_request for unknown toolCallId:',
-      data.toolCallId,
-    );
-    return;
-  }
-
-  let questions: unknown;
-  try {
-    questions = (JSON.parse(data.arguments) as { questions?: unknown }).questions;
-  } catch {
-    /* leave undefined — UI falls back to a plain "answer this" prompt */
-  }
-
-  const pluginState = {
-    askUserQuestion: {
-      apiName: data.apiName,
-      deadline: data.deadline,
-      identifier: data.identifier,
-      questions,
-      status: 'pending' as const,
-      toolCallId: data.toolCallId,
-    },
-  };
-
-  try {
-    await messageService.updateToolMessage(
-      toolMsgId,
-      { pluginState },
-      { agentId: context.agentId, topicId: context.topicId },
-    );
-  } catch (err) {
-    console.error('[HeterogeneousAgent] persistInterventionRequest failed:', err);
-  }
-};
-
-/**
  * Execute a prompt via an external agent CLI.
  *
  * Flow:
@@ -1378,45 +1323,39 @@ export const executeHeterogeneousAgent = async (
       trace.push({ event, timestamp: Date.now() });
 
       // ─── agent_intervention_request: CC AskUserQuestion needs user input ───
-      // Stamp pluginState.askUserQuestion on the matching tool message so the
-      // UI lights up the intervention card. Deferred behind persistQueue so
-      // it lands AFTER persistToolBatch (which creates the tool message and
-      // populates toolMsgIdByCallId from the assistant tool_use earlier in
-      // the same stream). Forwarded to the gateway handler is unnecessary —
-      // the persisted DB state and dispatched in-memory update are enough.
+      // Stamp the canonical `pluginIntervention.status='pending'` on the
+      // matching tool message via `optimisticUpdateMessagePlugin` — that
+      // single primitive (1) writes to DB, (2) updates the in-memory
+      // `dbMessagesMap` reducer, AND (3) mirrors the same intervention onto
+      // the parent assistant's `tools[].intervention` so both surfaces
+      // (inline tool body + bottom InterventionBar) light up immediately.
+      // The Intervention component registered under
+      // `BuiltinToolInterventions['claude-code'][askUserQuestion]` is
+      // rendered automatically by the framework while pending; the
+      // eventual `tool_result` content (formatted answer text) gets
+      // overwritten via the existing `tool_result` branch below.
+      // Deferred behind `persistQueue` so it lands AFTER `persistToolBatch`
+      // populates `toolMsgIdByCallId`.
       if (event.type === 'agent_intervention_request') {
         const data = event.data as AgentInterventionRequestData;
         persistQueue = persistQueue.then(async () => {
-          await persistInterventionRequest(data, toolMsgIdByCallId, context);
-          // Mirror onto the in-memory message so the UI reacts now without
-          // waiting for the next fetchAndReplaceMessages.
           const toolMsgId = toolMsgIdByCallId.get(data.toolCallId);
-          if (!toolMsgId) return;
-          let questions: unknown;
-          try {
-            questions = (JSON.parse(data.arguments) as { questions?: unknown }).questions;
-          } catch {
-            /* ignore */
+          if (!toolMsgId) {
+            console.warn(
+              '[HeterogeneousAgent] intervention_request for unknown toolCallId:',
+              data.toolCallId,
+            );
+            return;
           }
-          get().internal_dispatchMessage(
-            {
-              id: toolMsgId,
-              type: 'updateMessage',
-              value: {
-                pluginState: {
-                  askUserQuestion: {
-                    apiName: data.apiName,
-                    deadline: data.deadline,
-                    identifier: data.identifier,
-                    questions,
-                    status: 'pending',
-                    toolCallId: data.toolCallId,
-                  },
-                },
-              } as any,
-            },
-            { operationId },
-          );
+          try {
+            await get().optimisticUpdateMessagePlugin(
+              toolMsgId,
+              { intervention: { status: 'pending' } },
+              { operationId },
+            );
+          } catch (err) {
+            console.error('[HeterogeneousAgent] persist intervention pending failed:', err);
+          }
         });
         return;
       }

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -1,4 +1,7 @@
-import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
+import type {
+  AgentInterventionRequestData,
+  AgentStreamEvent,
+} from '@lobechat/agent-gateway-client';
 import { isDesktop } from '@lobechat/const';
 import {
   CLAUDE_CODE_CLI_INSTALL_DOCS_URL,
@@ -1013,6 +1016,61 @@ const persistToolResult = async (
 };
 
 /**
+ * Persist a CC AskUserQuestion intervention request: stamp the existing
+ * tool message's `pluginState.askUserQuestion` with the questions array
+ * and the wall-clock deadline so the UI can render the intervention card
+ * and a countdown.
+ *
+ * Runs only after `persistToolBatch` has populated `toolMsgIdByCallId` for
+ * the matching toolCallId. The MCP server uses CC's tool_use id as the
+ * correlation key (via `_meta.claudecode/toolUseId`) so the lookup hits
+ * the same message that the assistant `tool_use` created. Eventual
+ * `tool_result` clears `pluginState` and reveals the final answer.
+ */
+const persistInterventionRequest = async (
+  data: AgentInterventionRequestData,
+  toolMsgIdByCallId: Map<string, string>,
+  context: ConversationContext,
+) => {
+  const toolMsgId = toolMsgIdByCallId.get(data.toolCallId);
+  if (!toolMsgId) {
+    console.warn(
+      '[HeterogeneousAgent] intervention_request for unknown toolCallId:',
+      data.toolCallId,
+    );
+    return;
+  }
+
+  let questions: unknown;
+  try {
+    questions = (JSON.parse(data.arguments) as { questions?: unknown }).questions;
+  } catch {
+    /* leave undefined — UI falls back to a plain "answer this" prompt */
+  }
+
+  const pluginState = {
+    askUserQuestion: {
+      apiName: data.apiName,
+      deadline: data.deadline,
+      identifier: data.identifier,
+      questions,
+      status: 'pending' as const,
+      toolCallId: data.toolCallId,
+    },
+  };
+
+  try {
+    await messageService.updateToolMessage(
+      toolMsgId,
+      { pluginState },
+      { agentId: context.agentId, topicId: context.topicId },
+    );
+  } catch (err) {
+    console.error('[HeterogeneousAgent] persistInterventionRequest failed:', err);
+  }
+};
+
+/**
  * Execute a prompt via an external agent CLI.
  *
  * Flow:
@@ -1318,6 +1376,50 @@ export const executeHeterogeneousAgent = async (
 
       // Record for debugging
       trace.push({ event, timestamp: Date.now() });
+
+      // ─── agent_intervention_request: CC AskUserQuestion needs user input ───
+      // Stamp pluginState.askUserQuestion on the matching tool message so the
+      // UI lights up the intervention card. Deferred behind persistQueue so
+      // it lands AFTER persistToolBatch (which creates the tool message and
+      // populates toolMsgIdByCallId from the assistant tool_use earlier in
+      // the same stream). Forwarded to the gateway handler is unnecessary —
+      // the persisted DB state and dispatched in-memory update are enough.
+      if (event.type === 'agent_intervention_request') {
+        const data = event.data as AgentInterventionRequestData;
+        persistQueue = persistQueue.then(async () => {
+          await persistInterventionRequest(data, toolMsgIdByCallId, context);
+          // Mirror onto the in-memory message so the UI reacts now without
+          // waiting for the next fetchAndReplaceMessages.
+          const toolMsgId = toolMsgIdByCallId.get(data.toolCallId);
+          if (!toolMsgId) return;
+          let questions: unknown;
+          try {
+            questions = (JSON.parse(data.arguments) as { questions?: unknown }).questions;
+          } catch {
+            /* ignore */
+          }
+          get().internal_dispatchMessage(
+            {
+              id: toolMsgId,
+              type: 'updateMessage',
+              value: {
+                pluginState: {
+                  askUserQuestion: {
+                    apiName: data.apiName,
+                    deadline: data.deadline,
+                    identifier: data.identifier,
+                    questions,
+                    status: 'pending',
+                    toolCallId: data.toolCallId,
+                  },
+                },
+              } as any,
+            },
+            { operationId },
+          );
+        });
+        return;
+      }
 
       // ─── tool_result: update tool message content in DB (ACP-only) ───
       if (event.type === 'tool_result') {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-8725 — full plan + spike findings in the issue.

#### 🔀 Description of Change

Foundation layer for interactive AskUserQuestion in the CC integration. CC's built-in `AskUserQuestion` short-circuits in `-p` mode (PR #14629 already disables it as a stop-gap); this PR introduces the local MCP server + per-op bridge that an upcoming Step 3 will wire into Electron's `HeterogeneousAgentCtr`.

##### What lands here

- **`packages/heterogeneous-agents/src/askUser/`**
  - **`AskUserBridge`** — per-op pending map. `pending(args, opts)` returns a Promise the MCP handler awaits; producer side calls `resolve(toolCallId, ...)` / `cancel(...)` / `cancelAll(...)`. Built-in 5-min timeout, 30s `notifications/progress` keepalive cadence, async-iterable `events()` for the producer to forward.
  - **`AskUserMcpServer`** — process-wide HTTP/Streamable MCP host. One server, many ops: each spawn calls `registerOperation(opId)` and gets a URL with `?op=<id>`. Routing happens via `AsyncLocalStorage` → `onsessioninitialized` → `sessionId↔opId` map; tool handler reads `extra.sessionId` to find the matching bridge. Stateful session id (`sessionIdGenerator: randomUUID`) — empirically required, CC rejects stateless mode. Tool registration mirrors CC's built-in `AskUserQuestion` schema verbatim (1-4 questions × 2-4 options, optional multiSelect).
  - **`constants.ts`** — shared MCP server / tool / apiName strings consumed by both server and adapter.
  - 21 unit tests covering bridge lifecycle (resolve / cancel / timeout / progress / event stream) and an end-to-end MCP probe via `StreamableHTTPClientTransport`.

- **`packages/agent-gateway-client/src/types.ts`** — wire-level `agent_intervention_request` / `agent_intervention_response` event variants + `AgentInterventionRequestData` / `AgentInterventionResponseData` payload interfaces. Re-exported through the package barrel.

- **`packages/heterogeneous-agents/src/adapters/claudeCode.ts`** — when CC's `tool_use` carries `mcp__lobe_cc__ask_user_question`, the adapter rewrites `apiName` to `askUserQuestion`. Identifier stays `claude-code`. Applied on both the main-agent and subagent paths for symmetry.

- **`src/server/routers/lambda/aiAgent.ts`** — Zod schema for `aiAgent.heteroIngest` extended with the two new event types so the CLI sandbox can forward them.

##### Spike background (linked from LOBE-8725)

- HTTP/Streamable transport works end-to-end with CC; stdio works too but doesn't fit — handler needs IPC to the renderer and stdio is occupied by MCP.
- 5-min blocking pendings need `notifications/progress` every 30s as wire-level keepalive — without it CC drops the SSE around 5 min with `transport dropped mid-call`.
- `alwaysLoad: true` on the `--mcp-config` server entry promotes the MCP tools to eager-loaded (skip ToolSearch). Soft dependency — falls back to deferred + ToolSearch if the field stops working.
- Full spike trace + raw-output evidence is in LOBE-8725.

##### What does NOT land here

No producer wiring yet. Steps 3-6 will:
- Plug `AskUserMcpServer` into Electron `HeterogeneousAgentCtr` (start/stop, per-op `registerOperation`, write/cleanup temp `mcp.json`, append `--mcp-config` to driver args)
- Add `submitIntervention` IPC and renderer-side `agent_intervention_request` handling
- Build the dedicated AskUserQuestion intervention UI (separate from `lobe-user-interaction`, kept under CC's domain)
- Sandbox `lh hetero exec` keeps current text-fallback behavior — phase 2

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [x] No tests needed (beyond what's added)

```bash
cd packages/heterogeneous-agents && bunx vitest run
# 153 tests pass (all new + existing)

bun run type-check
# clean
```

The new bridge + server tests exercise:
- `pending()` resolve / cancel / 5-min timeout / progress notification cadence
- multi-op routing via `?op=` URL param
- end-to-end MCP probe (initialize → tools/list → tools/call → tool_result) using the SDK's `StreamableHTTPClientTransport`

No runtime path is invoked yet — the producer (Electron / sandbox) doesn't reference any of the new code in this PR. Behavior change lands in Step 3.

#### 📝 Additional Information

Followups tracked in LOBE-8725 acceptance checklist. Sandbox CLI inbound back-channel design is deferred to phase 2 (separate issue).