### PR TITLE
💄 refactor(ToolTag): always use filled variant regardless of dark mode

### DIFF
--- a/src/features/ToolTag/index.tsx
+++ b/src/features/ToolTag/index.tsx
@@ -156,7 +156,7 @@ const ToolTag = memo<ToolTagProps>(({ identifier, variant = 'default' }) => {
     <Tag
       className={isCompact ? styles.compact : styles.tag}
       icon={renderIcon()}
-      variant={isCompact ? 'borderless' : isDarkMode ? 'filled' : 'outlined'}
+      variant={isCompact ? 'borderless' : 'filled'}
     >
       {displayTitle}
     </Tag>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

#### 🔀 Description of Change

Simplify the `ToolTag` variant logic by always using the `filled` variant for non-compact tags, removing the conditional dark-mode check (`isDarkMode ? "filled" : "outlined"`).

This unifies the tag appearance across light and dark themes.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A — visual change only; verify tag appearance in both light and dark themes.

#### 📝 Additional Information

Pure visual refactor — no logic or API changes.