### PR TITLE
🐛 fix(portal): make markdown preview scrollable in LocalFile portal

### DIFF
--- a/src/features/Portal/LocalFile/Body.tsx
+++ b/src/features/Portal/LocalFile/Body.tsx
@@ -235,7 +235,7 @@ const TextPreviewPane = memo<TextPreviewPaneProps>(
             <span style={{ fontSize: 12, opacity: 0.65 }}>{truncatedLabel}</span>
           </Center>
         )}
-        <Flexbox flex={1} style={{ minHeight: 0, overflow: 'auto' }}>
+        <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
           {isMarkdown && mode === 'render' ? (
             <>
               <SkillFrontmatterPreviewCard metadata={frontmatterMetadata} />
@@ -249,7 +249,7 @@ const TextPreviewPane = memo<TextPreviewPaneProps>(
               {content}
             </Highlighter>
           )}
-        </Flexbox>
+        </div>
       </Flexbox>
     );
   },


### PR DESCRIPTION
## Summary

- The Hetero Agent right-side Portal's `LocalFile` markdown preview (the panel that opens when clicking a skill in the Space tab) couldn't be scrolled vertically — long `SKILL.md` bodies were cut off with no scrollbar.
- Root cause: the inner scroll wrapper in `TextPreviewPane` (`src/features/Portal/LocalFile/Body.tsx`) was a `<Flexbox>` (column flex). That made the `SkillFrontmatterPreviewCard` and the `Markdown` `<article>` flex items. With the card pinned at `flexShrink: 0` and the article subject to default flex-shrink, content got constrained inside the container instead of overflowing it, so `overflow: auto` never engaged.
- Fix: switch the wrapper to a plain `<div>` so children flow as normal block elements and the container overflows naturally, triggering the scrollbar.

The Raw / `Highlighter` branch was unaffected because it had `minHeight: '100%'` forcing it tall.

## Test plan

- [ ] Open a Hetero Agent session → right Space tab → click a long skill (e.g. `version-release`) → verify the middle markdown preview scrolls to the end of the doc
- [ ] Toggle to **Raw** mode on the same file → confirm scrolling still works (no regression on the Highlighter path)
- [ ] Open a short skill (1–2 paragraphs) → confirm no spurious scrollbar appears
- [ ] Open a non-markdown text file (e.g. `.ts`) → confirm raw preview still scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)