### PR TITLE
💄 style: standardize header action icon sizes

### DIFF
--- a/src/features/NavPanel/SideBarHeaderLayout.tsx
+++ b/src/features/NavPanel/SideBarHeaderLayout.tsx
@@ -11,6 +11,7 @@ import { memo } from 'react';
 import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
 import { isModifierClick } from '@/utils/navigation';
 
@@ -75,7 +76,7 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
           overflow: 'hidden',
         }}
       >
-        {showBack && <BackButton size={SIDEBAR_HEADER_ACTION_ICON_SIZE} to={backTo} />}
+        {showBack && <BackButton size={DESKTOP_HEADER_ICON_SMALL_SIZE} to={backTo} />}
         {left && typeof left === 'string' ? (
           <Text ellipsis fontSize={16} weight={500}>
             {left}
@@ -123,9 +124,7 @@ const SideBarHeaderLayout = memo<SideBarHeaderLayoutProps>(
       >
         {leftContent}
         <Flexbox horizontal align={'center'} gap={2} justify={'flex-end'}>
-          {showTogglePanelButton && (
-            <ToggleLeftPanelButton size={SIDEBAR_HEADER_ACTION_ICON_SIZE} />
-          )}
+          {showTogglePanelButton && <ToggleLeftPanelButton />}
           {right}
         </Flexbox>
       </Flexbox>

--- a/src/features/NavPanel/ToggleLeftPanelButton.tsx
+++ b/src/features/NavPanel/ToggleLeftPanelButton.tsx
@@ -8,7 +8,7 @@ import { type ReactNode } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
@@ -38,7 +38,7 @@ const ToggleLeftPanelButton = memo<ToggleLeftPanelButtonProps>(
         active={showActive ? expand : undefined}
         icon={icon || (expand ? PanelLeftClose : PanelLeftOpen)}
         id={TOGGLE_BUTTON_ID}
-        size={size || DESKTOP_HEADER_ICON_SIZE}
+        size={size || DESKTOP_HEADER_ICON_SMALL_SIZE}
         title={title || t('toggleLeftPanel.title', { ns: 'hotkey' })}
         tooltipProps={{
           hotkey,

--- a/src/features/NavPanel/components/BackButton.tsx
+++ b/src/features/NavPanel/components/BackButton.tsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon } from 'lucide-react';
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 
 export const BACK_BUTTON_ID = 'lobe-back-button';
 
@@ -15,7 +15,7 @@ const BackButton = memo<ActionIconProps & { to?: string }>(({ to = '/', onClick,
       <ActionIcon
         icon={ChevronLeftIcon}
         id={BACK_BUTTON_ID}
-        size={DESKTOP_HEADER_ICON_SIZE}
+        size={DESKTOP_HEADER_ICON_SMALL_SIZE}
         {...rest}
       />
     </Link>

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
@@ -6,6 +6,7 @@ import { type PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { SkeletonItem } from '@/features/NavPanel/components/SkeletonList';
 import { useAgentStore } from '@/store/agent';
@@ -55,7 +56,7 @@ const Agent = memo<PropsWithChildren>(() => {
         </Text>
         <ActionIcon
           icon={ChevronsUpDownIcon}
-          size={'small'}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
           style={{
             width: 24,
           }}

--- a/src/routes/(main)/home/_layout/Header/components/InboxButton.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxButton.tsx
@@ -6,7 +6,7 @@ import { BellIcon } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useClientDataSWR } from '@/libs/swr';
 import { notificationService } from '@/services/notification';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
@@ -40,7 +40,7 @@ const InboxButton = memo(() => {
       <Badge dot={unreadCount > 0} offset={[-6, 6]} size="small">
         <ActionIcon
           icon={BellIcon}
-          size={DESKTOP_HEADER_ICON_SIZE}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
           title={t('inbox.title')}
           onClick={handleToggle}
         />


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

Standardize sidebar and header action icons to use `DESKTOP_HEADER_ICON_SMALL_SIZE` for consistent visual density across the navigation panel.

Previously, several action icons used the larger `DESKTOP_HEADER_ICON_SIZE` or hardcoded values (`small`), resulting in inconsistent sizing in the sidebar header area. This PR unifies them all to the small variant.

**Affected components:**

| Component | Before | After |
| --- | --- | --- |
| `SideBarHeaderLayout` back button | `SIDEBAR_HEADER_ACTION_ICON_SIZE` | `DESKTOP_HEADER_ICON_SMALL_SIZE` |
| `ToggleLeftPanelButton` default | `DESKTOP_HEADER_ICON_SIZE` | `DESKTOP_HEADER_ICON_SMALL_SIZE` |
| `BackButton` default | `DESKTOP_HEADER_ICON_SIZE` | `DESKTOP_HEADER_ICON_SMALL_SIZE` |
| Agent sidebar header chevron | `small` (string) | `DESKTOP_HEADER_ICON_SMALL_SIZE` |
| `InboxButton` notification icon | `DESKTOP_HEADER_ICON_SIZE` | `DESKTOP_HEADER_ICON_SMALL_SIZE` |

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Visual change only — verify consistent icon sizing in:
1. Sidebar header (back button, toggle panel button)
2. Agent detail sidebar header (agent picker chevron)
3. Home header (inbox/notification bell)

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

Purely visual change with no behavioral impact. No logic, state, or API changes.