### PR TITLE
💄 style: format tool execution time as Xmin Ys instead of X.Y min

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.test.tsx
@@ -86,6 +86,29 @@ describe('ExecutionTime', () => {
     expect(screen.getByText('0ms')).toBeTruthy();
   });
 
+  it('formats elapsed times longer than a minute as Xmin Ys', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+
+    const { rerender } = render(
+      <ExecutionTime isExecuting startTime={10_000} timerKey="tool-minutes" />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(83_000);
+    });
+
+    expect(screen.getByText('1min23s')).toBeTruthy();
+
+    rerender(<ExecutionTime isExecuting startTime={10_000} timerKey="tool-minutes" />);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByText('2min23s')).toBeTruthy();
+  });
+
   it('clears the cached start time when execution stops', () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Inspector/ExecutionTime.tsx
@@ -37,8 +37,10 @@ const formatElapsedTime = (ms: number): string => {
   const seconds = ms / 1000;
   if (seconds < 60) return `${seconds.toFixed(1)}s`;
 
-  const minutes = seconds / 60;
-  return `${minutes.toFixed(1)}min`;
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}min${remainingSeconds}s`;
 };
 
 const ExecutionTime = memo<ExecutionTimeProps>(({ isExecuting, startTime, timerKey }) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The tool inspector header (e.g. for the Claude Code `Agent` subagent dispatch) was rendering durations longer than a minute as `1.5min`, which felt off compared to the rest of the app where durations are split into minutes + seconds (e.g. `formatDuration` in `Tasks/shared/utils.ts` uses `2m 30s`).

This PR changes `formatElapsedTime` in `ExecutionTime.tsx` to render minute-scale durations as `1min23s` instead. Sub-minute formats (`500ms`, `2.0s`) are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added a unit test covering both 1-minute and multi-minute cases. The existing 4 tests still pass.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| `1.5min` | `1min23s` |