### PR TITLE
🐛 fix(onboarding): hide ModeSwitch in production environment

### DIFF
--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -273,9 +273,9 @@ const AgentOnboardingPage = memo(() => {
           </Drawer>
         )}
       </Flexbox>
-      <ModeSwitch
-        actions={
-          isDev ? (
+      {isDev && (
+        <ModeSwitch
+          actions={
             <>
               <AgentOnboardingDebugExportButton
                 agentId={onboardingAgentId}
@@ -294,9 +294,9 @@ const AgentOnboardingPage = memo(() => {
                 {t('agent.modeSwitch.reset')}
               </Button>
             </>
-          ) : undefined
-        }
-      />
+          }
+        />
+      )}
     </OnboardingContainer>
   );
 });


### PR DESCRIPTION
## 💥 Summary

Hide the `ModeSwitch` component in production environments on the Agent onboarding page.

## 🧑‍💻 Change Type

- [x] 🐛 fix: Bug fix (non-breaking change which fixes an issue)

## 👨‍🎓 Description of Change

The cloud repo overrides `AGENT_ONBOARDING_ENABLED = true` (from `@cloud/business-const`), bypassing the `isDev` guard inside `ModeSwitch`. This caused the mode segmented control to render in production on the agent onboarding page, even though its dev-only actions were suppressed.

Wrap the entire `<ModeSwitch>` with `isDev` so neither the segmented control nor any dev actions appear in production.

## ✅ How to Test

- [x] Works on dev (`isDev` is true → ModeSwitch renders with dev actions)
- [x] In production build, ModeSwitch is completely absent from the DOM