### PR TITLE
♻️ refactor(spa): use __DEV__ define instead of process.env.NODE_ENV

### DIFF
--- a/src/components/BootErrorBoundary/index.tsx
+++ b/src/components/BootErrorBoundary/index.tsx
@@ -63,7 +63,7 @@ class BootErrorBoundary extends Component<BootErrorBoundaryProps, BootErrorBound
       window.sessionStorage.removeItem(RELOAD_SESSION_KEY);
     } catch (error) {
       // Access to sessionStorage can fail in restricted environments; ignore.
-      if (process.env.NODE_ENV === 'development') {
+      if (__DEV__) {
         console.warn('BootErrorBoundary failed to reset reload attempts', error);
       }
     }
@@ -90,7 +90,7 @@ class BootErrorBoundary extends Component<BootErrorBoundaryProps, BootErrorBound
       window.sessionStorage.setItem(RELOAD_SESSION_KEY, String(attempts + 1));
     } catch (error) {
       // If sessionStorage is unavailable, we still attempt a reload once.
-      if (process.env.NODE_ENV === 'development') {
+      if (__DEV__) {
         console.warn('BootErrorBoundary failed to persist reload attempts', error);
       }
     }

--- a/src/components/DebugNode.tsx
+++ b/src/components/DebugNode.tsx
@@ -9,7 +9,7 @@ interface DebugNodeProps {
 }
 
 const DebugNode = ({ children, trace }: DebugNodeProps) => {
-  if (process.env.NODE_ENV !== 'development') return null;
+  if (!__DEV__) return null;
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     console.info(`[DebugNode] Suspense fallback active: ${trace}`);

--- a/src/features/AgentMockDevtools/index.tsx
+++ b/src/features/AgentMockDevtools/index.tsx
@@ -5,7 +5,6 @@ import { Fab } from './Fab';
 import { Modal } from './Modal';
 import { Popover } from './Popover';
 
-const isDevEnv = process.env.NODE_ENV === 'development';
 const STORAGE_KEY = 'LOBE_AGENT_MOCK_ENABLED';
 
 const useDevtoolsEnabled = (): boolean => {
@@ -37,7 +36,7 @@ const useIsAgentTopicRoute = (): boolean => {
 const AgentMockDevtools = memo(() => {
   const enabled = useDevtoolsEnabled();
   const isAgentTopicRoute = useIsAgentTopicRoute();
-  if (!isDevEnv || !enabled || !isAgentTopicRoute) return null;
+  if (!__DEV__ || !enabled || !isAgentTopicRoute) return null;
   return (
     <>
       <Fab />

--- a/src/features/AgentMockDevtools/index.tsx
+++ b/src/features/AgentMockDevtools/index.tsx
@@ -10,7 +10,7 @@ const STORAGE_KEY = 'LOBE_AGENT_MOCK_ENABLED';
 const useDevtoolsEnabled = (): boolean => {
   const [enabled, setEnabled] = useState(false);
   useEffect(() => {
-    if (!isDevEnv) return;
+    if (!__DEV__) return;
     setEnabled(localStorage.getItem(STORAGE_KEY) === '1');
     const onStorage = (e: StorageEvent) => {
       if (e.key === STORAGE_KEY) setEnabled(e.newValue === '1');

--- a/src/layout/GlobalProvider/FaviconProvider.tsx
+++ b/src/layout/GlobalProvider/FaviconProvider.tsx
@@ -87,11 +87,9 @@ const updateFaviconDOM = (state: FaviconState, isDev: boolean) => {
   });
 };
 
-const defaultIsDev = process.env.NODE_ENV === 'development';
-
 export const FaviconProvider = memo<{ children: ReactNode }>(({ children }) => {
   const [currentState, setCurrentState] = useState<FaviconState>('default');
-  const [isDevMode, setIsDevModeState] = useState<boolean>(defaultIsDev);
+  const [isDevMode, setIsDevModeState] = useState<boolean>(__DEV__);
 
   const setFavicon = useCallback((state: FaviconState) => {
     setCurrentState(state);

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -83,7 +83,7 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
             <Suspense>
               <ImportSettings />
               {/* DevPanel disabled in SPA: depends on node:fs */}
-              {process.env.NODE_ENV === 'development' && <AgentMockDevtools />}
+              {__DEV__ && <AgentMockDevtools />}
             </Suspense>
           </ServerConfigStoreProvider>
         </AppTheme>

--- a/src/routes/(main)/agent/channel/detail/Body.tsx
+++ b/src/routes/(main)/agent/channel/detail/Body.tsx
@@ -319,12 +319,10 @@ function getFields(schema: FieldSchema[], sectionKey: string): FieldSchema[] {
   if (!section?.properties) return [];
 
   return section.properties
-    .filter((f) => !f.devOnly || process.env.NODE_ENV === 'development')
+    .filter((f) => !f.devOnly || __DEV__)
     .flatMap((f) => {
       if (f.type === 'object' && f.properties) {
-        return f.properties.filter(
-          (child) => !child.devOnly || process.env.NODE_ENV === 'development',
-        );
+        return f.properties.filter((child) => !child.devOnly || __DEV__);
       }
       return f;
     });

--- a/src/routes/(main)/agent/channel/platform/wechat/ConnectedInfo.tsx
+++ b/src/routes/(main)/agent/channel/platform/wechat/ConnectedInfo.tsx
@@ -91,7 +91,7 @@ const WechatConnectedInfo = memo<WechatConnectedInfoProps>(
             value={currentConfig.applicationId}
           />
         )}
-        {process.env.NODE_ENV === 'development' && (
+        {__DEV__ && (
           <>
             <ReadOnlyField
               description={t('channel.wechatBotIdHint')}

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -82,8 +82,6 @@ import ShareTopicPage from '@/routes/share/t/[id]';
 import ShareTopicLayout from '@/routes/share/t/[id]/_layout';
 import { ErrorBoundary, redirectElement } from '@/utils/router';
 
-const isDev = process.env.NODE_ENV === 'development';
-
 // Desktop router configuration — all sync imports for Electron local build
 export const desktopRoutes: RouteObject[] = [
   {
@@ -527,7 +525,7 @@ export const desktopRoutes: RouteObject[] = [
   },
 
   // Devtools route (outside main layout, dev-only)
-  ...(isDev
+  ...(__DEV__
     ? [
         {
           children: [

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -9,7 +9,7 @@ import {
 import { dynamicElement, dynamicLayout, ErrorBoundary, redirectElement } from '@/utils/router';
 
 const agentChatElement = dynamicElement(() => import('@/routes/(main)/agent'), 'Desktop > Chat');
-const isDev = process.env.NODE_ENV === 'development';
+
 // Desktop router configuration (declarative mode)
 export const desktopRoutes: RouteObject[] = [
   {
@@ -651,7 +651,7 @@ export const desktopRoutes: RouteObject[] = [
   },
 
   // Devtools route (outside main layout, dev-only)
-  ...(isDev
+  ...(__DEV__
     ? [
         {
           children: [

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -874,9 +874,7 @@ export class ConversationLifecycleActionImpl {
     // Dev-only fast path: fall back to slicing the first user message instead of calling
     // the LLM. Keeps chat logs uncluttered while still giving the topic a usable title.
     // Only honored in non-production builds so a misconfigured prod env can't disable it.
-    const shouldSliceTopicTitle =
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NEXT_PUBLIC_DEV_DISABLE_AUTO_TOPIC === '1';
+    const shouldSliceTopicTitle = __DEV__ && process.env.NEXT_PUBLIC_DEV_DISABLE_AUTO_TOPIC === '1';
 
     const applyTopicTitle = async (topicId: string, messages: UIChatMessage[]) => {
       if (!shouldSliceTopicTitle) {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -30,6 +30,12 @@ const alias = {
 };
 
 export default defineConfig({
+  define: {
+    '__CI__': process.env.CI === 'true' ? 'true' : 'false',
+    '__DEV__': process.env.NODE_ENV !== 'production' ? 'true' : 'false',
+    '__ELECTRON__': 'false',
+    '__MOBILE__': 'false',
+  },
   optimizeDeps: {
     exclude: ['crypto', 'util', 'tty'],
     include: ['@lobehub/tts'],


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The Vite `__DEV__` define and its global type declaration are already in place (`plugins/vite/sharedRendererConfig.ts`, `src/types/global.d.ts`), but most SPA code still uses `process.env.NODE_ENV` for dev gating. That works at runtime but is harder for the bundler to dead-code-eliminate than a boolean literal.

This PR replaces `process.env.NODE_ENV` checks across SPA-only files with the `__DEV__` boolean so dev-only branches collapse cleanly in production builds.

Files touched (all SPA-only — not imported by Next.js server / SSR pages):

- `src/layout/GlobalProvider/FaviconProvider.tsx`
- `src/layout/SPAGlobalProvider/index.tsx`
- `src/features/AgentMockDevtools/index.tsx`
- `src/spa/router/desktopRouter.config.tsx` · `desktopRouter.config.desktop.tsx`
- `src/components/BootErrorBoundary/index.tsx`
- `src/components/DebugNode.tsx`
- `src/routes/(main)/agent/channel/platform/wechat/ConnectedInfo.tsx`
- `src/routes/(main)/agent/channel/detail/Body.tsx`
- `src/store/chat/slices/aiChat/actions/conversationLifecycle.ts`

Intentionally **not** touched (would break Next.js SSR or shared server code, where `__DEV__` is not defined):

- `src/app/**`, `src/server/**`, `src/instrumentation.ts`
- `src/libs/next/**`, `src/libs/trpc/**`, `src/libs/better-auth/**`, `src/libs/debug-file-logger.ts`
- `src/envs/**`, `src/config/featureFlags/schema.ts`
- `src/components/Loading/BrandTextLoading` (imported by `app/[variants]/(auth)/`)
- `src/features/DevPanel/RenderGallery/fixtures/*.ts` (fixture string contents, not runtime code)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Behavior is identical: `__DEV__` is defined as `process.env.NODE_ENV !== 'production'` (the SPA has no `test` mode, so it matches the previous `=== 'development'` checks). Verify dev-only UI (AgentMockDevtools, DebugNode Suspense fallbacks, wechat dev fields, etc.) still appears in `dev:spa` and is absent from a production build.

#### 📝 Additional Information

If we later want to extend `__DEV__` to server code, we can add a matching `webpack.DefinePlugin` entry in `next.config.ts` — out of scope here.