### PR TITLE
🐛 fix(assistant-group): render trailing answer block after tool calls

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -322,6 +322,45 @@ describe('Group', () => {
     });
   });
 
+  // Regression: LOBE-9075
+  // The final assistant block after a tool call must carry contentOverride so
+  // MessageContent (which self-subscribes from the store since #14470) renders
+  // the canonical flatten-time content even when a streaming-chunk sync gap
+  // leaves the store-side content empty.
+  it('sets contentOverride on a trailing answer block that follows a workflow', () => {
+    const summary = '理清楚了。先说结论：根因是 ...';
+
+    render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1' } as any,
+              { apiName: 'grep', id: 'tool-2' } as any,
+            ],
+          }),
+          blk({
+            content: summary,
+            id: 'block-2',
+          }),
+        ]}
+      />,
+    );
+
+    const answers = parseAnswerSegments();
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toMatchObject({
+      content: summary,
+      contentOverride: summary,
+      domId: 'block-2__answer',
+      id: 'block-2',
+    });
+  });
+
   it('renders a single tool call inline instead of folding it', () => {
     render(
       <Group

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -310,7 +310,12 @@ const appendPostToolBlocks = (
   }
 
   for (const block of postBlocks.slice(index)) {
-    appendAnswerBlock(segments, block);
+    // Wrap in createAnswerRenderBlock so contentOverride is set from the
+    // flatten-time block content. MessageContent self-subscribes from the
+    // store (introduced by #14470) and a streaming-chunk sync gap can leave
+    // the store-side content empty even though the canonical block carries
+    // the full text. Without the override the card renders blank.
+    appendAnswerBlock(segments, createAnswerRenderBlock(block));
   }
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes [LOBE-9075](https://linear.app/lobehub/issue/LOBE-9075/trailing-answer-block-after-tool-calls-renders-blank-in-assistantgroup)

#### 🔀 Description of Change

The final assistant message that follows a tool call rendered as a card with the model header (e.g. `claude-opus-4-7`) and token count visible but the **body completely blank**, even though the full markdown was already persisted to the DB. Hard-reloading the page brought the content back, confirming a render-path issue rather than data loss.

**Root cause** — PR #14470 made `MessageContent` self-subscribe its content from the store (`dataSelectors.getBlockContent(id)`) instead of receiving it as a prop. PR #14504 introduced a `contentOverride` prop as a fallback and wired it through `createAnswerRenderBlock` / `createWorkflowRenderBlock` in `Group.tsx`. However, `appendPostToolBlocks` was not updated to use the wrapper for the trailing tail blocks:

```ts
for (const block of postBlocks.slice(index)) {
  appendAnswerBlock(segments, block);   // ← no contentOverride
}
```

When a streaming-chunk sync gap leaves `messagesMap[id].content === ''`, the store-side selector returns empty and `MessageContent` has no fallback — the card body renders blank. Conversation-flow's `flatten()` already extracted the correct content from the raw message, but it never reached the component.

**Fix** — wrap trailing post-tool answer blocks in `createAnswerRenderBlock(block)` so they also carry `contentOverride: block.content` from the flatten-time content, identical to every other answer-segment construction path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test in `Group.test.tsx` (`sets contentOverride on a trailing answer block that follows a workflow`) — sanity-checked it fails on `canary` without the one-line fix and passes after.

```
✓ src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx (6 tests)
✓ All AssistantGroup component tests (23 tests across 5 files)
✓ bun run type-check
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Final assistant card after a tool call: header + tokens visible, body blank. Hard-reload required to recover content. | Final assistant card renders the canonical content immediately, regardless of streaming-chunk sync state. |

#### 📝 Additional Information

This is a **regression** introduced by #14470 (2026-05-07) and only partially mitigated by #14504. Affects any conversation where the final assistant message immediately follows a tool call — i.e. virtually every agentic / Claude Code turn that ends with a textual conclusion.