### PR TITLE
🐛 fix(desktop): prevent webview from expanding beyond container in billing/referral pages

### DIFF
--- a/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx
+++ b/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx
@@ -146,16 +146,20 @@ export const SubscriptionIframeWrapper = memo<SubscriptionIframeWrapperProps>(({
   }
 
   return (
-    <webview
-      partition={PARTITION_ID}
-      ref={webviewRef}
-      src={iframeUrl}
-      style={{
-        border: 0,
-        inset: 0,
-        position: 'absolute',
-      }}
-    />
+    <div style={{ height: '100%', position: 'relative', width: '100%' }}>
+      <webview
+        partition={PARTITION_ID}
+        ref={webviewRef}
+        src={iframeUrl}
+        style={{
+          border: 0,
+          height: '100%',
+          inset: 0,
+          position: 'absolute',
+          width: '100%',
+        }}
+      />
+    </div>
   );
 });
 


### PR DESCRIPTION
## Description

In the Desktop app, the **Billing** and **Referral** settings pages use `SubscriptionIframeWrapper` to embed web content via a `<webview>` element.

The webview was styled with `position: 'absolute'` but had **no `position: 'relative'` parent container**. This caused it to break out of the `SettingContainer`'s `maxWidth: 1024` constraint. When the embedded page content was wider than the container, the entire page would expand horizontally, forcing users to scroll sideways to see the rest of the content.

## Root Cause

```tsx
// Before: webview with absolute positioning, no relative parent
<webview style={{ border: 0, inset: 0, position: 'absolute' }} />
```

An absolutely positioned element without a positioned ancestor will be positioned relative to the initial containing block (usually the viewport), ignoring the `maxWidth` set by `SettingContainer`.

## Fix

Wrap the `<webview>` in a `<div>` with `position: 'relative'`, and explicitly set `width: '100%'` and `height: '100%'` on the webview so it stays constrained within its parent.

```tsx
// After: webview properly constrained
<div style={{ height: '100%', position: 'relative', width: '100%' }}>
  <webview style={{ border: 0, height: '100%', inset: 0, position: 'absolute', width: '100%' }} />
</div>
```

## Affected Pages

- Settings → Billing
- Settings → Referral

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code follows the project style guidelines
- [x] Tested locally in Desktop app

## Related

This bug has not been previously reported in the upstream repository.