### PR TITLE
♻️ refactor(chat-input): adopt native submenu header/footer slots for skill menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.33.3",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "5.12.0",
+    "@lobehub/ui": "^5.14.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
@@ -1,7 +1,9 @@
 import { type ItemType } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ArrowRight, LibraryBig } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FileIcon from '@/components/FileIcon';
@@ -14,8 +16,41 @@ import CheckboxItem from '../components/CheckboxWithLoading';
 
 const labelMaxWidth = 'min(400px, 56vw)';
 
+const styles = createStaticStyles(({ css }) => ({
+  viewMore: css`
+    cursor: pointer;
+
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    width: calc(100% + 8px);
+    min-height: 32px;
+    margin-block-end: -4px;
+    margin-inline-start: -4px;
+    border: 0;
+    border-radius: 6px;
+
+    font-size: 14px;
+    color: ${cssVar.colorText};
+
+    background: transparent;
+
+    transition: background 150ms ${cssVar.motionEaseOut};
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  viewMoreLabel: css`
+    flex: 1;
+    text-align: start;
+  `,
+}));
+
 export interface KnowledgeControls {
   enabledCount: number;
+  footer: ReactNode;
   items: ItemType[];
 }
 
@@ -97,20 +132,20 @@ export const useControls = ({
       : []),
   ];
 
-  const items: ItemType[] = [
-    ...relatedGroups,
-    ...(relatedGroups.length > 0 ? [{ type: 'divider' as const }] : []),
-    {
-      closeOnClick: true,
-      extra: <Icon icon={ArrowRight} />,
-      icon: LibraryBig,
-      key: 'knowledge-base-store',
-      label: <span data-fixed-menu-footer>{t('knowledgeBase.viewMore')}</span>,
-      onClick: () => {
+  const footer = (
+    <button
+      className={cx(styles.viewMore)}
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
         openAttachKnowledgeModal();
-      },
-    },
-  ];
+      }}
+    >
+      <Icon icon={LibraryBig} size={16} />
+      <span className={cx(styles.viewMoreLabel)}>{t('knowledgeBase.viewMore')}</span>
+      <Icon icon={ArrowRight} size={16} />
+    </button>
+  );
 
-  return { enabledCount, items } satisfies KnowledgeControls;
+  return { enabledCount, footer, items: relatedGroups } satisfies KnowledgeControls;
 };

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -274,6 +274,8 @@ const PlusAction = memo(() => {
   const {
     autoCount: skillAutoCount,
     editPluginDrawer: skillEditPluginDrawer,
+    marketFooter: skillMarketFooter,
+    marketHeader: skillMarketHeader,
     marketItems: skillItems,
     pinnedCount: skillPinnedCount,
   } = useToolsControls();
@@ -406,6 +408,8 @@ const PlusAction = memo(() => {
             { type: 'divider' },
             {
               children: skillMenuItems,
+              footer: skillMarketFooter,
+              header: skillMarketHeader,
               icon: activeIcon(SkillsIcon, activeSkillCount > 0),
               key: 'tools',
               label: renderLabelWithCount(
@@ -417,7 +421,7 @@ const PlusAction = memo(() => {
                     : 'tools.skillActivateMode.manual.title',
                 ),
               ),
-            },
+            } as ActionDropdownMenuItems[number],
             {
               icon: Store,
               key: 'add-skills',
@@ -548,6 +552,8 @@ const PlusAction = memo(() => {
     tEditor,
     tSetting,
     skillItems,
+    skillMarketFooter,
+    skillMarketHeader,
     upload,
   ]);
 

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -268,9 +268,15 @@ const PlusAction = memo(() => {
   const [showTypoBar, setShowTypoBar] = useChatInputStore((s) => [s.showTypoBar, s.setShowTypoBar]);
   const { canUploadImage, canUploadVideo } = useVisualMediaUploadAbility(model, provider);
   const enableFC = useModelSupportToolUse(model, provider);
-  const { enabledCount: knowledgeEnabledCount, items: knowledgeItems } = useKnowledgeControls({
-    openAttachKnowledgeModal,
-  });
+  const handleOpenKnowledge = useCallback(() => {
+    setDropdownOpen(false);
+    openAttachKnowledgeModal();
+  }, []);
+  const {
+    enabledCount: knowledgeEnabledCount,
+    footer: knowledgeFooter,
+    items: knowledgeItems,
+  } = useKnowledgeControls({ openAttachKnowledgeModal: handleOpenKnowledge });
   const {
     autoCount: skillAutoCount,
     editPluginDrawer: skillEditPluginDrawer,
@@ -521,6 +527,7 @@ const PlusAction = memo(() => {
       ? [
           {
             children: knowledgeItems,
+            footer: knowledgeFooter,
             icon: activeIcon(LibraryBig, knowledgeEnabledCount > 0),
             key: 'knowledge-base',
             label: renderLabelWithCount(t('knowledgeBase.title'), knowledgeEnabledCount),
@@ -548,6 +555,7 @@ const PlusAction = memo(() => {
     skillAutoCount,
     skillPinnedCount,
     knowledgeItems,
+    knowledgeFooter,
     t,
     tEditor,
     tSetting,

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -276,15 +276,14 @@ const styles = createStaticStyles(({ css }) => ({
     flex: 1;
     text-align: start;
   `,
-  search: css`
-    width: 100%;
-  `,
   searchBox: css`
     display: flex;
     align-items: center;
 
     height: 36px;
-    padding-inline: 10px;
+    margin-block-start: -4px;
+    margin-inline: -8px;
+    padding-inline: 4px;
     border-radius: 10px;
 
     background: ${cssVar.colorFillQuaternary};
@@ -334,7 +333,9 @@ const styles = createStaticStyles(({ css }) => ({
     display: flex;
     gap: 14px;
     align-items: center;
+
     width: 100%;
+    margin-block-end: -4px;
   `,
   statsSettingsButton: css`
     cursor: pointer;
@@ -1252,33 +1253,49 @@ export const useControls = () => {
     </div>
   );
 
+  const marketHeader = (
+    <div className={cx(styles.searchBox)} onClick={stopPropagation} onKeyDown={stopPropagation}>
+      <SearchBar
+        allowClear
+        placeholder={t('tools.search')}
+        size="small"
+        style={{ flex: 1 }}
+        value={searchKeyword}
+        variant="borderless"
+        onChange={(event) => setSearchKeyword(event.target.value)}
+        onKeyDown={stopPropagation}
+      />
+    </div>
+  );
+
+  const marketFooter =
+    allSkillItems.length > 0 ? (
+      <div className={cx(styles.statsFooter)}>
+        <span className={cx(styles.statsItem)}>
+          <Icon icon={Pin} size={12} />
+          {allPinnedItems.length}
+        </span>
+        <span className={cx(styles.statsItem)}>
+          <Icon icon={Zap} size={12} />
+          {allAutoItems.length}
+        </span>
+        <Tooltip placement="top" title={t('tools.plugins.management')}>
+          <button
+            aria-label={t('tools.plugins.management')}
+            className={cx(styles.statsSettingsButton)}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              navigate('/settings/skill');
+            }}
+          >
+            <Icon icon={Settings} size={14} />
+          </button>
+        </Tooltip>
+      </div>
+    ) : undefined;
+
   const marketItems: ItemType[] = [
-    {
-      children: [],
-      key: 'skill-search',
-      label: (
-        <div
-          data-skill-menu-search
-          className={cx(styles.search)}
-          onClick={stopPropagation}
-          onKeyDown={stopPropagation}
-        >
-          <div className={cx(styles.searchBox)}>
-            <SearchBar
-              allowClear
-              placeholder={t('tools.search')}
-              size="small"
-              style={{ flex: 1 }}
-              value={searchKeyword}
-              variant="borderless"
-              onChange={(event) => setSearchKeyword(event.target.value)}
-              onKeyDown={stopPropagation}
-            />
-          </div>
-        </div>
-      ),
-      type: 'group' as const,
-    },
     ...(pinnedItems.length > 0
       ? [
           {
@@ -1315,41 +1332,6 @@ export const useControls = () => {
               onToggle: () => setAutoOpen((open) => !open),
             }),
             type: 'group' as const,
-          } as ItemType,
-        ]
-      : []),
-    ...(allSkillItems.length > 0
-      ? [
-          {
-            closeOnClick: false,
-            key: 'skill-stats-footer',
-            label: (
-              <span data-fixed-menu-footer data-skill-stats>
-                <div className={cx(styles.statsFooter)}>
-                  <span className={cx(styles.statsItem)}>
-                    <Icon icon={Pin} size={12} />
-                    {allPinnedItems.length}
-                  </span>
-                  <span className={cx(styles.statsItem)}>
-                    <Icon icon={Zap} size={12} />
-                    {allAutoItems.length}
-                  </span>
-                  <Tooltip placement="top" title={t('tools.plugins.management')}>
-                    <button
-                      aria-label={t('tools.plugins.management')}
-                      className={cx(styles.statsSettingsButton)}
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        navigate('/settings/skill');
-                      }}
-                    >
-                      <Icon icon={Settings} size={14} />
-                    </button>
-                  </Tooltip>
-                </div>
-              </span>
-            ),
           } as ItemType,
         ]
       : []),
@@ -1693,6 +1675,8 @@ export const useControls = () => {
     autoCount: allAutoItems.length,
     editPluginDrawer,
     installedPluginItems,
+    marketFooter,
+    marketHeader,
     marketItems,
     pinnedCount: allPinnedItems.length,
   };

--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -92,43 +92,6 @@ const SubmenuScrollStyle = createGlobalStyle`
   [data-submenu] > [role='menu'] [role='group']:has([data-skill-activation-group]) > [role='presentation'] {
     padding-block: 0;
   }
-
-  [data-submenu] > [role='menu']:has([role='menuitem']:has([data-fixed-menu-footer])) {
-    padding-block-end: 0 !important;
-  }
-
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]) {
-    position: sticky;
-    z-index: 2;
-    inset-block-end: 0;
-
-    min-height: 0;
-    padding-block: 8px 12px !important;
-    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: 0;
-
-    background: ${cssVar.colorBgElevated};
-  }
-
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]) > * {
-    display: flex;
-    align-items: center;
-
-    width: 100%;
-    min-height: 36px;
-    padding-block: 4px;
-    border-radius: ${cssVar.borderRadiusSM};
-  }
-
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]):hover,
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer])[data-highlighted] {
-    background: ${cssVar.colorBgElevated};
-  }
-
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]):hover > *,
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer])[data-highlighted] > * {
-    background: ${cssVar.colorFillTertiary};
-  }
 `;
 
 export type ActionDropdownMenuItem = MenuItemType;

--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -120,16 +120,6 @@ const SubmenuScrollStyle = createGlobalStyle`
     border-radius: ${cssVar.borderRadiusSM};
   }
 
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-skill-stats]) {
-    cursor: default;
-    padding-block: 0 !important;
-  }
-
-  [data-submenu] > [role='menu'] [role='group']:has([data-skill-menu-search]) > *:has([data-skill-menu-search]) {
-    padding-block: 6px 4px !important;
-    padding-inline: 8px !important;
-  }
-
   [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]):hover,
   [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer])[data-highlighted] {
     background: ${cssVar.colorBgElevated};
@@ -138,11 +128,6 @@ const SubmenuScrollStyle = createGlobalStyle`
   [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer]):hover > *,
   [data-submenu] > [role='menu'] [role='menuitem']:has([data-fixed-menu-footer])[data-highlighted] > * {
     background: ${cssVar.colorFillTertiary};
-  }
-
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-skill-stats]):hover > *,
-  [data-submenu] > [role='menu'] [role='menuitem']:has([data-skill-stats])[data-highlighted] > * {
-    background: transparent;
   }
 `;
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The skill menu inside the Plus dropdown previously pinned its search bar and stats footer as faux menu items, held in place by `position: sticky` CSS hacks keyed on `data-fixed-menu-footer` / `data-skill-menu-search` / `data-skill-stats`.

`@lobehub/ui` 5.14.0 adds native `header` / `footer` slots to submenu popups. This PR adopts them:

- Bumps `@lobehub/ui` to `^5.14.0`.
- `Tools/useControls.tsx` — extracts the search bar and stats row out of `marketItems` into separate `marketHeader` / `marketFooter` nodes.
- `Plus/index.tsx` — passes them to the `tools` submenu's `header` / `footer` props.
- `ActionDropdown.tsx` — drops the now-dead `data-skill-stats` / `data-skill-menu-search` CSS. The `data-fixed-menu-footer` rule stays, since the Knowledge submenu still uses it.

The submenu search now sits in a pinned header, the stats in a pinned footer, and the skill list scrolls between them — no more sticky-position hacks. Removing the faux items also fixes a latent double search bar in the standalone Tools popover.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open the chat input Plus menu, then the Tools submenu. The search bar should stay pinned at the top, the pin/auto stats and settings button pinned at the bottom, and the skill list scroll between them.

#### 📸 Screenshots / Videos

UI change — the submenu search/stats are now native pinned slots instead of sticky faux items. Screenshots pending.

#### 📝 Additional Information

Requires `@lobehub/ui` >= 5.14.0, which adds submenu `header` / `footer` slots. Without it the `header` / `footer` props on the submenu item are silently ignored.