### PR TITLE
🐛 fix(hetero-agent): keep parentId chain across toolless middle steps

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -2855,12 +2855,11 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
     });
 
     /**
-     * Hypothesis 2 from the issue: a toolless step in the middle.
-     * If Monitor's stdout triggers CC to respond with only text (no tool_use),
-     * the next step must still chain through. This test documents current
-     * behavior: toolless step breaks tool → next-tool chain.
+     * LOBE-8993 regression: a toolless step in the middle must NOT break the
+     * zigzag chain. The next step should chain back to the most recent tool
+     * result ever produced in the run, not to the toolless assistant.
      */
-    it('toolless middle step: chain visibly breaks at text-only step', async () => {
+    it('toolless middle step: next step chains back to last real tool', async () => {
       const idCounter = { tool: 0, assistant: 0 };
       mockCreateMessage.mockImplementation(async (params: any) => {
         if (params.role === 'tool') {
@@ -2889,15 +2888,61 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       );
       expect(assistantCreates.length).toBe(2);
 
-      // Step 1 parent = Monitor tool from step 0 → this IS correct (tool-1)
+      // Step 1 parent = Monitor tool from step 0 (tool-1)
       expect(assistantCreates[0][0].parentId).toBe('tool-1');
 
-      // Step 2 parent: step 1 had NO tools, so toolState.payloads is empty.
-      // Code falls back to currentAssistantMessageId (= step 1 assistant).
-      // BUG: this breaks the assistantGroup chain because collectAssistantChain
-      // only walks tool → assistant, never assistant → assistant.
-      expect(assistantCreates[1][0].parentId).toBe('ast-new-1');
-      // ^ If this assertion passes, the chain IS broken.
+      // Step 2 parent: step 1 was toolless, but the chain must skip back to
+      // step 0's Monitor (tool-1) so MessageCollector's assistant → tool →
+      // assistant walk keeps every assistant in the same group.
+      expect(assistantCreates[1][0].parentId).toBe('tool-1');
+    });
+
+    /**
+     * LOBE-8993 follow-up: N consecutive toolless steps (Monitor pushing
+     * stdout line by line, each line triggering a new LLM call that only
+     * answers with text). All toolless assistants must chain back to the
+     * same originating tool result; otherwise the UI splits one bubble per
+     * Monitor line.
+     */
+    it('consecutive toolless steps: all parents resolve to the originating tool', async () => {
+      const idCounter = { tool: 0, assistant: 0 };
+      mockCreateMessage.mockImplementation(async (params: any) => {
+        if (params.role === 'tool') {
+          idCounter.tool++;
+          return { id: `tool-${idCounter.tool}` };
+        }
+        idCounter.assistant++;
+        return { id: `ast-new-${idCounter.assistant}` };
+      });
+
+      await runWithEvents([
+        ccInit(),
+        // Step 0: Monitor kicks off the long-running task
+        ccToolUse('msg_01', 'toolu_mon_0', 'Monitor', { shell: 'tail -f log' }),
+        ccToolResult('toolu_mon_0', 'Monitor started'),
+        // Step 1, 2, 3: each Monitor stdout line drives a toolless reply
+        ccText('msg_02', '等 list 完。'),
+        ccText('msg_03', '84842 列完，开干。'),
+        ccText('msg_04', '100/84842 全 skip…'),
+        // Step 4: CC finally reacts with a Bash tool
+        ccToolUse('msg_05', 'toolu_bash_1', 'Bash', { command: 'echo ack' }),
+        ccToolResult('toolu_bash_1', 'ack'),
+        ccResult(),
+      ]);
+
+      const assistantCreates = mockCreateMessage.mock.calls.filter(
+        ([p]: any) => p.role === 'assistant',
+      );
+      // 4 new assistants (steps 1–4); step 0 reuses ast-initial
+      expect(assistantCreates.length).toBe(4);
+
+      // All toolless steps chain back to the Monitor tool from step 0
+      expect(assistantCreates[0][0].parentId).toBe('tool-1');
+      expect(assistantCreates[1][0].parentId).toBe('tool-1');
+      expect(assistantCreates[2][0].parentId).toBe('tool-1');
+      // Step 4 also chains to tool-1 — its own step had no tools yet at
+      // step_start, the Bash tool only persists after stream_start fires.
+      expect(assistantCreates[3][0].parentId).toBe('tool-1');
     });
 
     /**

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -1143,6 +1143,23 @@ export const executeHeterogeneousAgent = async (
   /** Adapter/CLI provider (e.g. `claude-code`) — carried on every turn_metadata. */
   let lastProvider: string | undefined;
   /**
+   * Most recent tool `result_msg_id` seen across step boundaries — survives the
+   * `toolState.payloads` reset that happens on every new step.
+   *
+   * Required for the **toolless middle step** case (LOBE-8993): when a step
+   * produces only text (e.g. Monitor stdout drives Claude to reply "等一下…"
+   * without invoking a tool), `toolState.payloads` is empty at the next step
+   * boundary. Without this tracker, `stepParentId` would fall back to
+   * `currentAssistantMessageId` (= the toolless assistant), forming an
+   * `assistant → assistant` link. `MessageCollector.collectAssistantChain`
+   * only walks the `assistant → tool → assistant` zigzag, so the UI splits
+   * into one bubble per Monitor stdout line.
+   *
+   * Scope: executor lifetime (one user run). A new user message spawns a
+   * new executor, so this resets implicitly at run boundaries.
+   */
+  let lastToolMsgIdEver: string | undefined;
+  /**
    * Deferred terminal event (agent_runtime_end or error). We don't forward
    * these to the gateway handler immediately because handler triggers
    * fetchAndReplaceMessages which would clobber our in-flight content
@@ -1552,7 +1569,11 @@ export const executeHeterogeneousAgent = async (
           const lastToolMsgId = [...toolState.payloads]
             .reverse()
             .find((p) => !!p.result_msg_id)?.result_msg_id;
-          const stepParentId = lastToolMsgId || currentAssistantMessageId;
+          if (lastToolMsgId) lastToolMsgIdEver = lastToolMsgId;
+          // Prefer this step's last tool, then the most recent tool ever seen
+          // in the run (rescues toolless middle steps — see LOBE-8993), then
+          // the previous assistant as a last resort.
+          const stepParentId = lastToolMsgId ?? lastToolMsgIdEver ?? currentAssistantMessageId;
 
           const newMsg = await messageService.createMessage({
             agentId: context.agentId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-8993
Related to LOBE-7365

#### 🔀 Description of Change

When a Claude Code step produced only text (no `tool_use`) — for example
Monitor pushing stdout that drove Claude to reply "等 list 完。" without
invoking a tool — the next step's `parentId` fell back to the previous
assistant message. `MessageCollector.collectAssistantChain` only walks
the `assistant → tool → assistant` zigzag, so each Monitor stdout line
split off into its own bubble, every one re-rendering the model label.

The executor tracks tool persistence in `toolState.payloads`, which is
**cleared on every step boundary**. So when a step had no tools,
`lastToolMsgId` came back empty and `stepParentId` defaulted to
`currentAssistantMessageId` (the toolless assistant) — producing an
`assistant → assistant` link that the UI couldn't aggregate.

Fix: introduce a run-scoped `lastToolMsgIdEver` tracker that survives
step boundaries (resets only when a new executor spawns, i.e. on a new
user message). Step boundary now resolves `stepParentId` in this order:

1. `lastToolMsgId` — last tool in **this** step (normal zigzag)
2. `lastToolMsgIdEver` — last tool ever seen in the run (rescues
   consecutive toolless middle steps)
3. `currentAssistantMessageId` — pure-text run with no tools at all

The reader (`MessageCollector`) is untouched; the semantics it expects
are now produced correctly on the writer side.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Test changes in `heterogeneousAgentExecutor.test.ts`:

- Flipped `LOBE-7365 Monitor parentId chain > toolless middle step` —
  asserts Step 2's `parentId` is the Step 0 Monitor tool (`tool-1`),
  not the toolless Step 1 assistant.
- Added `LOBE-7365 Monitor parentId chain > consecutive toolless steps`
  — replays 3 consecutive toolless text-only steps after a Monitor
  tool_use; asserts all 4 follow-up assistants chain back to `tool-1`.
- Existing `should fall back to assistant parentId when step has no
  tools` still passes (covers the pure-text run case where the
  fallback is `currentAssistantMessageId`).

Run:

```bash
bunx vitest run --silent='passed-only' src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
```

53/53 passing.

#### 📝 Additional Information

Impact: all Claude Code desktop sessions that use long-running
`Monitor` (and similar streaming tools — `tail -f`, CI watch, migration
progress loops). Beyond UI bubble fragmentation, the broken
`assistant → assistant` chain could mislead `findLastMessageId` and
session resume parent-pointer logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)