### PR TITLE
🐛 fix(agent-builder): use activeAgentId as tool ctx when scope is agent_builder

### DIFF
--- a/src/store/chat/slices/aiChat/actions/clientToolExecution.ts
+++ b/src/store/chat/slices/aiChat/actions/clientToolExecution.ts
@@ -92,8 +92,15 @@ export class ClientToolExecutionActionImpl {
       // ─── Builtin dispatch (via registry) ───
       if (hasExecutor(identifier, apiName)) {
         const operation = this.#get().operations[operationId];
+        // In agent_builder scope the operation's agentId is the builder agent itself,
+        // but write tools (updateConfig / updatePrompt / installPlugin) must target
+        // the agent being edited, which is chatStore.activeAgentId.
+        const isAgentBuilderScope = operation?.context?.scope === 'agent_builder';
+        const toolAgentId = isAgentBuilderScope
+          ? (this.#get().activeAgentId ?? operation?.context?.agentId)
+          : operation?.context?.agentId;
         const ctx: BuiltinToolContext = {
-          agentId: operation?.context?.agentId,
+          agentId: toolAgentId,
           documentId: operation?.context?.documentId,
           groupId: operation?.context?.groupId,
           // Gateway-side tool messages are persisted on the server; the client


### PR DESCRIPTION
## Problem

After #14774 (`enableAgentMode` defaults to `true`), the Agent Builder panel started calling its write tools (`updateConfig` / `updatePrompt` / `installPlugin`) on **every message**. But the `ctx.agentId` passed to those tools was wrong.

`clientToolExecution.ts` always takes `agentId` from `operation.context.agentId`, which equals `agentBuilderId` (the built-in builder agent itself) in the `agent_builder` scope. The write tools then mutated the **builder's own** config instead of the target agent being edited, corrupting the builder's system prompt. On subsequent turns the builder responded as a "different / strange agent" — the exact symptom users reported.

Before #14774 this was hidden because `undefined` → chat mode → tools disabled.

## Root Cause

```
operation.context.agentId = agentBuilderId   ← builder itself
chatStore.activeAgentId   = agt_z3MrW3HHDCqY ← agent being edited (set by AgentIdSync from URL :aid param)
```

`AgentBuilderExecutor.updateConfig/updatePrompt` used `ctx.agentId` to decide which agent to update — it was pointing at the builder instead of the target.

## Fix

When `scope === 'agent_builder'`, override `toolAgentId` with `chatStore.activeAgentId` (the agent the user opened the profile page for):

```ts
const isAgentBuilderScope = operation?.context?.scope === 'agent_builder';
const toolAgentId = isAgentBuilderScope
  ? (this.#get().activeAgentId ?? operation?.context?.agentId)
  : operation?.context?.agentId;
```

This mirrors the same pattern already used in `src/services/chat/index.ts` (line 199) when building `agentBuilderContext`.

## Test

1. Open `/agent/<any-agent-id>/profile`
2. Send a message in the Agent Builder right panel (e.g. "Add a greeting opening")
3. ✅ Builder correctly calls `updateConfig`/`updatePrompt` on the target agent
4. ✅ Subsequent messages still come from the Agent Builder, not a different agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)