### PR TITLE
🐛 fix(editor): stop showing per-line placeholder once the editor has content

### DIFF
--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -260,7 +260,6 @@ const InternalEditor = memo<InternalEditorProps>(
         <Editor
           content={''}
           editor={editor}
-          lineEmptyPlaceholder={finalPlaceholder}
           placeholder={finalPlaceholder}
           plugins={plugins}
           slashOption={slashItems ? { items: slashItems } : undefined}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8924

#### 🔀 Description of Change

`InternalEditor` (used by `EditorCanvas`, which Task description and several
other surfaces depend on) was forwarding the same string into both
`placeholder` and `lineEmptyPlaceholder` on `<Editor>` from `@lobehub/editor`.

- `placeholder` only shows when the whole editor is empty.
- `lineEmptyPlaceholder` writes the hint to every empty block via a
  `data-placeholder` attribute, so the hint re-appears inline next to the
  cursor whenever you move to a new empty line — even after you've already
  typed content.

The bug Rene reported was exactly that: typing some content and pressing Enter
showed "Add task instruction…" again on the new empty line, looking like an
extra row was being inserted.

Dropping `lineEmptyPlaceholder` from `InternalEditor` makes the hint a
classic "empty-only" placeholder. The other direct `<Editor>` callers that
genuinely want per-line hints (`SkillEditForm`, `agent/profile/EditorCanvas`,
builtin-tool `CreatePlan`) bypass `InternalEditor` and pass
`lineEmptyPlaceholder` themselves, so they are unaffected.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open a Task detail page.
2. Confirm the "Add task instruction…" placeholder shows when the description
   is empty.
3. Type any content (e.g. `123`), press Enter.
4. Confirm the placeholder no longer appears on the new empty line.
5. Clear all content — placeholder should reappear.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Placeholder reappears inline on every empty line after the user has typed content. | Placeholder only shows when the editor is fully empty. |

#### 📝 Additional Information

No breaking change for callers outside `EditorCanvas`/`InternalEditor`: the
three places that intentionally want per-line hints pass them directly to
`<Editor>`.