### PR TITLE
✨ feat(cc): render Linear MCP tool calls with branded inspector

### DIFF
--- a/packages/builtin-tool-claude-code/package.json
+++ b/packages/builtin-tool-claude-code/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
-    "./client": "./src/client/index.ts"
+    "./client": "./src/client/index.ts",
+    "./client/labels": "./src/client/Inspector/linearMcpLabels.ts"
   },
   "main": "./src/index.ts",
   "dependencies": {

--- a/packages/builtin-tool-claude-code/src/client/Inspector/LinearMcp.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/LinearMcp.tsx
@@ -6,57 +6,13 @@ import { createStaticStyles, cx } from 'antd-style';
 import { CornerLeftUp } from 'lucide-react';
 import { memo } from 'react';
 
-export const LINEAR_MCP_PREFIX = 'mcp__claude_ai_Linear__';
-
-// Mirrors the wire names CC emits for the claude.ai Linear MCP server.
-export const LINEAR_MCP_TOOL_NAMES = [
-  'create_attachment',
-  'create_attachment_from_upload',
-  'create_issue_label',
-  'delete_attachment',
-  'delete_comment',
-  'delete_customer',
-  'delete_customer_need',
-  'delete_status_update',
-  'extract_images',
-  'get_attachment',
-  'get_diff',
-  'get_diff_threads',
-  'get_document',
-  'get_initiative',
-  'get_issue',
-  'get_issue_status',
-  'get_milestone',
-  'get_project',
-  'get_status_updates',
-  'get_team',
-  'get_user',
-  'list_comments',
-  'list_customers',
-  'list_cycles',
-  'list_diffs',
-  'list_documents',
-  'list_initiatives',
-  'list_issue_labels',
-  'list_issue_statuses',
-  'list_issues',
-  'list_milestones',
-  'list_project_labels',
-  'list_projects',
-  'list_teams',
-  'list_users',
-  'prepare_attachment_upload',
-  'save_comment',
-  'save_customer',
-  'save_customer_need',
-  'save_document',
-  'save_initiative',
-  'save_issue',
-  'save_milestone',
-  'save_project',
-  'save_status_update',
-  'search_documentation',
-] as const;
+import {
+  capitalize,
+  LINEAR_MCP_PREFIX,
+  LINEAR_MCP_TOOL_NAMES,
+  type ParsedTool,
+  parseToolName,
+} from './linearMcpLabels';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -166,85 +122,6 @@ const LinearLogomark = memo<{ size?: number }>(({ size = 14 }) => (
   </svg>
 ));
 LinearLogomark.displayName = 'LinearLogomark';
-
-// One-time noun overrides — multi-word suffixes a naive split would mangle.
-const NOUN_OVERRIDES: Record<string, string> = {
-  customer_need: 'customer need',
-  diff_threads: 'diff threads',
-  documentation: 'docs',
-  issue_label: 'issue label',
-  issue_labels: 'issue labels',
-  issue_status: 'issue status',
-  issue_statuses: 'issue statuses',
-  project_labels: 'project labels',
-  status_update: 'status update',
-  status_updates: 'status updates',
-};
-
-interface ParsedTool {
-  noun: string;
-  verb: 'get' | 'list' | 'save' | 'create' | 'delete' | 'search' | 'extract' | 'prepare' | 'other';
-}
-
-const parseToolName = (apiName: string): ParsedTool => {
-  const suffix = apiName.startsWith(LINEAR_MCP_PREFIX)
-    ? apiName.slice(LINEAR_MCP_PREFIX.length)
-    : apiName;
-
-  if (suffix === 'extract_images') return { noun: 'images', verb: 'extract' };
-  if (suffix === 'prepare_attachment_upload') return { noun: 'attachment upload', verb: 'prepare' };
-  if (suffix === 'search_documentation') return { noun: 'docs', verb: 'search' };
-
-  const underscoreIdx = suffix.indexOf('_');
-  if (underscoreIdx <= 0) return { noun: suffix, verb: 'other' };
-
-  const head = suffix.slice(0, underscoreIdx);
-  const tail = suffix.slice(underscoreIdx + 1);
-  const noun = NOUN_OVERRIDES[tail] ?? tail.replaceAll('_', ' ');
-
-  switch (head) {
-    case 'get':
-    case 'list':
-    case 'save':
-    case 'create':
-    case 'delete': {
-      return { noun, verb: head };
-    }
-    default: {
-      return { noun: suffix.replaceAll('_', ' '), verb: 'other' };
-    }
-  }
-};
-
-const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-
-// args-free verb label; collapsed-summary view doesn't have access to runtime args,
-// so `save_*` stays "Save {noun}" rather than guessing Create vs Update.
-const staticLabelFor = (parsed: ParsedTool): string => {
-  const { verb, noun } = parsed;
-  switch (verb) {
-    case 'extract': {
-      return 'Extract images';
-    }
-    case 'prepare': {
-      return 'Prepare attachment upload';
-    }
-    case 'search': {
-      return 'Search docs';
-    }
-    case 'other': {
-      return capitalize(noun);
-    }
-    default: {
-      return `${capitalize(verb)} ${noun}`;
-    }
-  }
-};
-
-export const formatLinearMcpShortLabel = (apiName: string): string | null => {
-  if (!apiName.startsWith(LINEAR_MCP_PREFIX)) return null;
-  return `Linear · ${staticLabelFor(parseToolName(apiName))}`;
-};
 
 const labelFor = (parsed: ParsedTool, args: Record<string, unknown> | undefined): string => {
   const { verb, noun } = parsed;

--- a/packages/builtin-tool-claude-code/src/client/Inspector/LinearMcp.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/LinearMcp.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspector, BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { CornerLeftUp } from 'lucide-react';
+import { memo } from 'react';
+
+export const LINEAR_MCP_PREFIX = 'mcp__claude_ai_Linear__';
+
+// Mirrors the wire names CC emits for the claude.ai Linear MCP server.
+export const LINEAR_MCP_TOOL_NAMES = [
+  'create_attachment',
+  'create_attachment_from_upload',
+  'create_issue_label',
+  'delete_attachment',
+  'delete_comment',
+  'delete_customer',
+  'delete_customer_need',
+  'delete_status_update',
+  'extract_images',
+  'get_attachment',
+  'get_diff',
+  'get_diff_threads',
+  'get_document',
+  'get_initiative',
+  'get_issue',
+  'get_issue_status',
+  'get_milestone',
+  'get_project',
+  'get_status_updates',
+  'get_team',
+  'get_user',
+  'list_comments',
+  'list_customers',
+  'list_cycles',
+  'list_diffs',
+  'list_documents',
+  'list_initiatives',
+  'list_issue_labels',
+  'list_issue_statuses',
+  'list_issues',
+  'list_milestones',
+  'list_project_labels',
+  'list_projects',
+  'list_teams',
+  'list_users',
+  'prepare_attachment_upload',
+  'save_comment',
+  'save_customer',
+  'save_customer_need',
+  'save_document',
+  'save_initiative',
+  'save_issue',
+  'save_milestone',
+  'save_project',
+  'save_status_update',
+  'search_documentation',
+] as const;
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: stretch;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    line-height: 18px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  chipAction: css`
+    flex-shrink: 0;
+    padding-block: 2px;
+    padding-inline: 10px;
+    color: ${cssVar.colorText};
+  `,
+  chipDivider: css`
+    flex-shrink: 0;
+    align-self: stretch;
+    width: 1px;
+    background: ${cssVar.colorBorderSecondary};
+  `,
+  chipIcon: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextDescription};
+  `,
+  chipKey: css`
+    color: ${cssVar.colorTextDescription};
+  `,
+  chipValue: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    gap: 4px;
+    align-items: center;
+
+    min-width: 0;
+    padding-block: 2px;
+    padding-inline: 10px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    color: ${cssVar.colorText};
+  `,
+  chipValueText: css`
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  icon: css`
+    flex-shrink: 0;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  parentBadge: css`
+    display: inline-flex;
+    flex-shrink: 0;
+    gap: 4px;
+    align-items: center;
+
+    margin-inline-start: 6px;
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  parentBadgeIcon: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextDescription};
+  `,
+  productPrefix: css`
+    flex-shrink: 0;
+
+    margin-inline-end: 2px;
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+  `,
+}));
+
+const LinearLogomark = memo<{ size?: number }>(({ size = 14 }) => (
+  <svg
+    aria-hidden="true"
+    className={styles.icon}
+    height={size}
+    viewBox="0 0 100 100"
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M1.22541 61.5228c-.2225-.9485.90748-1.5459 1.59638-.857l36.5217 36.5208c.6889.6892.0915 1.8191-.857 1.5962C20.0696 93.4248 6.4263 79.7822 1.22541 61.5228ZM.00189 46.8083c-.034026.4081.115306.8067.405562 1.0969l51.683 51.683c.2903.2903.6888.4396 1.0969.4056 2.0035-.16708 3.9669-.49328 5.8741-.96868.7361-.18352.9961-1.0903.4607-1.6256L2.5907 40.4732c-.5353-.5354-1.4421-.2754-1.6256.4607-.475415 1.9072-.801574 3.8706-.968613 5.8744ZM4.21462 29.7355c-.16002.3549-.08227.7719.19288 1.047L69.2174 95.5901c.275.2752.6921.353 1.047.193 1.4913-.6716 2.9332-1.43 4.3197-2.275.5025-.3061.5856-1.0023.1674-1.4205L8.31112 25.279c-.41817-.4181-1.11435-.3349-1.42044.1675-.84572 1.3873-1.60473 2.8284-2.27606 4.319ZM12.6963 18.6088c-.3683-.3684-.3923-.9577-.0469-1.3489C21.7846 6.9544 35.1342 0 50 0c27.6142 0 50 22.3858 50 50 0 14.8669-6.9544 28.2155-17.2598 37.3499-.3912.3461-.9805.3214-1.349-.0469L12.6963 18.6088Z"
+      fill="currentColor"
+    />
+  </svg>
+));
+LinearLogomark.displayName = 'LinearLogomark';
+
+// One-time noun overrides — multi-word suffixes a naive split would mangle.
+const NOUN_OVERRIDES: Record<string, string> = {
+  customer_need: 'customer need',
+  diff_threads: 'diff threads',
+  documentation: 'docs',
+  issue_label: 'issue label',
+  issue_labels: 'issue labels',
+  issue_status: 'issue status',
+  issue_statuses: 'issue statuses',
+  project_labels: 'project labels',
+  status_update: 'status update',
+  status_updates: 'status updates',
+};
+
+interface ParsedTool {
+  noun: string;
+  verb: 'get' | 'list' | 'save' | 'create' | 'delete' | 'search' | 'extract' | 'prepare' | 'other';
+}
+
+const parseToolName = (apiName: string): ParsedTool => {
+  const suffix = apiName.startsWith(LINEAR_MCP_PREFIX)
+    ? apiName.slice(LINEAR_MCP_PREFIX.length)
+    : apiName;
+
+  if (suffix === 'extract_images') return { noun: 'images', verb: 'extract' };
+  if (suffix === 'prepare_attachment_upload') return { noun: 'attachment upload', verb: 'prepare' };
+  if (suffix === 'search_documentation') return { noun: 'docs', verb: 'search' };
+
+  const underscoreIdx = suffix.indexOf('_');
+  if (underscoreIdx <= 0) return { noun: suffix, verb: 'other' };
+
+  const head = suffix.slice(0, underscoreIdx);
+  const tail = suffix.slice(underscoreIdx + 1);
+  const noun = NOUN_OVERRIDES[tail] ?? tail.replaceAll('_', ' ');
+
+  switch (head) {
+    case 'get':
+    case 'list':
+    case 'save':
+    case 'create':
+    case 'delete': {
+      return { noun, verb: head };
+    }
+    default: {
+      return { noun: suffix.replaceAll('_', ' '), verb: 'other' };
+    }
+  }
+};
+
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+// args-free verb label; collapsed-summary view doesn't have access to runtime args,
+// so `save_*` stays "Save {noun}" rather than guessing Create vs Update.
+const staticLabelFor = (parsed: ParsedTool): string => {
+  const { verb, noun } = parsed;
+  switch (verb) {
+    case 'extract': {
+      return 'Extract images';
+    }
+    case 'prepare': {
+      return 'Prepare attachment upload';
+    }
+    case 'search': {
+      return 'Search docs';
+    }
+    case 'other': {
+      return capitalize(noun);
+    }
+    default: {
+      return `${capitalize(verb)} ${noun}`;
+    }
+  }
+};
+
+export const formatLinearMcpShortLabel = (apiName: string): string | null => {
+  if (!apiName.startsWith(LINEAR_MCP_PREFIX)) return null;
+  return `Linear · ${staticLabelFor(parseToolName(apiName))}`;
+};
+
+const labelFor = (parsed: ParsedTool, args: Record<string, unknown> | undefined): string => {
+  const { verb, noun } = parsed;
+  switch (verb) {
+    case 'save': {
+      const hasId = typeof args?.id === 'string' && (args.id as string).length > 0;
+      return `${hasId ? 'Update' : 'Create'} ${noun}`;
+    }
+    case 'extract': {
+      return 'Extract images';
+    }
+    case 'prepare': {
+      return 'Prepare attachment upload';
+    }
+    case 'search': {
+      return 'Search docs';
+    }
+    case 'other': {
+      return capitalize(noun);
+    }
+    default: {
+      return `${capitalize(verb)} ${noun}`;
+    }
+  }
+};
+
+const truncate = (value: string, max = 80): string =>
+  value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+const stringArg = (args: Record<string, unknown> | undefined, key: string): string | undefined => {
+  const value = args?.[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+};
+
+const PRIORITY_LABEL: Record<number, string> = {
+  0: 'None',
+  1: 'Urgent',
+  2: 'High',
+  3: 'Medium',
+  4: 'Low',
+};
+
+interface Chip {
+  iconType?: 'parent';
+  key?: string;
+  value: string;
+}
+
+interface ChipResult {
+  parentId?: string;
+  primary: Chip | null;
+}
+
+const pickPrimaryChip = (parsed: ParsedTool, args: Record<string, unknown>): Chip | null => {
+  const { verb } = parsed;
+
+  // Hard cap chip text so very long bodies/queries don't push the rest of the
+  // inspector row off-screen; CSS ellipsis was unreliable at deep flex nesting.
+  const PRIMARY_MAX = 60;
+  const FILTER_MAX = 40;
+
+  if (verb === 'search') {
+    const query = stringArg(args, 'query');
+    return query ? { value: truncate(query, PRIMARY_MAX) } : null;
+  }
+
+  if (verb === 'get' || verb === 'delete') {
+    const id = stringArg(args, 'id');
+    if (id) return { key: 'id', value: id };
+  }
+
+  if (verb === 'save' || verb === 'create') {
+    const id = stringArg(args, 'id');
+    if (id) return { key: 'id', value: id };
+    const title = stringArg(args, 'title') ?? stringArg(args, 'name') ?? stringArg(args, 'body');
+    if (title) return { value: truncate(title, PRIMARY_MAX) };
+  }
+
+  if (verb === 'list') {
+    const query = stringArg(args, 'query');
+    if (query) return { key: 'query', value: truncate(query, PRIMARY_MAX) };
+
+    const filterKeys = ['team', 'project', 'assignee', 'state', 'cycle', 'parentId', 'label'];
+    for (const key of filterKeys) {
+      const value = stringArg(args, key);
+      if (value) {
+        return key === 'parentId'
+          ? { iconType: 'parent', value }
+          : { key, value: truncate(value, FILTER_MAX) };
+      }
+    }
+    if (typeof args.priority === 'number') {
+      return {
+        key: 'priority',
+        value: PRIORITY_LABEL[args.priority as number] ?? String(args.priority),
+      };
+    }
+  }
+
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === 'string' && value.length > 0) {
+      return { key, value: truncate(value, PRIMARY_MAX) };
+    }
+  }
+  return null;
+};
+
+const pickChip = (parsed: ParsedTool, args: Record<string, unknown> | undefined): ChipResult => {
+  if (!args) return { primary: null };
+  const primary = pickPrimaryChip(parsed, args);
+  const parentId = stringArg(args, 'parentId');
+  // Skip the secondary badge when parentId is already the primary chip value
+  // (avoid duplicating the same identifier on the row).
+  const showParent = parentId && primary?.value !== parentId;
+  return { parentId: showParent ? parentId : undefined, primary };
+};
+
+const LinearMcpInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>(
+  ({ apiName, args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const effectiveArgs = args ?? partialArgs;
+    const parsed = parseToolName(apiName);
+    const label = labelFor(parsed, effectiveArgs);
+    const { primary, parentId } = pickChip(parsed, effectiveArgs);
+
+    return (
+      <div
+        className={cx(
+          inspectorTextStyles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <LinearLogomark />
+        <span className={styles.productPrefix}>Linear</span>
+        <span className={styles.chip}>
+          <span className={styles.chipAction}>{label}</span>
+          {primary && (
+            <>
+              <span className={styles.chipDivider} />
+              <span className={styles.chipValue}>
+                {primary.iconType === 'parent' ? (
+                  <CornerLeftUp className={styles.chipIcon} size={12} />
+                ) : (
+                  primary.key && <span className={styles.chipKey}>{primary.key}:</span>
+                )}
+                <span className={styles.chipValueText}>{primary.value}</span>
+              </span>
+            </>
+          )}
+        </span>
+        {parentId && (
+          <span className={styles.parentBadge} title={`parent: ${parentId}`}>
+            <CornerLeftUp className={styles.parentBadgeIcon} size={12} />
+            <span>{parentId}</span>
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+LinearMcpInspectorImpl.displayName = 'ClaudeCodeLinearMcpInspector';
+
+export const LinearMcpInspector = LinearMcpInspectorImpl as unknown as BuiltinInspector;
+
+export const LinearMcpInspectors: Record<string, BuiltinInspector> = Object.fromEntries(
+  LINEAR_MCP_TOOL_NAMES.map((tool) => [`${LINEAR_MCP_PREFIX}${tool}`, LinearMcpInspector]),
+);

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebFetch.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ClaudeCodeApiName, type WebFetchArgs } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 60%;
+    margin-inline-start: 6px;
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+}));
+
+/**
+ * Strip the protocol so the chip leads with the host — full URLs eat the
+ * width quickly and the `https://` prefix is noise.
+ */
+const stripProtocol = (url: string): string => url.replace(/^https?:\/\//i, '');
+
+export const WebFetchInspector = memo<BuiltinInspectorProps<WebFetchArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.WebFetch as any);
+    const url = (args?.url || partialArgs?.url || '').trim();
+
+    if (isArgumentsStreaming && !url) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <span>{url ? `${label}:` : label}</span>
+        {url && <span className={styles.chip}>{stripProtocol(url)}</span>}
+      </div>
+    );
+  },
+);
+
+WebFetchInspector.displayName = 'ClaudeCodeWebFetchInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/WebSearch.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {
+  highlightTextStyles,
+  inspectorTextStyles,
+  shinyTextStyles,
+} from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ClaudeCodeApiName, type WebSearchArgs } from '../../types';
+
+export const WebSearchInspector = memo<BuiltinInspectorProps<WebSearchArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t(ClaudeCodeApiName.WebSearch as any);
+    const query = (args?.query || partialArgs?.query || '').trim();
+
+    if (isArgumentsStreaming && !query) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <span>{label}</span>
+        {query && (
+          <>
+            <span>: </span>
+            <span className={highlightTextStyles.primary}>{query}</span>
+          </>
+        )}
+      </div>
+    );
+  },
+);
+
+WebSearchInspector.displayName = 'ClaudeCodeWebSearchInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
@@ -10,6 +10,7 @@ import { ClaudeCodeApiName } from '../../types';
 import { AgentInspector } from './Agent';
 import { AskUserQuestionInspector } from './AskUserQuestion';
 import { EditInspector } from './Edit';
+import { LinearMcpInspectors } from './LinearMcp';
 import { ReadInspector } from './Read';
 import { ScheduleWakeupInspector } from './ScheduleWakeup';
 import { SkillInspector } from './Skill';
@@ -45,4 +46,5 @@ export const ClaudeCodeInspectors = {
   [ClaudeCodeApiName.TodoWrite]: TodoWriteInspector,
   [ClaudeCodeApiName.ToolSearch]: ToolSearchInspector,
   [ClaudeCodeApiName.Write]: WriteInspector,
+  ...LinearMcpInspectors,
 };

--- a/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
@@ -18,6 +18,8 @@ import { TaskOutputInspector } from './TaskOutput';
 import { TaskStopInspector } from './TaskStop';
 import { TodoWriteInspector } from './TodoWrite';
 import { ToolSearchInspector } from './ToolSearch';
+import { WebFetchInspector } from './WebFetch';
+import { WebSearchInspector } from './WebSearch';
 import { WriteInspector } from './Write';
 
 // CC's own tool names (Bash / Edit / Glob / Grep / Read / Write) are already
@@ -45,6 +47,8 @@ export const ClaudeCodeInspectors = {
   [ClaudeCodeApiName.TaskStop]: TaskStopInspector,
   [ClaudeCodeApiName.TodoWrite]: TodoWriteInspector,
   [ClaudeCodeApiName.ToolSearch]: ToolSearchInspector,
+  [ClaudeCodeApiName.WebFetch]: WebFetchInspector,
+  [ClaudeCodeApiName.WebSearch]: WebSearchInspector,
   [ClaudeCodeApiName.Write]: WriteInspector,
   ...LinearMcpInspectors,
 };

--- a/packages/builtin-tool-claude-code/src/client/Inspector/linearMcpLabels.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/linearMcpLabels.ts
@@ -1,0 +1,135 @@
+// Pure label utilities for Linear MCP tool calls. Kept free of antd-style /
+// React / lucide imports so the workflow-summary path can pull
+// `formatLinearMcpShortLabel` without dragging the inspector component
+// (and its `keyframes`-using style modules) into test transitively.
+
+export const LINEAR_MCP_PREFIX = 'mcp__claude_ai_Linear__';
+
+// Mirrors the wire names CC emits for the claude.ai Linear MCP server.
+export const LINEAR_MCP_TOOL_NAMES = [
+  'create_attachment',
+  'create_attachment_from_upload',
+  'create_issue_label',
+  'delete_attachment',
+  'delete_comment',
+  'delete_customer',
+  'delete_customer_need',
+  'delete_status_update',
+  'extract_images',
+  'get_attachment',
+  'get_diff',
+  'get_diff_threads',
+  'get_document',
+  'get_initiative',
+  'get_issue',
+  'get_issue_status',
+  'get_milestone',
+  'get_project',
+  'get_status_updates',
+  'get_team',
+  'get_user',
+  'list_comments',
+  'list_customers',
+  'list_cycles',
+  'list_diffs',
+  'list_documents',
+  'list_initiatives',
+  'list_issue_labels',
+  'list_issue_statuses',
+  'list_issues',
+  'list_milestones',
+  'list_project_labels',
+  'list_projects',
+  'list_teams',
+  'list_users',
+  'prepare_attachment_upload',
+  'save_comment',
+  'save_customer',
+  'save_customer_need',
+  'save_document',
+  'save_initiative',
+  'save_issue',
+  'save_milestone',
+  'save_project',
+  'save_status_update',
+  'search_documentation',
+] as const;
+
+// Multi-word suffixes a naive split would mangle.
+const NOUN_OVERRIDES: Record<string, string> = {
+  customer_need: 'customer need',
+  diff_threads: 'diff threads',
+  documentation: 'docs',
+  issue_label: 'issue label',
+  issue_labels: 'issue labels',
+  issue_status: 'issue status',
+  issue_statuses: 'issue statuses',
+  project_labels: 'project labels',
+  status_update: 'status update',
+  status_updates: 'status updates',
+};
+
+export interface ParsedTool {
+  noun: string;
+  verb: 'get' | 'list' | 'save' | 'create' | 'delete' | 'search' | 'extract' | 'prepare' | 'other';
+}
+
+export const parseToolName = (apiName: string): ParsedTool => {
+  const suffix = apiName.startsWith(LINEAR_MCP_PREFIX)
+    ? apiName.slice(LINEAR_MCP_PREFIX.length)
+    : apiName;
+
+  if (suffix === 'extract_images') return { noun: 'images', verb: 'extract' };
+  if (suffix === 'prepare_attachment_upload') return { noun: 'attachment upload', verb: 'prepare' };
+  if (suffix === 'search_documentation') return { noun: 'docs', verb: 'search' };
+
+  const underscoreIdx = suffix.indexOf('_');
+  if (underscoreIdx <= 0) return { noun: suffix, verb: 'other' };
+
+  const head = suffix.slice(0, underscoreIdx);
+  const tail = suffix.slice(underscoreIdx + 1);
+  const noun = NOUN_OVERRIDES[tail] ?? tail.replaceAll('_', ' ');
+
+  switch (head) {
+    case 'get':
+    case 'list':
+    case 'save':
+    case 'create':
+    case 'delete': {
+      return { noun, verb: head };
+    }
+    default: {
+      return { noun: suffix.replaceAll('_', ' '), verb: 'other' };
+    }
+  }
+};
+
+export const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+// Args-free verb label; the collapsed-summary view has no runtime args, so
+// `save_*` stays "Save {noun}" rather than guessing Create vs Update.
+export const staticLabelFor = (parsed: ParsedTool): string => {
+  const { verb, noun } = parsed;
+  switch (verb) {
+    case 'extract': {
+      return 'Extract images';
+    }
+    case 'prepare': {
+      return 'Prepare attachment upload';
+    }
+    case 'search': {
+      return 'Search docs';
+    }
+    case 'other': {
+      return capitalize(noun);
+    }
+    default: {
+      return `${capitalize(verb)} ${noun}`;
+    }
+  }
+};
+
+export const formatLinearMcpShortLabel = (apiName: string): string | null => {
+  if (!apiName.startsWith(LINEAR_MCP_PREFIX)) return null;
+  return `Linear · ${staticLabelFor(parseToolName(apiName))}`;
+};

--- a/packages/builtin-tool-claude-code/src/client/Render/WebFetch/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/WebFetch/index.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { ToolResultCard } from '@lobechat/shared-tool-ui/components';
+import type { BuiltinRenderProps } from '@lobechat/types';
+import { Markdown, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { Link } from 'lucide-react';
+import { memo } from 'react';
+
+import type { WebFetchArgs } from '../../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  prompt: css`
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+    word-break: break-all;
+  `,
+  url: css`
+    font-family: ${cssVar.fontFamilyCode};
+    word-break: break-all;
+  `,
+}));
+
+const WebFetch = memo<BuiltinRenderProps<WebFetchArgs>>(({ args, content }) => {
+  const url = args?.url || '';
+  const prompt = args?.prompt || '';
+
+  return (
+    <ToolResultCard
+      wrapHeader
+      icon={Link}
+      header={
+        <>
+          {url && (
+            <Text ellipsis strong className={styles.url}>
+              {url}
+            </Text>
+          )}
+          {prompt && (
+            <Text ellipsis className={styles.prompt}>
+              {prompt}
+            </Text>
+          )}
+        </>
+      }
+    >
+      {content && (
+        <Markdown style={{ maxHeight: 240, overflow: 'auto' }} variant={'chat'}>
+          {content}
+        </Markdown>
+      )}
+    </ToolResultCard>
+  );
+});
+
+WebFetch.displayName = 'ClaudeCodeWebFetch';
+
+export default WebFetch;

--- a/packages/builtin-tool-claude-code/src/client/Render/WebSearch/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/WebSearch/index.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ToolResultCard } from '@lobechat/shared-tool-ui/components';
+import type { BuiltinRenderProps } from '@lobechat/types';
+import { Highlighter, Text } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { Globe } from 'lucide-react';
+import { memo } from 'react';
+
+import type { WebSearchArgs } from '../../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  domains: css`
+    font-size: 12px;
+    color: ${cssVar.colorTextTertiary};
+    word-break: break-all;
+  `,
+  query: css`
+    font-family: ${cssVar.fontFamilyCode};
+  `,
+}));
+
+const WebSearch = memo<BuiltinRenderProps<WebSearchArgs>>(({ args, content }) => {
+  const query = args?.query || '';
+  const allowed = args?.allowed_domains?.join(', ');
+  const blocked = args?.blocked_domains?.map((d) => `-${d}`).join(', ');
+  const scope = [allowed, blocked].filter(Boolean).join(' · ');
+
+  return (
+    <ToolResultCard
+      wrapHeader
+      icon={Globe}
+      header={
+        <>
+          {query && (
+            <Text strong className={styles.query}>
+              {query}
+            </Text>
+          )}
+          {scope && (
+            <Text ellipsis className={styles.domains}>
+              {scope}
+            </Text>
+          )}
+        </>
+      }
+    >
+      {content && (
+        <Highlighter
+          wrap
+          language={'text'}
+          showLanguage={false}
+          style={{ maxHeight: 240, overflow: 'auto' }}
+          variant={'borderless'}
+        >
+          {content}
+        </Highlighter>
+      )}
+    </ToolResultCard>
+  );
+});
+
+WebSearch.displayName = 'ClaudeCodeWebSearch';
+
+export default WebSearch;

--- a/packages/builtin-tool-claude-code/src/client/Render/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Render/index.ts
@@ -10,6 +10,8 @@ import Grep from './Grep';
 import Read from './Read';
 import Skill from './Skill';
 import TodoWrite from './TodoWrite';
+import WebFetch from './WebFetch';
+import WebSearch from './WebSearch';
 import Write from './Write';
 
 /**
@@ -30,6 +32,8 @@ export const ClaudeCodeRenders = {
   [ClaudeCodeApiName.Read]: Read,
   [ClaudeCodeApiName.Skill]: Skill,
   [ClaudeCodeApiName.TodoWrite]: TodoWrite,
+  [ClaudeCodeApiName.WebFetch]: WebFetch,
+  [ClaudeCodeApiName.WebSearch]: WebSearch,
   [ClaudeCodeApiName.Write]: Write,
 };
 

--- a/packages/builtin-tool-claude-code/src/client/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/index.ts
@@ -1,6 +1,6 @@
 export { ClaudeCodeApiName, ClaudeCodeIdentifier } from '../types';
 export { ClaudeCodeInspectors } from './Inspector';
-export { formatLinearMcpShortLabel } from './Inspector/LinearMcp';
+export { formatLinearMcpShortLabel } from './Inspector/linearMcpLabels';
 export { ClaudeCodeInterventions } from './Intervention';
 export { ClaudeCodeRenderDisplayControls, ClaudeCodeRenders } from './Render';
 export { ClaudeCodeStreamings } from './Streaming';

--- a/packages/builtin-tool-claude-code/src/client/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/index.ts
@@ -1,5 +1,6 @@
 export { ClaudeCodeApiName, ClaudeCodeIdentifier } from '../types';
 export { ClaudeCodeInspectors } from './Inspector';
+export { formatLinearMcpShortLabel } from './Inspector/LinearMcp';
 export { ClaudeCodeInterventions } from './Intervention';
 export { ClaudeCodeRenderDisplayControls, ClaudeCodeRenders } from './Render';
 export { ClaudeCodeStreamings } from './Streaming';

--- a/packages/builtin-tool-claude-code/src/types.ts
+++ b/packages/builtin-tool-claude-code/src/types.ts
@@ -41,6 +41,8 @@ export enum ClaudeCodeApiName {
   TaskStop = 'TaskStop',
   TodoWrite = 'TodoWrite',
   ToolSearch = 'ToolSearch',
+  WebFetch = 'WebFetch',
+  WebSearch = 'WebSearch',
   Write = 'Write',
 }
 
@@ -151,4 +153,24 @@ export interface AskUserQuestionItem {
  */
 export interface AskUserQuestionArgs {
   questions: AskUserQuestionItem[];
+}
+
+/**
+ * Arguments for CC's built-in `WebSearch` tool. CC issues a web search via
+ * Anthropic's hosted search and returns a text block of formatted results.
+ */
+export interface WebSearchArgs {
+  allowed_domains?: string[];
+  blocked_domains?: string[];
+  query?: string;
+}
+
+/**
+ * Arguments for CC's built-in `WebFetch` tool. CC fetches a URL and asks the
+ * model to extract `prompt` from the page; the tool_result is the model's
+ * summary, not the raw HTML.
+ */
+export interface WebFetchArgs {
+  prompt?: string;
+  url?: string;
 }

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -12,11 +12,27 @@ import WorkflowCollapse from './WorkflowCollapse';
 let mockIsGenerating = true;
 
 vi.mock('@lobehub/ui', () => ({
-  Accordion: ({ children, expandedKeys }: { children?: ReactNode; expandedKeys?: string[] }) => (
-    <div data-expanded-keys={JSON.stringify(expandedKeys ?? [])} data-testid="workflow-accordion">
-      {children}
-    </div>
-  ),
+  Accordion: ({
+    children,
+    expandedKeys,
+    onExpandedChange,
+  }: {
+    children?: ReactNode;
+    expandedKeys?: string[];
+    onExpandedChange?: (keys: string[]) => void;
+  }) => {
+    const isExpanded = (expandedKeys ?? []).includes('workflow');
+    return (
+      <div data-expanded-keys={JSON.stringify(expandedKeys ?? [])} data-testid="workflow-accordion">
+        <button
+          aria-label="toggle-accordion-header"
+          type="button"
+          onClick={() => onExpandedChange?.(isExpanded ? [] : ['workflow'])}
+        />
+        {children}
+      </div>
+    );
+  },
   AccordionItem: ({
     action,
     children,
@@ -291,6 +307,35 @@ describe('WorkflowCollapse', () => {
     expect(getExpandedKeys()).toBe('[]');
     expect(screen.queryByRole('button', { name: 'Expand fully' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Collapse' })).not.toBeInTheDocument();
+
+    act(() => {
+      screen.getByRole('button', { name: 'toggle-accordion-header' }).click();
+    });
+
+    expect(getExpandedKeys()).toBe('["workflow"]');
+    expect(screen.getByRole('button', { name: 'Expand fully' })).toBeInTheDocument();
+  });
+
+  it('manual expand jumps to full when any phase defaults to full (heterogeneous agents)', () => {
+    mockIsGenerating = false;
+    render(
+      <WorkflowCollapse
+        assistantMessageId="msg-1"
+        blocks={makeBlocks({ result: { content: 'ok' } })}
+        defaultWorkflowExpandLevel={{ streaming: 'full' }}
+      />,
+    );
+
+    // Completion default falls back to 'collapsed' since only streaming is overridden.
+    expect(getExpandedKeys()).toBe('[]');
+
+    act(() => {
+      screen.getByRole('button', { name: 'toggle-accordion-header' }).click();
+    });
+
+    expect(getExpandedKeys()).toBe('["workflow"]');
+    // The toggle next to the header would offer "collapse" because we landed at 'full' directly.
+    expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
   });
 
   it('collapses to collapsed when accordion header is clicked from full', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -174,6 +174,12 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
     );
     const streamingInitialLevel: WorkflowExpandLevel = streamingDefault ?? 'semi';
     const completionInitialLevel: WorkflowExpandLevel = completionDefault ?? 'collapsed';
+    /** When a consumer opts any phase into `full`, treat the workflow as a
+     *  "fully expanded" experience — manual expands from collapsed go to
+     *  `full` instead of the legacy `semi` cap. Heterogeneous agents rely on
+     *  this so all 40+ tool calls stay visible after the user re-expands. */
+    const manualExpandLevel: WorkflowExpandLevel =
+      streamingDefault === 'full' || completionDefault === 'full' ? 'full' : 'semi';
 
     const [expandLevel, setExpandLevel] = useState<WorkflowExpandLevel>(() =>
       allComplete ? completionInitialLevel : streamingInitialLevel,
@@ -308,13 +314,13 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
         if (forceExpanded && !nowExpanded) return;
 
         if (nowExpanded) {
-          setExpandLevel('semi');
+          setExpandLevel(manualExpandLevel);
           userOpenedRef.current = true;
         } else {
           setExpandLevel('collapsed');
         }
       },
-      [forceExpanded],
+      [forceExpanded, manualExpandLevel],
     );
     const expandedKeys = useMemo(() => (isExpanded ? ['workflow'] : []), [isExpanded]);
     const constrained = expandLevel === 'semi';

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -1,4 +1,4 @@
-import { formatLinearMcpShortLabel } from '@lobechat/builtin-tool-claude-code/client';
+import { formatLinearMcpShortLabel } from '@lobechat/builtin-tool-claude-code/client/labels';
 import { type ChatToolPayloadWithResult } from '@lobechat/types';
 import { t } from 'i18next';
 

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -1,3 +1,4 @@
+import { formatLinearMcpShortLabel } from '@lobechat/builtin-tool-claude-code/client';
 import { type ChatToolPayloadWithResult } from '@lobechat/types';
 import { t } from 'i18next';
 
@@ -102,6 +103,9 @@ const toTitleCase = (apiName: string): string => {
 };
 
 export const getToolDisplayName = (apiName: string): string => {
+  const linearLabel = formatLinearMcpShortLabel(apiName);
+  if (linearLabel) return linearLabel;
+
   const defaultValue = toTitleCase(apiName);
   const key = TOOL_API_DISPLAY_NAMES[apiName];
   if (!key) return defaultValue;


### PR DESCRIPTION
## Summary

CC emits Linear MCP tools as `mcp__claude_ai_Linear__<verb>_<noun>` — the default inspector and the collapsed workflow summary surface those raw names, which read as `Mcp__claude_ai_ Linear__get_issue` after title-casing. This adds a Linear-aware inspector + summary humanizer for all 46 Linear MCP tools.

- **Inspector header**: monochrome Linear logomark + `Linear` product prefix + a single chip split into action / value halves (e.g. `Get issue | id: LOBE-8743`)
- **Parent handling**: when args contain `parentId`, it's surfaced with a `CornerLeftUp` icon — either inside the chip (when `parentId` is the primary arg, e.g. `list_issues` filter) or as a secondary badge appended after the chip (e.g. `save_issue` create with both `title` and `parentId`). Mirrors the parent visual used by `TaskParentBar` in the AgentTasks UI.
- **Hard 60-char cap** on chip text so long comment bodies / search queries don't push the row off-screen.
- **Collapsed workflow summary**: a new `formatLinearMcpShortLabel` helper (exported from `@lobechat/builtin-tool-claude-code/client`) plugs into `getToolDisplayName`, replacing `Mcp__claude_ai_ Linear__get_issue` with `Linear · Get issue` in the bundled row.

All 46 Linear apiNames are registered to the same inspector component via `Object.fromEntries(LINEAR_MCP_TOOL_NAMES.map(...))` so adding/removing tools is a one-line change in the constant.

## Test plan

- [ ] Trigger `mcp__claude_ai_Linear__get_issue` → inspector shows `<linear> Linear [Get issue | id: LOBE-xxxx]`
- [ ] Trigger `mcp__claude_ai_Linear__save_issue` (create with title + parentId) → chip shows the title, secondary `↰ LOBE-xxxx` parent badge appears
- [ ] Trigger `mcp__claude_ai_Linear__save_issue` (update with id) → chip key reads `id`, value is the issue id; "Update issue" action label
- [ ] Trigger `mcp__claude_ai_Linear__save_comment` with a long body → body truncates at 60 chars with `…`, chip doesn't overflow the row
- [ ] Trigger `mcp__claude_ai_Linear__list_issues` with `parentId` filter → chip value renders `↰ LOBE-xxxx` (no `parentId:` text key)
- [ ] Trigger `mcp__claude_ai_Linear__search_documentation` → action reads "Search docs", chip value is the query (no double "Linear")
- [ ] Multi-tool workflow with Linear + non-Linear calls → collapsed summary shows `Linear · Get issue, Linear · Save comment, Agent` instead of raw `Mcp__…` names
- [ ] Verify monochrome icon swaps correctly between light/dark themes (uses `colorTextDescription`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)