### PR TITLE
fix: add LaTeX extensions to text-readable file types

### DIFF
--- a/packages/file-loaders/src/utils/isTextReadableFile.ts
+++ b/packages/file-loaders/src/utils/isTextReadableFile.ts
@@ -68,6 +68,13 @@ export const TEXT_READABLE_FILE_TYPES = [
   'patch',
   'diff',
   'db', // Often text-based, like SQLite journals
+
+  // LaTeX
+  'tex',
+  'sty',
+  'cls',
+  'bib',
+  'bbl',
 ];
 
 /**


### PR DESCRIPTION
This is an independent contribution — not associated with any organization, hackathon, or competition.

## Summary

Fixes lobehub/lobehub#14917

.tex (LaTeX) files are plain-text UTF-8/ASCII documents but the file loader rejected them as binary because the extensions were not in the text-readable whitelist. Users could not read `.tex`, `.sty`, `.cls`, `.bib`, or `.bbl` files through the file loader.

## Root Cause

The `TEXT_READABLE_FILE_TYPES` array in `packages/file-loaders/src/utils/isTextReadableFile.ts` did not include LaTeX-related extensions. The `isReadableFileType` function uses this array as a hard gate before even attempting to read a file — extensions not in the whitelist are rejected without content inspection.

## Fix

Added the five common LaTeX file extensions to `TEXT_READABLE_FILE_TYPES`:

* `tex` — LaTeX source files
* `sty` — LaTeX style/package files
* `cls` — LaTeX document class files
* `bib` — BibTeX bibliography files
* `bbl` — BibTeX compiled bibliography output

All of these are plain-text UTF-8/ASCII formats.

## Changes

* `packages/file-loaders/src/utils/isTextReadableFile.ts`: Added 5 LaTeX extensions (`+5 -0` lines)

## Testing

* `.tex` file: `isReadableFileType('tex')` returns `true` ✅
* `.sty` file: `isReadableFileType('sty')` returns `true` ✅
* `.cls` file: `isReadableFileType('cls')` returns `true` ✅
* `.bib` file: `isReadableFileType('bib')` returns `true` ✅
* `.bbl` file: `isReadableFileType('bbl')` returns `true` ✅
* Non-LaTeX binary (`.bin`): still correctly rejected ✅