### PR TITLE
💄 style: shorten usage token details

### DIFF
--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.test.ts
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.test.ts
@@ -1,23 +1,28 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatToken } from './TokenProgress';
+import { formatUsageValue } from './TokenProgress';
 
-describe('formatToken', () => {
+describe('formatUsageValue', () => {
   it('formats token usage details with short units', () => {
-    expect(formatToken(93_405)).toBe('93.4K');
-    expect(formatToken(92_119)).toBe('92.1K');
-    expect(formatToken(3_488)).toBe('3.5K');
-    expect(formatToken(189_018)).toBe('189K');
+    expect(formatUsageValue(93_405)).toBe('93.4K');
+    expect(formatUsageValue(92_119)).toBe('92.1K');
+    expect(formatUsageValue(3_488)).toBe('3.5K');
+    expect(formatUsageValue(189_018)).toBe('189K');
+  });
+
+  it('formats credit usage details with the same short units', () => {
+    expect(formatUsageValue(16_127)).toBe('16.1K');
+    expect(formatUsageValue(16_179)).toBe('16.2K');
   });
 
   it('keeps small token counts readable without suffixes', () => {
-    expect(formatToken(0)).toBe('0');
-    expect(formatToken(6)).toBe('6');
-    expect(formatToken(999)).toBe('999');
+    expect(formatUsageValue(0)).toBe('0');
+    expect(formatUsageValue(6)).toBe('6');
+    expect(formatUsageValue(999)).toBe('999');
   });
 
   it('formats million-level token counts with M suffix', () => {
-    expect(formatToken(1_000_000)).toBe('1M');
-    expect(formatToken(1_500_000)).toBe('1.5M');
+    expect(formatUsageValue(1_000_000)).toBe('1M');
+    expect(formatUsageValue(1_500_000)).toBe('1.5M');
   });
 });

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.test.ts
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatToken } from './TokenProgress';
+
+describe('formatToken', () => {
+  it('formats token usage details with short units', () => {
+    expect(formatToken(93_405)).toBe('93.4K');
+    expect(formatToken(92_119)).toBe('92.1K');
+    expect(formatToken(3_488)).toBe('3.5K');
+    expect(formatToken(189_018)).toBe('189K');
+  });
+
+  it('keeps small token counts readable without suffixes', () => {
+    expect(formatToken(0)).toBe('0');
+    expect(formatToken(6)).toBe('6');
+    expect(formatToken(999)).toBe('999');
+  });
+
+  it('formats million-level token counts with M suffix', () => {
+    expect(formatToken(1_000_000)).toBe('1M');
+    expect(formatToken(1_500_000)).toBe('1.5M');
+  });
+});

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
@@ -12,7 +12,6 @@ export interface TokenProgressItem {
 
 interface TokenProgressProps {
   data: TokenProgressItem[];
-  formatter?: (value: number) => string;
   showIcon?: boolean;
 }
 
@@ -22,55 +21,53 @@ export const formatUsageValue = (number: number) => {
   return numeral(number).format('0,0');
 };
 
-const TokenProgress = memo<TokenProgressProps>(
-  ({ data, formatter = formatUsageValue, showIcon }) => {
-    const total = data.reduce((acc, item) => acc + item.value, 0);
+const TokenProgress = memo<TokenProgressProps>(({ data, showIcon }) => {
+  const total = data.reduce((acc, item) => acc + item.value, 0);
 
-    return (
-      <Flexbox gap={8} style={{ position: 'relative' }} width={'100%'}>
-        <Flexbox
-          horizontal
-          height={6}
-          width={'100%'}
-          style={{
-            background: total === 0 ? cssVar.colorFill : undefined,
-            borderRadius: 3,
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
-          {data.map((item) => (
-            <Flexbox
-              height={'100%'}
-              key={item.id}
-              style={{ background: item.color, flex: item.value }}
-            />
-          ))}
-        </Flexbox>
-        <Flexbox>
-          {data.map((item) => (
-            <Flexbox horizontal align={'center'} gap={4} justify={'space-between'} key={item.id}>
-              <Flexbox horizontal align={'center'} gap={4}>
-                {showIcon && (
-                  <div
-                    style={{
-                      background: item.color,
-                      borderRadius: '50%',
-                      flex: 'none',
-                      height: 6,
-                      width: 6,
-                    }}
-                  />
-                )}
-                <div style={{ color: cssVar.colorTextSecondary }}>{item.title}</div>
-              </Flexbox>
-              <div style={{ fontWeight: 500 }}>{formatter(item.value)}</div>
-            </Flexbox>
-          ))}
-        </Flexbox>
+  return (
+    <Flexbox gap={8} style={{ position: 'relative' }} width={'100%'}>
+      <Flexbox
+        horizontal
+        height={6}
+        width={'100%'}
+        style={{
+          background: total === 0 ? cssVar.colorFill : undefined,
+          borderRadius: 3,
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+      >
+        {data.map((item) => (
+          <Flexbox
+            height={'100%'}
+            key={item.id}
+            style={{ background: item.color, flex: item.value }}
+          />
+        ))}
       </Flexbox>
-    );
-  },
-);
+      <Flexbox>
+        {data.map((item) => (
+          <Flexbox horizontal align={'center'} gap={4} justify={'space-between'} key={item.id}>
+            <Flexbox horizontal align={'center'} gap={4}>
+              {showIcon && (
+                <div
+                  style={{
+                    background: item.color,
+                    borderRadius: '50%',
+                    flex: 'none',
+                    height: 6,
+                    width: 6,
+                  }}
+                />
+              )}
+              <div style={{ color: cssVar.colorTextSecondary }}>{item.title}</div>
+            </Flexbox>
+            <div style={{ fontWeight: 500 }}>{formatUsageValue(item.value)}</div>
+          </Flexbox>
+        ))}
+      </Flexbox>
+    </Flexbox>
+  );
+});
 
 export default TokenProgress;

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
@@ -16,59 +16,61 @@ interface TokenProgressProps {
   showIcon?: boolean;
 }
 
-export const formatToken = (number: number) => {
+export const formatUsageValue = (number: number) => {
   if (number >= 1_000_000) return numeral(number / 1_000_000).format('0.[0]') + 'M';
   if (number >= 1_000) return numeral(number / 1_000).format('0.[0]') + 'K';
   return numeral(number).format('0,0');
 };
 
-const TokenProgress = memo<TokenProgressProps>(({ data, formatter = formatToken, showIcon }) => {
-  const total = data.reduce((acc, item) => acc + item.value, 0);
+const TokenProgress = memo<TokenProgressProps>(
+  ({ data, formatter = formatUsageValue, showIcon }) => {
+    const total = data.reduce((acc, item) => acc + item.value, 0);
 
-  return (
-    <Flexbox gap={8} style={{ position: 'relative' }} width={'100%'}>
-      <Flexbox
-        horizontal
-        height={6}
-        width={'100%'}
-        style={{
-          background: total === 0 ? cssVar.colorFill : undefined,
-          borderRadius: 3,
-          overflow: 'hidden',
-          position: 'relative',
-        }}
-      >
-        {data.map((item) => (
-          <Flexbox
-            height={'100%'}
-            key={item.id}
-            style={{ background: item.color, flex: item.value }}
-          />
-        ))}
-      </Flexbox>
-      <Flexbox>
-        {data.map((item) => (
-          <Flexbox horizontal align={'center'} gap={4} justify={'space-between'} key={item.id}>
-            <Flexbox horizontal align={'center'} gap={4}>
-              {showIcon && (
-                <div
-                  style={{
-                    background: item.color,
-                    borderRadius: '50%',
-                    flex: 'none',
-                    height: 6,
-                    width: 6,
-                  }}
-                />
-              )}
-              <div style={{ color: cssVar.colorTextSecondary }}>{item.title}</div>
+    return (
+      <Flexbox gap={8} style={{ position: 'relative' }} width={'100%'}>
+        <Flexbox
+          horizontal
+          height={6}
+          width={'100%'}
+          style={{
+            background: total === 0 ? cssVar.colorFill : undefined,
+            borderRadius: 3,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          {data.map((item) => (
+            <Flexbox
+              height={'100%'}
+              key={item.id}
+              style={{ background: item.color, flex: item.value }}
+            />
+          ))}
+        </Flexbox>
+        <Flexbox>
+          {data.map((item) => (
+            <Flexbox horizontal align={'center'} gap={4} justify={'space-between'} key={item.id}>
+              <Flexbox horizontal align={'center'} gap={4}>
+                {showIcon && (
+                  <div
+                    style={{
+                      background: item.color,
+                      borderRadius: '50%',
+                      flex: 'none',
+                      height: 6,
+                      width: 6,
+                    }}
+                  />
+                )}
+                <div style={{ color: cssVar.colorTextSecondary }}>{item.title}</div>
+              </Flexbox>
+              <div style={{ fontWeight: 500 }}>{formatter(item.value)}</div>
             </Flexbox>
-            <div style={{ fontWeight: 500 }}>{formatter(item.value)}</div>
-          </Flexbox>
-        ))}
+          ))}
+        </Flexbox>
       </Flexbox>
-    </Flexbox>
-  );
-});
+    );
+  },
+);
 
 export default TokenProgress;

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.tsx
@@ -12,12 +12,17 @@ export interface TokenProgressItem {
 
 interface TokenProgressProps {
   data: TokenProgressItem[];
+  formatter?: (value: number) => string;
   showIcon?: boolean;
 }
 
-const format = (number: number) => numeral(number).format('0,0');
+export const formatToken = (number: number) => {
+  if (number >= 1_000_000) return numeral(number / 1_000_000).format('0.[0]') + 'M';
+  if (number >= 1_000) return numeral(number / 1_000).format('0.[0]') + 'K';
+  return numeral(number).format('0,0');
+};
 
-const TokenProgress = memo<TokenProgressProps>(({ data, showIcon }) => {
+const TokenProgress = memo<TokenProgressProps>(({ data, formatter = formatToken, showIcon }) => {
   const total = data.reduce((acc, item) => acc + item.value, 0);
 
   return (
@@ -58,7 +63,7 @@ const TokenProgress = memo<TokenProgressProps>(({ data, showIcon }) => {
               )}
               <div style={{ color: cssVar.colorTextSecondary }}>{item.title}</div>
             </Flexbox>
-            <div style={{ fontWeight: 500 }}>{format(item.value)}</div>
+            <div style={{ fontWeight: 500 }}>{formatter(item.value)}</div>
           </Flexbox>
         ))}
       </Flexbox>

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -15,7 +15,7 @@ import { formatNumber, formatShortenNumber } from '@/utils/format';
 import AnimatedNumber from './AnimatedNumber';
 import ModelCard from './ModelCard';
 import type { TokenProgressItem } from './TokenProgress';
-import TokenProgress, { formatToken } from './TokenProgress';
+import TokenProgress, { formatUsageValue } from './TokenProgress';
 import { getDetailsToken } from './tokens';
 
 interface TokenDetailProps {
@@ -127,7 +127,7 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
       ? detailTokens.totalTokens.credit
       : detailTokens.totalTokens!.token;
 
-  const valueFormatter = isShowCredit ? formatNumber : formatToken;
+  const valueFormatter = formatUsageValue;
   const detailTotal = valueFormatter(totalCount);
 
   const averagePricing = formatNumber(

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -14,8 +14,8 @@ import { formatNumber, formatShortenNumber } from '@/utils/format';
 
 import AnimatedNumber from './AnimatedNumber';
 import ModelCard from './ModelCard';
-import { type TokenProgressItem } from './TokenProgress';
-import TokenProgress from './TokenProgress';
+import type { TokenProgressItem } from './TokenProgress';
+import TokenProgress, { formatToken } from './TokenProgress';
 import { getDetailsToken } from './tokens';
 
 interface TokenDetailProps {
@@ -127,7 +127,8 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
       ? detailTokens.totalTokens.credit
       : detailTokens.totalTokens!.token;
 
-  const detailTotal = formatNumber(totalCount);
+  const valueFormatter = isShowCredit ? formatNumber : formatToken;
+  const detailTotal = valueFormatter(totalCount);
 
   const averagePricing = formatNumber(
     detailTokens.totalTokens!.credit / detailTokens.totalTokens!.token,
@@ -159,7 +160,7 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     {t('messages.tokenDetails.inputTitle')}
                   </div>
                 </Flexbox>
-                <TokenProgress showIcon data={inputDetails} />
+                <TokenProgress showIcon data={inputDetails} formatter={valueFormatter} />
               </Flexbox>
             )}
             {outputDetails.length > 1 && (
@@ -175,11 +176,11 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     {t('messages.tokenDetails.outputTitle')}
                   </div>
                 </Flexbox>
-                <TokenProgress showIcon data={outputDetails} />
+                <TokenProgress showIcon data={outputDetails} formatter={valueFormatter} />
               </Flexbox>
             )}
             <Flexbox>
-              <TokenProgress showIcon data={totalDetail} />
+              <TokenProgress showIcon data={totalDetail} formatter={valueFormatter} />
               <Divider style={{ marginBlock: 8 }} />
               <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
                 <div style={{ color: cssVar.colorTextSecondary }}>

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -127,8 +127,7 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
       ? detailTokens.totalTokens.credit
       : detailTokens.totalTokens!.token;
 
-  const valueFormatter = formatUsageValue;
-  const detailTotal = valueFormatter(totalCount);
+  const detailTotal = formatUsageValue(totalCount);
 
   const averagePricing = formatNumber(
     detailTokens.totalTokens!.credit / detailTokens.totalTokens!.token,
@@ -160,7 +159,7 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     {t('messages.tokenDetails.inputTitle')}
                   </div>
                 </Flexbox>
-                <TokenProgress showIcon data={inputDetails} formatter={valueFormatter} />
+                <TokenProgress showIcon data={inputDetails} />
               </Flexbox>
             )}
             {outputDetails.length > 1 && (
@@ -176,11 +175,11 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
                     {t('messages.tokenDetails.outputTitle')}
                   </div>
                 </Flexbox>
-                <TokenProgress showIcon data={outputDetails} formatter={valueFormatter} />
+                <TokenProgress showIcon data={outputDetails} />
               </Flexbox>
             )}
             <Flexbox>
-              <TokenProgress showIcon data={totalDetail} formatter={valueFormatter} />
+              <TokenProgress showIcon data={totalDetail} />
               <Divider style={{ marginBlock: 8 }} />
               <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
                 <div style={{ color: cssVar.colorTextSecondary }}>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-6271

#### 🔀 Description of Change

- Show generation usage detail values with short `K` / `M` units in both Token and Credit modes.
- Rename the formatter to reflect that it formats usage values, not token-only values.
- Add regression coverage for token and credit usage detail formatting.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/TokenProgress.test.ts' 'src/features/ChatInput/ActionBar/Token/TokenProgress.test.ts'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Usage detail values were shown as full numbers such as `93,405`, `189,018`, or credit values like `16,179`. | Usage detail values are shown as short units such as `93.4K`, `189K`, and `16.2K`. |

#### 📝 Additional Information

This change covers the generation usage popover, which is separate from the chat input context token popover.