### PR TITLE
🐛 fix(hotkey): remove redundant onClear to prevent double updateHotkey calls

### DIFF
--- a/src/routes/(main)/settings/hotkey/features/Desktop.tsx
+++ b/src/routes/(main)/settings/hotkey/features/Desktop.tsx
@@ -61,7 +61,6 @@ const HotkeySetting = memo(() => {
         texts={{ clear: t('hotkey.clearBinding') }}
         value={hotkeys[item.id]}
         onChange={(value) => void updateHotkey(item.id, value)}
-        onClear={() => void updateHotkey(item.id, '')}
       />
     ),
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracking issue -->

#### 🔀 Description of Change

In \`Desktop.tsx\`, \`HotkeyInput\` was passed both \`onChange\` and \`onClear\` with the same side-effect (\`updateDesktopHotkey\`). When the user clicks the clear button, \`HotkeyInput\` internally calls \`setHotkeyValue('')\` which triggers \`onChange('')\`, and then also calls the \`onClear\` callback — resulting in **two concurrent requests** to \`updateDesktopHotkey\` and **two toast messages** for a single user action.

Fix: remove the redundant \`onClear\` prop. The clear action already fires \`onChange('')\`, so the single \`onChange\` handler is sufficient.

\`\`\`diff
- onClear={() => void updateHotkey(item.id, '')}
\`\`\`

#### 🧪 How to Test

1. Open Desktop → Settings → Hotkey
2. Set any hotkey binding
3. Click the clear (✕) button
4. Verify only **one** success/error toast appears (previously two would show)

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Two toast messages on clear | One toast message on clear |