### PR TITLE
📝 docs: simplify and refresh skill docs

### DIFF
--- a/.agents/skills/add-provider-doc/SKILL.md
+++ b/.agents/skills/add-provider-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-provider-doc
-description: Guide for adding new AI provider documentation. Use when adding documentation for a new AI provider (like OpenAI, Anthropic, etc.), including usage docs, environment variables, Docker config, and image resources. Triggers on provider documentation tasks.
+description: Add documentation for a new AI provider — usage docs, env vars, Docker config, image resources.
 disable-model-invocation: true
 argument-hint: '[provider-name]'
 ---

--- a/.agents/skills/add-setting-env/SKILL.md
+++ b/.agents/skills/add-setting-env/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-setting-env
-description: Guide for adding environment variables to configure user settings. Use when implementing server-side environment variables that control default values for user settings. Triggers on env var configuration or setting default value tasks.
+description: Add server-side environment variables that control default values for user settings.
 disable-model-invocation: true
 argument-hint: '[setting-name]'
 ---

--- a/.agents/skills/cli/SKILL.md
+++ b/.agents/skills/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli
-description: LobeHub CLI (@lobehub/cli) development guide. Use when working on CLI commands, adding new subcommands, fixing CLI bugs, or understanding CLI architecture. Triggers on CLI development, command implementation, or `lh` command questions.
+description: LobeHub CLI (@lobehub/cli) development guide — commands, subcommands, architecture.
 disable-model-invocation: true
 ---
 

--- a/.agents/skills/desktop/SKILL.md
+++ b/.agents/skills/desktop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: desktop
-description: Electron desktop development guide. Use when implementing desktop features, IPC handlers, controllers, preload scripts, window management, menu configuration, or Electron-specific functionality. Triggers on desktop app development, Electron IPC, or desktop local tools implementation.
+description: Electron desktop development guide — IPC handlers, controllers, preload scripts, window/menu management.
 disable-model-invocation: true
 ---
 

--- a/.agents/skills/project-overview/SKILL.md
+++ b/.agents/skills/project-overview/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: false
 
 # LobeHub Project Overview
 
+> The directory listings below are a **curated map of key locations**, not an
+> exhaustive tree. `packages/`, `src/store/`, route groups etc. grow over time —
+> run `ls` against the real directory for the current set.
+
 ## Project Description
 
 Open-source, modern-design AI Agent Workspace: **LobeHub** (previously LobeChat).
@@ -14,7 +18,7 @@ Open-source, modern-design AI Agent Workspace: **LobeHub** (previously LobeChat)
 
 - Web desktop/mobile
 - Desktop (Electron)
-- Mobile app (React Native) - coming soon
+- Mobile app (React Native) — **separate repo, already launched** (not in this monorepo)
 
 **Logo emoji:** 🤯
 
@@ -39,147 +43,92 @@ Open-source, modern-design AI Agent Workspace: **LobeHub** (previously LobeChat)
 | Database      | Neon PostgreSQL + Drizzle ORM              |
 | Testing       | Vitest                                     |
 
-## Complete Project Structure
+> Exact versions live in the root `package.json` — check there, not here.
 
-Monorepo using `@lobechat/` namespace for workspace packages.
+## Monorepo Layout
+
+This is a monorepo extending the open-source `lobehub` submodule. Two repos:
+
+- **cloud repo root** — `src/` and `packages/business/` (`config`, `const`, `model-runtime`) hold cloud-only SaaS code that overrides/extends the submodule. See `AGENTS.md` for the override mechanism.
+- **`lobehub/` submodule** — the open-source product core.
+
+### `lobehub/` submodule — key directories
 
 ```
 lobehub/
 ├── apps/
-│   └── desktop/                 # Electron desktop app
-├── docs/
-│   ├── changelog/
-│   ├── development/
-│   ├── self-hosting/
-│   └── usage/
-├── locales/
-│   ├── en-US/
-│   └── zh-CN/
-├── packages/
-│   ├── agent-runtime/           # Agent runtime
-│   ├── builtin-agents/
-│   ├── builtin-tool-*/          # Builtin tool packages
-│   ├── business/                # Cloud-only business logic
-│   │   ├── config/
-│   │   ├── const/
-│   │   └── model-runtime/
-│   ├── config/
-│   ├── const/
+│   ├── cli/                 # LobeHub CLI
+│   ├── desktop/             # Electron desktop app
+│   └── device-gateway/      # Device gateway service
+├── docs/                    # changelog, development, self-hosting, usage
+├── locales/                 # en-US, zh-CN, ...
+├── packages/                # ~80 @lobechat/* workspace packages — `ls` for the full set. Key ones:
+│   ├── agent-runtime/        # Agent runtime
+│   ├── agent-signal/         # Agent Signal pipeline
+│   ├── builtin-tool-*/       # Builtin tool packages
+│   ├── builtin-tools/        # Builtin tool registries
 │   ├── context-engine/
-│   ├── conversation-flow/
-│   ├── database/
-│   │   └── src/
-│   │       ├── models/
-│   │       ├── schemas/
-│   │       └── repositories/
-│   ├── desktop-bridge/
-│   ├── edge-config/
-│   ├── editor-runtime/
-│   ├── electron-client-ipc/
-│   ├── electron-server-ipc/
-│   ├── fetch-sse/
-│   ├── file-loaders/
-│   ├── memory-user-memory/
-│   ├── model-bank/
-│   ├── model-runtime/
-│   │   └── src/
-│   │       ├── core/
-│   │       └── providers/
-│   ├── observability-otel/
-│   ├── prompts/
-│   ├── python-interpreter/
-│   ├── ssrf-safe-fetch/
-│   ├── types/
-│   ├── utils/
-│   └── web-crawler/
-├── src/
-│   ├── app/
-│   │   ├── (backend)/
-│   │   │   ├── api/
-│   │   │   ├── f/
-│   │   │   ├── market/
-│   │   │   ├── middleware/
-│   │   │   ├── oidc/
-│   │   │   ├── trpc/
-│   │   │   └── webapi/
-│   │   ├── spa/                  # SPA HTML template service
-│   │   └── [variants]/
-│   │       └── (auth)/           # Auth pages (SSR required)
-│   ├── routes/                  # SPA page components (Vite)
-│   │   ├── (main)/
-│   │   ├── (mobile)/
-│   │   ├── (desktop)/
-│   │   ├── onboarding/
-│   │   └── share/
-│   ├── spa/                     # SPA entry points and router config
-│   │   ├── entry.web.tsx
-│   │   ├── entry.mobile.tsx
-│   │   ├── entry.desktop.tsx
-│   │   └── router/
-│   ├── business/                # Cloud-only (client/server)
-│   │   ├── client/
-│   │   ├── locales/
-│   │   └── server/
-│   ├── components/
-│   ├── config/
-│   ├── const/
-│   ├── envs/
-│   ├── features/
-│   ├── helpers/
-│   ├── hooks/
-│   ├── layout/
-│   │   ├── AuthProvider/
-│   │   └── GlobalProvider/
-│   ├── libs/
-│   │   ├── better-auth/
-│   │   ├── oidc-provider/
-│   │   └── trpc/
-│   ├── locales/
-│   │   └── default/
-│   ├── server/
-│   │   ├── featureFlags/
-│   │   ├── globalConfig/
-│   │   ├── modules/
-│   │   ├── routers/
-│   │   │   ├── async/
-│   │   │   ├── lambda/
-│   │   │   ├── mobile/
-│   │   │   └── tools/
-│   │   └── services/
-│   ├── services/
-│   ├── store/
-│   │   ├── agent/
-│   │   ├── chat/
-│   │   └── user/
-│   ├── styles/
-│   ├── tools/
+│   ├── database/             # src/{models,schemas,repositories}
+│   ├── model-bank/           # Model definitions & provider cards
+│   ├── model-runtime/        # src/{core,providers}
 │   ├── types/
 │   └── utils/
-└── e2e/                         # E2E tests (Cucumber + Playwright)
+└── src/
+    ├── app/
+    │   ├── (backend)/        # api, f, market, middleware, oidc, trpc, webapi
+    │   ├── spa/              # SPA HTML template service
+    │   └── [variants]/(auth)/ # Auth pages (SSR required)
+    ├── routes/               # SPA page segments (thin — delegate to features/)
+    │   └── (main)/ (mobile)/ (desktop)/ (popup)/ onboarding/ share/
+    ├── spa/                  # SPA entries + router config
+    │   ├── entry.{web,mobile,desktop,popup}.tsx
+    │   └── router/
+    ├── business/             # Open-source stubs (~50) overridden by cloud src/business/
+    ├── features/             # Domain business components
+    ├── store/                # ~28 zustand stores — `ls` for the full set
+    ├── server/               # featureFlags, globalConfig, modules, routers, services
+    └── ...                   # components, hooks, layout, libs, locales, services, types, utils
 ```
+
+### cloud repo — key directories
+
+```
+(cloud root)
+├── packages/business/        # Cloud overrides: config, const, model-runtime
+├── src/
+│   ├── business/             # Cloud impls of submodule stubs (client/server/locales)
+│   ├── routes/               # Cloud-only route groups: (cloud)/, embed/
+│   ├── store/                # Cloud-only stores (e.g. subscription/)
+│   ├── server/               # Cloud routers & services (billing, budget, risk control...)
+│   └── app/(backend)/cron/   # Vercel cron routes (schedules declared in root vercel.ts)
+└── vercel.ts                 # Cron schedule declarations
+```
+
+> File search rule: a path like `@/store/x` resolves cloud `src/store/x` first, then
+> `lobehub/packages/store/src/x`, then `lobehub/src/store/x`. Cloud override wins.
 
 ## Architecture Map
 
-| Layer            | Location                                            |
-| ---------------- | --------------------------------------------------- |
-| UI Components    | `src/components`, `src/features`                    |
-| SPA Pages        | `src/routes/`                                       |
-| React Router     | `src/spa/router/`                                   |
-| Global Providers | `src/layout`                                        |
-| Zustand Stores   | `src/store`                                         |
-| Client Services  | `src/services/`                                     |
-| REST API         | `src/app/(backend)/webapi`                          |
-| tRPC Routers     | `src/server/routers/{async\|lambda\|mobile\|tools}` |
-| Server Services  | `src/server/services` (can access DB)               |
-| Server Modules   | `src/server/modules` (no DB access)                 |
-| Feature Flags    | `src/server/featureFlags`                           |
-| Global Config    | `src/server/globalConfig`                           |
-| DB Schema        | `packages/database/src/schemas`                     |
-| DB Model         | `packages/database/src/models`                      |
-| DB Repository    | `packages/database/src/repositories`                |
-| Third-party      | `src/libs` (analytics, oidc, etc.)                  |
-| Builtin Tools    | `src/tools`, `packages/builtin-tool-*`              |
-| Cloud-only       | `src/business/*`, `packages/business/*`             |
+| Layer            | Location                                             |
+| ---------------- | ---------------------------------------------------- |
+| UI Components    | `src/components`, `src/features`                     |
+| SPA Pages        | `src/routes/`                                        |
+| React Router     | `src/spa/router/`                                    |
+| Global Providers | `src/layout`                                         |
+| Zustand Stores   | `src/store`                                          |
+| Client Services  | `src/services/`                                      |
+| REST API         | `src/app/(backend)/webapi`                           |
+| tRPC Routers     | `src/server/routers/{async\|lambda\|mobile\|tools}`  |
+| Server Services  | `src/server/services` (can access DB)                |
+| Server Modules   | `src/server/modules` (no DB access)                  |
+| Feature Flags    | `src/server/featureFlags`                            |
+| Global Config    | `src/server/globalConfig`                            |
+| DB Schema        | `packages/database/src/schemas`                      |
+| DB Model         | `packages/database/src/models`                       |
+| DB Repository    | `packages/database/src/repositories`                 |
+| Third-party      | `src/libs` (analytics, oidc, etc.)                   |
+| Builtin Tools    | `src/tools`, `packages/builtin-tool-*`               |
+| Cloud-only       | `src/business/*`, `packages/business/*` (cloud repo) |
 
 ## Data Flow
 

--- a/.agents/skills/version-release/SKILL.md
+++ b/.agents/skills/version-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: version-release
-description: "Version release workflow. Use when the user mentions 'release', 'hotfix', 'version upgrade', 'weekly release', or '发版'/'发布'/'小班车'. This skill is for release process and GitHub Release notes (not docs/changelog page writing)."
+description: 'Version release workflow — release process and GitHub Release notes (not docs/changelog pages).'
 disable-model-invocation: true
 argument-hint: '[minor|patch] [version?]'
 ---


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Two related skill-doc cleanups:

1. **Simplify descriptions of user-invoked-only skills.** Skills with `disable-model-invocation: true` are never auto-triggered by the model from their `description`, so the auto-trigger boilerplate ("Use when user says...", "Triggers on...", catch phrases) is dead weight — replaced with a concise one-line summary. Affected: `add-provider-doc`, `add-setting-env`, `cli`, `desktop`, `version-release`.

2. **Refresh a drifted guide skill.** The `project-overview` skill carried a manually maintained directory tree that had drifted badly (missing apps, ~25 of ~80 packages listed, stale route groups, a "React Native coming soon" line that has shipped). Rather than re-snapshot the full tree, it is rewritten as a curated map of key locations with explicit "not exhaustive — `ls` for current" notes.

#### 🧪 How to Test

- [x] No tests needed

#### 📝 Additional Information

Skill content only; no code changes.