### PR TITLE
🐛 fix(task-schedule): enforce maxExecutions cap and block sub-10min heartbeat

### DIFF
--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -313,7 +313,7 @@ export const TaskManifest: BuiltinToolManifest = {
           },
           heartbeatInterval: {
             description:
-              'Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear the interval. Recommend ≥600s.',
+              'Periodic execution interval in seconds (heartbeat mode). Pass 0 to clear the interval. Minimum 600s (10 minutes); the server rejects positive values below 600.',
             type: 'number',
           },
           identifier: {

--- a/packages/database/src/models/__tests__/taskTopic.test.ts
+++ b/packages/database/src/models/__tests__/taskTopic.test.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { topics, users } from '../../schemas';
+import { taskTopics, topics, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { TaskModel } from '../task';
 import { TaskTopicModel } from '../taskTopic';
@@ -195,6 +195,81 @@ describe('TaskTopicModel', () => {
       const t2 = await getTopic('tpc_t2');
       expect(t1.completedAt).toBeInstanceOf(Date);
       expect(t2.completedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('countByTask', () => {
+    it('counts every topic for the task when no options are passed', async () => {
+      const taskModel = new TaskModel(serverDB, userId);
+      const topicModel = new TaskTopicModel(serverDB, userId);
+      const task = await taskModel.create({ instruction: 'Test' });
+      await createTopic('tpc_c1');
+      await createTopic('tpc_c2');
+
+      await topicModel.add(task.id, 'tpc_c1', { seq: 1 });
+      await topicModel.add(task.id, 'tpc_c2', { seq: 2 });
+
+      expect(await topicModel.countByTask(task.id)).toBe(2);
+    });
+
+    it('only counts topics created on/after `since` when provided', async () => {
+      const taskModel = new TaskModel(serverDB, userId);
+      const topicModel = new TaskTopicModel(serverDB, userId);
+      const task = await taskModel.create({ instruction: 'Test' });
+      await createTopic('tpc_old');
+      await createTopic('tpc_new');
+
+      // Age the first topic 10 minutes into the past so the `since` window
+      // (5 minutes ago) excludes it but includes the just-inserted second one.
+      await topicModel.add(task.id, 'tpc_old', { seq: 1 });
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+      await serverDB
+        .update(taskTopics)
+        .set({ createdAt: tenMinutesAgo })
+        .where(eq(taskTopics.topicId, 'tpc_old'));
+
+      await topicModel.add(task.id, 'tpc_new', { seq: 2 });
+
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+      expect(await topicModel.countByTask(task.id, { since: fiveMinutesAgo })).toBe(1);
+      expect(await topicModel.countByTask(task.id)).toBe(2);
+    });
+
+    it('does not bleed across tasks', async () => {
+      const taskModel = new TaskModel(serverDB, userId);
+      const topicModel = new TaskTopicModel(serverDB, userId);
+      const task1 = await taskModel.create({ instruction: 'A' });
+      const task2 = await taskModel.create({ instruction: 'B' });
+      await createTopic('tpc_a1');
+      await createTopic('tpc_b1');
+
+      await topicModel.add(task1.id, 'tpc_a1', { seq: 1 });
+      await topicModel.add(task2.id, 'tpc_b1', { seq: 1 });
+
+      expect(await topicModel.countByTask(task1.id)).toBe(1);
+      expect(await topicModel.countByTask(task2.id)).toBe(1);
+    });
+
+    it('does not count topics owned by a different user', async () => {
+      const taskModel = new TaskModel(serverDB, userId);
+      const topicModel = new TaskTopicModel(serverDB, userId);
+      const otherTopicModel = new TaskTopicModel(serverDB, userId2);
+      const task = await taskModel.create({ instruction: 'Test' });
+      await createTopic('tpc_mine');
+      await createTopic('tpc_theirs', userId2);
+
+      await topicModel.add(task.id, 'tpc_mine', { seq: 1 });
+      // Directly insert a row attributed to userId2 on the same task to prove
+      // the scope is `userId`, not just `taskId`.
+      await serverDB.insert(taskTopics).values({
+        seq: 2,
+        taskId: task.id,
+        topicId: 'tpc_theirs',
+        userId: userId2,
+      });
+
+      expect(await topicModel.countByTask(task.id)).toBe(1);
+      expect(await otherTopicModel.countByTask(task.id)).toBe(1);
     });
   });
 

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -1,5 +1,5 @@
 import type { BriefDecision, TaskTopicHandoff } from '@lobechat/types';
-import { and, desc, eq, gte, sql } from 'drizzle-orm';
+import { and, count, desc, eq, gte, sql } from 'drizzle-orm';
 
 import type { TaskTopicItem } from '../schemas/task';
 import { tasks, taskTopics } from '../schemas/task';
@@ -200,18 +200,15 @@ export class TaskTopicModel {
     return result[0] || null;
   }
 
-  async countByTaskSince(taskId: string, since: Date): Promise<number> {
+  async countByTask(taskId: string, options?: { since?: Date }): Promise<number> {
+    const conditions = [eq(taskTopics.taskId, taskId), eq(taskTopics.userId, this.userId)];
+    if (options?.since) conditions.push(gte(taskTopics.createdAt, options.since));
+
     const rows = await this.db
-      .select({ count: sql<number>`count(*)::int` })
+      .select({ value: count() })
       .from(taskTopics)
-      .where(
-        and(
-          eq(taskTopics.taskId, taskId),
-          eq(taskTopics.userId, this.userId),
-          gte(taskTopics.createdAt, since),
-        ),
-      );
-    return Number(rows[0]?.count ?? 0);
+      .where(and(...conditions));
+    return rows[0]?.value ?? 0;
   }
 
   async findByTaskId(taskId: string): Promise<TaskTopicItem[]> {

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -1,5 +1,5 @@
 import type { BriefDecision, TaskTopicHandoff } from '@lobechat/types';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, sql } from 'drizzle-orm';
 
 import type { TaskTopicItem } from '../schemas/task';
 import { tasks, taskTopics } from '../schemas/task';
@@ -198,6 +198,20 @@ export class TaskTopicModel {
       .where(and(eq(taskTopics.topicId, topicId), eq(taskTopics.userId, this.userId)))
       .limit(1);
     return result[0] || null;
+  }
+
+  async countByTaskSince(taskId: string, since: Date): Promise<number> {
+    const rows = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(taskTopics)
+      .where(
+        and(
+          eq(taskTopics.taskId, taskId),
+          eq(taskTopics.userId, this.userId),
+          gte(taskTopics.createdAt, since),
+        ),
+      );
+    return Number(rows[0]?.count ?? 0);
   }
 
   async findByTaskId(taskId: string): Promise<TaskTopicItem[]> {

--- a/src/server/routers/lambda/task.ts
+++ b/src/server/routers/lambda/task.ts
@@ -54,7 +54,16 @@ const updateSchema = z.object({
   config: z.record(z.unknown()).optional(),
   context: z.record(z.unknown()).optional(),
   description: z.string().optional(),
-  heartbeatInterval: z.number().min(0).optional(),
+  // 0 clears the interval (disables heartbeat); any positive value must be
+  // ≥600s (10 min) to match the UI minimum and prevent sub-minute ticks if an
+  // LLM calls setTaskSchedule with a tiny number.
+  heartbeatInterval: z
+    .number()
+    .int()
+    .refine((v) => v === 0 || v >= 600, {
+      message: 'heartbeatInterval must be 0 (disabled) or at least 600 seconds (10 minutes)',
+    })
+    .optional(),
   heartbeatTimeout: z.number().min(1).nullable().optional(),
   instruction: z.string().optional(),
   name: z.string().optional(),

--- a/src/server/services/task/index.test.ts
+++ b/src/server/services/task/index.test.ts
@@ -31,6 +31,14 @@ vi.mock('@/database/models/user', () => ({
   UserModel: { findByIds: vi.fn().mockResolvedValue([]) },
 }));
 
+// AiAgentService pulls in ~14 sub-dependencies in its constructor; mock it so
+// the running-status branch in updateStatus doesn't drag them in.
+vi.mock('@/server/services/aiAgent', () => ({
+  AiAgentService: vi.fn().mockImplementation(() => ({
+    interruptTask: vi.fn(),
+  })),
+}));
+
 describe('TaskService', () => {
   const db = {} as LobeChatDatabase;
   const userId = 'user-1';
@@ -52,10 +60,13 @@ describe('TaskService', () => {
     getTreePinnedDocuments: vi.fn(),
     resolve: vi.fn(),
     update: vi.fn(),
+    updateContext: vi.fn(),
     updateStatus: vi.fn(),
   };
 
   const mockTaskTopicModel = {
+    cancelIfRunning: vi.fn(),
+    findByTaskId: vi.fn(),
     findWithHandoff: vi.fn(),
     timeoutRunning: vi.fn(),
   };
@@ -1254,6 +1265,89 @@ describe('TaskService', () => {
       // comment with time should come first, brief without time at end
       expect(result?.activities?.[0].type).toBe('comment');
       expect(result?.activities?.[1].type).toBe('brief');
+    });
+  });
+
+  describe('updateStatus / scheduleStartedAt', () => {
+    const baseTask = (overrides: Partial<Record<string, unknown>> = {}) => ({
+      automationMode: 'schedule',
+      context: {},
+      id: 'task-1',
+      identifier: 'T-1',
+      parentTaskId: null,
+      status: 'backlog',
+      ...overrides,
+    });
+
+    it('stamps scheduleStartedAt when a user starts a schedule (backlog → scheduled)', async () => {
+      const prev = baseTask({ status: 'backlog', automationMode: 'schedule' });
+      const next = baseTask({ status: 'scheduled', automationMode: 'schedule' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
+
+      expect(mockTaskModel.updateContext).toHaveBeenCalledTimes(1);
+      expect(mockTaskModel.updateContext).toHaveBeenCalledWith('task-1', {
+        scheduler: { scheduleStartedAt: expect.any(String) },
+      });
+      const stamped = (mockTaskModel.updateContext.mock.calls[0]![1] as any).scheduler
+        .scheduleStartedAt as string;
+      expect(() => new Date(stamped).toISOString()).not.toThrow();
+    });
+
+    it('does NOT stamp on the cron loop natural cycle (running → scheduled)', async () => {
+      // taskLifecycle parks finished ticks at 'scheduled' via taskModel.updateStatus,
+      // bypassing the service layer; the only way it reaches the service is when a
+      // user explicitly transitions. Either way, prev='running' must NOT reset the
+      // counter window — otherwise every successful tick would zero out the cap.
+      const prev = baseTask({ status: 'running', automationMode: 'schedule' });
+      const next = baseTask({ status: 'scheduled', automationMode: 'schedule' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+      mockTaskTopicModel.findByTaskId.mockResolvedValue([]);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
+
+      expect(mockTaskModel.updateContext).not.toHaveBeenCalled();
+    });
+
+    it('does NOT stamp for heartbeat-mode tasks', async () => {
+      const prev = baseTask({ status: 'backlog', automationMode: 'heartbeat' });
+      const next = baseTask({ status: 'scheduled', automationMode: 'heartbeat' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
+
+      expect(mockTaskModel.updateContext).not.toHaveBeenCalled();
+    });
+
+    it('does NOT stamp when the new status is not scheduled', async () => {
+      const prev = baseTask({ status: 'backlog' });
+      const next = baseTask({ status: 'paused' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'paused' as any });
+
+      expect(mockTaskModel.updateContext).not.toHaveBeenCalled();
+    });
+
+    it('stamps on user-initiated restart (paused → scheduled)', async () => {
+      const prev = baseTask({ status: 'paused', automationMode: 'schedule' });
+      const next = baseTask({ status: 'scheduled', automationMode: 'schedule' });
+      mockTaskModel.resolve.mockResolvedValue(prev);
+      mockTaskModel.updateStatus.mockResolvedValue(next);
+
+      const service = new TaskService(db, userId);
+      await service.updateStatus({ id: 'T-1', status: 'scheduled' as any });
+
+      expect(mockTaskModel.updateContext).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/server/services/task/index.ts
+++ b/src/server/services/task/index.ts
@@ -260,6 +260,22 @@ export class TaskService {
     const task = await this.taskModel.updateStatus(resolved.id, status, extra);
     if (!task) throw new TRPCError({ code: 'NOT_FOUND', message: 'Task not found' });
 
+    // Stamp the schedule run-count window each time the user (re)starts a
+    // scheduled task. The cron dispatcher itself flips a task running →
+    // scheduled on every tick, so we exclude that natural cycle by only
+    // resetting when the previous status was NOT 'running'. This lets
+    // `runScheduleTick` enforce `config.schedule.maxExecutions` by counting
+    // task_topics created since this timestamp.
+    if (
+      status === 'scheduled' &&
+      task.automationMode === 'schedule' &&
+      resolved.status !== 'running'
+    ) {
+      await this.taskModel.updateContext(task.id, {
+        scheduler: { scheduleStartedAt: new Date().toISOString() },
+      });
+    }
+
     const unlocked: string[] = [];
     const paused: string[] = [];
     let allSubtasksDone = false;

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -148,17 +148,30 @@ export class TaskLifecycleService {
       }
 
       // 5. Default post-tick transition.
-      //    - Automation tasks (heartbeat / schedule) loop running ↔ scheduled, so
-      //      a successful tick parks the task at 'scheduled' to wait for the next
-      //      tick. They never auto-pause on success — only `reason === 'error'`
-      //      below puts them in 'paused' for human attention.
-      //    - Non-automation tasks fall back to the legacy "pause for user review"
-      //      behavior: a 'result' brief from the agent is a *proposal* of
-      //      completion, and the user must explicitly approve via the brief action
-      //      to transition to 'completed'. Auto-complete only happens via the
-      //      Judge path above.
+      //    - Schedule-mode task that just consumed its final allowed run
+      //      (count ≥ maxExecutions) → park at 'completed' so the UI reflects
+      //      the cap immediately. Without this, a daily cron with
+      //      maxExecutions=1 would advertise itself as 'scheduled' for
+      //      another 24h before the pre-tick check in runScheduleTick
+      //      noticed.
+      //    - Other automation tasks (heartbeat, schedule under cap) loop
+      //      running ↔ scheduled, so a successful tick parks them at
+      //      'scheduled' to wait for the next tick. They never auto-pause
+      //      on success — only `reason === 'error'` below puts them in
+      //      'paused' for human attention.
+      //    - Non-automation tasks fall back to the legacy "pause for user
+      //      review" behavior: a 'result' brief from the agent is a
+      //      *proposal* of completion, and the user must explicitly approve
+      //      via the brief action to transition to 'completed'. Auto-complete
+      //      only happens via the Judge path above.
       if (currentTask) {
-        if (currentTask.automationMode) {
+        if (
+          currentTask.automationMode === 'schedule' &&
+          (await this.scheduleCapReached(currentTask))
+        ) {
+          log('cap reached for task=%s — marking completed post-tick', taskIdentifier);
+          await this.taskModel.updateStatus(taskId, 'completed', { completedAt: new Date() });
+        } else if (currentTask.automationMode) {
           await this.taskModel.updateStatus(taskId, 'scheduled', { error: null });
         } else if (this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
           await this.taskModel.updateStatus(taskId, 'paused', { error: null });
@@ -189,6 +202,41 @@ export class TaskLifecycleService {
     // next tick.
     const finalTask = await this.taskModel.findById(taskId);
     if (finalTask) await this.maybeRearmHeartbeat(finalTask, reason);
+  }
+
+  /**
+   * Has the task already consumed every allowed scheduled execution?
+   *
+   * Counts `task_topics` rows created since `context.scheduler.scheduleStartedAt`
+   * (stamped by `TaskService.updateStatus` on user-initiated start/restart) and
+   * compares against `config.schedule.maxExecutions`. Returns false when:
+   *   - the task isn't in schedule mode
+   *   - no cap is configured (null / 0)
+   *   - no `scheduleStartedAt` is stamped (pre-PR tasks fall through; enforcement
+   *     begins only after the user pauses + restarts)
+   *
+   * Mirrors the pre-tick check in `runScheduleTick` so a daily cron with
+   * `maxExecutions=1` doesn't sit in `scheduled` for 24h after consuming
+   * its single allowed run.
+   */
+  private async scheduleCapReached(task: TaskItem): Promise<boolean> {
+    if (task.automationMode !== 'schedule') return false;
+    const scheduleConfig =
+      ((task.config as { schedule?: { maxExecutions?: number | null } } | null) ?? {}).schedule ??
+      {};
+    const maxExecutions = scheduleConfig.maxExecutions ?? null;
+    if (maxExecutions == null || maxExecutions <= 0) return false;
+
+    const scheduler =
+      ((task.context as { scheduler?: { scheduleStartedAt?: string } } | null) ?? {}).scheduler ??
+      {};
+    const startedAtIso = scheduler.scheduleStartedAt;
+    if (!startedAtIso) return false;
+
+    const runCount = await this.taskTopicModel.countByTask(task.id, {
+      since: new Date(startedAtIso),
+    });
+    return runCount >= maxExecutions;
   }
 
   /**

--- a/src/server/services/taskLifecycle/onTopicComplete.test.ts
+++ b/src/server/services/taskLifecycle/onTopicComplete.test.ts
@@ -99,6 +99,81 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: null });
     });
 
+    it('schedule-mode task under maxExecutions still parks at "scheduled"', async () => {
+      const task = baseTask({
+        automationMode: 'schedule',
+        config: { schedule: { maxExecutions: 10 } } as any,
+        context: {
+          scheduler: { scheduleStartedAt: new Date('2026-05-01T00:00:00Z').toISOString() },
+        } as any,
+      });
+      findById.mockResolvedValue(task);
+      (service as any).taskTopicModel.countByTask = vi.fn().mockResolvedValue(3);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: null });
+      expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'completed', expect.anything());
+    });
+
+    it('schedule-mode task at maxExecutions parks at "completed" instead of "scheduled"', async () => {
+      // The reviewer-flagged P2 case: a daily cron with maxExecutions=1
+      // would otherwise sit in `scheduled` for 24h after the only allowed
+      // tick before the next pre-tick check noticed the cap.
+      const task = baseTask({
+        automationMode: 'schedule',
+        config: { schedule: { maxExecutions: 1 } } as any,
+        context: {
+          scheduler: { scheduleStartedAt: new Date('2026-05-01T00:00:00Z').toISOString() },
+        } as any,
+      });
+      findById.mockResolvedValue(task);
+      (service as any).taskTopicModel.countByTask = vi.fn().mockResolvedValue(1);
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateStatus).toHaveBeenCalledWith('task-1', 'completed', {
+        completedAt: expect.any(Date),
+      });
+      expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'scheduled', expect.anything());
+    });
+
+    it('schedule-mode task with no scheduleStartedAt (pre-PR) still parks at "scheduled"', async () => {
+      const task = baseTask({
+        automationMode: 'schedule',
+        config: { schedule: { maxExecutions: 1 } } as any,
+        context: {} as any,
+      });
+      findById.mockResolvedValue(task);
+      const countByTask = vi.fn().mockResolvedValue(99);
+      (service as any).taskTopicModel.countByTask = countByTask;
+
+      await service.onTopicComplete({
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      // Without scheduleStartedAt the helper short-circuits before querying,
+      // and the task falls through to the normal scheduled-park branch.
+      expect(countByTask).not.toHaveBeenCalled();
+      expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: null });
+    });
+
     it('non-automation task with default checkpoint → status="paused" (legacy behavior)', async () => {
       const task = baseTask({ automationMode: null });
       findById.mockResolvedValue(task);

--- a/src/server/services/taskRunner/scheduleTick.test.ts
+++ b/src/server/services/taskRunner/scheduleTick.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BriefModel } from '@/database/models/brief';
+import { TaskModel } from '@/database/models/task';
+import { TaskTopicModel } from '@/database/models/taskTopic';
+
+import { TaskRunnerService } from './index';
+import { runScheduleTick } from './scheduleTick';
+
+vi.mock('@/database/server', () => ({
+  getServerDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/database/models/task', () => ({
+  TaskModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/taskTopic', () => ({
+  TaskTopicModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/brief', () => ({
+  BriefModel: vi.fn(),
+}));
+
+vi.mock('./index', () => ({
+  TaskRunnerService: vi.fn(),
+}));
+
+describe('runScheduleTick', () => {
+  const taskId = 'task-1';
+  const userId = 'user-1';
+
+  const mockTaskModel = {
+    findById: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+  const mockTaskTopicModel = {
+    countByTask: vi.fn(),
+  };
+  const mockBriefModel = {
+    hasUnresolvedUrgentByTask: vi.fn().mockResolvedValue(false),
+  };
+  const mockRunner = {
+    runTask: vi.fn(),
+  };
+
+  const baseTask = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    automationMode: 'schedule',
+    config: {},
+    context: { scheduler: { scheduleStartedAt: new Date('2026-05-01T00:00:00Z').toISOString() } },
+    id: taskId,
+    identifier: 'T-1',
+    schedulePattern: '*/5 * * * *',
+    status: 'scheduled',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBriefModel.hasUnresolvedUrgentByTask.mockResolvedValue(false);
+    (TaskModel as any).mockImplementation(() => mockTaskModel);
+    (TaskTopicModel as any).mockImplementation(() => mockTaskTopicModel);
+    (BriefModel as any).mockImplementation(() => mockBriefModel);
+    (TaskRunnerService as any).mockImplementation(() => mockRunner);
+  });
+
+  it('skips not-found tasks', async () => {
+    mockTaskModel.findById.mockResolvedValue(null);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'not-found' });
+    expect(mockRunner.runTask).not.toHaveBeenCalled();
+  });
+
+  it('skips when automationMode has been changed away from schedule', async () => {
+    mockTaskModel.findById.mockResolvedValue(baseTask({ automationMode: 'heartbeat' }));
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'mode-changed' });
+    expect(mockRunner.runTask).not.toHaveBeenCalled();
+  });
+
+  it('skips terminal / paused tasks before checking maxExecutions', async () => {
+    mockTaskModel.findById.mockResolvedValue(baseTask({ status: 'paused' }));
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'paused' });
+    expect(mockTaskTopicModel.countByTask).not.toHaveBeenCalled();
+  });
+
+  it('runs the task when no maxExecutions is configured', async () => {
+    mockTaskModel.findById.mockResolvedValue(baseTask({ config: {} }));
+    mockRunner.runTask.mockResolvedValue(undefined);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
+    expect(mockTaskTopicModel.countByTask).not.toHaveBeenCalled();
+    expect(mockRunner.runTask).toHaveBeenCalledWith({ taskId });
+  });
+
+  it('runs the task when the run count is still under maxExecutions', async () => {
+    mockTaskModel.findById.mockResolvedValue(
+      baseTask({ config: { schedule: { maxExecutions: 10 } } }),
+    );
+    mockTaskTopicModel.countByTask.mockResolvedValue(7);
+    mockRunner.runTask.mockResolvedValue(undefined);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
+    expect(mockTaskTopicModel.countByTask).toHaveBeenCalledWith(taskId, {
+      since: new Date('2026-05-01T00:00:00Z'),
+    });
+    expect(mockRunner.runTask).toHaveBeenCalledWith({ taskId });
+    expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('marks the task completed and skips when the run count has reached maxExecutions', async () => {
+    mockTaskModel.findById.mockResolvedValue(
+      baseTask({ config: { schedule: { maxExecutions: 10 } } }),
+    );
+    mockTaskTopicModel.countByTask.mockResolvedValue(10);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'max-executions-reached' });
+    expect(mockRunner.runTask).not.toHaveBeenCalled();
+    expect(mockTaskModel.updateStatus).toHaveBeenCalledWith(taskId, 'completed', {
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it('falls back to running when maxExecutions is set but scheduleStartedAt is missing', async () => {
+    // Pre-existing scheduled tasks (created before this PR) won't have a
+    // scheduleStartedAt stamp. They should still tick normally; the cap will
+    // start enforcing once the user pauses + restarts.
+    mockTaskModel.findById.mockResolvedValue(
+      baseTask({ config: { schedule: { maxExecutions: 10 } }, context: {} }),
+    );
+    mockRunner.runTask.mockResolvedValue(undefined);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
+    expect(mockTaskTopicModel.countByTask).not.toHaveBeenCalled();
+    expect(mockRunner.runTask).toHaveBeenCalled();
+  });
+
+  it('returns in-flight when runTask raises a CONFLICT', async () => {
+    mockTaskModel.findById.mockResolvedValue(baseTask({ config: {} }));
+    mockRunner.runTask.mockRejectedValue(new TRPCError({ code: 'CONFLICT', message: 'busy' }));
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'in-flight' });
+  });
+
+  it('skips when a human is waiting on an urgent brief', async () => {
+    mockTaskModel.findById.mockResolvedValue(baseTask({ config: {} }));
+    mockBriefModel.hasUnresolvedUrgentByTask.mockResolvedValue(true);
+
+    const outcome = await runScheduleTick(taskId, userId);
+
+    expect(outcome).toEqual({ ran: false, reason: 'human-waiting' });
+    expect(mockRunner.runTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/taskRunner/scheduleTick.ts
+++ b/src/server/services/taskRunner/scheduleTick.ts
@@ -69,10 +69,17 @@ export async function runScheduleTick(
     return { ran: false, reason: 'human-waiting' };
   }
 
-  // Enforce `config.schedule.maxExecutions` by counting task_topics created
-  // since `context.scheduler.scheduleStartedAt` (stamped when the user starts
-  // the schedule). At the cap, mark the task `completed` so future dispatches
-  // filter it out via `getScheduledTasks`.
+  // Defense-in-depth cap check.
+  //
+  // `TaskLifecycleService.onTopicComplete` is the primary stopper — it parks
+  // a schedule-mode task at `completed` (instead of `scheduled`) the instant
+  // it consumes its final allowed run, so the UI reflects the cap immediately
+  // even on low-frequency crons (e.g. daily, maxExecutions=1).
+  //
+  // This pre-tick recheck catches the residual edge cases the lifecycle
+  // hook can miss: a crashed tick that never reached onTopicComplete; a
+  // user editing maxExecutions downward after the cap is already exceeded;
+  // or stale `scheduled` rows from older code paths.
   const scheduleConfig =
     ((task.config as { schedule?: { maxExecutions?: number | null } } | null) ?? {}).schedule ?? {};
   const maxExecutions = scheduleConfig.maxExecutions ?? null;

--- a/src/server/services/taskRunner/scheduleTick.ts
+++ b/src/server/services/taskRunner/scheduleTick.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 
 import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
+import { TaskTopicModel } from '@/database/models/taskTopic';
 import { getServerDB } from '@/database/server';
 
 import { TaskRunnerService } from './index';
@@ -19,6 +20,7 @@ export type ScheduleTickOutcome =
 export type ScheduleTickSkipReason =
   | 'human-waiting'
   | 'in-flight'
+  | 'max-executions-reached'
   | 'mode-changed'
   | 'no-pattern'
   | 'not-found'
@@ -65,6 +67,35 @@ export async function runScheduleTick(
   if (await briefModel.hasUnresolvedUrgentByTask(taskId)) {
     log('skip task=%s reason=human-waiting', taskId);
     return { ran: false, reason: 'human-waiting' };
+  }
+
+  // Enforce `config.schedule.maxExecutions` by counting task_topics created
+  // since `context.scheduler.scheduleStartedAt` (stamped when the user starts
+  // the schedule). At the cap, mark the task `completed` so future dispatches
+  // filter it out via `getScheduledTasks`.
+  const scheduleConfig =
+    ((task.config as { schedule?: { maxExecutions?: number | null } } | null) ?? {}).schedule ?? {};
+  const maxExecutions = scheduleConfig.maxExecutions ?? null;
+  if (maxExecutions != null && maxExecutions > 0) {
+    const scheduler =
+      ((task.context as { scheduler?: { scheduleStartedAt?: string } } | null) ?? {}).scheduler ??
+      {};
+    const startedAtIso = scheduler.scheduleStartedAt;
+    if (startedAtIso) {
+      const startedAt = new Date(startedAtIso);
+      const topicModel = new TaskTopicModel(db, userId);
+      const runCount = await topicModel.countByTaskSince(taskId, startedAt);
+      if (runCount >= maxExecutions) {
+        log(
+          'skip task=%s reason=max-executions-reached (%d/%d) — marking completed',
+          taskId,
+          runCount,
+          maxExecutions,
+        );
+        await taskModel.updateStatus(taskId, 'completed', { completedAt: new Date() });
+        return { ran: false, reason: 'max-executions-reached' };
+      }
+    }
   }
 
   const runner = new TaskRunnerService(db, userId);

--- a/src/server/services/taskRunner/scheduleTick.ts
+++ b/src/server/services/taskRunner/scheduleTick.ts
@@ -84,7 +84,7 @@ export async function runScheduleTick(
     if (startedAtIso) {
       const startedAt = new Date(startedAtIso);
       const topicModel = new TaskTopicModel(db, userId);
-      const runCount = await topicModel.countByTaskSince(taskId, startedAt);
+      const runCount = await topicModel.countByTask(taskId, { since: startedAt });
       if (runCount >= maxExecutions) {
         log(
           'skip task=%s reason=max-executions-reached (%d/%d) — marking completed',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — surfaced by an inspection brief on a scheduled task that kept looping past its run-count limit.

#### 🔀 Description of Change

Two related gaps in the task scheduler:

**1. `maxExecutions` was never enforced.**
The "运行次数限制" field on a scheduled task was accepted by `SchedulerForm` and persisted to `tasks.config.schedule.maxExecutions`, but **no execution path ever read it** — `scheduleDispatch` / `scheduleTick` / `runTask` had no counter and no cap check. A "stop after N runs" schedule would loop forever.

**2. Server accepted sub-minute heartbeat intervals.**
`heartbeatInterval` zod schema was `min(0)` and the `setTaskSchedule` tool manifest only said *"recommend ≥600s"*. An LLM (or any direct API caller) could pass `5` and trigger a 5-second-tick runaway loop, even though the UI itself caps the input at 10 minutes.

##### Enforcement (no schema migration)

- `TaskService.updateStatus` stamps `context.scheduler.scheduleStartedAt` (ISO) when a task transitions into `scheduled` from a non-`running` status. The cron loop's natural `running → scheduled` flips happen via `taskModel.updateStatus` in `taskLifecycle` (bypassing the service layer), so they don't reset the counter — only user-initiated (re)starts do.
- `TaskTopicModel.countByTaskSince(taskId, since)` counts `task_topics` rows created on/after a timestamp.
- `runScheduleTick` reads `config.schedule.maxExecutions`; if the count since `scheduleStartedAt` has reached the cap, it marks the task `completed` (so the next dispatch sweep filters it out via `getScheduledTasks`) and returns a new `max-executions-reached` skip reason.

##### Heartbeat lower bound

- `updateSchema.heartbeatInterval` on the lambda router now refines to `v === 0 || v >= 600`, matching `MIN_MINUTES = 10` in `TaskScheduleConfig.tsx`.
- `setTaskSchedule` tool manifest description updated to *"Minimum 600s (10 minutes); the server rejects positive values below 600"* so the LLM sees the hard limit before zod bounces the call.

##### Reset semantics

| Trigger | Reset counter? |
| --- | --- |
| First start (backlog → scheduled) | ✅ yes |
| Cron tick completes (running → scheduled via `taskLifecycle`) | ❌ no (bypasses service layer) |
| User pauses then restarts (paused → scheduled) | ✅ yes |
| User edits `maxExecutions` mid-schedule | ❌ no (fail-safe; if already past new cap, next tick stops the task) |

#### 🧪 How to Test

- [x] Tested locally (logic review only — local `vitest` is blocked by a pre-existing `tests/setup.ts` dep issue unrelated to this change)
- [ ] Added/updated tests
- [x] No tests needed for the manifest description; recommend follow-up unit tests for `runScheduleTick`'s max-exec branch and the new `countByTaskSince` helper

**Manual scenarios to verify:**
1. Create a schedule task running every minute, set 运行次数限制 = 3, click 启动定时. After 3 ticks the task should auto-transition to `completed`.
2. Same setup with 持续运行 checked. Task keeps running indefinitely (no behavior change).
3. Pause a scheduled task after 2/10 runs, then restart. Counter resets — next 10 ticks all fire.
4. Edit maxExecutions from 100 → 5 after 50 runs have already happened. Next tick marks the task `completed` immediately.
5. Try `setTaskSchedule({ heartbeatInterval: 5 })` via the tool — should be rejected by zod with a clear error.

#### 📸 Screenshots / Videos

N/A (no UI changes).

#### 📝 Additional Information

- No DB migration; reuses existing `task.config` and `task.context` JSONB pockets.
- Backwards compatible — tasks without `scheduleStartedAt` (created before this PR) will simply not be capped until the user pauses + restarts, at which point the timestamp gets stamped and enforcement begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)