### PR TITLE
✨ feat(chat): add Onboarding request trigger and pass via metadata

### DIFF
--- a/locales/en-US/spend.json
+++ b/locales/en-US/spend.json
@@ -21,6 +21,7 @@
   "table.columns.trigger.enums.file_embedding": "File Embedding",
   "table.columns.trigger.enums.image": "Image Generation",
   "table.columns.trigger.enums.memory": "Memory Extraction",
+  "table.columns.trigger.enums.onboarding": "Onboarding",
   "table.columns.trigger.enums.semantic_search": "Knowledge Search",
   "table.columns.trigger.enums.topic": "Topic Summary",
   "table.columns.trigger.enums.video": "Video Generation",

--- a/locales/zh-CN/spend.json
+++ b/locales/zh-CN/spend.json
@@ -21,6 +21,7 @@
   "table.columns.trigger.enums.file_embedding": "文件嵌入",
   "table.columns.trigger.enums.image": "图像生成",
   "table.columns.trigger.enums.memory": "记忆提取",
+  "table.columns.trigger.enums.onboarding": "引导流程",
   "table.columns.trigger.enums.semantic_search": "知识搜索",
   "table.columns.trigger.enums.topic": "话题总结",
   "table.columns.trigger.enums.video": "视频生成",

--- a/packages/builtin-agents/package.json
+++ b/packages/builtin-agents/package.json
@@ -2,7 +2,14 @@
   "name": "@lobechat/builtin-agents",
   "version": "1.0.0",
   "private": true,
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "dependencies": {
     "@lobechat/builtin-tool-agent-builder": "workspace:*",
     "@lobechat/builtin-tool-agent-documents": "workspace:*",

--- a/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
@@ -322,7 +322,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       onMessageHandle: (chunk) => {
         if (chunk.type === 'text') content += chunk.text || '';
       },
-      requestTrigger: RequestTrigger.VisualAnalysis,
+      metadata: { trigger: RequestTrigger.VisualAnalysis },
       signal: abortController.signal,
     });
 

--- a/packages/const/src/fetch.ts
+++ b/packages/const/src/fetch.ts
@@ -8,6 +8,8 @@ export const AZURE_OPENAI_API_VERSION = 'X-azure-openai-api-version';
 
 export const OAUTH_AUTHORIZED = 'X-oauth-authorized';
 export const REQUEST_TRIGGER_HEADER = 'x-lobechat-request-trigger';
+export const REQUEST_AGENT_ID_HEADER = 'x-agent-id';
+export const REQUEST_TOPIC_ID_HEADER = 'x-topic-id';
 
 /**
  * @deprecated

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -10,6 +10,7 @@ export enum RequestTrigger {
   Image = 'image',
   Memory = 'memory',
   Notify = 'notify',
+  Onboarding = 'onboarding',
   Openapi = 'openapi',
   SemanticSearch = 'semantic_search',
   Topic = 'topic',

--- a/packages/types/src/message/common/metadata.test.ts
+++ b/packages/types/src/message/common/metadata.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { RequestTrigger } from '../../agentRuntime';
+import { MessageMetadataSchema } from './metadata';
+
+describe('MessageMetadataSchema', () => {
+  it('preserves request trigger metadata during runtime parsing', () => {
+    const parsed = MessageMetadataSchema.parse({
+      trigger: RequestTrigger.Onboarding,
+      unknown: 'stripped',
+    });
+
+    expect(parsed).toEqual({ trigger: RequestTrigger.Onboarding });
+  });
+});

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import type { RequestTrigger } from '../../agentRuntime';
 import type { PageSelection } from './pageSelection';
 import { PageSelectionSchema } from './pageSelection';
 
@@ -330,6 +331,10 @@ export interface MessageMetadata {
   totalTokens?: number;
   /** @deprecated use `metadata.performance` instead */
   tps?: number;
+  /**
+   * Request source used by runtime routing, billing, and logs.
+   */
+  trigger?: RequestTrigger;
   /** @deprecated use `metadata.performance` instead */
   ttft?: number;
   usage?: ModelUsage;

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { RequestTrigger } from '../../agentRuntime';
+import { RequestTrigger } from '../../agentRuntime';
 import type { PageSelection } from './pageSelection';
 import { PageSelectionSchema } from './pageSelection';
 
@@ -175,6 +175,7 @@ export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSche
   scope: z.string().optional(),
   subAgentId: z.string().optional(),
   toolExecutionTimeMs: z.number().optional(),
+  trigger: z.nativeEnum(RequestTrigger).optional(),
   usage: ModelUsageSchema.optional(),
 });
 

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -3,6 +3,8 @@
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
 import { setAgentTemplatesFetcher } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
 import { SESSION_CHAT_TOPIC_URL } from '@lobechat/const';
+import type { SendMessageParams } from '@lobechat/types';
+import { RequestTrigger } from '@lobechat/types';
 import { Button, ErrorBoundary, Flexbox } from '@lobehub/ui';
 import { Drawer } from 'antd';
 import { History } from 'lucide-react';
@@ -129,7 +131,9 @@ const AgentOnboardingPage = memo(() => {
   const { onBeforeSendMessage, triggerExtract } = onboardingFollowUp;
 
   const composedOnBeforeSendMessage = useCallback(
-    async (params: { messages?: any }) => {
+    async (params: SendMessageParams) => {
+      params.metadata = { ...params.metadata, trigger: RequestTrigger.Onboarding };
+
       const welcomeContent = t('agent.welcome');
       await onBeforeSendMessage();
 

--- a/src/locales/default/spend.ts
+++ b/src/locales/default/spend.ts
@@ -23,6 +23,7 @@ export default {
   'table.columns.trigger.enums.image': 'Image Generation',
   'table.columns.trigger.enums.memory': 'Memory Extraction',
   'table.columns.trigger.enums.notify': 'Notification',
+  'table.columns.trigger.enums.onboarding': 'Onboarding',
   'table.columns.trigger.enums.openapi': 'OpenAPI',
   'table.columns.trigger.enums.semantic_search': 'Knowledge Search',
   'table.columns.trigger.enums.topic': 'Topic Summary',

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -1705,7 +1705,7 @@ describe('ChatService', () => {
       };
 
       await chatService.getChatCompletion(params, {
-        requestTrigger: RequestTrigger.VisualAnalysis,
+        metadata: { trigger: RequestTrigger.VisualAnalysis },
       });
 
       expect(mockFetchSSE).toHaveBeenCalledWith(
@@ -1719,6 +1719,7 @@ describe('ChatService', () => {
 
       const payload = JSON.parse(mockFetchSSE.mock.calls[0][1].body);
       expect(payload).not.toHaveProperty('requestTrigger');
+      expect(payload).not.toHaveProperty('metadata');
     });
 
     it('should make a POST request with chatCompletion apiMode in non-openai provider payload', async () => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -103,6 +103,7 @@ interface CreateAssistantMessageStream extends FetchSSEOptions {
   historySummary?: string;
   /** Initial context for page editor (captured at operation start) */
   initialContext?: RuntimeInitialContext;
+  metadata?: FetchOptions['metadata'];
   params: GetChatCompletionPayload;
   /** Step context for page editor (updated each step) */
   stepContext?: RuntimeStepContext;
@@ -332,6 +333,7 @@ class ChatService {
     onMessageHandle,
     onErrorHandle,
     onFinish,
+    metadata,
     trace,
     historySummary,
     initialContext,
@@ -344,6 +346,7 @@ class ChatService {
       onErrorHandle,
       onFinish,
       onMessageHandle,
+      metadata,
       signal: abortController?.signal,
       stepContext,
       trace: this.mapTrace(trace, TraceTagMap.Chat),
@@ -351,7 +354,8 @@ class ChatService {
   };
 
   getChatCompletion = async (params: Partial<ChatStreamPayload>, options?: FetchOptions) => {
-    const { agentId, requestTrigger, signal, responseAnimation, topicId } = options ?? {};
+    const { agentId, metadata, signal, responseAnimation, topicId } = options ?? {};
+    const requestTrigger = metadata?.trigger;
 
     const { provider = ModelProvider.OpenAI, ...res } = params;
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -2,6 +2,8 @@ import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import {
   KLAVIS_SERVER_TYPES,
   LOBEHUB_SKILL_PROVIDERS,
+  REQUEST_AGENT_ID_HEADER,
+  REQUEST_TOPIC_ID_HEADER,
   REQUEST_TRIGGER_HEADER,
 } from '@lobechat/const';
 import { type OfficialToolItem } from '@lobechat/context-engine';
@@ -452,9 +454,9 @@ class ChatService {
       headers: {
         'Content-Type': 'application/json',
         ...traceHeader,
-        ...(agentId && { 'x-agent-id': agentId }),
+        ...(agentId && { [REQUEST_AGENT_ID_HEADER]: agentId }),
         ...(requestTrigger && { [REQUEST_TRIGGER_HEADER]: requestTrigger }),
-        ...(topicId && { 'x-topic-id': topicId }),
+        ...(topicId && { [REQUEST_TOPIC_ID_HEADER]: topicId }),
       },
       provider,
     });

--- a/src/services/chat/types.ts
+++ b/src/services/chat/types.ts
@@ -6,12 +6,16 @@ import type {
   TracePayload,
 } from '@lobechat/types';
 
+interface ChatRequestMetadata extends Record<string, unknown> {
+  trigger?: RequestTrigger;
+}
+
 export interface FetchOptions extends FetchSSEOptions {
   agentId?: string;
   historySummary?: string;
   /** Initial context for page editor (captured at operation start) */
   initialContext?: RuntimeInitialContext;
-  requestTrigger?: RequestTrigger;
+  metadata?: ChatRequestMetadata;
   signal?: AbortSignal | undefined;
   /** Step context for page editor (updated each step) */
   stepContext?: RuntimeStepContext;

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1,6 +1,7 @@
 import { type GeneralAgentCallLLMResultPayload } from '@lobechat/agent-runtime';
 import { LOADING_FLAT } from '@lobechat/const';
-import { type MessageToolCall } from '@lobechat/types';
+import type { MessageToolCall } from '@lobechat/types';
+import { RequestTrigger } from '@lobechat/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { chatService } from '@/services/chat';
@@ -165,6 +166,33 @@ describe('call_llm executor', () => {
             model: 'gpt-4',
             provider: 'openai',
           }),
+        }),
+      );
+    });
+
+    it('should forward request metadata to chatService', async () => {
+      const mockStore = createMockStore();
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction({
+        messages: [createUserMessage({ content: 'Hello' })],
+      });
+      const state = createInitialState();
+
+      mockStreamResponse({ content: 'AI response' });
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        metadata: { trigger: RequestTrigger.Onboarding },
+        state,
+        mockStore,
+        context,
+      });
+
+      expect(chatService.createAssistantMessageStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { trigger: RequestTrigger.Onboarding },
         }),
       );
     });

--- a/src/store/chat/agents/__tests__/createAgentExecutors/helpers/testExecutor.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/helpers/testExecutor.ts
@@ -1,5 +1,5 @@
 import type { AgentInstruction, AgentState } from '@lobechat/agent-runtime';
-import type { MessageMapScope } from '@lobechat/types';
+import type { MessageMapScope, MessageMetadata } from '@lobechat/types';
 
 import { DEFAULT_AGENT_CHAT_CONFIG, DEFAULT_AGENT_CONFIG } from '@/const/settings';
 import { type ResolvedAgentConfig } from '@/services/chat/mecha';
@@ -35,6 +35,7 @@ export const executeWithMockContext = async ({
   state,
   mockStore,
   context,
+  metadata,
   skipCreateFirstMessage = false,
 }: {
   context: {
@@ -48,6 +49,7 @@ export const executeWithMockContext = async ({
     topicId?: string | null;
   };
   executor: AgentInstruction['type'];
+  metadata?: Pick<MessageMetadata, 'trigger'>;
   instruction: AgentInstruction;
   mockStore: ChatStore;
   skipCreateFirstMessage?: boolean;
@@ -77,6 +79,7 @@ export const executeWithMockContext = async ({
   const executors = createAgentExecutors({
     agentConfig: createMockResolvedAgentConfig(),
     get: () => mockStore,
+    metadata,
     messageKey: context.messageKey,
     operationId: context.operationId,
     parentId: context.parentId,

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -27,6 +27,7 @@ import {
   type ChatToolPayload,
   type ConversationContext,
   type CreateMessageParams,
+  type MessageMetadata,
   type MessageToolCall,
   type ModelUsage,
   TraceNameMap,
@@ -147,6 +148,7 @@ export const createAgentExecutors = (context: {
   /** Pre-resolved agent config with isSubAgent filtering applied */
   agentConfig: ResolvedAgentConfig;
   get: () => ChatStore;
+  metadata?: Pick<MessageMetadata, 'trigger'>;
   messageKey: string;
   operationId: string;
   parentId: string;
@@ -477,6 +479,7 @@ export const createAgentExecutors = (context: {
           ...agentConfigData.params,
         },
         initialContext: runtimeContext?.initialContext,
+        metadata: context.metadata,
         stepContext: runtimeContext?.stepContext,
         trace: {
           traceId,

--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
@@ -1,4 +1,4 @@
-import { type ConversationContext } from '@lobechat/types';
+import { type ConversationContext, RequestTrigger } from '@lobechat/types';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -1071,6 +1071,11 @@ describe('ConversationControl actions', () => {
         tone: 'Professional',
       };
 
+      const onboardingUserMessage = createMockMessage({
+        id: 'onboarding-user-msg',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      });
       const toolMessage = createMockMessage({
         groupId: 'group-1',
         id: 'tool-msg-1',
@@ -1089,10 +1094,10 @@ describe('ConversationControl actions', () => {
           activeTopicId: topicId,
           activeThreadId: undefined,
           dbMessagesMap: {
-            [chatKey]: [toolMessage],
+            [chatKey]: [onboardingUserMessage, toolMessage],
           },
           messagesMap: {
-            [chatKey]: [toolMessage],
+            [chatKey]: [onboardingUserMessage, toolMessage],
           },
         });
       });
@@ -1114,14 +1119,14 @@ describe('ConversationControl actions', () => {
 
           useChatStore.setState({
             dbMessagesMap: {
-              [chatKey]: [toolMessage, userMessage],
+              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
             },
             messagesMap: {
-              [chatKey]: [toolMessage, userMessage],
+              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
             },
           });
 
-          return { id: userMessageId, messages: [toolMessage, userMessage] };
+          return { id: userMessageId, messages: [onboardingUserMessage, toolMessage, userMessage] };
         });
 
       const initialContext = { phase: 'init' } as any;
@@ -1162,8 +1167,84 @@ describe('ConversationControl actions', () => {
       expect(executeClientAgentSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           initialContext,
+          metadata: { trigger: RequestTrigger.Onboarding },
           parentMessageId: userMessageId,
           parentMessageType: 'user',
+        }),
+      );
+    });
+
+    it('should preserve request trigger metadata when resuming from tool result only', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const agentId = 'global-agent';
+      const topicId = 'global-topic';
+      const chatKey = messageMapKey({ agentId, topicId });
+      const response = {
+        templateId: 'onboarding-template',
+      };
+
+      const onboardingUserMessage = createMockMessage({
+        id: 'onboarding-user-msg',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      });
+      const toolMessage = createMockMessage({
+        groupId: 'group-1',
+        id: 'tool-msg-1',
+        plugin: {
+          apiName: 'selectAgentTemplate',
+          arguments: '{}',
+          identifier: 'lobe-agent-marketplace',
+          type: 'default',
+        },
+        role: 'tool',
+      });
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          activeTopicId: topicId,
+          activeThreadId: undefined,
+          dbMessagesMap: {
+            [chatKey]: [onboardingUserMessage, toolMessage],
+          },
+          messagesMap: {
+            [chatKey]: [onboardingUserMessage, toolMessage],
+          },
+        });
+      });
+
+      vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticUpdateMessageContent').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticCreateMessage');
+
+      const initialContext = { phase: 'init' } as any;
+      vi.spyOn(result.current, 'internal_createAgentState').mockReturnValue({
+        agentConfig: createMockResolvedAgentConfig(),
+        context: initialContext,
+        state: {} as any,
+      });
+      const executeClientAgentSpy = vi
+        .spyOn(result.current, 'executeClientAgent')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.submitToolInteraction('tool-msg-1', response, undefined, {
+          createUserMessage: false,
+          toolResultContent: 'Selected onboarding template',
+        });
+      });
+
+      expect(result.current.optimisticCreateMessage).not.toHaveBeenCalled();
+      expect(executeClientAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialContext: expect.objectContaining({
+            phase: 'tool_result',
+          }),
+          metadata: { trigger: RequestTrigger.Onboarding },
+          parentMessageId: 'tool-msg-1',
+          parentMessageType: 'tool',
         }),
       );
     });
@@ -1178,6 +1259,11 @@ describe('ConversationControl actions', () => {
       const chatKey = messageMapKey({ agentId, topicId });
       const reason = 'Need to decide later';
 
+      const onboardingUserMessage = createMockMessage({
+        id: 'onboarding-user-msg',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      });
       const toolMessage = createMockMessage({
         groupId: 'group-1',
         id: 'tool-msg-1',
@@ -1196,10 +1282,10 @@ describe('ConversationControl actions', () => {
           activeTopicId: topicId,
           activeThreadId: undefined,
           dbMessagesMap: {
-            [chatKey]: [toolMessage],
+            [chatKey]: [onboardingUserMessage, toolMessage],
           },
           messagesMap: {
-            [chatKey]: [toolMessage],
+            [chatKey]: [onboardingUserMessage, toolMessage],
           },
         });
       });
@@ -1221,14 +1307,14 @@ describe('ConversationControl actions', () => {
 
           useChatStore.setState({
             dbMessagesMap: {
-              [chatKey]: [toolMessage, userMessage],
+              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
             },
             messagesMap: {
-              [chatKey]: [toolMessage, userMessage],
+              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
             },
           });
 
-          return { id: userMessageId, messages: [toolMessage, userMessage] };
+          return { id: userMessageId, messages: [onboardingUserMessage, toolMessage, userMessage] };
         });
 
       const initialContext = { phase: 'init' } as any;
@@ -1269,6 +1355,7 @@ describe('ConversationControl actions', () => {
       expect(executeClientAgentSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           initialContext,
+          metadata: { trigger: RequestTrigger.Onboarding },
           parentMessageId: userMessageId,
           parentMessageType: 'user',
         }),

--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
@@ -476,9 +476,7 @@ describe('ConversationControl actions', () => {
       });
 
       // Mock internal methods
-      const optimisticUpdatePluginSpy = vi
-        .spyOn(result.current, 'optimisticUpdateMessagePlugin')
-        .mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
       const internal_createAgentStateSpy = vi
         .spyOn(result.current, 'internal_createAgentState')
         .mockReturnValue({
@@ -1076,9 +1074,15 @@ describe('ConversationControl actions', () => {
         metadata: { trigger: RequestTrigger.Onboarding },
         role: 'user',
       });
+      const onboardingAssistantMessage = createMockMessage({
+        id: 'onboarding-assistant-msg',
+        parentId: onboardingUserMessage.id,
+        role: 'assistant',
+      });
       const toolMessage = createMockMessage({
         groupId: 'group-1',
         id: 'tool-msg-1',
+        parentId: onboardingAssistantMessage.id,
         plugin: {
           apiName: 'askUserQuestion',
           arguments: '{}',
@@ -1094,10 +1098,10 @@ describe('ConversationControl actions', () => {
           activeTopicId: topicId,
           activeThreadId: undefined,
           dbMessagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
           messagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
         });
       });
@@ -1119,14 +1123,27 @@ describe('ConversationControl actions', () => {
 
           useChatStore.setState({
             dbMessagesMap: {
-              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
+              [chatKey]: [
+                onboardingUserMessage,
+                onboardingAssistantMessage,
+                toolMessage,
+                userMessage,
+              ],
             },
             messagesMap: {
-              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
+              [chatKey]: [
+                onboardingUserMessage,
+                onboardingAssistantMessage,
+                toolMessage,
+                userMessage,
+              ],
             },
           });
 
-          return { id: userMessageId, messages: [onboardingUserMessage, toolMessage, userMessage] };
+          return {
+            id: userMessageId,
+            messages: [onboardingUserMessage, onboardingAssistantMessage, toolMessage, userMessage],
+          };
         });
 
       const initialContext = { phase: 'init' } as any;
@@ -1189,9 +1206,15 @@ describe('ConversationControl actions', () => {
         metadata: { trigger: RequestTrigger.Onboarding },
         role: 'user',
       });
+      const onboardingAssistantMessage = createMockMessage({
+        id: 'onboarding-assistant-msg',
+        parentId: onboardingUserMessage.id,
+        role: 'assistant',
+      });
       const toolMessage = createMockMessage({
         groupId: 'group-1',
         id: 'tool-msg-1',
+        parentId: onboardingAssistantMessage.id,
         plugin: {
           apiName: 'selectAgentTemplate',
           arguments: '{}',
@@ -1207,10 +1230,10 @@ describe('ConversationControl actions', () => {
           activeTopicId: topicId,
           activeThreadId: undefined,
           dbMessagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
           messagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
         });
       });
@@ -1248,6 +1271,95 @@ describe('ConversationControl actions', () => {
         }),
       );
     });
+
+    it('should not reuse onboarding trigger metadata from an older message outside the active tool chain', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const agentId = 'global-agent';
+      const topicId = 'global-topic';
+      const chatKey = messageMapKey({ agentId, topicId });
+
+      const oldOnboardingMessage = createMockMessage({
+        id: 'old-onboarding-user-msg',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      });
+      const normalUserMessage = createMockMessage({
+        id: 'normal-user-msg',
+        role: 'user',
+      });
+      const normalAssistantMessage = createMockMessage({
+        id: 'normal-assistant-msg',
+        parentId: normalUserMessage.id,
+        role: 'assistant',
+      });
+      const normalToolMessage = createMockMessage({
+        id: 'normal-tool-msg',
+        parentId: normalAssistantMessage.id,
+        plugin: {
+          apiName: 'selectAgentTemplate',
+          arguments: '{}',
+          identifier: 'lobe-agent-marketplace',
+          type: 'default',
+        },
+        role: 'tool',
+      });
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          activeTopicId: topicId,
+          activeThreadId: undefined,
+          dbMessagesMap: {
+            [chatKey]: [
+              oldOnboardingMessage,
+              normalUserMessage,
+              normalAssistantMessage,
+              normalToolMessage,
+            ],
+          },
+          messagesMap: {
+            [chatKey]: [
+              oldOnboardingMessage,
+              normalUserMessage,
+              normalAssistantMessage,
+              normalToolMessage,
+            ],
+          },
+        });
+      });
+
+      vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticUpdateMessageContent').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'internal_createAgentState').mockReturnValue({
+        agentConfig: createMockResolvedAgentConfig(),
+        context: { phase: 'init' } as any,
+        state: {} as any,
+      });
+      const executeClientAgentSpy = vi
+        .spyOn(result.current, 'executeClientAgent')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.submitToolInteraction(
+          normalToolMessage.id,
+          { templateId: 'normal-template' },
+          undefined,
+          {
+            createUserMessage: false,
+            toolResultContent: 'Selected normal template',
+          },
+        );
+      });
+
+      expect(executeClientAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: undefined,
+          parentMessageId: normalToolMessage.id,
+          parentMessageType: 'tool',
+        }),
+      );
+    });
   });
 
   describe('skipToolInteraction', () => {
@@ -1264,9 +1376,15 @@ describe('ConversationControl actions', () => {
         metadata: { trigger: RequestTrigger.Onboarding },
         role: 'user',
       });
+      const onboardingAssistantMessage = createMockMessage({
+        id: 'onboarding-assistant-msg',
+        parentId: onboardingUserMessage.id,
+        role: 'assistant',
+      });
       const toolMessage = createMockMessage({
         groupId: 'group-1',
         id: 'tool-msg-1',
+        parentId: onboardingAssistantMessage.id,
         plugin: {
           apiName: 'askUserQuestion',
           arguments: '{}',
@@ -1282,10 +1400,10 @@ describe('ConversationControl actions', () => {
           activeTopicId: topicId,
           activeThreadId: undefined,
           dbMessagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
           messagesMap: {
-            [chatKey]: [onboardingUserMessage, toolMessage],
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
           },
         });
       });
@@ -1307,14 +1425,27 @@ describe('ConversationControl actions', () => {
 
           useChatStore.setState({
             dbMessagesMap: {
-              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
+              [chatKey]: [
+                onboardingUserMessage,
+                onboardingAssistantMessage,
+                toolMessage,
+                userMessage,
+              ],
             },
             messagesMap: {
-              [chatKey]: [onboardingUserMessage, toolMessage, userMessage],
+              [chatKey]: [
+                onboardingUserMessage,
+                onboardingAssistantMessage,
+                toolMessage,
+                userMessage,
+              ],
             },
           });
 
-          return { id: userMessageId, messages: [onboardingUserMessage, toolMessage, userMessage] };
+          return {
+            id: userMessageId,
+            messages: [onboardingUserMessage, onboardingAssistantMessage, toolMessage, userMessage],
+          };
         });
 
       const initialContext = { phase: 'init' } as any;

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -97,12 +97,24 @@ export class ConversationControlActionImpl {
    * Preserve the request trigger so downstream chat requests keep the same
    * headers after a human-intervention pause.
    */
-  #getRequestMetadataFromMessages = (
+  #getRequestMetadataFromMessageChain = (
     messages: UIChatMessage[],
+    anchorMessageId: string,
   ): Pick<MessageMetadata, 'trigger'> | undefined => {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const trigger = messages[index]?.metadata?.trigger;
+    const messagesById = new Map(messages.map((message) => [message.id, message]));
+    const visitedIds = new Set<string>();
+    let currentMessageId: string | undefined = anchorMessageId;
+
+    while (currentMessageId && !visitedIds.has(currentMessageId)) {
+      visitedIds.add(currentMessageId);
+
+      const message = messagesById.get(currentMessageId);
+      if (!message) return;
+
+      const trigger = message.metadata?.trigger;
       if (trigger) return { trigger };
+
+      currentMessageId = message.parentId;
     }
   };
 
@@ -283,7 +295,10 @@ export class ConversationControlActionImpl {
     // 3. Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(
+      currentMessages,
+      toolMessageId,
+    );
 
     // 4. Create agent state and context with user intervention config
     const { state, context: initialContext } = this.#get().internal_createAgentState({
@@ -399,7 +414,10 @@ export class ConversationControlActionImpl {
     // tool result, not a fake user turn.
     if (!shouldCreateUserMessage) {
       const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-      const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
+      const requestMetadata = this.#getRequestMetadataFromMessageChain(
+        currentMessages,
+        toolMessageId,
+      );
 
       const { state, context: initialContext } = this.#get().internal_createAgentState({
         messages: currentMessages,
@@ -472,7 +490,10 @@ export class ConversationControlActionImpl {
 
     // 3. Resume agent from user message (not tool re-execution)
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(
+      currentMessages,
+      toolMessageId,
+    );
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -577,7 +598,10 @@ export class ConversationControlActionImpl {
     // 3. Resume agent from user message
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(
+      currentMessages,
+      toolMessageId,
+    );
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -1041,7 +1065,7 @@ export class ConversationControlActionImpl {
     // Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(currentMessages, messageId);
 
     // Create agent state and context to continue from rejected tool message
     const { state, context: initialContext } = this.#get().internal_createAgentState({

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -1,7 +1,11 @@
 // Disable the auto sort key eslint rule to make the code more logic and readable
 import { type AgentRuntimeContext } from '@lobechat/agent-runtime';
 import { MESSAGE_CANCEL_FLAT } from '@lobechat/const';
-import { type ConversationContext } from '@lobechat/types';
+import {
+  type ConversationContext,
+  type MessageMetadata,
+  type UIChatMessage,
+} from '@lobechat/types';
 
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -86,6 +90,20 @@ export class ConversationControlActionImpl {
       (op) =>
         op.type === 'execServerAgentRuntime' && op.status === 'running' && !op.metadata?.isAborting,
     );
+  };
+
+  /**
+   * Local tool-interaction resumes are continuations of the original request.
+   * Preserve the request trigger so downstream chat requests keep the same
+   * headers after a human-intervention pause.
+   */
+  #getRequestMetadataFromMessages = (
+    messages: UIChatMessage[],
+  ): Pick<MessageMetadata, 'trigger'> | undefined => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const trigger = messages[index]?.metadata?.trigger;
+      if (trigger) return { trigger };
+    }
   };
 
   /**
@@ -265,6 +283,7 @@ export class ConversationControlActionImpl {
     // 3. Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
+    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
 
     // 4. Create agent state and context with user intervention config
     const { state, context: initialContext } = this.#get().internal_createAgentState({
@@ -296,6 +315,7 @@ export class ConversationControlActionImpl {
         parentMessageType: 'tool', // Type is 'tool'
         initialState: state,
         initialContext: agentRuntimeContext,
+        metadata: requestMetadata,
         // Pass parent operation ID to establish parent-child relationship
         // This ensures proper cancellation propagation
         parentOperationId: operationId,
@@ -379,6 +399,7 @@ export class ConversationControlActionImpl {
     // tool result, not a fake user turn.
     if (!shouldCreateUserMessage) {
       const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
+      const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
 
       const { state, context: initialContext } = this.#get().internal_createAgentState({
         messages: currentMessages,
@@ -411,6 +432,7 @@ export class ConversationControlActionImpl {
           parentMessageType: 'tool',
           initialState: state,
           initialContext: agentRuntimeContext,
+          metadata: requestMetadata,
           parentOperationId: operationId,
         });
         completeOperation(operationId);
@@ -450,6 +472,7 @@ export class ConversationControlActionImpl {
 
     // 3. Resume agent from user message (not tool re-execution)
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
+    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -468,6 +491,7 @@ export class ConversationControlActionImpl {
         parentMessageType: 'user',
         initialState: state,
         initialContext,
+        metadata: requestMetadata,
         parentOperationId: operationId,
       });
       completeOperation(operationId);
@@ -553,6 +577,7 @@ export class ConversationControlActionImpl {
     // 3. Resume agent from user message
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
+    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -571,6 +596,7 @@ export class ConversationControlActionImpl {
         parentMessageType: 'user',
         initialState: state,
         initialContext,
+        metadata: requestMetadata,
         parentOperationId: operationId,
       });
       completeOperation(operationId);
@@ -1015,6 +1041,7 @@ export class ConversationControlActionImpl {
     // Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
+    const requestMetadata = this.#getRequestMetadataFromMessages(currentMessages);
 
     // Create agent state and context to continue from rejected tool message
     const { state, context: initialContext } = this.#get().internal_createAgentState({
@@ -1041,6 +1068,7 @@ export class ConversationControlActionImpl {
         parentMessageType: 'tool',
         initialState: state,
         initialContext: agentRuntimeContext,
+        metadata: requestMetadata,
         // Pass parent operation ID to establish parent-child relationship
         parentOperationId: operationId,
       });

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -321,6 +321,8 @@ export class ConversationLifecycleActionImpl {
       message,
       selectedTools,
     });
+    const requestTrigger = (metadata as Pick<MessageMetadata, 'trigger'> | undefined)?.trigger;
+    const requestMetadata = requestTrigger ? { trigger: requestTrigger } : undefined;
 
     const hasFile = !!fileIdList && fileIdList.length > 0;
 
@@ -1013,6 +1015,7 @@ export class ConversationLifecycleActionImpl {
           await executeClientAgent({
             context: execContext,
             initialContext: mergedAgentRuntimeInitialContext,
+            metadata: requestMetadata,
             messages: displayMessages,
             parentMessageId: data.assistantMessageId,
             parentMessageType: 'assistant',

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -15,6 +15,7 @@ import { type ToolsEngine } from '@lobechat/context-engine';
 import { buildTaskDetailPrompt, buildTaskListPrompt } from '@lobechat/prompts';
 import {
   type ConversationContext,
+  type MessageMetadata,
   type RuntimeInitialContext,
   type UIChatMessage,
 } from '@lobechat/types';
@@ -473,6 +474,7 @@ export class StreamingExecutorActionImpl {
     initialContext?: AgentRuntimeContext;
     initialState?: AgentState;
     inPortalThread?: boolean;
+    metadata?: Pick<MessageMetadata, 'trigger'>;
     messages: UIChatMessage[];
     operationId?: string;
     parentMessageId: string;
@@ -610,6 +612,7 @@ export class StreamingExecutorActionImpl {
       executors: createAgentExecutors({
         agentConfig, // Pass pre-resolved config to callLLM executor
         get: this.#get,
+        metadata: params.metadata,
         messageKey,
         operationId,
         parentId: params.parentMessageId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add `RequestTrigger.Onboarding` enum value so onboarding chat traffic can be distinguished from regular chat in routing, billing, and logs.
- Refactor the chat service / executor chain to pass request trigger via `metadata.trigger` instead of a top-level `requestTrigger` option. `MessageMetadata.trigger` is added so the trigger can be persisted on the message.
- The onboarding agent (`src/features/Onboarding/Agent`) now tags its `onBeforeSendMessage` payload with `metadata.trigger = RequestTrigger.Onboarding`, so downstream consumers (server runtime, spend logs) can identify the request source.
- Add the `onboarding` label to the spend log trigger column (`spend.ts` + zh/en locales).

#### 🧪 How to Test

- [x] Added/updated tests

Updated unit tests:

- `src/services/chat/chat.test.ts` — verifies the new `metadata` option flows through `getChatCompletion` and is not leaked into the outgoing payload.
- `src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts` — verifies `metadata.trigger` is forwarded from executor context into `chatService.createAssistantMessageStream`.

#### 📝 Additional Information

Used together with the corresponding cloud-side change that consumes `RequestTrigger.Onboarding` to bypass the `not_onboarded` security gate during the onboarding flow.