### PR TITLE
🐛 fix: surface stderr in errorOutput fallback and add `UNKNOWN_EXEC_ERROR` prefix

### DIFF
--- a/packages/builtin-tool-local-system/src/client/executor/index.ts
+++ b/packages/builtin-tool-local-system/src/client/executor/index.ts
@@ -66,7 +66,8 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
   }): BuiltinToolResult {
     const errorMessage =
       typeof output.error?.message === 'string' ? output.error.message : undefined;
-    const safeContent = output.content || errorMessage || 'Tool execution failed';
+    const safeContent =
+      output.content || errorMessage || '[UNKNOWN_EXEC_ERROR] Tool execution failed';
 
     if (!output.success) {
       return {

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -298,7 +298,10 @@ export abstract class ComputerRuntime {
       if (!result.success) {
         return this.errorOutput(result, {
           error: result.error?.message,
+          exitCode: result.result?.exitCode ?? result.result?.exit_code,
           isBackground: args.background || false,
+          stderr: result.result?.stderr,
+          stdout: result.result?.stdout,
           success: false,
         });
       }

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -468,10 +468,19 @@ export abstract class ComputerRuntime {
     // error object, JSON.stringify(undefined) returns the value `undefined`
     // (not the string "undefined"), which collapsed downstream into an empty
     // tool-message content while pluginState still got persisted.
+    //
+    // Priority chain:
+    //   1. result.error.message (explicit error from service layer)
+    //   2. JSON.stringify(result.error) (non-Error error objects)
+    //   3. state.stderr (e.g. git commit failure — exit ≠ 0, error in stderr)
+    //   4. state.error (runtime-level error message)
+    //   5. [UNKNOWN_EXEC_ERROR] Tool execution failed (last-resort fallback)
     const errorText =
       result.error?.message ||
       (result.error !== undefined ? JSON.stringify(result.error) : undefined) ||
-      'Tool execution failed';
+      (typeof state?.stderr === 'string' ? state.stderr : undefined) ||
+      (typeof state?.error === 'string' ? state.error : undefined) ||
+      '[UNKNOWN_EXEC_ERROR] Tool execution failed';
     return {
       content: errorText,
       state,


### PR DESCRIPTION
## Summary

When a shell command fails with a non-zero exit code (e.g. `git commit` with nothing to commit), the runner puts the error message in `stderr` but does not set the `error` field. This caused `errorOutput()` to fall through to the hardcoded `'Tool execution failed'` string, losing the actual error.

## Root Cause

In the `runCommand` call chain:

1. `local-file-shell/runner.ts` — non-zero exit → sets `stderr`, but `error` field remains `undefined`
2. `ExecutionRuntime.normalizeResult()` — passes through `error: undefined`
3. `ComputerRuntime.errorOutput()` — `result.error?.message` is `undefined`, falls to hardcoded string

## Changes

### `ComputerRuntime.errorOutput()`
- Added `state.stderr` and `state.error` as fallback sources before the final hardcoded string
- Final fallback changed to `[UNKNOWN_EXEC_ERROR] Tool execution failed` for easier grepping

### `executor/index.ts toResult()`
- Same `[UNKNOWN_EXEC_ERROR]` prefix applied for consistency

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `git commit` with clean tree | `Tool execution failed` | `nothing to commit, working tree clean` |
| Unknown error (all fields empty) | `Tool execution failed` | `[UNKNOWN_EXEC_ERROR] Tool execution failed` |
| Service error with message | unchanged | unchanged |