### PR TITLE
💄 style(chat-input): switch action tag chips to icon + colored label

### DIFF
--- a/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { styles } from './style';
 import type { ActionTagCategory } from './types';
 
-export interface ActionTagViewProps {
+export interface ActionMentionProps {
   category: ActionTagCategory;
   label: string;
 }
@@ -45,7 +45,7 @@ const CATEGORY_STYLE_KEY: Record<
   tool: 'toolTag',
 };
 
-export const ActionTagView = memo<ActionTagViewProps>(({ category, label }) => {
+export const ActionMention = memo<ActionMentionProps>(({ category, label }) => {
   const { t } = useTranslation('editor');
 
   const categoryLabel = t(CATEGORY_I18N_KEY[category] as any);
@@ -71,4 +71,4 @@ export const ActionTagView = memo<ActionTagViewProps>(({ category, label }) => {
   );
 });
 
-ActionTagView.displayName = 'ActionTagView';
+ActionMention.displayName = 'ActionMention';

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
@@ -2,7 +2,7 @@ import { Icon, Tooltip } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { cx } from 'antd-style';
 import { TerminalIcon, WrenchIcon } from 'lucide-react';
-import type { ComponentType } from 'react';
+import type { FC } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,7 +14,7 @@ export interface ActionMentionProps {
   label: string;
 }
 
-const CATEGORY_ICON: Record<ActionTagCategory, ComponentType<any>> = {
+const CATEGORY_ICON: Record<ActionTagCategory, FC<any>> = {
   command: TerminalIcon,
   projectSkill: SkillsIcon,
   skill: SkillsIcon,

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
@@ -1,8 +1,8 @@
 import { CLICK_COMMAND, COMMAND_PRIORITY_LOW, type LexicalEditor } from 'lexical';
 import { memo, useCallback, useEffect, useRef } from 'react';
 
+import { ActionMention } from './ActionMention';
 import type { ActionTagNode } from './ActionTagNode';
-import { ActionTagView } from './ActionTagView';
 
 interface ActionTagProps {
   editor: LexicalEditor;
@@ -26,7 +26,7 @@ const ActionTag = memo<ActionTagProps>(({ node, editor, label }) => {
 
   return (
     <span ref={spanRef}>
-      <ActionTagView category={node.actionCategory} label={label} />
+      <ActionMention category={node.actionCategory} label={label} />
     </span>
   );
 });

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTagNode.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTagNode.ts
@@ -14,7 +14,7 @@ import {
 } from 'lexical';
 import { createElement } from 'react';
 
-import { ActionTagView } from './ActionTagView';
+import { ActionMention } from './ActionMention';
 import type { ActionTagCategory, ActionTagType } from './types';
 
 export type SerializedActionTagNode = Spread<
@@ -126,7 +126,7 @@ export class ActionTagNode extends DecoratorNode<any> implements HeadlessRendera
   }
 
   renderHeadless({ key }: HeadlessRenderContext) {
-    return createElement(ActionTagView, {
+    return createElement(ActionMention, {
       category: this.__actionCategory as ActionTagCategory,
       key,
       label: this.__actionLabel,

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTagView.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTagView.tsx
@@ -1,5 +1,8 @@
-import { Tag, Tooltip } from '@lobehub/ui';
+import { Icon, Tooltip } from '@lobehub/ui';
+import { SkillsIcon } from '@lobehub/ui/icons';
 import { cx } from 'antd-style';
+import { TerminalIcon, WrenchIcon } from 'lucide-react';
+import type { ComponentType } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,11 +14,11 @@ export interface ActionTagViewProps {
   label: string;
 }
 
-const CATEGORY_COLOR: Record<ActionTagCategory, string> = {
-  command: 'purple',
-  projectSkill: 'green',
-  skill: 'blue',
-  tool: 'gold',
+const CATEGORY_ICON: Record<ActionTagCategory, ComponentType<any>> = {
+  command: TerminalIcon,
+  projectSkill: SkillsIcon,
+  skill: SkillsIcon,
+  tool: WrenchIcon,
 };
 
 const CATEGORY_I18N_KEY: Record<ActionTagCategory, string> = {
@@ -47,25 +50,24 @@ export const ActionTagView = memo<ActionTagViewProps>(({ category, label }) => {
 
   const categoryLabel = t(CATEGORY_I18N_KEY[category] as any);
   const categoryDescription = t(CATEGORY_TOOLTIP_I18N_KEY[category] as any);
-  const color = CATEGORY_COLOR[category];
+  const IconComponent = CATEGORY_ICON[category];
   const styleKey = CATEGORY_STYLE_KEY[category];
 
   return (
-    <span className={cx(styles[styleKey])}>
-      <Tooltip
-        title={
-          <div>
-            <div style={{ fontWeight: 500 }}>{label}</div>
-            <div>{categoryLabel}</div>
-            <div>{categoryDescription}</div>
-          </div>
-        }
-      >
-        <Tag color={color} variant="filled">
-          {label}
-        </Tag>
-      </Tooltip>
-    </span>
+    <Tooltip
+      title={
+        <div>
+          <div style={{ fontWeight: 500 }}>{label}</div>
+          <div>{categoryLabel}</div>
+          <div>{categoryDescription}</div>
+        </div>
+      }
+    >
+      <span className={cx(styles.actionTag, styles[styleKey])}>
+        <Icon icon={IconComponent} size={14} />
+        <span className={styles.actionTagLabel}>{label}</span>
+      </span>
+    </Tooltip>
   );
 });
 

--- a/src/features/ChatInput/InputEditor/ActionTag/style.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/style.ts
@@ -2,29 +2,41 @@ import { createStaticStyles } from 'antd-style';
 
 import { TAG_MARGIN_INLINE_END } from '../constants';
 
-const tagBase = (outlineColor: string, borderRadius: string) => `
-  cursor: default;
-  user-select: none;
-  display: inline-flex;
-  margin-inline-end: ${TAG_MARGIN_INLINE_END}px;
+const colored = (color: string, borderRadius: string) => `
+  color: ${color};
 
   &.selected {
     border-radius: ${borderRadius};
-    outline: 2px solid ${outlineColor};
+    outline: 2px solid ${color};
+    outline-offset: 1px;
   }
 `;
 
 export const styles = createStaticStyles(({ css, cssVar }) => ({
+  actionTag: css`
+    cursor: default;
+    user-select: none;
+
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+
+    margin-inline-end: ${TAG_MARGIN_INLINE_END}px;
+    padding-inline: 2px;
+  `,
+  actionTagLabel: css`
+    font-weight: 500;
+  `,
   commandTag: css`
-    ${tagBase('#722ED1', cssVar.borderRadius)}
+    ${colored(cssVar.purple, cssVar.borderRadius)}
   `,
   projectSkillTag: css`
-    ${tagBase(cssVar.colorSuccess, cssVar.borderRadius)}
+    ${colored(cssVar.colorSuccess, cssVar.borderRadius)}
   `,
   skillTag: css`
-    ${tagBase(cssVar.colorPrimary, cssVar.borderRadius)}
+    ${colored(cssVar.colorSuccess, cssVar.borderRadius)}
   `,
   toolTag: css`
-    ${tagBase(cssVar.colorWarning, cssVar.borderRadius)}
+    ${colored(cssVar.colorInfo, cssVar.borderRadius)}
   `,
 }));

--- a/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicView.tsx
+++ b/src/features/ChatInput/InputEditor/ReferTopic/ReferTopicView.tsx
@@ -38,7 +38,7 @@ export const ReferTopicView = memo<ReferTopicViewProps>(({ topicId, fallbackTitl
       }}
       onClick={handleClick}
     >
-      <Tag color="green" icon={<MessageSquarePlusIcon size={12} />} variant="outlined">
+      <Tag color="green" icon={<MessageSquarePlusIcon size={12} />} variant="filled">
         {title || t('defaultTitle')}
       </Tag>
     </span>

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -34,17 +34,21 @@ import {
 } from './ActionTag';
 import { createMentionMenu } from './MentionMenu';
 import type { MentionMenuState } from './MentionMenu/types';
+import { mentionFilledClassName } from './mentionStyle';
 import Placeholder, { type PlaceholderVariant } from './Placeholder';
 import { CHAT_INPUT_EMBED_PLUGINS, createChatInputRichPlugins } from './plugins';
 import { INSERT_REFER_TOPIC_COMMAND } from './ReferTopic';
 import { useLocalFileMention } from './useLocalFileMention';
 import { useMentionCategories } from './useMentionCategories';
 
-const className = cx(css`
-  p {
-    margin-block-end: 0;
-  }
-`);
+const className = cx(
+  css`
+    p {
+      margin-block-end: 0;
+    }
+  `,
+  mentionFilledClassName,
+);
 
 const InputEditor = memo<{
   defaultRows?: number;

--- a/src/features/ChatInput/InputEditor/mentionStyle.ts
+++ b/src/features/ChatInput/InputEditor/mentionStyle.ts
@@ -1,0 +1,10 @@
+import { css } from 'antd-style';
+
+// Override the default outlined chip style from `@lobehub/editor`'s mention
+// plugin so @-mentions render as a flat filled chip, matching the look of
+// other inline references (ActionMention, ReferTopic) in the chat UI.
+export const mentionFilledClassName = css`
+  .editor_mention {
+    border: none;
+  }
+`;

--- a/src/features/ChatInput/InputEditor/mentionStyle.ts
+++ b/src/features/ChatInput/InputEditor/mentionStyle.ts
@@ -1,10 +1,10 @@
-import { css } from 'antd-style';
+import { css, cx } from 'antd-style';
 
 // Override the default outlined chip style from `@lobehub/editor`'s mention
 // plugin so @-mentions render as a flat filled chip, matching the look of
 // other inline references (ActionMention, ReferTopic) in the chat UI.
-export const mentionFilledClassName = css`
+export const mentionFilledClassName = cx(css`
   .editor_mention {
     border: none;
   }
-`;
+`);

--- a/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
+++ b/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ActionTagNode } from '@/features/ChatInput/InputEditor/ActionTag/ActionTagNode';
+import { mentionFilledClassName } from '@/features/ChatInput/InputEditor/mentionStyle';
 import { ReferTopicNode } from '@/features/ChatInput/InputEditor/ReferTopic/ReferTopicNode';
 
 interface RichTextMessageProps {
@@ -23,7 +24,15 @@ const RichTextMessage = memo<RichTextMessageProps>(({ editorState }) => {
 
   if (!value) return null;
 
-  return <LexicalRenderer extraNodes={EXTRA_NODES} style={style} value={value} variant="chat" />;
+  return (
+    <LexicalRenderer
+      className={mentionFilledClassName}
+      extraNodes={EXTRA_NODES}
+      style={style}
+      value={value}
+      variant="chat"
+    />
+  );
 });
 
 RichTextMessage.displayName = 'RichTextMessage';

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
@@ -89,7 +89,7 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
-    isCurrentAgentHeterogeneous: () => false,
+    currentAgentHeterogeneousProviderType: () => undefined,
   },
 }));
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
@@ -29,9 +29,13 @@ const Nav = memo(() => {
   const router = useQueryRoute();
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
-  const isHeterogeneousAgent = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
+  const heterogeneousProviderType = useAgentStore(
+    agentSelectors.currentAgentHeterogeneousProviderType,
+  );
   const hideProfile = !isAgentEditable;
-  const hideChannel = hideProfile || isHeterogeneousAgent;
+  // Claude Code agents can use message channels; other hetero providers (e.g. codex) still hide it.
+  const hideChannel =
+    hideProfile || (!!heterogeneousProviderType && heterogeneousProviderType !== 'claude-code');
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
 

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/store/tool/slices/builtin/executors', () => ({
 // ─── Test Helpers ───
 
 function createMockStore() {
+  let reasoningCounter = 0;
   return {
     associateMessageWithOperation: vi.fn(),
     completeOperation: vi.fn(),
@@ -39,6 +40,13 @@ function createMockStore() {
       'op-1': { context: { agentId: 'agent-1', scope: 'session', topicId: 'topic-1' } },
     } as Record<string, any>,
     replaceMessages: vi.fn(),
+    startOperation: vi.fn(() => {
+      reasoningCounter += 1;
+      return {
+        abortController: new AbortController(),
+        operationId: `op-reasoning-${reasoningCounter}`,
+      };
+    }),
   };
 }
 
@@ -226,6 +234,131 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reasoning operation lifecycle', () => {
+    it('starts a reasoning op on the first reasoning chunk and associates it with the current assistant', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'pondering' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: '...' }));
+      await flush();
+
+      // Only one startOperation call — second chunk reuses the existing op
+      expect(store.startOperation).toHaveBeenCalledTimes(1);
+      expect(store.startOperation).toHaveBeenCalledWith({
+        context: expect.objectContaining({
+          agentId: 'agent-1',
+          messageId: 'msg-initial',
+          topicId: 'topic-1',
+        }),
+        parentOperationId: 'op-1',
+        type: 'reasoning',
+      });
+      expect(store.associateMessageWithOperation).toHaveBeenCalledWith(
+        'msg-initial',
+        'op-reasoning-1',
+      );
+      // The reasoning op is NOT completed while only reasoning chunks have arrived
+      expect(store.completeOperation).not.toHaveBeenCalled();
+    });
+
+    it('completes the reasoning op when text starts streaming', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'answer' }));
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('completes the reasoning op when tools_calling starts', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'tools_calling',
+          toolsCalling: [{ id: 'tc-1' }],
+        }),
+      );
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('starts a new reasoning op when reasoning resumes after text in the same stream', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'first pass' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'partial' }));
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'second pass' }));
+      await flush();
+
+      expect(store.startOperation).toHaveBeenCalledTimes(2);
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+      expect(store.completeOperation).not.toHaveBeenCalledWith('op-reasoning-2');
+    });
+
+    it('completes any open reasoning op on stream_end', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(makeEvent('stream_end'));
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('completes any open reasoning op on stream_start (carry-over between steps)', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-step2' } }));
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('completes any open reasoning op on agent_runtime_end', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(makeEvent('agent_runtime_end'));
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('completes any open reasoning op on error', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'reasoning', reasoning: 'thinking' }));
+      handler(makeEvent('error', { message: 'boom' }));
+      await flush();
+
+      expect(store.completeOperation).toHaveBeenCalledWith('op-reasoning-1');
+    });
+
+    it('does not start a reasoning op for text-only streams', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'hello' }));
+      handler(makeEvent('stream_end'));
+      await flush();
+
+      expect(store.startOperation).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -214,6 +214,30 @@ export const createGatewayEventHandler = (
   let accumulatedContent = '';
   let accumulatedReasoning = '';
 
+  // Active reasoning sub-op id. Mirrors the LLM `StreamingHandler` lifecycle so
+  // `isMessageInReasoning(messageId)` (which drives the Thinking UI's
+  // "thinking..." title + auto-expand) flips to `true` while thinking is
+  // streaming. Without this, heterogeneous server-mode messages render the
+  // collapsed "completed" state from the first chunk on.
+  let reasoningOperationId: string | undefined;
+
+  const startReasoningIfNeeded = () => {
+    if (reasoningOperationId) return;
+    const { operationId: reasoningOpId } = get().startOperation({
+      context: { ...context, messageId: currentAssistantMessageId },
+      parentOperationId: operationId,
+      type: 'reasoning',
+    });
+    get().associateMessageWithOperation(currentAssistantMessageId, reasoningOpId);
+    reasoningOperationId = reasoningOpId;
+  };
+
+  const endReasoningIfNeeded = () => {
+    if (!reasoningOperationId) return;
+    get().completeOperation(reasoningOperationId);
+    reasoningOperationId = undefined;
+  };
+
   // Sequential processing queue — ensures stream_chunk waits for stream_start's fetch
   let processingChain: Promise<void> = Promise.resolve();
 
@@ -241,6 +265,12 @@ export const createGatewayEventHandler = (
             // Associate the new message with the operation so UI shows generating state
             get().associateMessageWithOperation(currentAssistantMessageId, operationId);
           }
+
+          // Close any reasoning op carried over from the previous step.
+          // Safe to run after the assistant-id swap: the op was started with
+          // its own messageId context, so completion doesn't depend on the
+          // current id.
+          endReasoningIfNeeded();
 
           // Reset accumulators for the new stream
           accumulatedContent = '';
@@ -290,6 +320,9 @@ export const createGatewayEventHandler = (
           if (!data) return;
 
           if (data.chunkType === 'text' && data.content) {
+            // Text after reasoning marks the end of the thinking pass — see
+            // `StreamingHandler.handleText` for the same transition.
+            endReasoningIfNeeded();
             accumulatedContent += data.content;
             get().internal_dispatchMessage(
               {
@@ -302,6 +335,7 @@ export const createGatewayEventHandler = (
           }
 
           if (data.chunkType === 'reasoning' && data.reasoning) {
+            startReasoningIfNeeded();
             accumulatedReasoning += data.reasoning;
             get().internal_dispatchMessage(
               {
@@ -314,6 +348,7 @@ export const createGatewayEventHandler = (
           }
 
           if (data.chunkType === 'tools_calling' && data.toolsCalling) {
+            endReasoningIfNeeded();
             get().internal_dispatchMessage(
               {
                 id: currentAssistantMessageId,
@@ -348,6 +383,7 @@ export const createGatewayEventHandler = (
           // until agent_runtime_end so users don't think the session ended
           // during tool execution gaps between steps
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+          endReasoningIfNeeded();
         });
         break;
       }
@@ -443,6 +479,7 @@ export const createGatewayEventHandler = (
             sourceType: 'client.gateway.runtime_end',
           });
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+          endReasoningIfNeeded();
           get().completeOperation(operationId);
 
           const completedOp = get().operations[operationId];
@@ -472,6 +509,7 @@ export const createGatewayEventHandler = (
           });
 
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
+          endReasoningIfNeeded();
           get().completeOperation(operationId);
 
           const updateResult = await messageService


### PR DESCRIPTION
## Summary

- Replace the filled `<Tag>` chip used for slash-command / skill / tool references in `ActionTagView` with an inline **icon + colored label**, so they read like prose instead of UI badges.
- Use `SkillsIcon` (from `@lobehub/ui/icons`) for both `skill` and `projectSkill`, in `cssVar.colorSuccess` (green).
- Use `TerminalIcon` for `command`, in `cssVar.purple` (theme-aware token — replaces hard-coded `#722ED1` that read too saturated on dark BG).
- Use `WrenchIcon` for `tool`, in `cssVar.colorInfo` (blue).
- Selection outline is preserved on `.selected` so the editor's caret-selection visual still works.

| category | icon | color |
|---|---|---|
| command | Terminal | `cssVar.purple` |
| skill / projectSkill | SkillsIcon | `cssVar.colorSuccess` |
| tool | Wrench | `cssVar.colorInfo` |

The same `ActionTagView` is rendered both in the chat input editor and in the user-message renderer (`RichTextMessage`), so both surfaces update consistently.

## Test plan

- [ ] `bun run dev:spa`, type `/` in the chat input, pick a project skill (e.g. `/sync-submodule`) → tag shows `SkillsIcon` + green label, no filled chip background.
- [ ] Send the message → user bubble renders the same icon + colored label inline with the message text.
- [ ] Insert a `/compact` or `/newTopic` built-in command → terminal icon + purple label.
- [ ] Insert a tool via `@` mention → wrench icon + blue label.
- [ ] Click into the tag in the editor — the colored selection outline still appears.
- [ ] Toggle dark / light theme — colors remain legible (no hard-coded `#722ED1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)