### PR TITLE
💄 style: increase chat topic title length

### DIFF
--- a/packages/prompts/src/chains/__tests__/__snapshots__/summaryTitle.test.ts.snap
+++ b/packages/prompts/src/chains/__tests__/__snapshots__/summaryTitle.test.ts.snap
@@ -8,8 +8,8 @@ exports[`chainSummaryTitle > should use the default model if the token count is 
 
 Rules:
 - Output ONLY the title text, no explanations or additional context
-- Maximum 10 words
-- Maximum 50 characters
+- Maximum 15 words
+- Maximum 80 characters
 - No punctuation marks
 - Use the language specified by the locale code: en-US
 - The title should accurately reflect the main topic of the conversation

--- a/packages/prompts/src/chains/summaryTitle.ts
+++ b/packages/prompts/src/chains/summaryTitle.ts
@@ -10,8 +10,8 @@ export const chainSummaryTitle = (
 
 Rules:
 - Output ONLY the title text, no explanations or additional context
-- Maximum 10 words
-- Maximum 50 characters
+- Maximum 15 words
+- Maximum 80 characters
 - No punctuation marks
 - Use the language specified by the locale code: ${locale}
 - The title should accurately reflect the main topic of the conversation

--- a/src/server/routers/lambda/thread.ts
+++ b/src/server/routers/lambda/thread.ts
@@ -73,7 +73,7 @@ export const threadRouter = router({
           metadata: input.metadata,
           parentThreadId: input.parentThreadId,
           sourceMessageId: input.sourceMessageId,
-          title: input.message.content.slice(0, 40),
+          title: input.message.content.slice(0, 80),
           topicId: input.topicId,
           type: input.type,
         }),

--- a/src/server/routers/lambda/thread.ts
+++ b/src/server/routers/lambda/thread.ts
@@ -73,7 +73,7 @@ export const threadRouter = router({
           metadata: input.metadata,
           parentThreadId: input.parentThreadId,
           sourceMessageId: input.sourceMessageId,
-          title: input.message.content.slice(0, 20),
+          title: input.message.content.slice(0, 40),
           topicId: input.topicId,
           type: input.type,
         }),

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -504,7 +504,7 @@ export class ConversationLifecycleActionImpl {
             newTopic: !operationContext.topicId
               ? {
                   metadata: workingDirectory ? { workingDirectory } : undefined,
-                  title: message.slice(0, 20) || t('defaultTitle', { ns: 'topic' }),
+                  title: message.slice(0, 40) || t('defaultTitle', { ns: 'topic' }),
                   topicMessageIds: messages.map((m) => m.id),
                 }
               : undefined,
@@ -738,7 +738,7 @@ export class ConversationLifecycleActionImpl {
           newTopic: !topicId
             ? {
                 topicMessageIds: forceNewTopicFromExisting ? [] : messages.map((m) => m.id),
-                title: message.slice(0, 20) || t('defaultTitle', { ns: 'topic' }),
+                title: message.slice(0, 40) || t('defaultTitle', { ns: 'topic' }),
               }
             : undefined,
           agentId: operationContext.agentId,
@@ -885,7 +885,7 @@ export class ConversationLifecycleActionImpl {
       }
 
       const firstUserText = messages.find((m) => m.role === 'user')?.content?.trim() ?? '';
-      const title = firstUserText.slice(0, 30) || 'New Topic';
+      const title = firstUserText.slice(0, 40) || 'New Topic';
       await this.#get().internal_updateTopic(topicId, { title });
       // summaryTopicTitle would normally clear loading via onLoadingChange; do it manually.
       this.#get().internal_updateTopicLoading(topicId, false);

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -504,7 +504,7 @@ export class ConversationLifecycleActionImpl {
             newTopic: !operationContext.topicId
               ? {
                   metadata: workingDirectory ? { workingDirectory } : undefined,
-                  title: message.slice(0, 40) || t('defaultTitle', { ns: 'topic' }),
+                  title: message.slice(0, 80) || t('defaultTitle', { ns: 'topic' }),
                   topicMessageIds: messages.map((m) => m.id),
                 }
               : undefined,
@@ -738,7 +738,7 @@ export class ConversationLifecycleActionImpl {
           newTopic: !topicId
             ? {
                 topicMessageIds: forceNewTopicFromExisting ? [] : messages.map((m) => m.id),
-                title: message.slice(0, 40) || t('defaultTitle', { ns: 'topic' }),
+                title: message.slice(0, 80) || t('defaultTitle', { ns: 'topic' }),
               }
             : undefined,
           agentId: operationContext.agentId,
@@ -885,7 +885,7 @@ export class ConversationLifecycleActionImpl {
       }
 
       const firstUserText = messages.find((m) => m.role === 'user')?.content?.trim() ?? '';
-      const title = firstUserText.slice(0, 40) || 'New Topic';
+      const title = firstUserText.slice(0, 80) || 'New Topic';
       await this.#get().internal_updateTopic(topicId, { title });
       // summaryTopicTitle would normally clear loading via onLoadingChange; do it manually.
       this.#get().internal_updateTopicLoading(topicId, false);


### PR DESCRIPTION
## Summary

The chat topic title in the sidebar was getting truncated to around 10-15 visible characters (e.g. `你能否用 vercel cli 看下今`), which made entries hard to identify. Bumped the underlying truncation limits so titles carry more context.

- **Initial topic title** (`src/store/chat/slices/aiChat/actions/conversationLifecycle.ts`): `message.slice(0, 20)` → `slice(0, 40)` (heterogeneous + regular agent paths)
- **Dev fallback** (same file): `slice(0, 30)` → `slice(0, 40)` for consistency
- **Thread title** (`src/server/routers/lambda/thread.ts`): `slice(0, 20)` → `slice(0, 40)`
- **LLM summary prompt** (`packages/prompts/src/chains/summaryTitle.ts`): `Maximum 10 words / 50 characters` → `15 words / 80 characters`

The 40-char initial slice and 80-char LLM upper bound roughly double the previous lengths, giving the sidebar enough room to disambiguate titles while still fitting comfortably in typical sidebar widths.

## Test plan

- [x] `summaryTitle` snapshot updated and test passes
- [ ] Visually verify sidebar topic list — new topics show longer initial titles before LLM summarization kicks in
- [ ] Verify LLM-generated titles can now use more characters when content warrants it

🤖 Generated with [Claude Code](https://claude.com/claude-code)