### PR TITLE
💄 style(copyable-label): wrap long tool-call params instead of truncating

### DIFF
--- a/src/components/CopyableLabel/index.tsx
+++ b/src/components/CopyableLabel/index.tsx
@@ -6,31 +6,63 @@ interface CopyableLabelProps {
   className?: string;
   style?: CSSProperties;
   value?: string | null;
+  wrap?: boolean;
 }
 
-const CopyableLabel = memo<CopyableLabelProps>(({ className, style, value = '--' }) => {
+const CopyableLabel = memo<CopyableLabelProps>(({ className, style, value = '--', wrap }) => {
+  if (wrap) {
+    return (
+      <Flexbox
+        horizontal
+        align={'flex-start'}
+        className={className}
+        gap={4}
+        style={{
+          position: 'relative',
+          width: '100%',
+          ...style,
+        }}
+      >
+        <Text
+          style={{
+            color: 'inherit',
+            flex: 1,
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            margin: 0,
+            minWidth: 0,
+            overflowWrap: 'anywhere',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {value || '--'}
+        </Text>
+        <CopyButton content={value || '--'} size={'small'} />
+      </Flexbox>
+    );
+  }
+
   return (
     <Flexbox
       horizontal
-      align={'flex-start'}
+      align={'center'}
       className={className}
       gap={4}
       style={{
+        overflow: 'hidden',
         position: 'relative',
-        width: '100%',
         ...style,
       }}
     >
       <Text
+        ellipsis
         style={{
           color: 'inherit',
-          flex: 1,
           fontFamily: 'inherit',
           fontSize: 'inherit',
           margin: 0,
-          minWidth: 0,
-          overflowWrap: 'anywhere',
-          whiteSpace: 'pre-wrap',
+          overflow: 'hidden',
+          width: '100%',
         }}
       >
         {value || '--'}

--- a/src/components/CopyableLabel/index.tsx
+++ b/src/components/CopyableLabel/index.tsx
@@ -12,24 +12,25 @@ const CopyableLabel = memo<CopyableLabelProps>(({ className, style, value = '--'
   return (
     <Flexbox
       horizontal
-      align={'center'}
+      align={'flex-start'}
       className={className}
       gap={4}
       style={{
-        overflow: 'hidden',
         position: 'relative',
+        width: '100%',
         ...style,
       }}
     >
       <Text
-        ellipsis
         style={{
           color: 'inherit',
+          flex: 1,
           fontFamily: 'inherit',
           fontSize: 'inherit',
           margin: 0,
-          overflow: 'hidden',
-          width: '100%',
+          minWidth: 0,
+          overflowWrap: 'anywhere',
+          whiteSpace: 'pre-wrap',
         }}
       >
         {value || '--'}

--- a/src/components/Descriptions/index.tsx
+++ b/src/components/Descriptions/index.tsx
@@ -60,6 +60,7 @@ interface DescriptionsProps extends Omit<GridProps, 'children'> {
     label?: CSSProperties;
     value?: CSSProperties;
   };
+  wrap?: boolean;
 }
 
 const Descriptions = memo<DescriptionsProps>(
@@ -71,6 +72,7 @@ const Descriptions = memo<DescriptionsProps>(
     items,
     classNames,
     styles: customStyles,
+    wrap,
     ...rest
   }) => {
     return (
@@ -85,12 +87,12 @@ const Descriptions = memo<DescriptionsProps>(
           {items.map((item) => (
             <Flexbox
               horizontal
-              align={'center'}
+              align={wrap ? 'flex-start' : 'center'}
               className={cx(bordered && styles.cell, item.className, classNames?.item)}
               flex={1}
               key={item.key}
               style={{
-                overflow: 'hidden',
+                overflow: wrap ? undefined : 'hidden',
                 position: 'relative',
                 ...customStyles?.item,
                 ...item.style,
@@ -122,24 +124,37 @@ const Descriptions = memo<DescriptionsProps>(
               </Flexbox>
               <Flexbox
                 horizontal
-                align={'center'}
+                align={wrap ? 'flex-start' : 'center'}
                 flex={1}
                 justify={'flex-start'}
                 paddingBlock={bordered ? 12 : 4}
                 paddingInline={16}
-                style={{ height: '100%', overflow: 'hidden', position: 'relative' }}
+                style={{
+                  height: '100%',
+                  overflow: wrap ? undefined : 'hidden',
+                  position: 'relative',
+                }}
               >
                 {item.copyable ? (
                   <CopyableLabel
                     className={cx(classNames?.value, item.classNames?.value)}
                     style={{ ...customStyles?.value, ...item.styles?.value }}
                     value={item.value ? String(item.value) : '--'}
+                    wrap={wrap}
                   />
                 ) : (
                   <Text
-                    ellipsis
                     className={cx(classNames?.value, item.classNames?.value)}
-                    style={{ ...customStyles?.value, ...item.styles?.value }}
+                    ellipsis={!wrap}
+                    style={{
+                      ...(wrap && {
+                        overflowWrap: 'anywhere',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                      }),
+                      ...customStyles?.value,
+                      ...item.styles?.value,
+                    }}
                   >
                     {item.value}
                   </Text>

--- a/src/components/Descriptions/index.tsx
+++ b/src/components/Descriptions/index.tsx
@@ -46,7 +46,7 @@ export interface DescriptionItem {
   value: ReactNode;
 }
 
-interface DescriptionsProps extends Omit<GridProps, 'children'> {
+interface DescriptionsProps extends Omit<GridProps, 'children' | 'wrap'> {
   bordered?: boolean;
   classNames?: {
     item?: string;

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.tsx
@@ -66,6 +66,7 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', loading, actions
     contentNode = (
       <Flexbox paddingBlock={4} paddingInline={16}>
         <Descriptions
+          wrap
           bordered={false}
           items={items}
           labelWidth={140}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A — visual fix surfaced while reviewing tool-call detail UI.

#### 🔀 Description of Change

Tool-call parameter values rendered via `Descriptions` + `CopyableLabel` (e.g. the "参数列表" panel for an `Edit` tool call) were single-line ellipsis-truncated, hiding most of the content — long `file_path`, `old_string`, `new_string`, etc. became `...` with no way to read them inline.

`CopyableLabel` now wraps by default:

- Drop the `ellipsis` prop on the inner `Text` (the root cause of single-line truncation).
- Drop `overflow: hidden` on the wrapper and switch `align` from `center` → `flex-start` so the copy button stays anchored to the first line when content wraps.
- Switch the `Text` to `flex: 1` + `minWidth: 0` so it shrinks correctly inside the flex row.
- Add `whiteSpace: 'pre-wrap'` to preserve newlines in multi-line values (e.g. code blocks in `new_string`).
- Add `overflowWrap: 'anywhere'` so unbroken strings (file paths, URLs, JSON) still break when they exceed the cell width.

Short values still render on a single line; long values now expand vertically instead of being clipped. `CopyableLabel` is only consumed by `Descriptions`, which is used for tool-call params and the MCP plugin system-dependencies popover, so the blast radius is contained.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open any conversation with a tool call that has long arguments (e.g. an `Edit` call with multi-line `old_string` / `new_string`, or any tool with a long `file_path`) and verify that the parameter list shows the full value wrapped instead of `...`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Long values truncated to `...` (see issue screenshot) | Full value wraps; copy button stays at top-right |

#### 📝 Additional Information

No breaking changes. No perf impact (purely CSS prop changes on a leaf component).