### PR TITLE
✨ feat(skill): add PostHog LobeHub skill integration

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1066,6 +1066,8 @@
   "tools.lobehubSkill.providers.microsoft.readme": "Integrate with Outlook Calendar to view, create, and manage your events seamlessly. Schedule meetings, check availability, set reminders, and coordinate your time—all through natural language commands.",
   "tools.lobehubSkill.providers.notion.description": "Notion is a collaborative productivity and note-taking application.",
   "tools.lobehubSkill.providers.notion.readme": "Connect to Notion to access and manage your workspace. Create pages, search content, update databases, and organize your knowledge base—all through natural conversation with your AI assistant.",
+  "tools.lobehubSkill.providers.posthog.description": "PostHog is an open-source product analytics platform for tracking user behavior, analyzing funnels, managing feature flags, and debugging product issues.",
+  "tools.lobehubSkill.providers.posthog.readme": "Connect to PostHog to query analytics, inspect dashboards and insights, review feature flags, experiments, cohorts, persons, session recordings, surveys, and error tracking with your AI assistant.",
   "tools.lobehubSkill.providers.twitter.description": "X (Twitter) is a social media platform for sharing real-time updates, news, and engaging with your audience through posts, replies, and direct messages.",
   "tools.lobehubSkill.providers.twitter.readme": "Connect to X (Twitter) to post tweets, manage your timeline, and engage with your audience. Create content, schedule posts, monitor mentions, and build your social media presence through conversational AI.",
   "tools.lobehubSkill.providers.vercel.description": "Vercel is a cloud platform for frontend developers, providing hosting and serverless functions to deploy web applications with ease.",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1066,6 +1066,8 @@
   "tools.lobehubSkill.providers.microsoft.readme": "集成 Outlook 日历以无缝查看、创建和管理事件。安排会议、查看可用时间、设置提醒，并通过自然语言指令协调时间。",
   "tools.lobehubSkill.providers.notion.description": "Notion 是一款协作型效率与笔记应用。",
   "tools.lobehubSkill.providers.notion.readme": "连接 Notion 以访问和管理您的工作区。创建页面、搜索内容、更新数据库，并通过与 AI 助手的自然对话组织知识库。",
+  "tools.lobehubSkill.providers.posthog.description": "PostHog 是一个开源产品分析平台，可用于跟踪用户行为、分析漏斗、管理功能开关并排查产品问题。",
+  "tools.lobehubSkill.providers.posthog.readme": "连接 PostHog 后，AI 助手可帮您查询分析数据、查看仪表盘与洞察、检查功能开关、实验、群组、用户、会话录制、问卷和错误追踪。",
   "tools.lobehubSkill.providers.twitter.description": "X（原 Twitter）是一个社交媒体平台，用于分享实时动态、新闻，并通过推文、回复和私信与受众互动。",
   "tools.lobehubSkill.providers.twitter.readme": "连接 X（原 Twitter）以发布推文、管理时间线并与受众互动。创建内容、安排发布、监控提及，并通过对话式 AI 构建社交媒体影响力。",
   "tools.lobehubSkill.providers.vercel.description": "Vercel 是一个面向前端开发者的云平台，提供托管服务和无服务器函数，可轻松部署 Web 应用。",

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -60,7 +60,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 - Task requires environment variables (e.g., \`OPENAI_API_KEY\`, \`GITHUB_TOKEN\`)
 - User wants to store or manage sensitive information securely
 - Sandbox code execution requires credentials/secrets to be injected
-- User asks to connect to services like GitHub, Linear, Microsoft, Notion, Twitter, etc.
+- User asks to connect to services like GitHub, Linear, Microsoft, Notion, PostHog, Twitter, etc.
 - User wants to use, open, connect, or interact with a third-party integration service
   (e.g., Notion, Slack, Google Drive, Gmail, Airtable, Jira, Figma, HubSpot,
    Salesforce, Dropbox, ClickUp, Confluence, Supabase, WhatsApp, YouTube,
@@ -73,7 +73,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 2. Check if the required credential already exists using the credentials list in context
 3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
 4. If credential doesn't exist:
-   - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
+   - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, PostHog, Twitter) → use \`initiateOAuthConnect\`
    - For Klavis-managed services (Slack, Google Drive, Airtable, Jira, etc.)
      → use \`connectKlavisService\` after activating \`lobe-creds\`. The full list of
      available Klavis services is shown in \`<klavis_integrations>\` inside the

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -27,7 +27,7 @@ export const CredsManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Initiate OAuth connection flow for a LobeHub Skill provider (e.g., GitHub, Linear, Microsoft Outlook, Notion, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.',
+        'Initiate OAuth connection flow for a LobeHub Skill provider (e.g., GitHub, Linear, Microsoft Outlook, Notion, PostHog, Twitter/X). Returns an authorization URL that the user must click to authorize. After authorization, the credential will be automatically saved.',
       name: CredsApiName.initiateOAuthConnect,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -41,6 +41,7 @@ LobeHub provides built-in OAuth integrations for the following services:
 - **linear**: Linear issue tracking and project management. Connect to create/manage issues, track projects.
 - **microsoft**: Microsoft Outlook Calendar. Connect to view/create calendar events, manage meetings.
 - **notion**: Notion workspace and knowledge management. Connect to create pages, search content, update databases, and organize workspace knowledge.
+- **posthog**: PostHog product analytics. Connect to query analytics, inspect dashboards, review feature flags, experiments, cohorts, persons, recordings, surveys, and error tracking.
 - **twitter**: X (Twitter) social media. Connect to post tweets, manage timeline, engage with audience.
 
 When a user mentions they want to use one of these services, use \`initiateOAuthConnect\` to provide them with an authorization link. After they authorize, the credential will be automatically saved and available for use.

--- a/packages/builtin-tool-creds/src/types.ts
+++ b/packages/builtin-tool-creds/src/types.ts
@@ -39,6 +39,7 @@ export const LOBEHUB_OAUTH_PROVIDER_IDS = [
   'linear',
   'microsoft',
   'notion',
+  'posthog',
   'twitter',
 ] as const;
 
@@ -61,7 +62,7 @@ export interface GetPlaintextCredParams {
 
 export interface InitiateOAuthConnectParams {
   /**
-   * The OAuth provider ID (e.g., 'linear', 'microsoft', 'notion', 'twitter')
+   * The OAuth provider ID (e.g., 'linear', 'microsoft', 'notion', 'posthog', 'twitter')
    */
   provider: LobehubOAuthProviderId;
 }

--- a/packages/const/src/lobehubSkill.ts
+++ b/packages/const/src/lobehubSkill.ts
@@ -97,6 +97,18 @@ export const LOBEHUB_SKILL_PROVIDERS: LobehubSkillProviderType[] = [
     authorUrl: 'https://lobehub.com',
     defaultVisible: true,
     description:
+      'PostHog is an open-source product analytics platform for tracking user behavior, analyzing funnels, managing feature flags, and debugging product issues.',
+    icon: 'https://posthog.com/favicon.ico',
+    id: 'posthog',
+    readme:
+      'Connect to PostHog to query analytics, inspect dashboards and insights, review feature flags, experiments, cohorts, persons, session recordings, surveys, and error tracking with your AI assistant.',
+    label: 'PostHog',
+  },
+  {
+    author: 'LobeHub',
+    authorUrl: 'https://lobehub.com',
+    defaultVisible: true,
+    description:
       'X (Twitter) is a social media platform for sharing real-time updates, news, and engaging with your audience through posts, replies, and direct messages.',
     icon: SiX,
     id: 'twitter',

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -1345,6 +1345,10 @@ When I am ___, I need ___
     'Notion is a collaborative productivity and note-taking application.',
   'tools.lobehubSkill.providers.notion.readme':
     'Connect to Notion to access and manage your workspace. Create pages, search content, update databases, and organize your knowledge base—all through natural conversation with your AI assistant.',
+  'tools.lobehubSkill.providers.posthog.description':
+    'PostHog is an open-source product analytics platform for tracking user behavior, analyzing funnels, managing feature flags, and debugging product issues.',
+  'tools.lobehubSkill.providers.posthog.readme':
+    'Connect to PostHog to query analytics, inspect dashboards and insights, review feature flags, experiments, cohorts, persons, session recordings, surveys, and error tracking with your AI assistant.',
   'tools.lobehubSkill.providers.twitter.description':
     'X (Twitter) is a social media platform for sharing real-time updates, news, and engaging with your audience through posts, replies, and direct messages.',
   'tools.lobehubSkill.providers.twitter.readme':

--- a/src/server/services/market/index.test.ts
+++ b/src/server/services/market/index.test.ts
@@ -414,6 +414,23 @@ describe('MarketService', () => {
       });
     });
 
+    it('should use the static PostHog provider label for manifests', async () => {
+      const service = new MarketService();
+      (service as any).market.connect.listConnections = vi.fn().mockResolvedValue({
+        connections: [{ icon: 'posthog-icon', providerId: 'posthog', providerName: 'Product' }],
+      });
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue({
+        tools: [{ description: 'Query insights', inputSchema: {}, name: 'posthog-query' }],
+      });
+
+      const manifests = await service.getLobehubSkillManifests();
+      expect(manifests).toHaveLength(1);
+      expect(manifests[0].meta).toMatchObject({
+        description: 'LobeHub Skill: PostHog',
+        title: 'PostHog',
+      });
+    });
+
     it('should skip connections where listTools returns empty', async () => {
       const service = new MarketService();
       (service as any).market.connect.listConnections = vi.fn().mockResolvedValue({

--- a/src/server/services/market/index.ts
+++ b/src/server/services/market/index.ts
@@ -543,6 +543,7 @@ export class MarketService {
             linear: 'Linear',
             microsoft: 'Outlook Calendar',
             notion: 'Notion',
+            posthog: 'PostHog',
             twitter: 'X (Twitter)',
             vercel: 'Vercel',
           };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds PostHog as an official LobeHub Skill provider after the PostHog MCP provider became available in LobeHub Market.

This PR registers PostHog in the official skill provider list, adds setting copy for English and Chinese previews, exposes PostHog through the LobeHub OAuth credential schema and agent prompts, and adds the server-side provider label used when building connected skill manifests.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx vitest run --silent='passed-only' src/server/services/market/index.test.ts
bunx vitest run --silent='passed-only' src/store/tool/slices/lobehubSkillStore/selectors.test.ts
bun run type-check
```

Note: `src/store/tool/slices/lobehubSkillStore/action.test.ts` currently fails during test import with `Cannot read properties of undefined (reading 'getItem')` from `packages/utils/src/localStorage.ts`, which appears unrelated to the PostHog changes.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Created as a draft PR for review and final local acceptance against the deployed Market PostHog provider.
