### PR TITLE
🐛 fix(agent-builder): open builder panel after prompt creation

### DIFF
--- a/src/features/AgentBuilder/index.tsx
+++ b/src/features/AgentBuilder/index.tsx
@@ -15,10 +15,13 @@ const AgentBuilder = memo(() => {
   const agentId = useAgentStore((s) => s.activeAgentId);
   const agentBuilderId = useAgentStore(builtinAgentSelectors.agentBuilderId);
 
-  const [width, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.agentBuilderPanelWidth(s),
-    s.updateSystemStatus,
-  ]);
+  const [showAgentBuilderPanel, toggleAgentBuilderPanel, width, updateSystemStatus] =
+    useGlobalStore((s) => [
+      systemStatusSelectors.showAgentBuilderPanel(s),
+      s.toggleAgentBuilderPanel,
+      systemStatusSelectors.agentBuilderPanelWidth(s),
+      s.updateSystemStatus,
+    ]);
 
   const useInitBuiltinAgent = useAgentStore((s) => s.useInitBuiltinAgent);
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.agentBuilder);
@@ -26,6 +29,8 @@ const AgentBuilder = memo(() => {
   return (
     <RightPanel
       defaultWidth={width}
+      expand={showAgentBuilderPanel}
+      onExpandChange={toggleAgentBuilderPanel}
       onSizeChange={(size) => {
         if (size?.width) {
           const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;

--- a/src/hooks/useHotkeys/globalScope.test.ts
+++ b/src/hooks/useHotkeys/globalScope.test.ts
@@ -4,10 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { HotkeyId } from '@/types/hotkey';
 
-import { isTaskPanelRoute, useToggleRightPanelHotkey } from './globalScope';
+import {
+  isAgentProfilePanelRoute,
+  isTaskPanelRoute,
+  useToggleRightPanelHotkey,
+} from './globalScope';
 
 interface MockGlobalState {
   status: { zenMode: boolean };
+  toggleAgentBuilderPanel: () => void;
   toggleRightPanel: () => void;
   toggleTaskAgentPanel: () => void;
   updateSystemStatus: () => void;
@@ -18,6 +23,7 @@ type HotkeyRegistrationArgs = [HotkeyId, () => void, ...unknown[]];
 const mocks = vi.hoisted(() => ({
   hotkeyCallback: undefined as (() => void) | undefined,
   pathname: '/',
+  toggleAgentBuilderPanel: vi.fn(),
   toggleRightPanel: vi.fn(),
   toggleTaskAgentPanel: vi.fn(),
   useHotkeyById: vi.fn(),
@@ -39,6 +45,7 @@ vi.mock('@/store/global', () => ({
   useGlobalStore: (selector: (state: MockGlobalState) => unknown) =>
     selector({
       status: { zenMode: false },
+      toggleAgentBuilderPanel: mocks.toggleAgentBuilderPanel,
       toggleRightPanel: mocks.toggleRightPanel,
       toggleTaskAgentPanel: mocks.toggleTaskAgentPanel,
       updateSystemStatus: vi.fn(),
@@ -53,6 +60,7 @@ describe('globalScope hotkeys', () => {
   beforeEach(() => {
     mocks.hotkeyCallback = undefined;
     mocks.pathname = '/';
+    mocks.toggleAgentBuilderPanel.mockReset();
     mocks.toggleRightPanel.mockReset();
     mocks.toggleTaskAgentPanel.mockReset();
     mocks.useHotkeyById.mockReset();
@@ -69,6 +77,16 @@ describe('globalScope hotkeys', () => {
       expect(isTaskPanelRoute('/task/T-1')).toBe(true);
       expect(isTaskPanelRoute('/agent/inbox')).toBe(false);
       expect(isTaskPanelRoute('/task-template')).toBe(false);
+    });
+  });
+
+  describe('isAgentProfilePanelRoute', () => {
+    it('should match agent profile routes only', () => {
+      expect(isAgentProfilePanelRoute('/agent/agent-1/profile')).toBe(true);
+      expect(isAgentProfilePanelRoute('/agent/agent-1/profile/')).toBe(true);
+      expect(isAgentProfilePanelRoute('/agent/agent-1')).toBe(false);
+      expect(isAgentProfilePanelRoute('/agent/agent-1/profile/edit')).toBe(false);
+      expect(isAgentProfilePanelRoute('/group/group-1/profile')).toBe(false);
     });
   });
 
@@ -109,6 +127,21 @@ describe('globalScope hotkeys', () => {
       });
 
       expect(mocks.toggleRightPanel).toHaveBeenCalledTimes(1);
+      expect(mocks.toggleAgentBuilderPanel).not.toHaveBeenCalled();
+      expect(mocks.toggleTaskAgentPanel).not.toHaveBeenCalled();
+    });
+
+    it('should toggle the agent builder panel on agent profile routes', () => {
+      mocks.pathname = '/agent/agent-1/profile';
+
+      renderHook(() => useToggleRightPanelHotkey());
+
+      act(() => {
+        mocks.hotkeyCallback?.();
+      });
+
+      expect(mocks.toggleAgentBuilderPanel).toHaveBeenCalledTimes(1);
+      expect(mocks.toggleRightPanel).not.toHaveBeenCalled();
       expect(mocks.toggleTaskAgentPanel).not.toHaveBeenCalled();
     });
   });

--- a/src/hooks/useHotkeys/globalScope.ts
+++ b/src/hooks/useHotkeys/globalScope.ts
@@ -15,6 +15,13 @@ import { useHotkeyById } from './useHotkeyById';
 export const isTaskPanelRoute = (pathname: string) =>
   pathname === '/tasks' || pathname.startsWith('/tasks/') || pathname.startsWith('/task/');
 
+/**
+ * Agent profile renders AgentBuilder, whose panel status is intentionally
+ * independent from the generic right panel used by chat routes.
+ */
+export const isAgentProfilePanelRoute = (pathname: string) =>
+  /^\/agent\/[^/]+\/profile\/?$/.test(pathname);
+
 // Switch to chat tab (and focus on Lobe AI)
 export const useNavigateToChatHotkey = () => {
   const navigateToAgent = useNavigateToAgent();
@@ -49,10 +56,12 @@ export const useToggleLeftPanelHotkey = () => {
 export const useToggleRightPanelHotkey = () => {
   const { pathname } = useLocation();
   const isZenMode = useGlobalStore((s) => s.status.zenMode);
-  const [toggleRightPanel, toggleTaskAgentPanel] = useGlobalStore((s) => [
+  const [toggleAgentBuilderPanel, toggleRightPanel, toggleTaskAgentPanel] = useGlobalStore((s) => [
+    s.toggleAgentBuilderPanel,
     s.toggleRightPanel,
     s.toggleTaskAgentPanel,
   ]);
+  const isAgentProfileRoute = isAgentProfilePanelRoute(pathname);
   const isTaskRoute = isTaskPanelRoute(pathname);
 
   return useHotkeyById(
@@ -63,13 +72,24 @@ export const useToggleRightPanelHotkey = () => {
         return;
       }
 
+      if (isAgentProfileRoute) {
+        toggleAgentBuilderPanel();
+        return;
+      }
+
       toggleRightPanel();
     },
     {
       enableOnContentEditable: true,
       enabled: !isZenMode,
     },
-    [isTaskRoute, toggleRightPanel, toggleTaskAgentPanel],
+    [
+      isAgentProfileRoute,
+      isTaskRoute,
+      toggleAgentBuilderPanel,
+      toggleRightPanel,
+      toggleTaskAgentPanel,
+    ],
   );
 };
 

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -15,6 +15,8 @@ import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { resolveMarketAuthError } from '@/layout/AuthProvider/MarketAuth/errors';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
 import { useHomeStore } from '@/store/home';
 
 import AgentForkTag from './AgentForkTag';
@@ -34,6 +36,11 @@ const Header = memo(() => {
   const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
+  const [showAgentBuilderPanel, toggleAgentBuilderPanel, isStatusInit] = useGlobalStore((s) => [
+    systemStatusSelectors.showAgentBuilderPanel(s),
+    s.toggleAgentBuilderPanel,
+    systemStatusSelectors.isStatusInit(s),
+  ]);
   const removeAgent = useHomeStore((s) => s.removeAgent);
   const { isAuthenticated, isLoading: isAuthLoading, signIn } = useMarketAuth();
   const { isUnderReview } = useVersionReviewStatus();
@@ -179,8 +186,13 @@ const Header = memo(() => {
                 size={DESKTOP_HEADER_ICON_SMALL_SIZE}
               />
             </DropdownMenu>
-            {!isHeterogeneous && (
-              <ToggleRightPanelButton icon={BotMessageSquareIcon} showActive={true} />
+            {!isHeterogeneous && isStatusInit && (
+              <ToggleRightPanelButton
+                expand={showAgentBuilderPanel}
+                icon={BotMessageSquareIcon}
+                showActive={true}
+                onToggle={() => toggleAgentBuilderPanel()}
+              />
             )}
           </Flexbox>
         }

--- a/src/store/global/action.test.ts
+++ b/src/store/global/action.test.ts
@@ -61,6 +61,44 @@ describe('createPreferenceSlice', () => {
     });
   });
 
+  describe('toggleAgentBuilderPanel', () => {
+    it('should toggle agent builder panel without changing chat right panel', () => {
+      const { result } = renderHook(() => useGlobalStore());
+
+      act(() => {
+        useGlobalStore.setState({
+          isStatusInit: true,
+          status: {
+            ...initialState.status,
+            showAgentBuilderPanel: false,
+            showRightPanel: false,
+          },
+        });
+        result.current.toggleAgentBuilderPanel();
+      });
+
+      expect(result.current.status.showAgentBuilderPanel).toBe(true);
+      expect(result.current.status.showRightPanel).toBe(false);
+    });
+
+    it('should set agent builder panel to specified value', () => {
+      const { result } = renderHook(() => useGlobalStore());
+
+      act(() => {
+        useGlobalStore.setState({ isStatusInit: true });
+        result.current.toggleAgentBuilderPanel(true);
+      });
+
+      expect(result.current.status.showAgentBuilderPanel).toBe(true);
+
+      act(() => {
+        result.current.toggleAgentBuilderPanel(false);
+      });
+
+      expect(result.current.status.showAgentBuilderPanel).toBe(false);
+    });
+  });
+
   describe('toggleExpandSessionGroup', () => {
     it('should toggle expand session group', () => {
       const { result } = renderHook(() => useGlobalStore());

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -81,6 +81,16 @@ export class GlobalWorkspacePaneActionImpl {
     this.#get().updateSystemStatus({ showLeftPanel }, n('toggleLeftPanel', newValue));
   };
 
+  toggleAgentBuilderPanel = (newValue?: boolean): void => {
+    const showAgentBuilderPanel =
+      typeof newValue === 'boolean' ? newValue : !this.#get().status.showAgentBuilderPanel;
+
+    this.#get().updateSystemStatus(
+      { showAgentBuilderPanel },
+      n('toggleAgentBuilderPanel', newValue),
+    );
+  };
+
   togglePageAgentPanel = (newValue?: boolean): void => {
     const showPageAgentPanel =
       typeof newValue === 'boolean' ? newValue : !this.#get().status.showPageAgentPanel;

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -204,6 +204,11 @@ export interface SystemStatus {
     name: number;
     size: number;
   };
+  /**
+   * Visibility of the Agent profile right-side Agent Builder panel.
+   * Independent from `showRightPanel` so builder creation flows do not affect chat pages.
+   */
+  showAgentBuilderPanel?: boolean;
   showCommandMenu?: boolean;
   showFilePanel?: boolean;
   showHotkeyHelper?: boolean;
@@ -368,6 +373,7 @@ export const INITIAL_STATUS = {
   showHotkeyHelper: false,
   showImagePanel: true,
   showImageTopicPanel: true,
+  showAgentBuilderPanel: false,
   showLeftPanel: true,
   showPageAgentPanel: true,
   showRightPanel: false,

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -46,6 +46,7 @@ describe('systemStatusSelectors', () => {
         showSystemRole: true,
         mobileShowTopic: true,
         mobileShowPortal: true,
+        showAgentBuilderPanel: true,
         showRightPanel: true,
         showLeftPanel: true,
         showFilePanel: true,
@@ -64,6 +65,7 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.showSystemRole(s)).toBe(true);
       expect(systemStatusSelectors.mobileShowTopic(s)).toBe(true);
       expect(systemStatusSelectors.mobileShowPortal(s)).toBe(true);
+      expect(systemStatusSelectors.showAgentBuilderPanel(s)).toBe(true);
       expect(systemStatusSelectors.showRightPanel(s)).toBe(true);
       expect(systemStatusSelectors.showLeftPanel(s)).toBe(true);
       expect(systemStatusSelectors.showFilePanel(s)).toBe(true);
@@ -81,6 +83,7 @@ describe('systemStatusSelectors', () => {
       const zenState = merge(s, {
         status: { zenMode: true },
       });
+      expect(systemStatusSelectors.showAgentBuilderPanel(zenState)).toBe(false);
       expect(systemStatusSelectors.showRightPanel(zenState)).toBe(false);
       expect(systemStatusSelectors.showLeftPanel(zenState)).toBe(false);
       expect(systemStatusSelectors.showChatHeader(zenState)).toBe(false);

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -172,6 +172,8 @@ const sidebarItems = (s: GlobalState): string[] => {
 const showSystemRole = (s: GlobalState) => s.status.showSystemRole;
 const mobileShowTopic = (s: GlobalState) => s.status.mobileShowTopic;
 const mobileShowPortal = (s: GlobalState) => s.status.mobileShowPortal;
+const showAgentBuilderPanel = (s: GlobalState) =>
+  !s.status.zenMode && s.status.showAgentBuilderPanel;
 const showRightPanel = (s: GlobalState) => !s.status.zenMode && s.status.showRightPanel;
 const showLeftPanel = (s: GlobalState) => !s.status.zenMode && s.status.showLeftPanel;
 const showPageAgentPanel = (s: GlobalState) => !s.status.zenMode && s.status.showPageAgentPanel;
@@ -279,6 +281,7 @@ export const systemStatusSelectors = {
   sidebarExpandedKeys,
   sidebarItems,
   sessionGroupKeys,
+  showAgentBuilderPanel,
   showChatHeader,
   showFilePanel,
   showImagePanel,

--- a/src/store/home/slices/homeInput/action.test.ts
+++ b/src/store/home/slices/homeInput/action.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { HomeStore } from '@/store/home/store';
+import type { StoreSetter } from '@/store/types';
+
+import { HomeInputActionImpl } from './action';
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const createAgentMock = vi.hoisted(() => vi.fn());
+const updateAgentConfigByIdMock = vi.hoisted(() => vi.fn());
+const refreshBuiltinAgentMock = vi.hoisted(() => vi.fn());
+const sendMessageMock = vi.hoisted(() => vi.fn());
+const refreshAgentListMock = vi.hoisted(() => vi.fn());
+const toggleAgentBuilderPanelMock = vi.hoisted(() => vi.fn());
+const toggleRightPanelMock = vi.hoisted(() => vi.fn());
+const setChatPanelExpandedMock = vi.hoisted(() => vi.fn());
+const createGroupMock = vi.hoisted(() => vi.fn());
+const loadGroupsMock = vi.hoisted(() => vi.fn());
+
+const agentState = vi.hoisted(() => ({
+  agentConfigMap: {
+    inbox: {
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+    },
+  },
+  agentMap: {
+    agentBuilder: {},
+    groupAgentBuilder: {},
+  },
+  builtinAgentIdMap: {
+    'agent-builder': 'agentBuilder',
+    'group-agent-builder': 'groupAgentBuilder',
+  },
+  createAgent: createAgentMock,
+  inboxAgentId: 'inbox',
+  refreshBuiltinAgent: refreshBuiltinAgentMock,
+  updateAgentConfigById: updateAgentConfigByIdMock,
+}));
+
+vi.mock('@lobechat/builtin-agents', () => ({
+  BUILTIN_AGENT_SLUGS: {
+    agentBuilder: 'agent-builder',
+    groupAgentBuilder: 'group-agent-builder',
+  },
+}));
+
+vi.mock('@/services/chatGroup', () => ({
+  chatGroupService: {
+    createGroup: createGroupMock,
+  },
+}));
+
+vi.mock('@/store/agent', () => ({
+  getAgentStoreState: () => agentState,
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    getAgentConfigById:
+      (id: string) =>
+      (state: typeof agentState): { model: string; provider: string } | undefined =>
+        state.agentConfigMap[id as keyof typeof state.agentConfigMap],
+  },
+  builtinAgentSelectors: {
+    inboxAgentId: (state: typeof agentState) => state.inboxAgentId,
+  },
+}));
+
+vi.mock('@/store/agentGroup', () => ({
+  getChatGroupStoreState: () => ({
+    loadGroups: loadGroupsMock,
+  }),
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: {
+    getState: () => ({
+      sendMessage: sendMessageMock,
+    }),
+  },
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: {
+    getState: () => ({
+      toggleAgentBuilderPanel: toggleAgentBuilderPanelMock,
+      toggleRightPanel: toggleRightPanelMock,
+    }),
+  },
+}));
+
+vi.mock('@/store/groupProfile', () => ({
+  useGroupProfileStore: {
+    getState: () => ({
+      setChatPanelExpanded: setChatPanelExpandedMock,
+    }),
+  },
+}));
+
+vi.mock('@/utils/stableNavigate', () => ({
+  getStableNavigate: () => navigateMock,
+}));
+
+const createAction = () => {
+  const homeState: Partial<HomeStore> = {
+    refreshAgentList: refreshAgentListMock,
+  };
+
+  const setState: StoreSetter<HomeStore> = ((partial) => {
+    if (typeof partial === 'function') {
+      Object.assign(homeState, partial(homeState as HomeStore));
+      return;
+    }
+    Object.assign(homeState, partial);
+  }) as StoreSetter<HomeStore>;
+
+  return new HomeInputActionImpl(setState, () => homeState as HomeStore);
+};
+
+describe('HomeInputActionImpl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createAgentMock.mockResolvedValue({ agentId: 'agent-new' });
+    createGroupMock.mockResolvedValue({
+      group: {
+        id: 'group-new',
+      },
+    });
+  });
+
+  describe('sendAsAgent', () => {
+    it('opens the agent builder panel without touching the generic right panel', async () => {
+      const action = createAction();
+
+      await action.sendAsAgent({ message: 'build a support agent' });
+
+      expect(toggleAgentBuilderPanelMock).toHaveBeenCalledWith(true);
+      expect(toggleRightPanelMock).not.toHaveBeenCalled();
+      expect(navigateMock).toHaveBeenCalledWith('/agent/agent-new/profile');
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { agentId: 'agentBuilder', scope: 'agent_builder' },
+          message: 'build a support agent',
+        }),
+      );
+    });
+  });
+
+  describe('sendAsGroup', () => {
+    it('opens the existing group agent builder panel for prompt-based group creation', async () => {
+      const action = createAction();
+
+      await action.sendAsGroup({ message: 'build a research group' });
+
+      expect(setChatPanelExpandedMock).toHaveBeenCalledWith(true);
+      expect(navigateMock).toHaveBeenCalledWith('/group/group-new/profile');
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { agentId: 'groupAgentBuilder', scope: 'group_agent_builder' },
+          message: 'build a research group',
+        }),
+      );
+    });
+  });
+});

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -6,6 +6,8 @@ import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { getChatGroupStoreState } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
+import { useGlobalStore } from '@/store/global';
+import { useGroupProfileStore } from '@/store/groupProfile';
 import { type HomeStore } from '@/store/home/store';
 import { type StoreSetter } from '@/store/types';
 import { getStableNavigate } from '@/utils/stableNavigate';
@@ -86,6 +88,10 @@ export class HomeInputActionImpl {
         groupId,
       });
 
+      if (message.trim()) {
+        useGlobalStore.getState().toggleAgentBuilderPanel(true);
+      }
+
       // 3. Navigate to Agent profile page
       getStableNavigate()?.(`/agent/${result.agentId}/profile`);
 
@@ -156,6 +162,10 @@ export class HomeInputActionImpl {
 
       // 4. Refresh sidebar agent list
       this.#get().refreshAgentList();
+
+      if (message.trim()) {
+        useGroupProfileStore.getState().setChatPanelExpanded(true);
+      }
 
       // 5. Navigate to Group profile page
       getStableNavigate()?.(`/group/${group.id}/profile`);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Add an independent Agent Builder panel visibility state for Agent profile pages.
- Open the Agent Builder panel automatically after prompt-based Agent creation so the user can see the generated builder conversation.
- Keep the generic chat right panel state untouched, and reuse the existing group profile builder panel state for prompt-based group creation.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/store/home/slices/homeInput/action.test.ts
bunx vitest run --silent='passed-only' src/store/global/selectors/systemStatus.test.ts
bunx vitest run --silent='passed-only' src/store/global/action.test.ts
bun run type-check
git diff --check
```

Manual scenario:

- From Home, click Create Agent, enter a prompt, and send it.
- The app navigates to the new Agent profile and opens the Agent Builder panel instead of leaving the user on a static profile page.
- The generic chat right panel remains independent.

#### 📸 Screenshots / Videos

Not captured.

#### 📝 Additional Information

This mirrors the existing independent right-panel pattern used by PageEditor and Task surfaces, avoiding cross-page side effects from `showRightPanel`.