### PR TITLE
🐛 fix(chat-input): allow submenu to close on sibling-open and focus-out in ActionDropdown

### DIFF
--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -260,16 +260,6 @@ const ActionDropdown = memo<ActionDropdownProps>(
             return {
               ...item,
               children: decorateMenuItems(item.children),
-              onOpenChange: (subOpen: boolean, details: unknown) => {
-                if (!subOpen) {
-                  const reason = (details as { reason?: string })?.reason;
-                  if (reason === 'sibling-open' || reason === 'focus-out') {
-                    (details as { cancel?: () => void })?.cancel?.();
-                    return;
-                  }
-                }
-                originalOnOpenChange?.(subOpen, details);
-              },
               type: 'submenu',
             };
           }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 Description of Change

Remove the `onOpenChange` override in `ActionDropdown` that prevented submenu items from closing when a sibling submenu opens or when focus leaves the trigger. This handler was calling `cancel()` on the close event, which kept submenus stuck open in the chat input action dropdown.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open the chat input action dropdown with multiple submenu items
2. Hover over one submenu, then hover over another
3. Verify the first submenu closes properly instead of staying open
