### PR TITLE
⚡️ perf(agent-tracing): zstd-compress S3 snapshots

### DIFF
--- a/packages/agent-tracing/src/store/remote-store.ts
+++ b/packages/agent-tracing/src/store/remote-store.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
+import { zstdDecompress } from 'node:zlib';
 
 import type { ExecutionSnapshot } from '../types';
+
+const decompressZstd = promisify(zstdDecompress);
 
 const REMOTE_DIR = '_remote';
 const ENV_FILE = '.env';
@@ -32,7 +36,7 @@ export function buildRemoteUrl(baseUrl: string, opId: string): string | null {
   const parsed = parseOperationId(opId);
   if (!parsed) return null;
   const base = baseUrl.replace(/\/$/, '');
-  return `${base}/${parsed.agentId}/${parsed.topicId}/${parsed.operationId}.json`;
+  return `${base}/${parsed.agentId}/${parsed.topicId}/${parsed.operationId}.json.zst`;
 }
 
 /**
@@ -90,15 +94,17 @@ export class RemoteSnapshotStore {
       return cached;
     }
 
-    // Download
+    // Download — remote object is zstd-compressed JSON (`.json.zst`).
     console.error(`↓ Downloading: ${url}`);
     const res = await fetch(url);
     if (!res.ok) {
       throw new Error(`Failed to fetch snapshot: ${res.status} ${res.statusText}\n  URL: ${url}`);
     }
-    const snapshot = (await res.json()) as ExecutionSnapshot;
+    const compressed = Buffer.from(await res.arrayBuffer());
+    const decompressed = await decompressZstd(compressed);
+    const snapshot = JSON.parse(decompressed.toString('utf8')) as ExecutionSnapshot;
 
-    // Cache locally
+    // Cache locally as plain JSON for easy inspection.
     await fs.mkdir(this.cacheDir, { recursive: true });
     const filePath = path.join(this.cacheDir, `${operationId}.json`);
     await fs.writeFile(filePath, JSON.stringify(snapshot, null, 2), 'utf8');

--- a/packages/agent-tracing/src/store/remote-store.ts
+++ b/packages/agent-tracing/src/store/remote-store.ts
@@ -11,16 +11,6 @@ const REMOTE_DIR = '_remote';
 const ENV_FILE = '.env';
 const DEFAULT_DIR = '.agent-tracing';
 
-// zstd frame magic: 0x28 0xb5 0x2f 0xfd. Used to auto-detect the body format
-// regardless of which environment uploaded it (prod writes `.json.zst`, local
-// dev writes plain `.json`).
-const isZstdFrame = (bytes: Uint8Array): boolean =>
-  bytes.length >= 4 &&
-  bytes[0] === 0x28 &&
-  bytes[1] === 0xb5 &&
-  bytes[2] === 0x2f &&
-  bytes[3] === 0xfd;
-
 /**
  * Parse an operation ID to extract agentId and topicId for URL construction.
  *
@@ -104,27 +94,15 @@ export class RemoteSnapshotStore {
       return cached;
     }
 
-    // Download. Prod uploads `.json.zst`, local dev uploads plain `.json`. Try
-    // the zstd suffix first (dominant case); on 404 fall back to the plain
-    // sibling so dev-uploaded snapshots remain inspectable from another machine.
+    // Download — remote object is zstd-compressed JSON (`.json.zst`).
     console.error(`↓ Downloading: ${url}`);
-    let res = await fetch(url);
-    if (res.status === 404 && url.endsWith('.json.zst')) {
-      const plainUrl = url.slice(0, -'.zst'.length);
-      console.error(`↓ Falling back to plain JSON: ${plainUrl}`);
-      res = await fetch(plainUrl);
-    }
+    const res = await fetch(url);
     if (!res.ok) {
       throw new Error(`Failed to fetch snapshot: ${res.status} ${res.statusText}\n  URL: ${url}`);
     }
-
-    // Body format is determined by sniffing magic bytes, not by URL suffix —
-    // covers any combination of upload/download environment.
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const json = isZstdFrame(bytes)
-      ? (await decompressZstd(Buffer.from(bytes))).toString('utf8')
-      : Buffer.from(bytes).toString('utf8');
-    const snapshot = JSON.parse(json) as ExecutionSnapshot;
+    const compressed = Buffer.from(await res.arrayBuffer());
+    const decompressed = await decompressZstd(compressed);
+    const snapshot = JSON.parse(decompressed.toString('utf8')) as ExecutionSnapshot;
 
     // Cache locally as plain JSON for easy inspection.
     await fs.mkdir(this.cacheDir, { recursive: true });

--- a/packages/agent-tracing/src/store/remote-store.ts
+++ b/packages/agent-tracing/src/store/remote-store.ts
@@ -11,6 +11,16 @@ const REMOTE_DIR = '_remote';
 const ENV_FILE = '.env';
 const DEFAULT_DIR = '.agent-tracing';
 
+// zstd frame magic: 0x28 0xb5 0x2f 0xfd. Used to auto-detect the body format
+// regardless of which environment uploaded it (prod writes `.json.zst`, local
+// dev writes plain `.json`).
+const isZstdFrame = (bytes: Uint8Array): boolean =>
+  bytes.length >= 4 &&
+  bytes[0] === 0x28 &&
+  bytes[1] === 0xb5 &&
+  bytes[2] === 0x2f &&
+  bytes[3] === 0xfd;
+
 /**
  * Parse an operation ID to extract agentId and topicId for URL construction.
  *
@@ -94,15 +104,27 @@ export class RemoteSnapshotStore {
       return cached;
     }
 
-    // Download — remote object is zstd-compressed JSON (`.json.zst`).
+    // Download. Prod uploads `.json.zst`, local dev uploads plain `.json`. Try
+    // the zstd suffix first (dominant case); on 404 fall back to the plain
+    // sibling so dev-uploaded snapshots remain inspectable from another machine.
     console.error(`↓ Downloading: ${url}`);
-    const res = await fetch(url);
+    let res = await fetch(url);
+    if (res.status === 404 && url.endsWith('.json.zst')) {
+      const plainUrl = url.slice(0, -'.zst'.length);
+      console.error(`↓ Falling back to plain JSON: ${plainUrl}`);
+      res = await fetch(plainUrl);
+    }
     if (!res.ok) {
       throw new Error(`Failed to fetch snapshot: ${res.status} ${res.statusText}\n  URL: ${url}`);
     }
-    const compressed = Buffer.from(await res.arrayBuffer());
-    const decompressed = await decompressZstd(compressed);
-    const snapshot = JSON.parse(decompressed.toString('utf8')) as ExecutionSnapshot;
+
+    // Body format is determined by sniffing magic bytes, not by URL suffix —
+    // covers any combination of upload/download environment.
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const json = isZstdFrame(bytes)
+      ? (await decompressZstd(Buffer.from(bytes))).toString('utf8')
+      : Buffer.from(bytes).toString('utf8');
+    const snapshot = JSON.parse(json) as ExecutionSnapshot;
 
     // Cache locally as plain JSON for easy inspection.
     await fs.mkdir(this.cacheDir, { recursive: true });

--- a/src/server/modules/AgentTracing/S3SnapshotStore.test.ts
+++ b/src/server/modules/AgentTracing/S3SnapshotStore.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { promisify } from 'node:util';
+import { zstdCompress, zstdDecompress } from 'node:zlib';
+
+import type { ExecutionSnapshot } from '@lobechat/agent-tracing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const compressZstd = promisify(zstdCompress);
+const decompressZstd = promisify(zstdDecompress);
+
+// Stub FileS3 with vi.fn methods so we can assert calls + return canned data.
+const uploadBuffer = vi.fn();
+const getFileByteArray = vi.fn();
+const getFileContent = vi.fn();
+const deleteFile = vi.fn();
+
+vi.mock('@/server/modules/S3', () => ({
+  FileS3: vi.fn(() => ({
+    deleteFile,
+    getFileByteArray,
+    getFileContent,
+    uploadBuffer,
+  })),
+}));
+
+// Imported after the mock so the constructor pulls in the stub.
+const { S3SnapshotStore } = await import('./S3SnapshotStore');
+
+const sampleSnapshot = (overrides: Partial<ExecutionSnapshot> = {}): ExecutionSnapshot =>
+  ({
+    agentId: 'agt_abc',
+    completedAt: 1_777_000_000_500,
+    operationId: 'op_1777000000000_agt_abc_tpc_xyz_QwErTy',
+    startedAt: 1_777_000_000_000,
+    steps: [],
+    topicId: 'tpc_xyz',
+    totalCost: 0,
+    totalSteps: 0,
+    totalTokens: 0,
+    ...overrides,
+  }) as unknown as ExecutionSnapshot;
+
+beforeEach(() => {
+  uploadBuffer.mockReset().mockResolvedValue(undefined);
+  getFileByteArray.mockReset();
+  getFileContent.mockReset();
+  deleteFile.mockReset().mockResolvedValue(undefined);
+});
+
+describe('S3SnapshotStore.save', () => {
+  it('writes to agent-traces/{agentId}/{topicId}/{operationId}.json.zst with zstd body', async () => {
+    const store = new S3SnapshotStore();
+    const snap = sampleSnapshot();
+
+    await store.save(snap);
+
+    expect(uploadBuffer).toHaveBeenCalledTimes(1);
+    const [key, body, contentType] = uploadBuffer.mock.calls[0];
+    expect(key).toBe(`agent-traces/${snap.agentId}/${snap.topicId}/${snap.operationId}.json.zst`);
+    expect(contentType).toBe('application/zstd');
+    expect(Buffer.isBuffer(body)).toBe(true);
+
+    // zstd frame magic: 0x28 b5 2f fd
+    expect([body[0], body[1], body[2], body[3]]).toEqual([0x28, 0xb5, 0x2f, 0xfd]);
+
+    const roundtripped = JSON.parse((await decompressZstd(body)).toString('utf8'));
+    expect(roundtripped).toEqual(snap);
+  });
+
+  it('falls back to "unknown" when agentId or topicId is missing', async () => {
+    const store = new S3SnapshotStore();
+    await store.save(sampleSnapshot({ agentId: undefined, topicId: undefined }));
+
+    const [key] = uploadBuffer.mock.calls[0];
+    expect(key).toBe(
+      'agent-traces/unknown/unknown/op_1777000000000_agt_abc_tpc_xyz_QwErTy.json.zst',
+    );
+  });
+});
+
+describe('S3SnapshotStore.savePartial', () => {
+  it('writes to agent-traces/_partial/{operationId}.json.zst with compressed body', async () => {
+    const store = new S3SnapshotStore();
+    const partial = { operationId: 'op_partial_1', steps: [{ stepIndex: 0 }] };
+
+    await store.savePartial('op_partial_1', partial as Partial<ExecutionSnapshot>);
+
+    expect(uploadBuffer).toHaveBeenCalledTimes(1);
+    const [key, body, contentType] = uploadBuffer.mock.calls[0];
+    expect(key).toBe('agent-traces/_partial/op_partial_1.json.zst');
+    expect(contentType).toBe('application/zstd');
+
+    const roundtripped = JSON.parse((await decompressZstd(body)).toString('utf8'));
+    expect(roundtripped).toEqual(partial);
+  });
+});
+
+describe('S3SnapshotStore.loadPartial', () => {
+  it('decodes the zstd-compressed .json.zst object when present', async () => {
+    const partial = { operationId: 'op_load_1', steps: [{ stepIndex: 7 }] };
+    const compressed = await compressZstd(Buffer.from(JSON.stringify(partial)));
+    getFileByteArray.mockResolvedValueOnce(new Uint8Array(compressed));
+
+    const store = new S3SnapshotStore();
+    const result = await store.loadPartial('op_load_1');
+
+    expect(getFileByteArray).toHaveBeenCalledWith('agent-traces/_partial/op_load_1.json.zst');
+    expect(result).toEqual(partial);
+  });
+
+  it('falls back to legacy uncompressed .json when .json.zst is missing', async () => {
+    const partial = { operationId: 'op_legacy_1' };
+    getFileByteArray.mockRejectedValueOnce(new Error('NoSuchKey'));
+    getFileContent.mockResolvedValueOnce(JSON.stringify(partial));
+
+    const store = new S3SnapshotStore();
+    const result = await store.loadPartial('op_legacy_1');
+
+    expect(getFileByteArray).toHaveBeenCalledWith('agent-traces/_partial/op_legacy_1.json.zst');
+    expect(getFileContent).toHaveBeenCalledWith('agent-traces/_partial/op_legacy_1.json');
+    expect(result).toEqual(partial);
+  });
+
+  it('returns null when neither key exists', async () => {
+    getFileByteArray.mockRejectedValueOnce(new Error('NoSuchKey'));
+    getFileContent.mockRejectedValueOnce(new Error('NoSuchKey'));
+
+    const store = new S3SnapshotStore();
+    expect(await store.loadPartial('op_missing')).toBeNull();
+  });
+});
+
+describe('S3SnapshotStore.removePartial', () => {
+  it('deletes both the .json.zst and legacy .json keys', async () => {
+    const store = new S3SnapshotStore();
+    await store.removePartial('op_remove_1');
+
+    const keys = deleteFile.mock.calls.map(([k]) => k);
+    expect(keys).toContain('agent-traces/_partial/op_remove_1.json.zst');
+    expect(keys).toContain('agent-traces/_partial/op_remove_1.json');
+    expect(deleteFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw when one delete fails (allSettled)', async () => {
+    deleteFile.mockRejectedValueOnce(new Error('NoSuchKey')).mockResolvedValueOnce(undefined);
+
+    const store = new S3SnapshotStore();
+    await expect(store.removePartial('op_partial_err')).resolves.toBeUndefined();
+  });
+});
+
+describe('S3SnapshotStore query stubs', () => {
+  it('returns null/[] for unsupported query methods (OTEL backend owns querying)', async () => {
+    const store = new S3SnapshotStore();
+    expect(await store.get('any')).toBeNull();
+    expect(await store.getLatest()).toBeNull();
+    expect(await store.list()).toEqual([]);
+    expect(await store.listPartials()).toEqual([]);
+  });
+});

--- a/src/server/modules/AgentTracing/S3SnapshotStore.ts
+++ b/src/server/modules/AgentTracing/S3SnapshotStore.ts
@@ -1,18 +1,33 @@
+import { promisify } from 'node:util';
+import { zstdCompress, zstdDecompress } from 'node:zlib';
+
 import type { ExecutionSnapshot, ISnapshotStore, SnapshotSummary } from '@lobechat/agent-tracing';
 import debug from 'debug';
 
 import { FileS3 } from '@/server/modules/S3';
 
+const compressZstd = promisify(zstdCompress);
+const decompressZstd = promisify(zstdDecompress);
+
 const log = debug('lobe-server:agent-tracing:s3');
 
 const TRACE_PREFIX = 'agent-traces';
+const SNAPSHOT_SUFFIX = '.json.zst';
+const LEGACY_SUFFIX = '.json';
+const ZSTD_CONTENT_TYPE = 'application/zstd';
 
 /**
  * S3-backed snapshot store for production agent trace persistence.
  *
  * S3 paths:
- * - Final:   agent-traces/{agentId}/{topicId}/{operationId}.json
- * - Partial: agent-traces/_partial/{operationId}.json  (temporary, deleted after finalization)
+ * - Final:   agent-traces/{agentId}/{topicId}/{operationId}.json.zst
+ * - Partial: agent-traces/_partial/{operationId}.json.zst  (temporary, deleted after finalization)
+ *
+ * Snapshots are zstd-compressed (level 3) before upload — measured 8-9× average
+ * size reduction across production traces. The `.zst` suffix is the format
+ * indicator; Content-Encoding is intentionally NOT set so the object is served
+ * as opaque bytes (avoids HTTP middleware auto-decompressing into clients that
+ * don't expect it). Readers explicitly decompress.
  *
  * Partial snapshots are needed because QStash executes each step in a
  * separate HTTP request (no shared memory). Step data is accumulated
@@ -27,16 +42,30 @@ export class S3SnapshotStore implements ISnapshotStore {
   }
 
   private partialKey(operationId: string): string {
-    return `${TRACE_PREFIX}/_partial/${operationId}.json`;
+    return `${TRACE_PREFIX}/_partial/${operationId}${SNAPSHOT_SUFFIX}`;
+  }
+
+  private legacyPartialKey(operationId: string): string {
+    return `${TRACE_PREFIX}/_partial/${operationId}${LEGACY_SUFFIX}`;
+  }
+
+  private async encodeSnapshot(value: unknown): Promise<Buffer> {
+    return compressZstd(Buffer.from(JSON.stringify(value)));
+  }
+
+  private async decodeSnapshot<T>(bytes: Uint8Array): Promise<T> {
+    const buf = await decompressZstd(Buffer.from(bytes));
+    return JSON.parse(buf.toString('utf8')) as T;
   }
 
   async save(snapshot: ExecutionSnapshot): Promise<void> {
     const agentId = snapshot.agentId ?? 'unknown';
     const topicId = snapshot.topicId ?? 'unknown';
-    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}.json`;
+    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${SNAPSHOT_SUFFIX}`;
 
     log('Saving snapshot to S3: %s', key);
-    await this.s3.uploadContent(key, JSON.stringify(snapshot));
+    const compressed = await this.encodeSnapshot(snapshot);
+    await this.s3.uploadBuffer(key, compressed, ZSTD_CONTENT_TYPE);
   }
 
   // === Query methods — not supported, use OTEL backend ===
@@ -60,8 +89,18 @@ export class S3SnapshotStore implements ISnapshotStore {
   }
 
   async loadPartial(operationId: string): Promise<Partial<ExecutionSnapshot> | null> {
+    // Current format: .json.zst (zstd-compressed)
     try {
-      const content = await this.s3.getFileContent(this.partialKey(operationId));
+      const bytes = await this.s3.getFileByteArray(this.partialKey(operationId));
+      return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
+    } catch {
+      // fall through to legacy
+    }
+    // Legacy format: uncompressed .json. Kept to bridge in-flight partials across the
+    // deploy window — partials are deleted on finalization so this branch dies off
+    // naturally once the longest-running operation completes.
+    try {
+      const content = await this.s3.getFileContent(this.legacyPartialKey(operationId));
       return JSON.parse(content) as Partial<ExecutionSnapshot>;
     } catch {
       return null;
@@ -69,14 +108,16 @@ export class S3SnapshotStore implements ISnapshotStore {
   }
 
   async savePartial(operationId: string, partial: Partial<ExecutionSnapshot>): Promise<void> {
-    await this.s3.uploadContent(this.partialKey(operationId), JSON.stringify(partial));
+    const compressed = await this.encodeSnapshot(partial);
+    await this.s3.uploadBuffer(this.partialKey(operationId), compressed, ZSTD_CONTENT_TYPE);
   }
 
   async removePartial(operationId: string): Promise<void> {
-    try {
-      await this.s3.deleteFile(this.partialKey(operationId));
-    } catch {
-      // ignore — partial may already be cleaned up
-    }
+    // Clean up both the current key and any legacy uncompressed sibling that may
+    // exist if the operation was started before the zstd rollout.
+    await Promise.allSettled([
+      this.s3.deleteFile(this.partialKey(operationId)),
+      this.s3.deleteFile(this.legacyPartialKey(operationId)),
+    ]);
   }
 }

--- a/src/server/modules/AgentTracing/S3SnapshotStore.ts
+++ b/src/server/modules/AgentTracing/S3SnapshotStore.ts
@@ -12,42 +12,22 @@ const decompressZstd = promisify(zstdDecompress);
 const log = debug('lobe-server:agent-tracing:s3');
 
 const TRACE_PREFIX = 'agent-traces';
-const ZSTD_SUFFIX = '.json.zst';
-const PLAIN_SUFFIX = '.json';
+const SNAPSHOT_SUFFIX = '.json.zst';
+const LEGACY_SUFFIX = '.json';
 const ZSTD_CONTENT_TYPE = 'application/zstd';
-const PLAIN_CONTENT_TYPE = 'application/json';
-
-// Compress on production deployments only — local dev (even when opting into
-// S3 via ENABLE_AGENT_S3_TRACING=1) keeps writing plain `.json` so devs can
-// inspect the raw payload directly from the bucket.
-const COMPRESS_SNAPSHOTS = process.env.NODE_ENV === 'production';
-
-// zstd frame magic: 0x28 0xb5 0x2f 0xfd. Used to auto-detect the body format
-// regardless of which environment wrote it, so a prod-written `.json.zst` and
-// a dev-written `.json` both round-trip through the same reader.
-const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd] as const;
-const isZstdFrame = (bytes: Uint8Array): boolean =>
-  bytes.length >= 4 &&
-  bytes[0] === ZSTD_MAGIC[0] &&
-  bytes[1] === ZSTD_MAGIC[1] &&
-  bytes[2] === ZSTD_MAGIC[2] &&
-  bytes[3] === ZSTD_MAGIC[3];
 
 /**
  * S3-backed snapshot store for production agent trace persistence.
  *
  * S3 paths:
- * - Final:   agent-traces/{agentId}/{topicId}/{operationId}{.json|.json.zst}
- * - Partial: agent-traces/_partial/{operationId}{.json|.json.zst}  (temporary, deleted after finalization)
+ * - Final:   agent-traces/{agentId}/{topicId}/{operationId}.json.zst
+ * - Partial: agent-traces/_partial/{operationId}.json.zst  (temporary, deleted after finalization)
  *
- * Production deployments (NODE_ENV=production) zstd-compress snapshots before
- * upload — measured 8-9× average size reduction. The `.zst` suffix is the format
+ * Snapshots are zstd-compressed (level 3) before upload — measured 8-9× average
+ * size reduction across production traces. The `.zst` suffix is the format
  * indicator; Content-Encoding is intentionally NOT set so the object is served
  * as opaque bytes (avoids HTTP middleware auto-decompressing into clients that
- * don't expect it).
- *
- * Local dev keeps writing plain `.json` for easy bucket inspection. Readers
- * sniff the zstd magic bytes (0x28b52ffd) to handle either format transparently.
+ * don't expect it). Readers explicitly decompress.
  *
  * Partial snapshots are needed because QStash executes each step in a
  * separate HTTP request (no shared memory). Step data is accumulated
@@ -61,39 +41,31 @@ export class S3SnapshotStore implements ISnapshotStore {
     this.s3 = new FileS3();
   }
 
-  private get activeSuffix(): string {
-    return COMPRESS_SNAPSHOTS ? ZSTD_SUFFIX : PLAIN_SUFFIX;
+  private partialKey(operationId: string): string {
+    return `${TRACE_PREFIX}/_partial/${operationId}${SNAPSHOT_SUFFIX}`;
   }
 
-  private get legacySuffix(): string {
-    return COMPRESS_SNAPSHOTS ? PLAIN_SUFFIX : ZSTD_SUFFIX;
+  private legacyPartialKey(operationId: string): string {
+    return `${TRACE_PREFIX}/_partial/${operationId}${LEGACY_SUFFIX}`;
   }
 
-  private partialKey(operationId: string, suffix: string = this.activeSuffix): string {
-    return `${TRACE_PREFIX}/_partial/${operationId}${suffix}`;
-  }
-
-  private async encodeSnapshot(value: unknown): Promise<{ body: Buffer; contentType: string }> {
-    const json = Buffer.from(JSON.stringify(value));
-    if (!COMPRESS_SNAPSHOTS) return { body: json, contentType: PLAIN_CONTENT_TYPE };
-    return { body: await compressZstd(json), contentType: ZSTD_CONTENT_TYPE };
+  private async encodeSnapshot(value: unknown): Promise<Buffer> {
+    return compressZstd(Buffer.from(JSON.stringify(value)));
   }
 
   private async decodeSnapshot<T>(bytes: Uint8Array): Promise<T> {
-    const json = isZstdFrame(bytes)
-      ? (await decompressZstd(Buffer.from(bytes))).toString('utf8')
-      : Buffer.from(bytes).toString('utf8');
-    return JSON.parse(json) as T;
+    const buf = await decompressZstd(Buffer.from(bytes));
+    return JSON.parse(buf.toString('utf8')) as T;
   }
 
   async save(snapshot: ExecutionSnapshot): Promise<void> {
     const agentId = snapshot.agentId ?? 'unknown';
     const topicId = snapshot.topicId ?? 'unknown';
-    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${this.activeSuffix}`;
+    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${SNAPSHOT_SUFFIX}`;
 
     log('Saving snapshot to S3: %s', key);
-    const { body, contentType } = await this.encodeSnapshot(snapshot);
-    await this.s3.uploadBuffer(key, body, contentType);
+    const compressed = await this.encodeSnapshot(snapshot);
+    await this.s3.uploadBuffer(key, compressed, ZSTD_CONTENT_TYPE);
   }
 
   // === Query methods — not supported, use OTEL backend ===
@@ -117,31 +89,35 @@ export class S3SnapshotStore implements ISnapshotStore {
   }
 
   async loadPartial(operationId: string): Promise<Partial<ExecutionSnapshot> | null> {
-    // Try the active key first (matches whatever this process writes), then the
-    // sibling format. Covers prod↔dev round-trips and the deploy window when an
-    // in-flight partial may have been written by the previous binary.
-    for (const suffix of [this.activeSuffix, this.legacySuffix]) {
-      try {
-        const bytes = await this.s3.getFileByteArray(this.partialKey(operationId, suffix));
-        return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
-      } catch {
-        // try next
-      }
+    // Current format: .json.zst (zstd-compressed)
+    try {
+      const bytes = await this.s3.getFileByteArray(this.partialKey(operationId));
+      return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
+    } catch {
+      // fall through to legacy
     }
-    return null;
+    // Legacy format: uncompressed .json. Kept to bridge in-flight partials across the
+    // deploy window — partials are deleted on finalization so this branch dies off
+    // naturally once the longest-running operation completes.
+    try {
+      const content = await this.s3.getFileContent(this.legacyPartialKey(operationId));
+      return JSON.parse(content) as Partial<ExecutionSnapshot>;
+    } catch {
+      return null;
+    }
   }
 
   async savePartial(operationId: string, partial: Partial<ExecutionSnapshot>): Promise<void> {
-    const { body, contentType } = await this.encodeSnapshot(partial);
-    await this.s3.uploadBuffer(this.partialKey(operationId), body, contentType);
+    const compressed = await this.encodeSnapshot(partial);
+    await this.s3.uploadBuffer(this.partialKey(operationId), compressed, ZSTD_CONTENT_TYPE);
   }
 
   async removePartial(operationId: string): Promise<void> {
-    // Clean up both possible siblings — covers cross-env round-trips and the
-    // deploy window where a previous binary may have written the other format.
+    // Clean up both the current key and any legacy uncompressed sibling that may
+    // exist if the operation was started before the zstd rollout.
     await Promise.allSettled([
-      this.s3.deleteFile(this.partialKey(operationId, ZSTD_SUFFIX)),
-      this.s3.deleteFile(this.partialKey(operationId, PLAIN_SUFFIX)),
+      this.s3.deleteFile(this.partialKey(operationId)),
+      this.s3.deleteFile(this.legacyPartialKey(operationId)),
     ]);
   }
 }

--- a/src/server/modules/AgentTracing/S3SnapshotStore.ts
+++ b/src/server/modules/AgentTracing/S3SnapshotStore.ts
@@ -12,22 +12,42 @@ const decompressZstd = promisify(zstdDecompress);
 const log = debug('lobe-server:agent-tracing:s3');
 
 const TRACE_PREFIX = 'agent-traces';
-const SNAPSHOT_SUFFIX = '.json.zst';
-const LEGACY_SUFFIX = '.json';
+const ZSTD_SUFFIX = '.json.zst';
+const PLAIN_SUFFIX = '.json';
 const ZSTD_CONTENT_TYPE = 'application/zstd';
+const PLAIN_CONTENT_TYPE = 'application/json';
+
+// Compress on production deployments only — local dev (even when opting into
+// S3 via ENABLE_AGENT_S3_TRACING=1) keeps writing plain `.json` so devs can
+// inspect the raw payload directly from the bucket.
+const COMPRESS_SNAPSHOTS = process.env.NODE_ENV === 'production';
+
+// zstd frame magic: 0x28 0xb5 0x2f 0xfd. Used to auto-detect the body format
+// regardless of which environment wrote it, so a prod-written `.json.zst` and
+// a dev-written `.json` both round-trip through the same reader.
+const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd] as const;
+const isZstdFrame = (bytes: Uint8Array): boolean =>
+  bytes.length >= 4 &&
+  bytes[0] === ZSTD_MAGIC[0] &&
+  bytes[1] === ZSTD_MAGIC[1] &&
+  bytes[2] === ZSTD_MAGIC[2] &&
+  bytes[3] === ZSTD_MAGIC[3];
 
 /**
  * S3-backed snapshot store for production agent trace persistence.
  *
  * S3 paths:
- * - Final:   agent-traces/{agentId}/{topicId}/{operationId}.json.zst
- * - Partial: agent-traces/_partial/{operationId}.json.zst  (temporary, deleted after finalization)
+ * - Final:   agent-traces/{agentId}/{topicId}/{operationId}{.json|.json.zst}
+ * - Partial: agent-traces/_partial/{operationId}{.json|.json.zst}  (temporary, deleted after finalization)
  *
- * Snapshots are zstd-compressed (level 3) before upload — measured 8-9× average
- * size reduction across production traces. The `.zst` suffix is the format
+ * Production deployments (NODE_ENV=production) zstd-compress snapshots before
+ * upload — measured 8-9× average size reduction. The `.zst` suffix is the format
  * indicator; Content-Encoding is intentionally NOT set so the object is served
  * as opaque bytes (avoids HTTP middleware auto-decompressing into clients that
- * don't expect it). Readers explicitly decompress.
+ * don't expect it).
+ *
+ * Local dev keeps writing plain `.json` for easy bucket inspection. Readers
+ * sniff the zstd magic bytes (0x28b52ffd) to handle either format transparently.
  *
  * Partial snapshots are needed because QStash executes each step in a
  * separate HTTP request (no shared memory). Step data is accumulated
@@ -41,31 +61,39 @@ export class S3SnapshotStore implements ISnapshotStore {
     this.s3 = new FileS3();
   }
 
-  private partialKey(operationId: string): string {
-    return `${TRACE_PREFIX}/_partial/${operationId}${SNAPSHOT_SUFFIX}`;
+  private get activeSuffix(): string {
+    return COMPRESS_SNAPSHOTS ? ZSTD_SUFFIX : PLAIN_SUFFIX;
   }
 
-  private legacyPartialKey(operationId: string): string {
-    return `${TRACE_PREFIX}/_partial/${operationId}${LEGACY_SUFFIX}`;
+  private get legacySuffix(): string {
+    return COMPRESS_SNAPSHOTS ? PLAIN_SUFFIX : ZSTD_SUFFIX;
   }
 
-  private async encodeSnapshot(value: unknown): Promise<Buffer> {
-    return compressZstd(Buffer.from(JSON.stringify(value)));
+  private partialKey(operationId: string, suffix: string = this.activeSuffix): string {
+    return `${TRACE_PREFIX}/_partial/${operationId}${suffix}`;
+  }
+
+  private async encodeSnapshot(value: unknown): Promise<{ body: Buffer; contentType: string }> {
+    const json = Buffer.from(JSON.stringify(value));
+    if (!COMPRESS_SNAPSHOTS) return { body: json, contentType: PLAIN_CONTENT_TYPE };
+    return { body: await compressZstd(json), contentType: ZSTD_CONTENT_TYPE };
   }
 
   private async decodeSnapshot<T>(bytes: Uint8Array): Promise<T> {
-    const buf = await decompressZstd(Buffer.from(bytes));
-    return JSON.parse(buf.toString('utf8')) as T;
+    const json = isZstdFrame(bytes)
+      ? (await decompressZstd(Buffer.from(bytes))).toString('utf8')
+      : Buffer.from(bytes).toString('utf8');
+    return JSON.parse(json) as T;
   }
 
   async save(snapshot: ExecutionSnapshot): Promise<void> {
     const agentId = snapshot.agentId ?? 'unknown';
     const topicId = snapshot.topicId ?? 'unknown';
-    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${SNAPSHOT_SUFFIX}`;
+    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${this.activeSuffix}`;
 
     log('Saving snapshot to S3: %s', key);
-    const compressed = await this.encodeSnapshot(snapshot);
-    await this.s3.uploadBuffer(key, compressed, ZSTD_CONTENT_TYPE);
+    const { body, contentType } = await this.encodeSnapshot(snapshot);
+    await this.s3.uploadBuffer(key, body, contentType);
   }
 
   // === Query methods — not supported, use OTEL backend ===
@@ -89,35 +117,31 @@ export class S3SnapshotStore implements ISnapshotStore {
   }
 
   async loadPartial(operationId: string): Promise<Partial<ExecutionSnapshot> | null> {
-    // Current format: .json.zst (zstd-compressed)
-    try {
-      const bytes = await this.s3.getFileByteArray(this.partialKey(operationId));
-      return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
-    } catch {
-      // fall through to legacy
+    // Try the active key first (matches whatever this process writes), then the
+    // sibling format. Covers prod↔dev round-trips and the deploy window when an
+    // in-flight partial may have been written by the previous binary.
+    for (const suffix of [this.activeSuffix, this.legacySuffix]) {
+      try {
+        const bytes = await this.s3.getFileByteArray(this.partialKey(operationId, suffix));
+        return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
+      } catch {
+        // try next
+      }
     }
-    // Legacy format: uncompressed .json. Kept to bridge in-flight partials across the
-    // deploy window — partials are deleted on finalization so this branch dies off
-    // naturally once the longest-running operation completes.
-    try {
-      const content = await this.s3.getFileContent(this.legacyPartialKey(operationId));
-      return JSON.parse(content) as Partial<ExecutionSnapshot>;
-    } catch {
-      return null;
-    }
+    return null;
   }
 
   async savePartial(operationId: string, partial: Partial<ExecutionSnapshot>): Promise<void> {
-    const compressed = await this.encodeSnapshot(partial);
-    await this.s3.uploadBuffer(this.partialKey(operationId), compressed, ZSTD_CONTENT_TYPE);
+    const { body, contentType } = await this.encodeSnapshot(partial);
+    await this.s3.uploadBuffer(this.partialKey(operationId), body, contentType);
   }
 
   async removePartial(operationId: string): Promise<void> {
-    // Clean up both the current key and any legacy uncompressed sibling that may
-    // exist if the operation was started before the zstd rollout.
+    // Clean up both possible siblings — covers cross-env round-trips and the
+    // deploy window where a previous binary may have written the other format.
     await Promise.allSettled([
-      this.s3.deleteFile(this.partialKey(operationId)),
-      this.s3.deleteFile(this.legacyPartialKey(operationId)),
+      this.s3.deleteFile(this.partialKey(operationId, ZSTD_SUFFIX)),
+      this.s3.deleteFile(this.partialKey(operationId, PLAIN_SUFFIX)),
     ]);
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

n/a (internal optimization)

#### 🔀 Description of Change

Compress agent operation snapshots with **zstd (level 3)** before uploading to S3 and write them under a `.json.zst` key. Final snapshots and partial snapshots both go through this path.

The S3 store is already gated by `ENABLE_AGENT_S3_TRACING=1` upstream — local dev defaults to `FileSnapshotStore` (writes plain `.json` to local disk, untouched here). So whenever this code runs, we are by definition writing to a real bucket, and compression is always the right call.

**Measured on 76,839 production snapshots:**

| | Before | After |
|---|---|---|
| Total size | **217.08 GB** | **25.84 GB** |
| Average ratio | — | **8.4×** |
| p50 ratio | — | 6.6× |
| p99 ratio | — | 47.8× |
| Max ratio | — | 596× |

Storage cost drops by ~88%. New uploads only; existing `.json` objects are left as-is (we don't read them via this path anymore, per product decision).

##### Why these specific knobs

- **zstd level 3** — Node 22.15+ ships zstd in `node:zlib`, so no new runtime dependency. Level 3 is the sweet spot (~200 MB/s, only marginal gain at higher levels for this data shape).
- **`.json.zst` suffix as the format indicator** — the suffix tells readers to decompress. `Content-Encoding: zstd` is intentionally **not** set on the S3 object so the bytes are served as opaque binary; this avoids surprise behavior from HTTP clients that negotiate zstd (e.g. undici).
- **`application/zstd` content type** — registered MIME (RFC 8478).
- **Partial-snapshot legacy fallback** — `loadPartial` tries `.json.zst` first and falls back to `.json` for the duration of the deploy. Partials are deleted at finalization, so the legacy branch dies off as soon as the longest-running in-flight operation completes. `removePartial` cleans up both keys so nothing leaks.

##### Files touched

- `src/server/modules/AgentTracing/S3SnapshotStore.ts` — compress on `save` / `savePartial`, decompress on `loadPartial`, key suffix change, legacy fallback for partials.
- `packages/agent-tracing/src/store/remote-store.ts` — `buildRemoteUrl` now points at `.json.zst`; `RemoteSnapshotStore.fetch` decompresses before parsing. Local CLI cache stays as plain `.json` for easy inspection.

#### 🧪 How to Test

- [x] Tested locally — verified compression + decompression roundtrip is byte-identical and JSON-parsable across a 76k-file sample (`tmp-compress` benchmark in develop-center).
- [x] Type-check passes (`bun run type-check`).
- [x] ESLint passes on touched files.
- [ ] No tests added — `S3SnapshotStore` has no existing unit tests; behavior is exercised by the agent-tracing integration path.

To validate post-deploy:
1. Trigger a new agent run → confirm `.json.zst` keys appear under `agent-traces/{agentId}/{topicId}/`.
2. `agent-tracing inspect <op_id>` against a new operation → CLI should download, decompress, and render normally.
3. Spot-check S3 object sizes vs. an equivalent-shape pre-deploy snapshot.

#### 📝 Additional Information

- **Old data**: existing uncompressed `.json` snapshots remain readable directly from S3 if needed; they're just not surfaced through `buildRemoteUrl` anymore.
- **No DB migration**: `agent_operations.trace_s3_key` column was never written; the key is always re-derived from operationId. Nothing to backfill.
- **No new dependencies**: uses Node's built-in `node:zlib` zstd (Node 22.15+ / 24 in production).
- Pairs with a separate write-side optimization in `OperationTraceRecorder` that strips redundant `events` payloads from snapshots — together those two changes are expected to push average snapshot size down by **>99%** vs. the historical baseline.
- Commit history note: `70d0b3d8` added `NODE_ENV=production` gating + magic-byte sniffing — but since `ENABLE_AGENT_S3_TRACING` already gates this code path entirely, the extra gating was redundant. Reverted in `e9fc5a47`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)