### PR TITLE
🐛 fix: wire server-side exec_task/exec_tasks for callAgent async mode

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2496,6 +2496,7 @@ export const createRuntimeExecutors = (
 
     const effectiveTaskMessageId = taskMessageId ?? parentMessageId;
 
+    let dispatched = false;
     if (ctx.execSubAgentTask && topicId && agentId) {
       try {
         await ctx.execSubAgentTask({
@@ -2508,6 +2509,7 @@ export const createRuntimeExecutors = (
           title: task.description,
           topicId,
         });
+        dispatched = true;
         log('[%s] Spawned sub-agent task for agent %s', taskLogId, targetAgentId);
       } catch (error) {
         log('[%s] Failed to spawn sub-agent task: %O', taskLogId, error);
@@ -2532,7 +2534,7 @@ export const createRuntimeExecutors = (
         payload: {
           parentMessageId: effectiveTaskMessageId,
           result: {
-            success: !!ctx.execSubAgentTask,
+            success: dispatched,
             taskMessageId: effectiveTaskMessageId,
             threadId: '',
           },
@@ -2567,6 +2569,7 @@ export const createRuntimeExecutors = (
     log('[%s] Starting batch of %d tasks', taskLogId, tasks.length);
 
     let lastTaskMessageId: string | undefined;
+    const taskResults: Array<{ success: boolean; taskMessageId: string; threadId: string }> = [];
 
     for (const task of tasks) {
       const targetAgentId = (task as any).targetAgentId ?? agentId;
@@ -2592,6 +2595,7 @@ export const createRuntimeExecutors = (
         log('[%s] Failed to create task message for "%s": %O', taskLogId, task.description, error);
       }
 
+      let taskDispatched = false;
       if (ctx.execSubAgentTask && topicId && agentId) {
         try {
           await ctx.execSubAgentTask({
@@ -2604,6 +2608,7 @@ export const createRuntimeExecutors = (
             title: task.description,
             topicId,
           });
+          taskDispatched = true;
           log(
             '[%s] Spawned sub-agent task "%s" for agent %s',
             taskLogId,
@@ -2623,6 +2628,11 @@ export const createRuntimeExecutors = (
           }
         }
       }
+      taskResults.push({
+        success: taskDispatched,
+        taskMessageId: taskMessageId ?? parentMessageId,
+        threadId: '',
+      });
     }
 
     return {
@@ -2631,7 +2641,7 @@ export const createRuntimeExecutors = (
       nextContext: {
         payload: {
           parentMessageId: lastTaskMessageId ?? parentMessageId,
-          results: tasks.map(() => ({ success: !!ctx.execSubAgentTask, threadId: '' })),
+          results: taskResults,
         },
         phase: 'sub_agents_batch_result',
         session: {

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2,8 +2,8 @@ import {
   type AgentEvent,
   type AgentInstruction,
   type AgentInstructionCompressContext,
-  type AgentInstructionExecTask,
-  type AgentInstructionExecTasks,
+  type AgentInstructionExecSubAgent,
+  type AgentInstructionExecSubAgents,
   type AgentRuntimeContext,
   type AgentState,
   type CallLLMPayload,
@@ -33,7 +33,12 @@ import {
 import { parse } from '@lobechat/conversation-flow';
 import { consumeStreamUntilDone } from '@lobechat/model-runtime';
 import { chainCompressContext } from '@lobechat/prompts';
-import { type ChatToolPayload, type MessageToolCall, type UIChatMessage } from '@lobechat/types';
+import {
+  type ChatToolPayload,
+  type ExecSubAgentTaskParams,
+  type MessageToolCall,
+  type UIChatMessage,
+} from '@lobechat/types';
 import { sanitizeToolCallArguments, serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
 
@@ -208,17 +213,6 @@ const buildToolDiscoveryConfig = (operationToolSet: OperationToolSet, enabledToo
   return { availableTools };
 };
 
-export interface ExecSubAgentTaskCallbackParams {
-  agentId: string;
-  groupId?: string;
-  instruction: string;
-  parentMessageId: string;
-  parentOperationId?: string;
-  timeout?: number;
-  title?: string;
-  topicId: string;
-}
-
 export interface RuntimeExecutorContext {
   agentConfig?: any;
   botPlatformContext?: BotPlatformContext;
@@ -226,10 +220,10 @@ export interface RuntimeExecutorContext {
   evalContext?: EvalContext;
   /**
    * Callback to spawn a sub-agent task server-side.
-   * Injected by AiAgentService so exec_task / exec_tasks executors
+   * Injected by AiAgentService so exec_sub_agent / exec_sub_agents executors
    * can dispatch callAgent-triggered tasks without a circular import.
    */
-  execSubAgentTask?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
+  execSubAgentTask?: (params: ExecSubAgentTaskParams) => Promise<unknown>;
   hookDispatcher?: HookDispatcher;
   loadAgentState?: (operationId: string) => Promise<AgentState | null>;
   messageModel: MessageModel;
@@ -1873,13 +1867,14 @@ export const createRuntimeExecutors = (
 
       log('[%s:%d] Tool execution completed', operationId, stepIndex);
 
-      // When the tool result carries an execTask / execTasks state the
+      // When the tool result carries an execSubAgent / execSubAgents state the
       // GeneralChatAgent needs `stop: true` in the payload to detect it and
-      // emit the matching exec_task / exec_tasks instruction.  Without this
-      // flag the agent falls through to the normal LLM-call path and the
-      // sub-agent task is never spawned.
+      // emit the matching exec_sub_agent / exec_sub_agents instruction.  Without
+      // this flag the agent falls through to the normal LLM-call path and the
+      // sub-agent is never spawned.
       const execTaskStateType = executionResult.state?.type as string | undefined;
-      const isExecTaskState = execTaskStateType === 'execTask' || execTaskStateType === 'execTasks';
+      const isExecTaskState =
+        execTaskStateType === 'execSubAgent' || execTaskStateType === 'execSubAgents';
 
       return {
         events,
@@ -2456,22 +2451,22 @@ export const createRuntimeExecutors = (
   },
 
   /**
-   * Server-side exec_task executor
+   * Server-side exec_sub_agent executor
    *
-   * Mirrors the client-side exec_task executor in createAgentExecutors.ts but
-   * runs entirely server-side (no polling required).  Flow:
+   * Mirrors the client-side exec_sub_agent executor in createAgentExecutors.ts
+   * but runs entirely server-side (no polling required).  Flow:
    *   1. Create a task message (role: 'task') as a placeholder visible in the UI.
    *   2. Fire execSubAgentTask via the injected callback so the sub-agent runs as
    *      an independent QStash operation.
-   *   3. Return a task_result context so GeneralChatAgent calls the LLM once more
-   *      and the parent agent can acknowledge the delegation.
+   *   3. Return a sub_agent_result context so GeneralChatAgent calls the LLM once
+   *      more and the parent agent can acknowledge the delegation.
    */
-  exec_task: async (instruction, state) => {
-    const { payload } = instruction as AgentInstructionExecTask;
+  exec_sub_agent: async (instruction, state) => {
+    const { payload } = instruction as AgentInstructionExecSubAgent;
     const { parentMessageId, task } = payload;
     const events: AgentEvent[] = [];
     const { operationId } = ctx;
-    const taskLogId = `${operationId}:exec_task`;
+    const taskLogId = `${operationId}:exec_sub_agent`;
 
     const topicId = ctx.topicId ?? state.metadata?.topicId;
     const agentId = state.metadata?.agentId;
@@ -2542,29 +2537,29 @@ export const createRuntimeExecutors = (
             threadId: '',
           },
         },
-        phase: 'task_result',
+        phase: 'sub_agent_result',
         session: {
           messageCount: state.messages.length,
           sessionId: operationId,
           status: 'running',
           stepCount: state.stepCount + 1,
         },
-      } as AgentRuntimeContext,
+      } as unknown as AgentRuntimeContext,
     };
   },
 
   /**
-   * Server-side exec_tasks executor
+   * Server-side exec_sub_agents executor
    *
-   * Same as exec_task but for a batch of tasks.  Each task is fired
+   * Same as exec_sub_agent but for a batch.  Each sub-agent is fired
    * independently via execSubAgentTask and a task message is created for each.
    */
-  exec_tasks: async (instruction, state) => {
-    const { payload } = instruction as AgentInstructionExecTasks;
+  exec_sub_agents: async (instruction, state) => {
+    const { payload } = instruction as AgentInstructionExecSubAgents;
     const { parentMessageId, tasks } = payload;
     const events: AgentEvent[] = [];
     const { operationId } = ctx;
-    const taskLogId = `${operationId}:exec_tasks`;
+    const taskLogId = `${operationId}:exec_sub_agents`;
 
     const topicId = ctx.topicId ?? state.metadata?.topicId;
     const agentId = state.metadata?.agentId;
@@ -2638,14 +2633,14 @@ export const createRuntimeExecutors = (
           parentMessageId: lastTaskMessageId ?? parentMessageId,
           results: tasks.map(() => ({ success: !!ctx.execSubAgentTask, threadId: '' })),
         },
-        phase: 'tasks_batch_result',
+        phase: 'sub_agents_batch_result',
         session: {
           messageCount: state.messages.length,
           sessionId: operationId,
           status: 'running',
           stepCount: state.stepCount + 1,
         },
-      } as AgentRuntimeContext,
+      } as unknown as AgentRuntimeContext,
     };
   },
 

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2,6 +2,9 @@ import {
   type AgentEvent,
   type AgentInstruction,
   type AgentInstructionCompressContext,
+  type AgentInstructionExecTask,
+  type AgentInstructionExecTasks,
+  type AgentRuntimeContext,
   type AgentState,
   type CallLLMPayload,
   type GeneralAgentCallLLMResultPayload,
@@ -205,11 +208,28 @@ const buildToolDiscoveryConfig = (operationToolSet: OperationToolSet, enabledToo
   return { availableTools };
 };
 
+export interface ExecSubAgentTaskCallbackParams {
+  agentId: string;
+  groupId?: string;
+  instruction: string;
+  parentMessageId: string;
+  parentOperationId?: string;
+  timeout?: number;
+  title?: string;
+  topicId: string;
+}
+
 export interface RuntimeExecutorContext {
   agentConfig?: any;
   botPlatformContext?: BotPlatformContext;
   discordContext?: any;
   evalContext?: EvalContext;
+  /**
+   * Callback to spawn a sub-agent task server-side.
+   * Injected by AiAgentService so exec_task / exec_tasks executors
+   * can dispatch callAgent-triggered tasks without a circular import.
+   */
+  execSubAgentTask?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
   hookDispatcher?: HookDispatcher;
   loadAgentState?: (operationId: string) => Promise<AgentState | null>;
   messageModel: MessageModel;
@@ -1853,6 +1873,14 @@ export const createRuntimeExecutors = (
 
       log('[%s:%d] Tool execution completed', operationId, stepIndex);
 
+      // When the tool result carries an execTask / execTasks state the
+      // GeneralChatAgent needs `stop: true` in the payload to detect it and
+      // emit the matching exec_task / exec_tasks instruction.  Without this
+      // flag the agent falls through to the normal LLM-call path and the
+      // sub-agent task is never spawned.
+      const execTaskStateType = executionResult.state?.type as string | undefined;
+      const isExecTaskState = execTaskStateType === 'execTask' || execTaskStateType === 'execTasks';
+
       return {
         events,
         newState,
@@ -1863,6 +1891,7 @@ export const createRuntimeExecutors = (
             isSuccess,
             // Pass tool message ID as parentMessageId for the next LLM call
             parentMessageId: toolMessageId,
+            ...(isExecTaskState && { stop: true }),
             toolCall: chatToolPayload,
             toolCallId: chatToolPayload.id,
           },
@@ -2423,6 +2452,200 @@ export const createRuntimeExecutors = (
           stepCount: state.stepCount + 1,
         },
       },
+    };
+  },
+
+  /**
+   * Server-side exec_task executor
+   *
+   * Mirrors the client-side exec_task executor in createAgentExecutors.ts but
+   * runs entirely server-side (no polling required).  Flow:
+   *   1. Create a task message (role: 'task') as a placeholder visible in the UI.
+   *   2. Fire execSubAgentTask via the injected callback so the sub-agent runs as
+   *      an independent QStash operation.
+   *   3. Return a task_result context so GeneralChatAgent calls the LLM once more
+   *      and the parent agent can acknowledge the delegation.
+   */
+  exec_task: async (instruction, state) => {
+    const { payload } = instruction as AgentInstructionExecTask;
+    const { parentMessageId, task } = payload;
+    const events: AgentEvent[] = [];
+    const { operationId } = ctx;
+    const taskLogId = `${operationId}:exec_task`;
+
+    const topicId = ctx.topicId ?? state.metadata?.topicId;
+    const agentId = state.metadata?.agentId;
+    // targetAgentId is a cloud extension injected by agentManagement.callAgent
+    const targetAgentId = (task as any).targetAgentId ?? agentId;
+
+    let taskMessageId: string | undefined;
+    try {
+      const taskMessage = await ctx.messageModel.create({
+        agentId: agentId!,
+        content: '',
+        metadata: {
+          instruction: task.instruction,
+          taskTitle: task.description,
+          ...(targetAgentId && targetAgentId !== agentId && { targetAgentId }),
+        },
+        parentId: parentMessageId,
+        role: 'task',
+        threadId: state.metadata?.threadId ?? undefined,
+        topicId: topicId!,
+      });
+      taskMessageId = taskMessage.id;
+      log('[%s] Created task message: %s', taskLogId, taskMessageId);
+    } catch (error) {
+      log('[%s] Failed to create task message: %O', taskLogId, error);
+    }
+
+    const effectiveTaskMessageId = taskMessageId ?? parentMessageId;
+
+    if (ctx.execSubAgentTask && topicId && agentId) {
+      try {
+        await ctx.execSubAgentTask({
+          agentId: targetAgentId,
+          groupId: state.metadata?.groupId ?? undefined,
+          instruction: task.instruction,
+          parentMessageId: effectiveTaskMessageId,
+          parentOperationId: operationId,
+          timeout: task.timeout,
+          title: task.description,
+          topicId,
+        });
+        log('[%s] Spawned sub-agent task for agent %s', taskLogId, targetAgentId);
+      } catch (error) {
+        log('[%s] Failed to spawn sub-agent task: %O', taskLogId, error);
+        if (taskMessageId) {
+          try {
+            await ctx.messageModel.update(taskMessageId, {
+              content: `Task failed to start: ${(error as Error).message}`,
+            });
+          } catch {
+            // best-effort
+          }
+        }
+      }
+    } else {
+      log('[%s] execSubAgentTask not available, skipping sub-agent dispatch', taskLogId);
+    }
+
+    return {
+      events,
+      newState: state,
+      nextContext: {
+        payload: {
+          parentMessageId: effectiveTaskMessageId,
+          result: {
+            success: !!ctx.execSubAgentTask,
+            taskMessageId: effectiveTaskMessageId,
+            threadId: '',
+          },
+        },
+        phase: 'task_result',
+        session: {
+          messageCount: state.messages.length,
+          sessionId: operationId,
+          status: 'running',
+          stepCount: state.stepCount + 1,
+        },
+      } as AgentRuntimeContext,
+    };
+  },
+
+  /**
+   * Server-side exec_tasks executor
+   *
+   * Same as exec_task but for a batch of tasks.  Each task is fired
+   * independently via execSubAgentTask and a task message is created for each.
+   */
+  exec_tasks: async (instruction, state) => {
+    const { payload } = instruction as AgentInstructionExecTasks;
+    const { parentMessageId, tasks } = payload;
+    const events: AgentEvent[] = [];
+    const { operationId } = ctx;
+    const taskLogId = `${operationId}:exec_tasks`;
+
+    const topicId = ctx.topicId ?? state.metadata?.topicId;
+    const agentId = state.metadata?.agentId;
+
+    log('[%s] Starting batch of %d tasks', taskLogId, tasks.length);
+
+    let lastTaskMessageId: string | undefined;
+
+    for (const task of tasks) {
+      const targetAgentId = (task as any).targetAgentId ?? agentId;
+      let taskMessageId: string | undefined;
+
+      try {
+        const taskMessage = await ctx.messageModel.create({
+          agentId: agentId!,
+          content: '',
+          metadata: {
+            instruction: task.instruction,
+            taskTitle: task.description,
+            ...(targetAgentId && targetAgentId !== agentId && { targetAgentId }),
+          },
+          parentId: parentMessageId,
+          role: 'task',
+          threadId: state.metadata?.threadId ?? undefined,
+          topicId: topicId!,
+        });
+        taskMessageId = taskMessage.id;
+        lastTaskMessageId = taskMessageId;
+      } catch (error) {
+        log('[%s] Failed to create task message for "%s": %O', taskLogId, task.description, error);
+      }
+
+      if (ctx.execSubAgentTask && topicId && agentId) {
+        try {
+          await ctx.execSubAgentTask({
+            agentId: targetAgentId,
+            groupId: state.metadata?.groupId ?? undefined,
+            instruction: task.instruction,
+            parentMessageId: taskMessageId ?? parentMessageId,
+            parentOperationId: operationId,
+            timeout: task.timeout,
+            title: task.description,
+            topicId,
+          });
+          log(
+            '[%s] Spawned sub-agent task "%s" for agent %s',
+            taskLogId,
+            task.description,
+            targetAgentId,
+          );
+        } catch (error) {
+          log('[%s] Failed to spawn task "%s": %O', taskLogId, task.description, error);
+          if (taskMessageId) {
+            try {
+              await ctx.messageModel.update(taskMessageId, {
+                content: `Task failed to start: ${(error as Error).message}`,
+              });
+            } catch {
+              // best-effort
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      events,
+      newState: state,
+      nextContext: {
+        payload: {
+          parentMessageId: lastTaskMessageId ?? parentMessageId,
+          results: tasks.map(() => ({ success: !!ctx.execSubAgentTask, threadId: '' })),
+        },
+        phase: 'tasks_batch_result',
+        session: {
+          messageCount: state.messages.length,
+          sessionId: operationId,
+          status: 'running',
+          stepCount: state.stepCount + 1,
+        },
+      } as AgentRuntimeContext,
     };
   },
 

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -3826,4 +3826,147 @@ describe('RuntimeExecutors', () => {
       });
     });
   });
+
+  // ─── callAgent server-side exec_sub_agent fix ──────────────────────────────
+  describe('call_tool → exec_sub_agent (callAgent async mode)', () => {
+    const createMockState = (overrides?: Partial<AgentState>): AgentState => ({
+      cost: createMockCost(),
+      createdAt: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+      maxSteps: 100,
+      messages: [],
+      metadata: {
+        agentId: 'parent-agent-id',
+        topicId: 'topic-123',
+      },
+      modelRuntimeConfig: { model: 'gpt-4', provider: 'openai' },
+      operationId: 'op-123',
+      status: 'running',
+      stepCount: 0,
+      toolManifestMap: {},
+      usage: createMockUsage(),
+      ...overrides,
+    });
+
+    it('call_tool sets stop:true in tool_result payload when tool returns execSubAgent state', async () => {
+      // Simulate agentManagement.callAgent returning execSubAgent state
+      mockToolExecutionService.executeTool.mockResolvedValue({
+        content: '🚀 Triggered async task to call agent "target-agent"',
+        executionTime: 10,
+        state: {
+          parentMessageId: 'tool-msg-id',
+          task: {
+            description: 'Call agent target-agent',
+            instruction: 'Do something',
+            targetAgentId: 'target-agent-id',
+            timeout: 1_800_000,
+          },
+          type: 'execSubAgent',
+        },
+        success: true,
+      });
+
+      const executors = createRuntimeExecutors(ctx);
+      const state = createMockState();
+      const instruction = {
+        payload: {
+          parentMessageId: 'assistant-msg-id',
+          toolCalling: {
+            apiName: 'callAgent',
+            arguments: JSON.stringify({
+              agentId: 'target-agent-id',
+              instruction: 'Do something',
+              runAsTask: true,
+            }),
+            id: 'tool-call-1',
+            identifier: 'lobe-agent-management',
+            type: 'default',
+          },
+        },
+        type: 'call_tool' as const,
+      };
+
+      const result = await executors.call_tool!(instruction, state);
+
+      expect(result.nextContext?.phase).toBe('tool_result');
+      expect((result.nextContext?.payload as any).stop).toBe(true);
+    });
+
+    it('exec_sub_agent executor creates task message and calls execSubAgentTask callback', async () => {
+      const mockExecSubAgentTask = vi
+        .fn()
+        .mockResolvedValue({ success: true, operationId: 'child-op', threadId: 'thread-child' });
+      const ctxWithCallback = {
+        ...ctx,
+        execSubAgentTask: mockExecSubAgentTask,
+        topicId: 'topic-123',
+      };
+
+      const executors = createRuntimeExecutors(ctxWithCallback);
+      const state = createMockState();
+
+      const instruction = {
+        payload: {
+          parentMessageId: 'tool-msg-id',
+          task: {
+            description: 'Call agent target-agent',
+            instruction: 'Do something useful',
+            targetAgentId: 'target-agent-id',
+            timeout: 1_800_000,
+          },
+        },
+        type: 'exec_sub_agent' as const,
+      };
+
+      const result = await executors.exec_sub_agent!(instruction as any, state);
+
+      // Task message created with role:'task'
+      expect(mockMessageModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'parent-agent-id',
+          role: 'task',
+          parentId: 'tool-msg-id',
+          topicId: 'topic-123',
+        }),
+      );
+
+      // execSubAgentTask callback fired with targetAgentId
+      expect(mockExecSubAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'target-agent-id',
+          instruction: 'Do something useful',
+          topicId: 'topic-123',
+          parentOperationId: 'op-123',
+        }),
+      );
+
+      // Returns sub_agent_result so GeneralChatAgent continues with LLM call
+      expect(result.nextContext?.phase).toBe('sub_agent_result');
+    });
+
+    it('exec_sub_agent gracefully skips dispatch when execSubAgentTask not injected', async () => {
+      // No callback injected (e.g. in tests that don't set it up)
+      const executors = createRuntimeExecutors(ctx);
+      const state = createMockState();
+
+      const instruction = {
+        payload: {
+          parentMessageId: 'tool-msg-id',
+          task: {
+            description: 'Call agent target-agent',
+            instruction: 'Do something',
+            targetAgentId: 'target-agent-id',
+          },
+        },
+        type: 'exec_sub_agent' as const,
+      };
+
+      const result = await executors.exec_sub_agent!(instruction as any, state);
+
+      // Should still return sub_agent_result (not crash)
+      expect(result.nextContext?.phase).toBe('sub_agent_result');
+      // Task message still created for UI
+      expect(mockMessageModel.create).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -3880,7 +3880,7 @@ describe('RuntimeExecutors', () => {
             }),
             id: 'tool-call-1',
             identifier: 'lobe-agent-management',
-            type: 'default',
+            type: 'default' as const,
           },
         },
         type: 'call_tool' as const,

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -8,7 +8,12 @@ import { AgentRuntime, findInMessages, GeneralChatAgent } from '@lobechat/agent-
 import type { ISnapshotStore } from '@lobechat/agent-tracing';
 import { dynamicInterventionAudits } from '@lobechat/builtin-tools/dynamicInterventionAudits';
 import { getModelPropertyWithFallback } from '@lobechat/model-runtime';
-import { AgentRuntimeErrorType, ChatErrorType, type ChatMessageError } from '@lobechat/types';
+import {
+  AgentRuntimeErrorType,
+  ChatErrorType,
+  type ChatMessageError,
+  type ExecSubAgentTaskParams,
+} from '@lobechat/types';
 import debug from 'debug';
 import urlJoin from 'url-join';
 
@@ -19,7 +24,6 @@ import { type AgentRuntimeCoordinatorOptions } from '@/server/modules/AgentRunti
 import { AgentRuntimeCoordinator, createStreamEventManager } from '@/server/modules/AgentRuntime';
 import {
   createRuntimeExecutors,
-  type ExecSubAgentTaskCallbackParams,
   type RuntimeExecutorContext,
 } from '@/server/modules/AgentRuntime/RuntimeExecutors';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
@@ -124,7 +128,7 @@ export interface AgentRuntimeServiceOptions {
    * Injected by AiAgentService to wire up the exec_task / exec_tasks executors
    * without creating a circular import between RuntimeExecutors and AiAgentService.
    */
-  execSubAgentTask?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
+  execSubAgentTask?: (params: ExecSubAgentTaskParams) => Promise<unknown>;
   /**
    * Custom QueueService
    * Set to null to disable queue scheduling (for synchronous execution tests)
@@ -164,7 +168,7 @@ export class AgentRuntimeService {
   private agentFactory?: (config: GeneralAgentConfig) => Agent;
   private completionLifecycle: CompletionLifecycle;
   private coordinator: AgentRuntimeCoordinator;
-  private execSubAgentTaskCallback?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
+  private execSubAgentTaskCallback?: (params: ExecSubAgentTaskParams) => Promise<unknown>;
   private humanIntervention: HumanInterventionHandler;
   private streamManager: IStreamEventManager;
   private queueService: QueueService | null;

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -17,8 +17,11 @@ import { type LobeChatDatabase } from '@/database/type';
 import { appEnv } from '@/envs/app';
 import { type AgentRuntimeCoordinatorOptions } from '@/server/modules/AgentRuntime';
 import { AgentRuntimeCoordinator, createStreamEventManager } from '@/server/modules/AgentRuntime';
-import { type RuntimeExecutorContext } from '@/server/modules/AgentRuntime/RuntimeExecutors';
-import { createRuntimeExecutors } from '@/server/modules/AgentRuntime/RuntimeExecutors';
+import {
+  createRuntimeExecutors,
+  type ExecSubAgentTaskCallbackParams,
+  type RuntimeExecutorContext,
+} from '@/server/modules/AgentRuntime/RuntimeExecutors';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
 import { emitAgentSignalSourceEvent } from '@/server/services/agentSignal';
 import { toAgentSignalTraceEvents } from '@/server/services/agentSignal/observability/traceEvents';
@@ -117,6 +120,12 @@ export interface AgentRuntimeServiceOptions {
    */
   coordinatorOptions?: AgentRuntimeCoordinatorOptions;
   /**
+   * Callback to spawn a sub-agent task from within a running server-side agent.
+   * Injected by AiAgentService to wire up the exec_task / exec_tasks executors
+   * without creating a circular import between RuntimeExecutors and AiAgentService.
+   */
+  execSubAgentTask?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
+  /**
    * Custom QueueService
    * Set to null to disable queue scheduling (for synchronous execution tests)
    */
@@ -155,6 +164,7 @@ export class AgentRuntimeService {
   private agentFactory?: (config: GeneralAgentConfig) => Agent;
   private completionLifecycle: CompletionLifecycle;
   private coordinator: AgentRuntimeCoordinator;
+  private execSubAgentTaskCallback?: (params: ExecSubAgentTaskCallbackParams) => Promise<void>;
   private humanIntervention: HumanInterventionHandler;
   private streamManager: IStreamEventManager;
   private queueService: QueueService | null;
@@ -185,6 +195,7 @@ export class AgentRuntimeService {
       options?.snapshotStore ?? this.createDefaultSnapshotStore(),
     );
     this.agentFactory = options?.agentFactory;
+    this.execSubAgentTaskCallback = options?.execSubAgentTask;
     this.serverDB = db;
     this.userId = userId;
     this.messageModel = new MessageModel(db, this.userId);
@@ -1360,6 +1371,7 @@ export class AgentRuntimeService {
       discordContext: metadata?.discordContext,
       userTimezone: metadata?.userTimezone,
       evalContext: metadata?.evalContext,
+      execSubAgentTask: this.execSubAgentTaskCallback,
       hookDispatcher,
       loadAgentState: this.coordinator.loadAgentState.bind(this.coordinator),
       messageModel: this.messageModel,

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -263,7 +263,12 @@ export class AiAgentService {
     this.taskModel = new TaskModel(db, userId);
     this.threadModel = new ThreadModel(db, userId);
     this.topicModel = new TopicModel(db, userId);
-    this.agentRuntimeService = new AgentRuntimeService(db, userId, options?.runtimeOptions);
+    this.agentRuntimeService = new AgentRuntimeService(db, userId, {
+      ...options?.runtimeOptions,
+      execSubAgentTask: async (params) => {
+        await this.execSubAgentTask(params);
+      },
+    });
     this.marketService = new MarketService({ userInfo: { userId } });
     this.klavisService = new KlavisService({ db, userId });
   }

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -265,9 +265,7 @@ export class AiAgentService {
     this.topicModel = new TopicModel(db, userId);
     this.agentRuntimeService = new AgentRuntimeService(db, userId, {
       ...options?.runtimeOptions,
-      execSubAgentTask: async (params) => {
-        await this.execSubAgentTask(params);
-      },
+      execSubAgentTask: this.execSubAgentTask.bind(this),
     });
     this.marketService = new MarketService({ userInfo: { userId } });
     this.klavisService = new KlavisService({ db, userId });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracking issue yet -->

#### 🔀 Description of Change

When a parent agent runs as a **server-side QStash task** and calls `lobe-agent-management.callAgent(agentId, { runAsTask: true })`, the sub-agent was silently never spawned.

**Root cause — three missing links:**

1. **`RuntimeExecutors.ts` `call_tool`** did not set `stop: true` in the `tool_result` payload when the tool returned an `execTask`/`execTasks` state, so `GeneralChatAgent` fell through to the normal LLM-call path instead of emitting an `exec_task` instruction.

2. **No `exec_task` / `exec_tasks` executor** existed in `RuntimeExecutors.ts`, so even if the instruction had been emitted the runtime would have thrown `No executor found for instruction type: exec_task`.

3. **`AiAgentService` did not inject an `execSubAgentTask` callback** into `AgentRuntimeService`, so the executors had no way to spawn the child operation (direct import would create a circular dep).

**Fix:**

- Detect `execTask` / `execTasks` state type in `call_tool` and forward `stop: true` so `GeneralChatAgent` routes correctly.
- Add server-side `exec_task` and `exec_tasks` executors that create a task message and fire `execSubAgentTask` via an injected callback, then return a `task_result` / `tasks_batch_result` context so the parent agent can do a final LLM summary call.
- Extend `AgentRuntimeServiceOptions` with `execSubAgentTask` callback and propagate it through the executor context.
- Wire `this.execSubAgentTask` into `AgentRuntimeService` from `AiAgentService` constructor.

**New complete path (server-side parent → `callAgent` → sub-agent actually dispatched):**

```
agentManagement.callAgent
  → tool returns execTask state
  → call_tool adds stop: true
  → GeneralChatAgent emits exec_task instruction
  → server-side exec_task executor creates task message
  → calls execSubAgentTask → spawns sub-agent QStash job
  → returns task_result → parent agent does final LLM summary
```

#### 🧪 How to Test

- Configure an agent that uses `lobe-agent-management` and calls `callAgent` with `runAsTask: true` targeting another agent
- Run that parent agent as a server-side task (not from browser client)
- Verify the sub-agent task is spawned and a task message appears in the conversation

- [ ] Tested locally
- [ ] No tests needed (integration path requires full QStash setup)