### PR TITLE
💄 fix(nav-panel): polish SideBarDrawer & header layout details

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/TasksGroupConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskList/TasksGroupConfig.tsx
@@ -12,7 +12,7 @@ import {
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useTaskStore } from '@/store/task';
 import { taskListSelectors } from '@/store/task/selectors';
 
@@ -196,7 +196,7 @@ const TasksGroupConfig = memo<TasksHeaderProps>(({ options, setOptions }) => {
       trigger={['click']}
       onOpenChange={setIsViewConfigOpen}
     >
-      <ActionIcon icon={Settings2Icon} size={DESKTOP_HEADER_ICON_SIZE} />
+      <ActionIcon icon={Settings2Icon} size={DESKTOP_HEADER_ICON_SMALL_SIZE} />
     </Popover>
   );
 });

--- a/src/features/NavPanel/SideBarDrawer.tsx
+++ b/src/features/NavPanel/SideBarDrawer.tsx
@@ -7,7 +7,7 @@ import { XIcon } from 'lucide-react';
 import type { ReactNode, Ref } from 'react';
 import { cloneElement, isValidElement, memo, Suspense, useCallback, useState } from 'react';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 
 import { NAV_PANEL_RIGHT_DRAWER_ID } from './';
 import SkeletonList from './components/SkeletonList';
@@ -116,7 +116,12 @@ const SideBarDrawer = memo<SideBarDrawerProps>(
                 right={
                   <>
                     {action}
-                    <ActionIcon icon={XIcon} size={DESKTOP_HEADER_ICON_SIZE} onClick={onClose} />
+                    <ActionIcon
+                      icon={XIcon}
+                      size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+                      style={{ marginInlineEnd: -2 }}
+                      onClick={onClose}
+                    />
                   </>
                 }
               />

--- a/src/features/NavPanel/SideBarHeaderLayout.tsx
+++ b/src/features/NavPanel/SideBarHeaderLayout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { ActionIconProps } from '@lobehub/ui';
 import { Flexbox, Icon, Text } from '@lobehub/ui';
 import type { BreadcrumbProps } from 'antd';
 import { Breadcrumb } from 'antd';
@@ -12,14 +11,12 @@ import { flushSync } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
-import { isDesktop } from '@/const/version';
 import { isModifierClick } from '@/utils/navigation';
 
 import BackButton from './components/BackButton';
 import ToggleLeftPanelButton from './ToggleLeftPanelButton';
 
 const prefixCls = 'ant';
-const SIDEBAR_HEADER_ACTION_ICON_SIZE: ActionIconProps['size'] = 'small';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   breadcrumb: css`
@@ -43,7 +40,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   container: css`
     overflow: hidden;
-    margin-block-start: ${isDesktop ? '' : '8px'};
   `,
 }));
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -159,7 +159,7 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
       onScroll={handleScroll}
     >
       {activeTopicList?.map((topic) => (
-        <Flexbox gap={1} key={topic.id} padding={'4px 8px'}>
+        <Flexbox gap={1} key={topic.id} paddingInline={4}>
           <TopicItem
             active={activeTopicId === topic.id}
             fav={topic.favorite}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -13,7 +13,7 @@ import { topicSelectors } from '@/store/chat/selectors';
 
 import TopicItem from '../List/Item';
 
-const ITEM_HEIGHT = 44; // Each topic item height
+const ITEM_HEIGHT = 36; // Each topic item height (NavItem height, no vertical padding)
 
 interface ContentProps {
   open: boolean;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- No related issue -->

#### 🔀 Description of Change

Minor UI polish for the `SideBarDrawer` component and related nav-panel layout:

- **SideBarDrawer close button**: Switch from `DESKTOP_HEADER_ICON_SIZE` to `DESKTOP_HEADER_ICON_SMALL_SIZE` to match the header action icon convention; add slight margin adjustment for visual alignment.
- **TasksGroupConfig settings icon**: Same icon size correction (`SMALL`) for consistency inside the drawer header.
- **SideBarHeaderLayout**: Remove unused imports (`ActionIconProps`, `isDesktop`) and dead code (`SIDEBAR_HEADER_ACTION_ICON_SIZE`, the mobile `margin-block-start` override that is no longer needed).
- **AllTopicsDrawer Content**: Fix topic item padding from shorthand `4px 8px` to `paddingInline={4}` for consistent inline padding.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Visual-only changes; verify icon sizing and spacing in SideBarDrawer header across AllTopics, AllAgents, AllRecents, AllPages, and Inbox drawers.

#### 📸 Screenshots / Videos

<!-- UI changes are minor icon/spacing adjustments -->

#### 📝 Additional Information

Preparatory cleanup before a larger refactor to internalize drawer open/close state.