### PR TITLE
🐛 fix(builtin-tool-task): expose lobe-task and add setTaskSchedule

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -265,6 +265,7 @@
   "builtins.lobe-task.apiName.listTasks": "List tasks",
   "builtins.lobe-task.apiName.runTask": "Run task",
   "builtins.lobe-task.apiName.runTasks": "Run tasks",
+  "builtins.lobe-task.apiName.setTaskSchedule": "Set schedule",
   "builtins.lobe-task.apiName.updateTaskComment": "Update comment",
   "builtins.lobe-task.apiName.updateTaskStatus": "Update status",
   "builtins.lobe-task.apiName.viewTask": "View task",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -265,6 +265,7 @@
   "builtins.lobe-task.apiName.listTasks": "任务列表",
   "builtins.lobe-task.apiName.runTask": "启动任务",
   "builtins.lobe-task.apiName.runTasks": "批量启动任务",
+  "builtins.lobe-task.apiName.setTaskSchedule": "设置调度",
   "builtins.lobe-task.apiName.updateTaskComment": "更新评论",
   "builtins.lobe-task.apiName.updateTaskStatus": "更新状态",
   "builtins.lobe-task.apiName.viewTask": "查看任务",

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { inspectorTextStyles, shinyTextStyles } from '@/styles';
+
+import type { SetTaskScheduleParams, SetTaskScheduleState } from '../../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  identifierChip: css`
+    flex-shrink: 0;
+
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  modeChip: css`
+    flex-shrink: 0;
+
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    color: ${cssVar.colorInfo};
+
+    background: ${cssVar.colorInfoBg};
+  `,
+  separator: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+}));
+
+export const SetTaskScheduleInspector = memo<
+  BuiltinInspectorProps<SetTaskScheduleParams, SetTaskScheduleState>
+>(({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+  const { t } = useTranslation('plugin');
+
+  const identifier = args?.identifier || partialArgs?.identifier;
+  const automationMode = args?.automationMode ?? partialArgs?.automationMode;
+  const modeLabel = automationMode === null ? 'off' : automationMode;
+
+  return (
+    <div
+      style={{ flexWrap: 'wrap', gap: 4 }}
+      className={cx(
+        inspectorTextStyles.root,
+        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+      )}
+    >
+      <span>{t('builtins.lobe-task.apiName.setTaskSchedule')}</span>
+      {identifier && <span className={styles.identifierChip}>{identifier}</span>}
+      {modeLabel && (
+        <>
+          <span className={styles.separator}>·</span>
+          <span className={styles.modeChip}>{modeLabel}</span>
+        </>
+      )}
+    </div>
+  );
+});
+
+SetTaskScheduleInspector.displayName = 'SetTaskScheduleInspector';
+
+export default SetTaskScheduleInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-task/src/client/Inspector/index.ts
@@ -8,6 +8,7 @@ import { EditTaskInspector } from './EditTask';
 import { ListTasksInspector } from './ListTasks';
 import { RunTaskInspector } from './RunTask';
 import { RunTasksInspector } from './RunTasks';
+import { SetTaskScheduleInspector } from './SetTaskSchedule';
 import {
   AddTaskCommentInspector,
   DeleteTaskCommentInspector,
@@ -32,6 +33,7 @@ export const TaskInspectors: Record<string, BuiltinInspector> = {
   [TaskApiName.listTasks]: ListTasksInspector as BuiltinInspector,
   [TaskApiName.runTask]: RunTaskInspector as BuiltinInspector,
   [TaskApiName.runTasks]: RunTasksInspector as BuiltinInspector,
+  [TaskApiName.setTaskSchedule]: SetTaskScheduleInspector as BuiltinInspector,
   [TaskApiName.updateTaskComment]: UpdateTaskCommentInspector as BuiltinInspector,
   [TaskApiName.updateTaskStatus]: UpdateTaskStatusInspector as BuiltinInspector,
   [TaskApiName.viewTask]: ViewTaskInspector as BuiltinInspector,
@@ -44,6 +46,7 @@ export { EditTaskInspector } from './EditTask';
 export { ListTasksInspector } from './ListTasks';
 export { RunTaskInspector } from './RunTask';
 export { RunTasksInspector } from './RunTasks';
+export { SetTaskScheduleInspector } from './SetTaskSchedule';
 export {
   AddTaskCommentInspector,
   DeleteTaskCommentInspector,

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -8,7 +8,12 @@ import {
   formatTaskList,
   priorityLabel,
 } from '@lobechat/prompts';
-import type { BuiltinToolContext, BuiltinToolResult, TaskStatus } from '@lobechat/types';
+import type {
+  BuiltinToolContext,
+  BuiltinToolResult,
+  TaskAutomationMode,
+  TaskStatus,
+} from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
 
@@ -73,9 +78,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     params: {
       instruction: string;
       assigneeAgentId?: string;
+      automationMode?: TaskAutomationMode;
+      heartbeatInterval?: number;
       name: string;
       parentIdentifier?: string;
       priority?: number;
+      schedulePattern?: string;
+      scheduleTimezone?: string;
       sortOrder?: number;
     },
     ctx?: BuiltinToolContext,
@@ -83,16 +92,30 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     try {
       log('[TaskExecutor] createTask - params:', params);
       const parentIdentifier = params.parentIdentifier?.trim() || undefined;
+      const store = getTaskStoreState();
 
-      const task = await getTaskStoreState().createTask({
+      const task = await store.createTask({
         assigneeAgentId:
           params.assigneeAgentId ?? (ctx?.scope === 'task' ? undefined : ctx?.agentId),
+        automationMode: params.automationMode,
         createdByAgentId: ctx?.agentId,
         instruction: params.instruction,
         name: params.name,
         parentTaskId: parentIdentifier,
         priority: params.priority,
+        schedulePattern: params.schedulePattern,
+        scheduleTimezone: params.scheduleTimezone,
       });
+
+      // Heartbeat interval isn't part of the create schema (DB column defaults to
+      // null); apply it via a follow-up update so an LLM can set everything in
+      // one createTask call.
+      if (task?.identifier && params.heartbeatInterval !== undefined) {
+        await taskService.update(task.identifier, {
+          heartbeatInterval: params.heartbeatInterval,
+        });
+        await store.internal_refreshTaskDetail(task.identifier);
+      }
 
       if (!task) {
         return {
@@ -235,13 +258,18 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     params: {
       addDependencies?: string[];
       assigneeAgentId?: string | null;
+      automationMode?: TaskAutomationMode | null;
       description?: string;
+      heartbeatInterval?: number;
       identifier: string;
       instruction?: string;
+      maxExecutions?: number | null;
       name?: string;
       parentIdentifier?: string | null;
       priority?: number;
       removeDependencies?: string[];
+      schedulePattern?: string | null;
+      scheduleTimezone?: string | null;
     },
     _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
@@ -295,6 +323,66 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         ops.push(store.updateTask(identifier, updateData));
       }
 
+      // Schedule columns (top-level) — bypass store.updateTask so the optimistic
+      // path doesn't have to map flat columns onto the detail's nested shape.
+      const scheduleUpdate: {
+        automationMode?: TaskAutomationMode | null;
+        heartbeatInterval?: number;
+        schedulePattern?: string | null;
+        scheduleTimezone?: string | null;
+      } = {};
+      if (params.automationMode !== undefined) {
+        scheduleUpdate.automationMode = params.automationMode;
+        changes.push(
+          params.automationMode
+            ? `automation mode → ${params.automationMode}`
+            : 'automation disabled',
+        );
+      }
+      if (params.heartbeatInterval !== undefined) {
+        scheduleUpdate.heartbeatInterval = params.heartbeatInterval;
+        changes.push(
+          params.heartbeatInterval > 0
+            ? `heartbeat interval → ${params.heartbeatInterval}s`
+            : 'heartbeat interval cleared',
+        );
+      }
+      if (params.schedulePattern !== undefined) {
+        scheduleUpdate.schedulePattern = params.schedulePattern;
+        changes.push(
+          params.schedulePattern
+            ? `schedule pattern → "${params.schedulePattern}"`
+            : 'schedule pattern cleared',
+        );
+      }
+      if (params.scheduleTimezone !== undefined) {
+        scheduleUpdate.scheduleTimezone = params.scheduleTimezone;
+        changes.push(
+          params.scheduleTimezone
+            ? `schedule timezone → ${params.scheduleTimezone}`
+            : 'schedule timezone cleared',
+        );
+      }
+      const scheduleTouched = Object.keys(scheduleUpdate).length > 0;
+      if (scheduleTouched) {
+        ops.push(taskService.update(identifier, scheduleUpdate));
+      }
+
+      // maxExecutions lives in `tasks.config.schedule.maxExecutions` (JSONB);
+      // route through updateConfig so the server-side merge preserves siblings.
+      if (params.maxExecutions !== undefined) {
+        ops.push(
+          taskService.updateConfig(identifier, {
+            schedule: { maxExecutions: params.maxExecutions },
+          }),
+        );
+        changes.push(
+          params.maxExecutions === null
+            ? 'max executions cleared (unlimited)'
+            : `max executions → ${params.maxExecutions}`,
+        );
+      }
+
       if (addDependencies?.length) {
         addDependencies.forEach((dep) => {
           ops.push(store.addDependency(identifier, dep));
@@ -309,6 +397,12 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
       }
 
       await Promise.all(ops);
+
+      // Schedule / config edits bypass store.updateTask's optimistic path; pull
+      // the fresh detail so the UI reflects the new automation/cron state.
+      if (scheduleTouched || params.maxExecutions !== undefined) {
+        await store.internal_refreshTaskDetail(identifier);
+      }
 
       return {
         content: formatTaskEdited(identifier, changes),

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -78,13 +78,9 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     params: {
       instruction: string;
       assigneeAgentId?: string;
-      automationMode?: TaskAutomationMode;
-      heartbeatInterval?: number;
       name: string;
       parentIdentifier?: string;
       priority?: number;
-      schedulePattern?: string;
-      scheduleTimezone?: string;
       sortOrder?: number;
     },
     ctx?: BuiltinToolContext,
@@ -92,30 +88,16 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     try {
       log('[TaskExecutor] createTask - params:', params);
       const parentIdentifier = params.parentIdentifier?.trim() || undefined;
-      const store = getTaskStoreState();
 
-      const task = await store.createTask({
+      const task = await getTaskStoreState().createTask({
         assigneeAgentId:
           params.assigneeAgentId ?? (ctx?.scope === 'task' ? undefined : ctx?.agentId),
-        automationMode: params.automationMode,
         createdByAgentId: ctx?.agentId,
         instruction: params.instruction,
         name: params.name,
         parentTaskId: parentIdentifier,
         priority: params.priority,
-        schedulePattern: params.schedulePattern,
-        scheduleTimezone: params.scheduleTimezone,
       });
-
-      // Heartbeat interval isn't part of the create schema (DB column defaults to
-      // null); apply it via a follow-up update so an LLM can set everything in
-      // one createTask call.
-      if (task?.identifier && params.heartbeatInterval !== undefined) {
-        await taskService.update(task.identifier, {
-          heartbeatInterval: params.heartbeatInterval,
-        });
-        await store.internal_refreshTaskDetail(task.identifier);
-      }
 
       if (!task) {
         return {
@@ -258,18 +240,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     params: {
       addDependencies?: string[];
       assigneeAgentId?: string | null;
-      automationMode?: TaskAutomationMode | null;
       description?: string;
-      heartbeatInterval?: number;
       identifier: string;
       instruction?: string;
-      maxExecutions?: number | null;
       name?: string;
       parentIdentifier?: string | null;
       priority?: number;
       removeDependencies?: string[];
-      schedulePattern?: string | null;
-      scheduleTimezone?: string | null;
     },
     _ctx?: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
@@ -323,8 +300,59 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         ops.push(store.updateTask(identifier, updateData));
       }
 
-      // Schedule columns (top-level) — bypass store.updateTask so the optimistic
-      // path doesn't have to map flat columns onto the detail's nested shape.
+      if (addDependencies?.length) {
+        addDependencies.forEach((dep) => {
+          ops.push(store.addDependency(identifier, dep));
+          changes.push(formatDependencyAdded(identifier, dep));
+        });
+      }
+      if (removeDependencies?.length) {
+        removeDependencies.forEach((dep) => {
+          ops.push(store.removeDependency(identifier, dep));
+          changes.push(formatDependencyRemoved(identifier, dep));
+        });
+      }
+
+      await Promise.all(ops);
+
+      return {
+        content: formatTaskEdited(identifier, changes),
+        state: { identifier, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] editTask - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to edit task';
+      return {
+        content: `Failed to edit task: ${message}`,
+        error: { message, type: 'EditTaskFailed' },
+        success: false,
+      };
+    }
+  };
+
+  setTaskSchedule = async (
+    params: {
+      automationMode?: TaskAutomationMode | null;
+      heartbeatInterval?: number;
+      identifier: string;
+      maxExecutions?: number | null;
+      schedulePattern?: string | null;
+      scheduleTimezone?: string | null;
+    },
+    _ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] setTaskSchedule - params:', params);
+
+      const { identifier } = params;
+      const store = getTaskStoreState();
+      const changes: string[] = [];
+      const ops: Promise<unknown>[] = [];
+
+      // Top-level schedule columns — direct service.update bypasses the
+      // store.updateTask optimistic path, which would otherwise need to map
+      // flat columns onto the detail's nested `schedule.*` shape.
       const scheduleUpdate: {
         automationMode?: TaskAutomationMode | null;
         heartbeatInterval?: number;
@@ -363,13 +391,13 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
             : 'schedule timezone cleared',
         );
       }
-      const scheduleTouched = Object.keys(scheduleUpdate).length > 0;
-      if (scheduleTouched) {
+      if (Object.keys(scheduleUpdate).length > 0) {
         ops.push(taskService.update(identifier, scheduleUpdate));
       }
 
       // maxExecutions lives in `tasks.config.schedule.maxExecutions` (JSONB);
-      // route through updateConfig so the server-side merge preserves siblings.
+      // route through updateConfig so the server-side merge preserves siblings
+      // (checkpoint, review, model snapshot, etc).
       if (params.maxExecutions !== undefined) {
         ops.push(
           taskService.updateConfig(identifier, {
@@ -383,38 +411,28 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
         );
       }
 
-      if (addDependencies?.length) {
-        addDependencies.forEach((dep) => {
-          ops.push(store.addDependency(identifier, dep));
-          changes.push(formatDependencyAdded(identifier, dep));
-        });
-      }
-      if (removeDependencies?.length) {
-        removeDependencies.forEach((dep) => {
-          ops.push(store.removeDependency(identifier, dep));
-          changes.push(formatDependencyRemoved(identifier, dep));
-        });
+      if (ops.length === 0) {
+        return {
+          content: 'No schedule fields provided; nothing to update.',
+          error: { message: 'No schedule fields provided.', type: 'NoFields' },
+          success: false,
+        };
       }
 
       await Promise.all(ops);
-
-      // Schedule / config edits bypass store.updateTask's optimistic path; pull
-      // the fresh detail so the UI reflects the new automation/cron state.
-      if (scheduleTouched || params.maxExecutions !== undefined) {
-        await store.internal_refreshTaskDetail(identifier);
-      }
+      await store.internal_refreshTaskDetail(identifier);
 
       return {
         content: formatTaskEdited(identifier, changes),
-        state: { identifier, success: true },
+        state: { automationMode: params.automationMode, identifier, success: true },
         success: true,
       };
     } catch (error) {
-      log('[TaskExecutor] editTask - error:', error);
-      const message = error instanceof Error ? error.message : 'Failed to edit task';
+      log('[TaskExecutor] setTaskSchedule - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to set task schedule';
       return {
-        content: `Failed to edit task: ${message}`,
-        error: { message, type: 'EditTaskFailed' },
+        content: `Failed to set task schedule: ${message}`,
+        error: { message, type: 'SetTaskScheduleFailed' },
         success: false,
       };
     }

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -12,7 +12,7 @@ export const TaskManifest: BuiltinToolManifest = {
     // ==================== Task CRUD ====================
     {
       description:
-        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier.',
+        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier. To create a periodically running task in one shot, also set `automationMode` plus the corresponding `schedulePattern + scheduleTimezone` (cron mode) or `heartbeatInterval` (heartbeat mode).',
       name: TaskApiName.createTask,
       parameters: {
         properties: {
@@ -24,6 +24,17 @@ export const TaskManifest: BuiltinToolManifest = {
             description:
               'Optional agent ID to assign the task to. In task management context, omit it to create an unassigned task.',
             type: 'string',
+          },
+          automationMode: {
+            description:
+              'Enables periodic execution. `heartbeat` ticks every `heartbeatInterval` seconds; `schedule` fires when the cron `schedulePattern` matches. Omit for a one-shot manually-run task.',
+            enum: ['heartbeat', 'schedule'],
+            type: 'string',
+          },
+          heartbeatInterval: {
+            description:
+              'Periodic execution interval in seconds. Required when automationMode === "heartbeat" (minimum 600 = 10 minutes recommended).',
+            type: 'number',
           },
           name: {
             description: 'A short, descriptive name for the task.',
@@ -38,6 +49,16 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Priority level: 0=none, 1=urgent, 2=high, 3=normal, 4=low. Default is 0.',
             type: 'number',
           },
+          schedulePattern: {
+            description:
+              'Cron expression for scheduled execution, e.g. "0 9 * * *" (every day at 09:00). Required when automationMode === "schedule".',
+            type: 'string',
+          },
+          scheduleTimezone: {
+            description:
+              'IANA timezone for the cron expression, e.g. "Asia/Shanghai" or "America/New_York". Defaults to UTC when omitted.',
+            type: 'string',
+          },
           sortOrder: {
             description:
               'Sort order within parent task. Lower values appear first. Use to control display order (e.g. chapter 1=0, chapter 2=1, etc.).',
@@ -50,7 +71,7 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Create multiple tasks in a single call. Prefer this over multiple createTask calls when planning a batch of related tasks (e.g. all subtasks under one parent, or all chapters of an outline). Each item supports the same fields as createTask. Items are created sequentially in array order; failures on individual items do not abort the batch.',
+        'Create multiple tasks in a single call. Prefer this over multiple createTask calls when planning a batch of related tasks (e.g. all subtasks under one parent, or all chapters of an outline). Each item supports the same fields as createTask (including schedule fields). Items are created sequentially in array order; failures on individual items do not abort the batch.',
       name: TaskApiName.createTasks,
       parameters: {
         properties: {
@@ -68,6 +89,17 @@ export const TaskManifest: BuiltinToolManifest = {
                     'Optional agent ID to assign the task to. In task management context, omit it to create an unassigned task.',
                   type: 'string',
                 },
+                automationMode: {
+                  description:
+                    'Enables periodic execution. `heartbeat` uses heartbeatInterval; `schedule` uses schedulePattern + scheduleTimezone.',
+                  enum: ['heartbeat', 'schedule'],
+                  type: 'string',
+                },
+                heartbeatInterval: {
+                  description:
+                    'Periodic execution interval in seconds. Required when automationMode === "heartbeat".',
+                  type: 'number',
+                },
                 name: {
                   description: 'A short, descriptive name for the task.',
                   type: 'string',
@@ -81,6 +113,16 @@ export const TaskManifest: BuiltinToolManifest = {
                   description:
                     'Priority level: 0=none, 1=urgent, 2=high, 3=normal, 4=low. Default is 0.',
                   type: 'number',
+                },
+                schedulePattern: {
+                  description:
+                    'Cron expression for scheduled execution. Required when automationMode === "schedule".',
+                  type: 'string',
+                },
+                scheduleTimezone: {
+                  description:
+                    'IANA timezone for the cron expression. Defaults to UTC when omitted.',
+                  type: 'string',
                 },
                 sortOrder: {
                   description:
@@ -207,7 +249,7 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        "Edit a task's fields (name, description, instruction, priority), parent, or dependencies (batched). Status changes go through updateTaskStatus.",
+        "Edit a task's fields (name, description, instruction, priority), parent, dependencies (batched), or schedule (automationMode + schedulePattern/scheduleTimezone/heartbeatInterval/maxExecutions). Status changes go through updateTaskStatus.",
       name: TaskApiName.editTask,
       parameters: {
         properties: {
@@ -221,10 +263,21 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Assign the task to this agent ID. Pass null to clear the assignee.',
             type: ['string', 'null'],
           },
+          automationMode: {
+            description:
+              'Switch automation mode. "heartbeat" ticks every `heartbeatInterval` seconds; "schedule" fires on the cron `schedulePattern`. Pass null to disable automation entirely.',
+            enum: ['heartbeat', 'schedule', null],
+            type: ['string', 'null'],
+          },
           description: {
             description:
               'Human-readable description (displayed in UI). Separate from instruction, which guides the agent.',
             type: 'string',
+          },
+          heartbeatInterval: {
+            description:
+              'Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear the interval.',
+            type: 'number',
           },
           identifier: {
             description: 'The identifier of the task to edit.',
@@ -233,6 +286,11 @@ export const TaskManifest: BuiltinToolManifest = {
           instruction: {
             description: 'Updated instruction for the task.',
             type: 'string',
+          },
+          maxExecutions: {
+            description:
+              'Cap on the number of scheduled executions for this task. Pass null to remove the cap (run indefinitely).',
+            type: ['number', 'null'],
           },
           name: {
             description: 'Updated name for the task.',
@@ -251,6 +309,16 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Identifiers of existing dependencies to remove.',
             items: { type: 'string' },
             type: 'array',
+          },
+          schedulePattern: {
+            description:
+              'Cron expression for scheduled mode, e.g. "0 9 * * *". Pass null to clear the pattern.',
+            type: ['string', 'null'],
+          },
+          scheduleTimezone: {
+            description:
+              'IANA timezone for the cron expression, e.g. "Asia/Shanghai". Pass null to clear.',
+            type: ['string', 'null'],
           },
         },
         required: ['identifier'],

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -12,7 +12,7 @@ export const TaskManifest: BuiltinToolManifest = {
     // ==================== Task CRUD ====================
     {
       description:
-        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier. To create a periodically running task in one shot, also set `automationMode` plus the corresponding `schedulePattern + scheduleTimezone` (cron mode) or `heartbeatInterval` (heartbeat mode).',
+        'Create a new task. Optionally attach it as a subtask by specifying parentIdentifier.',
       name: TaskApiName.createTask,
       parameters: {
         properties: {
@@ -24,17 +24,6 @@ export const TaskManifest: BuiltinToolManifest = {
             description:
               'Optional agent ID to assign the task to. In task management context, omit it to create an unassigned task.',
             type: 'string',
-          },
-          automationMode: {
-            description:
-              'Enables periodic execution. `heartbeat` ticks every `heartbeatInterval` seconds; `schedule` fires when the cron `schedulePattern` matches. Omit for a one-shot manually-run task.',
-            enum: ['heartbeat', 'schedule'],
-            type: 'string',
-          },
-          heartbeatInterval: {
-            description:
-              'Periodic execution interval in seconds. Required when automationMode === "heartbeat" (minimum 600 = 10 minutes recommended).',
-            type: 'number',
           },
           name: {
             description: 'A short, descriptive name for the task.',
@@ -49,16 +38,6 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Priority level: 0=none, 1=urgent, 2=high, 3=normal, 4=low. Default is 0.',
             type: 'number',
           },
-          schedulePattern: {
-            description:
-              'Cron expression for scheduled execution, e.g. "0 9 * * *" (every day at 09:00). Required when automationMode === "schedule".',
-            type: 'string',
-          },
-          scheduleTimezone: {
-            description:
-              'IANA timezone for the cron expression, e.g. "Asia/Shanghai" or "America/New_York". Defaults to UTC when omitted.',
-            type: 'string',
-          },
           sortOrder: {
             description:
               'Sort order within parent task. Lower values appear first. Use to control display order (e.g. chapter 1=0, chapter 2=1, etc.).',
@@ -71,7 +50,7 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Create multiple tasks in a single call. Prefer this over multiple createTask calls when planning a batch of related tasks (e.g. all subtasks under one parent, or all chapters of an outline). Each item supports the same fields as createTask (including schedule fields). Items are created sequentially in array order; failures on individual items do not abort the batch.',
+        'Create multiple tasks in a single call. Prefer this over multiple createTask calls when planning a batch of related tasks (e.g. all subtasks under one parent, or all chapters of an outline). Each item supports the same fields as createTask. Items are created sequentially in array order; failures on individual items do not abort the batch.',
       name: TaskApiName.createTasks,
       parameters: {
         properties: {
@@ -89,17 +68,6 @@ export const TaskManifest: BuiltinToolManifest = {
                     'Optional agent ID to assign the task to. In task management context, omit it to create an unassigned task.',
                   type: 'string',
                 },
-                automationMode: {
-                  description:
-                    'Enables periodic execution. `heartbeat` uses heartbeatInterval; `schedule` uses schedulePattern + scheduleTimezone.',
-                  enum: ['heartbeat', 'schedule'],
-                  type: 'string',
-                },
-                heartbeatInterval: {
-                  description:
-                    'Periodic execution interval in seconds. Required when automationMode === "heartbeat".',
-                  type: 'number',
-                },
                 name: {
                   description: 'A short, descriptive name for the task.',
                   type: 'string',
@@ -113,16 +81,6 @@ export const TaskManifest: BuiltinToolManifest = {
                   description:
                     'Priority level: 0=none, 1=urgent, 2=high, 3=normal, 4=low. Default is 0.',
                   type: 'number',
-                },
-                schedulePattern: {
-                  description:
-                    'Cron expression for scheduled execution. Required when automationMode === "schedule".',
-                  type: 'string',
-                },
-                scheduleTimezone: {
-                  description:
-                    'IANA timezone for the cron expression. Defaults to UTC when omitted.',
-                  type: 'string',
                 },
                 sortOrder: {
                   description:
@@ -249,7 +207,7 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
-        "Edit a task's fields (name, description, instruction, priority), parent, dependencies (batched), or schedule (automationMode + schedulePattern/scheduleTimezone/heartbeatInterval/maxExecutions). Status changes go through updateTaskStatus.",
+        "Edit a task's fields (name, description, instruction, priority), parent, or dependencies (batched). Status changes go through updateTaskStatus; schedule configuration goes through setTaskSchedule.",
       name: TaskApiName.editTask,
       parameters: {
         properties: {
@@ -263,21 +221,10 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Assign the task to this agent ID. Pass null to clear the assignee.',
             type: ['string', 'null'],
           },
-          automationMode: {
-            description:
-              'Switch automation mode. "heartbeat" ticks every `heartbeatInterval` seconds; "schedule" fires on the cron `schedulePattern`. Pass null to disable automation entirely.',
-            enum: ['heartbeat', 'schedule', null],
-            type: ['string', 'null'],
-          },
           description: {
             description:
               'Human-readable description (displayed in UI). Separate from instruction, which guides the agent.',
             type: 'string',
-          },
-          heartbeatInterval: {
-            description:
-              'Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear the interval.',
-            type: 'number',
           },
           identifier: {
             description: 'The identifier of the task to edit.',
@@ -286,11 +233,6 @@ export const TaskManifest: BuiltinToolManifest = {
           instruction: {
             description: 'Updated instruction for the task.',
             type: 'string',
-          },
-          maxExecutions: {
-            description:
-              'Cap on the number of scheduled executions for this task. Pass null to remove the cap (run indefinitely).',
-            type: ['number', 'null'],
           },
           name: {
             description: 'Updated name for the task.',
@@ -309,16 +251,6 @@ export const TaskManifest: BuiltinToolManifest = {
             description: 'Identifiers of existing dependencies to remove.',
             items: { type: 'string' },
             type: 'array',
-          },
-          schedulePattern: {
-            description:
-              'Cron expression for scheduled mode, e.g. "0 9 * * *". Pass null to clear the pattern.',
-            type: ['string', 'null'],
-          },
-          scheduleTimezone: {
-            description:
-              'IANA timezone for the cron expression, e.g. "Asia/Shanghai". Pass null to clear.',
-            type: ['string', 'null'],
           },
         },
         required: ['identifier'],
@@ -364,6 +296,47 @@ export const TaskManifest: BuiltinToolManifest = {
           },
         },
         required: ['identifiers'],
+        type: 'object',
+      },
+    },
+    {
+      description:
+        'Configure (or clear) the recurring schedule of a task. Use this to turn a task into a periodically running one, switch between cron (`schedule`) and fixed-interval (`heartbeat`) automation, or disable automation entirely. Pass automationMode=null to stop the task from auto-running. For schedule mode, supply schedulePattern (cron) and scheduleTimezone (IANA). For heartbeat mode, supply heartbeatInterval (seconds). maxExecutions caps how many scheduled runs may fire (null = unlimited). Status changes still go through updateTaskStatus; this tool only touches schedule configuration.',
+      name: TaskApiName.setTaskSchedule,
+      parameters: {
+        properties: {
+          automationMode: {
+            description:
+              'Enables periodic execution. "schedule" fires on the cron `schedulePattern`; "heartbeat" ticks every `heartbeatInterval` seconds. Pass null to disable automation entirely.',
+            enum: ['heartbeat', 'schedule', null],
+            type: ['string', 'null'],
+          },
+          heartbeatInterval: {
+            description:
+              'Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear the interval. Recommend ≥600s.',
+            type: 'number',
+          },
+          identifier: {
+            description: 'The identifier of the task to configure (e.g. "TASK-1").',
+            type: 'string',
+          },
+          maxExecutions: {
+            description:
+              'Cap on the number of scheduled executions for this task. Pass null to remove the cap (run indefinitely).',
+            type: ['number', 'null'],
+          },
+          schedulePattern: {
+            description:
+              'Cron expression for scheduled mode, e.g. "0 9 * * *" (every day at 09:00). Pass null to clear the pattern.',
+            type: ['string', 'null'],
+          },
+          scheduleTimezone: {
+            description:
+              'IANA timezone for the cron expression, e.g. "Asia/Shanghai" or "America/New_York". Pass null to clear; defaults to UTC when unset.',
+            type: ['string', 'null'],
+          },
+        },
+        required: ['identifier'],
         type: 'object',
       },
     },

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,21 +1,22 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
-- **createTask**: Create a new task. Use parentIdentifier to make it a subtask. To create a recurring task in one shot, set automationMode + schedulePattern/scheduleTimezone (cron) or automationMode='heartbeat' + heartbeatInterval
+- **createTask**: Create a new task. Use parentIdentifier to make it a subtask
 - **createTasks**: Create multiple tasks in one call. Prefer this when you are about to create more than one task in a row (e.g. all subtasks under one parent, or all chapters of an outline) — it cuts the number of tool calls and keeps the batch atomic from the user's perspective
 - **listTasks**: List tasks. With no filters, defaults to top-level unfinished tasks of the current agent in normal agent conversations, or top-level unfinished tasks across all agents in task manager conversations. If you provide any filter, omitted filters are not applied implicitly
 - **viewTask**: View details of a specific task. Omitting identifier only works when there is a current task context
 - **addTaskComment / updateTaskComment / deleteTaskComment**: Record, revise, or remove task comments. Use viewTask to inspect existing comments and their comment ids
-- **editTask**: Modify a task's fields (name, description, instruction, priority), parent (parentIdentifier), dependencies (addDependencies/removeDependencies, batch), or schedule (automationMode + schedulePattern/scheduleTimezone/heartbeatInterval/maxExecutions). Use parentIdentifier=null to move a task to the top level; pass automationMode=null to disable automation. For status changes use updateTaskStatus
+- **editTask**: Modify a task's fields (name, description, instruction, priority), parent (parentIdentifier), or dependencies (addDependencies/removeDependencies, batch). Use parentIdentifier=null to move a task to the top level. For status changes use updateTaskStatus; for schedule configuration use setTaskSchedule
+- **setTaskSchedule**: Configure (or clear) the recurring schedule of a task. Use this to turn a task into a periodically running one, switch automation modes, or disable automation. See "Schedule fields" below for the supported params
 - **runTask**: Actually START a task — kicks off the assigned agent in a new (or continued) topic. Use this to launch execution; do NOT use updateTaskStatus(running) to start a task, that only flips a flag without executing. The task must have an assigneeAgentId
 - **runTasks**: Start multiple tasks in one call. Prefer this when launching a batch of related subtasks (e.g. all subtasks you just created); cuts down on tool calls and makes the start atomic from the user's perspective
 - **updateTaskStatus**: Change a task's status. If you mark a task as failed, include an error message explaining why. Use this to mark tasks completed/cancelled/paused/failed — NOT to start them (use runTask for that). Omitting identifier only works when there is a current task context
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
 
-Schedule fields (createTask / editTask):
-- **automationMode**: 'schedule' (cron-based) or 'heartbeat' (fixed interval). Pass null in editTask to disable
-- **schedulePattern + scheduleTimezone**: cron expression (e.g. "0 9 * * *") and IANA timezone (e.g. "Asia/Shanghai"); required for schedule mode
-- **heartbeatInterval**: seconds between ticks; required for heartbeat mode (recommend ≥600s)
-- **maxExecutions** (editTask only): cap on total scheduled runs; null means unlimited
+Schedule fields (setTaskSchedule):
+- **automationMode**: 'schedule' (cron-based) or 'heartbeat' (fixed interval). Pass null to disable automation
+- **schedulePattern + scheduleTimezone**: cron expression (e.g. "0 9 * * *") and IANA timezone (e.g. "Asia/Shanghai"); used by schedule mode
+- **heartbeatInterval**: seconds between ticks; used by heartbeat mode (recommend ≥600s). Pass 0 to clear
+- **maxExecutions**: cap on total scheduled runs; null means unlimited
 
 When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -1,15 +1,21 @@
 export const systemPrompt = `You have access to Task management tools. Use them to:
 
-- **createTask**: Create a new task. Use parentIdentifier to make it a subtask
+- **createTask**: Create a new task. Use parentIdentifier to make it a subtask. To create a recurring task in one shot, set automationMode + schedulePattern/scheduleTimezone (cron) or automationMode='heartbeat' + heartbeatInterval
 - **createTasks**: Create multiple tasks in one call. Prefer this when you are about to create more than one task in a row (e.g. all subtasks under one parent, or all chapters of an outline) — it cuts the number of tool calls and keeps the batch atomic from the user's perspective
 - **listTasks**: List tasks. With no filters, defaults to top-level unfinished tasks of the current agent in normal agent conversations, or top-level unfinished tasks across all agents in task manager conversations. If you provide any filter, omitted filters are not applied implicitly
 - **viewTask**: View details of a specific task. Omitting identifier only works when there is a current task context
 - **addTaskComment / updateTaskComment / deleteTaskComment**: Record, revise, or remove task comments. Use viewTask to inspect existing comments and their comment ids
-- **editTask**: Modify a task's fields (name, description, instruction, priority), parent (parentIdentifier), or dependencies (addDependencies/removeDependencies, batch). Use parentIdentifier=null to move a task to the top level. For status changes use updateTaskStatus
+- **editTask**: Modify a task's fields (name, description, instruction, priority), parent (parentIdentifier), dependencies (addDependencies/removeDependencies, batch), or schedule (automationMode + schedulePattern/scheduleTimezone/heartbeatInterval/maxExecutions). Use parentIdentifier=null to move a task to the top level; pass automationMode=null to disable automation. For status changes use updateTaskStatus
 - **runTask**: Actually START a task — kicks off the assigned agent in a new (or continued) topic. Use this to launch execution; do NOT use updateTaskStatus(running) to start a task, that only flips a flag without executing. The task must have an assigneeAgentId
 - **runTasks**: Start multiple tasks in one call. Prefer this when launching a batch of related subtasks (e.g. all subtasks you just created); cuts down on tool calls and makes the start atomic from the user's perspective
 - **updateTaskStatus**: Change a task's status. If you mark a task as failed, include an error message explaining why. Use this to mark tasks completed/cancelled/paused/failed — NOT to start them (use runTask for that). Omitting identifier only works when there is a current task context
 - **deleteTask**: Delete a task. Subtasks become top-level (not cascaded); dependencies/topics/comments cascade-delete; irreversible
+
+Schedule fields (createTask / editTask):
+- **automationMode**: 'schedule' (cron-based) or 'heartbeat' (fixed interval). Pass null in editTask to disable
+- **schedulePattern + scheduleTimezone**: cron expression (e.g. "0 9 * * *") and IANA timezone (e.g. "Asia/Shanghai"); required for schedule mode
+- **heartbeatInterval**: seconds between ticks; required for heartbeat mode (recommend ≥600s)
+- **maxExecutions** (editTask only): cap on total scheduled runs; null means unlimited
 
 When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)

--- a/packages/builtin-tool-task/src/types.ts
+++ b/packages/builtin-tool-task/src/types.ts
@@ -28,6 +28,9 @@ export const TaskApiName = {
   /** Trigger async runs for multiple tasks in one call */
   runTasks: 'runTasks',
 
+  /** Configure (or clear) the recurring schedule of a task */
+  setTaskSchedule: 'setTaskSchedule',
+
   /** Update a task comment */
   updateTaskComment: 'updateTaskComment',
 
@@ -44,18 +47,10 @@ export type TaskApiNameType = (typeof TaskApiName)[keyof typeof TaskApiName];
 
 export interface CreateTaskParams {
   assigneeAgentId?: string;
-  /** Enables periodic execution. `heartbeat` ticks every `heartbeatInterval` seconds; `schedule` fires on a cron pattern. */
-  automationMode?: TaskAutomationMode;
-  /** Periodic execution interval in seconds. Required when automationMode === 'heartbeat'. */
-  heartbeatInterval?: number;
   instruction: string;
   name: string;
   parentIdentifier?: string;
   priority?: number;
-  /** Cron expression for scheduled execution. Required when automationMode === 'schedule'. */
-  schedulePattern?: string;
-  /** IANA timezone for the cron expression (e.g. 'Asia/Shanghai'). Defaults to UTC. */
-  scheduleTimezone?: string;
   sortOrder?: number;
 }
 
@@ -151,23 +146,13 @@ export interface DeleteTaskCommentState {
 export interface EditTaskParams {
   addDependencies?: string[];
   assigneeAgentId?: string | null;
-  /** Switch automation mode. Pass null to disable automation entirely. */
-  automationMode?: TaskAutomationMode | null;
   description?: string;
-  /** Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear. */
-  heartbeatInterval?: number;
   identifier: string;
   instruction?: string;
-  /** Cap on the number of scheduled executions; null = unlimited. */
-  maxExecutions?: number | null;
   name?: string;
   parentIdentifier?: string | null;
   priority?: number;
   removeDependencies?: string[];
-  /** Cron expression for scheduled mode. Pass null to clear. */
-  schedulePattern?: string | null;
-  /** IANA timezone for the cron expression. Pass null to clear. */
-  scheduleTimezone?: string | null;
 }
 
 export interface EditTaskState {
@@ -209,6 +194,28 @@ export interface RunTasksState {
   failed: number;
   results: RunTasksItemResult[];
   succeeded: number;
+}
+
+// ==================== setTaskSchedule ====================
+
+export interface SetTaskScheduleParams {
+  /** Switch automation mode. Pass null to disable automation entirely. */
+  automationMode?: TaskAutomationMode | null;
+  /** Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear. */
+  heartbeatInterval?: number;
+  identifier: string;
+  /** Cap on the number of scheduled executions; null = unlimited. */
+  maxExecutions?: number | null;
+  /** Cron expression for scheduled mode. Pass null to clear. */
+  schedulePattern?: string | null;
+  /** IANA timezone for the cron expression. Pass null to clear. */
+  scheduleTimezone?: string | null;
+}
+
+export interface SetTaskScheduleState {
+  automationMode?: TaskAutomationMode | null;
+  identifier: string;
+  success: boolean;
 }
 
 // ==================== updateTaskStatus ====================

--- a/packages/builtin-tool-task/src/types.ts
+++ b/packages/builtin-tool-task/src/types.ts
@@ -1,4 +1,4 @@
-import type { TaskStatus } from '@lobechat/types';
+import type { TaskAutomationMode, TaskStatus } from '@lobechat/types';
 
 export const TaskApiName = {
   /** Add a comment to a task */
@@ -44,10 +44,18 @@ export type TaskApiNameType = (typeof TaskApiName)[keyof typeof TaskApiName];
 
 export interface CreateTaskParams {
   assigneeAgentId?: string;
+  /** Enables periodic execution. `heartbeat` ticks every `heartbeatInterval` seconds; `schedule` fires on a cron pattern. */
+  automationMode?: TaskAutomationMode;
+  /** Periodic execution interval in seconds. Required when automationMode === 'heartbeat'. */
+  heartbeatInterval?: number;
   instruction: string;
   name: string;
   parentIdentifier?: string;
   priority?: number;
+  /** Cron expression for scheduled execution. Required when automationMode === 'schedule'. */
+  schedulePattern?: string;
+  /** IANA timezone for the cron expression (e.g. 'Asia/Shanghai'). Defaults to UTC. */
+  scheduleTimezone?: string;
   sortOrder?: number;
 }
 
@@ -143,13 +151,23 @@ export interface DeleteTaskCommentState {
 export interface EditTaskParams {
   addDependencies?: string[];
   assigneeAgentId?: string | null;
+  /** Switch automation mode. Pass null to disable automation entirely. */
+  automationMode?: TaskAutomationMode | null;
   description?: string;
+  /** Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear. */
+  heartbeatInterval?: number;
   identifier: string;
   instruction?: string;
+  /** Cap on the number of scheduled executions; null = unlimited. */
+  maxExecutions?: number | null;
   name?: string;
   parentIdentifier?: string | null;
   priority?: number;
   removeDependencies?: string[];
+  /** Cron expression for scheduled mode. Pass null to clear. */
+  schedulePattern?: string | null;
+  /** IANA timezone for the cron expression. Pass null to clear. */
+  scheduleTimezone?: string | null;
 }
 
 export interface EditTaskState {

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -245,8 +245,6 @@ export const builtinTools: LobeBuiltinTool[] = [
     type: 'builtin',
   },
   {
-    discoverable: false,
-    hidden: true,
     identifier: TaskManifest.identifier,
     manifest: TaskManifest,
     type: 'builtin',

--- a/packages/const/src/recommendedSkill.ts
+++ b/packages/const/src/recommendedSkill.ts
@@ -15,6 +15,7 @@ export const RECOMMENDED_SKILLS: RecommendedSkillItem[] = [
   { id: 'lobe-user-memory', type: RecommendedSkillType.Builtin },
   { id: 'lobe-cloud-sandbox', type: RecommendedSkillType.Builtin },
   { id: 'lobe-gtd', type: RecommendedSkillType.Builtin },
+  { id: 'lobe-task', type: RecommendedSkillType.Builtin },
   { id: 'lobe-agent-documents', type: RecommendedSkillType.Builtin },
   { id: 'lobe-message', type: RecommendedSkillType.Builtin },
   // LobeHub skills

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -36,10 +36,7 @@ import {
   lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
-import {
-  type LobeToolMetaWithAvailability,
-  USER_HIDDEN_BUILTIN_TOOL_IDS,
-} from '@/store/tool/slices/builtin/selectors';
+import { type LobeToolMetaWithAvailability } from '@/store/tool/slices/builtin/selectors';
 
 import PluginTag from './PluginTag';
 import PopoverContent from './PopoverContent';
@@ -975,10 +972,7 @@ const AgentTool = memo<AgentToolProps>(
       if (showWebBrowsing && isSearchEnabled && !tools.includes(WEB_BROWSING_IDENTIFIER)) {
         tools.unshift(WEB_BROWSING_IDENTIFIER);
       }
-      return tools.filter(
-        (toolId) =>
-          !USER_HIDDEN_BUILTIN_TOOL_IDS.has(toolId) && !USER_HIDDEN_BUILTIN_SKILLS.has(toolId),
-      );
+      return tools.filter((toolId) => !USER_HIDDEN_BUILTIN_SKILLS.has(toolId));
     }, [plugins, isSearchEnabled, showWebBrowsing]);
 
     return (

--- a/src/locales/default/plugin.ts
+++ b/src/locales/default/plugin.ts
@@ -265,6 +265,7 @@ export default {
   'builtins.lobe-task.apiName.listTasks': 'List tasks',
   'builtins.lobe-task.apiName.runTask': 'Run task',
   'builtins.lobe-task.apiName.runTasks': 'Run tasks',
+  'builtins.lobe-task.apiName.setTaskSchedule': 'Set schedule',
   'builtins.lobe-task.apiName.updateTaskComment': 'Update comment',
   'builtins.lobe-task.apiName.updateTaskStatus': 'Update status',
   'builtins.lobe-task.apiName.viewTask': 'View task',

--- a/src/store/tool/slices/builtin/selectors.test.ts
+++ b/src/store/tool/slices/builtin/selectors.test.ts
@@ -78,7 +78,7 @@ describe('builtinToolSelectors', () => {
   });
 
   describe('metaListIncludingHidden', () => {
-    it('should keep task tools hidden from manual tool selection', () => {
+    it('should surface hidden tools so users can toggle them', () => {
       const state = {
         ...initialState,
         builtinTools: [
@@ -106,12 +106,12 @@ describe('builtinToolSelectors', () => {
       const result = builtinToolSelectors.metaListIncludingHidden(state);
 
       expect(result.map((item) => item.identifier)).toContain('tool-1');
-      expect(result.map((item) => item.identifier)).not.toContain('lobe-task');
+      expect(result.map((item) => item.identifier)).toContain('lobe-task');
     });
   });
 
   describe('installedAllMetaList', () => {
-    it('should keep task tools out of agent profile configuration', () => {
+    it('should include all non-uninstalled tools in agent profile configuration', () => {
       const state = {
         ...initialState,
         builtinTools: [
@@ -138,7 +138,7 @@ describe('builtinToolSelectors', () => {
 
       const result = builtinToolSelectors.installedAllMetaList(state);
 
-      expect(result.map((item) => item.identifier)).toEqual(['tool-1']);
+      expect(result.map((item) => item.identifier)).toEqual(['lobe-task', 'tool-1']);
     });
   });
 });

--- a/src/store/tool/slices/builtin/selectors.ts
+++ b/src/store/tool/slices/builtin/selectors.ts
@@ -70,7 +70,6 @@ const getKlavisMetasWithAvailability = (s: ToolStoreState): LobeToolMetaWithAvai
 
 // Set form for O(1) lookup inside the filter loop.
 const RUNTIME_MANAGED_TOOL_IDS = new Set(runtimeManagedToolIds);
-const USER_HIDDEN_BUILTIN_TOOL_IDS = new Set(['lobe-task']);
 
 /**
  * Shared list builder for the chat-input Tools popover.
@@ -103,8 +102,6 @@ const buildVisibleMetaList = (
       // (their enabled state is forced by AgentToolsEngine rules; user toggles would
       // be a no-op and create UI/state mismatch).
       if (includeHidden && RUNTIME_MANAGED_TOOL_IDS.has(item.identifier)) return false;
-      // Task tools are enabled by scenario/page context and should not be user-toggleable.
-      if (includeHidden && USER_HIDDEN_BUILTIN_TOOL_IDS.has(item.identifier)) return false;
 
       // Filter platform-specific tools (e.g., LocalSystem desktop-only)
       if (!isBuiltinToolAvailableInCurrentEnv(item.identifier)) return false;
@@ -192,7 +189,6 @@ const installedAllMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[]
   const builtinMetas = s.builtinTools
     .filter((item) => {
       if (EXCLUDED_TOOLS.has(item.identifier)) return false;
-      if (USER_HIDDEN_BUILTIN_TOOL_IDS.has(item.identifier)) return false;
       if (uninstalledBuiltinTools.includes(item.identifier)) return false;
 
       return true;
@@ -233,5 +229,3 @@ export const builtinToolSelectors = {
   metaListIncludingHidden,
   uninstalledBuiltinTools,
 };
-
-export { USER_HIDDEN_BUILTIN_TOOL_IDS };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The task tool is now generally available — flip it from a scenario-only internal tool to a user-toggleable recommended skill, and give the LLM a dedicated verb for configuring recurring execution.

**Part 1: Expose `lobe-task` to the client**

| File | Change |
|---|---|
| `packages/builtin-tools/src/index.ts` | Removed `discoverable: false, hidden: true` from the TaskManifest registration |
| `packages/const/src/recommendedSkill.ts` | Added `{ id: 'lobe-task', type: Builtin }` so it stays installed by default (otherwise `defaultUninstalledBuiltinTools` would default it to uninstalled) |
| `src/store/tool/slices/builtin/selectors.ts` | Dropped the `USER_HIDDEN_BUILTIN_TOOL_IDS` allowlist (only contained `lobe-task`) and its filters in `buildVisibleMetaList` and `installedAllMetaList` |
| `src/features/ProfileEditor/AgentTool.tsx` | Removed the matching filter on enabled-tools display |
| `src/store/tool/slices/builtin/selectors.test.ts` | Flipped the two assertions that expected `lobe-task` to be filtered out |

After this, `lobe-task` shows up in the chat-input Tools popover (manual mode), agent profile tool config, skill store / recommended skills, and the enabled-tools tag list.

**Part 2: Dedicated `setTaskSchedule` tool**

Schedule lives in its own verb instead of being mixed into `editTask` — keeps the field edit / status / schedule axes separate so the LLM (and any future human-in-the-loop review) audits cron / heartbeat changes independently. `createTask` stays a pure "make a task" verb without automation knobs.

| File | Change |
|---|---|
| `packages/builtin-tool-task/src/types.ts` | Added `TaskApiName.setTaskSchedule` + `SetTaskScheduleParams` / `SetTaskScheduleState` |
| `packages/builtin-tool-task/src/manifest.ts` | New API entry for `setTaskSchedule` with `automationMode`, `schedulePattern`, `scheduleTimezone`, `heartbeatInterval`, `maxExecutions`; description points the model at the right verb |
| `packages/builtin-tool-task/src/executor/index.ts` | `setTaskSchedule` routes schedule columns through `taskService.update` and `maxExecutions` through `taskService.updateConfig` (server merges into `tasks.config.schedule`), then refreshes detail |
| `packages/builtin-tool-task/src/client/Inspector/SetTaskSchedule/index.tsx` | Minimal inspector showing identifier + mode chip in the conversation UI |
| `packages/builtin-tool-task/src/client/Inspector/index.ts` | Registered the inspector |
| `packages/builtin-tool-task/src/systemRole.ts` | Documented the new verb + schedule fields |
| `src/locales/default/plugin.ts` + `locales/{en-US,zh-CN}/plugin.json` | i18n key for the inspector title |

Notes:

- `maxExecutions` lives in `tasks.config.schedule.maxExecutions` JSONB and uses `taskService.updateConfig` so siblings (checkpoint / review / model snapshot) are preserved via the server-side `merge`
- Direct `taskService.update` for schedule columns bypasses `store.updateTask`'s optimistic path — that path would need to map flat columns onto the detail's nested `schedule.*` shape, not worth wiring for an LLM-driven tool. The single `internal_refreshTaskDetail` at the end keeps the UI in sync

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run type-check` — clean
- Tool selector tests (`src/store/tool/slices/builtin/selectors.test.ts`): 5/5
- Task store tests (`src/store/task`): 71/71
- Task tool package tests (`packages/builtin-tool-task`): 3/3

Manual scenarios to verify:

- [ ] In chat-input Tools popover (manual mode), `lobe-task` appears and can be toggled on/off
- [ ] In agent profile tool config, `lobe-task` appears as installable / configurable
- [ ] LobeAI can call `setTaskSchedule({ identifier, automationMode: 'schedule', schedulePattern: '0 9 * * *', scheduleTimezone: 'Asia/Shanghai' })` and the task detail reflects the new schedule
- [ ] LobeAI can call `setTaskSchedule({ identifier, automationMode: null })` to disable automation
- [ ] LobeAI can call `setTaskSchedule({ identifier, maxExecutions: 5 })` and the cap shows up in `config.schedule`