### PR TITLE
🐛 fix: preserve resume request trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
   },
   "overrides": {
     "@types/react": "19.2.13",
+    "antd": "6.3.5",
     "better-auth": "1.4.6",
     "better-call": "1.1.8",
     "drizzle-orm": "^0.45.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
   },
   "overrides": {
     "@types/react": "19.2.13",
-    "antd": "6.3.5",
     "better-auth": "1.4.6",
     "better-call": "1.1.8",
     "drizzle-orm": "^0.45.1",

--- a/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -1,5 +1,6 @@
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
 import { SELF_FEEDBACK_INTENT_IDENTIFIER } from '@lobechat/builtin-tool-self-iteration';
+import { RequestTrigger } from '@lobechat/types';
 import type * as ModelBankModule from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -70,9 +71,7 @@ vi.mock('@/server/services/agentSignal/featureGate', () => ({
     agentSelfIterationEnabled?: boolean;
     isAgentSelfIterationFeatureEnabled: boolean;
     isLobeAiAgent: boolean;
-  }) =>
-    isAgentSelfIterationFeatureEnabled &&
-    (isLobeAiAgent || agentSelfIterationEnabled === true),
+  }) => isAgentSelfIterationFeatureEnabled && (isLobeAiAgent || agentSelfIterationEnabled === true),
 }));
 
 vi.mock('@/server/services/agentSignal', () => ({
@@ -274,6 +273,32 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
 
     const callArgs = mockCreateOperation.mock.calls[0][0];
     expect(callArgs.agentConfig.systemRole).toBe('');
+  });
+
+  it('should persist request trigger metadata on the created user message', async () => {
+    mockGetAgentConfig.mockResolvedValue({
+      chatConfig: {},
+      id: 'agent-custom',
+      model: 'gpt-4',
+      plugins: [],
+      provider: 'openai',
+      systemRole: '',
+    });
+
+    await service.execAgent({
+      agentId: 'agent-custom',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'Hello',
+      trigger: RequestTrigger.Onboarding,
+    });
+
+    expect(mockMessageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Hello',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      }),
+    );
   });
 
   it('should inject self-feedback intent tool for Lobe AI when user gate is enabled', async () => {

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1649,6 +1649,11 @@ export class AiAgentService {
 
     await throwIfExecutionAborted('message creation');
 
+    const requestTriggerMetadata =
+      trigger && Object.values(RequestTrigger).includes(trigger as RequestTrigger)
+        ? { trigger: trigger as RequestTrigger }
+        : undefined;
+
     // 13. Create user message in database
     // Include threadId if provided (for SubAgent task execution in isolated Thread)
     const userMessageRecord = effectiveResume
@@ -1657,6 +1662,7 @@ export class AiAgentService {
           agentId: resolvedAgentId,
           content: prompt,
           files: fileIds,
+          metadata: requestTriggerMetadata,
           role: 'user',
           threadId: appContext?.threadId ?? undefined,
           topicId,

--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
@@ -699,7 +699,7 @@ describe('ConversationControl actions', () => {
               parentMessageId: 'tool-msg-1',
               toolCallId: 'call_xyz',
             },
-            trigger: RequestTrigger.Onboarding,
+            metadata: { trigger: RequestTrigger.Onboarding },
           }),
         );
         expect(executeClientAgentSpy).not.toHaveBeenCalled();

--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts
@@ -26,6 +26,20 @@ vi.mock('@/services/agentRuntime', () => ({
   },
 }));
 
+vi.mock('@/utils/localStorage', () => {
+  class AsyncLocalStorage<State> {
+    async getFromLocalStorage(): Promise<State> {
+      return {} as State;
+    }
+
+    async saveToLocalStorage(): Promise<void> {
+      return undefined;
+    }
+  }
+
+  return { AsyncLocalStorage };
+});
+
 beforeEach(() => {
   resetTestEnvironment();
 });
@@ -617,8 +631,19 @@ describe('ConversationControl actions', () => {
         const topicId = 'server-topic';
         const chatKey = messageMapKey({ agentId, topicId });
 
+        const onboardingUserMessage = createMockMessage({
+          id: 'onboarding-user-msg',
+          metadata: { trigger: RequestTrigger.Onboarding },
+          role: 'user',
+        });
+        const onboardingAssistantMessage = createMockMessage({
+          id: 'onboarding-assistant-msg',
+          parentId: onboardingUserMessage.id,
+          role: 'assistant',
+        });
         const toolMessage = createMockMessage({
           id: 'tool-msg-1',
+          parentId: onboardingAssistantMessage.id,
           plugin: {
             apiName: 'search',
             arguments: '{"q":"test"}',
@@ -635,8 +660,12 @@ describe('ConversationControl actions', () => {
           useChatStore.setState({
             activeAgentId: agentId,
             activeTopicId: topicId,
-            dbMessagesMap: { [chatKey]: [toolMessage] },
-            messagesMap: { [chatKey]: [toolMessage] },
+            dbMessagesMap: {
+              [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
+            },
+            messagesMap: {
+              [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
+            },
           });
 
           // Presence of an `execServerAgentRuntime` op (any status) is one
@@ -670,6 +699,7 @@ describe('ConversationControl actions', () => {
               parentMessageId: 'tool-msg-1',
               toolCallId: 'call_xyz',
             },
+            trigger: RequestTrigger.Onboarding,
           }),
         );
         expect(executeClientAgentSpy).not.toHaveBeenCalled();
@@ -1166,6 +1196,7 @@ describe('ConversationControl actions', () => {
         expect.objectContaining({
           content: 'Writing documents, Professional',
           groupId: 'group-1',
+          metadata: { trigger: RequestTrigger.Onboarding },
           role: 'user',
         }),
         expect.objectContaining({ operationId: expect.any(String) }),
@@ -1468,6 +1499,7 @@ describe('ConversationControl actions', () => {
         expect.objectContaining({
           content: `I'll skip this. ${reason}`,
           groupId: 'group-1',
+          metadata: { trigger: RequestTrigger.Onboarding },
           role: 'user',
         }),
         expect.objectContaining({ operationId: expect.any(String) }),
@@ -1486,6 +1518,114 @@ describe('ConversationControl actions', () => {
       expect(executeClientAgentSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           initialContext,
+          metadata: { trigger: RequestTrigger.Onboarding },
+          parentMessageId: userMessageId,
+          parentMessageType: 'user',
+        }),
+      );
+    });
+
+    it('should preserve request trigger from raw messages when display messages are incomplete', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const agentId = 'global-agent';
+      const topicId = 'global-topic';
+      const chatKey = messageMapKey({ agentId, topicId });
+
+      const onboardingUserMessage = createMockMessage({
+        id: 'onboarding-user-msg',
+        metadata: { trigger: RequestTrigger.Onboarding },
+        role: 'user',
+      });
+      const onboardingAssistantMessage = createMockMessage({
+        id: 'onboarding-assistant-msg',
+        parentId: onboardingUserMessage.id,
+        role: 'assistant',
+      });
+      const toolMessage = createMockMessage({
+        groupId: 'group-1',
+        id: 'tool-msg-1',
+        parentId: onboardingAssistantMessage.id,
+        plugin: {
+          apiName: 'showAgentMarketplace',
+          arguments: '{}',
+          identifier: 'lobe-web-onboarding',
+          type: 'default',
+        },
+        role: 'tool',
+      });
+
+      act(() => {
+        useChatStore.setState({
+          activeAgentId: agentId,
+          activeTopicId: topicId,
+          activeThreadId: undefined,
+          dbMessagesMap: {
+            [chatKey]: [onboardingUserMessage, onboardingAssistantMessage, toolMessage],
+          },
+          messagesMap: {
+            [chatKey]: [toolMessage],
+          },
+        });
+      });
+
+      vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticUpdateMessageContent').mockResolvedValue(undefined);
+
+      const userMessageId = 'skipped-user-msg';
+      const optimisticCreateMessageSpy = vi
+        .spyOn(result.current, 'optimisticCreateMessage')
+        .mockImplementation(async (message) => {
+          const userMessage = createMockMessage({
+            content: message.content,
+            groupId: message.groupId,
+            id: userMessageId,
+            metadata: message.metadata,
+            role: 'user',
+            topicId,
+          });
+
+          useChatStore.setState({
+            dbMessagesMap: {
+              [chatKey]: [
+                onboardingUserMessage,
+                onboardingAssistantMessage,
+                toolMessage,
+                userMessage,
+              ],
+            },
+            messagesMap: {
+              [chatKey]: [toolMessage, userMessage],
+            },
+          });
+
+          return {
+            id: userMessageId,
+            messages: [onboardingUserMessage, onboardingAssistantMessage, toolMessage, userMessage],
+          };
+        });
+
+      vi.spyOn(result.current, 'internal_createAgentState').mockReturnValue({
+        agentConfig: createMockResolvedAgentConfig(),
+        context: { phase: 'init' } as any,
+        state: {} as any,
+      });
+      const executeClientAgentSpy = vi
+        .spyOn(result.current, 'executeClientAgent')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.skipToolInteraction('tool-msg-1');
+      });
+
+      expect(optimisticCreateMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { trigger: RequestTrigger.Onboarding },
+        }),
+        expect.objectContaining({ operationId: expect.any(String) }),
+      );
+      expect(executeClientAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
           metadata: { trigger: RequestTrigger.Onboarding },
           parentMessageId: userMessageId,
           parentMessageType: 'user',

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -1,4 +1,5 @@
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
+import { RequestTrigger } from '@lobechat/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { aiAgentService } from '@/services/aiAgent';
@@ -488,7 +489,7 @@ describe('GatewayActionImpl', () => {
       );
     });
 
-    it('should forward trigger to execAgentTask', async () => {
+    it('should forward metadata trigger to execAgentTask', async () => {
       const { action } = createExecuteTestAction();
 
       vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
@@ -509,7 +510,7 @@ describe('GatewayActionImpl', () => {
       await action.executeGatewayAgent({
         context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
         message: 'Hello',
-        trigger: 'onboarding',
+        metadata: { trigger: RequestTrigger.Onboarding },
       });
 
       expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -488,6 +488,39 @@ describe('GatewayActionImpl', () => {
       );
     });
 
+    it('should forward trigger to execAgentTask', async () => {
+      const { action } = createExecuteTestAction();
+
+      vi.mocked(aiAgentService.execAgentTask).mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
+        operationId: 'server-op-1',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      });
+
+      await action.executeGatewayAgent({
+        context: { agentId: 'agent-1', topicId: 'topic-1', threadId: null, scope: 'main' },
+        message: 'Hello',
+        trigger: 'onboarding',
+      });
+
+      expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'Hello',
+          trigger: 'onboarding',
+        }),
+        expect.anything(),
+      );
+    });
+
     it('should forward task manager default assignee and current task context', async () => {
       const { action } = createExecuteTestAction();
 

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -284,13 +284,13 @@ export class ConversationControlActionImpl {
         await this.#get().executeGatewayAgent({
           context: effectiveContext,
           message: '',
+          metadata: requestMetadata,
           parentMessageId: toolMessageId,
           resumeApproval: {
             decision: 'approved',
             parentMessageId: toolMessageId,
             toolCallId,
           },
-          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
@@ -952,6 +952,7 @@ export class ConversationControlActionImpl {
         await this.#get().executeGatewayAgent({
           context: effectiveContext,
           message: '',
+          metadata: requestMetadata,
           parentMessageId: messageId,
           resumeApproval: {
             decision: 'rejected_continue',
@@ -959,7 +960,6 @@ export class ConversationControlActionImpl {
             rejectionReason: reason,
             toolCallId,
           },
-          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
       } catch (error) {
@@ -1037,6 +1037,7 @@ export class ConversationControlActionImpl {
         await this.#get().executeGatewayAgent({
           context: effectiveContext,
           message: '',
+          metadata: requestMetadata,
           parentMessageId: messageId,
           resumeApproval: {
             decision: 'rejected_continue',
@@ -1044,7 +1045,6 @@ export class ConversationControlActionImpl {
             rejectionReason: reason,
             toolCallId,
           },
-          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -98,10 +98,21 @@ export class ConversationControlActionImpl {
    * headers after a human-intervention pause.
    */
   #getRequestMetadataFromMessageChain = (
-    messages: UIChatMessage[],
     anchorMessageId: string,
+    fallbackMessages: UIChatMessage[] = [],
   ): Pick<MessageMetadata, 'trigger'> | undefined => {
-    const messagesById = new Map(messages.map((message) => [message.id, message]));
+    const messagesById = new Map<string, UIChatMessage>();
+    const addMessages = (messages: UIChatMessage[]) => {
+      for (const message of messages) {
+        if (!messagesById.has(message.id)) messagesById.set(message.id, message);
+      }
+    };
+
+    for (const messages of Object.values(this.#get().dbMessagesMap)) {
+      addMessages(messages);
+    }
+    addMessages(fallbackMessages);
+
     const visitedIds = new Set<string>();
     let currentMessageId: string | undefined = anchorMessageId;
 
@@ -248,6 +259,7 @@ export class ConversationControlActionImpl {
       { intervention: { status: 'approved' } },
       optimisticContext,
     );
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(toolMessageId);
 
     // 2.5. Server-mode: start a **new** Gateway op carrying the approval
     // decision via `resumeApproval`. The server reads the target tool
@@ -278,6 +290,7 @@ export class ConversationControlActionImpl {
             parentMessageId: toolMessageId,
             toolCallId,
           },
+          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
@@ -295,9 +308,9 @@ export class ConversationControlActionImpl {
     // 3. Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessageChain(
-      currentMessages,
+    const currentRequestMetadata = this.#getRequestMetadataFromMessageChain(
       toolMessageId,
+      currentMessages,
     );
 
     // 4. Create agent state and context with user intervention config
@@ -330,7 +343,7 @@ export class ConversationControlActionImpl {
         parentMessageType: 'tool', // Type is 'tool'
         initialState: state,
         initialContext: agentRuntimeContext,
-        metadata: requestMetadata,
+        metadata: currentRequestMetadata,
         // Pass parent operation ID to establish parent-child relationship
         // This ensures proper cancellation propagation
         parentOperationId: operationId,
@@ -415,8 +428,8 @@ export class ConversationControlActionImpl {
     if (!shouldCreateUserMessage) {
       const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
       const requestMetadata = this.#getRequestMetadataFromMessageChain(
-        currentMessages,
         toolMessageId,
+        currentMessages,
       );
 
       const { state, context: initialContext } = this.#get().internal_createAgentState({
@@ -466,6 +479,7 @@ export class ConversationControlActionImpl {
     }
 
     // 2b. Default path: create a user message summarizing the response, resume from user
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(toolMessageId);
     const userMessageContent = Object.values(response).join(', ');
     const groupId = toolMessage.groupId;
     const userMsg = await this.#get().optimisticCreateMessage(
@@ -473,6 +487,7 @@ export class ConversationControlActionImpl {
         agentId: agentId!,
         content: userMessageContent,
         groupId: groupId ?? undefined,
+        ...(requestMetadata && { metadata: requestMetadata }),
         role: 'user',
         threadId: threadId ?? undefined,
         topicId: topicId ?? undefined,
@@ -490,10 +505,6 @@ export class ConversationControlActionImpl {
 
     // 3. Resume agent from user message (not tool re-execution)
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessageChain(
-      currentMessages,
-      toolMessageId,
-    );
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -573,6 +584,8 @@ export class ConversationControlActionImpl {
     );
 
     // 2. Create a user message indicating the skip
+    const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(toolMessageId);
     const userMessageContent = reason ? `I'll skip this. ${reason}` : "I'll skip this.";
     const groupId = toolMessage.groupId;
     const userMsg = await this.#get().optimisticCreateMessage(
@@ -580,6 +593,7 @@ export class ConversationControlActionImpl {
         agentId: agentId!,
         content: userMessageContent,
         groupId: groupId ?? undefined,
+        ...(requestMetadata && { metadata: requestMetadata }),
         role: 'user',
         threadId: threadId ?? undefined,
         topicId: topicId ?? undefined,
@@ -596,12 +610,7 @@ export class ConversationControlActionImpl {
     }
 
     // 3. Resume agent from user message
-    const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessageChain(
-      currentMessages,
-      toolMessageId,
-    );
 
     const { state, context: initialContext } = this.#get().internal_createAgentState({
       messages: currentMessages,
@@ -922,6 +931,7 @@ export class ConversationControlActionImpl {
       undefined,
       optimisticContext,
     );
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(messageId);
 
     // Server-mode: start a **new** Gateway op carrying the rejection.
     // We use `rejected_continue` uniformly — server-side `rejected` and
@@ -949,6 +959,7 @@ export class ConversationControlActionImpl {
             rejectionReason: reason,
             toolCallId,
           },
+          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
       } catch (error) {
@@ -984,6 +995,7 @@ export class ConversationControlActionImpl {
     // Skip the client-mode `rejectToolCalling` chain below — that would fire
     // a duplicate halting `reject` before this continue signal.
     if (this.#shouldUseGatewayResume(effectiveContext)) {
+      const requestMetadata = this.#getRequestMetadataFromMessageChain(messageId);
       const toolCallId = toolMessage.tool_call_id;
       if (!toolCallId) {
         console.warn(
@@ -1032,6 +1044,7 @@ export class ConversationControlActionImpl {
             rejectionReason: reason,
             toolCallId,
           },
+          trigger: requestMetadata?.trigger,
         });
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
@@ -1065,7 +1078,7 @@ export class ConversationControlActionImpl {
     // Get current messages for state construction using context
     const chatKey = messageMapKey({ agentId, topicId, threadId, scope });
     const currentMessages = displayMessageSelectors.getDisplayMessagesByKey(chatKey)(this.#get());
-    const requestMetadata = this.#getRequestMetadataFromMessageChain(currentMessages, messageId);
+    const requestMetadata = this.#getRequestMetadataFromMessageChain(messageId, currentMessages);
 
     // Create agent state and context to continue from rejected tool message
     const { state, context: initialContext } = this.#get().internal_createAgentState({

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -656,8 +656,8 @@ export class ConversationLifecycleActionImpl {
           context: operationContext,
           fileIds: fileIdList,
           message,
+          metadata: requestMetadata,
           parentOperationId: operationId,
-          trigger: requestMetadata?.trigger,
         });
 
         return {

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -657,6 +657,7 @@ export class ConversationLifecycleActionImpl {
           fileIds: fileIdList,
           message,
           parentOperationId: operationId,
+          trigger: requestMetadata?.trigger,
         });
 
         return {

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -4,7 +4,7 @@ import {
   type AgentStreamEvent,
   type ConnectionStatus,
 } from '@lobechat/agent-gateway-client';
-import type { ConversationContext, ExecAgentResult } from '@lobechat/types';
+import type { ConversationContext, ExecAgentResult, MessageMetadata } from '@lobechat/types';
 
 import { isDesktop } from '@/const/version';
 import { aiAgentService, type ResumeApprovalParam } from '@/services/aiAgent';
@@ -255,6 +255,8 @@ export class GatewayActionImpl {
     /** File IDs of already-uploaded attachments to attach to the new user message */
     fileIds?: string[];
     message: string;
+    /** Request metadata carried from the originating user message. */
+    metadata?: Pick<MessageMetadata, 'trigger'>;
     /** Called when the gateway session completes (agent finished running) */
     onComplete?: () => void;
     /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
@@ -275,17 +277,16 @@ export class GatewayActionImpl {
      * a fresh user prompt.
      */
     resumeApproval?: ResumeApprovalParam;
-    trigger?: string;
   }): Promise<ExecAgentResult> => {
     const {
       context,
       fileIds,
       message,
+      metadata,
       onComplete,
       parentMessageId,
       parentOperationId,
       resumeApproval,
-      trigger,
     } = params;
 
     const agentGatewayUrl =
@@ -337,7 +338,7 @@ export class GatewayActionImpl {
         parentMessageId,
         prompt: message,
         resumeApproval,
-        trigger,
+        trigger: metadata?.trigger,
       },
       { signal: abortSignal },
     );

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -275,6 +275,7 @@ export class GatewayActionImpl {
      * a fresh user prompt.
      */
     resumeApproval?: ResumeApprovalParam;
+    trigger?: string;
   }): Promise<ExecAgentResult> => {
     const {
       context,
@@ -284,6 +285,7 @@ export class GatewayActionImpl {
       parentMessageId,
       parentOperationId,
       resumeApproval,
+      trigger,
     } = params;
 
     const agentGatewayUrl =
@@ -335,6 +337,7 @@ export class GatewayActionImpl {
         parentMessageId,
         prompt: message,
         resumeApproval,
+        trigger,
       },
       { signal: abortSignal },
     );

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -130,6 +130,9 @@ export default defineConfig({
           'emoji-mart',
           '@lobehub/ui',
           '@lobehub/fluent-emoji',
+          // antd 6.4+ pulls ESM @rc-component packages with extensionless subpath imports.
+          // Inline them so Vite resolves those imports instead of Node's strict ESM loader.
+          /@rc-component\//,
           '@pierre/diffs',
           '@pierre/diffs/react',
           'lru_map',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -130,9 +130,6 @@ export default defineConfig({
           'emoji-mart',
           '@lobehub/ui',
           '@lobehub/fluent-emoji',
-          // antd 6.4+ pulls ESM @rc-component packages with extensionless subpath imports.
-          // Inline them so Vite resolves those imports instead of Node's strict ESM loader.
-          /@rc-component\//,
           '@pierre/diffs',
           '@pierre/diffs/react',
           'lru_map',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to lobehub-biz/lobehub-cloud#519

#### 🔀 Description of Change

- Preserve request trigger metadata from raw message chains when resuming tool interactions.
- Persist preserved trigger metadata on synthetic submit/skip user messages so later continuations remain in the same request scope.
- Forward preserved trigger metadata through Agent Gateway initial sends and human-intervention resumes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/store/chat/slices/aiChat/actions/__tests__/conversationControl.test.ts'
bunx vitest run --silent='passed-only' 'src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

`bun run type-check` is currently blocked by pre-existing generated `.next/dev/types` route imports, `@lobehub/ui` `HtmlPreview` type drift, and cloud-package path/type errors unrelated to this change.
