### PR TITLE
🐛 fix: reject inactive OIDC access

### DIFF
--- a/packages/openapi/src/middleware/auth.test.ts
+++ b/packages/openapi/src/middleware/auth.test.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -103,9 +102,8 @@ describe('OpenAPI auth middleware', () => {
 
   it('should reject an inactive OIDC bearer token without authenticating the request', async () => {
     const app = createApp();
-    const inactiveError = new TRPCError({
+    const inactiveError = Object.assign(new Error('OIDC user is no longer active'), {
       code: 'UNAUTHORIZED',
-      message: 'OIDC user is no longer active',
     });
     mockValidateOIDCJWT.mockResolvedValueOnce({
       tokenData: { sub: 'banned-user' },

--- a/packages/openapi/src/middleware/auth.test.ts
+++ b/packages/openapi/src/middleware/auth.test.ts
@@ -1,0 +1,123 @@
+import { TRPCError } from '@trpc/server';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requireAuth, userAuthMiddleware } from './auth';
+
+const {
+  mockAssertOIDCUserActive,
+  mockAuthEnv,
+  mockGetServerDB,
+  mockExtractBearerToken,
+  mockServerDB,
+  mockValidateApiKeyFormat,
+  mockValidateOIDCJWT,
+} = vi.hoisted(() => ({
+  mockAssertOIDCUserActive: vi.fn(),
+  mockAuthEnv: { ENABLE_OIDC: true },
+  mockExtractBearerToken: vi.fn(),
+  mockGetServerDB: vi.fn(),
+  mockServerDB: {},
+  mockValidateApiKeyFormat: vi.fn(),
+  mockValidateOIDCJWT: vi.fn(),
+}));
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: mockGetServerDB,
+}));
+
+vi.mock('@/database/models/apiKey', () => ({
+  ApiKeyModel: class {},
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: mockAuthEnv,
+}));
+
+vi.mock('@/libs/oidc-provider/access-control', () => ({
+  assertOIDCUserActive: mockAssertOIDCUserActive,
+}));
+
+vi.mock('@/libs/oidc-provider/jwt', () => ({
+  validateOIDCJWT: mockValidateOIDCJWT,
+}));
+
+vi.mock('@/utils/apiKey', () => ({
+  validateApiKeyFormat: mockValidateApiKeyFormat,
+}));
+
+vi.mock('@/utils/server/auth', () => ({
+  extractBearerToken: mockExtractBearerToken,
+}));
+
+const createApp = () => {
+  const app = new Hono();
+
+  app.onError((error, c) => {
+    if (error instanceof HTTPException) return error.getResponse();
+
+    return c.text(error.message, 500);
+  });
+
+  app.use('*', userAuthMiddleware);
+  app.get('/protected', requireAuth, (c) =>
+    c.json({
+      authType: c.get('authType'),
+      userId: c.get('userId'),
+    }),
+  );
+
+  return app;
+};
+
+describe('OpenAPI auth middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthEnv.ENABLE_OIDC = true;
+    mockExtractBearerToken.mockReturnValue('oidc-token');
+    mockGetServerDB.mockResolvedValue(mockServerDB);
+    mockValidateApiKeyFormat.mockReturnValue(false);
+    mockValidateOIDCJWT.mockResolvedValue({
+      tokenData: { sub: 'oidc-user' },
+      userId: 'oidc-user',
+    });
+    mockAssertOIDCUserActive.mockResolvedValue(undefined);
+  });
+
+  it('should authenticate an active OIDC bearer token', async () => {
+    const app = createApp();
+
+    const response = await app.request('/protected', {
+      headers: { Authorization: 'Bearer oidc-token' },
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      authType: 'oidc',
+      userId: 'oidc-user',
+    });
+    expect(response.status).toBe(200);
+    expect(mockValidateOIDCJWT).toHaveBeenCalledWith('oidc-token');
+    expect(mockAssertOIDCUserActive).toHaveBeenCalledWith(mockServerDB, 'oidc-user');
+  });
+
+  it('should reject an inactive OIDC bearer token without authenticating the request', async () => {
+    const app = createApp();
+    const inactiveError = new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'OIDC user is no longer active',
+    });
+    mockValidateOIDCJWT.mockResolvedValueOnce({
+      tokenData: { sub: 'banned-user' },
+      userId: 'banned-user',
+    });
+    mockAssertOIDCUserActive.mockRejectedValueOnce(inactiveError);
+
+    const response = await app.request('/protected', {
+      headers: { Authorization: 'Bearer oidc-token' },
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockAssertOIDCUserActive).toHaveBeenCalledWith(mockServerDB, 'banned-user');
+  });
+});

--- a/packages/openapi/src/middleware/auth.test.ts
+++ b/packages/openapi/src/middleware/auth.test.ts
@@ -4,6 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { requireAuth, userAuthMiddleware } from './auth';
 
+interface TestHonoEnv {
+  Variables: {
+    authData: unknown;
+    authorizationHeader: string | null;
+    authType: string | null;
+    userId: string | null;
+  };
+}
+
 const {
   mockAssertOIDCUserActive,
   mockAuthEnv,
@@ -51,7 +60,7 @@ vi.mock('@/utils/server/auth', () => ({
 }));
 
 const createApp = () => {
-  const app = new Hono();
+  const app = new Hono<TestHonoEnv>();
 
   app.onError((error, c) => {
     if (error instanceof HTTPException) return error.getResponse();

--- a/packages/openapi/src/middleware/auth.ts
+++ b/packages/openapi/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import { HTTPException } from 'hono/http-exception';
 import { getServerDB } from '@/database/core/db-adaptor';
 import { ApiKeyModel } from '@/database/models/apiKey';
 import { authEnv } from '@/envs/auth';
+import { assertOIDCUserActive } from '@/libs/oidc-provider/access-control';
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { validateApiKeyFormat } from '@/utils/apiKey';
 import { extractBearerToken } from '@/utils/server/auth';
@@ -174,6 +175,8 @@ export const userAuthMiddleware = async (c: Context, next: Next) => {
       try {
         // Use direct JWT validation instead of OIDCService
         const tokenInfo = await validateOIDCJWT(bearerToken);
+        const db = await getServerDB();
+        await assertOIDCUserActive(db, tokenInfo.userId);
 
         userId = tokenInfo.userId;
         authType = 'oidc';

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -2,11 +2,11 @@ import { AgentRuntimeError } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { assertOIDCUserActive } from '@/libs/oidc-provider/access-control';
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { createErrorResponse } from '@/utils/errorResponse';
 
 import { checkAuth, type RequestHandler } from './index';
-import { checkAuthMethod } from './utils';
 
 vi.mock('@lobechat/model-runtime', () => ({
   AgentRuntimeError: {
@@ -26,10 +26,6 @@ const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefi
 
 vi.mock('@/utils/errorResponse', () => ({
   createErrorResponse: vi.fn(),
-}));
-
-vi.mock('./utils', () => ({
-  checkAuthMethod: vi.fn(),
 }));
 
 vi.mock('@/auth', () => ({
@@ -57,6 +53,10 @@ vi.mock('@/libs/oidc-provider/jwt', () => ({
   validateOIDCJWT: vi.fn(),
 }));
 
+vi.mock('@/libs/oidc-provider/access-control', () => ({
+  assertOIDCUserActive: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/envs/auth', () => ({
   LOBE_CHAT_OIDC_AUTH_HEADER: 'Oidc-Auth',
 }));
@@ -71,20 +71,61 @@ describe('checkAuth', () => {
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
     vi.unstubAllEnvs();
   });
 
-  it('should return error response on checkAuthMethod error (no session)', async () => {
-    const mockError = AgentRuntimeError.createError(ChatErrorType.Unauthorized);
-    vi.mocked(checkAuthMethod).mockImplementationOnce(() => {
-      throw mockError;
+  it('should authenticate an active OIDC JWT and run the handler', async () => {
+    const oidcRequest = new Request('https://example.com/webapi/chat/lobehub', {
+      headers: { 'Oidc-Auth': 'valid-token' },
     });
+    vi.mocked(validateOIDCJWT).mockResolvedValueOnce({
+      tokenData: { sub: 'oidc-user' },
+      userId: 'oidc-user',
+    } as Awaited<ReturnType<typeof validateOIDCJWT>>);
+    vi.mocked(assertOIDCUserActive).mockResolvedValueOnce(undefined);
+    vi.mocked(mockHandler).mockResolvedValueOnce(new Response('ok'));
 
-    await checkAuth(mockHandler)(mockRequest, mockOptions);
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
+
+    expect(assertOIDCUserActive).toHaveBeenCalledWith(expect.any(Object), 'oidc-user');
+    expect(mockHandler).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        jwtPayload: { userId: 'oidc-user' },
+        userId: 'oidc-user',
+      }),
+    );
+  });
+
+  it('should reject an inactive OIDC user without running the handler', async () => {
+    const oidcRequest = new Request('https://example.com/webapi/chat/lobehub', {
+      headers: { 'Oidc-Auth': 'valid-token' },
+    });
+    const inactiveError = Object.assign(new Error('OIDC user is no longer active'), {
+      code: 'UNAUTHORIZED',
+    });
+    vi.mocked(validateOIDCJWT).mockResolvedValueOnce({
+      tokenData: { sub: 'banned-user' },
+      userId: 'banned-user',
+    } as Awaited<ReturnType<typeof validateOIDCJWT>>);
+    vi.mocked(assertOIDCUserActive).mockRejectedValueOnce(inactiveError);
+
+    await checkAuth(mockHandler)(oidcRequest, mockOptions);
 
     expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
-      error: mockError,
+      error: inactiveError,
+      provider: 'mock',
+    });
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('should return error response when no session is available', async () => {
+    await checkAuth(mockHandler)(mockRequest, mockOptions);
+
+    expect(AgentRuntimeError.createError).toHaveBeenCalledWith(ChatErrorType.Unauthorized);
+    expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
+      error: { errorType: ChatErrorType.Unauthorized },
       provider: 'mock',
     });
     expect(mockHandler).not.toHaveBeenCalled();

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -1,14 +1,15 @@
-import { type ChatCompletionErrorPayload } from '@lobechat/model-runtime';
+import type { ChatCompletionErrorPayload } from '@lobechat/model-runtime';
 import { AgentRuntimeError } from '@lobechat/model-runtime';
 import { context as otContext } from '@lobechat/observability-otel/api';
-import { type ClientSecretPayload } from '@lobechat/types';
+import type { ClientSecretPayload } from '@lobechat/types';
 import { ChatErrorType } from '@lobechat/types';
 
 import { auth } from '@/auth';
 import { getServerDB } from '@/database/core/db-adaptor';
-import { type LobeChatDatabase } from '@/database/type';
+import type { LobeChatDatabase } from '@/database/type';
 import { LOBE_CHAT_OIDC_AUTH_HEADER } from '@/envs/auth';
 import { extractTraceContext, injectActiveTraceHeaders } from '@/libs/observability/traceparent';
+import { assertOIDCUserActive } from '@/libs/oidc-provider/access-control';
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { createErrorResponse } from '@/utils/errorResponse';
 
@@ -88,6 +89,7 @@ export const checkAuth =
       if (oidcAuthorization) {
         const oidc = await validateOIDCJWT(oidcAuthorization);
         userId = oidc.userId;
+        await assertOIDCUserActive(serverDB, userId);
       } else {
         // Better Auth session authentication (web)
         const session = await auth.api.getSession({

--- a/src/libs/oidc-provider/access-control.test.ts
+++ b/src/libs/oidc-provider/access-control.test.ts
@@ -46,7 +46,9 @@ describe('OIDC access control', () => {
   });
 
   describe('assertOIDCUserActive', () => {
-    const createDb = (rows: Array<{ banned: boolean | null; id: string }>) => {
+    const createDb = (
+      rows: Array<{ banExpires: Date | null; banned: boolean | null; id: string }>,
+    ) => {
       const limit = vi.fn().mockResolvedValue(rows);
       const where = vi.fn(() => ({ limit }));
       const from = vi.fn(() => ({ where }));
@@ -62,15 +64,15 @@ describe('OIDC access control', () => {
     };
 
     it('passes for an existing active user', async () => {
-      const { db } = createDb([{ banned: false, id: 'user-1' }]);
+      const { db } = createDb([{ banExpires: null, banned: false, id: 'user-1' }]);
 
       await expect(
         assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
       ).resolves.toBeUndefined();
     });
 
-    it('rejects a banned user', async () => {
-      const { db } = createDb([{ banned: true, id: 'user-1' }]);
+    it('rejects a permanently banned user', async () => {
+      const { db } = createDb([{ banExpires: null, banned: true, id: 'user-1' }]);
 
       await expect(
         assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
@@ -78,6 +80,29 @@ describe('OIDC access control', () => {
         code: 'UNAUTHORIZED',
         message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
       });
+    });
+
+    it('rejects a temporarily banned user before the ban expires', async () => {
+      const { db } = createDb([
+        { banExpires: new Date(Date.now() + 60_000), banned: true, id: 'user-1' },
+      ]);
+
+      await expect(
+        assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
+      ).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
+      });
+    });
+
+    it('passes for a user whose temporary ban has expired', async () => {
+      const { db } = createDb([
+        { banExpires: new Date(Date.now() - 60_000), banned: true, id: 'user-1' },
+      ]);
+
+      await expect(
+        assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
+      ).resolves.toBeUndefined();
     });
 
     it('rejects a missing user', async () => {

--- a/src/libs/oidc-provider/access-control.test.ts
+++ b/src/libs/oidc-provider/access-control.test.ts
@@ -1,0 +1,97 @@
+import {
+  oidcAccessTokens,
+  oidcAuthorizationCodes,
+  oidcDeviceCodes,
+  oidcGrants,
+  oidcRefreshTokens,
+  oidcSessions,
+} from '@lobechat/database/schemas';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  assertOIDCUserActive,
+  OIDC_USER_INACTIVE_ERROR_MESSAGE,
+  revokeOIDCArtifactsByUserId,
+} from './access-control';
+
+describe('OIDC access control', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('revokeOIDCArtifactsByUserId', () => {
+    it('deletes all token and session artifacts for a user', async () => {
+      const where = vi.fn().mockResolvedValue({ rowCount: 1 });
+      const delete_ = vi.fn(() => ({ where }));
+      const tx = { delete: delete_ };
+      const db = {
+        transaction: vi.fn(async (callback: (tx: typeof tx) => Promise<void>) => callback(tx)),
+      };
+
+      await revokeOIDCArtifactsByUserId(
+        db as unknown as Parameters<typeof revokeOIDCArtifactsByUserId>[0],
+        'user-1',
+      );
+
+      expect(db.transaction).toHaveBeenCalledOnce();
+      expect(delete_).toHaveBeenCalledTimes(6);
+      expect(delete_).toHaveBeenCalledWith(oidcAccessTokens);
+      expect(delete_).toHaveBeenCalledWith(oidcAuthorizationCodes);
+      expect(delete_).toHaveBeenCalledWith(oidcRefreshTokens);
+      expect(delete_).toHaveBeenCalledWith(oidcDeviceCodes);
+      expect(delete_).toHaveBeenCalledWith(oidcGrants);
+      expect(delete_).toHaveBeenCalledWith(oidcSessions);
+      expect(where).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe('assertOIDCUserActive', () => {
+    const createDb = (rows: Array<{ banned: boolean | null; id: string }>) => {
+      const limit = vi.fn().mockResolvedValue(rows);
+      const where = vi.fn(() => ({ limit }));
+      const from = vi.fn(() => ({ where }));
+
+      return {
+        db: {
+          select: vi.fn(() => ({ from })),
+        },
+        from,
+        limit,
+        where,
+      };
+    };
+
+    it('passes for an existing active user', async () => {
+      const { db } = createDb([{ banned: false, id: 'user-1' }]);
+
+      await expect(
+        assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects a banned user', async () => {
+      const { db } = createDb([{ banned: true, id: 'user-1' }]);
+
+      await expect(
+        assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
+      ).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
+      });
+    });
+
+    it('rejects a missing user', async () => {
+      const { db } = createDb([]);
+
+      await expect(
+        assertOIDCUserActive(
+          db as unknown as Parameters<typeof assertOIDCUserActive>[0],
+          'missing-user',
+        ),
+      ).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
+      });
+    });
+  });
+});

--- a/src/libs/oidc-provider/access-control.test.ts
+++ b/src/libs/oidc-provider/access-control.test.ts
@@ -10,7 +10,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   assertOIDCUserActive,
+  isOIDCUserInactiveError,
   OIDC_USER_INACTIVE_ERROR_MESSAGE,
+  OIDCUserInactiveError,
   revokeOIDCArtifactsByUserId,
 } from './access-control';
 
@@ -73,10 +75,13 @@ describe('OIDC access control', () => {
 
     it('rejects a permanently banned user', async () => {
       const { db } = createDb([{ banExpires: null, banned: true, id: 'user-1' }]);
+      const promise = assertOIDCUserActive(
+        db as unknown as Parameters<typeof assertOIDCUserActive>[0],
+        'user-1',
+      );
 
-      await expect(
-        assertOIDCUserActive(db as unknown as Parameters<typeof assertOIDCUserActive>[0], 'user-1'),
-      ).rejects.toMatchObject({
+      await expect(promise).rejects.toBeInstanceOf(OIDCUserInactiveError);
+      await expect(promise).rejects.toMatchObject({
         code: 'UNAUTHORIZED',
         message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
       });
@@ -117,6 +122,11 @@ describe('OIDC access control', () => {
         code: 'UNAUTHORIZED',
         message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
       });
+    });
+
+    it('identifies the domain inactive-user error', () => {
+      expect(isOIDCUserInactiveError(new OIDCUserInactiveError())).toBe(true);
+      expect(isOIDCUserInactiveError(new Error(OIDC_USER_INACTIVE_ERROR_MESSAGE))).toBe(false);
     });
   });
 });

--- a/src/libs/oidc-provider/access-control.test.ts
+++ b/src/libs/oidc-provider/access-control.test.ts
@@ -25,9 +25,15 @@ describe('OIDC access control', () => {
     it('deletes all token and session artifacts for a user', async () => {
       const where = vi.fn().mockResolvedValue({ rowCount: 1 });
       const delete_ = vi.fn(() => ({ where }));
-      const tx = { delete: delete_ };
+      interface TestTransaction {
+        delete: typeof delete_;
+      }
+
+      const tx: TestTransaction = { delete: delete_ };
       const db = {
-        transaction: vi.fn(async (callback: (tx: typeof tx) => Promise<void>) => callback(tx)),
+        transaction: vi.fn(async (callback: (transaction: TestTransaction) => Promise<void>) =>
+          callback(tx),
+        ),
       };
 
       await revokeOIDCArtifactsByUserId(

--- a/src/libs/oidc-provider/access-control.ts
+++ b/src/libs/oidc-provider/access-control.ts
@@ -18,6 +18,17 @@ export const isOIDCUserInactiveError = (error: unknown) =>
   error.code === 'UNAUTHORIZED' &&
   error.message === OIDC_USER_INACTIVE_ERROR_MESSAGE;
 
+interface OIDCUserBanState {
+  banExpires: Date | null;
+  banned: boolean | null;
+}
+
+export const isOIDCUserBanned = (user: OIDCUserBanState, now = new Date()) => {
+  if (!user.banned) return false;
+
+  return !user.banExpires || user.banExpires > now;
+};
+
 const OIDC_USER_ARTIFACT_TABLES = [
   oidcAccessTokens,
   oidcAuthorizationCodes,
@@ -50,12 +61,12 @@ export const revokeOIDCArtifactsByUserId = async (db: LobeChatDatabase, userId: 
  */
 export const assertOIDCUserActive = async (db: LobeChatDatabase, userId: string) => {
   const [user] = await db
-    .select({ banned: users.banned, id: users.id })
+    .select({ banExpires: users.banExpires, banned: users.banned, id: users.id })
     .from(users)
     .where(eq(users.id, userId))
     .limit(1);
 
-  if (!user || user.banned) {
+  if (!user || isOIDCUserBanned(user)) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
       message: OIDC_USER_INACTIVE_ERROR_MESSAGE,

--- a/src/libs/oidc-provider/access-control.ts
+++ b/src/libs/oidc-provider/access-control.ts
@@ -1,0 +1,64 @@
+import type { LobeChatDatabase } from '@lobechat/database';
+import {
+  oidcAccessTokens,
+  oidcAuthorizationCodes,
+  oidcDeviceCodes,
+  oidcGrants,
+  oidcRefreshTokens,
+  oidcSessions,
+  users,
+} from '@lobechat/database/schemas';
+import { TRPCError } from '@trpc/server';
+import { eq } from 'drizzle-orm';
+
+export const OIDC_USER_INACTIVE_ERROR_MESSAGE = 'OIDC user is no longer active';
+
+export const isOIDCUserInactiveError = (error: unknown) =>
+  error instanceof TRPCError &&
+  error.code === 'UNAUTHORIZED' &&
+  error.message === OIDC_USER_INACTIVE_ERROR_MESSAGE;
+
+const OIDC_USER_ARTIFACT_TABLES = [
+  oidcAccessTokens,
+  oidcAuthorizationCodes,
+  oidcRefreshTokens,
+  oidcDeviceCodes,
+  oidcGrants,
+  oidcSessions,
+] as const;
+
+type OIDCUserArtifactTable = (typeof OIDC_USER_ARTIFACT_TABLES)[number];
+
+/**
+ * Revokes database-backed OIDC artifacts for a user.
+ *
+ * JWT access tokens are stateless and remain valid until runtime user-status
+ * checks reject them, but deleting these rows prevents refresh/session flows
+ * from minting replacement tokens after the account is disabled.
+ */
+export const revokeOIDCArtifactsByUserId = async (db: LobeChatDatabase, userId: string) => {
+  await db.transaction(async (tx) => {
+    const deleteByUserId = async (table: OIDCUserArtifactTable) =>
+      tx.delete(table).where(eq(table.userId, userId));
+
+    await Promise.all(OIDC_USER_ARTIFACT_TABLES.map(deleteByUserId));
+  });
+};
+
+/**
+ * Rejects stateless OIDC access tokens once their subject is no longer active.
+ */
+export const assertOIDCUserActive = async (db: LobeChatDatabase, userId: string) => {
+  const [user] = await db
+    .select({ banned: users.banned, id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user || user.banned) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
+    });
+  }
+};

--- a/src/libs/oidc-provider/access-control.ts
+++ b/src/libs/oidc-provider/access-control.ts
@@ -8,15 +8,20 @@ import {
   oidcSessions,
   users,
 } from '@lobechat/database/schemas';
-import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 
 export const OIDC_USER_INACTIVE_ERROR_MESSAGE = 'OIDC user is no longer active';
 
-export const isOIDCUserInactiveError = (error: unknown) =>
-  error instanceof TRPCError &&
-  error.code === 'UNAUTHORIZED' &&
-  error.message === OIDC_USER_INACTIVE_ERROR_MESSAGE;
+export class OIDCUserInactiveError extends Error {
+  readonly code = 'UNAUTHORIZED';
+
+  constructor() {
+    super(OIDC_USER_INACTIVE_ERROR_MESSAGE);
+    this.name = 'OIDCUserInactiveError';
+  }
+}
+
+export const isOIDCUserInactiveError = (error: unknown) => error instanceof OIDCUserInactiveError;
 
 interface OIDCUserBanState {
   banExpires: Date | null;
@@ -67,9 +72,6 @@ export const assertOIDCUserActive = async (db: LobeChatDatabase, userId: string)
     .limit(1);
 
   if (!user || isOIDCUserBanned(user)) {
-    throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: OIDC_USER_INACTIVE_ERROR_MESSAGE,
-    });
+    throw new OIDCUserInactiveError();
   }
 };

--- a/src/libs/oidc-provider/provider.ts
+++ b/src/libs/oidc-provider/provider.ts
@@ -194,6 +194,11 @@ export const createOIDCProvider = async (db: LobeChatDatabase): Promise<Provider
           return undefined;
         }
 
+        if (user.banned) {
+          logProvider('Account is banned for accountId: %s', accountIdToFind);
+          return undefined;
+        }
+
         return {
           accountId: user.id,
           async claims(use, scope): Promise<{ [key: string]: any; sub: string }> {

--- a/src/libs/oidc-provider/provider.ts
+++ b/src/libs/oidc-provider/provider.ts
@@ -10,6 +10,7 @@ import { appEnv } from '@/envs/app';
 import { getJWKS } from '@/libs/oidc-provider/jwt';
 import { normalizeLocale } from '@/locales/resources';
 
+import { isOIDCUserBanned } from './access-control';
 import { DrizzleAdapter } from './adapter';
 import { defaultClaims, defaultClients, defaultScopes } from './config';
 import { createInteractionPolicy } from './interaction-policy';
@@ -194,7 +195,7 @@ export const createOIDCProvider = async (db: LobeChatDatabase): Promise<Provider
           return undefined;
         }
 
-        if (user.banned) {
+        if (isOIDCUserBanned(user)) {
           logProvider('Account is banned for accountId: %s', accountIdToFind);
           return undefined;
         }

--- a/src/libs/trpc/lambda/context.test.ts
+++ b/src/libs/trpc/lambda/context.test.ts
@@ -6,15 +6,19 @@ import { ApiKeyModel } from '@/database/models/apiKey';
 import { createContextInner, createLambdaContext } from './context';
 
 const {
+  mockAssertOIDCUserActive,
   mockExtractTraceContext,
   mockFindByKey,
   mockGetSession,
+  mockIsOIDCUserInactiveError,
   mockUpdateLastUsed,
   mockValidateOIDCJWT,
 } = vi.hoisted(() => ({
+  mockAssertOIDCUserActive: vi.fn(),
   mockExtractTraceContext: vi.fn(),
   mockFindByKey: vi.fn(),
   mockGetSession: vi.fn(),
+  mockIsOIDCUserInactiveError: vi.fn(),
   mockUpdateLastUsed: vi.fn(),
   mockValidateOIDCJWT: vi.fn(),
 }));
@@ -56,6 +60,11 @@ vi.mock('@/libs/observability/traceparent', () => ({
 
 vi.mock('@/libs/oidc-provider/jwt', () => ({
   validateOIDCJWT: mockValidateOIDCJWT,
+}));
+
+vi.mock('@/libs/oidc-provider/access-control', () => ({
+  assertOIDCUserActive: mockAssertOIDCUserActive,
+  isOIDCUserInactiveError: mockIsOIDCUserInactiveError,
 }));
 
 vi.mock('@/utils/apiKey', async (importOriginal) => {
@@ -160,6 +169,8 @@ describe('createLambdaContext', () => {
     vi.clearAllMocks();
     mockExtractTraceContext.mockReturnValue(undefined);
     mockGetSession.mockResolvedValue({ user: { id: 'session-user' } });
+    mockAssertOIDCUserActive.mockResolvedValue(undefined);
+    mockIsOIDCUserInactiveError.mockReturnValue(false);
     mockValidateOIDCJWT.mockResolvedValue({
       tokenData: { sub: 'oidc-user' },
       userId: 'oidc-user',
@@ -221,5 +232,35 @@ describe('createLambdaContext', () => {
 
     expect(context.userId).toBe('session-user');
     expect(mockGetSession).toHaveBeenCalledOnce();
+  });
+
+  it('should authenticate with active OIDC auth and skip session fallback', async () => {
+    const request = new NextRequest('https://example.com/trpc/lambda', {
+      headers: { 'Oidc-Auth': 'oidc-token' },
+    });
+
+    const context = await createLambdaContext(request);
+
+    expect(context.userId).toBe('oidc-user');
+    expect(context.oidcAuth?.sub).toBe('oidc-user');
+    expect(mockAssertOIDCUserActive).toHaveBeenCalledWith(expect.any(Object), 'oidc-user');
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('should reject inactive OIDC auth without falling back to session', async () => {
+    const inactiveError = new Error('OIDC user is no longer active');
+    mockAssertOIDCUserActive.mockRejectedValueOnce(inactiveError);
+    mockIsOIDCUserInactiveError.mockReturnValueOnce(true);
+
+    const request = new NextRequest('https://example.com/trpc/lambda', {
+      headers: { 'Oidc-Auth': 'oidc-token' },
+    });
+
+    const context = await createLambdaContext(request);
+
+    expect(context.userId).toBeNull();
+    expect(context.oidcAuth).toBeUndefined();
+    expect(mockValidateOIDCJWT).toHaveBeenCalledWith('oidc-token');
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 });

--- a/src/libs/trpc/lambda/context.ts
+++ b/src/libs/trpc/lambda/context.ts
@@ -9,6 +9,7 @@ import { getServerDB } from '@/database/core/db-adaptor';
 import { ApiKeyModel } from '@/database/models/apiKey';
 import { authEnv, LOBE_CHAT_OIDC_AUTH_HEADER } from '@/envs/auth';
 import { extractTraceContext } from '@/libs/observability/traceparent';
+import { assertOIDCUserActive, isOIDCUserInactiveError } from '@/libs/oidc-provider/access-control';
 import { validateOIDCJWT } from '@/libs/oidc-provider/jwt';
 import { isApiKeyExpired, validateApiKeyFormat } from '@/utils/apiKey';
 
@@ -175,7 +176,8 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
 
     try {
       if (oidcAuthToken) {
-        // Use direct JWT validation instead of database lookup
+        // Validate the stateless JWT first, then check the current user state
+        // so banned/deleted accounts cannot keep using an already-issued token.
         const tokenInfo = await validateOIDCJWT(oidcAuthToken);
 
         oidcAuth = {
@@ -184,6 +186,8 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
           sub: tokenInfo.userId, // Use tokenData as payload
         };
         userId = tokenInfo.userId;
+        const db = await getServerDB();
+        await assertOIDCUserActive(db, userId);
         log('OIDC authentication successful, userId: %s', userId);
 
         // If OIDC authentication is successful, return context immediately
@@ -196,6 +200,16 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
         });
       }
     } catch (error) {
+      if (isOIDCUserInactiveError(error)) {
+        log('OIDC user is inactive, rejecting request without fallback auth');
+        console.error('OIDC authentication failed for inactive user:', error);
+        return createContextInner({
+          ...commonContext,
+          traceContext,
+          userId: null,
+        });
+      }
+
       // If OIDC authentication fails, log error and continue with other authentication methods
       if (oidcAuthToken) {
         log('OIDC authentication failed, error: %O', error);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8781

#### 🔀 Description of Change

- Revoke database-backed OIDC artifacts for banned users.
- Reject stateless OIDC JWTs when the token subject is banned or missing.
- Apply the active-user check across backend auth middleware, tRPC lambda context, OpenAPI bearer auth, and OIDC provider account lookup.
- Prevent inactive OIDC auth from falling back to session auth.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/libs/oidc-provider/access-control.test.ts' 'src/app/(backend)/middleware/auth/index.test.ts' 'src/libs/trpc/lambda/context.test.ts'
cd packages/openapi && bunx vitest run --silent='passed-only' 'src/middleware/auth.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

OIDC access tokens are JWTs and remain stateless until expiry, so revoking persisted artifacts alone is not enough. Runtime active-user checks are required for immediate ban enforcement.
