### PR TITLE
🐛 fix(agent-signal): avoid blocking agent execution

### DIFF
--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1650,7 +1650,11 @@ export class AiAgentService {
         });
     if (userMessageRecord) {
       log('execAgent: created user message %s', userMessageRecord.id);
-      await enqueueAgentSignalSourceEvent(
+      // Agent Signal is a governance side-channel for feedback and self-iteration.
+      // It must not block the primary agent execution path; local Workflow/QStash
+      // stalls would otherwise leave the conversation with only the user message
+      // persisted and no assistant placeholder or operation row.
+      void enqueueAgentSignalSourceEvent(
         {
           payload: {
             agentId: resolvedAgentId,
@@ -1667,7 +1671,9 @@ export class AiAgentService {
           agentId: resolvedAgentId,
           userId: this.userId,
         },
-      );
+      ).catch((error) => {
+        log('execAgent: failed to enqueue user message Agent Signal source event: %O', error);
+      });
     }
 
     // 14. Create assistant message placeholder in database


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Make Agent Signal source-event enqueue fire-and-forget during agent execution.
- Log enqueue failures without blocking assistant placeholder and operation row creation.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Ran:

```bash
node_modules/.bin/eslint src/server/services/aiAgent/index.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This only changes the Agent Signal side-channel enqueue behavior in `AiAgentService.execAgent`.