### PR TITLE
🐛 fix(heteroFinish): trigger task lifecycle on cloud sandbox agent completion

### DIFF
--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -1302,10 +1302,17 @@ export const aiAgentRouter = router({
       // The hetero path spawns the sandbox fire-and-forget and returns early, so
       // the hook is never registered or dispatched; we must call onTopicComplete
       // explicitly here when the CLI signals process exit.
+      //
+      // Guard: heteroFinish can be called more than once for the same operation
+      // (signal path sends cancelled, normal exit sends the real result, and
+      // transient transport failures can replay). onTopicComplete is NOT
+      // idempotent (reason='error' creates briefs), so skip the call when the
+      // topic is already in a terminal state.
+      const TERMINAL_TOPIC_STATUSES = new Set(['canceled', 'completed', 'failed', 'timeout']);
       try {
         const taskTopicModel = new TaskTopicModel(ctx.serverDB, ctx.userId);
         const taskTopic = await taskTopicModel.findByTopicId(topicId);
-        if (taskTopic) {
+        if (taskTopic && !TERMINAL_TOPIC_STATUSES.has(taskTopic.status)) {
           const taskModel = new TaskModel(ctx.serverDB, ctx.userId);
           const task = await taskModel.findById(taskTopic.taskId);
           if (task) {

--- a/src/server/routers/lambda/aiAgent.ts
+++ b/src/server/routers/lambda/aiAgent.ts
@@ -9,6 +9,8 @@ import pMap from 'p-map';
 import { z } from 'zod';
 
 import { MessageModel } from '@/database/models/message';
+import { TaskModel } from '@/database/models/task';
+import { TaskTopicModel } from '@/database/models/taskTopic';
 import { ThreadModel } from '@/database/models/thread';
 import { TopicModel } from '@/database/models/topic';
 import { authedProcedure, heteroAuthedProcedure, router } from '@/libs/trpc/lambda';
@@ -17,6 +19,7 @@ import { AgentRuntimeService } from '@/server/services/agentRuntime';
 import { AiAgentService } from '@/server/services/aiAgent';
 import { AiChatService } from '@/server/services/aiChat';
 import { HeterogeneousAgentService } from '@/server/services/heterogeneousAgent';
+import { TaskLifecycleService } from '@/server/services/taskLifecycle';
 import { nanoid } from '@/utils/uuid';
 
 const log = debug('lobe-server:ai-agent-router');
@@ -1293,6 +1296,38 @@ export const aiAgentRouter = router({
         sessionId,
         topicId,
       });
+
+      // Trigger task lifecycle transition — mirrors the onComplete hook that the
+      // normal LLM execAgent path dispatches after AgentRuntimeService finishes.
+      // The hetero path spawns the sandbox fire-and-forget and returns early, so
+      // the hook is never registered or dispatched; we must call onTopicComplete
+      // explicitly here when the CLI signals process exit.
+      try {
+        const taskTopicModel = new TaskTopicModel(ctx.serverDB, ctx.userId);
+        const taskTopic = await taskTopicModel.findByTopicId(topicId);
+        if (taskTopic) {
+          const taskModel = new TaskModel(ctx.serverDB, ctx.userId);
+          const task = await taskModel.findById(taskTopic.taskId);
+          if (task) {
+            const reason =
+              result === 'success' ? 'done' : result === 'cancelled' ? 'interrupted' : 'error';
+            const taskLifecycle = new TaskLifecycleService(ctx.serverDB, ctx.userId);
+            await taskLifecycle.onTopicComplete({
+              errorMessage: error?.message,
+              operationId,
+              reason,
+              taskId: task.id,
+              taskIdentifier: task.identifier,
+              topicId,
+            });
+          }
+        }
+      } catch (lifecycleErr: any) {
+        // Non-fatal: log but do not fail the heteroFinish ack. The CLI has
+        // already finished; failing here would cause it to retry unnecessarily.
+        log('heteroFinish: task lifecycle update failed (non-fatal): %s', lifecycleErr?.message);
+      }
+
       return { ack: true as const };
     } catch (err: any) {
       log('heteroFinish failed: %s', err?.message);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

In the cloud sandbox (hetero) path, `execAgent()` detects a heterogeneous agent and fire-and-forgets `spawnHeteroSandbox()`, returning immediately without going through `AgentRuntimeService.createOperation()`. This means the `onComplete` hooks registered by callers (e.g. `TaskRunnerService.runTask()`) are **never registered or dispatched**.

When the CLI finishes and calls `heteroFinish`, only `HeterogeneousAgentService.heteroFinish()` was called — which flushes persistence state and emits `agent_runtime_end` — but `TaskLifecycleService.onTopicComplete()` was never triggered. As a result, `taskTopic.status` and `task.status` stayed `running` forever, leaving the task detail page in a perpetual loading state.

**Fix**: In the `heteroFinish` mutation handler, after `heterogeneousAgentService.heteroFinish()` succeeds, look up the task via `TaskTopicModel.findByTopicId(topicId)` and call `TaskLifecycleService.onTopicComplete()` with the mapped reason (`success→done`, `cancelled→interrupted`, `error→error`). The lifecycle call is wrapped in a non-fatal try/catch so a lookup failure does not cause the CLI to retry unnecessarily.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] No tests needed

Run a cloud Claude Code sandbox task to completion and verify the task status transitions from `running` to `paused` (or `scheduled` for automation tasks) after the CLI exits.