### PR TITLE
💄 style(tab-bar): add Chrome-style divider between inactive tabs

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -100,6 +100,7 @@ const TabItem = memo<TabItemProps>(
           horizontal
           align="center"
           className={cx(electronStylish.nodrag, styles.tab, isActive && styles.tabActive)}
+          data-active={isActive ? 'true' : undefined}
           gap={6}
           onClick={handleClick}
         >

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -19,7 +19,7 @@ import { useStyles } from './styles';
 import TabItem from './TabItem';
 
 const TAB_WIDTH = 180;
-const TAB_GAP = 2;
+const TAB_GAP = 0;
 
 const TabBar = () => {
   const styles = useStyles;

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -68,6 +68,29 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
     &:hover {
       background-color: ${cssVar.colorFillTertiary};
     }
+
+    & + &::before {
+      content: '';
+
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 0;
+      transform: translateY(-50%);
+
+      width: 1px;
+      height: 16px;
+
+      background-color: ${cssVar.colorBorderSecondary};
+
+      transition: opacity 0.15s ${cssVar.motionEaseInOut};
+    }
+
+    &:hover::before,
+    &[data-active='true']::before,
+    &:hover + &::before,
+    &[data-active='true'] + &::before {
+      opacity: 0;
+    }
   `,
   tabActive: css`
     background-color: ${cssVar.colorBgElevated};


### PR DESCRIPTION
## Summary

After the previous PR (#13973) made inactive tabs blend into the titlebar, adjacent inactive tabs became visually indistinguishable. This PR adds a 1px vertical divider between them — same pattern Chrome uses to delineate flat tabs.

- Each tab paints a `1px × 16px` separator on its left edge via `::before` (uses `& + &::before` so the first tab naturally has none).
- Divider auto-hides next to a **hovered** or **active** tab — both the highlighted tab's own divider and the divider of its right-hand neighbor disappear, keeping the highlight surface clean.
- `TAB_GAP` is dropped from `2` → `0` so neighbors touch and the divider sits exactly at the seam.
- `data-active` attribute is added on the tab Flexbox so the sibling combinator (`[data-active='true'] + .tab::before`) can identify the active tab from outside.

Touched files:
- `src/features/Electron/titlebar/TabBar/styles.ts`
- `src/features/Electron/titlebar/TabBar/TabItem.tsx`
- `src/features/Electron/titlebar/TabBar/index.tsx`

## Test plan

- [ ] Run `bun run dev` and open the Electron desktop app
- [ ] Open 3+ tabs and confirm dividers appear between every adjacent pair (no divider before the first tab)
- [ ] Hover an inactive tab → its own divider AND the divider on the tab immediately to its right both fade out
- [ ] Switch active tab → divider on the active tab AND on its right neighbor are hidden
- [ ] Verify in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)