### PR TITLE
💄 style(agent-tasks): align Add Subtask button & card baseline

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
@@ -1,6 +1,6 @@
 import type { TaskDetailSubtask } from '@lobechat/types';
 import { ActionIcon, Block, Flexbox, Icon, showContextMenu, Text } from '@lobehub/ui';
-import { App, Button, ConfigProvider, Tree } from 'antd';
+import { App, ConfigProvider, Tree } from 'antd';
 import type { DataNode } from 'antd/es/tree';
 import { cssVar } from 'antd-style';
 import { ChevronDown, ListTodoIcon, PlayCircle, Plus } from 'lucide-react';
@@ -328,18 +328,22 @@ const TaskSubtasks = memo(() => {
         </>
       ) : (
         <>
-          <Flexbox horizontal align="flex-start">
-            <Button
-              className={styles.addSubtaskButton}
-              icon={<Icon icon={Plus} size={14} />}
-              shape="round"
-              size="small"
-              type="text"
-              onClick={toggleCreating}
-            >
+          <Block
+            clickable
+            horizontal
+            align="center"
+            gap={8}
+            paddingBlock={4}
+            paddingInline={8}
+            style={{ width: 'fit-content' }}
+            variant="borderless"
+            onClick={toggleCreating}
+          >
+            <Icon color={cssVar.colorTextDescription} icon={Plus} size={16} />
+            <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
               {t('taskDetail.addSubtask')}
-            </Button>
-          </Flexbox>
+            </Text>
+          </Block>
           {isCreating && (
             <CreateTaskInlineEntry
               autoFocus

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
@@ -167,7 +167,11 @@ const CreateTaskInlineEntry = memo<CreateTaskInlineEntryProps>((props) => {
         horizontal
         align={'center'}
         justify={'space-between'}
-        style={{ borderTop: `1px solid ${cssVar.colorBorderSecondary}`, padding: '8px 16px' }}
+        style={{
+          borderTop: `1px solid ${cssVar.colorBorderSecondary}`,
+          paddingBlock: 8,
+          paddingInline: '8px 16px',
+        }}
       >
         <Flexbox horizontal gap={2} wrap={'wrap'}>
           <TaskPriorityTag priority={priority} onChange={setPriority}>

--- a/src/features/AgentTasks/shared/style.ts
+++ b/src/features/AgentTasks/shared/style.ts
@@ -118,18 +118,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     inset-inline-end: 8px;
   `,
 
-  addSubtaskButton: css`
-    &.ant-btn {
-      font-size: 13px;
-      color: ${cssVar.colorTextDescription};
-    }
-
-    &.ant-btn:hover,
-    &.ant-btn:focus {
-      color: ${cssVar.colorTextSecondary};
-    }
-  `,
-
   agentAuthorName: css`
     cursor: pointer;
     font-weight: 500;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Fixes LOBE-8904

#### 🔀 Description of Change

Fix two visual issues on the "Add Subtask" empty-state button in the agent task detail page:

1. **Baseline misalignment** — The button previously used an antd `<Button shape="round" size="small" type="text">` whose icon slot produced subtle vertical baseline drift between the `+` glyph and the label. Replaced with the `<Block clickable>` pattern already used by the sibling "Subtasks" header, so icon and label share the same flex centering and color tokens (`cssVar.colorTextDescription` / `cssVar.colorTextSecondary`, `fontSize 13`, `weight 500`).
2. **Visual imbalance with card content** — The inline-create card's bottom row (priority / assignee) had `padding-left: 16px` plus an inner `paddingInline=8` Block, putting `--- No priority` ~25px from the card's left border while the editor placeholder above was at ~17px. Reduced the bottom row's `padding-inline-start` from `16` to `8`, so priority/assignee align with the editor content and visually with the `+ Add subtask` trigger above the card.

Also dropped the redundant outer `<Flexbox horizontal align="flex-start">` wrapper (Block's own `width: 'fit-content'` handles that) and removed the now-unused `addSubtaskButton` CSS class.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open an agent task that has no subtasks. The `+ Add subtask` row should sit at the same horizontal position as `--- No priority` / Assignee chip in the inline-create card. Click `+ Add subtask` → the card expands; both rows should remain visually aligned.

#### 📸 Screenshots / Videos

UI tweak only — see Linear issue LOBE-8904 for the before screenshot.

#### 📝 Additional Information

The bottom-row padding change in `CreateTaskInlineEntry.tsx` also affects the list-page and empty-state hero uses of the same component; in both cases the priority/assignee row now aligns better with the editor content above it (no regression observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)