### PR TITLE
🐛 fix(hetero-agent): fire IM bot-callback webhook from heteroFinish

### DIFF
--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -144,6 +144,17 @@ export interface ChatTopicMetadata {
    */
   runningOperation?: {
     assistantMessageId: string;
+    /**
+     * Webhook to fire when the operation completes.
+     * Populated by the IM bot path so heterogeneous agents (Claude Code / Codex)
+     * can call back to the bot-callback endpoint even though they bypass the
+     * normal hook registration flow.
+     */
+    completionWebhook?: {
+      body?: Record<string, unknown>;
+      delivery?: 'fetch' | 'qstash';
+      url: string;
+    };
     operationId: string;
     scope?: string;
     threadId?: string | null;

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -625,6 +625,13 @@ export const topicRouter = router({
           runningOperation: z
             .object({
               assistantMessageId: z.string(),
+              completionWebhook: z
+                .object({
+                  body: z.record(z.unknown()).optional(),
+                  delivery: z.enum(['fetch', 'qstash']).optional(),
+                  url: z.string(),
+                })
+                .optional(),
               operationId: z.string(),
               scope: z.string().optional(),
               threadId: z.string().nullable().optional(),

--- a/src/server/services/agentRuntime/hooks/HookDispatcher.ts
+++ b/src/server/services/agentRuntime/hooks/HookDispatcher.ts
@@ -18,7 +18,7 @@ const log = debug('lobe-server:hook-dispatcher');
 /**
  * Delivers a webhook via HTTP POST (fetch or QStash)
  */
-async function deliverWebhook(
+export async function deliverWebhook(
   webhook: AgentHookWebhook,
   payload: Record<string, unknown>,
 ): Promise<void> {

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -738,9 +738,12 @@ export class AiAgentService {
       };
 
       // Seed topic.metadata.runningOperation so heteroIngest can validate the operation.
+      // completionWebhook is stored so heteroFinish can call back to the IM bot-callback
+      // endpoint even though the hetero path bypasses the normal hook registration flow.
       await this.topicModel.updateMetadata(topicId, {
         runningOperation: {
           assistantMessageId: assistantMsg.id,
+          completionWebhook: hooks?.find((h) => h.type === 'onComplete')?.webhook,
           operationId,
           scope: appContext?.scope ?? undefined,
           threadId: appContext?.threadId ?? undefined,

--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -8,6 +8,7 @@ import { TopicModel } from '@/database/models/topic';
 import { createStreamEventManager } from '@/server/modules/AgentRuntime/factory';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
 import { deliverWebhook } from '@/server/services/agentRuntime/hooks/HookDispatcher';
+import type { AgentHookWebhook } from '@/server/services/agentRuntime/hooks/types';
 
 import { HeterogeneousPersistenceHandler } from './HeterogeneousPersistenceHandler';
 
@@ -152,23 +153,35 @@ export class HeterogeneousAgentService {
       type: 'agent_runtime_end',
     });
 
+    // Clear runningOperation from topic metadata so reconnect doesn't retrigger
+    // after completion — mirrors the same cleanup done in RuntimeExecutors for
+    // the normal LLM path.  Also read completionWebhook here so a second
+    // heteroFinish call (signal + normal exit replay) finds it already gone and
+    // skips delivery, preventing duplicate IM replies.
+    let completionWebhook: AgentHookWebhook | undefined;
+    try {
+      const topic = await this.topicModel.findById(topicId);
+      completionWebhook = topic?.metadata?.runningOperation?.completionWebhook;
+      await this.topicModel.updateMetadata(topicId, { runningOperation: null });
+    } catch (err) {
+      log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
+    }
+
     // Fire the IM bot-callback completion webhook if one was registered.
     // The hetero path bypasses the normal AgentHook registration flow, so
     // we persist the webhook config in topic.metadata.runningOperation and
     // deliver it here instead.
-    try {
-      const topic = await this.topicModel.findById(topicId);
-      const completionWebhook = topic?.metadata?.runningOperation?.completionWebhook;
-      if (completionWebhook?.url) {
+    if (completionWebhook?.url) {
+      try {
         await deliverWebhook(completionWebhook, {
-          ...completionWebhook.body,
           hookId: 'bot-completion',
           hookType: 'onComplete',
+          ...completionWebhook.body,
         });
         log('heteroFinish: completionWebhook delivered for op=%s', operationId);
+      } catch (err) {
+        log('heteroFinish: completionWebhook delivery failed (non-fatal): %O', err);
       }
-    } catch (err) {
-      log('heteroFinish: completionWebhook delivery failed (non-fatal): %O', err);
     }
   }
 

--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -7,6 +7,7 @@ import { ThreadModel } from '@/database/models/thread';
 import { TopicModel } from '@/database/models/topic';
 import { createStreamEventManager } from '@/server/modules/AgentRuntime/factory';
 import { type IStreamEventManager } from '@/server/modules/AgentRuntime/types';
+import { deliverWebhook } from '@/server/services/agentRuntime/hooks/HookDispatcher';
 
 import { HeterogeneousPersistenceHandler } from './HeterogeneousPersistenceHandler';
 
@@ -150,6 +151,25 @@ export class HeterogeneousAgentService {
       stepIndex: 0,
       type: 'agent_runtime_end',
     });
+
+    // Fire the IM bot-callback completion webhook if one was registered.
+    // The hetero path bypasses the normal AgentHook registration flow, so
+    // we persist the webhook config in topic.metadata.runningOperation and
+    // deliver it here instead.
+    try {
+      const topic = await this.topicModel.findById(topicId);
+      const completionWebhook = topic?.metadata?.runningOperation?.completionWebhook;
+      if (completionWebhook?.url) {
+        await deliverWebhook(completionWebhook, {
+          ...completionWebhook.body,
+          hookId: 'bot-completion',
+          hookType: 'onComplete',
+        });
+        log('heteroFinish: completionWebhook delivered for op=%s', operationId);
+      }
+    } catch (err) {
+      log('heteroFinish: completionWebhook delivery failed (non-fatal): %O', err);
+    }
   }
 
   /**

--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -155,10 +155,22 @@ export class HeterogeneousAgentService {
       type: 'agent_runtime_end',
     });
 
-    // Clear runningOperation from topic metadata so reconnect doesn't retrigger
-    // after completion — mirrors the same cleanup done in RuntimeExecutors for
-    // the normal LLM path.  Read completionWebhook and assistantMessageId first
-    // so they are available for webhook delivery below.
+    // Fire the IM bot-callback completion webhook if one was registered.
+    // The hetero path bypasses the normal AgentHook registration flow, so
+    // we persist the webhook config in topic.metadata.runningOperation and
+    // deliver it here instead.
+    //
+    // Skip on `cancelled` — heteroFinish may be called twice: first with
+    // result=cancelled (termination signal) then with result=success/error
+    // (normal process exit). We must NOT clear runningOperation on cancelled
+    // so the subsequent success/error call can still find completionWebhook
+    // and assistantMessageId. runningOperation is only cleared on the
+    // delivering call (success/error) so reconnect doesn't retrigger after
+    // completion — mirrors RuntimeExecutors cleanup for the normal LLM path.
+    // Transport-level retries of the same result are accepted: BotCallbackService
+    // reads the latest DB content each time, so duplicates are idempotent.
+    if (result === 'cancelled') return;
+
     let completionWebhook: AgentHookWebhook | undefined;
     let assistantMessageId: string | undefined;
     try {
@@ -170,18 +182,7 @@ export class HeterogeneousAgentService {
       log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
     }
 
-    // Fire the IM bot-callback completion webhook if one was registered.
-    // The hetero path bypasses the normal AgentHook registration flow, so
-    // we persist the webhook config in topic.metadata.runningOperation and
-    // deliver it here instead.
-    //
-    // Skip on `cancelled` — heteroFinish may be called twice when the CLI
-    // receives a termination signal (cancelled) followed by normal exit
-    // (success/error). Delivering on cancelled would send a truncated reply;
-    // the subsequent success/error call will deliver the real content instead.
-    // Transport-level retries of the same result are accepted: BotCallbackService
-    // reads the latest DB content each time, so duplicates are idempotent.
-    if (completionWebhook?.url && result !== 'cancelled') {
+    if (completionWebhook?.url) {
       try {
         // Read the final assistant message content so BotCallbackService.handleCompletion
         // has lastAssistantContent to render.  Without it the handler skips delivery.

--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -61,6 +61,7 @@ export interface HeterogeneousAgentServiceOptions {
  */
 export class HeterogeneousAgentService {
   private readonly db: LobeChatDatabase;
+  private readonly messageModel: MessageModel;
   private readonly persistenceHandler: HeterogeneousPersistenceHandler;
   private readonly streamEventManager: IStreamEventManager;
   private readonly topicModel: TopicModel;
@@ -73,12 +74,13 @@ export class HeterogeneousAgentService {
   ) {
     this.db = db;
     this.userId = userId;
+    this.messageModel = new MessageModel(db, userId);
     this.streamEventManager = options.streamEventManager ?? createStreamEventManager();
     this.topicModel = options.topicModel ?? new TopicModel(db, userId);
     this.persistenceHandler =
       options.persistenceHandler ??
       new HeterogeneousPersistenceHandler({
-        messageModel: new MessageModel(db, userId),
+        messageModel: this.messageModel,
         threadModel: new ThreadModel(db, userId),
         topicModel: this.topicModel,
       });
@@ -155,11 +157,14 @@ export class HeterogeneousAgentService {
 
     // Clear runningOperation from topic metadata so reconnect doesn't retrigger
     // after completion — mirrors the same cleanup done in RuntimeExecutors for
-    // the normal LLM path.
+    // the normal LLM path.  Read completionWebhook and assistantMessageId first
+    // so they are available for webhook delivery below.
     let completionWebhook: AgentHookWebhook | undefined;
+    let assistantMessageId: string | undefined;
     try {
       const topic = await this.topicModel.findById(topicId);
       completionWebhook = topic?.metadata?.runningOperation?.completionWebhook;
+      assistantMessageId = topic?.metadata?.runningOperation?.assistantMessageId;
       await this.topicModel.updateMetadata(topicId, { runningOperation: null });
     } catch (err) {
       log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);
@@ -178,9 +183,28 @@ export class HeterogeneousAgentService {
     // reads the latest DB content each time, so duplicates are idempotent.
     if (completionWebhook?.url && result !== 'cancelled') {
       try {
+        // Read the final assistant message content so BotCallbackService.handleCompletion
+        // has lastAssistantContent to render.  Without it the handler skips delivery.
+        let lastAssistantContent: string | undefined;
+        if (assistantMessageId) {
+          const msg = await this.messageModel.findById(assistantMessageId);
+          lastAssistantContent = msg?.content as string | undefined;
+        }
+
+        // Map hetero result → reason expected by handleCompletion
+        const reason = result === 'success' ? 'done' : 'error';
+
         await deliverWebhook(completionWebhook, {
+          // Dynamic completion fields (event-like payload)
+          ...(error ? { errorMessage: error.message, errorType: error.type } : {}),
           hookId: 'bot-completion',
           hookType: 'onComplete',
+          lastAssistantContent,
+          operationId,
+          reason,
+          // Static IM context stored at hook registration time — spread last so
+          // platform fields (applicationId, platformThreadId, type, userPrompt)
+          // are authoritative, matching HookDispatcher's { ...event, ...body } order.
           ...completionWebhook.body,
         });
         log('heteroFinish: completionWebhook delivered for op=%s result=%s', operationId, result);

--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -155,9 +155,7 @@ export class HeterogeneousAgentService {
 
     // Clear runningOperation from topic metadata so reconnect doesn't retrigger
     // after completion — mirrors the same cleanup done in RuntimeExecutors for
-    // the normal LLM path.  Also read completionWebhook here so a second
-    // heteroFinish call (signal + normal exit replay) finds it already gone and
-    // skips delivery, preventing duplicate IM replies.
+    // the normal LLM path.
     let completionWebhook: AgentHookWebhook | undefined;
     try {
       const topic = await this.topicModel.findById(topicId);
@@ -171,14 +169,21 @@ export class HeterogeneousAgentService {
     // The hetero path bypasses the normal AgentHook registration flow, so
     // we persist the webhook config in topic.metadata.runningOperation and
     // deliver it here instead.
-    if (completionWebhook?.url) {
+    //
+    // Skip on `cancelled` — heteroFinish may be called twice when the CLI
+    // receives a termination signal (cancelled) followed by normal exit
+    // (success/error). Delivering on cancelled would send a truncated reply;
+    // the subsequent success/error call will deliver the real content instead.
+    // Transport-level retries of the same result are accepted: BotCallbackService
+    // reads the latest DB content each time, so duplicates are idempotent.
+    if (completionWebhook?.url && result !== 'cancelled') {
       try {
         await deliverWebhook(completionWebhook, {
           hookId: 'bot-completion',
           hookType: 'onComplete',
           ...completionWebhook.body,
         });
-        log('heteroFinish: completionWebhook delivered for op=%s', operationId);
+        log('heteroFinish: completionWebhook delivered for op=%s result=%s', operationId, result);
       } catch (err) {
         log('heteroFinish: completionWebhook delivery failed (non-fatal): %O', err);
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follows up on #14913 (which fixed server-side `exec_sub_agent` for normal LLM agents).

#### 🔀 Description of Change

**Root cause**

When an IM bot (`AgentBridgeService.executeWithHooksQueueMode`) triggers a heterogeneous agent (Cloud Claude Code / Codex), `execAgent` takes the hetero early-exit path at the `isHeteroAgent` guard — dispatching the sandbox fire-and-forget and returning immediately. This path **discards all hooks** passed to `execAgent`, so the `bot-completion` webhook registered by the bot bridge is never delivered. `heteroFinish` only writes to the DB and publishes a stream event; it has no knowledge of any pending IM callback. The IM user receives no response.

**Fix — two-step store-then-deliver**

1. **Store**: in the hetero early-exit path, extract the `onComplete` webhook config from the passed hooks and write it into `topic.metadata.runningOperation.completionWebhook` alongside the existing `operationId` / `assistantMessageId` fields.

2. **Deliver**: at the end of `heteroFinish`, read `runningOperation.completionWebhook` from the topic and call the existing `deliverWebhook` helper (now exported from `HookDispatcher`). This honours QStash vs. fetch delivery and resolves relative URLs with `INTERNAL_APP_URL` / `APP_URL` — exactly the same behaviour as the normal LLM hook path.

**Files changed**

| File | Change |
|---|---|
| `packages/types/src/topic/topic.ts` | Add `completionWebhook` to `runningOperation` in `ChatTopicMetadata` |
| `src/server/routers/lambda/topic.ts` | Mirror the type addition in the tRPC Zod schema |
| `src/server/services/agentRuntime/hooks/HookDispatcher.ts` | Export `deliverWebhook` |
| `src/server/services/aiAgent/index.ts` | Persist `onComplete` webhook into `runningOperation` |
| `src/server/services/heterogeneousAgent/index.ts` | Import and fire webhook at end of `heteroFinish` |

**New complete path (IM → hetero agent → IM response)**

```
IM message
  → AgentBridgeService.executeWithHooksQueueMode (registers bot-completion onComplete hook)
  → execAgent(hooks) — hetero early exit
      → stores completionWebhook in topic.metadata.runningOperation
      → spawnHeteroSandbox (fire-and-forget)
  → Claude Code runs, calls heteroFinish
      → persistenceHandler.finish (write DB)
      → streamEventManager.publishStreamEvent (renderer)
      → deliverWebhook(completionWebhook)  ← NEW
          → POST /api/agent/webhooks/bot-callback
              → BotCallbackService.handleCallback
                  → Messenger.createMessage / editMessage
                      → IM user receives response ✓
```

#### 🧪 How to Test

- Configure a bot that routes to a Claude Code (heterogeneous) agent
- Send a message to the bot via IM (Slack / Teams / etc.)
- Verify the bot posts a final reply after Claude Code finishes

- [ ] Tested locally
- [ ] No automated tests (full path requires QStash + IM platform setup)