### PR TITLE
🐛 fix(agent-builder): use agentId instead of agentBuilderId in preview panel

### DIFF
--- a/src/features/AgentBuilder/index.tsx
+++ b/src/features/AgentBuilder/index.tsx
@@ -34,8 +34,8 @@ const AgentBuilder = memo(() => {
       }}
     >
       {agentId && agentBuilderId ? (
-        <AgentBuilderProvider agentId={agentBuilderId}>
-          <AgentBuilderConversation agentId={agentBuilderId} />
+        <AgentBuilderProvider agentId={agentId}>
+          <AgentBuilderConversation agentId={agentId} />
         </AgentBuilderProvider>
       ) : (
         <Loading debugId="AgentBuilder > Init" />


### PR DESCRIPTION
## Summary

- The AgentBuilder right-panel preview at `/agent/:id/profile` was passing `agentBuilderId` (the *builtin* agent-builder system agent) to both `AgentBuilderProvider` and `AgentBuilderConversation`, instead of `agentId` (the agent currently being configured).
- This caused every message sent from the preview panel to be answered by the builtin agent builder, not the custom agent being edited.
- The bug existed since `ede0ed6d37` but became clearly visible after `e0d20e86fc` (\"support chat mode\"), which changed `enableAgentMode` to default `true`. The builtin agent builder switched from implicit chat-mode (no tools) to agent-mode, began firing `AgentBuilderIdentifier` tool calls against its *own* ID, and responded visibly as a different agent.

## Root Cause

`src/features/AgentBuilder/index.tsx` lines 37-38 hardcoded `agentBuilderId` in both component props; the correctly-read `agentId` variable was unused:

```tsx
// Before (bug)
<AgentBuilderProvider agentId={agentBuilderId}>
  <AgentBuilderConversation agentId={agentBuilderId} />

// After (fix)
<AgentBuilderProvider agentId={agentId}>
  <AgentBuilderConversation agentId={agentId} />
```

`agentBuilderId` is still needed as a loading gate (`agentId && agentBuilderId`), so the `useInitBuiltinAgent` call is preserved.

## Test plan

- [ ] Navigate to `/agent/<any-custom-agent-id>/profile`
- [ ] Send a message in the right panel chat
- [ ] Confirm the reply comes from the custom agent being edited, not from the builtin agent builder system agent
- [ ] Confirm topics in the TopicSelector belong to the custom agent
- [ ] Confirm model/provider used for upload capability check matches the custom agent's config

🤖 Generated with [Claude Code](https://claude.com/claude-code)