### PR TITLE
💄 style(pricing): restore DeepSeek models to official pricing

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/deepseek.ts
@@ -14,26 +14,25 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-pro',
     maxOutput: 384_000,
     pricing: {
-      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
         {
           name: 'textInput_cacheRead',
           originalRate: 0.0145,
-          rate: 0.0003625,
+          rate: 0.003625,
           strategy: 'fixed',
           unit: 'millionTokens',
         },
         {
           name: 'textInput',
           originalRate: 1.74,
-          rate: 0.0435,
+          rate: 0.435,
           strategy: 'fixed',
           unit: 'millionTokens',
         },
         {
           name: 'textOutput',
           originalRate: 3.48,
-          rate: 0.087,
+          rate: 0.87,
           strategy: 'fixed',
           unit: 'millionTokens',
         },
@@ -58,11 +57,10 @@ export const deepseekChatModels: AIChatModelCard[] = [
     id: 'deepseek-v4-flash',
     maxOutput: 384_000,
     pricing: {
-      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2026-04-24',
@@ -86,11 +84,10 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
-      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',
@@ -111,11 +108,10 @@ export const deepseekChatModels: AIChatModelCard[] = [
     legacy: true,
     maxOutput: 384_000,
     pricing: {
-      // LobeHub-hosted discount price. Official DeepSeek API pricing stays in model-bank/deepseek.
       units: [
-        { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-        { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
     releasedAt: '2025-12-01',

--- a/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/computeChatCost.test.ts
@@ -146,42 +146,42 @@ describe('computeChatPricing', () => {
     it.each([
       {
         expectedCredits: {
-          textInput: 14_000,
-          textInput_cacheRead: 280,
-          textOutput: 28_000,
+          textInput: 140_000,
+          textInput_cacheRead: 2800,
+          textOutput: 280_000,
         },
         expectedUnits: [
-          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
         ],
         modelId: 'deepseek-v4-flash',
       },
       {
         expectedCredits: {
-          textInput: 43_500,
-          textInput_cacheRead: 363,
-          textOutput: 87_000,
+          textInput: 435_000,
+          textInput_cacheRead: 3625,
+          textOutput: 870_000,
         },
         expectedUnits: [
           {
             name: 'textInput_cacheRead',
             originalRate: 0.0145,
-            rate: 0.0003625,
+            rate: 0.003625,
             strategy: 'fixed',
             unit: 'millionTokens',
           },
           {
             name: 'textInput',
             originalRate: 1.74,
-            rate: 0.0435,
+            rate: 0.435,
             strategy: 'fixed',
             unit: 'millionTokens',
           },
           {
             name: 'textOutput',
             originalRate: 3.48,
-            rate: 0.087,
+            rate: 0.87,
             strategy: 'fixed',
             unit: 'millionTokens',
           },
@@ -190,32 +190,32 @@ describe('computeChatPricing', () => {
       },
       {
         expectedCredits: {
-          textInput: 14_000,
-          textInput_cacheRead: 280,
-          textOutput: 28_000,
+          textInput: 140_000,
+          textInput_cacheRead: 2800,
+          textOutput: 280_000,
         },
         expectedUnits: [
-          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
         ],
         modelId: 'deepseek-chat',
       },
       {
         expectedCredits: {
-          textInput: 14_000,
-          textInput_cacheRead: 280,
-          textOutput: 28_000,
+          textInput: 140_000,
+          textInput_cacheRead: 2800,
+          textOutput: 280_000,
         },
         expectedUnits: [
-          { name: 'textInput_cacheRead', rate: 0.00028, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textInput', rate: 0.014, strategy: 'fixed', unit: 'millionTokens' },
-          { name: 'textOutput', rate: 0.028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput_cacheRead', rate: 0.0028, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 0.14, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
         ],
         modelId: 'deepseek-reasoner',
       },
     ])(
-      'applies 10% hosted discount pricing for $modelId',
+      'applies LobeHub-hosted official pricing for $modelId',
       ({ expectedCredits, expectedUnits, modelId }) => {
         const pricing = lobehubChatModels.find((model) => model.id === modelId)?.pricing;
         expect(pricing).toBeDefined();


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Restore the DeepSeek model pricing in `aiModels/lobehub/chat/deepseek.ts` to the [official DeepSeek API pricing](https://api-docs.deepseek.com/quick_start/pricing) (USD per 1M tokens). Previous values were 10% of the official rate.

| Model | Field | Before | After |
| --- | --- | --- | --- |
| `deepseek-v4-pro` | `textInput_cacheRead` | 0.0003625 | **0.003625** |
| `deepseek-v4-pro` | `textInput` | 0.0435 | **0.435** |
| `deepseek-v4-pro` | `textOutput` | 0.087 | **0.87** |
| `deepseek-v4-flash` | `textInput_cacheRead` | 0.00028 | **0.0028** |
| `deepseek-v4-flash` | `textInput` | 0.014 | **0.14** |
| `deepseek-v4-flash` | `textOutput` | 0.028 | **0.28** |
| `deepseek-chat` (alias) | all | mirrors v4-flash | mirrors v4-flash |
| `deepseek-reasoner` (alias) | all | mirrors v4-flash | mirrors v4-flash |

`deepseek-v4-pro` keeps its `originalRate` (0.0145 / 1.74 / 3.48) so the UI can continue to show DeepSeek's official 75%-off discount banner.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

#### 📝 Additional Information

No code/API surface change — pricing data only.