### PR TITLE
🐛 fix(i18n): align confirmRemoveGroupItemAlert wording with key name

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -101,7 +101,7 @@
   "compression.summary": "Summary",
   "confirmClearCurrentMessages": "You are about to clear the current session messages. Once cleared, they cannot be retrieved. Please confirm your action.",
   "confirmRemoveChatGroupItemAlert": "This Group will be deleted. Group-specific assistants will also be deleted, while external assistants will not be affected.",
-  "confirmRemoveGroupItemAlert": "You are about to delete this category. After deletion, its agents will be moved to the default list. Please confirm your action.",
+  "confirmRemoveGroupItemAlert": "You are about to delete this group. After deletion, its agents will be moved to the default list. Please confirm your action.",
   "confirmRemoveGroupSuccess": "Group deleted successfully",
   "confirmRemoveSessionItemAlert": "You are about to delete this agent. Once deleted, it cannot be retrieved. Please confirm your action.",
   "confirmRemoveSessionSuccess": "Agent removed successfully",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -101,7 +101,7 @@
   "compression.summary": "摘要",
   "confirmClearCurrentMessages": "确认清空当前会话消息吗？清空后无法恢复",
   "confirmRemoveChatGroupItemAlert": "确认删除该群组吗？群组专有助理将会被同样删除，外部助理不受影响",
-  "confirmRemoveGroupItemAlert": "确认删除该分类吗？分类内的助理会移回默认列表",
+  "confirmRemoveGroupItemAlert": "确认删除该分组吗？分组内的助理会移回默认列表",
   "confirmRemoveGroupSuccess": "群组已删除",
   "confirmRemoveSessionItemAlert": "确认删除该助理吗？删除后无法恢复",
   "confirmRemoveSessionSuccess": "助理已删除",


### PR DESCRIPTION
## 💻 Changes

Update the value of `confirmRemoveGroupItemAlert` in **en-US** and **zh-CN** chat.json to use "group" / "分组" instead of "category" / "分类".

## 🤔 Motivation

The key `confirmRemoveGroupItemAlert` mentions **Group**, and its neighbors (`confirmRemoveChatGroupItemAlert`, `confirmRemoveGroupSuccess`) both consistently use **Group**. But en-US and zh-CN are the **only two locales** whose value still says "category" / "分类":

| Locale | Current value snippet | Uses "Group"? |
|---|---|---|
| **en-US** | "You are about to delete this **category**..." | ❌ |
| **zh-CN** | "确认删除该**分类**吗..." | ❌ |
| ar | "حذف هذه **المجموعة**..." | ✅ |
| bg-BG | "тази **група**..." | ✅ |
| de-DE | "diese **Gruppe** zu löschen..." | ✅ |
| es-ES | "este **grupo**..." | ✅ |
| fa-IR | "این **گروه**..." | ✅ |
| fr-FR | "ce **groupe**..." | ✅ |
| it-IT | "questo **gruppo**..." | ✅ |
| ja-JP | "この**グループ**を削除..." | ✅ |
| ko-KR | "이 **그룹**을 삭제..." | ✅ |
| nl-NL | "deze **groep**..." | ✅ |
| pl-PL | "tę **grupę**..." | ✅ |
| pt-BR | "este **grupo**..." | ✅ |
| ru-RU | "эту **группу**..." | ✅ |
| tr-TR | "bu **grubu**..." | ✅ |
| vi-VN | "**nhóm** này..." | ✅ |
| zh-TW | "此**分組**..." | ✅ |

**16 out of 18 locales already use "group"**. en-US and zh-CN appear to be a leftover from #8976 (introducing Group support), where the Category→Group rename was applied to derivative translations but not back-ported to the source-of-truth EN and zh-CN locales.

## ✅ Scope

- ✓ `locales/en-US/chat.json` (line 104): `category` → `group`
- ✓ `locales/zh-CN/chat.json` (line 104): `分类` → `分组`
- ✗ No other locale changed (they already match)
- ✗ No code change (this is purely a string fix)

## 🧪 Verification

After this PR, all 18 locales describe the entity consistently as a "group" in this confirmation dialog, matching:
- the key name `confirmRemoveGroupItemAlert`
- the adjacent `confirmRemoveChatGroupItemAlert` ("This Group will be deleted...")
- the adjacent `confirmRemoveGroupSuccess` ("Group deleted successfully")