### PR TITLE
🐛 fix(nav): align home sidebar layout

### DIFF
--- a/src/routes/(main)/home/_layout/Body/Agent/CreateAgentButton.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/CreateAgentButton.tsx
@@ -53,7 +53,10 @@ const CreateAgentButton = memo<CreateAgentButtonProps>(({ groupId, className }) 
   } = useCreateMenuItems();
 
   const isCustomGroup = Boolean(groupId) && groupId !== SessionDefaultGroup.Default;
-  const menuOptions = isCustomGroup ? { groupId } : undefined;
+  const menuOptions = useMemo(
+    () => (isCustomGroup ? { groupId } : undefined),
+    [groupId, isCustomGroup],
+  );
 
   const dropdownItems = useMemo(() => {
     const heteroItems = createHeterogeneousAgentMenuItems(menuOptions);
@@ -84,8 +87,9 @@ const CreateAgentButton = memo<CreateAgentButtonProps>(({ groupId, className }) 
       align={'center'}
       className={cx(styles.container, className)}
       gap={8}
-      height={32}
+      height={36}
       paddingInline={4}
+      style={{ height: 36 }}
       variant={'borderless'}
       onClick={handleClick}
     >

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -21,13 +21,13 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ActionIcon, Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { Modal } from '@lobehub/ui/base-ui';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { t } from 'i18next';
 import { Eye, EyeOff, GripVertical, PinIcon, RotateCcw } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { create } from 'zustand';
 
 import { getRouteById } from '@/config/routes';
 import { useGlobalStore } from '@/store/global';
@@ -61,21 +61,6 @@ const ALL_SIDEBAR_ITEMS: SidebarItemConfig[] = [
 const ITEM_MAP = new Map(ALL_SIDEBAR_ITEMS.map((item) => [item.id, item]));
 
 const isAccordionKey = (id: string) => SIDEBAR_ACCORDION_KEYS.has(id);
-
-// ---------------------------------------------------------------------------
-// Modal store
-// ---------------------------------------------------------------------------
-
-const useCustomizeSidebarModalStore = create<{
-  open: boolean;
-  setOpen: (open: boolean) => void;
-}>((set) => ({
-  open: false,
-  setOpen: (open) => set({ open }),
-}));
-
-export const openCustomizeSidebarModal = () =>
-  useCustomizeSidebarModalStore.getState().setOpen(true);
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -383,35 +368,23 @@ const CustomizeSidebarContent = memo(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Modal wrapper
+// Modal entry
 // ---------------------------------------------------------------------------
 
-export const CustomizeSidebarModal = memo(() => {
-  const { t } = useTranslation('common');
-  const open = useCustomizeSidebarModalStore((s) => s.open);
-  const setOpen = useCustomizeSidebarModalStore((s) => s.setOpen);
-  const resetSidebarCustomization = useGlobalStore((s) => s.resetSidebarCustomization);
-
-  return (
-    <Modal
-      centered
-      destroyOnHidden
-      open={open}
-      title={t('navPanel.customizeSidebar')}
-      width={360}
-      footer={
-        <Button
-          block
-          icon={<Icon icon={RotateCcw} />}
-          type={'text'}
-          onClick={resetSidebarCustomization}
-        >
-          {t('navPanel.resetDefault' as any)}
-        </Button>
-      }
-      onCancel={() => setOpen(false)}
-    >
-      <CustomizeSidebarContent />
-    </Modal>
-  );
-});
+export const openCustomizeSidebarModal = (): ModalInstance =>
+  createModal({
+    content: <CustomizeSidebarContent />,
+    footer: (
+      <Button
+        block
+        icon={<Icon icon={RotateCcw} />}
+        type={'text'}
+        onClick={() => useGlobalStore.getState().resetSidebarCustomization()}
+      >
+        {t('navPanel.resetDefault', { ns: 'common' })}
+      </Button>
+    ),
+    maskClosable: true,
+    title: t('navPanel.customizeSidebar', { ns: 'common' }),
+    width: 360,
+  });

--- a/src/routes/(main)/home/_layout/Body/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.test.tsx
@@ -78,7 +78,6 @@ vi.mock('./Agent', () => ({
 }));
 
 vi.mock('./CustomizeSidebarModal', () => ({
-  CustomizeSidebarModal: () => null,
   openCustomizeSidebarModal: vi.fn(),
 }));
 

--- a/src/routes/(main)/home/_layout/Body/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.test.tsx
@@ -14,6 +14,10 @@ interface MockGlobalState {
 
 const mocks = vi.hoisted(() => ({
   globalState: undefined as unknown as MockGlobalState,
+  navLayout: {
+    bottomMenuItems: [] as { key: string; title: string; url: string }[],
+    topNavItems: [] as { key: string; title: string; url: string }[],
+  },
   updateSystemStatus: vi.fn(),
 }));
 
@@ -34,7 +38,9 @@ vi.mock('@lobehub/ui', () => ({
   ),
   ActionIcon: () => <span />,
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  Flexbox: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Flexbox: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sidebar-body">{children}</div>
+  ),
   Icon: () => <span />,
 }));
 
@@ -58,7 +64,7 @@ vi.mock('@/hooks/useActiveTabKey', () => ({
 }));
 
 vi.mock('@/hooks/useNavLayout', () => ({
-  useNavLayout: () => ({ bottomMenuItems: [], topNavItems: [] }),
+  useNavLayout: () => mocks.navLayout,
 }));
 
 vi.mock('@/utils/navigation', () => ({
@@ -87,6 +93,10 @@ vi.mock('@/store/global', () => ({
 
 beforeEach(() => {
   mocks.updateSystemStatus.mockReset();
+  mocks.navLayout = {
+    bottomMenuItems: [],
+    topNavItems: [],
+  };
   mocks.globalState = {
     status: {
       hiddenSidebarSections: [],
@@ -119,5 +129,29 @@ describe('Home sidebar body', () => {
     fireEvent.click(screen.getByRole('button', { name: 'collapse recents' }));
 
     expect(mocks.updateSystemStatus).toHaveBeenCalledWith({ sidebarExpandedKeys: ['agent'] });
+  });
+
+  it('keeps custom top ordering above the bottom spacer', () => {
+    mocks.navLayout = {
+      bottomMenuItems: [
+        { key: 'image', title: 'Image', url: '/image' },
+        { key: 'resource', title: 'Resource', url: '/resource' },
+      ],
+      topNavItems: [{ key: 'pages', title: 'Pages', url: '/page' }],
+    };
+    mocks.globalState.status.sidebarItems = ['image', 'pages', 'recents', 'agent', 'resource'];
+
+    render(<Body />);
+
+    const children = Array.from(screen.getByTestId('sidebar-body').children);
+    const spacerIndex = children.findIndex((child) =>
+      child.hasAttribute('data-sidebar-bottom-spacer'),
+    );
+
+    expect(spacerIndex).toBe(2);
+    expect(children[0]).toHaveTextContent('Pages');
+    expect(children[1]).toHaveAttribute('data-testid', 'sidebar-accordion');
+    expect(children[3]).toHaveTextContent('Image');
+    expect(children[4]).toHaveTextContent('Resource');
   });
 });

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -19,7 +19,7 @@ import { isModifierClick } from '@/utils/navigation';
 import { prefetchRoute } from '@/utils/router';
 
 import Agent from './Agent';
-import { CustomizeSidebarModal, openCustomizeSidebarModal } from './CustomizeSidebarModal';
+import { openCustomizeSidebarModal } from './CustomizeSidebarModal';
 
 export enum GroupKey {
   Agent = 'agent',
@@ -101,6 +101,11 @@ const Body = memo(() => {
     return map;
   }, [topNavItems, bottomMenuItems]);
 
+  const bottomNavKeys = useMemo(
+    () => new Set(bottomMenuItems.map((item) => item.key)),
+    [bottomMenuItems],
+  );
+
   // Items that must always be visible regardless of hiddenSections
   const isVisible = useCallback(
     (k: string) => k === GroupKey.Agent || !hiddenSections.includes(k),
@@ -162,6 +167,7 @@ const Body = memo(() => {
   const content = useMemo(() => {
     const elements: ReactElement[] = [];
     let accGroup: { element: ReactElement; key: string }[] = [];
+    let bottomSpacerInserted = false;
 
     const flushAccordion = () => {
       if (accGroup.length > 0) {
@@ -188,17 +194,36 @@ const Body = memo(() => {
       } else {
         flushAccordion();
         const link = renderNavLink(key);
-        if (link) elements.push(link);
+        if (!link) continue;
+
+        if (!bottomSpacerInserted && bottomNavKeys.has(key)) {
+          elements.push(
+            <div
+              aria-hidden
+              data-sidebar-bottom-spacer
+              key={'bottom-nav-spacer'}
+              style={{ flex: '1 1 0', minHeight: 0 }}
+            />,
+          );
+          bottomSpacerInserted = true;
+        }
+
+        elements.push(link);
       }
     }
     flushAccordion();
     return elements;
-  }, [visibleKeys, renderNavLink, sidebarExpandedKeys, handleAccordionExpandedChange]);
+  }, [
+    visibleKeys,
+    renderNavLink,
+    sidebarExpandedKeys,
+    handleAccordionExpandedChange,
+    bottomNavKeys,
+  ]);
 
   return (
-    <Flexbox flex={1} gap={1} paddingInline={4}>
+    <Flexbox flex={1} gap={1} paddingInline={4} style={{ minHeight: '100%' }}>
       {content}
-      <CustomizeSidebarModal />
     </Flexbox>
   );
 });

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -165,54 +165,60 @@ const Body = memo(() => {
   // Render the flat list: group consecutive accordion items into an Accordion,
   // interleave non-accordion keys as nav links.
   const content = useMemo(() => {
-    const elements: ReactElement[] = [];
-    let accGroup: { element: ReactElement; key: string }[] = [];
-    let bottomSpacerInserted = false;
+    const renderSection = (keys: string[], section: 'bottom' | 'top') => {
+      const elements: ReactElement[] = [];
+      let accGroup: { element: ReactElement; key: string }[] = [];
 
-    const flushAccordion = () => {
-      if (accGroup.length > 0) {
-        const accordionKeys = accGroup.map((item) => item.key);
+      const flushAccordion = () => {
+        if (accGroup.length > 0) {
+          const accordionKeys = accGroup.map((item) => item.key);
 
-        elements.push(
-          <Accordion
-            expandedKeys={sidebarExpandedKeys}
-            gap={8}
-            key={`acc-${elements.length}`}
-            onExpandedChange={(keys) => handleAccordionExpandedChange(accordionKeys, keys)}
-          >
-            {accGroup.map((item) => item.element)}
-          </Accordion>,
-        );
-        accGroup = [];
+          elements.push(
+            <Accordion
+              expandedKeys={sidebarExpandedKeys}
+              gap={8}
+              key={`${section}-acc-${elements.length}`}
+              onExpandedChange={(keys) => handleAccordionExpandedChange(accordionKeys, keys)}
+            >
+              {accGroup.map((item) => item.element)}
+            </Accordion>,
+          );
+          accGroup = [];
+        }
+      };
+
+      for (const key of keys) {
+        if (ACCORDION_KEYS.has(key)) {
+          const comp = accordionComponents[key]?.(key);
+          if (comp) accGroup.push({ element: comp, key });
+        } else {
+          flushAccordion();
+          const link = renderNavLink(key);
+          if (link) elements.push(link);
+        }
       }
+      flushAccordion();
+
+      return elements;
     };
 
-    for (const key of visibleKeys) {
-      if (ACCORDION_KEYS.has(key)) {
-        const comp = accordionComponents[key]?.(key);
-        if (comp) accGroup.push({ element: comp, key });
-      } else {
-        flushAccordion();
-        const link = renderNavLink(key);
-        if (!link) continue;
+    const topKeys = visibleKeys.filter((key) => !bottomNavKeys.has(key));
+    const bottomKeys = visibleKeys.filter((key) => bottomNavKeys.has(key));
+    const topElements = renderSection(topKeys, 'top');
+    const bottomElements = renderSection(bottomKeys, 'bottom');
 
-        if (!bottomSpacerInserted && bottomNavKeys.has(key)) {
-          elements.push(
-            <div
-              aria-hidden
-              data-sidebar-bottom-spacer
-              key={'bottom-nav-spacer'}
-              style={{ flex: '1 1 0', minHeight: 0 }}
-            />,
-          );
-          bottomSpacerInserted = true;
-        }
+    if (bottomElements.length === 0) return topElements;
 
-        elements.push(link);
-      }
-    }
-    flushAccordion();
-    return elements;
+    return [
+      ...topElements,
+      <div
+        aria-hidden
+        data-sidebar-bottom-spacer
+        key={'bottom-nav-spacer'}
+        style={{ flex: '1 1 0', minHeight: 0 }}
+      />,
+      ...bottomElements,
+    ];
   }, [
     visibleKeys,
     renderNavLink,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Align the Home sidebar create-agent row height with regular navigation rows.
- Add a grow spacer before the bottom Home sidebar navigation links so Generation, Community, and Resources stay pushed toward the lower section when vertical space is available.
- Open the customize-sidebar modal through the imperative base-ui modal API instead of keeping the modal mounted in the sidebar body.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx eslint 'src/routes/(main)/home/_layout/Body/Agent/CreateAgentButton.tsx'
bunx eslint 'src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx' 'src/routes/(main)/home/_layout/Body/index.tsx' 'src/routes/(main)/home/_layout/Body/index.test.tsx'
bunx vitest run --silent='passed-only' 'src/routes/(main)/home/_layout/Body/index.test.tsx'
```

Note: `bun run type-check` still fails on an unrelated existing issue at `packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts:334` with TS2589.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The PR branch was rebuilt from `origin/canary` in a clean worktree to avoid unrelated history from the original local branch.
