### PR TITLE
🐛 fix(onboarding): restore FullNameStep back button to the shared prefix

### DIFF
--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -2,8 +2,8 @@
 
 import { MAX_ONBOARDING_STEPS } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
-import { Navigate } from 'react-router-dom';
+import { memo, useCallback } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
 import ModeSwitch from '@/features/Onboarding/components/ModeSwitch';
@@ -15,6 +15,7 @@ import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
 
 const ClassicOnboardingPage = memo(() => {
+  const navigate = useNavigate();
   const [isUserStateInit, commonStepsCompleted, currentStep, goToNextStep, goToPreviousStep] =
     useUserStore((s) => [
       s.isUserStateInit,
@@ -23,6 +24,12 @@ const ClassicOnboardingPage = memo(() => {
       s.goToNextStep,
       s.goToPreviousStep,
     ]);
+
+  // FullNameStep is the branch's first step, so its back button leaves the
+  // branch and re-enters the shared prefix's ResponseLanguageStep (step 2).
+  const backToResponseLanguageStep = useCallback(() => {
+    navigate('/onboarding?step=2', { replace: true });
+  }, [navigate]);
 
   if (!isUserStateInit) {
     return <Loading debugId="ClassicOnboarding" />;
@@ -35,7 +42,7 @@ const ClassicOnboardingPage = memo(() => {
   const renderStep = () => {
     switch (currentStep) {
       case 1: {
-        return <FullNameStep onBack={goToPreviousStep} onNext={goToNextStep} />;
+        return <FullNameStep onBack={backToResponseLanguageStep} onNext={goToNextStep} />;
       }
       case 2: {
         return <InterestsStep onBack={goToPreviousStep} onNext={goToNextStep} />;

--- a/src/features/Onboarding/Common/index.test.tsx
+++ b/src/features/Onboarding/Common/index.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,6 +8,7 @@ interface RenderOptions {
   desktop?: boolean;
   enableAgentOnboarding?: boolean;
   finishedAt?: string;
+  initialEntry?: string;
   isUserStateInit?: boolean;
   persistedStep?: number;
   serverConfigInit?: boolean;
@@ -20,6 +21,7 @@ const renderCommon = async ({
   desktop = false,
   enableAgentOnboarding = true,
   finishedAt,
+  initialEntry = '/onboarding',
   isUserStateInit = true,
   persistedStep,
   serverConfigInit = true,
@@ -45,7 +47,17 @@ const renderCommon = async ({
     default: () => <div>TelemetryStep</div>,
   }));
   vi.doMock('@/routes/onboarding/features/ResponseLanguageStep', () => ({
-    default: () => <div>ResponseLanguageStep</div>,
+    default: ({ onBack, onNext }: { onBack: () => void; onNext: () => void }) => (
+      <div>
+        ResponseLanguageStep
+        <button type="button" onClick={onBack}>
+          rl-back
+        </button>
+        <button type="button" onClick={onNext}>
+          rl-next
+        </button>
+      </div>
+    ),
   }));
 
   function selectFromServerConfigStore(selector: (state: Record<string, unknown>) => unknown) {
@@ -80,7 +92,7 @@ const renderCommon = async ({
   const { default: CommonOnboardingPage } = await import('./index');
 
   render(
-    <MemoryRouter initialEntries={['/onboarding']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route element={<CommonOnboardingPage />} path="/onboarding" />
         <Route element={<div>Agent onboarding</div>} path="/onboarding/agent" />
@@ -146,6 +158,34 @@ describe('CommonOnboardingPage', () => {
   it('shows loading until server config initializes when ready to redirect', async () => {
     await renderCommon({ commonStepsCompleted: true, serverConfigInit: false });
     expect(screen.getByText('Loading:CommonOnboarding/serverConfig')).toBeInTheDocument();
+  });
+
+  describe('shared-prefix re-entry', () => {
+    it('renders ResponseLanguageStep instead of redirecting when ?step=2 and prefix is complete', async () => {
+      await renderCommon({ commonStepsCompleted: true, initialEntry: '/onboarding?step=2' });
+      expect(screen.getByText('ResponseLanguageStep')).toBeInTheDocument();
+    });
+
+    it('renders TelemetryStep when ?step=1 and prefix is complete', async () => {
+      await renderCommon({ commonStepsCompleted: true, initialEntry: '/onboarding?step=1' });
+      expect(screen.getByText('TelemetryStep')).toBeInTheDocument();
+    });
+
+    it('goes back to TelemetryStep from a revisited ResponseLanguageStep', async () => {
+      await renderCommon({ commonStepsCompleted: true, initialEntry: '/onboarding?step=2' });
+      fireEvent.click(screen.getByText('rl-back'));
+      expect(await screen.findByText('TelemetryStep')).toBeInTheDocument();
+    });
+
+    it('redirects into the branch when finishing a revisited ResponseLanguageStep', async () => {
+      await renderCommon({
+        commonStepsCompleted: true,
+        enableAgentOnboarding: false,
+        initialEntry: '/onboarding?step=2',
+      });
+      fireEvent.click(screen.getByText('rl-next'));
+      expect(await screen.findByText('Classic onboarding')).toBeInTheDocument();
+    });
   });
 
   describe('legacy classic step migration', () => {

--- a/src/features/Onboarding/Common/index.tsx
+++ b/src/features/Onboarding/Common/index.tsx
@@ -40,6 +40,7 @@ const CommonOnboardingPage = memo(() => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const step: 1 | 2 = searchParams.get('step') === '2' ? 2 : 1;
+  const hasStepParam = searchParams.has('step');
 
   // One-time legacy migration: when the user lands on the shared prefix, if
   // their persisted `currentStep` was authored under the old 5-step schema,
@@ -73,20 +74,20 @@ const CommonOnboardingPage = memo(() => {
   }, [setSearchParams]);
 
   const goBackFromLanguage = useCallback(() => {
-    setSearchParams({}, { replace: true });
+    setSearchParams({ step: '1' }, { replace: true });
   }, [setSearchParams]);
 
   const finishCommon = useCallback(() => {
-    // No-op: completion of step 2 writes responseLanguage, which flips
-    // commonStepsCompleted to true; the early-return below then handles
-    // the redirect on the next render.
-  }, []);
+    setSearchParams({}, { replace: true });
+  }, [setSearchParams]);
 
   if (!isUserStateInit) {
     return <Loading debugId="CommonOnboarding/userState" />;
   }
 
-  if (commonStepsCompleted) {
+  // With the prefix complete, a bare `/onboarding` resumes the branch — but an
+  // explicit `?step` (FullNameStep's back button) re-enters the shared prefix.
+  if (commonStepsCompleted && !hasStepParam) {
     if (!serverConfigInit) {
       return <Loading debugId="CommonOnboarding/serverConfig" />;
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

`FullNameStep` is the first step of the classic onboarding branch. Its back
button was wired to `goToPreviousStep`, which early-returns at step 1 — so the
button did nothing. The chain broke when the telemetry/language steps were
extracted into the shared prefix (#14538): `FullNameStep` dropped from step 2
to step 1, leaving its back button with nowhere to go.

Changes:

- **`Classic/index.tsx`** — `FullNameStep`'s `onBack` now navigates to
  `/onboarding?step=2`, leaving the branch and re-entering the shared prefix's
  `ResponseLanguageStep`.
- **`Common/index.tsx`** — make the shared prefix re-enterable:
  - the completed-prefix redirect guard now only fires for a bare
    `/onboarding`; an explicit `?step` re-enters the prefix.
  - `goBackFromLanguage` targets `?step=1` so a re-entered `ResponseLanguageStep`
    can step back to `TelemetryStep` without bouncing.
  - `finishCommon` drops the `?step` param so the guard redirects into the
    branch on the next render.

Note: finishing a re-entered `ResponseLanguageStep` redirects to the branch
derived from feature flags — existing common→branch semantics, unchanged here.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`Common/index.test.tsx` adds a `shared-prefix re-entry` suite (re-entry
rendering, back to telemetry, forward redirect into the branch); 17 tests pass.

Manual: classic onboarding → `FullNameStep` → click back → lands on
`ResponseLanguageStep`; back again → `TelemetryStep`; forward → returns to the
classic branch.