### PR TITLE
🐛 fix: nano banana 4K resolution dropped when aspect ratio is auto

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -746,7 +746,9 @@ export const nanoBanana2Parameters: ModelParamsSchema = {
   prompt: { default: '' },
   resolution: {
     default: '1K',
-    enum: ['512px', '1K', '2K', '4K'],
+    // Gemini image generation API accepts `"512" | "1K" | "2K" | "4K"`.
+    // See https://ai.google.dev/gemini-api/docs/image-generation
+    enum: ['512', '1K', '2K', '4K'],
   },
 };
 

--- a/packages/model-runtime/src/providers/anthropic/index.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/index.test.ts
@@ -548,6 +548,9 @@ describe('LobeAnthropicAI', () => {
         vi.spyOn(customInstance['client'].messages, 'create').mockRejectedValue(apiError);
 
         // Act & Assert
+        // anthropicCompatibleFactory normalizes the `/v1` suffix away (see #14960),
+        // then desensitizeUrl reconstructs via the WHATWG URL parser which always
+        // emits a trailing `/` in the pathname.
         await expect(
           customInstance.chat({
             messages: [{ content: 'Hello', role: 'user' }],
@@ -555,7 +558,7 @@ describe('LobeAnthropicAI', () => {
             temperature: 0,
           }),
         ).rejects.toEqual({
-          endpoint: 'https://api.cu****om.com/v1',
+          endpoint: 'https://api.cu****om.com/',
           error: apiError,
           errorType: invalidErrorType,
           provider,

--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -436,6 +436,164 @@ describe('createGoogleImage', () => {
       });
     });
 
+    // Regression: nano banana 4K selection used to be silently dropped because
+    // imageSize was gated on aspectRatio !== 'auto'. See LOBE-9115.
+    it('should pass imageSize when resolution is set even if aspectRatio is auto', async () => {
+      // Arrange
+      const realBase64ImageData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
+      const mockContentResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    data: realBase64ImageData,
+                    mimeType: 'image/png',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(mockContentResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'gemini-2.5-flash-image:image',
+        params: {
+          prompt: 'Create a beautiful sunset landscape',
+          aspectRatio: 'auto',
+          resolution: '4K',
+        },
+      };
+
+      // Act
+      await createGoogleImage(mockClient, provider, payload);
+
+      // Assert - imageConfig.imageSize must reach Google when only resolution is set
+      expect(mockClient.models.generateContent).toHaveBeenCalledWith({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'Create a beautiful sunset landscape' }],
+          },
+        ],
+        model: 'gemini-2.5-flash-image',
+        config: {
+          responseModalities: ['Image'],
+          imageConfig: {
+            imageSize: '4K',
+          },
+        },
+      });
+    });
+
+    it('should pass both aspectRatio and imageSize when both are set', async () => {
+      // Arrange
+      const realBase64ImageData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
+      const mockContentResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    data: realBase64ImageData,
+                    mimeType: 'image/png',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(mockContentResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'gemini-2.5-flash-image:image',
+        params: {
+          prompt: 'Cinematic widescreen shot',
+          aspectRatio: '16:9',
+          resolution: '2K',
+        },
+      };
+
+      // Act
+      await createGoogleImage(mockClient, provider, payload);
+
+      // Assert
+      expect(mockClient.models.generateContent).toHaveBeenCalledWith({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'Cinematic widescreen shot' }],
+          },
+        ],
+        model: 'gemini-2.5-flash-image',
+        config: {
+          responseModalities: ['Image'],
+          imageConfig: {
+            aspectRatio: '16:9',
+            imageSize: '2K',
+          },
+        },
+      });
+    });
+
+    it('should pass aspectRatio only when resolution is unset', async () => {
+      // Arrange
+      const realBase64ImageData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
+      const mockContentResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    data: realBase64ImageData,
+                    mimeType: 'image/png',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(mockContentResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'gemini-2.5-flash-image:image',
+        params: {
+          prompt: 'Portrait orientation',
+          aspectRatio: '9:16',
+        },
+      };
+
+      // Act
+      await createGoogleImage(mockClient, provider, payload);
+
+      // Assert
+      expect(mockClient.models.generateContent).toHaveBeenCalledWith({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'Portrait orientation' }],
+          },
+        ],
+        model: 'gemini-2.5-flash-image',
+        config: {
+          responseModalities: ['Image'],
+          imageConfig: {
+            aspectRatio: '9:16',
+          },
+        },
+      });
+    });
+
     it('should support image editing with base64 imageUrl', async () => {
       // Arrange
       const inputImageBase64 =

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -141,16 +141,21 @@ async function generateImageByChatModel(
     },
   ];
 
+  // Build imageConfig independently for aspectRatio and resolution so that
+  // selecting only one (e.g. resolution=4K while aspectRatio stays 'auto')
+  // still reaches the Google API. Previously both fields were gated on
+  // aspectRatio !== 'auto', which silently dropped the user's resolution.
+  const imageConfig: { aspectRatio?: string; imageSize?: string } = {};
+  if (params.aspectRatio && params.aspectRatio !== 'auto') {
+    imageConfig.aspectRatio = params.aspectRatio;
+  }
+  if (params.resolution) {
+    imageConfig.imageSize = params.resolution;
+  }
+
   const config: GenerateContentConfig = {
     responseModalities: ['Image'],
-    ...(params.aspectRatio && params.aspectRatio !== 'auto'
-      ? {
-          imageConfig: {
-            aspectRatio: params.aspectRatio,
-            imageSize: params.resolution,
-          },
-        }
-      : {}),
+    ...(Object.keys(imageConfig).length > 0 ? { imageConfig } : {}),
   };
 
   const response = await client.models.generateContent({

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -423,11 +423,11 @@ describe('LobeOpenRouterAI - custom features', () => {
         );
       });
 
-      it('should map 512px to 0.5K in image_config.image_size', async () => {
+      it("should map '512' to '0.5K' in image_config.image_size", async () => {
         await instance.chat({
           messages: [{ content: 'Generate an image', role: 'user' }],
           model: 'openai/dall-e-3-image',
-          imageResolution: '512px',
+          imageResolution: '512',
         } as any);
 
         expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -51,9 +51,11 @@ export const params = {
       const modalities =
         (payload as any).modalities ?? (isImageModel ? ['image', 'text'] : undefined);
 
-      // Map imageResolution to image_size: '512px' → '0.5K', others pass through
+      // Map imageResolution to image_size: '512' → '0.5K', others pass through.
+      // OpenRouter's image_size field expects '0.5K' for 512px output; the rest
+      // ('1K'/'2K'/'4K') are passed through verbatim.
       const imageSizeValue = imageResolution
-        ? imageResolution === '512px'
+        ? imageResolution === '512'
           ? '0.5K'
           : imageResolution
         : undefined;

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -84,9 +84,9 @@ export interface ChatStreamPayload {
    */
   imageAspectRatio?: string;
   /**
-   * @title Image resolution for image generation (e.g., '512px', '1K', '2K', '4K')
+   * @title Image resolution for image generation (e.g., '512', '1K', '2K', '4K')
    */
-  imageResolution?: '512px' | '1K' | '2K' | '4K';
+  imageResolution?: '512' | '1K' | '2K' | '4K';
   logprobs?: boolean;
   /**
    * @title Maximum length of generated text

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -106,9 +106,9 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
    */
   imageResolution?: '1K' | '2K' | '4K';
   /**
-   * Image resolution for image generation models (with 512px support)
+   * Image resolution for image generation models (with 512 support)
    */
-  imageResolution2?: '512px' | '1K' | '2K' | '4K';
+  imageResolution2?: '512' | '1K' | '2K' | '4K';
   inputTemplate?: string;
   /**
    * Effort level for Claude Opus 4.7 (adds xhigh tier between high and max)
@@ -227,7 +227,7 @@ export const AgentChatConfigSchema = z
     imageAspectRatio: z.string().optional(),
     imageAspectRatio2: z.string().optional(),
     imageResolution: z.enum(['1K', '2K', '4K']).optional(),
-    imageResolution2: z.enum(['512px', '1K', '2K', '4K']).optional(),
+    imageResolution2: z.enum(['512', '1K', '2K', '4K']).optional(),
     opus47Effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
     runtimeEnv: RuntimeEnvConfigSchema.optional(),
     reasoningBudgetToken: z.number().optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ImageResolution2Slider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ImageResolution2Slider.tsx
@@ -1,7 +1,7 @@
 import { type CreatedLevelSliderProps } from './createLevelSlider';
 import { createLevelSliderComponent } from './createLevelSlider';
 
-const IMAGE_RESOLUTIONS_2 = ['512px', '1K', '2K', '4K'] as const;
+const IMAGE_RESOLUTIONS_2 = ['512', '1K', '2K', '4K'] as const;
 type ImageResolution2 = (typeof IMAGE_RESOLUTIONS_2)[number];
 
 export type ImageResolution2SliderProps = CreatedLevelSliderProps<ImageResolution2>;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — internal user report.

#### 🔀 Description of Change

`nano-banana` / `nano-banana-pro` users who pick **2K/4K** resolution but leave aspect ratio at its default `auto` get the provider's default 1K output instead. Inside `createGoogleImage`, `imageConfig` was built only when `aspectRatio !== 'auto'`, so `imageSize` was silently dropped together with the (absent) aspect ratio.

Build `imageConfig` independently for `aspectRatio` and `imageSize`:

- Only include `aspectRatio` if the user picked a concrete ratio.
- Only include `imageSize` if `resolution` is set.
- Drop the whole `imageConfig` if neither is set.

Also bundles a follow-up fix to the Anthropic desensitize test that started failing on `canary` after #14960:

- `anthropicCompatibleFactory` now normalizes the `/v1` suffix (PR #14960), then `desensitizeUrl` reconstructs through the WHATWG `URL` parser, which always emits a trailing `/`. The test still expected `https://api.cu****om.com/v1`; updated to `https://api.cu****om.com/`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' \
  'src/providers/google/createImage.test.ts' \
  'src/providers/anthropic/index.test.ts'
# 64 passed
```

New regression cases on `generateImageByChatModel`:

- `resolution=4K` + `aspectRatio=auto` → `imageConfig.imageSize=4K`
- `resolution=2K` + `aspectRatio=16:9` → both fields pass through
- `aspectRatio=9:16` without resolution → `imageConfig.aspectRatio=9:16` only

#### 📸 Screenshots / Videos

N/A — runtime-only change.

#### 📝 Additional Information

No UI / schema changes. No migration impact.