### PR TITLE
🐛 fix(agent-tracing): align DB trace_s3_key with .json.zst suffix

### DIFF
--- a/src/server/modules/AgentTracing/S3SnapshotStore.ts
+++ b/src/server/modules/AgentTracing/S3SnapshotStore.ts
@@ -17,6 +17,19 @@ const LEGACY_SUFFIX = '.json';
 const ZSTD_CONTENT_TYPE = 'application/zstd';
 
 /**
+ * Canonical S3 key for a finalized operation snapshot. Single source of truth
+ * for the layout — both this store's `save()` and the DB-persistence path
+ * (CompletionLifecycle) build keys through this helper so the value written to
+ * `agent_operations.trace_s3_key` stays aligned with the object actually put
+ * in S3.
+ */
+export const buildFinalSnapshotKey = (
+  agentId: string,
+  topicId: string,
+  operationId: string,
+): string => `${TRACE_PREFIX}/${agentId}/${topicId}/${operationId}${SNAPSHOT_SUFFIX}`;
+
+/**
  * S3-backed snapshot store for production agent trace persistence.
  *
  * S3 paths:
@@ -61,7 +74,7 @@ export class S3SnapshotStore implements ISnapshotStore {
   async save(snapshot: ExecutionSnapshot): Promise<void> {
     const agentId = snapshot.agentId ?? 'unknown';
     const topicId = snapshot.topicId ?? 'unknown';
-    const key = `${TRACE_PREFIX}/${agentId}/${topicId}/${snapshot.operationId}${SNAPSHOT_SUFFIX}`;
+    const key = buildFinalSnapshotKey(agentId, topicId, snapshot.operationId);
 
     log('Saving snapshot to S3: %s', key);
     const compressed = await this.encodeSnapshot(snapshot);

--- a/src/server/modules/AgentTracing/index.ts
+++ b/src/server/modules/AgentTracing/index.ts
@@ -1,1 +1,1 @@
-export { S3SnapshotStore } from './S3SnapshotStore';
+export { buildFinalSnapshotKey, S3SnapshotStore } from './S3SnapshotStore';

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -951,8 +951,8 @@ export class AgentRuntimeService {
       // failed op is observable in the same place as a successful run.
       // Without this, propagated errors (e.g. markPersistFatal from
       // RuntimeExecutors) leave the partial as an orphan at
-      // `_partial/<op>.json` and the canonical
-      // `agent-traces/<agentId>/<topicId>/<op>.json` returns 404 — see
+      // `_partial/<op>.json.zst` and the canonical
+      // `agent-traces/<agentId>/<topicId>/<op>.json.zst` returns 404 — see
       // LOBE-8533.
       //
       // `failedStep` synthesizes a step record for the failure because the

--- a/src/server/services/agentRuntime/CompletionLifecycle.ts
+++ b/src/server/services/agentRuntime/CompletionLifecycle.ts
@@ -6,6 +6,7 @@ import {
 } from '@/database/models/agentOperation';
 import { MessageModel } from '@/database/models/message';
 import { type LobeChatDatabase } from '@/database/type';
+import { buildFinalSnapshotKey } from '@/server/modules/AgentTracing';
 import { emitAgentSignalSourceEvent } from '@/server/services/agentSignal';
 import { toAgentSignalTraceEvents } from '@/server/services/agentSignal/observability/traceEvents';
 
@@ -99,7 +100,7 @@ export class CompletionLifecycle {
     const agentId = metadata?.agentId;
     const topicId = metadata?.topicId;
     const traceS3Key =
-      agentId && topicId ? `agent-traces/${agentId}/${topicId}/${operationId}.json` : null;
+      agentId && topicId ? buildFinalSnapshotKey(agentId, topicId, operationId) : null;
 
     const processingTimeMs = state?.createdAt
       ? Date.now() - new Date(state.createdAt).getTime()


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #14807

#### 🔀 Description of Change

**The bug:** PR #14807 switched the S3 object key written by `S3SnapshotStore.save()` from `.json` to `.json.zst`, but the DB-persistence path in `CompletionLifecycle.persistCompletion()` still hardcoded `.json`. Every row inserted into `agent_operations.trace_s3_key` since the rollout points at a key that **does not exist** — the actual object is the `.json.zst` sibling. Any consumer that GETs by the DB-recorded key (dc tracing UI, agent-tracing inspect via DB lookup) hits 404.

**Verified in prod** (`agent_operations` snapshot):

```
plain_json: 87012   ← all of these point to non-existent S3 keys
json_zst:       0
null_key:     147
total:      87159
```

The most recent rows (04:00 UTC today, well after #14807 deployed) also end in `.json`, confirming the writer is still broken.

##### Fix

Factor out a single `buildFinalSnapshotKey(agentId, topicId, operationId)` helper, exported from `@/server/modules/AgentTracing`, and use it from both:

- `S3SnapshotStore.save()` (S3 object key)
- `CompletionLifecycle.persistCompletion()` (`trace_s3_key` DB write)

Same source of truth → the two values can no longer drift.

Also updated a stale comment in `AgentRuntimeService.ts` that still referenced the old `.json` path.

##### Files touched

- `src/server/modules/AgentTracing/S3SnapshotStore.ts` — extract + export `buildFinalSnapshotKey`; refactor `save()` to use it.
- `src/server/modules/AgentTracing/index.ts` — re-export the helper.
- `src/server/services/agentRuntime/CompletionLifecycle.ts` — replace hardcoded \`agent-traces/.../op.json\` string with the helper.
- `src/server/services/agentRuntime/AgentRuntimeService.ts` — comment fix.

#### 🧪 How to Test

- [x] `bun run type-check` passes.
- [x] `npx vitest run src/server/modules/AgentTracing/S3SnapshotStore.test.ts` — 9/9 pass (existing tests still green with the refactor).
- [ ] Post-deploy verification: query \`agent_operations\` for any row created after this PR ships and confirm \`trace_s3_key LIKE '%.json.zst'\`.

#### 📝 Additional Information

**Existing rows need a one-off backfill** (to be run by dc-side ops, since `dc` has DB write access):

```sql
UPDATE agent_operations
SET trace_s3_key = trace_s3_key || '.zst'
WHERE trace_s3_key LIKE '%.json';
```

This is safe to run **after** this PR deploys — for the ~74k+ rows whose `.json.zst` already exists in S3 (post-#14807 writes + my one-off bulk migration of pre-deploy data) the new key will resolve. For the ~2-3k legacy rows whose `.json.zst` was never written, the UPDATE will leave a 404 — acceptable trade-off since those rows are old and rarely accessed; can be patched later via a one-off compress+upload pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)