### PR TITLE
✨ feat(builtin-tool): add onBeforeCall / onAfterCall lifecycle hooks

### DIFF
--- a/packages/builtin-tool-task/package.json
+++ b/packages/builtin-tool-task/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
-    "./executor": "./src/executor/index.ts",
     "./client": "./src/client/index.ts"
   },
   "main": "./src/index.ts",

--- a/packages/builtin-tool-task/src/client/executor/index.ts
+++ b/packages/builtin-tool-task/src/client/executor/index.ts
@@ -22,8 +22,8 @@ import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
 import { findSubtaskParentId } from '@/store/task/slices/detail/reducer';
 
-import { normalizeListTasksParams } from '../listTasks';
-import { TaskIdentifier } from '../manifest';
+import { normalizeListTasksParams } from '../../listTasks';
+import { TaskIdentifier } from '../../manifest';
 import type {
   AddTaskCommentParams,
   CreateTaskParams,
@@ -31,8 +31,8 @@ import type {
   DeleteTaskCommentParams,
   RunTasksItemResult,
   UpdateTaskCommentParams,
-} from '../types';
-import { TaskApiName } from '../types';
+} from '../../types';
+import { TaskApiName } from '../../types';
 
 const log = debug('lobe-task:executor');
 

--- a/packages/builtin-tool-task/src/client/index.ts
+++ b/packages/builtin-tool-task/src/client/index.ts
@@ -18,6 +18,9 @@ export {
 // Render components (read-only snapshots)
 export { CreateTaskRender, CreateTasksRender, RunTasksRender, TaskRenders } from './Render';
 
+// Client-side executor (browser runtime adapter for the agent)
+export { taskExecutor } from './executor';
+
 // Re-export manifest and types for convenience
 export { TaskIdentifier, TaskManifest } from '../manifest';
 export * from '../types';

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -13,6 +13,7 @@ import type {
   BuiltinToolResult,
   TaskAutomationMode,
   TaskStatus,
+  ToolAfterCallContext,
 } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
@@ -34,9 +35,61 @@ import { TaskApiName } from '../types';
 
 const log = debug('lobe-task:executor');
 
+// APIs whose execution mutates state that's surfaced in the renderer's task
+// list or detail caches. Used by `onAfterCall` to decide what to revalidate.
+const LIST_MUTATING_APIS = new Set<string>([
+  TaskApiName.createTask,
+  TaskApiName.createTasks,
+  TaskApiName.deleteTask,
+  TaskApiName.editTask,
+  TaskApiName.runTask,
+  TaskApiName.runTasks,
+  TaskApiName.setTaskSchedule,
+  TaskApiName.updateTaskStatus,
+]);
+
+const DETAIL_MUTATING_APIS = new Set<string>([
+  TaskApiName.addTaskComment,
+  TaskApiName.deleteTaskComment,
+  TaskApiName.editTask,
+  TaskApiName.runTask,
+  TaskApiName.setTaskSchedule,
+  TaskApiName.updateTaskComment,
+  TaskApiName.updateTaskStatus,
+  TaskApiName.viewTask,
+]);
+
+const extractIdentifier = (params: unknown, result: BuiltinToolResult): string | undefined => {
+  const fromState = (result.state as { identifier?: unknown } | undefined)?.identifier;
+  if (typeof fromState === 'string' && fromState.length > 0) return fromState;
+  const fromParams = (params as { identifier?: unknown } | null | undefined)?.identifier;
+  if (typeof fromParams === 'string' && fromParams.length > 0) return fromParams;
+  return undefined;
+};
+
 class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
   readonly identifier = TaskIdentifier;
   protected readonly apiEnum = TaskApiName;
+
+  onAfterCall = async ({ apiName, params, result }: ToolAfterCallContext): Promise<void> => {
+    if (!result.success) return;
+
+    const store = getTaskStoreState();
+    const identifier = extractIdentifier(params, result);
+
+    const refreshes: Promise<unknown>[] = [];
+    if (LIST_MUTATING_APIS.has(apiName)) {
+      refreshes.push(store.refreshTaskList());
+    }
+    if (identifier && DETAIL_MUTATING_APIS.has(apiName)) {
+      refreshes.push(store.internal_refreshTaskDetail(identifier));
+    }
+
+    if (refreshes.length === 0) return;
+    await Promise.all(refreshes).catch((error) => {
+      log('[TaskExecutor] onAfterCall - refresh failed:', error);
+    });
+  };
 
   addTaskComment = async (
     params: AddTaskCommentParams,

--- a/packages/builtin-tool-task/src/executor/index.ts
+++ b/packages/builtin-tool-task/src/executor/index.ts
@@ -20,6 +20,7 @@ import debug from 'debug';
 
 import { taskService } from '@/services/task';
 import { getTaskStoreState } from '@/store/task';
+import { findSubtaskParentId } from '@/store/task/slices/detail/reducer';
 
 import { normalizeListTasksParams } from '../listTasks';
 import { TaskIdentifier } from '../manifest';
@@ -77,12 +78,36 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
     const store = getTaskStoreState();
     const identifier = extractIdentifier(params, result);
 
+    // Build the set of task-detail keys to revalidate. Mirrors the pattern
+    // used by `updateTask` in the detail slice so subtask deletions / edits
+    // bubble up: when we mutate a subtask we must also refresh the parent
+    // whose `subtasks[]` array embeds it, otherwise the parent's view keeps
+    // showing the stale child until a manual reload.
+    const detailTargets = new Set<string>();
+    const touchesDetail = DETAIL_MUTATING_APIS.has(apiName) || LIST_MUTATING_APIS.has(apiName);
+    if (touchesDetail) {
+      if (identifier) {
+        // `deleteTask` is not in DETAIL_MUTATING_APIS (the row is gone), but
+        // edit/status/etc. need their own detail key revalidated.
+        if (DETAIL_MUTATING_APIS.has(apiName)) detailTargets.add(identifier);
+
+        const parentId = findSubtaskParentId(store.taskDetailMap, identifier);
+        if (parentId) detailTargets.add(parentId);
+      }
+
+      // Defensive: refresh whatever detail page the user is currently
+      // viewing — covers e.g. a `createTask` whose new identifier we don't
+      // yet know in the local map but whose parent the user is staring at.
+      const { activeTaskId } = store;
+      if (activeTaskId) detailTargets.add(activeTaskId);
+    }
+
     const refreshes: Promise<unknown>[] = [];
     if (LIST_MUTATING_APIS.has(apiName)) {
       refreshes.push(store.refreshTaskList());
     }
-    if (identifier && DETAIL_MUTATING_APIS.has(apiName)) {
-      refreshes.push(store.internal_refreshTaskDetail(identifier));
+    for (const id of detailTargets) {
+      refreshes.push(store.internal_refreshTaskDetail(id));
     }
 
     if (refreshes.length === 0) return;

--- a/packages/types/src/tool/builtin.ts
+++ b/packages/types/src/tool/builtin.ts
@@ -715,6 +715,52 @@ export interface IBuiltinToolExecutor {
    * @returns The execution result
    */
   invoke: (apiName: string, params: any, ctx: BuiltinToolContext) => Promise<BuiltinToolResult>;
+
+  /**
+   * Optional renderer-side hook fired AFTER a tool call completes — regardless
+   * of whether it actually executed in the client (this executor) or server-side
+   * (server runtime). Use to invalidate SWR caches, refresh stores, or trigger
+   * any other UI-side reaction to the mutation. Implementations should narrow
+   * `ctx.params` themselves based on `ctx.apiName`.
+   */
+  onAfterCall?: (ctx: ToolAfterCallContext) => void | Promise<void>;
+
+  /**
+   * Optional renderer-side hook fired BEFORE a tool call dispatches, regardless
+   * of whether the tool will execute client- or server-side. Use to optimistically
+   * update UI, set loading states, etc.
+   */
+  onBeforeCall?: (ctx: ToolBeforeCallContext) => void | Promise<void>;
+}
+
+/**
+ * Shared base for all renderer-side tool lifecycle hooks. New fields go here
+ * (or on the variants below) — keeping the call signature as a single object
+ * so additions stay non-breaking.
+ */
+export interface ToolHookContext {
+  /** API name being invoked (e.g. `'deleteTask'`). */
+  apiName: string;
+  /** Tool identifier (e.g. `'lobe-task'`). */
+  identifier: string;
+  /**
+   * Parsed tool arguments. Arrives JSON-decoded when the event comes off the
+   * agent stream; never the raw string. Hook implementations narrow per
+   * `apiName`.
+   */
+  params: unknown;
+  /**
+   * Stable id for this specific tool invocation (`ChatToolPayload.id`).
+   * Useful for correlating before/after hooks against the same call.
+   */
+  toolCallId?: string;
+}
+
+export interface ToolBeforeCallContext extends ToolHookContext {}
+
+export interface ToolAfterCallContext extends ToolHookContext {
+  /** Execution result returned by either the client executor or server runtime. */
+  result: BuiltinToolResult;
 }
 
 /**

--- a/src/features/AgentTasks/AgentTaskList/EmptyState.tsx
+++ b/src/features/AgentTasks/AgentTaskList/EmptyState.tsx
@@ -13,7 +13,7 @@ import WideScreenContainer from '@/features/WideScreenContainer';
 
 import CreateTaskInlineEntry from './CreateTaskInlineEntry';
 
-const HERO_MAX_WIDTH = 720;
+const HERO_MAX_WIDTH = 960;
 const EMPTY_STATE_RECOMMEND_COUNT = 10;
 
 const styles = createStaticStyles(({ css }) => ({

--- a/src/server/services/toolExecution/serverRuntimes/task.ts
+++ b/src/server/services/toolExecution/serverRuntimes/task.ts
@@ -9,7 +9,7 @@ import {
   formatTaskList,
   priorityLabel,
 } from '@lobechat/prompts';
-import type { TaskStatus } from '@lobechat/types';
+import type { TaskAutomationMode, TaskStatus } from '@lobechat/types';
 
 import { AgentModel } from '@/database/models/agent';
 import { TaskModel } from '@/database/models/task';
@@ -330,6 +330,86 @@ export const createTaskRuntime = ({
           success: false,
         };
       }
+    },
+
+    setTaskSchedule: async (args: {
+      automationMode?: TaskAutomationMode | null;
+      heartbeatInterval?: number;
+      identifier: string;
+      maxExecutions?: number | null;
+      schedulePattern?: string | null;
+      scheduleTimezone?: string | null;
+    }) => {
+      const task = await taskModel.resolve(args.identifier);
+      if (!task) return { content: `Task not found: ${args.identifier}`, success: false };
+
+      const changes: string[] = [];
+      const ops: Promise<unknown>[] = [];
+
+      // Mirrors client executor: schedule columns go through taskCaller.update;
+      // maxExecutions lives in `tasks.config.schedule.maxExecutions` (JSONB) and
+      // routes through updateConfig so server-side merge preserves siblings.
+      const scheduleUpdate: {
+        automationMode?: TaskAutomationMode | null;
+        heartbeatInterval?: number;
+        schedulePattern?: string | null;
+        scheduleTimezone?: string | null;
+      } = {};
+      if (args.automationMode !== undefined) {
+        scheduleUpdate.automationMode = args.automationMode;
+        changes.push(
+          args.automationMode ? `automation mode → ${args.automationMode}` : 'automation disabled',
+        );
+      }
+      if (args.heartbeatInterval !== undefined) {
+        scheduleUpdate.heartbeatInterval = args.heartbeatInterval;
+        changes.push(
+          args.heartbeatInterval > 0
+            ? `heartbeat interval → ${args.heartbeatInterval}s`
+            : 'heartbeat interval cleared',
+        );
+      }
+      if (args.schedulePattern !== undefined) {
+        scheduleUpdate.schedulePattern = args.schedulePattern;
+        changes.push(
+          args.schedulePattern
+            ? `schedule pattern → "${args.schedulePattern}"`
+            : 'schedule pattern cleared',
+        );
+      }
+      if (args.scheduleTimezone !== undefined) {
+        scheduleUpdate.scheduleTimezone = args.scheduleTimezone;
+        changes.push(
+          args.scheduleTimezone
+            ? `schedule timezone → ${args.scheduleTimezone}`
+            : 'schedule timezone cleared',
+        );
+      }
+      if (Object.keys(scheduleUpdate).length > 0) {
+        ops.push(taskCaller.update({ id: task.id, ...scheduleUpdate }));
+      }
+
+      if (args.maxExecutions !== undefined) {
+        ops.push(
+          taskCaller.updateConfig({
+            config: { schedule: { maxExecutions: args.maxExecutions } },
+            id: task.id,
+          }),
+        );
+        changes.push(
+          args.maxExecutions === null
+            ? 'max executions cleared (unlimited)'
+            : `max executions → ${args.maxExecutions}`,
+        );
+      }
+
+      if (ops.length === 0) {
+        return { content: 'No schedule fields provided; nothing to update.', success: false };
+      }
+
+      await Promise.all(ops);
+
+      return { content: formatTaskEdited(task.identifier, changes), success: true };
     },
 
     runTask: async (args: { continueTopicId?: string; identifier?: string; prompt?: string }) => {

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -20,6 +20,11 @@ vi.mock('@/store/chat/slices/aiChat/actions/agentSignalBridge', () => ({
   emitClientAgentSignalSourceEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
+const getExecutorMock = vi.fn();
+vi.mock('@/store/tool/slices/builtin/executors', () => ({
+  getExecutor: (...args: unknown[]) => getExecutorMock(...args),
+}));
+
 // ─── Test Helpers ───
 
 function createMockStore() {
@@ -350,6 +355,109 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.replaceMessages).toHaveBeenCalled();
+    });
+
+    it('should dispatch onAfterCall when payload is wrapped as { parentMessageId, toolCalling } (real gateway shape)', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+      const onAfterCall = vi.fn().mockResolvedValue(undefined);
+      getExecutorMock.mockReturnValueOnce({ onAfterCall });
+
+      handler(
+        makeEvent('tool_end', {
+          isSuccess: true,
+          payload: {
+            parentMessageId: 'msg-parent',
+            toolCalling: {
+              apiName: 'deleteTask',
+              arguments: JSON.stringify({ identifier: 'T-3' }),
+              id: 'tc-1',
+              identifier: 'lobe-task',
+            },
+          },
+          result: { content: 'Task deleted', success: true },
+        }),
+      );
+      await flush();
+
+      expect(getExecutorMock).toHaveBeenCalledWith('lobe-task');
+      expect(onAfterCall).toHaveBeenCalledWith({
+        apiName: 'deleteTask',
+        identifier: 'lobe-task',
+        params: { identifier: 'T-3' },
+        result: { content: 'Task deleted', success: true },
+        toolCallId: 'tc-1',
+      });
+    });
+
+    it('should also dispatch onAfterCall when payload is the flat ChatToolPayload', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+      const onAfterCall = vi.fn().mockResolvedValue(undefined);
+      getExecutorMock.mockReturnValueOnce({ onAfterCall });
+
+      handler(
+        makeEvent('tool_end', {
+          isSuccess: true,
+          payload: {
+            apiName: 'createTask',
+            arguments: JSON.stringify({ name: 'New', instruction: 'do thing' }),
+            id: 'tc-2',
+            identifier: 'lobe-task',
+          },
+          result: { success: true },
+        }),
+      );
+      await flush();
+
+      expect(onAfterCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiName: 'createTask',
+          identifier: 'lobe-task',
+          toolCallId: 'tc-2',
+        }),
+      );
+    });
+
+    it('should skip onAfterCall when payload identifier/apiName are missing', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+      const onAfterCall = vi.fn();
+      getExecutorMock.mockReturnValue({ onAfterCall });
+
+      handler(makeEvent('tool_end', { isSuccess: true, payload: { parentMessageId: 'x' } }));
+      await flush();
+
+      expect(onAfterCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tool_start', () => {
+    it('should dispatch onBeforeCall with the unwrapped ChatToolPayload', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+      const onBeforeCall = vi.fn().mockResolvedValue(undefined);
+      getExecutorMock.mockReturnValueOnce({ onBeforeCall });
+
+      handler(
+        makeEvent('tool_start', {
+          parentMessageId: 'msg-parent',
+          toolCalling: {
+            apiName: 'editTask',
+            arguments: JSON.stringify({ identifier: 'T-5', name: 'renamed' }),
+            id: 'tc-3',
+            identifier: 'lobe-task',
+          },
+        }),
+      );
+      await flush();
+
+      expect(onBeforeCall).toHaveBeenCalledWith({
+        apiName: 'editTask',
+        identifier: 'lobe-task',
+        params: { identifier: 'T-5', name: 'renamed' },
+        toolCallId: 'tc-3',
+      });
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -14,7 +14,16 @@ import { messageService } from '@/services/message';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/aiChat/actions/agentSignalBridge';
 import type { ChatStore } from '@/store/chat/store';
 import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
-import { getExecutor } from '@/store/tool/slices/builtin/executors';
+
+// Lazy-loaded to break the import cycle:
+//   gateway.ts → gatewayEventHandler.ts → executors/index.ts (which pulls in
+//   tool client barrels that import `@/store/chat/store`) → chat store
+//   creation → `new GatewayActionImpl(...)` while gateway.ts is still
+//   mid-evaluation, so the class binding is undefined.
+const loadGetExecutor = async () => {
+  const mod = await import('@/store/tool/slices/builtin/executors');
+  return mod.getExecutor;
+};
 
 /**
  * Fetch messages from DB and replace them in the chat store's dbMessagesMap.
@@ -78,6 +87,7 @@ const dispatchOnBeforeCall = async (data: ToolStartData | undefined): Promise<vo
   const identity = readToolPayload(payload);
   if (!identity) return;
 
+  const getExecutor = await loadGetExecutor();
   const executor = getExecutor(identity.identifier);
   if (!executor?.onBeforeCall) return;
 
@@ -110,6 +120,7 @@ const dispatchOnAfterCall = async (data: ToolEndData | undefined): Promise<void>
   const identity = readToolPayload(unwrapToolPayload(data?.payload));
   if (!identity) return;
 
+  const getExecutor = await loadGetExecutor();
   const executor = getExecutor(identity.identifier);
   if (!executor?.onAfterCall) return;
 

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -3,15 +3,18 @@ import type {
   StepCompleteData,
   StreamChunkData,
   StreamStartData,
+  ToolEndData,
   ToolExecuteData,
+  ToolStartData,
 } from '@lobechat/agent-gateway-client';
-import type { ChatMessageError, ConversationContext } from '@lobechat/types';
+import type { BuiltinToolResult, ChatMessageError, ConversationContext } from '@lobechat/types';
 import { AgentRuntimeErrorType } from '@lobechat/types';
 
 import { messageService } from '@/services/message';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/aiChat/actions/agentSignalBridge';
 import type { ChatStore } from '@/store/chat/store';
 import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
+import { getExecutor } from '@/store/tool/slices/builtin/executors';
 
 /**
  * Fetch messages from DB and replace them in the chat store's dbMessagesMap.
@@ -22,6 +25,82 @@ const fetchAndReplaceMessages = async (get: () => ChatStore, context: Conversati
   const messages = await messageService.getMessages(context);
   get().replaceMessages(messages, { context });
   return messages;
+};
+
+interface ChatToolPayloadLike {
+  apiName?: unknown;
+  arguments?: unknown;
+  id?: unknown;
+  identifier?: unknown;
+}
+
+interface ToolPayloadIdentity {
+  apiName: string;
+  identifier: string;
+  params: unknown;
+  toolCallId?: string;
+}
+
+/**
+ * Extract `{ identifier, apiName, params, toolCallId }` from a stream event's
+ * tool payload. Returns `undefined` when the payload is malformed so the
+ * caller can skip dispatch without throwing.
+ */
+const readToolPayload = (
+  payload: ChatToolPayloadLike | undefined,
+): ToolPayloadIdentity | undefined => {
+  const identifier = typeof payload?.identifier === 'string' ? payload.identifier : undefined;
+  const apiName = typeof payload?.apiName === 'string' ? payload.apiName : undefined;
+  if (!identifier || !apiName) return undefined;
+
+  let params: unknown = payload?.arguments;
+  if (typeof params === 'string') {
+    try {
+      params = JSON.parse(params);
+    } catch {
+      params = {};
+    }
+  } else if (params == null) {
+    params = {};
+  }
+
+  const toolCallId = typeof payload?.id === 'string' ? payload.id : undefined;
+  return { apiName, identifier, params, toolCallId };
+};
+
+/**
+ * Route a `tool_start` event to the executor's optional `onBeforeCall` hook so
+ * tool packages can react before their own mutations dispatch (e.g.
+ * optimistic UI). Fires for both client- and server-runtime tools.
+ */
+const dispatchOnBeforeCall = async (data: ToolStartData | undefined): Promise<void> => {
+  const payload = data?.toolCalling as ChatToolPayloadLike | undefined;
+  const identity = readToolPayload(payload);
+  if (!identity) return;
+
+  const executor = getExecutor(identity.identifier);
+  if (!executor?.onBeforeCall) return;
+
+  await executor.onBeforeCall(identity);
+};
+
+/**
+ * Route a `tool_end` event to the executor's optional `onAfterCall` hook so
+ * tool packages can react to their own mutations (e.g. invalidate store
+ * caches) regardless of whether the tool ran client- or server-side.
+ */
+const dispatchOnAfterCall = async (data: ToolEndData | undefined): Promise<void> => {
+  const payload = data?.payload as ChatToolPayloadLike | undefined;
+  const identity = readToolPayload(payload);
+  if (!identity) return;
+
+  const executor = getExecutor(identity.identifier);
+  if (!executor?.onAfterCall) return;
+
+  await executor.onAfterCall({
+    ...identity,
+    result: (data?.result ?? {}) as BuiltinToolResult,
+  });
 };
 
 type GatewayMessageLike = { id: string; role?: string };
@@ -249,6 +328,10 @@ export const createGatewayEventHandler = (
       case 'tool_start': {
         // Server creates tool messages in DB.
         // Loading is already active from stream_start (not cleared by stream_end).
+        const data = event.data as ToolStartData | undefined;
+        enqueue(async () => {
+          await dispatchOnBeforeCall(data).catch(console.error);
+        });
         break;
       }
 
@@ -286,8 +369,12 @@ export const createGatewayEventHandler = (
       }
 
       case 'tool_end': {
+        const data = event.data as ToolEndData | undefined;
         enqueue(async () => {
-          await fetchAndReplaceMessages(get, context).catch(console.error);
+          await Promise.all([
+            fetchAndReplaceMessages(get, context).catch(console.error),
+            dispatchOnAfterCall(data).catch(console.error),
+          ]);
         });
         break;
       }

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -85,13 +85,29 @@ const dispatchOnBeforeCall = async (data: ToolStartData | undefined): Promise<vo
 };
 
 /**
+ * Real gateway `tool_end` events ship `data.payload` as the
+ * `{ parentMessageId, toolCalling }` wrapper, NOT a flat `ChatToolPayload`
+ * (see `src/server/modules/AgentRuntime/RuntimeExecutors.ts` — both the
+ * single-tool and batch publish sites). Unwrap defensively, falling back to
+ * the flat shape so we tolerate test fixtures / future emission paths that
+ * pass the payload directly.
+ */
+const unwrapToolPayload = (raw: unknown): ChatToolPayloadLike | undefined => {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const wrapper = raw as { toolCalling?: unknown };
+  if (wrapper.toolCalling && typeof wrapper.toolCalling === 'object') {
+    return wrapper.toolCalling as ChatToolPayloadLike;
+  }
+  return raw as ChatToolPayloadLike;
+};
+
+/**
  * Route a `tool_end` event to the executor's optional `onAfterCall` hook so
  * tool packages can react to their own mutations (e.g. invalidate store
  * caches) regardless of whether the tool ran client- or server-side.
  */
 const dispatchOnAfterCall = async (data: ToolEndData | undefined): Promise<void> => {
-  const payload = data?.payload as ChatToolPayloadLike | undefined;
-  const identity = readToolPayload(payload);
+  const identity = readToolPayload(unwrapToolPayload(data?.payload));
   if (!identity) return;
 
   const executor = getExecutor(identity.identifier);

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -15,7 +15,7 @@ import { knowledgeBaseExecutor } from '@lobechat/builtin-tool-knowledge-base/cli
 import { lobeAgentExecutor } from '@lobechat/builtin-tool-lobe-agent/client';
 import { localSystemExecutor } from '@lobechat/builtin-tool-local-system/executor';
 import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
-import { taskExecutor } from '@lobechat/builtin-tool-task/executor';
+import { taskExecutor } from '@lobechat/builtin-tool-task/client';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
 import { activatorExecutor } from './lobe-activator';


### PR DESCRIPTION
## Summary

- Adds optional `onBeforeCall` / `onAfterCall` hooks to `IBuiltinToolExecutor`, both taking a single `ToolHookContext` object so future fields stay non-breaking.
- Gateway event handler dispatches them on `tool_start` / `tool_end`, regardless of whether the tool ran client- or server-side — so server-runtime tools can finally invalidate renderer caches.
- `TaskExecutor` implements `onAfterCall` to refresh task-list and task-detail SWR caches for write APIs (deleteTask, createTask(s), editTask, updateTaskStatus, runTask(s), setTaskSchedule).
- Fills the missing `setTaskSchedule` implementation in the **server runtime** (was client-only in #14713 — cloud-mode users couldn't actually configure schedules through the agent).
- Widens the empty-tasks hero from 720→960px to match the default `CONVERSATION_MIN_WIDTH`.

## Why

Previously, when an agent ran the `lobe-task` tool through Lobe Cloud / Gateway (server runtime), mutations succeeded on the server but the renderer's SWR caches went stale — e.g. asking the agent to delete all tasks, getting "已清空" back, and watching the kanban keep showing the deleted rows. The renderer-side executor's `getTaskStoreState().deleteTask()` was never called because that whole code path runs server-side.

Doing the cache invalidation inline in the gateway handler would scatter tool-specific knowledge across the dispatcher. Instead, this gives every tool package a place to declare its own client-side reaction, and the gateway just routes events to it.

```ts
// packages/types/src/tool/builtin.ts
interface ToolHookContext {
  apiName: string;
  identifier: string;
  params: unknown;
  toolCallId?: string;
}

interface IBuiltinToolExecutor {
  onBeforeCall?(ctx: ToolBeforeCallContext): void | Promise<void>;
  onAfterCall?(ctx: ToolAfterCallContext): void | Promise<void>;
}
```

## Test plan

- [x] `bunx vitest run src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts` — 28/28 ✅
- [x] `bunx vitest run src/server/services/toolExecution/serverRuntimes/__tests__/task.test.ts` — 24/24 ✅
- [x] `bun run type-check` clean on changed files
- [ ] Manual: in cloud mode, ask the agent to delete a task and confirm the kanban / list refreshes without a manual reload
- [ ] Manual: invoke `setTaskSchedule` from a cloud-mode chat and confirm both the schedule applies and the detail view reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)