### PR TITLE
🐛 fix(conversation): restore HTML preview for AssistantGroup messages

### DIFF
--- a/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/Assistant/useMarkdown.tsx
@@ -1,72 +1,17 @@
 'use client';
 
-import { type MarkdownProps } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
-import { type ReactNode, useMemo, useState } from 'react';
 
-import { HtmlPreviewDrawer } from '@/components/HtmlPreview';
-import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors } from '@/store/user/selectors';
-
-import { markdownElements } from '../../Markdown/plugins';
 import { dataSelectors, messageStateSelectors, useConversationStore } from '../../store';
+import { useChatMarkdown } from '../useChatMarkdown';
 
-const rehypePlugins = markdownElements.map((element) => element.rehypePlugin).filter(Boolean);
-const remarkPlugins = markdownElements.map((element) => element.remarkPlugin).filter(Boolean);
-
-export const useMarkdown = (
-  id: string,
-): { drawer: ReactNode; markdownProps: Partial<MarkdownProps> } => {
+export const useMarkdown = (id: string) => {
   const item = useConversationStore(dataSelectors.getDbMessageById(id), isEqual)!;
-  const { role, search } = item || {};
-  const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
-  const generating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
-  const animated = transitionMode === 'fadeIn' && generating;
+  const isGenerating = useConversationStore(messageStateSelectors.isMessageGenerating(id));
 
-  const [drawerContent, setDrawerContent] = useState<string | null>(null);
-
-  const components = useMemo(
-    () =>
-      Object.fromEntries(
-        markdownElements.map((element) => {
-          const Component = element.Component;
-          return [element.tag, (props: any) => <Component {...props} id={id} />];
-        }),
-      ),
-    [id],
-  );
-
-  const markdownProps = useMemo(
-    () =>
-      ({
-        animated,
-        citations: search?.citations,
-        componentProps: {
-          html: {
-            onExpand: (content: string) => setDrawerContent(content),
-          },
-        },
-        components,
-        enableCustomFootnotes: true,
-        enableHtmlPreview: true,
-        enableStream: true,
-        rehypePlugins,
-        remarkPlugins,
-        showFootnotes:
-          search?.citations &&
-          search?.citations.length > 0 &&
-          search?.citations.every((item) => item.title !== item.url),
-      }) satisfies Partial<MarkdownProps>,
-    [animated, components, role, search],
-  );
-
-  const drawer = drawerContent ? (
-    <HtmlPreviewDrawer
-      content={drawerContent}
-      open={!!drawerContent}
-      onClose={() => setDrawerContent(null)}
-    />
-  ) : null;
-
-  return useMemo(() => ({ drawer, markdownProps }), [drawer, markdownProps]);
+  return useChatMarkdown({
+    citations: item?.search?.citations,
+    id,
+    isGenerating,
+  });
 };

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -33,7 +33,7 @@ const MessageContent = memo<MessageContentProps>(
     const hasTools = hasToolsOverride ?? storeHasTools;
 
     const message = normalizeThinkTags(processWithArtifact(content ?? ''));
-    const markdownProps = useMarkdown(id, disableStreaming);
+    const { drawer, markdownProps } = useMarkdown(id, disableStreaming);
 
     if (!content && !hasTools) return <ContentLoading id={id} />;
 
@@ -47,9 +47,12 @@ const MessageContent = memo<MessageContentProps>(
 
     return (
       content && (
-        <MarkdownMessage {...markdownProps} className={cx(isToolSingleLine && styles.pWithTool)}>
-          {message}
-        </MarkdownMessage>
+        <>
+          {drawer}
+          <MarkdownMessage {...markdownProps} className={cx(isToolSingleLine && styles.pWithTool)}>
+            {message}
+          </MarkdownMessage>
+        </>
       )
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/useMarkdown.tsx
@@ -1,48 +1,14 @@
-import { type MarkdownProps } from '@lobehub/ui';
-import { useMemo } from 'react';
-
-import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors } from '@/store/user/selectors';
-
-import { type MarkdownElement } from '../../Markdown/plugins';
-import { markdownElements } from '../../Markdown/plugins';
 import { messageStateSelectors, useConversationStore } from '../../store';
+import { useChatMarkdown } from '../useChatMarkdown';
 
-const rehypePlugins = markdownElements
-  .map((element: MarkdownElement) => element.rehypePlugin)
-  .filter(Boolean);
-const remarkPlugins = markdownElements
-  .map((element: MarkdownElement) => element.remarkPlugin)
-  .filter(Boolean);
-
-export const useMarkdown = (id: string, disableStreaming = false): Partial<MarkdownProps> => {
-  const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
-  const generating = useConversationStore(messageStateSelectors.isAssistantGroupItemGenerating(id));
-
-  const enableStream = !disableStreaming;
-  const animated = enableStream && transitionMode === 'fadeIn' && generating;
-
-  const components = useMemo(
-    () =>
-      Object.fromEntries(
-        markdownElements.map((element: MarkdownElement) => {
-          const Component = element.Component;
-
-          return [element.tag, (props: any) => <Component {...props} id={id} />];
-        }),
-      ),
-    [id],
+export const useMarkdown = (id: string, disableStreaming = false) => {
+  const isGenerating = useConversationStore(
+    messageStateSelectors.isAssistantGroupItemGenerating(id),
   );
-  return useMemo(
-    () =>
-      ({
-        animated,
-        components,
-        enableCustomFootnotes: true,
-        enableStream,
-        rehypePlugins,
-        remarkPlugins,
-      }) satisfies Partial<MarkdownProps>,
-    [animated, components, enableStream],
-  );
+
+  return useChatMarkdown({
+    enableStream: !disableStreaming,
+    id,
+    isGenerating,
+  });
 };

--- a/src/features/Conversation/Messages/useChatMarkdown.tsx
+++ b/src/features/Conversation/Messages/useChatMarkdown.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { type MarkdownProps } from '@lobehub/ui';
+import { type ReactNode, useMemo, useState } from 'react';
+
+import { HtmlPreviewDrawer } from '@/components/HtmlPreview';
+import { useUserStore } from '@/store/user';
+import { userGeneralSettingsSelectors } from '@/store/user/selectors';
+
+import { type MarkdownElement, markdownElements } from '../Markdown/plugins';
+
+const rehypePlugins = markdownElements
+  .map((element: MarkdownElement) => element.rehypePlugin)
+  .filter(Boolean);
+const remarkPlugins = markdownElements
+  .map((element: MarkdownElement) => element.remarkPlugin)
+  .filter(Boolean);
+
+interface UseChatMarkdownOptions {
+  citations?: MarkdownProps['citations'];
+  enableStream?: boolean;
+  id: string;
+  isGenerating: boolean;
+}
+
+export const useChatMarkdown = ({
+  id,
+  isGenerating,
+  citations,
+  enableStream = true,
+}: UseChatMarkdownOptions): {
+  drawer: ReactNode;
+  markdownProps: Partial<MarkdownProps>;
+} => {
+  const { transitionMode } = useUserStore(userGeneralSettingsSelectors.config);
+  const animated = enableStream && transitionMode === 'fadeIn' && isGenerating;
+
+  const [drawerContent, setDrawerContent] = useState<string | null>(null);
+
+  const components = useMemo(
+    () =>
+      Object.fromEntries(
+        markdownElements.map((element: MarkdownElement) => {
+          const Component = element.Component;
+          return [element.tag, (props: any) => <Component {...props} id={id} />];
+        }),
+      ),
+    [id],
+  );
+
+  const markdownProps = useMemo(
+    () =>
+      ({
+        animated,
+        citations,
+        componentProps: {
+          html: {
+            onExpand: (content: string) => setDrawerContent(content),
+          },
+        },
+        components,
+        enableCustomFootnotes: true,
+        enableHtmlPreview: true,
+        enableStream,
+        rehypePlugins,
+        remarkPlugins,
+        showFootnotes:
+          !!citations && citations.length > 0 && citations.every((item) => item.title !== item.url),
+      }) satisfies Partial<MarkdownProps>,
+    [animated, citations, components, enableStream],
+  );
+
+  const drawer = drawerContent ? (
+    <HtmlPreviewDrawer
+      content={drawerContent}
+      open={!!drawerContent}
+      onClose={() => setDrawerContent(null)}
+    />
+  ) : null;
+
+  return useMemo(() => ({ drawer, markdownProps }), [drawer, markdownProps]);
+};


### PR DESCRIPTION
## Summary

- PR #14703 wired `@lobehub/ui`'s `enableHtmlPreview` into `Assistant/useMarkdown` but missed the sibling `AssistantGroup/useMarkdown`, so any full HTML document the LLM emits inside a grouped step (the path used when a tool call shares the same bubble as text — see screenshot below) rendered as a plain code block instead of the iframe preview.
- Extract the shared markdown wiring (components, rehype/remark plugins, `animated`, `enableHtmlPreview`, `HtmlPreviewDrawer` state) into a new `useChatMarkdown` hook. Both `Assistant` and `AssistantGroup` wrappers now delegate to it, keeping their slice-specific bits (`isMessageGenerating` vs `isAssistantGroupItemGenerating`, citations, `disableStreaming`) at the wrapper layer.
- Wire `drawer` into `AssistantGroup/components/MessageContent.tsx` so the "Open full preview" expand button works the same as on the Assistant path.

## Repro before this PR

LLM emits a `\`\`\`html` fence containing a full document inside a grouped tool-call message → renders as a collapsed `HTML` code block, no iframe preview.

## Test plan

- [x] `bun run type-check` — no new errors (unrelated pre-existing failures in `settings/tts/STT.tsx` and `KlavisServerList`)
- [x] `bunx vitest run 'src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx'` — passes
- [x] `bunx vitest run 'src/features/Conversation/Messages/Assistant/' 'src/features/Conversation/Messages/AssistantGroup/'` — 51 passed; 2 pre-existing `webOnboarding.test.tsx` failures (confirmed by stashing changes and re-running)
- [ ] Manual: ask an agent to produce a full `<!doctype html>` document in a grouped step, confirm it renders as iframe preview and the expand drawer opens