### PR TITLE
🐛 fix(cc): preserve trailing suffix after partial deltas

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1210,6 +1210,24 @@ describe('ClaudeCodeAdapter', () => {
       expect(textChunks).toHaveLength(0);
     });
 
+    it('emits only the missing text suffix when the final assistant block is longer than streamed deltas', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt(init);
+      adapter.adapt(messageStart('msg_1'));
+      adapter.adapt(delta('text_delta', 'text', '修'));
+
+      const events = adapter.adapt({
+        message: { id: 'msg_1', content: [{ text: '修复完成', type: 'text' }] },
+        type: 'assistant',
+      });
+
+      const textChunks = events.filter(
+        (e) => e.type === 'stream_chunk' && e.data.chunkType === 'text',
+      );
+      expect(textChunks).toHaveLength(1);
+      expect(textChunks[0].data.content).toBe('复完成');
+    });
+
     it('suppresses handleAssistant thinking emission when thinking_delta already streamed', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt(init);

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1226,6 +1226,7 @@ describe('ClaudeCodeAdapter', () => {
       );
       expect(textChunks).toHaveLength(1);
       expect(textChunks[0].data.content).toBe('复完成');
+      expect((adapter as any).streamedTextByMessageId.has('msg_1')).toBe(false);
     });
 
     it('suppresses handleAssistant thinking emission when thinking_delta already streamed', () => {

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1246,6 +1246,32 @@ describe('ClaudeCodeAdapter', () => {
       expect(reasoningChunks).toHaveLength(0);
     });
 
+    it('keeps the other modality dedupe state when assistant blocks reconcile separately', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt(init);
+      adapter.adapt(messageStart('msg_1'));
+      adapter.adapt(delta('text_delta', 'text', 'hello'));
+      adapter.adapt(delta('thinking_delta', 'thinking', 'pondering'));
+
+      const textEvents = adapter.adapt({
+        message: { id: 'msg_1', content: [{ text: 'hello', type: 'text' }] },
+        type: 'assistant',
+      });
+      const thinkingEvents = adapter.adapt({
+        message: { id: 'msg_1', content: [{ thinking: 'pondering', type: 'thinking' }] },
+        type: 'assistant',
+      });
+
+      expect(
+        textEvents.filter((e) => e.type === 'stream_chunk' && e.data.chunkType === 'text'),
+      ).toHaveLength(0);
+      expect(
+        thinkingEvents.filter((e) => e.type === 'stream_chunk' && e.data.chunkType === 'reasoning'),
+      ).toHaveLength(0);
+      expect((adapter as any).streamedTextByMessageId.has('msg_1')).toBe(false);
+      expect((adapter as any).streamedThinkingByMessageId.has('msg_1')).toBe(false);
+    });
+
     it('still emits tool_use from assistant event even when text was streamed via deltas', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt(init);

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -477,8 +477,11 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     if (thinkingCompletion) {
       events.push(this.makeChunkEvent({ chunkType: 'reasoning', reasoning: thinkingCompletion }));
     }
-    if (messageId && (textParts.length > 0 || reasoningParts.length > 0)) {
-      this.clearStreamedBuffers(messageId);
+    if (messageId) {
+      this.clearStreamedBuffers(messageId, {
+        thinking: reasoningParts.length > 0,
+        text: textParts.length > 0,
+      });
     }
     events.push(...this.emitToolChunk(newToolCalls, messageId));
 
@@ -921,9 +924,12 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     }
   }
 
-  private clearStreamedBuffers(messageId: string): void {
-    this.streamedTextByMessageId.delete(messageId);
-    this.streamedThinkingByMessageId.delete(messageId);
+  private clearStreamedBuffers(
+    messageId: string,
+    modes: { text?: boolean; thinking?: boolean },
+  ): void {
+    if (modes.text) this.streamedTextByMessageId.delete(messageId);
+    if (modes.thinking) this.streamedThinkingByMessageId.delete(messageId);
   }
 
   // ─── Event factories ───

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -477,6 +477,9 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     if (thinkingCompletion) {
       events.push(this.makeChunkEvent({ chunkType: 'reasoning', reasoning: thinkingCompletion }));
     }
+    if (messageId && (textParts.length > 0 || reasoningParts.length > 0)) {
+      this.clearStreamedBuffers(messageId);
+    }
     events.push(...this.emitToolChunk(newToolCalls, messageId));
 
     return events;
@@ -786,6 +789,8 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       : this.makeEvent('agent_runtime_end', {});
 
     this.pendingRateLimitInfo = undefined;
+    this.streamedTextByMessageId.clear();
+    this.streamedThinkingByMessageId.clear();
 
     return [...events, this.makeEvent('stream_end', {}), finalEvent];
   }
@@ -914,6 +919,11 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       const suffix = fullContent.slice(streamed.length);
       return suffix || undefined;
     }
+  }
+
+  private clearStreamedBuffers(messageId: string): void {
+    this.streamedTextByMessageId.delete(messageId);
+    this.streamedThinkingByMessageId.delete(messageId);
   }
 
   // ─── Event factories ───

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -288,10 +288,10 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
    * authoritative usage on `message_delta`.
    */
   private currentStreamEventModel: string | undefined;
-  /** message.ids whose text has already been streamed as deltas — skip the full-block emission */
-  private messagesWithStreamedText = new Set<string>();
-  /** message.ids whose thinking has already been streamed as deltas — skip the full-block emission */
-  private messagesWithStreamedThinking = new Set<string>();
+  /** Cumulative text streamed via partial-message deltas, keyed by message.id. */
+  private streamedTextByMessageId = new Map<string, string>();
+  /** Cumulative thinking streamed via partial-message deltas, keyed by message.id. */
+  private streamedThinkingByMessageId = new Map<string, string>();
   /**
    * Cumulative tool_use blocks per message.id. CC streams each tool_use in
    * its OWN assistant event, and the handler's in-memory assistant.tools
@@ -457,18 +457,25 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       }
     }
 
-    // Skip full-block emission when deltas have already been streamed for
-    // this message.id (partial-messages mode). Otherwise the UI would see
-    // the text/thinking twice — once as deltas, once as a giant trailing chunk.
-    const textAlreadyStreamed = !!messageId && this.messagesWithStreamedText.has(messageId);
-    const thinkingAlreadyStreamed = !!messageId && this.messagesWithStreamedThinking.has(messageId);
-    if (textParts.length > 0 && !textAlreadyStreamed) {
-      events.push(this.makeChunkEvent({ chunkType: 'text', content: textParts.join('') }));
+    // Under `--include-partial-messages`, CC may emit deltas first and then a
+    // final full assistant block for the SAME message.id. If the full block is
+    // longer than the streamed deltas, emit only the missing suffix so the
+    // persisted content does not lose the tail of the message.
+    const textCompletion = this.getTrailingCompletion(
+      messageId,
+      textParts.join(''),
+      this.streamedTextByMessageId,
+    );
+    const thinkingCompletion = this.getTrailingCompletion(
+      messageId,
+      reasoningParts.join(''),
+      this.streamedThinkingByMessageId,
+    );
+    if (textCompletion) {
+      events.push(this.makeChunkEvent({ chunkType: 'text', content: textCompletion }));
     }
-    if (reasoningParts.length > 0 && !thinkingAlreadyStreamed) {
-      events.push(
-        this.makeChunkEvent({ chunkType: 'reasoning', reasoning: reasoningParts.join('') }),
-      );
+    if (thinkingCompletion) {
+      events.push(this.makeChunkEvent({ chunkType: 'reasoning', reasoning: thinkingCompletion }));
     }
     events.push(...this.emitToolChunk(newToolCalls, messageId));
 
@@ -809,11 +816,21 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
         if (!delta) return [];
         const msgId = this.currentStreamEventMessageId;
         if (delta.type === 'text_delta' && delta.text) {
-          if (msgId) this.messagesWithStreamedText.add(msgId);
+          if (msgId) {
+            this.streamedTextByMessageId.set(
+              msgId,
+              `${this.streamedTextByMessageId.get(msgId) ?? ''}${delta.text}`,
+            );
+          }
           return [this.makeChunkEvent({ chunkType: 'text', content: delta.text })];
         }
         if (delta.type === 'thinking_delta' && delta.thinking) {
-          if (msgId) this.messagesWithStreamedThinking.add(msgId);
+          if (msgId) {
+            this.streamedThinkingByMessageId.set(
+              msgId,
+              `${this.streamedThinkingByMessageId.get(msgId) ?? ''}${delta.thinking}`,
+            );
+          }
           return [this.makeChunkEvent({ chunkType: 'reasoning', reasoning: delta.thinking })];
         }
         return [];
@@ -879,6 +896,24 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       this.makeEvent('stream_end', {}),
       this.makeEvent('stream_start', { model, newStep: true, provider: 'claude-code' }),
     ];
+  }
+
+  private getTrailingCompletion(
+    messageId: string | undefined,
+    fullContent: string,
+    streamedByMessageId: Map<string, string>,
+  ): string | undefined {
+    if (!fullContent) return;
+    if (!messageId) return fullContent;
+
+    const streamed = streamedByMessageId.get(messageId);
+    if (!streamed) return fullContent;
+    if (fullContent === streamed) return;
+
+    if (fullContent.startsWith(streamed)) {
+      const suffix = fullContent.slice(streamed.length);
+      return suffix || undefined;
+    }
   }
 
   // ─── Event factories ───


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Related to #14631

#### 🔀 Description of Change

This fixes a Claude Code partial-message truncation case on the heterogeneous-agent path.

What was happening:

- In production on 2026-05-13 10:30-10:45 CST, `aiAgent.heteroIngest` was healthy: 499 requests, all `200`.
- `aiAgent.heteroFinish` also completed successfully with `200`.
- Refreshing the topic still showed the last sentence truncated, which ruled out a pure frontend terminal-order issue and strongly suggested the DB had already persisted the shorter content.

Root cause:

- `ClaudeCodeAdapter` treated any message id that had streamed at least one `text_delta` as fully covered by partial messages.
- When the final `assistant` block for the same message id arrived, the adapter suppressed the whole block to avoid duplicate text.
- In traces where the final full block was longer than the streamed deltas, the trailing suffix was never emitted, so persistence only saw the truncated content.

Fix:

- Replace the `messagesWithStreamedText/messagesWithStreamedThinking` boolean sets with cumulative streamed-content maps keyed by `message.id`.
- When the final full assistant block arrives for the same message id:
  - emit nothing if it exactly matches the already streamed delta content;
  - emit only the missing trailing suffix if the final block is longer.

This preserves the original no-duplication behavior while preventing the last few characters from being dropped before DB persistence.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
cd packages/heterogeneous-agents
bunx vitest run --silent='passed-only' 'src/adapters/claudeCode.test.ts' 'src/adapters/claudeCode.e2e.test.ts'
```

Added regression coverage for:

- delta text equals final assistant text -> no duplicate chunk emitted
- delta text is a strict prefix of final assistant text -> only trailing suffix is emitted

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Last sentence could remain truncated even after refresh | Final assistant block backfills only the missing suffix |

#### 📝 Additional Information

This change is intentionally limited to the Claude Code adapter. It does not change the ingest/finish ordering, BatchIngester drain behavior, or Vercel replica persistence logic addressed in the earlier hetero fixes.
