### PR TITLE
🐛 fix(agent-tasks): prevent schedule pill from wrapping in Kanban card

### DIFF
--- a/src/features/AgentTasks/features/AgentTaskItem.tsx
+++ b/src/features/AgentTasks/features/AgentTaskItem.tsx
@@ -22,6 +22,8 @@ interface TaskItemProps {
   variant?: 'compact' | 'default';
 }
 
+const FLEX_MIN_WIDTH_0 = { minWidth: 0 };
+
 const TASK_STATUS_SET = new Set<TaskStatus>([
   'backlog',
   'canceled',
@@ -162,7 +164,7 @@ const AgentTaskItem = memo<TaskItemProps>(({ task, variant = 'default' }) => {
             />
           </Flexbox>
           <TaskLatestActivity activities={taskDetail?.activities} />
-          <Flexbox horizontal align={'center'} gap={8}>
+          <Flexbox horizontal align={'center'} gap={8} style={FLEX_MIN_WIDTH_0}>
             <TaskPriorityTag priority={task.priority} taskIdentifier={task.identifier} />
             {scheduleNode}
             {timeNode}

--- a/src/features/AgentTasks/features/TaskTriggerTag.tsx
+++ b/src/features/AgentTasks/features/TaskTriggerTag.tsx
@@ -18,6 +18,9 @@ interface TaskTriggerTagProps {
   scheduleTimezone?: string | null;
 }
 
+const FLEX_MIN_WIDTH_0 = { minWidth: 0 };
+const PILL_STYLE = { borderRadius: 24, minWidth: 0 };
+
 const TaskTriggerTag = memo<TaskTriggerTagProps>(
   ({ automationMode, heartbeatInterval, mode = 'tag', schedulePattern, scheduleTimezone }) => {
     const { t, i18n } = useTranslation('chat');
@@ -63,11 +66,11 @@ const TaskTriggerTag = memo<TaskTriggerTagProps>(
       // plus timezone on hover, so no information is lost.
       return (
         <Tooltip title={data?.tooltip}>
-          <Flexbox horizontal align="center" gap={10} style={{ minWidth: 0 }}>
+          <Flexbox horizontal align="center" gap={10} style={FLEX_MIN_WIDTH_0}>
             <Icon color={cssVar.colorTextDescription} icon={ClockIcon} size={16} />
             <Text
               ellipsis
-              style={{ minWidth: 0 }}
+              style={FLEX_MIN_WIDTH_0}
               type={data ? undefined : 'secondary'}
               weight={data ? 500 : undefined}
             >
@@ -90,11 +93,11 @@ const TaskTriggerTag = memo<TaskTriggerTagProps>(
           gap={4}
           height={24}
           paddingInline={'4px 8px'}
-          style={{ borderRadius: 24 }}
+          style={PILL_STYLE}
           variant={'outlined'}
         >
           <Icon color={cssVar.colorTextDescription} icon={ClockIcon} size={16} />
-          <Text fontSize={12} type={'secondary'}>
+          <Text ellipsis fontSize={12} style={FLEX_MIN_WIDTH_0} type={'secondary'}>
             {data.primary}
           </Text>
         </Block>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-9149

#### 🔀 Description of Change

In the Kanban view of Agent Tasks, the schedule pill (`TaskTriggerTag` in `tag` mode) has a fixed `height={24}` but its inner `<Text>` had no single-line / ellipsis constraint. Long schedule descriptions such as `每周 日/一/二/六 09:00 运行` wrapped onto two lines and broke the 24px row layout, shifting the date out of place.

This patch forces the pill to a single line with ellipsis truncation. The full description (plus timezone) is still surfaced through the existing tooltip on hover.

- `TaskTriggerTag.tsx`: added `ellipsis` + `minWidth: 0` to the inner `<Text>`, added `minWidth: 0` to the pill `<Block>` so it can shrink inside its flex parent.
- `AgentTaskItem.tsx`: added `minWidth: 0` to the compact-card bottom row (priority + schedule + time) so the schedule pill can actually shrink inside the 300px Kanban column.
- Hoisted inline style objects to module scope (`FLEX_MIN_WIDTH_0`, `PILL_STYLE`) — Kanban renders many cards, so stable references keep `React.memo` on `Block`/`Flexbox`/`Text` effective.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open the Agent Tasks Kanban view with a task whose schedule description is long (e.g. `每周 日/一/二/六 09:00 运行`). Verify:

1. The schedule pill stays on a single 24px-tall row.
2. Overflowing text shows ellipsis (`…`).
3. Hovering the pill displays the full schedule description plus timezone in the tooltip.
4. The date (`5月18日` etc.) on the same row no longer shifts down.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Schedule pill wraps to 2 lines, breaking the row | Pill stays on one line, ellipsises long text, tooltip shows full string |

#### 📝 Additional Information

No behavior change for short schedule descriptions (e.g. `每天 04:00 运行`) — those continue to render as before. Tooltip already contained the full string + timezone, so no information is lost when truncation happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="312" height="954" alt="image" src="https://github.com/user-attachments/assets/cd37e3c4-a21e-4a42-9cb9-0c611b7b94b6" />
