### PR TITLE
♻️ refactor(agent-settings): drop Meta/Documents tabs, restore inputTemplate

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -181,8 +181,6 @@
   "agentSkillModal.url.urlPlaceholder": "https://example.com/path/to/SKILL.md",
   "agentSkillTag": "Agent Skill",
   "agentTab.chat": "Chat Preferences",
-  "agentTab.documents": "Documents",
-  "agentTab.meta": "Agent info",
   "agentTab.modal": "Model Settings",
   "agentTab.opening": "Opening Settings",
   "agentTab.plugin": "Skill Settings",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -181,8 +181,6 @@
   "agentSkillModal.url.urlPlaceholder": "https://example.com/path/to/SKILL.md",
   "agentSkillTag": "Agent 技能",
   "agentTab.chat": "对话偏好",
-  "agentTab.documents": "文档",
-  "agentTab.meta": "助理信息",
   "agentTab.modal": "模型设置",
   "agentTab.opening": "开场设置",
   "agentTab.plugin": "技能设置",

--- a/src/features/AgentSetting/AgentCategory/useCategory.tsx
+++ b/src/features/AgentSetting/AgentCategory/useCategory.tsx
@@ -1,15 +1,6 @@
 import { Icon } from '@lobehub/ui';
 import { type MenuItemType } from 'antd/es/menu/interface';
-import {
-  Activity,
-  BookText,
-  Bot,
-  BrainCog,
-  Handshake,
-  MessagesSquare,
-  Mic2,
-  UserCircle,
-} from 'lucide-react';
+import { Activity, Bot, BrainCog, Handshake, MessagesSquare, Mic2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -32,20 +23,10 @@ export const useCategory = ({ mobile }: UseCategoryOptions = {}) => {
   const cateItems: MenuProps['items'] = useMemo(
     () =>
       [
-        !isInbox && {
-          icon: <Icon icon={UserCircle} size={iconSize} />,
-          key: ChatSettingsTabs.Meta,
-          label: t('agentTab.meta'),
-        },
         {
           icon: <Icon icon={Bot} size={iconSize} />,
           key: ChatSettingsTabs.Prompt,
           label: t('agentTab.prompt'),
-        },
-        {
-          icon: <Icon icon={BookText} size={iconSize} />,
-          key: ChatSettingsTabs.Documents,
-          label: t('agentTab.documents'),
         },
         (!isInbox && {
           icon: <Icon icon={Handshake} size={iconSize} />,

--- a/src/features/AgentSetting/AgentChat/index.tsx
+++ b/src/features/AgentSetting/AgentChat/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormGroupItemType } from '@lobehub/ui';
-import { Form, SliderWithInput } from '@lobehub/ui';
+import { Form, SliderWithInput, TextArea } from '@lobehub/ui';
 import { Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
@@ -19,6 +19,12 @@ const AgentChat = memo(() => {
 
   const chat: FormGroupItemType = {
     children: [
+      {
+        children: <TextArea placeholder={t('settingChat.inputTemplate.placeholder')} />,
+        desc: t('settingChat.inputTemplate.desc'),
+        label: t('settingChat.inputTemplate.title'),
+        name: 'inputTemplate',
+      },
       {
         children: <Switch />,
         desc: t('settingChat.enableAutoCreateTopic.desc'),

--- a/src/features/AgentSetting/AgentSettings.tsx
+++ b/src/features/AgentSetting/AgentSettings.tsx
@@ -12,7 +12,7 @@ export interface AgentSettingsProps extends StoreUpdaterProps {
   tab: ChatSettingsTabs;
 }
 
-const AgentSettings = memo<AgentSettingsProps>(({ tab = ChatSettingsTabs.Meta, ...rest }) => {
+const AgentSettings = memo<AgentSettingsProps>(({ tab = ChatSettingsTabs.Opening, ...rest }) => {
   const isMobile = useServerConfigStore((s) => s.isMobile);
   const loadingSkeleton = (
     <Skeleton active paragraph={{ rows: 6 }} style={{ padding: isMobile ? 16 : 0 }} title={false} />

--- a/src/features/AgentSetting/AgentSettingsContent.tsx
+++ b/src/features/AgentSetting/AgentSettingsContent.tsx
@@ -7,8 +7,6 @@ import { ChatSettingsTabs } from '@/store/global/initialState';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 import AgentChat from './AgentChat';
-import AgentDocuments from './AgentDocuments';
-import AgentMeta from './AgentMeta';
 import AgentModal from './AgentModal';
 import AgentOpening from './AgentOpening';
 import AgentSelfIteration from './AgentSelfIteration';
@@ -26,8 +24,6 @@ const AgentSettingsContent = memo<AgentSettingsContentProps>(({ tab, loadingSkel
 
   return (
     <>
-      {tab === ChatSettingsTabs.Meta && <AgentMeta />}
-      {tab === ChatSettingsTabs.Documents && <AgentDocuments />}
       {tab === ChatSettingsTabs.Opening && <AgentOpening />}
       {tab === ChatSettingsTabs.Chat && <AgentChat />}
       {tab === ChatSettingsTabs.Modal && <AgentModal />}

--- a/src/hooks/useInterceptingRoutes.test.ts
+++ b/src/hooks/useInterceptingRoutes.test.ts
@@ -31,7 +31,7 @@ describe('useOpenChatSettings', () => {
   it('navigates to mobile chat settings with session info', () => {
     useAgentStore.setState({ activeAgentId: '123' });
     vi.mocked(useIsMobile).mockReturnValue(true);
-    const { result } = renderHook(() => useOpenChatSettings(ChatSettingsTabs.Meta));
+    const { result } = renderHook(() => useOpenChatSettings(ChatSettingsTabs.Opening));
 
     act(() => {
       result.current();
@@ -46,7 +46,7 @@ describe('useOpenChatSettings', () => {
     useAgentStore.setState({ activeAgentId: '456' });
     vi.mocked(useIsMobile).mockReturnValue(false);
 
-    const { result } = renderHook(() => useOpenChatSettings(ChatSettingsTabs.Meta));
+    const { result } = renderHook(() => useOpenChatSettings(ChatSettingsTabs.Opening));
 
     act(() => {
       result.current();

--- a/src/hooks/useInterceptingRoutes.ts
+++ b/src/hooks/useInterceptingRoutes.ts
@@ -5,7 +5,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { useAgentStore } from '@/store/agent';
 import { ChatSettingsTabs } from '@/store/global/initialState';
 
-export const useOpenChatSettings = (tab: ChatSettingsTabs = ChatSettingsTabs.Meta) => {
+export const useOpenChatSettings = (tab: ChatSettingsTabs = ChatSettingsTabs.Opening) => {
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
 
   const isMobile = useIsMobile();

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -178,8 +178,6 @@ export default {
   'agentSkillModal.url.urlPlaceholder': 'https://example.com/path/to/SKILL.md',
   'agentSkillTag': 'Agent Skill',
   'agentTab.chat': 'Chat Preferences',
-  'agentTab.documents': 'Documents',
-  'agentTab.meta': 'Agent info',
   'agentTab.modal': 'Model Settings',
   'agentTab.opening': 'Opening Settings',
   'agentTab.plugin': 'Skill Settings',

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -4,14 +4,7 @@ import { Avatar, Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import {
-  ActivityIcon,
-  BookTextIcon,
-  BrainIcon,
-  MessageSquareHeartIcon,
-  MessagesSquareIcon,
-  UserIcon,
-} from 'lucide-react';
+import { ActivityIcon, BrainIcon, MessageSquareHeartIcon, MessagesSquareIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
@@ -34,7 +27,7 @@ const Content = memo(() => {
   const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
   const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
   const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
-  const [tab, setTab] = useState(isInbox ? ChatSettingsTabs.Modal : ChatSettingsTabs.Meta);
+  const [tab, setTab] = useState(isInbox ? ChatSettingsTabs.Modal : ChatSettingsTabs.Opening);
 
   const updateAgentConfig = async (config: any) => {
     if (!agentId) return;
@@ -51,23 +44,11 @@ const Content = memo(() => {
       [
         !isInbox
           ? {
-              icon: <Icon icon={UserIcon} />,
-              key: ChatSettingsTabs.Meta,
-              label: t('agentTab.meta'),
-            }
-          : null,
-        !isInbox
-          ? {
               icon: <Icon icon={MessageSquareHeartIcon} />,
               key: ChatSettingsTabs.Opening,
               label: t('agentTab.opening'),
             }
           : null,
-        {
-          icon: <Icon icon={BookTextIcon} />,
-          key: ChatSettingsTabs.Documents,
-          label: t('agentTab.documents'),
-        },
         {
           icon: <Icon icon={MessagesSquareIcon} />,
           key: ChatSettingsTabs.Chat,

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -23,8 +23,6 @@ export enum SidebarTabKey {
 
 export enum ChatSettingsTabs {
   Chat = 'chat',
-  Documents = 'documents',
-  Meta = 'meta',
   Modal = 'modal',
   Opening = 'opening',
   Plugin = 'plugin',


### PR DESCRIPTION
## Summary

- ♻️ Remove the legacy **助理信息 (Meta)** and **文档 (Documents)** tabs from the agent profile/settings UI. Default chat-settings tab now falls back to `Opening` for non-inbox agents.
- ✨ Restore the **User Input Preprocessing** (`inputTemplate`) form field in Chat Preferences — the field was removed in 2.0 while the underlying `InputTemplateProcessor` pipeline, i18n, and type definitions were kept intact. Only the form entry is added back.

The two changes ship as separate commits so each can be reviewed (or reverted) on its own.

## Test plan

- [ ] Open an agent's settings → confirm the Meta and Documents tabs are gone, default tab is **Opening**
- [ ] Open Chat Preferences → confirm the `User Input Preprocessing` TextArea appears at the top
- [ ] Enter a template like `Please rephrase: {{text}}`, send a message → the rephrased text reaches the model (verify via `DEBUG=context-engine:processor:InputTemplateProcessor`)
- [ ] Inbox agent still routes correctly to `Modal` default tab
- [ ] `bun run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)