### PR TITLE
🐛 fix(market-auth): add offline_access scope and guard expiresIn default

### DIFF
--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -179,7 +179,7 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
         baseUrl,
         clientId: isDesktop ? 'lobehub-desktop' : 'lobechat-com',
         redirectUri,
-        scope: 'openid profile email',
+        scope: 'openid profile email offline_access',
       };
       setOidcClient(new MarketOIDC(oidcConfig));
     }
@@ -343,11 +343,12 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
       const userInfo = await fetchUserInfo(tokenResponse.accessToken);
 
       // Create session object
-      const expiresAt = Date.now() + tokenResponse.expiresIn * 1000;
+      const expiresIn = tokenResponse.expiresIn ?? 3600;
+      const expiresAt = Date.now() + expiresIn * 1000;
       const newSession: MarketAuthSession = {
         accessToken: tokenResponse.accessToken,
         expiresAt,
-        expiresIn: tokenResponse.expiresIn,
+        expiresIn,
         scope: tokenResponse.scope,
         tokenType: tokenResponse.tokenType as 'Bearer',
         userInfo: userInfo || undefined,


### PR DESCRIPTION
## 问题根因

Market OIDC 授权过期后用户被迫重新登录，根因有两处：

### 根因 1 — 缺少 `offline_access` scope（主要）

OAuth2/OIDC 标准规定，只有授权请求中包含 `offline_access` scope，服务端才会在 token 响应中返回 `refresh_token`。

**调用链：**
1. `MarketAuthProvider` 初始化 `MarketOIDC` 时 scope 为 `'openid profile email'`（无 `offline_access`）
2. Market OIDC 服务器收到请求，不返回 `refresh_token`
3. `saveMarketTokensToDB(accessToken, undefined, expiresAt)` 保存时 `refreshToken` 为 `undefined`
4. access token 过期（约 24h）后，`initializeSession` 检查 `dbTokens.refreshToken` 为空，跳过 refresh，直接设为 `unauthenticated`
5. 用户被迫重新登录

### 根因 2 — `handleActualSignIn` 缺少 `expiresIn` 默认值（次要）

`OAuthTokenResponse` 中 `expiresIn` 是可选字段（`expiresIn?: number`）。若服务端未返回此字段，`expiresAt` 会变成 `NaN`，导致每次页面加载时 token 立即被视为过期。

## 修复内容

**Fix 1** (`src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx:182`)

```diff
- scope: 'openid profile email',
+ scope: 'openid profile email offline_access',
```

**Fix 2** (`src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx:346`)

```diff
- const expiresAt = Date.now() + tokenResponse.expiresIn * 1000;
+ const expiresIn = tokenResponse.expiresIn ?? 3600;
+ const expiresAt = Date.now() + expiresIn * 1000;
  ...
- expiresIn: tokenResponse.expiresIn,
+ expiresIn,
```

与 `tryRefreshToken`（line 202）和 `refreshToken`（line 593）的现有处理方式保持一致。

## Test plan

- [ ] 登录后确认 DB 中有 `refreshToken` 记录
- [ ] 等待 access token 过期（或手动缩短过期时间），确认自动续期正常，不弹重新登录
- [ ] 服务端不返回 `expiresIn` 时，`expiresAt` 不为 `NaN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)