### PR TITLE
💄 style(tool): add word wrap toggle to tool arguments display

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentType, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Arguments from './index';
+
+vi.mock('@lobehub/ui', () => ({
+  ActionIcon: ({
+    active,
+    icon: IconComponent,
+    onClick,
+    title,
+  }: {
+    active?: boolean;
+    icon?: ComponentType;
+    onClick?: () => void;
+    title?: string;
+  }) => (
+    <button aria-pressed={active} type="button" onClick={onClick}>
+      {title}
+      {IconComponent ? <IconComponent /> : null}
+    </button>
+  ),
+  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Highlighter: ({ children, wrap }: { children?: ReactNode; wrap?: boolean }) => (
+    <pre data-testid="highlighter" data-wrap={String(Boolean(wrap))}>
+      {children}
+    </pre>
+  ),
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('antd', () => ({
+  Divider: () => <hr />,
+}));
+
+vi.mock('@/components/Descriptions', () => ({
+  default: ({
+    items,
+    wrap,
+  }: {
+    items: Array<{ key: string; value: ReactNode }>;
+    wrap?: boolean;
+  }) => (
+    <div data-testid="descriptions" data-wrap={String(Boolean(wrap))}>
+      {items.map((item) => (
+        <span key={item.key}>{item.value}</span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { ns?: string }) =>
+      (
+        ({
+          'arguments.title': 'Arguments',
+          'workingPanel.review.wordWrap.disable': 'Disable word wrap',
+          'workingPanel.review.wordWrap.enable': 'Enable word wrap',
+        }) as Record<string, string>
+      )[options?.ns === 'chat' ? key : key] || key,
+  }),
+}));
+
+describe('Arguments', () => {
+  it('keeps argument values collapsed by default and toggles wrapping', () => {
+    render(<Arguments arguments={JSON.stringify({ file_path: '/very/long/path/to/file.ts' })} />);
+
+    expect(screen.getByTestId('descriptions')).toHaveAttribute('data-wrap', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: /enable word wrap/i }));
+
+    expect(screen.getByTestId('descriptions')).toHaveAttribute('data-wrap', 'true');
+    expect(screen.getByRole('button', { name: /disable word wrap/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Arguments/index.tsx
@@ -1,12 +1,13 @@
-import { Flexbox, Highlighter, Text } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Highlighter, Text } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { cssVar, cx } from 'antd-style';
+import { WrapText } from 'lucide-react';
 import { parse } from 'partial-json';
-import { type ReactNode } from 'react';
-import { memo, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { type DescriptionItem } from '@/components/Descriptions';
+import type { DescriptionItem } from '@/components/Descriptions';
 import Descriptions from '@/components/Descriptions';
 import { useYamlArguments } from '@/hooks/useYamlArguments';
 import { shinyTextStyles } from '@/styles';
@@ -32,6 +33,7 @@ export interface ArgumentsProps {
 
 const Arguments = memo<ArgumentsProps>(({ arguments: args = '', loading, actions }) => {
   const { t } = useTranslation('plugin');
+  const [wrap, setWrap] = useState(false);
 
   const displayArgs = useMemo(() => {
     try {
@@ -49,7 +51,7 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', loading, actions
 
   if (typeof displayArgs === 'string') {
     contentNode = !!yaml && (
-      <Highlighter language={'yaml'} showLanguage={false}>
+      <Highlighter language={'yaml'} showLanguage={false} wrap={wrap}>
         {yaml}
       </Highlighter>
     );
@@ -66,11 +68,11 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', loading, actions
     contentNode = (
       <Flexbox paddingBlock={4} paddingInline={16}>
         <Descriptions
-          wrap
           bordered={false}
           items={items}
           labelWidth={140}
           maxItemWidth={'100%'}
+          wrap={wrap}
           classNames={{
             label: cx(loading && shinyTextStyles.shinyText),
           }}
@@ -96,6 +98,16 @@ const Arguments = memo<ArgumentsProps>(({ arguments: args = '', loading, actions
       >
         <Text>{t('arguments.title')}</Text>
         <Flexbox horizontal gap={4}>
+          <ActionIcon
+            active={wrap}
+            icon={WrapText}
+            size={'small'}
+            title={t(
+              wrap ? 'workingPanel.review.wordWrap.disable' : 'workingPanel.review.wordWrap.enable',
+              { ns: 'chat' },
+            )}
+            onClick={() => setWrap((value) => !value)}
+          />
           {actions}
         </Flexbox>
       </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Add a word wrap toggle (`WrapText` ActionIcon) to the Arguments header in the tool detail view, alongside any existing actions. The toggle controls the `wrap` prop of both `Highlighter` (YAML view) and `Descriptions` (structured view), so users can switch between single-line and wrapped display for long argument values such as file paths or URLs.

Reuses the existing `workingPanel.review.wordWrap.enable` / `disable` strings (under the `chat` namespace) for the tooltip.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Unit test covers the default collapsed state and toggling behavior for the `Descriptions` view.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Argument values truncate to one line with no way to wrap | New WrapText icon in header toggles `wrap` for both YAML and Descriptions views |