### PR TITLE
🐛 fix(chat): respect useCmdEnterToSend preference in thread & task inputs

### DIFF
--- a/packages/utils/src/keyboard.ts
+++ b/packages/utils/src/keyboard.ts
@@ -1,11 +1,6 @@
 import { isMacOS } from './platform';
 
-export const isCommandPressed = (event: KeyboardEvent) => {
-  const isMac = isMacOS();
-
-  if (isMac) {
-    return event.metaKey; // Use metaKey (Command key) on macOS
-  } else {
-    return event.ctrlKey; // Use ctrlKey on Windows/Linux
-  }
+export const isCommandPressed = (event: Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>) => {
+  // metaKey on macOS = Command; ctrlKey elsewhere
+  return isMacOS() ? event.metaKey : event.ctrlKey;
 };

--- a/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
@@ -3,6 +3,7 @@ import { Avatar, Flexbox } from '@lobehub/ui';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useEnterToSend } from '@/hooks/useEnterToSend';
 import { useUserAvatar } from '@/hooks/useUserAvatar';
 import { useTaskStore } from '@/store/task';
 
@@ -15,6 +16,7 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
   const userAvatar = useUserAvatar();
   const [submitting, setSubmitting] = useState(false);
   const [hasContent, setHasContent] = useState(false);
+  const shouldSendOnEnter = useEnterToSend();
 
   const handleSubmit = useCallback(async () => {
     const trimmed = String(editor?.getDocument?.('markdown') ?? '').trim();
@@ -42,7 +44,7 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
           type={'text'}
           variant={'chat'}
           onPressEnter={({ event }) => {
-            if (event.metaKey || event.ctrlKey) {
+            if (shouldSendOnEnter(event)) {
               handleSubmit();
               return true;
             }

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/FeedbackInput.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
+import { useEnterToSend } from '@/hooks/useEnterToSend';
 import { useUserAvatar } from '@/hooks/useUserAvatar';
 import { useTaskStore } from '@/store/task';
 
@@ -28,6 +29,7 @@ const FeedbackInput = memo<FeedbackInputProps>(({ taskId, topicId }) => {
   );
   const [submitting, setSubmitting] = useState(false);
   const [hasContent, setHasContent] = useState(false);
+  const shouldSendOnEnter = useEnterToSend();
 
   const handleSubmit = useCallback(async () => {
     const trimmed = String(editor?.getDocument?.('markdown') ?? '').trim();
@@ -64,7 +66,7 @@ const FeedbackInput = memo<FeedbackInputProps>(({ taskId, topicId }) => {
           type={'text'}
           variant={'chat'}
           onPressEnter={({ event }) => {
-            if (event.metaKey || event.ctrlKey) {
+            if (shouldSendOnEnter(event)) {
               handleSubmit();
               return true;
             }

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -13,6 +13,7 @@ import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef } from 'r
 import { useHotkeysContext } from 'react-hotkeys-hook';
 
 import { usePasteFile, useUploadFiles } from '@/components/DragUploadZone';
+import { useEnterToSend } from '@/hooks/useEnterToSend';
 import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
 import { chatService } from '@/services/chat';
 import { useAgentStore } from '@/store/agent';
@@ -20,7 +21,6 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import {
   labPreferSelectors,
-  preferenceSelectors,
   settingsSelectors,
   systemAgentSelectors,
 } from '@/store/user/selectors';
@@ -78,7 +78,7 @@ const InputEditor = memo<{
 
   const { compositionProps, isComposingRef } = useIMECompositionEvent();
 
-  const useCmdEnterToSend = useUserStore(preferenceSelectors.useCmdEnterToSend);
+  const shouldSendOnEnter = useEnterToSend();
 
   // --- Category-based mention system ---
   const categories = useMentionCategories();
@@ -390,26 +390,17 @@ const InputEditor = memo<{
         if (e.shiftKey || isComposingRef.current) return;
         // when user like alt + enter to add ai message
         if (e.altKey && hotkey === combineKeys([KeyEnum.Alt, KeyEnum.Enter])) return true;
-        const commandKey = isCommandPressed(e);
         // In fullscreen mode, Enter inserts newline; only Cmd/Ctrl+Enter sends
         if (expand) {
-          if (commandKey) {
+          if (isCommandPressed(e)) {
             send();
             return true;
           }
           return;
         }
-        // when user like cmd + enter to send message
-        if (useCmdEnterToSend) {
-          if (commandKey) {
-            send();
-            return true;
-          }
-        } else {
-          if (!commandKey) {
-            send();
-            return true;
-          }
+        if (shouldSendOnEnter(e)) {
+          send();
+          return true;
         }
       }}
     />

--- a/src/features/DailyBrief/CommentInput.tsx
+++ b/src/features/DailyBrief/CommentInput.tsx
@@ -5,6 +5,8 @@ import { ChevronLeft } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useEnterToSend } from '@/hooks/useEnterToSend';
+
 interface CommentInputProps {
   onCancel: () => void;
   onSubmit: (text: string) => Promise<void> | void;
@@ -14,6 +16,7 @@ const CommentInput = memo<CommentInputProps>(({ onSubmit, onCancel }) => {
   const { t } = useTranslation('home');
   const editor = useEditor();
   const [submitting, setSubmitting] = useState(false);
+  const shouldSendOnEnter = useEnterToSend();
 
   const handleSubmit = useCallback(async () => {
     const content = String(editor?.getDocument?.('markdown') ?? '').trim();
@@ -65,7 +68,7 @@ const CommentInput = memo<CommentInputProps>(({ onSubmit, onCancel }) => {
         type={'text'}
         variant={'chat'}
         onPressEnter={({ event }) => {
-          if (event.metaKey || event.ctrlKey) {
+          if (shouldSendOnEnter(event)) {
             handleSubmit();
             return true;
           }

--- a/src/hooks/useEnterToSend.ts
+++ b/src/hooks/useEnterToSend.ts
@@ -1,0 +1,24 @@
+import { isCommandPressed } from '@lobechat/utils';
+import { useCallback } from 'react';
+
+import { useUserStore } from '@/store/user';
+import { preferenceSelectors } from '@/store/user/selectors';
+
+type EnterEvent = Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'shiftKey'>;
+
+/**
+ * Returns a predicate that decides whether a chat-input key event should
+ * fire send, based on the global `useCmdEnterToSend` preference.
+ */
+export const useEnterToSend = () => {
+  const useCmdEnterToSend = useUserStore(preferenceSelectors.useCmdEnterToSend);
+
+  return useCallback(
+    (event: EnterEvent): boolean => {
+      if (event.shiftKey) return false;
+      const commandKey = isCommandPressed(event);
+      return useCmdEnterToSend ? commandKey : !commandKey;
+    },
+    [useCmdEnterToSend],
+  );
+};


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8899

#### 🔀 Description of Change

Thread feedback and task comment inputs hardcoded `Cmd/Ctrl + Enter` to send, ignoring the user's "Use Cmd+Enter to send" preference and diverging from the main chat input. This made the Thread input inconsistent with the basic chat input — users reported that pressing `Enter` only inserts a newline and `Cmd + Enter` is required, contrary to their setting.

This PR:

- Extracts a shared `useEnterToSend()` hook in `src/hooks/useEnterToSend.ts` that returns a predicate respecting the global `useCmdEnterToSend` preference (Shift+Enter → newline always; otherwise Enter or Cmd+Enter depending on the user setting).
- Adopts it in `ChatInput/InputEditor`, `AgentTaskDetail/CommentInput`, `AgentTaskDetail/TopicChatDrawer/FeedbackInput`, and `DailyBrief/CommentInput` so all chat-like inputs behave consistently.
- Loosens `isCommandPressed` typing in `packages/utils/src/keyboard.ts` to accept any object with `ctrlKey`/`metaKey` (so it works with the React-wrapped events emitted by `onPressEnter`).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Open Settings → toggle "Use Cmd+Enter to send" off → in Thread feedback input and AgentTask comment input, plain `Enter` should send and `Shift + Enter` inserts a newline.
2. Toggle "Use Cmd+Enter to send" on → plain `Enter` inserts a newline and `Cmd + Enter` (macOS) / `Ctrl + Enter` (Win/Linux) sends.
3. Verify the main `ChatInput` still honors fullscreen mode (Enter inserts newline, only Cmd/Ctrl+Enter sends in expanded mode).

#### 📸 Screenshots / Videos

N/A — interaction-only change, no visual difference.

#### 📝 Additional Information

No breaking changes. The new hook is the single source of truth for Enter-to-send logic across the app.