### PR TITLE
✨ feat(markdown): user_feedback card + task card polish + Run now context menu

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -567,6 +567,7 @@
   "taskList.contextMenu.copyLink": "Copy Link",
   "taskList.contextMenu.copyLinkSuccess": "Link copied",
   "taskList.contextMenu.priority": "Priority",
+  "taskList.contextMenu.runNow": "Run now",
   "taskList.contextMenu.status": "Status",
   "taskList.empty": "No tasks yet",
   "taskList.emptyHero.greeting": "What should we tackle today?",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -567,6 +567,7 @@
   "taskList.contextMenu.copyLink": "复制链接",
   "taskList.contextMenu.copyLinkSuccess": "链接已复制",
   "taskList.contextMenu.priority": "优先级",
+  "taskList.contextMenu.runNow": "立即运行",
   "taskList.contextMenu.status": "状态",
   "taskList.empty": "暂无任务",
   "taskList.emptyHero.greeting": "今天想搞定点什么？",

--- a/packages/const/src/plugin.ts
+++ b/packages/const/src/plugin.ts
@@ -7,6 +7,7 @@ export const MENTION_TAG = 'mention';
 export const THINKING_TAG = 'think';
 export const LOCAL_FILE_TAG = 'localFile';
 export const TASK_TAG = 'task';
+export const USER_FEEDBACK_TAG = 'user_feedback';
 // https://regex101.com/r/TwzTkf/2
 export const ARTIFACT_TAG_REGEX = /<lobeArtifact\b[^>]*>(?<content>[\S\s]*?)(?:<\/lobeArtifact>|$)/;
 

--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
@@ -170,12 +170,14 @@ const TaskSubtasks = memo(() => {
       event.preventDefault();
       showContextMenu(
         buildItems({
+          assigneeAgentId: subtask.assignee?.id,
           identifier: subtask.identifier,
           priority: subtask.priority,
           status: subtask.status,
         }),
       );
       installKeyboardHandlers({
+        assigneeAgentId: subtask.assignee?.id,
         identifier: subtask.identifier,
         priority: subtask.priority,
         status: subtask.status,

--- a/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
+++ b/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
@@ -2,11 +2,20 @@ import type { TaskStatus } from '@lobechat/types';
 import { closeContextMenu, copyToClipboard, type GenericItemType, Icon } from '@lobehub/ui';
 import { App } from 'antd';
 import { cssVar } from 'antd-style';
-import { BarChart3Icon, CircleDashedIcon, CopyIcon, LinkIcon, Trash2Icon } from 'lucide-react';
+import {
+  BarChart3Icon,
+  CircleDashedIcon,
+  CopyIcon,
+  LinkIcon,
+  PlayIcon,
+  Trash2Icon,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAppOrigin } from '@/hooks/useAppOrigin';
+import { useAgentStore } from '@/store/agent';
+import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useTaskStore } from '@/store/task';
 
 import { renderMenuExtra } from './menuExtra';
@@ -22,10 +31,13 @@ interface TaskItemContextMenu {
 }
 
 export interface TaskContextMenuTarget {
+  assigneeAgentId?: string | null;
   identifier: string;
   priority?: number | null;
   status: string;
 }
+
+const RUN_NOW_STATUSES = new Set<TaskStatus>(['backlog', 'completed']);
 
 export interface TaskContextMenuActions {
   buildItems: (task: TaskContextMenuTarget) => GenericItemType[];
@@ -41,6 +53,8 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
   const updateTask = useTaskStore((s) => s.updateTask);
   const refreshTaskList = useTaskStore((s) => s.refreshTaskList);
   const deleteTask = useTaskStore((s) => s.deleteTask);
+  const runTask = useTaskStore((s) => s.runTask);
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
 
   const cleanupRef = useRef<(() => void) | null>(null);
 
@@ -103,8 +117,26 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
       });
 
       const taskUrl = `${appOrigin}/task/${task.identifier}`;
+      const canRunNow = RUN_NOW_STATUSES.has(currentStatus);
 
       return [
+        ...(canRunNow
+          ? ([
+              {
+                icon: <Icon icon={PlayIcon} />,
+                key: 'runNow',
+                label: t('taskList.contextMenu.runNow'),
+                onClick: async ({ domEvent }) => {
+                  domEvent.stopPropagation();
+                  if (!task.assigneeAgentId && inboxAgentId) {
+                    await updateTask(task.identifier, { assigneeAgentId: inboxAgentId });
+                  }
+                  await runTask(task.identifier);
+                },
+              },
+              { type: 'divider' },
+            ] satisfies GenericItemType[])
+          : []),
         {
           children: statusChildren,
           icon: <Icon {...{ [SUBMENU_MARKER]: 'status' }} icon={CircleDashedIcon} />,
@@ -230,14 +262,25 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
     };
 
     return { buildItems, installKeyboardHandlers };
-  }, [modal, message, t, appOrigin, updateTaskStatus, updateTask, refreshTaskList, deleteTask]);
+  }, [
+    modal,
+    message,
+    t,
+    appOrigin,
+    updateTaskStatus,
+    updateTask,
+    refreshTaskList,
+    deleteTask,
+    runTask,
+    inboxAgentId,
+  ]);
 };
 
 export const useTaskItemContextMenu = (task: TaskContextMenuTarget): TaskItemContextMenu => {
   const { buildItems, installKeyboardHandlers } = useTaskContextMenuActions();
   const items = useMemo(
     () => buildItems(task),
-    [buildItems, task.identifier, task.status, task.priority],
+    [buildItems, task.identifier, task.status, task.priority, task.assigneeAgentId],
   );
   const onContextMenu = useCallback(
     () => installKeyboardHandlers(task),

--- a/src/features/Conversation/Markdown/plugins/Task/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Task/Render.tsx
@@ -1,25 +1,11 @@
-import type { TaskStatus } from '@lobechat/types';
 import { Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ClipboardList } from 'lucide-react';
 import { memo, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
-
-import TaskStatusIcon from '@/features/AgentTasks/features/TaskStatusIcon';
 
 import { type MarkdownElementProps } from '../type';
 import { useTaskCardScope } from './context';
 import { type ParsedTaskContent, parseTaskContent } from './parseTaskContent';
-
-const KNOWN_STATUSES: TaskStatus[] = [
-  'backlog',
-  'canceled',
-  'completed',
-  'failed',
-  'paused',
-  'running',
-  'scheduled',
-];
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   divider: css`
@@ -77,21 +63,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorFillQuaternary};
   `,
-  statusBadge: css`
-    display: inline-flex;
-    flex: none;
-    gap: 4px;
-    align-items: center;
-
-    padding-block: 1px;
-    padding-inline: 6px;
-    border-radius: 4px;
-
-    font-size: 12px;
-    color: ${cssVar.colorTextSecondary};
-
-    background: ${cssVar.colorFillQuaternary};
-  `,
   instruction: css`
     font-size: 13px;
     line-height: 1.7;
@@ -128,9 +99,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const isKnownStatus = (status?: string): status is TaskStatus =>
-  !!status && (KNOWN_STATUSES as string[]).includes(status);
-
 const FieldRow = memo<{ label: string; value?: string }>(({ label, value }) => {
   if (!value) return null;
   return (
@@ -163,7 +131,6 @@ interface TaskRenderProps extends MarkdownElementProps {
 
 const Render = memo<TaskRenderProps>(({ children }) => {
   const enabled = useTaskCardScope();
-  const { t } = useTranslation('chat');
   const text = typeof children === 'string' ? children : String(children ?? '');
   const parsed = useMemo<ParsedTaskContent>(() => parseTaskContent(text), [text]);
 
@@ -172,10 +139,6 @@ const Render = memo<TaskRenderProps>(({ children }) => {
   }
 
   const titleText = parsed.name || parsed.identifier || '';
-  const showStatusBadge = parsed.status && isKnownStatus(parsed.status);
-  const statusLabel = showStatusBadge
-    ? t(`taskDetail.status.${parsed.status as TaskStatus}`)
-    : parsed.status;
 
   return (
     <Flexbox gap={12}>
@@ -189,12 +152,6 @@ const Render = memo<TaskRenderProps>(({ children }) => {
             <Text ellipsis style={{ flex: 1, minWidth: 0 }} weight={500}>
               {titleText}
             </Text>
-            {showStatusBadge && (
-              <span className={styles.statusBadge}>
-                <TaskStatusIcon size={12} status={parsed.status as TaskStatus} />
-                {statusLabel}
-              </span>
-            )}
           </Flexbox>
         </Flexbox>
       </Flexbox>

--- a/src/features/Conversation/Markdown/plugins/Task/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Task/Render.tsx
@@ -1,8 +1,9 @@
 import type { TaskStatus } from '@lobechat/types';
 import { Flexbox, Text } from '@lobehub/ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { ClipboardList } from 'lucide-react';
 import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import TaskStatusIcon from '@/features/AgentTasks/features/TaskStatusIcon';
 
@@ -71,6 +72,21 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: 4px;
 
     font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  statusBadge: css`
+    display: inline-flex;
+    flex: none;
+    gap: 4px;
+    align-items: center;
+
+    padding-block: 1px;
+    padding-inline: 6px;
+    border-radius: 4px;
+
     font-size: 12px;
     color: ${cssVar.colorTextSecondary};
 
@@ -147,6 +163,7 @@ interface TaskRenderProps extends MarkdownElementProps {
 
 const Render = memo<TaskRenderProps>(({ children }) => {
   const enabled = useTaskCardScope();
+  const { t } = useTranslation('chat');
   const text = typeof children === 'string' ? children : String(children ?? '');
   const parsed = useMemo<ParsedTaskContent>(() => parseTaskContent(text), [text]);
 
@@ -155,6 +172,10 @@ const Render = memo<TaskRenderProps>(({ children }) => {
   }
 
   const titleText = parsed.name || parsed.identifier || '';
+  const showStatusBadge = parsed.status && isKnownStatus(parsed.status);
+  const statusLabel = showStatusBadge
+    ? t(`taskDetail.status.${parsed.status as TaskStatus}`)
+    : parsed.status;
 
   return (
     <Flexbox gap={12}>
@@ -165,33 +186,16 @@ const Render = memo<TaskRenderProps>(({ children }) => {
         <Flexbox flex={1} gap={4} style={{ minWidth: 0 }}>
           <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
             {parsed.identifier && <span className={styles.identifier}>{parsed.identifier}</span>}
-            <Text ellipsis weight={500}>
+            <Text ellipsis style={{ flex: 1, minWidth: 0 }} weight={500}>
               {titleText}
             </Text>
+            {showStatusBadge && (
+              <span className={styles.statusBadge}>
+                <TaskStatusIcon size={12} status={parsed.status as TaskStatus} />
+                {statusLabel}
+              </span>
+            )}
           </Flexbox>
-          {(parsed.status || parsed.priority) && (
-            <Flexbox horizontal align={'center'} gap={8}>
-              {parsed.status && (
-                <Flexbox horizontal align={'center'} gap={4}>
-                  {isKnownStatus(parsed.status) ? (
-                    <TaskStatusIcon size={14} status={parsed.status} />
-                  ) : (
-                    <span style={{ color: cssVar.colorTextTertiary, fontSize: 12 }}>
-                      {parsed.statusIcon}
-                    </span>
-                  )}
-                  <Text fontSize={12} type={'secondary'}>
-                    {parsed.status}
-                  </Text>
-                </Flexbox>
-              )}
-              {parsed.priority && (
-                <Text fontSize={12} type={'secondary'}>
-                  · Priority: {parsed.priority}
-                </Text>
-              )}
-            </Flexbox>
-          )}
         </Flexbox>
       </Flexbox>
 
@@ -207,17 +211,9 @@ const Render = memo<TaskRenderProps>(({ children }) => {
         </>
       )}
 
-      {(parsed.description ||
-        parsed.agent ||
-        parsed.parent ||
-        parsed.topics ||
-        parsed.dependencies ||
-        parsed.review) && (
+      {(parsed.description || parsed.dependencies || parsed.review) && (
         <Flexbox gap={4}>
           <FieldRow label="Description" value={parsed.description} />
-          <FieldRow label="Agent" value={parsed.agent} />
-          <FieldRow label="Parent" value={parsed.parent} />
-          <FieldRow label="Topics" value={parsed.topics} />
           <FieldRow label="Dependencies" value={parsed.dependencies} />
           <FieldRow label="Review" value={parsed.review} />
         </Flexbox>

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -43,8 +43,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   root: css`
     /* Override @lobehub/ui Markdown's default <details> card chrome (bg + padding + box-shadow).
-       Need !important because the lib targets via .parent details (higher specificity). */
-    margin-block: 0 !important;
+       Need !important because the lib targets via .parent details (higher specificity).
+       padding-bottom puts a 12px gap above the divider; margin-bottom puts a 12px gap below it,
+       matching the symmetric 12px the task card uses around its own internal divider. */
+    margin-block: 0 12px !important;
     padding-block: 0 12px !important;
     padding-inline: 0 !important;
     border-block-end: 1px solid ${cssVar.colorSplit} !important;

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -8,12 +8,9 @@ import { type ParsedUserFeedbackComment, parseUserFeedback } from './parseUserFe
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
-    padding-block: 8px;
-    padding-inline: 12px;
+    padding-block: 2px;
+    padding-inline-start: 12px;
     border-inline-start: 2px solid ${cssVar.colorBorderSecondary};
-    border-radius: 4px;
-
-    background: ${cssVar.colorFillQuaternary};
   `,
   comment: css`
     font-size: 13px;

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -7,38 +7,35 @@ import { type MarkdownElementProps } from '../type';
 import { type ParsedUserFeedbackComment, parseUserFeedback } from './parseUserFeedback';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  card: css`
+    padding-block: 8px;
+    padding-inline: 12px;
+    border-inline-start: 2px solid ${cssVar.colorBorderSecondary};
+    border-radius: 4px;
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
   comment: css`
     font-size: 13px;
-    line-height: 1.7;
+    line-height: 1.6;
     color: ${cssVar.colorText};
     word-break: break-word;
     white-space: pre-wrap;
   `,
-  divider: css`
-    inline-size: 100%;
-    block-size: 1px;
-    background: ${cssVar.colorSplit};
-  `,
-  headerIcon: css`
-    display: flex;
-    flex: none;
-    align-items: center;
-    justify-content: center;
-
-    inline-size: 32px;
-    block-size: 32px;
-
+  header: css`
+    font-size: 12px;
     color: ${cssVar.colorTextSecondary};
+  `,
+  time: css`
+    flex: none;
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
   `,
 }));
 
 const Comment = memo<{ comment: ParsedUserFeedbackComment }>(({ comment }) => (
   <Flexbox gap={2}>
-    {comment.time && (
-      <Text fontSize={12} type={'secondary'}>
-        {comment.time}
-      </Text>
-    )}
+    {comment.time && <span className={styles.time}>{comment.time}</span>}
     <div className={styles.comment}>{comment.content}</div>
   </Flexbox>
 ));
@@ -52,22 +49,15 @@ const Render = memo<MarkdownElementProps>(({ children }) => {
   if (comments.length === 0) return null;
 
   return (
-    <Flexbox gap={12}>
-      <Flexbox horizontal align={'center'} gap={12}>
-        <span className={styles.headerIcon}>
-          <MessageSquareText size={16} />
-        </span>
-        <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
-          <Text weight={500}>User feedback</Text>
-          <Text fontSize={12} type={'secondary'}>
-            {comments.length === 1 ? '1 comment' : `${comments.length} comments`}
-          </Text>
-        </Flexbox>
+    <Flexbox className={styles.card} gap={8}>
+      <Flexbox horizontal align={'center'} className={styles.header} gap={6}>
+        <MessageSquareText size={12} />
+        <Text fontSize={12} type={'secondary'}>
+          User feedback · {comments.length === 1 ? '1 comment' : `${comments.length} comments`}
+        </Text>
       </Flexbox>
 
-      <div className={styles.divider} />
-
-      <Flexbox gap={12}>
+      <Flexbox gap={8}>
         {comments.map((comment, idx) => (
           <Comment comment={comment} key={comment.id ?? idx} />
         ))}

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -42,8 +42,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextSecondary};
   `,
   root: css`
-    padding-block-end: 12px;
-    border-block-end: 1px solid ${cssVar.colorSplit};
+    /* Override @lobehub/ui Markdown's default <details> card chrome (bg + padding + box-shadow).
+       Need !important because the lib targets via .parent details (higher specificity). */
+    margin-block: 0 !important;
+    padding-block: 0 12px !important;
+    padding-inline: 0 !important;
+    border-block-end: 1px solid ${cssVar.colorSplit} !important;
+    border-radius: 0 !important;
+
+    background: transparent !important;
+    box-shadow: none !important;
   `,
   summary: css`
     cursor: pointer;

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -1,0 +1,81 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { MessageSquareText } from 'lucide-react';
+import { memo, useMemo } from 'react';
+
+import { type MarkdownElementProps } from '../type';
+import { type ParsedUserFeedbackComment, parseUserFeedback } from './parseUserFeedback';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  comment: css`
+    font-size: 13px;
+    line-height: 1.7;
+    color: ${cssVar.colorText};
+    word-break: break-word;
+    white-space: pre-wrap;
+  `,
+  divider: css`
+    inline-size: 100%;
+    block-size: 1px;
+    background: ${cssVar.colorSplit};
+  `,
+  headerIcon: css`
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    inline-size: 32px;
+    block-size: 32px;
+
+    color: ${cssVar.colorTextSecondary};
+  `,
+}));
+
+const Comment = memo<{ comment: ParsedUserFeedbackComment }>(({ comment }) => (
+  <Flexbox gap={2}>
+    {comment.time && (
+      <Text fontSize={12} type={'secondary'}>
+        {comment.time}
+      </Text>
+    )}
+    <div className={styles.comment}>{comment.content}</div>
+  </Flexbox>
+));
+
+Comment.displayName = 'UserFeedbackComment';
+
+const Render = memo<MarkdownElementProps>(({ children }) => {
+  const text = typeof children === 'string' ? children : String(children ?? '');
+  const comments = useMemo(() => parseUserFeedback(text), [text]);
+
+  if (comments.length === 0) return null;
+
+  return (
+    <Flexbox gap={12}>
+      <Flexbox horizontal align={'center'} gap={12}>
+        <span className={styles.headerIcon}>
+          <MessageSquareText size={16} />
+        </span>
+        <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
+          <Text weight={500}>User feedback</Text>
+          <Text fontSize={12} type={'secondary'}>
+            {comments.length === 1 ? '1 comment' : `${comments.length} comments`}
+          </Text>
+        </Flexbox>
+      </Flexbox>
+
+      <div className={styles.divider} />
+
+      <Flexbox gap={12}>
+        {comments.map((comment, idx) => (
+          <Comment comment={comment} key={comment.id ?? idx} />
+        ))}
+      </Flexbox>
+    </Flexbox>
+  );
+});
+
+Render.displayName = 'UserFeedbackRender';
+
+export default Render;

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/Render.tsx
@@ -7,10 +7,9 @@ import { type MarkdownElementProps } from '../type';
 import { type ParsedUserFeedbackComment, parseUserFeedback } from './parseUserFeedback';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  card: css`
-    padding-block: 2px;
-    padding-inline-start: 12px;
-    border-inline-start: 2px solid ${cssVar.colorBorderSecondary};
+  body: css`
+    padding-block-start: 12px;
+    padding-inline-start: 44px;
   `,
   comment: css`
     font-size: 13px;
@@ -19,12 +18,42 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     word-break: break-word;
     white-space: pre-wrap;
   `,
-  header: css`
+  countBadge: css`
+    flex: none;
+
+    padding-block: 1px;
+    padding-inline: 6px;
+    border-radius: 4px;
+
     font-size: 12px;
     color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  headerIcon: css`
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    inline-size: 32px;
+    block-size: 32px;
+
+    color: ${cssVar.colorTextSecondary};
+  `,
+  root: css`
+    padding-block-end: 12px;
+    border-block-end: 1px solid ${cssVar.colorSplit};
+  `,
+  summary: css`
+    cursor: pointer;
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
   `,
   time: css`
-    flex: none;
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
@@ -45,21 +74,29 @@ const Render = memo<MarkdownElementProps>(({ children }) => {
 
   if (comments.length === 0) return null;
 
-  return (
-    <Flexbox className={styles.card} gap={8}>
-      <Flexbox horizontal align={'center'} className={styles.header} gap={6}>
-        <MessageSquareText size={12} />
-        <Text fontSize={12} type={'secondary'}>
-          User feedback · {comments.length === 1 ? '1 comment' : `${comments.length} comments`}
-        </Text>
-      </Flexbox>
+  const countLabel = comments.length === 1 ? '1 comment' : `${comments.length} comments`;
 
-      <Flexbox gap={8}>
+  return (
+    <details className={styles.root}>
+      <summary className={styles.summary}>
+        <Flexbox horizontal align={'center'} gap={12}>
+          <span className={styles.headerIcon}>
+            <MessageSquareText size={16} />
+          </span>
+          <Flexbox horizontal align={'center'} flex={1} gap={8} style={{ minWidth: 0 }}>
+            <Text ellipsis weight={500}>
+              User feedback
+            </Text>
+            <span className={styles.countBadge}>{countLabel}</span>
+          </Flexbox>
+        </Flexbox>
+      </summary>
+      <Flexbox className={styles.body} gap={12}>
         {comments.map((comment, idx) => (
           <Comment comment={comment} key={comment.id ?? idx} />
         ))}
       </Flexbox>
-    </Flexbox>
+    </details>
   );
 });
 

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/index.ts
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/index.ts
@@ -1,0 +1,14 @@
+import { USER_FEEDBACK_TAG } from '@/const/plugin';
+
+import { type MarkdownElement } from '../type';
+import { remarkUserFeedbackBlock } from './remarkUserFeedbackBlock';
+import Component from './Render';
+
+const UserFeedbackElement: MarkdownElement = {
+  Component,
+  remarkPlugin: remarkUserFeedbackBlock,
+  scope: 'user',
+  tag: USER_FEEDBACK_TAG,
+};
+
+export default UserFeedbackElement;

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/integration.test.ts
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/integration.test.ts
@@ -1,0 +1,80 @@
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { describe, expect, it } from 'vitest';
+
+import { USER_FEEDBACK_TAG } from '@/const/plugin';
+
+import { remarkTaskBlock } from '../Task/remarkTaskBlock';
+import { remarkUserFeedbackBlock } from './remarkUserFeedbackBlock';
+
+const runRemark = (markdown: string) => {
+  const processor = unified().use(remarkParse).use(remarkUserFeedbackBlock).use(remarkTaskBlock);
+  const tree = processor.parse(markdown);
+  return processor.runSync(tree);
+};
+
+describe('user_feedback remark integration', () => {
+  it('captures a user_feedback block sitting next to a <task> block', () => {
+    const markdown = `<user_feedback>
+<comment id="cmt_1" time="9d ago">你能否写成文档而不是写在最后一个输出里？ </comment>
+<comment id="cmt_2" time="9d ago">不是写到linear 里，而是写 agent Document 里面</comment>
+</user_feedback>
+
+<task>
+T-31 总结下我前一天在 linear 上的工作情况
+Status: ⏰ scheduled     Priority: -
+Instruction: 总结下我前一天在 linear 上的工作情况。以文档形式产出内容
+
+Review: (not configured)
+</task>`;
+
+    const tree: any = runRemark(markdown);
+    const feedbackNodes = (tree.children as any[]).filter(
+      (c) => c.type === `${USER_FEEDBACK_TAG}Block`,
+    );
+    const taskNodes = (tree.children as any[]).filter((c) => c.type === 'taskBlock');
+
+    expect(feedbackNodes).toHaveLength(1);
+    expect(taskNodes).toHaveLength(1);
+
+    const feedbackInner = feedbackNodes[0].data.hChildren[0].value as string;
+    expect(feedbackInner).toContain('<comment id="cmt_1"');
+    expect(feedbackInner).toContain('你能否写成文档而不是写在最后一个输出里？');
+    expect(feedbackInner).toContain('不是写到linear 里，而是写 agent Document 里面');
+
+    const taskInner = taskNodes[0].data.hChildren[0].value as string;
+    expect(taskInner).toContain('T-31');
+    expect(taskInner).toContain('Review: (not configured)');
+  });
+
+  it('captures a simple user_feedback block', () => {
+    const markdown = `<user_feedback>
+<comment time="1m ago">looks good</comment>
+</user_feedback>`;
+    const tree: any = runRemark(markdown);
+    const feedbackNodes = (tree.children as any[]).filter(
+      (c) => c.type === `${USER_FEEDBACK_TAG}Block`,
+    );
+    expect(feedbackNodes).toHaveLength(1);
+    expect(feedbackNodes[0].data.hChildren[0].value).toContain('looks good');
+  });
+
+  it('does not match when only the opening tag is present', () => {
+    const markdown = `<user_feedback>
+<comment time="1m ago">orphan</comment>`;
+    const tree: any = runRemark(markdown);
+    const feedbackNodes = (tree.children as any[]).filter(
+      (c) => c.type === `${USER_FEEDBACK_TAG}Block`,
+    );
+    expect(feedbackNodes).toHaveLength(0);
+  });
+
+  it('leaves unrelated markdown untouched', () => {
+    const markdown = `Just a normal paragraph without any tag.`;
+    const tree: any = runRemark(markdown);
+    const feedbackNodes = (tree.children as any[]).filter(
+      (c) => c.type === `${USER_FEEDBACK_TAG}Block`,
+    );
+    expect(feedbackNodes).toHaveLength(0);
+  });
+});

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/parseUserFeedback.test.ts
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/parseUserFeedback.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseUserFeedback } from './parseUserFeedback';
+
+describe('parseUserFeedback', () => {
+  it('parses comments with id and time', () => {
+    const raw = `<comment id="cmt_1" time="9d ago">你能否写成文档而不是写在最后一个输出里？</comment>
+<comment id="cmt_2" time="9d ago">不是写到linear 里，而是写 agent Document 里面</comment>`;
+
+    const parsed = parseUserFeedback(raw);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toEqual({
+      content: '你能否写成文档而不是写在最后一个输出里？',
+      id: 'cmt_1',
+      time: '9d ago',
+    });
+    expect(parsed[1].content).toBe('不是写到linear 里，而是写 agent Document 里面');
+  });
+
+  it('handles comments without attributes', () => {
+    const raw = `<comment>plain feedback</comment>`;
+    const parsed = parseUserFeedback(raw);
+    expect(parsed).toEqual([{ content: 'plain feedback', id: undefined, time: undefined }]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseUserFeedback('')).toEqual([]);
+  });
+
+  it('ignores stray text between comments', () => {
+    const raw = `noise<comment time="1m ago">a</comment>more noise<comment>b</comment>`;
+    const parsed = parseUserFeedback(raw);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].content).toBe('a');
+    expect(parsed[1].content).toBe('b');
+  });
+});

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/parseUserFeedback.ts
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/parseUserFeedback.ts
@@ -1,0 +1,34 @@
+export interface ParsedUserFeedbackComment {
+  content: string;
+  id?: string;
+  time?: string;
+}
+
+const COMMENT_REGEX = /<comment\b(?<attrs>[^>]*)>(?<body>[\S\s]*?)<\/comment>/g;
+const ATTR_REGEX = /(\w+)\s*=\s*"([^"]*)"/g;
+
+const parseAttrs = (attrs: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+  ATTR_REGEX.lastIndex = 0;
+  while ((match = ATTR_REGEX.exec(attrs)) !== null) {
+    out[match[1]] = match[2];
+  }
+  return out;
+};
+
+export const parseUserFeedback = (raw: string): ParsedUserFeedbackComment[] => {
+  if (!raw) return [];
+  const comments: ParsedUserFeedbackComment[] = [];
+  let match: RegExpExecArray | null;
+  COMMENT_REGEX.lastIndex = 0;
+  while ((match = COMMENT_REGEX.exec(raw)) !== null) {
+    const attrs = parseAttrs(match.groups?.attrs ?? '');
+    comments.push({
+      content: (match.groups?.body ?? '').trim(),
+      id: attrs.id,
+      time: attrs.time,
+    });
+  }
+  return comments;
+};

--- a/src/features/Conversation/Markdown/plugins/UserFeedback/remarkUserFeedbackBlock.ts
+++ b/src/features/Conversation/Markdown/plugins/UserFeedback/remarkUserFeedbackBlock.ts
@@ -1,0 +1,60 @@
+import { SKIP, visit } from 'unist-util-visit';
+
+import { USER_FEEDBACK_TAG } from '@/const/plugin';
+
+const OPEN_TAG = `<${USER_FEEDBACK_TAG}>`;
+const CLOSE_TAG = `</${USER_FEEDBACK_TAG}>`;
+
+/**
+ * Captures `<user_feedback>...</user_feedback>` blocks from a markdown AST.
+ *
+ * Because the CommonMark/remark HTML parser only recognises tag names
+ * matching `[a-zA-Z][a-zA-Z0-9-]*`, an underscore in `user_feedback` keeps
+ * the opening and closing tags from being parsed as `html` nodes; they end
+ * up as plain text inside a paragraph (mixed with html nodes for inner
+ * `<comment ...>` tags). This plugin operates on those paragraphs.
+ */
+export const remarkUserFeedbackBlock = () => (tree: any) => {
+  visit(tree, 'paragraph', (paragraph: any, index, parent) => {
+    if (!parent || index == null) return;
+    if (!Array.isArray(paragraph.children)) return;
+
+    const buffer = paragraph.children
+      .map((child: any) => (typeof child.value === 'string' ? child.value : ''))
+      .join('');
+
+    const openIdx = buffer.indexOf(OPEN_TAG);
+    if (openIdx === -1) return;
+    const closeIdx = buffer.indexOf(CLOSE_TAG, openIdx + OPEN_TAG.length);
+    if (closeIdx === -1) return;
+
+    const inner = buffer.slice(openIdx + OPEN_TAG.length, closeIdx).trim();
+    const before = buffer.slice(0, openIdx).trim();
+    const after = buffer.slice(closeIdx + CLOSE_TAG.length).trim();
+
+    const replacement: any[] = [];
+    if (before) {
+      replacement.push({
+        children: [{ type: 'text', value: before }],
+        type: 'paragraph',
+      });
+    }
+    replacement.push({
+      data: {
+        hChildren: [{ type: 'text', value: inner }],
+        hName: USER_FEEDBACK_TAG,
+      },
+      position: paragraph.position,
+      type: `${USER_FEEDBACK_TAG}Block`,
+    });
+    if (after) {
+      replacement.push({
+        children: [{ type: 'text', value: after }],
+        type: 'paragraph',
+      });
+    }
+
+    parent.children.splice(index, 1, ...replacement);
+    return [SKIP, index + replacement.length];
+  });
+};

--- a/src/features/Conversation/Markdown/plugins/index.ts
+++ b/src/features/Conversation/Markdown/plugins/index.ts
@@ -7,6 +7,7 @@ import Mention from './Mention';
 import Task from './Task';
 import Thinking from './Thinking';
 import { type MarkdownElement } from './type';
+import UserFeedback from './UserFeedback';
 
 export type { MarkdownElement } from './type';
 
@@ -17,6 +18,7 @@ export const markdownElements: MarkdownElement[] = [
   LocalFile,
   Mention,
   Task,
+  UserFeedback,
   ImageSearchRef,
   LobeAgents,
 ];

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -700,6 +700,7 @@ export default {
   'taskList.contextMenu.copyLink': 'Copy Link',
   'taskList.contextMenu.copyLinkSuccess': 'Link copied',
   'taskList.contextMenu.priority': 'Priority',
+  'taskList.contextMenu.runNow': 'Run now',
   'taskList.contextMenu.status': 'Status',
   'taskList.kanban.addTask': 'Create task',
   'taskList.kanban.backlog': 'Backlog',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -259,9 +259,18 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
               return <ProviderIcon color={cssVar.colorTextDescription} size={16} />;
             }
           }
-          if (isHeterogeneousAgent) return null;
           return (
-            <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />
+            <Icon
+              icon={HashIcon}
+              size={'small'}
+              style={{
+                color: cssVar.colorTextDescription,
+                // Heterogeneous agents (Claude Code, Codex, …) have no chat-style
+                // topic semantics, so suppress the `#` glyph while keeping its
+                // box so the title stays aligned with sibling rows.
+                visibility: isHeterogeneousAgent ? 'hidden' : undefined,
+              }}
+            />
           );
         })()}
         onClick={handleClick}


### PR DESCRIPTION
## Summary

Three changes that all touch the task drawer experience:

1. **`<user_feedback>` block rendering** — `buildTaskRunPrompt` wraps user comments in `<user_feedback>` next to `<task>`. Previously only `<task>` had a Markdown plugin, so `<user_feedback>` leaked into the chat as raw XML. Added a `UserFeedback` plugin that captures the block and renders it as a default-collapsed `<details>` whose head matches the task title row layout, with a bottom rule that doubles as a divider between the user_feedback head and the task card.

2. **Task card polish** — dropped the standalone status / Priority row, the Agent / Parent / Topics field rows, and the inline status badge. The task drawer header and the detail-page schedule strip already convey status; the card now reads as just `[icon] [T-31 badge] [title]` + Instruction.

3. **"Run now" task card context menu** — adds a "Run now" item to the right-click menu on backlog / completed task cards, mirroring the inbox-agent fallback used by the detail-page Run Now action.

### Root-cause subtlety (user_feedback)

CommonMark/remark only recognise html tag names matching `[a-zA-Z][a-zA-Z0-9-]*`, so the underscore in `user_feedback` keeps the open/close tags from being parsed as `html` nodes — they sit inside a `paragraph` as plain `text` mixed with the inner `<comment>` html nodes. The new `remarkUserFeedbackBlock` plugin walks `paragraph` children to extract the block (different shape than `<task>`-style html-node capture).

The collapsible head also needed `!important` overrides on the root `<details>` to strip `@lobehub/ui`'s default Markdown details card chrome (bg + padding + box-shadow + border-radius) — the lib selector wins on specificity.

## Test plan

- [x] `bunx vitest run src/features/Conversation/Markdown/plugins/{Task,UserFeedback}` — 15 tests pass
- [x] Local-tested in Electron dev (T-31 topic #22): user feedback head renders as a collapsible row matching task title style; expanding shows both comments + relative time; task card shows only `T-31 / title / Instruction`; symmetric 12px spacing around both internal dividers
- [ ] Manual test of "Run now" context menu on a backlog and a completed task card
- [ ] Verify on cloud once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)