### PR TITLE
💄 style(thread): indent subagent rows and drop SUBAGENT badge

### DIFF
--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -749,7 +749,6 @@ export default {
   'thread.closeSubagentThread': 'Collapse SubAgent conversation',
   'thread.divider': 'Subtopic',
   'thread.openSubagentThread': 'View full SubAgent conversation',
-  'thread.subagentBadge': 'SubAgent',
   'thread.subagentReadOnlyHint':
     'SubAgent conversations are read-only — execution is driven by the parent agent.',
   'thread.threadMessageCount': '{{messageCount}} messages',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -1,8 +1,7 @@
-import { Flexbox, Icon, Tag } from '@lobehub/ui';
-import { TreeDownRightIcon } from '@lobehub/ui/icons';
+import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
+import { CornerDownRight } from 'lucide-react';
 import { memo, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useChatStore } from '@/store/chat';
@@ -19,8 +18,12 @@ export interface ThreadItemProps {
   title: string;
 }
 
+// Indent applied INSIDE the NavItem's Block (overrides default paddingInline=4
+// on the start side), so the icon + title shift right by one icon-slot width
+// while the row background/highlight stays full-width.
+const SUBAGENT_PADDING_INLINE_START = 32;
+
 const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
-  const { t } = useTranslation('chat');
   const [editing, activeThreadId] = useChatStore((s) => [
     s.threadRenamingId === id,
     s.activeThreadId,
@@ -47,9 +50,6 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
 
   const active = id === activeThreadId;
 
-  // Subagent threads (spawned by an external agent's subagent tool call)
-  // only get a plain "Subagent" badge — the specific template name is
-  // surfaced on the Thread header instead, where there's room for it.
   return (
     <>
       <NavItem
@@ -57,24 +57,9 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         active={active && !isInAgentSubRoute}
         contextMenuItems={dropdownMenu}
         disabled={editing}
-        icon={<Icon color={cssVar.colorTextDescription} icon={TreeDownRightIcon} size={'small'} />}
-        title={
-          isSubagent ? (
-            <Flexbox horizontal align={'center'} flex={1} gap={6}>
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {title}
-              </span>
-              <Tag
-                size={'small'}
-                style={{ color: cssVar.colorTextDescription, flexShrink: 0, fontSize: 10 }}
-              >
-                {t('thread.subagentBadge')}
-              </Tag>
-            </Flexbox>
-          ) : (
-            title
-          )
-        }
+        icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
+        style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}
+        title={title}
         onClick={handleClick}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -1,8 +1,7 @@
-import { Flexbox, Icon, Tag } from '@lobehub/ui';
-import { TreeDownRightIcon } from '@lobehub/ui/icons';
+import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
+import { CornerDownRight } from 'lucide-react';
 import { memo, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useChatStore } from '@/store/chat';
@@ -19,8 +18,9 @@ export interface ThreadItemProps {
   title: string;
 }
 
+const SUBAGENT_PADDING_INLINE_START = 32;
+
 const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
-  const { t } = useTranslation('chat');
   const [editing, activeThreadId] = useChatStore((s) => [
     s.threadRenamingId === id,
     s.activeThreadId,
@@ -54,24 +54,9 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         active={active && !isInAgentSubRoute}
         contextMenuItems={dropdownMenu}
         disabled={editing}
-        icon={<Icon color={cssVar.colorTextDescription} icon={TreeDownRightIcon} size={'small'} />}
-        title={
-          isSubagent ? (
-            <Flexbox horizontal align={'center'} flex={1} gap={6}>
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {title}
-              </span>
-              <Tag
-                size={'small'}
-                style={{ color: cssVar.colorTextDescription, flexShrink: 0, fontSize: 10 }}
-              >
-                {t('thread.subagentBadge')}
-              </Tag>
-            </Flexbox>
-          ) : (
-            title
-          )
-        }
+        icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
+        style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}
+        title={title}
         onClick={handleClick}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Restyle subagent thread rows in the Topic sidebar so the nesting reads at a glance:

- Switch the `└` `TreeDownRightIcon` for `↳` `CornerDownRight` from `lucide-react`
- Drop the right-aligned `SUBAGENT` Tag badge (it crowded long titles and was redundant with the new indent)
- Apply `paddingInlineStart: 32` on the NavItem's inner Block so subagent rows shift right by ~one icon slot. The padding lives **inside** the Block (not on a wrapper), so the row's background / active highlight stays full-width and aligns with sibling topic rows
- Sync the change across the agent sidebar and the group-chat sidebar copies (`src/routes/(main)/agent/.../ThreadList/ThreadItem/index.tsx` and `src/routes/(main)/group/.../ThreadList/ThreadItem/index.tsx`)
- Drop the now-unused `chat:thread.subagentBadge` i18n key from `src/locales/default/chat.ts`

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual check: open a topic that has subagent-spawned threads (Claude Code / Codex agent run that spawns a subagent), confirm the rows render with the indented `↳` and no badge, and that hover / active highlight still covers the full row width.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| `└` aligned with parent `○`; right-aligned `SubAgent` tag crowds long titles | `↳` indented by ~one icon slot; no badge; full-width row highlight retained |

#### 📝 Additional Information

The 21 translated `chat.json` files still carry the `thread.subagentBadge` entry — run `pnpm i18n` before merging (or in a follow-up housekeeping pass) to clean up the dead key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)