### PR TITLE
🐛 fix(home): blank user bubble when sending the placeholder hint

### DIFF
--- a/src/routes/(main)/home/features/InputArea/useSend.test.ts
+++ b/src/routes/(main)/home/features/InputArea/useSend.test.ts
@@ -62,8 +62,19 @@ const globalState = vi.hoisted(() => ({
   updateSystemStatus: vi.fn(),
 }));
 
+const homeDailyBriefState = vi.hoisted(() => ({
+  advance: vi.fn(),
+  currentIndex: 0,
+  currentPair: undefined as { hint: string; welcome: string } | undefined,
+  pairs: [] as { hint: string; welcome: string }[],
+}));
+
 vi.mock('@/hooks/useQueryRoute', () => ({
   useQueryRoute: () => routerMock,
+}));
+
+vi.mock('@/hooks/useHomeDailyBrief', () => ({
+  useHomeDailyBrief: () => homeDailyBriefState,
 }));
 
 vi.mock('@/store/agent', () => ({
@@ -126,6 +137,9 @@ describe('Home InputArea useSend', () => {
     clearContentMock.mockReset();
     clearChatUploadFileListMock.mockReset();
     clearChatContextSelectionsMock.mockReset();
+    homeDailyBriefState.advance.mockReset();
+    homeDailyBriefState.currentPair = undefined;
+    chatState.inputMessage = 'hello';
   });
 
   it('routes cold homepage sends to the created topic instead of relying on ChatHydration timing', async () => {
@@ -157,5 +171,34 @@ describe('Home InputArea useSend', () => {
     });
 
     expect(routerMock.replace).toHaveBeenCalledWith('/agent/agt_inbox/tpc_created');
+  });
+
+  it('drops editorData when sending the placeholder hint so the user message renders the markdown content', async () => {
+    homeDailyBriefState.currentPair = {
+      hint: '看下 Bug #14153 + #14112 Agent 手机端不同步/不显示...',
+      welcome: 'welcome',
+    };
+    chatState.inputMessage = '';
+
+    const { result } = renderHook(() => useSend());
+    const params: Parameters<SendButtonHandler>[0] = {
+      clearContent: vi.fn(),
+      editor: {} as Parameters<SendButtonHandler>[0]['editor'],
+      // Empty editor still returns a non-null JSON state; this would
+      // previously be forwarded as editorData and blank the rendered
+      // user bubble.
+      getEditorData: () => ({ type: 'doc' }),
+      getMarkdownContent: () => '',
+    };
+
+    await act(async () => {
+      await result.current.send(params);
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const sentPayload = sendMessageMock.mock.calls[0][0];
+    expect(sentPayload.message).toBe('看下 Bug #14153 + #14112 Agent 手机端不同步/不显示');
+    expect(sentPayload.editorData).toBeUndefined();
+    expect(homeDailyBriefState.advance).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/routes/(main)/home/features/InputArea/useSend.ts
+++ b/src/routes/(main)/home/features/InputArea/useSend.ts
@@ -61,7 +61,6 @@ export const useSend = () => {
       // `onChange`, so a fast type-then-Enter sequence can fire before the
       // cache catches up and the empty-message guard would bail incorrectly.
       const typed = (getMarkdownContent?.() ?? inputMessage ?? '').trim();
-      const editorData = getEditorData?.() ?? mainInputEditor?.getJSONState();
       const fileList = fileChatSelectors.chatUploadFileList(useFileStore.getState());
       const contextList = fileChatSelectors.chatContextSelections(useFileStore.getState());
       const { sendAsAgent, sendAsGroup, sendAsWrite, sendAsResearch, inputActiveMode } =
@@ -75,6 +74,17 @@ export const useSend = () => {
       const usedHint = !typed && !!hint;
       const message = typed || hint;
       if (usedHint) advance();
+
+      // When falling back to the hint, the editor is empty — but its JSON
+      // state still contains root nodes (e.g. `{ type: 'doc' }`), which is
+      // truthy under `Object.keys(editorData).length > 0`. That makes the
+      // user-message renderer take the RichTextMessage branch and draw
+      // nothing, so the chat shows a blank user bubble while the agent
+      // happily processes the hint text. Skip editorData in that case so
+      // the renderer falls back to the markdown `content`.
+      const editorData = usedHint
+        ? undefined
+        : (getEditorData?.() ?? mainInputEditor?.getJSONState());
 
       // Require input content (except for default inbox which can have files/context)
       if (!message && fileList.length === 0 && contextList.length === 0) return;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A — internal regression caught while QA-ing the home daily-brief hint flow. -->

#### 🔀 Description of Change

When the home input was empty and the user pressed send, `useSend` correctly fell back to the daily-brief placeholder hint for `message`, but it also forwarded `mainInputEditor.getJSONState()` as `editorData`. An empty editor still returns a non-null JSON state (e.g. `{ type: 'doc' }`), which makes `UserMessageContent.hasEditorData` truthy — so the renderer took the `RichTextMessage` branch and drew nothing, while the agent happily processed the hint text behind a blank user bubble.

Skip `editorData` when the hint is being used so the renderer falls back to the markdown `content`.

- `src/routes/(main)/home/features/InputArea/useSend.ts` — compute `editorData` after `usedHint`; return `undefined` when sending the hint.
- `src/routes/(main)/home/features/InputArea/useSend.test.ts` — mock `useHomeDailyBrief`; new regression test for the empty-editor + hint case.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

1. Open the home page, leave the input empty, wait until a daily-brief hint shows up as the placeholder.
2. Click the send button.
3. Before this fix: the user bubble in the resulting chat is blank, even though the agent responds to the hint. After: the user bubble shows the hint text as markdown.

#### 📝 Additional Information

No locale or schema changes.