### PR TITLE
[codex] Fix completed onboarding context injection

### DIFF
--- a/packages/context-engine/src/providers/OnboardingActionHintInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingActionHintInjector.ts
@@ -50,7 +50,13 @@ export class OnboardingActionHintInjector extends BaseVirtualLastUserContentProv
   }
 
   protected shouldSkip(_context: PipelineContext): boolean {
-    if (!this.config.enabled || !this.config.onboardingContext?.phaseGuidance) {
+    const { onboardingContext } = this.config;
+
+    if (
+      !this.config.enabled ||
+      onboardingContext?.finished === true ||
+      !onboardingContext?.phaseGuidance
+    ) {
       log('Disabled or no phaseGuidance configured, skipping');
       return true;
     }
@@ -59,7 +65,7 @@ export class OnboardingActionHintInjector extends BaseVirtualLastUserContentProv
 
   protected buildContent(context: PipelineContext): string | null {
     const ctx = this.config.onboardingContext;
-    if (!ctx) return null;
+    if (!ctx || ctx.finished === true) return null;
 
     const hints: string[] = [];
     const phase = ctx.phaseGuidance;

--- a/packages/context-engine/src/providers/OnboardingContextInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingContextInjector.ts
@@ -8,6 +8,8 @@ const log = debug('context-engine:provider:OnboardingContextInjector');
 export interface OnboardingContext {
   /** User messages observed after discovery began */
   discoveryUserMessageCount?: number;
+  /** Whether onboarding has already completed */
+  finished?: boolean;
   /** User persona document content (markdown) */
   personaContent?: string | null;
   /** Formatted phase guidance from getOnboardingState */
@@ -50,7 +52,13 @@ export class OnboardingContextInjector extends BaseFirstUserContentProvider {
   }
 
   protected buildContent(context: PipelineContext): string | null {
-    if (!this.config.enabled || !this.config.onboardingContext?.phaseGuidance) {
+    const { onboardingContext } = this.config;
+
+    if (
+      !this.config.enabled ||
+      onboardingContext?.finished === true ||
+      !onboardingContext?.phaseGuidance
+    ) {
       log('Disabled or no phaseGuidance configured, skipping injection');
       return null;
     }
@@ -65,7 +73,6 @@ export class OnboardingContextInjector extends BaseFirstUserContentProvider {
       return null;
     }
 
-    const { onboardingContext } = this.config;
     const parts: string[] = [onboardingContext.phaseGuidance];
 
     if (onboardingContext.soulContent) {

--- a/packages/context-engine/src/providers/OnboardingSyntheticStateInjector.ts
+++ b/packages/context-engine/src/providers/OnboardingSyntheticStateInjector.ts
@@ -35,12 +35,12 @@ export class OnboardingSyntheticStateInjector extends BaseProcessor {
   }
 
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
-    if (!this.config.enabled || !this.config.onboardingContext?.phaseGuidance) {
+    const ctx = this.config.onboardingContext;
+
+    if (!this.config.enabled || ctx?.finished === true || !ctx?.phaseGuidance) {
       log('Disabled or no phaseGuidance, skipping');
       return this.markAsExecuted(context);
     }
-
-    const ctx = this.config.onboardingContext;
 
     // Build the synthetic tool result content (mimics getOnboardingState response)
     const stateResult = this.buildStateResult(

--- a/packages/context-engine/src/providers/__tests__/OnboardingActionHintInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/OnboardingActionHintInjector.test.ts
@@ -23,6 +23,43 @@ const buildProvider = (phaseGuidance: string, context?: Partial<OnboardingContex
   });
 
 describe('OnboardingActionHintInjector', () => {
+  it('injects next actions when onboarding is active with finished=false', async () => {
+    const provider = buildProvider('Phase: User Identity. Learn the user name.', {
+      finished: false,
+    });
+
+    const result = await provider.process(
+      createContext([
+        { content: 'sys', role: 'system' },
+        { content: 'My name is Arvin', role: 'user' },
+      ]),
+    );
+
+    const last = result.messages.at(-1);
+    expect(result.messages).toHaveLength(3);
+    expect(last?.role).toBe('user');
+    expect(last?.content).toContain('<next_actions>');
+    expect(last?.content).toContain('saveUserQuestion with fullName');
+  });
+
+  it('skips next actions when onboarding is finished', async () => {
+    const provider = buildProvider('Onboarding is complete.', {
+      finished: true,
+    });
+
+    const result = await provider.process(
+      createContext([
+        { content: 'sys', role: 'system' },
+        { content: 'Unrelated follow-up', role: 'user' },
+      ]),
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.some((message) => message.content?.includes('<next_actions>'))).toBe(
+      false,
+    );
+  });
+
   describe('discovery turn reminder', () => {
     const phaseGuidance = 'Phase: Discovery. Explore the user world.';
 

--- a/packages/context-engine/src/providers/__tests__/OnboardingContextInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/OnboardingContextInjector.test.ts
@@ -15,6 +15,7 @@ describe('OnboardingContextInjector', () => {
     const provider = new OnboardingContextInjector({
       enabled: true,
       onboardingContext: {
+        finished: false,
         personaContent: '# Persona',
         phaseGuidance: '<phase>collect-profile</phase>',
         soulContent: '# SOUL',
@@ -120,5 +121,29 @@ describe('OnboardingContextInjector', () => {
 
     expect(result.messages).toHaveLength(2);
     expect(result.messages[1].content).toContain('<phase>existing</phase>');
+  });
+
+  it('should skip injection when onboarding is finished', async () => {
+    const provider = new OnboardingContextInjector({
+      enabled: true,
+      onboardingContext: {
+        finished: true,
+        personaContent: '# Persona',
+        phaseGuidance: 'Onboarding is complete.',
+        soulContent: '# SOUL',
+      },
+    });
+
+    const result = await provider.process(
+      createContext([
+        { content: 'System role', role: 'system' },
+        { content: 'Hello', role: 'user' },
+      ]),
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(
+      result.messages.some((message) => message.content?.includes('<onboarding_context>')),
+    ).toBe(false);
   });
 });

--- a/packages/context-engine/src/providers/__tests__/OnboardingSyntheticStateInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/OnboardingSyntheticStateInjector.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PipelineContext } from '../../types';
+import { OnboardingSyntheticStateInjector } from '../OnboardingSyntheticStateInjector';
+import type { OnboardingContext } from '../OnboardingContextInjector';
+
+const createContext = (messages: any[]): PipelineContext => ({
+  initialState: { messages: [] },
+  isAborted: false,
+  messages,
+  metadata: {},
+});
+
+const buildProvider = (context?: Partial<OnboardingContext>) =>
+  new OnboardingSyntheticStateInjector({
+    enabled: true,
+    onboardingContext: {
+      personaContent: '# Persona',
+      phaseGuidance: 'Phase: Discovery. Explore the user world.',
+      soulContent: '# SOUL',
+      ...context,
+    },
+  });
+
+describe('OnboardingSyntheticStateInjector', () => {
+  it.each([
+    ['finished undefined', undefined],
+    ['finished false', false],
+  ])(
+    'injects synthetic getOnboardingState pair when onboarding is active with %s',
+    async (_, finished) => {
+      const provider = buildProvider({ finished });
+
+      const result = await provider.process(
+        createContext([
+          { content: 'sys', role: 'system' },
+          { content: 'I mostly write docs', role: 'user' },
+        ]),
+      );
+
+      expect(result.messages).toHaveLength(4);
+      expect(result.messages[2].role).toBe('assistant');
+      expect(result.messages[2].tool_calls?.[0]?.function?.name).toBe(
+        'lobe-web-onboarding____getOnboardingState',
+      );
+      expect(result.messages[3].role).toBe('tool');
+      expect(result.messages[3].content).toContain('Phase: Discovery');
+      expect(result.messages[3].content).toContain('<current_soul_document>');
+      expect(result.messages[3].content).toContain('<current_user_persona>');
+    },
+  );
+
+  it('skips synthetic getOnboardingState pair when onboarding is finished', async () => {
+    const provider = buildProvider({
+      finished: true,
+      phaseGuidance: 'Onboarding is complete.',
+    });
+
+    const result = await provider.process(
+      createContext([
+        { content: 'sys', role: 'system' },
+        { content: 'Unrelated follow-up', role: 'user' },
+      ]),
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(
+      result.messages.some(
+        (message) =>
+          message.role === 'tool' ||
+          message.tool_calls?.some(
+            (toolCall: any) =>
+              toolCall?.function?.name === 'lobe-web-onboarding____getOnboardingState',
+          ),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -486,6 +486,7 @@ export const createRuntimeExecutors = (
 
             onboardingContext = {
               discoveryUserMessageCount: onboardingState.discoveryUserMessageCount,
+              finished: onboardingState.finished,
               personaContent: persona?.persona ?? null,
               phaseGuidance: formatWebOnboardingStateMessage(onboardingState),
               remainingDiscoveryExchanges: onboardingState.remainingDiscoveryExchanges,

--- a/src/server/routers/lambda/user.ts
+++ b/src/server/routers/lambda/user.ts
@@ -273,6 +273,7 @@ export const userRouter = router({
 
     return {
       discoveryUserMessageCount: state.discoveryUserMessageCount,
+      finished: state.finished,
       personaContent: persona?.persona || null,
       phaseGuidance: formatWebOnboardingStateMessage(state),
       remainingDiscoveryExchanges: state.remainingDiscoveryExchanges,

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,4 +1,4 @@
-import type { OnboardingUserInfo } from '@lobechat/context-engine';
+import type { OnboardingContext } from '@lobechat/context-engine';
 import { type MarkdownPatchHunk } from '@lobechat/markdown-patch';
 import { type PartialDeep } from 'type-fest';
 
@@ -42,12 +42,7 @@ export class UserService {
     return lambdaClient.user.getOrCreateOnboardingState.query();
   };
 
-  getOnboardingAgentContext = async (): Promise<{
-    personaContent: string | null;
-    phaseGuidance: string;
-    soulContent: string | null;
-    userInfo?: OnboardingUserInfo;
-  }> => {
+  getOnboardingAgentContext = async (): Promise<OnboardingContext> => {
     return lambdaClient.user.getOnboardingAgentContext.query();
   };
 


### PR DESCRIPTION
## Summary

Fixes #14310.

This adds the completed-onboarding state to the web onboarding context and prevents all onboarding-specific context providers from injecting guidance after onboarding is finished.

## Root Cause

`OnboardingService.getState()` reports `finished: true`, but `formatWebOnboardingStateMessage(state)` still returns a non-empty string: `Onboarding is complete.` The context pipeline only checked `enabled` and `phaseGuidance`, so later unrelated turns could still receive:

- `<onboarding_context>`
- `<next_actions>`
- synthetic assistant/tool `getOnboardingState` messages

That could incorrectly trigger onboarding-only instructions like `finishOnboarding`, `showAgentMarketplace`, or persistence calls after onboarding was already done.

## Changes

- Add `finished?: boolean` to `OnboardingContext`.
- Pass `finished: state.finished` from `getOnboardingAgentContext`.
- Pass `finished: onboardingState.finished` from the direct runtime context builder.
- Make `OnboardingContextInjector`, `OnboardingActionHintInjector`, and `OnboardingSyntheticStateInjector` skip when `onboardingContext.finished === true`.
- Add focused provider tests for active and finished onboarding behavior.

## Validation

- `pnpm --dir packages/context-engine exec vitest run --silent='passed-only' src/providers/__tests__/OnboardingContextInjector.test.ts src/providers/__tests__/OnboardingActionHintInjector.test.ts src/providers/__tests__/OnboardingSyntheticStateInjector.test.ts`
- `pnpm exec prettier --check packages/context-engine/src/providers/OnboardingActionHintInjector.ts packages/context-engine/src/providers/OnboardingContextInjector.ts packages/context-engine/src/providers/OnboardingSyntheticStateInjector.ts packages/context-engine/src/providers/__tests__/OnboardingActionHintInjector.test.ts packages/context-engine/src/providers/__tests__/OnboardingContextInjector.test.ts packages/context-engine/src/providers/__tests__/OnboardingSyntheticStateInjector.test.ts src/server/modules/AgentRuntime/RuntimeExecutors.ts src/server/routers/lambda/user.ts src/services/user/index.ts`
- `pnpm exec tsgo --noEmit`
- `git diff --check`

I also reproduced the relevant local backend state after finishing onboarding: `getOnboardingAgentContext` returns `finished: true` together with `phaseGuidance: "Onboarding is complete."`. The fix gates the injection providers on that `finished` flag, so the non-empty completion guidance no longer leaks onboarding artifacts into later turns.
