### PR TITLE
🐛 fix(agent-tasks): enable send button after pasting into thread/comment input

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
@@ -41,14 +41,14 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
           placeholder={t('taskDetail.commentPlaceholder')}
           type={'text'}
           variant={'chat'}
+          onChange={(ed) => {
+            setHasContent(!ed?.isEmpty);
+          }}
           onPressEnter={({ event }) => {
             if (event.metaKey || event.ctrlKey) {
               handleSubmit();
               return true;
             }
-          }}
-          onTextChange={(ed) => {
-            setHasContent(!!String(ed?.getDocument?.('markdown') ?? '').trim());
           }}
         />
       </div>

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
@@ -63,14 +63,14 @@ const FeedbackInput = memo<FeedbackInputProps>(({ taskId, topicId }) => {
           placeholder={t('taskDetail.commentPlaceholder')}
           type={'text'}
           variant={'chat'}
+          onChange={(ed) => {
+            setHasContent(!ed?.isEmpty);
+          }}
           onPressEnter={({ event }) => {
             if (event.metaKey || event.ctrlKey) {
               handleSubmit();
               return true;
             }
-          }}
-          onTextChange={(ed) => {
-            setHasContent(!!String(ed?.getDocument?.('markdown') ?? '').trim());
           }}
         />
       </div>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-8897

#### 🔀 Description of Change

In `FeedbackInput` (topic thread) and `CommentInput` (task comment), pasting content **without** subsequently typing left the send button disabled — clicking did nothing, and only after editing the pasted text could the user submit.

**Root cause.** The `@lobehub/editor` `ReactPlainText` `onTextChange` listener (`node_modules/@lobehub/editor/es/ReactSlashPlugin-CBLFF1e6.js:20970-20980`) uses a `previousContent` baseline that's `undefined` at registration. The first dirty-update after registration only seeds `previousContent` and does **not** fire `onTextChange`. Because the parent recreates the inline callback on every render, the underlying `useEffect` re-registers the listener and resets `previousContent` — so a single paste transaction is consumed as the "initial" event, `hasContent` stays `false`, and the `SendButton` stays disabled. Typing produces additional dirty updates which eventually flip the state, which matches the reported behavior.

A workaround for this exact upstream bug is already documented at `src/features/EditorCanvas/InternalEditor.tsx:221`.

**Fix.** Switch the two inputs from `onTextChange` to `onChange`, which fires unconditionally on every editor update and isn't gated by the baseline check. To offset the higher invocation rate (cursor moves / selection changes also fire `onChange`), the callback now uses the O(1) `editor.isEmpty` getter instead of serializing the full document to markdown.

#### 🧪 How to Test

1. Open an agent task and reveal the topic thread (right-side drawer) for any completed topic.
2. Paste any non-empty text into the feedback input. **Do not type anything.**
3. The send button should become enabled immediately and clicking it should submit.
4. Repeat with the task-level comment input at the bottom of the task detail page.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

The deeper bug lives in `@lobehub/editor`; this PR is a client-side workaround for the two affected inputs only. Other callers of `onTextChange` (`SkillEditForm.tsx:125`, `agent/profile/features/EditorCanvas/index.tsx:124`) are theoretically exposed but were not reported and aren't part of this fix.