### PR TITLE
🐛 fix(google): add magic thoughtSignature to all functionCall parts, not just last turn

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -552,7 +552,7 @@ describe('google contextBuilders', () => {
         ]);
       });
 
-      it('should add magic signature only after last user message in multi-turn scenario', async () => {
+      it('should add magic signature to all function calls in multi-turn scenario', async () => {
         const messages: OpenAIChatMessage[] = [
           {
             content: 'First question',
@@ -618,7 +618,8 @@ describe('google contextBuilders', () => {
                   args: { query: 'first' },
                   name: 'search',
                 },
-                // No magic signature for this one (before last user message)
+                // Magic signature added to all function calls (cross-provider scenario)
+                thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
               },
             ],
             role: 'model',
@@ -645,7 +646,6 @@ describe('google contextBuilders', () => {
                   args: { query: 'second' },
                   name: 'search',
                 },
-                // Magic signature added (after last user message)
                 thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
               },
             ],
@@ -665,7 +665,7 @@ describe('google contextBuilders', () => {
         ]);
       });
 
-      it('should NOT add magic signature when last message is user text message', async () => {
+      it('should add magic signature when last message is user text (cross-provider scenario)', async () => {
         const messages: OpenAIChatMessage[] = [
           {
             content: '<plugins>Web Browsing plugin available</plugins>',
@@ -724,7 +724,9 @@ describe('google contextBuilders', () => {
                   args: { query: '杭州天气', searchEngines: ['google'] },
                   name: 'lobe-web-browsing____search',
                 },
-                // No thoughtSignature should be added when last message is user text
+                // Magic signature added even when last message is user text
+                // (cross-provider scenario: OpenAI → Gemini switch)
+                thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
               },
             ],
             role: 'model',

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -248,33 +248,16 @@ export const buildGoogleMessages = async (messages: OpenAIChatMessage[]): Promis
     }
   }
 
-  // Check if the last message is a tool message
-  const lastMessage = messages.at(-1);
-  const shouldAddMagicSignature = lastMessage?.role === 'tool';
-
-  if (shouldAddMagicSignature) {
-    // Find the last user message index in filtered contents
-    let lastUserIndex = -1;
-    for (let i = filteredContents.length - 1; i >= 0; i--) {
-      if (filteredContents[i].role === 'user') {
-        // Skip if it's a functionResponse (tool result)
-        const hasFunctionResponse = filteredContents[i].parts?.some((p) => p.functionResponse);
-        if (!hasFunctionResponse) {
-          lastUserIndex = i;
-          break;
-        }
-      }
-    }
-
-    // Add magic signature to all function calls after last user message that don't have thoughtSignature
-    for (let i = lastUserIndex + 1; i < filteredContents.length; i++) {
-      const content = filteredContents[i];
-      if (content.role === 'model' && content.parts) {
-        for (const part of content.parts) {
-          if (part.functionCall && !part.thoughtSignature) {
-            // Only add magic signature if thoughtSignature doesn't exist
-            part.thoughtSignature = GEMINI_MAGIC_THOUGHT_SIGNATURE;
-          }
+  // Add magic signature to all function calls that don't have thoughtSignature.
+  // This handles cross-provider scenarios (e.g., OpenAI → Gemini switch) where
+  // historical tool_calls lack thoughtSignature, as well as multi-turn Gemini
+  // conversations where earlier turns may have lost their signatures.
+  // @see https://linear.app/lobehub/issue/LOBE-8662
+  for (const content of filteredContents) {
+    if (content.role === 'model' && content.parts) {
+      for (const part of content.parts) {
+        if (part.functionCall && !part.thoughtSignature) {
+          part.thoughtSignature = GEMINI_MAGIC_THOUGHT_SIGNATURE;
         }
       }
     }
@@ -308,26 +291,30 @@ export const sanitizeGeminiSchema = (schema: any): any => {
 
   // Strip enum from non-STRING types and empty enums
   // Gemini proto: "enum: only allowed for STRING type"
-  if (sanitized.enum !== undefined) {
-    if (!isStringType(sanitized.type) || !Array.isArray(sanitized.enum) || sanitized.enum.length === 0) {
-      console.warn(
-        '[google] sanitizeGeminiSchema stripped enum — not allowed for non-STRING type or empty',
-        { type: sanitized.type, enumLength: sanitized.enum?.length },
-      );
-      delete sanitized.enum;
-    }
+  if (
+    sanitized.enum !== undefined &&
+    (!isStringType(sanitized.type) || !Array.isArray(sanitized.enum) || sanitized.enum.length === 0)
+  ) {
+    console.warn(
+      '[google] sanitizeGeminiSchema stripped enum — not allowed for non-STRING type or empty',
+      { type: sanitized.type, enumLength: sanitized.enum?.length },
+    );
+    delete sanitized.enum;
   }
 
   // Strip required from non-OBJECT types and empty required arrays
   // Gemini proto: "required: only allowed for OBJECT type"
-  if (sanitized.required !== undefined) {
-    if (!isObjectType(sanitized.type) || !Array.isArray(sanitized.required) || sanitized.required.length === 0) {
-      console.warn(
-        '[google] sanitizeGeminiSchema stripped required — not allowed for non-OBJECT type or empty',
-        { type: sanitized.type, requiredLength: sanitized.required?.length },
-      );
-      delete sanitized.required;
-    }
+  if (
+    sanitized.required !== undefined &&
+    (!isObjectType(sanitized.type) ||
+      !Array.isArray(sanitized.required) ||
+      sanitized.required.length === 0)
+  ) {
+    console.warn(
+      '[google] sanitizeGeminiSchema stripped required — not allowed for non-OBJECT type or empty',
+      { type: sanitized.type, requiredLength: sanitized.required?.length },
+    );
+    delete sanitized.required;
   }
 
   // Recursively sanitize properties


### PR DESCRIPTION
## Summary

Fix LOBE-8662: Gemini thinking 模式下，跨 provider 切换时 functionCall 缺少 `thought_signature` 导致 API 报警。

## Root Cause

`buildGoogleMessages` 中的 magic signature 补丁逻辑有两个限制：
1. 只在 `lastMessage.role === 'tool'` 时触发
2. 只补最后一个 user message 之后的 functionCall parts

当用户从 OpenAI GPT-5 切换到 Gemini thinking 模型继续对话时，历史消息中的 `tool_calls` 没有 `thoughtSignature`（OpenAI 不产生此字段），且切换后第一条消息通常是 user 消息而非 tool 消息，导致补丁不触发。

## Fix

移除条件限制，改为对所有 `model` role 的 functionCall parts 做检查，缺少 `thoughtSignature` 就补 `GEMINI_MAGIC_THOUGHT_SIGNATURE`。

## Changes

- `packages/model-runtime/src/core/contextBuilders/google.ts`: 简化 magic signature 补丁逻辑（-27/+10）
- `packages/model-runtime/src/core/contextBuilders/google.test.ts`: 更新 2 个测试用例以反映新行为

## Test

```
 ✓ src/core/contextBuilders/google.test.ts (39 tests) 5ms
```

## Related

- LOBE-8662