### PR TITLE
🐛 fix: preserve TopicChatDrawer state during close animation

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@lobehub/ui', () => ({
     open ? <div data-testid="topic-drawer">{children}</div> : null,
   DropdownMenu: ({ children }: { children?: ReactNode }) => <>{children}</>,
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Freeze: ({ children }: { children?: ReactNode; frozen?: boolean }) => <>{children}</>,
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -2,7 +2,15 @@
 
 import type { ConversationContext } from '@lobechat/types';
 import type { DropdownItem } from '@lobehub/ui';
-import { ActionIcon, copyToClipboard, Drawer, DropdownMenu, Flexbox, Text } from '@lobehub/ui';
+import {
+  ActionIcon,
+  copyToClipboard,
+  Drawer,
+  DropdownMenu,
+  Flexbox,
+  Freeze,
+  Text,
+} from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Copy, MoreHorizontal, Share2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -200,17 +208,20 @@ const TopicChatDrawer = memo(() => {
     )
   ) : null;
 
+  // Freeze title/extra/body during the close animation so the drawer keeps
+  // its last rendered state instead of flashing to the empty/"untitled" view
+  // while topicId/agentId clear.
   return (
     <Drawer
       destroyOnHidden
       containerMaxWidth={'auto'}
-      extra={extra}
+      extra={<Freeze frozen={!open}>{extra}</Freeze>}
       getContainer={false}
       mask={false}
       open={open}
       placement={'right'}
       push={false}
-      title={title}
+      title={<Freeze frozen={!open}>{title}</Freeze>}
       width={640}
       styles={{
         body: { padding: 0 },
@@ -228,9 +239,11 @@ const TopicChatDrawer = memo(() => {
       }}
       onClose={closeTopicDrawer}
     >
-      {open && activeTaskId && (
-        <TopicChatDrawerBody agentId={agentId!} taskId={activeTaskId} topicId={topicId!} />
-      )}
+      <Freeze frozen={!open}>
+        {open && activeTaskId && (
+          <TopicChatDrawerBody agentId={agentId!} taskId={activeTaskId} topicId={topicId!} />
+        )}
+      </Freeze>
     </Drawer>
   );
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-8900

#### 🔀 Description of Change

When closing the task `TopicChatDrawer`, `topicId` / `agentId` clear immediately while the drawer is still playing its slide-out animation. That causes `activity` to become `undefined`, the title flashes to the "untitled" fallback, and the body unmounts mid-animation, producing a visible flicker.

Wrap the drawer's `title`, `extra`, and body in `Freeze` from `@lobehub/ui` with `frozen={!open}`. While closing, Freeze suspends the subtree via Suspense and keeps its previously rendered DOM in place (with a MutationObserver guarding `display: contents`). After the animation completes, the existing `destroyOnHidden` on the Drawer unmounts and cleans up as before.

Three separate `Freeze` wrappers are required because `title` and `extra` are passed as Drawer props and are rendered by antd into different DOM containers from the body.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Open a topic from the task detail page, then close the drawer — the title, status icon and chat content should remain visible until the slide-out animation finishes, with no "untitled" flash.

Unit test updated to mock the new `Freeze` export from `@lobehub/ui`.

#### 📸 Screenshots / Videos

See LOBE-8900 for the original repro video.

#### 📝 Additional Information

Follows the existing `Freeze` usage pattern in `src/features/PageEditor/RightPanel/index.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)