### PR TITLE
🐛 fix(sidebar): restore home nav for task workspace

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -56,6 +56,7 @@
   "renameModal.title": "Rename Topic",
   "searchPlaceholder": "Search Topics...",
   "searchResultEmpty": "No search results found.",
+  "sidebar.title": "Topics",
   "taskManager.agent": "Task Agent",
   "taskManager.welcome": "Ask me about your tasks",
   "temp": "Temporary",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -56,6 +56,7 @@
   "renameModal.title": "重命名话题",
   "searchPlaceholder": "搜索话题…",
   "searchResultEmpty": "暂无搜索结果",
+  "sidebar.title": "话题",
   "taskManager.agent": "任务助手",
   "taskManager.welcome": "问我关于你的任务",
   "temp": "临时",

--- a/src/features/AgentTasks/TaskWorkspaceLayout.test.tsx
+++ b/src/features/AgentTasks/TaskWorkspaceLayout.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetNavPanel } from '@/features/NavPanel';
+
+import TaskWorkspaceLayout from './TaskWorkspaceLayout';
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+vi.mock('react-router-dom', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = (await vi.importActual('react-router-dom')) as typeof import('react-router-dom');
+
+  return {
+    ...actual,
+    Outlet: () => <div data-testid="task-workspace-outlet">outlet</div>,
+  };
+});
+
+vi.mock('@/features/AgentTaskManager', () => ({
+  default: () => <div data-testid="task-agent-manager" />,
+}));
+
+vi.mock('@/features/NavPanel', () => ({
+  resetNavPanel: vi.fn(),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+describe('TaskWorkspaceLayout', () => {
+  beforeEach(() => {
+    vi.mocked(resetNavPanel).mockClear();
+  });
+
+  it('resets the nav panel to the home sidebar fallback', () => {
+    render(<TaskWorkspaceLayout />);
+
+    expect(resetNavPanel).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('task-workspace-outlet')).toBeInTheDocument();
+    expect(screen.getByTestId('task-agent-manager')).toBeInTheDocument();
+  });
+});

--- a/src/features/AgentTasks/TaskWorkspaceLayout.tsx
+++ b/src/features/AgentTasks/TaskWorkspaceLayout.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
+import { memo, useLayoutEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import AgentTaskManager from '@/features/AgentTaskManager';
+import { resetNavPanel } from '@/features/NavPanel';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 const TaskWorkspaceLayout = memo(() => {
   const isMobile = useIsMobile();
+
+  useLayoutEffect(() => {
+    resetNavPanel();
+  }, []);
 
   return (
     <Flexbox flex={1} height={'100%'} horizontal={!isMobile} width={'100%'}>

--- a/src/features/NavPanel/index.tsx
+++ b/src/features/NavPanel/index.tsx
@@ -28,6 +28,12 @@ const setNavPanelSnapshot = (snapshot: NavPanelSnapshot) => {
   listeners.forEach((listener) => listener());
 };
 
+export const resetNavPanel = () => {
+  if (!currentSnapshot) return;
+
+  setNavPanelSnapshot(null);
+};
+
 const FALLBACK_NAV_KEY = 'home';
 
 const getActiveNavKey = () => currentSnapshot?.key ?? FALLBACK_NAV_KEY;

--- a/src/locales/default/topic.ts
+++ b/src/locales/default/topic.ts
@@ -59,6 +59,7 @@ export default {
   'renameModal.title': 'Rename Topic',
   'searchPlaceholder': 'Search Topics...',
   'searchResultEmpty': 'No search results found.',
+  'sidebar.title': 'Topics',
   'taskManager.agent': 'Task Agent',
   'taskManager.welcome': 'Ask me about your tasks',
   'temp': 'Temporary',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/index.tsx
@@ -42,8 +42,13 @@ const Topic = memo<TopicProps>(({ itemKey }) => {
       title={
         <Flexbox horizontal align="center" gap={4}>
           <Text ellipsis fontSize={12} type={'secondary'} weight={500}>
-            {`${t('title')} ${topicCount > 0 ? topicCount : ''}`}
+            {t('sidebar.title')}
           </Text>
+          {topicCount > 0 && (
+            <Text fontSize={11} type="secondary">
+              {topicCount}
+            </Text>
+          )}
           {isRevalidating && <NeuralNetworkLoading size={14} />}
         </Flexbox>
       }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No linked issue found.

#### 🔀 Description of Change

- Reset the shared NavPanel snapshot when the task workspace mounts so `/tasks` falls back to the home sidebar instead of keeping the previous agent sidebar.
- Keep the home sidebar's existing route-driven active state, so `Tasks` is selected on `/tasks`.
- Split the agent sidebar topic title and count into separate text nodes and add a dedicated `topic.sidebar.title` locale key.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bunx vitest run --silent='passed-only' src/features/AgentTasks/TaskWorkspaceLayout.test.tsx
```

Manual verification:

- Opened an agent task detail page.
- Clicked `All tasks`.
- Confirmed `/tasks` shows the home sidebar with `Tasks` selected instead of the agent detail sidebar.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Agent sidebar stayed visible after clicking `All tasks`. | Home sidebar is shown and `Tasks` is selected. |

#### 📝 Additional Information

The untracked `exports/` files were intentionally left out of this PR.
