### PR TITLE
🐛 fix(desktop): resolve Windows npm CLI shims before spawning agents

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -24,11 +24,15 @@ import {
   buildAgentInput,
   materializeImageToPath,
   normalizeImage,
+  spawnCli,
 } from '@lobechat/heterogeneous-agents/spawn';
 import { app as electronApp, BrowserWindow } from 'electron';
 
 import { getHeterogeneousAgentDriver } from '@/modules/heterogeneousAgent';
-import type { HeterogeneousAgentImageAttachment } from '@/modules/heterogeneousAgent/types';
+import type {
+  HeterogeneousAgentBuildPlan,
+  HeterogeneousAgentImageAttachment,
+} from '@/modules/heterogeneousAgent/types';
 import { buildProxyEnv } from '@/modules/networkProxy/envBuilder';
 import { detectHeterogeneousCliCommand } from '@/modules/toolDetectors';
 import { createLogger } from '@/utils/logger';
@@ -869,168 +873,217 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     const useStdin = spawnPlan.stdinPayload !== undefined;
     const cliArgs = spawnPlan.args;
 
-    return new Promise<void>((resolve, reject) => {
-      logger.info('Spawning agent:', session.command, cliArgs.join(' '), `(cwd: ${cwd})`);
+    logger.info('Spawning agent:', session.command, cliArgs.join(' '), `(cwd: ${cwd})`);
 
-      // `detached: true` on Unix puts the child in a new process group so we
-      // can SIGINT/SIGKILL the whole tree (claude + any tool subprocesses)
-      // via `process.kill(-pid, sig)` on cancel. Without this, SIGINT to just
-      // the claude binary can leave bash/grep/etc. tool children running and
-      // the CLI hung waiting on them. Windows has different semantics — use
-      // taskkill /T /F there; no detached flag needed.
-      // Forward the user's proxy settings to the CLI. The main-process undici
-      // dispatcher doesn't reach child processes — they need env vars.
-      const proxyEnv = buildProxyEnv(this.app.storeManager.get('networkProxy'));
+    // `detached: true` on Unix puts the child in a new process group so we
+    // can SIGINT/SIGKILL the whole tree (claude + any tool subprocesses)
+    // via `process.kill(-pid, sig)` on cancel. Without this, SIGINT to just
+    // the claude binary can leave bash/grep/etc. tool children running and
+    // the CLI hung waiting on them. Windows has different semantics — use
+    // taskkill /T /F there; no detached flag needed.
+    // Forward the user's proxy settings to the CLI. The main-process undici
+    // dispatcher doesn't reach child processes — they need env vars.
+    const proxyEnv = buildProxyEnv(this.app.storeManager.get('networkProxy'));
 
-      const proc = spawn(session.command, cliArgs, {
-        cwd,
-        detached: process.platform !== 'win32',
-        env: { ...process.env, ...proxyEnv, ...session.env },
-        stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
-      });
+    const spawnOptions = {
+      cwd,
+      detached: process.platform !== 'win32',
+      env: { ...process.env, ...proxyEnv, ...session.env },
+      stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'] as ['pipe' | 'ignore', 'pipe', 'pipe'],
+    };
 
-      // In stdin mode, write the prepared payload and close stdin.
-      if (useStdin && spawnPlan.stdinPayload !== undefined && proc.stdin) {
-        void this.writeCliTraceFile(traceSession, 'stdin.txt', spawnPlan.stdinPayload);
-        const stdin = proc.stdin as Writable;
-        stdin.write(spawnPlan.stdinPayload, () => {
-          stdin.end();
+    let proc: ChildProcess;
+    try {
+      proc = await spawnCli(session.command, cliArgs, spawnOptions);
+    } catch (err) {
+      if (intervention) {
+        await intervention.cleanup().catch((cleanupErr) => {
+          logger.warn('AskUserQuestion cleanup error during spawn failure:', cleanupErr);
         });
       }
+      throw err;
+    }
 
-      session.process = proc;
-
-      // Producer-side conversion (V3 contract): JSONL framing + adapter +
-      // toStreamEvent all run inside the shared pipeline, so renderer + future
-      // server `heteroIngest` see the same `AgentStreamEvent` wire shape with
-      // no per-consumer adapter. The pipeline auto-wires the Codex
-      // file-change line-stat tracker when `agentType === 'codex'`, so this
-      // controller stays agent-agnostic.
-      const pipeline = new AgentStreamPipeline({
-        agentType: session.agentType,
-        operationId: params.operationId,
+    return new Promise<void>((resolve, reject) => {
+      this.handleSpawnedAgentProcess({
+        cliArgs,
+        intervention,
+        params,
+        proc,
+        reject,
+        resolve,
+        session,
+        traceSession,
+        useStdin,
+        spawnPlan,
       });
-      let stdoutBroadcastQueue: Promise<void> = Promise.resolve();
+    });
+  }
 
-      const broadcastPipelineBatch = (produce: () => ReturnType<AgentStreamPipeline['push']>) => {
-        stdoutBroadcastQueue = stdoutBroadcastQueue
-          .then(async () => {
-            const events = await produce();
-            // Adapter-extracted CC/Codex session id powers `--resume` on the
-            // next prompt; surface it through the existing `getSessionInfo`
-            // IPC by mirroring the freshest value onto the session record.
-            if (pipeline.sessionId && pipeline.sessionId !== session.agentSessionId) {
-              session.agentSessionId = pipeline.sessionId;
-            }
-            for (const event of events) {
-              this.broadcast('heteroAgentEvent', {
-                event,
-                sessionId: session.sessionId,
-              });
-            }
-          })
-          .catch((error) => {
-            logger.error('Failed to broadcast agent stream batch:', error);
-          });
-      };
-
-      // Stream stdout events through the producer pipeline.
-      const stdout = proc.stdout as Readable;
-      stdout.on('data', (chunk: Buffer) => {
-        void this.appendCliTraceFile(traceSession, 'stdout.jsonl', chunk);
-        broadcastPipelineBatch(() => pipeline.push(chunk));
+  private handleSpawnedAgentProcess({
+    cliArgs,
+    intervention,
+    params,
+    proc,
+    reject,
+    resolve,
+    session,
+    spawnPlan,
+    traceSession,
+    useStdin,
+  }: {
+    cliArgs: string[];
+    intervention?: Awaited<ReturnType<HeterogeneousAgentCtr['setupInterventionForOp']>>;
+    params: SendPromptParams;
+    proc: ChildProcess;
+    reject: (reason?: unknown) => void;
+    resolve: () => void;
+    session: AgentSession;
+    spawnPlan: HeterogeneousAgentBuildPlan;
+    traceSession: CliTraceSession | undefined;
+    useStdin: boolean;
+  }) {
+    // In stdin mode, write the prepared payload and close stdin.
+    if (useStdin && spawnPlan.stdinPayload !== undefined && proc.stdin) {
+      void this.writeCliTraceFile(traceSession, 'stdin.txt', spawnPlan.stdinPayload);
+      const stdin = proc.stdin as Writable;
+      stdin.write(spawnPlan.stdinPayload, () => {
+        stdin.end();
       });
-      stdout.on('end', () => {
-        broadcastPipelineBatch(() => pipeline.flush());
-      });
+    }
 
-      // Capture stderr
-      const stderrChunks: string[] = [];
-      const stderr = proc.stderr as Readable;
-      stderr.on('data', (chunk: Buffer) => {
-        void this.appendCliTraceFile(traceSession, 'stderr.log', chunk);
-        stderrChunks.push(chunk.toString('utf8'));
-      });
+    session.process = proc;
 
-      proc.on('error', (err) => {
-        logger.error('Agent process error:', err);
-        void this.writeCliTraceJson(traceSession, 'process-error.json', {
-          message: err.message,
-          name: err.name,
-        });
-        void this.flushCliTrace(traceSession);
-        const sessionError = this.getSessionErrorPayload(err, session);
-        this.broadcast('heteroAgentSessionError', {
-          error: sessionError,
-          sessionId: session.sessionId,
-        });
-        reject(new Error(typeof sessionError === 'string' ? sessionError : sessionError.message));
-      });
+    // Producer-side conversion (V3 contract): JSONL framing + adapter +
+    // toStreamEvent all run inside the shared pipeline, so renderer + future
+    // server `heteroIngest` see the same `AgentStreamEvent` wire shape with
+    // no per-consumer adapter. The pipeline auto-wires the Codex
+    // file-change line-stat tracker when `agentType === 'codex'`, so this
+    // controller stays agent-agnostic.
+    const pipeline = new AgentStreamPipeline({
+      agentType: session.agentType,
+      operationId: params.operationId,
+    });
+    let stdoutBroadcastQueue: Promise<void> = Promise.resolve();
 
-      proc.on('exit', (code, signal) => {
-        // Node may emit `'exit'` BEFORE stdio finishes draining (documented:
-        // child_process docs note "stdio streams might still be open" at exit
-        // time). Wait for stdout to fully end/close so the `stdout.on('end')`
-        // handler has scheduled `pipeline.flush()` onto `stdoutBroadcastQueue`,
-        // THEN wait for the queue itself to settle. Without this two-step
-        // gate, trailing flushed events (final synthesized tool_end /
-        // tool_result) would race against — and lose to — the
-        // `heteroAgentSessionComplete` broadcast, leaving renderer-side
-        // persistence to finalize on incomplete state.
-        const stdoutDrained = streamFinished(stdout, { writable: false }).catch(() => {
-          /* end / close / error are all "done"; we still want to settle. */
-        });
-
-        void stdoutDrained
-          .then(() => stdoutBroadcastQueue)
-          .finally(async () => {
-            // Tear down the AskUserQuestion bridge / temp `mcp.json` for this
-            // op. Pending MCP handlers get a `session_ended` cancellation so
-            // they return cleanly even if CC was killed mid-tool-call.
-            if (intervention) {
-              await intervention.cleanup().catch((err) => {
-                logger.warn('AskUserQuestion cleanup error:', err);
-              });
-            }
-
-            void this.writeCliTraceJson(traceSession, 'exit.json', {
-              code,
-              finishedAt: new Date().toISOString(),
-              signal,
+    const broadcastPipelineBatch = (produce: () => ReturnType<AgentStreamPipeline['push']>) => {
+      stdoutBroadcastQueue = stdoutBroadcastQueue
+        .then(async () => {
+          const events = await produce();
+          // Adapter-extracted CC/Codex session id powers `--resume` on the
+          // next prompt; surface it through the existing `getSessionInfo`
+          // IPC by mirroring the freshest value onto the session record.
+          if (pipeline.sessionId && pipeline.sessionId !== session.agentSessionId) {
+            session.agentSessionId = pipeline.sessionId;
+          }
+          for (const event of events) {
+            this.broadcast('heteroAgentEvent', {
+              event,
+              sessionId: session.sessionId,
             });
-            await this.flushCliTrace(traceSession);
+          }
+        })
+        .catch((error) => {
+          logger.error('Failed to broadcast agent stream batch:', error);
+        });
+    };
 
-            logger.info('Agent process exited:', { code, sessionId: session.sessionId, signal });
-            session.process = undefined;
+    // Stream stdout events through the producer pipeline.
+    const stdout = proc.stdout as Readable;
+    stdout.on('data', (chunk: Buffer) => {
+      void this.appendCliTraceFile(traceSession, 'stdout.jsonl', chunk);
+      broadcastPipelineBatch(() => pipeline.push(chunk));
+    });
+    stdout.on('end', () => {
+      broadcastPipelineBatch(() => pipeline.flush());
+    });
 
-            // If *we* killed it (cancel / stop / before-quit), treat the non-zero
-            // exit as a clean shutdown — surfacing it as an error would make a
-            // user-initiated cancel look like an agent failure, and an Electron
-            // shutdown affecting OTHER running CC sessions would pollute their
-            // topics with a misleading "Agent exited with code 143" message.
-            if (session.cancelledByUs) {
-              this.broadcast('heteroAgentSessionComplete', { sessionId: session.sessionId });
-              resolve();
-              return;
-            }
+    // Capture stderr
+    const stderrChunks: string[] = [];
+    const stderr = proc.stderr as Readable;
+    stderr.on('data', (chunk: Buffer) => {
+      void this.appendCliTraceFile(traceSession, 'stderr.log', chunk);
+      stderrChunks.push(chunk.toString('utf8'));
+    });
 
-            if (code === 0) {
-              this.broadcast('heteroAgentSessionComplete', { sessionId: session.sessionId });
-              resolve();
-            } else {
-              const stderrOutput = stderrChunks.join('').trim();
-              const errorMsg = this.getExitErrorMessage(code, session, stderrOutput);
-              const sessionError = this.getSessionErrorPayload(errorMsg, session);
-              this.broadcast('heteroAgentSessionError', {
-                error: sessionError,
-                sessionId: session.sessionId,
-              });
-              reject(
-                new Error(typeof sessionError === 'string' ? sessionError : sessionError.message),
-              );
-            }
-          });
+    proc.on('error', (err) => {
+      logger.error('Agent process error:', err);
+      void this.writeCliTraceJson(traceSession, 'process-error.json', {
+        message: err.message,
+        name: err.name,
       });
+      void this.flushCliTrace(traceSession);
+      const sessionError = this.getSessionErrorPayload(err, session);
+      this.broadcast('heteroAgentSessionError', {
+        error: sessionError,
+        sessionId: session.sessionId,
+      });
+      reject(new Error(typeof sessionError === 'string' ? sessionError : sessionError.message));
+    });
+
+    proc.on('exit', (code, signal) => {
+      // Node may emit `'exit'` BEFORE stdio finishes draining (documented:
+      // child_process docs note "stdio streams might still be open" at exit
+      // time). Wait for stdout to fully end/close so the `stdout.on('end')`
+      // handler has scheduled `pipeline.flush()` onto `stdoutBroadcastQueue`,
+      // THEN wait for the queue itself to settle. Without this two-step
+      // gate, trailing flushed events (final synthesized tool_end /
+      // tool_result) would race against — and lose to — the
+      // `heteroAgentSessionComplete` broadcast, leaving renderer-side
+      // persistence to finalize on incomplete state.
+      const stdoutDrained = streamFinished(stdout, { writable: false }).catch(() => {
+        /* end / close / error are all "done"; we still want to settle. */
+      });
+
+      void stdoutDrained
+        .then(() => stdoutBroadcastQueue)
+        .finally(async () => {
+          // Tear down the AskUserQuestion bridge / temp `mcp.json` for this
+          // op. Pending MCP handlers get a `session_ended` cancellation so
+          // they return cleanly even if CC was killed mid-tool-call.
+          if (intervention) {
+            await intervention.cleanup().catch((err) => {
+              logger.warn('AskUserQuestion cleanup error:', err);
+            });
+          }
+
+          void this.writeCliTraceJson(traceSession, 'exit.json', {
+            code,
+            finishedAt: new Date().toISOString(),
+            signal,
+          });
+          await this.flushCliTrace(traceSession);
+
+          logger.info('Agent process exited:', { code, sessionId: session.sessionId, signal });
+          session.process = undefined;
+
+          // If *we* killed it (cancel / stop / before-quit), treat the non-zero
+          // exit as a clean shutdown — surfacing it as an error would make a
+          // user-initiated cancel look like an agent failure, and an Electron
+          // shutdown affecting OTHER running CC sessions would pollute their
+          // topics with a misleading "Agent exited with code 143" message.
+          if (session.cancelledByUs) {
+            this.broadcast('heteroAgentSessionComplete', { sessionId: session.sessionId });
+            resolve();
+            return;
+          }
+
+          if (code === 0) {
+            this.broadcast('heteroAgentSessionComplete', { sessionId: session.sessionId });
+            resolve();
+          } else {
+            const stderrOutput = stderrChunks.join('').trim();
+            const errorMsg = this.getExitErrorMessage(code, session, stderrOutput);
+            const sessionError = this.getSessionErrorPayload(errorMsg, session);
+            this.broadcast('heteroAgentSessionError', {
+              error: sessionError,
+              sessionId: session.sessionId,
+            });
+            reject(
+              new Error(typeof sessionError === 'string' ? sessionError : sessionError.message),
+            );
+          }
+        });
     });
   }
 

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -24,7 +24,7 @@ import {
   buildAgentInput,
   materializeImageToPath,
   normalizeImage,
-  spawnCli,
+  resolveCliSpawnPlan,
 } from '@lobechat/heterogeneous-agents/spawn';
 import { app as electronApp, BrowserWindow } from 'electron';
 
@@ -872,8 +872,14 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     }
     const useStdin = spawnPlan.stdinPayload !== undefined;
     const cliArgs = spawnPlan.args;
+    const resolvedCliSpawnPlan = await resolveCliSpawnPlan(session.command, cliArgs);
 
-    logger.info('Spawning agent:', session.command, cliArgs.join(' '), `(cwd: ${cwd})`);
+    logger.info(
+      'Spawning agent:',
+      resolvedCliSpawnPlan.command,
+      resolvedCliSpawnPlan.args.join(' '),
+      `(cwd: ${cwd})`,
+    );
 
     // `detached: true` on Unix puts the child in a new process group so we
     // can SIGINT/SIGKILL the whole tree (claude + any tool subprocesses)
@@ -892,21 +898,9 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'] as ['pipe' | 'ignore', 'pipe', 'pipe'],
     };
 
-    let proc: ChildProcess;
-    try {
-      proc = await spawnCli(session.command, cliArgs, spawnOptions);
-    } catch (err) {
-      if (intervention) {
-        await intervention.cleanup().catch((cleanupErr) => {
-          logger.warn('AskUserQuestion cleanup error during spawn failure:', cleanupErr);
-        });
-      }
-      throw err;
-    }
-
     return new Promise<void>((resolve, reject) => {
+      const proc = spawn(resolvedCliSpawnPlan.command, resolvedCliSpawnPlan.args, spawnOptions);
       this.handleSpawnedAgentProcess({
-        cliArgs,
         intervention,
         params,
         proc,
@@ -921,7 +915,6 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
   }
 
   private handleSpawnedAgentProcess({
-    cliArgs,
     intervention,
     params,
     proc,
@@ -932,7 +925,6 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     traceSession,
     useStdin,
   }: {
-    cliArgs: string[];
     intervention?: Awaited<ReturnType<HeterogeneousAgentCtr['setupInterventionForOp']>>;
     params: SendPromptParams;
     proc: ChildProcess;
@@ -943,6 +935,21 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     traceSession: CliTraceSession | undefined;
     useStdin: boolean;
   }) {
+    proc.on('error', (err) => {
+      logger.error('Agent process error:', err);
+      void this.writeCliTraceJson(traceSession, 'process-error.json', {
+        message: err.message,
+        name: err.name,
+      });
+      void this.flushCliTrace(traceSession);
+      const sessionError = this.getSessionErrorPayload(err, session);
+      this.broadcast('heteroAgentSessionError', {
+        error: sessionError,
+        sessionId: session.sessionId,
+      });
+      reject(new Error(typeof sessionError === 'string' ? sessionError : sessionError.message));
+    });
+
     // In stdin mode, write the prepared payload and close stdin.
     if (useStdin && spawnPlan.stdinPayload !== undefined && proc.stdin) {
       void this.writeCliTraceFile(traceSession, 'stdin.txt', spawnPlan.stdinPayload);
@@ -1004,21 +1011,6 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     stderr.on('data', (chunk: Buffer) => {
       void this.appendCliTraceFile(traceSession, 'stderr.log', chunk);
       stderrChunks.push(chunk.toString('utf8'));
-    });
-
-    proc.on('error', (err) => {
-      logger.error('Agent process error:', err);
-      void this.writeCliTraceJson(traceSession, 'process-error.json', {
-        message: err.message,
-        name: err.name,
-      });
-      void this.flushCliTrace(traceSession);
-      const sessionError = this.getSessionErrorPayload(err, session);
-      this.broadcast('heteroAgentSessionError', {
-        error: sessionError,
-        sessionId: session.sessionId,
-      });
-      reject(new Error(typeof sessionError === 'string' ? sessionError : sessionError.message));
     });
 
     proc.on('exit', (code, signal) => {

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { access, mkdtemp, readdir, readFile, rm, unlink, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import * as os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
@@ -8,6 +8,11 @@ import { HeterogeneousAgentSessionErrorCode } from '@lobechat/electron-client-ip
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import HeterogeneousAgentCtr from '../HeterogeneousAgentCtr';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof os>('node:os');
+  return { ...actual, platform: vi.fn(() => 'linux') };
+});
 
 const FAKE_DESKTOP_PATH = '/Users/fake/Desktop';
 
@@ -111,7 +116,7 @@ describe('HeterogeneousAgentCtr', () => {
   let appStoragePath: string;
 
   beforeEach(async () => {
-    appStoragePath = await mkdtemp(path.join(tmpdir(), 'lobehub-hetero-'));
+    appStoragePath = await mkdtemp(path.join(os.tmpdir(), 'lobehub-hetero-'));
   });
 
   afterEach(async () => {
@@ -817,7 +822,7 @@ describe('HeterogeneousAgentCtr', () => {
      * it like a real pending intervention and tries to unlink it.
      */
     const seedPendingIntervention = async (ctr: HeterogeneousAgentCtr, opId: string) => {
-      const tmpConfigPath = path.join(tmpdir(), `lobe-cc-mcp-test-${opId}.json`);
+      const tmpConfigPath = path.join(os.tmpdir(), `lobe-cc-mcp-test-${opId}.json`);
       await writeFile(tmpConfigPath, '{"mcpServers":{}}');
       const slot = {
         bridge: {} as any,

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -159,18 +159,47 @@ describe('cliSpawn', () => {
     });
   });
 
-  it('uses the current Node executable when a shim invokes bare node plus a JS bin', async () => {
+  it('uses the node executable from PATH when a shim invokes bare node plus a JS bin', async () => {
     platformMock.mockReturnValue('win32');
     const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\example-cli.cmd';
+    const nodePath = 'C:\\Program Files\\nodejs\\node.exe';
     const scriptPath =
       'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\example-cli\\bin\\cli.js';
     existingPaths(shimPath, scriptPath);
+    callExecFile(`${nodePath}\r\n`);
     readFileMock.mockResolvedValue('node "%dp0%\\node_modules\\example-cli\\bin\\cli.js" %*\r\n');
 
     const { resolveCliSpawnPlan } = await import('./cliSpawn');
     await expect(resolveCliSpawnPlan(shimPath, ['--help'])).resolves.toEqual({
       args: [scriptPath, '--help'],
-      command: process.execPath,
+      command: nodePath,
+    });
+  });
+
+  it('resolves the npm generated %_prog% .cmd shim form used by Codex and Gemini', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\codex.cmd';
+    const nodePath = 'C:\\Program Files\\nodejs\\node.exe';
+    const scriptPath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@openai\\codex\\bin\\codex.js';
+    existingPaths(shimPath, scriptPath);
+    callExecFile(`${nodePath}\r\n`);
+    readFileMock.mockResolvedValue(
+      [
+        '@ECHO off',
+        'IF EXIST "%dp0%\\node.exe" (',
+        '  SET "_prog=%dp0%\\node.exe"',
+        ') ELSE (',
+        '  SET "_prog=node"',
+        ')',
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*',
+      ].join('\r\n'),
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['--version'])).resolves.toEqual({
+      args: [scriptPath, '--version'],
+      command: nodePath,
     });
   });
 

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -1,0 +1,115 @@
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import * as fsPromises from 'node:fs/promises';
+import * as os from 'node:os';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof os>('node:os');
+  return { ...actual, platform: vi.fn(() => actual.platform()) };
+});
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof fsPromises>('node:fs/promises');
+  return {
+    ...actual,
+    access: vi.fn(),
+    readFile: vi.fn(),
+  };
+});
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof childProcess>('node:child_process');
+  return {
+    ...actual,
+    execFile: vi.fn(),
+    spawn: vi.fn(() => new EventEmitter()),
+  };
+});
+
+const platformMock = vi.mocked(os.platform);
+const execFileMock = vi.mocked(childProcess.execFile);
+const spawnMock = vi.mocked(childProcess.spawn);
+const accessMock = vi.mocked(fsPromises.access);
+const readFileMock = vi.mocked(fsPromises.readFile);
+
+const callExecFile = (stdout: string) => {
+  execFileMock.mockImplementationOnce(((...args: unknown[]) => {
+    const callback = [...args].reverse().find((arg) => typeof arg === 'function') as
+      | ((error: Error | null, stdout: string) => void)
+      | undefined;
+    callback?.(null, stdout);
+    return {} as childProcess.ChildProcess;
+  }) as typeof childProcess.execFile);
+};
+
+describe('cliSpawn', () => {
+  beforeEach(() => {
+    platformMock.mockReturnValue('linux');
+    execFileMock.mockReset();
+    spawnMock.mockClear();
+    accessMock.mockReset();
+    readFileMock.mockReset();
+  });
+
+  it('keeps non-Windows commands unchanged', async () => {
+    platformMock.mockReturnValue('darwin');
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+
+    await expect(resolveCliSpawnPlan('claude', ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command: 'claude',
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves Windows npm shell shim to the package claude.exe', async () => {
+    platformMock.mockReturnValue('win32');
+    callExecFile(
+      [
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude',
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd',
+      ].join('\r\n'),
+    );
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockResolvedValue(
+      'exec "$basedir/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"\n',
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan('claude', ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command:
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe',
+    });
+  });
+
+  it('resolves Windows npm .cmd shim to the package claude.exe when configured directly', async () => {
+    platformMock.mockReturnValue('win32');
+    accessMock.mockResolvedValue(undefined);
+    readFileMock.mockResolvedValue(
+      '@ECHO off\r\n"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"   %*\r\n',
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(
+      resolveCliSpawnPlan('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd', ['--version']),
+    ).resolves.toEqual({
+      args: ['--version'],
+      command:
+        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe',
+    });
+  });
+
+  it('spawns the resolved command', async () => {
+    platformMock.mockReturnValue('win32');
+    callExecFile('C:\\Tools\\claude.exe\r\n');
+    const options = { cwd: 'C:\\repo', stdio: ['pipe', 'pipe', 'pipe'] } as any;
+
+    const { spawnCli } = await import('./cliSpawn');
+    await spawnCli('claude', ['-p'], options);
+
+    expect(spawnMock).toHaveBeenCalledWith('C:\\Tools\\claude.exe', ['-p'], options);
+  });
+});

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -44,6 +44,14 @@ const callExecFile = (stdout: string) => {
   }) as typeof childProcess.execFile);
 };
 
+const existingPaths = (...paths: string[]) => {
+  const normalizedPaths = new Set(paths.map((filePath) => filePath.toLowerCase()));
+  accessMock.mockImplementation(async (filePath) => {
+    if (normalizedPaths.has(String(filePath).toLowerCase())) return;
+    throw new Error(`missing: ${String(filePath)}`);
+  });
+};
+
 describe('cliSpawn', () => {
   beforeEach(() => {
     platformMock.mockReturnValue('linux');
@@ -64,15 +72,27 @@ describe('cliSpawn', () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  it('resolves Windows npm shell shim to the package claude.exe', async () => {
+  it('prefers a Windows executable returned by where', async () => {
     platformMock.mockReturnValue('win32');
     callExecFile(
-      [
-        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude',
-        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd',
-      ].join('\r\n'),
+      ['C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd', 'C:\\Tools\\gemini.exe'].join('\r\n'),
     );
-    accessMock.mockResolvedValue(undefined);
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan('gemini', ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command: 'C:\\Tools\\gemini.exe',
+    });
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves Windows npm shell shim to a package executable', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude';
+    const exePath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe';
+    callExecFile([shimPath, `${shimPath}.cmd`].join('\r\n'));
+    existingPaths(shimPath, exePath);
     readFileMock.mockResolvedValue(
       'exec "$basedir/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"\n',
     );
@@ -80,29 +100,109 @@ describe('cliSpawn', () => {
     const { resolveCliSpawnPlan } = await import('./cliSpawn');
     await expect(resolveCliSpawnPlan('claude', ['--version'])).resolves.toEqual({
       args: ['--version'],
-      command:
-        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe',
+      command: exePath,
     });
   });
 
-  it('resolves Windows npm .cmd shim to the package claude.exe when configured directly', async () => {
+  it('resolves Windows npm .cmd shim to a package executable when configured directly', async () => {
     platformMock.mockReturnValue('win32');
-    accessMock.mockResolvedValue(undefined);
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd';
+    const exePath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe';
+    existingPaths(shimPath, exePath);
     readFileMock.mockResolvedValue(
       '@ECHO off\r\n"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"   %*\r\n',
     );
 
     const { resolveCliSpawnPlan } = await import('./cliSpawn');
-    await expect(
-      resolveCliSpawnPlan('C:\\Users\\Hanam\\AppData\\Roaming\\npm\\claude.cmd', ['--version']),
-    ).resolves.toEqual({
+    await expect(resolveCliSpawnPlan(shimPath, ['--version'])).resolves.toEqual({
       args: ['--version'],
-      command:
-        'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe',
+      command: exePath,
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves a .cmd npm shim that invokes node.exe plus a JS bin', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';
+    const nodePath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node.exe';
+    const scriptPath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@google\\gemini-cli\\dist\\index.js';
+    existingPaths(shimPath, nodePath, scriptPath);
+    readFileMock.mockResolvedValue(
+      '@ECHO off\r\n"%dp0%\\node.exe" "%dp0%\\node_modules\\@google\\gemini-cli\\dist\\index.js" %*\r\n',
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['--version'])).resolves.toEqual({
+      args: [scriptPath, '--version'],
+      command: nodePath,
     });
   });
 
-  it('spawns the resolved command', async () => {
+  it('resolves an extensionless npm shell shim that invokes node.exe plus a JS bin', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\kimi';
+    const nodePath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node.exe';
+    const scriptPath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\kimi-cli\\bin\\kimi.js';
+    callExecFile([shimPath, `${shimPath}.cmd`].join('\r\n'));
+    existingPaths(shimPath, nodePath, scriptPath);
+    readFileMock.mockResolvedValue(
+      'exec "$basedir/node.exe" "$basedir/node_modules/kimi-cli/bin/kimi.js" "$@"\n',
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan('kimi', ['chat', '--json'])).resolves.toEqual({
+      args: [scriptPath, 'chat', '--json'],
+      command: nodePath,
+    });
+  });
+
+  it('uses the current Node executable when a shim invokes bare node plus a JS bin', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\example-cli.cmd';
+    const scriptPath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\example-cli\\bin\\cli.js';
+    existingPaths(shimPath, scriptPath);
+    readFileMock.mockResolvedValue('node "%dp0%\\node_modules\\example-cli\\bin\\cli.js" %*\r\n');
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['--help'])).resolves.toEqual({
+      args: [scriptPath, '--help'],
+      command: process.execPath,
+    });
+  });
+
+  it('falls back to the original command and args when a JS bin target is missing', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';
+    existingPaths(shimPath, 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node.exe');
+    readFileMock.mockResolvedValue(
+      '"%dp0%\\node.exe" "%dp0%\\node_modules\\@google\\gemini-cli\\dist\\index.js" %*\r\n',
+    );
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command: shimPath,
+    });
+  });
+
+  it('falls back to the original command and args when shim content is unsupported', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\unknown.cmd';
+    existingPaths(shimPath);
+    readFileMock.mockResolvedValue('@ECHO off\r\nset SOME_VAR=1\r\n');
+
+    const { resolveCliSpawnPlan } = await import('./cliSpawn');
+    await expect(resolveCliSpawnPlan(shimPath, ['--version'])).resolves.toEqual({
+      args: ['--version'],
+      command: shimPath,
+    });
+  });
+
+  it('spawns the resolved executable command', async () => {
     platformMock.mockReturnValue('win32');
     callExecFile('C:\\Tools\\claude.exe\r\n');
     const options = { cwd: 'C:\\repo', stdio: ['pipe', 'pipe', 'pipe'] } as any;
@@ -111,5 +211,23 @@ describe('cliSpawn', () => {
     await spawnCli('claude', ['-p'], options);
 
     expect(spawnMock).toHaveBeenCalledWith('C:\\Tools\\claude.exe', ['-p'], options);
+  });
+
+  it('spawns a JS-backed shim with the script path prepended to args', async () => {
+    platformMock.mockReturnValue('win32');
+    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';
+    const nodePath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node.exe';
+    const scriptPath =
+      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@google\\gemini-cli\\dist\\index.js';
+    existingPaths(shimPath, nodePath, scriptPath);
+    readFileMock.mockResolvedValue(
+      '"%dp0%\\node.exe" "%dp0%\\node_modules\\@google\\gemini-cli\\dist\\index.js" %*\r\n',
+    );
+    const options = { cwd: 'C:\\repo', stdio: ['pipe', 'pipe', 'pipe'] } as any;
+
+    const { spawnCli } = await import('./cliSpawn');
+    await spawnCli(shimPath, ['--version'], options);
+
+    expect(spawnMock).toHaveBeenCalledWith(nodePath, [scriptPath, '--version'], options);
   });
 });

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.test.ts
@@ -1,5 +1,4 @@
 import * as childProcess from 'node:child_process';
-import { EventEmitter } from 'node:events';
 import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 
@@ -24,13 +23,11 @@ vi.mock('node:child_process', async () => {
   return {
     ...actual,
     execFile: vi.fn(),
-    spawn: vi.fn(() => new EventEmitter()),
   };
 });
 
 const platformMock = vi.mocked(os.platform);
 const execFileMock = vi.mocked(childProcess.execFile);
-const spawnMock = vi.mocked(childProcess.spawn);
 const accessMock = vi.mocked(fsPromises.access);
 const readFileMock = vi.mocked(fsPromises.readFile);
 
@@ -56,7 +53,6 @@ describe('cliSpawn', () => {
   beforeEach(() => {
     platformMock.mockReturnValue('linux');
     execFileMock.mockReset();
-    spawnMock.mockClear();
     accessMock.mockReset();
     readFileMock.mockReset();
   });
@@ -229,34 +225,5 @@ describe('cliSpawn', () => {
       args: ['--version'],
       command: shimPath,
     });
-  });
-
-  it('spawns the resolved executable command', async () => {
-    platformMock.mockReturnValue('win32');
-    callExecFile('C:\\Tools\\claude.exe\r\n');
-    const options = { cwd: 'C:\\repo', stdio: ['pipe', 'pipe', 'pipe'] } as any;
-
-    const { spawnCli } = await import('./cliSpawn');
-    await spawnCli('claude', ['-p'], options);
-
-    expect(spawnMock).toHaveBeenCalledWith('C:\\Tools\\claude.exe', ['-p'], options);
-  });
-
-  it('spawns a JS-backed shim with the script path prepended to args', async () => {
-    platformMock.mockReturnValue('win32');
-    const shimPath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\gemini.cmd';
-    const nodePath = 'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node.exe';
-    const scriptPath =
-      'C:\\Users\\Hanam\\AppData\\Roaming\\npm\\node_modules\\@google\\gemini-cli\\dist\\index.js';
-    existingPaths(shimPath, nodePath, scriptPath);
-    readFileMock.mockResolvedValue(
-      '"%dp0%\\node.exe" "%dp0%\\node_modules\\@google\\gemini-cli\\dist\\index.js" %*\r\n',
-    );
-    const options = { cwd: 'C:\\repo', stdio: ['pipe', 'pipe', 'pipe'] } as any;
-
-    const { spawnCli } = await import('./cliSpawn');
-    await spawnCli(shimPath, ['--version'], options);
-
-    expect(spawnMock).toHaveBeenCalledWith(nodePath, [scriptPath, '--version'], options);
   });
 });

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -5,9 +5,15 @@ import { platform } from 'node:os';
 import path from 'node:path';
 
 const WINDOWS_EXE_EXT_PATTERN = /\.exe$/i;
+const WINDOWS_NODE_EXE_PATTERN = /(?:^|[\\/])node(?:\.exe)?$/i;
 
 export interface CliSpawnPlan {
   args: string[];
+  command: string;
+}
+
+interface WindowsShimTarget {
+  argsPrefix?: string[];
   command: string;
 }
 
@@ -44,28 +50,127 @@ const execFileString = async (command: string, args: string[]): Promise<string> 
 const pickWindowsExecutable = (candidates: string[]): string | undefined =>
   candidates.find((candidate) => WINDOWS_EXE_EXT_PATTERN.test(candidate));
 
-const inferWindowsNpmBinaryFromShim = async (shimPath: string): Promise<string | undefined> => {
-  if (WINDOWS_EXE_EXT_PATTERN.test(shimPath)) return shimPath;
+const joinShimRelativePath = (shimPath: string, relativePath: string) =>
+  path.win32.join(
+    path.win32.dirname(shimPath),
+    ...relativePath.replaceAll('\\', '/').split('/').filter(Boolean),
+  );
+
+const resolveShimPathToken = (shimPath: string, token: string): string | undefined => {
+  const trimmedToken = token.trim().replaceAll(/^['"]|['"]$/g, '');
+  const lowerToken = trimmedToken.toLowerCase();
+
+  if (lowerToken.startsWith('$basedir')) {
+    return joinShimRelativePath(
+      shimPath,
+      trimmedToken.slice('$basedir'.length).replace(/^[\\/]/, ''),
+    );
+  }
+
+  if (lowerToken.startsWith('%dp0%')) {
+    return joinShimRelativePath(shimPath, trimmedToken.slice('%dp0%'.length).replace(/^[\\/]/, ''));
+  }
+
+  if (path.win32.isAbsolute(trimmedToken)) return trimmedToken;
+
+  if (/[\\/]/.test(trimmedToken)) return joinShimRelativePath(shimPath, trimmedToken);
+};
+
+const getExistingShimPathToken = async (
+  shimPath: string,
+  token: string,
+): Promise<string | undefined> => {
+  const resolvedPath = resolveShimPathToken(shimPath, token);
+  if (!resolvedPath) return;
+  return (await fileExists(resolvedPath)) ? resolvedPath : undefined;
+};
+
+const getNodeCommand = async (shimPath: string, token: string): Promise<string | undefined> => {
+  if (/^node(?:\.exe)?$/i.test(token.trim())) return process.execPath;
+
+  const resolvedPath = await getExistingShimPathToken(shimPath, token);
+  if (!resolvedPath) return;
+
+  return WINDOWS_NODE_EXE_PATTERN.test(resolvedPath) ? resolvedPath : undefined;
+};
+
+const getNodeScriptTarget = async (
+  shimPath: string,
+  nodeToken: string,
+  scriptToken: string,
+): Promise<WindowsShimTarget | undefined> => {
+  const command = await getNodeCommand(shimPath, nodeToken);
+  if (!command) return;
+
+  const scriptPath = await getExistingShimPathToken(shimPath, scriptToken);
+  if (!scriptPath) return;
+
+  return { argsPrefix: [scriptPath], command };
+};
+
+const inferWindowsNodeScriptFromShim = async (
+  shimPath: string,
+  source: string,
+): Promise<WindowsShimTarget | undefined> => {
+  const patterns: Array<RegExp | [RegExp, string]> = [
+    /exec\s+"(\$basedir[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
+    /exec\s+(node(?:\.exe)?)\s+"([^"]+)"/i,
+    /"(%dp0%[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
+    [/(?:^|\r?\n)\s*(node(?:\.exe)?)\s+"([^"]+)"/i, 'node'],
+  ];
+
+  for (const pattern of patterns) {
+    const regex = Array.isArray(pattern) ? pattern[0] : pattern;
+    const match = source.match(regex);
+    if (!match) continue;
+
+    const nodeToken = Array.isArray(pattern) ? pattern[1] : match[1];
+    const scriptToken = Array.isArray(pattern) ? match[2] : match[2];
+    if (!nodeToken || !scriptToken) continue;
+
+    const target = await getNodeScriptTarget(shimPath, nodeToken, scriptToken);
+    if (target) return target;
+  }
+};
+
+const inferWindowsExecutableFromShim = async (
+  shimPath: string,
+  source: string,
+): Promise<WindowsShimTarget | undefined> => {
+  const matches = [
+    ...source.matchAll(/\$basedir[\\/]([^"\s]+?\.exe)/gi),
+    ...source.matchAll(/%dp0%\\([^"\r\n]+?\.exe)/gi),
+  ];
+
+  for (const match of matches) {
+    const relativePath = match[1]?.replaceAll('\\', '/');
+    if (!relativePath || WINDOWS_NODE_EXE_PATTERN.test(relativePath)) continue;
+
+    const command = joinShimRelativePath(shimPath, relativePath);
+    if (await fileExists(command)) return { command };
+  }
+};
+
+const inferWindowsNpmShimTarget = async (
+  shimPath: string,
+): Promise<WindowsShimTarget | undefined> => {
+  if (WINDOWS_EXE_EXT_PATTERN.test(shimPath)) return { command: shimPath };
   if (!(await fileExists(shimPath))) return;
 
   try {
     const source = await readFile(shimPath, 'utf8');
-    const extensionlessMatch = source.match(/exec\s+"\$basedir\/([^"]+\.exe)"/i);
-    const cmdMatch = source.match(/"%dp0%\\([^\r\n"]+\.exe)"/i);
-    const relativeBinaryPath = extensionlessMatch?.[1] ?? cmdMatch?.[1]?.replaceAll('\\', '/');
-    if (!relativeBinaryPath) return;
-
-    const binaryPath = path.win32.join(
-      path.win32.dirname(shimPath),
-      ...relativeBinaryPath.split('/'),
+    return (
+      (await inferWindowsNodeScriptFromShim(shimPath, source)) ??
+      (await inferWindowsExecutableFromShim(shimPath, source))
     );
-    return (await fileExists(binaryPath)) ? binaryPath : undefined;
   } catch {
     return;
   }
 };
 
-const resolveWindowsBareCommand = async (command: string): Promise<string | undefined> => {
+const resolveWindowsBareCommand = async (
+  command: string,
+): Promise<WindowsShimTarget | undefined> => {
   try {
     const stdout = await execFileString('where', [command]);
     const candidates = stdout
@@ -74,11 +179,11 @@ const resolveWindowsBareCommand = async (command: string): Promise<string | unde
       .filter(Boolean);
 
     const executable = pickWindowsExecutable(candidates);
-    if (executable) return executable;
+    if (executable) return { command: executable };
 
     for (const candidate of candidates) {
-      const binaryPath = await inferWindowsNpmBinaryFromShim(candidate);
-      if (binaryPath) return binaryPath;
+      const target = await inferWindowsNpmShimTarget(candidate);
+      if (target) return target;
     }
 
     return undefined;
@@ -94,11 +199,13 @@ export const resolveCliSpawnPlan = async (
   const trimmedCommand = command.trim();
   if (!isWindows() || !trimmedCommand) return { args, command };
 
-  const resolvedCommand = isPathLikeCommand(trimmedCommand)
-    ? ((await inferWindowsNpmBinaryFromShim(trimmedCommand)) ?? trimmedCommand)
-    : ((await resolveWindowsBareCommand(trimmedCommand)) ?? trimmedCommand);
+  const target = isPathLikeCommand(trimmedCommand)
+    ? await inferWindowsNpmShimTarget(trimmedCommand)
+    : await resolveWindowsBareCommand(trimmedCommand);
 
-  return { args, command: resolvedCommand };
+  if (!target) return { args, command };
+
+  return { args: [...(target.argsPrefix ?? []), ...args], command: target.command };
 };
 
 export const spawnCli = async (

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -1,5 +1,4 @@
-import type { ChildProcess, SpawnOptions } from 'node:child_process';
-import { execFile, spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { access, readFile } from 'node:fs/promises';
 import { platform } from 'node:os';
 import path from 'node:path';
@@ -233,13 +232,4 @@ export const resolveCliSpawnPlan = async (
   if (!target) return { args, command };
 
   return { args: [...(target.argsPrefix ?? []), ...args], command: target.command };
-};
-
-export const spawnCli = async (
-  command: string,
-  args: string[],
-  options: SpawnOptions,
-): Promise<ChildProcess> => {
-  const plan = await resolveCliSpawnPlan(command, args);
-  return spawn(plan.command, plan.args, options);
 };

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess, SpawnOptionsWithoutStdio } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { execFile, spawn } from 'node:child_process';
 import { access, readFile } from 'node:fs/promises';
 import { platform } from 'node:os';
@@ -50,6 +50,12 @@ const execFileString = async (command: string, args: string[]): Promise<string> 
 const pickWindowsExecutable = (candidates: string[]): string | undefined =>
   candidates.find((candidate) => WINDOWS_EXE_EXT_PATTERN.test(candidate));
 
+const pickWindowsNodeExecutable = (candidates: string[]): string | undefined =>
+  candidates.find(
+    (candidate) =>
+      WINDOWS_EXE_EXT_PATTERN.test(candidate) && WINDOWS_NODE_EXE_PATTERN.test(candidate),
+  );
+
 const joinShimRelativePath = (shimPath: string, relativePath: string) =>
   path.win32.join(
     path.win32.dirname(shimPath),
@@ -85,10 +91,30 @@ const getExistingShimPathToken = async (
   return (await fileExists(resolvedPath)) ? resolvedPath : undefined;
 };
 
-const getNodeCommand = async (shimPath: string, token: string): Promise<string | undefined> => {
-  if (/^node(?:\.exe)?$/i.test(token.trim())) return process.execPath;
+const resolveWindowsNodeCommand = async (shimPath: string): Promise<string | undefined> => {
+  const localNodePath = path.win32.join(path.win32.dirname(shimPath), 'node.exe');
+  if (await fileExists(localNodePath)) return localNodePath;
 
-  const resolvedPath = await getExistingShimPathToken(shimPath, token);
+  try {
+    const stdout = await execFileString('where', ['node']);
+    const candidates = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    return pickWindowsNodeExecutable(candidates);
+  } catch {
+    return;
+  }
+};
+
+const getNodeCommand = async (shimPath: string, token: string): Promise<string | undefined> => {
+  const trimmedToken = token.trim().replaceAll(/^['"]|['"]$/g, '');
+  if (/^node(?:\.exe)?$/i.test(trimmedToken) || /^%_prog%$/i.test(trimmedToken)) {
+    return resolveWindowsNodeCommand(shimPath);
+  }
+
+  const resolvedPath = await getExistingShimPathToken(shimPath, trimmedToken);
   if (!resolvedPath) return;
 
   return WINDOWS_NODE_EXE_PATTERN.test(resolvedPath) ? resolvedPath : undefined;
@@ -116,6 +142,7 @@ const inferWindowsNodeScriptFromShim = async (
     /exec\s+"(\$basedir[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
     /exec\s+(node(?:\.exe)?)\s+"([^"]+)"/i,
     /"(%dp0%[^"]*node(?:\.exe)?)"\s+"([^"]+)"/i,
+    /"(%_prog%)"\s+"([^"]+)"/i,
     [/(?:^|\r?\n)\s*(node(?:\.exe)?)\s+"([^"]+)"/i, 'node'],
   ];
 
@@ -211,7 +238,7 @@ export const resolveCliSpawnPlan = async (
 export const spawnCli = async (
   command: string,
   args: string[],
-  options: SpawnOptionsWithoutStdio,
+  options: SpawnOptions,
 ): Promise<ChildProcess> => {
   const plan = await resolveCliSpawnPlan(command, args);
   return spawn(plan.command, plan.args, options);

--- a/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
+++ b/packages/heterogeneous-agents/src/spawn/cliSpawn.ts
@@ -1,0 +1,111 @@
+import type { ChildProcess, SpawnOptionsWithoutStdio } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
+import { platform } from 'node:os';
+import path from 'node:path';
+
+const WINDOWS_EXE_EXT_PATTERN = /\.exe$/i;
+
+export interface CliSpawnPlan {
+  args: string[];
+  command: string;
+}
+
+const isWindows = () => platform() === 'win32';
+
+const isPathLikeCommand = (command: string) =>
+  path.win32.isAbsolute(command) || path.posix.isAbsolute(command) || /[\\/]/.test(command);
+
+const fileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const execFileString = async (command: string, args: string[]): Promise<string> =>
+  new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { timeout: 3000, windowsHide: true },
+      (error: Error | null, stdout: string) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout.toString());
+      },
+    );
+  });
+
+const pickWindowsExecutable = (candidates: string[]): string | undefined =>
+  candidates.find((candidate) => WINDOWS_EXE_EXT_PATTERN.test(candidate));
+
+const inferWindowsNpmBinaryFromShim = async (shimPath: string): Promise<string | undefined> => {
+  if (WINDOWS_EXE_EXT_PATTERN.test(shimPath)) return shimPath;
+  if (!(await fileExists(shimPath))) return;
+
+  try {
+    const source = await readFile(shimPath, 'utf8');
+    const extensionlessMatch = source.match(/exec\s+"\$basedir\/([^"]+\.exe)"/i);
+    const cmdMatch = source.match(/"%dp0%\\([^\r\n"]+\.exe)"/i);
+    const relativeBinaryPath = extensionlessMatch?.[1] ?? cmdMatch?.[1]?.replaceAll('\\', '/');
+    if (!relativeBinaryPath) return;
+
+    const binaryPath = path.win32.join(
+      path.win32.dirname(shimPath),
+      ...relativeBinaryPath.split('/'),
+    );
+    return (await fileExists(binaryPath)) ? binaryPath : undefined;
+  } catch {
+    return;
+  }
+};
+
+const resolveWindowsBareCommand = async (command: string): Promise<string | undefined> => {
+  try {
+    const stdout = await execFileString('where', [command]);
+    const candidates = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const executable = pickWindowsExecutable(candidates);
+    if (executable) return executable;
+
+    for (const candidate of candidates) {
+      const binaryPath = await inferWindowsNpmBinaryFromShim(candidate);
+      if (binaryPath) return binaryPath;
+    }
+
+    return undefined;
+  } catch {
+    return;
+  }
+};
+
+export const resolveCliSpawnPlan = async (
+  command: string,
+  args: string[],
+): Promise<CliSpawnPlan> => {
+  const trimmedCommand = command.trim();
+  if (!isWindows() || !trimmedCommand) return { args, command };
+
+  const resolvedCommand = isPathLikeCommand(trimmedCommand)
+    ? ((await inferWindowsNpmBinaryFromShim(trimmedCommand)) ?? trimmedCommand)
+    : ((await resolveWindowsBareCommand(trimmedCommand)) ?? trimmedCommand);
+
+  return { args, command: resolvedCommand };
+};
+
+export const spawnCli = async (
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio,
+): Promise<ChildProcess> => {
+  const plan = await resolveCliSpawnPlan(command, args);
+  return spawn(plan.command, plan.args, options);
+};

--- a/packages/heterogeneous-agents/src/spawn/index.ts
+++ b/packages/heterogeneous-agents/src/spawn/index.ts
@@ -13,7 +13,7 @@
  * that producers have no business pulling in).
  */
 export { AgentStreamPipeline, type AgentStreamPipelineOptions } from './agentStreamPipeline';
-export { type CliSpawnPlan, resolveCliSpawnPlan, spawnCli } from './cliSpawn';
+export { type CliSpawnPlan, resolveCliSpawnPlan } from './cliSpawn';
 export { CodexFileChangeTracker } from './codexFileChangeTracker';
 export {
   type AgentContentBlock,

--- a/packages/heterogeneous-agents/src/spawn/index.ts
+++ b/packages/heterogeneous-agents/src/spawn/index.ts
@@ -13,6 +13,7 @@
  * that producers have no business pulling in).
  */
 export { AgentStreamPipeline, type AgentStreamPipelineOptions } from './agentStreamPipeline';
+export { type CliSpawnPlan, resolveCliSpawnPlan, spawnCli } from './cliSpawn';
 export { CodexFileChangeTracker } from './codexFileChangeTracker';
 export {
   type AgentContentBlock,

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -1,5 +1,6 @@
+import * as childProcess from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import type * as os from 'node:os';
+import * as os from 'node:os';
 import { PassThrough } from 'node:stream';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,14 +8,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const spawnCalls: Array<{ args: string[]; command: string; options: any }> = [];
 let nextFakeProc: any = null;
 
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
+const platformMock = vi.mocked(os.platform);
+const execFileMock = vi.mocked(childProcess.execFile);
+
+const callExecFile = (stdout: string) => {
+  execFileMock.mockImplementationOnce(((...args: unknown[]) => {
+    const callback = [...args].reverse().find((arg) => typeof arg === 'function') as
+      | ((error: Error | null, stdout: string) => void)
+      | undefined;
+    callback?.(null, stdout);
+    return {} as childProcess.ChildProcess;
+  }) as typeof childProcess.execFile);
+};
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof childProcess>('node:child_process');
   return {
     ...actual,
-    spawn: (command: string, args: string[], options: any) => {
+    execFile: vi.fn(),
+    spawn: vi.fn((command: string, args: string[], options: any) => {
       spawnCalls.push({ args, command, options });
       return nextFakeProc;
-    },
+    }),
   };
 });
 
@@ -84,6 +99,8 @@ describe('spawnAgent', () => {
   beforeEach(() => {
     spawnCalls.length = 0;
     nextFakeProc = null;
+    platformMock.mockReturnValue('linux');
+    execFileMock.mockReset();
   });
 
   afterEach(() => {
@@ -173,6 +190,19 @@ describe('spawnAgent', () => {
     expect(args).toContain('--json');
     expect(args).toContain('--skip-git-repo-check');
     expect(args).toContain('--full-auto');
+  });
+
+  it('spawns the Windows executable resolved by the shared CLI spawn plan', async () => {
+    platformMock.mockReturnValue('win32');
+    callExecFile('C:\\Tools\\codex.exe\r\n');
+    nextFakeProc = createFakeProc().proc;
+
+    const { spawnAgent } = await import('./spawnAgent');
+    await spawnAgent({ agentType: 'codex', operationId: 'op-1', prompt: 'hello' });
+
+    const { args, command } = spawnCalls[0];
+    expect(command).toBe('C:\\Tools\\codex.exe');
+    expect(args[0]).toBe('exec');
   });
 
   it('uses codex `exec resume` form with thread id + `-` stdin marker on resume', async () => {

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import type * as os from 'node:os';
 import { PassThrough } from 'node:stream';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,11 @@ vi.mock('node:child_process', async (importOriginal) => {
       return nextFakeProc;
     },
   };
+});
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof os>('node:os');
+  return { ...actual, platform: vi.fn(() => 'linux') };
 });
 
 const createFakeProc = ({
@@ -242,7 +248,9 @@ describe('spawnAgent', () => {
     const imageIdx = args.indexOf('--image');
     expect(imageIdx).toBeGreaterThan(-1);
     const materializedPath = args[imageIdx + 1]!;
-    expect(materializedPath.startsWith(cacheDir)).toBe(true);
+    const normalizedCacheDir = cacheDir.replaceAll('\\', '/');
+    const normalizedMaterializedPath = materializedPath.replaceAll('\\', '/');
+    expect(normalizedMaterializedPath.startsWith(normalizedCacheDir)).toBe(true);
     expect(materializedPath.endsWith('.png')).toBe(true);
     // Codex receives the prompt text on stdin.
     const stdinPayload = (nextFakeProc as any).stdin.write.mock.calls[0][0] as string;

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -1,9 +1,9 @@
 import type { ChildProcess } from 'node:child_process';
-import { spawn } from 'node:child_process';
 
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 
 import { AgentStreamPipeline } from './agentStreamPipeline';
+import { spawnCli } from './cliSpawn';
 import type { AgentPromptInput, BuildAgentInputOptions } from './input';
 import { buildAgentInput } from './input';
 
@@ -230,7 +230,7 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
   });
   const cwd = options.cwd || process.cwd();
 
-  const proc = spawn(command, args, {
+  const proc = await spawnCli(command, args, {
     cwd,
     detached: process.platform !== 'win32',
     env: { ...process.env, ...options.env },

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -1,9 +1,10 @@
 import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 
 import { AgentStreamPipeline } from './agentStreamPipeline';
-import { spawnCli } from './cliSpawn';
+import { resolveCliSpawnPlan } from './cliSpawn';
 import type { AgentPromptInput, BuildAgentInputOptions } from './input';
 import { buildAgentInput } from './input';
 
@@ -230,12 +231,20 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
   });
   const cwd = options.cwd || process.cwd();
 
-  const proc = await spawnCli(command, args, {
+  const cliSpawnPlan = await resolveCliSpawnPlan(command, args);
+  const proc = spawn(cliSpawnPlan.command, cliSpawnPlan.args, {
     cwd,
     detached: process.platform !== 'win32',
     env: { ...process.env, ...options.env },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      proc.on('exit', (code, signal) => resolve({ code, signal }));
+      proc.on('error', (err) => reject(err));
+    },
+  );
 
   if (proc.stdin) {
     proc.stdin.write(inputPlan.stdin, () => {
@@ -337,13 +346,6 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
       };
     },
   };
-
-  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      proc.on('exit', (code, signal) => resolve({ code, signal }));
-      proc.on('error', (err) => reject(err));
-    },
-  );
 
   return {
     events,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

修复 Windows 桌面端在启动异构 Agent CLI 时，无法稳定调用通过 npm 安装的 CLI shim 的问题。

本次改动将外部 CLI 的启动逻辑集中到共享 `spawnCli()` 路径中，在 Windows 下启动前先解析 npm 生成的 shim，而不是直接 `spawn()` `claude` / `claude.cmd` / `codex.cmd` 这类入口文件。

主要变更：

- 新增通用 Windows CLI spawn resolver：
  - 对裸命令使用 `where <command>` 解析候选路径。
  - 优先使用真实 `.exe`。
  - 支持读取 npm 生成的 extensionless shim 和 `.cmd` shim。
- 支持两类 npm CLI：
  - `.exe` backed CLI，例如 Claude Code：解析到包内真实 `.exe` 后直接 spawn。
  - JS backed CLI，例如 Codex / Gemini：解析到 `node.exe + script.js`，并把 JS 入口插入 argv 第一个参数。
- 支持 npm `.cmd` 常见 `%_prog%` 模板，避免桌面端检测到 `codex.cmd` / `gemini.cmd` 后直接 spawn `.cmd` 导致 Windows `EINVAL`。
- 桌面端 `HeterogeneousAgentCtr` 改为通过共享 `spawnCli()` 启动外部 CLI，保持原有 stdout / stderr / stdin / cancel 处理逻辑。
- 不使用 `shell: true`，不增加 `cmd.exe /c` fallback，继续保持 argv 数组传参，避免 shell quoting 和参数注入风险。

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

本地测试：

```bash
corepack pnpm --dir "D:/GitLibrary/lobehub/packages/heterogeneous-agents" exec vitest run --silent='passed-only' "src/spawn/cliSpawn.test.ts" "src/spawn/spawnAgent.test.ts"
```
结果：
cliSpawn.test.ts：12 tests passed
spawnAgent.test.ts：13 tests passed

桌面端类型检查：

```
corepack pnpm --dir "D:/GitLibrary/lobehub/apps/desktop" run type-check
```
结果：通过。

真实 Windows CLI smoke test：

Claude Code：解析到 npm 包内 claude.exe，可正常启动。
Codex：codex.cmd 解析为 node.exe + @openai/codex/bin/codex.js，--version 可正常执行。
Gemini：gemini.cmd 解析为 node.exe + @google/gemini-cli/bundle/gemini.js，--version 可正常执行。
GitHub Actions：

Test CI：通过
E2E CI：通过
Desktop Manual Build：通过
Windows build：通过
macOS build：通过

#### 📸 Screenshots / Videos
<img width="301" height="201" alt="image" src="https://github.com/user-attachments/assets/f1271059-fe85-4f0d-b3de-abf71b6fd4db" />
<img width="301" height="201" alt="20260514_001054_149_copy" src="https://github.com/user-attachments/assets/377adf48-79b1-416c-aefd-21599d351216" />

#### 📝 Additional Information
这个修复只处理 Windows 下外部 CLI 的进程启动问题，不新增任何具体 Agent 类型，也不改变 Codex / Gemini / Claude Code 的协议解析逻辑。
设计上刻意避免按 CLI 名称写特殊分支，因此后续其他通过 npm 安装、且使用相同 shim 模板的 CLI 也可以复用同一套解析逻辑。