### PR TITLE
🐛 fix(task-card): localize task card date independent of dayjs global locale

### DIFF
--- a/src/features/AgentTasks/features/AgentTaskItem.tsx
+++ b/src/features/AgentTasks/features/AgentTaskItem.tsx
@@ -36,7 +36,7 @@ const toTaskStatus = (status: string): TaskStatus =>
   TASK_STATUS_SET.has(status as TaskStatus) ? (status as TaskStatus) : 'backlog';
 
 const AgentTaskItem = memo<TaskItemProps>(({ task, variant = 'default' }) => {
-  const { t } = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
   const { t: tChat } = useTranslation('chat');
   const useFetchTaskDetail = useTaskStore((s) => s.useFetchTaskDetail);
   useFetchTaskDetail(task.identifier);
@@ -49,6 +49,7 @@ const AgentTaskItem = memo<TaskItemProps>(({ task, variant = 'default' }) => {
   const time = formatTaskItemDate(task.updatedAt || task.createdAt, {
     formatOtherYear: t('time.formatOtherYear'),
     formatThisYear: t('time.formatThisYear'),
+    locale: i18n.language,
   });
   const status = toTaskStatus(task.status);
   const hasName = Boolean(task.name?.trim());

--- a/src/features/AgentTasks/features/formatTaskItemDate.test.ts
+++ b/src/features/AgentTasks/features/formatTaskItemDate.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import dayjs from 'dayjs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { formatTaskItemDate } from './formatTaskItemDate';
 
@@ -14,5 +15,35 @@ describe('formatTaskItemDate', () => {
   it('returns an empty string for invalid input', () => {
     expect(formatTaskItemDate()).toBe('');
     expect(formatTaskItemDate('invalid date')).toBe('');
+  });
+
+  describe('with explicit locale', () => {
+    beforeAll(async () => {
+      await import('dayjs/locale/zh-cn');
+      await import('dayjs/locale/en');
+      // Simulate the regression: dayjs's global locale stuck on zh-cn while the
+      // caller wants English output.
+      dayjs.locale('zh-cn');
+    });
+
+    afterAll(() => {
+      dayjs.locale('en');
+    });
+
+    it('renders English month names when locale is en-US, regardless of dayjs global', () => {
+      expect(formatTaskItemDate('2026-05-12', { locale: 'en-US', now: '2026-05-20' })).toBe(
+        'May 12',
+      );
+    });
+
+    it('renders Chinese month names when locale is zh-CN with a Chinese format string', () => {
+      expect(
+        formatTaskItemDate('2026-05-12', {
+          formatThisYear: 'M月D日',
+          locale: 'zh-CN',
+          now: '2026-05-20',
+        }),
+      ).toBe('5月12日');
+    });
   });
 });

--- a/src/features/AgentTasks/features/formatTaskItemDate.ts
+++ b/src/features/AgentTasks/features/formatTaskItemDate.ts
@@ -1,8 +1,14 @@
 import dayjs from 'dayjs';
 
+import { normalizeDayjsLocale } from '@/utils/dayjsLocale';
+
 export interface TaskItemDateFormatOptions {
   formatOtherYear?: string;
   formatThisYear?: string;
+  // i18next language code (e.g. "en-US", "zh-CN"); decouples month-name
+  // rendering from dayjs's global locale so transient render windows during a
+  // language switch don't mix English format strings with Chinese MMM tokens.
+  locale?: string;
   now?: Date | string;
 }
 
@@ -16,8 +22,14 @@ export const formatTaskItemDate = (
 
   if (!date.isValid()) return '';
 
-  const { formatOtherYear = 'MMM D, YYYY', formatThisYear = 'MMM D', now = new Date() } = options;
+  const {
+    formatOtherYear = 'MMM D, YYYY',
+    formatThisYear = 'MMM D',
+    locale,
+    now = new Date(),
+  } = options;
   const current = dayjs(now);
+  const localized = locale ? date.locale(normalizeDayjsLocale(locale)) : date;
 
-  return date.format(date.isSame(current, 'year') ? formatThisYear : formatOtherYear);
+  return localized.format(date.isSame(current, 'year') ? formatThisYear : formatOtherYear);
 };

--- a/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
+++ b/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
@@ -3,6 +3,7 @@ import {
   closeContextMenu,
   type ContextMenuItem,
   copyToClipboard,
+  type GenericItemType,
   Icon,
   type MenuInfo,
 } from '@lobehub/ui';
@@ -134,7 +135,7 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
                 icon: <Icon icon={PlayIcon} />,
                 key: 'runNow',
                 label: t('taskList.contextMenu.runNow'),
-                onClick: async ({ domEvent }) => {
+                onClick: async ({ domEvent }: MenuInfo) => {
                   domEvent.stopPropagation();
                   if (!task.assigneeAgentId && inboxAgentId) {
                     await updateTask(task.identifier, { assigneeAgentId: inboxAgentId });

--- a/src/layout/SPAGlobalProvider/Locale.tsx
+++ b/src/layout/SPAGlobalProvider/Locale.tsx
@@ -5,19 +5,15 @@ import { isRtlLang } from 'rtl-detect';
 
 import Editor from '@/layout/GlobalProvider/Editor';
 import { createI18nNext } from '@/locales/create';
+import { normalizeDayjsLocale } from '@/utils/dayjsLocale';
 import { getAntdLocale } from '@/utils/locale';
 
 const dayjsLocaleLoaders = import.meta.glob<{ default: ILocale }>(
   '/node_modules/dayjs/esm/locale/{ar,bg,de,en,es,fa,fr,it,ja,ko,nl,pl,pt-br,ru,tr,vi,zh-cn,zh-tw}.js',
 );
 
-const dayjsLocaleAliases: Record<string, string> = {
-  'en-us': 'en',
-  'zh': 'zh-cn',
-};
-
 const updateDayjs = async (lang: string) => {
-  const locale = dayjsLocaleAliases[lang.toLowerCase()] ?? lang.toLowerCase();
+  const locale = normalizeDayjsLocale(lang);
   const key = `/node_modules/dayjs/esm/locale/${locale}.js`;
   const loader =
     dayjsLocaleLoaders[key] ?? dayjsLocaleLoaders['/node_modules/dayjs/esm/locale/en.js'];

--- a/src/utils/dayjsLocale.ts
+++ b/src/utils/dayjsLocale.ts
@@ -1,0 +1,12 @@
+// dayjs registers some locales under shorter keys than the i18next language code
+// (e.g. `en` for `en-US`, `zh-cn` for `zh`). Keep the alias map alongside the
+// loader logic in `SPAGlobalProvider/Locale.tsx` so reads and writes stay in sync.
+const DAYJS_LOCALE_ALIASES: Record<string, string> = {
+  'en-us': 'en',
+  'zh': 'zh-cn',
+};
+
+export const normalizeDayjsLocale = (lang: string): string => {
+  const lower = lang.toLowerCase();
+  return DAYJS_LOCALE_ALIASES[lower] ?? lower;
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Task kanban cards rendered dates like `5月 12` even when the UI language was English.

Root cause: `t('time.formatThisYear')` correctly returned the English format string `MMM D`, but `dayjs`'s global locale was still `zh-cn`, so the `MMM` token rendered as the Chinese short month name (`5月`). The format-string locale and dayjs's runtime locale could drift apart during a language switch (async dayjs locale loading in `SPAGlobalProvider/Locale.tsx`) or because of a stale stray `dayjs.locale(i18n.language)` call elsewhere.

This PR threads the i18n language into `formatTaskItemDate` so the date is rendered with the same locale as the format string, fully decoupled from dayjs's global state.

- New `src/utils/dayjsLocale.ts` — single source of truth for the `en-us → en` / `zh → zh-cn` alias map.
- `formatTaskItemDate` accepts an explicit `locale` option and applies it via `dayjs(time).locale(...)`.
- `AgentTaskItem` passes `i18n.language` in.
- `SPAGlobalProvider/Locale.tsx` reuses the same alias util (no behavior change).

#### 🧪 How to Test

Regression covered by `formatTaskItemDate.test.ts`: with dayjs's global locale forced to `zh-cn`, passing `locale: 'en-US'` still produces `May 12`, and a Chinese format string with `locale: 'zh-CN'` produces `5月12日`.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before          | After   |
| --------------- | ------- |
| \`5月 12\` (en UI) | \`May 12\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)