### PR TITLE
🐛 fix(home): fetch agent config so knowledge toggles reflect in UI

### DIFF
--- a/src/routes/(main)/home/_layout/index.tsx
+++ b/src/routes/(main)/home/_layout/index.tsx
@@ -3,7 +3,6 @@ import { useTheme } from 'antd-style';
 import { Activity, type FC, type ReactNode, useEffect, useMemo, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
-import { useInitAgentConfig } from '@/hooks/useInitAgentConfig';
 import { useIsDark } from '@/hooks/useIsDark';
 
 import HomeAgentIdSync from './HomeAgentIdSync';
@@ -16,8 +15,6 @@ interface LayoutProps {
 }
 
 const Layout: FC<LayoutProps> = ({ children }) => {
-  useInitAgentConfig();
-
   const isDarkMode = useIsDark();
   const theme = useTheme(); // Keep for colorBgContainerSecondary (not in cssVar)
   const { pathname } = useLocation();

--- a/src/routes/(main)/home/_layout/index.tsx
+++ b/src/routes/(main)/home/_layout/index.tsx
@@ -3,6 +3,7 @@ import { useTheme } from 'antd-style';
 import { Activity, type FC, type ReactNode, useEffect, useMemo, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
+import { useInitAgentConfig } from '@/hooks/useInitAgentConfig';
 import { useIsDark } from '@/hooks/useIsDark';
 
 import HomeAgentIdSync from './HomeAgentIdSync';
@@ -15,6 +16,8 @@ interface LayoutProps {
 }
 
 const Layout: FC<LayoutProps> = ({ children }) => {
+  useInitAgentConfig();
+
   const isDarkMode = useIsDark();
   const theme = useTheme(); // Keep for colorBgContainerSecondary (not in cssVar)
   const { pathname } = useLocation();

--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -5,6 +5,7 @@ import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
 import { type ActionKeys } from '@/features/ChatInput';
 import { ChatInputProvider, DesktopChatInput } from '@/features/ChatInput';
 import { useHomeDailyBrief } from '@/hooks/useHomeDailyBrief';
+import { useInitAgentConfig } from '@/hooks/useInitAgentConfig';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { builtinAgentSelectors } from '@/store/agent/selectors/builtinAgentSelectors';
@@ -27,6 +28,17 @@ type BannerKind = 'skill' | 'botIntegration' | 'messenger';
 
 const InputArea = () => {
   const { loading, send, agentId } = useSend();
+  // Subscribe to the SWR key so `internal_refreshAgentConfig`'s `mutate(...)`
+  // has a listener after toggleFile / toggleKnowledgeBase — otherwise the
+  // Library submenu doesn't reflect server-side toggles. Pass `agentId`
+  // explicitly so AgentSelect switches refetch too.
+  useInitAgentConfig(agentId);
+  // Use the "config absent from agentMap" loading shape (same as Memory /
+  // Search / History) instead of SWR's `isLoading`, which would flash on
+  // every mount-time revalidation even when inbox data is already cached.
+  const isAgentConfigLoading = useAgentStore((s) =>
+    agentByIdSelectors.isAgentConfigLoadingById(agentId ?? '')(s),
+  );
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
   const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
   const isKlavisEnabled = useServerConfigStore(serverConfigSelectors.enableKlavis);
@@ -134,7 +146,7 @@ const InputArea = () => {
               useChatStore.setState({ mainInputEditor: instance });
             }}
             sendButtonProps={{
-              disabled: loading,
+              disabled: loading || isAgentConfigLoading,
               generating: loading,
               onStop: () => {},
               shape: 'round',


### PR DESCRIPTION
## Summary

- Toggling files/knowledge bases from the chat input "+" → Library submenu on the **home page** updated the server but the checkbox UI didn't reflect the change.
- Root cause: `Home` layout never called `useInitAgentConfig()`, so there was no SWR subscription on `[FETCH_AGENT_CONFIG_KEY, agentId]`. After `toggleFile` / `toggleKnowledgeBase` ran, the `mutate(...)` call inside `internal_refreshAgentConfig` had no listener — `agentMap` was never refreshed and selectors kept reading the stale `files` array.
- Fix: call `useInitAgentConfig()` in `src/routes/(main)/home/_layout/index.tsx`, matching what the `/agent` layout already does.

## Test plan

- [ ] Open home page while logged in, click "+" → Library, toggle a file/knowledge base — the checkbox state updates immediately.
- [ ] Toggle off, then close & reopen the menu — the persisted state still matches the server.
- [ ] Navigate to `/agent/...` and back to home — Library toggles still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)