### PR TITLE
🐛 fix(hetero-agent): drop ALL subagent-tagged events from main gateway handler

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -265,6 +265,25 @@ const ccSubagentSpawnResult = (spawnToolUseId: string, finalText: string) => ({
   type: 'user',
 });
 
+/**
+ * Subagent INNER tool_result: a user event tagged with `parent_tool_use_id`,
+ * which the adapter routes through its subagent path so the emitted
+ * `tool_result` + `tool_end` events both carry the `subagent` peer field.
+ */
+const ccSubagentToolResult = (
+  toolUseId: string,
+  parentToolUseId: string,
+  content: string,
+  isError = false,
+) => ({
+  message: {
+    content: [{ content, is_error: isError, tool_use_id: toolUseId, type: 'tool_result' }],
+    role: 'user',
+  },
+  parent_tool_use_id: parentToolUseId,
+  type: 'user',
+});
+
 const ccText = (msgId: string, text: string) => ccAssistant(msgId, [{ text, type: 'text' }]);
 
 const ccThinking = (msgId: string, thinking: string) =>
@@ -2793,6 +2812,91 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(seenToolIds).toContain('toolu_task');
       expect(seenToolIds).toContain('toolu_read');
       expect(seenToolIds).not.toContain('toolu_grep');
+    });
+
+    /**
+     * Regression for LOBE-8991: the subagent forwarding guard initially only
+     * filtered `stream_chunk` events. `tool_start` / `tool_end` for subagent
+     * inner tools still reached the main gateway handler, where:
+     *   - `tool_start` would fire `dispatchOnBeforeCall` against the MAIN
+     *     context for what is actually a subagent inner tool.
+     *   - `tool_end`  would call `fetchAndReplaceMessages(main)` once per
+     *     subagent inner tool result — wasted work AND a state-drift window
+     *     that surfaced as the "orphan tool call" banner on the spawn's
+     *     Task/Agent bubble in the main topic.
+     *
+     * The guard now covers ALL subagent-tagged events. Main-agent tool
+     * lifecycle events (no `subagent` peer) must still reach the handler
+     * so the main bubble's animation / onAfterCall hooks fire.
+     */
+    it('does NOT forward subagent-tagged tool_start / tool_end events to the gateway handler', async () => {
+      await runWithEvents([
+        ccInit(),
+        // Main emits Task + a parallel Read in the same message.id.
+        ccToolUse('msg_main', 'toolu_task', 'Task', {
+          description: 'inspect',
+          prompt: 'go',
+          subagent_type: 'Explore',
+        }),
+        ccToolUse('msg_main', 'toolu_read', 'Read', { file_path: '/a.ts' }),
+        // Subagent inner tool — adapter emits tool_start(subagent) here.
+        ccSubagentToolUse('msg_sub_1', 'toolu_task', 'toolu_grep', 'Grep', {
+          pattern: 'foo',
+        }),
+        // Subagent inner tool_result with parent_tool_use_id — adapter emits
+        // tool_result(subagent) + tool_end(subagent) here. Without the
+        // broadened guard, tool_end(subagent) would reach the main handler.
+        ccSubagentToolResult('toolu_grep', 'toolu_task', 'grep output'),
+        ccSubagentText('msg_sub_2', 'toolu_task', 'subagent summary'),
+        // Main's own parallel tool result — emits tool_end (no subagent flag),
+        // MUST reach the handler so dispatchOnAfterCall fires on main bucket.
+        ccToolResult('toolu_read', 'read content'),
+        // Spawn result closes the subagent run.
+        ccSubagentSpawnResult('toolu_task', 'task done'),
+        ccResult(),
+      ]);
+
+      const handlerSpy = vi.mocked(createGatewayEventHandler).mock.results[0]?.value as ReturnType<
+        typeof vi.fn
+      >;
+      expect(handlerSpy).toBeDefined();
+
+      const forwardedEvents = handlerSpy.mock.calls.map((call) => call[0]);
+
+      // No forwarded event of ANY type may carry the subagent peer field —
+      // they're all handled inline (tool_result) or routed through the
+      // per-spawn thread-scoped dispatcher (stream_chunk, tool_start,
+      // tool_end). The main gateway handler is main-agent-only.
+      const leakedSubagentEvents = forwardedEvents.filter(
+        (e: any) => e?.data?.subagent !== undefined,
+      );
+      expect(leakedSubagentEvents).toHaveLength(0);
+
+      // Sanity: main-agent tool lifecycle for `toolu_read` still reaches the
+      // handler — this is the path that drives the main bubble's tool card
+      // animation + invalidates renderer caches via dispatchOnAfterCall.
+      const mainToolStarts = forwardedEvents.filter(
+        (e: any) => e?.type === 'tool_start' && e.data?.toolCalling?.id === 'toolu_read',
+      );
+      expect(mainToolStarts.length).toBeGreaterThan(0);
+
+      const mainToolEnds = forwardedEvents.filter(
+        (e: any) => e?.type === 'tool_end' && e.data?.toolCallId === 'toolu_read',
+      );
+      expect(mainToolEnds.length).toBeGreaterThan(0);
+
+      // The subagent's inner Grep tool_start / tool_end specifically must
+      // not appear in the forwarded set — guards against a future regression
+      // that narrows the filter back to stream_chunk only.
+      const grepToolStarts = forwardedEvents.filter(
+        (e: any) => e?.type === 'tool_start' && e.data?.toolCalling?.id === 'toolu_grep',
+      );
+      expect(grepToolStarts).toHaveLength(0);
+
+      const grepToolEnds = forwardedEvents.filter(
+        (e: any) => e?.type === 'tool_end' && e.data?.toolCallId === 'toolu_grep',
+      );
+      expect(grepToolEnds).toHaveLength(0);
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -1688,18 +1688,28 @@ export const executeHeterogeneousAgent = async (
         }
       }
 
-      // Subagent-tagged stream_chunks are persisted above via
-      // persistSubagent*Chunk into the in-thread assistant. The gateway
-      // handler is main-agent-only: forwarding would dispatch
-      // `updateMessage { tools }` onto `currentAssistantMessageId` (main),
-      // overwriting main.tools[] with subagent tools — main's own
-      // tool_use messages then lose their tools[] pairing and render
-      // as orphans until the next fetchAndReplaceMessages. Text /
-      // reasoning chunks similarly bleed subagent content into the
-      // main bubble. DB state is already correct (the subagent persist
-      // path writes to the thread scope), so dropping the forward
-      // keeps in-memory state aligned with DB.
-      if (event.type === 'stream_chunk' && (event.data as any)?.subagent) {
+      // ALL subagent-tagged events are handled inline (tool_result, line
+      // 1407) or routed through the per-spawn thread-scoped dispatcher
+      // (stream_chunk via persistSubagent*Chunk). They must NOT reach the
+      // main gateway handler, which is main-agent-only:
+      //   - `stream_chunk { tools_calling }` → handler dispatches
+      //     `updateMessage { tools }` onto `currentAssistantMessageId`
+      //     (main), overwriting main.tools[] with subagent tools. Main's
+      //     own tool_use messages then lose their tools[] pairing and
+      //     render as orphans until the next fetchAndReplaceMessages.
+      //   - `stream_chunk { text | reasoning }` → bleeds subagent content
+      //     into the main bubble.
+      //   - `tool_start` → fires `dispatchOnBeforeCall` against the MAIN
+      //     context for what is actually a subagent inner tool, leaking
+      //     renderer-side onBeforeCall hooks into the wrong scope.
+      //   - `tool_end`  → triggers `fetchAndReplaceMessages(main)` on
+      //     every subagent inner tool result. Wasted work, AND it widens
+      //     the in-memory ↔ DB drift window that surfaces as orphan
+      //     warnings even after the DB has settled (LOBE-8991).
+      // DB state is already correct (the subagent persist path writes to
+      // the thread scope), so dropping the forward keeps in-memory state
+      // aligned with DB.
+      if ((event.data as any)?.subagent) {
         return;
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

Closes [LOBE-8991](https://linear.app/lobehub/issue/LOBE-8991/subagent-tool-start-tool-end-events-leak-into-main-gateway-handler).

#### 🔀 Description of Change

The subagent forwarding guard in `heterogeneousAgentExecutor.ts` only filtered `stream_chunk` events. `tool_start` and `tool_end` for **subagent inner tools** still carried `event.data.subagent` but bypassed the guard and reached the main gateway handler, causing two distinct leaks:

- **`tool_start(subagent)`** → fires `dispatchOnBeforeCall` against the **main** context for what is actually a subagent inner tool, leaking renderer-side onBeforeCall hooks into the wrong scope.
- **`tool_end(subagent)`** → triggers `fetchAndReplaceMessages(main)` on every subagent inner tool result. Wasted work, AND it widens the in-memory ↔ DB drift window that surfaces as the "Orphaned Skill call" banner on the spawn's Task / Agent bubble even after the DB has settled.

The new guard drops **any** event with `event.data.subagent` before forwarding. Subagent paths are already covered:

- `tool_result(subagent)` → handled inline at executor:1407 with an early `return`.
- `stream_chunk(subagent)` → routed through `persistSubagentToolChunk` / `persistSubagentTextChunk` into the per-spawn thread scope.
- `tool_start` / `tool_end` are pure renderer-notification hooks; the subagent's own in-thread renderer state is already streamed via the thread-scoped dispatcher introduced in #14024.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression test in `heterogeneousAgentExecutor.test.ts`:

> `does NOT forward subagent-tagged tool_start / tool_end events to the gateway handler`

It feeds the main agent a parallel `Task` + `Read`, runs a subagent `Grep` inner tool, and asserts:

1. No forwarded event of any type carries `event.data.subagent` (was 2 before fix: `toolu_grep` `tool_start` + `tool_end`).
2. Main's own `toolu_read` `tool_start` / `tool_end` still reach the handler so the main bubble's animation + `dispatchOnAfterCall` still fire.
3. Specifically, `toolu_grep`'s `tool_start` / `tool_end` are NOT in the forwarded set — guards against a future regression that narrows the filter back to `stream_chunk` only.

Local results:

```
heterogeneousAgentExecutor.test.ts  53 passed (53)
gatewayEventHandler.test.ts         32 passed (32)
bun run type-check                  clean
```

#### 📸 Screenshots / Videos

N/A — internal event-routing fix, no UI changes.

#### 📝 Additional Information

- The original guard was added in #14024 (commit `f3fca500`) to fix a parallel-tool orphan caused by `stream_chunk(subagent)` overwriting main's `tools[]`. This PR extends the same guard family to cover the remaining leak paths surfaced by topic [`tpc_ZJ8oB62hE7hx`](#) (DB was internally consistent, banner still showed → stale UI from the drift window described above).
- No breaking changes. No new public API. Behavior changes only for events the main handler had no business processing in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)