### PR TITLE
🐛 fix(agent-signal): isolate memory-agent messages into a child thread

### DIFF
--- a/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
+++ b/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
@@ -11,10 +11,11 @@ import {
   createAgentSignalMemoryWriterPrompt,
   createAgentSignalMemoryWriterSystemRole,
 } from '@lobechat/prompts';
-import { LayersEnum, RequestTrigger } from '@lobechat/types';
+import { LayersEnum, RequestTrigger, ThreadType } from '@lobechat/types';
 import { nanoid } from '@lobechat/utils';
 
 import { PluginModel } from '@/database/models/plugin';
+import { ThreadModel } from '@/database/models/thread';
 import type { LobeChatDatabase } from '@/database/type';
 import {
   InMemoryAgentStateManager,
@@ -98,6 +99,7 @@ export interface UserMemoryActionHandlerOptions {
     reason?: string;
     serializedContext?: string;
     sourceHints?: AgentSignalFeedbackSourceHints;
+    sourceMessageId?: string;
     topicId?: string;
   }) => Promise<MemoryAgentActionResult>;
   pluginModel?: Pick<PluginModel, 'query'>;
@@ -378,6 +380,13 @@ export const runMemoryActionAgent = async (
     reason?: string;
     serializedContext?: string;
     sourceHints?: AgentSignalFeedbackSourceHints;
+    /**
+     * The assistant message id that triggered this memory action.
+     * When provided together with topicId, a child thread is created
+     * under this message so that memory-agent messages are isolated
+     * from the main topic conversation.
+     */
+    sourceMessageId?: string;
     topicId?: string;
   },
   options: UserMemoryActionHandlerOptions,
@@ -458,11 +467,34 @@ export const runMemoryActionAgent = async (
     streamEventManager,
   });
 
+  // Create a child thread under the triggering assistant message so that
+  // memory-agent messages are isolated from the main topic conversation
+  // instead of being flattened into it.
+  let threadId: string | undefined;
+  if (input.topicId && input.sourceMessageId) {
+    try {
+      const threadModel = new ThreadModel(options.db, options.userId);
+      const thread = await threadModel.create({
+        agentId: input.agentId,
+        metadata: { operationId },
+        sourceMessageId: input.sourceMessageId,
+        title: 'Agent Signal Memory',
+        topicId: input.topicId,
+        type: ThreadType.Isolation,
+      });
+      threadId = thread?.id;
+    } catch {
+      // Non-fatal: fall back to writing into the main topic if thread creation fails.
+    }
+  }
+
   await runtimeService.createOperation({
     agentConfig: memoryRuntimeAgentConfig,
     appContext: {
       agentId: input.agentId,
       scope: 'chat',
+      sourceMessageId: input.sourceMessageId,
+      threadId: threadId ?? null,
       topicId: input.topicId ?? null,
       trigger: RequestTrigger.AgentSignal,
     },
@@ -589,6 +621,14 @@ export const handleUserMemoryAction = async (
         typeof action.payload.sourceHints === 'object' && action.payload.sourceHints
           ? action.payload.sourceHints
           : undefined,
+      // The assistant message that triggered this signal — used to anchor the
+      // memory-agent thread under that message rather than the main topic.
+      sourceMessageId:
+        typeof action.payload.assistantMessageId === 'string'
+          ? action.payload.assistantMessageId
+          : typeof action.payload.messageId === 'string'
+            ? action.payload.messageId
+            : undefined,
       topicId: typeof action.payload.topicId === 'string' ? action.payload.topicId : undefined,
     };
     const runner = options.memoryActionRunner ?? ((input) => runMemoryActionAgent(input, options));

--- a/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
+++ b/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
@@ -621,14 +621,14 @@ export const handleUserMemoryAction = async (
         typeof action.payload.sourceHints === 'object' && action.payload.sourceHints
           ? action.payload.sourceHints
           : undefined,
-      // The assistant message that triggered this signal — used to anchor the
-      // memory-agent thread under that message rather than the main topic.
+      // The assistant message that completed the turn — used to anchor the
+      // memory-agent child thread under that message instead of the main topic.
+      // Populated by planUserMemory via extractAssistantMessageIdFromSourceId;
+      // absent for non-clientRuntimeComplete sources where no assistant boundary exists.
       sourceMessageId:
         typeof action.payload.assistantMessageId === 'string'
           ? action.payload.assistantMessageId
-          : typeof action.payload.messageId === 'string'
-            ? action.payload.messageId
-            : undefined,
+          : undefined,
       topicId: typeof action.payload.topicId === 'string' ? action.payload.topicId : undefined,
     };
     const runner = options.memoryActionRunner ?? ((input) => runMemoryActionAgent(input, options));

--- a/src/server/services/agentSignal/processors/actions.ts
+++ b/src/server/services/agentSignal/processors/actions.ts
@@ -15,6 +15,25 @@ interface SourcePayloadCarrier {
 }
 
 /**
+ * Extracts the assistant message id embedded in a hydrated `clientRuntimeComplete` source id.
+ *
+ * Hydration produces source ids with the format:
+ *   `${assistantMessageId}:completion:${parentMessageId}`
+ *
+ * For all other source types the source id does not follow this pattern, so undefined is returned.
+ */
+const extractAssistantMessageIdFromSourceId = (
+  sourceId: string | undefined,
+): string | undefined => {
+  if (!sourceId) return undefined;
+  const completionMarker = ':completion:';
+  const idx = sourceId.indexOf(completionMarker);
+  if (idx === -1) return undefined;
+  const candidate = sourceId.slice(0, idx);
+  return candidate.length > 0 ? candidate : undefined;
+};
+
+/**
  * Skill-domain feedback signal that is eligible for direct skill-management action planning.
  */
 export type DirectSkillFeedbackDomainSignal = SignalFeedbackDomainSkill & {
@@ -64,6 +83,10 @@ export const planUserMemory = (signal: SignalFeedbackDomainMemory): ActionUserMe
     },
     payload: {
       agentId: payload.agentId,
+      // Propagate the assistant message id so that the memory-agent thread
+      // can be anchored under the assistant message that completed the turn,
+      // rather than under the user message (messageId).
+      assistantMessageId: extractAssistantMessageIdFromSourceId(signal.source?.sourceId),
       conflictPolicy: payload.conflictPolicy,
       evidence: payload.evidence,
       feedbackHint: payload.satisfactionResult === 'satisfied' ? 'satisfied' : 'not_satisfied',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

Memory-agent messages generated by `runMemoryActionAgent` were being written directly into the triggering topic, polluting the main conversation timeline.

**Root cause:** `createOperation`'s `appContext` only carried `topicId` — no `threadId` or `sourceMessageId` — so `RuntimeExecutors.messageModel.create()` flattened every message into the main topic.

**Fix:**
- Add optional `sourceMessageId` to `runMemoryActionAgent` input and `memoryActionRunner` interface
- Before `createOperation`, when both `topicId` and `sourceMessageId` are present, create a `ThreadType.Isolation` child thread anchored to the triggering assistant message via `ThreadModel.create()`
- Pass `threadId` + `sourceMessageId` through `appContext` so RuntimeExecutors stamps every persisted message with the correct thread scope
- In `handleUserMemoryAction`, extract `assistantMessageId` (fallback `messageId`) from action payload and forward it as `sourceMessageId`
- Thread creation is non-fatal: failures fall back to existing behaviour (write into main topic)

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a memory-write signal and confirm that the resulting messages appear as a child thread under the assistant message rather than as top-level messages in the topic.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Memory-agent messages appear inline in the main topic | Memory-agent messages are isolated in a child thread under the triggering assistant message |

#### 📝 Additional Information

Only  is touched (41-line change).