### PR TITLE
🐛 fix(market): map getUserByUsername 404 to NOT_FOUND instead of 500

### DIFF
--- a/src/layout/AuthProvider/MarketAuth/useMarketUserProfile.ts
+++ b/src/layout/AuthProvider/MarketAuth/useMarketUserProfile.ts
@@ -26,6 +26,8 @@ export const useMarketUserProfile = (username: string | null | undefined) => {
       dedupingInterval: 60_000, // 1 minute deduplication
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
+      // NOT_FOUND means the user hasn't created a market username yet — no point retrying
+      shouldRetryOnError: (error) => error?.data?.code !== 'NOT_FOUND',
     },
   );
 };

--- a/src/server/routers/lambda/market/user.ts
+++ b/src/server/routers/lambda/market/user.ts
@@ -70,6 +70,19 @@ export const userRouter = router({
       } catch (error) {
         if (error instanceof TRPCError) throw error;
 
+        // 404 is expected when a user hasn't set up a market username yet — not an internal error
+        if (
+          error instanceof Error &&
+          'status' in error &&
+          (error as Error & { status: unknown }).status === 404
+        ) {
+          throw new TRPCError({
+            cause: error,
+            code: 'NOT_FOUND',
+            message: `User not found: ${input.username}`,
+          });
+        }
+
         log('Error getting user profile: %O', error);
         throw new TRPCError({
           cause: error,


### PR DESCRIPTION
## Problem

When a user logs in for the first time and hasn't set up a market username yet, every component that calls `useMarketUserProfile` (UserAvatar, MarketAuthProvider, user detail pages) triggers `market.user.getUserByUsername` with the user's OIDC `sub` (a user ID like `user_kPzYZgyQNModFPISpsN7ShhDnD0`, not a real username). The market API correctly returns 404 for this. However:

1. The tRPC handler caught the `MarketAPIError` (status 404) and re-threw it as `INTERNAL_SERVER_ERROR` (500).
2. SWR retried 3× per component on any error.
3. Three components all call the hook → the log gets flooded with repeated false-alarm 500s (and equivalent Sentry noise).

This is a pure observability / signal-to-noise bug — no user-visible functionality is broken.

## Fix

**`src/server/routers/lambda/market/user.ts`** — Before falling through to the generic 500 handler, detect `MarketAPIError` responses with `status === 404` and rethrow as `TRPCError { code: 'NOT_FOUND' }`. `checkNeedsProfileSetup` in `MarketAuthProvider.tsx` already documents this expectation ("Error fetching profile (e.g., NOT_FOUND), assume needs setup").

**`src/layout/AuthProvider/MarketAuth/useMarketUserProfile.ts`** — Add `shouldRetryOnError` so SWR stops retrying when the server returns `NOT_FOUND`. First-login 404s are deterministic; retrying three times just amplifies the noise.

## Test plan

- [ ] Log in with an account that has never set a market username — no 500 errors appear in server logs, only a single (silent) NOT_FOUND per component
- [ ] Log in with an account that has an existing market username — profile loads normally, no regression
- [ ] Trigger a genuine backend error (e.g., market service down) — still surfaces as 500 in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)