### PR TITLE
🐛 fix(local-file-shell): auto-enable hidden matching for dot-prefixed patterns

### DIFF
--- a/apps/desktop/src/main/modules/contentSearch/__tests__/base.test.ts
+++ b/apps/desktop/src/main/modules/contentSearch/__tests__/base.test.ts
@@ -143,6 +143,30 @@ describe('BaseContentSearch', () => {
         expect(args).toContain('*.ts');
       });
 
+      it('should add --hidden when glob references a dot-prefixed segment', () => {
+        const params: GrepContentParams = {
+          glob: '.github/workflows/*.yml',
+          pattern: 'jobs',
+        };
+
+        const args = contentSearch.testBuildGrepArgs('rg', params);
+
+        expect(args).toContain('--hidden');
+        expect(args).toContain('-g');
+        expect(args).toContain('.github/workflows/*.yml');
+      });
+
+      it('should not add --hidden for a normal glob', () => {
+        const params: GrepContentParams = {
+          glob: '*.ts',
+          pattern: 'test',
+        };
+
+        const args = contentSearch.testBuildGrepArgs('rg', params);
+
+        expect(args).not.toContain('--hidden');
+      });
+
       it('should build rg args with type filter', () => {
         const params: GrepContentParams = {
           pattern: 'test',
@@ -203,6 +227,17 @@ describe('BaseContentSearch', () => {
 
         expect(args).toContain('-G');
         expect(args).toContain('*.tsx');
+      });
+
+      it('should add --hidden when glob references a dot-prefixed segment', () => {
+        const params: GrepContentParams = {
+          glob: '.github/workflows/*.yml',
+          pattern: 'jobs',
+        };
+
+        const args = contentSearch.testBuildGrepArgs('ag', params);
+
+        expect(args).toContain('--hidden');
       });
 
       it('should build ag args for count mode', () => {

--- a/apps/desktop/src/main/modules/contentSearch/base.ts
+++ b/apps/desktop/src/main/modules/contentSearch/base.ts
@@ -65,6 +65,12 @@ export abstract class BaseContentSearch {
     const { pattern, output_mode = 'files_with_matches' } = params;
     const args: string[] = [];
 
+    // When the caller's glob references a dot-prefixed segment (e.g.
+    // `.github/workflows/*.yml`), rg and ag both default to skipping hidden
+    // paths and would silently return zero results. `.git/` is still excluded
+    // explicitly below.
+    const wantsHidden = !!params.glob && /(?:^|\/)\.[^./]/.test(params.glob);
+
     switch (tool) {
       case 'rg': {
         // ripgrep arguments
@@ -74,6 +80,7 @@ export abstract class BaseContentSearch {
         if (params['-B']) args.push('-B', String(params['-B']));
         if (params['-C']) args.push('-C', String(params['-C']));
         if (params.multiline) args.push('-U');
+        if (wantsHidden) args.push('--hidden');
         if (params.glob) args.push('-g', params.glob);
         if (params.type) args.push('-t', params.type);
 
@@ -100,6 +107,7 @@ export abstract class BaseContentSearch {
         if (params['-A']) args.push('-A', String(params['-A']));
         if (params['-B']) args.push('-B', String(params['-B']));
         if (params['-C']) args.push('-C', String(params['-C']));
+        if (wantsHidden) args.push('--hidden');
         if (params.glob) args.push('-G', params.glob);
 
         // Output mode

--- a/packages/local-file-shell/src/file/__tests__/file.test.ts
+++ b/packages/local-file-shell/src/file/__tests__/file.test.ts
@@ -515,6 +515,38 @@ describe('file operations', () => {
 
       expect(result.files).toEqual(['src.ts']);
     });
+
+    it('should auto-enable hidden matching when pattern contains a dot-prefixed segment', async () => {
+      await mkdir(path.join(tmpDir, '.github', 'workflows'), { recursive: true });
+      await writeFile(path.join(tmpDir, '.github', 'workflows', 'ci.yml'), 'name: ci');
+      await writeFile(path.join(tmpDir, '.github', 'workflows', 'release.yaml'), 'name: release');
+
+      const result = await globLocalFiles({
+        cwd: tmpDir,
+        pattern: '.github/workflows/*.{yml,yaml}',
+      });
+
+      expect(result.files).toHaveLength(2);
+      expect(result.files).toContain('.github/workflows/ci.yml');
+      expect(result.files).toContain('.github/workflows/release.yaml');
+      expect(result.hint).toContain('hidden');
+    });
+
+    it('should not return a hint when pattern has no dot-prefixed segment', async () => {
+      await writeFile(path.join(tmpDir, 'a.ts'), 'a');
+
+      const result = await globLocalFiles({ cwd: tmpDir, pattern: '*.ts' });
+
+      expect(result.hint).toBeUndefined();
+    });
+
+    it('should treat ./ and ../ as relative path indicators, not hidden segments', async () => {
+      await writeFile(path.join(tmpDir, 'a.ts'), 'a');
+
+      const result = await globLocalFiles({ cwd: tmpDir, pattern: './*.ts' });
+
+      expect(result.hint).toBeUndefined();
+    });
   });
 
   // ─── grepContent ───
@@ -534,6 +566,29 @@ describe('file operations', () => {
 
       const result = await grepContent({ cwd: tmpDir, pattern: 'xyz_not_found' });
       expect(result.matches).toEqual([]);
+    });
+
+    it('should return a hidden-matching hint when filePattern contains a dot-prefixed segment', async () => {
+      // The hint is set regardless of whether rg is installed on the host —
+      // it signals to the agent why we're auto-enabling --hidden so a zero
+      // match doesn't look like a silent failure.
+      const result = await grepContent({
+        cwd: tmpDir,
+        filePattern: '.github/workflows/*.yml',
+        pattern: 'jobs',
+      });
+
+      expect(result.hint).toContain('hidden');
+    });
+
+    it('should not return a hint for a normal filePattern', async () => {
+      const result = await grepContent({
+        cwd: tmpDir,
+        filePattern: '*.ts',
+        pattern: 'jobs',
+      });
+
+      expect(result.hint).toBeUndefined();
     });
   });
 
@@ -572,6 +627,18 @@ describe('file operations', () => {
       });
 
       expect(result).toEqual([]);
+    });
+
+    it('should find dot-prefixed files when keywords starts with a dot', async () => {
+      await writeFile(path.join(tmpDir, '.env'), 'A=1');
+      await writeFile(path.join(tmpDir, '.envrc'), 'export A=1');
+      await writeFile(path.join(tmpDir, 'env.txt'), 'unrelated');
+
+      const result = await searchLocalFiles({ directory: tmpDir, keywords: '.env' });
+
+      const names = result.map((r) => r.name);
+      expect(names).toContain('.env');
+      expect(names).toContain('.envrc');
     });
   });
 });

--- a/packages/local-file-shell/src/file/glob.ts
+++ b/packages/local-file-shell/src/file/glob.ts
@@ -2,14 +2,28 @@ import fg from 'fast-glob';
 
 import type { GlobFilesParams, GlobFilesResult } from '../types';
 import { expandTilde } from './expandTilde';
+import { hasHiddenSegment } from './hasHiddenSegment';
 
 export async function globLocalFiles({ pattern, cwd }: GlobFilesParams): Promise<GlobFilesResult> {
   try {
+    // When the pattern explicitly references a dot-prefixed segment (e.g.
+    // `.github/workflows/*.yml`), the caller clearly wants to traverse a
+    // hidden directory — auto-enable hidden matching so it doesn't silently
+    // return zero results.
+    const wantsHidden = hasHiddenSegment(pattern);
+
     const files = await fg(pattern, {
       cwd: expandTilde(cwd) || process.cwd(),
-      dot: false,
+      dot: wantsHidden,
       ignore: ['**/node_modules/**', '**/.git/**'],
     });
+
+    if (wantsHidden) {
+      return {
+        files,
+        hint: `Auto-enabled hidden-file matching because pattern contains a dot-prefixed segment.`,
+      };
+    }
     return { files };
   } catch (error) {
     return { error: (error as Error).message, files: [] };

--- a/packages/local-file-shell/src/file/grep.ts
+++ b/packages/local-file-shell/src/file/grep.ts
@@ -2,14 +2,27 @@ import { spawn } from 'node:child_process';
 
 import type { GrepContentParams, GrepContentResult } from '../types';
 import { expandTilde } from './expandTilde';
+import { hasHiddenSegment } from './hasHiddenSegment';
 
 export async function grepContent({
   pattern,
   cwd,
   filePattern,
 }: GrepContentParams): Promise<GrepContentResult> {
+  // When the filePattern explicitly references a dot-prefixed segment, the
+  // caller wants to scan inside a hidden directory — pass `--hidden` to rg so
+  // it doesn't silently skip these paths. We still rely on rg's built-in
+  // `.git/` exclusion via .gitignore semantics, plus add an explicit guard.
+  const wantsHidden = hasHiddenSegment(filePattern);
+  const hint = wantsHidden
+    ? `Auto-enabled hidden-file matching because filePattern contains a dot-prefixed segment.`
+    : undefined;
+
   return new Promise<GrepContentResult>((resolve) => {
     const args = ['--json', '-n'];
+    if (wantsHidden) {
+      args.push('--hidden', '--glob', '!**/.git/**');
+    }
     if (filePattern) args.push('--glob', filePattern);
     args.push(pattern);
 
@@ -25,7 +38,7 @@ export async function grepContent({
 
     child.on('close', (code) => {
       if (code !== 0 && code !== 1) {
-        resolve({ matches: [], success: false });
+        resolve({ hint, matches: [], success: false });
         return;
       }
 
@@ -42,14 +55,14 @@ export async function grepContent({
           })
           .filter(Boolean);
 
-        resolve({ matches, success: true });
+        resolve({ hint, matches, success: true });
       } catch {
-        resolve({ matches: [], success: true });
+        resolve({ hint, matches: [], success: true });
       }
     });
 
     child.on('error', () => {
-      resolve({ matches: [], success: false });
+      resolve({ hint, matches: [], success: false });
     });
   });
 }

--- a/packages/local-file-shell/src/file/hasHiddenSegment.ts
+++ b/packages/local-file-shell/src/file/hasHiddenSegment.ts
@@ -1,0 +1,13 @@
+/**
+ * Detect whether a glob pattern (or path) contains a dot-prefixed segment such
+ * as `.github`, `.husky`, or `foo/.config`. Used to auto-enable hidden-file
+ * matching when the caller's intent is clearly to traverse a hidden directory
+ * — otherwise `fast-glob` (`dot: false`) and `ripgrep` (no `--hidden`) silently
+ * return zero results.
+ *
+ * Skips `.` and `..` (relative path indicators), which are not hidden segments.
+ */
+export const HIDDEN_SEGMENT_RE = /(?:^|\/)\.[^./]/;
+
+export const hasHiddenSegment = (pattern: string | undefined): boolean =>
+  !!pattern && HIDDEN_SEGMENT_RE.test(pattern);

--- a/packages/local-file-shell/src/file/search.ts
+++ b/packages/local-file-shell/src/file/search.ts
@@ -14,9 +14,12 @@ export async function searchLocalFiles({
 }: SearchFilesParams): Promise<SearchFilesResult[]> {
   try {
     const cwd = expandTilde(directory) || process.cwd();
+    // If the caller is searching for a dot-prefixed name (e.g. `.env`, `.github`),
+    // auto-enable hidden matching so the file/directory is actually reachable.
+    const wantsHidden = keywords.startsWith('.');
     const files = await fg(`**/*${keywords}*`, {
       cwd,
-      dot: false,
+      dot: wantsHidden,
       ignore: ['**/node_modules/**', '**/.git/**'],
     });
 

--- a/packages/local-file-shell/src/types.ts
+++ b/packages/local-file-shell/src/types.ts
@@ -124,6 +124,8 @@ export interface GlobFilesParams {
 export interface GlobFilesResult {
   error?: string;
   files: string[];
+  /** Diagnostic note returned when the engine had to adjust behavior, e.g. auto-enabling hidden-file matching. */
+  hint?: string;
 }
 
 export interface SearchFilesParams {
@@ -173,6 +175,8 @@ export interface GrepContentParams {
 
 export interface GrepContentResult {
   error?: string;
+  /** Diagnostic note returned when the engine had to adjust behavior, e.g. auto-enabling hidden-file matching. */
+  hint?: string;
   matches: any[];
   success: boolean;
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — reported via internal agent trace where `globLocalFiles({ pattern: '.github/workflows/*.{yml,yaml}' })` silently returned `0 files`.

#### 🔀 Description of Change

When callers passed patterns like `.github/workflows/*.yml` to `globLocalFiles`, `searchLocalFiles`, or `grepContent`, the underlying engines (`fast-glob` with `dot: false`, and `rg` without `--hidden`) silently skipped dot-prefixed directories and returned zero results — making it look like the files didn't exist.

This PR detects when a pattern explicitly references a hidden segment (`.foo/...` or `foo/.bar/...`, excluding `./` and `../` relative-path indicators) and **auto-enables hidden matching**. A `hint` field on the result explains the auto-adjustment so the agent doesn't treat an empty match as a silent failure.

**Files changed**

- `packages/local-file-shell/src/file/hasHiddenSegment.ts` (new) — shared dot-segment detector using `(?:^|\/)\.[^./]`
- `packages/local-file-shell/src/file/glob.ts` — pattern contains dot segment → `fast-glob` `dot: true` + `hint`
- `packages/local-file-shell/src/file/search.ts` — `keywords` starts with `.` → `fast-glob` `dot: true`
- `packages/local-file-shell/src/file/grep.ts` — `filePattern` contains dot segment → `rg --hidden` + explicit `--glob '!**/.git/**'` + `hint`
- `packages/local-file-shell/src/types.ts` — add `hint?: string` to `GlobFilesResult` / `GrepContentResult`
- `apps/desktop/src/main/modules/contentSearch/base.ts` — `buildGrepArgs` adds `--hidden` for rg/ag when `glob` contains a dot segment (desktop `fileSearch/impl/unix.ts` already used `--hidden --no-ignore` / `dot: true`, so it didn't need changes)

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

\`\`\`bash
# local-file-shell — 54/54
cd packages/local-file-shell && bunx vitest run --silent='passed-only' 'src/file/__tests__/file.test.ts'

# desktop contentSearch — 25/25
cd apps/desktop && bunx vitest run --silent='passed-only' 'src/main/modules/contentSearch/__tests__/base.test.ts'

# builtin-tool-local-system integration — 32/32
cd packages/builtin-tool-local-system && bunx vitest run --silent='passed-only' 'src/__tests__/'
\`\`\`

New test cases cover:
- `globLocalFiles` auto-matches `.github/workflows/*.{yml,yaml}` and returns `hint`
- Plain patterns (`*.ts`) get no `hint`
- `./` and `../` are treated as relative indicators, not hidden segments
- `searchLocalFiles({ keywords: '.env' })` finds `.env` / `.envrc`
- `grepContent` sets `hint` when `filePattern` contains a dot segment
- Desktop `buildGrepArgs` adds `--hidden` to rg/ag for dot-prefixed globs, omits it for normal globs

#### 📝 Additional Information

`packages/electron-client-ipc/src/types/localSystem.ts` declares its own `GlobFilesResult` / `GrepContentResult` for the IPC surface and was intentionally left unchanged to keep the IPC contract minimal. The `hint` field still propagates at runtime via structured-clone — if we want the renderer to consume it explicitly, we can add `hint?: string` there in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)