### PR TITLE
fix(local-system): strip createPatch preamble to prevent PatchDiff crash

### DIFF
--- a/packages/local-file-shell/src/file/edit.ts
+++ b/packages/local-file-shell/src/file/edit.ts
@@ -42,10 +42,18 @@ export async function editLocalFile({
 
     await writeFile(filePath, newContent, 'utf8');
 
-    const patch = createPatch(filePath, content, newContent, '', '');
-    const diffText = `diff --git a${filePath} b${filePath}\n${patch}`;
+    const rawPatch = createPatch(filePath, content, newContent, '', '');
+    // createPatch() emits an "Index: …\n===…\n" preamble that makes
+    // PatchDiff's getSingularPatch see multiple diff blocks and crash with
+    // "Provided patch must include only 1 patch, with 1 diff".
+    // Strip the preamble lines (everything before the first "--- ") so the
+    // renderer receives a single clean unified-diff block.
+    const unifiedLines = rawPatch.split('\n');
+    const firstMinusIdx = unifiedLines.findIndex((l) => l.startsWith('--- '));
+    const cleanPatch = firstMinusIdx > 0 ? unifiedLines.slice(firstMinusIdx).join('\n') : rawPatch;
+    const diffText = `diff --git a/${filePath} b/${filePath}\n${cleanPatch}`;
 
-    const patchLines = patch.split('\n');
+    const patchLines = rawPatch.split('\n');
     let linesAdded = 0;
     let linesDeleted = 0;
 

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-local-system.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-local-system.ts
@@ -9,7 +9,7 @@ export default defineFixtures({
       args: { path: '/workspace/src/spa/router/desktopRouter.config.tsx' },
       pluginState: {
         diffText:
-          "--- a/workspace/src/spa/router/desktopRouter.config.tsx\n+++ b/workspace/src/spa/router/desktopRouter.config.tsx\n@@ -1,3 +1,7 @@\n export const desktopRoutes = [\n+  {\n+    path: 'devtools',\n+  },\n ];\n",
+          "diff --git a/workspace/src/spa/router/desktopRouter.config.tsx b/workspace/src/spa/router/desktopRouter.config.tsx\n--- a/workspace/src/spa/router/desktopRouter.config.tsx\n+++ b/workspace/src/spa/router/desktopRouter.config.tsx\n@@ -1,3 +1,7 @@\n export const desktopRoutes = [\n+  {\n+    path: 'devtools',\n+  },\n ];\n",
       },
     }),
     listLocalFiles: single({


### PR DESCRIPTION
Fixes PatchDiff crash on editFile calls by removing createPatch preamble before unified diff.