### PR TITLE
💄 style(nav): unify ActionIcon sizing and improve TodoList encapsulation

### DIFF
--- a/src/features/NavPanel/SideBarHeaderLayout.tsx
+++ b/src/features/NavPanel/SideBarHeaderLayout.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import type { ActionIconProps } from '@lobehub/ui';
 import { Flexbox, Icon, Text } from '@lobehub/ui';
-import { type BreadcrumbProps } from 'antd';
+import type { BreadcrumbProps } from 'antd';
 import { Breadcrumb } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ChevronRightIcon, HomeIcon } from 'lucide-react';
-import { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
@@ -17,6 +18,7 @@ import BackButton from './components/BackButton';
 import ToggleLeftPanelButton from './ToggleLeftPanelButton';
 
 const prefixCls = 'ant';
+const SIDEBAR_HEADER_ACTION_ICON_SIZE: ActionIconProps['size'] = 'small';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   breadcrumb: css`
@@ -73,15 +75,7 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
           overflow: 'hidden',
         }}
       >
-        {showBack && (
-          <BackButton
-            to={backTo}
-            size={{
-              blockSize: 32,
-              size: 16,
-            }}
-          />
-        )}
+        {showBack && <BackButton size={SIDEBAR_HEADER_ACTION_ICON_SIZE} to={backTo} />}
         {left && typeof left === 'string' ? (
           <Text ellipsis fontSize={16} weight={500}>
             {left}
@@ -129,7 +123,9 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
       >
         {leftContent}
         <Flexbox horizontal align={'center'} gap={2} justify={'flex-end'}>
-          {showTogglePanelButton && <ToggleLeftPanelButton />}
+          {showTogglePanelButton && (
+            <ToggleLeftPanelButton size={SIDEBAR_HEADER_ACTION_ICON_SIZE} />
+          )}
           {right}
         </Flexbox>
       </Flexbox>

--- a/src/features/Portal/Document/Body.tsx
+++ b/src/features/Portal/Document/Body.tsx
@@ -57,11 +57,6 @@ const styles = createStaticStyles(({ css }) => ({
   textArea: css`
     font-family: ${cssVar.fontFamilyCode};
   `,
-  todoContainer: css`
-    flex-shrink: 0;
-    padding-block-end: 12px;
-    padding-inline: 12px;
-  `,
 }));
 
 interface SkillFrontmatterBlockProps {
@@ -212,9 +207,7 @@ const DocumentBody = memo(() => {
         )}
         <EditorCanvas />
       </div>
-      <div className={styles.todoContainer}>
-        <TodoList />
-      </div>
+      <TodoList />
     </Flexbox>
   );
 });

--- a/src/features/Portal/Document/TodoList.tsx
+++ b/src/features/Portal/Document/TodoList.tsx
@@ -96,6 +96,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorSuccess};
     transition: width 0.3s ${cssVar.motionEaseInOut};
   `,
+  root: css`
+    flex-shrink: 0;
+    padding-block-end: 12px;
+    padding-inline: 12px;
+  `,
   textChecked: css`
     color: ${cssVar.colorTextQuaternary};
     text-decoration: line-through;
@@ -131,54 +136,56 @@ const TodoList = memo(() => {
   const toggleExpanded = () => setExpanded(!expanded);
 
   return (
-    <div className={styles.container} onClick={toggleExpanded}>
-      {/* Header */}
-      <Flexbox horizontal align="center" gap={8} justify="space-between">
-        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, minWidth: 0 }}>
-          <Icon icon={ListTodo} size={16} style={{ color: cssVar.colorPrimary, flexShrink: 0 }} />
-          <span className={styles.header}>
-            {currentPendingTask?.text || t('document.todos.allCompleted')}
-          </span>
-          <Tag size="small" style={{ flexShrink: 0 }}>
-            <span className={styles.count}>
-              {completed}/{total}
+    <div className={styles.root}>
+      <div className={styles.container} onClick={toggleExpanded}>
+        {/* Header */}
+        <Flexbox horizontal align="center" gap={8} justify="space-between">
+          <Flexbox horizontal align="center" gap={8} style={{ flex: 1, minWidth: 0 }}>
+            <Icon icon={ListTodo} size={16} style={{ color: cssVar.colorPrimary, flexShrink: 0 }} />
+            <span className={styles.header}>
+              {currentPendingTask?.text || t('document.todos.allCompleted')}
             </span>
-          </Tag>
+            <Tag size="small" style={{ flexShrink: 0 }}>
+              <span className={styles.count}>
+                {completed}/{total}
+              </span>
+            </Tag>
+          </Flexbox>
+          <Icon
+            icon={expanded ? ChevronUp : ChevronDown}
+            size={16}
+            style={{ color: cssVar.colorTextTertiary, flexShrink: 0 }}
+          />
         </Flexbox>
-        <Icon
-          icon={expanded ? ChevronUp : ChevronDown}
-          size={16}
-          style={{ color: cssVar.colorTextTertiary, flexShrink: 0 }}
-        />
-      </Flexbox>
 
-      {/* Progress Bar */}
-      <Flexbox horizontal gap={8} style={{ marginTop: 8 }}>
-        <div className={styles.progress}>
-          <div className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
+        {/* Progress Bar */}
+        <Flexbox horizontal gap={8} style={{ marginTop: 8 }}>
+          <div className={styles.progress}>
+            <div className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
+          </div>
+        </Flexbox>
+
+        {/* Expandable Todo List */}
+        <div className={cx(styles.listContainer, expanded ? styles.expanded : styles.collapsed)}>
+          {items.map((item, index) => (
+            <Checkbox
+              backgroundColor={cssVar.colorSuccess}
+              checked={item.completed}
+              key={index}
+              shape="circle"
+              style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
+              classNames={{
+                text: item.completed ? styles.textChecked : undefined,
+                wrapper: styles.itemRow,
+              }}
+              textProps={{
+                type: item.completed ? 'secondary' : undefined,
+              }}
+            >
+              {item.text}
+            </Checkbox>
+          ))}
         </div>
-      </Flexbox>
-
-      {/* Expandable Todo List */}
-      <div className={cx(styles.listContainer, expanded ? styles.expanded : styles.collapsed)}>
-        {items.map((item, index) => (
-          <Checkbox
-            backgroundColor={cssVar.colorSuccess}
-            checked={item.completed}
-            key={index}
-            shape="circle"
-            style={{ borderWidth: 1.5, cursor: 'default', pointerEvents: 'none' }}
-            classNames={{
-              text: item.completed ? styles.textChecked : undefined,
-              wrapper: styles.itemRow,
-            }}
-            textProps={{
-              type: item.completed ? 'secondary' : undefined,
-            }}
-          >
-            {item.text}
-          </Checkbox>
-        ))}
       </div>
     </div>
   );

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
@@ -55,10 +55,7 @@ const Agent = memo<PropsWithChildren>(() => {
         </Text>
         <ActionIcon
           icon={ChevronsUpDownIcon}
-          size={{
-            blockSize: 28,
-            size: 16,
-          }}
+          size={'small'}
           style={{
             width: 24,
           }}

--- a/src/routes/(main)/home/_layout/Header/components/Nav.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/Nav.tsx
@@ -28,7 +28,7 @@ const Nav = memo(() => {
   );
 
   return (
-    <Flexbox gap={1} paddingInline={4}>
+    <Flexbox gap={4} paddingInline={4}>
       {items
         .filter((item) => HEADER_KEYS.has(item.key) && !item.hidden)
         .map((item) => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None

#### 🔀 Description of Change

- **ActionIcon sizing**: Extract `SIDEBAR_HEADER_ACTION_ICON_SIZE` constant in `SideBarHeaderLayout` for consistent sidebar header icon sizing, replacing ad-hoc `blockSize`/`size` objects. Also pass the `size` prop through to `ToggleLeftPanelButton`.
- **Agent selector**: Simplify ActionIcon from inline `{ blockSize: 28, size: 16 }` to `small` preset.
- **TodoList encapsulation**: Move the layout wrapper styles (`flex-shrink: 0`, padding) from the parent `Body` component into `TodoList` as a `root` style rule, improving component self-containment.
- **Nav spacing**: Increase gap from `1` to `4` in home header Nav for proper visual spacing.
- **Import hygiene**: Use `import type` where only type imports are needed.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verify visually:
1. Sidebar header — back button and toggle panel button should render at consistent small size
2. Agent selector dropdown — icon size unchanged visually
3. Document portal — todo list container padding and layout identical to before
4. Home page header nav — item spacing slightly more relaxed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...    |

#### 📝 Additional Information

Purely visual/style changes, no behavioral changes.