### PR TITLE
🐛 fix: normalize Anthropic-compatible base URLs

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -2,7 +2,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createDefaultAnthropicClient } from './index';
+import { createAnthropicCompatibleRuntime, createDefaultAnthropicClient } from './index';
 
 vi.mock('@anthropic-ai/sdk', () => {
   const MockAnthropic = vi.fn();
@@ -44,5 +44,42 @@ describe('createDefaultAnthropicClient', () => {
       'User-Agent': 'lobehub/1.0.0-test',
       'X-Custom': 'value',
     });
+  });
+
+  it.each([
+    ['https://aihubmix.com/v1', 'https://aihubmix.com'],
+    ['https://aihubmix.com/v1/messages', 'https://aihubmix.com'],
+    ['https://api.example.com/anthropic/v1', 'https://api.example.com/anthropic'],
+    ['https://api.example.com/anthropic', 'https://api.example.com/anthropic'],
+  ])('should normalize Anthropic SDK-managed baseURL path %s', (baseURL, expectedBaseURL) => {
+    MockedAnthropic.mockClear();
+
+    createDefaultAnthropicClient({ apiKey: 'test-key', baseURL });
+
+    expect(MockedAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: expectedBaseURL,
+      }),
+    );
+  });
+});
+
+describe('createAnthropicCompatibleRuntime', () => {
+  it('should normalize default baseURL before creating a custom client', () => {
+    const createClient = vi.fn((options) => ({ baseURL: options.baseURL }) as unknown as Anthropic);
+    const Runtime = createAnthropicCompatibleRuntime({
+      baseURL: 'https://aihubmix.com/v1',
+      customClient: { createClient },
+      provider: 'test-provider',
+    });
+
+    const runtime = new Runtime({ apiKey: 'test-key' });
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://aihubmix.com',
+      }),
+    );
+    expect(runtime.baseURL).toBe('https://aihubmix.com');
   });
 });

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -44,6 +44,10 @@ type ConstructorOptions<T extends Record<string, any> = any> = ClientOptions & T
 type AnthropicTools = Anthropic.Tool | Anthropic.WebSearchTool20250305;
 
 export const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+const ANTHROPIC_SDK_MESSAGES_PATH_PATTERN = /\/v1(?:\/messages)?\/?$/;
+
+const normalizeAnthropicCompatibleBaseURL = (baseURL?: string | null) =>
+  baseURL?.replace(ANTHROPIC_SDK_MESSAGES_PATH_PATTERN, '');
 
 export interface CustomClientOptions<T extends Record<string, any> = any> {
   createClient?: (options: ConstructorOptions<T>) => Anthropic;
@@ -250,13 +254,14 @@ export const createDefaultAnthropicClient = <T extends Record<string, any> = any
   options: ConstructorOptions<T>,
 ) => {
   const betaHeaders = process.env.ANTHROPIC_BETA_HEADERS;
+  const baseURL = normalizeAnthropicCompatibleBaseURL(options.baseURL);
   const defaultHeaders = {
     'User-Agent': `lobehub/${CURRENT_VERSION}`,
     ...options.defaultHeaders,
     ...(betaHeaders ? { 'anthropic-beta': betaHeaders } : {}),
   };
 
-  return new Anthropic({ ...options, defaultHeaders });
+  return new Anthropic({ ...options, ...(baseURL ? { baseURL } : {}), defaultHeaders });
 };
 
 /**
@@ -435,13 +440,17 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
 
     constructor(options: ClientOptions & Record<string, any> = {}) {
       const apiKey = typeof options.apiKey === 'string' ? options.apiKey.trim() : options.apiKey;
-      const baseURL =
+      const inputBaseURL =
         typeof options.baseURL === 'string' ? options.baseURL.trim() : options.baseURL;
+      // Anthropic SDK appends `/v1/messages`; normalize gateway URLs that already
+      // include that SDK-managed path segment before constructing any client.
+      const baseURL = normalizeAnthropicCompatibleBaseURL(inputBaseURL);
+      const defaultBaseURL = normalizeAnthropicCompatibleBaseURL(DEFAULT_BASE_URL);
 
       const resolvedOptions = {
         ...options,
         apiKey: apiKey || DEFAULT_API_KEY,
-        baseURL: baseURL || DEFAULT_BASE_URL,
+        baseURL: baseURL || defaultBaseURL,
       };
       const {
         apiKey: finalApiKey,
@@ -465,7 +474,7 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
         this.client = new Anthropic(initOptions as ConstructorOptions<T>);
       }
 
-      this.baseURL = baseURL || this.client.baseURL;
+      this.baseURL = finalBaseURL || this.client.baseURL;
       this.id = options.id || provider;
       this.logPrefix = `lobe-model-runtime:${this.id}`;
     }

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -102,6 +102,15 @@ describe('LobeDeepSeekAI', () => {
       expect((runtime as any).baseURL).toBe('https://aihubmix.com');
     });
 
+    it('should normalize /v1 before creating an Anthropic SDK runtime', async () => {
+      const { option } = await resolveFirstRouterOption('https://aihubmix.com/v1', 'anthropic');
+      const runtime = new LobeDeepSeekAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
+
+      expect(option.baseURL).toBe('https://aihubmix.com');
+      expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
+      expect((runtime as any).baseURL).toBe('https://aihubmix.com');
+    });
+
     it('should normalize /anthropic/v1/messages before creating an Anthropic SDK runtime', async () => {
       const { option } = await resolveFirstRouterOption(
         'https://api.deepseek.com/anthropic/v1/messages',

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -102,11 +102,11 @@ describe('LobeDeepSeekAI', () => {
       expect((runtime as any).baseURL).toBe('https://aihubmix.com');
     });
 
-    it('should normalize /v1 before creating an Anthropic SDK runtime', async () => {
+    it('should let Anthropic-compatible runtime normalize /v1 baseURL', async () => {
       const { option } = await resolveFirstRouterOption('https://aihubmix.com/v1', 'anthropic');
       const runtime = new LobeDeepSeekAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
 
-      expect(option.baseURL).toBe('https://aihubmix.com');
+      expect(option.baseURL).toBe('https://aihubmix.com/v1');
       expect(runtime).toBeInstanceOf(LobeDeepSeekAnthropicAI);
       expect((runtime as any).baseURL).toBe('https://aihubmix.com');
     });

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -23,7 +23,7 @@ export interface DeepSeekModelCard {
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
 const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
-const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1(?:\/messages)?\/?$/;
+const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
 
 type DeepSeekSDKType = 'anthropic' | 'openai';
 
@@ -42,8 +42,6 @@ const toContentArray = (content: any) =>
     ? content
     : [{ text: isEmptyContent(content) ? ' ' : content, type: 'text' as const }];
 
-// Anthropic SDK appends `/v1/messages`; gateways configured as `/v1` must be
-// normalized to avoid requests like `/v1/v1/messages`.
 const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
 

--- a/packages/model-runtime/src/providers/deepseek/index.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.ts
@@ -23,7 +23,7 @@ export interface DeepSeekModelCard {
 const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_DEEPSEEK_ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
 const DEEPSEEK_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
-const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
+const DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1(?:\/messages)?\/?$/;
 
 type DeepSeekSDKType = 'anthropic' | 'openai';
 
@@ -42,6 +42,8 @@ const toContentArray = (content: any) =>
     ? content
     : [{ text: isEmptyContent(content) ? ' ' : content, type: 'text' as const }];
 
+// Anthropic SDK appends `/v1/messages`; gateways configured as `/v1` must be
+// normalized to avoid requests like `/v1/v1/messages`.
 const normalizeDeepSeekAnthropicBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(DEEPSEEK_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - internal provider routing incident, no public issue found.

#### 🔀 Description of Change

Normalize Anthropic-compatible runtime base URLs that end with `/v1` or `/v1/messages` before constructing Anthropic SDK clients.

The Anthropic SDK appends `/v1/messages` to the configured base URL. When a gateway channel is configured as `https://example.com/v1`, requests become `https://example.com/v1/v1/messages` and fail with 404.

This change moves the normalization into `anthropicCompatibleFactory` so the guard applies to all Anthropic-compatible providers, including DeepSeek and Moonshot style gateway routes. DeepSeek keeps a regression test for the incident path where the router option remains `/v1` and the lower-level Anthropic-compatible runtime normalizes it before SDK construction.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified with:

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' 'src/core/anthropicCompatibleFactory/index.test.ts' 'src/providers/deepseek/index.test.ts'
```

Local incident reproduction:

- Before this fix, a DeepSeek Anthropic-compatible aihubmix route attempted `https://aihubmix.com/v1/v1/messages` and returned 404.
- After this fix, the Anthropic-compatible runtime normalizes the base URL before Anthropic SDK request construction.

#### 📸 Screenshots / Videos

N/A - runtime-only change.

#### 📝 Additional Information

No UI changes.
