### PR TITLE
♻️ refactor(onboarding): group chat input feature switches

### DIFF
--- a/src/features/ChatInput/ChatInputProvider.tsx
+++ b/src/features/ChatInput/ChatInputProvider.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from 'react';
 import { memo, useRef } from 'react';
 
 import { createStore, Provider } from './store';
+import { DEFAULT_CHAT_INPUT_FEATURE } from './store/initialState';
 import { type StoreUpdaterProps } from './StoreUpdater';
 import StoreUpdater from './StoreUpdater';
 
@@ -15,8 +16,7 @@ export const ChatInputProvider = memo<ChatInputProviderProps>(
     agentId,
     children,
     contextWindowMessages,
-    disableMention,
-    disableSlash,
+    feature = DEFAULT_CHAT_INPUT_FEATURE,
     leftActions,
     rightActions,
     mobile,
@@ -39,9 +39,8 @@ export const ChatInputProvider = memo<ChatInputProviderProps>(
           createStore({
             allowExpand,
             contextWindowMessages,
-            disableMention,
-            disableSlash,
             editor,
+            feature,
             leftActions,
             mentionItems,
             mobile,
@@ -58,8 +57,7 @@ export const ChatInputProvider = memo<ChatInputProviderProps>(
           allowExpand={allowExpand}
           chatInputEditorRef={chatInputEditorRef}
           contextWindowMessages={contextWindowMessages}
-          disableMention={disableMention}
-          disableSlash={disableSlash}
+          feature={feature}
           getMessages={getMessages}
           leftActions={leftActions}
           mentionItems={mentionItems}

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -62,8 +62,9 @@ const InputEditor = memo<{
     updateMarkdownContent,
     expand,
     slashPlacement,
-    disableMention,
-    disableSlash,
+    isInputCompletionEnabled,
+    isMentionEnabled,
+    isSlashEnabled,
   ] = useChatInputStore((s) => [
     s.editor,
     s.slashMenuRef,
@@ -71,8 +72,9 @@ const InputEditor = memo<{
     s.updateMarkdownContent,
     s.expand,
     s.slashPlacement ?? 'top',
-    s.disableMention,
-    s.disableSlash,
+    s.feature?.inputCompletion ?? true,
+    s.feature?.mention ?? true,
+    s.feature?.slash ?? true,
   ]);
 
   const storeApi = useStoreApi();
@@ -132,13 +134,13 @@ const InputEditor = memo<{
 
   const MentionMenuComp = useMemo(() => createMentionMenu(stateRef, categoriesRef), []);
 
-  const enableMention = !disableMention && (allMentionItems.length > 0 || enableLocalFileMention);
+  const enableMention = isMentionEnabled && (allMentionItems.length > 0 || enableLocalFileMention);
   const heterogeneousName = heterogeneousType
     ? (HETEROGENEOUS_TYPE_LABELS[heterogeneousType] ?? heterogeneousType)
     : undefined;
   // Heterogeneous agents (e.g. Claude Code) don't yet support @-assigning to other agents
   const showAgentAssignmentHint =
-    !disableMention && !heterogeneousName && categories.some((category) => category.id === 'agent');
+    isMentionEnabled && !heterogeneousName && categories.some((category) => category.id === 'agent');
   const { handleUploadFiles } = useUploadFiles({ model, provider });
 
   // Listen to editor's paste event for file uploads
@@ -175,7 +177,7 @@ const InputEditor = memo<{
 
   // --- Auto-completion ---
   const inputCompletionConfig = useUserStore(systemAgentSelectors.inputCompletion);
-  const isAutoCompleteEnabled = inputCompletionConfig.enabled;
+  const isAutoCompleteEnabled = isInputCompletionEnabled && inputCompletionConfig.enabled;
 
   const getMessagesRef = useRef(storeApi.getState().getMessages);
   useEffect(() => {
@@ -298,10 +300,10 @@ const InputEditor = memo<{
     [enableMention, mentionItemsFn, mentionMarkdownWriter, mentionOnSelect, MentionMenuComp],
   );
 
-  const slashOption = useMemo(
-    () => (disableSlash ? undefined : { items: slashItems }),
-    [disableSlash, slashItems],
-  );
+  const slashOption = useMemo(() => (isSlashEnabled ? { items: slashItems } : undefined), [
+    isSlashEnabled,
+    slashItems,
+  ]);
 
   const richRenderProps = useMemo(() => {
     const basePlugins = !enableRichRender

--- a/src/features/ChatInput/StoreUpdater.tsx
+++ b/src/features/ChatInput/StoreUpdater.tsx
@@ -8,6 +8,7 @@ import { type ChatInputEditor } from './hooks/useChatInputEditor';
 import { useChatInputEditor } from './hooks/useChatInputEditor';
 import { type PublicState } from './store';
 import { useStoreApi } from './store';
+import { DEFAULT_CHAT_INPUT_FEATURE } from './store/initialState';
 
 export interface StoreUpdaterProps extends Partial<PublicState> {
   chatInputEditorRef?: ForwardedRef<ChatInputEditor | null>;
@@ -18,8 +19,7 @@ const StoreUpdater = memo<StoreUpdaterProps>(
     agentId,
     chatInputEditorRef,
     contextWindowMessages,
-    disableMention,
-    disableSlash,
+    feature = DEFAULT_CHAT_INPUT_FEATURE,
     mobile,
     sendButtonProps,
     leftActions,
@@ -43,8 +43,7 @@ const StoreUpdater = memo<StoreUpdaterProps>(
     useStoreUpdater('leftActions', leftActions!);
     useStoreUpdater('rightActions', rightActions!);
     useStoreUpdater('allowExpand', allowExpand);
-    useStoreUpdater('disableMention', disableMention);
-    useStoreUpdater('disableSlash', disableSlash);
+    useStoreUpdater('feature', feature);
     useStoreUpdater('slashPlacement', slashPlacement);
     useStoreUpdater('getMessages', getMessages);
 

--- a/src/features/ChatInput/index.ts
+++ b/src/features/ChatInput/index.ts
@@ -4,4 +4,4 @@ export { default as DesktopChatInput } from './Desktop';
 export type { ChatInputEditor } from './hooks/useChatInputEditor';
 export { useChatInputEditor } from './hooks/useChatInputEditor';
 export { default as MobileChatInput } from './Mobile';
-export type { SendButtonHandler } from './store/initialState';
+export type { ChatInputFeature, SendButtonHandler } from './store/initialState';

--- a/src/features/ChatInput/store/initialState.ts
+++ b/src/features/ChatInput/store/initialState.ts
@@ -32,19 +32,24 @@ export interface ContextWindowMessage {
   content: string;
 }
 
+export interface ChatInputFeature {
+  inputCompletion?: boolean;
+  mention?: boolean;
+  slash?: boolean;
+}
+
+export const DEFAULT_CHAT_INPUT_FEATURE = {
+  inputCompletion: true,
+  mention: true,
+  slash: true,
+} as const satisfies Required<ChatInputFeature>;
+
 export interface PublicState {
   agentId?: string;
   allowExpand?: boolean;
   contextWindowMessages?: ContextWindowMessage[];
-  /**
-   * Disable @ mention trigger (no menu, no agent-assignment hint in placeholder)
-   */
-  disableMention?: boolean;
-  /**
-   * Disable / slash command trigger
-   */
-  disableSlash?: boolean;
   expand?: boolean;
+  feature?: ChatInputFeature;
   getMessages?: () => OpenAIChatMessage[];
   leftActions: ActionKeys[];
   mentionItems?: SlashOptions['items'];
@@ -72,6 +77,7 @@ export interface State extends PublicState {
 export const initialState: State = {
   allowExpand: true,
   expand: false,
+  feature: DEFAULT_CHAT_INPUT_FEATURE,
   isContentEmpty: false,
   leftActions: [],
   markdownContent: '',

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -61,13 +61,13 @@ export interface ChatInputProps {
    */
   disableQueue?: boolean;
   /**
-   * Chat input capability switches. Omitted capabilities keep the default enabled state.
-   */
-  feature?: ChatInputFeature;
-  /**
    * Extra action items to append to the ActionBar
    */
   extraActionItems?: ChatInputActionsProps['items'];
+  /**
+   * Chat input capability switches. Omitted capabilities keep the default enabled state.
+   */
+  feature?: ChatInputFeature;
   /**
    * Swap the action bar and send area for skeleton placeholders while
    * the underlying agent/session config is still hydrating. The editor

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -8,7 +8,7 @@ import { type ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { type ActionKeys } from '@/features/ChatInput';
+import type { ActionKeys, ChatInputFeature } from '@/features/ChatInput';
 import { ChatInputProvider, DesktopChatInput } from '@/features/ChatInput';
 import {
   type SendButtonHandler,
@@ -56,18 +56,14 @@ export interface ChatInputProps {
    */
   disableFollowUpVariant?: boolean;
   /**
-   * Disable the @ mention trigger and its placeholder hint
-   */
-  disableMention?: boolean;
-  /**
    * Disable enqueuing follow-up messages while the agent is streaming.
    * Hides the QueueTray and gates handleSend so Enter does not enqueue.
    */
   disableQueue?: boolean;
   /**
-   * Disable the / slash command trigger
+   * Chat input capability switches. Omitted capabilities keep the default enabled state.
    */
-  disableSlash?: boolean;
+  feature?: ChatInputFeature;
   /**
    * Extra action items to append to the ActionBar
    */
@@ -136,9 +132,8 @@ const ChatInput = memo<ChatInputProps>(
     actionBarStyle,
     allowExpand,
     disableFollowUpVariant,
-    disableMention,
     disableQueue,
-    disableSlash,
+    feature,
     leftActions = [],
     leftContent,
     rightActions = [],
@@ -340,8 +335,7 @@ const ChatInput = memo<ChatInputProps>(
         agentId={agentId}
         allowExpand={allowExpand}
         contextWindowMessages={contextWindowMessages}
-        disableMention={disableMention}
-        disableSlash={disableSlash}
+        feature={feature}
         getMessages={getMessages}
         leftActions={leftActions}
         mentionItems={mentionItems}

--- a/src/features/Onboarding/Agent/Conversation.test.tsx
+++ b/src/features/Onboarding/Agent/Conversation.test.tsx
@@ -122,7 +122,7 @@ describe('AgentOnboardingConversation', () => {
     );
   });
 
-  it('disables / @ triggers, follow-up placeholder, and message queueing', () => {
+  it('disables input completion, / @ triggers, follow-up placeholder, and message queueing', () => {
     mockState.displayMessages = [{ id: 'assistant-1', role: 'assistant' }];
 
     render(<AgentOnboardingConversation />);
@@ -130,9 +130,12 @@ describe('AgentOnboardingConversation', () => {
     expect(chatInputSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         disableFollowUpVariant: true,
-        disableMention: true,
         disableQueue: true,
-        disableSlash: true,
+        feature: expect.objectContaining({
+          inputCompletion: false,
+          mention: false,
+          slash: false,
+        }),
       }),
     );
   });

--- a/src/features/Onboarding/Agent/Conversation.tsx
+++ b/src/features/Onboarding/Agent/Conversation.tsx
@@ -8,7 +8,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
-import type { ActionKeys } from '@/features/ChatInput';
+import type { ActionKeys, ChatInputFeature } from '@/features/ChatInput';
 import {
   ChatInput,
   ChatList,
@@ -43,6 +43,11 @@ interface AgentOnboardingConversationProps {
 
 const chatInputLeftActions: ActionKeys[] = isDev ? ['model'] : [];
 const chatInputRightActions: ActionKeys[] = [];
+const chatInputFeature = {
+  inputCompletion: false,
+  mention: false,
+  slash: false,
+} satisfies ChatInputFeature;
 
 const AgentOnboardingConversation = memo<AgentOnboardingConversationProps>(
   ({
@@ -212,10 +217,9 @@ const AgentOnboardingConversation = memo<AgentOnboardingConversationProps>(
             )}
             <ChatInput
               disableFollowUpVariant
-              disableMention
               disableQueue
-              disableSlash
               allowExpand={false}
+              feature={chatInputFeature}
               leftActions={chatInputLeftActions}
               rightActions={chatInputRightActions}
               showRuntimeConfig={false}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a grouped `ChatInputFeature` capability object for input completion, mentions, and slash commands.
- Thread the feature object through `ChatInputProvider` and the conversation chat input boundary.
- Disable input completion, mention, and slash capabilities for the onboarding chat input.
- Subscribe `InputEditor` to individual feature fields instead of the whole feature object.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/features/Onboarding/Agent/Conversation.test.tsx src/features/ChatInput/StoreUpdater.test.tsx
bun run type-check
git diff --check origin/canary..HEAD
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No migration required.
