### PR TITLE
🐛 fix(model): allow multiple reference images for gpt-image-2

### DIFF
--- a/packages/model-bank/src/aiModels/lobehub/utils.ts
+++ b/packages/model-bank/src/aiModels/lobehub/utils.ts
@@ -86,7 +86,7 @@ export const gptImage1Schema = {
 // Until the schema/UI supports free-form W×H input, we expose the official
 // "Popular sizes" list from https://developers.openai.com/docs/guides/image-generation.
 export const gptImage2Schema = {
-  imageUrls: { default: [], maxCount: 1, maxFileSize: 5 * 1024 * 1024 },
+  imageUrls: { default: [], maxCount: 10, maxFileSize: 5 * 1024 * 1024 },
   prompt: { default: '' },
   size: {
     default: 'auto',


### PR DESCRIPTION
## 💻 Changes

Raise `gptImage2Schema.imageUrls.maxCount` from **1** to **10** in `packages/model-bank/src/aiModels/lobehub/utils.ts`.

## 🤔 Motivation

OpenAI's `/v1/images/edits` endpoint with `model=gpt-image-2` accepts an **array** of input images:

- The official guide states: *"You can use one or more images as a reference to generate a new image."*
- The official Python example passes **4 images** at once:

  ```python
  client.images.edit(
      model="gpt-image-2",
      image=[
          open("body-lotion.png", "rb"),
          open("bath-bomb.png", "rb"),
          open("incense-kit.png", "rb"),
          open("soap.png", "rb"),
      ],
      prompt=prompt,
  )
  ```

- The API reference further notes: *"For GPT image models, you can provide up to 16 images."*

Previously the hardcoded `maxCount: 1` silently capped users to a single reference image, blocking multi-image composition — a core differentiator of gpt-image-2.

## ⚖️ Why 10 (not 16)?

- 10 covers virtually all practical use cases.
- Each input image is billed under `imageInput` token rates — keeping a soft ceiling avoids accidental cost spikes.
- Operators can still raise this further in their own fork if needed.

## ✅ Scope

- ✓ Only `gptImage2Schema` changes (line 89).
- ✗ `gptImage1Schema` (line 76) stays at `maxCount: 1` — gpt-image-1 only supports a single reference image per its own API spec.

## 📚 References

- https://developers.openai.com/docs/guides/image-generation
- OpenAI API reference: `/v1/images/edits` → `image` parameter (array, up to 16)