### PR TITLE
🐛 fix(conversation): refine workflow collapse rendering

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import ContentBlocksScroll from './ContentBlocksScroll';
@@ -10,11 +10,28 @@ import type { RenderableAssistantContentBlock } from './types';
 
 vi.mock('@lobehub/ui', () => ({
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  ScrollArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ScrollArea: ({
+    children,
+    contentProps,
+    scrollbarProps,
+  }: {
+    children?: ReactNode;
+    contentProps?: { style?: CSSProperties };
+    scrollbarProps?: { style?: CSSProperties };
+  }) => (
+    <div
+      data-content-style={JSON.stringify(contentProps?.style ?? {})}
+      data-scrollbar-style={JSON.stringify(scrollbarProps?.style ?? {})}
+      data-testid="scroll-area"
+    >
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock('antd-style', () => ({
   createStaticStyles: () => ({
+    scrollRoot: 'scroll-root',
     scrollTask: 'scroll-task',
     scrollWorkflow: 'scroll-workflow',
   }),
@@ -61,5 +78,27 @@ describe('ContentBlocksScroll', () => {
       'data-disable-markdown-streaming',
       'true',
     );
+  });
+
+  it('reserves content space for the vertical scrollbar', () => {
+    render(
+      <ContentBlocksScroll
+        assistantId="assistant-1"
+        blocks={[{ content: 'workflow block', id: 'block-2' }]}
+        variant="workflow"
+      />,
+    );
+
+    expect(
+      JSON.parse(screen.getByTestId('scroll-area').dataset.contentStyle || '{}'),
+    ).toMatchObject({
+      paddingInlineEnd: 16,
+    });
+    expect(
+      JSON.parse(screen.getByTestId('scroll-area').dataset.scrollbarStyle || '{}'),
+    ).toMatchObject({
+      marginInlineEnd: 2,
+      marginInlineStart: 0,
+    });
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -3,7 +3,7 @@
 import type { UIChatMessage } from '@lobechat/types';
 import { Flexbox, ScrollArea } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import type { RefObject } from 'react';
+import type { CSSProperties, RefObject } from 'react';
 import { memo, useMemo } from 'react';
 
 import { resolveAssistantGroupFromMessages } from '../utils/resolveAssistantGroupFromMessages';
@@ -22,6 +22,21 @@ const styles = createStaticStyles(({ css }) => ({
     max-height: min(40vh, 320px);
   `,
 }));
+
+const SCROLL_CONTENT_STYLE = {
+  color: 'inherit',
+  display: 'block',
+  fontSize: 'inherit',
+  gap: 0,
+  lineHeight: 'inherit',
+  paddingInlineEnd: 16,
+} satisfies CSSProperties;
+
+const SCROLLBAR_STYLE = {
+  marginBlock: 8,
+  marginInlineEnd: 2,
+  marginInlineStart: 0,
+} satisfies CSSProperties;
 
 interface ContentBlocksScrollBaseProps {
   disableEditing?: boolean;
@@ -92,15 +107,8 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
     <ScrollArea
       scrollFade
       className={styles.scrollRoot}
-      contentProps={{
-        style: {
-          color: 'inherit',
-          display: 'block',
-          fontSize: 'inherit',
-          gap: 0,
-          lineHeight: 'inherit',
-        },
-      }}
+      contentProps={{ style: SCROLL_CONTENT_STYLE }}
+      scrollbarProps={{ style: SCROLLBAR_STYLE }}
       viewportProps={{
         className: scrollClass,
         ref: scrollRef as RefObject<HTMLDivElement>,

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -44,6 +44,7 @@ vi.mock('./WorkflowCollapse', () => ({
       contentOverride?: string;
       disableMarkdownStreaming?: boolean;
       domId?: string;
+      error?: unknown;
       hasToolsOverride?: boolean;
       tools?: unknown[];
     }>;
@@ -57,6 +58,7 @@ vi.mock('./WorkflowCollapse', () => ({
             contentOverride,
             disableMarkdownStreaming,
             domId,
+            error,
             hasToolsOverride,
             tools,
           }) => ({
@@ -64,6 +66,7 @@ vi.mock('./WorkflowCollapse', () => ({
             contentOverride,
             disableMarkdownStreaming: !!disableMarkdownStreaming,
             domId,
+            hasError: !!error,
             hasToolsOverride,
             toolCount: tools?.length ?? 0,
           }),
@@ -79,6 +82,7 @@ vi.mock('./GroupItem', () => ({
     contentOverride,
     disableMarkdownStreaming,
     domId,
+    error,
     hasToolsOverride,
     id,
     isFirstBlock,
@@ -88,6 +92,7 @@ vi.mock('./GroupItem', () => ({
     contentOverride?: string;
     disableMarkdownStreaming?: boolean;
     domId?: string;
+    error?: unknown;
     hasToolsOverride?: boolean;
     id: string;
     isFirstBlock?: boolean;
@@ -100,6 +105,7 @@ vi.mock('./GroupItem', () => ({
         contentOverride,
         disableMarkdownStreaming: !!disableMarkdownStreaming,
         domId,
+        hasError: !!error,
         hasToolsOverride,
         id,
         isFirstBlock: !!isFirstBlock,
@@ -159,6 +165,7 @@ describe('Group', () => {
         contentOverride: longContent,
         disableMarkdownStreaming: true,
         domId: 'block-1__answer',
+        hasError: false,
         hasToolsOverride: false,
         id: 'block-1',
         isFirstBlock: false,
@@ -169,6 +176,7 @@ describe('Group', () => {
         contentOverride: '',
         disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
+        hasError: false,
         hasToolsOverride: true,
         id: 'block-1',
         isFirstBlock: false,
@@ -198,6 +206,7 @@ describe('Group', () => {
         content: '现在我来搜索资料。',
         disableMarkdownStreaming: true,
         domId: undefined,
+        hasError: false,
         id: 'block-1',
         isFirstBlock: false,
         toolCount: 1,
@@ -235,6 +244,7 @@ describe('Group', () => {
       contentOverride: '我先帮你查一下。',
       disableMarkdownStreaming: true,
       domId: 'block-1__answer',
+      hasError: false,
       hasToolsOverride: false,
       id: 'block-1',
       isFirstBlock: false,
@@ -246,6 +256,7 @@ describe('Group', () => {
         contentOverride: '接下来我会继续整理结果。',
         disableMarkdownStreaming: true,
         domId: 'block-1__workflow',
+        hasError: false,
         hasToolsOverride: true,
         toolCount: 1,
       },
@@ -253,9 +264,62 @@ describe('Group', () => {
         content: '',
         disableMarkdownStreaming: false,
         domId: undefined,
+        hasError: false,
         toolCount: 1,
       },
     ]);
+  });
+
+  it('keeps assistant runtime errors outside the workflow collapse', () => {
+    const { container } = render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            error: {
+              body: { code: 'rate_limit' },
+              message: 'rate limit',
+              type: 'ProviderBizError',
+            } as any,
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1' } as any,
+              { apiName: 'bash', id: 'tool-2' } as any,
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const sequence = Array.from(container.querySelectorAll('[data-testid]')).map((node) =>
+      node.getAttribute('data-testid'),
+    );
+
+    expect(sequence).toEqual(['workflow-segment', 'answer-segment']);
+    expect(parseWorkflowSegment()).toEqual([
+      {
+        content: '',
+        contentOverride: '',
+        disableMarkdownStreaming: true,
+        domId: 'block-1__workflow',
+        hasError: false,
+        hasToolsOverride: true,
+        toolCount: 2,
+      },
+    ]);
+    expect(parseAnswerSegment()).toEqual({
+      content: '',
+      contentOverride: '',
+      disableMarkdownStreaming: true,
+      domId: 'block-1__answer',
+      hasError: true,
+      hasToolsOverride: false,
+      id: 'block-1',
+      isFirstBlock: false,
+      toolCount: 0,
+    });
   });
 
   it('renders a single tool call inline instead of folding it', () => {
@@ -279,6 +343,7 @@ describe('Group', () => {
         content: '',
         disableMarkdownStreaming: true,
         domId: undefined,
+        hasError: false,
         id: 'block-1',
         isFirstBlock: false,
         toolCount: 1,

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -209,6 +209,31 @@ const appendWorkflowRangeBlock = (
   block: AssistantContentBlock,
   allowLeadingSentencePromotion = false,
 ) => {
+  if (block.error) {
+    if (hasTools(block)) {
+      appendWorkflowBlock(
+        segments,
+        createWorkflowRenderBlock(block, {
+          content: '',
+          error: undefined,
+          imageList: undefined,
+          reasoning: undefined,
+        }),
+      );
+      appendAnswerBlock(
+        segments,
+        createAnswerRenderBlock(block, {
+          reasoning: undefined,
+          tools: undefined,
+        }),
+      );
+      return;
+    }
+
+    appendAnswerBlock(segments, block);
+    return;
+  }
+
   if (!shouldPromoteMixedBlockContent(block)) {
     const leadingSentenceSplit =
       allowLeadingSentencePromotion && segments.length === 0 && hasTools(block)


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Keep assistant runtime error panels outside the workflow collapse so failures remain visible in the message stream.
- Preserve tool-call rendering inside the workflow collapse when the same assistant block also contains tool calls.
- Reserve right-side content space inside the workflow `ScrollArea` content layer so the Base UI vertical scrollbar does not overlap rendered workflow content.
- Adjust the scrollbar inline margins to keep the scrollbar visually outside the content column.
- Add regression assertions for both workflow error partitioning and workflow scroll spacing.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx' 'src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx'
git diff --check
bunx prettier --check 'src/features/Conversation/Messages/AssistantGroup/components/Group.tsx' 'src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx' 'src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx' 'src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx'
```

#### 📸 Screenshots / Videos

The screenshots below are local mock renderings that use the same message shape to isolate the workflow partitioning behavior.

| Before | After |
| ------ | ----- |
| ![Before fix: error panel is folded into workflow](https://gist.githubusercontent.com/Innei/beec65e49de024383661812261d63935/raw/3d072e7b19746c06804d660450eb426c21f2378b/workflow-error-before.svg) | ![After fix: error panel stays visible outside workflow](https://gist.githubusercontent.com/Innei/beec65e49de024383661812261d63935/raw/936bebf57a85c2fe642eb0da8a3609a891379ebe/workflow-error-after.svg) |

#### 📝 Additional Information

The workflow viewport remains responsible for height constraints and scroll events. The content layer now owns the right-side spacing reservation.