### PR TITLE
🐛 fix(compression): 修复群聊 /compact 生成空摘要的问题

### DIFF
--- a/src/server/services/message/index.ts
+++ b/src/server/services/message/index.ts
@@ -285,20 +285,36 @@ export class MessageService {
     messagesToSummarize: UIChatMessage[];
     success: boolean;
   }> {
-    // 1. Get messages that need to be summarized (before marking them as compressed)
-    const allMessages = await this.messageModel.query(
-      { topicId, ...options },
-      this.getQueryOptions(),
-    );
+    // 1. Get messages that need to be summarized (before marking them as compressed).
+    // Query by ID directly instead of going through messageModel.query — that path applies
+    // a scope filter (agentId / groupId / threadId) and additionally drops any message
+    // whose messageGroupId is non-null. Both of those interact badly with /compact:
+    //   - Group-chat /compact called from useAgentContext sends groupId=undefined while
+    //     the actual messages have groupId='cg_...', so scope filtering returns 0 rows.
+    //   - Re-compressing a topic that already has one compression group would also lose
+    //     every messageId because of the isNull(messageGroupId) clause.
+    // Client passed an explicit messageIds list — look those up by ID, then confine the
+    // result to the active topic so a malformed/crafted request cannot drag in messages
+    // from other topics (queryByIds scopes by userId only).
+    const { postProcessUrl } = this.getQueryOptions();
+    const rawMessages = await this.messageModel.queryByIds(messageIds, { postProcessUrl });
+    const messagesToSummarize = rawMessages.filter((msg) => msg.topicId === topicId);
+    const scopedMessageIds = messagesToSummarize.map((msg) => msg.id);
 
-    const messagesToSummarize = allMessages.filter((msg) => messageIds.includes(msg.id));
+    if (scopedMessageIds.length === 0) {
+      throw new Error(
+        '[createCompressionGroup] No messages found for the provided messageIds within the ' +
+          'requested topic. The ids may have been deleted, never persisted, belong to a ' +
+          'different user, or reference another topic.',
+      );
+    }
 
     // 2. Create compression group with placeholder content
     const messageGroupId = await this.compressionRepository.createCompressionGroup({
       content: '...', // Placeholder content
-      messageIds,
+      messageIds: scopedMessageIds,
       metadata: {
-        originalMessageCount: messageIds.length,
+        originalMessageCount: scopedMessageIds.length,
       },
       topicId,
     });

--- a/src/store/chat/utils/compression.ts
+++ b/src/store/chat/utils/compression.ts
@@ -9,11 +9,24 @@ import { type Operation } from '../slices/operation/types';
 export const isCompressionOperationType = (type?: string) =>
   type === 'contextCompression' || type === 'generateSummary';
 
-export const getCompressionCandidateMessageIds = (messages: UIChatMessage[]) =>
-  messages
-    .filter((message) => message.role !== 'compressedGroup')
+export const getCompressionCandidateMessageIds = (messages: UIChatMessage[]) => {
+  // Collect ids of messages that are already inside a compression group
+  // (surfaced via the compressedGroup node's compressedMessages array) so we
+  // don't re-submit them — server MessageModel.query filters out messages with
+  // a non-null messageGroupId, which would otherwise yield an empty summary payload.
+  const alreadyCompressed = new Set<string>();
+  for (const message of messages) {
+    if (message.role === 'compressedGroup' && message.compressedMessages) {
+      for (const inner of message.compressedMessages) {
+        if (inner.id) alreadyCompressed.add(inner.id);
+      }
+    }
+  }
+  return messages
+    .filter((message) => message.role !== 'compressedGroup' && !alreadyCompressed.has(message.id))
     .map((message) => message.id)
     .filter(Boolean);
+};
 
 export const createPendingCompressedGroup = ({
   agentId,


### PR DESCRIPTION
## 问题

在群聊中手动触发 `/compact`（或点击上下文超限错误卡片上的压缩按钮）后，摘要内容是 summarizer 模型用自然语言返回的一句话，每次措辞不同：

- No conversation history provided to compress.
- Empty conversation history provided - no content to summarize.
- No conversation history provided - unable to generate summary.

这些字符串在源码里都搜不到，说明模型收到了空的 `<chat_history></chat_history>`，于是好心回复了一句没有内容可总结——前端把它当成了真实摘要。

## 根因

### 根因 1：服务端 scope 过滤把消息全部过滤掉（主因）

`MessageService.createCompressionGroup` 拿到客户端传来的 `messageIds` 后，走的是：

```ts
const allMessages = await this.messageModel.query({ topicId, ...options }, ...);
const messagesToSummarize = allMessages.filter(msg => messageIds.includes(msg.id));
```

但 `MessageModel.query` 会按 `options` 里的 `agentId / groupId / threadId` 做 scope 过滤，并且在底层 `queryWithWhere` 里强制加了 `isNull(messages.messageGroupId)`。在两种常见场景下交集会变成空：

- **群聊场景**：`/compact` 从 `useAgentContext` 构造的 `context` 不包含 `groupId`（`groupId` 只在 `useGroupContext` 里填），但数据库里群聊消息的 `group_id` 是非空的，于是 `matchGroup(undefined)` → `isNull(messages.groupId)` 与数据不匹配，query 返回 0 行。
- **重复压缩场景**：已压缩过的消息 `messageGroupId` 非空，会被 `isNull(messages.messageGroupId)` 过滤掉。

两种情况下 `messagesToSummarize` 都是空数组，但代码没有做任何检查，直接拿空 messages 去创建 compression group 并调用 summarizer LLM，最终在 UI 上看到一段看起来合理但跟对话无关的幻觉摘要或一句自然语言解释。

### 根因 2：前端候选挑选没排除已压缩消息（次因）

`getCompressionCandidateMessageIds` 只过滤 `role === 'compressedGroup'` 的伪节点，但 `compressedGroup.compressedMessages` 里的真实消息 id 仍然会被当成候选，导致前端把已经在某个 compression group 里的 `messageIds` 重复提交。

## 修法

### 服务端（主修）

`createCompressionGroup` 改用 `messageModel.queryByIds(messageIds)` 按 ID 直接查。客户端已经显式给了 `messageIds` 列表，按 ID 查就够了，不需要再按作用域二次过滤。同时对 `queryByIds` 结果为空的情况抛错，避免静默走到 summarizer 产生幻觉摘要。

### 前端（兜底）

`getCompressionCandidateMessageIds` 先收集所有 `compressedGroup.compressedMessages[*].id` 到一个 Set，挑候选时跳过这些 id。严格来说服务端修好后这个兜底不是必需的，但能避免无效的 tRPC 往返，算一层 UX 改善——同时也能覆盖未来其它可能把已压缩消息带进候选的代码路径。

## 影响范围

- 修复后：群聊 `/compact`、重复压缩已压缩 topic、上下文超限卡片按钮——三条路径都能正确生成真实摘要。
- 非破坏性：普通 agent topic（非群聊、首次压缩）行为不变。

## 验证

在群聊中触发 `/compact`：修复前生成假摘要，修复后正常生成真实摘要。

## Test plan

- [x] 群聊中 `/compact` 手动触发，能生成真实摘要
- [ ] 建议维护者增加单测覆盖 `createCompressionGroup` 的以下情形：
  - messageIds 全部归属于某 compressedGroup（应正常返回 messagesToSummarize）
  - messageIds 全部不存在（应抛错）
  - 群聊消息 + context 不含 groupId（应正常返回 messagesToSummarize）