### PR TITLE
🐛 fix: replace ScrollShadow with ScrollArea to fix React #185 infinite render loop

### DIFF
--- a/src/components/StreamingMarkdown/index.tsx
+++ b/src/components/StreamingMarkdown/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Markdown, ScrollShadow } from '@lobehub/ui';
+import { Markdown, ScrollArea } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { type RefObject } from 'react';
+import type { RefObject } from 'react';
 import { memo, useEffect } from 'react';
 
 import { useAutoScroll } from '@/hooks/useAutoScroll';
@@ -13,6 +13,10 @@ const styles = createStaticStyles(({ css }) => ({
     padding-inline: 16px;
     border-radius: 8px;
     font-size: 14px;
+  `,
+  scrollRoot: css`
+    border-radius: 0;
+    background: transparent;
   `,
 }));
 
@@ -36,18 +40,29 @@ const StreamingMarkdown = memo<StreamingMarkdownProps>(({ children, maxHeight = 
   if (!children) return null;
 
   return (
-    <ScrollShadow
-      className={styles.container}
-      offset={12}
-      ref={ref as RefObject<HTMLDivElement>}
-      size={12}
-      style={{ maxHeight }}
-      onScroll={handleScroll}
+    <ScrollArea
+      scrollFade
+      className={styles.scrollRoot}
+      contentProps={{
+        style: {
+          color: 'inherit',
+          display: 'block',
+          fontSize: 'inherit',
+          gap: 0,
+          lineHeight: 'inherit',
+        },
+      }}
+      viewportProps={{
+        className: styles.container,
+        ref: ref as RefObject<HTMLDivElement>,
+        style: { maxHeight },
+        onScroll: handleScroll,
+      }}
     >
       <Markdown animated style={{ overflow: 'unset' }} variant={'chat'}>
         {children}
       </Markdown>
-    </ScrollShadow>
+    </ScrollArea>
   );
 });
 

--- a/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
@@ -1,5 +1,5 @@
-import { ScrollShadow } from '@lobehub/ui';
-import { type PropsWithChildren, type RefObject } from 'react';
+import { ScrollArea } from '@lobehub/ui';
+import type { PropsWithChildren, RefObject } from 'react';
 import { memo, useEffect } from 'react';
 
 import { useAutoScroll } from '@/hooks/useAutoScroll';
@@ -29,15 +29,26 @@ const AutoScrollShadow = memo<AutoScrollShadowProps>(({ children, content, strea
   }, [content, resetScrollLock]);
 
   return (
-    <ScrollShadow
-      hideScrollBar
-      height={'max(33vh, 480px)'}
-      ref={ref as RefObject<HTMLDivElement>}
-      size={16}
-      onScroll={handleScroll}
+    <ScrollArea
+      scrollFade
+      style={{ background: 'transparent', borderRadius: 0 }}
+      contentProps={{
+        style: {
+          color: 'inherit',
+          display: 'block',
+          fontSize: 'inherit',
+          gap: 0,
+          lineHeight: 'inherit',
+        },
+      }}
+      viewportProps={{
+        ref: ref as RefObject<HTMLDivElement>,
+        style: { height: 'max(33vh, 480px)' },
+        onScroll: handleScroll,
+      }}
     >
       {children}
-    </ScrollShadow>
+    </ScrollArea>
   );
 });
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
@@ -10,7 +10,7 @@ import type { RenderableAssistantContentBlock } from './types';
 
 vi.mock('@lobehub/ui', () => ({
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  ScrollShadow: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ScrollArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('antd-style', () => ({

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import type { UIChatMessage } from '@lobechat/types';
-import { Flexbox, ScrollShadow } from '@lobehub/ui';
+import { Flexbox, ScrollArea } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo, type RefObject, useMemo } from 'react';
+import type { RefObject } from 'react';
+import { memo, useMemo } from 'react';
 
 import { resolveAssistantGroupFromMessages } from '../utils/resolveAssistantGroupFromMessages';
 import ContentBlock from './ContentBlock';
 import type { RenderableAssistantContentBlock } from './types';
 
 const styles = createStaticStyles(({ css }) => ({
+  scrollRoot: css`
+    border-radius: 0;
+    background: transparent;
+  `,
   scrollTask: css`
     max-height: min(50vh, 300px);
   `,
@@ -82,18 +87,28 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
   }
 
   const scrollClass = variant === 'task' ? styles.scrollTask : styles.scrollWorkflow;
-  const shadowSize = variant === 'task' ? 8 : 12;
 
   return (
-    <ScrollShadow
-      className={scrollClass}
-      offset={12}
-      ref={scrollRef as RefObject<HTMLDivElement>}
-      size={shadowSize}
-      onScroll={onScroll}
+    <ScrollArea
+      scrollFade
+      className={styles.scrollRoot}
+      contentProps={{
+        style: {
+          color: 'inherit',
+          display: 'block',
+          fontSize: 'inherit',
+          gap: 0,
+          lineHeight: 'inherit',
+        },
+      }}
+      viewportProps={{
+        className: scrollClass,
+        ref: scrollRef as RefObject<HTMLDivElement>,
+        onScroll,
+      }}
     >
       {body}
-    </ScrollShadow>
+    </ScrollArea>
   );
 });
 

--- a/src/features/Conversation/components/Thinking/index.tsx
+++ b/src/features/Conversation/components/Thinking/index.tsx
@@ -1,6 +1,6 @@
-import { Accordion, AccordionItem, ScrollShadow } from '@lobehub/ui';
+import { Accordion, AccordionItem, ScrollArea } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { type CSSProperties, type ReactNode, type RefObject } from 'react';
+import type { CSSProperties, ReactNode, RefObject } from 'react';
 import { memo, useEffect, useState } from 'react';
 
 import MarkdownMessage from '@/features/Conversation/Markdown';
@@ -19,6 +19,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     article * {
       color: ${cssVar.colorTextDescription};
     }
+  `,
+  scrollRoot: css`
+    border-radius: 0;
+    background: transparent;
   `,
 }));
 
@@ -57,12 +61,23 @@ const Thinking = memo<ThinkingProps>((props) => {
         paddingInline={4}
         title={<Title duration={duration} showDetail={showDetail} thinking={thinking} />}
       >
-        <ScrollShadow
-          className={styles.contentScroll}
-          offset={12}
-          ref={ref as RefObject<HTMLDivElement>}
-          size={12}
-          onScroll={handleScroll}
+        <ScrollArea
+          scrollFade
+          className={styles.scrollRoot}
+          contentProps={{
+            style: {
+              color: 'inherit',
+              display: 'block',
+              fontSize: 'inherit',
+              gap: 0,
+              lineHeight: 'inherit',
+            },
+          }}
+          viewportProps={{
+            className: styles.contentScroll,
+            ref: ref as RefObject<HTMLDivElement>,
+            onScroll: handleScroll,
+          }}
         >
           {typeof content === 'string' ? (
             <MarkdownMessage
@@ -78,7 +93,7 @@ const Thinking = memo<ThinkingProps>((props) => {
           ) : (
             content
           )}
-        </ScrollShadow>
+        </ScrollArea>
       </AccordionItem>
     </Accordion>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes lobehub/lobehub#14650

#### 🔀 Description of Change

The `ScrollShadow` component from `@lobehub/ui` has an internal scroll overflow hook that unconditionally calls `setScrollState()` inside a `useEffect`, creating an `effect → setState → render → effect` infinite loop. This triggers React error #185 (Maximum update depth exceeded), causing the desktop app to crash.

**Fix:** Migrate all `ScrollShadow` usages to `ScrollArea` with the `scrollFade` prop, which uses a different scroll detection mechanism that does not suffer from this render loop.

**Affected components:**
- `StreamingMarkdown` — streaming message content
- `AgentCouncil/AutoScrollShadow` — council agent scroll container
- `AssistantGroup/ContentBlocksScroll` — task/workflow content blocks
- `Conversation/Thinking` — thinking/reasoning accordion

**Migration pattern applied consistently:**
- `ScrollShadow` → `ScrollArea scrollFade`
- `className`/`ref`/`style`/`onScroll` → moved to `viewportProps`
- `contentProps` added to reset inherited layout styles
- Root `scrollRoot` style resets `borderRadius` and `background`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Updated `ContentBlocksScroll.test.tsx` mock from `ScrollShadow` to `ScrollArea`
- All existing tests pass
- Manual verification: open a conversation with long messages, verify scroll behavior and no React errors

#### 📸 Screenshots / Videos

Visual appearance is equivalent — `scrollFade` provides the same fade-at-edges effect as `ScrollShadow`.

#### 📝 Additional Information

This is a client-side only change with no API or data model impact. The fix avoids the upstream `ScrollShadow` bug until it is patched in `@lobehub/ui`.