### PR TITLE
🐛 fix(web-crawler): cap response body size to prevent serverless OOM

### DIFF
--- a/packages/ssrf-safe-fetch/index.browser.ts
+++ b/packages/ssrf-safe-fetch/index.browser.ts
@@ -13,6 +13,8 @@ export interface SSRFOptions {
   allowIPAddressList?: string[];
   /** Whether to allow private/local IP addresses */
   allowPrivateIPAddress?: boolean;
+  /** Maximum response body size in bytes (server-only; ignored in browser) */
+  maxContentLength?: number;
 }
 
 /**

--- a/packages/ssrf-safe-fetch/index.test.ts
+++ b/packages/ssrf-safe-fetch/index.test.ts
@@ -280,6 +280,71 @@ describe('ssrfSafeFetch', () => {
     });
   });
 
+  describe('maxContentLength (response body cap)', () => {
+    const buildBodyResponse = (chunks: Buffer[]) => ({
+      // arrayBuffer should NOT be called when maxContentLength is set;
+      // make it throw so the test fails loudly if the cap path falls through.
+      arrayBuffer: vi.fn().mockImplementation(async () => {
+        throw new Error('arrayBuffer should not be called when maxContentLength is set');
+      }),
+      body: (async function* () {
+        for (const chunk of chunks) yield chunk;
+      })(),
+      headers: new Map([['content-type', 'text/html']]),
+      status: 200,
+      statusText: 'OK',
+    });
+
+    it('returns the full body when it fits within the cap', async () => {
+      mockFetch.mockResolvedValue(buildBodyResponse([Buffer.from('hello '), Buffer.from('world')]));
+
+      const response = await ssrfSafeFetch('https://example.com', {}, { maxContentLength: 1024 });
+
+      expect(await response.text()).toBe('hello world');
+    });
+
+    it('truncates the body once the cap is reached and stops reading further chunks', async () => {
+      const chunks = [
+        Buffer.from('a'.repeat(60)),
+        Buffer.from('b'.repeat(60)),
+        Buffer.from('c'.repeat(60)),
+      ];
+      mockFetch.mockResolvedValue(buildBodyResponse(chunks));
+
+      const response = await ssrfSafeFetch('https://example.com', {}, { maxContentLength: 100 });
+
+      const text = await response.text();
+      expect(text).toHaveLength(100);
+      expect(text).toBe('a'.repeat(60) + 'b'.repeat(40));
+    });
+
+    it('returns an empty body when the response stream is null', async () => {
+      mockFetch.mockResolvedValue({
+        arrayBuffer: vi.fn(),
+        body: null,
+        headers: new Map(),
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const response = await ssrfSafeFetch('https://example.com', {}, { maxContentLength: 1024 });
+
+      expect(await response.text()).toBe('');
+    });
+
+    it('falls back to arrayBuffer when maxContentLength is not set', async () => {
+      const mockResponse = createMockResponse({
+        arrayBuffer: new TextEncoder().encode('legacy path').buffer as ArrayBuffer,
+      });
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const response = await ssrfSafeFetch('https://example.com');
+
+      expect(mockResponse.arrayBuffer).toHaveBeenCalledTimes(1);
+      expect(await response.text()).toBe('legacy path');
+    });
+  });
+
   describe('integration scenarios', () => {
     it('should work with complex request configurations', async () => {
       process.env.SSRF_ALLOW_IP_ADDRESS_LIST = '127.0.0.1';

--- a/packages/ssrf-safe-fetch/index.test.ts
+++ b/packages/ssrf-safe-fetch/index.test.ts
@@ -345,6 +345,117 @@ describe('ssrfSafeFetch', () => {
     });
   });
 
+  /*
+   * Regression tests for the production SIGABRT crashes on /trpc/tools/search.webSearch
+   * (rss=2889MB heap=2473MB → V8 "allocation failed" → SIGABRT). These verify the cap
+   * actually prevents unbounded buffering even when the source body is huge.
+   */
+  describe('OOM regression: bounded memory under oversized response bodies', () => {
+    const ONE_MB = 1024 * 1024;
+    const SIXTY_FOUR_KB = 64 * 1024;
+
+    /**
+     * Builds a mock response whose body generator tracks how many bytes it has
+     * yielded into a shared counter. Lets us assert that we did not drain the
+     * full source — the whole point of the cap is to stop pulling early.
+     */
+    const buildHugeBodyResponse = (
+      counter: { bytesYielded: number },
+      totalAvailableBytes: number,
+    ) => {
+      const chunk = Buffer.alloc(SIXTY_FOUR_KB, 0x61);
+      const totalChunks = Math.ceil(totalAvailableBytes / chunk.length);
+
+      async function* gen() {
+        for (let i = 0; i < totalChunks; i++) {
+          counter.bytesYielded += chunk.length;
+          yield chunk;
+        }
+      }
+
+      return {
+        arrayBuffer: vi.fn().mockImplementation(async () => {
+          throw new Error('arrayBuffer should not be called when maxContentLength is set');
+        }),
+        body: gen(),
+        headers: new Map([['content-type', 'text/html']]),
+        status: 200,
+        statusText: 'OK',
+      };
+    };
+
+    it('stops pulling chunks from the source once the cap is reached', async () => {
+      // Source has 200 MB available; cap at 1 MB. Pre-fix would buffer all 200 MB
+      // before the downstream truncation could apply.
+      const counter = { bytesYielded: 0 };
+      mockFetch.mockResolvedValue(buildHugeBodyResponse(counter, 200 * ONE_MB));
+
+      const response = await ssrfSafeFetch(
+        'https://huge.example.com',
+        {},
+        { maxContentLength: ONE_MB },
+      );
+      const body = await response.arrayBuffer();
+
+      expect(body.byteLength).toBe(ONE_MB);
+      // We should have pulled at most CAP + one chunk of slack (the last chunk
+      // that triggered the break). Definitely not the full 200 MB.
+      expect(counter.bytesYielded).toBeLessThanOrEqual(ONE_MB + SIXTY_FOUR_KB);
+    });
+
+    it('keeps total source pull bounded under CRAWL_CONCURRENCY=3 (production scenario)', async () => {
+      // Three concurrent oversized fetches — matches the production setup where
+      // pMap with concurrency=3 over 3 large search results triggered SIGABRT.
+      const counter = { bytesYielded: 0 };
+      mockFetch
+        .mockResolvedValueOnce(buildHugeBodyResponse(counter, 100 * ONE_MB))
+        .mockResolvedValueOnce(buildHugeBodyResponse(counter, 100 * ONE_MB))
+        .mockResolvedValueOnce(buildHugeBodyResponse(counter, 100 * ONE_MB));
+
+      const responses = await Promise.all([
+        ssrfSafeFetch('https://a.example.com', {}, { maxContentLength: ONE_MB }),
+        ssrfSafeFetch('https://b.example.com', {}, { maxContentLength: ONE_MB }),
+        ssrfSafeFetch('https://c.example.com', {}, { maxContentLength: ONE_MB }),
+      ]);
+
+      for (const r of responses) {
+        expect((await r.arrayBuffer()).byteLength).toBe(ONE_MB);
+      }
+      // Without the cap we would have pulled 300 MB. With cap=1 MB × 3 fetches,
+      // expect ≤ 3 × (cap + one chunk slack).
+      expect(counter.bytesYielded).toBeLessThanOrEqual(3 * (ONE_MB + SIXTY_FOUR_KB));
+    });
+
+    /*
+     * Real heap-pressure test — only runs when --expose-gc is available
+     * (e.g. `NODE_OPTIONS=--expose-gc bunx vitest run`). Skipped otherwise so CI
+     * doesn't false-fail due to GC timing.
+     */
+    const itIfGc = typeof globalThis.gc === 'function' ? it : it.skip;
+    itIfGc('heap delta stays bounded when a 50 MB body is fetched with a 1 MB cap', async () => {
+      const counter = { bytesYielded: 0 };
+      mockFetch.mockResolvedValue(buildHugeBodyResponse(counter, 50 * ONE_MB));
+
+      globalThis.gc!();
+      const before = process.memoryUsage().heapUsed;
+
+      const response = await ssrfSafeFetch(
+        'https://heavy.example.com',
+        {},
+        { maxContentLength: ONE_MB },
+      );
+      await response.arrayBuffer();
+
+      globalThis.gc!();
+      const after = process.memoryUsage().heapUsed;
+      const deltaMB = (after - before) / ONE_MB;
+
+      // Without the cap, delta would be ≥ 50 MB. With cap=1 MB, we expect
+      // a few MB of overhead at most.
+      expect(deltaMB).toBeLessThan(10);
+    });
+  });
+
   describe('integration scenarios', () => {
     it('should work with complex request configurations', async () => {
       process.env.SSRF_ALLOW_IP_ADDRESS_LIST = '127.0.0.1';

--- a/packages/ssrf-safe-fetch/index.ts
+++ b/packages/ssrf-safe-fetch/index.ts
@@ -10,7 +10,47 @@ export interface SSRFOptions {
   allowIPAddressList?: string[];
   /** Whether to allow private/local IP addresses */
   allowPrivateIPAddress?: boolean;
+  /**
+   * Maximum response body size in bytes. When set, the body is consumed
+   * incrementally and reading stops as soon as the cap is reached. The returned
+   * Response contains only the bytes received up to that point (soft truncation —
+   * still considered a successful response).
+   *
+   * Use this for any fetch that downloads untrusted content (e.g. web crawlers)
+   * to prevent unbounded buffering of large or malicious responses from blowing
+   * up serverless function memory.
+   */
+  maxContentLength?: number;
 }
+
+/**
+ * Consume a node-fetch Response body up to `cap` bytes, then stop. Breaking out
+ * of `for await` closes the async iterator, which destroys the underlying stream
+ * and releases the HTTP connection.
+ */
+const readBodyWithCap = async (
+  body: NodeJS.ReadableStream | null,
+  cap: number,
+): Promise<Uint8Array> => {
+  if (!body) return new Uint8Array(0);
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const remaining = cap - total;
+    if (buf.length >= remaining) {
+      chunks.push(buf.subarray(0, remaining));
+      total = cap;
+      break;
+    }
+    chunks.push(buf);
+    total += buf.length;
+  }
+
+  return Buffer.concat(chunks, total);
+};
 
 /**
  * SSRF-safe fetch implementation for server-side use
@@ -54,8 +94,16 @@ export const ssrfSafeFetch = async (
       agent: (parsedURL: URL) => (parsedURL.protocol === 'https:' ? httpsAgent : httpAgent),
     } as any);
 
+    const cap = ssrfOptions?.maxContentLength;
+    const body: BodyInit =
+      cap && cap > 0
+        ? // Buffer is a Uint8Array subclass; the Response constructor accepts it at
+          // runtime even though the BodyInit lib type doesn't list Uint8Array.
+          ((await readBodyWithCap(response.body as NodeJS.ReadableStream | null, cap)) as any)
+        : await response.arrayBuffer();
+
     // Convert node-fetch Response to standard Response
-    return new Response(await response.arrayBuffer(), {
+    return new Response(body, {
       headers: response.headers as any,
       status: response.status,
       statusText: response.statusText,

--- a/packages/web-crawler/src/crawImpl/naive.ts
+++ b/packages/web-crawler/src/crawImpl/naive.ts
@@ -2,7 +2,7 @@ import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 
 import type { CrawlImpl, CrawlSuccessResult } from '../type';
 import { PageNotFoundError, toFetchError } from '../utils/errorType';
-import { htmlToMarkdown } from '../utils/htmlToMarkdown';
+import { htmlToMarkdown, MAX_HTML_SIZE } from '../utils/htmlToMarkdown';
 import { createHTTPStatusError } from '../utils/response';
 import { DEFAULT_TIMEOUT, withTimeout } from '../utils/withTimeout';
 
@@ -41,10 +41,14 @@ export const naive: CrawlImpl = async (url, { filterOptions }) => {
   try {
     res = await withTimeout(
       (signal) =>
-        ssrfSafeFetch(url, {
-          headers: mixinHeaders,
-          signal,
-        }),
+        ssrfSafeFetch(
+          url,
+          {
+            headers: mixinHeaders,
+            signal,
+          },
+          { maxContentLength: MAX_HTML_SIZE },
+        ),
       DEFAULT_TIMEOUT,
     );
   } catch (e) {

--- a/packages/web-crawler/src/utils/htmlToMarkdown.ts
+++ b/packages/web-crawler/src/utils/htmlToMarkdown.ts
@@ -6,7 +6,7 @@ import { NodeHtmlMarkdown } from 'node-html-markdown';
 import type { FilterOptions } from '../type';
 
 /** Truncate HTML to 1 MB before DOM parsing to prevent CPU spikes on large pages */
-const MAX_HTML_SIZE = 1024 * 1024;
+export const MAX_HTML_SIZE = 1024 * 1024;
 
 const cleanObj = <T extends object>(
   obj: T,
@@ -36,53 +36,60 @@ export const htmlToMarkdown = (
     url,
   });
 
-  const document = window.document;
-  document.body.innerHTML = html;
-
-  let parsedContent: ReturnType<Readability<string>['parse']> = null;
   try {
-    // @ts-expect-error reason: Readability expects a Document type
-    parsedContent = new Readability(document).parse();
-  } catch {
-    // happy-dom may throw on pages with invalid CSS selectors — fall back to raw HTML
+    const document = window.document;
+    document.body.innerHTML = html;
+
+    let parsedContent: ReturnType<Readability<string>['parse']> = null;
+    try {
+      // @ts-expect-error reason: Readability expects a Document type
+      parsedContent = new Readability(document).parse();
+    } catch {
+      // happy-dom may throw on pages with invalid CSS selectors — fall back to raw HTML
+    }
+
+    const useReadability = filterOptions.enableReadability ?? true;
+
+    let htmlNode = html;
+
+    if (useReadability && parsedContent?.content) {
+      htmlNode = parsedContent?.content;
+    }
+
+    const customTranslators = (
+      filterOptions.pureText
+        ? {
+            a: {
+              postprocess: (_: string, content: string) => content,
+            },
+            img: {
+              ignore: true,
+            },
+          }
+        : {}
+    ) as TranslatorConfigObject;
+
+    const nodeHtmlMarkdown = new NodeHtmlMarkdown({}, customTranslators);
+
+    const content = nodeHtmlMarkdown.translate(htmlNode);
+
+    const result = {
+      author: parsedContent?.byline,
+      content,
+      description: parsedContent?.excerpt,
+      dir: parsedContent?.dir,
+      lang: parsedContent?.lang,
+      length: parsedContent?.length,
+      publishedTime: parsedContent?.publishedTime,
+      siteName: parsedContent?.siteName,
+      title: parsedContent?.title,
+    };
+
+    return cleanObj(result) as HtmlToMarkdownOutput;
+  } finally {
+    // Release the happy-dom Window so its DOM tree is GC-able immediately, instead
+    // of waiting for the function scope to drop. JS evaluation is disabled so the
+    // returned promise resolves synchronously in practice — fire and forget.
+    void window.happyDOM.close();
   }
-
-  const useReadability = filterOptions.enableReadability ?? true;
-
-  let htmlNode = html;
-
-  if (useReadability && parsedContent?.content) {
-    htmlNode = parsedContent?.content;
-  }
-
-  const customTranslators = (
-    filterOptions.pureText
-      ? {
-          a: {
-            postprocess: (_: string, content: string) => content,
-          },
-          img: {
-            ignore: true,
-          },
-        }
-      : {}
-  ) as TranslatorConfigObject;
-
-  const nodeHtmlMarkdown = new NodeHtmlMarkdown({}, customTranslators);
-
-  const content = nodeHtmlMarkdown.translate(htmlNode);
-
-  const result = {
-    author: parsedContent?.byline,
-    content,
-    description: parsedContent?.excerpt,
-    dir: parsedContent?.dir,
-    lang: parsedContent?.lang,
-    length: parsedContent?.length,
-    publishedTime: parsedContent?.publishedTime,
-    siteName: parsedContent?.siteName,
-    title: parsedContent?.title,
-  };
-
-  return cleanObj(result) as HtmlToMarkdownOutput;
 };


### PR DESCRIPTION
## Summary

Production saw repeated `SIGABRT (signal 6, core dumped)` crashes on `/trpc/tools/search.webSearch` — Node aborted with V8 `FATAL ERROR: ... allocation failed`. Memory snapshots logged from `lobe-oom:web-browsing:search-service` showed `rss=2889.3MB heap=2473.1MB` right before the crash, well above Vercel's 1769 MB lambda ceiling.

Root cause: `ssrfSafeFetch` calls `await response.arrayBuffer()`, materialising the entire HTTP body into heap before returning. The naive crawler's downstream 1 MB truncation in `htmlToMarkdown` runs *after* the body is already in memory, so a single oversized page (or a batch of three under default `CRAWL_CONCURRENCY=3`) can blow past the lambda memory limit before any guard kicks in.

## Changes

- **`@lobechat/ssrf-safe-fetch`**: add opt-in `maxContentLength` option. When set, the response body is consumed via `for await (const chunk of response.body)` and reading stops the moment the cap is hit. Breaking out of the iterator closes it, which destroys the underlying stream and releases the HTTP connection. The returned `Response` contains only the bytes received up to the cap (soft truncation — still treated as success). Default behaviour (full `arrayBuffer()` read) is unchanged when the option is absent, so other callers (`imageToBase64`, `videoToBase64`, replicate provider) are unaffected.
- **`@lobechat/web-crawler` / `naive.ts`**: pass `maxContentLength: MAX_HTML_SIZE` (1 MB) so any body beyond that size is dropped at the network layer instead of being materialised in heap. Pages larger than the cap still crawl successfully, just truncated — same end-state as before, just with bounded memory.
- **`htmlToMarkdown`**: wrap the parse in `try / finally` and call `window.happyDOM.close()` so the parsed DOM tree is released as soon as parsing finishes, rather than waiting for the function scope to drop. JS evaluation is disabled in our `Window` config, so the returned promise resolves synchronously in practice — fire-and-forget.

## Why not lower `CRAWL_CONCURRENCY`?

It's already env-configurable (`CRAWL_CONCURRENCY`, default 3) and is the right knob for ops to dial down per-deployment. The fix here removes the underlying memory bomb so concurrency=3 is actually safe.

## Regression tests

Three new tests in `packages/ssrf-safe-fetch/index.test.ts` under "OOM regression: bounded memory under oversized response bodies" — they verify the cap actually prevents the production SIGABRT scenario, not just produces a truncated body:

1. **Source-pull bound**: a body source with 200 MB available, capped at 1 MB, must not be drained beyond ~1 MB. Asserts on bytes pulled from the generator — the property that prevents OOM at the source.
2. **Concurrency bound** (production scenario): three concurrent oversized fetches matching `CRAWL_CONCURRENCY=3` should pull at most ~3 MB total, not 300 MB.
3. **Heap-delta bound** (gated on `--expose-gc`): under real GC pressure, fetching a 50 MB body with a 1 MB cap should grow `heapUsed` by < 10 MB. Run with `NODE_OPTIONS=--expose-gc bunx vitest run` to exercise; skipped by default so CI doesn't false-fail on GC timing.

## Test plan

- [x] `bunx vitest run packages/ssrf-safe-fetch` — 32 passed, 1 skipped (heap-delta, requires `--expose-gc`)
- [x] `NODE_OPTIONS='--expose-gc' bunx vitest run packages/ssrf-safe-fetch` — 33 passed including heap-delta
- [x] `bunx vitest run packages/web-crawler` — 157 passed, htmlToMarkdown snapshots unchanged
- [x] `bunx vitest run src/server/services/search/index.test.ts` — 26 passed
- [x] `bun run type-check` — clean
- [ ] Production verification: monitor `vc logs -p lobehub-cloud-next --query 'Process exited'` for 24h after deploy and confirm SIGABRT rate on `/trpc/tools/search.webSearch` drops to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)