### PR TITLE
fix(desktop): validate skill zipHash to prevent path traversal in cache directory handling

### DIFF
--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -328,9 +328,36 @@ export default class LocalFileCtr extends ControllerModule {
     zipHash,
   }: PrepareSkillDirectoryParams): Promise<PrepareSkillDirectoryResult> {
     const cacheRoot = path.join(this.app.appStoragePath, 'file-storage', 'skills');
-    const extractedDir = path.join(cacheRoot, 'extracted', zipHash);
+
+    // zipHash is used as an on-disk identifier for the cache directory and
+    // archive file. Reject any value that is not a plain hex digest so that
+    // callers cannot smuggle path separators or '..' segments to escape the
+    // cache root and cause arbitrary file deletion / writes via rm() and
+    // writeFile() below. See CWE-22.
+    if (typeof zipHash !== 'string' || !/^[a-f0-9]{8,128}$/i.test(zipHash)) {
+      const error = `Invalid skill zipHash: must be a hex digest`;
+      const extractedDir = path.join(cacheRoot, 'extracted');
+      const zipPath = path.join(cacheRoot, 'archives');
+      return { error, extractedDir, success: false, zipPath };
+    }
+
+    const extractedRoot = path.resolve(cacheRoot, 'extracted');
+    const archivesRoot = path.resolve(cacheRoot, 'archives');
+    const extractedDir = path.resolve(extractedRoot, zipHash);
+    const zipPath = path.resolve(archivesRoot, `${zipHash}.zip`);
+    const extractedRootPrefix = `${extractedRoot}${path.sep}`;
+    const archivesRootPrefix = `${archivesRoot}${path.sep}`;
+
+    if (!extractedDir.startsWith(extractedRootPrefix) || !zipPath.startsWith(archivesRootPrefix)) {
+      return {
+        error: `Invalid skill zipHash: resolved path escapes cache root`,
+        extractedDir,
+        success: false,
+        zipPath,
+      };
+    }
+
     const markerPath = path.join(extractedDir, '.prepared');
-    const zipPath = path.join(cacheRoot, 'archives', `${zipHash}.zip`);
 
     try {
       if (!forceRefresh) {

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
@@ -367,27 +367,51 @@ describe('LocalFileCtr', () => {
 
       const result = await (localFileCtr as any).handlePrepareSkillDirectory({
         url: 'https://example.com/demo-skill.zip',
-        zipHash: 'zip-hash-123',
+        zipHash: 'a'.repeat(64),
       });
 
       expect(result).toEqual({
-        extractedDir: '/mock/app/storage/file-storage/skills/extracted/zip-hash-123',
+        extractedDir: `/mock/app/storage/file-storage/skills/extracted/${'a'.repeat(64)}`,
         success: true,
-        zipPath: '/mock/app/storage/file-storage/skills/archives/zip-hash-123.zip',
+        zipPath: `/mock/app/storage/file-storage/skills/archives/${'a'.repeat(64)}.zip`,
       });
       expect(fetchMock).toHaveBeenCalledWith('https://example.com/demo-skill.zip');
       expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
-        '/mock/app/storage/file-storage/skills/archives/zip-hash-123.zip',
+        `/mock/app/storage/file-storage/skills/archives/${'a'.repeat(64)}.zip`,
         expect.any(Buffer),
       );
       expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
-        '/mock/app/storage/file-storage/skills/extracted/zip-hash-123/SKILL.md',
+        `/mock/app/storage/file-storage/skills/extracted/${'a'.repeat(64)}/SKILL.md`,
         expect.any(Buffer),
       );
       expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
-        '/mock/app/storage/file-storage/skills/extracted/zip-hash-123/docs/reference.txt',
+        `/mock/app/storage/file-storage/skills/extracted/${'a'.repeat(64)}/docs/reference.txt`,
         expect.any(Buffer),
       );
+    });
+
+    it('should reject zipHash with path traversal segments', async () => {
+      const result = await (localFileCtr as any).handlePrepareSkillDirectory({
+        url: 'https://example.com/demo-skill.zip',
+        zipHash: '../../etc/passwd',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid skill zipHash/);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockFsPromises.rm).not.toHaveBeenCalled();
+      expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject zipHash containing path separators', async () => {
+      const result = await (localFileCtr as any).handlePrepareSkillDirectory({
+        url: 'https://example.com/demo-skill.zip',
+        zipHash: 'abcd/../../evil',
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockFsPromises.rm).not.toHaveBeenCalled();
+      expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
     });
 
     it('should reuse the cached extracted directory when it is already prepared', async () => {
@@ -395,13 +419,13 @@ describe('LocalFileCtr', () => {
 
       const result = await (localFileCtr as any).handlePrepareSkillDirectory({
         url: 'https://example.com/demo-skill.zip',
-        zipHash: 'zip-hash-123',
+        zipHash: 'a'.repeat(64),
       });
 
       expect(result).toEqual({
-        extractedDir: '/mock/app/storage/file-storage/skills/extracted/zip-hash-123',
+        extractedDir: `/mock/app/storage/file-storage/skills/extracted/${'a'.repeat(64)}`,
         success: true,
-        zipPath: '/mock/app/storage/file-storage/skills/archives/zip-hash-123.zip',
+        zipPath: `/mock/app/storage/file-storage/skills/archives/${'a'.repeat(64)}.zip`,
       });
       expect(fetchMock).not.toHaveBeenCalled();
       expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
@@ -415,11 +439,11 @@ describe('LocalFileCtr', () => {
       const result = await (localFileCtr as any).handleResolveSkillResourcePath({
         path: 'docs/reference.txt',
         url: 'https://example.com/demo-skill.zip',
-        zipHash: 'zip-hash-123',
+        zipHash: 'a'.repeat(64),
       });
 
       expect(result).toEqual({
-        fullPath: '/mock/app/storage/file-storage/skills/extracted/zip-hash-123/docs/reference.txt',
+        fullPath: `/mock/app/storage/file-storage/skills/extracted/${'a'.repeat(64)}/docs/reference.txt`,
         success: true,
       });
       expect(fetchMock).not.toHaveBeenCalled();
@@ -431,7 +455,7 @@ describe('LocalFileCtr', () => {
       const result = await (localFileCtr as any).handleResolveSkillResourcePath({
         path: '../secrets.txt',
         url: 'https://example.com/demo-skill.zip',
-        zipHash: 'zip-hash-123',
+        zipHash: 'a'.repeat(64),
       });
 
       expect(result).toEqual({


### PR DESCRIPTION
## Summary

This PR fixes a path traversal vulnerability (CWE-22) in the desktop app's `LocalFileCtr.handlePrepareSkillDirectory` method.

## Vulnerability

The `zipHash` parameter in `handlePrepareSkillDirectory` is received via IPC (`@IpcMethod`) and used directly in `path.join()` to construct file paths for the skill cache directory. Because no validation is performed on `zipHash`, a value like `../../etc` would cause:

- **Arbitrary directory deletion** via `rm(extractedDir, { force: true, recursive: true })`
- **Arbitrary file writes** via `writeFile()` to attacker-controlled paths

The data flow is: renderer process → IPC → `zipHash` parameter → `path.join(cacheRoot, "extracted", zipHash)` → `rm()` / `writeFile()`.

**Precondition:** A compromised renderer process (e.g., via XSS in rendered chat content). Since the desktop app runs with `sandbox: false`, IPC methods are directly accessible from the renderer.

Before submitting, we verified that no existing validation or sanitization exists on the `zipHash` parameter between the IPC boundary and the filesystem operations. The `sandbox: false` configuration means standard Electron sandboxing does not prevent a compromised renderer from invoking this IPC method with arbitrary arguments.

## Fix

Two layers of defense:

1. **Input validation:** Reject any `zipHash` that is not a hex digest (`/^[a-f0-9]{8,128}$/i`). Since `zipHash` represents a hash of the zip archive, only hex characters are valid.

2. **Path prefix check:** After `path.resolve()`, verify that the resulting `extractedDir` and `zipPath` still fall within their expected parent directories. This guards against any edge cases the regex might miss.

Both checks return an error result with `success: false` instead of throwing, consistent with the existing error handling pattern in this method.

## Tests

- Updated existing tests to use valid hex hashes instead of `zip-hash-123`
- Added two new test cases:
  - `should reject zipHash with path traversal segments` — verifies `../../etc/passwd` is rejected
  - `should reject zipHash containing path separators` — verifies `abcd/../../evil` is rejected
- Both tests confirm that `rm()` and `writeFile()` are never called when validation fails

**File:** `apps/desktop/src/main/controllers/LocalFileCtr.ts` (31 lines added)
**Tests:** `apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts` (updated + 2 new cases)