### PR TITLE
✨ feat(skill): add Canva LobeHub skill integration

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1058,6 +1058,8 @@
   "tools.lobehubSkill.disconnectConfirm.title": "Disconnect {{name}}?",
   "tools.lobehubSkill.disconnected": "Disconnected",
   "tools.lobehubSkill.error": "Error",
+  "tools.lobehubSkill.providers.canva.description": "Canva is an online design and visual communication platform for creating presentations, social posts, brand assets, and other visual content.",
+  "tools.lobehubSkill.providers.canva.readme": "Connect to Canva to create and update designs, upload and organize assets, manage brand kits and folders, export files, and collaborate through comments with your AI assistant.",
   "tools.lobehubSkill.providers.github.description": "GitHub is a platform for version control and collaboration, enabling developers to host, review, and manage code repositories.",
   "tools.lobehubSkill.providers.github.readme": "Connect to GitHub to access your repositories, create and manage issues, review pull requests, and collaborate on code—all through natural conversation with your AI assistant.",
   "tools.lobehubSkill.providers.linear.description": "Linear is a modern issue tracking and project management tool designed for high-performance teams to build better software faster",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1058,6 +1058,8 @@
   "tools.lobehubSkill.disconnectConfirm.title": "断开 {{name}} 的连接？",
   "tools.lobehubSkill.disconnected": "已断开连接",
   "tools.lobehubSkill.error": "错误",
+  "tools.lobehubSkill.providers.canva.description": "Canva 是一个在线设计与视觉沟通平台，可用于创建演示文稿、社交媒体内容、品牌素材等视觉内容。",
+  "tools.lobehubSkill.providers.canva.readme": "连接 Canva 后，AI 助手可帮您创建和更新设计、上传并整理素材、管理品牌套件与文件夹、导出文件，并通过评论协作。",
   "tools.lobehubSkill.providers.github.description": "GitHub 是一个面向版本控制和协作的平台，开发者可以在此托管、审查并管理代码仓库。",
   "tools.lobehubSkill.providers.github.readme": "连接 GitHub 以访问您的代码仓库，创建并管理 Issue、审查 Pull Request，并通过与 AI 助手的自然对话协作开发。",
   "tools.lobehubSkill.providers.linear.description": "Linear 是一款现代化的问题跟踪和项目管理工具，专为高效团队打造，助力更快构建更优软件。",

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -60,7 +60,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 - Task requires environment variables (e.g., \`OPENAI_API_KEY\`, \`GITHUB_TOKEN\`)
 - User wants to store or manage sensitive information securely
 - Sandbox code execution requires credentials/secrets to be injected
-- User asks to connect to services like GitHub, Linear, Microsoft, Notion, Twitter, etc.
+- User asks to connect to services like Canva, GitHub, Linear, Microsoft, Notion, Twitter, etc.
 - User wants to use, open, connect, or interact with a third-party integration service
   (e.g., Notion, Slack, Google Drive, Gmail, Airtable, Jira, Figma, HubSpot,
    Salesforce, Dropbox, ClickUp, Confluence, Supabase, WhatsApp, YouTube,
@@ -73,7 +73,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 2. Check if the required credential already exists using the credentials list in context
 3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
 4. If credential doesn't exist:
-   - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
+   - For LobeHub OAuth services (Canva, GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
    - For Klavis-managed services (Slack, Google Drive, Airtable, Jira, etc.)
      → use \`connectKlavisService\` after activating \`lobe-creds\`. The full list of
      available Klavis services is shown in \`<klavis_integrations>\` inside the

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -27,7 +27,7 @@ export const CredsManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Initiate OAuth connection flow for a LobeHub Skill provider (e.g., GitHub, Linear, Microsoft Outlook, Notion, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.',
+        'Initiate OAuth connection flow for a LobeHub Skill provider (e.g., Canva, GitHub, Linear, Microsoft Outlook, Notion, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.',
       name: CredsApiName.initiateOAuthConnect,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -37,6 +37,7 @@ Sandbox mode: {{sandbox_enabled}}
 
 <oauth_providers>
 LobeHub provides built-in OAuth integrations for the following services:
+- **canva**: Canva design and visual communication. Connect to create and update designs, manage assets, export files, and collaborate through comments.
 - **github**: GitHub repository and code management. Connect to access repositories, create issues, manage pull requests.
 - **linear**: Linear issue tracking and project management. Connect to create/manage issues, track projects.
 - **microsoft**: Microsoft Outlook Calendar. Connect to view/create calendar events, manage meetings.

--- a/packages/builtin-tool-creds/src/types.ts
+++ b/packages/builtin-tool-creds/src/types.ts
@@ -35,6 +35,7 @@ export const CredsApiName = {
 export type CredsApiNameType = (typeof CredsApiName)[keyof typeof CredsApiName];
 
 export const LOBEHUB_OAUTH_PROVIDER_IDS = [
+  'canva',
   'github',
   'linear',
   'microsoft',
@@ -61,7 +62,7 @@ export interface GetPlaintextCredParams {
 
 export interface InitiateOAuthConnectParams {
   /**
-   * The OAuth provider ID (e.g., 'linear', 'microsoft', 'notion', 'twitter')
+   * The OAuth provider ID (e.g., 'canva', 'linear', 'microsoft', 'notion', 'twitter')
    */
   provider: LobehubOAuthProviderId;
 }

--- a/packages/const/src/lobehubSkill.ts
+++ b/packages/const/src/lobehubSkill.ts
@@ -50,6 +50,18 @@ export const LOBEHUB_SKILL_PROVIDERS: LobehubSkillProviderType[] = [
     authorUrl: 'https://lobehub.com',
     defaultVisible: true,
     description:
+      'Canva is an online design and visual communication platform for creating presentations, social posts, brand assets, and other visual content.',
+    icon: 'https://www.canva.com/favicon.ico',
+    id: 'canva',
+    label: 'Canva',
+    readme:
+      'Connect to Canva to create and update designs, upload and organize assets, manage brand kits and folders, export files, and collaborate through comments with your AI assistant.',
+  },
+  {
+    author: 'LobeHub',
+    authorUrl: 'https://lobehub.com',
+    defaultVisible: true,
+    description:
       'GitHub is a platform for version control and collaboration, enabling developers to host, review, and manage code repositories.',
     icon: SiGithub,
     id: 'github',

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -1329,6 +1329,10 @@ When I am ___, I need ___
 
   'tools.lobehubSkill.error': 'Error',
   // LobeHub Skill Providers i18n
+  'tools.lobehubSkill.providers.canva.description':
+    'Canva is an online design and visual communication platform for creating presentations, social posts, brand assets, and other visual content.',
+  'tools.lobehubSkill.providers.canva.readme':
+    'Connect to Canva to create and update designs, upload and organize assets, manage brand kits and folders, export files, and collaborate through comments with your AI assistant.',
   'tools.lobehubSkill.providers.github.description':
     'GitHub is a platform for version control and collaboration, enabling developers to host, review, and manage code repositories.',
   'tools.lobehubSkill.providers.github.readme':

--- a/src/server/services/market/index.test.ts
+++ b/src/server/services/market/index.test.ts
@@ -414,6 +414,23 @@ describe('MarketService', () => {
       });
     });
 
+    it('should use the static Canva provider label for manifests', async () => {
+      const service = new MarketService();
+      (service as any).market.connect.listConnections = vi.fn().mockResolvedValue({
+        connections: [{ icon: 'canva-icon', providerId: 'canva', providerName: 'Design Team' }],
+      });
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue({
+        tools: [{ description: 'Search designs', inputSchema: {}, name: 'canva-search-designs' }],
+      });
+
+      const manifests = await service.getLobehubSkillManifests();
+      expect(manifests).toHaveLength(1);
+      expect(manifests[0].meta).toMatchObject({
+        description: 'LobeHub Skill: Canva',
+        title: 'Canva',
+      });
+    });
+
     it('should skip connections where listTools returns empty', async () => {
       const service = new MarketService();
       (service as any).market.connect.listConnections = vi.fn().mockResolvedValue({

--- a/src/server/services/market/index.ts
+++ b/src/server/services/market/index.ts
@@ -539,6 +539,7 @@ export class MarketService {
           // Static label map — avoids importing LOBEHUB_SKILL_PROVIDERS which
           // pulls in react-icons (client-side only). Keep in sync with lobehubSkill.ts.
           const PROVIDER_LABELS: Record<string, string> = {
+            canva: 'Canva',
             github: 'GitHub',
             linear: 'Linear',
             microsoft: 'Outlook Calendar',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds Canva as an official LobeHub Skill provider after the Canva MCP provider was added to LobeHub Market.

This PR registers Canva in the official skill provider list, adds setting copy for English and Chinese previews, exposes Canva through the LobeHub OAuth credential schema and agent prompts, and adds the server-side provider label used when building connected skill manifests.

Keep this PR as draft until Canva allowlists the production Market OAuth callback:

```text
https://market.lobehub.com/api/connect/canva/callback
```

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx vitest run --silent='passed-only' src/server/services/market/index.test.ts
bunx vitest run --silent='passed-only' src/store/tool/slices/lobehubSkillStore/selectors.test.ts
bun run type-check
```

Note: `src/store/tool/slices/lobehubSkillStore/action.test.ts` currently fails during test import with `Cannot read properties of undefined (reading 'getItem')` from `packages/utils/src/localStorage.ts`, which appears unrelated to the Canva changes.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Canva OAuth connection will fail with `Invalid redirect URI. It must be from an allowed host.` until Canva approves the callback allowlist entry.
