### PR TITLE
🐛 fix(topic): restore indent for heterogeneous agent topic rows

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -259,7 +259,6 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, meta
               return <ProviderIcon color={cssVar.colorTextDescription} size={16} />;
             }
           }
-          if (isHeterogeneousAgent) return null;
           return (
             <Icon
               icon={HashIcon}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #14707

#### 🔀 Description of Change

Commit `49c8d17e2c` added `if (isHeterogeneousAgent) return null` before the `HashIcon` render in the agent sidebar topic item. This caused `NavItem` to skip the entire 28 px icon `<Center>` container, shifting the title text leftward and breaking visual alignment with regular (non-heterogeneous) topic rows.

The same commit also added `visibility: isHeterogeneousAgent ? 'hidden' : undefined` on the `HashIcon` style — the correct approach that keeps the layout box intact while hiding the glyph — but it was dead code due to the early `return null` above it.

This PR removes the dead `return null` so the `visibility: hidden` path takes effect, restoring consistent indentation for Claude Code / Codex topic rows.

#### 🧪 How to Test

1. Open an agent that uses a heterogeneous provider (Claude Code or Codex)
2. Check the topic list in the sidebar
3. Verify topic rows are horizontally aligned with other agents' topic rows (no leftward shift)

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Topic titles shifted left (no icon space) | Topic titles aligned with regular rows |