### PR TITLE
🔥 remove: 下线技能授权提示框 (ToolAuthAlert)

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/AgentWelcome/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/AgentWelcome/index.tsx
@@ -13,7 +13,6 @@ import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import OpeningQuestions from './OpeningQuestions';
-import ToolAuthAlert from './ToolAuthAlert';
 
 const InboxWelcome = memo(() => {
   const { t } = useTranslation(['welcome', 'chat']);
@@ -64,7 +63,6 @@ const InboxWelcome = memo(() => {
         {openingQuestions.length > 0 && (
           <OpeningQuestions mobile={mobile} questions={openingQuestions} />
         )}
-        <ToolAuthAlert />
       </Flexbox>
     </>
   );

--- a/src/routes/(main)/group/features/Conversation/AgentWelcome/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/AgentWelcome/index.tsx
@@ -14,7 +14,6 @@ import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 import OpeningQuestions from './OpeningQuestions';
-import ToolAuthAlert from './ToolAuthAlert';
 
 const InboxWelcome = memo(() => {
   const { t } = useTranslation(['welcome', 'chat']);
@@ -74,7 +73,6 @@ const InboxWelcome = memo(() => {
         {openingQuestions.length > 0 && (
           <OpeningQuestions mobile={mobile} questions={openingQuestions} />
         )}
-        <ToolAuthAlert />
       </Flexbox>
     </>
   );


### PR DESCRIPTION
## Summary

- 移除 `agent` 欢迎页中的 `<ToolAuthAlert />` 组件及其 import
- 移除 `group` 欢迎页中的 `<ToolAuthAlert />` 组件及其 import

该功能已不再使用，下线整个展示框。

Closes T-34

## Files Changed

- `src/routes/(main)/agent/features/Conversation/AgentWelcome/index.tsx`
- `src/routes/(main)/group/features/Conversation/AgentWelcome/index.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)