### PR TITLE
🐛 fix(desktop): restore route after update restart

### DIFF
--- a/apps/desktop/src/main/const/store.ts
+++ b/apps/desktop/src/main/const/store.ts
@@ -37,6 +37,7 @@ export const STORE_DEFAULTS: ElectronMainStore = {
   locale: 'auto',
   localFileWorkspaceRoots: [],
   networkProxy: defaultProxySettings,
+  pendingRestoreRoute: '',
   shortcuts: DEFAULT_ELECTRON_DESKTOP_SHORTCUTS,
   storagePath: appStorageDir,
   themeMode: 'system',

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -257,6 +257,20 @@ export class BrowserManager {
   }
 
   /**
+   * Resolve the main window initial path, consuming a route captured before an
+   * update restart. The captured route is restored on exactly one launch, then
+   * cleared so a subsequent normal launch never restores a stale route.
+   */
+  private resolveMainWindowInitialPath(isOnboardingCompleted: boolean): string {
+    const pendingRestoreRoute = this.app.storeManager.get('pendingRestoreRoute', '');
+    if (pendingRestoreRoute) this.app.storeManager.set('pendingRestoreRoute', '');
+
+    if (!isOnboardingCompleted) return '/desktop-onboarding';
+    if (pendingRestoreRoute) return pendingRestoreRoute;
+    return '/';
+  }
+
+  /**
    * Initialize all browsers when app starts up
    */
   async initializeBrowsers() {
@@ -271,7 +285,7 @@ export class BrowserManager {
 
       // Dynamically determine initial path for main window
       if (browser.identifier === BrowsersIdentifiers.app) {
-        const initialPath = isOnboardingCompleted ? '/' : '/desktop-onboarding';
+        const initialPath = this.resolveMainWindowInitialPath(isOnboardingCompleted);
         browser = {
           ...browser,
           keepAlive: isLinux ? false : browser.keepAlive,

--- a/apps/desktop/src/main/core/browser/BrowserManager.ts
+++ b/apps/desktop/src/main/core/browser/BrowserManager.ts
@@ -257,14 +257,20 @@ export class BrowserManager {
   }
 
   /**
-   * Resolve the main window initial path, consuming a route captured before an
-   * update restart. The captured route is restored on exactly one launch, then
-   * cleared so a subsequent normal launch never restores a stale route.
+   * Consume a route captured before an update restart. The captured route is
+   * cleared before any navigation decision so a subsequent normal launch never
+   * restores a stale route.
    */
-  private resolveMainWindowInitialPath(isOnboardingCompleted: boolean): string {
+  private consumePendingRestoreRoute(): string {
     const pendingRestoreRoute = this.app.storeManager.get('pendingRestoreRoute', '');
     if (pendingRestoreRoute) this.app.storeManager.set('pendingRestoreRoute', '');
+    return pendingRestoreRoute;
+  }
 
+  private resolveMainWindowInitialPath(
+    isOnboardingCompleted: boolean,
+    pendingRestoreRoute: string,
+  ): string {
     if (!isOnboardingCompleted) return '/desktop-onboarding';
     if (pendingRestoreRoute) return pendingRestoreRoute;
     return '/';
@@ -285,7 +291,11 @@ export class BrowserManager {
 
       // Dynamically determine initial path for main window
       if (browser.identifier === BrowsersIdentifiers.app) {
-        const initialPath = this.resolveMainWindowInitialPath(isOnboardingCompleted);
+        const pendingRestoreRoute = this.consumePendingRestoreRoute();
+        const initialPath = this.resolveMainWindowInitialPath(
+          isOnboardingCompleted,
+          pendingRestoreRoute,
+        );
         browser = {
           ...browser,
           keepAlive: isLinux ? false : browser.keepAlive,

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -110,6 +110,10 @@ describe('BrowserManager', () => {
       getController: vi.fn().mockReturnValue({
         isRemoteServerConfigured: vi.fn().mockResolvedValue(true),
       }),
+      storeManager: {
+        get: vi.fn().mockReturnValue(''),
+        set: vi.fn(),
+      },
     } as unknown as AppCore;
 
     manager = new BrowserManager(mockApp);
@@ -265,6 +269,34 @@ describe('BrowserManager', () => {
       // app has keepAlive: true, settings has keepAlive: false
       expect(manager.browsers.has('app')).toBe(true);
       expect(manager.browsers.has('settings')).toBe(false);
+    });
+
+    it('restores a captured route as the main window initial path', async () => {
+      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/agent/abc');
+    });
+
+    it('clears the captured route after consuming it', async () => {
+      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+
+      await manager.initializeBrowsers();
+
+      expect(mockApp.storeManager.set).toHaveBeenCalledWith('pendingRestoreRoute', '');
+    });
+
+    it('ignores the captured route when onboarding is not completed', async () => {
+      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+      (mockApp.getController as any).mockReturnValue({
+        isRemoteServerConfigured: vi.fn().mockResolvedValue(false),
+      });
+
+      await manager.initializeBrowsers();
+
+      expect(manager.browsers.get('app')?.options.path).toBe('/desktop-onboarding');
+      expect(mockApp.storeManager.set).toHaveBeenCalledWith('pendingRestoreRoute', '');
     });
   });
 

--- a/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/BrowserManager.test.ts
@@ -111,7 +111,10 @@ describe('BrowserManager', () => {
         isRemoteServerConfigured: vi.fn().mockResolvedValue(true),
       }),
       storeManager: {
-        get: vi.fn().mockReturnValue(''),
+        get: vi.fn((key: string) => {
+          if (key === 'pendingRestoreRoute') return '';
+          return '';
+        }),
         set: vi.fn(),
       },
     } as unknown as AppCore;
@@ -272,7 +275,10 @@ describe('BrowserManager', () => {
     });
 
     it('restores a captured route as the main window initial path', async () => {
-      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'pendingRestoreRoute') return '/agent/abc';
+        return '';
+      });
 
       await manager.initializeBrowsers();
 
@@ -280,7 +286,10 @@ describe('BrowserManager', () => {
     });
 
     it('clears the captured route after consuming it', async () => {
-      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'pendingRestoreRoute') return '/agent/abc';
+        return '';
+      });
 
       await manager.initializeBrowsers();
 
@@ -288,7 +297,10 @@ describe('BrowserManager', () => {
     });
 
     it('ignores the captured route when onboarding is not completed', async () => {
-      (mockApp.storeManager.get as any).mockReturnValue('/agent/abc');
+      (mockApp.storeManager.get as any).mockImplementation((key: string) => {
+        if (key === 'pendingRestoreRoute') return '/agent/abc';
+        return '';
+      });
       (mockApp.getController as any).mockReturnValue({
         isRemoteServerConfigured: vi.fn().mockResolvedValue(false),
       });

--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -12,6 +12,7 @@ import { autoUpdater } from 'electron-updater';
 import { isDev, isWindows } from '@/const/env';
 import { getDesktopEnv } from '@/env';
 import { UPDATE_CHANNEL, UPDATE_SERVER_URL, updaterConfig } from '@/modules/updater/configs';
+import { extractRestoreRoute } from '@/modules/updater/utils';
 import { createLogger } from '@/utils/logger';
 
 import type { App as AppCore } from '../App';
@@ -239,11 +240,28 @@ export class UpdaterManager {
     }
   };
 
+  private captureRestoreRoute = () => {
+    try {
+      const url = this.mainWindow.webContents?.getURL();
+      if (!url) return;
+
+      const route = extractRestoreRoute(url);
+      if (!route) return;
+
+      this.app.storeManager.set('pendingRestoreRoute', route);
+      logger.info(`Captured route for restore after update restart: ${route}`);
+    } catch (error) {
+      logger.warn('Failed to capture route for restore after update restart:', error);
+    }
+  };
+
   /**
    * Install update immediately
    */
   public installNow = () => {
     logger.info('Installing update now...');
+
+    this.captureRestoreRoute();
 
     this.app.isQuiting = true;
 

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -361,6 +361,51 @@ describe('UpdaterManager', () => {
     });
   });
 
+  describe('captureRestoreRoute', () => {
+    const callCapture = () => (updaterManager as any).captureRestoreRoute();
+
+    it('stores the derived route from the main window URL', () => {
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue({
+        webContents: { getURL: () => 'app://renderer/agent/abc' },
+      });
+
+      callCapture();
+
+      expect(mockApp.storeManager.set).toHaveBeenCalledWith('pendingRestoreRoute', '/agent/abc');
+    });
+
+    it('stores nothing when the URL is not a restorable route', () => {
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue({
+        webContents: { getURL: () => 'app://renderer/' },
+      });
+
+      callCapture();
+
+      expect(mockApp.storeManager.set).not.toHaveBeenCalled();
+    });
+
+    it('stores nothing when there is no webContents', () => {
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue({ webContents: null });
+
+      callCapture();
+
+      expect(mockApp.storeManager.set).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when reading the URL fails', () => {
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue({
+        webContents: {
+          getURL: () => {
+            throw new Error('boom');
+          },
+        },
+      });
+
+      expect(() => callCapture()).not.toThrow();
+      expect(mockApp.storeManager.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe('installLater', () => {
     it('should set autoInstallOnAppQuit to true', () => {
       updaterManager.installLater();

--- a/apps/desktop/src/main/modules/updater/__tests__/utils.test.ts
+++ b/apps/desktop/src/main/modules/updater/__tests__/utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractRestoreRoute } from '../utils';
+
+describe('extractRestoreRoute', () => {
+  it('extracts the route from a production renderer URL', () => {
+    expect(extractRestoreRoute('app://renderer/agent/abc')).toBe('/agent/abc');
+  });
+
+  it('extracts the route from a dev renderer URL', () => {
+    expect(extractRestoreRoute('http://localhost:5173/settings/provider')).toBe(
+      '/settings/provider',
+    );
+  });
+
+  it('strips the lng query param but keeps the rest', () => {
+    expect(extractRestoreRoute('app://renderer/agent?lng=zh-CN&x=1')).toBe('/agent?x=1');
+  });
+
+  it('strips a lone lng query param', () => {
+    expect(extractRestoreRoute('app://renderer/chat?lng=en-US')).toBe('/chat');
+  });
+
+  it('returns null for the root route', () => {
+    expect(extractRestoreRoute('app://renderer/')).toBeNull();
+  });
+
+  it('returns null for file: protocol (splash/error pages)', () => {
+    expect(extractRestoreRoute('file:///Users/x/resources/splash.html')).toBeNull();
+  });
+
+  it('returns null for static asset paths', () => {
+    expect(extractRestoreRoute('app://renderer/assets/index.js')).toBeNull();
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(extractRestoreRoute('not a url')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/modules/updater/__tests__/utils.test.ts
+++ b/apps/desktop/src/main/modules/updater/__tests__/utils.test.ts
@@ -33,6 +33,16 @@ describe('extractRestoreRoute', () => {
     expect(extractRestoreRoute('app://renderer/assets/index.js')).toBeNull();
   });
 
+  it('returns null for root static files', () => {
+    expect(extractRestoreRoute('app://renderer/favicon.ico')).toBeNull();
+  });
+
+  it('preserves dotted SPA route slugs', () => {
+    expect(extractRestoreRoute('app://renderer/community/skill/github.owner.repo')).toBe(
+      '/community/skill/github.owner.repo',
+    );
+  });
+
   it('returns null for an unparseable URL', () => {
     expect(extractRestoreRoute('not a url')).toBeNull();
   });

--- a/apps/desktop/src/main/modules/updater/utils.ts
+++ b/apps/desktop/src/main/modules/updater/utils.ts
@@ -1,6 +1,11 @@
-import path from 'node:path';
-
 import semver from 'semver';
+
+const STATIC_ASSET_PATH_PREFIXES = ['/assets/', '/_next/', '/static/'];
+const ROOT_STATIC_FILE_RE = /^\/[^/]+\.[^/]+$/;
+
+const isStaticAssetPath = (pathname: string) =>
+  ROOT_STATIC_FILE_RE.test(pathname) ||
+  STATIC_ASSET_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 
 /**
  * Determine if application update is needed rather than just renderer update
@@ -37,8 +42,8 @@ export const shouldUpdateApp = (currentVersion: string, nextVersion: string): bo
 /**
  * Extract a restorable SPA route (`pathname + search`) from a renderer window URL.
  * Returns `null` when the URL is not a restorable route — splash/error pages
- * (`file:` protocol), static assets (path has an extension), or the root route
- * (identical to the default, nothing worth restoring).
+ * (`file:` protocol), known static asset paths, or the root route (identical
+ * to the default, nothing worth restoring).
  */
 export const extractRestoreRoute = (rawUrl: string): string | null => {
   let url: URL;
@@ -49,7 +54,7 @@ export const extractRestoreRoute = (rawUrl: string): string | null => {
   }
 
   if (url.protocol === 'file:') return null;
-  if (path.extname(url.pathname)) return null;
+  if (isStaticAssetPath(url.pathname)) return null;
 
   // `lng` is re-appended by Browser.buildUrlWithLocale on the next load
   url.searchParams.delete('lng');

--- a/apps/desktop/src/main/modules/updater/utils.ts
+++ b/apps/desktop/src/main/modules/updater/utils.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import semver from 'semver';
 
 /**
@@ -30,4 +32,30 @@ export const shouldUpdateApp = (currentVersion: string, nextVersion: string): bo
     // Default to application update when parsing fails
     return true;
   }
+};
+
+/**
+ * Extract a restorable SPA route (`pathname + search`) from a renderer window URL.
+ * Returns `null` when the URL is not a restorable route — splash/error pages
+ * (`file:` protocol), static assets (path has an extension), or the root route
+ * (identical to the default, nothing worth restoring).
+ */
+export const extractRestoreRoute = (rawUrl: string): string | null => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol === 'file:') return null;
+  if (path.extname(url.pathname)) return null;
+
+  // `lng` is re-appended by Browser.buildUrlWithLocale on the next load
+  url.searchParams.delete('lng');
+
+  const route = `${url.pathname}${url.search}`;
+  if (route === '/' || route === '') return null;
+
+  return route;
 };

--- a/apps/desktop/src/main/types/store.ts
+++ b/apps/desktop/src/main/types/store.ts
@@ -21,6 +21,7 @@ export interface ElectronMainStore {
   locale: string;
   localFileWorkspaceRoots: string[];
   networkProxy: NetworkProxySettings;
+  pendingRestoreRoute: string;
   shortcuts: Record<string, string>;
   storagePath: string;
   themeMode: 'dark' | 'light' | 'system';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching open issue found. -->

#### 🔀 Description of Change

When the desktop app shows the "new version available" notification and the user clicks "upgrade now" / "restart and install", `autoUpdater.quitAndInstall` fully restarts the app. On the next launch the main `app` window always reloaded `path: '/'`, so the user lost whatever route they were on and landed back on the home page.

This PR records the active route before the update restart and restores it on the next launch.

- **Capture** — `UpdaterManager.installNow()` calls `captureRestoreRoute()` before closing windows: it reads the main window URL via `webContents.getURL()`, derives the route with the new pure helper `extractRestoreRoute()`, and persists it to `StoreManager` under a new `pendingRestoreRoute` key. Wrapped in `try/catch` so a capture failure never blocks the update.
- **Restore** — `BrowserManager.initializeBrowsers()` resolves the main window initial path via `resolveMainWindowInitialPath()`: when onboarding is completed and a pending route exists, it uses that route; the key is then cleared (**consume-once**), so a subsequent normal launch never restores a stale route.
- `extractRestoreRoute()` strips the `lng` query param (re-applied at load time) and returns `null` for non-restorable URLs (`file:` splash/error pages, static assets, the root route).

Scope: update-restart only and the main `app` window only. Normal quit + relaunch and multi-instance chat/popup windows are out of scope.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- New `extractRestoreRoute` unit tests (8 cases): prod/dev URLs, `lng` stripping, root/`file:`/asset/unparseable → `null`.
- `UpdaterManager` — `captureRestoreRoute` stores the derived route, stores nothing for non-restorable URLs, and swallows errors.
- `BrowserManager` — `initializeBrowsers` uses the captured route as the initial path, clears it after consuming, and ignores it when onboarding is incomplete.
- Run: `cd apps/desktop && bunx vitest run src/main/modules/updater/__tests__/utils.test.ts src/main/core/infrastructure/__tests__/UpdaterManager.test.ts src/main/core/browser/__tests__/BrowserManager.test.ts` — 79 passed.

#### 📝 Additional Information

No DB migration. The `pendingRestoreRoute` store key defaults to `''` (nothing to restore).